### PR TITLE
Playwright: add basic page flow spec

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -1,7 +1,7 @@
 import { Frame, Page } from 'playwright';
 
 export type EditorSidebarTab = 'Post' | 'Block' | 'Page';
-export type EditorSidebarSection = 'Categories' | 'Tags' | 'Status & Visibility';
+export type EditorSidebarSection = 'Categories' | 'Tags' | 'Status & Visibility' | 'Permalink';
 export type PrivacyOptions = 'Public' | 'Private' | 'Password';
 
 const sidebarParentSelector = '[aria-label="Editor settings"]';
@@ -36,6 +36,9 @@ const selectors = {
 	addedTag: ( tagName: string ) =>
 		`${ sidebarParentSelector } .components-form-token-field:has-text("Add New Tag") .components-form-token-field__token:has-text("${ tagName }")`,
 	closeSidebarButton: `${ sidebarParentSelector } [aria-label="Close settings"]:visible`, // there's a hidden copy in there
+
+	// URl Slug
+	urlSlugInput: '.components-base-control__field:has-text("URL Slug") input',
 };
 
 /**
@@ -159,6 +162,18 @@ export class EditorSettingsSidebarComponent {
 		await this.frame.fill( selectors.tagInput, tagName );
 		await this.page.keyboard.press( 'Enter' );
 		await this.frame.waitForSelector( selectors.addedTag( tagName ) ); // make sure it got added!
+	}
+
+	/**
+	 * Enter the URL slug for the page/post.
+	 *
+	 * @param {string} slug URL slug to set.
+	 */
+	async enterUrlSlug( slug: string ) {
+		await this.frame.fill( selectors.urlSlugInput, slug );
+		// Playwright is so fast, let's make sure the post's/page's state actually updates in case we're going to publish or update right after.
+		// By adding the forward slash, we ensure the new route has been appended to the fully qualified URL in the sidebar.
+		await this.frame.waitForSelector( `text=/${ slug }` );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -37,7 +37,7 @@ const selectors = {
 		`${ sidebarParentSelector } .components-form-token-field:has-text("Add New Tag") .components-form-token-field__token:has-text("${ tagName }")`,
 	closeSidebarButton: `${ sidebarParentSelector } [aria-label="Close settings"]:visible`, // there's a hidden copy in there
 
-	// URl Slug
+	// URL Slug
 	urlSlugInput: '.components-base-control__field:has-text("URL Slug") input',
 };
 

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -13,5 +13,6 @@ export * from './isolated-block-editor-component';
 export * from './block-widget-editor-component';
 export * from './revisions-component';
 export * from './snackbar-notification-component';
+export * from './page-template-modal-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
@@ -8,6 +8,7 @@ const selectors = {
 		`.page-pattern-modal__category-list button:has-text("${ category }")`,
 	mobileTemplateCategorySelectBox: '.page-pattern-modal__mobile-category-dropdown',
 	template: ( label: string ) => `button.pattern-selector-item__label:has-text("${ label }")`,
+	blankPageButton: 'button:has-text("Blank page")',
 };
 
 /**
@@ -52,6 +53,14 @@ export class PageTemplateModalComponent {
 	 */
 	async selectTemplate( label: string ): Promise< void > {
 		const locator = this.editorIframe.locator( selectors.template( label ) );
+		await locator.click();
+	}
+
+	/**
+	 * Select a blank page as your template.
+	 */
+	async selectBlankPage(): Promise< void > {
+		const locator = this.editorIframe.locator( selectors.blankPageButton );
 		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
@@ -1,0 +1,57 @@
+import { Frame, Page } from 'playwright';
+import { envVariables } from '../..';
+
+type TemplateCategory = 'About';
+
+const selectors = {
+	templateCategoryButton: ( category: TemplateCategory ) =>
+		`.page-pattern-modal__category-list button:has-text("${ category }")`,
+	mobileTemplateCategorySelectBox: '.page-pattern-modal__mobile-category-dropdown',
+	template: ( label: string ) => `button.pattern-selector-item__label:has-text("${ label }")`,
+};
+
+/**
+ * Represents the page template selection modal when first loading a new page in the editor.
+ */
+export class PageTemplateModalComponent {
+	private page: Page;
+	private editorIframe: Frame;
+
+	/**
+	 * Creates an instance of the page.
+	 *
+	 * @param {Frame} editorIframe Iframe from the gutenberg editor.
+	 * @param {Page} page Object representing the base page.
+	 */
+	constructor( editorIframe: Frame, page: Page ) {
+		this.page = page;
+		this.editorIframe = editorIframe;
+	}
+
+	/**
+	 * Select a template category from the sidebar of options.
+	 *
+	 * @param {TemplateCategory} category Name of the category to select.
+	 */
+	async selectTemplateCatagory( category: TemplateCategory ): Promise< void > {
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			await this.editorIframe.selectOption(
+				selectors.mobileTemplateCategorySelectBox,
+				category.toLowerCase()
+			);
+		} else {
+			const locator = this.editorIframe.locator( selectors.templateCategoryButton( category ) );
+			await locator.click();
+		}
+	}
+
+	/**
+	 * Select a template from the grid of options.
+	 *
+	 * @param {string} label Label for the template (the string underneath the preview).
+	 */
+	async selectTemplate( label: string ): Promise< void > {
+		const locator = this.editorIframe.locator( selectors.template( label ) );
+		await locator.click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -13,10 +13,6 @@ const selectors = {
 	editorFrame: '.calypsoify.is-iframe iframe.is-loaded',
 	editorTitle: '.editor-post-title__input',
 
-	// Editor: Page
-	blankPageButton: '.page-pattern-modal__blank-button',
-	pageDesign: ( name: string ) => `li:text(${ name })`,
-
 	// Block inserter
 	blockInserterToggle: 'button.edit-post-header-toolbar__inserter-toggle',
 	blockInserterPanel: '.block-editor-inserter__content',
@@ -135,27 +131,6 @@ export class GutenbergEditorPage {
 
 			return actionPayload.show === false;
 		} );
-	}
-
-	/**
-	 * Choose a page design.
-	 *
-	 * If a non-default value is provided, this method will select from
-	 * a matching design from the list.
-	 *
-	 * If the value provided is `blank`, the button on the modal labeled
-	 * "Blank Page" will be selected instead.
-	 *
-	 * @param {string} name Name of the design.
-	 */
-	async selectPageDesign( name: string ): Promise< void > {
-		const frame = await this.getEditorFrame();
-
-		if ( name.toLowerCase() === 'blank' ) {
-			await frame.click( selectors.blankPageButton );
-		} else {
-			await frame.click( selectors.pageDesign( name ) );
-		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -49,7 +49,7 @@ const selectors = {
 	// corner. This addresses the bug where the post-publish panel is immediately
 	// closed when publishing with certain blocks on the editor canvas.
 	// See https://github.com/Automattic/wp-calypso/issues/54421.
-	viewButton: 'text=/View (Post|Page)/',
+	viewButton: 'a:text-matches("View (Post|Page)")',
 	addNewButton: '.editor-post-publish-panel a:text-matches("Add a New P(ost|age)")',
 	closePublishPanel: 'button[aria-label="Close panel"]',
 
@@ -410,7 +410,7 @@ export class GutenbergEditorPage {
 	 * Publishes the post or page.
 	 *
 	 * @param {boolean} visit Whether to then visit the page.
-	 * @returns {Promise<string>} URL of the published post or page.
+	 * @returns {Promise<string>} The published URL.
 	 */
 	async publish( { visit = false }: { visit?: boolean } = {} ): Promise< string > {
 		const frame = await this.getEditorFrame();
@@ -533,6 +533,7 @@ export class GutenbergEditorPage {
 
 		const frame = await this.getEditorFrame();
 
+		console.log( url );
 		await Promise.all( [
 			this.page.waitForNavigation( { url: url, waitUntil: 'domcontentloaded' } ),
 			frame.click( selectors.viewButton ),

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -45,7 +45,7 @@ const selectors = {
 	// corner. This addresses the bug where the post-publish panel is immediately
 	// closed when publishing with certain blocks on the editor canvas.
 	// See https://github.com/Automattic/wp-calypso/issues/54421.
-	viewButton: 'a:text-matches("View (Post|Page)")',
+	viewButton: 'a:text-matches("View (Post|Page)", "i")',
 	addNewButton: '.editor-post-publish-panel a:text-matches("Add a New P(ost|age)")',
 	closePublishPanel: 'button[aria-label="Close panel"]',
 

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -23,5 +23,6 @@ export * from './use-a-domain-i-own-page';
 export * from './p2-page';
 export * from './woocommerce-landing-page';
 export * from './posts-page';
+export * from './pages-page';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/pages/pages-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/pages-page.ts
@@ -1,0 +1,40 @@
+import { Page, Response } from 'playwright';
+import { getCalypsoURL } from '../../data-helper';
+
+const selectors = {
+	addNewPageButton: 'a:has-text("Add new page")',
+};
+
+/**
+ * Represents the Pages page
+ */
+export class PagesPage {
+	private page: Page;
+
+	/**
+	 * Creates an instance of the page.
+	 *
+	 * @param {Page} page Object representing the base page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Opens the Pages page.
+	 *
+	 * Example {@link https://wordpress.com/pages}
+	 */
+	async visit(): Promise< Response | null > {
+		const response = await this.page.goto( getCalypsoURL( 'pages' ) );
+		return response;
+	}
+
+	/**
+	 * Start a new page using the 'Add new page' button.
+	 */
+	async addNewPage(): Promise< void > {
+		const locator = this.page.locator( selectors.addNewPageButton );
+		await locator.click();
+	}
+}

--- a/test/e2e/specs/specs-playwright/shared-specs/privacy-testing.ts
+++ b/test/e2e/specs/specs-playwright/shared-specs/privacy-testing.ts
@@ -6,6 +6,7 @@ import {
 	PrivacyOptions,
 	PublishedPostPage,
 	EditorSettingsSidebarComponent,
+	PageTemplateModalComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
@@ -44,7 +45,9 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 			it( 'Start new page', async function () {
 				gutenbergEditorPage = new GutenbergEditorPage( page );
 				await gutenbergEditorPage.visit( 'page' );
-				await gutenbergEditorPage.selectPageDesign( 'blank' );
+				const editorIframe = await gutenbergEditorPage.waitUntilLoaded();
+				const pageTemplateModalComponent = new PageTemplateModalComponent( editorIframe, page );
+				await pageTemplateModalComponent.selectBlankPage();
 			} );
 
 			it( 'Enter page title', async function () {

--- a/test/e2e/specs/specs-wpcom/wp-editor__page-basic-flow.ts
+++ b/test/e2e/specs/specs-wpcom/wp-editor__page-basic-flow.ts
@@ -1,0 +1,91 @@
+import {
+	DataHelper,
+	EditorSettingsSidebarComponent,
+	envVariables,
+	GutenbergEditorPage,
+	PublishedPostPage,
+	TestAccount,
+	PagesPage,
+	PageTemplateModalComponent,
+} from '@automattic/calypso-e2e';
+import { Browser, Page, Frame } from 'playwright';
+
+declare const browser: Browser;
+
+const pageTemplateCategory = 'About';
+const pageTemplateLable = 'About layout with intro and contact';
+const expectedTemplateText = 'Our Mission';
+const customUrlSlug = `about-${ DataHelper.getTimestamp() }-${ DataHelper.getRandomInteger(
+	0,
+	100
+) }`;
+
+describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
+	let page: Page;
+	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorIframe: Frame;
+	let pagesPage: PagesPage;
+	let editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
+	let publishedUrl: string;
+	const accountName = envVariables.GUTENBERG_EDGE
+		? 'gutenbergSimpleSiteEdgeUser'
+		: 'simpleSitePersonalPlanUser';
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+
+		const testAccount = new TestAccount( accountName );
+		await testAccount.authenticate( page );
+	} );
+
+	it( 'Visit /pages page', async function () {
+		pagesPage = new PagesPage( page );
+		await pagesPage.visit();
+	} );
+
+	it( 'Start a new page', async function () {
+		await pagesPage.addNewPage();
+	} );
+
+	it( 'Select page template', async function () {
+		gutenbergEditorPage = new GutenbergEditorPage( page );
+		editorIframe = await gutenbergEditorPage.waitUntilLoaded();
+		const pageTemplateComponent = new PageTemplateModalComponent( editorIframe, page );
+		await pageTemplateComponent.selectTemplateCatagory( pageTemplateCategory );
+		await pageTemplateComponent.selectTemplate( pageTemplateLable );
+	} );
+
+	it( 'Template content loads into editor', async function () {
+		await editorIframe.waitForSelector( `text=${ expectedTemplateText }` );
+	} );
+
+	it( 'Open setting sidebar', async function () {
+		await gutenbergEditorPage.openSettings();
+		editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( editorIframe, page );
+		await editorSettingsSidebarComponent.clickTab( 'Page' );
+	} );
+
+	it( 'Set custom URL slug', async function () {
+		await editorSettingsSidebarComponent.expandSection( 'Permalink' );
+		await editorSettingsSidebarComponent.enterUrlSlug( customUrlSlug );
+	} );
+
+	// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional.
+	it( 'Close settings sidebar', async function () {
+		await editorSettingsSidebarComponent.closeSidebar();
+	} );
+
+	it( 'Publish page', async function () {
+		publishedUrl = await gutenbergEditorPage.publish( { visit: true } );
+	} );
+
+	it( 'Published URL contains the custom URL slug', async function () {
+		expect( publishedUrl ).toContain( `/${ customUrlSlug }` );
+	} );
+
+	it( 'Published page contains template content', async function () {
+		// Not a typo, it's the POM page class for a WordPress page. :)
+		const publishedPagePage = new PublishedPostPage( page );
+		await publishedPagePage.validateTextInPost( expectedTemplateText );
+	} );
+} );

--- a/test/e2e/specs/specs-wpcom/wp-editor__page-basic-flow.ts
+++ b/test/e2e/specs/specs-wpcom/wp-editor__page-basic-flow.ts
@@ -38,7 +38,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		await testAccount.authenticate( page );
 	} );
 
-	it( 'Visit /pages page', async function () {
+	it( 'Visit Pages page', async function () {
 		pagesPage = new PagesPage( page );
 		await pagesPage.visit();
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the WPCOM Playwright transition (pciE2j-sq-p2), this creates the basic page spec outlined in issue #55948.

#### Testing instructions

- [x] Gutenberg mobile passes
- [x] Gutenberg desktop passes

Closes #55948