### PR TITLE
Update inline-help widgets path

### DIFF
--- a/apps/happychat/README.md
+++ b/apps/happychat/README.md
@@ -1,3 +1,5 @@
 # Happychat
 
-This package contains an extracted happychat widget which can be used in wp-admin or other contexts.
+This code is developed in the calypso monorepo at <https://github.com/Automattic/wp-calypso/tree/trunk/apps/happychat>.
+
+This app contains an extracted happychat widget which can be used in wp-admin or other contexts.

--- a/apps/inline-help/README.md
+++ b/apps/inline-help/README.md
@@ -1,3 +1,5 @@
 # Inline Help
 
-This package contains an extracted inline help widget which can be used in wp-admin or other contexts.
+This code is developed in the calypso monorepo at <https://github.com/Automattic/wp-calypso/tree/trunk/apps/inline-help>.
+
+This app contains an extracted inline help widget which can be used in wp-admin or other contexts.

--- a/apps/inline-help/package.json
+++ b/apps/inline-help/package.json
@@ -20,7 +20,7 @@
 		"clean": "npx rimraf dist",
 		"build": "NODE_ENV=production yarn dev",
 		"build:inline-help": "calypso-build",
-		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/inline-help",
+		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/calypso-inline-help",
 		"dev-server": "webpack serve",
 		"show-stats": "NODE_ENV=production EMIT_STATS=true yarn build"
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the path for inline-help to use the new name we decided on.

#### Testing instructions

`yarn dev --sync` from `apps/inline-help` should sync changes to `public_html/widgets.wp.com/calypso-inline-help`