### PR TITLE
Emails: Match billing term for email upsell with the current plan term

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -555,17 +555,17 @@ const trackUpsellButtonClick = ( eventName ) => {
 	return recordTracksEvent( eventName, { section: 'checkout' } );
 };
 
-const resolveProductSlug = ( upsellType, productAlias, billingTerm ) => {
+const getProductSlug = ( upsellType, productAlias, planTerm ) => {
 	switch ( upsellType ) {
 		case BUSINESS_PLAN_UPGRADE_UPSELL:
 			return getPlanByPathSlug( productAlias )?.getStoreSlug();
+
 		case ANNUAL_PLAN_UPGRADE:
 			return productAlias;
+
 		case PROFESSIONAL_EMAIL_UPSELL:
-			if ( billingTerm === TERM_MONTHLY ) {
-				return TITAN_MAIL_MONTHLY_SLUG;
-			}
-			return TITAN_MAIL_YEARLY_SLUG;
+			return planTerm === TERM_MONTHLY ? TITAN_MAIL_MONTHLY_SLUG : TITAN_MAIL_YEARLY_SLUG;
+
 		case CONCIERGE_QUICKSTART_SESSION:
 		case CONCIERGE_SUPPORT_SESSION:
 		default:
@@ -595,7 +595,7 @@ export default connect(
 		const cards = getStoredCards( state );
 
 		const currentPlanTerm = getCurrentPlanTerm( state, selectedSiteId ) ?? TERM_MONTHLY;
-		const productSlug = resolveProductSlug( upsellType, upgradeItem, currentPlanTerm );
+		const productSlug = getProductSlug( upsellType, upgradeItem, currentPlanTerm );
 		const productProperties = pick( getProductBySlug( state, productSlug ), [
 			'product_slug',
 			'product_id',

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -72,7 +72,7 @@ const ProfessionalEmailUpsell = ( {
 
 	const optionalMailboxFields = [ 'alternativeEmail', 'name' ];
 
-	const resolveFormattedPrice = (
+	const getFormattedPrice = (
 		currencyCode: string,
 		productCost: number,
 		productSlug: string
@@ -85,6 +85,7 @@ const ProfessionalEmailUpsell = ( {
 				comment: '{{price/}} is the formatted price, e.g. $20',
 			} );
 		}
+
 		return translate( '{{price/}} /mailbox /year', {
 			components: {
 				price: <span>{ formatCurrency( productCost ?? 0, currencyCode ) }</span>,
@@ -93,7 +94,7 @@ const ProfessionalEmailUpsell = ( {
 		} );
 	};
 
-	const formattedPrice = resolveFormattedPrice( currencyCode, productCost ?? 0, productSlug );
+	const formattedPrice = getFormattedPrice( currencyCode, productCost ?? 0, productSlug );
 
 	const onMailboxValueChange = ( fieldName: string, fieldValue: string | null ) => {
 		const updatedMailboxData = {
@@ -108,15 +109,6 @@ const ProfessionalEmailUpsell = ( {
 		if ( validatedMailboxData ) {
 			setMailboxData( validatedMailboxData );
 		}
-	};
-
-	const resolveTitanMailProduct = (
-		productSlug: string
-	): ( ( properties: TitanProductProps ) => MinimalRequestCartProduct ) => {
-		if ( productSlug === TITAN_MAIL_MONTHLY_SLUG ) {
-			return titanMailMonthly;
-		}
-		return titanMailYearly;
 	};
 
 	const handleAddEmail = () => {
@@ -134,15 +126,20 @@ const ProfessionalEmailUpsell = ( {
 		if ( ! mailboxesAreValid ) {
 			return;
 		}
-		const titanMailProduct = resolveTitanMailProduct( productSlug );
-		const cartItem = titanMailProduct( {
+
+		const cartItemArgs: TitanProductProps = {
 			domain: domainName,
 			quantity: validatedTitanMailboxes.length,
 			extra: {
 				email_users: validatedTitanMailboxes.map( transformMailboxForCart ),
 				new_quantity: validatedTitanMailboxes.length,
 			},
-		} );
+		};
+
+		const cartItem =
+			productSlug === TITAN_MAIL_MONTHLY_SLUG
+				? titanMailMonthly( cartItemArgs )
+				: titanMailYearly( cartItemArgs );
 
 		setCartItem( cartItem, () => handleClickAccept( 'accept' ) );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

During the upsell nudge once we have purchased a plan, we are presented with a monthly subscription for Professional Email. This code matches the billing term for the Professional Email with the billing term that the user has purchased.

#### Testing instructions

Have two sites with a personal plan, and a domain attached to them.
One of the sites should have a monthly billing and the other a yearly billing.
Note the receipt id for the domain for each site, the site slug and also the domain in each case. This is needed to build a URL that will present us with the emails upsell nudge.

Scenario 1: Monthly billing
Run this branch locally or use the calypso live branch.
For the monthly billing plan, build the following URL: (append it to the base AKA http://wordpress.com/ or your Calypso local branch) checkout/offer-professional-email/{domain}/{receipt-id}/{site-slug}

Check that you are presented with the following information:
![image](https://user-images.githubusercontent.com/5689927/154078309-1291b029-b57f-4763-9bfd-7c780322512b.png)

Check that once you click on "Add Professional Email" you are presented with the following information:
![image](https://user-images.githubusercontent.com/5689927/154079277-b3585167-f572-4599-8ecc-26d12fe160b6.png)

Please, note that the dates in the blue box should be different, ideally 3 months ahead of today the date of renewal attempt for Professional Email.

Scenario 2: Annual billing
Run the same test as the Scenario 1, but with the site that contains the annual plan.

Check that you are presented with the following information:
![image](https://user-images.githubusercontent.com/5689927/154079872-867b83f0-f619-4ead-a157-d8a21aa9d78b.png)

Check that once you click on "Add Professional Email" you are presented with the following information:
![image](https://user-images.githubusercontent.com/5689927/154080478-50b1b4e6-3932-4138-9165-0fd1c0e1c91c.png)

Please, note that the dates in the blue box should be different, ideally 3 months ahead of today the date of renewal attempt for Professional Email. And also note that the price is prorated, so it is equivalent to pay 9 months (26.47$ instead of 35.00$) 

Extra test, not needed right now:
Assign yourself to the treatment for an A/B experiment and check that the billing terms matches the plan terms.

Related to {1200182182542585-as-1201815195387520}
