### PR TITLE
Adding device_type prop to calypso_page_view

### DIFF
--- a/client/lib/analytics/page-view.js
+++ b/client/lib/analytics/page-view.js
@@ -1,6 +1,7 @@
 // pageView is a wrapper for pageview events across Tracks and GA.
 
 import { recordTracksPageViewWithPageParams } from '@automattic/calypso-analytics';
+import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { retarget as retargetAdTrackers } from 'calypso/lib/analytics/ad-tracking';
 import { retargetFullStory } from 'calypso/lib/analytics/fullstory';
 import { updateQueryParamsTracking } from 'calypso/lib/analytics/sem';
@@ -13,6 +14,9 @@ export function recordPageView( urlPath, pageTitle, params = {}, options = {} ) 
 	// Add delay to avoid stale `_dl` in recorded calypso_page_view event details.
 	// `_dl` (browserdocumentlocation) is read from the current URL by external JavaScript.
 	setTimeout( () => {
+		// Add device type to Tracks page view event.
+		params.device_type = resolveDeviceTypeByViewPort();
+
 		// Tracks, Google Analytics, Refer platform.
 		recordTracksPageViewWithPageParams( urlPath, params );
 		safeGoogleAnalyticsPageView( urlPath, pageTitle, options?.useJetpackGoogleAnalytics );


### PR DESCRIPTION
Adding a new prop to `calypso_page_view`. This prop contains the device type (desktop, tablet, mobile) based on the device viewport size. For background see: pau2Xa-3Zw-p2

#### Testing instructions
* Go to a few different pages in Calypso (i.e. signup flow, home page, settings, etc.). 
* Verify no related console errors
* Verify (i.e. via network tab in browser) that the call to `calypso_page_view` (via t.gif) contains the `device_type` prop. 

Example
```
Request URL: http://pixel.wp.com/t.gif?do_not_track=0&path=%2Fread&build_timestamp=2022-02-14T14%3A45%3A58.025Z&device_type=desktop&last_pageview_path_with[...]
```