### PR TITLE
Fix padding for Jetpack pricing page cards

### DIFF
--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -42,11 +42,6 @@
 		}
 	}
 
-	.main {
-		padding-left: 0;
-		padding-right: 0;
-	}
-
 	.layout__content {
 		padding-left: 0;
 		padding-right: 0;


### PR DESCRIPTION
Fixes 1164141197617539-as-1201817226344075/f

#### Changes proposed in this Pull Request

* Fix the padding issue in Jetpack pricing page cards

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot up the PR and run `yarn start` before running `start-jetpack-cloud-p`
* Goto [jetpack.cloud.localhost:3001/pricing](http://jetpack.cloud.localhost:3001/pricing)
* Check the padding of pricing grid/cards on all viewpoint sizes
* Check for any regression

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


| BEFORE | AFTER |
| - | - |
| <img width="852" alt="Screenshot 2022-02-16 at 10 46 02 AM" src="https://user-images.githubusercontent.com/18226415/154201059-4fa749b8-2cf8-4cc2-a33d-bc0a0b79da96.png"> | <img width="852" alt="Screenshot 2022-02-16 at 10 45 29 AM" src="https://user-images.githubusercontent.com/18226415/154200824-c51c8b32-10da-4336-8fd5-17b8fb6204ba.png"> |