### PR TITLE
Refactor SupportLink

### DIFF
--- a/client/components/support-info/index.jsx
+++ b/client/components/support-info/index.jsx
@@ -1,52 +1,59 @@
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import InfoPopover from 'calypso/components/info-popover';
 
 import './style.scss';
 
-class SupportInfo extends Component {
-	static propTypes = {
-		text: PropTypes.string,
-		link: PropTypes.string,
-		position: PropTypes.string,
-		privacyLink: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
-	};
+function SupportInfo( { text, link, position, translate, privacyLink } ) {
+	function makePrivacyLink() {
+		if ( privacyLink ) {
+			if ( typeof privacyLink === 'string' ) {
+				return privacyLink + '#privacy';
+			}
 
-	static defaultProps = {
-		text: '',
-		link: '',
-		privacyLink: '',
-	};
+			return link + '#privacy';
+		}
 
-	render() {
-		const { text, link, position, privacyLink, translate } = this.props;
-		const actualPrivacyLink =
-			! privacyLink && privacyLink !== false && link ? link + '#privacy' : privacyLink;
-
-		return (
-			<div className="support-info">
-				<InfoPopover position={ position || 'left' } screenReaderText={ translate( 'Learn more' ) }>
-					{ text + ' ' }
-					{ link && (
-						<span className="support-info__learn-more">
-							<ExternalLink href={ link } target="_blank" rel="noopener noreferrer">
-								{ translate( 'Learn more' ) }
-							</ExternalLink>
-						</span>
-					) }
-					{ actualPrivacyLink && (
-						<span className="support-info__privacy">
-							<ExternalLink href={ actualPrivacyLink } target="_blank" rel="noopener noreferrer">
-								{ translate( 'Privacy Information' ) }
-							</ExternalLink>
-						</span>
-					) }
-				</InfoPopover>
-			</div>
-		);
+		return null;
 	}
+
+	const actualPrivacyLink = makePrivacyLink();
+
+	return (
+		<div className="support-info">
+			<InfoPopover position={ position || 'left' } screenReaderText={ translate( 'Learn more' ) }>
+				{ text + ' ' }
+				{ link && (
+					<span className="support-info__learn-more">
+						<ExternalLink href={ link } target="_blank" rel="noopener noreferrer">
+							{ translate( 'Learn more' ) }
+						</ExternalLink>
+					</span>
+				) }
+				{ actualPrivacyLink && (
+					<span className="support-info__privacy">
+						<ExternalLink href={ actualPrivacyLink } target="_blank" rel="noopener noreferrer">
+							{ translate( 'Privacy Information' ) }
+						</ExternalLink>
+					</span>
+				) }
+			</InfoPopover>
+		</div>
+	);
 }
+
+SupportInfo.defaultProps = {
+	text: '',
+	link: '',
+	privacyLink: true,
+};
+
+SupportInfo.propTypes = {
+	text: PropTypes.string,
+	link: PropTypes.string,
+	position: PropTypes.string,
+	privacyLink: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+};
 
 export default localize( SupportInfo );

--- a/client/components/support-info/index.jsx
+++ b/client/components/support-info/index.jsx
@@ -9,7 +9,7 @@ function SupportInfo( { text, link, position, translate, privacyLink } ) {
 	function makePrivacyLink() {
 		if ( privacyLink ) {
 			if ( typeof privacyLink === 'string' ) {
-				return privacyLink + '#privacy';
+				return privacyLink;
 			}
 
 			return link + '#privacy';

--- a/client/components/support-info/index.jsx
+++ b/client/components/support-info/index.jsx
@@ -5,20 +5,20 @@ import InfoPopover from 'calypso/components/info-popover';
 
 import './style.scss';
 
-function SupportInfo( { text, link, position, translate, privacyLink } ) {
-	function makePrivacyLink() {
-		if ( privacyLink ) {
-			if ( typeof privacyLink === 'string' ) {
-				return privacyLink;
-			}
-
-			return link + '#privacy';
+function makePrivacyLink( privacyLink, link ) {
+	if ( privacyLink ) {
+		if ( typeof privacyLink === 'string' ) {
+			return privacyLink;
 		}
 
-		return null;
+		return link + '#privacy';
 	}
 
-	const actualPrivacyLink = makePrivacyLink();
+	return null;
+}
+
+function SupportInfo( { text, link, position, translate, privacyLink } ) {
+	const filteredPrivacyLink = makePrivacyLink( privacyLink, link );
 
 	return (
 		<div className="support-info">
@@ -31,9 +31,9 @@ function SupportInfo( { text, link, position, translate, privacyLink } ) {
 						</ExternalLink>
 					</span>
 				) }
-				{ actualPrivacyLink && (
+				{ filteredPrivacyLink && (
 					<span className="support-info__privacy">
-						<ExternalLink href={ actualPrivacyLink } target="_blank" rel="noopener noreferrer">
+						<ExternalLink href={ filteredPrivacyLink } target="_blank" rel="noopener noreferrer">
 							{ translate( 'Privacy Information' ) }
 						</ExternalLink>
 					</span>


### PR DESCRIPTION
## Changes proposed in this Pull Request
While working on support links in the settings I noticed the `actualPrivacyLink` prop was difficult to understand and did not accept the value of `true`. This refactors the prop to be easier to read and defaults to true. This allows the prop to accept `true` and use the `link` as it did already.

## Testing instructions

* Load branch and `yarn start`
* Check a few support links such as the ones in Settings ⇢ Writing
* There should be no changes to the functionality
* The only time the privacy link should not show is if `privacyLink = false`
* If a link is specified then it should default to that link given
* Otherwise it should return the link given + `#privacy`