### PR TITLE
check for likes button being disabled in reader

### DIFF
--- a/client/reader/like-helper.jsx
+++ b/client/reader/like-helper.jsx
@@ -4,13 +4,28 @@ import {
 	isDiscoverSitePick,
 } from 'calypso/reader/discover/helper';
 
+/**
+ * True if likes are explicitly disabled.
+ * False if likes are enabled or the property does not exist.
+ *
+ * @param {object} post
+ * @returns {boolean} True if likes are explicitly disabled
+ */
+function isLikesDisabled( post ) {
+	return post?.likes_enabled === false;
+}
+
 export function shouldShowLikes( post ) {
 	let showLikes = false;
 	if ( isDiscoverPost( post ) ) {
-		if ( isInternalDiscoverPost( post ) && ! isDiscoverSitePick( post ) ) {
+		if (
+			isInternalDiscoverPost( post ) &&
+			! isDiscoverSitePick( post ) &&
+			! isLikesDisabled( post )
+		) {
 			showLikes = true;
 		}
-	} else if ( post && post.site_ID && ! post.is_external ) {
+	} else if ( post && post.site_ID && ! post.is_external && ! isLikesDisabled( post ) ) {
 		showLikes = true;
 	}
 


### PR DESCRIPTION
We have the ability to disable likes for the whole site or a specific post, but the reader isn't currently respecting this https://github.com/Automattic/wp-calypso/issues/56239

This PR adds logic to check that likes have been explicitly disabled. I check for an explicit false value because I'm not sure if all sites will have a `likes_enabled=true` value returned by the `/rest/v1.2/read/feed` endpoint and this prevents disabling the button for sites without an explicit value.

Fixes https://github.com/Automattic/wp-calypso/issues/56239


Testing instructions:

likes can be disabled sitewide by going to `https://wordpress.com/marketing/sharing-buttons/$your_site.wordpress.com`
your site can be loaded in the reader by going to `https://wordpress.com/read/feeds/$your_site_id`