### PR TITLE
Show price and upsell for premium themes on Atomic.

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -48,6 +48,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 	} = props;
 
 	const displayUpsellBanner = isAtomic && ! requestingSitePlans && currentPlan;
+	const upsellUrl = isAtomic && `/plans/${ siteId }?feature=upload-themes&plan=business-bundle`;
 
 	const upsellBanner = (
 		<UpsellNudge
@@ -70,6 +71,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 			<CurrentTheme siteId={ siteId } />
 			<ThemeShowcase
 				{ ...props }
+				upsellUrl={ upsellUrl }
 				siteId={ siteId }
 				emptyContent={ showWpcomThemesList ? <div /> : null }
 				isJetpackSite={ true }

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -48,7 +48,8 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 	} = props;
 
 	const displayUpsellBanner = isAtomic && ! requestingSitePlans && currentPlan;
-	const upsellUrl = isAtomic && `/plans/${ siteId }?feature=upload-themes&plan=business-bundle`;
+	const upsellUrl =
+		isAtomic && `/plans/${ siteId }?feature=${ FEATURE_UPLOAD_THEMES }&plan=${ PLAN_BUSINESS }`;
 
 	const upsellBanner = (
 		<UpsellNudge

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -7,6 +7,7 @@ import QueryThemes from 'calypso/components/data/query-themes';
 import ThemesList from 'calypso/components/themes-list';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer.js';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
 import {
@@ -207,13 +208,14 @@ export const ConnectedThemesSelection = connect(
 		}
 	) => {
 		const isJetpack = isJetpackSite( state, siteId );
+		const isAtomic = isSiteAutomatedTransfer( state, siteId );
 		const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
 
 		let sourceSiteId;
 		if ( source === 'wpcom' || source === 'wporg' ) {
 			sourceSiteId = source;
 		} else {
-			sourceSiteId = siteId && isJetpack ? siteId : 'wpcom';
+			sourceSiteId = siteId && isJetpack && ! isAtomic ? siteId : 'wpcom';
 		}
 
 		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the

--- a/client/state/themes/selectors/get-premium-theme-price.js
+++ b/client/state/themes/selectors/get-premium-theme-price.js
@@ -1,9 +1,9 @@
 import i18n from 'i18n-calypso';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 import { isPremiumThemeAvailable } from 'calypso/state/themes/selectors/is-premium-theme-available';
 import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import 'calypso/state/themes/init';
 
 /**

--- a/client/state/themes/selectors/get-premium-theme-price.js
+++ b/client/state/themes/selectors/get-premium-theme-price.js
@@ -3,7 +3,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 import { isPremiumThemeAvailable } from 'calypso/state/themes/selectors/is-premium-theme-available';
 import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
-
+import isSiteAutomatedTransfer from '../../selectors/is-site-automated-transfer';
 import 'calypso/state/themes/init';
 
 /**
@@ -21,7 +21,7 @@ export function getPremiumThemePrice( state, themeId, siteId ) {
 		return '';
 	}
 
-	if ( isJetpackSite( state, siteId ) ) {
+	if ( isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId ) ) {
 		return i18n.translate( 'Upgrade', {
 			comment:
 				'Used to indicate a premium theme is available to the user once they upgrade their plan',

--- a/client/state/themes/selectors/get-premium-theme-price.js
+++ b/client/state/themes/selectors/get-premium-theme-price.js
@@ -3,7 +3,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 import { isPremiumThemeAvailable } from 'calypso/state/themes/selectors/is-premium-theme-available';
 import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
-import isSiteAutomatedTransfer from '../../selectors/is-site-automated-transfer';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import 'calypso/state/themes/init';
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On the [themes page](https://wordpress.com/themes), Premium themes should include the price and upsell nudge/star on Atomic sites with sub Premium plans. Atomic sites with Premium and higher plans should not show the price or upsell nudge/star.

See https://github.com/Automattic/wp-calypso/issues/51590#issuecomment-849512348 for additional details.

<table>
<tr>
<td>
<h3>Before</h3>

![themes-atomic-free-before](https://user-images.githubusercontent.com/140841/153307732-f0022af0-f533-4e9a-b8ec-bca1cd3ade6a.png)

</td>
<td>
<h3>After</h3>

![themes-atomic-free-after](https://user-images.githubusercontent.com/140841/153307759-9df9bed5-b643-493b-af63-6c9a6dbb9453.png)

</td>
</tr>
</table>

#### Testing instructions

* Checkout this PR.
* Ensure that Atomic sites with sub Premium plans display the theme's price and upsell nudge (the clickable star beside the price).
* Ensure that Atomic Premium, Business, and eCommerce plans do not show the price or upsell nudge.
* Regression test that simple sites and Jetpack sites are unaffected by this PR. For reference, simple sites with sub Premium plans should display the theme's price and upsell nudge, Premium and up simple sites should not. Jetpack sites should not display Premium themes. See pics below.

<table>
<tr>
<td>
<h3>Simple Free</h3>

![themes-simple-free](https://user-images.githubusercontent.com/140841/153308181-0c76a0b6-0c61-472b-bae0-934d4924aa1c.png)


</td>
<td>
<h3>Jetpack</h3>

![themes-no-premium-jetpack](https://user-images.githubusercontent.com/140841/153308214-1f73dbfe-4de7-4a58-8a57-61944e49e1f5.png)

</td>
</tr>
</table>

Related to #51590
