### PR TITLE
Substitute example.com with gravatar.com on import E2E tests

### DIFF
--- a/test/e2e/specs/specs-playwright/wp-start__importer.ts
+++ b/test/e2e/specs/specs-playwright/wp-start__importer.ts
@@ -49,12 +49,12 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 	describe.each( [
 		// wordpress.com is already a WPCOM site and ever will be.
 		{ url: 'wordpress.com', reason: 'Your site is already on WordPress.com' },
-		// example.com will never be a WordPress site.
-		{ url: 'example.com', reason: "Your existing content can't be imported" },
+		// gravatar.com is not a WordPress site.
+		{ url: 'gravatar.com', reason: "Your existing content can't be imported" },
 	] )( "Follow the WordPress can't be imported flow", ( { url, reason } ) => {
 		navigateToSetup();
 
-		it( `Start an invalid WordPress import (${ reason })`, async () => {
+		it( `Start an invalid WordPress import on ${ url } (${ reason })`, async () => {
 			await startImportFlow.enterURL( url );
 			await startImportFlow.validateBuildingPage( reason );
 			await startImportFlow.startBuilding();
@@ -69,8 +69,8 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 		// One of several errors found on Blogs::get_blog_name_error_code.
 		// A deleted wpcom site does generate the same error.
 		it( 'Start an invalid WordPress import typo', async () => {
-			// 1.example.com is guaranteed never to be a valid DNS
-			await startImportFlow.enterURL( '1.example.com' );
+			// 1.gravatar.com is guaranteed never to be a valid DNS
+			await startImportFlow.enterURL( 'zz.gravatar.com' );
 			await startImportFlow.validateErrorCapturePage(
 				'The address you entered is not valid. Please try again.'
 			);
@@ -128,7 +128,7 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), () => {
 
 		// Back to URL capture page from the error page
 		it( 'Back to URL capture page from error page', async () => {
-			await startImportFlow.enterURL( 'example.com' );
+			await startImportFlow.enterURL( 'gravatar.com' );
 			await startImportFlow.clickButton( 'Back to start' );
 			await startImportFlow.validateURLCapturePage();
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change `example.com` with `gravatar.com` on site import E2E tests

After a too-quick arbitrary number of calls (3-4) to `example.com`, the site responds a 404. Probably this is due to a DDoS blocker. Changed the site to a company-owned one guaranteed not to be a WordPress site.

#### Testing instructions

- Ensure that the environment variable `NODE_CONFIG_ENV` is set. Otherwise: `export NODE_CONFIG_ENV='decrypted'`
- Ensure that in the `test/e2e/config/local-decrypted.json` blob there's a `"calypsoBaseURL": "http://calypso.localhost:3000/"`
- First tab: From `test/e2e` run `yarn install`
- Second tab: run `yarn workspace @automattic/calypso-e2e build --watch`
- Third tab: from `test/e2e` run: `yarn jest specs/specs-playwright/wp-start__importer.ts`

All **18** tests must **pass**.

Related to #60892.