### PR TITLE
Seller experience: Added call to set footer credit

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -452,6 +452,12 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 			show_on_front: 'page',
 			page_on_front: newPage.id,
 		} )( reduxStore.dispatch );
+
+		// Set footer to the 'store' option
+		await wpcom.req.post( {
+			path: `/sites/${ siteSlug }/seller_footer`,
+			apiNamespace: 'wpcom/v2',
+		} );
 	} catch ( e ) {
 		defer( callback );
 		return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* ~~Depends on D75294-code~~ Deployed
* Adds a call to set the footer credit option to 'store'

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* ~~Apply D75294-code to your sandbox~~ Deployed
* Switch to this PR, navigate to `/start?flags=seller-experience`
* Create a new free site
* Choose Sell at the intent step
* Choose the Simple option
* Visit the website and check the footer

![image](https://user-images.githubusercontent.com/3801502/154741600-45c3c4e2-30e7-44ae-8c99-5712a04b1887.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #61017