### PR TITLE
Media: Remove unused `TitleItem` component and styles

### DIFF
--- a/client/components/section-nav/item.scss
+++ b/client/components/section-nav/item.scss
@@ -129,14 +129,3 @@
 		width: auto;
 	}
 }
-
-.section-nav-tab__title {
-	display: flex;
-	align-items: center;
-	box-sizing: border-box;
-	padding: 15px;
-	width: 100%;
-	font-size: $font-body-small;
-	line-height: 18px;
-	color: var( --color-neutral-70 );
-}

--- a/client/my-sites/media-library/title-item.jsx
+++ b/client/my-sites/media-library/title-item.jsx
@@ -1,6 +1,0 @@
-const TitleItem = ( props ) => {
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	return <h6 className="section-nav-tab__title">{ props.children }</h6>;
-};
-
-export default TitleItem;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While working on #61254 and #61252, I found that we have an unused component inside the media library - `TitleItem`. It's been unused since #16612. 

This PR removes that component, as well as its related styles.

#### Testing instructions

Verify the removed component and its styles are not in use.