### PR TITLE
Full Site Editing: no hiding the FSE tag

### DIFF
--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -1,5 +1,4 @@
 import i18n from 'i18n-calypso';
-import { omit } from 'lodash';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -21,9 +20,7 @@ const fetchFilters = ( action ) =>
 	);
 
 const storeFilters = ( action, data ) => {
-	// Don't show FSE themes to non-FSE sites until switching to a FSE theme activates FSE.
-	const filters = action.isCoreFse ? data : omit( data, 'feature.full-site-editing' );
-	return { type: THEME_FILTERS_ADD, filters };
+	return { type: THEME_FILTERS_ADD, filters: data };
 };
 
 const reportError = () => errorNotice( i18n.translate( 'Problem fetching theme filters.' ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* don't hide the `full-site-editing` feature tag in the theme showcase

Formerly we were hiding it from non-FSE sites. But now that all sites are activating FSE when switching to a FSE theme, that's no longer needed.

#### Testing instructions

On a non-FSE (Classic) site, ensure the the Full Site Editing filter shows up in the search box:

<img width="833" alt="Screen Shot 2022-02-18 at 11 13 17" src="https://user-images.githubusercontent.com/195089/154730308-71350742-aad7-4eac-81d4-91491ed04d8d.png">



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #61167
