### PR TITLE
Fix: Annual discount calculation fails on P2 plans

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -236,7 +236,12 @@ export class PlanFeaturesHeader extends Component {
 			eligibleForWpcomMonthlyPlans,
 		} = this.props;
 
-		if ( isMonthlyPlan || ! relatedMonthlyPlan || ! eligibleForWpcomMonthlyPlans ) {
+		if (
+			isMonthlyPlan ||
+			! relatedMonthlyPlan ||
+			! eligibleForWpcomMonthlyPlans ||
+			! relatedYearlyPlan
+		) {
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a check for the related Yearly plan before trying to calculate the discount.

#### Testing instructions

* Go to the `/plans` page for a P2 site
* The page should load properly
<img width="480" alt="Screenshot on 2022-02-09 at 12-56-49" src="https://user-images.githubusercontent.com/2749938/153185362-611d8f73-c771-4ba2-942b-5f6209eeedc1.png">


* Go to the `/plans` page for a site which doesn't have a Yearly plans subscription
* Make sure the `You're saving #% by paying annually` subtitle is shown for plan upgrades
<img width="480" alt="Screenshot on 2022-02-09 at 12-56-40" src="https://user-images.githubusercontent.com/2749938/153185373-867be86e-b15f-4a19-bf6a-b2a63fdb58fc.png">

