### PR TITLE
Site Settings: refactor and update support links

### DIFF
--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -1,8 +1,5 @@
 import { CompactCard } from '@automattic/components';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import DateTimeFormat from '../date-time-format';
 import DefaultPostFormat from './default-post-format';
 import Latex from './latex';
@@ -11,6 +8,8 @@ import PublishConfirmation from './publish-confirmation';
 import Shortcodes from './shortcodes';
 
 const Composing = ( {
+	siteIsAutomatedTransfer,
+	siteIsJetpack,
 	eventTracker,
 	fields,
 	handleSelect,
@@ -19,7 +18,6 @@ const Composing = ( {
 	isSavingSettings,
 	onChangeField,
 	setFieldValue,
-	siteIsJetpack,
 	updateFields,
 } ) => (
 	<>
@@ -38,6 +36,8 @@ const Composing = ( {
 			fields={ fields }
 			isRequestingSettings={ isRequestingSettings }
 			isSavingSettings={ isSavingSettings }
+			siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+			siteIsJetpack={ siteIsJetpack }
 			handleToggle={ handleToggle }
 		/>
 
@@ -48,6 +48,7 @@ const Composing = ( {
 					handleToggle={ handleToggle }
 					isRequestingSettings={ isRequestingSettings }
 					isSavingSettings={ isSavingSettings }
+					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
 					setFieldValue={ setFieldValue }
 				/>
 				<Shortcodes
@@ -55,6 +56,7 @@ const Composing = ( {
 					handleToggle={ handleToggle }
 					isRequestingSettings={ isRequestingSettings }
 					isSavingSettings={ isSavingSettings }
+					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
 					setFieldValue={ setFieldValue }
 				/>
 			</>
@@ -77,6 +79,8 @@ Composing.defaultProps = {
 };
 
 Composing.propTypes = {
+	siteIsAutomatedTransfer: PropTypes.bool,
+	siteIsJetpack: PropTypes.bool,
 	eventTracker: PropTypes.func.isRequired,
 	fields: PropTypes.object,
 	handleSelect: PropTypes.func.isRequired,
@@ -88,6 +92,4 @@ Composing.propTypes = {
 	updateFields: PropTypes.func.isRequired,
 };
 
-export default connect( ( state ) => ( {
-	siteIsJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
-} ) )( Composing );
+export default Composing;

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -1,5 +1,6 @@
 import { CompactCard } from '@automattic/components';
 import PropTypes from 'prop-types';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import DateTimeFormat from '../date-time-format';
 import DefaultPostFormat from './default-post-format';
 import Latex from './latex';
@@ -8,6 +9,7 @@ import PublishConfirmation from './publish-confirmation';
 import Shortcodes from './shortcodes';
 
 const Composing = ( {
+	translate,
 	siteIsAutomatedTransfer,
 	siteIsJetpack,
 	eventTracker,
@@ -17,10 +19,17 @@ const Composing = ( {
 	isRequestingSettings,
 	isSavingSettings,
 	onChangeField,
-	setFieldValue,
 	updateFields,
+	handleSubmitForm,
 } ) => (
 	<>
+		<SettingsSectionHeader
+			disabled={ isRequestingSettings || isSavingSettings }
+			isSaving={ isSavingSettings }
+			onButtonClick={ handleSubmitForm }
+			showButton
+			title={ translate( 'Composing' ) }
+		/>
 		<CompactCard className="composing__card site-settings">
 			<PublishConfirmation />
 			<DefaultPostFormat
@@ -44,20 +53,14 @@ const Composing = ( {
 		{ siteIsJetpack && (
 			<>
 				<Latex
-					fields={ fields }
-					handleToggle={ handleToggle }
 					isRequestingSettings={ isRequestingSettings }
 					isSavingSettings={ isSavingSettings }
 					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
-					setFieldValue={ setFieldValue }
 				/>
 				<Shortcodes
-					fields={ fields }
-					handleToggle={ handleToggle }
 					isRequestingSettings={ isRequestingSettings }
 					isSavingSettings={ isSavingSettings }
 					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
-					setFieldValue={ setFieldValue }
 				/>
 			</>
 		) }
@@ -82,13 +85,14 @@ Composing.propTypes = {
 	siteIsAutomatedTransfer: PropTypes.bool,
 	siteIsJetpack: PropTypes.bool,
 	eventTracker: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
+	handleSubmitForm: PropTypes.func.isRequired,
 	fields: PropTypes.object,
 	handleSelect: PropTypes.func.isRequired,
 	handleToggle: PropTypes.func.isRequired,
 	isRequestingSettings: PropTypes.bool,
 	isSavingSettings: PropTypes.bool,
 	onChangeField: PropTypes.func.isRequired,
-	setFieldValue: PropTypes.func.isRequired,
 	updateFields: PropTypes.func.isRequired,
 };
 

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -10,7 +10,7 @@ import Shortcodes from './shortcodes';
 
 const Composing = ( {
 	translate,
-	siteIsAutomatedTransfer,
+	isAtomic,
 	siteIsJetpack,
 	eventTracker,
 	fields,
@@ -45,7 +45,7 @@ const Composing = ( {
 			fields={ fields }
 			isRequestingSettings={ isRequestingSettings }
 			isSavingSettings={ isSavingSettings }
-			siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+			isAtomic={ isAtomic }
 			siteIsJetpack={ siteIsJetpack }
 			handleToggle={ handleToggle }
 		/>
@@ -55,12 +55,12 @@ const Composing = ( {
 				<Latex
 					isRequestingSettings={ isRequestingSettings }
 					isSavingSettings={ isSavingSettings }
-					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+					isAtomic={ isAtomic }
 				/>
 				<Shortcodes
 					isRequestingSettings={ isRequestingSettings }
 					isSavingSettings={ isSavingSettings }
-					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+					isAtomic={ isAtomic }
 				/>
 			</>
 		) }
@@ -82,7 +82,7 @@ Composing.defaultProps = {
 };
 
 Composing.propTypes = {
-	siteIsAutomatedTransfer: PropTypes.bool,
+	isAtomic: PropTypes.bool,
 	siteIsJetpack: PropTypes.bool,
 	eventTracker: PropTypes.func.isRequired,
 	translate: PropTypes.func.isRequired,

--- a/client/my-sites/site-settings/composing/latex.jsx
+++ b/client/my-sites/site-settings/composing/latex.jsx
@@ -1,68 +1,58 @@
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connection';
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
-import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-class Latex extends Component {
-	static defaultProps = {
-		isSavingSettings: false,
-		isRequestingSettings: true,
-		fields: {},
-	};
-
-	static propTypes = {
-		handleToggle: PropTypes.func.isRequired,
-		setFieldValue: PropTypes.func.isRequired,
-		isSavingSettings: PropTypes.bool,
-		isRequestingSettings: PropTypes.bool,
-		fields: PropTypes.object,
-		siteIsAutomatedTransfer: PropTypes.bool,
-	};
-
-	render() {
-		const {
-			siteIsAutomatedTransfer,
-			isRequestingSettings,
-			isSavingSettings,
-			moduleUnavailable,
-			selectedSiteId,
-			translate,
-		} = this.props;
-
-		return (
-			<Card className="composing__card site-settings__card">
-				<QueryJetpackConnection siteId={ selectedSiteId } />
-				<SupportInfo
-					text={ translate(
-						'LaTeX is a powerful markup language for writing complex mathematical equations and formulas.'
-					) }
-					link={
-						siteIsAutomatedTransfer
-							? 'https://wordpress.com/support/latex/'
-							: 'https://jetpack.com/support/beautiful-math-with-latex/'
-					}
-					privacyLink="https://jetpack.com/support/beautiful-math-with-latex/#privacy"
-				/>
-				<JetpackModuleToggle
-					siteId={ selectedSiteId }
-					moduleSlug="latex"
-					label={ translate(
-						'Use the LaTeX markup language to write mathematical equations and formulas'
-					) }
-					disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
-				/>
-			</Card>
-		);
-	}
+function Latex( {
+	siteIsAutomatedTransfer,
+	isRequestingSettings,
+	isSavingSettings,
+	moduleUnavailable,
+	selectedSiteId,
+	translate,
+} ) {
+	return (
+		<Card className="composing__card site-settings__card">
+			<QueryJetpackConnection siteId={ selectedSiteId } />
+			<SupportInfo
+				text={ translate(
+					'LaTeX is a powerful markup language for writing complex mathematical equations and formulas.'
+				) }
+				link={
+					siteIsAutomatedTransfer
+						? 'https://wordpress.com/support/latex/'
+						: 'https://jetpack.com/support/beautiful-math-with-latex/'
+				}
+				privacyLink="https://jetpack.com/support/beautiful-math-with-latex/#privacy"
+			/>
+			<JetpackModuleToggle
+				siteId={ selectedSiteId }
+				moduleSlug="latex"
+				label={ translate(
+					'Use the LaTeX markup language to write mathematical equations and formulas'
+				) }
+				disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
+			/>
+		</Card>
+	);
 }
+
+Latex.defaultProps = {
+	isSavingSettings: false,
+	isRequestingSettings: true,
+};
+
+Latex.propTypes = {
+	isSavingSettings: PropTypes.bool,
+	isRequestingSettings: PropTypes.bool,
+	siteIsAutomatedTransfer: PropTypes.bool,
+};
 
 export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
@@ -75,7 +65,6 @@ export default connect( ( state ) => {
 
 	return {
 		selectedSiteId,
-		afterTheDeadlineModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'latex' ),
 		moduleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 	};
 } )( localize( Latex ) );

--- a/client/my-sites/site-settings/composing/latex.jsx
+++ b/client/my-sites/site-settings/composing/latex.jsx
@@ -24,10 +24,12 @@ class Latex extends Component {
 		isSavingSettings: PropTypes.bool,
 		isRequestingSettings: PropTypes.bool,
 		fields: PropTypes.object,
+		siteIsAutomatedTransfer: PropTypes.bool,
 	};
 
 	render() {
 		const {
+			siteIsAutomatedTransfer,
 			isRequestingSettings,
 			isSavingSettings,
 			moduleUnavailable,
@@ -42,7 +44,12 @@ class Latex extends Component {
 					text={ translate(
 						'LaTeX is a powerful markup language for writing complex mathematical equations and formulas.'
 					) }
-					link="https://jetpack.com/support/beautiful-math/"
+					link={
+						siteIsAutomatedTransfer
+							? 'https://wordpress.com/support/latex/'
+							: 'https://jetpack.com/support/beautiful-math-with-latex/'
+					}
+					privacyLink="https://jetpack.com/support/beautiful-math-with-latex/#privacy"
 				/>
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }

--- a/client/my-sites/site-settings/composing/latex.jsx
+++ b/client/my-sites/site-settings/composing/latex.jsx
@@ -10,7 +10,7 @@ import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-s
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 function Latex( {
-	siteIsAutomatedTransfer,
+	isAtomic,
 	isRequestingSettings,
 	isSavingSettings,
 	moduleUnavailable,
@@ -25,11 +25,11 @@ function Latex( {
 					'LaTeX is a powerful markup language for writing complex mathematical equations and formulas.'
 				) }
 				link={
-					siteIsAutomatedTransfer
+					isAtomic
 						? 'https://wordpress.com/support/latex/'
 						: 'https://jetpack.com/support/beautiful-math-with-latex/'
 				}
-				privacyLink="https://jetpack.com/support/beautiful-math-with-latex/#privacy"
+				privacyLink={ ! isAtomic }
 			/>
 			<JetpackModuleToggle
 				siteId={ selectedSiteId }
@@ -51,7 +51,7 @@ Latex.defaultProps = {
 Latex.propTypes = {
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,
-	siteIsAutomatedTransfer: PropTypes.bool,
+	isAtomic: PropTypes.bool,
 };
 
 export default connect( ( state ) => {

--- a/client/my-sites/site-settings/composing/markdown.jsx
+++ b/client/my-sites/site-settings/composing/markdown.jsx
@@ -2,17 +2,17 @@ import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
 import SupportInfo from 'calypso/components/support-info';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-const Markdown = ( { fields, handleToggle, isRequestingSettings, isSavingSettings } ) => {
+const Markdown = ( {
+	fields,
+	handleToggle,
+	isRequestingSettings,
+	isSavingSettings,
+	siteIsAutomatedTransfer,
+	siteIsJetpack,
+} ) => {
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
-	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 
 	return (
 		<Card className="composing__card site-settings__card">
@@ -21,10 +21,11 @@ const Markdown = ( { fields, handleToggle, isRequestingSettings, isSavingSetting
 					'Use Markdown syntax to compose content with links, lists, and other styles. This setting enables Markdown in the Classic Editor as well as within a Classic Editor block.'
 				) }
 				link={
-					isJetpack && ! isAtomic
+					siteIsJetpack && ! siteIsAutomatedTransfer
 						? 'https://jetpack.com/support/markdown/'
 						: 'https://wordpress.com/support/markdown-quick-reference/'
 				}
+				privacyLink="https://jetpack.com/support/markdown/#privacy"
 			/>
 			<ToggleControl
 				checked={ !! fields.wpcom_publish_posts_with_markdown }
@@ -47,6 +48,8 @@ Markdown.propTypes = {
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,
 	fields: PropTypes.object,
+	siteIsAutomatedTransfer: PropTypes.bool,
+	siteIsJetpack: PropTypes.bool,
 };
 
 export default Markdown;

--- a/client/my-sites/site-settings/composing/markdown.jsx
+++ b/client/my-sites/site-settings/composing/markdown.jsx
@@ -25,7 +25,7 @@ const Markdown = ( {
 						? 'https://jetpack.com/support/markdown/'
 						: 'https://wordpress.com/support/markdown-quick-reference/'
 				}
-				privacyLink={ ! isAtomic }
+				privacyLink={ siteIsJetpack && ! isAtomic }
 			/>
 			<ToggleControl
 				checked={ !! fields.wpcom_publish_posts_with_markdown }

--- a/client/my-sites/site-settings/composing/markdown.jsx
+++ b/client/my-sites/site-settings/composing/markdown.jsx
@@ -9,7 +9,7 @@ const Markdown = ( {
 	handleToggle,
 	isRequestingSettings,
 	isSavingSettings,
-	siteIsAutomatedTransfer,
+	isAtomic,
 	siteIsJetpack,
 } ) => {
 	const translate = useTranslate();
@@ -21,11 +21,11 @@ const Markdown = ( {
 					'Use Markdown syntax to compose content with links, lists, and other styles. This setting enables Markdown in the Classic Editor as well as within a Classic Editor block.'
 				) }
 				link={
-					siteIsJetpack && ! siteIsAutomatedTransfer
+					siteIsJetpack && ! isAtomic
 						? 'https://jetpack.com/support/markdown/'
 						: 'https://wordpress.com/support/markdown-quick-reference/'
 				}
-				privacyLink="https://jetpack.com/support/markdown/#privacy"
+				privacyLink={ ! isAtomic }
 			/>
 			<ToggleControl
 				checked={ !! fields.wpcom_publish_posts_with_markdown }
@@ -48,7 +48,7 @@ Markdown.propTypes = {
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,
 	fields: PropTypes.object,
-	siteIsAutomatedTransfer: PropTypes.bool,
+	isAtomic: PropTypes.bool,
 	siteIsJetpack: PropTypes.bool,
 };
 

--- a/client/my-sites/site-settings/composing/shortcodes.jsx
+++ b/client/my-sites/site-settings/composing/shortcodes.jsx
@@ -15,7 +15,7 @@ function Shortcodes( {
 	moduleUnavailable,
 	selectedSiteId,
 	translate,
-	siteIsAutomatedTransfer,
+	isAtomic,
 } ) {
 	return (
 		<Card className="composing__card site-settings__card">
@@ -25,11 +25,11 @@ function Shortcodes( {
 					'Shortcodes are WordPress-specific markup that let you add media from popular sites. This feature is no longer necessary as the editor now handles media embeds rather gracefully.'
 				) }
 				link={
-					siteIsAutomatedTransfer
+					isAtomic
 						? 'https://wordpress.com/support/shortcodes/'
 						: 'https://jetpack.com/support/shortcode-embeds/'
 				}
-				privacyLink="https://jetpack.com/support/shortcode-embeds/#privacy"
+				privacyLink={ ! isAtomic }
 			/>
 			<JetpackModuleToggle
 				siteId={ selectedSiteId }
@@ -47,6 +47,7 @@ Shortcodes.defaultProps = {
 };
 
 Shortcodes.propTypes = {
+	isAtomic: PropTypes.bool,
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,
 };

--- a/client/my-sites/site-settings/composing/shortcodes.jsx
+++ b/client/my-sites/site-settings/composing/shortcodes.jsx
@@ -33,6 +33,7 @@ class Shortcodes extends Component {
 			moduleUnavailable,
 			selectedSiteId,
 			translate,
+			siteIsAutomatedTransfer,
 		} = this.props;
 
 		return (
@@ -42,7 +43,12 @@ class Shortcodes extends Component {
 					text={ translate(
 						'Shortcodes are WordPress-specific markup that let you add media from popular sites. This feature is no longer necessary as the editor now handles media embeds rather gracefully.'
 					) }
-					link="https://jetpack.com/support/shortcode-embeds/"
+					link={
+						siteIsAutomatedTransfer
+							? 'https://wordpress.com/support/shortcodes/'
+							: 'https://jetpack.com/support/shortcode-embeds/'
+					}
+					privacyLink="https://jetpack.com/support/shortcode-embeds/#privacy"
 				/>
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }

--- a/client/my-sites/site-settings/composing/shortcodes.jsx
+++ b/client/my-sites/site-settings/composing/shortcodes.jsx
@@ -1,65 +1,55 @@
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connection';
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
-import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-class Shortcodes extends Component {
-	static defaultProps = {
-		isSavingSettings: false,
-		isRequestingSettings: true,
-		fields: {},
-	};
-
-	static propTypes = {
-		handleToggle: PropTypes.func.isRequired,
-		setFieldValue: PropTypes.func.isRequired,
-		isSavingSettings: PropTypes.bool,
-		isRequestingSettings: PropTypes.bool,
-		fields: PropTypes.object,
-	};
-
-	render() {
-		const {
-			isRequestingSettings,
-			isSavingSettings,
-			moduleUnavailable,
-			selectedSiteId,
-			translate,
-			siteIsAutomatedTransfer,
-		} = this.props;
-
-		return (
-			<Card className="composing__card site-settings__card">
-				<QueryJetpackConnection siteId={ selectedSiteId } />
-				<SupportInfo
-					text={ translate(
-						'Shortcodes are WordPress-specific markup that let you add media from popular sites. This feature is no longer necessary as the editor now handles media embeds rather gracefully.'
-					) }
-					link={
-						siteIsAutomatedTransfer
-							? 'https://wordpress.com/support/shortcodes/'
-							: 'https://jetpack.com/support/shortcode-embeds/'
-					}
-					privacyLink="https://jetpack.com/support/shortcode-embeds/#privacy"
-				/>
-				<JetpackModuleToggle
-					siteId={ selectedSiteId }
-					moduleSlug="shortcodes"
-					label={ translate( 'Compose using shortcodes to embed media from popular sites' ) }
-					disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
-				/>
-			</Card>
-		);
-	}
+function Shortcodes( {
+	isRequestingSettings,
+	isSavingSettings,
+	moduleUnavailable,
+	selectedSiteId,
+	translate,
+	siteIsAutomatedTransfer,
+} ) {
+	return (
+		<Card className="composing__card site-settings__card">
+			<QueryJetpackConnection siteId={ selectedSiteId } />
+			<SupportInfo
+				text={ translate(
+					'Shortcodes are WordPress-specific markup that let you add media from popular sites. This feature is no longer necessary as the editor now handles media embeds rather gracefully.'
+				) }
+				link={
+					siteIsAutomatedTransfer
+						? 'https://wordpress.com/support/shortcodes/'
+						: 'https://jetpack.com/support/shortcode-embeds/'
+				}
+				privacyLink="https://jetpack.com/support/shortcode-embeds/#privacy"
+			/>
+			<JetpackModuleToggle
+				siteId={ selectedSiteId }
+				moduleSlug="shortcodes"
+				label={ translate( 'Compose using shortcodes to embed media from popular sites' ) }
+				disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
+			/>
+		</Card>
+	);
 }
+
+Shortcodes.defaultProps = {
+	isSavingSettings: false,
+	isRequestingSettings: true,
+};
+
+Shortcodes.propTypes = {
+	isSavingSettings: PropTypes.bool,
+	isRequestingSettings: PropTypes.bool,
+};
 
 export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
@@ -72,7 +62,6 @@ export default connect( ( state ) => {
 
 	return {
 		selectedSiteId,
-		afterTheDeadlineModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'shortcodes' ),
 		moduleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 	};
 } )( localize( Shortcodes ) );

--- a/client/my-sites/site-settings/custom-content-types/blog-posts.jsx
+++ b/client/my-sites/site-settings/custom-content-types/blog-posts.jsx
@@ -4,6 +4,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 
 function BlogPosts( { fields, translate, onChangeField, isDisabled } ) {
 	const name = 'post';
+	const numberFieldIdentifier = 'posts_per_page';
 
 	return (
 		<FormFieldset>
@@ -18,13 +19,17 @@ function BlogPosts( { fields, translate, onChangeField, isDisabled } ) {
 						components: {
 							field: (
 								<FormTextInput
-									name={ name }
+									name={ numberFieldIdentifier }
 									type="number"
 									step="1"
 									min="0"
-									aria-labelledby={ name }
-									value={ 'undefined' === typeof fields[ name ] ? 10 : fields[ name ] }
-									onChange={ onChangeField( name ) }
+									aria-labelledby={ numberFieldIdentifier }
+									value={
+										'undefined' === typeof fields[ numberFieldIdentifier ]
+											? 10
+											: fields[ numberFieldIdentifier ]
+									}
+									onChange={ onChangeField( numberFieldIdentifier ) }
 									disabled={ isDisabled }
 								/>
 							),

--- a/client/my-sites/site-settings/custom-content-types/blog-posts.jsx
+++ b/client/my-sites/site-settings/custom-content-types/blog-posts.jsx
@@ -1,0 +1,42 @@
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+
+function BlogPosts( { fields, translate, onChangeField, isDisabled } ) {
+	const name = 'post';
+
+	return (
+		<FormFieldset>
+			<div className="custom-content-types__module-settings">
+				<div id={ name } className={ 'custom-content-types__label indented-form-field' }>
+					{ translate( 'Blog posts' ) }
+				</div>
+				<div className="custom-content-types__indented-form-field indented-form-field">
+					{ translate( 'Display {{field /}} per page', {
+						comment:
+							'The field value is a number that refers to site content type, e.g., blog post, testimonial or portfolio project',
+						components: {
+							field: (
+								<FormTextInput
+									name={ name }
+									type="number"
+									step="1"
+									min="0"
+									aria-labelledby={ name }
+									value={ 'undefined' === typeof fields[ name ] ? 10 : fields[ name ] }
+									onChange={ onChangeField( name ) }
+									disabled={ isDisabled }
+								/>
+							),
+						},
+					} ) }
+				</div>
+				<FormSettingExplanation isIndented>
+					{ translate( 'On blog pages, the number of posts to show per page.' ) }
+				</FormSettingExplanation>
+			</div>
+		</FormFieldset>
+	);
+}
+
+export default BlogPosts;

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -63,6 +63,7 @@ class CustomContentTypes extends Component {
 			isSavingSettings,
 			activatingCustomContentTypesModule,
 			isAtomic,
+			siteIsJetpack,
 		} = this.props;
 		const isDisabled =
 			isRequestingSettings || isSavingSettings || activatingCustomContentTypesModule;
@@ -92,6 +93,7 @@ class CustomContentTypes extends Component {
 								handleAutosavingToggle={ handleAutosavingToggle }
 								isDisabled={ isDisabled }
 								isAtomic={ isAtomic }
+								siteIsJetpack={ siteIsJetpack }
 							/>
 							<Portfolios
 								fields={ fields }
@@ -100,6 +102,7 @@ class CustomContentTypes extends Component {
 								handleAutosavingToggle={ handleAutosavingToggle }
 								isDisabled={ isDisabled }
 								isAtomic={ isAtomic }
+								siteIsJetpack={ siteIsJetpack }
 							/>
 						</>
 					) }

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -1,15 +1,8 @@
 import { Card } from '@automattic/components';
-import { ToggleControl } from '@wordpress/components';
-import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import InlineSupportLink from 'calypso/components/inline-support-link';
-import SupportInfo from 'calypso/components/support-info';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
@@ -17,6 +10,9 @@ import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-act
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import BlogPosts from './blog-posts';
+import Portfolios from './portfolios';
+import Testimonials from './testimonials';
 
 import './style.scss';
 
@@ -55,145 +51,47 @@ class CustomContentTypes extends Component {
 		this.props.activateModule( siteId, 'custom-content-types', true );
 	}
 
-	isFormPending() {
-		const { isRequestingSettings, isSavingSettings } = this.props;
-
-		return isRequestingSettings || isSavingSettings;
-	}
-
-	renderContentTypeSettings( name, label, description ) {
-		const {
-			activatingCustomContentTypesModule,
-			fields,
-			handleAutosavingToggle,
-			onChangeField,
-			translate,
-		} = this.props;
-		const numberFieldIdentifier = name === 'post' ? 'posts_per_page' : name + '_posts_per_page';
-		const isDisabled = this.isFormPending() || ( ! fields[ name ] && name !== 'post' );
-		const hasToggle = name !== 'post';
-
-		return (
-			<div className="custom-content-types__module-settings">
-				{ hasToggle ? (
-					<ToggleControl
-						checked={ !! fields[ name ] }
-						disabled={ this.isFormPending() || activatingCustomContentTypesModule }
-						onChange={ handleAutosavingToggle( name ) }
-						label={ <span className="custom-content-types__label">{ label }</span> }
-					/>
-				) : (
-					<div
-						id={ numberFieldIdentifier }
-						className={ classnames( 'custom-content-types__label', {
-							'indented-form-field': ! hasToggle,
-						} ) }
-					>
-						{ label }
-					</div>
-				) }
-				<div className="custom-content-types__indented-form-field indented-form-field">
-					{ translate( 'Display {{field /}} per page', {
-						comment:
-							'The field value is a number that refers to site content type, e.g., blog post, testimonial or portfolio project',
-						components: {
-							field: (
-								<FormTextInput
-									name={ numberFieldIdentifier }
-									type="number"
-									step="1"
-									min="0"
-									aria-labelledby={ numberFieldIdentifier }
-									value={
-										'undefined' === typeof fields[ numberFieldIdentifier ]
-											? 10
-											: fields[ numberFieldIdentifier ]
-									}
-									onChange={ onChangeField( numberFieldIdentifier ) }
-									disabled={ isDisabled }
-								/>
-							),
-						},
-					} ) }
-				</div>
-				<FormSettingExplanation isIndented>{ description }</FormSettingExplanation>
-			</div>
-		);
-	}
-
-	renderBlogPostSettings() {
-		const { translate } = this.props;
-		const fieldLabel = translate( 'Blog posts' );
-		const fieldDescription = translate( 'On blog pages, the number of posts to show per page.' );
-
-		return (
-			<div className="custom-content-types__module-settings">
-				{ this.renderContentTypeSettings( 'post', fieldLabel, fieldDescription ) }
-			</div>
-		);
-	}
-
-	renderTestimonialSettings() {
-		const { translate } = this.props;
-		const fieldLabel = translate( 'Testimonials' );
-		const fieldDescription = translate(
-			'Add, organize, and display {{link}}testimonials{{/link}}. If your theme doesn’t support testimonials yet, ' +
-				'you can display them using the shortcode [testimonials].',
-			{
-				components: {
-					link: <InlineSupportLink supportContext="testimonials" />,
-				},
-			}
-		);
-
-		return this.renderContentTypeSettings( 'jetpack_testimonial', fieldLabel, fieldDescription );
-	}
-
-	renderPortfolioSettings() {
-		const { translate } = this.props;
-		const fieldLabel = translate( 'Portfolio projects' );
-		const fieldDescription = translate(
-			'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
-				'you can display them using the shortcode [portfolio].',
-			{
-				components: {
-					link: <InlineSupportLink supportContext="portfolios" />,
-				},
-			}
-		);
-
-		return this.renderContentTypeSettings( 'jetpack_portfolio', fieldLabel, fieldDescription );
-	}
-
 	render() {
-		const { translate, isWPForTeamsSite } = this.props;
+		const {
+			translate,
+			isWPForTeamsSite,
+			fields,
+			onChangeField,
+			handleAutosavingToggle,
+			isRequestingSettings,
+			isSavingSettings,
+			activatingCustomContentTypesModule,
+			siteIsAutomatedTransfer,
+		} = this.props;
+		const isDisabled =
+			isRequestingSettings || isSavingSettings || activatingCustomContentTypesModule;
 		return (
 			<Card className="custom-content-types site-settings">
-				<FormFieldset>{ this.renderBlogPostSettings() }</FormFieldset>
+				<BlogPosts
+					fields={ fields }
+					translate={ translate }
+					onChangeField={ onChangeField }
+					isDisabled={ isDisabled }
+				/>
 
 				{ ! isWPForTeamsSite && (
 					<>
-						<FormFieldset>
-							<SupportInfo
-								text={ translate(
-									'Adds the Testimonial custom post type, allowing you to collect, organize, ' +
-										'and display testimonials on your site.'
-								) }
-								link="https://jetpack.com/support/custom-content-types/"
-							/>
-							{ this.renderTestimonialSettings() }
-						</FormFieldset>
-
-						<FormFieldset>
-							<SupportInfo
-								text={ translate(
-									'Adds the Portfolio custom post type, allowing you to ' +
-										'manage and showcase projects on your site.'
-								) }
-								link="https://jetpack.com/support/custom-content-types/"
-							/>
-							{ this.renderPortfolioSettings() }
-						</FormFieldset>
+						<Testimonials
+							fields={ fields }
+							translate={ translate }
+							onChangeField={ onChangeField }
+							handleAutosavingToggle={ handleAutosavingToggle }
+							isDisabled={ isDisabled }
+							siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+						/>
+						<Portfolios
+							fields={ fields }
+							translate={ translate }
+							onChangeField={ onChangeField }
+							handleAutosavingToggle={ handleAutosavingToggle }
+							isDisabled={ isDisabled }
+							siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+						/>
 					</>
 				) }
 			</Card>

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -62,7 +62,7 @@ class CustomContentTypes extends Component {
 			isRequestingSettings,
 			isSavingSettings,
 			activatingCustomContentTypesModule,
-			siteIsAutomatedTransfer,
+			isAtomic,
 		} = this.props;
 		const isDisabled =
 			isRequestingSettings || isSavingSettings || activatingCustomContentTypesModule;
@@ -91,7 +91,7 @@ class CustomContentTypes extends Component {
 								onChangeField={ onChangeField }
 								handleAutosavingToggle={ handleAutosavingToggle }
 								isDisabled={ isDisabled }
-								siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+								isAtomic={ isAtomic }
 							/>
 							<Portfolios
 								fields={ fields }
@@ -99,7 +99,7 @@ class CustomContentTypes extends Component {
 								onChangeField={ onChangeField }
 								handleAutosavingToggle={ handleAutosavingToggle }
 								isDisabled={ isDisabled }
-								siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+								isAtomic={ isAtomic }
 							/>
 						</>
 					) }
@@ -116,7 +116,7 @@ CustomContentTypes.defaultProps = {
 };
 
 CustomContentTypes.propTypes = {
-	siteIsAutomatedTransfer: PropTypes.bool,
+	isAtomic: PropTypes.bool,
 	siteIsJetpack: PropTypes.bool,
 	handleAutosavingToggle: PropTypes.func.isRequired,
 	onChangeField: PropTypes.func.isRequired,

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -3,12 +3,12 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import BlogPosts from './blog-posts';
 import Portfolios from './portfolios';
@@ -54,6 +54,7 @@ class CustomContentTypes extends Component {
 	render() {
 		const {
 			translate,
+			handleSubmitForm,
 			isWPForTeamsSite,
 			fields,
 			onChangeField,
@@ -66,35 +67,44 @@ class CustomContentTypes extends Component {
 		const isDisabled =
 			isRequestingSettings || isSavingSettings || activatingCustomContentTypesModule;
 		return (
-			<Card className="custom-content-types site-settings">
-				<BlogPosts
-					fields={ fields }
-					translate={ translate }
-					onChangeField={ onChangeField }
-					isDisabled={ isDisabled }
+			<>
+				<SettingsSectionHeader
+					disabled={ isRequestingSettings || isSavingSettings }
+					isSaving={ isSavingSettings }
+					onButtonClick={ handleSubmitForm }
+					showButton
+					title={ translate( 'Content types' ) }
 				/>
+				<Card className="custom-content-types site-settings">
+					<BlogPosts
+						fields={ fields }
+						translate={ translate }
+						onChangeField={ onChangeField }
+						isDisabled={ isDisabled }
+					/>
 
-				{ ! isWPForTeamsSite && (
-					<>
-						<Testimonials
-							fields={ fields }
-							translate={ translate }
-							onChangeField={ onChangeField }
-							handleAutosavingToggle={ handleAutosavingToggle }
-							isDisabled={ isDisabled }
-							siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
-						/>
-						<Portfolios
-							fields={ fields }
-							translate={ translate }
-							onChangeField={ onChangeField }
-							handleAutosavingToggle={ handleAutosavingToggle }
-							isDisabled={ isDisabled }
-							siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
-						/>
-					</>
-				) }
-			</Card>
+					{ ! isWPForTeamsSite && (
+						<>
+							<Testimonials
+								fields={ fields }
+								translate={ translate }
+								onChangeField={ onChangeField }
+								handleAutosavingToggle={ handleAutosavingToggle }
+								isDisabled={ isDisabled }
+								siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+							/>
+							<Portfolios
+								fields={ fields }
+								translate={ translate }
+								onChangeField={ onChangeField }
+								handleAutosavingToggle={ handleAutosavingToggle }
+								isDisabled={ isDisabled }
+								siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+							/>
+						</>
+					) }
+				</Card>
+			</>
 		);
 	}
 }
@@ -106,6 +116,8 @@ CustomContentTypes.defaultProps = {
 };
 
 CustomContentTypes.propTypes = {
+	siteIsAutomatedTransfer: PropTypes.bool,
+	siteIsJetpack: PropTypes.bool,
 	handleAutosavingToggle: PropTypes.func.isRequired,
 	onChangeField: PropTypes.func.isRequired,
 	isSavingSettings: PropTypes.bool,
@@ -120,7 +132,6 @@ export default connect(
 		return {
 			siteId,
 			isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
-			siteIsJetpack: isJetpackSite( state, siteId ),
 			customContentTypesModuleActive: isJetpackModuleActive(
 				state,
 				siteId,

--- a/client/my-sites/site-settings/custom-content-types/portfolios.jsx
+++ b/client/my-sites/site-settings/custom-content-types/portfolios.jsx
@@ -12,6 +12,7 @@ function Portfolios( {
 	onChangeField,
 	isDisabled,
 	isAtomic,
+	siteIsJetpack,
 } ) {
 	const name = 'jetpack_portfolio';
 	const numberFieldIdentifier = name + '_posts_per_page';
@@ -23,11 +24,11 @@ function Portfolios( {
 						'manage and showcase projects on your site.'
 				) }
 				link={
-					isAtomic
-						? 'https://wordpress.com/support/portfolios/'
-						: 'https://jetpack.com/support/custom-content-types/'
+					siteIsJetpack && ! isAtomic
+						? 'https://jetpack.com/support/custom-content-types/'
+						: 'https://wordpress.com/support/portfolios/'
 				}
-				privacyLink={ ! isAtomic }
+				privacyLink={ siteIsJetpack && ! isAtomic }
 			/>
 			<div className="custom-content-types__module-settings">
 				<ToggleControl

--- a/client/my-sites/site-settings/custom-content-types/portfolios.jsx
+++ b/client/my-sites/site-settings/custom-content-types/portfolios.jsx
@@ -11,7 +11,7 @@ function Portfolios( {
 	fields,
 	onChangeField,
 	isDisabled,
-	siteIsAutomatedTransfer,
+	isAtomic,
 } ) {
 	const name = 'jetpack_portfolio';
 	const numberFieldIdentifier = name + '_posts_per_page';
@@ -23,11 +23,11 @@ function Portfolios( {
 						'manage and showcase projects on your site.'
 				) }
 				link={
-					siteIsAutomatedTransfer
+					isAtomic
 						? 'https://wordpress.com/support/portfolios/'
 						: 'https://jetpack.com/support/custom-content-types/#portfolios'
 				}
-				privacyLink="https://jetpack.com/support/custom-content-types/#privacy"
+				privacyLink={ ! isAtomic }
 			/>
 			<div className="custom-content-types__module-settings">
 				<ToggleControl

--- a/client/my-sites/site-settings/custom-content-types/portfolios.jsx
+++ b/client/my-sites/site-settings/custom-content-types/portfolios.jsx
@@ -25,7 +25,7 @@ function Portfolios( {
 				link={
 					isAtomic
 						? 'https://wordpress.com/support/portfolios/'
-						: 'https://jetpack.com/support/custom-content-types/#portfolios'
+						: 'https://jetpack.com/support/custom-content-types/'
 				}
 				privacyLink={ ! isAtomic }
 			/>

--- a/client/my-sites/site-settings/custom-content-types/portfolios.jsx
+++ b/client/my-sites/site-settings/custom-content-types/portfolios.jsx
@@ -1,0 +1,82 @@
+import { ToggleControl } from '@wordpress/components';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import SupportInfo from 'calypso/components/support-info';
+
+function Portfolios( {
+	translate,
+	handleAutosavingToggle,
+	fields,
+	onChangeField,
+	isDisabled,
+	siteIsAutomatedTransfer,
+} ) {
+	const name = 'jetpack_portfolio';
+	const numberFieldIdentifier = name + '_posts_per_page';
+	return (
+		<FormFieldset>
+			<SupportInfo
+				text={ translate(
+					'Adds the Portfolio custom post type, allowing you to ' +
+						'manage and showcase projects on your site.'
+				) }
+				link={
+					siteIsAutomatedTransfer
+						? 'https://wordpress.com/support/portfolios/'
+						: 'https://jetpack.com/support/custom-content-types/#portfolios'
+				}
+				privacyLink="https://jetpack.com/support/custom-content-types/#privacy"
+			/>
+			<div className="custom-content-types__module-settings">
+				<ToggleControl
+					checked={ !! fields[ name ] }
+					disabled={ isDisabled }
+					onChange={ handleAutosavingToggle( name ) }
+					label={ translate( '{{span}}Portfolio projects{{/span}}', {
+						components: { span: <span className="custom-content-types__label" /> },
+					} ) }
+				/>
+
+				<div className="custom-content-types__indented-form-field indented-form-field">
+					{ translate( 'Display {{field /}} per page', {
+						comment:
+							'The field value is a number that refers to site content type, e.g., blog post, testimonial or portfolio project',
+						components: {
+							field: (
+								<FormTextInput
+									name={ numberFieldIdentifier }
+									type="number"
+									step="1"
+									min="0"
+									aria-labelledby={ numberFieldIdentifier }
+									value={
+										'undefined' === typeof fields[ numberFieldIdentifier ]
+											? 10
+											: fields[ numberFieldIdentifier ]
+									}
+									onChange={ onChangeField( numberFieldIdentifier ) }
+									disabled={ isDisabled || ! fields[ name ] }
+								/>
+							),
+						},
+					} ) }
+				</div>
+				<FormSettingExplanation isIndented>
+					{ translate(
+						'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
+							'you can display them using the shortcode [portfolio].',
+						{
+							components: {
+								link: <InlineSupportLink supportContext="portfolios" />,
+							},
+						}
+					) }
+				</FormSettingExplanation>
+			</div>
+		</FormFieldset>
+	);
+}
+
+export default Portfolios;

--- a/client/my-sites/site-settings/custom-content-types/testimonials.jsx
+++ b/client/my-sites/site-settings/custom-content-types/testimonials.jsx
@@ -1,0 +1,82 @@
+import { ToggleControl } from '@wordpress/components';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import SupportInfo from 'calypso/components/support-info';
+
+function Testimonials( {
+	translate,
+	handleAutosavingToggle,
+	fields,
+	onChangeField,
+	isDisabled,
+	siteIsAutomatedTransfer,
+} ) {
+	const name = 'jetpack_testimonial';
+	const numberFieldIdentifier = name + '_posts_per_page';
+	return (
+		<FormFieldset>
+			<SupportInfo
+				text={ translate(
+					'Adds the Testimonial custom post type, allowing you to collect, organize, ' +
+						'and display testimonials on your site.'
+				) }
+				link={
+					siteIsAutomatedTransfer
+						? 'https://wordpress.com/support/testimonials/'
+						: 'https://jetpack.com/support/custom-content-types/#testimonials'
+				}
+				privacyLink="https://jetpack.com/support/custom-content-types/#privacy"
+			/>
+			<div className="custom-content-types__module-settings">
+				<ToggleControl
+					checked={ !! fields[ name ] }
+					disabled={ isDisabled }
+					onChange={ handleAutosavingToggle( name ) }
+					label={ translate( '{{span}}Testimonials{{/span}}', {
+						components: { span: <span className="custom-content-types__label" /> },
+					} ) }
+				/>
+
+				<div className="custom-content-types__indented-form-field indented-form-field">
+					{ translate( 'Display {{field /}} per page', {
+						comment:
+							'The field value is a number that refers to site content type, e.g., blog post, testimonial or portfolio project',
+						components: {
+							field: (
+								<FormTextInput
+									name={ numberFieldIdentifier }
+									type="number"
+									step="1"
+									min="0"
+									aria-labelledby={ numberFieldIdentifier }
+									value={
+										'undefined' === typeof fields[ numberFieldIdentifier ]
+											? 10
+											: fields[ numberFieldIdentifier ]
+									}
+									onChange={ onChangeField( numberFieldIdentifier ) }
+									disabled={ isDisabled || ! fields[ name ] }
+								/>
+							),
+						},
+					} ) }
+				</div>
+				<FormSettingExplanation isIndented>
+					{ translate(
+						'Add, organize, and display {{link}}testimonials{{/link}}. If your theme doesn’t support testimonials yet, ' +
+							'you can display them using the shortcode [testimonials].',
+						{
+							components: {
+								link: <InlineSupportLink supportContext="testimonials" />,
+							},
+						}
+					) }
+				</FormSettingExplanation>
+			</div>
+		</FormFieldset>
+	);
+}
+
+export default Testimonials;

--- a/client/my-sites/site-settings/custom-content-types/testimonials.jsx
+++ b/client/my-sites/site-settings/custom-content-types/testimonials.jsx
@@ -12,6 +12,7 @@ function Testimonials( {
 	onChangeField,
 	isDisabled,
 	isAtomic,
+	siteIsJetpack,
 } ) {
 	const name = 'jetpack_testimonial';
 	const numberFieldIdentifier = name + '_posts_per_page';
@@ -23,11 +24,11 @@ function Testimonials( {
 						'and display testimonials on your site.'
 				) }
 				link={
-					isAtomic
-						? 'https://wordpress.com/support/testimonials/'
-						: 'https://jetpack.com/support/custom-content-types/'
+					siteIsJetpack && ! isAtomic
+						? 'https://jetpack.com/support/custom-content-types/'
+						: 'https://wordpress.com/support/testimonials/'
 				}
-				privacyLink={ ! isAtomic }
+				privacyLink={ siteIsJetpack && ! isAtomic }
 			/>
 			<div className="custom-content-types__module-settings">
 				<ToggleControl

--- a/client/my-sites/site-settings/custom-content-types/testimonials.jsx
+++ b/client/my-sites/site-settings/custom-content-types/testimonials.jsx
@@ -11,7 +11,7 @@ function Testimonials( {
 	fields,
 	onChangeField,
 	isDisabled,
-	siteIsAutomatedTransfer,
+	isAtomic,
 } ) {
 	const name = 'jetpack_testimonial';
 	const numberFieldIdentifier = name + '_posts_per_page';
@@ -23,11 +23,11 @@ function Testimonials( {
 						'and display testimonials on your site.'
 				) }
 				link={
-					siteIsAutomatedTransfer
+					isAtomic
 						? 'https://wordpress.com/support/testimonials/'
-						: 'https://jetpack.com/support/custom-content-types/#testimonials'
+						: 'https://jetpack.com/support/custom-content-types/'
 				}
-				privacyLink="https://jetpack.com/support/custom-content-types/#privacy"
+				privacyLink={ ! isAtomic }
 			/>
 			<div className="custom-content-types__module-settings">
 				<ToggleControl

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -28,7 +28,6 @@ class SiteSettingsFormWriting extends Component {
 	render() {
 		const {
 			eventTracker,
-			uniqueEventTracker,
 			fields,
 			handleSelect,
 			handleToggle,
@@ -40,7 +39,6 @@ class SiteSettingsFormWriting extends Component {
 			isRequestingSettings,
 			isSavingSettings,
 			onChangeField,
-			setFieldValue,
 			siteId,
 			siteIsJetpack,
 			translate,
@@ -54,22 +52,15 @@ class SiteSettingsFormWriting extends Component {
 				onSubmit={ handleSubmitForm }
 				className="site-settings__writing-settings"
 			>
-				<SettingsSectionHeader
-					disabled={ isRequestingSettings || isSavingSettings }
-					isSaving={ isSavingSettings }
-					onButtonClick={ handleSubmitForm }
-					showButton
-					title={ translate( 'Composing' ) }
-				/>
 				<Composing
+					handleSubmitForm={ handleSubmitForm }
+					translate={ translate }
 					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
 					siteIsJetpack={ siteIsJetpack }
 					handleSelect={ handleSelect }
 					handleToggle={ handleToggle }
 					onChangeField={ onChangeField }
-					setFieldValue={ setFieldValue }
 					eventTracker={ eventTracker }
-					uniqueEventTracker={ uniqueEventTracker }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
@@ -77,39 +68,26 @@ class SiteSettingsFormWriting extends Component {
 				/>
 
 				{ siteIsJetpack && ! siteIsAutomatedTransfer && (
-					<div>
-						<SettingsSectionHeader
-							disabled={ isRequestingSettings || isSavingSettings }
-							isSaving={ isSavingSettings }
-							onButtonClick={ handleSubmitForm }
-							showButton
-							title={ translate( 'Media' ) }
-						/>
-						<MediaSettingsWriting
-							siteId={ siteId }
-							handleAutosavingToggle={ handleAutosavingToggle }
-							onChangeField={ onChangeField }
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-							fields={ fields }
-						/>
-					</div>
+					<MediaSettingsWriting
+						handleSubmitForm={ handleSubmitForm }
+						siteId={ siteId }
+						handleAutosavingToggle={ handleAutosavingToggle }
+						onChangeField={ onChangeField }
+						isSavingSettings={ isSavingSettings }
+						isRequestingSettings={ isRequestingSettings }
+						fields={ fields }
+					/>
 				) }
 
-				<SettingsSectionHeader
-					disabled={ isRequestingSettings || isSavingSettings }
-					isSaving={ isSavingSettings }
-					onButtonClick={ handleSubmitForm }
-					showButton
-					title={ translate( 'Content types' ) }
-				/>
 				<CustomContentTypes
+					handleSubmitForm={ handleSubmitForm }
 					handleAutosavingToggle={ handleAutosavingToggle }
 					onChangeField={ onChangeField }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
 					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+					siteIsJetpack={ siteIsJetpack }
 				/>
 
 				<FeedSettings
@@ -119,6 +97,7 @@ class SiteSettingsFormWriting extends Component {
 					handleSubmitForm={ handleSubmitForm }
 					handleToggle={ handleToggle }
 					onChangeField={ onChangeField }
+					translate={ translate }
 				/>
 
 				{ isPodcastingSupported && <PodcastingLink fields={ fields } /> }
@@ -126,6 +105,7 @@ class SiteSettingsFormWriting extends Component {
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
 				<ThemeEnhancements
+					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
 					onSubmitForm={ handleSubmitForm }
 					handleAutosavingToggle={ handleAutosavingToggle }
 					handleAutosavingRadio={ handleAutosavingRadio }
@@ -136,15 +116,16 @@ class SiteSettingsFormWriting extends Component {
 
 				{ siteIsJetpack && (
 					<Widgets
-						onSubmitForm={ handleSubmitForm }
+						siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+						translate={ translate }
 						isSavingSettings={ isSavingSettings }
 						isRequestingSettings={ isRequestingSettings }
-						fields={ fields }
 					/>
 				) }
 
 				{ siteIsJetpack && config.isEnabled( 'press-this' ) && (
 					<PublishingTools
+						siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
 						onSubmitForm={ handleSubmitForm }
 						isSavingSettings={ isSavingSettings }
 						isRequestingSettings={ isRequestingSettings }
@@ -154,21 +135,16 @@ class SiteSettingsFormWriting extends Component {
 
 				{ config.isEnabled( 'press-this' ) && ! this.isMobile() && ! siteIsJetpack && (
 					<div>
-						<SettingsSectionHeader
-							title={ translate( 'Press This', { context: 'name of browser bookmarklet tool' } ) }
-						/>
+						<SettingsSectionHeader title={ translate( 'Publishing Tools' ) } />
 						<PressThis />
 					</div>
 				) }
 
 				{ isMasterbarSectionVisible && (
-					<div>
-						<SettingsSectionHeader title={ translate( 'WordPress.com toolbar' ) } />
-						<Masterbar
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-						/>
-					</div>
+					<Masterbar
+						isSavingSettings={ isSavingSettings }
+						isRequestingSettings={ isRequestingSettings }
+					/>
 				) }
 			</form>
 		);

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -109,6 +109,7 @@ class SiteSettingsFormWriting extends Component {
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
+					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
 				/>
 
 				<FeedSettings

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -112,6 +112,8 @@ class SiteSettingsFormWriting extends Component {
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
+					siteId={ siteId }
+					siteIsJetpack={ siteIsJetpack }
 				/>
 
 				{ siteIsJetpack && (

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -42,7 +42,7 @@ class SiteSettingsFormWriting extends Component {
 			siteId,
 			siteIsJetpack,
 			translate,
-			siteIsAutomatedTransfer,
+			isAtomic,
 			updateFields,
 		} = this.props;
 
@@ -55,7 +55,7 @@ class SiteSettingsFormWriting extends Component {
 				<Composing
 					handleSubmitForm={ handleSubmitForm }
 					translate={ translate }
-					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+					isAtomic={ isAtomic }
 					siteIsJetpack={ siteIsJetpack }
 					handleSelect={ handleSelect }
 					handleToggle={ handleToggle }
@@ -67,7 +67,7 @@ class SiteSettingsFormWriting extends Component {
 					updateFields={ updateFields }
 				/>
 
-				{ siteIsJetpack && ! siteIsAutomatedTransfer && (
+				{ siteIsJetpack && ! isAtomic && (
 					<MediaSettingsWriting
 						handleSubmitForm={ handleSubmitForm }
 						siteId={ siteId }
@@ -86,7 +86,7 @@ class SiteSettingsFormWriting extends Component {
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
-					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+					isAtomic={ isAtomic }
 					siteIsJetpack={ siteIsJetpack }
 				/>
 
@@ -105,7 +105,7 @@ class SiteSettingsFormWriting extends Component {
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
 				<ThemeEnhancements
-					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+					isAtomic={ isAtomic }
 					onSubmitForm={ handleSubmitForm }
 					handleAutosavingToggle={ handleAutosavingToggle }
 					handleAutosavingRadio={ handleAutosavingRadio }
@@ -118,7 +118,7 @@ class SiteSettingsFormWriting extends Component {
 
 				{ siteIsJetpack && (
 					<Widgets
-						siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+						isAtomic={ isAtomic }
 						translate={ translate }
 						isSavingSettings={ isSavingSettings }
 						isRequestingSettings={ isRequestingSettings }
@@ -127,7 +127,7 @@ class SiteSettingsFormWriting extends Component {
 
 				{ siteIsJetpack && config.isEnabled( 'press-this' ) && (
 					<PublishingTools
-						siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+						isAtomic={ isAtomic }
 						onSubmitForm={ handleSubmitForm }
 						isSavingSettings={ isSavingSettings }
 						isRequestingSettings={ isRequestingSettings }
@@ -157,8 +157,8 @@ const connectComponent = connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const siteIsJetpack = isJetpackSite( state, siteId );
-		const siteIsAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
-		const isPodcastingSupported = ! siteIsJetpack || siteIsAutomatedTransfer;
+		const isAtomic = isSiteAutomatedTransfer( state, siteId );
+		const isPodcastingSupported = ! siteIsJetpack || isAtomic;
 
 		return {
 			siteIsJetpack,
@@ -166,9 +166,9 @@ const connectComponent = connect(
 			isMasterbarSectionVisible:
 				siteIsJetpack &&
 				// Masterbar can't be turned off on Atomic sites - don't show the toggle in that case
-				! siteIsAutomatedTransfer,
+				! isAtomic,
 			isPodcastingSupported,
-			siteIsAutomatedTransfer,
+			isAtomic,
 		};
 	},
 	{ requestPostTypes }

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -62,6 +62,8 @@ class SiteSettingsFormWriting extends Component {
 					title={ translate( 'Composing' ) }
 				/>
 				<Composing
+					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+					siteIsJetpack={ siteIsJetpack }
 					handleSelect={ handleSelect }
 					handleToggle={ handleToggle }
 					onChangeField={ onChangeField }

--- a/client/my-sites/site-settings/masterbar.jsx
+++ b/client/my-sites/site-settings/masterbar.jsx
@@ -6,6 +6,7 @@ import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connec
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -21,6 +22,7 @@ const Masterbar = ( {
 		<div>
 			<QueryJetpackConnection siteId={ selectedSiteId } />
 
+			<SettingsSectionHeader title={ translate( 'WordPress.com toolbar' ) } />
 			<Card className="masterbar__card site-settings__security-settings">
 				<FormFieldset>
 					<SupportInfo

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -70,7 +70,7 @@ class MediaSettingsPerformance extends Component {
 								? 'https://wordpress.com/support/videopress/'
 								: 'https://jetpack.com/support/videopress/'
 						}
-						privacyLink="https://jetpack.com/support/videopress/#privacy"
+						privacyLink={ ! siteIsAtomic }
 					/>
 					<JetpackModuleToggle
 						siteId={ siteId }

--- a/client/my-sites/site-settings/media-settings-writing.jsx
+++ b/client/my-sites/site-settings/media-settings-writing.jsx
@@ -10,6 +10,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -22,6 +23,7 @@ class MediaSettingsWriting extends Component {
 		isSavingSettings: PropTypes.bool,
 		onChangeField: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
+		handleSubmitForm: PropTypes.func.isRequired,
 
 		// Connected props
 		carouselActive: PropTypes.bool.isRequired,
@@ -31,6 +33,7 @@ class MediaSettingsWriting extends Component {
 
 	render() {
 		const {
+			handleSubmitForm,
 			carouselActive,
 			fields,
 			handleAutosavingToggle,
@@ -46,6 +49,13 @@ class MediaSettingsWriting extends Component {
 
 		return (
 			<div className="site-settings__module-settings site-settings__media-settings">
+				<SettingsSectionHeader
+					disabled={ isRequestingSettings || isSavingSettings }
+					isSaving={ isSavingSettings }
+					onButtonClick={ handleSubmitForm }
+					showButton
+					title={ translate( 'Media' ) }
+				/>
 				<Card>
 					<QueryJetpackConnection siteId={ selectedSiteId } />
 

--- a/client/my-sites/site-settings/press-this/index.jsx
+++ b/client/my-sites/site-settings/press-this/index.jsx
@@ -3,6 +3,9 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLegend from 'calypso/components/forms/form-legend';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PressThisLink from './link';
@@ -27,16 +30,16 @@ class PressThis extends Component {
 		return (
 			<div className="press-this">
 				<Card className="press-this__card site-settings">
-					<p>
+					<FormLegend>{ translate( 'Press This' ) }</FormLegend>
+					<FormSettingExplanation>
 						{ translate(
 							'{{strong}}Press This{{/strong}} allows you to copy text, images, and video from any web page and add them to a new post on your site, along with an automatic citation.',
 							{ components: { strong: <strong /> } }
 						) }
-					</p>
-					<p>
-						<strong>{ translate( 'How to use Press This' ) }</strong>
-					</p>
-					<p>
+					</FormSettingExplanation>
+
+					<FormFieldset>
+						<FormLegend>{ translate( 'How to use Press This' ) }</FormLegend>
 						<ul>
 							<li>
 								{ translate(
@@ -48,21 +51,22 @@ class PressThis extends Component {
 							</li>
 							<li>{ translate( 'Click on the "Press This" bookmarklet / favorite.' ) }</li>
 						</ul>
-					</p>
-					{ site && (
-						<p className="press-this__link-container">
-							<PressThisLink
-								site={ site }
-								onClick={ this.recordEvent( 'Clicked Press This Button' ) }
-								onDragStart={ this.recordEvent( 'Dragged Press This Button' ) }
-							>
-								<Gridicon icon="create" />
-								<span>
-									{ translate( 'Press This', { context: 'name of browser bookmarklet tool' } ) }
-								</span>
-							</PressThisLink>
-						</p>
-					) }
+
+						{ site && (
+							<p className="press-this__link-container">
+								<PressThisLink
+									site={ site }
+									onClick={ this.recordEvent( 'Clicked Press This Button' ) }
+									onDragStart={ this.recordEvent( 'Dragged Press This Button' ) }
+								>
+									<Gridicon icon="create" />
+									<span>
+										{ translate( 'Press This', { context: 'name of browser bookmarklet tool' } ) }
+									</span>
+								</PressThisLink>
+							</p>
+						) }
+					</FormFieldset>
 				</Card>
 			</div>
 		);

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -112,7 +112,7 @@ class PublishingTools extends Component {
 					) }
 					link={
 						isAtomic
-							? 'https://wordpress.com/en/support/post-by-email/'
+							? 'https://wordpress.com/support/post-by-email/'
 							: 'https://jetpack.com/support/post-by-email/'
 					}
 					privacyLink={ ! isAtomic }

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -8,7 +7,6 @@ import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connection';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
-import FormLegend from 'calypso/components/forms/form-legend';
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
@@ -103,7 +101,7 @@ class PublishingTools extends Component {
 	}
 
 	renderPostByEmailModule() {
-		const { moduleUnavailable, selectedSiteId, translate } = this.props;
+		const { moduleUnavailable, selectedSiteId, translate, siteIsAutomatedTransfer } = this.props;
 		const formPending = this.isFormPending();
 
 		return (
@@ -112,7 +110,12 @@ class PublishingTools extends Component {
 					text={ translate(
 						'Allows you to publish new posts by sending an email to a special address.'
 					) }
-					link="https://jetpack.com/support/post-by-email/"
+					link={
+						siteIsAutomatedTransfer
+							? 'https://wordpress.com/en/support/post-by-email/'
+							: 'https://jetpack.com/support/post-by-email/'
+					}
+					privacyLink="https://jetpack.com/support/post-by-email/#privacy"
 				/>
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
@@ -123,20 +126,6 @@ class PublishingTools extends Component {
 
 				{ this.renderPostByEmailSettings() }
 			</FormFieldset>
-		);
-	}
-
-	renderPressThis() {
-		const { translate } = this.props;
-		if ( ! config.isEnabled( 'press-this' ) ) {
-			return null;
-		}
-
-		return (
-			<div>
-				<FormLegend>{ translate( 'Press This' ) }</FormLegend>
-				<PressThis />
-			</div>
 		);
 	}
 
@@ -152,7 +141,9 @@ class PublishingTools extends Component {
 				<Card className="publishing-tools__card site-settings__module-settings">
 					{ this.renderPostByEmailModule() }
 					<hr />
-					{ this.renderPressThis() }
+					<FormFieldset>
+						<PressThis />
+					</FormFieldset>
 				</Card>
 			</div>
 		);

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -101,7 +101,7 @@ class PublishingTools extends Component {
 	}
 
 	renderPostByEmailModule() {
-		const { moduleUnavailable, selectedSiteId, translate, siteIsAutomatedTransfer } = this.props;
+		const { moduleUnavailable, selectedSiteId, translate, isAtomic } = this.props;
 		const formPending = this.isFormPending();
 
 		return (
@@ -111,11 +111,11 @@ class PublishingTools extends Component {
 						'Allows you to publish new posts by sending an email to a special address.'
 					) }
 					link={
-						siteIsAutomatedTransfer
+						isAtomic
 							? 'https://wordpress.com/en/support/post-by-email/'
 							: 'https://jetpack.com/support/post-by-email/'
 					}
-					privacyLink="https://jetpack.com/support/post-by-email/#privacy"
+					privacyLink={ ! isAtomic }
 				/>
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -72,7 +72,7 @@ class SpeedUpSiteSettings extends Component {
 									? 'https://wordpress.com/support/settings/performance-settings/#enable-site-accelerator'
 									: 'https://jetpack.com/support/site-accelerator/'
 							}
-							privacyLink="https://jetpack.com/support/site-accelerator/#privacy"
+							privacyLink={ ! siteIsAtomic }
 						/>
 						<FormSettingExplanation className="site-settings__feature-description">
 							{ translate(
@@ -113,7 +113,7 @@ class SpeedUpSiteSettings extends Component {
 										? 'https://wordpress.com/support/settings/performance-settings/#lazy-load-images'
 										: 'https://jetpack.com/support/lazy-images/'
 								}
-								privacyLink="https://jetpack.com/support/lazy-images/#privacy"
+								privacyLink={ ! siteIsAtomic }
 							/>
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -72,7 +72,7 @@ function ThemeEnhancements( {
 						) }
 						link={
 							isAtomic
-								? 'https://wordpress.com/en/support/infinite-scroll/'
+								? 'https://wordpress.com/support/infinite-scroll/'
 								: 'https://jetpack.com/support/infinite-scroll/'
 						}
 						privacyLink={ ! isAtomic }
@@ -90,7 +90,7 @@ function ThemeEnhancements( {
 						) }
 						link={
 							isAtomic
-								? 'https://wordpress.com/en/support/editing-css/'
+								? 'https://wordpress.com/support/editing-css/'
 								: 'https://jetpack.com/support/custom-css/'
 						}
 						privacyLink={ ! isAtomic }

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -15,7 +15,7 @@ import { getCustomizerUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 function ThemeEnhancements( {
-	siteIsAutomatedTransfer,
+	isAtomic,
 	siteIsJetpack,
 	handleAutosavingToggle,
 	handleAutosavingRadio,
@@ -71,11 +71,11 @@ function ThemeEnhancements( {
 							'Loads the next posts automatically when the reader approaches the bottom of the page.'
 						) }
 						link={
-							siteIsAutomatedTransfer
+							isAtomic
 								? 'https://wordpress.com/en/support/infinite-scroll/'
 								: 'https://jetpack.com/support/infinite-scroll/'
 						}
-						privacyLink="https://jetpack.com/support/infinite-scroll/#privacy"
+						privacyLink={ ! isAtomic }
 					/>
 					<FormSettingExplanation>
 						{ translate(
@@ -89,11 +89,11 @@ function ThemeEnhancements( {
 							"Adds names for CSS preprocessor use, disabling the theme's CSS, or custom image width."
 						) }
 						link={
-							siteIsAutomatedTransfer
+							isAtomic
 								? 'https://wordpress.com/en/support/editing-css/'
 								: 'https://jetpack.com/support/custom-css/'
 						}
-						privacyLink="https://jetpack.com/support/custom-css/#privacy"
+						privacyLink={ ! isAtomic }
 					/>
 					<JetpackModuleToggle
 						siteId={ siteId }
@@ -143,6 +143,8 @@ ThemeEnhancements.defaultProps = {
 };
 
 ThemeEnhancements.propTypes = {
+	isAtomic: PropTypes.bool,
+	siteIsJetpack: PropTypes.bool,
 	onSubmitForm: PropTypes.func.isRequired,
 	handleAutosavingToggle: PropTypes.func.isRequired,
 	handleAutosavingRadio: PropTypes.func.isRequired,

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -11,7 +11,7 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import { getCustomizerUrl, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getCustomizerUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 function ThemeEnhancements( {
@@ -23,7 +23,7 @@ function ThemeEnhancements( {
 	isRequestingSettings,
 	fields,
 	customizeUrl,
-	selectedSiteId,
+	siteId,
 } ) {
 	const isFormPending = isRequestingSettings || isSavingSettings;
 	const translate = useTranslate();
@@ -96,7 +96,7 @@ function ThemeEnhancements( {
 						privacyLink="https://jetpack.com/support/custom-css/#privacy"
 					/>
 					<JetpackModuleToggle
-						siteId={ selectedSiteId }
+						siteId={ siteId }
 						moduleSlug="custom-css"
 						label={ translate( 'Enhance CSS customization panel' ) }
 						disabled={ isFormPending }
@@ -159,7 +159,5 @@ export default connect( ( state ) => {
 	return {
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		selectedSiteId,
-		siteIsJetpack: isJetpackSite( state, selectedSiteId ),
-		site,
 	};
 } )( localize( ThemeEnhancements ) );

--- a/client/my-sites/site-settings/widgets.jsx
+++ b/client/my-sites/site-settings/widgets.jsx
@@ -40,7 +40,7 @@ function Widgets( { isSavingSettings, isRequestingSettings, isAtomic, translate 
 						) }
 						link={
 							isAtomic
-								? 'https://wordpress.com/en/support/widgets/#widget-visibility'
+								? 'https://wordpress.com/support/widgets/#widget-visibility'
 								: 'https://jetpack.com/support/widget-visibility'
 						}
 						privacyLink={ ! isAtomic }

--- a/client/my-sites/site-settings/widgets.jsx
+++ b/client/my-sites/site-settings/widgets.jsx
@@ -7,7 +7,7 @@ import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-t
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-function Widgets( { isSavingSettings, isRequestingSettings, siteIsAutomatedTransfer, translate } ) {
+function Widgets( { isSavingSettings, isRequestingSettings, isAtomic, translate } ) {
 	const isFormPending = isRequestingSettings || isSavingSettings;
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
@@ -39,11 +39,11 @@ function Widgets( { isSavingSettings, isRequestingSettings, siteIsAutomatedTrans
 							'Widget visibility lets you decide which widgets appear on which pages, so you can finely tailor widget content.'
 						) }
 						link={
-							siteIsAutomatedTransfer
+							isAtomic
 								? 'https://wordpress.com/en/support/widgets/#widget-visibility'
 								: 'https://jetpack.com/support/widget-visibility'
 						}
-						privacyLink="https://jetpack.com/support/widget-visibility#privacy"
+						privacyLink={ ! isAtomic }
 					/>
 					<JetpackModuleToggle
 						siteId={ selectedSiteId }

--- a/client/my-sites/site-settings/widgets.jsx
+++ b/client/my-sites/site-settings/widgets.jsx
@@ -1,113 +1,72 @@
 import { Card } from '@automattic/components';
-import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
-import { getCustomizerUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-class Widgets extends Component {
-	static defaultProps = {
-		isSavingSettings: false,
-		isRequestingSettings: true,
-		fields: {},
-	};
+function Widgets( { isSavingSettings, isRequestingSettings, siteIsAutomatedTransfer, translate } ) {
+	const isFormPending = isRequestingSettings || isSavingSettings;
+	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
-	static propTypes = {
-		onSubmitForm: PropTypes.func.isRequired,
-		handleAutosavingToggle: PropTypes.func.isRequired,
-		handleAutosavingRadio: PropTypes.func.isRequired,
-		isSavingSettings: PropTypes.bool,
-		isRequestingSettings: PropTypes.bool,
-		fields: PropTypes.object,
-	};
+	return (
+		<>
+			<SettingsSectionHeader title={ translate( 'Widgets' ) } />
 
-	isFormPending = () => this.props.isRequestingSettings || this.props.isSavingSettings;
+			<Card className="site-settings">
+				<FormFieldset>
+					<SupportInfo
+						text={ translate( 'Provides additional widgets for use on your site.' ) }
+						link="https://jetpack.com/support/extra-sidebar-widgets/"
+					/>
 
-	renderWidgetsSettings() {
-		const { selectedSiteId, translate } = this.props;
-		const formPending = this.isFormPending();
+					<JetpackModuleToggle
+						siteId={ selectedSiteId }
+						moduleSlug="widgets"
+						label={ translate(
+							'Make extra widgets available for use on your site including images and Twitter streams'
+						) }
+						disabled={ isFormPending }
+					/>
+				</FormFieldset>
+				<hr />
 
-		return (
-			<FormFieldset>
-				<SupportInfo
-					text={ translate( 'Provides additional widgets for use on your site.' ) }
-					link="https://jetpack.com/support/extra-sidebar-widgets/"
-				/>
-
-				<JetpackModuleToggle
-					siteId={ selectedSiteId }
-					moduleSlug="widgets"
-					label={ translate(
-						'Make extra widgets available for use on your site including images and Twitter streams'
-					) }
-					disabled={ formPending }
-				/>
-			</FormFieldset>
-		);
-	}
-
-	renderWidgetVisibilitySettings() {
-		const { selectedSiteId, translate } = this.props;
-		const formPending = this.isFormPending();
-
-		return (
-			<FormFieldset>
-				<SupportInfo
-					text={ translate(
-						'Widget visibility lets you decide which widgets appear on which pages, so you can finely tailor widget content.'
-					) }
-					link="https://jetpack.com/support/widget-visibility"
-				/>
-
-				<JetpackModuleToggle
-					siteId={ selectedSiteId }
-					moduleSlug="widget-visibility"
-					label={ translate(
-						'Enable widget visibility controls to display widgets only on particular posts or pages'
-					) }
-					disabled={ formPending }
-				/>
-			</FormFieldset>
-		);
-	}
-
-	render() {
-		const { translate } = this.props;
-
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		return (
-			<Fragment>
-				<SettingsSectionHeader title={ translate( 'Widgets' ) } />
-
-				<Card className="site-settings">
-					{ this.renderWidgetsSettings() }
-					<hr />
-					{ this.renderWidgetVisibilitySettings() }
-				</Card>
-			</Fragment>
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
-	}
+				<FormFieldset>
+					<SupportInfo
+						text={ translate(
+							'Widget visibility lets you decide which widgets appear on which pages, so you can finely tailor widget content.'
+						) }
+						link={
+							siteIsAutomatedTransfer
+								? 'https://wordpress.com/en/support/widgets/#widget-visibility'
+								: 'https://jetpack.com/support/widget-visibility'
+						}
+						privacyLink="https://jetpack.com/support/widget-visibility#privacy"
+					/>
+					<JetpackModuleToggle
+						siteId={ selectedSiteId }
+						moduleSlug="widget-visibility"
+						label={ translate(
+							'Enable widget visibility controls to display widgets only on particular posts or pages'
+						) }
+						disabled={ isFormPending }
+					/>
+				</FormFieldset>
+			</Card>
+		</>
+	);
 }
 
-export default connect( ( state ) => {
-	const selectedSiteId = getSelectedSiteId( state );
+Widgets.defaultProps = {
+	isSavingSettings: false,
+	isRequestingSettings: true,
+};
 
-	return {
-		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
-		selectedSiteId,
-		siteIsJetpack: isJetpackSite( state, selectedSiteId ),
-		widgetsModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'widgets' ),
-		widgetVisibilityModuleActive: !! isJetpackModuleActive(
-			state,
-			selectedSiteId,
-			'widget-visibility'
-		),
-	};
-} )( localize( Widgets ) );
+Widgets.propTypes = {
+	isSavingSettings: PropTypes.bool,
+	isRequestingSettings: PropTypes.bool,
+};
+
+export default Widgets;


### PR DESCRIPTION
## Changes proposed in this Pull Request
This started out as a simple PR to update the links to the support guide links and during the process, I decided to refactor a few things and make it a little cleaner and more uniform. Here are the major changes I made:
<img width="1075" alt="Markup 2022-02-16 at 20 25 07" src="https://user-images.githubusercontent.com/33258733/154340516-ff3062ed-11e7-4778-8827-6af059a65649.png">

#### Main Index
* Moved section headings within the appropriate components
* Removed unused props
* Added `siteIsAutomatedTransfer` prop to the sections that needed to provide the different support links based on that context.

#### Composing section
* Removed unnecessary connect to the store
* Removed unused props
* Added section header
* Changed `Latex` and `Shortcodes` components from class components to functions
* Updated support links
<img width="1629" alt="Markup 2022-02-16 at 20 30 35" src="https://user-images.githubusercontent.com/33258733/154341299-b10edddf-9b27-4075-ab37-45ecc50f86b1.png">

#### Content Types
* Extrapolated each fieldset into a component `BlogPosts`, `Testimonials`, and `Portfolios`.
* I tried to convert the index from a class to a function but was not successful with the autosave/update feature so I left this as a class.
* Updated support links
<img width="1626" alt="Markup 2022-02-16 at 20 31 05" src="https://user-images.githubusercontent.com/33258733/154341550-329fdc1f-a392-4ab0-8dad-636149a3ced1.png">

#### Masterbar (only in self-hosted Jetpack sites)
* Added section header

#### Media (only in self-hosted Jetpack sites)
* Added section header

#### Publishing Tools
* Updated support links
* Replaced the generic HTML elements with the standardized Form components to make things consistent
* Adjusted section header
<img width="1637" alt="Markup 2022-02-16 at 20 32 00" src="https://user-images.githubusercontent.com/33258733/154341592-bac4933f-8969-4c2c-be66-c217aa246cd9.png">

#### Theme Enhancements
* Changed from class to function component
* Removed unused props
* Updated support links
<img width="1636" alt="Markup 2022-02-16 at 20 29 05" src="https://user-images.githubusercontent.com/33258733/154341085-912db1c4-e187-4c9d-8e74-f0af75fa7f62.png">

#### Widgets
* Removed unused props
* Changed from class to function component

## Testing instructions
* Pull branch and launch calypso with `yarn start`
* Go to Settings ⇢ Writing
* Adjust all settings and options and verify they update correctly
* Visually inspect for errors (there are slight variations due to the update to match styling)
* Click the `( i )` and make sure the link goes to Jetpack links on JPOP only sites and WPCOM for Simple and AT sites
* Repeat this process with each version - Simple, AT, and JPOP site
* I tested side-by-side with the live version. After a change in my test environment, I would refresh my live version to make sure the changes applied to the site settings.

Fixes #59977 