### PR TITLE
Videos UI: Fix back button is broken on mobile

### DIFF
--- a/client/lib/route-modal/index.ts
+++ b/client/lib/route-modal/index.ts
@@ -1,0 +1,1 @@
+export { default as useRouteModal } from './use-route-modal';

--- a/client/lib/route-modal/use-route-modal.tsx
+++ b/client/lib/route-modal/use-route-modal.tsx
@@ -2,15 +2,15 @@ import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import page from 'page';
 import { useSelector } from 'react-redux';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import getPreviousRoute from 'calypso/state/selectors/get-previous-route.js';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 
 interface ReturnValues {
 	/** Whether the query key exists or not */
 	isModalOpen: boolean;
 	/** The value of query key */
-	value: any;
+	value: unknown;
 	/** Set the query key to value */
-	openModal: ( value?: any ) => void;
+	openModal: ( currentValue?: unknown ) => void;
 	/** Clears the query key */
 	closeModal: () => void;
 }
@@ -18,7 +18,7 @@ interface ReturnValues {
 /**
  * React hook providing utils to control opening and closing modal via query string.
  */
-const useRouteModal = ( queryKey: string, defaultValue: any = '' ): ReturnValues => {
+const useRouteModal = ( queryKey: string, defaultValue: unknown = '' ): ReturnValues => {
 	const { currentQuery, previousRoute } = useSelector( ( state ) => ( {
 		currentQuery: getCurrentQueryArguments( state ),
 		previousRoute: getPreviousRoute( state ),
@@ -28,7 +28,7 @@ const useRouteModal = ( queryKey: string, defaultValue: any = '' ): ReturnValues
 
 	const isModalOpen = value != null;
 
-	const openModal = ( currentValue: any = defaultValue ) => {
+	const openModal = ( currentValue: unknown = defaultValue ) => {
 		const url = window.location.href.replace( window.location.origin, '' );
 		const queryParams = {
 			[ queryKey ]: currentValue,

--- a/client/lib/route-modal/use-route-modal.tsx
+++ b/client/lib/route-modal/use-route-modal.tsx
@@ -1,63 +1,47 @@
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import page from 'page';
-import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route.js';
 
-type Params = { [ key: string ]: any };
-
 interface ReturnValues {
-	/** The values from query string and the properties are defined by queries argument */
-	params: Params;
-	openModal: ( queryArgs: Params ) => void;
+	/** Whether the query key exists or not */
+	isModalOpen: boolean;
+	/** The value of query key */
+	value: any;
+	/** Set the query key to value */
+	openModal: ( value?: any ) => void;
+	/** Clears the query key */
 	closeModal: () => void;
 }
 
 /**
  * React hook providing utils to control opening and closing modal via query string.
  */
-const useRouteModal = ( ...queries: string[] ): ReturnValues => {
+const useRouteModal = ( queryKey: string, defaultValue: any = '' ): ReturnValues => {
 	const { currentQuery, previousRoute } = useSelector( ( state ) => ( {
 		currentQuery: getCurrentQueryArguments( state ),
 		previousRoute: getPreviousRoute( state ),
 	} ) );
 
-	const params = useMemo( () => {
-		const results: Params = {};
+	const value = currentQuery?.[ queryKey ];
 
-		queries.forEach( ( key ) => {
-			if ( currentQuery?.hasOwnProperty( key ) ) {
-				results[ key ] = currentQuery[ key ];
-			}
-		} );
+	const isModalOpen = value != null;
 
-		return results;
-	}, [ currentQuery, queries ] );
-
-	const openModal = ( currentParams: Params ) => {
+	const openModal = ( currentValue: any = defaultValue ) => {
 		const url = window.location.href.replace( window.location.origin, '' );
-		const defaultParams = queries.reduce(
-			( acc, cur ) => ( {
-				...acc,
-				[ cur ]: '',
-			} ),
-			{}
-		);
+		const queryParams = {
+			[ queryKey ]: currentValue,
+		};
 
-		page(
-			addQueryArgs( url, {
-				...defaultParams,
-				...currentParams,
-			} )
-		);
+		page( addQueryArgs( url, queryParams ) );
 	};
 
 	const closeModal = () => {
-		page( removeQueryArgs( previousRoute, ...queries ) );
+		page( removeQueryArgs( previousRoute, queryKey ) );
 	};
 
-	return { params, openModal, closeModal };
+	return { isModalOpen, value, openModal, closeModal };
 };
 
 export default useRouteModal;

--- a/client/lib/route-modal/use-route-modal.tsx
+++ b/client/lib/route-modal/use-route-modal.tsx
@@ -1,0 +1,63 @@
+import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
+import page from 'page';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route.js';
+
+type Params = { [ key: string ]: any };
+
+interface ReturnValues {
+	/** The values from query string and the properties are defined by queries argument */
+	params: Params;
+	openModal: ( queryArgs: Params ) => void;
+	closeModal: () => void;
+}
+
+/**
+ * React hook providing utils to control opening and closing modal via query string.
+ */
+const useRouteModal = ( ...queries: string[] ): ReturnValues => {
+	const { currentQuery, previousRoute } = useSelector( ( state ) => ( {
+		currentQuery: getCurrentQueryArguments( state ),
+		previousRoute: getPreviousRoute( state ),
+	} ) );
+
+	const params = useMemo( () => {
+		const results: Params = {};
+
+		queries.forEach( ( key ) => {
+			if ( currentQuery?.hasOwnProperty( key ) ) {
+				results[ key ] = currentQuery[ key ];
+			}
+		} );
+
+		return results;
+	}, [ currentQuery, queries ] );
+
+	const openModal = ( currentParams: Params ) => {
+		const url = window.location.href.replace( window.location.origin, '' );
+		const defaultParams = queries.reduce(
+			( acc, cur ) => ( {
+				...acc,
+				[ cur ]: '',
+			} ),
+			{}
+		);
+
+		page(
+			addQueryArgs( url, {
+				...defaultParams,
+				...currentParams,
+			} )
+		);
+	};
+
+	const closeModal = () => {
+		page( removeQueryArgs( previousRoute, ...queries ) );
+	};
+
+	return { params, openModal, closeModal };
+};
+
+export default useRouteModal;

--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
@@ -8,7 +8,10 @@ import BloggingQuickStartModal from './blogging-quick-start-modal';
 
 const BloggingQuickStart = () => {
 	const translate = useTranslate();
-	const { params, openModal, closeModal } = useRouteModal( 'courseSlug' );
+	const { isModalOpen, openModal, closeModal } = useRouteModal(
+		'courseSlug',
+		COURSE_SLUGS.BLOGGING_QUICK_START
+	);
 
 	return (
 		<EducationalContent
@@ -20,13 +23,13 @@ const BloggingQuickStart = () => {
 				{
 					ModalComponent: BloggingQuickStartModal,
 					modalComponentProps: {
-						isVisible: !! params.courseSlug,
+						isVisible: isModalOpen,
 						onClose: ( event ) => {
 							event.preventDefault();
 							closeModal();
 						},
 					},
-					onClick: () => openModal( { courseSlug: COURSE_SLUGS.BLOGGING_QUICK_START } ),
+					onClick: () => openModal(),
 					text: translate( 'Start learning' ),
 				},
 			] }

--- a/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
+++ b/client/my-sites/customer-home/cards/education/blogging-quick-start/index.jsx
@@ -1,13 +1,14 @@
-import { useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import startLearningPrompt from 'calypso/assets/images/customer-home/illustration--secondary-start-learning.svg';
+import { COURSE_SLUGS } from 'calypso/data/courses';
+import { useRouteModal } from 'calypso/lib/route-modal';
 import { EDUCATION_BLOGGING_QUICK_START } from 'calypso/my-sites/customer-home/cards/constants';
 import EducationalContent from '../educational-content';
 import BloggingQuickStartModal from './blogging-quick-start-modal';
 
 const BloggingQuickStart = () => {
 	const translate = useTranslate();
-	const [ isModalVisible, setIsModalVisible ] = useState( false );
+	const { params, openModal, closeModal } = useRouteModal( 'courseSlug' );
 
 	return (
 		<EducationalContent
@@ -19,13 +20,13 @@ const BloggingQuickStart = () => {
 				{
 					ModalComponent: BloggingQuickStartModal,
 					modalComponentProps: {
-						isVisible: isModalVisible,
+						isVisible: !! params.courseSlug,
 						onClose: ( event ) => {
 							event.preventDefault();
-							setIsModalVisible( false );
+							closeModal();
 						},
 					},
-					onClick: () => setIsModalVisible( true ),
+					onClick: () => openModal( { courseSlug: COURSE_SLUGS.BLOGGING_QUICK_START } ),
 					text: translate( 'Start learning' ),
 				},
 			] }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `useRouteModal` hook to provide utils to control the opening and closing modal via query string.
* Control the opening and closing `BloggingQuickStartModal` via `useRouteModal` so that the back button works well and the user can go back to the previous page correctly.

https://user-images.githubusercontent.com/13596067/154047513-47c16453-13cd-43cd-b84e-555e1fc84142.mp4


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to My Home on mobile
* Click “Start Learning” to open the video course modal
* Click “back button” of browser to see the modal is close and back to previous page

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/58511
