### PR TITLE
Show wp-admin importers for the Atomic target site

### DIFF
--- a/client/signup/steps/import-from/wordpress/index.tsx
+++ b/client/signup/steps/import-from/wordpress/index.tsx
@@ -8,6 +8,7 @@ import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { SitesItem } from 'calypso/state/selectors/get-sites-items';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteBySlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getWpOrgImporterUrl } from '../../import/util';
 import { Importer, ImportJob } from '../types';
 import { ContentChooser } from './content-chooser';
 import ImportContentOnly from './import-content-only';
@@ -59,7 +60,9 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	}
 
 	function switchToContentUploadScreen() {
-		updateCurrentPageQueryParam( { option: WPImportOption.CONTENT_ONLY } );
+		isSiteAtomic
+			? redirectToWpAdminWordPressImporter()
+			: updateCurrentPageQueryParam( { option: WPImportOption.CONTENT_ONLY } );
 	}
 
 	function checkImporterAvailability() {
@@ -93,6 +96,10 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 
 	function redirectToWpAdminImportPage() {
 		return page( `/import/${ siteSlug }` );
+	}
+
+	function redirectToWpAdminWordPressImporter() {
+		return page( getWpOrgImporterUrl( siteSlug, 'wordpress' ) );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Onboarding import flow: Redirect user to the `wp-admin` importer page when the target site is an Atomic.

#### Testing instructions

* Go to `start/importer/capture?siteSlug={ATOMIC_WP_SITE}`
* Enter, for example, a blogger site URL
* Press `Import your content` button
* Check if it is  `wp-admin` importer related to the siteSlug from the first step

Closes #60990
