### PR TITLE
Fix/onboarding atomic transition

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -703,13 +703,14 @@ class Signup extends Component {
 			this.props.isLoggedIn &&
 			this.props.signupDependencies.siteSlug &&
 			0 === this.props.siteDomains.length;
+		const isImportingFlow = this.props.flowName === 'from' && this.props.stepName === 'importing';
 
 		if ( isStepRemovedFromFlow ) {
 			return true;
 		}
 
 		// siteDomains is sometimes empty, so we need to force update.
-		if ( isDomainsForSiteEmpty ) {
+		if ( isDomainsForSiteEmpty && ! isImportingFlow ) {
 			return <QuerySiteDomains siteId={ this.props.siteId } />;
 		}
 	}

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -66,6 +66,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	 */
 	useEffect( fetchImporters, [ siteId ] );
 	useEffect( checkInitialRunState, [ siteId ] );
+	useEffect( checkSiteSlugUpdate, [ site?.slug ] );
 	useEffect( () => {
 		fromSiteData?.url && dispatch( analyzeUrl( fromSite as string ) );
 	}, [ fromSiteData?.url ] );
@@ -94,6 +95,14 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 		if ( searchParams.get( 'run' ) === 'true' ) {
 			setRunImportInitially( true );
 			page.replace( path.replace( '&run=true', '' ).replace( 'run=true', '' ) );
+		}
+	}
+
+	function checkSiteSlugUpdate() {
+		// update site slug when destination site is in transition from simple to atomic
+		if ( site?.slug && siteSlug !== site.slug ) {
+			page.replace( path.replace( `to=${ siteSlug }`, `to=${ site.slug }` ) );
+			siteSlug = site.slug;
 		}
 	}
 

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -2,52 +2,40 @@ import { isEnabled } from '@automattic/calypso-config';
 import classnames from 'classnames';
 import page from 'page';
 import React, { useEffect, useState } from 'react';
-import { connect, useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
-import { decodeURIComponentIfValid } from 'calypso/lib/url';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getStepUrl } from 'calypso/signup/utils';
 import { fetchImporterState, resetImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import {
 	getImporterStatusForSiteId,
-	isImporterStatusHydrated,
+	isImporterStatusHydrated as isImporterStatusHydratedSelector,
 } from 'calypso/state/imports/selectors';
 import { analyzeUrl } from 'calypso/state/imports/url-analyzer/actions';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { getSite, getSiteId } from 'calypso/state/sites/selectors';
-import { UrlData } from '../import/types';
 import BloggerImporter from './blogger';
 import NotAuthorized from './components/not-authorized';
 import NotFound from './components/not-found';
 import MediumImporter from './medium';
 import SquarespaceImporter from './squarespace';
-import './style.scss';
-import { Importer, ImportJob, QueryObject } from './types';
+import { Importer, ImportJob } from './types';
 import { getImporterTypeForEngine } from './util';
 import WixImporter from './wix';
 import WordpressImporter from './wordpress';
 import type { SitesItem } from 'calypso/state/selectors/get-sites-items';
+import './style.scss';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 interface Props {
-	urlData: UrlData;
 	path: string;
 	stepName: string;
 	stepSectionName: string;
-	queryObject: QueryObject;
-	siteId: number;
-	site: SitesItem;
-	siteSlug: string;
-	fromSite: string;
-	canImport: boolean;
-	isImporterStatusHydrated: boolean;
-	siteImports: ImportJob[];
-	fetchImporterState: ( siteId: number ) => void;
-	resetImport: ( siteId: number, importerId: string ) => void;
 }
 const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	const IMPORT_ROUTE = '/start/from/importing';
@@ -56,25 +44,22 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	/**
 	 ↓ Fields
 	 */
-	const {
-		urlData,
-		stepName,
-		stepSectionName,
-		siteId,
-		site,
-		canImport,
-		siteSlug,
-		siteImports,
-		isImporterStatusHydrated,
-		fromSite,
-		path,
-	} = props;
+	const { path, stepName, stepSectionName } = props;
 	const engine: Importer = stepSectionName.toLowerCase() as Importer;
 	const [ runImportInitially, setRunImportInitially ] = useState( false );
+	const urlData = useSelector( getUrlData );
+	const searchParams = useSelector( getCurrentQueryArguments );
+	let siteSlug = searchParams?.to as string;
+	const [ siteId ] = useState( useSelector( ( state ) => getSiteId( state, siteSlug ) as number ) );
+	const site = useSelector( ( state ) => getSite( state, siteId ) as SitesItem );
+	const siteImports = useSelector( ( state ) => getImporterStatusForSiteId( state, siteId ) );
+	const canImport = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
+	const fromSite = searchParams?.from as string;
+	const fromSiteData = useSelector( getUrlData );
+	const isImporterStatusHydrated = useSelector( isImporterStatusHydratedSelector );
 	const getImportJob = ( engine: Importer ): ImportJob | undefined => {
 		return siteImports.find( ( x ) => x.type === getImporterTypeForEngine( engine ) );
 	};
-	const fromSiteData = useSelector( getUrlData );
 
 	/**
 	 ↓ Effects
@@ -82,16 +67,14 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	useEffect( fetchImporters, [ siteId ] );
 	useEffect( checkInitialRunState, [ siteId ] );
 	useEffect( () => {
-		if ( typeof fromSiteData?.url === 'undefined' ) {
-			dispatch( analyzeUrl( fromSite ) );
-		}
+		fromSiteData?.url && dispatch( analyzeUrl( fromSite as string ) );
 	}, [ fromSiteData?.url ] );
 
 	/**
 	 ↓ Methods
 	 */
 	function fetchImporters() {
-		siteId && props.fetchImporterState( siteId );
+		siteId && dispatch( fetchImporterState( siteId ) );
 	}
 
 	function isLoading() {
@@ -139,7 +122,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 			case appStates.UPLOAD_SUCCESS:
 			case appStates.UPLOADING:
 			case appStates.UPLOAD_FAILURE:
-				return props.resetImport( siteId, job.importerId );
+				return dispatch( resetImport( siteId, job.importerId ) );
 		}
 	}
 
@@ -267,27 +250,4 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	);
 };
 
-export default connect(
-	( state ) => {
-		const searchParams = new URLSearchParams( window.location.search );
-
-		const siteSlug = decodeURIComponentIfValid( searchParams.get( 'to' ) );
-		const fromSite = decodeURIComponentIfValid( searchParams.get( 'from' ) );
-		const siteId = getSiteId( state, siteSlug ) as number;
-
-		return {
-			urlData: getUrlData( state ),
-			siteId,
-			site: getSite( state, siteId ) as SitesItem,
-			siteSlug,
-			fromSite,
-			siteImports: getImporterStatusForSiteId( state, siteId ),
-			isImporterStatusHydrated: isImporterStatusHydrated( state ),
-			canImport: canCurrentUser( state, siteId, 'manage_options' ),
-		};
-	},
-	{
-		fetchImporterState,
-		resetImport,
-	}
-)( ImportOnboardingFrom );
+export default ImportOnboardingFrom;

--- a/client/signup/steps/import-from/wordpress/import-everything/index.tsx
+++ b/client/signup/steps/import-from/wordpress/import-everything/index.tsx
@@ -232,6 +232,7 @@ export const connector = connect(
 			sourceSite: ownProps.sourceSiteId && getSite( state, ownProps.sourceSiteId ),
 			startMigration: !! get( getCurrentQueryArguments( state ), 'start', false ),
 			sourceSiteHasJetpack: false,
+			targetSiteId: ownProps.targetSiteId,
 			targetSiteImportAdminUrl: getSiteAdminUrl(
 				state,
 				ownProps.targetSiteId as number,

--- a/client/signup/steps/import-from/wordpress/index.tsx
+++ b/client/signup/steps/import-from/wordpress/index.tsx
@@ -7,7 +7,7 @@ import { convertToFriendlyWebsiteName } from 'calypso/signup/steps/import/util';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { SitesItem } from 'calypso/state/selectors/get-sites-items';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { getSiteBySlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteBySlug, getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getWpOrgImporterUrl } from '../../import/util';
 import { Importer, ImportJob } from '../types';
 import { ContentChooser } from './content-chooser';
@@ -34,7 +34,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	 */
 	const [ option, setOption ] = useState< WPImportOption >();
 	const { job, fromSite, siteSlug, siteId } = props;
-	const siteItem = useSelector( ( state ) => getSiteBySlug( state, siteSlug ) );
+	const siteItem = useSelector( ( state ) => getSite( state, siteId ) );
 	const fromSiteItem = useSelector( ( state ) =>
 		getSiteBySlug( state, fromSite ? convertToFriendlyWebsiteName( fromSite ) : '' )
 	);
@@ -126,7 +126,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 							sourceSiteId={ fromSiteItem?.ID as number }
 							sourceUrlAnalyzedData={ fromSiteAnalyzedData }
 							targetSite={ siteItem as SitesItem }
-							targetSiteId={ siteItem?.ID as number }
+							targetSiteId={ siteId }
 							targetSiteSlug={ siteSlug }
 						/>
 					);
@@ -135,7 +135,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 						<ImportContentOnly
 							job={ job }
 							importer={ importer }
-							siteItem={ siteItem }
+							siteItem={ siteItem as SitesItem }
 							siteSlug={ siteSlug }
 							siteAnalyzedData={ fromSiteAnalyzedData }
 						/>

--- a/client/state/selectors/get-sites-items.ts
+++ b/client/state/selectors/get-sites-items.ts
@@ -8,6 +8,7 @@ export interface SitesItem {
 	name?: string;
 	description?: string;
 	URL?: string;
+	slug?: string;
 	capabilities?: Record< string, boolean >;
 	jetpack?: boolean;
 	is_multisite?: boolean;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor: got rid of the connect function and instead of it use `useSelector` and `dispatch` react-redux methods.
* Fixed and handled a case when a simple site becomes atomic in the middle of the migration process.

#### Testing instructions

* Go to `/start/importer/capture?siteSlug={SLUG}.wordpress.com` (simple site)
* Enter the URL of jetpack connected website (use jurassic.ninja)
* Press `Import your content` button
* Select option `Everything`
* Press `See plans` (in this context means start import)
* Pay for the business plan
* Run the import `Start import`
* Check if the process passes without screen breaks.
* Check if the URL is updated. In a moment when the simple site becomes atomic, the URL printed on the screen and in the browser's URL bar should be updated.

Related to #60993
