### PR TITLE
Fix MouseEvent controlKey to ctrlKey

### DIFF
--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -42,7 +42,7 @@ class ReaderCombinedCardPost extends Component {
 		const selection = window.getSelection && window.getSelection();
 
 		// if the click has modifier or was not primary, ignore it
-		if ( event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey ) {
+		if ( event.button > 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey ) {
 			if ( closest( event.target, '.reader-combined-card__post-title-link', rootNode ) ) {
 				recordPermalinkClick( 'card_title_with_modifier', this.props.post );
 			}

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -77,7 +77,7 @@ class ReaderPostCard extends Component {
 		const selection = window.getSelection && window.getSelection();
 
 		// if the click has modifier or was not primary, ignore it
-		if ( event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey ) {
+		if ( event.button > 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey ) {
 			if ( closest( event.target, '.reader-post-card__title-link', rootNode ) ) {
 				stats.recordPermalinkClick( 'card_title_with_modifier', this.props.post );
 			}

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -98,7 +98,7 @@ const PeopleProfile = ( { siteId, type, user, invite } ) => {
 
 	const handleLinkToReaderSiteStream = ( event ) => {
 		const modifierPressed =
-			event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey;
+			event.button > 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
 
 		recordTrack( 'calypso_sites_people_followers_link_click', {
 			modifier_pressed: modifierPressed,

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -233,11 +233,7 @@ class StatsListItem extends Component {
 				if ( this.isFollowersModule && siteId ) {
 					onClickHandler = ( event ) => {
 						const modifierPressed =
-							event.button > 0 ||
-							event.metaKey ||
-							event.controlKey ||
-							event.shiftKey ||
-							event.altKey;
+							event.button > 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
 						recordTrack( 'calypso_reader_stats_module_site_stream_link_click', {
 							site_id: siteId,
 							module_name: this.props.moduleName,

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -36,7 +36,7 @@ class CrossPost extends PureComponent {
 
 	handleTitleClick = ( event ) => {
 		// modified clicks should let the default action open a new tab/window
-		if ( event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey ) {
+		if ( event.button > 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey ) {
 			return;
 		}
 		event.preventDefault();
@@ -65,7 +65,7 @@ class CrossPost extends PureComponent {
 		}
 
 		// if the click has modifier, ignore it
-		if ( event.metaKey || event.controlKey || event.shiftKey || event.altKey ) {
+		if ( event.metaKey || event.ctrlKey || event.shiftKey || event.altKey ) {
 			return;
 		}
 

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -4,7 +4,7 @@ import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 
 export function isSpecialClick( event ) {
-	return event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey;
+	return event.button > 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
 }
 
 export function isPostNotFound( post ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix `controlKey` to `ctrlKey` on Mouse event handlers (https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/ctrlKey). This appears to just have been a typo as `controlKey` was never a property of the MouseEvent object as far as I can tell.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Reader and hold "control" while clicking an item. It should open in a new tab in Firefox and Chrome (not sure about other browsers). Previously this behavior would get ignored and the default click event handler would go through opening the post in Reader itself.

Note: On macOS the "open in new tab" shortcut is "cmd + click" so this PR won't be testable on macOS. It's definitely testable on Linux and I have to assume it also affects Windows users as well.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
