### PR TITLE
Framework: Refactor `QueryJetpackUserConnection` away from `UNSAFE_` methods

### DIFF
--- a/client/components/data/query-jetpack-user-connection/index.jsx
+++ b/client/components/data/query-jetpack-user-connection/index.jsx
@@ -1,43 +1,27 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestJetpackUserConnectionData } from 'calypso/state/jetpack/connection/actions';
 import isRequestingJetpackUserConnection from 'calypso/state/selectors/is-requesting-jetpack-user-connection';
 
-class QueryJetpackUserConnection extends Component {
-	static propTypes = {
-		siteId: PropTypes.number,
-		// Connected props
-		isRequesting: PropTypes.bool,
-		requestJetpackUserConnectionData: PropTypes.func.isRequired,
-	};
-
-	componentDidMount() {
-		this.request( this.props );
+const request = ( siteId ) => ( dispatch, getState ) => {
+	if ( ! isRequestingJetpackUserConnection( getState(), siteId ) ) {
+		dispatch( requestJetpackUserConnectionData( siteId ) );
 	}
+};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteId === nextProps.siteId ) {
-			return;
-		}
-		this.request( nextProps );
-	}
+function QueryJetpackUserConnection( { siteId } ) {
+	const dispatch = useDispatch();
 
-	request( props ) {
-		if ( props.siteId && ! props.isRequesting ) {
-			props.requestJetpackUserConnectionData( props.siteId );
-		}
-	}
+	useEffect( () => {
+		dispatch( request( siteId ) );
+	}, [ dispatch, siteId ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect(
-	( state, { siteId } ) => ( {
-		isRequesting: isRequestingJetpackUserConnection( state, siteId ),
-	} ),
-	{ requestJetpackUserConnectionData }
-)( QueryJetpackUserConnection );
+QueryJetpackUserConnection.propTypes = {
+	siteId: PropTypes.number.isRequired,
+};
+
+export default QueryJetpackUserConnection;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `QueryJetpackUserConnection` component away from the `UNSAFE_` deprecated React component methods. We use the opportunity to convert the component into a functional one.

Part of #58453.

#### Testing instructions
* Go to `/settings/manage-connection/:site` where `:site` is a Jetpack site you're the owner of.
* Verify that a request to `jetpack-blogs/1234/rest-api/?http_envelope=1&path=%2Fjetpack%2Fv4%2Fconnection%2Fdata%2F` is made, where `1234` is your site ID.
* Verify that in the "Site ownership" section you see a "You are the owner of this site's connection to WordPress.com." message.
* Open the same page for a Jetpack site you are an admin of, but someone else connected initially.
* Verify that a request to `jetpack-blogs/1234/rest-api/?http_envelope=1&path=%2Fjetpack%2Fv4%2Fconnection%2Fdata%2F` is made, where `1234` is your site ID.
* Verify you see a "USER owns this site's connection to WordPress.com." message in the "Site ownership" box.