### PR TITLE
Announcement Modal: fix mobile close button positioning

### DIFF
--- a/client/blocks/announcement-modal/style.scss
+++ b/client/blocks/announcement-modal/style.scss
@@ -41,23 +41,22 @@ $modal-footer-height: 30px + ( $modal-footer-padding-v * 2 );
 		box-sizing: border-box;
 	}
 
+	.components-modal__content {
+		position: relative;
+	}
+
 	.components-modal__header {
 		display: block;
 		position: absolute;
 		text-align: right;
 
 		svg {
-			fill: white;
-			filter: drop-shadow( 0 0 1px black );
+			fill: currentColor;
+			filter: none;
 		}
 
 		@media ( min-width: $modal-breakpoint ) {
 			position: fixed;
-
-			svg {
-				fill: currentColor;
-				filter: none;
-			}
 		}
 	}
 


### PR DESCRIPTION
When the announcement modal is viewed on a modal device, the close button is lost in the top-right corner of the viewport. Since the announcement modal isn't 100% width and height, we should position the close button within the modal content itself.

Fixes: #61035

| Before      | After |
| ----------- | ----------- |
| <img width="331" alt="Screen Shot 2022-02-11 at 10 45 45 AM" src="https://user-images.githubusercontent.com/942359/153623040-32de0f70-1f9a-4a85-95f4-3553f104588b.png"> | <img width="335" alt="Screen Shot 2022-02-11 at 10 45 23 AM" src="https://user-images.githubusercontent.com/942359/153623082-e3fb507f-a3f8-4f7b-99b4-1af8b27a5c4a.png"> |

**To test:**
- In a mobile browser, on a new site, visit "plugins"
- verify that the close button matches the screenshot above
- verify that clicking the close button closes the modal
- Repeat on desktop to make sure nothing has changed