### PR TITLE
Layout: Fix guided tours step `scrollContainer`

### DIFF
--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -123,7 +123,7 @@ export default class Step extends Component< Props, State > {
 			this.setStepSection( this.context, { init: true } );
 			debug( 'Step#componentWillMount: stepSection:', this.stepSection );
 			this.skipIfInvalidContext( this.props, this.context );
-			this.scrollContainer = query( this.props.scrollContainer ?? '' )[ 0 ] || window;
+			this.scrollContainer = query( this.props.scrollContainer ?? 'body' )[ 0 ];
 			// Don't pass `shouldScrollTo` as argument since mounting hasn't occured at this point yet.
 			this.setStepPosition( this.props );
 			this.safeSetState( { initialized: true } );
@@ -151,7 +151,7 @@ export default class Step extends Component< Props, State > {
 			if ( this.scrollContainer ) {
 				this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
 			}
-			this.scrollContainer = query( nextProps.scrollContainer ?? '' )[ 0 ] || window;
+			this.scrollContainer = query( nextProps.scrollContainer ?? 'body' )[ 0 ];
 			this.scrollContainer.addEventListener( 'scroll', this.onScrollOrResize );
 			this.setStepPosition( nextProps, shouldScrollTo );
 			this.watchTarget();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, when a guided tour step is mounted, if no `scrollContainer` is provided, it will trigger an error:

![](https://cldup.com/o-RfeRUCwy.png)

This PR addresses that by properly falling back to the `body` element as a default scroll container in those instances.

I found this while working on potential optimizations for the Inline Help and Happychat apps.

#### Testing instructions

* Go to `/media/:site`
* Click on the inline help question mark on the bottom right portion of the screen
* Click on the "Learn Media Library Basics" item.
* Click "Start Tour"
* Verify tour starts and works well:

![](https://cldup.com/hexH7_Bob8.png)