### PR TITLE
Search: Send users to the right place for customization post-checkout

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -111,6 +111,8 @@ export class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( this.isSearch() ) {
+			// Handle the Atomic vs Simple division here if needed.
+			// Might be fine to have the same message in both cases though.
 			return (
 				<div>
 					<p>{ translate( 'We are currently indexing your site.' ) }</p>
@@ -118,7 +120,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 						{ translate(
 							'In the meantime, we have configured Jetpack Search on your site' +
 								' ' +
-								'— you should try customizing it in your traditional WordPress dashboard.'
+								'— try customizing it!'
 						) }
 					</p>
 				</div>

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -34,7 +34,10 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { recordStartTransferClickInThankYou } from 'calypso/state/domains/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
-import { getJetpackSearchCustomizeUrl } from 'calypso/state/sites/selectors';
+import {
+	getJetpackSearchCustomizeUrl,
+	getJetpackSearchDashboardUrl,
+} from 'calypso/state/sites/selectors';
 import getCheckoutUpgradeIntent from '../../../state/selectors/get-checkout-upgrade-intent';
 
 import './style.scss';
@@ -480,10 +483,12 @@ export class CheckoutThankYouHeader extends PureComponent {
 	}
 
 	getSearchButtonProps() {
-		const { translate, selectedSite, jetpackSearchCustomizeUrl } = this.props;
-
-		// Should come from a selector.
-		const jetpackSearchDashboardUrl = '#';
+		const {
+			translate,
+			selectedSite,
+			jetpackSearchCustomizeUrl,
+			jetpackSearchDashboardUrl,
+		} = this.props;
 
 		const buttonTitle = selectedSite.jetpack
 			? translate( 'Go to Search Dashboard' )
@@ -662,6 +667,7 @@ export default connect(
 	( state, ownProps ) => ( {
 		isAtomic: isAtomicSite( state, ownProps.selectedSite?.ID ),
 		jetpackSearchCustomizeUrl: getJetpackSearchCustomizeUrl( state, ownProps.selectedSite?.ID ),
+		jetpackSearchDashboardUrl: getJetpackSearchDashboardUrl( state, ownProps.selectedSite?.ID ),
 		titanAppsUrlPrefix: getTitanAppsUrlPrefix(
 			getDomainsBySiteId( state, ownProps.selectedSite?.ID ).find( hasTitanMailWithUs )
 		),

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -494,18 +494,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 		const isConciergePurchase = 'concierge' === displayMode;
 		const isTrafficGuidePurchase = 'traffic-guide' === displayMode;
 
-		if (
-			isDataLoaded &&
-			( ! primaryPurchase || ! selectedSite || ( selectedSite.jetpack && ! isAtomic ) )
-		) {
-			return (
-				<div className="checkout-thank-you__header-button">
-					<Button className={ headerButtonClassName } primary onClick={ this.visitMyHome }>
-						{ translate( 'Go to My Home' ) }
-					</Button>
-				</div>
-			);
-		}
 		if ( this.isSearch() ) {
 			return (
 				<div className="checkout-thank-you__header-button">
@@ -516,6 +504,19 @@ export class CheckoutThankYouHeader extends PureComponent {
 						onClick={ this.recordThankYouClick }
 					>
 						{ translate( 'Customize Search' ) }
+					</Button>
+				</div>
+			);
+		}
+
+		if (
+			isDataLoaded &&
+			( ! primaryPurchase || ! selectedSite || ( selectedSite.jetpack && ! isAtomic ) )
+		) {
+			return (
+				<div className="checkout-thank-you__header-button">
+					<Button className={ headerButtonClassName } primary onClick={ this.visitMyHome }>
+						{ translate( 'Go to My Home' ) }
 					</Button>
 				</div>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -58,8 +58,13 @@ export class CheckoutThankYouHeader extends PureComponent {
 		upgradeIntent: PropTypes.string,
 	};
 
+	isSearch() {
+		const { purchases } = this.props;
+		return purchases?.length > 0 && purchases[ 0 ].productType === 'search';
+	}
+
 	getHeading() {
-		const { translate, isDataLoaded, hasFailedPurchases, primaryPurchase, purchases } = this.props;
+		const { translate, isDataLoaded, hasFailedPurchases, primaryPurchase } = this.props;
 
 		if ( ! isDataLoaded ) {
 			return this.props.translate( 'Loading…' );
@@ -69,7 +74,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			return translate( 'Some items failed.' );
 		}
 
-		if ( purchases?.length > 0 && purchases[ 0 ].productType === 'search' ) {
+		if ( this.isSearch() ) {
 			return translate( 'Welcome to Jetpack Search!' );
 		}
 
@@ -99,14 +104,13 @@ export class CheckoutThankYouHeader extends PureComponent {
 			hasFailedPurchases,
 			primaryPurchase,
 			displayMode,
-			purchases,
 		} = this.props;
 
 		if ( hasFailedPurchases ) {
 			return translate( 'Some of the items in your cart could not be added.' );
 		}
 
-		if ( purchases?.length > 0 && purchases[ 0 ].productType === 'search' ) {
+		if ( this.isSearch() ) {
 			return (
 				<div>
 					<p>{ translate( 'We are currently indexing your site.' ) }</p>
@@ -480,7 +484,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 			jetpackSearchCustomizeUrl,
 			translate,
 			primaryPurchase,
-			purchases,
 			selectedSite,
 			displayMode,
 			isAtomic,
@@ -488,7 +491,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 		const headerButtonClassName = 'button is-primary';
 		const isConciergePurchase = 'concierge' === displayMode;
 		const isTrafficGuidePurchase = 'traffic-guide' === displayMode;
-		const isSearch = purchases?.length > 0 && purchases[ 0 ].productType === 'search';
 
 		if (
 			isDataLoaded &&
@@ -502,7 +504,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 				</div>
 			);
 		}
-		if ( isSearch ) {
+		if ( this.isSearch() ) {
 			return (
 				<div className="checkout-thank-you__header-button">
 					<Button

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -114,8 +114,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( this.isSearch() ) {
-			// Handle the Atomic vs Simple division here if needed.
-			// Might be fine to have the same message in both cases though.
 			return (
 				<div>
 					<p>{ translate( 'We are currently indexing your site.' ) }</p>

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -479,11 +479,24 @@ export class CheckoutThankYouHeader extends PureComponent {
 		);
 	}
 
+	getSearchButtonProps() {
+		const { translate, selectedSite, jetpackSearchCustomizeUrl } = this.props;
+
+		// Should come from a selector.
+		const jetpackSearchDashboardUrl = '#';
+
+		const buttonTitle = selectedSite.jetpack
+			? translate( 'Go to Search Dashboard' )
+			: translate( 'Customize Search' );
+		const targetUrl = selectedSite.jetpack ? jetpackSearchDashboardUrl : jetpackSearchCustomizeUrl;
+
+		return { title: buttonTitle, url: targetUrl };
+	}
+
 	getButtons() {
 		const {
 			hasFailedPurchases,
 			isDataLoaded,
-			jetpackSearchCustomizeUrl,
 			translate,
 			primaryPurchase,
 			selectedSite,
@@ -495,15 +508,16 @@ export class CheckoutThankYouHeader extends PureComponent {
 		const isTrafficGuidePurchase = 'traffic-guide' === displayMode;
 
 		if ( this.isSearch() ) {
+			const buttonProps = this.getSearchButtonProps();
 			return (
 				<div className="checkout-thank-you__header-button">
 					<Button
 						className={ headerButtonClassName }
 						primary
-						href={ jetpackSearchCustomizeUrl }
+						href={ buttonProps.url }
 						onClick={ this.recordThankYouClick }
 					>
-						{ translate( 'Customize Search' ) }
+						{ buttonProps.title }
 					</Button>
 				</div>
 			);

--- a/client/state/sites/selectors/get-jetpack-search-dashboard-url.js
+++ b/client/state/sites/selectors/get-jetpack-search-dashboard-url.js
@@ -1,4 +1,5 @@
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import versionCompare from 'calypso/lib/version-compare';
+import { getJetpackVersion, getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 
 /**
  * Returns the Jetpack Search dashboard URL.
@@ -14,5 +15,13 @@ export default function getJetpackSearchDashboardUrl( state, siteID ) {
 	if ( ! isJetpackSite( state, siteID ) ) {
 		return null;
 	}
-	return '#';
+	const adminUrl = getSiteAdminUrl( state, siteID );
+	if ( ! adminUrl ) {
+		return null;
+	}
+	const jetpackVersion = getJetpackVersion( state, siteID );
+	if ( jetpackVersion && versionCompare( jetpackVersion, '10.1', '>=' ) ) {
+		return adminUrl + 'admin.php?page=jetpack-search';
+	}
+	return adminUrl + 'admin.php?page=jetpack';
 }

--- a/client/state/sites/selectors/get-jetpack-search-dashboard-url.js
+++ b/client/state/sites/selectors/get-jetpack-search-dashboard-url.js
@@ -23,5 +23,5 @@ export default function getJetpackSearchDashboardUrl( state, siteID ) {
 	if ( jetpackVersion && versionCompare( jetpackVersion, '10.1', '>=' ) ) {
 		return adminUrl + 'admin.php?page=jetpack-search';
 	}
-	return adminUrl + 'admin.php?page=jetpack';
+	return adminUrl + 'admin.php?page=jetpack#/performance';
 }

--- a/client/state/sites/selectors/get-jetpack-search-dashboard-url.js
+++ b/client/state/sites/selectors/get-jetpack-search-dashboard-url.js
@@ -1,0 +1,18 @@
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+
+/**
+ * Returns the Jetpack Search dashboard URL.
+ *
+ * @param  {object}    state        Global state tree
+ * @param  {object}    siteID       Site ID
+ * @returns {?string}  URL for Jetpack Search dashboard.
+ *                     Falls back to the Jetpack dashboard for older versions.
+ *                     Returns null for Simple sites.
+ */
+
+export default function getJetpackSearchDashboardUrl( state, siteID ) {
+	if ( ! isJetpackSite( state, siteID ) ) {
+		return null;
+	}
+	return '#';
+}

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -65,4 +65,5 @@ export { default as getSelectedSiteWithFallback } from './get-site-with-fallback
 export { default as getSiteWooCommerceUrl } from './get-site-woocommerce-url';
 export { default as getSiteWooCommerceWizardUrl } from './get-site-woocommerce-wizard-url';
 export { default as getJetpackSearchCustomizeUrl } from './get-jetpack-search-customize-url';
+export { default as getJetpackSearchDashboardUrl } from './get-jetpack-search-dashboard-url';
 export { default as getJetpackVersion } from './get-jetpack-version';

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -38,6 +38,7 @@ import {
 	canJetpackSiteUpdateFiles,
 	canJetpackSiteAutoUpdateFiles,
 	canJetpackSiteAutoUpdateCore,
+	getJetpackSearchDashboardUrl,
 	isJetpackSiteMultiSite,
 	isJetpackSiteSecondaryNetworkSite,
 	verifyJetpackModulesActive,
@@ -2597,6 +2598,38 @@ describe( 'selectors', () => {
 
 			const canAutoUpdateCore = canJetpackSiteAutoUpdateCore( state, siteId );
 			chaiExpect( canAutoUpdateCore ).to.equal( false );
+		} );
+	} );
+
+	describe( 'getJetpackSearchDashboardUrl()', () => {
+		test( 'should return null if no sites loaded', () => {
+			const dashboardUrl = getJetpackSearchDashboardUrl(
+				{
+					sites: {
+						items: {},
+					},
+				},
+				2916284
+			);
+
+			chaiExpect( dashboardUrl ).to.be.null;
+		} );
+		test( "should return '#' if we have a Jetpack site", () => {
+			const dashboardUrl = getJetpackSearchDashboardUrl(
+				{
+					sites: {
+						items: {
+							2916284: {
+								ID: 2916284,
+								jetpack: true,
+							},
+						},
+					},
+				},
+				2916284
+			);
+
+			chaiExpect( dashboardUrl ).to.equal( '#' );
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2663,7 +2663,7 @@ describe( 'selectors', () => {
 			);
 
 			expect( dashboardUrl ).toEqual(
-				'https://example.wordpress.com/wp-admin/admin.php?page=jetpack'
+				'https://example.wordpress.com/wp-admin/admin.php?page=jetpack#/performance'
 			);
 		} );
 		test( 'should return Search dashboard for new JP versions', () => {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2614,14 +2614,14 @@ describe( 'selectors', () => {
 
 			chaiExpect( dashboardUrl ).to.be.null;
 		} );
-		test( "should return '#' if we have a Jetpack site", () => {
+		test( 'should return null if we have a Simple site', () => {
 			const dashboardUrl = getJetpackSearchDashboardUrl(
 				{
 					sites: {
 						items: {
 							2916284: {
 								ID: 2916284,
-								jetpack: true,
+								jetpack: false,
 							},
 						},
 					},
@@ -2629,7 +2629,65 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( dashboardUrl ).to.equal( '#' );
+			chaiExpect( dashboardUrl ).to.be.null;
+		} );
+		test( "should return null if we can't find the adminUrl", () => {
+			const dashboardUrl = getJetpackSearchDashboardUrl(
+				{
+					sites: {
+						items: {},
+					},
+				},
+				2916284
+			);
+
+			chaiExpect( dashboardUrl ).to.be.null;
+		} );
+		test( 'should return default dashboard for old JP versions', () => {
+			const dashboardUrl = getJetpackSearchDashboardUrl(
+				{
+					sites: {
+						items: {
+							2916284: {
+								ID: 2916284,
+								jetpack: true,
+								options: {
+									admin_url: 'https://example.wordpress.com/wp-admin/',
+									jetpack_version: '10.0',
+								},
+							},
+						},
+					},
+				},
+				2916284
+			);
+
+			chaiExpect( dashboardUrl ).to.equal(
+				'https://example.wordpress.com/wp-admin/admin.php?page=jetpack'
+			);
+		} );
+		test( 'should return Search dashboard for new JP versions', () => {
+			const dashboardUrl = getJetpackSearchDashboardUrl(
+				{
+					sites: {
+						items: {
+							2916284: {
+								ID: 2916284,
+								jetpack: true,
+								options: {
+									admin_url: 'https://example.wordpress.com/wp-admin/',
+									jetpack_version: '10.1',
+								},
+							},
+						},
+					},
+				},
+				2916284
+			);
+
+			chaiExpect( dashboardUrl ).to.equal(
+				'https://example.wordpress.com/wp-admin/admin.php?page=jetpack-search'
+			);
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2612,7 +2612,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( dashboardUrl ).to.be.null;
+			expect( dashboardUrl ).toBeNull();
 		} );
 		test( 'should return null if we have a Simple site', () => {
 			const dashboardUrl = getJetpackSearchDashboardUrl(
@@ -2629,7 +2629,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( dashboardUrl ).to.be.null;
+			expect( dashboardUrl ).toBeNull();
 		} );
 		test( "should return null if we can't find the adminUrl", () => {
 			const dashboardUrl = getJetpackSearchDashboardUrl(
@@ -2641,7 +2641,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( dashboardUrl ).to.be.null;
+			expect( dashboardUrl ).toBeNull();
 		} );
 		test( 'should return default dashboard for old JP versions', () => {
 			const dashboardUrl = getJetpackSearchDashboardUrl(
@@ -2662,7 +2662,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( dashboardUrl ).to.equal(
+			expect( dashboardUrl ).toEqual(
 				'https://example.wordpress.com/wp-admin/admin.php?page=jetpack'
 			);
 		} );
@@ -2685,7 +2685,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( dashboardUrl ).to.equal(
+			expect( dashboardUrl ).toEqual(
 				'https://example.wordpress.com/wp-admin/admin.php?page=jetpack-search'
 			);
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates the copy to direct users to either the Search Dashboard (for Atomic) or the Search Customizer (for Simple).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm tests are passing. Run the isolated tests with this command: `yarn run test-client client/state/sites/test/selectors.js`
* Create a Simple site and purchase a Jetpack Search plan. You'll be punted to WordPress.com for the actual checkout. Once completed, return to `http://calypso.localhost` and load the `/checkout/thank-you/DOMAIN-BITS` URL to confirm the copy has been updated and the button does the correct thing. The button should read, "Customize Search" and should load the correct customizer page.
* Create a new site, purchase a Business plan, install a plugin (to go Atomic), then add a Search plan. Again, return to local Calypso and test the `/checkout/thank-you/DOMAIN-BITS` URL to confirm the button is shown correctly. Should read "Go to Search Dashboard" and link to `/wp-admin/admin.php?page=jetpack-search`.
* Test with a self-hosted site. Should work the same as for Atomic.
* Test with JP 10.0 or earlier. In those versions, the default dashboard URL is returned (`/wp-admin/admin.php?page=jetpack`). Only on 10.1 or later do you get the Jetpack Search dashboard.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Notes:

1. This is a test/draft PR. — Linked to issue now.
2. I had to disable the `.husky/pre-commit` and `.husky/pre-push` hooks to work on this branch. — Fixed. Issue was specific to Tower for macOS.

For Translation:

1. In the meantime, we have configured Jetpack Search on your site — try customizing it!
2. Go to Search Dashboard

![LocalizeSnap](https://user-images.githubusercontent.com/40267301/155655554-fcb91231-e745-484b-a28e-c2c67e6a5500.png)