### PR TITLE
Emails: Add billing toggle to Professional Email Upsell nudge.

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -31,6 +31,7 @@ import {
 } from 'calypso/my-sites/checkout/composite-checkout/lib/contact-validation';
 import ProfessionalEmailUpsell from 'calypso/my-sites/checkout/upsell-nudge/professional-email-upsell';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
+import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import {
 	retrieveSignupDestination,
 	clearSignupDestinationCookie,
@@ -299,6 +300,7 @@ export class UpsellNudge extends Component {
 		const {
 			receiptId,
 			currencyCode,
+			currentPlanTerm,
 			productCost,
 			planRawPrice,
 			planDiscountedRawPrice,
@@ -310,7 +312,6 @@ export class UpsellNudge extends Component {
 			hasSevenDayRefundPeriod,
 			pricePerMonthForMonthlyPlan,
 			pricePerMonthForAnnualPlan,
-			productSlug,
 			annualPlanSlug,
 		} = this.props;
 
@@ -348,8 +349,10 @@ export class UpsellNudge extends Component {
 						domainName={ upgradeItem }
 						handleClickAccept={ this.handleClickAccept }
 						handleClickDecline={ this.handleClickDecline }
+						intervalLength={
+							currentPlanTerm === TERM_MONTHLY ? IntervalLength.MONTHLY : IntervalLength.ANNUALLY
+						}
 						productCost={ productCost }
-						productSlug={ productSlug }
 						/* Use the callback form of setState() to ensure handleClickAccept()
 						 is called after the state update */
 						setCartItem={ ( newCartItem, callback = noop ) =>
@@ -624,6 +627,7 @@ export default connect(
 			isFetchingStoredCards: areStoredCardsLoading,
 			cards,
 			currencyCode: getCurrentUserCurrencyCode( state ),
+			currentPlanTerm,
 			isLoading:
 				isFetchingCards ||
 				isProductsListFetching( state ) ||

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -99,55 +99,26 @@ const ProfessionalEmailUpsell = ( {
 		);
 	};
 
-	function addMonths( date: Date, months: number ) {
-		const d = date.getDate();
-		date.setMonth( date.getMonth() + months );
-		if ( date.getDate() !== d ) {
-			date.setDate( 0 );
-		}
-		return date;
-	}
-
-	/**
-	 * We calculate the price for a year subscription, given how many months we are going to offer for free.
-	 * It takes into account leap years, and months like february.
-	 *
-	 * Example: If we give 3 months for free in February, for a product that cost 35$ yearly then we return the price
-	 * that we need to bill after those 3 months for the rest of the year.
-	 *
-	 * @param productCost
-	 * @param freeMonths
-	 */
-	const getProratedPrice = ( productCost: number, freeMonths: number ) => {
-		const now = new Date();
-		const freeTime = addMonths( new Date(), freeMonths ).getTime();
-		const nextYearDate = addMonths( new Date(), 12 );
-		const diff = nextYearDate.getTime() - freeTime;
-		const diffDays = ( nextYearDate.getTime() - now.getTime() ) / 86400000 - diff / 86400000;
-		const price = ( 365 - Math.round( diffDays ) ) / 365;
-		return price * productCost;
-	};
-
 	const getFormattedPrice = (
 		currencyCode: string,
 		intervalLength: IntervalLength,
 		productCost: number
 	): TranslateResult => {
-		if ( intervalLength === IntervalLength.MONTHLY ) {
-			return translate( '{{price/}} /mailbox /month', {
-				components: {
-					price: <span>{ formatCurrency( productCost ?? 0, currencyCode ) }</span>,
-				},
-				comment: '{{price/}} is the formatted price, e.g. $20',
-			} );
-		}
-		const proratedPrice = getProratedPrice( productCost, 3 );
-		return translate( '{{price/}} /mailbox /year', {
+		const translateOptions = {
 			components: {
-				price: <span>{ formatCurrency( proratedPrice, currencyCode ) }</span>,
+				price: (
+					<span className="professional-email-upsell__discounted">
+						{ formatCurrency( productCost ?? 0, currencyCode ) }
+					</span>
+				),
 			},
 			comment: '{{price/}} is the formatted price, e.g. $20',
-		} );
+		};
+		if ( intervalLength === IntervalLength.MONTHLY ) {
+			return translate( '{{price/}} /mailbox /month', translateOptions );
+		}
+
+		return translate( '{{price/}} /mailbox /year', translateOptions );
 	};
 
 	const formattedPrice = getFormattedPrice(

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -4,7 +4,7 @@ import formatCurrency from '@automattic/format-currency';
 import { MOBILE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan-caps.svg';
@@ -175,15 +175,11 @@ const ProfessionalEmailUpsell = ( {
 		setCartItem( cartItem, () => handleClickAccept( 'accept' ) );
 	};
 
-	const threeMonthsFreeBadge = (
-		<span>
-			<Badge type="success">{ translate( '3 months free' ) }</Badge>
-		</span>
-	);
-
 	const pricingComponent = (
 		<div className="professional-email-upsell__pricing">
-			{ threeMonthsFreeBadge }
+			<span>
+				<Badge type="success">{ translate( '3 months free' ) }</Badge>
+			</span>
 			<span
 				className={ classNames( 'professional-email-upsell__standard-price', {
 					'is-discounted': true,
@@ -196,7 +192,7 @@ const ProfessionalEmailUpsell = ( {
 
 	return (
 		<div>
-			<header className="professional-email-upsell__header notouch">
+			<header className="professional-email-upsell__header">
 				<h3 className="professional-email-upsell__small-title">
 					{ translate( "Hold tight, we're getting your site ready." ) }
 				</h3>
@@ -209,7 +205,9 @@ const ProfessionalEmailUpsell = ( {
 					} ) }
 				</h1>
 				<h3 className="professional-email-upsell__small-subtitle">
-					{ translate( 'No setup required. Easy to manage.' ) }
+					{ i18n.hasTranslation( 'No setup required. Easy to manage.' )
+						? translate( 'No setup required. Easy to manage.' )
+						: null }
 				</h3>
 				<BillingIntervalToggle
 					intervalLength={ selectedIntervalLength }

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
@@ -15,10 +15,54 @@
 
 .professional-email-upsell__header {
 	text-align: center;
+
+	.segmented-control {
+		background-color: var( --studio-gray-5 );
+		border-color: var( --studio-gray-5 );
+		border-radius: 6px; /* stylelint-disable-line */
+		color: var( --color-text );
+		margin-top: 16px;
+
+		.segmented-control__link {
+			padding: 6px 11px;
+		}
+
+		.segmented-control__item {
+			border: 6px;
+			padding: 2px;
+
+			& .segmented-control__link {
+				border: 0 solid #f2f2f2;
+				&:hover {
+					border: 0 solid var( --studio-gray-10 );
+					background-color: unset;
+					border-radius: 5px; /* stylelint-disable-line */
+				}
+			}
+
+			&.is-selected .segmented-control__link {
+				border: 0.5px solid rgba( 0, 0, 0, 0.04 );
+				box-shadow: 0 3px 8px rgba( 0, 0, 0, 0.12 ), 0 3px 1px rgba( 0, 0, 0, 0.04 );
+				border-radius: 5px; /* stylelint-disable-line */
+
+				&:hover {
+					background-color: #fff;
+					border-color: rgba( 0, 0, 0, 0.04 );
+				}
+			}
+		}
+
+
+	}
 }
 
 .professional-email-upsell__small-title {
 	font-size: $font-body-small;
+}
+
+.professional-email-upsell__small-subtitle {
+	font-size: $font-body-small;
+	margin-top: 1em;
 }
 
 .professional-email-upsell__title {
@@ -30,15 +74,22 @@
 .professional-email-upsell__pricing {
 	display: flex;
 	flex-direction: column;
-	margin-top: 10px;
+	margin-bottom: 24px;
 
 	@include break-mobile {
-		flex-direction: row;
 		justify-content: center;
+		margin-bottom: 10px;
 
 		span + span {
 			margin-left: 8px;
 		}
+	}
+}
+
+.professional-email-upsell__standard-price {
+	span {
+		font-size: $font-title-small;
+		font-weight: 600;
 	}
 }
 

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
@@ -16,43 +16,54 @@
 .professional-email-upsell__header {
 	text-align: center;
 
-	.segmented-control {
-		background-color: var( --studio-gray-5 );
-		border-color: var( --studio-gray-5 );
-		border-radius: 6px; /* stylelint-disable-line */
-		color: var( --color-text );
-		margin-top: 16px;
+	.billing-interval-toggle {
+		.segmented-control {
+			background-color: var( --studio-gray-5 );
+			border-color: var( --studio-gray-5 );
+			border-radius: 6px; /* stylelint-disable-line */
+			color: var( --color-text );
 
-		.segmented-control__link {
-			padding: 6px 11px;
-		}
+			.segmented-control__item {
+				border: 1px solid;
+				border-radius: 6px; /* stylelint-disable-line */
+				border-color: var( --studio-gray-5 );
 
-		.segmented-control__item {
-			border: 6px;
-			padding: 2px;
+				&.is-selected {
+					padding: 1px 0 0 1px;
+				}
 
-			& .segmented-control__link {
-				border: 0 solid #f2f2f2;
-				&:hover {
-					border: 0 solid var( --studio-gray-10 );
-					background-color: unset;
+				&:hover:not( .is-selected ) {
+					border-color: var( --studio-gray-30 );
+				}
+
+				&:first-child {
+					margin-right: 5px;
+				}
+
+				& .segmented-control__link {
+					color: var( --color-text );
+					border: 0;
+
+					&:hover {
+						background-color: unset;
+					}
+				}
+
+				&.is-selected .segmented-control__link {
 					border-radius: 5px; /* stylelint-disable-line */
-				}
-			}
+					background-color: var( --studio-white );
+					border-color: var( --studio-white );
+					box-shadow: 0 4px 4px rgba( 0, 0, 0, 0.25 ), 0 3px 8px rgba( 0, 0, 0, 0.12 ),
+					inset 0 0 0 rgba( 0, 0, 0, 0.2 );
+					border: 0.5px solid rgba( 0, 0, 0, 0.07 );
+					color: var( --color-text );
 
-			&.is-selected .segmented-control__link {
-				border: 0.5px solid rgba( 0, 0, 0, 0.04 );
-				box-shadow: 0 3px 8px rgba( 0, 0, 0, 0.12 ), 0 3px 1px rgba( 0, 0, 0, 0.04 );
-				border-radius: 5px; /* stylelint-disable-line */
-
-				&:hover {
-					background-color: #fff;
-					border-color: rgba( 0, 0, 0, 0.04 );
+					&:hover {
+						background-color: var( --studio-white );
+					}
 				}
 			}
 		}
-
-
 	}
 }
 

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
@@ -17,16 +17,23 @@
 	text-align: center;
 
 	.billing-interval-toggle {
+		display: flex;
+
 		.segmented-control {
-			background-color: var( --studio-gray-5 );
-			border-color: var( --studio-gray-5 );
+			background-color: #f2f2f2;
+			border: solid 1px var( --studio-gray-5 );
 			border-radius: 6px; /* stylelint-disable-line */
 			color: var( --color-text );
 
+			&.is-compact {
+				margin-bottom: 0;
+				max-width: unset;
+			}
+
 			.segmented-control__item {
-				border: 1px solid;
 				border-radius: 6px; /* stylelint-disable-line */
-				border-color: var( --studio-gray-5 );
+				border: 1px solid #f2f2f2;
+				padding: 2px;
 
 				&.is-selected {
 					padding: 1px 0 0 1px;
@@ -43,7 +50,9 @@
 				& .segmented-control__link {
 					color: var( --color-text );
 					border: 0;
-
+					line-height: 18px;
+					margin: 1px;
+					padding-bottom: 6px;
 					&:hover {
 						background-color: unset;
 					}
@@ -55,8 +64,8 @@
 					border-color: var( --studio-white );
 					box-shadow: 0 4px 4px rgba( 0, 0, 0, 0.25 ), 0 3px 8px rgba( 0, 0, 0, 0.12 ),
 					inset 0 0 0 rgba( 0, 0, 0, 0.2 );
-					border: 0.5px solid rgba( 0, 0, 0, 0.07 );
 					color: var( --color-text );
+					padding-top: 6px;
 
 					&:hover {
 						background-color: var( --studio-white );
@@ -65,6 +74,10 @@
 			}
 		}
 	}
+}
+
+.professional-email-upsell__discounted {
+	text-decoration: line-through;
 }
 
 .professional-email-upsell__small-title {

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
@@ -20,8 +20,8 @@
 		display: flex;
 
 		.segmented-control {
-			background-color: #f2f2f2;
-			border: solid 1px var( --studio-gray-5 );
+			background-color: var( --studio-gray-0 );
+			border: 1px solid var( --studio-gray-5 );
 			border-radius: 6px; /* stylelint-disable-line */
 			color: var( --color-text );
 
@@ -32,7 +32,7 @@
 
 			.segmented-control__item {
 				border-radius: 6px; /* stylelint-disable-line */
-				border: 1px solid #f2f2f2;
+				border: 1px solid var( --studio-gray-0 );
 				padding: 2px;
 
 				&.is-selected {

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -33,37 +33,3 @@ export function addHttpIfMissing( inputUrl: string, httpsIsDefault = true ): str
 	}
 	return untrailingslashit( url );
 }
-
-function addMonths( date: Date, months: number ) {
-	const d = date.getDate();
-	date.setMonth( date.getMonth() + months );
-	if ( date.getDate() !== d ) {
-		date.setDate( 0 );
-	}
-	return date;
-}
-
-/**
- * We calculate the price for a year subscription, given how many months we are going to offer for free.
- * It takes into account leap years, and months like february.
- *
- * Example: If we give 3 months for free in February, for a product that cost 35$ yearly then we return the price
- * that we need to bill after those 3 months for the rest of the year.
- *
- * @param productCost
- * @param freeMonths
- * @param startDate
- */
-export function getProratedPrice(
-	productCost: number,
-	freeMonths: number,
-	startDate: Date = new Date()
-): number {
-	const now = startDate;
-	const freeTime = addMonths( new Date( startDate ), freeMonths ).getTime();
-	const nextYearDate = addMonths( new Date( startDate ), 12 );
-	const diff = nextYearDate.getTime() - freeTime;
-	const diffDays = ( nextYearDate.getTime() - now.getTime() ) / 86400000 - diff / 86400000;
-	const price = ( 365 - Math.round( diffDays ) ) / 365;
-	return price * productCost;
-}

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -33,3 +33,37 @@ export function addHttpIfMissing( inputUrl: string, httpsIsDefault = true ): str
 	}
 	return untrailingslashit( url );
 }
+
+function addMonths( date: Date, months: number ) {
+	const d = date.getDate();
+	date.setMonth( date.getMonth() + months );
+	if ( date.getDate() !== d ) {
+		date.setDate( 0 );
+	}
+	return date;
+}
+
+/**
+ * We calculate the price for a year subscription, given how many months we are going to offer for free.
+ * It takes into account leap years, and months like february.
+ *
+ * Example: If we give 3 months for free in February, for a product that cost 35$ yearly then we return the price
+ * that we need to bill after those 3 months for the rest of the year.
+ *
+ * @param productCost
+ * @param freeMonths
+ * @param startDate
+ */
+export function getProratedPrice(
+	productCost: number,
+	freeMonths: number,
+	startDate: Date = new Date()
+): number {
+	const now = startDate;
+	const freeTime = addMonths( new Date( startDate ), freeMonths ).getTime();
+	const nextYearDate = addMonths( new Date( startDate ), 12 );
+	const diff = nextYearDate.getTime() - freeTime;
+	const diffDays = ( nextYearDate.getTime() - now.getTime() ) / 86400000 - diff / 86400000;
+	const price = ( 365 - Math.round( diffDays ) ) / 365;
+	return price * productCost;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In addition to default the billing term for Professional Email, we are also allowing the user to set the billing term that better suits for him. It also calculates the price that the user will pay after the three month discount.

#### Testing instructions

Have two sites with a personal plan, and a domain attached to them.
One of the sites should have a monthly billing and the other a yearly billing.
Note the receipt id for the domain for each site, the site slug and also the domain in each case. This is needed to build a URL that will present us with the emails upsell nudge.

### Scenario 1: Monthly billing
Run this branch locally or use the calypso live branch.
For the monthly billing plan, build the following URL: (append it to the base AKA http://wordpress.com/ or your Calypso local branch) checkout/offer-professional-email/{domain}/{receipt-id}/{site-slug}

Check that you are presented with the following information:
![image](https://user-images.githubusercontent.com/5689927/154561635-e27bf9d9-2df2-43c6-a813-480bd9cb791d.png)

### Scenario 2: Annual billing
Run the same test as the Scenario 1, but with the site that contains the annual plan.

Check that you are presented with the following information:
![image](https://user-images.githubusercontent.com/5689927/154561575-3984ad51-81d8-42e7-80ee-7251d0acf604.png)

### Scenario 3: Mobile view
![image](https://user-images.githubusercontent.com/5689927/154561727-f8d83fb3-b750-4d1b-b995-7b22696d0e3e.png)

Extra tests, not needed right now:

1. Assign yourself to the treatment for an A/B experiment and check that the billing terms matches the plan terms.
2. Check that the price that you get in the TOS is the same price that you get in the upsell page.

Related to {1200182182542585-as-1201829471756319}
