### PR TITLE
Add basic CI for renovate config validation

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -53,6 +53,7 @@ project {
 	subProject(_self.projects.MarTech)
 	buildType(BuildBaseImages)
 	buildType(CheckCodeStyle)
+	buildType(ValidateRenovateConfig)
 	buildType(SmartBuildLauncher)
 
 	params {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -268,6 +268,58 @@ object CheckCodeStyle : BuildType({
 	}
 })
 
+object ValidateRenovateConfig : BuildType({
+	name = "Validate Renovate Configuration"
+	description = "Validates the renovate configuration file"
+
+	vcs {
+		root(WpCalypso)
+		cleanCheckout = true
+	}
+
+	steps {
+		bashNodeScript {
+			name = "Validate Configuration"
+			scriptContent = """
+				echo "Hello, world"
+			"""
+		}
+	}
+
+	triggers {
+		vcs {
+			// Only trigger on changes to the renovate configuration file.
+			triggerRules = "+:root=${Settings.WpCalypso.id}:renovate.json"
+			branchFilter = """
+				+:*
+				-:pull*
+			""".trimIndent()
+		}
+	}
+
+	features {
+		pullRequests {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			provider = github {
+				authType = token {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
+			}
+		}
+		commitStatusPublisher {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			publisher = github {
+				githubUrl = "https://api.github.com"
+				authType = personalToken {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+			}
+		}
+	}
+})
+
+
 object SmartBuildLauncher : BuildType({
 	name = "Smart Build Launcher"
 	description = "Launches TeamCity builds based on which files were modified in VCS."

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -16,6 +16,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.project
 import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.dockerRegistry
 import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.githubConnection
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
 import jetbrains.buildServer.configs.kotlin.v2019_2.version
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Create new CI build for renovate config validation. It doesn't do anything yet -- we'll add that after the build exists on trunk.

#### Testing instructions
TeamCity
