### PR TITLE
desktop: update electron

### DIFF
--- a/desktop/app/env.js
+++ b/desktop/app/env.js
@@ -35,9 +35,6 @@ process.chdir( apppath );
 // Set app config path
 app.setPath( 'userData', appData );
 
-// Default value of false deprecated in Electron v9
-app.allowRendererProcessReuse = true;
-
 // Fixes rendering bug on Linux when sandbox === true (Electron 11.0)
 if ( process.platform === 'linux' ) {
 	app.disableHardwareAcceleration();

--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -32,7 +32,6 @@ function showAppWindow() {
 	const windowConfig = Settings.getSettingGroup( Config.mainWindow, null );
 	windowConfig.webPreferences.spellcheck = Settings.getSetting( 'spellcheck-enabled' );
 	windowConfig.webPreferences.preload = preloadFile;
-	windowConfig.webPreferences.nativeWindowOpen = true;
 
 	const bounds = {
 		...{ width: 800, height: 600 },

--- a/desktop/app/window-handlers/external-links/index.js
+++ b/desktop/app/window-handlers/external-links/index.js
@@ -5,8 +5,21 @@ const log = require( '../../lib/logger' )( 'desktop:external-links' );
 let targetURL = '';
 
 module.exports = function ( { view } ) {
-	// TODO: Replace the "new-window" event with webcontents.setWindowOpenHandler
-	// when Electron is updated to >= 13.x
+	view.webContents.setWindowOpenHandler( ( details ) => {
+		const url = details.url;
+
+		// If the URL trying to open a new window is the Google Social login link, allow new window to open
+		if ( url.includes( 'https://accounts.google.com/o/oauth2/auth' ) ) {
+			return { action: 'allow' };
+		}
+		// Check if the incoming URL is blank and if it is send to the targetURL instead
+		const urlToLoad = url.includes( 'about:blank' ) || url === '' ? targetURL : url;
+		log.info( `Navigating to URL: '${ urlToLoad }'` );
+
+		view.webContents.loadURL( urlToLoad );
+		return { action: 'deny' };
+	} );
+
 	view.webContents.on( 'new-window', function ( event, url ) {
 		// If the URL trying to open a new window is the Google Social login link, allow new window to open
 		if ( url.includes( 'https://accounts.google.com/o/oauth2/auth' ) ) {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -40,7 +40,7 @@
 		"electron": "17.0.0",
 		"electron-builder": "^22.11.7",
 		"electron-notarize": "^0.1.1",
-		"electron-rebuild": "^2.3.5",
+		"electron-rebuild": "^3.2.7",
 		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -37,7 +37,7 @@
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"copy-webpack-plugin": "^10.1.0",
-		"electron": "12.2.3",
+		"electron": "17.0.0",
 		"electron-builder": "^22.11.7",
 		"electron-notarize": "^0.1.1",
 		"electron-rebuild": "^2.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3721,6 +3721,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gar/promisify@npm:^1.0.1":
+  version: 1.1.2
+  resolution: "@gar/promisify@npm:1.1.2"
+  checksum: 5272869fb1e0b765710f8aa522b4c1be9319a9be5b70510daccc570e2a0d69478e5b8a6a665040fdea78f4cf1a4f0e3d7eaaf862410493a201c9ddb961b74b80
+  languageName: node
+  linkType: hard
+
 "@github/webauthn-json@npm:^0.4.1":
   version: 0.4.1
   resolution: "@github/webauthn-json@npm:0.4.1"
@@ -4323,12 +4330,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@malept/cross-spawn-promise@npm:^1.1.0, @malept/cross-spawn-promise@npm:^1.1.1":
+"@malept/cross-spawn-promise@npm:^1.1.0":
   version: 1.1.1
   resolution: "@malept/cross-spawn-promise@npm:1.1.1"
   dependencies:
     cross-spawn: ^7.0.1
   checksum: 74c427a152ffff0f19b74af6479d05bef1e996d5e081cfc3b8c47477b9240bd1c42a930884cbcd0c89ee3835201a3bd88d0b0bfd754c0cbb56fc84a28996a8e7
+  languageName: node
+  linkType: hard
+
+"@malept/cross-spawn-promise@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@malept/cross-spawn-promise@npm:2.0.0"
+  dependencies:
+    cross-spawn: ^7.0.1
+  checksum: 84d60b8d467f4252114849f0a33c3763f07898335269eec5c94978ccac9d5680e1e268d993dd1a6d25a91476f9e0992759d7e1f385f9f3a090d862f9bb949603
   languageName: node
   linkType: hard
 
@@ -4426,6 +4442,16 @@ __metadata:
     "@nodelib/fs.scandir": 2.1.3
     fastq: ^1.6.0
   checksum: ebc8e292c5099003c78a70dddc04cde5f0316f0046eb66ba48429fba094c15e43ab93f180a14eabe06c7a29dcb91e3c008be2377a79c0fb3c9a459d075a33303
+  languageName: node
+  linkType: hard
+
+"@npmcli/fs@npm:^1.0.0":
+  version: 1.1.1
+  resolution: "@npmcli/fs@npm:1.1.1"
+  dependencies:
+    "@gar/promisify": ^1.0.1
+    semver: ^7.3.5
+  checksum: 4143c317a7542af9054018b71601e3c3392e6704e884561229695f099a71336cbd580df9a9ffb965d0024bf0ed593189ab58900fd1714baef1c9ee59c738c3e2
   languageName: node
   linkType: hard
 
@@ -9866,7 +9892,7 @@ __metadata:
     electron-builder: ^22.11.7
     electron-fetch: ^1.7.4
     electron-notarize: ^0.1.1
-    electron-rebuild: ^2.3.5
+    electron-rebuild: ^3.2.7
     electron-updater: ^4.2.5
     enzyme: ^3.11.0
     jest: ^27.3.1
@@ -10489,6 +10515,16 @@ __metadata:
     delegates: ^1.0.0
     readable-stream: ^3.6.0
   checksum: 375f753c10329153c8d66dc95e8f8b6c7cc2aa66e05cb0960bd69092b10dae22900cacc7d653ad11d26b3ecbdbfe1e8bfb6ccf0265ba8077a7d979970f16b99c
+  languageName: node
+  linkType: hard
+
+"are-we-there-yet@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "are-we-there-yet@npm:3.0.0"
+  dependencies:
+    delegates: ^1.0.0
+    readable-stream: ^3.6.0
+  checksum: 91cd4ad8a914437720bd726a36304ae279209fb13ce0f7e183ae752ae6d0070b56717a06a96b186728f9e74cb90837e5ee167a717119367b0ff3c4d2cef389ff
   languageName: node
   linkType: hard
 
@@ -12212,6 +12248,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cacache@npm:^15.2.0":
+  version: 15.3.0
+  resolution: "cacache@npm:15.3.0"
+  dependencies:
+    "@npmcli/fs": ^1.0.0
+    "@npmcli/move-file": ^1.0.1
+    chownr: ^2.0.0
+    fs-minipass: ^2.0.0
+    glob: ^7.1.4
+    infer-owner: ^1.0.4
+    lru-cache: ^6.0.0
+    minipass: ^3.1.1
+    minipass-collect: ^1.0.2
+    minipass-flush: ^1.0.5
+    minipass-pipeline: ^1.2.2
+    mkdirp: ^1.0.3
+    p-map: ^4.0.0
+    promise-inflight: ^1.0.1
+    rimraf: ^3.0.2
+    ssri: ^8.0.1
+    tar: ^6.0.2
+    unique-filename: ^1.1.1
+  checksum: 886fcc0acc4f6fd5cd142d373d8276267bc6d655d7c4ce60726fbbec10854de3395ee19bbf9e7e73308cdca9fdad0ad55060ff3bd16c6d4165c5b8d21515e1d8
+  languageName: node
+  linkType: hard
+
 "cache-base@npm:^1.0.1":
   version: 1.0.1
   resolution: "cache-base@npm:1.0.1"
@@ -13507,7 +13569,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colors@npm:1.4.0, colors@npm:^1.1.2, colors@npm:^1.2.1, colors@npm:^1.3.3":
+"colors@npm:1.4.0, colors@npm:^1.1.2, colors@npm:^1.2.1":
   version: 1.4.0
   resolution: "colors@npm:1.4.0"
   checksum: 9af357c019da3c5a098a301cf64e3799d27549d8f185d86f79af23069e4f4303110d115da98483519331f6fb71c8568d5688fa1c6523600044fd4a54e97c4efb
@@ -16156,25 +16218,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-rebuild@npm:^2.3.5":
-  version: 2.3.5
-  resolution: "electron-rebuild@npm:2.3.5"
+"electron-rebuild@npm:^3.2.7":
+  version: 3.2.7
+  resolution: "electron-rebuild@npm:3.2.7"
   dependencies:
-    "@malept/cross-spawn-promise": ^1.1.1
-    colors: ^1.3.3
+    "@malept/cross-spawn-promise": ^2.0.0
+    chalk: ^4.0.0
     debug: ^4.1.1
     detect-libc: ^1.0.3
-    fs-extra: ^9.0.1
+    fs-extra: ^10.0.0
     got: ^11.7.0
-    lzma-native: ^6.0.1
-    node-abi: ^2.19.2
-    node-gyp: ^7.1.0
+    lzma-native: ^8.0.5
+    node-abi: ^3.0.0
+    node-api-version: ^0.1.4
+    node-gyp: ^8.4.0
     ora: ^5.1.0
+    semver: ^7.3.5
     tar: ^6.0.5
-    yargs: ^16.0.0
+    yargs: ^17.0.1
   bin:
     electron-rebuild: lib/src/cli.js
-  checksum: ced4706356e411a210e53a31b0e7bcac6d7dcdc4d83239db58f793cd55113599750677b46ce23c9a8de1036048dd31fc9a890cceb7be85834f891e28088e2155
+  checksum: 95fe16d5fba9e64634773f32ba675866aa51404b355c5cd0b0bc16138115fcf2c9a23464187dd0a62c5dd320fc787401e3d63c63a1758d102a43dabd05d9272f
   languageName: node
   linkType: hard
 
@@ -19051,6 +19115,23 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"gauge@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "gauge@npm:4.0.1"
+  dependencies:
+    ansi-regex: ^5.0.1
+    aproba: ^1.0.3 || ^2.0.0
+    color-support: ^1.1.2
+    console-control-strings: ^1.0.0
+    has-unicode: ^2.0.1
+    signal-exit: ^3.0.0
+    string-width: ^4.2.3
+    strip-ansi: ^6.0.1
+    wide-align: ^1.1.2
+  checksum: e545da035b012d6de9973aaf4205ec5dc428d30d382e591dce7b73f00944a6c9e83726f44a432b49681af5a64d9d2fdd3ddccab544850078c6fa3e803231e9cd
+  languageName: node
+  linkType: hard
+
 "gauge@npm:~2.7.3":
   version: 2.7.4
   resolution: "gauge@npm:2.7.4"
@@ -19655,7 +19736,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.4, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.3, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.4, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.9
   resolution: "graceful-fs@npm:4.2.9"
   checksum: 2a66760ce6677ca18a24a1ef15d440cfd970086446af1e78c9e9de083c48122d8bd9c3fdc37f8f80f34aae833fa0d9dd52725e75a1c3f433ddd34eece39e7376
@@ -24822,6 +24903,30 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"make-fetch-happen@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "make-fetch-happen@npm:9.1.0"
+  dependencies:
+    agentkeepalive: ^4.1.3
+    cacache: ^15.2.0
+    http-cache-semantics: ^4.1.0
+    http-proxy-agent: ^4.0.1
+    https-proxy-agent: ^5.0.0
+    is-lambda: ^1.0.1
+    lru-cache: ^6.0.0
+    minipass: ^3.1.3
+    minipass-collect: ^1.0.2
+    minipass-fetch: ^1.3.2
+    minipass-flush: ^1.0.5
+    minipass-pipeline: ^1.2.4
+    negotiator: ^0.6.2
+    promise-retry: ^2.0.1
+    socks-proxy-agent: ^6.0.0
+    ssri: ^8.0.0
+  checksum: 2c737faf6a7f67077679da548b5bfeeef890595bf8c4323a1f76eae355d27ebb33dcf9cf1a673f944cf2f2a7cbf4e2b09f0a0a62931737728f210d902c6be966
+  languageName: node
+  linkType: hard
+
 "makeerror@npm:1.0.x":
   version: 1.0.11
   resolution: "makeerror@npm:1.0.11"
@@ -26451,6 +26556,13 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"negotiator@npm:^0.6.2":
+  version: 0.6.3
+  resolution: "negotiator@npm:0.6.3"
+  checksum: 3ec9fd413e7bf071c937ae60d572bc67155262068ed522cf4b3be5edbe6ddf67d095ec03a3a14ebf8fc8e95f8e1d61be4869db0dbb0de696f6b837358bd43fc2
+  languageName: node
+  linkType: hard
+
 "neo-async@npm:^2.5.0, neo-async@npm:^2.6.0, neo-async@npm:^2.6.1, neo-async@npm:^2.6.2":
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
@@ -26561,12 +26673,21 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"node-abi@npm:^2.19.2, node-abi@npm:^2.21.0":
+"node-abi@npm:^2.21.0":
   version: 2.30.0
   resolution: "node-abi@npm:2.30.0"
   dependencies:
     semver: ^5.4.1
   checksum: 656da9820083b76b33d2474144707a93ea8550a05c7523619ead78ec861879efa1ba839d3a7454f4ccc2e6044d38e7a4be85ebc9539ccb01881658e3d98cd2cd
+  languageName: node
+  linkType: hard
+
+"node-abi@npm:^3.0.0":
+  version: 3.8.0
+  resolution: "node-abi@npm:3.8.0"
+  dependencies:
+    semver: ^7.3.5
+  checksum: 583611583411b43390940f53160d71ed974df4d609999abc95809410a9f1249b3d18e7f6b275e1666fc0ab1d3131b50510f8d8e65d844d667a8a0689724571b1
   languageName: node
   linkType: hard
 
@@ -26594,6 +26715,15 @@ fsevents@~2.1.2:
   dependencies:
     node-gyp: latest
   checksum: 41f21c9d12318875a2c429befd06070ce367065a3ef02952cfd4ea17ef69fa14012732f510b82b226e99c254da8d671847ea018cad785f839a5366e02dd56302
+  languageName: node
+  linkType: hard
+
+"node-api-version@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "node-api-version@npm:0.1.4"
+  dependencies:
+    semver: ^7.3.5
+  checksum: 3f46ece55e1a254da2d20d2b7f1be11125d37788607aa807ef75b321de289739accc30df46395bee87f1fef210472eacbe421adaa540f3b6d9e986b289a37674
   languageName: node
   linkType: hard
 
@@ -26650,23 +26780,23 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:^7.1.0":
-  version: 7.1.2
-  resolution: "node-gyp@npm:7.1.2"
+"node-gyp@npm:^8.4.0":
+  version: 8.4.1
+  resolution: "node-gyp@npm:8.4.1"
   dependencies:
     env-paths: ^2.2.0
     glob: ^7.1.4
-    graceful-fs: ^4.2.3
+    graceful-fs: ^4.2.6
+    make-fetch-happen: ^9.1.0
     nopt: ^5.0.0
-    npmlog: ^4.1.2
-    request: ^2.88.2
+    npmlog: ^6.0.0
     rimraf: ^3.0.2
-    semver: ^7.3.2
-    tar: ^6.0.2
+    semver: ^7.3.5
+    tar: ^6.1.2
     which: ^2.0.2
   bin:
     node-gyp: bin/node-gyp.js
-  checksum: 2fe78d02fb152c8f5a59c9b0a558cbc5beb7f574c25646d4cfdbb62eaa36f3b43ebc585d7b53df84ef4eff5c5b4ad0a2b5a37c09816ac11f61a3bdcedd82df04
+  checksum: 80ef333b3a882eb6a2695a8e08f31d618f4533eff192864e4a3a16b67ff0abc9d8c1d5fac0395550ec699326b9248c5e2b3be178492f7f4d1ccf97d2cf948021
   languageName: node
   linkType: hard
 
@@ -26987,6 +27117,18 @@ fsevents@~2.1.2:
     gauge: ^3.0.0
     set-blocking: ^2.0.0
   checksum: 489ba519031013001135c463406f55491a17fc7da295c18a04937fe3a4d523fd65e88dd418a28b967ab743d913fdeba1e29838ce0ad8c75557057c481f7d49fa
+  languageName: node
+  linkType: hard
+
+"npmlog@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "npmlog@npm:6.0.1"
+  dependencies:
+    are-we-there-yet: ^3.0.0
+    console-control-strings: ^1.1.0
+    gauge: ^4.0.0
+    set-blocking: ^2.0.0
+  checksum: 794996b9a9def47026418ed961bbb5c3c5c6e62b9d54e1024f8f68e35052fc80c3af6a9e65c4817a6d43262c5e83fdbc965f49af9666bdccc5e34d7513f67e3a
   languageName: node
   linkType: hard
 
@@ -33675,7 +33817,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^6.1.0":
+"socks-proxy-agent@npm:^6.0.0, socks-proxy-agent@npm:^6.1.0":
   version: 6.1.1
   resolution: "socks-proxy-agent@npm:6.1.1"
   dependencies:
@@ -33998,7 +34140,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"ssri@npm:^8.0.0":
+"ssri@npm:^8.0.0, ssri@npm:^8.0.1":
   version: 8.0.1
   resolution: "ssri@npm:8.0.1"
   dependencies:
@@ -34223,7 +34365,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.0.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.2":
+"string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.0.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.2, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -38765,7 +38907,7 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"yargs@npm:^16.0.0, yargs@npm:^16.1.0, yargs@npm:^16.2.0":
+"yargs@npm:^16.1.0, yargs@npm:^16.2.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3281,7 +3281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron/get@npm:^1.0.1":
+"@electron/get@npm:^1.13.0":
   version: 1.13.1
   resolution: "@electron/get@npm:1.13.1"
   dependencies:
@@ -9862,7 +9862,7 @@ __metadata:
     archiver: ^3.1.1
     copy-webpack-plugin: ^10.1.0
     cross-env: ^7.0.3
-    electron: 12.2.3
+    electron: 17.0.0
     electron-builder: ^22.11.7
     electron-fetch: ^1.7.4
     electron-notarize: ^0.1.1
@@ -16200,16 +16200,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:12.2.3":
-  version: 12.2.3
-  resolution: "electron@npm:12.2.3"
+"electron@npm:17.0.0":
+  version: 17.0.0
+  resolution: "electron@npm:17.0.0"
   dependencies:
-    "@electron/get": ^1.0.1
+    "@electron/get": ^1.13.0
     "@types/node": ^14.6.2
     extract-zip: ^1.0.3
   bin:
     electron: cli.js
-  checksum: 5fcf095ad1a27c82507207cf3eae1a47953faaf986996cfd17d5700f0314f88deffa578ab57279361acb5e0e172af0e67ce31acba65548e68c584b1830ef24a5
+  checksum: de761a77581469d3f36ab717fda9674105291351adfb5b3e5ea93bafc545958fc25d39f3a72b2898c4d3bcc06cf9cc7157edb7365a8cf3696007ffca0f0ee4a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update Electron to latest (v17.0.0).

Use Electron [breaking changes](https://www.electronjs.org/docs/latest/breaking-changes) docs to update deprecated APIs:

- `nativeWindowOpen` - defaults to `true`, deprecated
- `new-window` - deprecated, replaced by `setWindowOpenHandler`
- `allowRendererProcessReuse` - deprecated