### PR TITLE
Rename Featured (paid) to Premium and reinstate Featured (free)

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -461,7 +461,7 @@ const translateCategory = ( { category, translate } ) => {
 				context: 'Category description for the plugin browser.',
 			} );
 		case 'paid':
-			return translate( 'Featured', {
+			return translate( 'Premium', {
 				context: 'Category description for the plugin browser.',
 			} );
 	}
@@ -557,7 +557,10 @@ const PluginBrowserContent = ( props ) => {
 	return (
 		<>
 			{ ! props.jetpackNonAtomic ? (
-				<PluginSingleListView { ...props } category="paid" />
+				<>
+					<PluginSingleListView { ...props } category="paid" />
+					<PluginSingleListView { ...props } category="featured" />
+				</>
 			) : (
 				<PluginSingleListView { ...props } category="featured" />
 			) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename "Featured" (paid) to "Premium" and reinstate "Featured" (free) section.

#### Testing instructions

* [x] http://calypso.localhost:3000/plugins
* [x] Confirm "Featured" / "Premium" headings and what's below them makes sense
* [x] Confirm Jetpack non atomic sites still only show the "Featured" (free) section.

#### Before 
![Screenshot 2022-02-15 at 16-47-32 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/154000266-7385912a-9d93-4c68-8fa9-35a9f0012bf8.png)

#### After
![Screenshot 2022-02-15 at 16-47-16 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/154000273-9cbfdc2c-416c-48d4-bb88-ad22b2ee6bff.png)


Related to https://github.com/Automattic/wp-calypso/issues/60553
