### PR TITLE
Copy and i18n fixes

### DIFF
--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -66,7 +66,7 @@ function WebsiteContentStep( {
 		if ( siteCategory ) {
 			dispatch(
 				initializePages( [
-					{ id: 'Home', name: translate( 'Homepage' ) },
+					{ id: 'Home', name: translate( 'Home' ) },
 					{ id: 'About', name: translate( 'About' ) },
 					{ id: 'Contact', name: translate( 'Contact' ) },
 					getPageFromCategory( siteCategory ),

--- a/client/signup/steps/website-content/page-details.tsx
+++ b/client/signup/steps/website-content/page-details.tsx
@@ -2,7 +2,6 @@ import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
-	SubLabel,
 	Label,
 	TextAreaField,
 	HorizontalGrid,
@@ -62,23 +61,21 @@ export function PageDetails( {
 		<>
 			<TextAreaField
 				name={ fieldName }
-				label={ translate( 'Content' ) }
 				onChange={ onContentChange }
 				value={ page.content }
 				error={ formErrors[ fieldName ] }
-				sublabel={ translate(
+				label={ translate(
 					'Please provide the text you want to appear on your %(pageTitle)s page.',
 					{
 						args: { pageTitle },
 					}
 				) }
 			/>
-			<Label>{ translate( 'Media' ) }</Label>
-			<SubLabel>
-				{ translate( 'Upload up to 3 images to be used on your %(pageTitle)s page', {
+			<Label>
+				{ translate( 'Upload up to 3 images to be used on your %(pageTitle)s page.', {
 					args: { pageTitle },
 				} ) }
-			</SubLabel>
+			</Label>
 			<HorizontalGrid>
 				{ page.images.map( ( image, i ) => (
 					<WordpressMediaUpload

--- a/client/signup/steps/website-content/section-generator.tsx
+++ b/client/signup/steps/website-content/section-generator.tsx
@@ -1,3 +1,4 @@
+import { TranslateResult } from 'i18n-calypso';
 import {
 	AccordionSectionProps,
 	SectionGeneratorReturnType,
@@ -5,10 +6,9 @@ import {
 import { WebsiteContent } from 'calypso/state/signup/steps/website-content/schema';
 import { CONTENT_SUFFIX, PageDetails } from './page-details';
 
-const PAGE_TITLES: Record< string, string > = { Home: 'Homepage' };
-
 export const sectionGenerator = ( params: SectionGeneratorReturnType< WebsiteContent > ) => {
 	const { translate, formValues, formErrors, onChangeField } = params;
+	const PAGE_TITLES: Record< string, TranslateResult > = { Home: translate( 'Homepage' ) };
 	const sections: AccordionSectionProps< WebsiteContent >[] = formValues.map( ( page, index ) => {
 		const fieldNumber = index + 1;
 		const pageTitle = PAGE_TITLES[ page.id ] ? PAGE_TITLES[ page.id ] : page.title;

--- a/client/signup/steps/website-content/section-generator.tsx
+++ b/client/signup/steps/website-content/section-generator.tsx
@@ -8,7 +8,7 @@ import { CONTENT_SUFFIX, PageDetails } from './page-details';
 
 export const sectionGenerator = ( params: SectionGeneratorReturnType< WebsiteContent > ) => {
 	const { translate, formValues, formErrors, onChangeField } = params;
-	const PAGE_TITLES: Record< string, TranslateResult > = { Home: translate( 'Homepage' ) };
+	const PAGE_TITLES: Record< string, TranslateResult > = { Home: translate( 'Home' ) };
 	const sections: AccordionSectionProps< WebsiteContent >[] = formValues.map( ( page, index ) => {
 		const fieldNumber = index + 1;
 		const pageTitle = PAGE_TITLES[ page.id ] ? PAGE_TITLES[ page.id ] : page.title;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: pdh1Xd-xv-p2#comment-832

1. Change the title of the "Home" page from `Homepage` to `Home`.
2. Remove the "Content" and "Media" labels on the website content step.
3. Adds `translate` to the static `PAGE_TITLES` array.

<img width="1631" alt="image" src="https://user-images.githubusercontent.com/5436027/154420162-b679755e-6817-4f07-a21a-00c189c1c63f.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the DIFM lite purchase flow (`/start/do-if-for-me`) and make sure that after checkout you see the website content filling page.
* Confirm that it matches the screenshot above.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
