### PR TITLE
Update regex to ignore case sensitivity

### DIFF
--- a/client/signup/steps/import/capture/index.tsx
+++ b/client/signup/steps/import/capture/index.tsx
@@ -21,7 +21,7 @@ const trackEventParams = {
 };
 
 const validateUrl = ( url: string ): boolean => {
-	const urlRgx = /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.][a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/;
+	const urlRgx = /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.][a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/i;
 
 	return urlRgx.test( url );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update regex to ignore case sensitive

#### Testing instructions

* Go to `/start/importer/capture?siteSlug={SLUG}.wordpress.com
* Enter the URL with some capital letters, ex. `Example.com'
* Check if there is a confirm button

Note: The same behavior is for mobile devices.

#### Screenshot
<img width="360" alt="Screenshot 2022-02-15 at 19 39 54" src="https://user-images.githubusercontent.com/1241413/154127494-9117f7db-2b47-4b64-ace1-dd6ee95ede70.png">

Closes #60952
