### PR TITLE
Update the append breadcrumb logic to compare against an id.

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -166,6 +166,7 @@ class ActivityLog extends Component {
 			{
 				label: this.props.translate( 'Activity Log' ),
 				href: `/activity-log/${ this.props.slug || '' }`,
+				id: 'activity-log',
 			},
 		] );
 	}

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -203,6 +203,7 @@ function PluginDetails( props ) {
 				appendBreadcrumb( {
 					label: translate( 'Plugins' ),
 					href: `/plugins/${ selectedSite?.slug || '' }`,
+					id: 'plugins',
 				} )
 			);
 		}
@@ -212,6 +213,7 @@ function PluginDetails( props ) {
 				appendBreadcrumb( {
 					label: fullPlugin.name,
 					href: `/plugins/${ fullPlugin.slug }/${ selectedSite?.slug || '' }`,
+					id: `plugin-${ fullPlugin.slug }`,
 				} )
 			);
 		}

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -157,11 +157,14 @@ const PluginsBrowser = ( {
 	}, [ isJetpack, selectedSite, hasJetpack ] );
 
 	useEffect( () => {
-		const items = [ { label: translate( 'Plugins' ), href: `/plugins/${ siteSlug || '' }` } ];
+		const items = [
+			{ label: translate( 'Plugins' ), href: `/plugins/${ siteSlug || '' }`, id: 'plugins' },
+		];
 		if ( search ) {
 			items.push( {
 				label: translate( 'Search Results' ),
 				href: `/plugins/${ siteSlug || '' }?s=${ search }`,
+				id: 'plugins-search',
 			} );
 		}
 

--- a/client/state/breadcrumb/reducer.js
+++ b/client/state/breadcrumb/reducer.js
@@ -12,11 +12,11 @@ export default ( state = [], action ) => {
 		case BREADCRUMB_UPDATE_LIST:
 			return [ ...action.items ];
 		case BREADCRUMB_APPEND_ITEM:
-			// Don't append if it is the same as the last item
+			// If it is the same kind as the last item, replace it.
 			// eslint-disable-next-line no-case-declarations
 			const currentLastItem = state[ state.length - 1 ] || {};
-			if ( currentLastItem.label === action.item?.label ) {
-				return [ ...state ];
+			if ( currentLastItem.id === action.item?.id ) {
+				state.pop();
 			}
 
 			return [ ...state, action.item ];


### PR DESCRIPTION
### Problem
When the plugin name gets updated while the user is already on the plugin details screen, it will get the breadcrumb adding more items on each name change. 


![Kapture 2022-02-11 at 15 24 47](https://user-images.githubusercontent.com/5039531/153650263-cd3a7fb4-27f7-4ced-b939-b5365c03e4e2.gif)

Currently, the plugin details look for plugin information on 3 sources: the WPCom directory, the WPOrg directory, and the list of installed plugins. If the information from another source with higher priority is received, the information is updated. And this can cause the issue mentioned above.


### Changes proposed in this Pull Request

Update the append breadcrumb logic to compare against an id.

Before this change, when the label of an item gets changed, it turns out to duplicate the item.
After this change, if the last item has the same id as the appended version, it will get replaced.

### Testing instructions
* Install mailpoet on your site
* Go to `Jetpack -> Activity Log`
* Click on MailPeet on the jetpack log
* Check if the breadcrumbs show only one item for MailPoet

### Demo
![Kapture 2022-02-11 at 15 42 56](https://user-images.githubusercontent.com/5039531/153650793-2401ac91-cdf8-41ec-9393-fa49588caeb2.gif)

