### PR TITLE
Add VideoPress JWT-based auth.

### DIFF
--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -7,6 +7,7 @@ import ReactDom from 'react-dom';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
+import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import TrackInputChanges from 'calypso/components/track-input-changes';
@@ -45,6 +46,12 @@ class EditorMediaModalDetailFields extends Component {
 		if ( nextProps.item && nextProps.item.ID !== this.props.item?.ID ) {
 			this.updateChange( true );
 			this.setState( { modifiedChanges: null } );
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.item && prevProps.item.privacy_setting !== this.props.item?.privacy_setting ) {
+			window.postMessage( { event: 'videopress_refresh_iframe' }, '*' );
 		}
 	}
 
@@ -116,6 +123,10 @@ class EditorMediaModalDetailFields extends Component {
 
 	handleRatingChange = ( { currentTarget } ) => {
 		this.setFieldByName( 'rating', currentTarget.value );
+	};
+
+	handlePrivacySettingChange = ( { currentTarget } ) => {
+		this.setFieldByName( 'privacy_setting', parseInt( currentTarget.value ) );
 	};
 
 	handleDisplayEmbed = () => {
@@ -212,6 +223,25 @@ class EditorMediaModalDetailFields extends Component {
 						</FormLabel>
 					) ) }
 				</div>
+			</EditorMediaModalFieldset>
+		);
+	};
+
+	renderPrivacySetting = () => {
+		const privacySetting = this.getItemValue( 'privacy_setting' );
+		return (
+			<EditorMediaModalFieldset legend={ this.props.translate( 'Privacy' ) }>
+				<FormSelect value={ privacySetting } onChange={ this.handlePrivacySettingChange }>
+					<option key={ 2 } value={ 2 }>
+						{ this.props.translate( 'Site Default' ) }
+					</option>
+					<option key={ 0 } value={ 0 }>
+						{ this.props.translate( 'Public' ) }
+					</option>
+					<option key={ 1 } value={ 1 }>
+						{ this.props.translate( 'Private' ) }
+					</option>
+				</FormSelect>
 			</EditorMediaModalFieldset>
 		);
 	};
@@ -316,6 +346,7 @@ class EditorMediaModalDetailFields extends Component {
 				{ this.renderShareEmbed() }
 				{ this.renderAllowDownloadOption() }
 				{ this.renderRating() }
+				{ this.renderPrivacySetting() }
 				{ this.renderVideoPressShortcode() }
 			</div>
 		);

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -18,6 +18,7 @@ import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { getMimePrefix, url } from 'calypso/lib/media/utils';
 import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EditorMediaModalFieldset from '../fieldset';
 
@@ -362,11 +363,9 @@ class EditorMediaModalDetailFields extends Component {
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const hasVideoPrivacyFeature = hasActiveSiteFeature(
-		state,
-		siteId,
-		'videopress-privacy-setting'
-	);
+	const isWpcom = ! isJetpackSite( state, siteId );
+	const hasVideoPrivacyFeature =
+		isWpcom && hasActiveSiteFeature( state, siteId, 'videopress-privacy-setting' );
 
 	return {
 		siteId,

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -349,7 +349,10 @@ class EditorMediaModalDetailFields extends Component {
 				{ this.renderShareEmbed() }
 				{ this.renderAllowDownloadOption() }
 				{ this.renderRating() }
-				{ this.props.hasVideoPrivacyFeature && this.renderPrivacySetting() }
+				{
+					false && this.props.hasVideoPrivacyFeature && this.renderPrivacySetting()
+					/* TODO: Remove false when VP Privacy Setting PR lands */
+				}
 				{ this.renderVideoPressShortcode() }
 			</div>
 		);

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -4,6 +4,7 @@ import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ReactDom from 'react-dom';
+import { connect } from 'react-redux';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
@@ -16,6 +17,8 @@ import { FormCheckbox } from 'calypso/devdocs/design/playground-scope';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { getMimePrefix, url } from 'calypso/lib/media/utils';
+import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EditorMediaModalFieldset from '../fieldset';
 
 const noop = () => {};
@@ -346,11 +349,23 @@ class EditorMediaModalDetailFields extends Component {
 				{ this.renderShareEmbed() }
 				{ this.renderAllowDownloadOption() }
 				{ this.renderRating() }
-				{ this.renderPrivacySetting() }
+				{ this.props.hasVideoPrivacyFeature && this.renderPrivacySetting() }
 				{ this.renderVideoPressShortcode() }
 			</div>
 		);
 	}
 }
 
-export default localize( withUpdateMedia( EditorMediaModalDetailFields ) );
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const hasVideoPrivacyFeature = hasActiveSiteFeature(
+		state,
+		siteId,
+		'videopress-privacy-setting'
+	);
+
+	return {
+		siteId,
+		hasVideoPrivacyFeature,
+	};
+} )( localize( withUpdateMedia( EditorMediaModalDetailFields ) ) );

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -129,7 +129,8 @@ class EditorMediaModalDetailFields extends Component {
 	};
 
 	handlePrivacySettingChange = ( { currentTarget } ) => {
-		this.setFieldByName( 'privacy_setting', parseInt( currentTarget.value ) );
+		const clippedValue = Math.max( 0, Math.min( 2, parseInt( currentTarget.value, 10 ) ) );
+		this.setFieldByName( 'privacy_setting', clippedValue );
 	};
 
 	handleDisplayEmbed = () => {

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -62,13 +62,25 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	setVideoInstance = ( ref ) => ( this.video = ref );
 
 	receiveMessage = ( event ) => {
-		if ( event.origin && event.origin !== 'https://video.wordpress.com' ) {
-			return;
-		}
-
 		const { data } = event;
 
 		if ( ! data || ! data.event ) {
+			return;
+		}
+
+		// events received from calypso
+		if ( 'videopress_refresh_iframe' === data.event ) {
+			// in a timeout to guard against a race condition with cache not being busted prior to this message being received
+			// and the `privacy_setting` not being accurate as a result.
+			// Potential solution to this is to prevent the `videopress_refresh_iframe` message from being SENT until
+			// the update has completed.
+			setTimeout( () => {
+				this.video.src += ''; // force reload of potentially cross-origin iframe
+			}, 1000 );
+		}
+
+		// events received from player only
+		if ( event.origin && event.origin !== 'https://video.wordpress.com' ) {
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a Video Privacy Setting on a Video's media edit screen.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D75160-code if not merged. Sandbox public-api and your test site.
* On `client/post-editor/media-modal/detail/detail-fields.jsx` remove flag `false` from the line that renders the privacy setting: (search for `this.renderPrivacySetting()`) to enable privacy setting.
* Open site media `http://calypso.localhost:3000/media/<yoursite>` and view a video.
* You should see a privacy setting select box. Changing the setting around should persist.
* Video previews work.
* Visit a Jetpack site calypso media library and open a video. The select box should not show.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/22948
