### PR TITLE
Settings: fix security support links

### DIFF
--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -84,6 +84,7 @@ class SiteSettingsFormSecurity extends Component {
 
 				<SettingsSectionHeader title={ translate( 'WordPress.com log in' ) } />
 				<Sso
+					siteIsAutomatedTransfer={ isAtomic }
 					handleAutosavingToggle={ handleAutosavingToggle }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -23,7 +23,7 @@ class SiteSettingsFormSecurity extends Component {
 			fields,
 			handleAutosavingToggle,
 			handleSubmitForm,
-			siteIsAutomatedTransfer,
+			isAtomic,
 			isRequestingSettings,
 			isSavingSettings,
 			onChangeField,
@@ -62,7 +62,7 @@ class SiteSettingsFormSecurity extends Component {
 
 				<QueryJetpackSettings siteId={ siteId } />
 
-				{ ! siteIsAutomatedTransfer && (
+				{ ! isAtomic && (
 					<div>
 						<SettingsSectionHeader
 							disabled={ isRequestingSettings || isSavingSettings || disableSpamFiltering }
@@ -84,7 +84,7 @@ class SiteSettingsFormSecurity extends Component {
 
 				<SettingsSectionHeader title={ translate( 'WordPress.com log in' ) } />
 				<Sso
-					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
+					isAtomic={ isAtomic }
 					handleAutosavingToggle={ handleAutosavingToggle }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
@@ -97,7 +97,7 @@ class SiteSettingsFormSecurity extends Component {
 
 const connectComponent = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const siteIsAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
+	const isAtomic = isSiteAutomatedTransfer( state, siteId );
 	const protectModuleActive = !! isJetpackModuleActive( state, siteId, 'protect' );
 	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, siteId );
 	const protectIsUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
@@ -113,7 +113,7 @@ const connectComponent = connect( ( state ) => {
 
 	return {
 		siteId,
-		siteIsAutomatedTransfer,
+		isAtomic,
 		protectModuleActive,
 		protectModuleUnavailable: siteInDevMode && protectIsUnavailableInDevMode,
 		akismetUnavailable: siteInDevMode && akismetIsUnavailableInDevMode,

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -23,7 +23,7 @@ class SiteSettingsFormSecurity extends Component {
 			fields,
 			handleAutosavingToggle,
 			handleSubmitForm,
-			isAtomic,
+			siteIsAutomatedTransfer,
 			isRequestingSettings,
 			isSavingSettings,
 			onChangeField,
@@ -62,7 +62,7 @@ class SiteSettingsFormSecurity extends Component {
 
 				<QueryJetpackSettings siteId={ siteId } />
 
-				{ ! isAtomic && (
+				{ ! siteIsAutomatedTransfer && (
 					<div>
 						<SettingsSectionHeader
 							disabled={ isRequestingSettings || isSavingSettings || disableSpamFiltering }
@@ -84,7 +84,7 @@ class SiteSettingsFormSecurity extends Component {
 
 				<SettingsSectionHeader title={ translate( 'WordPress.com log in' ) } />
 				<Sso
-					siteIsAutomatedTransfer={ isAtomic }
+					siteIsAutomatedTransfer={ siteIsAutomatedTransfer }
 					handleAutosavingToggle={ handleAutosavingToggle }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
@@ -97,7 +97,7 @@ class SiteSettingsFormSecurity extends Component {
 
 const connectComponent = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const isAtomic = isSiteAutomatedTransfer( siteId );
+	const siteIsAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
 	const protectModuleActive = !! isJetpackModuleActive( state, siteId, 'protect' );
 	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, siteId );
 	const protectIsUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
@@ -112,7 +112,8 @@ const connectComponent = connect( ( state ) => {
 	);
 
 	return {
-		isAtomic,
+		siteId,
+		siteIsAutomatedTransfer,
 		protectModuleActive,
 		protectModuleUnavailable: siteInDevMode && protectIsUnavailableInDevMode,
 		akismetUnavailable: siteInDevMode && akismetIsUnavailableInDevMode,

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -13,7 +13,7 @@ import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-s
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const Sso = ( {
-	siteIsAutomatedTransfer,
+	isAtomic,
 	fields,
 	handleAutosavingToggle,
 	isRequestingSettings,
@@ -34,7 +34,7 @@ const Sso = ( {
 							'Allows registered users to log in to your site with their WordPress.com accounts.'
 						) }
 						link={
-							siteIsAutomatedTransfer
+							isAtomic
 								? 'https://wordpress.com/en/support/wordpress-com-secure-sign-on-sso/'
 								: 'https://jetpack.com/support/sso/'
 						}
@@ -87,7 +87,7 @@ Sso.defaultProps = {
 };
 
 Sso.propTypes = {
-	siteIsAutomatedTransfer: PropTypes.bool,
+	isAtomic: PropTypes.bool,
 	siteIsJetpack: PropTypes.bool,
 	handleAutosavingToggle: PropTypes.func.isRequired,
 	isSavingSettings: PropTypes.bool,

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -13,6 +13,7 @@ import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-s
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const Sso = ( {
+	siteIsAutomatedTransfer,
 	fields,
 	handleAutosavingToggle,
 	isRequestingSettings,
@@ -32,7 +33,12 @@ const Sso = ( {
 						text={ translate(
 							'Allows registered users to log in to your site with their WordPress.com accounts.'
 						) }
-						link="https://jetpack.com/support/sso/"
+						link={
+							siteIsAutomatedTransfer
+								? 'https://wordpress.com/en/support/wordpress-com-secure-sign-on-sso/'
+								: 'https://jetpack.com/support/sso//#testimonials'
+						}
+						privacyLink="https://jetpack.com/support/sso/#privacy"
 					/>
 
 					<JetpackModuleToggle
@@ -81,6 +87,8 @@ Sso.defaultProps = {
 };
 
 Sso.propTypes = {
+	siteIsAutomatedTransfer: PropTypes.bool,
+	siteIsJetpack: PropTypes.bool,
 	handleAutosavingToggle: PropTypes.func.isRequired,
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -38,7 +38,7 @@ const Sso = ( {
 								? 'https://wordpress.com/en/support/wordpress-com-secure-sign-on-sso/'
 								: 'https://jetpack.com/support/sso/'
 						}
-						privacyLink={ isAtomic }
+						privacyLink={ ! isAtomic }
 					/>
 
 					<JetpackModuleToggle

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -38,7 +38,7 @@ const Sso = ( {
 								? 'https://wordpress.com/en/support/wordpress-com-secure-sign-on-sso/'
 								: 'https://jetpack.com/support/sso/'
 						}
-						privacyLink="https://jetpack.com/support/sso/#privacy"
+						privacyLink={ isAtomic }
 					/>
 
 					<JetpackModuleToggle
@@ -88,7 +88,6 @@ Sso.defaultProps = {
 
 Sso.propTypes = {
 	isAtomic: PropTypes.bool,
-	siteIsJetpack: PropTypes.bool,
 	handleAutosavingToggle: PropTypes.func.isRequired,
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -36,7 +36,7 @@ const Sso = ( {
 						link={
 							siteIsAutomatedTransfer
 								? 'https://wordpress.com/en/support/wordpress-com-secure-sign-on-sso/'
-								: 'https://jetpack.com/support/sso//#testimonials'
+								: 'https://jetpack.com/support/sso/'
 						}
 						privacyLink="https://jetpack.com/support/sso/#privacy"
 					/>


### PR DESCRIPTION
## Changes proposed in this Pull Request
Similar to the other fixes ( #60962, #61175 ) this uses the `siteIsAutomatedTransfer` prop with a ternary operator to change links depending on the context. I also changed `isAtomic` to `siteIsAutomatedTransfer` to match the naming in the other setting components.

There was also an error with the check for `isAtomic`, the selector needed to have the state passed along with the siteId. This was causing the check to return `NULL` and showing this when it shoudln't have:

## Screenshots
#### Before
<img width="909" alt="Markup 2022-02-17 at 11 56 23" src="https://user-images.githubusercontent.com/33258733/154467931-dd4206ed-a036-44e6-809a-d5bab35f13b7.png">

#### After
<img width="1464" alt="Markup 2022-02-17 at 12 03 06" src="https://user-images.githubusercontent.com/33258733/154468412-4ef513b5-2f30-4be2-a0b1-03ba394a3eca.png">

## Testing instructions
1. Load the branch and launch calypso `yarn start`
2. Go to Settings ⇢ Security
3. Click the `( i )` and verify the links all work as explained
4. Make sure the Akismet section is only showing for JPOP sites
5. Repeat the test with Simple, Atomic, and Jetpack sites


Fixes #59975 