### PR TITLE
Stats: Refactor `StoreStatsModule` away from `UNSAFE_` lifecycle methods

### DIFF
--- a/client/my-sites/store/app/store-stats/store-stats-list/index.js
+++ b/client/my-sites/store/app/store-stats/store-stats-list/index.js
@@ -36,14 +36,8 @@ const StoreStatsList = ( { data, values } ) => {
 StoreStatsList.propTypes = {
 	data: PropTypes.array.isRequired,
 	values: PropTypes.array.isRequired,
-	fetchedData: PropTypes.oneOfType( [ PropTypes.array, PropTypes.object ] ),
 };
 
-export default connect( ( state, { siteId, statType, query, fetchedData } ) => {
-	const data = fetchedData
-		? fetchedData
-		: getSiteStatsNormalizedData( state, siteId, statType, query );
-	return {
-		data,
-	};
-} )( StoreStatsList );
+export default connect( ( state, { siteId, statType, query } ) => ( {
+	data: getSiteStatsNormalizedData( state, siteId, statType, query ),
+} ) )( StoreStatsList );

--- a/client/my-sites/store/app/store-stats/store-stats-module/index.js
+++ b/client/my-sites/store/app/store-stats/store-stats-module/index.js
@@ -1,8 +1,6 @@
 import { Card } from '@automattic/components';
 import classnames from 'classnames';
-import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 import { connect } from 'react-redux';
 import ErrorPanel from 'calypso/my-sites/stats/stats-error';
 import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
@@ -11,58 +9,39 @@ import {
 	getSiteStatsNormalizedData,
 } from 'calypso/state/stats/lists/selectors';
 
-class StoreStatsModule extends Component {
-	static propTypes = {
-		data: PropTypes.array,
-		emptyMessage: PropTypes.string,
-		header: PropTypes.node,
-		siteId: PropTypes.number,
-		statType: PropTypes.string,
-		query: PropTypes.object,
-		fetchedData: PropTypes.oneOfType( [ PropTypes.array, PropTypes.object ] ),
-		className: PropTypes.string,
-	};
-
-	state = {
-		loaded: false,
-	};
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( ! nextProps.requesting && this.props.requesting ) {
-			this.setState( { loaded: true } );
-		}
-
-		if ( ! isEqual( nextProps.query, this.props.query ) && this.state.loaded ) {
-			this.setState( { loaded: false } );
-		}
-	}
-
-	render() {
-		const { header, children, data, emptyMessage, className } = this.props;
-		const { loaded } = this.state;
-		const isLoading = ! loaded && ! ( data && data.length );
-		const hasEmptyData = loaded && data && data.length === 0;
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		return (
-			<div className={ classnames( 'store-stats-module', className ) }>
-				{ header }
-				{ isLoading && (
-					<Card>
-						<StatsModulePlaceholder isLoading={ isLoading } />
-					</Card>
-				) }
-				{ ! isLoading && hasEmptyData && (
-					<Card className="stats-module is-showing-error has-no-data">
-						<ErrorPanel message={ emptyMessage } />
-					</Card>
-				) }
-				{ ! isLoading && ! hasEmptyData && children }
-			</div>
-			/* eslint-enable wpcalypso/jsx-classname-namespace */
-		);
-	}
+function StoreStatsModule( { header, children, data, emptyMessage, className, requesting } ) {
+	const isLoading = requesting && ! ( data && data.length );
+	const hasEmptyData = ! requesting && data && data.length === 0;
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<div className={ classnames( 'store-stats-module', className ) }>
+			{ header }
+			{ isLoading && (
+				<Card>
+					<StatsModulePlaceholder isLoading={ isLoading } />
+				</Card>
+			) }
+			{ ! isLoading && hasEmptyData && (
+				<Card className="stats-module is-showing-error has-no-data">
+					<ErrorPanel message={ emptyMessage } />
+				</Card>
+			) }
+			{ ! isLoading && ! hasEmptyData && children }
+		</div>
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	);
 }
+
+StoreStatsModule.propTypes = {
+	data: PropTypes.array,
+	emptyMessage: PropTypes.string,
+	header: PropTypes.node,
+	siteId: PropTypes.number,
+	statType: PropTypes.string,
+	query: PropTypes.object,
+	fetchedData: PropTypes.oneOfType( [ PropTypes.array, PropTypes.object ] ),
+	className: PropTypes.string,
+};
 
 export default connect( ( state, { siteId, statType, query, fetchedData } ) => {
 	const statsData = fetchedData

--- a/client/my-sites/store/app/store-stats/store-stats-module/index.js
+++ b/client/my-sites/store/app/store-stats/store-stats-module/index.js
@@ -38,14 +38,12 @@ StoreStatsModule.propTypes = {
 	siteId: PropTypes.number,
 	statType: PropTypes.string,
 	query: PropTypes.object,
-	fetchedData: PropTypes.oneOfType( [ PropTypes.array, PropTypes.object ] ),
 	className: PropTypes.string,
 };
 
-export default connect( ( state, { siteId, statType, query, fetchedData } ) => {
-	const statsData = fetchedData
-		? fetchedData
-		: getSiteStatsNormalizedData( state, siteId, statType, query );
+export default connect( ( state, { siteId, statType, query } ) => {
+	const statsData = getSiteStatsNormalizedData( state, siteId, statType, query );
+
 	return {
 		data: statType === 'statsOrders' ? statsData.data : statsData,
 		requesting: isRequestingSiteStatsForQuery( state, siteId, statType, query ),

--- a/client/my-sites/store/app/store-stats/store-stats-module/index.js
+++ b/client/my-sites/store/app/store-stats/store-stats-module/index.js
@@ -12,7 +12,7 @@ import {
 function StoreStatsModule( { header, children, data, emptyMessage, className, requesting } ) {
 	const isLoading = requesting && ! ( data && data.length );
 	const hasEmptyData = ! requesting && data && data.length === 0;
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
+
 	return (
 		<div className={ classnames( 'store-stats-module', className ) }>
 			{ header }
@@ -22,13 +22,12 @@ function StoreStatsModule( { header, children, data, emptyMessage, className, re
 				</Card>
 			) }
 			{ ! isLoading && hasEmptyData && (
-				<Card className="stats-module is-showing-error has-no-data">
+				<Card className="store-stats-module__card stats-module is-showing-error has-no-data">
 					<ErrorPanel message={ emptyMessage } />
 				</Card>
 			) }
 			{ ! isLoading && ! hasEmptyData && children }
 		</div>
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	);
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `StoreStatsModule` component away from the `UNSAFE_` deprecated React component methods. 

We're removing the `loaded` component state because we can rely on an inverted `requesting` prop the same way.  We're also refactoring the component to a functional one because that leaves us only with a `render()` method.

We also use the opportunity to remove an unused prop - `fetchedData` and to fix a classname eslint rule violation.

Part of #58453.

#### Testing instructions
* Go to `/store/stats/orders/day/:site` where `:site` is a WooCommerce store.
* Verify all 5 modules at the bottom still load correctly and display a loading state while loading.