### PR TITLE
TeamCity: Cleanup unused `failOnMetricChange`

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -413,20 +413,6 @@ object RunAllUnitTests : BuildType({
 
 	failureConditions {
 		executionTimeoutMin = 10
-
-		failOnMetricChange {
-			metric = BuildFailureOnMetric.MetricType.INSPECTION_ERROR_COUNT
-			units = BuildFailureOnMetric.MetricUnit.DEFAULT_UNIT
-			comparison = BuildFailureOnMetric.MetricComparison.MORE
-			threshold = 0
-			compareTo = build {
-				buildRule = buildWithTag {
-					tag = "release-candidate"
-				}
-			}
-			stopBuildOnFailure = true
-		}
-
 	}
 	features {
 		feature {

--- a/client/state/account/test/actions.js
+++ b/client/state/account/test/actions.js
@@ -7,7 +7,6 @@ describe( 'actions', () => {
 			const action = closeAccount();
 			expect( action ).toEqual( {
 				type: ACCOUNT_CLOSE,
-				foo: 'bar',
 			} );
 		} );
 	} );

--- a/client/state/account/test/actions.js
+++ b/client/state/account/test/actions.js
@@ -7,6 +7,7 @@ describe( 'actions', () => {
 			const action = closeAccount();
 			expect( action ).toEqual( {
 				type: ACCOUNT_CLOSE,
+				foo: 'bar',
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a follow-up cleanup to https://github.com/Automattic/wp-calypso/pull/60925, as suggested by @noahtallen in https://github.com/Automattic/wp-calypso/pull/60925#pullrequestreview-878094356. We're essentially removing the `failOnMetricChange` from the `WebApp` TC config, since it's not used anymore.

Just in case, I've added a commit that fails the unit test build intentionally, and then another one to revert it. The purpose of that is to demonstrate that unit tests still pass under regular circumstances, and when there is a failure, it's still reported properly.

#### Testing instructions

Verify that the unit tests after the second commit fail, while the ones after the third one pass.