### PR TITLE
Improve heading tag hierarchy on My Home

### DIFF
--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -19,6 +19,7 @@ class FoldableCard extends Component {
 		disabled: PropTypes.bool,
 		expandedSummary: PropTypes.node,
 		expanded: PropTypes.bool,
+		headerTagName: PropTypes.string,
 		icon: PropTypes.string,
 		onClick: PropTypes.func,
 		onClose: PropTypes.func,
@@ -32,6 +33,7 @@ class FoldableCard extends Component {
 		onOpen: noop,
 		onClose: noop,
 		cardKey: '',
+		headerTagName: 'span',
 		icon: 'chevron-down',
 		expanded: false,
 		screenReaderText: false,
@@ -121,7 +123,7 @@ class FoldableCard extends Component {
 			'has-border': !! this.props.summary,
 		} );
 		const header = createElement(
-			this.props.headerTag ?? 'span',
+			this.props.headerTagName,
 			{ classnames: 'foldable-card__main' },
 			this.props.header,
 			this.renderActionButton()

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -2,7 +2,7 @@ import { Card, CompactCard, ScreenReaderText, Gridicon } from '@automattic/compo
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { Component, createElement } from 'react';
 
 import './style.scss';
 
@@ -120,12 +120,16 @@ class FoldableCard extends Component {
 			'is-clickable': !! this.props.clickableHeader,
 			'has-border': !! this.props.summary,
 		} );
+		const header = createElement(
+			this.props.headerTag ?? 'span',
+			{ classnames: 'foldable-card__main' },
+			this.props.header,
+			this.renderActionButton()
+		);
+
 		return (
 			<div className={ headerClasses } role="presentation" onClick={ headerClickAction }>
-				<span className="foldable-card__main">
-					{ this.props.header }
-					{ this.renderActionButton() }
-				</span>
+				{ header }
 				<span className="foldable-card__secondary">
 					{ summary }
 					{ expandedSummary }

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -124,7 +124,7 @@ class FoldableCard extends Component {
 		} );
 		const header = createElement(
 			this.props.headerTagName,
-			{ classnames: 'foldable-card__main' },
+			{ className: 'foldable-card__main' },
 			this.props.header,
 			this.renderActionButton()
 		);

--- a/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
@@ -34,7 +34,7 @@ const ActionBox = ( {
 		>
 			<div className="quick-links__action-box-image">{ getIcon() }</div>
 			<div className="quick-links__action-box-text">
-				<h6 className="quick-links__action-box-label">{ label }</h6>
+				<span className="quick-links__action-box-label">{ label }</span>
 			</div>
 		</CompactCard>
 	);

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -230,6 +230,7 @@ export const QuickLinks = ( {
 	return (
 		<FoldableCard
 			className="quick-links"
+			headerTag="h2"
 			header={ translate( 'Quick links' ) }
 			clickableHeader
 			expanded={ isExpanded }

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -230,7 +230,7 @@ export const QuickLinks = ( {
 	return (
 		<FoldableCard
 			className="quick-links"
-			headerTag="h2"
+			headerTagName="h2"
 			header={ translate( 'Quick links' ) }
 			clickableHeader
 			expanded={ isExpanded }

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -64,6 +64,10 @@
 		transition: all 0.1s;
 	}
 
+	.quick-links__action-box-text {
+		display: flex;
+	}
+
 	.quick-links__action-box-label {
 		color: var( --color-text );
 		font-size: $font-body-small;

--- a/client/my-sites/customer-home/cards/education/educational-content/index.jsx
+++ b/client/my-sites/customer-home/cards/education/educational-content/index.jsx
@@ -31,7 +31,7 @@ function EducationalContent( {
 	return (
 		<div className="educational-content">
 			<div className="educational-content__wrapper">
-				<h3>{ title }</h3>
+				<h2>{ title }</h2>
 				<p className="educational-content__description customer-home__card-subheader">
 					{ description }
 				</p>

--- a/client/my-sites/customer-home/cards/education/educational-content/style.scss
+++ b/client/my-sites/customer-home/cards/education/educational-content/style.scss
@@ -11,7 +11,7 @@
 		text-align: center;
 	}
 
-	h3 {
+	h2 {
 		font-weight: 600;
 		font-size: $font-body;
 		margin-bottom: 8px;

--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -29,10 +29,10 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 		<Card className="go-mobile customer-home__card">
 			<div className={ classnames( 'go-mobile__row', { 'has-2-cols': showOnlyOneBadge } ) }>
 				<div className="go-mobile__title">
-					<CardHeading>{ translate( 'WordPress app' ) }</CardHeading>
-					<h6 className="go-mobile__subheader customer-home__card-subheader">
+					<CardHeading tagName="h2">{ translate( 'WordPress app' ) }</CardHeading>
+					<h3 className="go-mobile__subheader customer-home__card-subheader">
 						{ translate( 'Make updates on the go.' ) }
-					</h6>
+					</h3>
 				</div>
 				<div className="go-mobile__app-badges">
 					{ showIosBadge && (

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -47,7 +47,7 @@ export default function HelpSearch() {
 		<>
 			<Card className="help-search customer-home__card">
 				<div className="help-search__inner">
-					<CardHeading>{ translate( 'Get help' ) }</CardHeading>
+					<CardHeading tagName="h2">{ translate( 'Get help' ) }</CardHeading>
 					<div className="help-search__content">
 						<div className="help-search__search inline-help__search">
 							<HelpSearchCard

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -22,7 +22,7 @@ const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout
 					</div>
 				) }
 				{ ! useAccordionLayout && (
-					<h2 className="site-setup-list__task-title task__title">{ currentTask.title }</h2>
+					<h3 className="site-setup-list__task-title task__title">{ currentTask.title }</h3>
 				) }
 				<p className="site-setup-list__task-description task__description">
 					{ currentTask.description }

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -262,7 +262,7 @@ const SiteSetupList = ( {
 			) }
 
 			<div className="site-setup-list__nav">
-				<CardHeading>
+				<CardHeading tagName="h2">
 					{ isBlogger ? translate( 'Blog setup' ) : translate( 'Site setup' ) }
 				</CardHeading>
 				<ul

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -51,7 +51,7 @@ const NavItem = ( {
 				) }
 			</div>
 			<div className="nav-item__text">
-				<h6>{ text }</h6>
+				<span>{ text }</span>
 			</div>
 			{ useAccordionLayout && (
 				<div className="nav-item__end">

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -165,6 +165,7 @@
 	}
 
 	.nav-item__text {
+		display: flex;
 		text-align: left;
 		line-height: 20px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change updates the HTML tag structuring of several components in My Home so that the heading hierarchy makes more sense. The new proposed hierarchy is as described in the screenshot below:
 
![Screen Shot 2022-02-15 at 6 11 49 PM](https://user-images.githubusercontent.com/797888/154045084-a93bd02f-8e88-4727-9188-ca8e808a68fe.png)


  
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to My Home.
* Using the browser's developer tools, verify that the HTML tags are as described in the screenshot provided above.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53617
