### PR TITLE
Plugins: Display chat info in checkout summary for plugins

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -30,8 +30,6 @@ import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
-import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -298,13 +296,11 @@ function CheckoutSummaryPlanFeatures( props: {
 }
 
 function CheckoutSummaryChatIfAvailable( props: { siteId: number | undefined } ) {
+	const translate = useTranslate();
+
 	const currentPlan = useSelector( ( state ) =>
 		props.siteId ? getCurrentPlan( state, props.siteId ) : undefined
 	);
-	const translate = useTranslate();
-
-	const billingPeriod = useSelector( getBillingInterval );
-	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
 
 	const currentPlanSlug = currentPlan?.productSlug;
 
@@ -313,7 +309,7 @@ function CheckoutSummaryChatIfAvailable( props: { siteId: number | undefined } )
 		( isWpComPremiumPlan( currentPlanSlug ) ||
 			isWpComBusinessPlan( currentPlanSlug ) ||
 			isWpComEcommercePlan( currentPlanSlug ) ) &&
-		isAnnualPeriod;
+		! isMonthly( currentPlanSlug );
 
 	if ( ! isChatAvailable ) return null;
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -176,22 +176,6 @@ function CheckoutSummaryFeaturesList( props: {
 	}
 	const refundText = getRefundText( refundDays, null, translate );
 
-	const currentPlan = useSelector( ( state ) =>
-		siteId ? getCurrentPlan( state, siteId ) : undefined
-	);
-	const billingPeriod = useSelector( getBillingInterval );
-	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
-
-	const currentPlanSlug = currentPlan?.productSlug;
-
-	const isChatAvailable =
-		! hasPlanInCart &&
-		currentPlanSlug &&
-		( isWpComPremiumPlan( currentPlanSlug ) ||
-			isWpComBusinessPlan( currentPlanSlug ) ||
-			isWpComEcommercePlan( currentPlanSlug ) ) &&
-		isAnnualPeriod;
-
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
 			{ hasDomainsInCart &&
@@ -208,12 +192,8 @@ function CheckoutSummaryFeaturesList( props: {
 				<WPCheckoutCheckIcon id="features-list-support-text" />
 				<SupportText hasPlanInCart={ hasPlanInCart } isJetpackNotAtomic={ isJetpackNotAtomic } />
 			</CheckoutSummaryFeaturesListItem>
-			{ isChatAvailable && (
-				<CheckoutSummaryFeaturesListItem>
-					<WPCheckoutCheckIcon id={ 'annual-live-chat' } />
-					{ translate( 'Live chat support' ) }
-				</CheckoutSummaryFeaturesListItem>
-			) }
+
+			{ ! hasPlanInCart && <CheckoutSummaryChatIfAvailable siteId={ siteId } /> }
 
 			{ showRefundText && (
 				<CheckoutSummaryFeaturesListItem>
@@ -314,6 +294,34 @@ function CheckoutSummaryPlanFeatures( props: {
 				);
 			} ) }
 		</>
+	);
+}
+
+function CheckoutSummaryChatIfAvailable( props: { siteId: number | undefined } ) {
+	const currentPlan = useSelector( ( state ) =>
+		props.siteId ? getCurrentPlan( state, props.siteId ) : undefined
+	);
+	const translate = useTranslate();
+
+	const billingPeriod = useSelector( getBillingInterval );
+	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
+
+	const currentPlanSlug = currentPlan?.productSlug;
+
+	const isChatAvailable =
+		currentPlanSlug &&
+		( isWpComPremiumPlan( currentPlanSlug ) ||
+			isWpComBusinessPlan( currentPlanSlug ) ||
+			isWpComEcommercePlan( currentPlanSlug ) ) &&
+		isAnnualPeriod;
+
+	if ( ! isChatAvailable ) return null;
+
+	return (
+		<CheckoutSummaryFeaturesListItem>
+			<WPCheckoutCheckIcon id={ 'annual-live-chat' } />
+			{ translate( 'Live chat support' ) }
+		</CheckoutSummaryFeaturesListItem>
 	);
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -7,6 +7,9 @@ import {
 	isDomainTransfer,
 	isWpComPersonalPlan,
 	isWpComPlan,
+	isWpComBusinessPlan,
+	isWpComEcommercePlan,
+	isWpComPremiumPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import {
@@ -27,7 +30,10 @@ import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
+import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getPlanFeatures from '../lib/get-plan-features';
 import getRefundText from '../lib/get-refund-text';
@@ -170,6 +176,22 @@ function CheckoutSummaryFeaturesList( props: {
 	}
 	const refundText = getRefundText( refundDays, null, translate );
 
+	const currentPlan = useSelector( ( state ) =>
+		siteId ? getCurrentPlan( state, siteId ) : undefined
+	);
+	const billingPeriod = useSelector( getBillingInterval );
+	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
+
+	const currentPlanSlug = currentPlan?.productSlug;
+
+	const isChatAvailable =
+		! hasPlanInCart &&
+		currentPlanSlug &&
+		( isWpComPremiumPlan( currentPlanSlug ) ||
+			isWpComBusinessPlan( currentPlanSlug ) ||
+			isWpComEcommercePlan( currentPlanSlug ) ) &&
+		isAnnualPeriod;
+
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
 			{ hasDomainsInCart &&
@@ -186,6 +208,13 @@ function CheckoutSummaryFeaturesList( props: {
 				<WPCheckoutCheckIcon id="features-list-support-text" />
 				<SupportText hasPlanInCart={ hasPlanInCart } isJetpackNotAtomic={ isJetpackNotAtomic } />
 			</CheckoutSummaryFeaturesListItem>
+			{ isChatAvailable && (
+				<CheckoutSummaryFeaturesListItem>
+					<WPCheckoutCheckIcon id={ 'annual-live-chat' } />
+					{ translate( 'Live chat support' ) }
+				</CheckoutSummaryFeaturesListItem>
+			) }
+
 			{ showRefundText && (
 				<CheckoutSummaryFeaturesListItem>
 					<WPCheckoutCheckIcon id="features-list-refund-text" />

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -727,6 +727,11 @@ export function createTestReduxStore() {
 			},
 			purchases: {},
 			countries: { payments: countryList, domains: countryList },
+			marketplace: {
+				billingInterval: {
+					interval: 'MONTHLY',
+				},
+			},
 		};
 	} );
 }

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -727,11 +727,6 @@ export function createTestReduxStore() {
 			},
 			purchases: {},
 			countries: { payments: countryList, domains: countryList },
-			marketplace: {
-				billingInterval: {
-					interval: 'MONTHLY',
-				},
-			},
 		};
 	} );
 }


### PR DESCRIPTION
The live chat support information was not displayed in the checkout
summary when purchasing individual plugins.

To display the live chat support, the current plan information is
extracted using selectors. The following criteria are required to allow
live chat support:
- Plan type
- ~Billing period~ Plan period

Also, the live chat support is already displayed as part of the plan
summary so it will only be displayed when not purchasing a plan.

#### Changes proposed in this Pull Request

* Include the `Live chat support` message in the checkout details card that will be displayed if:
  * There is no plan in cart
  * The user plan is either Premium, Business or eCommerce. 
    :warning: **Note:** Currently Premium plans cannot purchase plugins but the logic has been [copied from getPlanFeatures](https://github.com/Automattic/wp-calypso/blob/4ef9895f501b61e017f0b8b8edaacdb2a4088f5e/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts#L13)
  * The ~plugin~ plan is billed _Annually_
* The existing logic that displays features when a plan is purchased has not been modified

|Before | After|
|-------|------|
|![CleanShot 2022-02-22 at 09 38 24@2x](https://user-images.githubusercontent.com/3519124/155094341-917703ae-178f-4744-9c8e-4b2adb6e4e2d.png)|![CleanShot 2022-02-22 at 09 42 18@2x](https://user-images.githubusercontent.com/3519124/155094990-14fcc679-176b-4684-8d30-c0616eefcaaf.png)|

#### Testing instructions

##### Scenario 1
* Open a site with either a Business or eCommerce plan _which is **not** billed Monthly_
* Add a paid plugin ~and select to pay _Annually_~
* Click on Purchase and Activate
* If a prompt is displayed to notify that the site will be moved, click Continue
* The card with the title `Included with your purchase` on the top right should include `Live chat support`

##### Scenario 2
* Open a site with either a Business or eCommerce plan _which is billed Monthly_
* Add a paid plugin ~and select to pay _Monthly_~
* Click on Purchase and Activate
* If a prompt is displayed to notify that the site will be moved, click Continue
* The card with the title `Included with your purchase` on the top right should **not** include `Live chat support`

Fixes #61207
