### PR TITLE
Add plugins page e2e toggle price test

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -8,8 +8,9 @@ const selectors = {
 	browseAllPopular: 'a[href^="/plugins/popular"]',
 	breadcrumb: ( section: string ) => `.plugins-browser__header li a:text("${ section }") `,
 	pricingToggle: '.select-dropdown__container',
-	monthlyPricingSelect: 'li a:text("Monthly price")',
-	annualPricingSelect: 'li a:text("Annual price")',
+	pricingToggleOpen: '.select-dropdown__container[aria-expanded="true"]',
+	monthlyPricingSelect: 'a[data-bold-text^="Monthly price"]',
+	annualPricingSelect: 'a[data-bold-text^="Annual price"]',
 	monthlyPricing: '.plugins-browser-item__period:text("monthly")',
 	annualPricing: '.plugins-browser-item__period:text("per year")',
 };
@@ -81,6 +82,7 @@ export class PluginsPage {
 	 */
 	async selectMonthlyPricing(): Promise< void > {
 		await this.page.click( selectors.pricingToggle );
+		await this.page.waitForSelector( selectors.pricingToggleOpen );
 		await this.page.click( selectors.monthlyPricingSelect );
 	}
 
@@ -89,6 +91,7 @@ export class PluginsPage {
 	 */
 	async selectAnnualPricing(): Promise< void > {
 		await this.page.click( selectors.pricingToggle );
+		await this.page.waitForSelector( selectors.pricingToggleOpen );
 		await this.page.click( selectors.annualPricingSelect );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -7,6 +7,13 @@ const selectors = {
 	sectionTitles: '.plugins-browser-list__title',
 	browseAllPopular: 'a[href^="/plugins/popular"]',
 	breadcrumb: ( section: string ) => `.plugins-browser__header li a:text("${ section }") `,
+	monthlyPricingToggle: 'a:text("Monthly")',
+	annualPricingToggle: 'a:text("Annually")',
+	pricingToggle: '.select-dropdown__container',
+	monthlyPricingSelect: 'li a:text("Monthly price")',
+	annualPricingSelect: 'li a:text("Annual price")',
+	monthlyPricing: '.plugins-browser-item__period:text("monthly")',
+	annualPricing: '.plugins-browser-item__period:text("per year")',
 };
 
 /**
@@ -69,5 +76,49 @@ export class PluginsPage {
 	 */
 	async clickPluginsBreadcrumb(): Promise< void > {
 		await this.page.click( selectors.breadcrumb( 'Plugins' ) );
+	}
+
+	/**
+	 * Click Monthly Pricing
+	 */
+	async clickMonthlyPricing(): Promise< void > {
+		await this.page.click( selectors.monthlyPricingToggle );
+	}
+
+	/**
+	 * Click Annual Pricing
+	 */
+	async clickAnnualPricing(): Promise< void > {
+		await this.page.click( selectors.annualPricingToggle );
+	}
+
+	/**
+	 * Select monthly
+	 */
+	async selectMonthlyPricing(): Promise< void > {
+		await this.page.click( selectors.pricingToggle );
+		await this.page.click( selectors.monthlyPricingSelect );
+	}
+
+	/**
+	 * Select annual
+	 */
+	async selectAnnualPricing(): Promise< void > {
+		await this.page.click( selectors.pricingToggle );
+		await this.page.click( selectors.annualPricingSelect );
+	}
+
+	/**
+	 * Check Is Monthly Pricing
+	 */
+	async checkMonthlyPricing(): Promise< void > {
+		await this.page.waitForSelector( selectors.monthlyPricing );
+	}
+
+	/**
+	 * Check Is Annual Pricing
+	 */
+	async checkAnnualPricing(): Promise< void > {
+		await this.page.waitForSelector( selectors.annualPricing );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -98,14 +98,14 @@ export class PluginsPage {
 	/**
 	 * Check Is Monthly Pricing
 	 */
-	async checkMonthlyPricing(): Promise< void > {
+	async validateIsMonthlyPricing(): Promise< void > {
 		await this.page.waitForSelector( selectors.monthlyPricing );
 	}
 
 	/**
 	 * Check Is Annual Pricing
 	 */
-	async checkAnnualPricing(): Promise< void > {
+	async validateIsAnnualPricing(): Promise< void > {
 		await this.page.waitForSelector( selectors.annualPricing );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -7,8 +7,6 @@ const selectors = {
 	sectionTitles: '.plugins-browser-list__title',
 	browseAllPopular: 'a[href^="/plugins/popular"]',
 	breadcrumb: ( section: string ) => `.plugins-browser__header li a:text("${ section }") `,
-	monthlyPricingToggle: 'a:text("Monthly")',
-	annualPricingToggle: 'a:text("Annually")',
 	pricingToggle: '.select-dropdown__container',
 	monthlyPricingSelect: 'li a:text("Monthly price")',
 	annualPricingSelect: 'li a:text("Annual price")',
@@ -76,20 +74,6 @@ export class PluginsPage {
 	 */
 	async clickPluginsBreadcrumb(): Promise< void > {
 		await this.page.click( selectors.breadcrumb( 'Plugins' ) );
-	}
-
-	/**
-	 * Click Monthly Pricing
-	 */
-	async clickMonthlyPricing(): Promise< void > {
-		await this.page.click( selectors.monthlyPricingToggle );
-	}
-
-	/**
-	 * Click Annual Pricing
-	 */
-	async clickAnnualPricing(): Promise< void > {
-		await this.page.click( selectors.annualPricingToggle );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -7,8 +7,7 @@ const selectors = {
 	sectionTitles: '.plugins-browser-list__title',
 	browseAllPopular: 'a[href^="/plugins/popular"]',
 	breadcrumb: ( section: string ) => `.plugins-browser__header li a:text("${ section }") `,
-	pricingToggle: '.select-dropdown__container',
-	pricingToggleOpen: '.select-dropdown__container[aria-expanded="true"]',
+	pricingToggle: ':text("Monthly Price"), :text("Annual Price")',
 	monthlyPricingSelect: 'a[data-bold-text^="Monthly price"]',
 	annualPricingSelect: 'a[data-bold-text^="Annual price"]',
 	monthlyPricing: '.plugins-browser-item__period:text("monthly")',
@@ -82,7 +81,6 @@ export class PluginsPage {
 	 */
 	async selectMonthlyPricing(): Promise< void > {
 		await this.page.click( selectors.pricingToggle );
-		await this.page.waitForSelector( selectors.pricingToggleOpen );
 		await this.page.click( selectors.monthlyPricingSelect );
 	}
 
@@ -91,7 +89,6 @@ export class PluginsPage {
 	 */
 	async selectAnnualPricing(): Promise< void > {
 		await this.page.click( selectors.pricingToggle );
-		await this.page.waitForSelector( selectors.pricingToggleOpen );
 		await this.page.click( selectors.annualPricingSelect );
 	}
 

--- a/test/e2e/specs/plugins/plugins__pricing.ts
+++ b/test/e2e/specs/plugins/plugins__pricing.ts
@@ -1,0 +1,32 @@
+/**
+ * @group calypso-pr
+ */
+
+import { DataHelper, TestAccount, PluginsPage } from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Plugins page pricing toggle' ), function () {
+	let page: Page;
+	let pluginsPage: PluginsPage;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		const testAccount = new TestAccount( 'defaultUser' );
+		await testAccount.authenticate( page );
+	} );
+
+	it( 'Visit plugins page', async function () {
+		pluginsPage = new PluginsPage( page );
+		await pluginsPage.visit();
+	} );
+
+	it( 'Pricing toggle', async function () {
+		await pluginsPage.checkMonthlyPricing();
+		await pluginsPage.selectAnnualPricing();
+		await pluginsPage.checkAnnualPricing();
+		await pluginsPage.selectMonthlyPricing();
+		await pluginsPage.checkMonthlyPricing();
+	} );
+} );

--- a/test/e2e/specs/plugins/plugins__pricing.ts
+++ b/test/e2e/specs/plugins/plugins__pricing.ts
@@ -20,13 +20,15 @@ describe( DataHelper.createSuiteTitle( 'Plugins page pricing toggle' ), function
 	it( 'Visit plugins page', async function () {
 		pluginsPage = new PluginsPage( page );
 		await pluginsPage.visit();
+		await pluginsPage.validateIsMonthlyPricing();
 	} );
 
-	it( 'Pricing toggle', async function () {
-		await pluginsPage.checkMonthlyPricing();
+	it( 'Toggle pricing to annual', async function () {
 		await pluginsPage.selectAnnualPricing();
-		await pluginsPage.checkAnnualPricing();
+		await pluginsPage.validateIsAnnualPricing();
+	} );
+	it( 'Toggle pricing back to monthly', async function () {
 		await pluginsPage.selectMonthlyPricing();
-		await pluginsPage.checkMonthlyPricing();
+		await pluginsPage.validateIsMonthlyPricing();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add plugins page e2e toggle price test

#### Testing instructions

[Prereq setup](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)

```
cd e2e/tests
yarn workspace @automattic/calypso-e2e build && yarn jest specs/plugins/plugins__pricing.ts
```

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/61094
