### PR TITLE
P2: add tracks to P2 Accept Invite page

### DIFF
--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -65,6 +65,15 @@ class InviteAccept extends Component {
 
 			if ( invite?.site?.is_wpforteams_site ) {
 				this.props.hideMasterbar();
+
+				recordTracksEvent( 'calypso_p2_invite_accept_load_page', {
+					site_id: invite?.site?.ID,
+					invited_by: invite?.inviter?.ID,
+					invite_date: invite?.date,
+					role: invite?.role,
+					from_marketing_campaign: !! invite?.site?.p2_signup_campaign,
+					campaign_name: invite?.site?.p2_signup_campaign || null,
+				} );
 			}
 
 			this.handleFetchInvite( false, invite );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Record event where user loads the P2 Accept Invite screen.

#### Testing instructions
* Send your test user an invite (email or group invite works fine).
* Verify that the Accept Invite page loads without errors.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 4586-gh-Automattic/p2