### PR TITLE
App Banner: remove mobile app banner if previous flow was onboarding 

### DIFF
--- a/client/state/selectors/should-display-app-banner.ts
+++ b/client/state/selectors/should-display-app-banner.ts
@@ -4,6 +4,7 @@ import { includes } from 'lodash';
 import {
 	APP_BANNER_DISMISS_TIMES_PREFERENCE,
 	ALLOWED_SECTIONS,
+	GUTENBERG,
 	isDismissed,
 	getCurrentSection,
 } from 'calypso/blocks/app-banner/utils';
@@ -12,6 +13,7 @@ import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { shouldDisplayTosUpdateBanner } from 'calypso/state/selectors/should-display-tos-update-banner';
+import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
 import { getSectionName, appBannerIsEnabled } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 
@@ -45,6 +47,11 @@ export const shouldDisplayAppBanner = ( state: AppState ): boolean | undefined =
 	const sectionName = getSectionName( state );
 	const isNotesOpen = isNotificationsOpen( state );
 	const currentSection = getCurrentSection( sectionName, isNotesOpen );
+
+	// Never show the AppBanner in the site setup flow in the gutenberg section
+	if ( getCurrentFlowName( state ) === 'setup-site' && GUTENBERG === currentSection ) {
+		return false;
+	}
 
 	if ( ! includes( ALLOWED_SECTIONS, currentSection ) ) {
 		return false;

--- a/client/state/ui/selectors/app-banner-is-visible.js
+++ b/client/state/ui/selectors/app-banner-is-visible.js
@@ -1,7 +1,12 @@
 import 'calypso/state/ui/init';
+import { getPreviousFlowName } from 'calypso/state/signup/flow/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 
 export default function isAppBannerEnabled( state ) {
+	// Never show the AppBanner if the previous flow is set to onboarding.
+	if ( getPreviousFlowName( state ) === 'onboarding' ) {
+		return false;
+	}
 	// since on mobile the sidebar layout focus take up the whole "Page" we never want to show the App Banner
 	// when the side bar in in focus.
 	return state.ui.appBannerVisibility && getCurrentLayoutFocus( state ) !== 'sidebar';

--- a/client/state/ui/selectors/app-banner-is-visible.js
+++ b/client/state/ui/selectors/app-banner-is-visible.js
@@ -1,10 +1,10 @@
 import 'calypso/state/ui/init';
-import { getPreviousFlowName } from 'calypso/state/signup/flow/selectors';
+import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 
 export default function isAppBannerEnabled( state ) {
-	// Never show the AppBanner if the previous flow is set to onboarding.
-	if ( getPreviousFlowName( state ) === 'onboarding' ) {
+	// Never show the AppBanner in the site setup flow.
+	if ( getCurrentFlowName( state ) === 'setup-site' ) {
 		return false;
 	}
 	// since on mobile the sidebar layout focus take up the whole "Page" we never want to show the App Banner

--- a/client/state/ui/selectors/app-banner-is-visible.js
+++ b/client/state/ui/selectors/app-banner-is-visible.js
@@ -1,12 +1,7 @@
 import 'calypso/state/ui/init';
-import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 
 export default function isAppBannerEnabled( state ) {
-	// Never show the AppBanner in the site setup flow.
-	if ( getCurrentFlowName( state ) === 'setup-site' ) {
-		return false;
-	}
 	// since on mobile the sidebar layout focus take up the whole "Page" we never want to show the App Banner
 	// when the side bar in in focus.
 	return state.ui.appBannerVisibility && getCurrentLayoutFocus( state ) !== 'sidebar';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removed the App Banner for the site editor if the user experienced the onboarding flow. 

See p1644591908914389-slack-C01DF571R5Y

#### Testing instructions

* Create a new site and select a template that has FSE enabled. 

