### PR TITLE
TeamCity: Fix Translate build publish artifacts during the build step

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -571,10 +571,6 @@ object Translate : BuildType({
 		cleanCheckout = true
 	}
 
-	artifactRules = """
-		translate => translate
-	""".trimIndent()
-
 	steps {
 		bashNodeScript {
 			name = "Prepare environment"
@@ -593,6 +589,9 @@ object Translate : BuildType({
 				# Move `calypso-strings.pot` to artifacts directory
 				mkdir -p ./translate
 				mv public/calypso-strings.pot ./translate/
+
+				# Publish calypso-string.pot artifact
+				echo "##teamcity[publishArtifacts './translate/calypso-strings.pot']"
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}
@@ -611,6 +610,9 @@ object Translate : BuildType({
 
 				# Remove GP LocalCI Client
 				rm -rf gp-localci-client
+
+				# Publish localci-new-strings.pot artifact
+				echo "##teamcity[publishArtifacts './translate/localci-new-strings.pot']"
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove artifact rules in favour of using [service message in order to publish the artifacts during the build process](https://www.jetbrains.com/help/teamcity/service-messages.html#Publishing+Artifacts+While+Build+is+in+Progress), instead of when it finishes. This is a required change as we need to make sure artifacts are already available when we notify GlotPress.

#### Testing instructions

* TeamCity Translate build pass.
* Check TeamCity build logs to confirm response from GlotPress is ok.
