### PR TITLE
`MapDomain`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -146,26 +146,21 @@ export class MapDomain extends Component {
 		page( '/checkout/' + selectedSiteSlug + '/domain-mapping:' + domain );
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		this.checkSiteIsUpgradeable( this.props );
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		this.checkSiteIsUpgradeable( nextProps );
-	}
-
 	componentDidMount() {
 		this.isMounted = true;
+		this.checkSiteIsUpgradeable();
+	}
+
+	componentDidUpdate() {
+		this.checkSiteIsUpgradeable();
 	}
 
 	componentWillUnmount() {
 		this.isMounted = false;
 	}
 
-	checkSiteIsUpgradeable( props ) {
-		if ( props.selectedSite && ! props.isSiteUpgradeable ) {
+	checkSiteIsUpgradeable() {
+		if ( this.props.selectedSite && ! this.props.isSiteUpgradeable ) {
 			page.redirect( '/domains/add/mapping' );
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `MapDomain`: refactor away from `UNSAFE_*`

#### Testing instructions

* Use a WP.com account which has a role for a site which doesn't allow for managing options (I think anything but _Administrator_)
* Go to `/domains/add/mapping`
* Click on the mentioned site and verify you're being redirected back to the site selector

There may be other ways to test this but I found these steps to be the easiest. An alternative way would be to use React devtools and toggle the `isSiteUpgradeable` prop and observe how you're redirected to the site selector (at `/domains/add/mapping`).

Related to #58453 
