### PR TITLE
Add renovate validation script

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -281,9 +281,13 @@ object ValidateRenovateConfig : BuildType({
 
 	steps {
 		bashNodeScript {
-			name = "Validate Configuration"
+			name = "Run renovate config validator"
 			scriptContent = """
-				echo "Hello, world"
+				# Run renovate-config-validator from the latest version of renovate
+				# in a temporary environment (to avoid installing every package.)
+				# We use the latest version because the managed renovate service
+				# controls the renovate version we use.
+				yarn dlx -p renovate renovate-config-validator
 			"""
 		}
 	}

--- a/renovate.json
+++ b/renovate.json
@@ -85,7 +85,7 @@
 	"ignoreDeps": [ "electron-builder" ],
 	"labels": [ "Framework", "[Type] Task" ],
 	"postUpdateOptions": [ "yarnDedupeHighest" ],
-	"prConcurrentLimit": 20,
+	"prConcurrentLimit": 18,
 	"prHourlyLimit": 10,
 	"semanticCommits": true,
 	"semanticCommitType": "chore",

--- a/renovate.json
+++ b/renovate.json
@@ -25,11 +25,12 @@
 			"includePaths": [ "packages/interpolate-components" ]
 		},
 		{
-			"packagePatterns": [ "react" ],
+			"matchPackagePatterns": [ "react" ],
 			"prPriority": 1
 		},
 		{
-			"packagePatterns": [ "redux", "react-redux" ],
+			"matchPackagePatterns": [ "redux" ],
+			"matchPackageNames": [ "react-redux" ],
 			"prPriority": 2
 		},
 		{
@@ -38,13 +39,13 @@
 		},
 		{
 			"groupName": "Type definitions",
-			"packagePatterns": [ "^@types/" ],
+			"matchPackagePatterns": [ "^@types/" ],
 			"prPriority": 2
 		},
 		{
 			"groupName": [ "webpack packages" ],
-			"packages": [ "style-loader", "html-loader", "exports-loader", "loader-utils" ],
-			"packagePatterns": [ "webpack", "terser" ],
+			"matchPackageNames": [ "style-loader", "html-loader", "exports-loader", "loader-utils" ],
+			"matchPackagePatterns": [ "webpack", "terser" ],
 			"prPriority": 2
 		},
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- Add renovate validation script
- Fix renovate validation errors

#### Testing instructions
- The first commit should _not_ run the renovate config validator. (It only runs on changes to the configuration file)
- The second commit should run it, and correctly fail if there are errors.
- The third commit should run it, and pass once the errors have been fixed.
