### PR TITLE
`EditorMediaModalDetailPreviewImage`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -261,6 +261,7 @@ export class EditorMediaModalDetailItem extends Component {
 		}
 
 		return createElement( Item, {
+			key: item.ID,
 			className: 'editor-media-modal-detail__preview',
 			site: site,
 			item: item,

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -20,13 +20,6 @@ export default class EditorMediaModalDetailPreviewImage extends Component {
 
 	state = { loading: true };
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.item.URL !== nextProps.item.URL ) {
-			this.setState( { loading: true } );
-		}
-	}
-
 	onImagePreloaderLoad = () => {
 		this.setState( { loading: false } );
 		this.props.onLoad();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `EditorMediaModalDetailPreviewImage`: refactor away from `UNSAFE_*`

#### Testing instructions

* Open the media library, select at least 2 items (it helps if they've a large file size) and hit _Edit_
* Switch between selected images and verify loading states are not interfering
* Via React devtools you should be able observe how you get a new `<EditorMediaModalDetailPreviewImage />` every time you switch between images (see the `key` prop)

Throttling the network connection helps to observe the mentioned loading state.

Related to #58453 
