### PR TITLE
Update WP 'View the import guide' modal content

### DIFF
--- a/client/signup/steps/import/ready/platform-details.tsx
+++ b/client/signup/steps/import/ready/platform-details.tsx
@@ -93,7 +93,7 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 				);
 			case 'wordpress':
 				return __(
-					"Our Self-Hosted WordPress content importer is the quickest way to move your content. After clicking 'Import your content', either enter your site's URL to move all your content, plugins, and custom themes to WordPress.com, or use the 'Import' feature to import just your site's content, including posts, pages, and media."
+					"Our Self-Hosted WordPress content importer is the quickest way to move your content. After clicking 'Import your content', you will have two options:"
 				);
 			case 'medium':
 				return __(
@@ -122,33 +122,74 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 					{ __( 'Learn more' ) }
 				</a>
 
-				<div className={ 'import__details-features' }>
-					<p>
-						{ createInterpolateElement( __( 'Things we <strong>can</strong> import:' ), {
-							strong: createElement( 'strong' ),
-						} ) }
-					</p>
-					<ul className={ 'import__details-list' }>
-						{ platformFeatureList[ platform ].supported.map( ( key ) => (
-							<li key={ key }>
-								<Icon size={ 20 } icon={ check } /> { translatedFeatureList[ key as FeatureName ] }
-							</li>
-						) ) }
-					</ul>
+				{ platform !== 'wordpress' && (
+					<div className={ 'import__details-features' }>
+						<p>
+							{ createInterpolateElement( __( 'Things we <strong>can</strong> import:' ), {
+								strong: createElement( 'strong' ),
+							} ) }
+						</p>
+						<ul className={ 'import__details-list' }>
+							{ platformFeatureList[ platform ].supported.map( ( key ) => (
+								<li key={ key }>
+									<Icon size={ 20 } icon={ check } />{ ' ' }
+									{ translatedFeatureList[ key as FeatureName ] }
+								</li>
+							) ) }
+						</ul>
 
-					<p>
-						{ createInterpolateElement( __( "Things we <strong>can't</strong> import:" ), {
-							strong: createElement( 'strong' ),
-						} ) }
-					</p>
-					<ul className={ 'import__details-list' }>
-						{ platformFeatureList[ platform ].unsupported.map( ( key ) => (
-							<li key={ key }>
-								<Icon size={ 20 } icon={ close } /> { translatedFeatureList[ key as FeatureName ] }
-							</li>
-						) ) }
-					</ul>
-				</div>
+						<p>
+							{ createInterpolateElement( __( "Things we <strong>can't</strong> import:" ), {
+								strong: createElement( 'strong' ),
+							} ) }
+						</p>
+						<ul className={ 'import__details-list' }>
+							{ platformFeatureList[ platform ].unsupported.map( ( key ) => (
+								<li key={ key }>
+									<Icon size={ 20 } icon={ close } />{ ' ' }
+									{ translatedFeatureList[ key as FeatureName ] }
+								</li>
+							) ) }
+						</ul>
+					</div>
+				) }
+
+				{ platform === 'wordpress' && (
+					<div className={ 'import__details-features' }>
+						<p>
+							{ createInterpolateElement( __( 'Import <strong>Content only</strong>:' ), {
+								strong: createElement( 'strong' ),
+							} ) }
+						</p>
+						<ul className={ 'import__details-list' }>
+							{ platformFeatureList[ platform ].supported.map( ( key ) => (
+								<li key={ key }>
+									<Icon size={ 20 } icon={ check } />{ ' ' }
+									{ translatedFeatureList[ key as FeatureName ] }
+								</li>
+							) ) }
+						</ul>
+
+						<p>
+							{ createInterpolateElement( __( 'Import <strong>Everything*</strong>:' ), {
+								strong: createElement( 'strong' ),
+							} ) }
+						</p>
+						<ul className={ 'import__details-list' }>
+							{ platformFeatureList[ platform ].supported
+								.concat( platformFeatureList[ platform ].unsupported )
+								.map( ( key ) => (
+									<li key={ key }>
+										<Icon size={ 20 } icon={ close } />{ ' ' }
+										{ translatedFeatureList[ key as FeatureName ] }
+									</li>
+								) ) }
+						</ul>
+						<div className={ 'import__details-footer' }>
+							<i>*{ __( 'Requires a Business plan.' ) }</i>
+						</div>
+					</div>
+				) }
 			</div>
 		</Modal>
 	);

--- a/client/signup/steps/import/ready/platform-details.tsx
+++ b/client/signup/steps/import/ready/platform-details.tsx
@@ -180,7 +180,7 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 								.concat( platformFeatureList[ platform ].unsupported )
 								.map( ( key ) => (
 									<li key={ key }>
-										<Icon size={ 20 } icon={ close } />{ ' ' }
+										<Icon size={ 20 } icon={ check } />{ ' ' }
 										{ translatedFeatureList[ key as FeatureName ] }
 									</li>
 								) ) }

--- a/client/signup/steps/import/ready/style.scss
+++ b/client/signup/steps/import/ready/style.scss
@@ -143,4 +143,10 @@
 			color: var( --studio-gray-100 );
 		}
 	}
+
+	.import__details-footer {
+		font-weight: 300; /* stylelint-disable-line */
+		font-size: 0.875em; /* stylelint-disable-line */
+		color: var( --studio-gray-80 );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update WordPress 'View the import guide' modal content

#### Testing instructions

* Go to `/start/importer/ready?siteSlug={SLUG}.wordpress.com`
* Select `I don't have a site address` in the top right corner
* Select WordPress importer
* Click on the `View the import guide` link
* Check if there is updated content

#### Screenshots
<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img width="747" alt="Screenshot 2022-02-16 at 20 30 46" src="https://user-images.githubusercontent.com/1241413/154341583-6e4ca9bb-933c-46d9-9166-4b2c6d1afd2b.png">
</td>
<td>
<img width="739" alt="Screenshot 2022-02-18 at 10 36 58" src="https://user-images.githubusercontent.com/1241413/154656861-b84840ae-52e7-4761-9a80-569f5af19e0b.png">
</td>
</tr>

</table>

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #60839
