### PR TITLE
Licensing Portal: Add sites pagination to license assignment

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/constants.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/constants.tsx
@@ -1,0 +1,1 @@
+export const SITE_CARDS_PER_PAGE = 7;

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -21,33 +21,40 @@ function setPage( pageNumber: number ): void {
 	page( addQueryArgs( queryParams, currentPath ) );
 }
 
+function paginate( arr: Array< any >, currentPage: number ): Array< any > {
+	return (
+		arr
+			// Slices sites list based on pagination settings
+			.slice( SITE_CARDS_PER_PAGE * ( currentPage - 1 ), SITE_CARDS_PER_PAGE * currentPage )
+	);
+}
+
 export default function AssignLicenseForm( { sites, currentPage }: any ): ReactElement {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const [ filter, setFilter ] = useState( false );
+	const [ filter, setFilter ] = useState( null );
 	const [ selectedSite, setSelectedSite ] = useState( false );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const licenseKey = getQueryArg( window.location.href, 'key' ) as string;
 	const onSelectSite = ( site: any ) => setSelectedSite( site );
 
-	const siteCards = sites
-		// Slices sites list based on pagination settings before creating site cards components
-		.slice( SITE_CARDS_PER_PAGE * ( currentPage - 1 ), SITE_CARDS_PER_PAGE * currentPage )
-		.map( ( site: any ) => {
-			if ( -1 !== site.domain.search( filter ) || false === filter ) {
-				return (
-					<Card key={ site.ID } className="assign-license-form__site-card">
-						<FormRadio
-							className="assign-license-form__site-card-radio"
-							label={ site.domain }
-							name="site_select"
-							disabled={ isSubmitting }
-							onClick={ () => onSelectSite( site.ID ) }
-						/>
-					</Card>
-				);
-			}
-		} );
+	const hasFilter = filter === null || '' === filter;
+
+	const siteCards = sites.map( ( site: any ) => {
+		if ( -1 !== site.domain.search( filter ) || null === filter ) {
+			return (
+				<Card key={ site.ID } className="assign-license-form__site-card">
+					<FormRadio
+						className="assign-license-form__site-card-radio"
+						label={ site.domain }
+						name="site_select"
+						disabled={ isSubmitting }
+						onClick={ () => onSelectSite( site.ID ) }
+					/>
+				</Card>
+			);
+		}
+	} );
 
 	const assignLicense = useAssignLicenseMutation( {
 		onSuccess: ( license: any ) => {
@@ -116,15 +123,17 @@ export default function AssignLicenseForm( { sites, currentPage }: any ): ReactE
 				onSearch={ ( query: any ) => setFilter( query ) }
 			/>
 
-			{ siteCards }
+			{ hasFilter ? paginate( siteCards, currentPage ) : siteCards }
 
-			<Pagination
-				className="assign-license-form__pagination"
-				page={ currentPage }
-				perPage={ SITE_CARDS_PER_PAGE }
-				total={ sites.length }
-				pageClick={ onPageClick }
-			/>
+			{ hasFilter && (
+				<Pagination
+					className="assign-license-form__pagination"
+					page={ currentPage }
+					perPage={ SITE_CARDS_PER_PAGE }
+					total={ sites.length }
+					pageClick={ onPageClick }
+				/>
+			) }
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -31,6 +31,7 @@ export default function AssignLicenseForm( { sites, currentPage }: any ): ReactE
 	const onSelectSite = ( site: any ) => setSelectedSite( site );
 
 	const siteCards = sites
+		// Slices sites list based on pagination settings before creating site cards components
 		.slice( SITE_CARDS_PER_PAGE * ( currentPage - 1 ), SITE_CARDS_PER_PAGE * currentPage )
 		.map( ( site: any ) => {
 			if ( -1 !== site.domain.search( filter ) || false === filter ) {

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -5,14 +5,23 @@ import page from 'page';
 import { ReactElement, useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import FormRadio from 'calypso/components/forms/form-radio';
+import Pagination from 'calypso/components/pagination';
 import SearchCard from 'calypso/components/search-card';
+import { SITE_CARDS_PER_PAGE } from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-form/constants';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 import useAssignLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-assign-license-mutation';
 import './style.scss';
 
-export default function AssignLicenseForm( { sites }: any ): ReactElement {
+function setPage( pageNumber: number ): void {
+	const queryParams = { page: pageNumber };
+	const currentPath = window.location.pathname + window.location.search;
+
+	page( addQueryArgs( queryParams, currentPath ) );
+}
+
+export default function AssignLicenseForm( { sites, currentPage }: any ): ReactElement {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const [ filter, setFilter ] = useState( false );
@@ -21,21 +30,23 @@ export default function AssignLicenseForm( { sites }: any ): ReactElement {
 	const licenseKey = getQueryArg( window.location.href, 'key' ) as string;
 	const onSelectSite = ( site: any ) => setSelectedSite( site );
 
-	const siteCards = sites.map( ( site: any ) => {
-		if ( -1 !== site.domain.search( filter ) || false === filter ) {
-			return (
-				<Card key={ site.ID } className="assign-license-form__site-card">
-					<FormRadio
-						className="assign-license-form__site-card-radio"
-						label={ site.domain }
-						name="site_select"
-						disabled={ isSubmitting }
-						onClick={ () => onSelectSite( site.ID ) }
-					/>
-				</Card>
-			);
-		}
-	} );
+	const siteCards = sites
+		.slice( SITE_CARDS_PER_PAGE * ( currentPage - 1 ), SITE_CARDS_PER_PAGE * currentPage )
+		.map( ( site: any ) => {
+			if ( -1 !== site.domain.search( filter ) || false === filter ) {
+				return (
+					<Card key={ site.ID } className="assign-license-form__site-card">
+						<FormRadio
+							className="assign-license-form__site-card-radio"
+							label={ site.domain }
+							name="site_select"
+							disabled={ isSubmitting }
+							onClick={ () => onSelectSite( site.ID ) }
+						/>
+					</Card>
+				);
+			}
+		} );
 
 	const assignLicense = useAssignLicenseMutation( {
 		onSuccess: ( license: any ) => {
@@ -63,6 +74,13 @@ export default function AssignLicenseForm( { sites }: any ): ReactElement {
 
 	const onAssignLater = () =>
 		page.redirect( addQueryArgs( { highlight: licenseKey }, '/partner-portal/licenses' ) );
+
+	const onPageClick = useCallback(
+		( pageNumber: number ) => {
+			setPage( pageNumber );
+		},
+		[ setPage ]
+	);
 
 	return (
 		<div className="assign-license-form">
@@ -98,6 +116,14 @@ export default function AssignLicenseForm( { sites }: any ): ReactElement {
 			/>
 
 			{ siteCards }
+
+			<Pagination
+				className="assign-license-form__sites-pagination"
+				page={ currentPage }
+				perPage={ SITE_CARDS_PER_PAGE }
+				total={ sites.length }
+				pageClick={ onPageClick }
+			/>
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -118,7 +118,7 @@ export default function AssignLicenseForm( { sites, currentPage }: any ): ReactE
 			{ siteCards }
 
 			<Pagination
-				className="assign-license-form__sites-pagination"
+				className="assign-license-form__pagination"
 				page={ currentPage }
 				perPage={ SITE_CARDS_PER_PAGE }
 				total={ sites.length }

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -22,7 +22,7 @@ function setPage( pageNumber: number ): void {
 }
 
 function setSearch( search: string ): void {
-	const queryParams = { search };
+	const queryParams = { search, page: 1 };
 	const currentPath = window.location.pathname + window.location.search;
 
 	page( addQueryArgs( queryParams, currentPath ) );

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
@@ -40,6 +40,10 @@
 			margin: 0 10px;
 		}
 	}
+
+	&__pagination {
+		margin: 64px 0;
+	}
 }
 
 .assign-license-form__top {

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -89,12 +89,14 @@ export function issueLicenseContext( context: PageJS.Context, next: () => void )
 }
 
 export function assignLicenseContext( context: PageJS.Context, next: () => void ): void {
+	const { page } = context.query;
 	const state = context.store.getState();
 	const sites = getSites( state );
+	const currentPage = parseInt( page ) || 1;
 
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
-	context.primary = <AssignLicense sites={ sites } />;
+	context.primary = <AssignLicense sites={ sites } currentPage={ currentPage } />;
 	next();
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -89,14 +89,16 @@ export function issueLicenseContext( context: PageJS.Context, next: () => void )
 }
 
 export function assignLicenseContext( context: PageJS.Context, next: () => void ): void {
-	const { page } = context.query;
+	const { page, search } = context.query;
 	const state = context.store.getState();
 	const sites = getSites( state );
 	const currentPage = parseInt( page ) || 1;
 
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
-	context.primary = <AssignLicense sites={ sites } currentPage={ currentPage } />;
+	context.primary = (
+		<AssignLicense sites={ sites } currentPage={ currentPage } search={ search || '' } />
+	);
 	next();
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -6,7 +6,7 @@ import Main from 'calypso/components/main';
 import AssignLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-form';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 
-export default function AssignLicense( { sites }: any ): ReactElement {
+export default function AssignLicense( { sites, currentPage }: any ): ReactElement {
 	const translate = useTranslate();
 
 	useEffect( () => {
@@ -26,7 +26,7 @@ export default function AssignLicense( { sites }: any ): ReactElement {
 			<SidebarNavigation />
 			<CardHeading size={ 36 }>{ translate( 'Assign your License' ) }</CardHeading>
 
-			<AssignLicenseForm sites={ sites } />
+			<AssignLicenseForm sites={ sites } currentPage={ currentPage } />
 		</Main>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -6,7 +6,15 @@ import Main from 'calypso/components/main';
 import AssignLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-form';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 
-export default function AssignLicense( { sites, currentPage }: any ): ReactElement {
+export default function AssignLicense( {
+	sites,
+	currentPage,
+	search,
+}: {
+	sites: Array< any >;
+	currentPage: number;
+	search: string;
+} ): ReactElement {
 	const translate = useTranslate();
 
 	useEffect( () => {
@@ -26,7 +34,7 @@ export default function AssignLicense( { sites, currentPage }: any ): ReactEleme
 			<SidebarNavigation />
 			<CardHeading size={ 36 }>{ translate( 'Assign your License' ) }</CardHeading>
 
-			<AssignLicenseForm sites={ sites } currentPage={ currentPage } />
+			<AssignLicenseForm sites={ sites } currentPage={ currentPage } search={ search } />
 		</Main>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR completes 1201801459945917-as-1201809016993527/f
* Adds a pagination component to the list of sites on license assignment flow
* I used the same 7 websites per page as shown on designs, but I am not sure if what is a good value to use.

UPDATES
* Pagination is disabled when doing text search

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure to have a Partner Account 👉🏻 PCYsg-zPi-p2
* Issue some license
* Run the following snippet on your console:
```javascript
dispatch(
{
  type: 'SITES_RECEIVE',
  sites: Array(10000).fill(null).map((site, idx) => (
    {
      ID: idx,
      URL: 'http://'+idx+'.com'
    }
  ))
});
```
* Click on "Assign license" on the list of licenses to start the flow, you will be taken to a list of your sites to assign that license to
* The list of sites should have a pagination component at the bottom and behave properly


#### Screenshots

![image](https://user-images.githubusercontent.com/5550190/154728408-037a6b26-ee5e-4b88-8906-3b8c0c686faf.png)

**While searching**
![image](https://user-images.githubusercontent.com/5550190/155773680-4a64b9d3-6343-4832-8c83-c22f7a37b9c8.png)
![image](https://user-images.githubusercontent.com/5550190/155773760-519dbc75-131a-4b1b-a824-462ba65e0f39.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->