### PR TITLE
e2e: Add test to confirm jetpack users don't see paid plugins

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -1,8 +1,9 @@
+import assert from 'assert';
 import { Page } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 
 const selectors = {
-	sectionTitle: ( section: string ) => `.plugins-browser-list__title:text("${ section }")`,
+	sectionTitle: '.plugins-browser-list__title',
 };
 
 /**
@@ -28,7 +29,14 @@ export class PluginsPage {
 	/**
 	 * Has Section
 	 */
-	async hasSection( section: string ): Promise< void > {
-		await this.page.waitForSelector( selectors.sectionTitle( section ) );
+	async onlyHasSections( sections: Array< string > ): Promise< void > {
+		await this.page.waitForSelector( selectors.sectionTitle );
+		const titles = await this.page.locator( selectors.sectionTitle );
+		const count = await titles.count();
+		assert.strictEqual( count, sections.length );
+		for ( let i = 0; i < count; i++ ) {
+			const title = await titles.nth( i ).innerText();
+			assert.strictEqual( title, sections[ i ] );
+		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -20,10 +20,17 @@ export class PluginsPage {
 	}
 
 	/**
-	 * Visit /plugins/*
+	 * Visit /plugins or /plugins/:site
 	 */
-	async visit( route?: string ): Promise< void > {
-		await this.page.goto( getCalypsoURL( `${ route || '' }` ) );
+	async visit( site = '' ): Promise< void > {
+		await this.page.goto( getCalypsoURL( `plugins/${ site }` ) );
+	}
+
+	/**
+	 * Visit /plugins/:page/ or /plugins/:page/:site
+	 */
+	async visitPage( page: string, site = '' ): Promise< void > {
+		await this.page.goto( getCalypsoURL( `plugins/${ page }/${ site }` ) );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -45,9 +45,10 @@ export class PluginsPage {
 	 * Validate section is not present on page
 	 */
 	async validateNotHasSection( section: string ): Promise< void > {
+		await this.page.waitForSelector( selectors.sectionTitles );
 		const titles = this.page.locator( selectors.sectionTitles );
-		await titles.waitFor();
 		const count = await titles.count();
+		assert.notEqual( count, 0 ); // ensure at least one is loaded before checking the negative
 		for ( let i = 0; i < count; i++ ) {
 			const title = await titles.nth( i ).innerText();
 			assert.notEqual( title, section );

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -3,7 +3,8 @@ import { Page } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 
 const selectors = {
-	sectionTitle: '.plugins-browser-list__title',
+	sectionTitle: ( section: string ) => `.plugins-browser-list__title:text("${ section }")`,
+	sectionTitles: '.plugins-browser-list__title',
 };
 
 /**
@@ -36,14 +37,19 @@ export class PluginsPage {
 	/**
 	 * Has Section
 	 */
-	async onlyHasSections( sections: Array< string > ): Promise< void > {
-		await this.page.waitForSelector( selectors.sectionTitle );
-		const titles = await this.page.locator( selectors.sectionTitle );
+	async hasSection( section: string ): Promise< void > {
+		await this.page.waitForSelector( selectors.sectionTitle( section ) );
+	}
+
+	/**
+	 * Not Has Section
+	 */
+	async notHasSection( section: string ): Promise< void > {
+		const titles = this.page.locator( selectors.sectionTitles );
 		const count = await titles.count();
-		assert.strictEqual( count, sections.length );
 		for ( let i = 0; i < count; i++ ) {
 			const title = await titles.nth( i ).innerText();
-			assert.strictEqual( title, sections[ i ] );
+			assert.notEqual( title, section );
 		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -46,6 +46,7 @@ export class PluginsPage {
 	 */
 	async validateNotHasSection( section: string ): Promise< void > {
 		const titles = this.page.locator( selectors.sectionTitles );
+		await titles.waitFor();
 		const count = await titles.count();
 		for ( let i = 0; i < count; i++ ) {
 			const title = await titles.nth( i ).innerText();

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -35,16 +35,16 @@ export class PluginsPage {
 	}
 
 	/**
-	 * Has Section
+	 * Validate page has the section
 	 */
-	async hasSection( section: string ): Promise< void > {
+	async validateHasSection( section: string ): Promise< void > {
 		await this.page.waitForSelector( selectors.sectionTitle( section ) );
 	}
 
 	/**
-	 * Not Has Section
+	 * Validate section is not present on page
 	 */
-	async notHasSection( section: string ): Promise< void > {
+	async validateNotHasSection( section: string ): Promise< void > {
 		const titles = this.page.locator( selectors.sectionTitles );
 		const count = await titles.count();
 		for ( let i = 0; i < count; i++ ) {

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -82,6 +82,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:jetpack-site' ), 
 		}
 	);
 
+	// We don't support marketplace plugin purchases on self hosted sites. (Source code download restrictions)
 	it( 'Plugins page does not load premium plugins on Jetpack sites', async function () {
 		await pluginsPage.notHasSection( 'Premium' );
 	} );

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -25,7 +25,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins' ), function () {
 	it.each( [ 'Premium', 'Featured', 'Popular', 'New' ] )(
 		'Plugins page loads %s section',
 		async function ( section: string ) {
-			await pluginsPage.hasSection( section );
+			await pluginsPage.validateHasSection( section );
 		}
 	);
 } );
@@ -50,7 +50,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:wpcom-site' ), fu
 	it.each( [ 'Premium', 'Featured', 'Popular', 'New' ] )(
 		'Plugins page loads %s section',
 		async function ( section: string ) {
-			await pluginsPage.hasSection( section );
+			await pluginsPage.validateHasSection( section );
 		}
 	);
 } );
@@ -78,12 +78,12 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:jetpack-site' ), 
 	it.each( [ 'Featured', 'Popular', 'New' ] )(
 		'Plugins page loads %s section',
 		async function ( section: string ) {
-			await pluginsPage.hasSection( section );
+			await pluginsPage.validateHasSection( section );
 		}
 	);
 
 	// We don't support marketplace plugin purchases on self hosted sites. (Source code download restrictions)
 	it( 'Plugins page does not load premium plugins on Jetpack sites', async function () {
-		await pluginsPage.notHasSection( 'Premium' );
+		await pluginsPage.validateNotHasSection( 'Premium' );
 	} );
 } );

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -75,6 +75,13 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:jetpack-site' ), 
 		await pluginsPage.visit( siteUrl );
 	} );
 
+	it.each( [ 'Featured', 'Popular', 'New' ] )(
+		'Plugins page loads %s section',
+		async function ( section: string ) {
+			await pluginsPage.hasSection( section );
+		}
+	);
+
 	it( 'Plugins page does not load premium plugins on Jetpack sites', async function () {
 		await pluginsPage.notHasSection( 'Premium' );
 	} );

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -26,7 +26,7 @@ describe( DataHelper.createSuiteTitle( 'WooCommerce Landing Page' ), function ()
 		siteUrl = testAccount.getSiteURL( { protocol: false } );
 
 		pluginsPage = new PluginsPage( page );
-		await pluginsPage.visit( `/plugins/${ siteUrl }` );
+		await pluginsPage.visit( siteUrl );
 		await pluginsPage.onlyHasSections( [ 'Premium', 'Featured', 'Popular', 'New' ] );
 	} );
 
@@ -39,7 +39,7 @@ describe( DataHelper.createSuiteTitle( 'WooCommerce Landing Page' ), function ()
 			.replace( '/wp-admin', '' );
 
 		pluginsPage = new PluginsPage( page );
-		await pluginsPage.visit( `/plugins/${ siteUrl }` );
+		await pluginsPage.visit( siteUrl );
 		await pluginsPage.onlyHasSections( [ 'Featured', 'Popular', 'New' ] );
 	} );
 } );

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -12,20 +12,34 @@ describe( DataHelper.createSuiteTitle( 'WooCommerce Landing Page' ), function ()
 	let pluginsPage: PluginsPage;
 	let siteUrl: string;
 
-	beforeAll( async () => {
+	beforeEach( async () => {
 		page = await browser.newPage();
+	} );
 
-		const testAccount = new TestAccount( 'defaultUser' );
-		await testAccount.authenticate( page );
-		siteUrl = testAccount.getSiteURL( { protocol: false } );
+	afterEach( async () => {
+		await page.close();
 	} );
 
 	it( 'Plugins page loads premium,featured,popular,new sections', async function () {
+		const testAccount = new TestAccount( 'defaultUser' );
+		await testAccount.authenticate( page );
+		siteUrl = testAccount.getSiteURL( { protocol: false } );
+
 		pluginsPage = new PluginsPage( page );
 		await pluginsPage.visit( `/plugins/${ siteUrl }` );
-		await pluginsPage.hasSection( 'Premium' );
-		await pluginsPage.hasSection( 'Featured' );
-		await pluginsPage.hasSection( 'Popular' );
-		await pluginsPage.hasSection( 'New' );
+		await pluginsPage.onlyHasSections( [ 'Premium', 'Featured', 'Popular', 'New' ] );
+	} );
+
+	it( 'Plugins page loads featured,popular,new sections on Jetpack sites', async function () {
+		const testAccount = new TestAccount( 'jetpackUserPREMIUM' );
+		await testAccount.authenticate( page );
+		siteUrl = testAccount
+			.getSiteURL( { protocol: false } )
+			.replace( 'https://', '' )
+			.replace( '/wp-admin', '' );
+
+		pluginsPage = new PluginsPage( page );
+		await pluginsPage.visit( `/plugins/${ siteUrl }` );
+		await pluginsPage.onlyHasSections( [ 'Featured', 'Popular', 'New' ] );
 	} );
 } );

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -7,39 +7,75 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'WooCommerce Landing Page' ), function () {
+describe( DataHelper.createSuiteTitle( 'Plugins page /plugins' ), function () {
+	let page: Page;
+	let pluginsPage: PluginsPage;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		const testAccount = new TestAccount( 'defaultUser' );
+		await testAccount.authenticate( page );
+	} );
+
+	it( 'Visit plugins page', async function () {
+		pluginsPage = new PluginsPage( page );
+		await pluginsPage.visit();
+	} );
+
+	it.each( [ 'Premium', 'Featured', 'Popular', 'New' ] )(
+		'Plugins page loads %s section',
+		async function ( section: string ) {
+			await pluginsPage.hasSection( section );
+		}
+	);
+} );
+
+describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:wpcom-site' ), function () {
 	let page: Page;
 	let pluginsPage: PluginsPage;
 	let siteUrl: string;
 
-	beforeEach( async () => {
+	beforeAll( async () => {
 		page = await browser.newPage();
-	} );
-
-	afterEach( async () => {
-		await page.close();
-	} );
-
-	it( 'Plugins page loads premium,featured,popular,new sections', async function () {
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
 		siteUrl = testAccount.getSiteURL( { protocol: false } );
-
-		pluginsPage = new PluginsPage( page );
-		await pluginsPage.visit( siteUrl );
-		await pluginsPage.onlyHasSections( [ 'Premium', 'Featured', 'Popular', 'New' ] );
 	} );
 
-	it( 'Plugins page loads featured,popular,new sections on Jetpack sites', async function () {
+	it( 'Visit plugins page', async function () {
+		pluginsPage = new PluginsPage( page );
+		await pluginsPage.visit( siteUrl );
+	} );
+
+	it.each( [ 'Premium', 'Featured', 'Popular', 'New' ] )(
+		'Plugins page loads %s section',
+		async function ( section: string ) {
+			await pluginsPage.hasSection( section );
+		}
+	);
+} );
+
+describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:jetpack-site' ), function () {
+	let page: Page;
+	let pluginsPage: PluginsPage;
+	let siteUrl: string;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
 		const testAccount = new TestAccount( 'jetpackUserPREMIUM' );
 		await testAccount.authenticate( page );
 		siteUrl = testAccount
 			.getSiteURL( { protocol: false } )
 			.replace( 'https://', '' )
 			.replace( '/wp-admin', '' );
+	} );
 
+	it( 'Visit plugins page', async function () {
 		pluginsPage = new PluginsPage( page );
 		await pluginsPage.visit( siteUrl );
-		await pluginsPage.onlyHasSections( [ 'Featured', 'Popular', 'New' ] );
+	} );
+
+	it( 'Plugins page does not load premium plugins on Jetpack sites', async function () {
+		await pluginsPage.notHasSection( 'Premium' );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Follow up to https://github.com/Automattic/wp-calypso/pull/61224
* Adds test to confirm jetpack users don't see paid plugins

#### Testing instructions

[Prereq setup](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)

```
cd e2e/tests
yarn workspace @automattic/calypso-e2e build && yarn jest specs/plugins/plugins__browse.ts
```

Related to https://github.com/Automattic/wp-calypso/issues/61094
