### PR TITLE
Hide Used Introductory Offers in Cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -9,6 +9,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import '@testing-library/jest-dom/extend-expect';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
+import getIntroOfferIsEligible from 'calypso/state/selectors/get-intro-offer-is-eligible';
 import getIntroOfferPrice from 'calypso/state/selectors/get-intro-offer-price';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
@@ -52,6 +53,7 @@ describe( 'CompositeCheckout with a variant picker', () => {
 		getDomainsBySiteId.mockImplementation( () => [] );
 		isMarketplaceProduct.mockImplementation( () => false );
 		getIntroOfferPrice.mockImplementation( () => null );
+		getIntroOfferIsEligible.mockImplementation( () => false );
 
 		const initialCart = {
 			coupon: '',

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -9,7 +9,6 @@ import { Provider as ReduxProvider } from 'react-redux';
 import '@testing-library/jest-dom/extend-expect';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
-import getIntroOfferIsEligible from 'calypso/state/selectors/get-intro-offer-is-eligible';
 import getIntroOfferPrice from 'calypso/state/selectors/get-intro-offer-price';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
@@ -53,7 +52,6 @@ describe( 'CompositeCheckout with a variant picker', () => {
 		getDomainsBySiteId.mockImplementation( () => [] );
 		isMarketplaceProduct.mockImplementation( () => false );
 		getIntroOfferPrice.mockImplementation( () => null );
-		getIntroOfferIsEligible.mockImplementation( () => false );
 
 		const initialCart = {
 			coupon: '',

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -1,5 +1,6 @@
 import { GROUP_WPCOM } from '@automattic/calypso-products';
 import { getPlanRawPrice } from 'calypso/state/plans/selectors';
+import getIntroOfferIsEligible from 'calypso/state/selectors/get-intro-offer-is-eligible';
 import getIntroOfferPrice from 'calypso/state/selectors/get-intro-offer-price';
 import { getPlanPrice } from './get-plan-price';
 import { getProductCost } from './get-product-cost';
@@ -30,8 +31,10 @@ export const computeFullAndMonthlyPricesForPlan = (
 	const planOrProductPrice = ! getPlanPrice( state, siteId, planObject, false )
 		? getProductCost( state, planObject.getStoreSlug() )
 		: getPlanPrice( state, siteId, planObject, false );
-
-	const introductoryOfferPrice = getIntroOfferPrice( state, planObject.getProductId(), siteId );
+	const introOfferIsEligible = getIntroOfferIsEligible( state, planObject.getProductId(), siteId );
+	const introductoryOfferPrice = introOfferIsEligible
+		? getIntroOfferPrice( state, planObject.getProductId(), siteId )
+		: null;
 
 	return {
 		priceFull: planOrProductPrice,

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -128,7 +128,7 @@ describe( 'selectors', () => {
 			getIntroOfferPrice.mockReset();
 			getIntroOfferPrice.mockImplementation( () => null );
 			getIntroOfferIsEligible.mockReset();
-			getIntroOfferPrice.mockImplementation( () => false );
+			getIntroOfferIsEligible.mockImplementation( () => false );
 		} );
 		test( 'Should return shape { priceFull }', () => {
 			getPlanDiscountedRawPrice.mockImplementation( ( a, b, c, { isMonthly } ) =>

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -164,7 +164,7 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		test( 'Should not return the iintroductoryOfferPrice value if ineligible', () => {
+		test( 'Should not return the introductoryOfferPrice value if ineligible', () => {
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
 			getIntroOfferPrice.mockImplementation( () => 60 );
 			getIntroOfferIsEligible.mockImplementation( () => false );

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -1,6 +1,7 @@
 import { getPlan, TERM_MONTHLY, TERM_ANNUALLY } from '@automattic/calypso-products';
 import deepFreeze from 'deep-freeze';
 import { getPlanRawPrice } from 'calypso/state/plans/selectors';
+import getIntroOfferIsEligible from 'calypso/state/selectors/get-intro-offer-is-eligible';
 import getIntroOfferPrice from 'calypso/state/selectors/get-intro-offer-price';
 import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
 import {
@@ -13,6 +14,7 @@ import {
 } from '../selectors';
 
 jest.mock( 'calypso/state/selectors/get-intro-offer-price', () => jest.fn() );
+jest.mock( 'calypso/state/selectors/get-intro-offer-is-eligible', () => jest.fn() );
 
 jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
 	getPlanDiscountedRawPrice: jest.fn(),
@@ -125,6 +127,8 @@ describe( 'selectors', () => {
 		beforeEach( () => {
 			getIntroOfferPrice.mockReset();
 			getIntroOfferPrice.mockImplementation( () => null );
+			getIntroOfferIsEligible.mockReset();
+			getIntroOfferPrice.mockImplementation( () => false );
 		} );
 		test( 'Should return shape { priceFull }', () => {
 			getPlanDiscountedRawPrice.mockImplementation( ( a, b, c, { isMonthly } ) =>
@@ -149,11 +153,23 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		test( 'Should return the isIntroductoryOfferApplied value', () => {
+		test( 'Should return the iintroductoryOfferPrice value', () => {
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
 			getIntroOfferPrice.mockImplementation( () => 60 );
+			getIntroOfferIsEligible.mockImplementation( () => true );
 			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0, {} ) ).toEqual( {
 				introductoryOfferPrice: 60,
+				priceFull: 120,
+				priceFinal: 120,
+			} );
+		} );
+
+		test( 'Should not return the iintroductoryOfferPrice value if ineligible', () => {
+			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
+			getIntroOfferPrice.mockImplementation( () => 60 );
+			getIntroOfferIsEligible.mockImplementation( () => false );
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0, {} ) ).toEqual( {
+				introductoryOfferPrice: null,
 				priceFull: 120,
 				priceFinal: 120,
 			} );

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -153,7 +153,7 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		test( 'Should return the iintroductoryOfferPrice value', () => {
+		test( 'Should return the introductoryOfferPrice value', () => {
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
 			getIntroOfferPrice.mockImplementation( () => 60 );
 			getIntroOfferIsEligible.mockImplementation( () => true );

--- a/client/state/selectors/get-intro-offer-is-eligible.ts
+++ b/client/state/selectors/get-intro-offer-is-eligible.ts
@@ -1,0 +1,21 @@
+import type { AppState } from 'calypso/types';
+
+/**
+ * @param  {object}  state       Global state tree
+ * @param  {number}  productId   The productId to check for intro offers
+ * @param  {number}  siteId      The ID of the site we're querying
+ * @returns {boolean}            True if the offer is eligible for an intro offer
+ */
+export default function getIntroOfferIsEligible(
+	state: AppState,
+	productId: number,
+	siteId: number | 'none'
+): boolean {
+	const siteIdKey = siteId && typeof siteId === 'number' && siteId > 0 ? siteId : 'none';
+
+	// if siteIdKey is 'none' we are querying into offers without a site and so intro offers so always be eligible
+	return siteIdKey === 'none'
+		? true
+		: ( state.sites?.introOffers?.items?.[ siteIdKey ]?.[ productId ]?.ineligibleReason ?? [] )
+				.length === 0;
+}

--- a/client/state/sites/plans/selectors/get-plan-discounted-raw-price.js
+++ b/client/state/sites/plans/selectors/get-plan-discounted-raw-price.js
@@ -19,10 +19,6 @@ export function getPlanDiscountedRawPrice(
 ) {
 	const plan = getSitePlan( state, siteId, productSlug );
 
-	if ( ( plan?.introductoryOfferRawPrice ?? -1 ) > 0 ) {
-		return plan.introductoryOfferRawPrice;
-	}
-
 	if ( ( plan?.rawPrice ?? -1 ) < 0 || ! isSitePlanDiscounted( state, siteId, productSlug ) ) {
 		return null;
 	}

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -23,7 +23,6 @@ import {
 	isSitePlanDiscounted,
 	getSitePlanSlug,
 	hasFeature,
-	isIntroductoryOfferAppliedToPlanPrice,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -359,7 +358,6 @@ describe( 'selectors', () => {
 				{
 					currentPlan: false,
 					productSlug: 'jetpack_security',
-					introductoryOfferRawPrice: 15,
 					rawPrice: 30,
 					rawDiscount: 0,
 				},
@@ -406,12 +404,6 @@ describe( 'selectors', () => {
 				isMonthly: true,
 			} );
 			expect( discountPrice ).to.equal( null );
-		} );
-		test( 'should return the introductory offer discounted price if available', () => {
-			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'jetpack_security', {
-				isMonthly: true,
-			} );
-			expect( discountPrice ).to.equal( 15 );
 		} );
 	} );
 
@@ -842,49 +834,6 @@ describe( 'selectors', () => {
 					FEATURE_AUDIO_UPLOADS
 				)
 			).to.be.true;
-		} );
-	} );
-	describe( '#isIntroductoryOfferAppliedToPlanPrice()', () => {
-		const plans = {
-			data: [
-				{
-					currentPlan: false,
-					productSlug: 'personal-bundle',
-					rawPrice: 299,
-					rawDiscount: 0,
-				},
-				{
-					currentPlan: false,
-					productSlug: 'personal-bundle-offer',
-					introductoryOfferRawPrice: 99,
-					rawPrice: 199,
-					rawDiscount: 0,
-				},
-			],
-		};
-		const state = {
-			sites: {
-				plans: {
-					77203074: plans,
-				},
-			},
-		};
-
-		test( 'should return a discount price', () => {
-			const isIntroductoryOfferApplied = isIntroductoryOfferAppliedToPlanPrice(
-				state,
-				77203074,
-				'personal-bundle'
-			);
-			expect( isIntroductoryOfferApplied ).to.equal( false );
-		} );
-		test( 'should return a monthly discount price - annual term', () => {
-			const isIntroductoryOfferApplied = isIntroductoryOfferAppliedToPlanPrice(
-				state,
-				77203074,
-				'personal-bundle-offer'
-			);
-			expect( isIntroductoryOfferApplied ).to.equal( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use data from `/introductory-offers` endpoint to create `getIntroOfferIsEligible` selector
* Use `getIntroOfferIsEligible` selector to hide the intro offer price in the cart variant selector if the site is not eligible for an offer
* Update relevant tests 

| Before | After |
| ------ | ----- |
| <img width="571" alt="Screen Shot 2022-02-17 at 10 52 05" src="https://user-images.githubusercontent.com/2810519/154550734-01a539df-75b2-445d-a359-8b5e5ad540e3.png"> | <img width="571" alt="Screen Shot 2022-02-17 at 10 52 00" src="https://user-images.githubusercontent.com/2810519/154550707-a983e470-5244-4de8-adb7-860dfaa314a8.png"> |

#### Testing instructions

1. Set up a Jetpcak test site by:
  - Purchasing an annual plan or product with an intro offer
  - Removing the annual plan or product from the site
2. Add the same annual plan or product to the cart
3. Verify the variant selectors in the cart match the "After" screenshot above
4. Verify unit tests have passed on the PR
