### PR TITLE
Redirect to new thank-you page in domain-only:add-existing-site flow

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -231,8 +231,8 @@ export default function getThankYouPageUrl( {
 			? `${ urlFromCookie }/${ pendingOrReceiptId }`
 			: fallbackUrl;
 		debug( 'new blog created, so returning', newBlogReceiptUrl );
-		// Subflow domain:add-new-site must skip the thankyou page
-		if ( newBlogReceiptUrl.includes( '/thank-you/' ) ) {
+		// Skip composed url if we have to redirect to intent flow
+		if ( ! newBlogReceiptUrl.includes( '/start/setup-site' ) ) {
 			return newBlogReceiptUrl;
 		}
 	}

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -576,6 +576,23 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/cookie/1234abcd' );
 	} );
 
+	it( 'redirects to url from cookie followed by receipt id if create_new_blog is not set but wpcom_signup_complete_flow_name from session storage is equal to "domain"', () => {
+		const getUrlFromCookie = jest.fn( () => '/cookie' );
+		window.sessionStorage.setItem( 'wpcom_signup_complete_flow_name', 'domain' );
+		const cart = {
+			create_new_blog: false,
+			products: [ { id: '123' } ],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+			receiptId: '1234abcd',
+			getUrlFromCookie,
+		} );
+		expect( url ).toBe( '/cookie/1234abcd' );
+	} );
+
 	it( 'redirects to url from cookie followed by pending order id if create_new_blog is set', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -85,10 +85,13 @@ function getLaunchDestination( dependencies ) {
 	return `/home/${ dependencies.siteSlug }`;
 }
 
-function getDomainSignupFlowDestination( { domainItem, cartItem, siteId } ) {
-	if ( domainItem && cartItem ) {
+function getDomainSignupFlowDestination( { domainItem, cartItem, siteId, designType, siteSlug } ) {
+	if ( domainItem && cartItem && designType !== 'existing-site' ) {
 		return addQueryArgs( { siteId }, '/start/setup-site' );
+	} else if ( designType === 'existing-site' ) {
+		return `/checkout/thank-you/${ siteSlug }`;
 	}
+
 	return getThankYouNoSiteDestination();
 }
 

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -32,3 +32,5 @@ export const getSignupCompleteFlowName = () =>
 	sessionStorage.getItem( 'wpcom_signup_complete_flow_name' );
 export const setSignupCompleteFlowName = ( value ) =>
 	sessionStorage.setItem( 'wpcom_signup_complete_flow_name', value );
+export const clearSignupCompleteFlowName = () =>
+	sessionStorage.removeItem( 'wpcom_signup_complete_flow_name' );


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR redirect the domain only signup flow (subflow "Existing WordPress.com site") to the redesigned than you page.

It's part of the new domain-only flow (pcYYhz-ye-p2)

![new-thankyou-fixed](https://user-images.githubusercontent.com/2797601/154714630-9e2e9575-3476-4d43-8f5d-7f1a8ce3d053.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- Navigate to to `/start/domain`
- Type a domain name
- In the next step, choose "Existing WordPress.com site", then select a site
- Complete the checkout and verify that the new thankyou page is rendered 
