### PR TITLE
Fix | Disable Restore buttons when one is already in progress

### DIFF
--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -12,6 +12,7 @@ import { settingsPath } from 'calypso/lib/jetpack/paths';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
+import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
 import { getSiteSlug, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import { Activity } from '../types';
 import downloadIcon from './download-icon.svg';
@@ -44,6 +45,10 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 		getDoesRewindNeedCredentials( state, siteId )
 	);
 
+	const isRestoreInProgress = useSelector( ( state ) => getIsRestoreInProgress( state, siteId ) );
+
+	const isRestoreDisabled = doesRewindNeedCredentials || isRestoreInProgress;
+
 	return (
 		<>
 			<Button
@@ -63,9 +68,9 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 				className="toolbar__actions-popover"
 			>
 				<Button
-					href={ ! doesRewindNeedCredentials && backupRestorePath( siteSlug, rewindId ) }
+					href={ ! isRestoreDisabled && backupRestorePath( siteSlug, rewindId ) }
 					className="toolbar__restore-button"
-					disabled={ doesRewindNeedCredentials }
+					disabled={ isRestoreDisabled }
 				>
 					{ translate( 'Restore to this point' ) }
 				</Button>

--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -5,6 +5,7 @@ import Button from 'calypso/components/forms/form-button';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
+import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -40,9 +41,10 @@ const RestoreButton = ( { disabled, rewindId } ) => {
 	const needsCredentials = useSelector( ( state ) =>
 		getDoesRewindNeedCredentials( state, siteId )
 	);
+	const isRestoreInProgress = useSelector( ( state ) => getIsRestoreInProgress( state, siteId ) );
 
-	const canRestore = ! disabled && ! needsCredentials;
-	const href = canRestore ? backupRestorePath( siteSlug, rewindId ) : undefined;
+	const isRestoreDisabled = disabled || needsCredentials || isRestoreInProgress;
+	const href = ! isRestoreDisabled ? backupRestorePath( siteSlug, rewindId ) : undefined;
 	const onRestore = () =>
 		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore', { rewind_id: rewindId } ) );
 
@@ -51,7 +53,7 @@ const RestoreButton = ( { disabled, rewindId } ) => {
 			isPrimary
 			className="daily-backup-status__restore-button"
 			href={ href }
-			disabled={ ! canRestore }
+			disabled={ isRestoreDisabled }
 			onClick={ onRestore }
 		>
 			{ translate( 'Restore to this point' ) }

--- a/client/state/selectors/get-is-restore-in-progress.ts
+++ b/client/state/selectors/get-is-restore-in-progress.ts
@@ -1,0 +1,16 @@
+import getRestoreProgress from './get-restore-progress';
+import getRewindState from './get-rewind-state';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns true if a restore is in progres, false otherwise
+ *
+ */
+export default function getIsRestoreInProgress( state: AppState, siteId: number ): boolean {
+	const rewindState = getRewindState( state, siteId );
+	const restoreProgress = getRestoreProgress( state, siteId );
+
+	const isRewindActive = rewindState.state === 'active';
+
+	return isRewindActive && [ 'queued', 'running' ].includes( String( restoreProgress?.status ) );
+}

--- a/client/state/selectors/get-rewind-state.ts
+++ b/client/state/selectors/get-rewind-state.ts
@@ -1,4 +1,5 @@
 import { AppState } from 'calypso/types';
+import type { RewindState } from 'calypso/state/data-layer/wpcom/sites/rewind/type';
 
 import 'calypso/state/rewind/init';
 
@@ -16,7 +17,7 @@ const uninitialized = {
 export default function getRewindState(
 	state: AppState,
 	siteId?: number | string | null
-): { state: string } {
+): RewindState {
 	if ( ! siteId ) {
 		return uninitialized;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable **Restore to this point** buttons when a restore is already in progress.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create JN Site and add a back up plan
* Enable Restore by adding SSH/SFTP credentials
* Boot up this PR and goto `http://calypso.localhost:3000/backup/:site`
* Wait for a backup to complete or Queue one using Rewind Debugger
* Restore a back up
* Goto `http://calypso.localhost:3000/backup/:site` again
* Confirm that **Restore to this point** is disabled for the latest backup
* Confirm that **Restore to this point** in all the previous backup actions is disabled

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #61066 / 1164141197617539-as-1201825952025343/f


BEFORE

https://user-images.githubusercontent.com/18226415/153870137-9d3702c8-32b1-4cff-803c-3e6afa1d990a.mov 

AFTER

https://user-images.githubusercontent.com/18226415/153869874-928320c4-4445-44d8-9170-91583666251e.mov