### PR TITLE
desktop: try with updated playwright

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -37,7 +37,7 @@
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"copy-webpack-plugin": "^10.1.0",
-		"electron": "^12.2.3",
+		"electron": "12.2.3",
 		"electron-builder": "^22.11.7",
 		"electron-notarize": "^0.1.1",
 		"electron-rebuild": "^2.3.5",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -44,7 +44,7 @@
 		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",
-		"playwright": "1.16",
+		"playwright": "^1.18",
 		"postcss": "^8.4.5",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -37,7 +37,7 @@
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"copy-webpack-plugin": "^10.1.0",
-		"electron": "12.1.0",
+		"electron": "^12.2.3",
 		"electron-builder": "^22.11.7",
 		"electron-notarize": "^0.1.1",
 		"electron-rebuild": "^2.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9862,7 +9862,7 @@ __metadata:
     archiver: ^3.1.1
     copy-webpack-plugin: ^10.1.0
     cross-env: ^7.0.3
-    electron: 12.1.0
+    electron: ^12.2.3
     electron-builder: ^22.11.7
     electron-fetch: ^1.7.4
     electron-notarize: ^0.1.1
@@ -16200,16 +16200,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:12.1.0":
-  version: 12.1.0
-  resolution: "electron@npm:12.1.0"
+"electron@npm:^12.2.3":
+  version: 12.2.3
+  resolution: "electron@npm:12.2.3"
   dependencies:
     "@electron/get": ^1.0.1
     "@types/node": ^14.6.2
     extract-zip: ^1.0.3
   bin:
     electron: cli.js
-  checksum: d33b4603d7f9cdfa9755dc9b14d41a00f5775eda8e0d4b2e3d0530180f808d96a7225383ba5c96a8a6de6647908a169599e4ab6b2cd577fd97640a8a1a8b41eb
+  checksum: 5fcf095ad1a27c82507207cf3eae1a47953faaf986996cfd17d5700f0314f88deffa578ab57279361acb5e0e172af0e67ce31acba65548e68c584b1830ef24a5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9862,7 +9862,7 @@ __metadata:
     archiver: ^3.1.1
     copy-webpack-plugin: ^10.1.0
     cross-env: ^7.0.3
-    electron: ^12.2.3
+    electron: 12.2.3
     electron-builder: ^22.11.7
     electron-fetch: ^1.7.4
     electron-notarize: ^0.1.1
@@ -16200,7 +16200,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^12.2.3":
+"electron@npm:12.2.3":
   version: 12.2.3
   resolution: "electron@npm:12.2.3"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9874,7 +9874,7 @@ __metadata:
     keytar: ^7.7.0
     lodash: ^4.17.21
     make-dir: ^3.1.0
-    playwright: 1.16
+    playwright: ^1.18
     postcss: ^8.4.5
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -28343,32 +28343,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:=1.16.3":
-  version: 1.16.3
-  resolution: "playwright-core@npm:1.16.3"
-  dependencies:
-    commander: ^8.2.0
-    debug: ^4.1.1
-    extract-zip: ^2.0.1
-    https-proxy-agent: ^5.0.0
-    jpeg-js: ^0.4.2
-    mime: ^2.4.6
-    pngjs: ^5.0.0
-    progress: ^2.0.3
-    proper-lockfile: ^4.1.1
-    proxy-from-env: ^1.1.0
-    rimraf: ^3.0.2
-    socks-proxy-agent: ^6.1.0
-    stack-utils: ^2.0.3
-    ws: ^7.4.6
-    yauzl: ^2.10.0
-    yazl: ^2.5.1
-  bin:
-    playwright: cli.js
-  checksum: 9ae0cc2714d24fc464ab29cd9c9f4ed2b6d6cf0d88ed1034d40763501f4a9c5094bdff2008c1eb23123671eb61590b0c71af1971714d3b0b7541e42d3ba0d519
-  languageName: node
-  linkType: hard
-
 "playwright-core@npm:=1.18.1":
   version: 1.18.1
   resolution: "playwright-core@npm:1.18.1"
@@ -28392,17 +28366,6 @@ fsevents@~2.1.2:
   bin:
     playwright: cli.js
   checksum: e64581928d9a42dce66f623b3af8ff8774ab2b09518756eb72449b3c5988cbe7336e898926b0bf3a56c8f317e4419f7aaa2ca3d826e9b705e8912738ffb3d9c0
-  languageName: node
-  linkType: hard
-
-"playwright@npm:1.16":
-  version: 1.16.3
-  resolution: "playwright@npm:1.16.3"
-  dependencies:
-    playwright-core: =1.16.3
-  bin:
-    playwright: cli.js
-  checksum: dff5dd835a6d0a61d15b03dd2626971274c839babbc6533c6d0716129ec470fc3b95f3996d4e6f4a794c55e3380c20c97049a13d4fe8b06cc6a32fa418e4c0e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Try to update playwright for desktop to match Calypso.

### Updates

- [x] Remove major version lock (`^12.2.3` to `12.2.3`) because `electron-builder` doesn't like that (fails to resolve electron version)
