### PR TITLE
`TransferDomain`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -107,18 +107,16 @@ export class TransferDomain extends Component {
 		} );
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		this.checkSiteIsUpgradeable( this.props );
+	componentDidMount() {
+		this.checkSiteIsUpgradeable();
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		this.checkSiteIsUpgradeable( nextProps );
+	componentDidUpdate() {
+		this.checkSiteIsUpgradeable();
 	}
 
-	checkSiteIsUpgradeable( props ) {
-		if ( props.selectedSite && ! props.isSiteUpgradeable ) {
+	checkSiteIsUpgradeable() {
+		if ( this.props.selectedSite && ! this.props.isSiteUpgradeable ) {
 			page.redirect( '/domains/add/transfer' );
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `TransferDomain`: refactor away from `UNSAFE_*`

#### Testing instructions

* Use a WP.com account which has a role for a site which doesn't allow for managing options
* Go to `/domains/add/transfer`
* Choose mentioned site and verify you're being redirected back to the site selector

On a site you're allowed to manage options use React devtools and toggle the `isSiteUpgradeable` prop (on `<TransferDomain />`) and observe how you're redirected to the site selector (at `/domains/add/transfer`).

Related to #58453 
