### PR TITLE
Remove experiment prop

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -454,7 +454,6 @@ export class UserStep extends Component {
 					suggestedUsername={ this.props.suggestedUsername }
 					handleSocialResponse={ this.handleSocialResponse }
 					isPasswordless={ isMobile() }
-					experimentName={ this.state.experiment }
 					isSocialSignupEnabled={ isSocialSignupEnabled }
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow up PR to https://github.com/Automattic/wp-calypso/pull/60940 that removes a prop that is no longer being used.

#### Testing instructions

* Are you able to create a new user/site by going through the signup flow?



Related to https://github.com/Automattic/wp-calypso/pull/60940#discussion_r806683584
