### PR TITLE
Improve focus state for components in My Home

### DIFF
--- a/client/blocks/get-apps/apps-badge.scss
+++ b/client/blocks/get-apps/apps-badge.scss
@@ -2,8 +2,16 @@
 	display: flex;
 	max-width: 135px;
 	max-height: 40px;
-	overflow: hidden;
 	margin-left: 0.5rem;
+
+	// Set overflow: hidden here instead of the parent node so that its focus outline is not cut-off.
+	> a {
+		overflow: hidden;
+
+		&:focus-visible {
+			box-shadow: 0 0 0 2px var( --color-primary );
+		}
+	}
 
 	&:first-child {
 		margin-left: 0;

--- a/client/components/dot-pager/style.scss
+++ b/client/components/dot-pager/style.scss
@@ -44,6 +44,10 @@
 	&:disabled {
 		cursor: default;
 	}
+
+	&:focus-visible {
+		box-shadow: 0 0 0 2px var( --color-primary );
+	}
 }
 
 .dot-pager__control-prev,

--- a/client/my-sites/customer-home/cards/education/educational-content/style.scss
+++ b/client/my-sites/customer-home/cards/education/educational-content/style.scss
@@ -25,6 +25,7 @@
 			color: var( --color-link );
 			font-size: 1rem;
 			cursor: pointer;
+
 			&:hover {
 				color: var( --color-link-dark );
 			}
@@ -38,6 +39,14 @@
 		.material-icon {
 			margin-right: 0.5rem;
 			fill: var( --color-neutral-60 );
+		}
+
+		button,
+		.inline-support-link {
+			&:focus-visible {
+				box-shadow: inset 0 0 0 2px var( --color-primary );
+				outline: none;
+			}
 		}
 	}
 }

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -50,6 +50,11 @@
 
 .stats .inline-support-link {
 	margin-left: 4px;
+
+	&:focus-visible {
+		box-shadow: 0 0 0 2px var( --color-primary );
+		outline: 0;
+	}
 }
 
 .stats__empty {

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -194,6 +194,12 @@
 		margin-top: 0;
 	}
 
+	.site-setup-list__task-skip {
+		&:focus-visible {
+			box-shadow: 0 0 0 2px var( --color-primary );
+		}
+	}
+
 	.spinner {
 		position: absolute;
 		left: 50%;

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -87,6 +87,14 @@
 		padding-top: 0;
 		margin-top: auto;
 		font-size: $font-body-small;
+
+		.is-link {
+			padding: 0 8px;
+	
+			&:focus-visible {
+				box-shadow: 0 0 0 2px var( --color-primary );
+			}
+		}
 	}
 
 	.task__action {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the focus state on several components used in My Home so that they are most consistent and clearer.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to My Home.
* Check that a blue outline shows for the components below.

![Screen Shot 2022-02-15 at 5 03 36 PM](https://user-images.githubusercontent.com/797888/154028557-ed0d7517-996f-43cd-a0c9-459937f55d9b.png)

![Screen Shot 2022-02-15 at 5 17 56 PM](https://user-images.githubusercontent.com/797888/154031086-48339e1e-ce75-4ae4-8499-0db725119159.png)


![image](https://user-images.githubusercontent.com/13596067/154191098-deb53e3e-a2d1-4874-a196-7d3f230e09f6.png)

![image](https://user-images.githubusercontent.com/13596067/154190596-b40da667-ae24-4b68-af13-e95b39f34275.png)

![Screen Shot 2022-02-17 at 3 23 03 PM](https://user-images.githubusercontent.com/797888/154425716-182c28eb-04da-4a03-873a-283a8973164a.png)


![image](https://user-images.githubusercontent.com/13596067/154190777-52e12fff-4e90-4b6c-be44-a5116a5a1bbd.png)
 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53617
