### PR TITLE
Limit website content filling page access

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -394,7 +394,7 @@ export function generateFlows( {
 
 		{
 			name: 'site-content-collection',
-			steps: [ 'website-content' ],
+			steps: [ 'user', 'website-content' ],
 			destination: getDIFMSiteContentCollectionDestination,
 			description: 'A flow to collect DIFM lite site content',
 			excludeFromManageSiteFlows: true,

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -71,7 +71,7 @@ function WebsiteContentStep( {
 	useEffect( () => {
 		if ( isSiteInformationLoaded && ! isDifmLitePurchased ) {
 			debug( 'DIFM not purchased yet, redirecting to DIFM purchase flow' );
-			page( `/start/do-it-for-me?siteSlug=${ queryObject.siteSlug }` );
+			page( `/start/do-it-for-me` );
 		} else if ( isWebsiteContentSubmitted ) {
 			debug( 'Website content content already submitted, redirecting to home' );
 			page( `/home/${ queryObject.siteSlug }` );

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -56,20 +56,20 @@ function WebsiteContentStep( {
 	const isWebsiteContentSubmitted = useSelector( ( state ) =>
 		isDIFMLiteWebsiteContentSubmitted( state, siteId )
 	);
-	const isSiteInformationLoaded = useSelector( ( state ) =>
+	const isLoadingSiteInformation = useSelector( ( state ) =>
 		isRequestingSite( state, siteId as number )
 	);
 
 	// We assume that difm lite is purchased when the is_difm_lite_in_progress sticker is active in a given blog
 	const isDifmLitePurchased = useSelector( ( state ) => isDIFMLiteInProgress( state, siteId ) );
 
-	//Make sure site information is loaded so that we can validate access to this page
+	//Make sure the most up to date site information is loaded so that we can validate access to this page
 	useEffect( () => {
 		siteId && dispatch( requestSite( siteId ) );
 	}, [ siteId ] );
 
 	useEffect( () => {
-		if ( isSiteInformationLoaded && ! isDifmLitePurchased ) {
+		if ( ! isLoadingSiteInformation && ! isDifmLitePurchased ) {
 			debug( 'DIFM not purchased yet, redirecting to DIFM purchase flow' );
 			page( `/start/do-it-for-me` );
 		} else if ( isWebsiteContentSubmitted ) {
@@ -77,7 +77,7 @@ function WebsiteContentStep( {
 			page( `/home/${ queryObject.siteSlug }` );
 		}
 	}, [
-		isSiteInformationLoaded,
+		isLoadingSiteInformation,
 		isDifmLitePurchased,
 		isWebsiteContentSubmitted,
 		queryObject.siteSlug,

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -3,7 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useEffect, useState, ChangeEvent, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import AccordionForm from 'calypso/signup/accordion-form/accordion-form';
 import { ValidationErrors } from 'calypso/signup/accordion-form/types';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -142,7 +141,6 @@ function WebsiteContentStep( {
 	const generatedSections = generatedSectionsCallback();
 	return (
 		<>
-			<QueryUserPurchases></QueryUserPurchases>
 			<AccordionForm
 				generatedSections={ generatedSections }
 				onErrorUpdates={ ( errors ) => setFormErrors( errors ) }

--- a/client/signup/steps/website-content/page-details.tsx
+++ b/client/signup/steps/website-content/page-details.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, ReactChild } from 'react';
+import { ChangeEvent } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
 	SubLabel,
@@ -7,6 +7,7 @@ import {
 	TextAreaField,
 	HorizontalGrid,
 } from 'calypso/signup/accordion-form/form-components';
+import { ValidationErrors } from 'calypso/signup/accordion-form/types';
 import { imageUploaded, textChanged } from 'calypso/state/signup/steps/website-content/actions';
 import { PageData } from 'calypso/state/signup/steps/website-content/schema';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -22,7 +23,7 @@ export function PageDetails( {
 	onChangeField,
 }: {
 	page: PageData;
-	formErrors: Record< string, ReactChild >;
+	formErrors: ValidationErrors;
 	onChangeField?: ( { target: { name, value } }: ChangeEvent< HTMLInputElement > ) => void;
 } ) {
 	const translate = useTranslate();

--- a/client/signup/steps/website-content/page-details.tsx
+++ b/client/signup/steps/website-content/page-details.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, ReactChild } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
 	SubLabel,
@@ -22,7 +22,7 @@ export function PageDetails( {
 	onChangeField,
 }: {
 	page: PageData;
-	formErrors: any;
+	formErrors: Record< string, ReactChild >;
 	onChangeField?: ( { target: { name, value } }: ChangeEvent< HTMLInputElement > ) => void;
 } ) {
 	const translate = useTranslate();

--- a/client/signup/steps/website-content/wordpress-media-upload.tsx
+++ b/client/signup/steps/website-content/wordpress-media-upload.tsx
@@ -90,6 +90,7 @@ export function WordpressMediaUpload( {
 			setImageCaption( title );
 			onMediaUploaded( { title, URL, uploadID: ID, mediaIndex } );
 			setUploadState( UPLOAD_STATES.COMPLETED );
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		} catch ( e: any ) {
 			setUploadState( UPLOAD_STATES.FAILED );
 			debug( 'Image upload failed' );

--- a/client/state/selectors/is-difm-lite-in-progress.js
+++ b/client/state/selectors/is-difm-lite-in-progress.js
@@ -5,10 +5,14 @@ import getRawSite from 'calypso/state/selectors/get-raw-site';
  * or null if the site is unknown.
  *
  * @param  {object}   state  Global state tree
- * @param  {number}   siteId Site ID
+ * @param  {?number}   siteId Site ID
  * @returns {?boolean}        Whether site is marked as a DIFM In Progress site
  */
 export default function isDIFMLiteInProgress( state, siteId ) {
+	if ( ! siteId ) {
+		return null;
+	}
+
 	const site = getRawSite( state, siteId );
 
 	if ( ! site ) {

--- a/client/state/selectors/is-difm-lite-website-content-submitted.ts
+++ b/client/state/selectors/is-difm-lite-website-content-submitted.ts
@@ -11,8 +11,12 @@ import type { AppState, SiteId } from 'calypso/types';
  */
 export default function isDIFMLiteWebsiteContentSubmitted(
 	state: AppState,
-	siteId: SiteId
+	siteId: SiteId | null
 ): boolean {
+	if ( ! siteId ) {
+		return false;
+	}
+
 	const site = getRawSite( state, siteId ) as SiteData;
 
 	if ( ! site ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Block access to the form if the purchase is not valid or if the form has already been submitted.

#### Testing instructions
* Go through the DIFM lite purchase and make sure that after checkout you see the website content filling page
* Use a site that not have the DIFM purchase, And you should be redirected to the DIFM flow `/start/do-it-for-me`
    * i.e. : `/start/site-content-collection/website-content?siteSlug=<site-without-difm>`
* Use a site that has already submitted website content and you should be redirected to the home page 

Related to #59895
