### PR TITLE
Adds confirmation dialog to Website Content step

### DIFF
--- a/client/signup/accordion-form/accordion-form-section.tsx
+++ b/client/signup/accordion-form/accordion-form-section.tsx
@@ -6,6 +6,7 @@ import { AccordionSectionProps } from './types';
 interface AccordionFormSectionProps< T > extends AccordionSectionProps< T > {
 	isExpanded: boolean;
 	isTouched: boolean;
+	showSubmit: boolean;
 	onOpen: () => void;
 	onNext: () => void;
 	blockNavigation?: boolean;
@@ -114,11 +115,15 @@ export default function AccordionFormSection< T >( props: AccordionFormSectionPr
 				<SectionContent>
 					{ props.component ? props.component : props.children }
 					<ButtonsContainer>
-						<NextButton onClick={ props.onNext } disabled={ props.blockNavigation }>
-							{ translate( 'Next' ) }
+						<NextButton
+							primary={ props.showSubmit }
+							onClick={ props.onNext }
+							disabled={ props.blockNavigation }
+						>
+							{ props.showSubmit ? translate( 'Submit' ) : translate( 'Next' ) }
 							<Gridicon icon={ isRTL ? 'arrow-left' : 'arrow-right' } />
 						</NextButton>
-						{ props.showSkip && (
+						{ props.showSkip && ! props.showSubmit && (
 							<SkipLink onClick={ () => ( props.blockNavigation ? null : props.onNext() ) }>
 								{ translate( 'Skip' ) }
 							</SkipLink>

--- a/client/signup/accordion-form/accordion-form-section.tsx
+++ b/client/signup/accordion-form/accordion-form-section.tsx
@@ -121,7 +121,7 @@ export default function AccordionFormSection< T >( props: AccordionFormSectionPr
 							disabled={ props.blockNavigation }
 						>
 							{ props.showSubmit ? translate( 'Submit' ) : translate( 'Next' ) }
-							<Gridicon icon={ isRTL ? 'arrow-left' : 'arrow-right' } />
+							{ ! props.showSubmit && <Gridicon icon={ isRTL ? 'arrow-left' : 'arrow-right' } /> }
 						</NextButton>
 						{ props.showSkip && ! props.showSubmit && (
 							<SkipLink onClick={ () => ( props.blockNavigation ? null : props.onNext() ) }>

--- a/client/signup/accordion-form/accordion-form.tsx
+++ b/client/signup/accordion-form/accordion-form.tsx
@@ -134,6 +134,7 @@ export default function AccordionForm< T >( {
 					onNext={ () => onNext( section.validate ) }
 					onOpen={ () => onOpen( index ) }
 					blockNavigation={ blockNavigation }
+					showSubmit={ index === sections.length - 1 }
 				/>
 			) ) }
 		</>

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -40,7 +40,7 @@ const DialogContent = styled.div`
 const DialogButton = styled( Button )`
 	box-shadow: 0px 1px 2px rgba( 0, 0, 0, 0.05 );
 	border-radius: 5px;
-	padding: 10px 64px;
+	padding: ${ ( props ) => ( props.primary ? '10px 64px' : '10px 32px' ) };
 	--color-accent: #117ac9;
 	--color-accent-60: #0e64a5;
 	.gridicon {
@@ -138,7 +138,7 @@ function WebsiteContentStep( {
 	const generatedSections = generatedSectionsCallback();
 
 	const dialogButtons = [
-		<DialogButton borderless onClick={ () => setIsConfirmDialogOpen( false ) }>
+		<DialogButton onClick={ () => setIsConfirmDialogOpen( false ) }>
 			{ translate( 'Cancel' ) }
 		</DialogButton>,
 		<DialogButton primary onClick={ onSubmit }>

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -1,3 +1,5 @@
+import { Button, Dialog } from '@automattic/components';
+import styled from '@emotion/styled';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -26,6 +28,25 @@ import { sectionGenerator } from './section-generator';
 import './style.scss';
 
 const debug = debugFactory( 'calypso:difm' );
+
+const DialogContent = styled.div`
+	padding: 16px;
+	p {
+		font-size: 1rem;
+		color: var( --studio-gray-50 );
+	}
+`;
+
+const DialogButton = styled( Button )`
+	box-shadow: 0px 1px 2px rgba( 0, 0, 0, 0.05 );
+	border-radius: 5px;
+	padding: 10px 64px;
+	--color-accent: #117ac9;
+	--color-accent-60: #0e64a5;
+	.gridicon {
+		margin-left: 10px;
+	}
+`;
 
 interface WebsiteContentStepProps {
 	additionalStepData: object;
@@ -57,6 +78,9 @@ function WebsiteContentStep( {
 	const isImageUploading = useSelector( ( state ) =>
 		isImageUploadInProgress( state as WebsiteContentStateModel )
 	);
+
+	const [ isConfirmDialogOpen, setIsConfirmDialogOpen ] = useState( false );
+
 	useEffect( () => {
 		function getPageFromCategory( category: string | null ) {
 			switch ( category ) {
@@ -69,7 +93,6 @@ function WebsiteContentStep( {
 					return { id: 'Menu', name: translate( 'Menu' ) };
 				default:
 					return { id: 'Blog', name: translate( 'Blog' ) };
-					break;
 			}
 		}
 
@@ -113,18 +136,45 @@ function WebsiteContentStep( {
 		[ translate, websiteContent, formErrors ]
 	);
 	const generatedSections = generatedSectionsCallback();
+
+	const dialogButtons = [
+		<DialogButton borderless onClick={ () => setIsConfirmDialogOpen( false ) }>
+			{ translate( 'Cancel' ) }
+		</DialogButton>,
+		<DialogButton primary onClick={ onSubmit }>
+			{ translate( 'Submit' ) }
+		</DialogButton>,
+	];
+
 	return (
-		<AccordionForm
-			generatedSections={ generatedSections }
-			onErrorUpdates={ ( errors ) => setFormErrors( errors ) }
-			formValuesInitialState={ websiteContent }
-			currentIndex={ currentIndex }
-			updateCurrentIndex={ ( currentIndex ) => {
-				dispatch( updateWebsiteContentCurrentIndex( currentIndex ) );
-			} }
-			onSubmit={ onSubmit }
-			blockNavigation={ isImageUploading }
-		/>
+		<>
+			<Dialog
+				isVisible={ isConfirmDialogOpen }
+				onClose={ () => setIsConfirmDialogOpen( false ) }
+				buttons={ dialogButtons }
+			>
+				<DialogContent>
+					<h1>{ translate( 'Submit Content?' ) }</h1>
+					<p>
+						{ translate(
+							'Click "Submit" to start your site build or "Cancel" to make further edits.'
+						) }
+					</p>
+				</DialogContent>
+			</Dialog>
+
+			<AccordionForm
+				generatedSections={ generatedSections }
+				onErrorUpdates={ ( errors ) => setFormErrors( errors ) }
+				formValuesInitialState={ websiteContent }
+				currentIndex={ currentIndex }
+				updateCurrentIndex={ ( currentIndex ) => {
+					dispatch( updateWebsiteContentCurrentIndex( currentIndex ) );
+				} }
+				onSubmit={ () => setIsConfirmDialogOpen( true ) }
+				blockNavigation={ isImageUploading }
+			/>
+		</>
 	);
 }
 
@@ -161,7 +211,7 @@ export default function WrapperWebsiteContent(
 	//Make sure the most up to date site information is loaded so that we can validate access to this page
 	useEffect( () => {
 		siteId && dispatch( requestSite( siteId ) );
-	}, [ siteId ] );
+	}, [ dispatch, siteId ] );
 
 	useEffect( () => {
 		if ( ! isLoadingSiteInformation ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: pdh1Xd-xv-p2#comment-864

* Makes the last button of the accordion form a primary "Submit" button.
* Adds a confirmation dialog to the Website Content step before submitting it.

#### Testing instructions

* Go to `/start/do-it-for-me`.
* On the Site Information screen, confirm that on the Contact Page section, the CTA is a "Submit" button. 
<img width="1741" alt="image" src="https://user-images.githubusercontent.com/5436027/154675540-a03c52ee-6b95-4f9e-8a83-c3d7d2e5f803.png">

* Proceed through the flow and complete the purchase. 
* On the Website Content screen, confirm that on the last section, the CTA is a "Submit" button. 

<img width="1879" alt="image" src="https://user-images.githubusercontent.com/5436027/154676589-fab2381d-f800-4b12-8d57-bebca2c5a0a2.png">

* Click on the Submit button. Confirm that a confirmation dialog is shown. 🙃 
<img width="1360" alt="image" src="https://user-images.githubusercontent.com/5436027/155471826-fc187f32-7bdd-43e1-95cd-d8788f6cad3c.png">


* Clicking on "Cancel" should dismiss the dialog and clicking on the "Submit" button should submit and take you to the processing screen.
