### PR TITLE
Fix domain search results for long domain names

### DIFF
--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -13,6 +13,7 @@
 
 		.is-white-signup & {
 			align-items: flex-end;
+			min-width: 220px;
 		}
 	}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -331,9 +331,10 @@ body.is-section-signup.is-white-signup {
 		}
 
 		@include break-wide {
-			align-self: center;
+			align-self: baseline;
 			margin-left: 12px;
 			margin-bottom: 0;
+			flex: 1;
 		}
 	}
 
@@ -389,6 +390,7 @@ body.is-section-signup.is-white-signup {
 
 			@include break-mobile {
 				font-size: 1rem;
+				align-self: baseline;
 			}
 		}
 		&.is-placeholder.card .domain-suggestion__action {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -328,6 +328,7 @@ body.is-section-signup.is-white-signup {
 			border-radius: 4px; /* stylelint-disable-line */
 			font-size: 0.75rem;
 			font-weight: 500; /* stylelint-disable-line */
+			white-space: nowrap;
 		}
 
 		@include break-wide {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -234,7 +234,7 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 		font-size: $font-title-medium;
 		padding-right: 0;
 		margin-bottom: 0;
-		flex: 3;
+		flex: 0 1 auto;
     align-self: baseline;
 	}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -234,6 +234,8 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 		font-size: $font-title-medium;
 		padding-right: 0;
 		margin-bottom: 0;
+		flex: 3;
+    align-self: baseline;
 	}
 
 	&.domain-suggestion.is-clickable:hover {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -235,7 +235,7 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 		padding-right: 0;
 		margin-bottom: 0;
 		flex: 0 1 auto;
-    align-self: baseline;
+		align-self: baseline;
 	}
 
 	&.domain-suggestion.is-clickable:hover {
@@ -261,7 +261,7 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 body.is-section-signup.is-white-signup .featured-domain-suggestions {
 	margin: 0;
 	border-top: 1px solid rgba( 220, 220, 222, 0.64 );
-	
+
 	@include break-mobile {
 		margin: 0 20px;
 		border-top: none;


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes layout issues when entering long domain name in domain search signup step (white reskinned version).

<img width="1354" alt="152833214-f5d58cce-6e75-4581-9213-b84d174261a3" src="https://user-images.githubusercontent.com/2797601/153179783-53cb24bf-a569-4105-aef9-475d67b1d18b.png">

![domain-desktop-after](https://user-images.githubusercontent.com/2797601/153179721-705d5ede-ec11-4400-8d69-3aa06a1d509b.png)

![domain-after-mobile](https://user-images.githubusercontent.com/2797601/153179714-4254652d-ca2d-4aed-a43d-abc3c9baf92c.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- Navigate to `/start/domain`
- Enter a very long domain and verify that issues mentioned above has been fixed