### PR TITLE
Plugin Details: Update the author page to display the author plugins inside Calypso.

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -69,6 +69,7 @@ export function getAllowedPluginData( plugin ) {
 		'action_links',
 		'active',
 		'author',
+		'author_profile',
 		'author_url',
 		'autoupdate',
 		'banners',
@@ -262,4 +263,20 @@ export function extractSearchInformation( searchTerm = '' ) {
 	const search = searchTerm.replace( DEVELOPER_PATTERN, '' ).trim();
 
 	return [ search, author ];
+}
+
+export const WPORG_PROFILE_URL = 'https://profiles.wordpress.org/';
+
+/**
+ * Returns an author keyword to be used on plugin search by author
+ *
+ * @param plugin
+ * @returns {string} the keyword
+ */
+export function getPluginAuthorKeyword( plugin ) {
+	if ( plugin?.author_profile?.includes( WPORG_PROFILE_URL ) ) {
+		return plugin.author_profile.replace( WPORG_PROFILE_URL, '' ).replaceAll( '/', '' );
+	}
+
+	return plugin.author_name || '';
 }

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -74,6 +74,7 @@ export function getAllowedPluginData( plugin ) {
 		'autoupdate',
 		'banners',
 		'compatibility',
+		'contributors',
 		'description',
 		'active_installs',
 		'short_description',
@@ -265,18 +266,49 @@ export function extractSearchInformation( searchTerm = '' ) {
 	return [ search, author ];
 }
 
+/**
+ * Returns an author keyword to be used on plugin search by author
+ * The follow actions are taken:
+ * * Try to get the main author from the list of contributors
+ * * Try to extract the author keyword from author_profile
+ * * Try to get the author_name
+ * * Send an empty string if none of the previous actions works
+ *
+ * @param plugin
+ * @returns {string} the author keyword or an empty string
+ */
+export function getPluginAuthorKeyword( plugin ) {
+	const { contributors = {} } = plugin;
+
+	return (
+		Object.keys( contributors ).find( ( contributorKey ) => {
+			const authorName = plugin.author_name;
+			const contributorName = contributors[ contributorKey ].display_name;
+
+			return (
+				authorName &&
+				contributorName &&
+				( authorName.includes( contributorName ) || contributorName.includes( authorName ) )
+			);
+		} ) ||
+		getPluginAuthorProfileKeyword( plugin ) ||
+		plugin.author_name ||
+		''
+	);
+}
+
 export const WPORG_PROFILE_URL = 'https://profiles.wordpress.org/';
 
 /**
- * Returns an author keyword to be used on plugin search by author
+ * Get the author keywrod from author_profile property
  *
  * @param plugin
- * @returns {string} the keyword
+ * @returns {string|null} the author keyword
  */
-export function getPluginAuthorKeyword( plugin ) {
-	if ( plugin?.author_profile?.includes( WPORG_PROFILE_URL ) ) {
-		return plugin.author_profile.replace( WPORG_PROFILE_URL, '' ).replaceAll( '/', '' );
+export function getPluginAuthorProfileKeyword( plugin ) {
+	if ( ! plugin?.author_profile?.includes( WPORG_PROFILE_URL ) ) {
+		return null;
 	}
 
-	return plugin.author_name || '';
+	return plugin.author_profile.replace( WPORG_PROFILE_URL, '' ).replaceAll( '/', '' );
 }

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -46,7 +46,7 @@ export function fetchPluginInformation( pluginSlug, locale ) {
 		action: 'plugin_information',
 		'request[slug]': pluginSlug.replace( new RegExp( '.php$' ), '' ),
 		'request[locale]': getWporgLocaleCode( locale ),
-		'request[fields]': 'icons,short_description,-contributors,-added,-donate_link,-homepage',
+		'request[fields]': 'icons,short_description,contributors,-added,-donate_link,-homepage',
 	};
 
 	return getRequest( WPORG_PLUGINS_ENDPOINT, query );

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -1,13 +1,17 @@
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { preventWidows } from 'calypso/lib/formatting';
 import { getPluginAuthorKeyword } from 'calypso/lib/plugins/utils';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
+
+	const selectedSite = useSelector( getSelectedSite );
 
 	const tags = Object.values( plugin?.tags || {} )
 		.slice( 0, 3 )
@@ -29,7 +33,11 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 					<div className="plugin-details-header__info">
 						<div className="plugin-details-header__info-title">{ translate( 'Developer' ) }</div>
 						<div className="plugin-details-header__info-value">
-							<a href={ `/plugins?s=developer:"${ getPluginAuthorKeyword( plugin ) }"` }>
+							<a
+								href={ `/plugins/${
+									selectedSite?.slug || ''
+								}?s=developer:"${ getPluginAuthorKeyword( plugin ) }"` }
+							>
 								{ plugin.author_name }
 							</a>
 						</div>

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -28,7 +28,9 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 					<div className="plugin-details-header__info">
 						<div className="plugin-details-header__info-title">{ translate( 'Developer' ) }</div>
 						<div className="plugin-details-header__info-value">
-							<a href={ plugin.author_url }>{ plugin.author_name }</a>
+							<a href={ `/plugins?s=author:"${ plugin.author_name || '' }"` }>
+								{ plugin.author_name }
+							</a>
 						</div>
 					</div>
 					{ !! plugin.rating && (

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -29,7 +29,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 					<div className="plugin-details-header__info">
 						<div className="plugin-details-header__info-title">{ translate( 'Developer' ) }</div>
 						<div className="plugin-details-header__info-value">
-							<a href={ `/plugins?s=author:"${ getPluginAuthorKeyword( plugin ) }"` }>
+							<a href={ `/plugins?s=developer:"${ getPluginAuthorKeyword( plugin ) }"` }>
 								{ plugin.author_name }
 							</a>
 						</div>

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { preventWidows } from 'calypso/lib/formatting';
+import { getPluginAuthorKeyword } from 'calypso/lib/plugins/utils';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import './style.scss';
 
@@ -28,7 +29,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 					<div className="plugin-details-header__info">
 						<div className="plugin-details-header__info-title">{ translate( 'Developer' ) }</div>
 						<div className="plugin-details-header__info-value">
-							<a href={ `/plugins?s=author:"${ plugin.author_name || '' }"` }>
+							<a href={ `/plugins?s=author:"${ getPluginAuthorKeyword( plugin ) }"` }>
 								{ plugin.author_name }
 							</a>
 						</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the author page to display the author plugins inside Calypso.

The following actions are taken when trying to find the developer keyword:

1. Try to get the main author from the list of contributors
1. Try to extract the author keyword from author_profile
1. Try to get the author_name
1. Send an empty string if none of the previous actions works

#### Testing instructions
* Go to a plugin details page. Ex:`/plugins/woocommerce-subscriptions`
* Check if the developer name displays properly 
* Click on the developer name
* It should redirect you to a page inside calypso with plugins of the given author.


#### Demo
![Kapture 2022-02-09 at 17 59 15](https://user-images.githubusercontent.com/5039531/153289822-aa3bcca2-a1d3-4b7b-930f-6fccf93b6c25.gif)

---

Fixes #57749
