### PR TITLE
Use more specific CTA for plan upgrade nudge on email home

### DIFF
--- a/client/my-sites/email/email-management/home/email-no-domain.jsx
+++ b/client/my-sites/email/email-management/home/email-no-domain.jsx
@@ -24,12 +24,12 @@ const EmailNoDomain = ( { selectedSite, translate, source } ) => {
 	if ( isFreePlanProduct ) {
 		return (
 			<EmptyContent
-				action={ translate( 'Upgrade', { context: 'verb' } ) }
+				action={ translate( 'Upgrade to a plan' ) }
 				actionCallback={ trackEvent }
 				actionURL={ `/plans/${ selectedSite.slug }` }
 				illustration={ Illustration }
 				line={ translate(
-					'Upgrade now, set up your domain and pick from one of our flexible options to connect your domain with email and start getting emails today.'
+					'Upgrade to a plan now, set up your domain and pick from one of our flexible options to connect your domain with email and start getting emails today.'
 				) }
 				title={ translate( 'Get your own domain for a custom email address' ) }
 			/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR changes the CTA and subheading on the upsell page we show users without a domain or paid plan on their site, mainly to make it clearer what will happen when they click on the CTA. The current CTA of "Upgrade" doesn't make it clear that we're going to kick off a plan purchase flow, we want to make the transition less jarring.
  - This mismatch was flagged internally here: p58i-bIN-p2#comment-52852

#### Testing instructions

* Run this branch locally or via [the Calypso live branch](https://github.com/Automattic/wp-calypso/pull/61106#issuecomment-1040062267).
* For a free site without any domains, navigate to **Upgrades** -> **Emails**
* Verify that the CTA on the upsell is "Upgrade to a plan"

##### Screenshots

| Before | After |
| ------ | ----- |
| <img width="1094" alt="Screenshot 2022-02-15 at 11 03 01" src="https://user-images.githubusercontent.com/3376401/154034892-fcfdc643-d765-4b9c-85f9-a385f369f04f.png"> | <img width="1094" alt="Screenshot 2022-02-15 at 11 02 44" src="https://user-images.githubusercontent.com/3376401/154034871-0eabd99b-6683-445b-b42a-5ae445ec2525.png"> |