### PR TITLE
Fix Titan URLs for staging platforms

### DIFF
--- a/client/lib/titan/get-titan-urls.js
+++ b/client/lib/titan/get-titan-urls.js
@@ -10,14 +10,14 @@ const TITAN_APPS = {
 /**
  * Generates a URL pointing to the given Titan App
  *
- * @param {undefined|{titanMailSubscription?:{webmailUrl?: string}}} domain - Domain object
+ * @param {undefined|{titanMailSubscription?:{appsUrl?: string}}} domain - Domain object
  * @param {string?} email - The email address of the Titan account. Used for autofill on Titan's login page.
  * @param {string?} app - Can be one of the `TITAN_APPS` - `email`, `calendar` or `contacts`
  * @param {boolean?} clearPreviousSessions - Whether to clear previously logged-in sessions.
  * @returns The URL with app and prefilled `email_account` as query parameter
  */
 function getTitanUrl( domain, email, app = TITAN_APPS.EMAIL, clearPreviousSessions = false ) {
-	const titanBaseUrl = domain?.titanMailSubscription?.webmailUrl ?? 'https://wp.titan.email';
+	const titanBaseUrl = domain?.titanMailSubscription?.appsUrl ?? 'https://wp.titan.email';
 	const titanAppUrl = new URL( `${ titanBaseUrl }/${ app }/` );
 
 	if ( email?.includes( '@' ) ) {

--- a/client/lib/titan/get-titan-urls.js
+++ b/client/lib/titan/get-titan-urls.js
@@ -4,20 +4,21 @@
 const TITAN_APPS = {
 	CALENDAR: 'calendar',
 	CONTACTS: 'contacts',
-	EMAIL: 'email',
+	MAIL: 'mail',
 };
 
 /**
  * Generates a URL pointing to the given Titan App
  *
+ * @param {undefined|{titanMailSubscription?:{baseUrl?: string}}} domain - Domain object
  * @param {string?} email - The email address of the Titan account. Used for autofill on Titan's login page.
  * @param {string?} app - Can be one of the `TITAN_APPS` - `email`, `calendar` or `contacts`
- * @param {boolean?} clearPreviousSessions - Whether to clear previously logged in sessions.
+ * @param {boolean?} clearPreviousSessions - Whether to clear previously logged-in sessions.
  * @returns The URL with app and prefilled `email_account` as query parameter
  */
-function getTitanUrl( email, app = TITAN_APPS.EMAIL, clearPreviousSessions = false ) {
-	const titanBaseUrl = 'https://wp.titan.email';
-	const titanAppUrl = new URL( `${ titanBaseUrl }/${ app }` );
+function getTitanUrl( domain, email, app = TITAN_APPS.MAIL, clearPreviousSessions = false ) {
+	const titanBaseUrl = domain?.titanMailSubscription?.baseUrl ?? 'https://wp.titan.email';
+	const titanAppUrl = new URL( `${ titanBaseUrl }/${ app }/` );
 
 	if ( email?.includes( '@' ) ) {
 		titanAppUrl.searchParams.append( 'email_account', email );
@@ -30,14 +31,14 @@ function getTitanUrl( email, app = TITAN_APPS.EMAIL, clearPreviousSessions = fal
 	return titanAppUrl.href;
 }
 
-export function getTitanCalendarlUrl( email ) {
-	return getTitanUrl( email, TITAN_APPS.CALENDAR );
+export function getTitanCalendarlUrl( domain, email ) {
+	return getTitanUrl( domain, email, TITAN_APPS.CALENDAR );
 }
 
-export function getTitanContactsUrl( email ) {
-	return getTitanUrl( email, TITAN_APPS.CONTACTS );
+export function getTitanContactsUrl( domain, email ) {
+	return getTitanUrl( domain, email, TITAN_APPS.CONTACTS );
 }
 
-export function getTitanEmailUrl( email, clearPreviousSessions = false ) {
-	return getTitanUrl( email, TITAN_APPS.EMAIL, clearPreviousSessions );
+export function getTitanEmailUrl( domain, email, clearPreviousSessions = false ) {
+	return getTitanUrl( domain, email, TITAN_APPS.MAIL, clearPreviousSessions );
 }

--- a/client/lib/titan/get-titan-urls.js
+++ b/client/lib/titan/get-titan-urls.js
@@ -8,17 +8,31 @@ const TITAN_APPS = {
 };
 
 /**
- * Generates a URL pointing to the given Titan App
+ * Returns the base URL for Titan Apps
  *
  * @param {undefined|{titanMailSubscription?:{appsUrl?: string}}} domain - Domain object
+ * @returns {string} - The Apps URL prefix
+ */
+export function getTitanAppsUrlPrefix( domain ) {
+	return domain?.titanMailSubscription?.appsUrl ?? 'https://wp.titan.email';
+}
+
+/**
+ * Generates a URL pointing to the given Titan App
+ *
+ * @param {string} titanAppsUrlPrefix - The base url for Titan Apps
  * @param {string?} email - The email address of the Titan account. Used for autofill on Titan's login page.
  * @param {string?} app - Can be one of the `TITAN_APPS` - `email`, `calendar` or `contacts`
  * @param {boolean?} clearPreviousSessions - Whether to clear previously logged-in sessions.
  * @returns The URL with app and prefilled `email_account` as query parameter
  */
-function getTitanUrl( domain, email, app = TITAN_APPS.EMAIL, clearPreviousSessions = false ) {
-	const titanBaseUrl = domain?.titanMailSubscription?.appsUrl ?? 'https://wp.titan.email';
-	const titanAppUrl = new URL( `${ titanBaseUrl }/${ app }/` );
+function getTitanUrl(
+	titanAppsUrlPrefix,
+	email,
+	app = TITAN_APPS.EMAIL,
+	clearPreviousSessions = false
+) {
+	const titanAppUrl = new URL( `${ titanAppsUrlPrefix }/${ app }/` );
 
 	if ( email?.includes( '@' ) ) {
 		titanAppUrl.searchParams.append( 'email_account', email );
@@ -31,14 +45,14 @@ function getTitanUrl( domain, email, app = TITAN_APPS.EMAIL, clearPreviousSessio
 	return titanAppUrl.href;
 }
 
-export function getTitanCalendarUrl( domain, email ) {
-	return getTitanUrl( domain, email, TITAN_APPS.CALENDAR );
+export function getTitanCalendarUrl( titanAppsUrlPrefix, email ) {
+	return getTitanUrl( titanAppsUrlPrefix, email, TITAN_APPS.CALENDAR );
 }
 
-export function getTitanContactsUrl( domain, email ) {
-	return getTitanUrl( domain, email, TITAN_APPS.CONTACTS );
+export function getTitanContactsUrl( titanAppsUrlPrefix, email ) {
+	return getTitanUrl( titanAppsUrlPrefix, email, TITAN_APPS.CONTACTS );
 }
 
-export function getTitanEmailUrl( domain, email, clearPreviousSessions = false ) {
-	return getTitanUrl( domain, email, TITAN_APPS.EMAIL, clearPreviousSessions );
+export function getTitanEmailUrl( titanAppsUrlPrefix, email, clearPreviousSessions = false ) {
+	return getTitanUrl( titanAppsUrlPrefix, email, TITAN_APPS.EMAIL, clearPreviousSessions );
 }

--- a/client/lib/titan/get-titan-urls.js
+++ b/client/lib/titan/get-titan-urls.js
@@ -4,7 +4,7 @@
 const TITAN_APPS = {
 	CALENDAR: 'calendar',
 	CONTACTS: 'contacts',
-	MAIL: 'mail',
+	EMAIL: 'mail',
 };
 
 /**
@@ -16,7 +16,7 @@ const TITAN_APPS = {
  * @param {boolean?} clearPreviousSessions - Whether to clear previously logged-in sessions.
  * @returns The URL with app and prefilled `email_account` as query parameter
  */
-function getTitanUrl( domain, email, app = TITAN_APPS.MAIL, clearPreviousSessions = false ) {
+function getTitanUrl( domain, email, app = TITAN_APPS.EMAIL, clearPreviousSessions = false ) {
 	const titanBaseUrl = domain?.titanMailSubscription?.baseUrl ?? 'https://wp.titan.email';
 	const titanAppUrl = new URL( `${ titanBaseUrl }/${ app }/` );
 
@@ -31,7 +31,7 @@ function getTitanUrl( domain, email, app = TITAN_APPS.MAIL, clearPreviousSession
 	return titanAppUrl.href;
 }
 
-export function getTitanCalendarlUrl( domain, email ) {
+export function getTitanCalendarUrl( domain, email ) {
 	return getTitanUrl( domain, email, TITAN_APPS.CALENDAR );
 }
 
@@ -40,5 +40,5 @@ export function getTitanContactsUrl( domain, email ) {
 }
 
 export function getTitanEmailUrl( domain, email, clearPreviousSessions = false ) {
-	return getTitanUrl( domain, email, TITAN_APPS.MAIL, clearPreviousSessions );
+	return getTitanUrl( domain, email, TITAN_APPS.EMAIL, clearPreviousSessions );
 }

--- a/client/lib/titan/get-titan-urls.js
+++ b/client/lib/titan/get-titan-urls.js
@@ -10,14 +10,14 @@ const TITAN_APPS = {
 /**
  * Generates a URL pointing to the given Titan App
  *
- * @param {undefined|{titanMailSubscription?:{baseUrl?: string}}} domain - Domain object
+ * @param {undefined|{titanMailSubscription?:{webmailUrl?: string}}} domain - Domain object
  * @param {string?} email - The email address of the Titan account. Used for autofill on Titan's login page.
  * @param {string?} app - Can be one of the `TITAN_APPS` - `email`, `calendar` or `contacts`
  * @param {boolean?} clearPreviousSessions - Whether to clear previously logged-in sessions.
  * @returns The URL with app and prefilled `email_account` as query parameter
  */
 function getTitanUrl( domain, email, app = TITAN_APPS.EMAIL, clearPreviousSessions = false ) {
-	const titanBaseUrl = domain?.titanMailSubscription?.baseUrl ?? 'https://wp.titan.email';
+	const titanBaseUrl = domain?.titanMailSubscription?.webmailUrl ?? 'https://wp.titan.email';
 	const titanAppUrl = new URL( `${ titanBaseUrl }/${ app }/` );
 
 	if ( email?.includes( '@' ) ) {

--- a/client/lib/titan/hooks/use-first-titan-domain-for-current-site.ts
+++ b/client/lib/titan/hooks/use-first-titan-domain-for-current-site.ts
@@ -1,0 +1,11 @@
+import { useSelector } from 'react-redux';
+import { hasTitanMailWithUs } from 'calypso/lib/titan';
+import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
+
+export default function useFirstTitanDomainForCurrentSite(): SiteDomain | undefined {
+	const siteId = useSelector( getSelectedSiteId );
+	const siteDomains = useSiteDomains( siteId ?? undefined );
+	return siteDomains.find( hasTitanMailWithUs );
+}

--- a/client/lib/titan/hooks/use-titan-apps-url-prefix.ts
+++ b/client/lib/titan/hooks/use-titan-apps-url-prefix.ts
@@ -1,7 +1,7 @@
 import { getTitanAppsUrlPrefix } from 'calypso/lib/titan/get-titan-urls';
 import useFirstTitanDomainForCurrentSite from 'calypso/lib/titan/hooks/use-first-titan-domain-for-current-site';
 
-export default function useTitanAppsUrlPrefix(): string {
+export function useTitanAppsUrlPrefix(): string {
 	const firstTitanDomain = useFirstTitanDomainForCurrentSite();
 	return getTitanAppsUrlPrefix( firstTitanDomain );
 }

--- a/client/lib/titan/hooks/use-titan-apps-url-prefix.ts
+++ b/client/lib/titan/hooks/use-titan-apps-url-prefix.ts
@@ -1,0 +1,7 @@
+import { getTitanAppsUrlPrefix } from 'calypso/lib/titan/get-titan-urls';
+import useFirstTitanDomainForCurrentSite from 'calypso/lib/titan/hooks/use-first-titan-domain-for-current-site';
+
+export default function useTitanAppsUrlPrefix(): string {
+	const firstTitanDomain = useFirstTitanDomainForCurrentSite();
+	return getTitanAppsUrlPrefix( firstTitanDomain );
+}

--- a/client/lib/titan/index.js
+++ b/client/lib/titan/index.js
@@ -12,3 +12,4 @@ export { getTitanCalendarUrl, getTitanContactsUrl, getTitanEmailUrl } from './ge
 export { hasTitanMailWithUs } from './has-titan-mail-with-us';
 export { isDomainEligibleForTitanFreeTrial } from './is-domain-eligible-for-titan-free-trial';
 export { isTitanMonthlyProduct } from './is-titan-monthly-product';
+export { useTitanAppsUrlPrefix } from './hooks/use-titan-apps-url-prefix';

--- a/client/lib/titan/index.js
+++ b/client/lib/titan/index.js
@@ -8,7 +8,7 @@ export { getTitanMailOrderId } from './get-titan-mail-order-id';
 export { getTitanProductName } from './get-titan-product-name';
 export { getTitanProductSlug } from './get-titan-product-slug';
 export { getTitanSubscriptionId } from './get-titan-subscription-id';
-export { getTitanCalendarlUrl, getTitanContactsUrl, getTitanEmailUrl } from './get-titan-urls';
+export { getTitanCalendarUrl, getTitanContactsUrl, getTitanEmailUrl } from './get-titan-urls';
 export { hasTitanMailWithUs } from './has-titan-mail-with-us';
 export { isDomainEligibleForTitanFreeTrial } from './is-domain-eligible-for-titan-free-trial';
 export { isTitanMonthlyProduct } from './is-titan-monthly-product';

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
@@ -1,7 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
-import { getTitanEmailUrl } from 'calypso/lib/titan';
-import useTitanAppsUrlPrefix from 'calypso/lib/titan/hooks/use-titan-apps-url-prefix';
+import { getTitanEmailUrl, useTitanAppsUrlPrefix } from 'calypso/lib/titan';
 import DomainMappingProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-mapping';
 import DomainRegistrationThankYouProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration';
 import DomainTransferProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-transfer';

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
@@ -1,22 +1,19 @@
 import { Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
-import { getTitanEmailUrl, hasTitanMailWithUs } from 'calypso/lib/titan';
+import { getTitanEmailUrl } from 'calypso/lib/titan';
+import useTitanAppsUrlPrefix from 'calypso/lib/titan/hooks/use-titan-apps-url-prefix';
 import DomainMappingProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-mapping';
 import DomainRegistrationThankYouProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration';
 import DomainTransferProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-transfer';
-import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { ThankYouNextStepProps } from 'calypso/components/thank-you/types';
 import type {
 	DomainThankYouParams,
 	DomainThankYouPropsGetter,
 	DomainThankYouType,
 } from 'calypso/my-sites/checkout/checkout-thank-you/domains/types';
-import type { FunctionComponent } from 'react';
 
 const thankYouContentGetter: Record< DomainThankYouType, DomainThankYouPropsGetter > = {
 	MAPPING: DomainMappingProps,
@@ -32,14 +29,12 @@ interface StepCTAProps {
 	primary: boolean;
 }
 
-const StepCTA: FunctionComponent< StepCTAProps > = ( { email, primary, domainType } ) => {
-	const siteId = useSelector( getSelectedSiteId );
-	const domains = useSiteDomains( siteId ?? undefined );
-	const firstTitanDomain = domains.find( hasTitanMailWithUs );
+const StepCTA = ( { email, primary, domainType }: StepCTAProps ): JSX.Element => {
+	const titanAppsUrlPrefix = useTitanAppsUrlPrefix();
 
 	return (
 		<FullWidthButton
-			href={ getTitanEmailUrl( firstTitanDomain, email, true ) }
+			href={ getTitanEmailUrl( titanAppsUrlPrefix, email, true ) }
 			target="_blank"
 			primary={ primary }
 			onClick={ () => {

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
@@ -1,18 +1,22 @@
 import { Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
-import { getTitanEmailUrl } from 'calypso/lib/titan';
+import { useSelector } from 'react-redux';
+import { getTitanEmailUrl, hasTitanMailWithUs } from 'calypso/lib/titan';
 import DomainMappingProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-mapping';
 import DomainRegistrationThankYouProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration';
 import DomainTransferProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-transfer';
+import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { ThankYouNextStepProps } from 'calypso/components/thank-you/types';
 import type {
 	DomainThankYouParams,
 	DomainThankYouPropsGetter,
 	DomainThankYouType,
 } from 'calypso/my-sites/checkout/checkout-thank-you/domains/types';
+import type { FunctionComponent } from 'react';
 
 const thankYouContentGetter: Record< DomainThankYouType, DomainThankYouPropsGetter > = {
 	MAPPING: DomainMappingProps,
@@ -21,6 +25,36 @@ const thankYouContentGetter: Record< DomainThankYouType, DomainThankYouPropsGett
 };
 
 export default thankYouContentGetter;
+
+interface StepCTAProps {
+	email?: string;
+	primary: boolean;
+	domainType: DomainThankYouType;
+}
+
+const StepCTA: FunctionComponent< StepCTAProps > = ( { email, primary, domainType } ) => {
+	const siteId = useSelector( getSelectedSiteId );
+	const domains = useSiteDomains( siteId ?? undefined );
+	const firstTitanDomain = domains.find( hasTitanMailWithUs );
+
+	return (
+		<FullWidthButton
+			href={ getTitanEmailUrl( firstTitanDomain, email, true ) }
+			target="_blank"
+			primary={ primary }
+			onClick={ () => {
+				recordEmailAppLaunchEvent( {
+					provider: 'titan',
+					app: 'webmail',
+					context: 'checkout-thank-you',
+				} );
+			} }
+		>
+			{ translate( 'Go to Inbox' ) }
+			<Gridicon className={ `domain-${ domainType }__icon-external` } icon="external" />
+		</FullWidthButton>
+	);
+};
 
 /**
  * Helper function to reuse Get Inbox/Access your inbox components
@@ -70,22 +104,6 @@ export function buildDomainStepForProfessionalEmail(
 		stepKey: `domain_${ domainType }_whats_next_email_setup_view_inbox`,
 		stepTitle: translate( 'Access your inbox' ),
 		stepDescription: translate( 'Access your email from anywhere with our webmail.' ),
-		stepCta: (
-			<FullWidthButton
-				href={ getTitanEmailUrl( email ) }
-				target="_blank"
-				primary={ primary }
-				onClick={ () => {
-					recordEmailAppLaunchEvent( {
-						provider: 'titan',
-						app: 'webmail',
-						context: 'checkout-thank-you',
-					} );
-				} }
-			>
-				{ translate( 'Go to Inbox' ) }
-				<Gridicon className={ `domain-${ domainType }__icon-external` } icon="external" />
-			</FullWidthButton>
-		),
+		stepCta: <StepCTA email={ email } primary={ primary } domainType={ domainType } />,
 	};
 }

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
@@ -27,9 +27,9 @@ const thankYouContentGetter: Record< DomainThankYouType, DomainThankYouPropsGett
 export default thankYouContentGetter;
 
 interface StepCTAProps {
+	domainType: DomainThankYouType;
 	email?: string;
 	primary: boolean;
-	domainType: DomainThankYouType;
 }
 
 const StepCTA: FunctionComponent< StepCTAProps > = ( { email, primary, domainType } ) => {

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -23,6 +23,7 @@ import {
 	isGSuiteOrGoogleWorkspaceProductSlug,
 } from 'calypso/lib/gsuite';
 import { getTitanEmailUrl, hasTitanMailWithUs } from 'calypso/lib/titan';
+import { getTitanAppsUrlPrefix } from 'calypso/lib/titan/get-titan-urls';
 import {
 	domainManagementEdit,
 	domainManagementTransferInPrecheck,
@@ -41,7 +42,6 @@ import './style.scss';
 export class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
 		displayMode: PropTypes.string,
-		domains: PropTypes.array,
 		hasFailedPurchases: PropTypes.bool,
 		isAtomic: PropTypes.bool,
 		isDataLoaded: PropTypes.bool.isRequired,
@@ -53,6 +53,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 		recordStartTransferClickInThankYou: PropTypes.func.isRequired,
 		selectedSite: PropTypes.object,
 		siteUnlaunchedBeforeUpgrade: PropTypes.bool,
+		titanAppsUrlPrefix: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 		upgradeIntent: PropTypes.string,
 	};
@@ -348,11 +349,9 @@ export class CheckoutThankYouHeader extends PureComponent {
 	visitTitanWebmail = ( event ) => {
 		event.preventDefault();
 
-		const firstTitanDomain = this.props.domains.find( hasTitanMailWithUs );
-
 		this.props.recordTracksEvent( 'calypso_thank_you_titan_webmail_click' );
 
-		window.open( getTitanEmailUrl( firstTitanDomain, '' ) );
+		window.open( getTitanEmailUrl( this.props.titanAppsUrlPrefix, '' ) );
 	};
 
 	downloadTrafficGuideHandler = ( event ) => {
@@ -642,9 +641,11 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 export default connect(
 	( state, ownProps ) => ( {
-		domains: getDomainsBySiteId( state, ownProps.selectedSite?.ID ),
 		isAtomic: isAtomicSite( state, ownProps.selectedSite?.ID ),
 		jetpackSearchCustomizeUrl: getJetpackSearchCustomizeUrl( state, ownProps.selectedSite?.ID ),
+		titanAppsUrlPrefix: getTitanAppsUrlPrefix(
+			getDomainsBySiteId( state, ownProps.selectedSite?.ID ).find( hasTitanMailWithUs )
+		),
 		upgradeIntent: ownProps.upgradeIntent || getCheckoutUpgradeIntent( state ),
 	} ),
 	{

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -40,8 +40,8 @@ import {
 	getTitanContactsUrl,
 	getTitanEmailUrl,
 	hasTitanMailWithUs,
+	useTitanAppsUrlPrefix,
 } from 'calypso/lib/titan';
-import useTitanAppsUrlPrefix from 'calypso/lib/titan/hooks/use-titan-apps-url-prefix';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import { removeEmailForward } from 'calypso/state/email-forwarding/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -41,6 +41,7 @@ import {
 	getTitanEmailUrl,
 	hasTitanMailWithUs,
 } from 'calypso/lib/titan';
+import useTitanAppsUrlPrefix from 'calypso/lib/titan/hooks/use-titan-apps-url-prefix';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import { removeEmailForward } from 'calypso/state/email-forwarding/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -79,18 +80,23 @@ const getTitanClickHandler = ( app ) => {
  * Returns the available menu items for Titan Emails
  *
  * @param {Object} titanMenuParams The argument for this function.
- * @param {Object} titanMenuParams.domain The domain object.
  * @param {Object} titanMenuParams.mailbox The mailbox object.
  * @param {Function} titanMenuParams.showRemoveMailboxDialog The function that removes modal dialogs for confirming mailbox removals
+ * @param {string} titanMenuParams.titanAppsUrlPrefix The URL prefix for Titan Apps
  * @param {Function} titanMenuParams.translate The translate function.
  * @returns Array of menu items
  */
-const getTitanMenuItems = ( { domain, mailbox, showRemoveMailboxDialog, translate } ) => {
+const getTitanMenuItems = ( {
+	mailbox,
+	showRemoveMailboxDialog,
+	titanAppsUrlPrefix,
+	translate,
+} ) => {
 	const email = getEmailAddress( mailbox );
 
 	return [
 		{
-			href: getTitanEmailUrl( domain, email ),
+			href: getTitanEmailUrl( titanAppsUrlPrefix, email ),
 			image: titanMailIcon,
 			imageAltText: translate( 'Titan Mail icon' ),
 			title: translate( 'View Mail', {
@@ -99,7 +105,7 @@ const getTitanMenuItems = ( { domain, mailbox, showRemoveMailboxDialog, translat
 			onClick: getTitanClickHandler( 'webmail' ),
 		},
 		{
-			href: getTitanCalendarUrl( domain, email ),
+			href: getTitanCalendarUrl( titanAppsUrlPrefix, email ),
 			image: titanCalendarIcon,
 			imageAltText: translate( 'Titan Calendar icon' ),
 			title: translate( 'View Calendar', {
@@ -108,7 +114,7 @@ const getTitanMenuItems = ( { domain, mailbox, showRemoveMailboxDialog, translat
 			onClick: getTitanClickHandler( 'calendar' ),
 		},
 		{
-			href: getTitanContactsUrl( domain, email ),
+			href: getTitanContactsUrl( titanAppsUrlPrefix, email ),
 			image: titanContactsIcon,
 			imageAltText: translate( 'Titan Contacts icon' ),
 			title: translate( 'View Contacts', {
@@ -323,6 +329,7 @@ RemoveTitanMailboxConfirmationDialog.propTypes = {
 const EmailMailboxActionMenu = ( { account, domain, mailbox } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const titanAppsUrlPrefix = useTitanAppsUrlPrefix();
 
 	const [ removeTitanMailboxDialogVisible, setRemoveTitanMailboxDialogVisible ] = useState( false );
 
@@ -331,9 +338,9 @@ const EmailMailboxActionMenu = ( { account, domain, mailbox } ) => {
 	const getMenuItems = () => {
 		if ( domainHasTitanMailWithUs ) {
 			return getTitanMenuItems( {
-				domain,
 				mailbox,
 				showRemoveMailboxDialog: () => setRemoveTitanMailboxDialogVisible( true ),
+				titanAppsUrlPrefix,
 				translate,
 			} );
 		}

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -36,7 +36,7 @@ import {
 	hasGSuiteWithUs,
 } from 'calypso/lib/gsuite';
 import {
-	getTitanCalendarlUrl,
+	getTitanCalendarUrl,
 	getTitanContactsUrl,
 	getTitanEmailUrl,
 	hasTitanMailWithUs,
@@ -99,7 +99,7 @@ const getTitanMenuItems = ( { domain, mailbox, showRemoveMailboxDialog, translat
 			onClick: getTitanClickHandler( 'webmail' ),
 		},
 		{
-			href: getTitanCalendarlUrl( domain, email ),
+			href: getTitanCalendarUrl( domain, email ),
 			image: titanCalendarIcon,
 			imageAltText: translate( 'Titan Calendar icon' ),
 			title: translate( 'View Calendar', {

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -79,17 +79,18 @@ const getTitanClickHandler = ( app ) => {
  * Returns the available menu items for Titan Emails
  *
  * @param {Object} titanMenuParams The argument for this function.
- * @param {Function} titanMenuParams.showRemoveMailboxDialog The function that removes modal dialogs for confirming mailbox removals
+ * @param {Object} titanMenuParams.domain The domain object.
  * @param {Object} titanMenuParams.mailbox The mailbox object.
+ * @param {Function} titanMenuParams.showRemoveMailboxDialog The function that removes modal dialogs for confirming mailbox removals
  * @param {Function} titanMenuParams.translate The translate function.
  * @returns Array of menu items
  */
-const getTitanMenuItems = ( { mailbox, showRemoveMailboxDialog, translate } ) => {
+const getTitanMenuItems = ( { domain, mailbox, showRemoveMailboxDialog, translate } ) => {
 	const email = getEmailAddress( mailbox );
 
 	return [
 		{
-			href: getTitanEmailUrl( email ),
+			href: getTitanEmailUrl( domain, email ),
 			image: titanMailIcon,
 			imageAltText: translate( 'Titan Mail icon' ),
 			title: translate( 'View Mail', {
@@ -98,7 +99,7 @@ const getTitanMenuItems = ( { mailbox, showRemoveMailboxDialog, translate } ) =>
 			onClick: getTitanClickHandler( 'webmail' ),
 		},
 		{
-			href: getTitanCalendarlUrl( email ),
+			href: getTitanCalendarlUrl( domain, email ),
 			image: titanCalendarIcon,
 			imageAltText: translate( 'Titan Calendar icon' ),
 			title: translate( 'View Calendar', {
@@ -107,7 +108,7 @@ const getTitanMenuItems = ( { mailbox, showRemoveMailboxDialog, translate } ) =>
 			onClick: getTitanClickHandler( 'calendar' ),
 		},
 		{
-			href: getTitanContactsUrl( email ),
+			href: getTitanContactsUrl( domain, email ),
 			image: titanContactsIcon,
 			imageAltText: translate( 'Titan Contacts icon' ),
 			title: translate( 'View Contacts', {
@@ -330,8 +331,9 @@ const EmailMailboxActionMenu = ( { account, domain, mailbox } ) => {
 	const getMenuItems = () => {
 		if ( domainHasTitanMailWithUs ) {
 			return getTitanMenuItems( {
-				showRemoveMailboxDialog: () => setRemoveTitanMailboxDialogVisible( true ),
+				domain,
 				mailbox,
+				showRemoveMailboxDialog: () => setRemoveTitanMailboxDialogVisible( true ),
 				translate,
 			} );
 		}

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -17,9 +17,8 @@ import {
 } from 'calypso/lib/emails';
 import { getGmailUrl } from 'calypso/lib/gsuite';
 import { GOOGLE_PROVIDER_NAME } from 'calypso/lib/gsuite/constants';
-import { getTitanEmailUrl } from 'calypso/lib/titan';
+import { getTitanEmailUrl, useTitanAppsUrlPrefix } from 'calypso/lib/titan';
 import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
-import useTitanAppsUrlPrefix from 'calypso/lib/titan/hooks/use-titan-apps-url-prefix';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import {
 	recordEmailAppLaunchEvent,

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -17,9 +17,10 @@ import {
 } from 'calypso/lib/emails';
 import { getGmailUrl } from 'calypso/lib/gsuite';
 import { GOOGLE_PROVIDER_NAME } from 'calypso/lib/gsuite/constants';
-import { getTitanEmailUrl } from 'calypso/lib/titan';
+import { getTitanEmailUrl, hasTitanMailWithUs } from 'calypso/lib/titan';
 import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
 import {
 	recordEmailAppLaunchEvent,
 	recordInboxNewMailboxUpsellClickEvent,
@@ -27,7 +28,7 @@ import {
 import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import { emailManagement, emailManagementInbox } from 'calypso/my-sites/email/paths';
 import { recordPageView } from 'calypso/state/analytics/actions';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ProgressLine from './progress-line';
 
 /**
@@ -35,9 +36,9 @@ import ProgressLine from './progress-line';
  */
 import './style.scss';
 
-const getExternalUrl = ( mailbox ) => {
+const getExternalUrl = ( domain, mailbox ) => {
 	if ( isTitanMailAccount( mailbox ) ) {
-		return getTitanEmailUrl( getEmailAddress( mailbox ), true );
+		return getTitanEmailUrl( domain, getEmailAddress( mailbox ), true );
 	}
 
 	if ( isGoogleEmailAccount( mailbox ) ) {
@@ -93,6 +94,10 @@ MailboxItemIcon.propType = {
 };
 
 const MailboxItem = ( { mailbox } ) => {
+	const siteId = useSelector( getSelectedSiteId );
+	const domains = useSiteDomains( siteId ?? null );
+	const firstTitanDomain = domains.find( hasTitanMailWithUs );
+
 	if ( isEmailForwardAccount( mailbox ) ) {
 		return null;
 	}
@@ -103,7 +108,7 @@ const MailboxItem = ( { mailbox } ) => {
 				trackAppLaunchEvent( { mailbox, app: 'webmail', context: 'inbox-mailbox-selection' } )
 			}
 			className="mailbox-selection-list__item"
-			href={ getExternalUrl( mailbox ) }
+			href={ getExternalUrl( firstTitanDomain, mailbox ) }
 			target="external"
 		>
 			<span className="mailbox-selection-list__icon">

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -17,10 +17,10 @@ import {
 } from 'calypso/lib/emails';
 import { getGmailUrl } from 'calypso/lib/gsuite';
 import { GOOGLE_PROVIDER_NAME } from 'calypso/lib/gsuite/constants';
-import { getTitanEmailUrl, hasTitanMailWithUs } from 'calypso/lib/titan';
+import { getTitanEmailUrl } from 'calypso/lib/titan';
 import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
+import useTitanAppsUrlPrefix from 'calypso/lib/titan/hooks/use-titan-apps-url-prefix';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
-import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
 import {
 	recordEmailAppLaunchEvent,
 	recordInboxNewMailboxUpsellClickEvent,
@@ -28,7 +28,7 @@ import {
 import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import { emailManagement, emailManagementInbox } from 'calypso/my-sites/email/paths';
 import { recordPageView } from 'calypso/state/analytics/actions';
-import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ProgressLine from './progress-line';
 
 /**
@@ -36,9 +36,9 @@ import ProgressLine from './progress-line';
  */
 import './style.scss';
 
-const getExternalUrl = ( domain, mailbox ) => {
+const getExternalUrl = ( mailbox, titanAppsUrlPrefix ) => {
 	if ( isTitanMailAccount( mailbox ) ) {
-		return getTitanEmailUrl( domain, getEmailAddress( mailbox ), true );
+		return getTitanEmailUrl( titanAppsUrlPrefix, getEmailAddress( mailbox ), true );
 	}
 
 	if ( isGoogleEmailAccount( mailbox ) ) {
@@ -94,9 +94,7 @@ MailboxItemIcon.propType = {
 };
 
 const MailboxItem = ( { mailbox } ) => {
-	const siteId = useSelector( getSelectedSiteId );
-	const domains = useSiteDomains( siteId ?? null );
-	const firstTitanDomain = domains.find( hasTitanMailWithUs );
+	const titanAppsUrlPrefix = useTitanAppsUrlPrefix();
 
 	if ( isEmailForwardAccount( mailbox ) ) {
 		return null;
@@ -108,7 +106,7 @@ const MailboxItem = ( { mailbox } ) => {
 				trackAppLaunchEvent( { mailbox, app: 'webmail', context: 'inbox-mailbox-selection' } )
 			}
 			className="mailbox-selection-list__item"
-			href={ getExternalUrl( firstTitanDomain, mailbox ) }
+			href={ getExternalUrl( mailbox, titanAppsUrlPrefix ) }
 			target="external"
 		>
 			<span className="mailbox-selection-list__icon">

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -3,10 +3,9 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import thankYouEmail from 'calypso/assets/images/illustrations/thank-you-email.svg';
 import { ThankYou } from 'calypso/components/thank-you';
-import { getSelectedDomain } from 'calypso/lib/domains';
 import { getTitanEmailUrl } from 'calypso/lib/titan';
 import { TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP } from 'calypso/lib/titan/constants';
-import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
+import useTitanAppsUrlPrefix from 'calypso/lib/titan/hooks/use-titan-apps-url-prefix';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import {
 	emailManagement,
@@ -37,13 +36,8 @@ const TitanSetUpThankYou = ( {
 	const currentRoute = useSelector( getCurrentRoute );
 	const selectedSite = useSelector( getSelectedSite );
 	const selectedSiteSlug = selectedSite?.slug ?? null;
-	const domains = useSiteDomains( selectedSite?.ID ?? undefined );
+	const titanAppsUrlPrefix = useTitanAppsUrlPrefix();
 	const translate = useTranslate();
-
-	const domain = getSelectedDomain( {
-		domains,
-		selectedDomainName: domainName,
-	} );
 
 	const emailManagementPath = emailManagement( selectedSiteSlug, domainName, currentRoute );
 
@@ -71,7 +65,7 @@ const TitanSetUpThankYou = ( {
 				stepDescription: translate( 'Access your email from anywhere with our webmail.' ),
 				stepCta: (
 					<FullWidthButton
-						href={ getTitanEmailUrl( domain, emailAddress, true ) }
+						href={ getTitanEmailUrl( titanAppsUrlPrefix, emailAddress, true ) }
 						primary
 						target="_blank"
 						onClick={ () => {

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -1,11 +1,12 @@
 import { Gridicon } from '@automattic/components';
-import { localize, useTranslate } from 'i18n-calypso';
-import { connect, useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import thankYouEmail from 'calypso/assets/images/illustrations/thank-you-email.svg';
 import { ThankYou } from 'calypso/components/thank-you';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { getTitanEmailUrl } from 'calypso/lib/titan';
 import { TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP } from 'calypso/lib/titan/constants';
+import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import {
 	emailManagement,
@@ -13,9 +14,7 @@ import {
 } from 'calypso/my-sites/email/paths';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getDomainsBySite } from 'calypso/state/sites/domains/selectors';
-import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { SiteData } from 'calypso/state/ui/selectors/site-data';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 /**
  * Import styles
@@ -29,12 +28,23 @@ type TitanSetUpThankYouProps = {
 	subtitle?: string;
 };
 
-const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
+const TitanSetUpThankYou = ( {
+	domainName,
+	emailAddress,
+	subtitle,
+	title,
+}: TitanSetUpThankYouProps ): JSX.Element => {
 	const currentRoute = useSelector( getCurrentRoute );
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const selectedSite = useSelector( getSelectedSite );
+	const selectedSiteSlug = selectedSite?.slug ?? null;
+	const domains = useSiteDomains( selectedSite?.ID ?? undefined );
 	const translate = useTranslate();
 
-	const { domainName, emailAddress, subtitle, title } = props;
+	const domain = getSelectedDomain( {
+		domains,
+		isSiteRedirect: false,
+		selectedDomainName: domainName,
+	} );
 
 	const emailManagementPath = emailManagement( selectedSiteSlug, domainName, currentRoute );
 
@@ -62,7 +72,7 @@ const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
 				stepDescription: translate( 'Access your email from anywhere with our webmail.' ),
 				stepCta: (
 					<FullWidthButton
-						href={ getTitanEmailUrl( emailAddress ) }
+						href={ getTitanEmailUrl( domain, emailAddress, true ) }
 						primary
 						target="_blank"
 						onClick={ () => {
@@ -127,18 +137,4 @@ const TitanSetUpThankYou = ( props: TitanSetUpThankYouProps ): JSX.Element => {
 	);
 };
 
-export default connect( ( state, ownProps: TitanSetUpThankYouProps ) => {
-	const selectedSite = getSelectedSite( state ) as SiteData;
-
-	const domain = getSelectedDomain( {
-		domains: getDomainsBySite( state, selectedSite ),
-		isSiteRedirect: false,
-		selectedDomainName: ownProps.domainName,
-	} );
-
-	return {
-		currentRoute: getCurrentRoute( state ),
-		domain,
-		selectedSite,
-	};
-} )( localize( TitanSetUpThankYou ) );
+export default TitanSetUpThankYou;

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -3,9 +3,8 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import thankYouEmail from 'calypso/assets/images/illustrations/thank-you-email.svg';
 import { ThankYou } from 'calypso/components/thank-you';
-import { getTitanEmailUrl } from 'calypso/lib/titan';
+import { getTitanEmailUrl, useTitanAppsUrlPrefix } from 'calypso/lib/titan';
 import { TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP } from 'calypso/lib/titan/constants';
-import useTitanAppsUrlPrefix from 'calypso/lib/titan/hooks/use-titan-apps-url-prefix';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import {
 	emailManagement,

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -42,7 +42,6 @@ const TitanSetUpThankYou = ( {
 
 	const domain = getSelectedDomain( {
 		domains,
-		isSiteRedirect: false,
 		selectedDomainName: domainName,
 	} );
 

--- a/client/state/sites/domains/types.ts
+++ b/client/state/sites/domains/types.ts
@@ -10,7 +10,7 @@ export interface SiteDomain {
 	expiry?: string | null;
 	expirySoon?: boolean;
 	googleAppsSubscription?: { status?: string };
-	titanMailSubscription?: unknown;
+	titanMailSubscription?: { status?: string; appsUrl?: string };
 	hasRegistration?: boolean;
 	hasWpcomNameservers?: boolean;
 	hasZone?: boolean;


### PR DESCRIPTION
This PR depends on D74878-code to function properly.

We use a `appsURL` sent with the site domain to craft the external Titan url for Professional Email resources. This url varies for the production and staging platforms.

#### Changes proposed in this Pull Request

* A new `appsURL` field fetched with the site domain is used for fetching Titan URLs
* A new dependency ( i.e. site domain object ) is used for generating the proper environment URLs
* All existing invocations are modified to include the site domain object
* The `TitanSetUpThankYou` functional component is refactored to jettison its reliance on `redux connect`. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure that D74878-code is active if it's not already merged. 

#### Platform variations 
A. Store Sandbox enabled (i.e. staging)
B. Store Sandbox disabled (i.e. production)

#### Expected URLs

Production | https://wp.titan.email/email
-- | --
Staging | https://webmail-staging.riva.co/mail/

* Sandbox `public-api.wordpress.com` 
* Checkout this branch, or use the calypso-live branch
* **Scenario I**: Purchase a Professional Email subscription via the domain upsell path
    * Purchase a domain. Fill the Professional Email upsell form that comes up before checkout
    * Confirm that you see the thank you page after a successful purchase, and a `Go to Inbox` button.
    * Confirm the external URL you are redirected to based on your platform variation ( i.e. A or B )
    * Confirm that you can login with your mailbox parameters.

<img width="783" alt="Screenshot 2022-02-12 at 5 35 04 PM" src="https://user-images.githubusercontent.com/277661/153719776-2dacf9ab-35c3-4a7e-8abd-060dbd7a1f72.png">

* **Scenario II**: Action menu items
    * Using Calypso , navigate to the email plan view of the previous subscription you purchased earlier
    * Use any of the mailbox menu action items that redirects you to an external URL for Titan i.e. `Webmail`, `Calendar`, `Contacts`
    * Confirm the external URL you are redirected to based on your platform variation ( i.e. A or B )
    * Confirm that you can login with your mailbox parameters.
   
<img width="1116" alt="Screenshot 2022-02-12 at 5 56 21 PM" src="https://user-images.githubusercontent.com/277661/153720501-be4501ec-28cb-48ac-89d9-c85575cbedfa.png">

* **Scenario III**: Non-checkout setup
    * Using Calypso , navigate to the email plan view of the previous subscription you purchased earlier
    * Using the mailbox menu action items, remove all mailboxes
    * Click on the `Set up mailbox` button displayed when all mailboxes are gone
    * Fill the set up form shown
    * Confirm that you see the thank you page after a successful set up, and a `Go to Inbox` button.
    * Confirm the external URL you are redirected to based on your platform variation ( i.e. A or B )
    * Confirm that you can login with your mailbox parameters.

<img width="685" alt="Screenshot 2022-02-12 at 5 49 06 PM" src="https://user-images.githubusercontent.com/277661/153720295-1b79add3-d1ad-4708-9400-d304e1b25bca.png">

* **Scenario IV**: Inbox
    * Ensure you have one or more Professional Email subscriptions
    * Navigate to the inbox view i.e. `/Inbox`
    * For the list of mailboxes shown, click on the external URL icon
    * Confirm the external URL you are redirected to based on your platform variation ( i.e. A or B )
    * Confirm that you can login with your mailbox parameters.

<img width="775" alt="Screenshot 2022-02-12 at 6 00 09 PM" src="https://user-images.githubusercontent.com/277661/153720621-3d004bbe-53e1-4c85-b051-83fbbf8497e6.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

