### PR TITLE
Comments: Redirect after deleting a comment

### DIFF
--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -56,6 +56,7 @@ export class CommentActions extends Component {
 			window.confirm( this.props.translate( 'Delete this comment permanently?' ) )
 		) {
 			this.props.deletePermanently();
+			this.props.redirect();
 		}
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an issue discovered by @flootr in https://github.com/Automattic/wp-calypso/pull/60961#pullrequestreview-880968281 - when on a single comment page, after permanently deleting that page, we don't get redirected to the all comments page, but we are presented with a placeholder instead.

In this PR, after accepting to delete the comment permanently, we redirect to the page with all comments.

#### Testing instructions

* Go to `/comments/all/:site` where `:site` is a site you are an admin of, and it has some comments.
* Click on the date of a comment to navigate to the comment page.
* Trash the comment.
* Click "Delete Permanently" and accept.
* Verify you're redirected to the list of all comments.