### PR TITLE
Update annual sale total for Search if sales-coupon exists

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -26,6 +26,7 @@ import {
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { updateContactDetailsCache } from 'calypso/state/domains/management/actions';
+import { getJetpackSaleCoupon } from 'calypso/state/marketing/selectors';
 import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
 import getIsIntroOfferRequesting from 'calypso/state/selectors/get-is-requesting-into-offers';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
@@ -199,9 +200,11 @@ export default function CompositeCheckout( {
 
 	const updatedSiteId = isJetpackCheckout ? parseInt( String( responseCart.blog_id ), 10 ) : siteId;
 
+	const saleTitle = useSelector( getJetpackSaleCoupon )?.sale_title || '';
 	const maybeJetpackIntroCouponCode = useMaybeJetpackIntroCouponCode(
 		productsForCart,
-		couponStatus === 'applied'
+		couponStatus === 'applied',
+		saleTitle
 	);
 
 	const isInitialCartLoading = useAddProductsFromUrl( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-maybe-jetpack-intro-coupon-code.ts
@@ -13,11 +13,12 @@ const isNewPurchase = ( product: MinimalRequestCartProduct ) =>
 // rely on auto-applied coupons for introductory new purchase pricing.
 const useMaybeJetpackIntroCouponCode = (
 	products: MinimalRequestCartProduct[],
-	isCouponApplied: boolean
+	isCouponApplied: boolean,
+	saleTitle: string
 ): string | undefined => {
 	return useMemo( () => {
 		// If a coupon is already applied to this cart, don't try to apply another one.
-		if ( isCouponApplied ) {
+		if ( isCouponApplied || saleTitle ) {
 			return undefined;
 		}
 
@@ -30,7 +31,7 @@ const useMaybeJetpackIntroCouponCode = (
 		}
 
 		return undefined;
-	}, [ products, isCouponApplied ] );
+	}, [ products, isCouponApplied, saleTitle ] );
 };
 
 export default useMaybeJetpackIntroCouponCode;

--- a/client/state/marketing/selectors.ts
+++ b/client/state/marketing/selectors.ts
@@ -49,13 +49,17 @@ export function getJetpackCouponDiscountMap( state: AppState ): DiscountMap {
 	// discountedPricePercentage is 1 - discountPercentage.
 	const discountedPricePercentage =
 		( 100 - ( getJetpackSaleCoupon( state )?.discount || 0 ) ) / 100;
+	const searchDiscountPricePercentage =
+		( 100 - ( getJetpackSaleCoupon( state )?.final_discount || 0 ) ) / 100;
 	const discountMap: DiscountMap = {};
 
 	//  outside of sales ( when the discountedPricePercentage is 100% or full price ) there is no need to build this object
 	if ( discountedPricePercentage < 1 ) {
 		[ ...JETPACK_RESET_PLANS_BY_TERM, ...JETPACK_PRODUCTS_BY_TERM ].forEach( ( { yearly } ) => {
 			// search requires special discount support since it does not have an introductory offer
-			if ( yearly !== PRODUCT_JETPACK_SEARCH ) {
+			if ( yearly === PRODUCT_JETPACK_SEARCH ) {
+				discountMap[ yearly ] = searchDiscountPricePercentage;
+			} else {
 				discountMap[ yearly ] = discountedPricePercentage;
 			}
 		} );


### PR DESCRIPTION
- suppress the FIRSTYEAR50 coupon if sales-coupon exists

#### Changes proposed in this Pull Request

Fix annual total calculated for Jetpack Search when a "sales-coupon" is applied. 

- `getJetpackCouponDiscountMap` now includes Jetpack search but uses the `final_discount` as opposed to the `discount` used by other Jetpack products
- added a check for a sales coupon - if present, it suppresses the default `FIRSTYEAR50` coupon which prevents the backend from erroring when the coupon is present but not used

#### Testing instructions

1. Follow instructions in D74110-code to setup a test coupon and return in via the coupon API - currently 2 sales coupons exist one for some Jetpack Yearly search at 60%, and one for other yearly Jetpack products at 20% - you can try pointing the API at `00ec735a6dd36593+003` - which is the 20% main coupon - resulting in a 60% total in step 3 below.
2. Sandbox `public-api.wordpress.com`, boot branch as Calypso Blue or use Calypso Live link, and navigate to `/plans/:siteSlug` for a test jetpack site.
3. Verify that your test coupon is working by observing that the "Get X% off your first year.*" is greater than 50%.
   - It should be X% greater. For example, a 20% sale should be 50 x 1.2 = 60% off.
4. Add Jetpack Search Product to the cart.
5. In the cart verify:
   1. That the annual variant selector is applied and is for the full amount of the discount 60%
   2. There is **_no_** notification of error around not being eligible for a coupon.

* Before
![Screenshot 2022-02-10 at 11 22 08](https://user-images.githubusercontent.com/8742105/153422945-262c3677-9ff8-48c6-9683-a9d00302c006.png)

* After - no notification of not being eligible for coupon, and annual total updated
![Screenshot 2022-02-10 at 14 01 17](https://user-images.githubusercontent.com/8742105/153423175-1ddca21f-d250-42d2-a14b-76bd3b9bced7.png)


Related to #60896
