### PR TITLE
Fix the showing of 'no results' message when there are paid plugins to be shown.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -409,6 +409,7 @@ const SearchListView = ( {
 
 	if (
 		pluginsBySearchTerm.length > 0 ||
+		paidPluginsBySearchTerm.length > 0 ||
 		isFetchingPluginsBySearchTerm ||
 		isFetchingPaidPluginsBySearchTerm
 	) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Check if there are paid plugins before show the *no results* message

#### Testing instructions

* Go to `/plugins page`
* Search for a term that returns only paid results. Ex: `yoa`


| Before  |  After |
| ------------- | ------------- |
| <img width="1140" alt="Screen Shot 2022-02-18 at 11 04 44" src="https://user-images.githubusercontent.com/5039531/154699580-09c0aac2-e2af-495c-a864-efd1b6484b9c.png">|<img width="1140" alt="Screen Shot 2022-02-18 at 11 04 58" src="https://user-images.githubusercontent.com/5039531/154699604-d7aa6aba-448a-47e3-ae70-1953bc4dccb8.png">|


