### PR TITLE
Signup: Fix calypso_signup_plan_change_event format

### DIFF
--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -176,13 +176,13 @@ export const recordSignupPlanChange = (
 ) => {
 	const device = resolveDeviceTypeByViewPort();
 
-	recordTracksEvent( 'calypso_signup_plan_change ', {
+	recordTracksEvent( 'calypso_signup_plan_change', {
 		flow,
 		step,
 		device,
-		previousPlanName,
-		previousPlanSlug,
-		currentPlanName,
-		currentPlanSlug,
+		previous_plan_name: previousPlanName,
+		previous_plan_slug: previousPlanSlug,
+		current_plan_name: currentPlanName,
+		current_plan_slug: currentPlanSlug,
 	} );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the event name ended with redundant space and format the properties to snake_case.
* Maybe we can always format the event properties to snake_case in `recordTracksEvent` function 🤔

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/setup-site?siteSlug=<your_site>` with free plan
* Select build
* Select Upgrade Plan on one of the premium theme
* After you upgrade the plan and back to the design picker, you should see `calypso_signup_plan_change` event

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/60988, https://github.com/Automattic/wp-calypso/pull/60545
