### PR TITLE
Reader: Fix React key warning in `FollowingStream`

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -47,7 +47,12 @@ function FollowingStream( { suggestions, ...props } ) {
 		suggestions &&
 		suggestions
 			.flatMap( ( query ) => [
-				<Suggestion suggestion={ query.text } source="following" railcar={ query.railcar } />,
+				<Suggestion
+					suggestion={ query.text }
+					source="following"
+					railcar={ query.railcar }
+					key={ query.railcar.railcar }
+				/>,
 				', ',
 			] )
 			.slice( 0, -1 );

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -48,10 +48,10 @@ function FollowingStream( { suggestions, ...props } ) {
 		suggestions
 			.flatMap( ( query ) => [
 				<Suggestion
+					key={ query.railcar.railcar }
 					suggestion={ query.text }
 					source="following"
 					railcar={ query.railcar }
-					key={ query.railcar.railcar }
 				/>,
 				', ',
 			] )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a React warning that is displayed in the console every time one opens `/read`:

![](https://cldup.com/ISEYfyPpeK.png)

#### Testing instructions

* Go to `/read`
* Verify that the error is no longer displayed in the console.
* Verify that suggestions below the search form still work and look well.