### PR TITLE
Fix masterbar padding/width for Jetpack cloud

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -17,7 +17,7 @@
 
 	// Breakpoint taken from jetpack.com, not standard in Calypso
 	@media ( min-width: 661px ) {
-		width: 100%;
+		width: calc( 100% - 2rem );
 		margin-top: -52px; // Undo the padding-top set by .layout__content
 		padding: 0;
 	}


### PR DESCRIPTION
Fixes 1164141197617539-as-1201835255344103/f
Addresses https://github.com/Automattic/wp-calypso/pull/61146#pullrequestreview-884220573

#### Changes proposed in this Pull Request

* Fix the padding/width issue for masterbar on Jetpack cloud on smaller screens

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot up the PR and run `yarn start` before running `start-jetpack-cloud-p`
* Goto [jetpack.cloud.localhost:3001/pricing](http://jetpack.cloud.localhost:3001/pricing)
* Check the padding of masterbar (Logo/Menu) on all viewpoint sizes, especially smaller screens
* Check for any regression

| BEFORE | AFTER |
| - | - |
| <img width="767" alt="Screenshot 2022-02-16 at 3 48 36 PM" src="https://user-images.githubusercontent.com/18226415/154244893-4dfa8681-edf5-4a5c-bbdf-586c9652c177.png"> | <img width="768" alt="Screenshot 2022-02-16 at 3 50 08 PM" src="https://user-images.githubusercontent.com/18226415/154244945-61775543-30e9-471b-899c-b1fd116eb96b.png"> |