### PR TITLE
Jetpack Connection: Fix broken route when site_url is trailing slashed

### DIFF
--- a/client/lib/route/path.ts
+++ b/client/lib/route/path.ts
@@ -45,7 +45,7 @@ export function getSiteFragment( path: URLString ): SiteSlug | SiteId | false {
 	for ( let i = 2; i > 0; i-- ) {
 		const piece = pieces[ pieces.length - i ];
 		if ( piece && -1 !== piece.indexOf( '.' ) ) {
-			return piece.endsWith( '::' ) ? piece.replace( '::', '' ) : piece;
+			return piece.endsWith( '::' ) ? piece.replace( /::$/, '' ) : piece;
 		}
 	}
 

--- a/client/lib/route/path.ts
+++ b/client/lib/route/path.ts
@@ -45,7 +45,7 @@ export function getSiteFragment( path: URLString ): SiteSlug | SiteId | false {
 	for ( let i = 2; i > 0; i-- ) {
 		const piece = pieces[ pieces.length - i ];
 		if ( piece && -1 !== piece.indexOf( '.' ) ) {
-			return piece;
+			return piece.endsWith( '::' ) ? piece.replace( '::', '' ) : piece;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the Jetpack connection flow for IONOS users, if a site_url/home_url is trailingslashed, we end up without a valid selected site when we send them to checkout, and the flow breaks. This seems to happen because the home_url/site_url is converted to a site slug with the trailing slash, thereby creating a site slug that ends with the double colon. This cannot be matched against a valid site, and siteSelection fails.

A most direct fix is to strip off the trailing double colon when present, which is what we're doing here.

#### Testing instructions

* Create a new JN site. SSH into the new site and define home_url and site_url with a trailing slash in wp-config.php.
* Enter the IONOS flow via `/wp-admin/admin.php?jetpack-partner-coupon=IONOS_IONA_99999` and ensure you are led to a checkout screen with the coupon applied, after a connection is completed.
* Obviously, check around Calypso for any other breakage, even though we cannot think of any valid reason to have a trailing-double-colon site slug.

It doesn't have to be IONOS or partner coupon specific in testing. The following instructions - without this PR - should reveal the issue as well:

1. Create a JN site
2. SSH into JN and add WP_HOME + WP_SITEURL constants in wp-config.php that ends with a trailing slash.
3. Go to Jetpack Dashboard and connect Jetpack
4. Press "Authorize" in Calypso to make a user connection
5. You should now end up on https://wordpress.com/jetpack/connect/store (which is incorrect - it should be the site specific plan page)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

