### PR TITLE
Components: Refactor `TrackInputChanges` away from `UNSAFE_` methods

### DIFF
--- a/client/components/track-input-changes/index.jsx
+++ b/client/components/track-input-changes/index.jsx
@@ -14,8 +14,7 @@ export default class TrackInputChanges extends Component {
 		onNewValue: noop,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		this.inputEdited = false;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `TrackInputChanges` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* In your console, type: `localStorage.setItem('debug', 'calypso:analytics*');`
* Go to `/media/:site` where `:site` is one of your sites.
* Select a media and click "Edit" to edit it.
* Change the alt or caption of the media and blur the field.
* Verify you can still see events be recorded like this:

![](https://cldup.com/Y_Q1tm_iNH.png)