### PR TITLE
CircleCI: Remove `translate` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ references:
     command: |
       mkdir -p                                  \
         "$CIRCLE_ARTIFACTS/notifications-panel" \
-        "$CIRCLE_ARTIFACTS/translate"           \
         "$CIRCLE_ARTIFACTS/screenshots"         \
         "$CIRCLE_ARTIFACTS/wpcom-block-editor"  \
         "$CIRCLE_TEST_REPORTS/client"           \
@@ -142,54 +141,6 @@ commands:
           path: /tmp/artifacts
 
 jobs:
-  translate:
-    <<: *defaults
-    steps:
-      - restore_cache: *restore-git-cache
-      - checkout
-      - run: *update-git
-      - save_cache: *save-git-cache
-      - run: *update-node
-      - restore_cache: *restore-yarn-cache
-      - run: *yarn-install
-      - save_cache: *save-yarn-cache
-      - run: *setup-results-and-artifacts
-      - run:
-          name: Extract strings
-          command: |
-            yarn run translate
-            mv public/calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
-      - run:
-          name: Build New Strings .pot
-          when: always
-          command: |
-            git clone --single-branch --depth=1 https://github.com/Automattic/gp-localci-client.git
-            DEFAULT_BRANCH=trunk bash gp-localci-client/generate-new-strings-pot.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1" "$CIRCLE_ARTIFACTS/translate"
-            rm -rf gp-localci-client
-      - store-artifacts-and-test-results
-      - run:
-          name: Notify GlotPress translations are ready
-          when: always
-          command: |
-            curl -X POST https://translate.wordpress.com/api/localci/-relay-new-strings-to-gh \
-              -H 'Cache-Control: no-cache' \
-              -H 'Content-Type: application/json' \
-              -d '{
-                    "payload": {
-                      "branch": "'"$CIRCLE_BRANCH"'",
-                      "build_num": '"$CIRCLE_BUILD_NUM"',
-                      "pull_requests": [
-                        {
-                          "url": "'"$CIRCLE_PULL_REQUEST"'"
-                        }
-                      ],
-                      "reponame": "'"$CIRCLE_PROJECT_REPONAME"'",
-                      "username": "'"$CIRCLE_PROJECT_USERNAME"'",
-                      "vcs_revision": "'"$CIRCLE_SHA1"'",
-                      "vcs_type": "github"
-                    }
-                  }'
-
   wp-desktop-assets:
     docker:
       - image: circleci/node:12.16.2-browsers
@@ -511,9 +462,6 @@ jobs:
 
 workflows:
   version: 2
-  calypso:
-    jobs:
-      - translate
   wp-desktop:
     jobs:
       - wp-desktop-assets:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove CircleCI `translate` job, as it has been replace by [Translate build configuration for TeamCity](https://github.com/Automattic/wp-calypso/blob/51a5432843507c2121987948296b6fad59b25aa0/.teamcity/_self/projects/WebApp.kt#L565). (See pMz3w-eHV-p2)

This PR should be merged after D74940-code and #61159 are deployed.

#### Testing instructions

* Review config changes.

Related to 378-gh-Automattic/i18n-issues
