### PR TITLE
Add postcss-loader and css-loader to webpack packages group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,7 +44,14 @@
 		},
 		{
 			"groupName": [ "webpack packages" ],
-			"matchPackageNames": [ "style-loader", "html-loader", "exports-loader", "loader-utils" ],
+			"matchPackageNames": [
+				"style-loader",
+				"html-loader",
+				"exports-loader",
+				"loader-utils",
+				"postcss-loader",
+				"css-loader"
+			],
 			"matchPackagePatterns": [ "webpack", "terser" ],
 			"prPriority": 2
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add postcss-loader and css-loader to webpack packages group to bundle more webpack related updates 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #61269
