### PR TITLE
Welcome Tour/FSE: New FSE slide if in Site Editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/test/tour-steps.test.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/test/tour-steps.test.ts
@@ -74,6 +74,24 @@ describe( 'Welcome Tour', () => {
 				] )
 			);
 		} );
+		it( 'should retrieve the "Edit your site" slide, when in site editor', () => {
+			expect( getTourSteps( 'en', true, true ) ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						meta: expect.objectContaining( { heading: 'Edit your site!' } ),
+					} ),
+				] )
+			);
+		} );
+		it( 'should not retrieve the "Edit your site" slide, when not in site editor', () => {
+			expect( getTourSteps( 'en', true, false ) ).not.toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						meta: expect.objectContaining( { heading: 'Edit your site!' } ),
+					} ),
+				] )
+			);
+		} );
 		it( 'should retrieve the "Congratulations!" slide, with correct url', () => {
 			expect( getTourSteps( 'en', true ) ).toEqual(
 				expect.arrayContaining( [

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/test/tour-steps.test.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/test/tour-steps.test.ts
@@ -78,7 +78,7 @@ describe( 'Welcome Tour', () => {
 			expect( getTourSteps( 'en', true, true ) ).toEqual(
 				expect.arrayContaining( [
 					expect.objectContaining( {
-						meta: expect.objectContaining( { heading: 'Edit your site!' } ),
+						meta: expect.objectContaining( { heading: 'Edit your site' } ),
 					} ),
 				] )
 			);
@@ -87,7 +87,7 @@ describe( 'Welcome Tour', () => {
 			expect( getTourSteps( 'en', true, false ) ).not.toEqual(
 				expect.arrayContaining( [
 					expect.objectContaining( {
-						meta: expect.objectContaining( { heading: 'Edit your site!' } ),
+						meta: expect.objectContaining( { heading: 'Edit your site' } ),
 					} ),
 				] )
 			);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -53,7 +53,9 @@ function WelcomeTour() {
 	const isWelcomeTourNext = () => {
 		return new URLSearchParams( document.location.search ).has( 'welcome-tour-next' );
 	};
-	const tourSteps = getTourSteps( localeSlug, isWelcomeTourNext() );
+	const isSiteEditor = useSelect( ( select ) => !! select( 'core/edit-site' ) );
+
+	const tourSteps = getTourSteps( localeSlug, isWelcomeTourNext(), isSiteEditor );
 
 	// Only keep Payment block step if user comes from seller simple flow
 	if ( ! ( 'sell' === intent && sitePlan && 'ecommerce-bundle' !== sitePlan.product_slug ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -36,12 +36,26 @@ function getTourAssets( key: string ): TourAsset | undefined {
 			desktop: { src: `${ CDN_PREFIX }/slide-welcome.png`, type: 'image/png' },
 			mobile: { src: `${ CDN_PREFIX }/slide-welcome_mobile.jpg`, type: 'image/jpeg' },
 		},
+		editYourSite: {
+			desktop: {
+				src: `https://s.w.org/images/block-editor/edit-your-site.gif?1`,
+				type: 'image/gif',
+			},
+			mobile: {
+				src: `https://s.w.org/images/block-editor/edit-your-site.gif?1`,
+				type: 'image/gif',
+			},
+		},
 	} as { [ key: string ]: TourAsset };
 
 	return tourAssets[ key ];
 }
 
-function getTourSteps( localeSlug: string, referencePositioning = false ): WpcomStep[] {
+function getTourSteps(
+	localeSlug: string,
+	referencePositioning = false,
+	isSiteEditor: boolean
+): WpcomStep[] {
 	return [
 		{
 			slug: 'welcome',
@@ -265,6 +279,34 @@ function getTourSteps( localeSlug: string, referencePositioning = false ): Wpcom
 				},
 			},
 		},
+		...( isSiteEditor
+			? [
+					{
+						slug: 'edit-your-site',
+						meta: {
+							heading: __( 'Edit your site', 'full-site-editing' ),
+							descriptions: {
+								desktop: __(
+									'Design everything on your site - from the header right down to the footer - using blocks.',
+									'full-site-editing'
+								),
+								mobile: __(
+									'Design everything on your site - from the header right down to the footer - using blocks.',
+									'full-site-editing'
+								),
+							},
+							imgSrc: getTourAssets( 'editYourSite' ),
+							animation: 'undo-button',
+						},
+						options: {
+							classNames: {
+								desktop: 'wpcom-editor-welcome-tour__step',
+								mobile: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+							},
+						},
+					},
+			  ]
+			: [] ),
 		{
 			slug: 'congratulations',
 			meta: {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -54,7 +54,7 @@ function getTourAssets( key: string ): TourAsset | undefined {
 function getTourSteps(
 	localeSlug: string,
 	referencePositioning = false,
-	isSiteEditor: boolean
+	isSiteEditor = false
 ): WpcomStep[] {
 	return [
 		{
@@ -296,7 +296,6 @@ function getTourSteps(
 								),
 							},
 							imgSrc: getTourAssets( 'editYourSite' ),
-							animation: 'undo-button',
 						},
 						options: {
 							classNames: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Added a new slide to the Welcome Tour for FSE when in site editor.

<img width="403" alt="image" src="https://user-images.githubusercontent.com/52076348/161117149-5e3d8bde-f674-4d18-a099-074b70234e35.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- checkout branch
- `yarn dev --sync` from `apps/editing-toolkit`
- in post editor, verify that the new slide is not shown
- in site editor, verify that the new slide is shown

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #61231
Fixes #61231
