### PR TITLE
e2e: Plugin browse all links and category page

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -3,7 +3,6 @@ import { Page } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 
 const selectors = {
-	sectionHeader: '.plugins-browser-list__header',
 	sectionTitle: ( section: string ) => `.plugins-browser-list__title:text("${ section }")`,
 	sectionTitles: '.plugins-browser-list__title',
 	browseAllPopular: 'a[href^="/plugins/popular"]',

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -3,8 +3,11 @@ import { Page } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 
 const selectors = {
+	sectionHeader: '.plugins-browser-list__header',
 	sectionTitle: ( section: string ) => `.plugins-browser-list__title:text("${ section }")`,
 	sectionTitles: '.plugins-browser-list__title',
+	browseAll: 'a:text("Browse All")',
+	breadcrumb: ( section: string ) => `.plugins-browser__header li a:text("${ section }") `,
 };
 
 /**
@@ -53,5 +56,21 @@ export class PluginsPage {
 			const title = await titles.nth( i ).innerText();
 			assert.notEqual( title, section );
 		}
+	}
+
+	/**
+	 * Click Browse All
+	 */
+	async clickBrowseAll(): Promise< void > {
+		await this.page.click( selectors.browseAll );
+		assert.match( this.page.url(), /.*\/plugins\/(featured|paid|new|popular)$/ );
+	}
+
+	/**
+	 * Click breadcrumb
+	 */
+	async clickBreadcrumb( text: string ): Promise< void > {
+		await this.page.click( selectors.breadcrumb( text ) );
+		assert.match( this.page.url(), /.*\/plugins$/ );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -6,7 +6,7 @@ const selectors = {
 	sectionHeader: '.plugins-browser-list__header',
 	sectionTitle: ( section: string ) => `.plugins-browser-list__title:text("${ section }")`,
 	sectionTitles: '.plugins-browser-list__title',
-	browseAll: 'a:text("Browse All")',
+	browseAllPopular: 'a[href^="/plugins/popular"]',
 	breadcrumb: ( section: string ) => `.plugins-browser__header li a:text("${ section }") `,
 };
 
@@ -61,16 +61,14 @@ export class PluginsPage {
 	/**
 	 * Click Browse All
 	 */
-	async clickBrowseAll(): Promise< void > {
-		await this.page.click( selectors.browseAll );
-		assert.match( this.page.url(), /.*\/plugins\/(featured|paid|new|popular)$/ );
+	async clickBrowseAllPopular(): Promise< void > {
+		await this.page.click( selectors.browseAllPopular );
 	}
 
 	/**
-	 * Click breadcrumb
+	 * Click the Plugins breadcrumb
 	 */
-	async clickBreadcrumb( text: string ): Promise< void > {
-		await this.page.click( selectors.breadcrumb( text ) );
-		assert.match( this.page.url(), /.*\/plugins$/ );
+	async clickPluginsBreadcrumb(): Promise< void > {
+		await this.page.click( selectors.breadcrumb( 'Plugins' ) );
 	}
 }

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -29,12 +29,14 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins' ), function () {
 		}
 	);
 
-	it( 'Can browse all plugins', async function () {
-		await pluginsPage.clickBrowseAll();
+	it( 'Can browse all popular plugins', async function () {
+		await pluginsPage.clickBrowseAllPopular();
+		await pluginsPage.validateHasSection( 'All Popular Plugins' );
 	} );
 
 	it( 'Can return via breadcrumb', async function () {
-		await pluginsPage.clickBreadcrumb( 'Plugins' );
+		await pluginsPage.clickPluginsBreadcrumb();
+		await pluginsPage.validateHasSection( 'Premium' );
 	} );
 } );
 

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -28,6 +28,14 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins' ), function () {
 			await pluginsPage.validateHasSection( section );
 		}
 	);
+
+	it( 'Can browse all plugins', async function () {
+		await pluginsPage.clickBrowseAll();
+	} );
+
+	it( 'Can return via breadcrumb', async function () {
+		await pluginsPage.clickBreadcrumb( 'Plugins' );
+	} );
 } );
 
 describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:wpcom-site' ), function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Follow on from https://github.com/Automattic/wp-calypso/pull/61224 / https://github.com/Automattic/wp-calypso/pull/61229
* Tests browse all links load the category page

#### Testing instructions

[Prereq setup](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)

```
cd e2e/tests
yarn workspace @automattic/calypso-e2e build && yarn jest specs/plugins/plugins__browse.ts
```

Related to https://github.com/Automattic/wp-calypso/issues/61094
