### PR TITLE
Full Site Editing: use `full-site-editing` showcase tag to align with Core FSE

### DIFF
--- a/client/my-sites/themes/fse-themes.jsx
+++ b/client/my-sites/themes/fse-themes.jsx
@@ -9,7 +9,7 @@ const FseThemes = localize( ( { translate, ...restProps } ) => {
 		'fse-themes',
 		() =>
 			wpcom.req.get( '/themes', {
-				filter: 'block-templates',
+				filter: 'full-site-editing',
 				number: 50,
 				tier: '',
 				apiVersion: '1.2',

--- a/client/my-sites/themes/is-full-site-editing-theme.ts
+++ b/client/my-sites/themes/is-full-site-editing-theme.ts
@@ -2,5 +2,5 @@ import { Theme } from 'calypso/types';
 
 export function isFullSiteEditingTheme( theme: Theme | null ): boolean {
 	const features = theme?.taxonomies?.theme_feature;
-	return features?.some( ( feature ) => feature.slug === 'block-templates' ) ?? false;
+	return features?.some( ( feature ) => feature.slug === 'full-site-editing' ) ?? false;
 }

--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -19,7 +19,7 @@ const RecommendedThemes = ( props ) => {
 	);
 
 	const isFSEEligible = data?.is_fse_eligible ?? false;
-	const recommendedThemesFilter = isFSEEligible ? 'block-templates' : 'auto-loading-homepage';
+	const recommendedThemesFilter = isFSEEligible ? 'full-site-editing' : 'auto-loading-homepage';
 
 	const customizedThemesList = useSelector( ( state ) =>
 		getRecommendedThemesSelector( state, recommendedThemesFilter )

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import QueryThemes from 'calypso/components/data/query-themes';
 import ThemesList from 'calypso/components/themes-list';
-import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer.js';
@@ -192,90 +191,72 @@ function bindGetPremiumThemePrice( state, siteId ) {
 	return ( themeId ) => getPremiumThemePrice( state, themeId, siteId );
 }
 
-function filterOutUniversalThemes( themes = [] ) {
-	return themes.filter( ( theme ) => {
-		return theme?.template !== 'blockbase' && theme?.id !== 'blockbase';
-	} );
-}
-
 // Exporting this for use in customized themes lists (recommended-themes.jsx, etc.)
 // We do not want pagination triggered in that use of the component.
-export const ConnectedThemesSelection = withBlockEditorSettings(
-	connect(
-		(
-			state,
-			{
-				filter,
-				page,
-				search,
-				tier,
-				vertical,
-				siteId,
-				source,
-				isLoading: isCustomizedThemeListLoading,
-				blockEditorSettings,
-			}
-		) => {
-			const isJetpack = isJetpackSite( state, siteId );
-			const isAtomic = isSiteAutomatedTransfer( state, siteId );
-			const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
+export const ConnectedThemesSelection = connect(
+	(
+		state,
+		{
+			filter,
+			page,
+			search,
+			tier,
+			vertical,
+			siteId,
+			source,
+			isLoading: isCustomizedThemeListLoading,
+		}
+	) => {
+		const isJetpack = isJetpackSite( state, siteId );
+		const isAtomic = isSiteAutomatedTransfer( state, siteId );
+		const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
 
-			let sourceSiteId;
-			if ( source === 'wpcom' || source === 'wporg' ) {
-				sourceSiteId = source;
-			} else {
-				sourceSiteId = siteId && isJetpack && ! isAtomic ? siteId : 'wpcom';
-			}
+		let sourceSiteId;
+		if ( source === 'wpcom' || source === 'wporg' ) {
+			sourceSiteId = source;
+		} else {
+			sourceSiteId = siteId && isJetpack && ! isAtomic ? siteId : 'wpcom';
+		}
 
-			// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the
-			// results and sends all of the themes at once. QueryManager is not expecting such behaviour
-			// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
-			// Jetpack themes endpoint.
-			const number = ! [ 'wpcom', 'wporg' ].includes( sourceSiteId ) ? 2000 : 100;
-			const query = {
-				search,
-				page,
-				tier: premiumThemesEnabled ? tier : 'free',
-				filter: compact( [ filter, vertical ] ).join( ',' ),
-				number,
-			};
+		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the
+		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
+		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
+		// Jetpack themes endpoint.
+		const number = ! [ 'wpcom', 'wporg' ].includes( sourceSiteId ) ? 2000 : 100;
+		const query = {
+			search,
+			page,
+			tier: premiumThemesEnabled ? tier : 'free',
+			filter: compact( [ filter, vertical ] ).join( ',' ),
+			number,
+		};
 
-			let themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [];
+		const themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [];
 
-			// The block templates filter is used to search for full site editing (FSE) themes, which includes both
-			// universal and block themes. If, however, a user is in the classic experience without FSE enabled,
-			// selecting another universal theme will not enable the full site editor. Because of this, we filter out
-			// universal themes from the block-templates filter search results for classic sites. This logic will be
-			// removed when FSE is enabled for all sites with universal themes.
-			if ( filter === 'block-templates' && ! blockEditorSettings?.is_fse_eligible ) {
-				themes = filterOutUniversalThemes( themes );
-			}
-
-			return {
-				query,
-				source: sourceSiteId,
-				siteId: siteId,
-				siteSlug: getSiteSlug( state, siteId ),
-				themes,
-				themesCount: getThemesFoundForQuery( state, sourceSiteId, query ),
-				isRequesting:
-					isCustomizedThemeListLoading || isRequestingThemesForQuery( state, sourceSiteId, query ),
-				isLastPage: isThemesLastPageForQuery( state, sourceSiteId, query ),
-				isLoggedIn: isUserLoggedIn( state ),
-				isThemeActive: bindIsThemeActive( state, siteId ),
-				isInstallingTheme: bindIsInstallingTheme( state, siteId ),
-				// Note: This component assumes that purchase and plans data is already present in the state tree
-				// (used by the `isPremiumThemeAvailable` selector). That data is provided by the `<QuerySitePurchases />`
-				// and `<QuerySitePlans />` components, respectively. At the time of implementation, neither of them
-				// provides caching, and both are already being rendered by a parent component. So to avoid
-				// redundant AJAX requests, we're not rendering these query components locally.
-				getPremiumThemePrice: bindGetPremiumThemePrice( state, siteId ),
-				filterString: prependThemeFilterKeys( state, query.filter ),
-			};
-		},
-		{ setThemePreviewOptions, recordGoogleEvent, recordTracksEvent }
-	)( ThemesSelection )
-);
+		return {
+			query,
+			source: sourceSiteId,
+			siteId: siteId,
+			siteSlug: getSiteSlug( state, siteId ),
+			themes,
+			themesCount: getThemesFoundForQuery( state, sourceSiteId, query ),
+			isRequesting:
+				isCustomizedThemeListLoading || isRequestingThemesForQuery( state, sourceSiteId, query ),
+			isLastPage: isThemesLastPageForQuery( state, sourceSiteId, query ),
+			isLoggedIn: isUserLoggedIn( state ),
+			isThemeActive: bindIsThemeActive( state, siteId ),
+			isInstallingTheme: bindIsInstallingTheme( state, siteId ),
+			// Note: This component assumes that purchase and plans data is already present in the state tree
+			// (used by the `isPremiumThemeAvailable` selector). That data is provided by the `<QuerySitePurchases />`
+			// and `<QuerySitePlans />` components, respectively. At the time of implementation, neither of them
+			// provides caching, and both are already being rendered by a parent component. So to avoid
+			// redundant AJAX requests, we're not rendering these query components locally.
+			getPremiumThemePrice: bindGetPremiumThemePrice( state, siteId ),
+			filterString: prependThemeFilterKeys( state, query.filter ),
+		};
+	},
+	{ setThemePreviewOptions, recordGoogleEvent, recordTracksEvent }
+)( ThemesSelection );
 
 /**
  * Provide page state management needed for `ThemesSelection`. We cannot store the

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -77,7 +77,7 @@ export default function DesignPickerStep( props ) {
 	} = useBlockEditorSettingsQuery( siteId, userLoggedIn && ! props.useDIFMThemes );
 	const isFSEEligible = blockEditorSettings?.is_fse_eligible ?? false;
 	const themeFilters = isFSEEligible
-		? 'auto-loading-homepage,block-templates'
+		? 'auto-loading-homepage,full-site-editing'
 		: 'auto-loading-homepage';
 
 	const { data: apiThemes = [] } = useThemeDesignsQuery(

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -1,4 +1,5 @@
 import i18n from 'i18n-calypso';
+import { omit } from 'lodash';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -20,7 +21,9 @@ const fetchFilters = ( action ) =>
 	);
 
 const storeFilters = ( action, data ) => {
-	return { type: THEME_FILTERS_ADD, filters: data };
+	// Don't show FSE themes to non-FSE sites until switching to a FSE theme activates FSE.
+	const filters = action.isCoreFse ? data : omit( data, 'feature.full-site-editing' );
+	return { type: THEME_FILTERS_ADD, filters };
 };
 
 const reportError = () => errorNotice( i18n.translate( 'Problem fetching theme filters.' ) );

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -1,5 +1,4 @@
 import i18n from 'i18n-calypso';
-import { omit } from 'lodash';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -21,8 +20,7 @@ const fetchFilters = ( action ) =>
 	);
 
 const storeFilters = ( action, data ) => {
-	const filters = action.isFse ? data : omit( data, 'feature.full-site-editing' );
-	return { type: THEME_FILTERS_ADD, filters };
+	return { type: THEME_FILTERS_ADD, filters: data };
 };
 
 const reportError = () => errorNotice( i18n.translate( 'Problem fetching theme filters.' ) );

--- a/client/state/themes/selectors/get-trending-themes.js
+++ b/client/state/themes/selectors/get-trending-themes.js
@@ -15,11 +15,6 @@ export function getTrendingThemes( state ) {
 		return emptyList;
 	}
 	let themes = Object.values( state.themes.trendingThemes?.themes );
-	// Only return themes which do not have the "Block Templates" feature.
-	// @TODO remove this check when it is valid to do so.
-	themes = themes.filter( ( t ) =>
-		t?.taxonomies?.features.every( ( f ) => f.slug !== 'block-templates' )
-	);
 
 	// Remove premium themes if not supported
 	const siteId = state.ui ? getSelectedSiteId( state ) : false;

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -421,9 +421,9 @@ describe( 'actions', () => {
 			taxonomies: {
 				theme_feature: [
 					{
-						name: 'Block Templates',
-						slug: 'block-templates',
-						term_id: '230717188',
+						name: 'Full Site Editing',
+						slug: 'full-site-editing',
+						term_id: '686035051',
 					},
 				],
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `full-site-editing` as the tag for Core FSE themes

#### Testing instructions

Ensure that all former `block-templates`-tagged themes in the theme showcase have also been tagged with `full-site-editing`. All functionality should be unchanged.

Ensure that Legacy FSE sites are now showing Core FSE themes in Recommended. This will help encourage those sites to use a Core FSE theme if they choose to switch.

Related to #61167 
