### PR TITLE
Disable Jetpack Search Coupon Injection

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -41,7 +41,7 @@ import useCreatePaymentCompleteCallback from './hooks/use-create-payment-complet
 import useCreatePaymentMethods from './hooks/use-create-payment-methods';
 import useDetectedCountryCode from './hooks/use-detected-country-code';
 import useGetThankYouUrl from './hooks/use-get-thank-you-url';
-import useMaybeJetpackIntroCouponCode from './hooks/use-maybe-jetpack-intro-coupon-code';
+// import useMaybeJetpackIntroCouponCode from './hooks/use-maybe-jetpack-intro-coupon-code';
 import usePrepareProductsForCart from './hooks/use-prepare-products-for-cart';
 import useRecordCartLoaded from './hooks/use-record-cart-loaded';
 import useRecordCheckoutLoaded from './hooks/use-record-checkout-loaded';
@@ -184,7 +184,7 @@ export default function CompositeCheckout( {
 
 	const cartKey = useCartKey();
 	const {
-		couponStatus,
+		// couponStatus,
 		applyCoupon,
 		updateLocation,
 		replaceProductInCart,
@@ -199,10 +199,10 @@ export default function CompositeCheckout( {
 
 	const updatedSiteId = isJetpackCheckout ? parseInt( String( responseCart.blog_id ), 10 ) : siteId;
 
-	const maybeJetpackIntroCouponCode = useMaybeJetpackIntroCouponCode(
-		productsForCart,
-		couponStatus === 'applied'
-	);
+	// const maybeJetpackIntroCouponCode = useMaybeJetpackIntroCouponCode(
+	// 	productsForCart,
+	// 	couponStatus === 'applied'
+	// );
 
 	const isInitialCartLoading = useAddProductsFromUrl( {
 		isLoadingCart,
@@ -210,7 +210,8 @@ export default function CompositeCheckout( {
 		isJetpackSitelessCheckout,
 		productsForCart,
 		areCartProductsPreparing,
-		couponCodeFromUrl: couponCodeFromUrl || maybeJetpackIntroCouponCode,
+		// couponCodeFromUrl: couponCodeFromUrl || maybeJetpackIntroCouponCode,
+		couponCodeFromUrl: couponCodeFromUrl,
 		applyCoupon,
 		addProductsToCart,
 		replaceProductsInCart,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
@@ -2,7 +2,7 @@ import { isJetpackSearch } from '@automattic/calypso-products';
 import { useMemo } from 'react';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
-// const JETPACK_SEARCH_INTRO_COUPON_CODE = 'FIRSTYEAR50';
+const JETPACK_SEARCH_INTRO_COUPON_CODE = 'FIRSTYEAR50';
 
 const isYearly = ( product: MinimalRequestCartProduct ) =>
 	! product.product_slug.endsWith( '_monthly' );
@@ -26,7 +26,7 @@ const useMaybeJetpackIntroCouponCode = (
 		);
 
 		if ( isEligibleForFirstYear50 ) {
-			// 	return JETPACK_SEARCH_INTRO_COUPON_CODE;
+			return JETPACK_SEARCH_INTRO_COUPON_CODE;
 		}
 
 		return undefined;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
@@ -2,7 +2,7 @@ import { isJetpackSearch } from '@automattic/calypso-products';
 import { useMemo } from 'react';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
-const JETPACK_SEARCH_INTRO_COUPON_CODE = 'FIRSTYEAR50';
+// const JETPACK_SEARCH_INTRO_COUPON_CODE = 'FIRSTYEAR50';
 
 const isYearly = ( product: MinimalRequestCartProduct ) =>
 	! product.product_slug.endsWith( '_monthly' );
@@ -26,7 +26,7 @@ const useMaybeJetpackIntroCouponCode = (
 		);
 
 		if ( isEligibleForFirstYear50 ) {
-			return JETPACK_SEARCH_INTRO_COUPON_CODE;
+			// 	return JETPACK_SEARCH_INTRO_COUPON_CODE;
 		}
 
 		return undefined;


### PR DESCRIPTION
#### Summary

To prevent conflict with coupons from upcoming sales, pause the coupon injection used to Jetpack Search Annual plans

**DO NOT MERGE** until sales are ready to go live

#### Changes proposed in this Pull Request

* Stop injection of Jetpack Search `FIRSTYEAR50` coupon


#### Testing instructions

1. Boot branch
2. Add Jetpack Search Annual to cart
3. Verify the `FIRSTYEAR50` coupon has not been added to your cart as well.