### PR TITLE
Seller Experience: Use placeholders for paragraph and heading blocks

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -450,9 +450,7 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 			<!-- /wp:paragraph -->
 
 			<!-- wp:jetpack/recurring-payments -->
-			<div class="wp-block-jetpack-recurring-payments"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":${ translate(
-				'Buy Now'
-			) },"customTextColor":"#ffffff","backgroundColor":"black","borderRadius":0,"width":"100%"} /--></div>
+			<div class="wp-block-jetpack-recurring-payments"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":'Buy Now'},"customTextColor":"#ffffff","backgroundColor":"black","borderRadius":0,"width":"100%"} /--></div>
 			<!-- /wp:jetpack/recurring-payments -->
 
 			<!-- wp:spacer {"height":"20px"} -->

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -437,18 +437,16 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 			<!-- /wp:column -->
 
 			<!-- wp:column {"style":{"spacing":{"padding":{"right":"40px","left":"40px"}}}} -->
-			<div class="wp-block-column" style="padding-right:40px;padding-left:40px"><!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"40px"},"spacing":{"margin":{"top":"0px"}}}} -->
-			<h1 id="item-name" style="font-size:40px;margin-top:0px">${ translate( 'Item Name' ) }</h1>
+			<div class="wp-block-column" style="padding-right:40px;padding-left:40px"><!-- wp:heading {"level":1,"placeholder":"Item name","style":{"typography":{"fontSize":"40px"},"spacing":{"margin":{"top":"0px"}}}} -->
+			<h1 id="item-name" style="font-size:40px;margin-top:0px"></h1>
 			<!-- /wp:heading -->
 
-			<!-- wp:heading {"style":{"color":{"text":"#444444"}},"fontSize":"medium"} -->
-			<h2 class="has-text-color has-medium-font-size" id="0-00" style="color:#444444">$0.00</h2>
+			<!-- wp:heading {"placeholder":"$0.00","style":{"color":{"text":"#444444"}},"fontSize":"medium"} -->
+			<h2 class="has-text-color has-medium-font-size" id="0-00" style="color:#444444"></h2>
 			<!-- /wp:heading -->
 
-			<!-- wp:paragraph {"style":{"color":{"text":"#444444"}},"fontSize":"small"} -->
-			<p class="has-text-color has-small-font-size" style="color:#444444">${ translate(
-				'Short description of your item.'
-			) }</p>
+			<!-- wp:paragraph {"placeholder":"Short description of your item.","style":{"color":{"text":"#444444"}},"fontSize":"small"} -->
+			<p class="has-text-color has-small-font-size" style="color:#444444"></p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:jetpack/recurring-payments -->
@@ -461,14 +459,12 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 			<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
 			<!-- /wp:spacer -->
 
-			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size"><strong>${ translate( 'Description' ) }</strong></p>
+			<!-- wp:paragraph {"placeholder":"Description","fontSize":"small"} -->
+			<p class="has-small-font-size"><strong></strong></p>
 			<!-- /wp:paragraph -->
 
-			<!-- wp:paragraph {"style":{"color":{"text":"#444444"}},"fontSize":"small"} -->
-			<p class="has-text-color has-small-font-size" style="color:#444444">${ translate(
-				'Describe your item. Use this section to add a full description and details of your product, along with its many selling points.'
-			) }</p>
+			<!-- wp:paragraph {"placeholder":"Describe your item. Use this section to add a full description and details of your product, along with its many selling points.","style":{"color":{"text":"#444444"}},"fontSize":"small"} -->
+			<p class="has-text-color has-small-font-size" style="color:#444444"></p>
 			<!-- /wp:paragraph --></div>
 			<!-- /wp:column --></div>
 			<!-- /wp:columns --></div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Related to #61021
* Try replacing hard-coded copy with `placeholder` props; makes it easier for users to overwrite the text.
* It does not appear we can localize `placeholder`s at this point in time; the parser used for block patterns does not see block properties, only their contents. See related issue here: https://github.com/Automattic/wp-calypso/issues/61178#issuecomment-1042347080

**Video demo**

https://user-images.githubusercontent.com/2124984/154152000-eb3f4e76-b849-42ff-a4a1-4b52a4b31472.mov


#### Testing instructions

* Switch to this PR, go to `/start?flags=seller-experience`
* Create a free site and choose the Sell option at the intent step
* Choose "Start simple" 
* When you're brought to the editor, the blocks should have placeholder text (clicking on the block overwrites the placeholder without the user having to delete stuff themselves).