### PR TITLE
Add ARIA attributes to quick-links

### DIFF
--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -97,6 +97,7 @@ class FoldableCard extends Component {
 					disabled={ this.props.disabled }
 					type="button"
 					className="foldable-card__action foldable-card__expand"
+					aria-expanded={ this.state.expanded }
 					onClick={ clickAction }
 				>
 					<ScreenReaderText>{ screenReaderText }</ScreenReaderText>

--- a/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
@@ -32,7 +32,9 @@ const ActionBox = ( {
 				'quick-links__action-box__hide-link-indicator': hideLinkIndicator,
 			} ) }
 		>
-			<div className="quick-links__action-box-image">{ getIcon() }</div>
+			<div className="quick-links__action-box-image" aria-hidden="true">
+				{ getIcon() }
+			</div>
 			<div className="quick-links__action-box-text">
 				<span className="quick-links__action-box-label">{ label }</span>
 			</div>

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -23,6 +23,11 @@
 
 	.foldable-card__action {
 		margin-right: 8px;
+
+		&:focus-visible {
+			box-shadow: inset 0 0 0 2px var( --color-primary );
+			outline: 0;
+		}
 	}
 
 	.foldable-card__content {
@@ -100,6 +105,11 @@
 		.quick-links__action-box-icon {
 			fill: var( --color-neutral-80 );
 		}
+	}
+
+	&:focus-visible {
+		box-shadow: inset 0 0 0 2px var( --color-primary );
+		outline: 0;
 	}
 
 	&:last-of-type {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR improves accessibility of the `QuickLinks` component by adding ARIA attributes and better focus states.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to My Home.
* Find the `QuickLinks` component on the right side of the page.
* Using the browser's developer tools, check that the following ARIA attributes are set:
  * The collapse/expand button (chevron) should have a `aria-expanded` value set according to the component state.
  * Decorative icons on the link items should have `aria-hidden="true"`
  * Collapse/expand button should have a blue outline when focused via keyboard.
  * Link items should have a blue outline when focused via keyboard.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53617
