### PR TITLE
App Download CTA Test: Replace loadExperimentAssignment with ProvideExperimentData

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -7,6 +7,7 @@ import { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { ProvideExperimentData } from 'calypso/lib/explat';
 import versionCompare from 'calypso/lib/version-compare';
 import {
 	bumpStat,
@@ -30,7 +31,6 @@ import {
 	getNewDismissTimes,
 	getCurrentSection,
 	APP_BANNER_DISMISS_TIMES_PREFERENCE,
-	APP_BANNER_EXPERIMENT_NAME,
 } from './utils';
 
 import './style.scss';
@@ -151,45 +151,56 @@ export class AppBanner extends Component {
 		const { title, copy } = getAppBannerData( translate, currentSection );
 
 		return (
-			<div className={ classNames( 'app-banner-overlay' ) } ref={ this.preventNotificationsClose }>
-				<Card
-					className={ classNames( 'app-banner', 'is-compact', currentSection ) }
-					ref={ this.preventNotificationsClose }
-				>
-					<TrackComponentView
-						eventName="calypso_mobile_app_banner_impression"
-						eventProperties={ {
-							page: currentSection,
-						} }
-						statGroup="calypso_mobile_app_banner"
-						statName="impression"
-					/>
-					<div className="app-banner__circle is-top-left is-yellow" />
-					<div className="app-banner__circle is-top-right is-blue" />
-					<div className="app-banner__circle is-bottom-right is-red" />
-					<div className="app-banner__text-content">
-						<div className="app-banner__title">
-							<span> { title } </span>
-						</div>
-						<div className="app-banner__copy">
-							<span> { copy } </span>
-						</div>
-					</div>
-					<div className="app-banner__buttons">
-						<Button
-							primary
-							className="app-banner__open-button"
-							onClick={ this.openApp }
-							href={ this.getDeepLink() }
+			<ProvideExperimentData name="calypso_mobileweb_appbanner_frequency_20220128_v1">
+				{ ( isLoading, experimentAssignment ) => {
+					this.experimentIsControl = isLoading ? true : ! experimentAssignment?.variationName;
+
+					return (
+						<div
+							className={ classNames( 'app-banner-overlay' ) }
+							ref={ this.preventNotificationsClose }
 						>
-							{ translate( 'Open in app' ) }
-						</Button>
-						<Button className="app-banner__no-thanks-button" onClick={ this.dismiss }>
-							{ translate( 'No thanks' ) }
-						</Button>
-					</div>
-				</Card>
-			</div>
+							<Card
+								className={ classNames( 'app-banner', 'is-compact', currentSection ) }
+								ref={ this.preventNotificationsClose }
+							>
+								<TrackComponentView
+									eventName="calypso_mobile_app_banner_impression"
+									eventProperties={ {
+										page: currentSection,
+									} }
+									statGroup="calypso_mobile_app_banner"
+									statName="impression"
+								/>
+								<div className="app-banner__circle is-top-left is-yellow" />
+								<div className="app-banner__circle is-top-right is-blue" />
+								<div className="app-banner__circle is-bottom-right is-red" />
+								<div className="app-banner__text-content">
+									<div className="app-banner__title">
+										<span> { title } </span>
+									</div>
+									<div className="app-banner__copy">
+										<span> { copy } </span>
+									</div>
+								</div>
+								<div className="app-banner__buttons">
+									<Button
+										primary
+										className="app-banner__open-button"
+										onClick={ this.openApp }
+										href={ this.getDeepLink() }
+									>
+										{ translate( 'Open in app' ) }
+									</Button>
+									<Button className="app-banner__no-thanks-button" onClick={ this.dismiss }>
+										{ translate( 'No thanks' ) }
+									</Button>
+								</div>
+							</Card>
+						</div>
+					);
+				} }
+			</ProvideExperimentData>
 		);
 	}
 }

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -154,6 +154,8 @@ export class AppBanner extends Component {
 			<ProvideExperimentData name="calypso_mobileweb_appbanner_frequency_20220128_v1">
 				{ ( isLoading, experimentAssignment ) => {
 					this.experimentIsControl = isLoading ? true : ! experimentAssignment?.variationName;
+						return null;
+					}
 
 					return (
 						<div

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -106,11 +106,11 @@ export class AppBanner extends Component {
 		return this.isiOS() || this.isAndroid();
 	}
 
-	dismiss = ( event ) => {
+	dismiss = ( experimentIsControl, event ) => {
 		event.preventDefault();
-		const { currentSection, dismissedUntil } = this.props;
 
-		this.props.saveDismissTime( currentSection, dismissedUntil, this.experimentIsControl );
+		const { currentSection, dismissedUntil } = this.props;
+		this.props.saveDismissTime( currentSection, dismissedUntil, experimentIsControl );
 		this.props.dismissAppBanner();
 	};
 
@@ -153,7 +153,7 @@ export class AppBanner extends Component {
 		return (
 			<ProvideExperimentData name="calypso_mobileweb_appbanner_frequency_20220128_v1">
 				{ ( isLoading, experimentAssignment ) => {
-					this.experimentIsControl = isLoading ? true : ! experimentAssignment?.variationName;
+					if ( isLoading ) {
 						return null;
 					}
 
@@ -194,7 +194,10 @@ export class AppBanner extends Component {
 									>
 										{ translate( 'Open in app' ) }
 									</Button>
-									<Button className="app-banner__no-thanks-button" onClick={ this.dismiss }>
+									<Button
+										className="app-banner__no-thanks-button"
+										onClick={ this.dismiss.bind( null, ! experimentAssignment?.variationName ) }
+									>
 										{ translate( 'No thanks' ) }
 									</Button>
 								</div>

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -151,7 +151,7 @@ export class AppBanner extends Component {
 		const { title, copy } = getAppBannerData( translate, currentSection );
 
 		return (
-			<ProvideExperimentData name="calypso_mobileweb_appbanner_frequency_20220128_v1">
+			<ProvideExperimentData name="calypso_mobileweb_appbanner_frequency_20220128_v2">
 				{ ( isLoading, experimentAssignment ) => {
 					if ( isLoading ) {
 						return null;

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -7,7 +7,6 @@ import { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import versionCompare from 'calypso/lib/version-compare';
 import {
 	bumpStat,
@@ -71,15 +70,6 @@ export class AppBanner extends Component {
 		} else {
 			this.state = { isDraftPostModalShown: false };
 		}
-	}
-
-	loadDismissTimesExperiment() {
-		// Set a default value just in case the assignment hasn't loaded yet
-		this.experimentIsControl = true;
-
-		loadExperimentAssignment( APP_BANNER_EXPERIMENT_NAME ).then( ( experimentObject ) => {
-			this.experimentIsControl = ! experimentObject?.variationName;
-		} );
 	}
 
 	stopBubblingEvents = ( event ) => {
@@ -157,8 +147,6 @@ export class AppBanner extends Component {
 		if ( ! this.props.shouldDisplayAppBanner || this.state.isDraftPostModalShown ) {
 			return null;
 		}
-
-		this.loadDismissTimesExperiment();
 
 		const { title, copy } = getAppBannerData( translate, currentSection );
 

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -12,7 +12,6 @@ export const ONE_MONTH_IN_MILLISECONDS = 2419200000; // 28 days
 // Experiment Configuration
 export const TWO_WEEKS_IN_MILLISECONDS = 1209600000;
 export const ONE_DAY_IN_MILLISECONDS = 86400000;
-export const APP_BANNER_EXPERIMENT_NAME = 'calypso_mobileweb_appbanner_frequency_20220128_v1';
 
 export function getAppBannerData( translate, sectionName ) {
 	switch ( sectionName ) {


### PR DESCRIPTION
Ref: https://github.com/Automattic/wp-calypso/pull/60830#pullrequestreview-879581805

#### Changes proposed in this Pull Request

Replaces the loadExperimentAssignment with ProvideExperimentData

#### Testing instructions

1. Apply the PR
2. Enable "mobile" testing mode using dev tools in your browser of choice
3. Go to http://calypso.localhost:3000/read
4. Verify you see the 'Open In App' banner (see screenshots above)
5. If you do not, you can reset your preferences by entering Desktop mode in your browser, hovering the Dev button in the bottom right, then preferences, then tapping the X next to `appBannerDismissTimes`. Then reload the page
6. Tap the no thanks button
7. Enter Desktop mode and enter the dev preferences again, and look for: `appBannerDismissTimes`
8. Verify the section you were currently on's timestamp is set for 1 month from now
8.a Note: You can test this by pasting the timestamp into: https://www.unixtimestamp.com/
9. Verify the other sections are set for 1 week from now
10. Delete the preference
11. Open the file: `/client/blocks/app-banner/index.jsx`
12. Go to line: 81
13. Change: `const variationName = experimentObject.variationName;` to `const variationName = "hello"`;
14. Reload and tap the no thanks button
15. Enter the dev preferences again and look at the `appBannerDismissTimes`
16. Verify the current section's timestamp is set to 2 weeks from now
17. Verify the other sections are set for 1 day from now
