### PR TITLE
Seller Experience: Apply BranchSteps on the store-features step

### DIFF
--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -25,7 +25,7 @@ interface Props {
 	};
 }
 
-const EXCLUDED_STEPS: { [ key: string ]: string[] } = {
+export const EXCLUDED_STEPS: { [ key: string ]: string[] } = {
 	write: [ 'store-options', 'store-features' ],
 	build: [ 'site-options', 'starting-point', 'courses', 'store-options', 'store-features' ],
 	sell: [ 'site-options', 'starting-point', 'courses', 'design-setup-site' ],

--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -8,11 +8,13 @@ import paymentBlocksImage from 'calypso/assets/images/onboarding/payment-blocks.
 import wooCommerceImage from 'calypso/assets/images/onboarding/woo-commerce.svg';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { localizeUrl } from 'calypso/lib/i18n-utils/utils';
+import useBranchSteps from 'calypso/signup/hooks/use-branch-steps';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSite } from 'calypso/state/sites/selectors';
 import { shoppingBag, truck } from '../../icons';
 import SelectItems, { SelectItem } from '../../select-items';
+import { EXCLUDED_STEPS } from '../intent/index';
 import { StoreFeatureSet } from './types';
 import './index.scss';
 
@@ -32,6 +34,14 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 	const subHeaderText = translate( 'Let’s create a website that suits your needs.' );
 	const siteSlug = props.signupDependencies.siteSlug;
 	const { stepName, goToNextStep } = props;
+
+	/**
+	 * In the regular flow the "EXCLUDED_STEPS" are already excluded,
+	 * but this information is lost if the user leaves the flow and comes back,
+	 * e.g. they go to "More Power" and then click "Back"
+	 */
+	const branchSteps = useBranchSteps( stepName, () => EXCLUDED_STEPS.sell );
+	branchSteps( EXCLUDED_STEPS.sell );
 
 	const sitePlanSlug = useSelector( ( state ) => getSite( state, siteSlug )?.plan?.product_slug );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

By the end of the Seller Experience flow, if the user pick "More Power" (Woo flow) and hits the "Back" button, the flow is reseted and the information about the excluded steps are lost.

This PR adds the `useBranchSteps` hook to the `store-features` step to make sure the current steps are consistent.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the seller experience flow
* Pick the "More Power" option
* Hit the "Back" button
* Choose the "Start Simple" option
* It should work!

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #61016
