### PR TITLE
Seller Experience: Specify page template when creating the new home page

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -494,6 +494,7 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 				content: patternPost,
 				title: translate( 'Home' ),
 				status: 'publish',
+				template: 'header-footer-only',
 			},
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the "Header and Footer Only" page template for the new home page content to remove the page title and featured image, cleaning things up a bit.

**Before**

<img width="1899" alt="Screen Shot 2022-02-14 at 2 31 53 PM" src="https://user-images.githubusercontent.com/2124984/153933246-d4780fff-5b85-4921-9895-8fd59c15cce2.png">

**After**

<img width="1899" alt="Screen Shot 2022-02-14 at 2 22 35 PM" src="https://user-images.githubusercontent.com/2124984/153932005-0ab0991e-75b4-4394-9dda-984569d655e2.png">


#### Testing instructions

* Switch to this PR and navigate to `/start?flags=seller-experience`
* Go through signup and create a free site
* At the intent step, choose "Sell"
* Choose "Start simple"
* You should be brought to the site editor with the payments block template in place; no page title or featured image placeholder should be present, and the template at the top of the screen should be set to Header and Footer Only.

Related to #61014
