### PR TITLE
Welcome Tour/Site Editor: Disable WP Core welcome guide when in site editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
@@ -8,6 +8,9 @@ const unsubscribe = subscribe( () => {
 	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
 	}
+	if ( select( 'core/edit-site' )?.isFeatureActive( 'welcomeGuide' ) ) {
+		dispatch( 'core/edit-site' ).toggleFeature( 'welcomeGuide' );
+	}
 	unsubscribe();
 } );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
@@ -24,4 +24,10 @@ subscribe( () => {
 			openedManually: true,
 		} );
 	}
+	if ( select( 'core/edit-site' )?.isFeatureActive( 'welcomeGuide' ) ) {
+		dispatch( 'core/edit-site' ).toggleFeature( 'welcomeGuide' );
+		dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true, {
+			openedManually: true,
+		} );
+	}
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Read convo in pbAok1-2vM-p2

Currently, when landing in Full Site Editor we show two modals to the user, the WP Core one and the wordpress.com (see screenshot). 
To fix it quickly we decided to show the wpcom welcome tour only.


#### Screenshots

Before
![image](https://user-images.githubusercontent.com/52076348/154254841-b09916a5-9685-41c1-9410-0efaed0f8761.png)


After
![image](https://user-images.githubusercontent.com/52076348/154255471-703048cb-0eb9-4181-b812-23c6f1b0b7df.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Checkout branch
* `yarn dev --sync` from `apps/editing-toolkit` to sync the welcome tour to the sandbox
*  In Incognito, go to `https://horizon.wordpress.com/start` and create a new website. Choose a FSE theme (like Geologist for example)
*  Before entering the site editor, be sure to sandbox the new website you just created: add `your.sandbox.ip  new-site-name.wordpress.com` to your `/etc/hosts` file 
* Check that only the wpcom welcome tour shows
* Check that the Styles core modal is still showing
![image](https://user-images.githubusercontent.com/52076348/154269607-01337cd8-5027-46a4-ba95-9da146f2fcd6.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #61036