### PR TITLE
Add StripeCardElement to the type definitions when creating a Stripe setup intent or payment method

### DIFF
--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -9,6 +9,7 @@ import type {
 	SetupIntent,
 	StripeElementLocale,
 	StripeCardNumberElement,
+	StripeCardElement,
 } from '@stripe/stripe-js';
 
 const debug = debugFactory( 'calypso-stripe' );
@@ -179,13 +180,13 @@ export class StripePaymentMethodError extends Error {
  * `incomplete_cvc`.
  *
  * @param {object} stripe The stripe object with payment data included
- * @param {object} element The StripeCardNumberElement
+ * @param {object} element The StripeCardNumberElement or StripeCardElement
  * @param {object} paymentDetails The `billing_details` field of the `createPaymentMethod()` request
  * @returns {Promise} Promise that will be resolved or rejected
  */
 export async function createStripePaymentMethod(
 	stripe: Stripe,
-	element: StripeCardNumberElement,
+	element: StripeCardNumberElement | StripeCardElement,
 	paymentDetails: PaymentDetails
 ): Promise< { id: string } > {
 	debug( 'creating payment method...', paymentDetails );
@@ -214,7 +215,7 @@ export async function createStripePaymentMethod(
 
 export async function createStripeSetupIntent(
 	stripe: Stripe,
-	element: StripeCardNumberElement,
+	element: StripeCardNumberElement | StripeCardElement,
 	setupIntentId: StripeSetupIntentId,
 	paymentDetails: PaymentDetails
 ): Promise< StripeSetupIntent > {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, in Calypso, we are using the number field for entering credit card details, but we have decided to try the `StripeCardElement` in the licensing portal, which combines multiple fields into one for better UX. This change should have no functional effect, it's needed to avoid type errors like this:

```
Argument of type 'StripeCardElement' is not assignable to parameter of type 'StripeCardNumberElement'.
```

Here's the API of both fields:
- https://github.com/stripe/stripe-js/blob/v1.17.1/types/stripe-js/elements/card.d.ts
- https://github.com/stripe/stripe-js/blob/v1.17.1/types/stripe-js/elements/card-number.d.ts

More context: pbtFFM-1pJ-p2#comment-2219

#### Testing instructions

- Download this PR.
- Open your editor and make sure that there are no TypeScript errors for the usages of: `createStripeSetupIntent()` and ` createStripePaymentMethod()`.