### PR TITLE
Plugins: Improve messaging for Jetpack Scan detected errors

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -68,6 +68,7 @@ const MarketplacePluginInstall = ( {
 	const pluginUploadProgress = useSelector( ( state ) => getPluginUploadProgress( state, siteId ) );
 	const pluginUploadError = useSelector( ( state ) => getPluginUploadError( state, siteId ) );
 	const pluginExists = pluginUploadError?.error === 'folder_exists';
+	const pluginMalicious = pluginUploadError?.error === 'plugin_malicious';
 	const wporgPlugin = useSelector( ( state ) => getPlugin( state, productSlug ) );
 	const isWporgPluginFetched = useSelector( ( state ) => isFetched( state, productSlug ) );
 	const uploadedPluginSlug = useSelector( ( state ) =>
@@ -340,6 +341,21 @@ const MarketplacePluginInstall = ( {
 					title={ null }
 					line={ translate(
 						'This plugin already exists on your site. If you want to upgrade or downgrade the plugin, please continue by uploading the plugin again from WP Admin.'
+					) }
+					secondaryAction={ translate( 'Back' ) }
+					secondaryActionURL={ `/plugins/upload/${ selectedSiteSlug }` }
+					action={ translate( 'Continue' ) }
+					actionURL={ `https://${ selectedSiteSlug }/wp-admin/plugin-install.php?tab=upload` }
+				/>
+			);
+		}
+		if ( pluginMalicious ) {
+			return (
+				<EmptyContent
+					illustration="/calypso/images/illustrations/error.svg"
+					title={ null }
+					line={ translate(
+						'This plugin is identified as malicious. If you want to install the plugin, please continue by uploading the plugin again from WP Admin.'
 					) }
 					secondaryAction={ translate( 'Back' ) }
 					secondaryActionURL={ `/plugins/upload/${ selectedSiteSlug }` }

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -355,7 +355,7 @@ const MarketplacePluginInstall = ( {
 					illustration="/calypso/images/illustrations/error.svg"
 					title={ null }
 					line={ translate(
-						'This plugin is identified as malicious. If you want to install the plugin, please continue by uploading the plugin again from WP Admin.'
+						'This plugin is identified as malicious. If you still insist to install the plugin, please continue by uploading the plugin again from WP Admin.'
 					) }
 					secondaryAction={ translate( 'Back' ) }
 					secondaryActionURL={ `/plugins/upload/${ selectedSiteSlug }` }

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -36,6 +36,7 @@ const showErrorNotice = ( error ) => {
 		'too large': translate( 'The plugin zip file must be smaller than 10MB.' ),
 		incompatible: translate( 'The uploaded file is not a compatible plugin.' ),
 		unsupported_mime_type: translate( 'The uploaded file is not a valid zip.' ),
+		'invalid plugin': translate( 'The uploaded file is identified as malicious.' ),
 	};
 	const errorString = `${ error.error }${ error.message }`.toLowerCase();
 	const knownError = find( knownErrors, ( v, key ) => includes( errorString, key ) );

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -36,7 +36,7 @@ const showErrorNotice = ( error ) => {
 		'too large': translate( 'The plugin zip file must be smaller than 10MB.' ),
 		incompatible: translate( 'The uploaded file is not a compatible plugin.' ),
 		unsupported_mime_type: translate( 'The uploaded file is not a valid zip.' ),
-		'invalid plugin': translate( 'The uploaded file is identified as malicious.' ),
+		plugin_malicious: translate( 'The uploaded file is identified as malicious.' ),
 	};
 	const errorString = `${ error.error }${ error.message }`.toLowerCase();
 	const knownError = find( knownErrors, ( v, key ) => includes( errorString, key ) );

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -29,6 +29,11 @@ const ERROR_RESPONSE = {
 	message: 'folder_exists',
 };
 
+const UNKNOWN_ERROR_RESPONSE = {
+	error: 'unknown_error',
+	message: 'unknown_error',
+};
+
 describe( 'uploadPlugin', () => {
 	test( 'should return an http request action', () => {
 		const action = uploadPlugin( { siteId, file: 'xyz' } );
@@ -69,10 +74,16 @@ describe( 'uploadComplete', () => {
 } );
 
 describe( 'receiveError', () => {
-	test( 'should return a plugin upload error action', () => {
+	test( 'should return a plugin upload error action for a known error', () => {
 		const action = receiveError( { siteId }, ERROR_RESPONSE );
 		expect( action ).toEqual(
 			expect.arrayContaining( [ pluginUploadError( siteId, ERROR_RESPONSE ) ] )
+		);
+	} );
+	test( 'should return a plugin upload error action for an unknown error', () => {
+		const action = receiveError( { siteId }, UNKNOWN_ERROR_RESPONSE );
+		expect( action ).toEqual(
+			expect.arrayContaining( [ pluginUploadError( siteId, UNKNOWN_ERROR_RESPONSE ) ] )
 		);
 	} );
 } );


### PR DESCRIPTION
When uploading a plugin, it is scanned using Jetpack. The previous message
was unclear, so it has been improved to a more explicit message.

Depends on D74922-code

#### Changes proposed in this Pull Request

* Change the error message when Jetpack Scan reports a failure from
  > Upload problem: Invalid plugin. 

  to

  > The uploaded file is identified as malicious.

Additionally, the displayed page offers a workaround that reads:

> This plugin is identified as malicious. If you want to install the plugin, please continue by uploading the plugin again from WP Admin.

|Before | After|
|-------|------|
|<img width="1583" alt="image" src="https://user-images.githubusercontent.com/3519124/153840359-a0c4d1ce-1b85-48c3-9460-547499b7da19.png">|<img width="1048" alt="image" src="https://user-images.githubusercontent.com/3519124/153935776-7991e075-9b6e-459c-bc05-43ce5c12f164.png">|

Pinging to @emmnyc85 and @cavalierlife to check if the suggested message is fine 🙂 

#### Testing instructions


* Apply D74922-code
* In an Atomic site, go to  https://wordpress.com/plugins/upload
* Upload a plugin that fails, for example, this one pdh6GB-6h-p2#comment-698 
* The notification message should display `The uploaded file is identified as malicious.` and the displayed page should contain the message `This plugin is identified as malicious. If you want to install the plugin, please continue by uploading the plugin again from WP Admin.`. That page will contain two action buttons:
  *  `Back` that will navigate to previous page
  * `Continue` that will re-direct to the upload plugin from the `wp-admin` page.

Fixes #58942