### PR TITLE
Signup: Fix spacing of select items in intent screen

### DIFF
--- a/client/signup/select-items-alt/style.scss
+++ b/client/signup/select-items-alt/style.scss
@@ -46,7 +46,7 @@
 	}
 
 	&-button {
-		margin-top: 24px;
+		margin-top: 8px;
 		padding: 0;
 		min-width: 130px;
 		border: none;

--- a/client/signup/select-items/style.scss
+++ b/client/signup/select-items/style.scss
@@ -65,7 +65,7 @@
 		font-size: $font-body-small;
 		color: #646970;
 
-		p {
+		> p:last-child {
 			margin-bottom: 0;
 		}
 	}

--- a/client/signup/select-items/style.scss
+++ b/client/signup/select-items/style.scss
@@ -6,10 +6,11 @@
 	flex-direction: column;
 	justify-content: center;
 	margin-top: -12px;
-	margin-bottom: 40px;
+	margin-bottom: 16px;
 	padding-left: 40px;
 
 	@include break-small {
+		margin-bottom: 40px;
 		padding-left: 60px;
 	}
 }
@@ -63,7 +64,10 @@
 	&-description {
 		font-size: $font-body-small;
 		color: #646970;
-		margin-bottom: 0;
+
+		p {
+			margin-bottom: 0;
+		}
 	}
 
 	&-button {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As p58i-c55-p2 mentioned, the spacing of items in the intent screen is weird. The problem is introduced from https://github.com/Automattic/wp-calypso/pull/60405 because the HTML tag changes from `p` to `div` and wraps the description into `p`.
* This PR updates the style to fix the spacing.

**Spacing on mobile should looks better**

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/153141529-33e4a8a9-afb9-4cba-9781-2a086158b1b5.png) | ![image](https://user-images.githubusercontent.com/13596067/153141669-82f8648f-c0fc-4002-9887-f8893b2d9eb6.png) |

**Spacing of Set up your store on mobile**

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/153161658-b6144ea5-d9be-45cb-8e6d-daf91f15787e.png) | ![image](https://user-images.githubusercontent.com/13596067/153161658-b6144ea5-d9be-45cb-8e6d-daf91f15787e.png) |

**Spacing on desktop should keep the same**

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/153141874-9583e766-9b16-40ba-90c0-adeb905b2e28.png) | ![image](https://user-images.githubusercontent.com/13596067/153141851-c0535f0a-4b02-4e03-ab9c-8b1bd4ad2ed1.png) |


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site/intent?siteSlug=<your_site>`
* Check the spacing is correct on both desktop and mobile.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p58i-c55-p2