### PR TITLE
Welcome Tour: Removed checks for translations

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/test/tour-steps.test.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/test/tour-steps.test.ts
@@ -2,7 +2,52 @@ import getTourSteps from '../tour-steps';
 
 describe( 'Welcome Tour', () => {
 	describe( 'Tour Steps', () => {
-		it( 'should retrieve the "Find your way" slide when on English Locale', () => {
+		it( 'should retrieve the "Welcome to WordPress!" slide', () => {
+			expect( getTourSteps( 'en', true ) ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						meta: expect.objectContaining( { heading: 'Welcome to WordPress!' } ),
+					} ),
+				] )
+			);
+		} );
+		it( 'should retrieve the "Everything is a block" slide', () => {
+			expect( getTourSteps( 'en', true ) ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						meta: expect.objectContaining( { heading: 'Everything is a block' } ),
+					} ),
+				] )
+			);
+		} );
+		it( 'should retrieve the "Adding a new block" slide', () => {
+			expect( getTourSteps( 'en', true ) ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						meta: expect.objectContaining( { heading: 'Adding a new block' } ),
+					} ),
+				] )
+			);
+		} );
+		it( 'should retrieve the "Click a block to change it" slide', () => {
+			expect( getTourSteps( 'en', true ) ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						meta: expect.objectContaining( { heading: 'Click a block to change it' } ),
+					} ),
+				] )
+			);
+		} );
+		it( 'should retrieve the "More Options" slide', () => {
+			expect( getTourSteps( 'en', true ) ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						meta: expect.objectContaining( { heading: 'More Options' } ),
+					} ),
+				] )
+			);
+		} );
+		it( 'should retrieve the "Find your way" slide', () => {
 			expect( getTourSteps( 'en', true ) ).toEqual(
 				expect.arrayContaining( [
 					expect.objectContaining( {
@@ -11,12 +56,29 @@ describe( 'Welcome Tour', () => {
 				] )
 			);
 		} );
-
-		it( 'should not retrieve the "Find your way" slide when on non-English Locale', () => {
-			expect( getTourSteps( 'nl', true ) ).not.toEqual(
+		it( 'should retrieve the "Undo any mistake" slide', () => {
+			expect( getTourSteps( 'en', true ) ).toEqual(
 				expect.arrayContaining( [
 					expect.objectContaining( {
-						meta: expect.objectContaining( { heading: 'Find your way' } ),
+						meta: expect.objectContaining( { heading: 'Undo any mistake' } ),
+					} ),
+				] )
+			);
+		} );
+		it( 'should retrieve the "Drag & drop" slide', () => {
+			expect( getTourSteps( 'en', true ) ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						meta: expect.objectContaining( { heading: 'Undo any mistake' } ),
+					} ),
+				] )
+			);
+		} );
+		it( 'should retrieve the "Congratulations!" slide, with correct url', () => {
+			expect( getTourSteps( 'en', true ) ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						meta: expect.objectContaining( { heading: 'Congratulations!' } ),
 					} ),
 				] )
 			);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.js
@@ -148,31 +148,27 @@ function getTourSteps( localeSlug, referencePositioning ) {
 				},
 			},
 		},
-		...( localeSlug === 'en'
-			? [
-					{
-						meta: {
-							heading: __( 'Find your way', 'full-site-editing' ),
-							descriptions: {
-								desktop: __(
-									"Use List View to see all the blocks you've added. Click and drag any block to move it around.",
-									'full-site-editing'
-								),
-								mobile: null,
-							},
-							imgSrc: getTourAssets( 'findYourWay' ),
-							animation: null,
-							isDesktopOnly: true,
-						},
-						options: {
-							classNames: {
-								desktop: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
-								mobile: 'wpcom-editor-welcome-tour__step',
-							},
-						},
-					},
-			  ]
-			: [] ),
+		{
+			meta: {
+				heading: __( 'Find your way', 'full-site-editing' ),
+				descriptions: {
+					desktop: __(
+						"Use List View to see all the blocks you've added. Click and drag any block to move it around.",
+						'full-site-editing'
+					),
+					mobile: null,
+				},
+				imgSrc: getTourAssets( 'findYourWay' ),
+				animation: null,
+				isDesktopOnly: true,
+			},
+			options: {
+				classNames: {
+					desktop: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+					mobile: 'wpcom-editor-welcome-tour__step',
+				},
+			},
+		},
 		{
 			referenceElements: referencePositioning && {
 				desktop:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removed checks used while waiting for translations of the [new slide](https://github.com/Automattic/wp-calypso/pull/59498) introduced in the Welcome Tour.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Checkout branch
* `yarn dev --sync` from `apps/editing-toolkit` to sync the welcome tour to the sandbox
* Check that the slide "Find your way" (6th on desktop) is correctly showing on desktop
* Change language in [https://wordpress.com/me/account](https://wordpress.com/me/account)
* Check that translations exist

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59498
