### PR TITLE
e2e: Add basic plugins page test

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -24,5 +24,6 @@ export * from './p2-page';
 export * from './woocommerce-landing-page';
 export * from './posts-page';
 export * from './pages-page';
+export * from './plugins-page';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -1,0 +1,34 @@
+import { Page } from 'playwright';
+import { getCalypsoURL } from '../../data-helper';
+
+const selectors = {
+	sectionTitle: ( section: string ) => `.plugins-browser-list__title:text("${ section }")`,
+};
+
+/**
+ * Plugins page https://wordpress.com/plugins/.
+ */
+export class PluginsPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Visit /plugins/*
+	 */
+	async visit( route?: string ): Promise< void > {
+		await this.page.goto( getCalypsoURL( `${ route || '' }` ) );
+	}
+
+	/**
+	 * Has Section
+	 */
+	async hasSection( section: string ): Promise< void > {
+		await this.page.waitForSelector( selectors.sectionTitle( section ) );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/woocommerce-landing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/woocommerce-landing-page.ts
@@ -1,6 +1,6 @@
 import { Page } from 'playwright';
 
-export const selectors = {
+const selectors = {
 	start: '.woocommerce .empty-content button:text("Start a new store")',
 	installer: '.is-woocommerce-install',
 	learnMore: '.woocommerce span:text("Learn more")',

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -1,0 +1,31 @@
+/**
+ * @group calypso-pr
+ */
+
+import { DataHelper, TestAccount, PluginsPage } from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'WooCommerce Landing Page' ), function () {
+	let page: Page;
+	let pluginsPage: PluginsPage;
+	let siteUrl: string;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+
+		const testAccount = new TestAccount( 'defaultUser' );
+		await testAccount.authenticate( page );
+		siteUrl = testAccount.getSiteURL( { protocol: false } );
+	} );
+
+	it( 'Plugins page loads premium,featured,popular,new sections', async function () {
+		pluginsPage = new PluginsPage( page );
+		await pluginsPage.visit( `/plugins/${ siteUrl }` );
+		await pluginsPage.hasSection( 'Premium' );
+		await pluginsPage.hasSection( 'Featured' );
+		await pluginsPage.hasSection( 'Popular' );
+		await pluginsPage.hasSection( 'New' );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds basic plugins page e2e test

#### Testing instructions
```
cd e2e/tests
yarn workspace @automattic/calypso-e2e build && yarn jest specs/plugins/plugins__browse.ts         
```

Related to https://github.com/Automattic/wp-calypso/issues/61094
