### PR TITLE
`SiteRedirect`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/my-sites/domains/domain-search/site-redirect.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect.jsx
@@ -33,18 +33,17 @@ class SiteRedirect extends Component {
 	};
 
 	componentDidMount() {
-		this.checkSiteIsUpgradeable( this.props );
+		this.checkSiteIsUpgradeable();
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.selectedSiteId !== this.props.selectedSiteId ) {
-			this.checkSiteIsUpgradeable( nextProps );
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.selectedSiteId !== this.props.selectedSiteId ) {
+			this.checkSiteIsUpgradeable();
 		}
 	}
 
-	checkSiteIsUpgradeable( props ) {
-		if ( ! props.isSiteUpgradeable ) {
+	checkSiteIsUpgradeable() {
+		if ( ! this.props.isSiteUpgradeable ) {
 			page.redirect( '/domains/add' );
 		}
 	}

--- a/client/my-sites/domains/domain-search/site-redirect.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect.jsx
@@ -77,7 +77,9 @@ class SiteRedirect extends Component {
 					{ translate( 'Redirect a Site' ) }
 				</HeaderCake>
 
-				<SiteRedirectStep products={ productsList } selectedSite={ selectedSite } />
+				{ selectedSite && (
+					<SiteRedirectStep products={ productsList } selectedSite={ selectedSite } />
+				) }
 			</Main>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `SiteRedirect`: refactor away from `UNSAFE_*`

#### Testing instructions

* Use a WP.com account which has a role for a site which doesn't allow for managing options (I think anything but _Administrator_)
* Go to `/domains/add/site-redirect/:site` where `site` is a site where you're **allowed** to manage options (e.g. you own)
* Change your currently active site to a site you don't own or aren't allowed to manage options
* Verify you're redirected to the site selector at `/domains/add`

Related to #58453 
