### PR TITLE
Media: Remove undefined `onEditImageCancel`

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -126,8 +126,6 @@ class Media extends Component {
 
 	onImageEditorDone = ( error, blob, imageEditorProps ) => {
 		if ( error ) {
-			this.onEditImageCancel( imageEditorProps );
-
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While working on #61252 I found that we're running into an error if we edit an image and quickly click the "Done" button before the image has loaded in the modal:

![](https://cldup.com/V1QEMis-jl.png)

Turns out that this has been present forever - since the introduction of the v1 of the media editor in #9141, over than 5 years ago.

#### Testing instructions

* Load up `/media/:site`
* Click on an image and click the "Edit" button.
* Click on the "Edit Image" button inside the image preview area.
* Quickly click on the "Done" button before the image has loaded in the edit modal. If you need to, throttle your internet connection from the browser dev tools.
* Verify there is no error.
* Verify that after the image loads, you can properly do changes and click "Done", and the media is saved.