### PR TITLE
Plugins: Always filter popular plugins to remove duplicates from featured

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -127,8 +127,7 @@ const PluginsBrowser = ( {
 	);
 	const pluginsByCategoryPopular = filterPopularPlugins(
 		popularPlugins,
-		pluginsByCategoryFeatured,
-		jetpackNonAtomic
+		pluginsByCategoryFeatured
 	);
 	const isFetchingPluginsByCategory = useSelector( ( state ) =>
 		isFetchingPluginsList( state, category )
@@ -709,13 +708,7 @@ function updateWpComRating( plugin ) {
  * @param {Array} popularPlugins
  * @param {Array} featuredPlugins
  */
-function filterPopularPlugins( popularPlugins = [], featuredPlugins = [], jetpackNonAtomic ) {
-	// Since paid plugins will not be available for Jetpack self hosted sites,
-	// continue with filtering the popular plugins.
-	if ( ! jetpackNonAtomic ) {
-		featuredPlugins = [];
-	}
-
+function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
 	const displayedFeaturedSlugsMap = new Map(
 		featuredPlugins
 			.slice( 0, SHORT_LIST_LENGTH ) // only displayed plugins


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Follow up from https://github.com/Automattic/wp-calypso/pull/61098 to always filter popular by whats been seen in featured already.

#### Testing instructions

- http://calypso.localhost:3000/plugins/
- [x] Confirm duplicate featured plugins no longer show under the popular heading on all sites (not just jetpack)

Before
![Screenshot 2022-02-16 at 15-40-18 Plugins ‹ Site Title — WordPress com](https://user-images.githubusercontent.com/811776/154197492-94a466bf-c429-4905-b1d7-da7fffb6348a.png)

After
![Screenshot 2022-02-16 at 15-40-33 Plugins ‹ test — WordPress com](https://user-images.githubusercontent.com/811776/154197497-96ac88ac-b3d3-436b-96e0-20f6f2229c0e.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/60553 / https://github.com/Automattic/wp-calypso/issues/60553#issuecomment-1040079281
