### PR TITLE
Seller Experience: Update initial block pattern with clearer copy and an image

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -428,11 +428,11 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 		 * Original pattern: https://dotcompatterns.wordpress.com/wp-admin/post.php?post=4348&action=edit
 		 */
 		const patternPost = `
-			<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"100px","bottom":"100px"}},"color":{"background":"#ecf2f3"}},"layout":{"inherit":true}} -->
-			<div class="wp-block-group alignfull has-background" style="background-color:#ecf2f3;padding-top:100px;padding-bottom:100px"><!-- wp:columns {"align":"wide"} -->
+			<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"100px","bottom":"100px"}},"color":{"background":"#f6f6f6"}},"textColor":"black","layout":{"inherit":true}} -->
+			<div class="wp-block-group alignfull has-black-color has-text-color has-background" style="background-color:#f6f6f6;padding-top:100px;padding-bottom:100px"><!-- wp:columns {"align":"wide"} -->
 			<div class="wp-block-columns alignwide"><!-- wp:column -->
-			<div class="wp-block-column"><!-- wp:image {"id":4390,"sizeSlug":"large","linkDestination":"none"} -->
-			<figure class="wp-block-image size-large"><img src="https://dotcompatterns.files.wordpress.com/2022/02/pexels-cottonbro-7026777.jpg?w=683" alt="" class="wp-image-4390"/></figure>
+			<div class="wp-block-column"><!-- wp:image {"id":4407,"sizeSlug":"large","linkDestination":"none"} -->
+			<figure class="wp-block-image size-large"><img src="https://dotcompatterns.files.wordpress.com/2022/02/image-placeholder.png?w=1024" alt="" class="wp-image-4407"/></figure>
 			<!-- /wp:image --></div>
 			<!-- /wp:column -->
 
@@ -441,8 +441,8 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 			<h1 id="item-name" style="font-size:40px;margin-top:0px">Item Name</h1>
 			<!-- /wp:heading -->
 
-			<!-- wp:heading {"style":{"color":{"text":"#76797a"}},"fontSize":"medium"} -->
-			<h2 class="has-text-color has-medium-font-size" id="0-00" style="color:#76797a">$0.00</h2>
+			<!-- wp:heading {"style":{"color":{"text":"#444444"}},"fontSize":"medium"} -->
+			<h2 class="has-text-color has-medium-font-size" id="0-00" style="color:#444444">$0.00</h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"style":{"color":{"text":"#444444"}},"fontSize":"small"} -->
@@ -450,7 +450,7 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 			<!-- /wp:paragraph -->
 
 			<!-- wp:jetpack/recurring-payments -->
-			<div class="wp-block-jetpack-recurring-payments"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":"Buy Now","textColor":"background","backgroundColor":"black","borderRadius":0,"width":"100%"} /--></div>
+			<div class="wp-block-jetpack-recurring-payments"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":"Buy Now","customTextColor":"#ffffff","backgroundColor":"black","borderRadius":0,"width":"100%"} /--></div>
 			<!-- /wp:jetpack/recurring-payments -->
 
 			<!-- wp:spacer {"height":"20px"} -->
@@ -463,13 +463,7 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 
 			<!-- wp:paragraph {"style":{"color":{"text":"#444444"}},"fontSize":"small"} -->
 			<p class="has-text-color has-small-font-size" style="color:#444444">Describe your item. Use this section to add a full description and details of your product, along with its many selling points.</p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:social-links {"iconColor":"cyan-bluish-gray","iconColorValue":"#abb8c3","className":"is-style-logos-only"} -->
-			<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"#","service":"facebook"} /-->
-
-			<!-- wp:social-link {"url":"#","service":"instagram"} /--></ul>
-			<!-- /wp:social-links --></div>
+			<!-- /wp:paragraph --></div>
 			<!-- /wp:column --></div>
 			<!-- /wp:columns --></div>
 			<!-- /wp:group -->

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -428,63 +428,51 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 		 * Original pattern: https://dotcompatterns.wordpress.com/wp-admin/post.php?post=4348&action=edit
 		 */
 		const patternPost = `
-			<!-- wp:columns {"align":"wide"} -->
-			<div class="wp-block-columns alignwide">
-				<!-- wp:column -->
-				<div class="wp-block-column">
-					<!-- wp:image -->
-					<figure class="wp-block-image"><img alt="" /></figure>
-					<!-- /wp:image -->
-				</div>
-				<!-- /wp:column -->
+			<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"100px","bottom":"100px"}},"color":{"background":"#ecf2f3"}},"layout":{"inherit":true}} -->
+			<div class="wp-block-group alignfull has-background" style="background-color:#ecf2f3;padding-top:100px;padding-bottom:100px"><!-- wp:columns {"align":"wide"} -->
+			<div class="wp-block-columns alignwide"><!-- wp:column -->
+			<div class="wp-block-column"><!-- wp:image {"id":4390,"sizeSlug":"large","linkDestination":"none"} -->
+			<figure class="wp-block-image size-large"><img src="https://dotcompatterns.files.wordpress.com/2022/02/pexels-cottonbro-7026777.jpg?w=683" alt="" class="wp-image-4390"/></figure>
+			<!-- /wp:image --></div>
+			<!-- /wp:column -->
 
-				<!-- wp:column {"style":{"spacing":{"padding":{"right":"10%","left":"5%"}}}} -->
-				<div class="wp-block-column" style="padding-right:10%;padding-left:5%">
-					<!-- wp:heading {"textAlign":"left","fontSize":"x-large"} -->
-					<h2 class="has-text-align-left has-x-large-font-size" id="item-name">${ translate(
-						'Item Name'
-					) }</h2>
-					<!-- /wp:heading -->
+			<!-- wp:column {"style":{"spacing":{"padding":{"right":"40px","left":"40px"}}}} -->
+			<div class="wp-block-column" style="padding-right:40px;padding-left:40px"><!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"40px"},"spacing":{"margin":{"top":"0px"}}}} -->
+			<h1 id="item-name" style="font-size:40px;margin-top:0px">Item Name</h1>
+			<!-- /wp:heading -->
 
-					<!-- wp:paragraph {"align":"left","style":{"color":{"text":"#808080"}},"fontSize":"small"} -->
-					<p class="has-text-align-left has-text-color has-small-font-size" style="color:#808080">${ translate(
-						'Quick details'
-					) }</p>
-					<!-- /wp:paragraph -->
+			<!-- wp:heading {"style":{"color":{"text":"#76797a"}},"fontSize":"medium"} -->
+			<h2 class="has-text-color has-medium-font-size" id="0-00" style="color:#76797a">$0.00</h2>
+			<!-- /wp:heading -->
 
-					<!-- wp:heading {"level":3,"fontSize":"medium"} -->
-					<h3 class="has-medium-font-size" id="0-00">$0.00</h3>
-					<!-- /wp:heading -->
+			<!-- wp:paragraph {"style":{"color":{"text":"#444444"}},"fontSize":"small"} -->
+			<p class="has-text-color has-small-font-size" style="color:#444444">Short description of your item.</p>
+			<!-- /wp:paragraph -->
 
-					<!-- wp:jetpack/recurring-payments -->
-					<div class="wp-block-jetpack-recurring-payments">
-						<!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":"${ translate(
-							'Buy Now'
-						) }","backgroundColor":"primary","borderRadius":0,"width":"100%"} /-->
-					</div>
-					<!-- /wp:jetpack/recurring-payments -->
+			<!-- wp:jetpack/recurring-payments -->
+			<div class="wp-block-jetpack-recurring-payments"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":"Buy Now","textColor":"background","backgroundColor":"black","borderRadius":0,"width":"100%"} /--></div>
+			<!-- /wp:jetpack/recurring-payments -->
 
-					<!-- wp:spacer {"height":"20px"} -->
-					<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
-					<!-- /wp:spacer -->
+			<!-- wp:spacer {"height":"20px"} -->
+			<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
 
-					<!-- wp:paragraph {"align":"left","style":{"typography":{"fontSize":18}}} -->
-					<p class="has-text-align-left" style="font-size:18px">${ translate(
-						`Describe your item. You can add a few lines here that describe the item you're selling. Or just delete this block if you don't need it!`
-					) }</p>
-					<!-- /wp:paragraph -->
+			<!-- wp:paragraph {"fontSize":"small"} -->
+			<p class="has-small-font-size"><strong>Description</strong></p>
+			<!-- /wp:paragraph -->
 
-					<!-- wp:social-links {"iconColor":"foreground-dark","iconColorValue":"#101010","className":"is-style-logos-only"} -->
-					<ul class="wp-block-social-links has-icon-color is-style-logos-only">
-						<!-- wp:social-link {"service":"facebook"} /-->
+			<!-- wp:paragraph {"style":{"color":{"text":"#444444"}},"fontSize":"small"} -->
+			<p class="has-text-color has-small-font-size" style="color:#444444">Describe your item. Use this section to add a full description and details of your product, along with its many selling points.</p>
+			<!-- /wp:paragraph -->
 
-						<!-- wp:social-link {"service":"twitter"} /-->
-					</ul>
-					<!-- /wp:social-links -->
-				</div>
-				<!-- /wp:column -->
-			</div>
-			<!-- /wp:columns -->
+			<!-- wp:social-links {"iconColor":"cyan-bluish-gray","iconColorValue":"#abb8c3","className":"is-style-logos-only"} -->
+			<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"#","service":"facebook"} /-->
+
+			<!-- wp:social-link {"url":"#","service":"instagram"} /--></ul>
+			<!-- /wp:social-links --></div>
+			<!-- /wp:column --></div>
+			<!-- /wp:columns --></div>
+			<!-- /wp:group -->
 		`;
 		// Create a new Home page
 		const newPage = await wpcom.req.post( {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -438,7 +438,7 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 
 			<!-- wp:column {"style":{"spacing":{"padding":{"right":"40px","left":"40px"}}}} -->
 			<div class="wp-block-column" style="padding-right:40px;padding-left:40px"><!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"40px"},"spacing":{"margin":{"top":"0px"}}}} -->
-			<h1 id="item-name" style="font-size:40px;margin-top:0px">Item Name</h1>
+			<h1 id="item-name" style="font-size:40px;margin-top:0px">${ translate( 'Item Name' ) }</h1>
 			<!-- /wp:heading -->
 
 			<!-- wp:heading {"style":{"color":{"text":"#444444"}},"fontSize":"medium"} -->
@@ -446,11 +446,15 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"style":{"color":{"text":"#444444"}},"fontSize":"small"} -->
-			<p class="has-text-color has-small-font-size" style="color:#444444">Short description of your item.</p>
+			<p class="has-text-color has-small-font-size" style="color:#444444">${ translate(
+				'Short description of your item.'
+			) }</p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:jetpack/recurring-payments -->
-			<div class="wp-block-jetpack-recurring-payments"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":"Buy Now","customTextColor":"#ffffff","backgroundColor":"black","borderRadius":0,"width":"100%"} /--></div>
+			<div class="wp-block-jetpack-recurring-payments"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":${ translate(
+				'Buy Now'
+			) },"customTextColor":"#ffffff","backgroundColor":"black","borderRadius":0,"width":"100%"} /--></div>
 			<!-- /wp:jetpack/recurring-payments -->
 
 			<!-- wp:spacer {"height":"20px"} -->
@@ -458,11 +462,13 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 			<!-- /wp:spacer -->
 
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size"><strong>Description</strong></p>
+			<p class="has-small-font-size"><strong>${ translate( 'Description' ) }</strong></p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:paragraph {"style":{"color":{"text":"#444444"}},"fontSize":"small"} -->
-			<p class="has-text-color has-small-font-size" style="color:#444444">Describe your item. Use this section to add a full description and details of your product, along with its many selling points.</p>
+			<p class="has-text-color has-small-font-size" style="color:#444444">${ translate(
+				'Describe your item. Use this section to add a full description and details of your product, along with its many selling points.'
+			) }</p>
 			<!-- /wp:paragraph --></div>
 			<!-- /wp:column --></div>
 			<!-- /wp:columns --></div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds an image and some color to the default block template for the seller experience.

(This may change between now and tomorrow! This PR is good for testing upcoming updates to the pattern in the flow since it's currently hard-coded there.)

**Before**

<img width="1121" alt="Screen Shot 2022-02-14 at 2 49 53 PM" src="https://user-images.githubusercontent.com/2124984/153935871-bdb2383c-ebda-40cd-9ebb-e2bba9393241.png">

**After**

<img width="1269" alt="Screen Shot 2022-02-15 at 10 16 25 AM" src="https://user-images.githubusercontent.com/2124984/154091488-c79a2b60-86d6-4bf7-a1c7-cbf8b69e2ff1.png">



#### Testing instructions

* Switch to this PR, navigate to `/start?flags=seller-experience`
* Create a new free site, choose Sell from the intent step
* Choose Start simple
* You should see updates to the starter content when you land in the site editor 

Related to #61015, https://github.com/Automattic/wp-calypso/issues/61014#issuecomment-1036322201
