### PR TITLE
Wraps "Edit custom name servers" in translate function

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -239,7 +239,9 @@ const NameServersCard = ( {
 				{ nameservers.map( ( nameserver ) => (
 					<p key={ nameserver }>{ nameserver }</p>
 				) ) }
-				<Button onClick={ editCustomNameServers }>Edit custom name servers</Button>
+				<Button onClick={ editCustomNameServers }>
+					{ translate( 'Edit custom name servers' ) }
+				</Button>
 			</div>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* "Edit custom name servers" should be wrapped in a translate function call. 

#### Testing instructions

1. Go to a site with a custom domain managed by WordPress.com with language set to non-English
1. Go to Upgrades>Domains
1. Click on the three dots next to the domain to see the domain settings.
1. Expand the DNS Servers panel
1. Toggle off "Use WordPress.com name servers"
1. Click the button "Save Custom Name Servers"
1. The resulting button "Edit Custom Name Servers" is in English.

![](https://user-images.githubusercontent.com/36699353/152061768-d2d5b8d8-01d1-4fd7-80a4-5cf3e5242e8f.png)

Please note that the string is not currently translated so even with the fix it will still be momentarily displayed in English. 
