### PR TITLE
Update Lazy Load docs link for AT sites

### DIFF
--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -53,6 +53,7 @@ class MediaSettingsPerformance extends Component {
 			isRequestingSettings,
 			isSavingSettings,
 			isVideoPressAvailable,
+			siteIsAtomic,
 			siteId,
 			translate,
 		} = this.props;
@@ -63,7 +64,12 @@ class MediaSettingsPerformance extends Component {
 				<FormFieldset className="site-settings__formfieldset jetpack-video-hosting-settings">
 					<SupportInfo
 						text={ translate( 'Hosts your video files on the global WordPress.com servers.' ) }
-						link="https://jetpack.com/support/videopress/"
+						link={
+							siteIsAtomic
+								? 'https://wordpress.com/support/videopress/'
+								: 'https://jetpack.com/support/videopress/'
+						}
+						privacyLink={ ! siteIsAtomic }
 					/>
 					<JetpackModuleToggle
 						siteId={ siteId }
@@ -179,6 +185,7 @@ const checkForActiveJetpackVideoPressPurchases = ( purchase ) =>
 export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
+	const siteIsAtomic = isSiteAutomatedTransfer( state, selectedSiteId );
 	const isVideoPressAvailable =
 		isJetpackSite( state, selectedSiteId ) ||
 		planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS ) ||
@@ -186,11 +193,12 @@ export default connect( ( state ) => {
 		planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PRO );
 
 	return {
+		siteIsAtomic,
 		isVideoPressActive: isJetpackModuleActive( state, selectedSiteId, 'videopress' ),
 		isVideoPressAvailable,
 		isVideoPressFreeTier:
 			isJetpackSite( state, selectedSiteId ) &&
-			! isSiteAutomatedTransfer( state, selectedSiteId ) &&
+			! siteIsAtomic &&
 			! getSitePurchases( state, selectedSiteId ).find(
 				checkForActiveJetpackVideoPressPurchases
 			) &&

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -185,7 +185,6 @@ const checkForActiveJetpackVideoPressPurchases = ( purchase ) =>
 export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
-	const siteIsAtomic = isSiteAutomatedTransfer( state, selectedSiteId );
 	const isVideoPressAvailable =
 		isJetpackSite( state, selectedSiteId ) ||
 		planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS ) ||
@@ -193,12 +192,11 @@ export default connect( ( state ) => {
 		planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PRO );
 
 	return {
-		siteIsAtomic,
 		isVideoPressActive: isJetpackModuleActive( state, selectedSiteId, 'videopress' ),
 		isVideoPressAvailable,
 		isVideoPressFreeTier:
 			isJetpackSite( state, selectedSiteId ) &&
-			! siteIsAtomic &&
+			! isSiteAutomatedTransfer( state, selectedSiteId ) &&
 			! getSitePurchases( state, selectedSiteId ).find(
 				checkForActiveJetpackVideoPressPurchases
 			) &&

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -38,6 +38,7 @@ class MediaSettingsPerformance extends Component {
 		isSavingSettings: PropTypes.bool,
 		onChangeField: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
+		siteIsAtomic: PropTypes.bool,
 
 		// Connected props
 		isVideoPressActive: PropTypes.bool,

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -69,6 +69,7 @@ class MediaSettingsPerformance extends Component {
 								? 'https://wordpress.com/support/videopress/'
 								: 'https://jetpack.com/support/videopress/'
 						}
+						privacyLink="https://jetpack.com/support/videopress/#privacy"
 					/>
 					<JetpackModuleToggle
 						siteId={ siteId }

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -69,7 +69,6 @@ class MediaSettingsPerformance extends Component {
 								? 'https://wordpress.com/support/videopress/'
 								: 'https://jetpack.com/support/videopress/'
 						}
-						privacyLink={ ! siteIsAtomic }
 					/>
 					<JetpackModuleToggle
 						siteId={ siteId }

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -99,6 +99,7 @@ class SiteSettingsPerformance extends Component {
 									isRequestingSettings={ isRequestingSettings }
 									submitForm={ submitForm }
 									updateFields={ updateFields }
+									siteIsAtomic={ siteIsAtomic }
 								/>
 
 								<SettingsSectionHeader title={ translate( 'Media' ) } />
@@ -110,6 +111,7 @@ class SiteSettingsPerformance extends Component {
 									isSavingSettings={ isSavingSettings }
 									isRequestingSettings={ isRequestingSettings }
 									fields={ fields }
+									siteIsAtomic={ siteIsAtomic }
 								/>
 							</>
 						) }

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -12,7 +12,6 @@ import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-act
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
 import isPluginActive from 'calypso/state/selectors/is-plugin-active';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite, getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -161,7 +160,6 @@ export default connect( ( state ) => {
 		selectedSiteId,
 		siteAcceleratorStatus,
 		siteIsJetpack: isJetpackSite( state, selectedSiteId ),
-		siteIsAtomic: isSiteAutomatedTransfer( state, selectedSiteId ),
 		isPageOptimizeActive: isPluginActive( state, selectedSiteId, 'page-optimize' ),
 		pageOptimizeUrl: getSiteAdminUrl( state, selectedSiteId, 'admin.php?page=page-optimize' ),
 	};

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -72,7 +72,6 @@ class SpeedUpSiteSettings extends Component {
 									? 'https://wordpress.com/support/settings/performance-settings/#enable-site-accelerator'
 									: 'https://jetpack.com/support/site-accelerator/'
 							}
-							privacyLink={ ! siteIsAtomic }
 						/>
 						<FormSettingExplanation className="site-settings__feature-description">
 							{ translate(
@@ -113,7 +112,6 @@ class SpeedUpSiteSettings extends Component {
 										? 'https://wordpress.com/support/settings/performance-settings/#lazy-load-images'
 										: 'https://jetpack.com/support/lazy-images/'
 								}
-								privacyLink={ ! siteIsAtomic }
 							/>
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -12,6 +12,7 @@ import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-act
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
 import isPluginActive from 'calypso/state/selectors/is-plugin-active';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite, getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -51,6 +52,7 @@ class SpeedUpSiteSettings extends Component {
 			selectedSiteId,
 			siteAcceleratorStatus,
 			siteIsJetpack,
+			siteIsAtomic,
 			translate,
 		} = this.props;
 
@@ -102,7 +104,11 @@ class SpeedUpSiteSettings extends Component {
 								text={ translate(
 									"Delays the loading of images until they are visible in the visitor's browser."
 								) }
-								link="https://jetpack.com/support/lazy-images/"
+								link={
+									siteIsAtomic
+										? 'https://wordpress.com/support/settings/performance-settings/#performance-amp-speed'
+										: 'https://jetpack.com/support/lazy-images/'
+								}
 							/>
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }
@@ -149,6 +155,7 @@ export default connect( ( state ) => {
 		selectedSiteId,
 		siteAcceleratorStatus,
 		siteIsJetpack: isJetpackSite( state, selectedSiteId ),
+		siteIsAtomic: isSiteAutomatedTransfer( state, selectedSiteId ),
 		isPageOptimizeActive: isPluginActive( state, selectedSiteId, 'page-optimize' ),
 		pageOptimizeUrl: getSiteAdminUrl( state, selectedSiteId, 'admin.php?page=page-optimize' ),
 	};

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -68,7 +68,12 @@ class SpeedUpSiteSettings extends Component {
 									'files and images so your visitors enjoy ' +
 									'the fastest experience regardless of device or location.'
 							) }
-							link="http://jetpack.com/support/site-accelerator/"
+							link={
+								siteIsAtomic
+									? 'https://wordpress.com/support/settings/performance-settings/#enable-site-accelerator'
+									: 'https://jetpack.com/support/site-accelerator/'
+							}
+							privacyLink={ ! siteIsAtomic }
 						/>
 						<FormSettingExplanation className="site-settings__feature-description">
 							{ translate(
@@ -106,9 +111,10 @@ class SpeedUpSiteSettings extends Component {
 								) }
 								link={
 									siteIsAtomic
-										? 'https://wordpress.com/support/settings/performance-settings/#performance-amp-speed'
+										? 'https://wordpress.com/support/settings/performance-settings/#lazy-load-images'
 										: 'https://jetpack.com/support/lazy-images/'
 								}
+								privacyLink={ ! siteIsAtomic }
 							/>
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -72,6 +72,7 @@ class SpeedUpSiteSettings extends Component {
 									? 'https://wordpress.com/support/settings/performance-settings/#enable-site-accelerator'
 									: 'https://jetpack.com/support/site-accelerator/'
 							}
+							privacyLink="https://jetpack.com/support/site-accelerator/#privacy"
 						/>
 						<FormSettingExplanation className="site-settings__feature-description">
 							{ translate(
@@ -112,6 +113,7 @@ class SpeedUpSiteSettings extends Component {
 										? 'https://wordpress.com/support/settings/performance-settings/#lazy-load-images'
 										: 'https://jetpack.com/support/lazy-images/'
 								}
+								privacyLink="https://jetpack.com/support/lazy-images/#privacy"
 							/>
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }


### PR DESCRIPTION
## Changes proposed in this Pull Request
In order to show relevant links based on the site type (Jetpack self-hosted or Atomic on WPCOM) I added an additional calypso selector `isSiteAutomatedTransfer`. With that information, I added a ternary operator to the link prop to return the appropriate link based on the site and for `privacyLink`.

## Testing instructions

1. Select an AT site from your site selector
2. Go to Settings ⇢ Performance
3. Click the `( i )` and view the links and make sure Privacy is not shown.
4. Repeat the same with a Jetpack site

## Screenshots
#### Atomic
![Screen Capture on 2022-02-09 at 16-31-27](https://user-images.githubusercontent.com/33258733/153234407-aa064239-f9aa-42c4-9911-054cba2207f8.gif)

#### Jetpack
![Screen Capture on 2022-02-09 at 16-28-04](https://user-images.githubusercontent.com/33258733/153234520-e4f54533-8715-4737-b370-81e69472172b.gif)

Fixes #59976 