### PR TITLE
Shopping Cart: Return undefined cart key if manage_options cap check fails

### DIFF
--- a/client/my-sites/checkout/get-cart-key.ts
+++ b/client/my-sites/checkout/get-cart-key.ts
@@ -5,16 +5,21 @@ export default function getCartKey( {
 	selectedSite,
 	isLoggedOutCart,
 	isNoSiteCart,
+	doesUserHavePermission,
 }: {
 	selectedSite: SiteData | undefined | null;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
+	doesUserHavePermission?: boolean;
 } ): CartKey | undefined {
 	if ( ! selectedSite?.slug && ( isLoggedOutCart || isNoSiteCart ) ) {
 		return 'no-user';
 	}
 	if ( ! selectedSite?.slug && ! isLoggedOutCart && ! isNoSiteCart ) {
 		return 'no-site';
+	}
+	if ( selectedSite?.ID && ! doesUserHavePermission ) {
+		return undefined;
 	}
 	if ( selectedSite?.ID ) {
 		return selectedSite.ID;

--- a/client/my-sites/checkout/use-cart-key.ts
+++ b/client/my-sites/checkout/use-cart-key.ts
@@ -1,3 +1,4 @@
+import { useDebugValue } from 'react';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -21,9 +22,17 @@ export default function useCartKey(): ReturnType< typeof getCartKey > {
 			currentUrlPath.includes( '/checkout/no-site' ) &&
 			'no-user' === searchParams.get( 'cart' ) );
 	const doesUserHavePermission = useSelector(
-		( state ) =>
-			!! selectedSite?.ID && ! canCurrentUser( state, selectedSite?.ID, 'manage_options' )
+		( state ) => !! selectedSite?.ID && canCurrentUser( state, selectedSite.ID, 'manage_options' )
 	);
 
-	return getCartKey( { selectedSite, isLoggedOutCart, isNoSiteCart, doesUserHavePermission } );
+	const cartKey = getCartKey( {
+		selectedSite,
+		isLoggedOutCart,
+		isNoSiteCart,
+		doesUserHavePermission,
+	} );
+	useDebugValue( `cart key is ${ cartKey }` );
+	useDebugValue( `site ID ${ selectedSite?.ID }` );
+	useDebugValue( `does user have permission? ${ doesUserHavePermission }` );
+	return cartKey;
 }

--- a/client/my-sites/checkout/use-cart-key.ts
+++ b/client/my-sites/checkout/use-cart-key.ts
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import getCartKey from './get-cart-key';
 
@@ -19,6 +20,10 @@ export default function useCartKey(): ReturnType< typeof getCartKey > {
 		( ! isLoggedOutCart &&
 			currentUrlPath.includes( '/checkout/no-site' ) &&
 			'no-user' === searchParams.get( 'cart' ) );
+	const doesUserHavePermission = useSelector(
+		( state ) =>
+			!! selectedSite?.ID && ! canCurrentUser( state, selectedSite?.ID, 'manage_options' )
+	);
 
-	return getCartKey( { selectedSite, isLoggedOutCart, isNoSiteCart } );
+	return getCartKey( { selectedSite, isLoggedOutCart, isNoSiteCart, doesUserHavePermission } );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We see a very large number of errors where a user in Calypso tries to request the shopping-cart data for a site they do not own. It's still a mystery how this could come to pass, but this PR attempts to address the immediate effect by adding an additional guard to `useCartKey()`; after this PR if the user does not have the `manage_options` capability for the current site, the cart will not attempt to load.

#### Testing instructions

Just visit checkout and make sure it loads.

Because this blocks loading the cart for a specific circumstance, it's important for us to verify that all legitimate variations of cart access still work, so it may be worth testing unusual versions of checkout like userless and siteless and Jetpack checkout (although those shouldn't affected since they have their own conditions in most cases).