### PR TITLE
Activity Log: Refactor `QueryRewindBackupStatus` away from `UNSAFE_` methods

### DIFF
--- a/client/components/data/query-rewind-backup-status/index.js
+++ b/client/components/data/query-rewind-backup-status/index.js
@@ -10,8 +10,7 @@ class QueryRewindBackupStatus extends Component {
 		siteId: PropTypes.number.isRequired,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		// We want to run this only once: when the page is loaded. In such case, there is not known download Id.
 		// If there's a download Id here it means this was mounted during an action requesting progress for a
 		// specific download Id, so we will do nothing here,since it will be handled by the <Interval /> below.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `QueryRewindBackupStatus` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/activity-log/:site` where `:site` is an Atomic site with backups that have been enabled for a while.
* Verify you can still "Download" a backup.
* Verify that when you click "Create download", it still tracks progress accurately until it succeeds.
* Verify that after you refresh the page, you still see the successful backup to download.