### PR TITLE
Redirect Jetpack installation to the new tab

### DIFF
--- a/client/signup/steps/import-from/wordpress/index.tsx
+++ b/client/signup/steps/import-from/wordpress/index.tsx
@@ -52,7 +52,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	 ↓ Methods
 	 */
 	function installJetpack() {
-		page( `https://wordpress.com/jetpack/connect/?url=${ fromSite }` );
+		window.open( `/jetpack/connect/?url=${ fromSite }`, '_blank' );
 	}
 
 	function switchToMigrationScreen() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Redirect Jetpack installation to the new tab

#### Testing instructions

* Go to `/start/importer/capture?siteSlug={SLUG}.wordpress.com`
* Enter the URL of a self-hosted WP site without an established Jetpack connection (you can create a test site from jurassic.ninja)
* Press the "Import your content" button
* Press the "Install Jetpack" button
* Check if the installation process is in a new browser tab

Related to #59042
