### PR TITLE
P2: Payments: remove "active" members line

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -614,8 +614,8 @@ function LineItemSublabelAndPrice( {
 			return (
 				<>
 					{ translate(
-						'Monthly subscription: %(itemPrice)s x %(members)s active member',
-						'Monthly subscription: %(itemPrice)s x %(members)s active members',
+						'Monthly subscription: %(itemPrice)s x %(members)s member',
+						'Monthly subscription: %(itemPrice)s x %(members)s members',
 						p2Options
 					) }
 				</>


### PR DESCRIPTION
In this PR, we remove the "active" word from the "active members" line when paying for the P2+ subscription for a P2 site.

Recently, we dropped the activity requirement for paying for a member of a P2 site.

## Testing instructions

Navigate to the checkout screen of a P2+ purchase and notice the missing "active" here:

<img width="1157" alt="Markup 2022-02-09 at 11 51 27" src="https://user-images.githubusercontent.com/4988512/153183611-82f4aa70-8916-4265-a086-6ea8a430d48a.png">

