### PR TITLE
Jetpack Connect: Refactor `JetpackSignup` away from `UNSAFE_` methods

### DIFF
--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -71,17 +71,14 @@ export class JetpackSignup extends Component {
 		wooDnaFormType: 'login',
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		const { from, clientId } = this.props.authQuery;
+
 		this.props.recordTracksEvent( 'calypso_jpc_authorize_form_view', {
 			from,
 			site: clientId,
 		} );
-	}
 
-	componentDidMount() {
-		const { from, clientId } = this.props.authQuery;
 		this.props.recordTracksEvent( 'calypso_jpc_signup_view', {
 			from,
 			site: clientId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `JetpackSignup` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Type `localStorage.setItem('debug', 'calypso:analytics*')` in your browser console.
* Go to `/jetpack/connect/authorize?client_id=12345678&redirect_uri=https%3A%2F%2Feveryday-dwarf.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D12345678%26redirect%3Dhttps%253A%252F%252Feveryday-dwarf.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Djetpack&state=1&scope=administrator%3A12345662131231231231231231231233&user_email=someemail@example.com&user_login=someusername&jp_version=10.3&secret=23423423423432432423423432423443342&blogname=Everyday+Dwarf&site_url=https%3A%2F%2Feveryday-dwarf.jurassic.ninja&home_url=https%3A%2F%2Feveryday-dwarf.jurassic.ninja&site_icon&site_lang=en_US&site_created=2021-11-29+12%3A30%3A33&allow_site_connection=1&locale=en&_ui=12345678&_ut=wpcom%3Auser_id&_as=wp-cli&purchase_nonce=TaqP9WAn&_wp_nonce=12345678&redirect_after_auth=https%3A%2F%2Feveryday-dwarf.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack&site=https%3A%2F%2Feveryday-dwarf.jurassic.ninja`
* Verify you see the following events be tracked after the page loads:

![](https://cldup.com/I6cPy8AtWO.png)