### PR TITLE
Layout: Remove masterbar for the editor section

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -345,7 +345,9 @@ export default withCurrentRoute(
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );
 		const noMasterbarForRoute = isJetpackLogin || currentRoute === '/me/account/closed';
-		const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
+		const noMasterbarForSection = [ 'signup', 'jetpack-connect', 'gutenberg-editor' ].includes(
+			sectionName
+		);
 		const masterbarIsHidden =
 			! masterbarIsVisible( state ) ||
 			noMasterbarForSection ||


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, we hide the masterbar while in the editor section. However, regardless, we keep loading it and all its various bits (drafts, notifications, etc), and that's unnecessary. This PR removes the masterbar completely for the editor section.

This was inspired by the recent discussion on editor performance we had during the frameworks squad hangout with @griffbrad and @jsnajdr.

#### Testing instructions

* Open `/post/:site` where `:site` is one of your sites.
* Verify that the masterbar is just an empty `div` and there are no visual regressions introduced.