### PR TITLE
Remove the subdomain restriction for restoring DNS records for Professional Email

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
@@ -52,14 +52,8 @@ const emailProviderConfig: Record< EmailProviderKey, EmailProviderConfiguration 
 		dnsTemplate: dnsTemplates.TITAN,
 		shouldRestoreOptionBeEnabled: ( domain: ResponseDomain ): boolean =>
 			hasTitanMailWithUs( domain ) &&
-			false === domain?.titanMailSubscription?.hasExpectedDnsRecords &&
-			! domain?.isSubdomain,
+			false === domain?.titanMailSubscription?.hasExpectedDnsRecords,
 		providerSlug: 'titan',
-		templateVariableBuilder: (): object => {
-			return {
-				dmarc_host: '_dmarc',
-			};
-		},
 	},
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Owing to recent updates from D75193-code, the subdomain restriction for restoring DNS for Professional Email is removed
* The `dmarc_host` template variable is now redundant and removed as well

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a Professional Email subscription on a sub-domain
* After setup, go to the Domain DNS section i.e.  `/domains/manage/<sub-domain>/dns/<site>` and nuke some email related records like MX, or DMARC records
* Prior to this PR, the restore button should be hidden to you ( for sub-domains )
* Apply D75260-code
* Checkout this branch locally, or via [calypso live](https://github.com/Automattic/wp-calypso/pull/61251#issuecomment-1044635111)
* Visit the DNS page again
* Confirm that you now see the `Restore DNS records for Professional Email` ( a refresh may be needed)

<img width="410" alt="Screenshot 2022-02-18 at 3 42 13 PM" src="https://user-images.githubusercontent.com/277661/154704079-244d05ff-3b1b-493a-b938-a475aac03a58.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60709 and D75260-code