### PR TITLE
Playwright: Implement remaining Jetpack block smoke tests

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/contact-info.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/contact-info.ts
@@ -1,0 +1,56 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '..';
+
+interface ConfigurationData {
+	email: string;
+	phoneNumber: string;
+}
+
+const blockParentSelector = '[aria-label="Block: Contact Info"]';
+const selectors = {
+	emailTextArea: 'textarea[aria-label=Email]',
+	phoneNumberTextArea: 'textarea[aria-label="Phone number"]',
+};
+
+/**
+ * Class representing the flow of using a Contact Info block in the editor.
+ */
+export class ContactInfoBlock implements BlockFlow {
+	private configurationData: ConfigurationData;
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+	}
+
+	blockSidebarName = 'Contact Info';
+	blockEditorSelector = blockParentSelector;
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		await context.editorIframe.fill( selectors.emailTextArea, this.configurationData.email );
+		await context.editorIframe.fill(
+			selectors.phoneNumberTextArea,
+			this.configurationData.phoneNumber
+		);
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		const numericOnlyPhoneNumber = this.configurationData.phoneNumber.replace( /\D/g, '' );
+
+		await context.page.waitForSelector( `[href="mailto:${ this.configurationData.email }"]` );
+		await context.page.waitForSelector( `[href="tel:${ numericOnlyPhoneNumber }"]` );
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/contact-info.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/contact-info.ts
@@ -7,8 +7,8 @@ interface ConfigurationData {
 
 const blockParentSelector = '[aria-label="Block: Contact Info"]';
 const selectors = {
-	emailTextArea: 'textarea[aria-label=Email]',
-	phoneNumberTextArea: 'textarea[aria-label="Phone number"]',
+	emailTextarea: `${ blockParentSelector } textarea[aria-label=Email]`,
+	phoneNumberTextarea: `${ blockParentSelector } textarea[aria-label="Phone number"]`,
 };
 
 /**
@@ -35,9 +35,9 @@ export class ContactInfoBlockFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		await context.editorIframe.fill( selectors.emailTextArea, this.configurationData.email );
+		await context.editorIframe.fill( selectors.emailTextarea, this.configurationData.email );
 		await context.editorIframe.fill(
-			selectors.phoneNumberTextArea,
+			selectors.phoneNumberTextarea,
 			this.configurationData.phoneNumber
 		);
 	}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/contact-info.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/contact-info.ts
@@ -14,7 +14,7 @@ const selectors = {
 /**
  * Class representing the flow of using a Contact Info block in the editor.
  */
-export class ContactInfoBlock implements BlockFlow {
+export class ContactInfoBlockFlow implements BlockFlow {
 	private configurationData: ConfigurationData;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -9,3 +9,7 @@ export * from './blog-posts';
 export * from './post-carousel';
 export * from './timeline';
 export * from './premium-content';
+export * from './subscription-form';
+export * from './payments';
+export * from './contact-info';
+export * from './star-rating';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -13,3 +13,5 @@ export * from './subscription-form';
 export * from './payments';
 export * from './contact-info';
 export * from './star-rating';
+export * from './slideshow';
+export * from './tiled-gallery';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -8,3 +8,4 @@ export * from './contact-form';
 export * from './blog-posts';
 export * from './post-carousel';
 export * from './timeline';
+export * from './premium-content';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/payments.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/payments.ts
@@ -1,0 +1,61 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '..';
+
+interface ConfigurationData {
+	buttonText: string;
+}
+
+const blockParentSelector = '[aria-label="Block: Payments"]';
+const selectors = {
+	editableButtonText: `${ blockParentSelector } [role=textbox]`,
+};
+
+/**
+ * Class representing the flow of using a Contact Info block in the editor.
+ */
+export class PaymentsBlockFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+	}
+
+	blockSidebarName = 'Payments';
+	blockEditorSelector = blockParentSelector;
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		// On mobile, you need to focus the parent block first, then the sub-block. This is also desktop safe.
+		await context.editorIframe.click( blockParentSelector );
+		// We can't use the 'fill' method because it's not a real textarea :(
+		await context.editorIframe.click( selectors.editableButtonText );
+		await context.editorIframe.type(
+			selectors.editableButtonText,
+			this.configurationData.buttonText
+		);
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		// Because Stripe isn't connected to this WordPress.com account, we shouldn't see this block published.
+		if (
+			await context.page.isVisible( `button:has-text("${ this.configurationData.buttonText }")` )
+		) {
+			throw new Error(
+				'Payments button should not be visible on published post without Stripe connection'
+			);
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/payments.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/payments.ts
@@ -6,7 +6,7 @@ interface ConfigurationData {
 
 const blockParentSelector = '[aria-label="Block: Payments"]';
 const selectors = {
-	editableButtonText: `${ blockParentSelector } [role=textbox]`,
+	buttonText: `${ blockParentSelector } [role=textbox]`,
 };
 
 /**
@@ -33,14 +33,7 @@ export class PaymentsBlockFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		// On mobile, you need to focus the parent block first, then the sub-block. This is also desktop safe.
-		await context.editorIframe.click( blockParentSelector );
-		// We can't use the 'fill' method because it's not a real textarea :(
-		await context.editorIframe.click( selectors.editableButtonText );
-		await context.editorIframe.type(
-			selectors.editableButtonText,
-			this.configurationData.buttonText
-		);
+		await context.editorIframe.fill( selectors.buttonText, this.configurationData.buttonText );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/premium-content.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/premium-content.ts
@@ -1,0 +1,59 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '..';
+
+interface ConfigurationData {
+	subscriberTitle: string;
+	subscriberText: string;
+}
+
+const blockParentSelector = '[aria-label="Block: Premium Content"]';
+const selectors = {
+	subscriberViewButton: 'button:has-text("Subscriber View")',
+	subscriberHeader: '[aria-label="Block: Subscriber View"] [aria-label="Block: Heading"]',
+	subscriberParagraph: '[aria-label="Block: Subscriber View"] [aria-label="Paragraph block"]',
+};
+
+/**
+ * Class representing the flow of using a Contact Info block in the editor.
+ */
+export class PremiumContentBlockFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+	}
+
+	blockSidebarName = 'Premium Content';
+	blockEditorSelector = blockParentSelector;
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		await context.editorIframe.click( selectors.subscriberViewButton );
+		await context.editorIframe.fill(
+			selectors.subscriberHeader,
+			this.configurationData.subscriberTitle
+		);
+		await context.editorIframe.fill(
+			selectors.subscriberParagraph,
+			this.configurationData.subscriberText
+		);
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		await context.page.waitForSelector( `text="${ this.configurationData.subscriberTitle }"` );
+		await context.page.waitForSelector( `text="${ this.configurationData.subscriberText }"` );
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/premium-content.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/premium-content.ts
@@ -13,7 +13,7 @@ const selectors = {
 };
 
 /**
- * Class representing the flow of using a Contact Info block in the editor.
+ * Class representing the flow of using a Premium Content block in the editor.
  */
 export class PremiumContentBlockFlow implements BlockFlow {
 	private configurationData: ConfigurationData;
@@ -53,6 +53,7 @@ export class PremiumContentBlockFlow implements BlockFlow {
 	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		// Since we're viewing as the publishing user, we should see the subscriber version of the content.
 		await context.page.waitForSelector( `text="${ this.configurationData.subscriberTitle }"` );
 		await context.page.waitForSelector( `text="${ this.configurationData.subscriberText }"` );
 	}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/slideshow.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/slideshow.ts
@@ -13,7 +13,7 @@ const selectors = {
 };
 
 /**
- * Class representing the flow of using a Contact Info block in the editor.
+ * Class representing the flow of using a Slideshow block in the editor.
  */
 export class SlideshowBlockFlow implements BlockFlow {
 	private configurationData: ConfigurationData;
@@ -39,9 +39,9 @@ export class SlideshowBlockFlow implements BlockFlow {
 	 */
 	async configure( context: EditorContext ): Promise< void > {
 		for ( const imagePath of this.configurationData.imagePaths ) {
-			// Always make a duplicate test version first.
+			// Always make a duplicate "test" version of the image to preserve the original.
 			const testFile = await createTestFile( imagePath );
-			// We keep track of the names for later validation.
+			// We keep track of the names for later validation in the published post.
 			this.preparedImageFileNames.push( testFile.basename );
 			await context.editorIframe.setInputFiles( selectors.fileInput, testFile.fullpath );
 			await context.editorIframe.waitForSelector( selectors.uploadingIndicator, {
@@ -58,7 +58,7 @@ export class SlideshowBlockFlow implements BlockFlow {
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
 		for ( const imageFileName of this.preparedImageFileNames ) {
 			await context.page.waitForSelector( selectors.publishedImage( imageFileName ), {
-				state: 'attached', // May not be visible if not the current slide
+				state: 'attached', // The image not be visible if it's not the current slide.
 			} );
 		}
 	}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/slideshow.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/slideshow.ts
@@ -1,0 +1,65 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '..';
+import { createTestFile } from '../../../media-helper';
+
+interface ConfigurationData {
+	imagePaths: string[];
+}
+
+const blockParentSelector = '[aria-label="Block: Slideshow"]';
+const selectors = {
+	fileInput: `${ blockParentSelector } input[type=file]`,
+	uploadingIndicator: `${ blockParentSelector } .components-spinner`,
+	publishedImage: ( fileName: string ) => `.wp-block-jetpack-slideshow img[src*="${ fileName }"]`,
+};
+
+/**
+ * Class representing the flow of using a Contact Info block in the editor.
+ */
+export class SlideshowBlockFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+	private preparedImageFileNames: string[];
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+		this.preparedImageFileNames = [];
+	}
+
+	blockSidebarName = 'Slideshow';
+	blockEditorSelector = blockParentSelector;
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		for ( const imagePath of this.configurationData.imagePaths ) {
+			// Always make a duplicate test version first.
+			const testFile = await createTestFile( imagePath );
+			// We keep track of the names for later validation.
+			this.preparedImageFileNames.push( testFile.basename );
+			await context.editorIframe.setInputFiles( selectors.fileInput, testFile.fullpath );
+			await context.editorIframe.waitForSelector( selectors.uploadingIndicator, {
+				state: 'detached',
+			} );
+		}
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		for ( const imageFileName of this.preparedImageFileNames ) {
+			await context.page.waitForSelector( selectors.publishedImage( imageFileName ), {
+				state: 'attached', // May not be visible if not the current slide
+			} );
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/star-rating.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/star-rating.ts
@@ -1,0 +1,85 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '..';
+
+const wholeRatings = [ 1, 2, 3, 4, 5 ] as const;
+type WholeRating = typeof wholeRatings[ number ];
+
+const halfRatings = [ 0.5, 1.5, 2.5, 3.5, 4.5 ] as const;
+type HalfRating = typeof halfRatings[ number ];
+
+type StarRating = WholeRating | HalfRating;
+
+interface ConfigurationData {
+	rating: StarRating;
+}
+
+const blockParentSelector = '[aria-label="Block: Star Rating"]';
+const selectors = {
+	starButton: ( nthIndex: number ) => `.jetpack-ratings-button:nth-child(${ nthIndex })`,
+};
+
+/**
+ * Class representing the flow of using a Contact Info block in the editor.
+ */
+export class ContactInfoBlock implements BlockFlow {
+	private configurationData: ConfigurationData;
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+	}
+
+	blockSidebarName = 'Star Rating';
+	blockEditorSelector = blockParentSelector;
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		const rating = this.configurationData.rating;
+		if ( rating === 1 ) {
+			// this is the default!
+			return;
+		}
+
+		if ( rating === 0.5 ) {
+			// because the default is 1 start, we just have one click to do here
+			await context.editorIframe.click( selectors.starButton( 1 ) );
+			return;
+		}
+
+		if ( wholeRatings.includes( rating as WholeRating ) ) {
+			await context.editorIframe.click( selectors.starButton( rating ) );
+			return;
+		}
+
+		if ( halfRatings.includes( rating as HalfRating ) ) {
+			const starNthIndex = Math.ceil( rating );
+			// two clicks creates a half star rating!
+			await context.editorIframe.click( selectors.starButton( starNthIndex ) );
+			await context.editorIframe.click( selectors.starButton( starNthIndex ) );
+			return;
+		}
+
+		throw new Error( `${ rating } is not a valid Star Rating value.` );
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		// This is screen-reader text, and the easiest way to validate the star rating.
+		// Because it's not actually visual text on the page, we're using 'attached' state instead of default of 'visible'.
+		await context.page.waitForSelector(
+			`text=Rating: ${ this.configurationData.rating } out of 5.`,
+			{ state: 'attached' }
+		);
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/star-rating.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/star-rating.ts
@@ -18,7 +18,7 @@ const selectors = {
 };
 
 /**
- * Class representing the flow of using a Contact Info block in the editor.
+ * Class representing the flow of using a Star Rating block in the editor.
  */
 export class StarRatingBlock implements BlockFlow {
 	private configurationData: ConfigurationData;
@@ -43,12 +43,12 @@ export class StarRatingBlock implements BlockFlow {
 	async configure( context: EditorContext ): Promise< void > {
 		const rating = this.configurationData.rating;
 		if ( rating === 1 ) {
-			// this is the default!
+			// This is the default when you add the block -- we're done here.
 			return;
 		}
 
 		if ( rating === 0.5 ) {
-			// because the default is 1 start, we just have one click to do here
+			// Because the default is 1 start, we just have one click to do here.
 			await context.editorIframe.click( selectors.starButton( 1 ) );
 			return;
 		}
@@ -60,7 +60,7 @@ export class StarRatingBlock implements BlockFlow {
 
 		if ( halfRatings.includes( rating as HalfRating ) ) {
 			const starNthIndex = Math.ceil( rating );
-			// two clicks creates a half star rating!
+			// Two clicks creates a half star rating.
 			await context.editorIframe.click( selectors.starButton( starNthIndex ) );
 			await context.editorIframe.click( selectors.starButton( starNthIndex ) );
 			return;

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/star-rating.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/star-rating.ts
@@ -20,7 +20,7 @@ const selectors = {
 /**
  * Class representing the flow of using a Contact Info block in the editor.
  */
-export class ContactInfoBlock implements BlockFlow {
+export class StarRatingBlock implements BlockFlow {
 	private configurationData: ConfigurationData;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/subscription-form.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/subscription-form.ts
@@ -1,4 +1,4 @@
-import { BlockFlow, EditorContext, PublishedPostContext } from '..';
+import { BlockFlow, PublishedPostContext } from '..';
 
 const blockParentSelector = '[aria-label="Block: Subscription Form"]';
 const selectors = {
@@ -12,17 +12,6 @@ const selectors = {
 export class SubscriptionFormBlockFlow implements BlockFlow {
 	blockSidebarName = 'Subscription Form';
 	blockEditorSelector = blockParentSelector;
-
-	// TODO: Delete this post-rebase
-	/**
-	 * Configure the block in the editor with the configuration data from the constructor
-	 *
-	 * @param {EditorContext} context The current context for the editor at the point of test execution
-	 */
-	async configure( context: EditorContext ): Promise< void > {
-		await context.page.waitForSelector( 'foo' );
-		return;
-	}
 
 	/**
 	 * Validate the block in the published post

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/subscription-form.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/subscription-form.ts
@@ -1,0 +1,38 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '..';
+
+const blockParentSelector = '[aria-label="Block: Subscription Form"]';
+const selectors = {
+	emailInput: 'input[name=email]',
+	subscribeButton: 'button:has-text("Subscribe")',
+};
+
+/**
+ * Class representing the flow of using a Subscription Form block in the editor.
+ */
+export class SubscriptionFormBlockFlow implements BlockFlow {
+	blockSidebarName = 'Subscription Form';
+	blockEditorSelector = blockParentSelector;
+
+	// TODO: Delete this post-rebase
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		await context.page.waitForSelector( 'foo' );
+		return;
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		// Is there an interactive email field?
+		await context.page.fill( selectors.emailInput, 'foo@example.com' );
+		// And a subscribe button?
+		await context.page.waitForSelector( selectors.subscribeButton );
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/tiled-gallery.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/tiled-gallery.ts
@@ -1,0 +1,64 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '..';
+import { createTestFile } from '../../../media-helper';
+
+interface ConfigurationData {
+	imagePaths: string[];
+}
+
+const blockParentSelector = '[aria-label="Block: Tiled Gallery"]';
+const selectors = {
+	fileInput: `${ blockParentSelector } input[type=file]`,
+	uploadingIndicator: `${ blockParentSelector } .components-spinner`,
+	publishedImage: ( fileName: string ) =>
+		`.wp-block-jetpack-tiled-gallery img[src*="${ fileName }"]`,
+};
+
+/**
+ * Class representing the flow of using a Contact Info block in the editor.
+ */
+export class TiledGalleryBlockFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+	private preparedImageFileNames: string[];
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+		this.preparedImageFileNames = [];
+	}
+
+	blockSidebarName = 'Tiled Gallery';
+	blockEditorSelector = blockParentSelector;
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		for ( const imagePath of this.configurationData.imagePaths ) {
+			// Always make a duplicate test version first.
+			const testFile = await createTestFile( imagePath );
+			// We keep track of the names for later validation.
+			this.preparedImageFileNames.push( testFile.basename );
+			await context.editorIframe.setInputFiles( selectors.fileInput, testFile.fullpath );
+			await context.editorIframe.waitForSelector( selectors.uploadingIndicator, {
+				state: 'detached',
+			} );
+		}
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		for ( const imageFileName of this.preparedImageFileNames ) {
+			await context.page.waitForSelector( selectors.publishedImage( imageFileName ) );
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/tiled-gallery.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/tiled-gallery.ts
@@ -14,7 +14,7 @@ const selectors = {
 };
 
 /**
- * Class representing the flow of using a Contact Info block in the editor.
+ * Class representing the flow of using a Tiled Gallery block in the editor.
  */
 export class TiledGalleryBlockFlow implements BlockFlow {
 	private configurationData: ConfigurationData;
@@ -40,9 +40,9 @@ export class TiledGalleryBlockFlow implements BlockFlow {
 	 */
 	async configure( context: EditorContext ): Promise< void > {
 		for ( const imagePath of this.configurationData.imagePaths ) {
-			// Always make a duplicate test version first.
+			// Always make a duplicate "test" version of the image to preserve the original.
 			const testFile = await createTestFile( imagePath );
-			// We keep track of the names for later validation.
+			// We keep track of the names for later validation in the published post.
 			this.preparedImageFileNames.push( testFile.basename );
 			await context.editorIframe.setInputFiles( selectors.fileInput, testFile.fullpath );
 			await context.editorIframe.waitForSelector( selectors.uploadingIndicator, {

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/timeline.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/timeline.ts
@@ -7,14 +7,8 @@ interface ConfigurationData {
 	secondEntry: string;
 }
 
-interface EntryDetails {
-	nthIndex: number;
-	entryText: string;
-}
-
 const blockParentSelector = '[aria-label="Block: Timeline"]';
 const selectors = {
-	entry: ( nthIndex: number ) => `[aria-label="Block: Timeline Entry"]:nth-child(${ nthIndex })`,
 	entryParagraph: ( nthIndex: number ) =>
 		`[aria-label="Block: Timeline Entry"]:nth-child(${ nthIndex }) [data-title=Paragraph]`,
 	addEntryButton: `${ blockParentSelector } button:has-text("Add entry")`,
@@ -44,36 +38,14 @@ export class TimelineBlockFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		await this.enterTextInEntry( context, {
-			nthIndex: 1,
-			entryText: this.configurationData.firstEntry,
-		} );
+		await context.editorIframe.fill(
+			selectors.entryParagraph( 1 ),
+			this.configurationData.firstEntry
+		);
 		await context.editorIframe.click( selectors.addEntryButton );
-		await this.enterTextInEntry( context, {
-			nthIndex: 2,
-			entryText: this.configurationData.secondEntry,
-		} );
-	}
-
-	/**
-	 * Enters text into a Timeline block entry.
-	 *
-	 * @param context Editor context.
-	 * @param entryDetails The details (nth index and text) for the entry.
-	 */
-	private async enterTextInEntry(
-		context: EditorContext,
-		entryDetails: EntryDetails
-	): Promise< void > {
-		// In the mobile case, you have to first click on the entry itself, and THEN on the paragraph block.
-		// Otherwise, it will just eat the first click!
-		// This extra click works for both desktop and mobile.
-		await context.editorIframe.click( selectors.entry( entryDetails.nthIndex ) );
-		await context.editorIframe.click( selectors.entryParagraph( entryDetails.nthIndex ) );
-		// 'fill' doesn't work on div or paragraph elements, have to use the more primitive 'type' method.
-		await context.editorIframe.type(
-			selectors.entryParagraph( entryDetails.nthIndex ),
-			entryDetails.entryText
+		await context.editorIframe.fill(
+			selectors.entryParagraph( 2 ),
+			this.configurationData.secondEntry
 		);
 	}
 

--- a/test/e2e/specs/constants.js
+++ b/test/e2e/specs/constants.js
@@ -2,6 +2,7 @@ import path from 'path';
 
 export const TEST_FILES_FOLDER_PATH = path.join( __dirname, '..', 'image-uploads' );
 export const TEST_IMAGE_PATH = path.join( TEST_FILES_FOLDER_PATH, 'test-image-01.png' );
+export const ALT_TEST_IMAGE_PATH = path.join( TEST_FILES_FOLDER_PATH, 'test-image-02.png' );
 export const TEST_AUDIO_PATH = path.join( TEST_FILES_FOLDER_PATH, 'test-audio-01.mp3' );
 export const TEST_UNSUPPORTED_FILE_PATH = path.join(
 	TEST_FILES_FOLDER_PATH,

--- a/test/e2e/specs/specs-wpcom/wp-blocks__jetpack-earn.ts
+++ b/test/e2e/specs/specs-wpcom/wp-blocks__jetpack-earn.ts
@@ -1,7 +1,12 @@
 /**
  * @group gutenberg
  */
-import { BlockFlow, PayWithPaypalBlockFlow, OpenTableFlow } from '@automattic/calypso-e2e';
+import {
+	BlockFlow,
+	PayWithPaypalBlockFlow,
+	OpenTableFlow,
+	PaymentsBlockFlow,
+} from '@automattic/calypso-e2e';
 import { createBlockTests } from '../specs-playwright/shared-specs/block-testing';
 
 const blockFlows: BlockFlow[] = [
@@ -13,6 +18,7 @@ const blockFlows: BlockFlow[] = [
 	new OpenTableFlow( {
 		restaurant: 'Miku Restaurant - Vancouver',
 	} ),
+	new PaymentsBlockFlow( { buttonText: 'Donate to Me' } ),
 ];
 
 createBlockTests( 'Blocks: Jetpack Earn', blockFlows );

--- a/test/e2e/specs/specs-wpcom/wp-blocks__jetpack-grow.ts
+++ b/test/e2e/specs/specs-wpcom/wp-blocks__jetpack-grow.ts
@@ -6,6 +6,8 @@ import {
 	BusinessHoursFlow,
 	WhatsAppButtonFlow,
 	ContactFormFlow,
+	PremiumContentBlockFlow,
+	DataHelper,
 } from '@automattic/calypso-e2e';
 import { createBlockTests } from '../specs-playwright/shared-specs/block-testing';
 
@@ -13,6 +15,10 @@ const blockFlows: BlockFlow[] = [
 	new BusinessHoursFlow( { day: 'Sat' } ),
 	new WhatsAppButtonFlow( { phoneNumber: 1234567890, buttonText: 'Porpoises swim happily' } ),
 	new ContactFormFlow( { nameLabel: 'Angry dolphins flip swiftly' } ),
+	new PremiumContentBlockFlow( {
+		subscriberTitle: DataHelper.getRandomPhrase(),
+		subscriberText: DataHelper.getRandomPhrase(),
+	} ),
 ];
 
 createBlockTests( 'Blocks: Jetpack Grow', blockFlows );

--- a/test/e2e/specs/specs-wpcom/wp-blocks__jetpack-grow.ts
+++ b/test/e2e/specs/specs-wpcom/wp-blocks__jetpack-grow.ts
@@ -10,6 +10,7 @@ import {
 	SubscriptionFormBlockFlow,
 	ContactInfoBlockFlow,
 	DataHelper,
+	envVariables,
 } from '@automattic/calypso-e2e';
 import { createBlockTests } from '../specs-playwright/shared-specs/block-testing';
 
@@ -17,12 +18,19 @@ const blockFlows: BlockFlow[] = [
 	new BusinessHoursFlow( { day: 'Sat' } ),
 	new WhatsAppButtonFlow( { phoneNumber: 1234567890, buttonText: 'Porpoises swim happily' } ),
 	new ContactFormFlow( { nameLabel: 'Angry dolphins flip swiftly' } ),
-	new PremiumContentBlockFlow( {
-		subscriberTitle: DataHelper.getRandomPhrase(),
-		subscriberText: DataHelper.getRandomPhrase(),
-	} ),
 	new SubscriptionFormBlockFlow(),
 	new ContactInfoBlockFlow( { email: 'foo@example.com', phoneNumber: '(213) 621-0002' } ),
 ];
+
+// Interacting with the Premium Content toolbar is currently broken on mobile, so only adding for desktop:
+// https://github.com/Automattic/jetpack/issues/22745
+if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
+	blockFlows.push(
+		new PremiumContentBlockFlow( {
+			subscriberTitle: DataHelper.getRandomPhrase(),
+			subscriberText: DataHelper.getRandomPhrase(),
+		} )
+	);
+}
 
 createBlockTests( 'Blocks: Jetpack Grow', blockFlows );

--- a/test/e2e/specs/specs-wpcom/wp-blocks__jetpack-grow.ts
+++ b/test/e2e/specs/specs-wpcom/wp-blocks__jetpack-grow.ts
@@ -7,6 +7,8 @@ import {
 	WhatsAppButtonFlow,
 	ContactFormFlow,
 	PremiumContentBlockFlow,
+	SubscriptionFormBlockFlow,
+	ContactInfoBlockFlow,
 	DataHelper,
 } from '@automattic/calypso-e2e';
 import { createBlockTests } from '../specs-playwright/shared-specs/block-testing';
@@ -19,6 +21,8 @@ const blockFlows: BlockFlow[] = [
 		subscriberTitle: DataHelper.getRandomPhrase(),
 		subscriberText: DataHelper.getRandomPhrase(),
 	} ),
+	new SubscriptionFormBlockFlow(),
+	new ContactInfoBlockFlow( { email: 'foo@example.com', phoneNumber: '(213) 621-0002' } ),
 ];
 
 createBlockTests( 'Blocks: Jetpack Grow', blockFlows );

--- a/test/e2e/specs/specs-wpcom/wp-blocks__jetpack-other.ts
+++ b/test/e2e/specs/specs-wpcom/wp-blocks__jetpack-other.ts
@@ -1,0 +1,19 @@
+/**
+ * @group gutenberg
+ */
+import {
+	BlockFlow,
+	SlideshowBlockFlow,
+	StarRatingBlock,
+	TiledGalleryBlockFlow,
+} from '@automattic/calypso-e2e';
+import { TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH } from '../constants';
+import { createBlockTests } from '../specs-playwright/shared-specs/block-testing';
+
+const blockFlows: BlockFlow[] = [
+	new SlideshowBlockFlow( { imagePaths: [ TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH ] } ),
+	new TiledGalleryBlockFlow( { imagePaths: [ TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH ] } ),
+	new StarRatingBlock( { rating: 3.5 } ),
+];
+
+createBlockTests( 'Blocks: Other Jetpack Blocks', blockFlows );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the remaining Jetpack-added block smoke tests as outlined in pciE2j-sq-p2.

Blocks added:
- Premium Content
- Subscription Form
- Contact Info
- Payments
- Slideshow
- Star Rating
- Tiled Gallery

#### Testing instructions

- [x] Gutenberg E2E desktop tests pass
- [x] Gutenberg E2E mobile tests pass


Closes #55958