### PR TITLE
Plugins: Only offer email support for monthly plans 

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -46,11 +46,10 @@ const USPS: React.FC< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 
+	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
+
 	const planDisplayCost = useSelector( ( state ) =>
-		getProductDisplayCost(
-			state,
-			billingPeriod === IntervalLength.ANNUALLY ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY
-		)
+		getProductDisplayCost( state, isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY )
 	);
 
 	const filteredUSPS = [
@@ -113,7 +112,9 @@ const USPS: React.FC< Props > = ( {
 					{
 						id: 'support',
 						image: <Gridicon icon="chat" size={ 16 } />,
-						text: translate( 'Live chat support 24x7' ),
+						text: isAnnualPeriod
+							? translate( 'Live chat support 24x7' )
+							: translate( 'Unlimited Email Support' ),
 						eligibilities: [ 'needs-upgrade', 'marketplace' ],
 					},
 			  ]

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -1,5 +1,6 @@
 import { useBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
+import { Fragment } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import FoldableCard from 'calypso/components/foldable-card';
 
@@ -69,14 +70,14 @@ const PluginDetailsSidebarUSP = ( { id, icon, title, description, links, first }
 			{ ! isNarrow && <Header /> }
 			<Description>{ description }</Description>
 			{ links &&
-				links.map( ( link ) => {
+				links.map( ( link, idx ) => {
 					return (
-						<>
+						<Fragment key={ idx }>
 							<ExternalLink icon href={ link.href }>
 								{ link.label }
 							</ExternalLink>
 							<br />
-						</>
+						</Fragment>
 					);
 				} ) }
 		</Container>

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -4,6 +4,7 @@ import eye from 'calypso/assets/images/marketplace/eye.svg';
 import support from 'calypso/assets/images/marketplace/support.svg';
 import wooLogo from 'calypso/assets/images/marketplace/woo-logo.svg';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
 
 const PluginDetailsSidebar = ( {
@@ -14,8 +15,11 @@ const PluginDetailsSidebar = ( {
 		demo_url = null,
 		documentation_url = null,
 	},
+	billingPeriod,
 } ) => {
 	const translate = useTranslate();
+
+	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
 
 	if ( ! isMarketplaceProduct ) {
 		return (
@@ -91,7 +95,11 @@ const PluginDetailsSidebar = ( {
 				id="support"
 				icon={ { src: support } }
 				title={ translate( 'Support' ) }
-				description={ translate( 'Live chat support 24x7.' ) }
+				description={
+					isAnnualPeriod
+						? translate( 'Live chat support 24x7.' )
+						: translate( 'Unlimited Email Support' )
+				}
 				links={ supportLinks }
 			/>
 		</div>

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -1,11 +1,13 @@
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
+import { useSelector } from 'react-redux';
 import eye from 'calypso/assets/images/marketplace/eye.svg';
 import support from 'calypso/assets/images/marketplace/support.svg';
 import wooLogo from 'calypso/assets/images/marketplace/woo-logo.svg';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
+import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 
 const PluginDetailsSidebar = ( {
 	plugin: {
@@ -15,10 +17,9 @@ const PluginDetailsSidebar = ( {
 		demo_url = null,
 		documentation_url = null,
 	},
-	billingPeriod,
 } ) => {
 	const translate = useTranslate();
-
+	const billingPeriod = useSelector( getBillingInterval );
 	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
 
 	if ( ! isMarketplaceProduct ) {

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -97,7 +97,7 @@ const PluginDetailsSidebar = ( {
 				title={ translate( 'Support' ) }
 				description={
 					isAnnualPeriod
-						? translate( 'Live chat support 24x7.' )
+						? translate( 'Live chat support 24x7' )
 						: translate( 'Unlimited Email Support' )
 				}
 				links={ supportLinks }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -339,7 +339,7 @@ function PluginDetails( props ) {
 								) }
 							</div>
 							<div className="plugin-details__layout-col-right">
-								<PluginDetailsSidebar plugin={ fullPlugin } />
+								<PluginDetailsSidebar plugin={ fullPlugin } billingPeriod={ billingPeriod } />
 							</div>
 						</div>
 					</>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -339,7 +339,7 @@ function PluginDetails( props ) {
 								) }
 							</div>
 							<div className="plugin-details__layout-col-right">
-								<PluginDetailsSidebar plugin={ fullPlugin } billingPeriod={ billingPeriod } />
+								<PluginDetailsSidebar plugin={ fullPlugin } />
 							</div>
 						</div>
 					</>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The plugin details page will show `Unlimited Email Support` for monthly
plans and `Live chat support 24x7` for Annual plans.

|Before | After|
|-------|------|
|![image](https://user-images.githubusercontent.com/3519124/154542415-1f6df76d-5ff6-4b37-99cd-0a1915f9f555.png)|![image](https://user-images.githubusercontent.com/3519124/154541497-d17099e6-9092-4ff6-87d4-de6a173f27d4.png)|
|![image](https://user-images.githubusercontent.com/3519124/154542016-84d37b4c-c4c5-4642-b619-c0b99079f3ec.png)|![image](https://user-images.githubusercontent.com/3519124/154541254-bcc4e304-a214-4713-b45c-57116da11d2c.png)|

#### Testing instructions

* In a Business or eCommerce plan
* Go to plugins and add a Premium plugin
* Select Monthly period for the plugin
  * There should be a message in the Plugin details section (see screenshots above) that reads: `Unlimited Email Support`  
* Select Annually period for the plugin
  * There should be a message in the Plugin details section (see screenshots above) that reads: `Live chat support 24x7`


Fixes #59753 
