### PR TITLE
View Switcher: Add Tracking and update tab label

### DIFF
--- a/client/components/screen-options-tab/index.js
+++ b/client/components/screen-options-tab/index.js
@@ -2,6 +2,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 import versionCompare from 'calypso/lib/version-compare';
 import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
@@ -17,7 +18,7 @@ const isBoolean = ( val ) => 'boolean' === typeof val;
 const ScreenOptionsTab = ( { wpAdminPath } ) => {
 	const ref = useRef( null );
 	const [ isOpen, setIsOpen ] = useState( false );
-	const { __ } = useI18n();
+	const { _x } = useI18n();
 	const dispatch = useDispatch();
 
 	const siteId = useSelector( getSelectedSiteId );
@@ -32,6 +33,7 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 		( bool ) => {
 			if ( isBoolean( bool ) ) {
 				setIsOpen( bool );
+				bumpStat( 'view-switcher', 'open' );
 			} else {
 				setIsOpen( ! isOpen );
 			}
@@ -86,6 +88,7 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 	}
 
 	const onSwitchView = ( view ) => {
+		bumpStat( 'view-switcher-preference', view );
 		if ( view === DEFAULT_VIEW ) {
 			setIsOpen( false );
 		}
@@ -94,7 +97,9 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 	return (
 		<div className="screen-options-tab" ref={ ref } data-testid="screen-options-tab">
 			<button className="screen-options-tab__button" onClick={ handleToggle }>
-				<span className="screen-options-tab__label">{ __( 'Screen Options' ) }</span>
+				<span className="screen-options-tab__label">
+					{ _x( 'View', 'View options to switch between' ) }
+				</span>
 				<span
 					className={ classNames( 'screen-options-tab__icon', {
 						'screen-options-tab__icon--open': isOpen,

--- a/client/components/screen-options-tab/index.js
+++ b/client/components/screen-options-tab/index.js
@@ -89,12 +89,14 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 	}
 
 	const onSwitchView = ( view ) => {
-		recordTracksEvent( 'wpcom_dashboard_quick_switch_link_clicked', {
-			blog_id: siteId,
-			current_page: wpAdminPath,
-			destination: view,
-			plan,
-		} );
+		dispatch(
+			recordTracksEvent( 'wpcom_dashboard_quick_switch_link_clicked', {
+				blog_id: siteId,
+				current_page: wpAdminPath,
+				destination: view,
+				plan,
+			} )
+		);
 
 		if ( view === DEFAULT_VIEW ) {
 			setIsOpen( false );

--- a/client/components/screen-options-tab/index.js
+++ b/client/components/screen-options-tab/index.js
@@ -2,11 +2,12 @@ import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { bumpStat } from 'calypso/lib/analytics/mc';
 import versionCompare from 'calypso/lib/version-compare';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite, getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ScreenSwitcher, { DEFAULT_VIEW } from './screen-switcher';
@@ -28,12 +29,12 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 		getSiteOption( state, siteId, 'jetpack_version' )
 	);
 	const isSsoActive = useSelector( ( state ) => isJetpackModuleActive( state, siteId, 'sso' ) );
+	const plan = useSelector( ( state ) => getSitePlanSlug( state, siteId ) );
 
 	const handleToggle = useCallback(
 		( bool ) => {
 			if ( isBoolean( bool ) ) {
 				setIsOpen( bool );
-				bumpStat( 'view-switcher', 'open' );
 			} else {
 				setIsOpen( ! isOpen );
 			}
@@ -88,7 +89,13 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 	}
 
 	const onSwitchView = ( view ) => {
-		bumpStat( 'view-switcher-preference', view );
+		recordTracksEvent( 'wpcom_dashboard_quick_switch_link_clicked', {
+			blog_id: siteId,
+			current_page: wpAdminPath,
+			destination: view,
+			plan,
+		} );
+
 		if ( view === DEFAULT_VIEW ) {
 			setIsOpen( false );
 		}

--- a/client/components/screen-options-tab/index.js
+++ b/client/components/screen-options-tab/index.js
@@ -90,7 +90,7 @@ const ScreenOptionsTab = ( { wpAdminPath } ) => {
 
 	const onSwitchView = ( view ) => {
 		dispatch(
-			recordTracksEvent( 'wpcom_dashboard_quick_switch_link_clicked', {
+			recordTracksEvent( 'calypso_dashboard_quick_switch_link_clicked', {
 				blog_id: siteId,
 				current_page: wpAdminPath,
 				destination: view,


### PR DESCRIPTION
Also updates the tab label to differ from screen options in wp-admin, so the same UI can be re-used there.

#### Changes proposed in this Pull Request

* Bumps stats for when the View tab is opened
* Bumps stat for when a view is selected.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the posts screen for a test site.
* Open dev tools and select the navigation tab.
* Click the View tab in the top right of the screen and select a preferred view
* Verify that g.gif requests are sent for those clicks.

Before | After
---|---
<img width="256" alt="Screen Shot 2022-02-11 at 12 54 04 PM" src="https://user-images.githubusercontent.com/1398304/153668836-d7ec89b3-43e3-4b4f-9588-a9e7b2c93cfd.png"> | <img width="257" alt="Screen Shot 2022-02-11 at 12 54 31 PM" src="https://user-images.githubusercontent.com/1398304/153668844-e8391f3c-6ce6-4463-b465-dff5d622de30.png">

There will be a corresponding Jetpack PR that will change the wp-admin version to look the same.