### PR TITLE
Add tab/tabpanel ARIA attributes to site-setup-list

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -5,7 +5,7 @@ import Badge from 'calypso/components/badge';
 
 const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout } ) => {
 	return (
-		<div className="site-setup-list__task task">
+		<div className="site-setup-list__task task" role="tabpanel">
 			<div className="site-setup-list__task-text task__text">
 				{ currentTask.isCompleted && ! currentTask.hideLabel && (
 					<Badge type="info" className="site-setup-list__task-badge task__badge">

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -269,6 +269,9 @@ const SiteSetupList = ( {
 					className={ classnames( 'site-setup-list__list', {
 						'is-mobile-app-completed': isMobileAppTaskCompleted,
 					} ) }
+					role="tablist"
+					aria-label="Site setup"
+					aria-orientation="vertical"
 				>
 					{ tasks.map( ( task ) => {
 						const enhancedTask = getTask( task, { isBlogger, userEmail } );

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -32,6 +32,8 @@ const NavItem = ( {
 				trackExpand();
 				onClick();
 			} }
+			role="tab"
+			aria-selected={ isCurrent }
 			data-task={ taskId }
 		>
 			<div className="nav-item__status">

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -126,6 +126,10 @@
 			}
 		}
 
+		&:focus-visible {
+			box-shadow: inset 0 0 0 2px var( --color-primary );
+		}
+
 		&.is-current {
 			background-color: var( --color-primary-0 );
 			font-weight: 600;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR improves accessibility of the `SiteSetupList` component by adding tab related ARIA attributes.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to My Home with a site that's not "set up".
* The page's primary location will display the `SiteSetupList` component. 
* Using the browser's developer tools, check that the following ARIA attributes are set:
  * Panels should have `role=tabpanel`
  * Sidebar's tab list section should have `role=tablist`, `aria-orientation=vertical` and `aria-label="Site Setup"`
  * Sidebar's tab list item should have `role=tab` and `aria-selected` with either `true` or `false`.

Since we're using `:focus-visible`, the focus state for tabs will be visible only when focused with keyboard.
![Screen Shot 2022-02-16 at 2 03 57 PM](https://user-images.githubusercontent.com/797888/154206288-6a634b25-ecc3-4e40-a7de-43854f4b637b.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53617
