### PR TITLE
Hide step progress indicator in the domain-only flow

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -117,7 +117,7 @@ function removeLoadingScreenClassNamesFromBody() {
 }
 
 function showProgressIndicator( flowName ) {
-	const DISABLED_PROGRESS_INDICATOR_FLOWS = [ 'pressable-nux', 'setup-site', 'importer' ];
+	const DISABLED_PROGRESS_INDICATOR_FLOWS = [ 'pressable-nux', 'setup-site', 'importer', 'domain' ];
 
 	return ! DISABLED_PROGRESS_INDICATOR_FLOWS.includes( flowName );
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR remove the step progress indicator in the domain-only flow.

![Markup on 2022-02-16 at 17:18:41](https://user-images.githubusercontent.com/2797601/154308852-264704a3-c279-417d-8a12-03fd4cf63b4f.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- Navigate to to `/start/domain`
- Verify that the step progress indicator is no longer displayed