### PR TITLE
Enable FSE for all universal themes, clean up what we can

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-universal-themes/index.php
@@ -15,26 +15,18 @@ namespace A8C\FSE;
 define( 'ACTIVATE_FSE_OPTION_NAME', 'wpcom_is_fse_activated' );
 
 /**
- * Checks if Core's FSE is active via this plugin,
- * always returning false when `gutenberg_is_fse_theme` is false.
+ * TODO - NOTE - This function becomes unnecessary when we enable all universal themes to run in FSE
+ * mode as it can be replaced by `is_fse_theme`. We can clean this up after removing backend
+ * references.
+ *
+ * Checks if Core's FSE is active via this plugin, always returning false when
+ * `gutenberg_is_fse_theme` is false.
  *
  * @return boolean Core FSE is active.
  */
 function is_core_fse_active() {
-	// If `gutenberg_is_fse_theme` is false, this is a non-starter.
-	if ( ! is_fse_theme() ) {
-		return false;
-	}
-
-	if ( is_universal_theme() ) {
-		return (bool) get_option( ACTIVATE_FSE_OPTION_NAME );
-	}
-
-	// Universal themes can use the customizer to customize the site, regardless of whether or
-	// not the full site editor is activated. Block themes, however, don't have access to the
-	// customizer. If the site editor is disabled for them, it will severely limit site
-	// customizability. Because of this we always activate FSE for block themes.
-	return true;
+	// Always run FSE for eligible themes, including universal.
+	return is_fse_theme();
 }
 
 /**
@@ -71,8 +63,11 @@ function is_universal_theme() {
 }
 
 /**
- * Activates Core FSE by setting our option.
- * Note that even setting this option to true will make no difference on a classic theme.
+ * TODO - Cleanup once backend references are removed, this option is no longer required to run FSE
+ * for universal themes.
+ *
+ * Activates Core FSE by setting our option. Note that even setting this
+ * option to true will make no difference on a classic theme.
  *
  * @return void
  */
@@ -81,6 +76,9 @@ function activate_core_fse() {
 }
 
 /**
+ * TODO - Cleanup once backend references are removed, this option is no longer required to run FSE
+ * for universal themes.
+ *
  * Deactivates Core FSE by setting the option to NULL (matches the Options API).
  *
  * @return void
@@ -96,40 +94,17 @@ function deactivate_core_fse() {
  */
 function load_core_fse() {
 	// perfect parity would put the admin notices back but we don't want that.
-	add_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
-	add_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
-	add_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
 	add_action( 'admin_menu', __NAMESPACE__ . '\hide_nav_menus_submenu' );
-	remove_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
-	remove_action( 'restapi_theme_init', __NAMESPACE__ . '\hide_template_cpts', 11 );
-	remove_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
-	remove_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_template_editing', 11 );
-	remove_action( 'admin_menu', __NAMESPACE__ . '\hide_core_site_editor' );
 }
 
 /**
- * Unhooks anything that Gutenberg uses for Full Site Editing
+ * Unhooks the Gutenberg notice for Full Site Editing.
  *
  * @return void
  */
 function unload_core_fse() {
-	remove_action( 'admin_notices', 'gutenberg_full_site_editing_notice' );
-	remove_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
-	remove_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
-	remove_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
 	remove_action( 'admin_menu', __NAMESPACE__ . '\hide_nav_menus_submenu' );
-
-	if ( defined( 'REST_API_REQUEST' ) && true === REST_API_REQUEST ) {
-		// Do not hook to init during the REST API requests, as it causes PHP warnings
-		// while loading the alloptions (unable to access wp_0_ prefixed tables).
-		// Use the restapi_theme_init hook instead.
-		add_action( 'restapi_theme_init', __NAMESPACE__ . '\hide_template_cpts', 11 );
-	} else {
-		add_action( 'init', __NAMESPACE__ . '\hide_template_cpts', 11 );
-	}
-	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_fse_blocks' );
-	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\hide_template_editing', 11 );
-	add_action( 'admin_menu', __NAMESPACE__ . '\hide_core_site_editor' );
+	remove_action( 'admin_notices', 'gutenberg_full_site_editing_notice' );
 }
 
 /**
@@ -152,10 +127,6 @@ function load_helpers() {
 	// This menu toggles site editor visibility for universal themes.
 	// It's unnecessary for block themes because the site editor
 	// will always be visible.
-	if ( is_universal_theme() ) {
-		add_action( 'admin_menu', __NAMESPACE__ . '\add_submenu' );
-	}
-	add_action( 'admin_notices', __NAMESPACE__ . '\theme_nag' );
 	add_action( 'admin_init', __NAMESPACE__ . '\init_settings' );
 }
 
@@ -165,8 +136,6 @@ function load_helpers() {
  * @return void
  */
 function unload_helpers() {
-	remove_action( 'admin_notices', __NAMESPACE__ . '\theme_nag' );
-	remove_action( 'admin_menu', __NAMESPACE__ . '\add_submenu' );
 	remove_action( 'admin_init', __NAMESPACE__ . '\init_settings' );
 	remove_action( 'admin_menu', __NAMESPACE__ . '\maybe_juggle_amp_priority', 0 );
 }
@@ -189,200 +158,17 @@ function maybe_juggle_amp_priority() {
 }
 
 /**
- * Adds our submenu
- *
- * @return void
- */
-function add_submenu() {
-	add_options_page(
-		__( 'Full Site Editing (beta)', 'full-site-editing' ),
-		sprintf(
-		/* translators: %s: "beta" label. */
-			__( 'Full Site Editing %s', 'full-site-editing' ),
-			'<span class="awaiting-mod">' . esc_html__( 'beta', 'full-site-editing' ) . '</span>'
-		),
-		'manage_options',
-		'site-editor-toggle',
-		__NAMESPACE__ . '\menu_page'
-	);
-}
-
-/**
- * Prints an admin notice on the themes screen when an FSE theme is active and
- * this plugin's toggle is inactive. Links to our submenu for activation.
- *
- * @return void
- */
-function theme_nag() {
-	$is_active        = is_core_fse_active();
-	$is_themes_screen = 'themes' === get_current_screen()->id;
-	$is_fse_theme     = is_fse_theme();
-	if ( $is_active || ! $is_themes_screen || ! $is_fse_theme ) {
-		return;
-	}
-	$message = sprintf(
-		/* translators: %s: URL for linking to activation subpage */
-		__( 'You are running a theme capable of Full Site Editing! <a href="%s" class="button">Try the Site Editor</a>', 'full-site-editing' ),
-		admin_url( 'themes.php?page=site-editor-toggle' )
-	);
-	printf(
-		'<div class="notice is-dismissible"><p>%s</p></div>',
-		wp_kses(
-			$message,
-			array(
-				'a' => array(
-					'href'  => array(),
-					'class' => array(),
-				),
-			)
-		)
-	);
-
-}
-
-/**
- * Filter for `block_editor_settings_all` in order to prevent expermiental
- * blocks from showing up in the post editor when FSE is inactive.
- *
- * @param [array] $editor_settings Editor settings.
- * @return array Possibly modified editor settings.
- */
-function hide_fse_blocks( $editor_settings ) {
-	// this shouldn't even be hooked under this condition, but let's be sure.
-	if ( is_core_fse_active() ) {
-		return $editor_settings;
-	}
-	$editor_settings['__unstableEnableFullSiteEditingBlocks'] = false;
-	return $editor_settings;
-}
-
-/**
- * Filter for `block_editor_settings_all` in order to prevent template
- * editing from showing up in the post editor when FSE is inactive.
- *
- * @param [array] $editor_settings Editor settings.
- * @return array Possibly modified editor settings.
- */
-function hide_template_editing( $editor_settings ) {
-	// this shouldn't even be hooked under this condition, but let's be sure.
-	if ( is_core_fse_active() ) {
-		return $editor_settings;
-	}
-	$editor_settings['supportsTemplateMode'] = false;
-	return $editor_settings;
-}
-
-/**
- * Hides the Template and Template Part Custom Post Types' UI
- *
- * @return void
- */
-function hide_template_cpts() {
-	// This can interfere with Legacy FSE, bail if it's active.
-	if ( is_full_site_editing_active() ) {
-		return;
-	}
-	global $wp_post_types;
-	if ( isset( $wp_post_types['wp_template'] ) ) {
-		$wp_post_types['wp_template']->show_ui = false;
-	}
-	if ( isset( $wp_post_types['wp_template_part'] ) ) {
-		$wp_post_types['wp_template_part']->show_ui = false;
-	}
-}
-
-/**
- * Prints the screen for our toggle page
- *
- * @return void
- */
-function menu_page() {
-	?>
-	<div
-		id="site-editor-toggle"
-		class="wrap"
-	>
-	<h1><?php esc_html_e( 'Full Site Editing (beta)', 'full-site-editing' ); ?></h1>
-	<?php settings_errors(); ?>
-	<form method="post" action="options.php">
-		<?php settings_fields( 'site-editor-toggle' ); ?>
-		<?php do_settings_sections( 'site-editor-toggle' ); ?>
-		<?php submit_button(); ?>
-	</form>
-	</div>
-	<?php
-}
-
-/**
  * Adds our settings sections and fields
  *
  * @return void
  */
 function init_settings() {
-	add_settings_section(
-		'fse_toggle_section',
-		// The empty string ensures the render function won't output a h2.
-		'',
-		__NAMESPACE__ . '\display_fse_section',
-		'site-editor-toggle'
-	);
-	add_settings_field(
-		'fse-universal-theme-toggle',
-		__( 'Site Editor', 'full-site-editing' ),
-		__NAMESPACE__ . '\do_field',
-		'site-editor-toggle',
-		'fse_toggle_section'
-	);
+	// TODO - Clean up this setting registration once we clean up adding this setting on site
+	// creation.
 	register_setting(
 		'site-editor-toggle',
 		ACTIVATE_FSE_OPTION_NAME
 	);
-}
-
-/**
- * Prints our setting field
- *
- * @return void
- */
-function do_field() {
-	$value       = (bool) get_option( ACTIVATE_FSE_OPTION_NAME ) ? 1 : 0;
-	$for_sprintf = <<<HTML
-	<label for="%s">
-		<input type="checkbox" name="%s" id="%s" value="1" %s />
-		%s
-	</label>
-HTML;
-	// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-	printf(
-		$for_sprintf,
-		ACTIVATE_FSE_OPTION_NAME,
-		ACTIVATE_FSE_OPTION_NAME,
-		ACTIVATE_FSE_OPTION_NAME,
-		checked( 1, $value, false ),
-		esc_html__( 'Enable Site Editor', 'full-site-editing' )
-	);
-	// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
-}
-
-/**
- * Prints our settings section
- *
- * @return void
- */
-function display_fse_section() {
-	printf(
-		'<p>%s</p>',
-		esc_html__( 'The Site Editor is an exciting new direction for WordPress themes! Blocks are now the foundation of your whole site and everything is editable.', 'full-site-editing' )
-	);
-}
-
-/**
- * Hide the Core Site Editor (in addition to the Gutenberg one) when unloading Core FSE.
- *
- * @return void
- */
-function hide_core_site_editor() {
-	remove_submenu_page( 'themes.php', 'site-editor.php' );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables FSE for all universal themes.
* Cleans up what we can for now.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Take a non-FSE site running a universal themes.
* Apply this ETK build. Sandbox the public-api and the site.
* Verify the site editor becomes available and works as expected for universal-FSE.

Also test alongside D74666-code and verify FSE flows work as expected for an existing non-FSE eligible site.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
