### PR TITLE
Domains: change breadcrumbs in domain connection setup

### DIFF
--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -14,7 +14,11 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import wpcom from 'calypso/lib/wp';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
-import { domainManagementList, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
+import {
+	domainManagementEdit,
+	domainManagementList,
+	domainUseMyDomain,
+} from 'calypso/my-sites/domains/paths';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConnectDomainStepSwitchSetupInfoLink from './connect-domain-step-switch-setup-info-link';
@@ -25,7 +29,14 @@ import { connectADomainStepsDefinition } from './page-definitions.js';
 
 import './style.scss';
 
-function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialStep, showErrors } ) {
+function ConnectDomainStep( {
+	domain,
+	selectedSite,
+	initialSetupInfo,
+	initialStep,
+	showErrors,
+	isFirstVisit,
+} ) {
 	const { __ } = useI18n();
 	const [ pageSlug, setPageSlug ] = useState( stepSlug.SUGGESTED_START );
 	const [ verificationStatus, setVerificationStatus ] = useState( {} );
@@ -113,7 +124,7 @@ function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialSte
 	}, [ showErrors, verifyConnection ] );
 
 	const renderBreadcrumbs = () => {
-		const items = [
+		let items = [
 			{
 				label: __( 'Domains' ),
 				href: domainManagementList( selectedSite.slug, domain ),
@@ -129,11 +140,31 @@ function ConnectDomainStep( { domain, selectedSite, initialSetupInfo, initialSte
 			{ label: __( 'Connect' ) },
 		];
 
-		const mobileItem = {
+		let mobileItem = {
 			label: __( 'Back to transfer or connect' ),
 			href: domainUseMyDomain( selectedSite.slug, domain ),
 			showBackArrow: true,
 		};
+
+		if ( ! isFirstVisit ) {
+			items = [
+				{
+					label: __( 'Domains' ),
+					href: domainManagementList( selectedSite.slug, domain ),
+				},
+				{
+					label: domain,
+					href: domainManagementEdit( selectedSite.slug, domain ),
+				},
+				{ label: __( 'Connect' ) },
+			];
+
+			mobileItem = {
+				label: __( 'Back' ),
+				href: domainManagementEdit( selectedSite.slug, domain ),
+				showBackArrow: true,
+			};
+		}
 
 		return <Breadcrumbs items={ items } mobileItem={ mobileItem } />;
 	};
@@ -229,6 +260,7 @@ ConnectDomainStep.propTypes = {
 	initialStep: PropTypes.string,
 	showErrors: PropTypes.bool,
 	hasSiteDomainsLoaded: PropTypes.bool,
+	isFirstVisit: PropTypes.bool,
 };
 
 export default connect( ( state ) => {

--- a/client/components/domains/use-my-domain/utilities/connect-domain-action.js
+++ b/client/components/domains/use-my-domain/utilities/connect-domain-action.js
@@ -38,7 +38,7 @@ export const connectDomainAction = (
 					)
 				);
 				const step = result.points_to_wpcom ? stepSlug.SUGGESTED_CONNECTED : '';
-				page( domainMappingSetup( selectedSite.slug, domain, step ) );
+				page( domainMappingSetup( selectedSite.slug, domain, step, false, true ) );
 			} )
 			.catch( ( error ) => {
 				if ( 'ownership_verification_failed' !== error.error ) {

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -108,6 +108,7 @@ const mapDomain = ( context, next ) => {
 
 const mapDomainSetup = ( context, next ) => {
 	const showErrors = context.query?.showErrors === 'true' || context.query?.showErrors === '1';
+	const isFirstVisit = context.query?.firstVisit === 'true' || context.query?.firstVisit === '1';
 
 	context.primary = (
 		<Main wideLayout>
@@ -120,6 +121,7 @@ const mapDomainSetup = ( context, next ) => {
 				<ConnectDomainStep
 					domain={ context.params.domain }
 					initialStep={ context.query.step }
+					isFirstVisit={ isFirstVisit }
 					showErrors={ showErrors }
 				/>
 			</CalypsoShoppingCartProvider>

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -267,10 +267,17 @@ export function domainMapping( siteName, domain = '' ) {
  * @param { string } siteName	The slug for the site.
  * @param { string } domainName	The domain name to map.
  * @param { string } step		The step slug to start from (optional)
- * @param { boolean } showErrors Whether to show the mapping setup errors.
+ * @param { boolean } showErrors Whether to show the mapping setup errors (optional).
+ * @param { boolean } firstVisit Whether this is the first time the user is going through the setup (optional).
  * @returns {string} Path to the mapping setup flow.
  */
-export function domainMappingSetup( siteName, domainName, step = '', showErrors = false ) {
+export function domainMappingSetup(
+	siteName,
+	domainName,
+	step = '',
+	showErrors = false,
+	firstVisit = false
+) {
 	let path = `/domains/mapping/${ siteName }/setup/${ domainName }`;
 	const params = {};
 
@@ -280,6 +287,10 @@ export function domainMappingSetup( siteName, domainName, step = '', showErrors 
 
 	if ( showErrors ) {
 		params[ 'show-errors' ] = true;
+	}
+
+	if ( firstVisit ) {
+		params.firstVisit = true;
 	}
 
 	const queryString = stringify( params );


### PR DESCRIPTION
### Changes proposed in this Pull Request

Note: This depends on #60974, so that one should be reviewed first.

This PR updates the breadcrumbs in the domain connection setup pages depending on a new `firstVisit` query parameter. When the user first connects a domain and sees the setup for the first time, that parameter will be set to `true`. In subsequent visits to the setup, it'll be `false`, making breadcrumbs show a different set of steps.

#### Screenshots

- Breadcrumbs when first connecting a domain

<img width="1076" alt="Screen Shot 2022-02-14 at 17 29 09" src="https://user-images.githubusercontent.com/5324818/153942930-c878a36f-4480-4847-9804-21395675cfff.png" />

- Breadcrumbs in subsequent visits to the connection setup page

<img width="1071" alt="Screen Shot 2022-02-14 at 17 30 23" src="https://user-images.githubusercontent.com/5324818/153942957-a3871dd4-e266-4ab8-a6b9-80da3b6b8904.png" />

### Testing instructions

- Build this branch locally or open the live Calypso link
- The ideal way to test this is to connect a new domain to a site (this tests if the `firstVisit` parameter is being added when connecting a domain to a site):
    - Select a site
    - Go to Upgrades > Domains
    - Click on "+ Add a domain"
    - Connect a new domain
    - Ensure you are taken to the connection setup page with the breadcrumbs shown in the screenshot above and the `firstVisit=true` query parameter is present in the URL
    - Leave the page and go back to the setup again by clicking on the "setup instructions" link on the domain notice message and ensure the breadcrumbs are different now

<img width="1074" alt="Screen Shot 2022-02-14 at 17 40 07" src="https://user-images.githubusercontent.com/5324818/153942904-b2db48d5-801f-448b-aaa8-7bff6094be64.png">

- Alternatively, you can just access the connection setup page for a domain at `/domains/mapping/<site_slug>/setup/<domain>`, append the `firstVisit=true` query parameter and ensure the breadcrumbs are correct
