### PR TITLE
Seller Experience: Make sure site data is saved when moving from signup to Woo flow

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { englishLocales } from '@automattic/i18n-utils';
+import { addQueryArgs as addWPQueryArgs } from '@wordpress/url';
 import { get, includes, reject } from 'lodash';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -98,7 +99,7 @@ function getEditorDestination( dependencies ) {
 }
 
 function getDestinationFromIntent( dependencies ) {
-	const { intent, startingPoint, siteSlug, isFSEActive } = dependencies;
+	const { intent, storeType, startingPoint, siteSlug, isFSEActive } = dependencies;
 
 	// If the user skips starting point, redirect them to My Home
 	if ( intent === 'write' && startingPoint !== 'skip-to-my-home' ) {
@@ -107,6 +108,13 @@ function getDestinationFromIntent( dependencies ) {
 		}
 
 		return `/post/${ siteSlug }`;
+	}
+
+	if ( intent === 'sell' && storeType === 'woocommerce' ) {
+		return addWPQueryArgs( `/start/woocommerce-install`, {
+			back_to: `/start/setup-site/store-features?siteSlug=${ siteSlug }`,
+			siteSlug: siteSlug,
+		} );
 	}
 
 	if ( ! isFSEActive && intent === 'sell' ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,6 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { englishLocales } from '@automattic/i18n-utils';
-import { addQueryArgs as addWPQueryArgs } from '@wordpress/url';
 import { get, includes, reject } from 'lodash';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -111,10 +110,13 @@ function getDestinationFromIntent( dependencies ) {
 	}
 
 	if ( intent === 'sell' && storeType === 'woocommerce' ) {
-		return addWPQueryArgs( `/start/woocommerce-install`, {
-			back_to: `/start/setup-site/store-features?siteSlug=${ siteSlug }`,
-			siteSlug: siteSlug,
-		} );
+		return addQueryArgs(
+			{
+				back_to: `/start/setup-site/store-features?siteSlug=${ siteSlug }`,
+				siteSlug: siteSlug,
+			},
+			`/start/woocommerce-install`
+		);
 	}
 
 	if ( ! isFSEActive && intent === 'sell' ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -192,11 +192,10 @@ export function generateSteps( {
 
 		'store-features': {
 			stepName: 'store-features',
-			dependencies: [ 'siteSlug' ],
+			dependencies: [ 'siteSlug', 'siteTitle', 'tagline' ],
 			apiRequestFunction: setStoreFeatures,
-			delayApiRequestUntilComplete: true,
-			providesDependencies: [ 'isFSEActive' ],
-			optionalDependencies: [ 'isFSEActive' ],
+			providesDependencies: [ 'isFSEActive', 'siteTitle', 'tagline', 'storeType' ],
+			optionalDependencies: [ 'isFSEActive', 'siteTitle', 'tagline', 'storeType' ],
 		},
 
 		'starting-point': {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -192,10 +192,10 @@ export function generateSteps( {
 
 		'store-features': {
 			stepName: 'store-features',
-			dependencies: [ 'siteSlug', 'siteTitle', 'tagline' ],
+			dependencies: [ 'siteSlug' ],
 			apiRequestFunction: setStoreFeatures,
-			providesDependencies: [ 'isFSEActive', 'siteTitle', 'tagline', 'storeType' ],
-			optionalDependencies: [ 'isFSEActive', 'siteTitle', 'tagline', 'storeType' ],
+			providesDependencies: [ 'isFSEActive', 'storeType' ],
+			optionalDependencies: [ 'isFSEActive', 'storeType' ],
 		},
 
 		'starting-point': {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -187,7 +187,6 @@ export function generateSteps( {
 			dependencies: [ 'siteSlug', 'siteTitle', 'tagline' ],
 			providesDependencies: [ 'siteTitle', 'tagline' ],
 			apiRequestFunction: setOptionsOnSite,
-			delayApiRequestUntilComplete: true,
 		},
 
 		'store-features': {

--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -28,7 +28,7 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 	const translate = useTranslate();
 	const headerText = translate( 'Set up your store' );
 	const subHeaderText = translate( 'Let’s create a website that suits your needs.' );
-	const { siteSlug } = props.signupDependencies;
+	const siteSlug = props.signupDependencies.siteSlug;
 	const { stepName, goToNextStep } = props;
 
 	const sitePlanSlug = useSelector( ( state ) => getSite( state, siteSlug )?.plan?.product_slug );

--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -28,7 +28,7 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 	const translate = useTranslate();
 	const headerText = translate( 'Set up your store' );
 	const subHeaderText = translate( 'Let’s create a website that suits your needs.' );
-	const { siteSlug, siteTitle, tagline } = props.signupDependencies;
+	const { siteSlug } = props.signupDependencies;
 	const { stepName, goToNextStep } = props;
 
 	const sitePlanSlug = useSelector( ( state ) => getSite( state, siteSlug )?.plan?.product_slug );
@@ -153,9 +153,7 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 		} );
 		switch ( selectedOption ) {
 			case 'power':
-				dispatch(
-					submitSignupStep( { stepName }, { siteTitle, tagline, storeType: 'woocommerce' } )
-				);
+				dispatch( submitSignupStep( { stepName }, { storeType: 'woocommerce' } ) );
 				break;
 
 			case 'simple': {

--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -1,6 +1,4 @@
-import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import intentImageUrl from 'calypso/assets/images/onboarding/intent.svg';
@@ -30,7 +28,7 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 	const translate = useTranslate();
 	const headerText = translate( 'Set up your store' );
 	const subHeaderText = translate( 'Let’s create a website that suits your needs.' );
-	const siteSlug = props.signupDependencies.siteSlug;
+	const { siteSlug, siteTitle, tagline } = props.signupDependencies;
 	const { stepName, goToNextStep } = props;
 
 	const sitePlanSlug = useSelector( ( state ) => getSite( state, siteSlug )?.plan?.product_slug );
@@ -155,19 +153,16 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 		} );
 		switch ( selectedOption ) {
 			case 'power':
-				page(
-					addQueryArgs( `/start/woocommerce-install`, {
-						back_to: `/start/setup-site/store-features?siteSlug=${ siteSlug }`,
-						siteSlug: siteSlug,
-					} )
+				dispatch(
+					submitSignupStep( { stepName }, { siteTitle, tagline, storeType: 'woocommerce' } )
 				);
 				break;
 
 			case 'simple': {
 				dispatch( submitSignupStep( { stepName } ) );
-				goToNextStep();
 			}
 		}
+		goToNextStep();
 	};
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Don't delay API calls until the end of the flow; run them as the data is submitted.
* Refactor WooCommerce seller experience flow to use `getDestinationFromIntent`
* Set a new `storeType` dependency to determine when to go to the Woo signup flow

**Video demo:**

https://user-images.githubusercontent.com/2124984/153952487-55d1a001-50b8-4cf4-8fa3-ae5feeeb8a9b.mov


(Pardon the awkward cuts around the address and checkout steps, 1PW kept auto-filling my actual address. 🙃 )

#### Testing instructions

* Switch to this PR, navigate to `/start?flags=seller-experience`
* Create a new free site
* Choose Sell at the intent step
* Add a custom site title and tagline
* Choose "More power" from the store features step
* You should be redirected to the WooCommerce setup; complete these steps, including checkout with a Business plan
* When you land in My Home with your new WooCommerce-enabled site, your site title and tagline should be set in the site card of the sidebar, and when viewing the front end of your site.

Fixes #60978
