### PR TITLE
Buggy homepage screen for DIFM

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -12,7 +12,7 @@ import { emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import isDIFMLiteWebsiteContentSubmitted from 'calypso/state/selectors/is-difm-lite-website-content-submitted';
-import { getSiteSlug, isRequestingSite } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isRequestingSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { AppState } from 'calypso/types';
 
 import './difm-lite-in-progress.scss';
@@ -23,7 +23,9 @@ type DIFMLiteInProgressProps = {
 
 function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ): React.ReactElement {
 	const slug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
-	const isLoadingSite = useSelector( ( state: AppState ) => isRequestingSite( state, siteId ) );
+	const isLoadingSite = useSelector(
+		( state: AppState ) => isRequestingSite( state, siteId ) || isRequestingSites( state )
+	);
 	const isWebsiteContentSubmitted = useSelector( ( state ) =>
 		isDIFMLiteWebsiteContentSubmitted( state, siteId )
 	);

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -12,7 +12,7 @@ import { emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import isDIFMLiteWebsiteContentSubmitted from 'calypso/state/selectors/is-difm-lite-website-content-submitted';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isRequestingSite } from 'calypso/state/sites/selectors';
 import { AppState } from 'calypso/types';
 
 import './difm-lite-in-progress.scss';
@@ -23,6 +23,7 @@ type DIFMLiteInProgressProps = {
 
 function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ): React.ReactElement {
 	const slug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
+	const isLoadingSite = useSelector( ( state: AppState ) => isRequestingSite( state, siteId ) );
 	const isWebsiteContentSubmitted = useSelector( ( state ) =>
 		isDIFMLiteWebsiteContentSubmitted( state, siteId )
 	);
@@ -32,7 +33,7 @@ function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ): React.ReactE
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	if ( ! primaryDomain ) {
+	if ( ! primaryDomain || isLoadingSite ) {
 		return (
 			<>
 				<QuerySiteDomains siteId={ siteId } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Post website-content filling we update a flag in the back end (in blog difm lite options) that the website content has been submitted. However after submitting the content and fetching the site, since we are fetching the site inside an async thunk there will be a brief window there the website-content-submitted flag will be falsy in the front end. 

This bug is visible clearly in this usage report : pdh1Xd-xv-p2#comment-890

This change shows the loading screen whenever site information is being loaded.
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the DIFM flow
* Purchase DIFM
* Fill website content
* When redirected to the home screen make sure the website content not submitted warning page is not briefly visible.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59895