### PR TITLE
`Login`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -62,21 +62,21 @@ export class Login extends Component {
 	}
 
 	componentDidMount() {
-		this.recordPageView( this.props );
+		this.recordPageView();
 	}
 
 	componentDidUpdate( prevProps ) {
 		if ( this.props.twoFactorAuthType !== prevProps.twoFactorAuthType ) {
-			this.recordPageView( this.props );
+			this.recordPageView();
 		}
 
 		if ( this.props.socialConnect !== prevProps.socialConnect ) {
-			this.recordPageView( this.props );
+			this.recordPageView();
 		}
 	}
 
-	recordPageView( props ) {
-		const { socialConnect, twoFactorAuthType } = props;
+	recordPageView() {
+		const { socialConnect, twoFactorAuthType } = this.props;
 
 		let url = '/log-in';
 		let title = 'Login';

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -65,14 +65,13 @@ export class Login extends Component {
 		this.recordPageView( this.props );
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.twoFactorAuthType !== nextProps.twoFactorAuthType ) {
-			this.recordPageView( nextProps );
+	componentDidUpdate( prevProps ) {
+		if ( this.props.twoFactorAuthType !== prevProps.twoFactorAuthType ) {
+			this.recordPageView( this.props );
 		}
 
-		if ( this.props.socialConnect !== nextProps.socialConnect ) {
-			this.recordPageView( nextProps );
+		if ( this.props.socialConnect !== prevProps.socialConnect ) {
+			this.recordPageView( this.props );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `Login`: refactor away from `UNSAFE_*`

#### Testing instructions

* Enable Calypso debug statements via `localStorage.setItem('debug', 'calypso:analytics*')`
* While being logged out go to `/log-in`
* Type in credentials for an account with 2FA enabled
* Once you reach the step to enter your second factor you should see a `recordPageView` debug statement in your console (see below)
* Now open the React devtools and search for the `<Login />` component, toggle the `socialConnect` prop
* You should now see another `recordPageView` debug statement (see below)

<img width="495" alt="Screenshot 2022-02-16 at 17 17 42" src="https://user-images.githubusercontent.com/9202899/154309236-43c2b689-de86-4217-a59c-00d26ad4b4d5.png">
<img width="504" alt="Screenshot 2022-02-16 at 17 17 34" src="https://user-images.githubusercontent.com/9202899/154309252-4ce9aa3b-5c3b-4431-a458-702dd94eb7ee.png">


Related to #58453 
