### PR TITLE
Comments: Refactor `ModerateComment` away from `UNSAFE_` lifecycle methods

### DIFF
--- a/client/components/data/moderate-comment/index.jsx
+++ b/client/components/data/moderate-comment/index.jsx
@@ -27,17 +27,17 @@ class ModerateComment extends Component {
 		this.moderate( this.props );
 	}
 
-	componentDidUpdate( nextProps ) {
+	componentDidUpdate( prevProps ) {
 		if (
-			this.props.siteId === nextProps.siteId &&
-			this.props.postId === nextProps.postId &&
-			this.props.commentId === nextProps.commentId &&
-			this.props.newStatus === nextProps.newStatus
+			this.props.siteId === prevProps.siteId &&
+			this.props.postId === prevProps.postId &&
+			this.props.commentId === prevProps.commentId &&
+			this.props.newStatus === prevProps.newStatus
 		) {
 			return;
 		}
 
-		this.moderate( nextProps );
+		this.moderate( prevProps );
 	}
 
 	showNotice( status ) {

--- a/client/components/data/moderate-comment/index.jsx
+++ b/client/components/data/moderate-comment/index.jsx
@@ -27,8 +27,7 @@ class ModerateComment extends Component {
 		this.moderate( this.props );
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
+	componentDidUpdate( nextProps ) {
 		if (
 			this.props.siteId === nextProps.siteId &&
 			this.props.postId === nextProps.postId &&

--- a/client/components/data/moderate-comment/index.jsx
+++ b/client/components/data/moderate-comment/index.jsx
@@ -37,7 +37,7 @@ class ModerateComment extends Component {
 			return;
 		}
 
-		this.moderate( prevProps );
+		this.moderate( this.props );
 	}
 
 	showNotice( status ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `ModerateComment` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/comments/all/:site` where `:site` is a site you are an admin of, and it has some comments.
* Click on the date of a comment to navigate to the comment page.
* Try each of the following actions and verify it succeeds and you see a success notice afterward:
  * Approve a comment (available if unapproved)
  * Unapprove a comment (available if approved)
  * Spam a comment (available if not yet in spam)
  * Trash a comment (available if not yet trashed).