### PR TITLE
DIFM Lite: Make local services the top category & remove the Blog category

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -696,7 +696,7 @@ export function generateSteps( {
 				hideExternalPreview: true,
 				useDIFMThemes: true,
 				showDesignPickerCategories: true,
-				showDesignPickerCategoriesAllFilter: false,
+				showDesignPickerCategoriesAllFilter: true,
 				showLetUsChoose: true,
 				hideFullScreenPreview: true,
 				hideDesignTitle: true,

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -154,6 +154,14 @@ export default function DesignPickerStep( props ) {
 				result.sort = sortBlogToTop;
 				break;
 		}
+
+		// This is a temporary change until DIFM Lite switches to the full WPCOM theme catalog.
+		// We'll then use the 'difm' intent here.
+		if ( props.useDIFMThemes ) {
+			result.defaultSelection = null;
+			result.sort = sortLocalServicesToTop;
+		}
+
 		return result;
 	};
 	const categorization = useCategorization( designs, getCategorizationOptionsForStep() );
@@ -418,6 +426,17 @@ function sortEcommerceToTop( a, b ) {
 	} else if ( a.slug === 'business' ) {
 		return -1;
 	} else if ( b.slug === 'business' ) {
+		return 1;
+	}
+	return 0;
+}
+
+function sortLocalServicesToTop( a, b ) {
+	if ( a.slug === b.slug ) {
+		return 0;
+	} else if ( a.slug === 'local-services' ) {
+		return -1;
+	} else if ( b.slug === 'local-services' ) {
 		return 1;
 	}
 	return 0;

--- a/client/signup/steps/difm-design-picker/themes.tsx
+++ b/client/signup/steps/difm-design-picker/themes.tsx
@@ -7,10 +7,6 @@ const difmThemes: Design[] = [
 				name: 'Creative Arts',
 				slug: 'creative-arts',
 			},
-			{
-				name: 'Blog',
-				slug: 'blog',
-			},
 		],
 		features: [ 'difm-lite-default' ],
 		is_premium: false,
@@ -25,10 +21,6 @@ const difmThemes: Design[] = [
 				name: 'Creative Arts',
 				slug: 'creative-arts',
 			},
-			{
-				name: 'Blog',
-				slug: 'blog',
-			},
 		],
 		features: [],
 		is_premium: false,
@@ -38,13 +30,7 @@ const difmThemes: Design[] = [
 		title: 'Zoologist',
 	},
 	{
-		categories: [
-			{ name: 'Professional Services', slug: 'professional-services' },
-			{
-				name: 'Blog',
-				slug: 'blog',
-			},
-		],
+		categories: [ { name: 'Professional Services', slug: 'professional-services' } ],
 		features: [],
 		is_premium: false,
 		slug: 'quadrat',
@@ -53,13 +39,7 @@ const difmThemes: Design[] = [
 		title: 'Quadrat',
 	},
 	{
-		categories: [
-			{ name: 'Creative Arts', slug: 'creative-arts' },
-			{
-				name: 'Blog',
-				slug: 'blog',
-			},
-		],
+		categories: [ { name: 'Creative Arts', slug: 'creative-arts' } ],
 		features: [],
 		is_premium: false,
 		slug: 'geologist',
@@ -114,10 +94,6 @@ const difmThemes: Design[] = [
 			{
 				name: 'Creative Arts',
 				slug: 'creative-arts',
-			},
-			{
-				name: 'Blog',
-				slug: 'blog',
 			},
 		],
 		features: [],
@@ -300,10 +276,6 @@ const difmThemes: Design[] = [
 				name: 'Creative Arts',
 				slug: 'creative-arts',
 			},
-			{
-				name: 'Blog',
-				slug: 'blog',
-			},
 		],
 		features: [],
 		is_premium: false,
@@ -317,11 +289,6 @@ const difmThemes: Design[] = [
 			{
 				name: 'Local Services',
 				slug: 'local-services',
-			},
-
-			{
-				name: 'Blog',
-				slug: 'blog',
 			},
 		],
 		features: [],
@@ -337,10 +304,6 @@ const difmThemes: Design[] = [
 				name: 'Creative Arts',
 				slug: 'creative-arts',
 			},
-			{
-				name: 'Blog',
-				slug: 'blog',
-			},
 		],
 		features: [],
 		is_premium: false,
@@ -354,10 +317,6 @@ const difmThemes: Design[] = [
 			{
 				name: 'Creative Arts',
 				slug: 'creative-arts',
-			},
-			{
-				name: 'Blog',
-				slug: 'blog',
 			},
 		],
 		features: [],

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -84,15 +84,12 @@ function WebsiteContentStep( {
 	useEffect( () => {
 		function getPageFromCategory( category: string | null ) {
 			switch ( category ) {
-				case 'professional-services':
-				case 'local-services':
-					return { id: 'Services', name: translate( 'Services' ) };
 				case 'creative-arts':
 					return { id: 'Portfolio', name: translate( 'Portfolio' ) };
 				case 'restaurant':
 					return { id: 'Menu', name: translate( 'Menu' ) };
 				default:
-					return { id: 'Blog', name: translate( 'Blog' ) };
+					return { id: 'Services', name: translate( 'Services' ) };
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: pdh1Xd-xv-p2#comment-804

* Makes "Local Services" the top category in the design picker for the DIFM Lite signup flow.
* Enables the "Show All" filter in the category list.
* Removes the "Blog" category from the DIFM Lite flow. (pdh1Xd-Fe-p2#comment-918)
  * Removes the Blog category from the DIFM themes list.
  * Makes "Services" the default category on the Website Content step. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the DIFM Lite flow by going to `/start/do-it-for-me`.
* Click on "New Site".
* On the Design Picker step, confirm that "Local Services" is the first category.
* Confirm that you see the "Show All" filter.
* Confirm that there is no "Blog" category.

<img width="1430" alt="image" src="https://user-images.githubusercontent.com/5436027/155469167-3d7f22f6-7f04-45c9-8f87-fd6cc1d0d7a8.png">

* Complete checkout. On the Website Content page, confirm that the last page title is "Services"

**Testing for regressions**
* Go to `/start/setup-site/design-setup-site?siteSlug=<site slug>`.
* Confirm that "Blog" is the first category.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->