### PR TITLE
e2e: Plugin search results are as expected

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -14,6 +14,7 @@ const selectors = {
 	annualPricing: '.plugins-browser-item__period:text("per year")',
 	search: 'input[placeholder="Try searching ‘ecommerce’"]',
 	searchResult: ( text: string ) => `.plugins-browser-item__title:text("${ text }")`,
+	searchResultTitle: ( text: string ) => `:text("Search results for ${ text }")`,
 };
 
 /**
@@ -114,6 +115,7 @@ export class PluginsPage {
 	async search( query: string, expectedResult: string ): Promise< void > {
 		await this.page.fill( selectors.search, query );
 		await this.page.press( selectors.search, 'Enter' );
+		await this.page.waitForSelector( selectors.searchResultTitle( query ) );
 		await this.page.waitForSelector( selectors.searchResult( expectedResult ) );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -12,6 +12,8 @@ const selectors = {
 	annualPricingSelect: 'a[data-bold-text^="Annual price"]',
 	monthlyPricing: '.plugins-browser-item__period:text("monthly")',
 	annualPricing: '.plugins-browser-item__period:text("per year")',
+	search: 'input[placeholder="Try searching ‘ecommerce’"]',
+	searchResult: ( text: string ) => `.plugins-browser-item__title:text("${ text }")`,
 };
 
 /**
@@ -104,5 +106,14 @@ export class PluginsPage {
 	 */
 	async validateIsAnnualPricing(): Promise< void > {
 		await this.page.waitForSelector( selectors.annualPricing );
+	}
+
+	/**
+	 * Search
+	 */
+	async search( query: string, expectedResult: string ): Promise< void > {
+		await this.page.fill( selectors.search, query );
+		await this.page.press( selectors.search, 'Enter' );
+		await this.page.waitForSelector( selectors.searchResult( expectedResult ) );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -12,7 +12,7 @@ const selectors = {
 	annualPricingSelect: 'a[data-bold-text^="Annual price"]',
 	monthlyPricing: '.plugins-browser-item__period:text("monthly")',
 	annualPricing: '.plugins-browser-item__period:text("per year")',
-	search: 'input[placeholder="Try searching ‘ecommerce’"]',
+	search: 'input[placeholder="Try searching ‘ecommerce’"]:visible',
 	searchResult: ( text: string ) => `.plugins-browser-item__title:text("${ text }")`,
 	searchResultTitle: ( text: string ) => `:text("Search results for ${ text }")`,
 };

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -112,10 +112,16 @@ export class PluginsPage {
 	/**
 	 * Search
 	 */
-	async search( query: string, expectedResult: string ): Promise< void > {
+	async search( query: string ): Promise< void > {
 		await this.page.fill( selectors.search, query );
 		await this.page.press( selectors.search, 'Enter' );
 		await this.page.waitForSelector( selectors.searchResultTitle( query ) );
+	}
+
+	/**
+	 * Validate Expected Search Result Found
+	 */
+	async validateExpectedSearchResultFound( expectedResult: string ): Promise< void > {
 		await this.page.waitForSelector( selectors.searchResult( expectedResult ) );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -12,7 +12,8 @@ const selectors = {
 	annualPricingSelect: 'a[data-bold-text^="Annual price"]',
 	monthlyPricing: '.plugins-browser-item__period:text("monthly")',
 	annualPricing: '.plugins-browser-item__period:text("per year")',
-	search: 'input[placeholder="Try searching ‘ecommerce’"]:visible',
+	searchIcon: '.search-component__open-icon',
+	searchInput: 'input[placeholder="Try searching ‘ecommerce’"]',
 	searchResult: ( text: string ) => `.plugins-browser-item__title:text("${ text }")`,
 	searchResultTitle: ( text: string ) => `:text("Search results for ${ text }")`,
 };
@@ -113,8 +114,9 @@ export class PluginsPage {
 	 * Search
 	 */
 	async search( query: string ): Promise< void > {
-		await this.page.fill( selectors.search, query );
-		await this.page.press( selectors.search, 'Enter' );
+		await this.page.click( selectors.searchIcon );
+		await this.page.fill( selectors.searchInput, query );
+		await this.page.press( selectors.searchInput, 'Enter' );
 		await this.page.waitForSelector( selectors.searchResultTitle( query ) );
 	}
 

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -23,6 +23,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 	} );
 
 	it( 'Search for ecommerce', async function () {
-		await pluginsPage.search( 'ecommerce', 'WooCommerce' );
+		await pluginsPage.search( 'ecommerce' );
+		await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
 	} );
 } );

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -1,0 +1,28 @@
+/**
+ * @group calypso-pr
+ */
+
+import { DataHelper, TestAccount, PluginsPage } from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
+	let page: Page;
+	let pluginsPage: PluginsPage;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		const testAccount = new TestAccount( 'defaultUser' );
+		await testAccount.authenticate( page );
+	} );
+
+	it( 'Visit plugins page', async function () {
+		pluginsPage = new PluginsPage( page );
+		await pluginsPage.visit();
+	} );
+
+	it( 'Search for ecommerce', async function () {
+		await pluginsPage.search( 'ecommerce', 'WooCommerce' );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Tests that searching for "ecommerce" results in at least one plugin search result with the title "WooCommerce"

#### Testing instructions

[Prereq setup](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e)

```
cd e2e/tests
yarn workspace @automattic/calypso-e2e build && yarn jest specs/plugins/plugins__search.ts
yarn workspace @automattic/calypso-e2e build && VIEWPORT_NAME=mobile yarn jest specs/plugins/plugins__search.ts
```

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/61094
