### PR TITLE
`DomainWarnings`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -1079,8 +1079,7 @@ export class DomainWarnings extends PureComponent {
 		);
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		if ( ! this.props.domains && ! this.props.domain ) {
 			debug( 'You need provide either "domains" or "domain" property to this component.' );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `DomainWarnings`: refactor away from `UNSAFE_*`

#### Testing instructions

I think in this case it's enough to do a code review. If you want to test the debug statement you'd have to manually remove one of the mentioned props from one of the usages of `<DomainWarnings />` because afaics it's ensured those props are present. 

Related to #58453 
