### PR TITLE
Plugins-browser: Update plugins search placeholder font size

### DIFF
--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -15,7 +15,7 @@
 		}
 
 		&.is-open input.search-component__input[type='search'] {
-			font-size: $font-body-extra-small;
+			font-size: $font-body-small;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- Change the "Try searching "ecommerce"" [placeholder font-size](https://github.com/Automattic/wp-calypso/blob/831b4c593e979f6b214724ff4693c2aebbc9fa26/client/my-sites/plugins/plugins-browser/style.scss#L18) to font-body-small from font-body-extra-small.

#### Testing instructions

- Visit /plugins page and check the font size of the placeholder of the search box 

#### Before
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/402286/154149735-8409f3c7-c368-4849-95e8-cb12c95c7215.png">

#### After
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/402286/154149804-f4570690-a345-43f7-8794-6f172a2decd2.png">


Related to [#58293](https://github.com/Automattic/wp-calypso/issues/58293)
