### PR TITLE
Add support to LocaleSwitcher for handling URLs already containing a locale value

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-footer/locale-switcher/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-footer/locale-switcher/index.tsx
@@ -40,7 +40,9 @@ const LocaleSwitcher: React.FC< Props > = ( { isVisible, onClose } ) => {
 		: [];
 	const absoluteHref =
 		typeof window !== 'undefined'
-			? window.location.href.replace( window.location.origin, '' )
+			? window.location.href
+					.replace( window.location.origin, '' )
+					.replace( new RegExp( `^(/${ selectedLocale }/)` ), '/' )
 			: '/pricing';
 
 	const onMouseOver = useCallback( ( code ) => setSelectedLocale( code ), [ setSelectedLocale ] );

--- a/client/jetpack-cloud/sections/pricing/jpcom-footer/locale-switcher/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-footer/locale-switcher/index.tsx
@@ -42,7 +42,7 @@ const LocaleSwitcher: React.FC< Props > = ( { isVisible, onClose } ) => {
 		typeof window !== 'undefined'
 			? window.location.href
 					.replace( window.location.origin, '' )
-					.replace( new RegExp( `^(/${ selectedLocale }/)` ), '/' )
+					.replace( new RegExp( `^(/${ defaultLocale }/)` ), '/' )
 			: '/pricing';
 
 	const onMouseOver = useCallback( ( code ) => setSelectedLocale( code ), [ setSelectedLocale ] );


### PR DESCRIPTION
This PR addresses a bug where changing the locale for a second time on the Jetpack pricing page results in a 404 (1164141197617539-as-1201845976325723).

This issue was due to an update where the locale parameter was kept in the URL (i.e. `/en/pricing`, `/fr/pricing` instead of just `/pricing`), while the `<LocaleSwitcher>` does not expect the URL to include the locale prefix. This resulted in the locale switcher creating links such as `/en/fr/pricing`.

#### Changes proposed in this Pull Request

* This PR adds support to `<LocaleSwitcher>` to handle URLs with a locale prefix.
* This is accomplished by removing the locale prefix from the start of the current URL, before prefixing it with the newly selected locale code. 
* A regular expression was used in this case to ensure the locale is only trimmed when it is at the beginning of the absolute href value.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `git checkout fix/locale-switcher-absolute-href` 
* `yarn start-jetpack-cloud`
* Open http://jetpack.cloud.localhost:3000/pricing
* Scroll down to the footer and open the language switcher, select a language.
* Validate the language on the page is updated, and the URL is updated to `/[LANGUAGE_CODE_YOU_CHOSE]/pricing`.
* Open the language picker a second time, and select another language.
* Validate the language and URL are updated correctly.
* Repeat above test with pricing URL variations such as:
  * /pricing/[SITE]
  * /pricing/storage/[SITE]

#### Screenshots

**Before:**

![before](https://user-images.githubusercontent.com/10933065/154743679-5ee4ef13-858e-4dfb-b3ff-f6338ead143c.gif)

**After:**

![after](https://user-images.githubusercontent.com/10933065/154743726-5d47cabe-548c-4fa8-8f48-1a4d5a39fb98.gif)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60852