### PR TITLE
Use first-of-type instead of first-child - per react warning

### DIFF
--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -23,7 +23,7 @@ const StyledLi = styled.li`
 		--color-link: var( --studio-gray-80 );
 	}
 
-	:last-child:not( :first-child ) {
+	:last-of-type:not( :first-of-type ) {
 		--color-link: var( --studio-gray-50 );
 	}
 `;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use first-of-type instead of first-child - per react warning

Before
![first-child-before](https://user-images.githubusercontent.com/811776/153996390-16af3511-8111-49ed-9fdc-892d2115d7f2.png)

After
![first-child-after](https://user-images.githubusercontent.com/811776/153996397-ad6624b8-4711-40de-8204-e6071e31bfe0.png)

#### Testing instructions

* Check the first-child warning is no longer present on plugins or woocommerce landing screens e.g. http://calypso.localhost:3000/woocommerce-installation/
* Check the last breadcrumb font color is still a lighter grey than other breadcrumbs:
![Screenshot 2022-02-15 at 16-07-08 WooCommerce Subscriptions Plugin ‹ test — WordPress com](https://user-images.githubusercontent.com/811776/153996515-745a4fec-78d1-48ea-b5be-520c058853f1.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/58222
