### PR TITLE
Signup: Remove ecommerce-onboarding flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -184,8 +184,6 @@ export function generateFlows( {
 			lastModified: '2018-05-28',
 			disallowResume: true,
 		},
-		// Important: For any changes done to the ecommerce flow,
-		// please copy the same changes to ecommerce-onboarding flow too
 		{
 			name: 'ecommerce',
 			steps: [ 'user', 'domains', 'plans-ecommerce-fulfilled' ],
@@ -193,13 +191,6 @@ export function generateFlows( {
 			description: 'Signup flow for creating an online store with an Atomic site',
 			lastModified: '2020-08-11',
 			showRecaptcha: true,
-		},
-		{
-			name: 'ecommerce-onboarding',
-			steps: [ 'user', 'domains', 'plans-ecommerce' ],
-			destination: getSignupDestination,
-			description: 'Signup flow for creating an online store with an Atomic site',
-			lastModified: '2020-03-04',
 		},
 		{
 			name: 'ecommerce-design-first',

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -658,7 +658,7 @@ class DomainsStep extends Component {
 		const subHeaderPropertyName = 'signUpFlowDomainsStepSubheader';
 		const onboardingSubHeaderCopy =
 			siteType &&
-			[ 'onboarding' ].includes( flowName ) &&
+			flowName === 'onboarding' &&
 			getSiteTypePropertyValue( 'slug', siteType, subHeaderPropertyName );
 
 		if ( onboardingSubHeaderCopy ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -658,7 +658,7 @@ class DomainsStep extends Component {
 		const subHeaderPropertyName = 'signUpFlowDomainsStepSubheader';
 		const onboardingSubHeaderCopy =
 			siteType &&
-			[ 'onboarding', 'ecommerce-onboarding' ].includes( flowName ) &&
+			[ 'onboarding' ].includes( flowName ) &&
 			getSiteTypePropertyValue( 'slug', siteType, subHeaderPropertyName );
 
 		if ( onboardingSubHeaderCopy ) {

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -11,7 +11,7 @@ import SiteTypeForm from './form';
 
 const siteTypeToFlowname = {
 	import: 'import-onboarding',
-	'online-store': 'ecommerce-onboarding',
+	'online-store': 'ecommerce',
 };
 
 class SiteType extends Component {

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -198,7 +198,6 @@
 		"business-monthly",
 		"ecommerce",
 		"ecommerce-monthly",
-		"ecommerce-onboarding",
 		"domain"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `ecommerce-onboarding` flow as it seems not to get any traffic.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start`
* Check existing flows work well

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/60281
