### PR TITLE
Signup: Remove developer flow

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -138,7 +138,7 @@ const devdocs = {
 				action: 'Log In to WordPress.com',
 				actionURL: login( { redirectTo } ),
 				secondaryAction: 'Register',
-				secondaryActionURL: '/start/developer',
+				secondaryActionURL: '/start/account',
 				illustration: '/calypso/images/illustrations/illustration-nosites.svg',
 			} );
 			next();

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -121,13 +121,6 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
-			name: 'developer',
-			steps: [ 'site', 'user' ],
-			destination: '/devdocs/welcome',
-			description: 'Signup flow for developers in developer environment',
-			lastModified: '2015-11-23',
-		},
-		{
 			name: 'pressable-nux',
 			steps: [ 'creds-permission', 'creds-confirm', 'creds-complete' ],
 			destination: '/stats',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `developer` flow as it seems not to get any traffic.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start`
* Check existing flows work well

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/60281
