### PR TITLE
Plugins page searchbox height fix

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -265,10 +265,10 @@ const PluginsBrowser = ( {
 						/>
 
 						<UploadPluginButton isMobile={ isMobile } siteSlug={ siteSlug } />
-					</div>
 
-					<div className="plugins-browser__searchbox">
-						{ <SearchBox isMobile={ isMobile } doSearch={ doSearch } search={ search } /> }
+						<div className="plugins-browser__searchbox">
+							{ <SearchBox isMobile={ isMobile } doSearch={ doSearch } search={ search } /> }
+						</div>
 					</div>
 				</FixedNavigationHeader>
 			) }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -265,10 +265,9 @@ const PluginsBrowser = ( {
 						/>
 
 						<UploadPluginButton isMobile={ isMobile } siteSlug={ siteSlug } />
-
-						<div className="plugins-browser__searchbox">
-							{ <SearchBox isMobile={ isMobile } doSearch={ doSearch } search={ search } /> }
-						</div>
+					</div>
+					<div className="plugins-browser__searchbox">
+						{ <SearchBox isMobile={ isMobile } doSearch={ doSearch } search={ search } /> }
 					</div>
 				</FixedNavigationHeader>
 			) }

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -7,6 +7,10 @@
 
 	.search-component {
 		height: 30px;
+		&.is-expanded-to-container {
+			height: 100%;
+		}
+
 		box-shadow: 0 0 0 1px var( --studio-gray-10 );
 
 		.search-component__open-icon,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Applies [the 100% height](https://github.com/Automattic/wp-calypso/blob/ad5405ffeb368943205429975c11307ad38ac422/packages/search/src/style.scss#L127) from Searchbox's `is-expanded-to-container` to `plugins-browser__searchbox`. 
 
[The plugin browsers 30px height](https://github.com/Automattic/wp-calypso/blob/ad5405ffeb368943205429975c11307ad38ac422/client/my-sites/plugins/plugins-browser/style.scss#L9) was overriding the 100% due to matching specificity (I think? see ss below). Which rule applied depended on which got seen last and because we [calculated `isMobile`](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/plugins/plugins-browser/index.jsx#L198) in JS this seems to be down to chance. `isMobile` flipping in plugins-browser [triggers](https://github.com/Automattic/wp-calypso/blob/ad5405ffeb368943205429975c11307ad38ac422/packages/search/src/search.tsx#L348) `is-expanded-to-container` application via `fitsContainer`.

Css rules applying in the incorrect order:

![Screenshot_2022-02-14_17-14-31](https://user-images.githubusercontent.com/811776/153811033-0a266cf7-313b-4faa-9e1e-9ff97ae0a8b4.png)

^ Screenshot from chrome as refreshes can "fix" the issue and this was the only one I still had open. The thing we're looking at here is the 30px applying when the 100% should be instead (or at least does in most page loads).

This video shows me toggling which height applies in order to show how this bug might play out via JS:

https://user-images.githubusercontent.com/811776/153811027-82b9049e-77d0-4ed6-86f9-1d2d8588a297.mp4


#### Testing instructions

View plugins page with mobile screen sizes on multiple browsers / devices / incog windows until you are sure its fixed

Before

https://user-images.githubusercontent.com/811776/153807017-5d85a243-9f03-4c0e-94e1-81ba863f4f8e.mp4

After

https://user-images.githubusercontent.com/811776/153805962-956d3859-b6ff-43e3-83d0-9def92100db9.mp4

Related to https://github.com/Automattic/wp-calypso/issues/61033
