### PR TITLE
Marketplace: Redirect to Yoast Onboarding after plugin install

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -91,6 +91,7 @@ export function getAllowedPluginData( plugin ) {
 		'ratings',
 		'requirements',
 		'sections',
+		'setup_url',
 		'slug',
 		'support_URL',
 		'tags',

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -162,10 +162,10 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 		| undefined
 		| { action_links?: { Settings?: string }; name?: string };
 
+	const fallbackSetupUrl = wpComPluginData?.setup_url && siteAdminUrl + wpComPluginData?.setup_url;
+
 	const setupURL =
-		pluginOnSiteData?.action_links?.Settings ||
-		siteAdminUrl + wpComPluginData?.setup_url ||
-		`${ siteAdminUrl }plugins.php`;
+		pluginOnSiteData?.action_links?.Settings || fallbackSetupUrl || `${ siteAdminUrl }plugins.php`;
 
 	const setupSection = {
 		sectionKey: 'setup_whats_next',

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -20,7 +20,7 @@ import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
-import { getSiteAdminUrl, getSiteUrl } from 'calypso/state/sites/selectors';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const ThankYouContainer = styled.div`
@@ -98,7 +98,6 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 	const wporgPlugin = useSelector( ( state ) => getPlugin( state, productSlug ) );
 	const isWporgPluginFetched = useSelector( ( state ) => isFetched( state, productSlug ) );
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
-	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
 	const { transfer } = useSelector( ( state ) => getLatestAtomicTransfer( state, siteId ) );
 	const [ pluginIcon, setPluginIcon ] = useState( '' );
 
@@ -163,7 +162,7 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 		| undefined
 		| { action_links?: { Settings?: string }; name?: string };
 
-	const fallbackSetupUrl = wpComPluginData?.setup_url && siteUrl + wpComPluginData?.setup_url;
+	const fallbackSetupUrl = wpComPluginData?.setup_url && siteAdminUrl + wpComPluginData?.setup_url;
 
 	const setupURL =
 		pluginOnSiteData?.action_links?.Settings || fallbackSetupUrl || `${ siteAdminUrl }plugins.php`;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -6,6 +6,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import successImage from 'calypso/assets/images/marketplace/check-circle.svg';
 import { ThankYou } from 'calypso/components/thank-you';
 import WordPressLogo from 'calypso/components/wordpress-logo';
+import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
@@ -136,6 +137,9 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 		}
 	}, [ wporgPlugin ] );
 
+	// retrieve WPCom plugin data
+	const { data: wpComPluginData } = useWPCOMPlugin( productSlug );
+
 	// Site is already Atomic (or just transferred).
 	// Poll the plugin installation status.
 	useEffect( () => {
@@ -158,7 +162,10 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 		| undefined
 		| { action_links?: { Settings?: string }; name?: string };
 
-	const setupURL = pluginOnSiteData?.action_links?.Settings || `${ siteAdminUrl }plugins.php`;
+	const setupURL =
+		pluginOnSiteData?.action_links?.Settings ||
+		siteAdminUrl + wpComPluginData?.setup_url ||
+		`${ siteAdminUrl }plugins.php`;
 
 	const setupSection = {
 		sectionKey: 'setup_whats_next',

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -20,7 +20,7 @@ import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
-import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { getSiteAdminUrl, getSiteUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const ThankYouContainer = styled.div`
@@ -98,6 +98,7 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 	const wporgPlugin = useSelector( ( state ) => getPlugin( state, productSlug ) );
 	const isWporgPluginFetched = useSelector( ( state ) => isFetched( state, productSlug ) );
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
 	const { transfer } = useSelector( ( state ) => getLatestAtomicTransfer( state, siteId ) );
 	const [ pluginIcon, setPluginIcon ] = useState( '' );
 
@@ -162,7 +163,7 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 		| undefined
 		| { action_links?: { Settings?: string }; name?: string };
 
-	const fallbackSetupUrl = wpComPluginData?.setup_url && siteAdminUrl + wpComPluginData?.setup_url;
+	const fallbackSetupUrl = wpComPluginData?.setup_url && siteUrl + wpComPluginData?.setup_url;
 
 	const setupURL =
 		pluginOnSiteData?.action_links?.Settings || fallbackSetupUrl || `${ siteAdminUrl }plugins.php`;

--- a/client/state/sites/selectors/get-site-url.js
+++ b/client/state/sites/selectors/get-site-url.js
@@ -7,7 +7,7 @@ import isSiteConflicting from './is-site-conflicting';
  * Returns the URL for a site, or null if the site is unknown.
  *
  * @param  {object}  state  Global state tree
- * @param  {?number}  siteId Site ID
+ * @param  {number}  siteId Site ID
  * @returns {?string}        Site Url
  */
 export default function getSiteUrl( state, siteId ) {

--- a/client/state/sites/selectors/get-site-url.js
+++ b/client/state/sites/selectors/get-site-url.js
@@ -7,7 +7,7 @@ import isSiteConflicting from './is-site-conflicting';
  * Returns the URL for a site, or null if the site is unknown.
  *
  * @param  {object}  state  Global state tree
- * @param  {number}  siteId Site ID
+ * @param  {?number}  siteId Site ID
  * @returns {?string}        Site Url
  */
 export default function getSiteUrl( state, siteId ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* D75013-code added a `setup_url` field to Yoast Premium that contains the onboarding admin URL
* This PR adds the `setup_url` as fallback to use if the `https://public-api.wordpress.com/rest/v1.1/sites/:site/plugins` response doesn't contain a `action_links.Settings` field

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install Yoast Premium
* On the thank you page (`/marketplace/thank-you/wordpress-seo-premium/:site`), verify that the `Manage plugin` plugin redirects to `/wp-admin/admin.php?page=wpseo_workouts`
  ![image](https://user-images.githubusercontent.com/11555574/154116203-91764f06-3856-48f7-b357-04aa31bc324b.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #60718