### PR TITLE
E2E: migrate the `Editor: Schedule a Post` spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -4,6 +4,15 @@ export type EditorSidebarTab = 'Post' | 'Block' | 'Page';
 export type EditorSidebarSection = 'Categories' | 'Tags' | 'Status & Visibility' | 'Permalink';
 export type PrivacyOptions = 'Public' | 'Private' | 'Password';
 
+interface Schedule {
+	year: number;
+	month: number;
+	date: number;
+	hours: number;
+	minutes: number;
+	meridian: 'am' | 'pm';
+}
+
 const sidebarParentSelector = '[aria-label="Editor settings"]';
 
 const selectors = {
@@ -26,6 +35,13 @@ const selectors = {
 	visibilityPopover: 'fieldset.editor-post-visibility__dialog-fieldset',
 	visibilityOption: ( option: PrivacyOptions ) => `input[value="${ option.toLowerCase() }"]`,
 	postPasswordInput: '.editor-post-visibility__dialog-password-input',
+
+	// Schedule
+	scheduleButton: `button.edit-post-post-schedule__toggle`,
+	scheduleInput: ( attribute: string ) => `input[name="${ attribute }"]`,
+	scheduleMeridianButton: ( meridian: 'am' | 'pm' ) =>
+		`button.components-datetime__time-${ meridian }-button`,
+	scheduleResetButton: 'button.components-datetime__date-reset-button',
 
 	// Category
 	categoryCheckbox: ( categoryName: string ) =>
@@ -134,7 +150,71 @@ export class EditorSettingsSidebarComponent {
 	}
 
 	/**
-	 * Clikcks on the Revisions section in the sidebar to show a revisions modal.
+	 * Opens the scheduler if required.
+	 */
+	async openSchedule(): Promise< void > {
+		const expanded = await this.frame.getAttribute( selectors.scheduleButton, 'aria-expanded' );
+		if ( expanded !== 'true' ) {
+			await this.frame.click( selectors.scheduleButton );
+		}
+		await this.frame.waitForSelector( `${ selectors.scheduleButton }[aria-expanded="true"]` );
+	}
+
+	/**
+	 * Closes the scheduler if required.
+	 *
+	 * Under certain circumstances, the scheduler is auto-dismissed at the end
+	 * of interaction and thus the closure is not required.
+	 *
+	 * For instance, if the current time is in the 'am' and the article is
+	 * scheduled for 'pm', the act of clicking on the 'pm' button dismisses the
+	 * scheduler.
+	 */
+	async closeSchedule(): Promise< void > {
+		const expanded = await this.frame.getAttribute( selectors.scheduleButton, 'aria-expanded' );
+		if ( expanded !== 'false' ) {
+			await this.frame.click( selectors.scheduleButton );
+		}
+		await this.frame.waitForSelector( `${ selectors.scheduleButton }[aria-expanded="false"]` );
+	}
+
+	/**
+	 * Schedules the page/post.
+	 *
+	 * @param {Schedule} date Date of the article to be scheduled.
+	 */
+	async schedule( date: Schedule ): Promise< void > {
+		for ( const [ key, value ] of Object.entries( date ) ) {
+			if ( key === 'meridian' ) {
+				// am/pm is a button.
+				await this.frame.click( selectors.scheduleMeridianButton( value ) );
+				continue;
+			}
+			if ( key === 'month' ) {
+				// For month numbers less than 10, pad the digit to be
+				// 2 digits as required by the select.
+				await this.frame.selectOption(
+					'select[name="month"]',
+					value.toString().padStart( 2, '0' )
+				);
+				continue;
+			}
+
+			// Regular input fields.
+			const targetSelector = selectors.scheduleInput( key );
+			await this.frame.fill( targetSelector, value.toString() );
+		}
+	}
+
+	/**
+	 * Resets previously set schedule.
+	 */
+	async resetSchedule(): Promise< void > {
+		await this.frame.click( selectors.scheduleResetButton );
+	}
+
+	/**
+	 * Clicks on the Revisions section in the sidebar to show a revisions modal.
 	 */
 	async showRevisions(): Promise< void > {
 		await this.frame.click( selectors.revisionsToggle );

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -184,10 +184,12 @@ export class EditorSettingsSidebarComponent {
 	 * @param {Schedule} date Date of the article to be scheduled.
 	 */
 	async schedule( date: Schedule ): Promise< void > {
-		for ( const [ key, value ] of Object.entries( date ) ) {
+		let key: keyof Schedule;
+
+		for ( key in date ) {
 			if ( key === 'meridian' ) {
 				// am/pm is a button.
-				await this.frame.click( selectors.scheduleMeridianButton( value ) );
+				await this.frame.click( selectors.scheduleMeridianButton( date[ key ] ) );
 				continue;
 			}
 			if ( key === 'month' ) {
@@ -195,14 +197,14 @@ export class EditorSettingsSidebarComponent {
 				// 2 digits as required by the select.
 				await this.frame.selectOption(
 					'select[name="month"]',
-					value.toString().padStart( 2, '0' )
+					date[ key ].toString().padStart( 2, '0' )
 				);
 				continue;
 			}
 
 			// Regular input fields.
 			const targetSelector = selectors.scheduleInput( key );
-			await this.frame.fill( targetSelector, value.toString() );
+			await this.frame.fill( targetSelector, date[ key ].toString() );
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -34,6 +34,8 @@ const selectors = {
 		`${ parentSelector } button:text("Publish")[aria-disabled=false]`,
 	updateButton: 'button:text("Update")',
 	switchToDraftButton: 'button.editor-post-switch-to-draft',
+	scheduleButton: ( parentSelector: string ) =>
+		`${ parentSelector } button:has-text("Schedule")[aria-disabled=false]`,
 
 	// Settings panel.
 	settingsPanel: '.interface-complementary-area',
@@ -381,6 +383,7 @@ export class GutenbergEditorPage {
 		const frame = await this.getEditorFrame();
 		await frame.click( selectors.closeSettingsButton );
 	}
+
 	/**
 	 * Publishes the post or page.
 	 *
@@ -390,8 +393,15 @@ export class GutenbergEditorPage {
 	async publish( { visit = false }: { visit?: boolean } = {} ): Promise< string > {
 		const frame = await this.getEditorFrame();
 
-		await frame.click( selectors.publishButton( selectors.postToolbar ) );
-		await frame.click( selectors.publishButton( selectors.publishPanel ) );
+		const initialPublishButton = `${ selectors.publishButton(
+			selectors.postToolbar
+		) }, ${ selectors.scheduleButton( selectors.postToolbar ) }`;
+		const secondaryPublishButton = `${ selectors.publishButton(
+			selectors.publishPanel
+		) }, ${ selectors.scheduleButton( selectors.publishPanel ) }`;
+
+		await frame.click( initialPublishButton );
+		await frame.click( secondaryPublishButton );
 		const publishedURL = await this.getPublishedURL();
 
 		if ( visit ) {
@@ -451,6 +461,15 @@ export class GutenbergEditorPage {
 
 		const viewPublishedArticleButton = await frame.waitForSelector( selectors.viewButton );
 		return ( await viewPublishedArticleButton.getAttribute( 'href' ) ) as string;
+	}
+
+	/**
+	 * Closes the post-publish panel.
+	 */
+	async closePostPublishPanel(): Promise< void > {
+		const frame = await this.getEditorFrame();
+
+		await frame.click( selectors.closePublishPanel );
 	}
 
 	/**

--- a/test/e2e/specs/specs-wpcom/wp-editor__schedule.ts
+++ b/test/e2e/specs/specs-wpcom/wp-editor__schedule.ts
@@ -58,11 +58,12 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 
 		it( 'Schedule the post for next year', async function () {
 			const date = new Date();
+			date.setUTCFullYear( date.getFullYear() + 1 );
 
 			await editorSettingsSidebarComponent.schedule( {
-				year: date.getFullYear() + 1,
-				month: date.getMonth(),
-				date: date.getDate(),
+				year: date.getUTCFullYear(),
+				month: date.getUTCMonth(),
+				date: date.getUTCDate(),
 				hours: 12,
 				minutes: 1,
 				meridian: 'am',
@@ -112,15 +113,14 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 			await editorSettingsSidebarComponent.openSchedule();
 		} );
 
-		it( 'Schedule post to first day of last month', async function () {
-			// Get the previous month. Dates in JS are 0-indexed.
+		it( 'Schedule post to fist of the current month of last year', async function () {
 			const date = new Date();
-			date.setMonth( new Date().getMonth() - 1 );
+			date.setUTCFullYear( date.getUTCFullYear() - 1 );
 
 			await editorSettingsSidebarComponent.schedule( {
-				year: date.getFullYear(),
+				year: date.getUTCFullYear(),
 				date: 1,
-				month: date.getMonth() + 1,
+				month: date.getUTCMonth(),
 				hours: 12,
 				minutes: 59,
 				meridian: 'pm',

--- a/test/e2e/specs/specs-wpcom/wp-editor__schedule.ts
+++ b/test/e2e/specs/specs-wpcom/wp-editor__schedule.ts
@@ -66,6 +66,8 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 				minutes: 1,
 				meridian: 'am',
 			} );
+			// On mobile, the sidebar covers all of the screen.
+			await editorSettingsSidebarComponent.closeSidebar();
 		} );
 
 		it( 'Publish post', async function () {
@@ -122,6 +124,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 				minutes: 59,
 				meridian: 'pm',
 			} );
+			await editorSettingsSidebarComponent.closeSidebar();
 		} );
 
 		it( 'Publish post', async function () {

--- a/test/e2e/specs/specs-wpcom/wp-editor__schedule.ts
+++ b/test/e2e/specs/specs-wpcom/wp-editor__schedule.ts
@@ -1,0 +1,146 @@
+/**
+ * @group gutenberg
+ */
+
+import {
+	DataHelper,
+	TestAccount,
+	envVariables,
+	GutenbergEditorPage,
+	EditorSettingsSidebarComponent,
+	PublishedPostPage,
+} from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
+	const accountName = envVariables.GUTENBERG_EDGE
+		? 'gutenbergSimpleSiteEdgeUser'
+		: 'simpleSitePersonalPlanUser';
+	const postTitle = `Scheduled Post: ${ DataHelper.getTimestamp() }`;
+	const postContent = DataHelper.getRandomPhrase();
+	let postURL: string;
+	let gutenbergEditorPage: GutenbergEditorPage;
+	let page: Page;
+
+	beforeAll( async function () {
+		page = await browser.newPage();
+
+		const testAccount = new TestAccount( accountName );
+		await testAccount.authenticate( page );
+	} );
+
+	it( 'Go to the new post page', async function () {
+		gutenbergEditorPage = new GutenbergEditorPage( page );
+		await gutenbergEditorPage.visit( 'post' );
+	} );
+
+	it( 'Enter page title', async function () {
+		gutenbergEditorPage = new GutenbergEditorPage( page );
+		await gutenbergEditorPage.enterTitle( postTitle );
+	} );
+
+	it( 'Enter page content', async function () {
+		await gutenbergEditorPage.enterText( postContent );
+	} );
+
+	describe( 'Schedule: future', function () {
+		let editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
+
+		it( 'Open scheduler', async function () {
+			const frame = await gutenbergEditorPage.getEditorFrame();
+			await gutenbergEditorPage.openSettings();
+			editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
+			await editorSettingsSidebarComponent.clickTab( 'Post' );
+			await editorSettingsSidebarComponent.openSchedule();
+		} );
+
+		it( 'Schedule the post for next year', async function () {
+			const currentDate = new Date();
+			await editorSettingsSidebarComponent.schedule( {
+				year: currentDate.getFullYear() + 1,
+				month: ( ( new Date().getMonth() + 1 ) % 12 ) + 1,
+				date: currentDate.getDate(),
+				hours: 12,
+				minutes: 1,
+				meridian: 'am',
+			} );
+		} );
+
+		it( 'Publish post', async function () {
+			postURL = await gutenbergEditorPage.publish();
+			await gutenbergEditorPage.closePostPublishPanel();
+		} );
+
+		it( `View post as ${ accountName }`, async function () {
+			const testPage = await browser.newPage();
+
+			const testAccount = new TestAccount( accountName );
+			await testAccount.authenticate( testPage );
+
+			await testPage.goto( postURL );
+			const publishedPostPage = new PublishedPostPage( testPage );
+			await publishedPostPage.validateTextInPost( postContent );
+		} );
+
+		it( 'View post as public', async function () {
+			const testPage = await browser.newPage();
+
+			await testPage.goto( postURL );
+			const publishedPostPage = new PublishedPostPage( testPage );
+			await publishedPostPage.validateTextInPost(
+				'It looks like nothing was found at this location. Maybe try a search?'
+			);
+		} );
+	} );
+
+	describe( 'Schedule: past', function () {
+		let editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
+
+		it( 'Open scheduler', async function () {
+			const frame = await gutenbergEditorPage.getEditorFrame();
+			await gutenbergEditorPage.openSettings();
+			editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
+			await editorSettingsSidebarComponent.clickTab( 'Post' );
+			await editorSettingsSidebarComponent.openSchedule();
+		} );
+
+		it( 'Schedule post to first day of last month', async function () {
+			await page.pause();
+
+			// Get the previous month.
+			const date = new Date();
+			date.setMonth( new Date().getMonth() - 1 );
+
+			await editorSettingsSidebarComponent.schedule( {
+				year: date.getFullYear(),
+				date: 1,
+				month: date.getMonth() + 1,
+				hours: 12,
+				minutes: 59,
+				meridian: 'pm',
+			} );
+		} );
+
+		it( 'Publish post', async function () {
+			postURL = await gutenbergEditorPage.publish();
+		} );
+
+		it.each( [ 'public', accountName, 'defaultUser' ] )(
+			'View post as %s',
+			async function ( user ) {
+				const testPage = await browser.newPage();
+
+				if ( user !== 'public' ) {
+					const testAccount = new TestAccount( accountName );
+					await testAccount.authenticate( testPage );
+				}
+
+				await testPage.goto( postURL );
+				const publishedPostPage = new PublishedPostPage( testPage );
+				await publishedPostPage.validateTextInPost( postContent );
+			}
+		);
+	} );
+} );

--- a/test/e2e/specs/specs-wpcom/wp-editor__schedule.ts
+++ b/test/e2e/specs/specs-wpcom/wp-editor__schedule.ts
@@ -82,6 +82,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 			await testPage.goto( postURL );
 			const publishedPostPage = new PublishedPostPage( testPage );
 			await publishedPostPage.validateTextInPost( postContent );
+			await testPage.close();
 		} );
 
 		it( 'View post as public', async function () {
@@ -92,6 +93,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 			await publishedPostPage.validateTextInPost(
 				'It looks like nothing was found at this location. Maybe try a search?'
 			);
+			await testPage.close();
 		} );
 	} );
 
@@ -102,14 +104,13 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 			const frame = await gutenbergEditorPage.getEditorFrame();
 			await gutenbergEditorPage.openSettings();
 			editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
+
 			await editorSettingsSidebarComponent.clickTab( 'Post' );
 			await editorSettingsSidebarComponent.openSchedule();
 		} );
 
 		it( 'Schedule post to first day of last month', async function () {
-			await page.pause();
-
-			// Get the previous month.
+			// Get the previous month. Dates in JS are 0-indexed.
 			const date = new Date();
 			date.setMonth( new Date().getMonth() - 1 );
 
@@ -140,6 +141,8 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 				await testPage.goto( postURL );
 				const publishedPostPage = new PublishedPostPage( testPage );
 				await publishedPostPage.validateTextInPost( postContent );
+
+				await testPage.close();
 			}
 		);
 	} );

--- a/test/e2e/specs/specs-wpcom/wp-editor__schedule.ts
+++ b/test/e2e/specs/specs-wpcom/wp-editor__schedule.ts
@@ -57,11 +57,12 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 		} );
 
 		it( 'Schedule the post for next year', async function () {
-			const currentDate = new Date();
+			const date = new Date();
+
 			await editorSettingsSidebarComponent.schedule( {
-				year: currentDate.getFullYear() + 1,
-				month: ( ( new Date().getMonth() + 1 ) % 12 ) + 1,
-				date: currentDate.getDate(),
+				year: date.getFullYear() + 1,
+				month: date.getMonth(),
+				date: date.getDate(),
 				hours: 12,
 				minutes: 1,
 				meridian: 'am',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the Editor: Schedule a Post spec to Playwright.

Key changes:
- addition of new methods and selectors to in the `EditorSettingsSidebarComponent` to interact with the scheduler.
- changes to the `GutenbergEditorPage.publish` method to support both Schedule and regular Post interactions.

#### Testing instructions

- [x] Ensure the following:
  - [x] Desktop passes.
  - [x] Mobile passes.

Related to #55950.