### PR TITLE
`CloneCredentialsStep`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/signup/steps/clone-credentials/index.jsx
+++ b/client/signup/steps/clone-credentials/index.jsx
@@ -21,10 +21,6 @@ class CloneCredentialsStep extends Component {
 		signupDependencies: PropTypes.object,
 	};
 
-	state = {
-		gotSuccess: false,
-	};
-
 	goToNextStep = () => {
 		this.props.submitSignupStep( { stepName: this.props.stepName }, { roleName: 'alternate' } );
 		this.props.goToNextStep();
@@ -59,10 +55,8 @@ class CloneCredentialsStep extends Component {
 		);
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( 'success' === nextProps.updateStatus && ! this.state.gotSuccess ) {
-			this.setState( { gotSuccess: true } );
+	componentDidUpdate( prevProps ) {
+		if ( 'success' !== prevProps.updateStatus && 'success' === this.props.updateStatus ) {
 			this.goToNextStep();
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `CloneCredentialsStep`: refactor away from `UNSAFE_*`

#### Testing instructions

* For a Jetpack-connected site with active rewind status go to `/settings/general/:site`
* Under _Site tools_ click on _Clone_
* Go through the process until you reach the form to enter SFTP credentials for the destination site
* Enter credentials and hit _Save_
* After a successful test you should be forwarded to the next step

Related to #58453 
