### PR TITLE
Add support for new property `aftermarketAuction` on `ResponseDomain` object

### DIFF
--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -48,6 +48,7 @@ export type ResponseDomain = {
 	aRecordsRequiredForMapping?: Array< string >;
 	autoRenewalDate: string;
 	autoRenewing: boolean;
+	aftermarketAuction: boolean;
 	beginTransferUntilDate: string;
 	blogId: number;
 	bundledPlanSubscriptionId: string | number | null | undefined;

--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -50,6 +50,7 @@ export const createSiteDomainObject = ( domain ) => {
 		aRecordsRequiredForMapping: domain.a_records_required_for_mapping,
 		autoRenewalDate: String( domain.auto_renewal_date ),
 		adminEmail: domain.admin_email,
+		aftermarketAuction: Boolean( domain.aftermarket_auction ),
 		autoRenewing: Boolean( domain.auto_renewing ),
 		beginTransferUntilDate: String( domain.begin_transfer_until_date ),
 		blogId: Number( domain.blog_id ),

--- a/client/state/sites/domains/schema.js
+++ b/client/state/sites/domains/schema.js
@@ -8,6 +8,7 @@ export const itemsSchema = {
 				type: 'object',
 				required: [ 'domain' ],
 				properties: {
+					aftermarketAuction: { type: 'boolean' },
 					autoRenewalDate: { type: 'string' },
 					autoRenewing: { type: 'boolean' },
 					blogId: { type: 'number' },

--- a/client/state/sites/domains/test/fixture/index.js
+++ b/client/state/sites/domains/test/fixture/index.js
@@ -19,6 +19,7 @@ export const DOMAIN_EXPIRED_ERROR_MESSAGE = 'Domain expired message';
 
 // testing primary-domain
 export const DOMAIN_PRIMARY = {
+	aftermarketAuction: false,
 	aRecordsRequiredForMapping: undefined,
 	autoRenewalDate: '2017-02-07T00:00:00+00:00',
 	autoRenewing: true,
@@ -101,6 +102,7 @@ export const DOMAIN_PRIMARY = {
 
 // testing not-primary-domain
 export const DOMAIN_NOT_PRIMARY = {
+	aftermarketAuction: false,
 	aRecordsRequiredForMapping: undefined,
 	autoRenewalDate: '',
 	autoRenewing: false,
@@ -189,6 +191,7 @@ export const ERROR_MESSAGE_RESPONSE =
 	'There was a problem fetching site domains. Please try again later or contact support.';
 
 export const REST_API_SITE_DOMAIN_FIRST = {
+	aftermarket_auction: false,
 	auto_renewal_date: '2017-02-07T00:00:00+00:00',
 	auto_renewing: 1,
 	admin_email: null,
@@ -255,6 +258,7 @@ export const REST_API_SITE_DOMAIN_FIRST = {
 };
 
 export const REST_API_SITE_DOMAIN_SECOND = {
+	aftermarket_auction: false,
 	auto_renewal_date: '',
 	auto_renewing: false,
 	admin_email: null,

--- a/client/state/sites/domains/types.ts
+++ b/client/state/sites/domains/types.ts
@@ -1,4 +1,5 @@
 export interface SiteDomain {
+	aftermarketAuction: boolean;
 	autoRenewalDate?: string;
 	autoRenewing?: boolean;
 	blogId?: number;

--- a/client/state/sites/domains/types.ts
+++ b/client/state/sites/domains/types.ts
@@ -1,5 +1,5 @@
 export interface SiteDomain {
-	aftermarketAuction: boolean;
+	aftermarketAuction?: boolean;
 	autoRenewalDate?: string;
 	autoRenewing?: boolean;
 	blogId?: number;


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR add support for the new property `aftermarketAuction` in the `ResponseDomain` object. 

It will be used in the next PRs to disable some domain functionalities in Calypso.

This is part of the new Attrition Monetization project (pcYYhz-vX-p2) 

## Testing instructions

At the moment there is nothing to test, just assure that the code looks correct.

You can run the specific test suite with:

`yarn run test-client client/state/sites/domains `