### PR TITLE
`CommentList`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -42,19 +42,12 @@ export class CommentList extends Component {
 		selectedComments: [],
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const { siteId, status, changePage } = this.props;
+	componentDidUpdate() {
+		const { changePage } = this.props;
 		const totalPages = this.getTotalPages();
+
 		if ( ! this.isRequestedPageValid() && totalPages > 1 ) {
 			return changePage( totalPages );
-		}
-
-		if ( siteId !== nextProps.siteId || status !== nextProps.status ) {
-			this.setState( {
-				isBulkMode: false,
-				selectedComments: [],
-			} );
 		}
 	}
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -54,7 +54,7 @@ export class CommentList extends Component {
 	shouldComponentUpdate = ( nextProps, nextState ) =>
 		! isEqual( this.props, nextProps ) || ! isEqual( this.state, nextState );
 
-	changePage = ( page ) => {
+	handlePageClick = ( page ) => {
 		const { recordChangePage, changePage } = this.props;
 
 		recordChangePage( page, this.getTotalPages() );
@@ -210,7 +210,7 @@ export class CommentList extends Component {
 					<Pagination
 						key="comment-list-pagination"
 						page={ validPage }
-						pageClick={ this.changePage }
+						pageClick={ this.handlePageClick }
 						perPage={ COMMENTS_PER_PAGE }
 						total={ commentsCount }
 					/>

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -93,6 +93,7 @@ export class CommentsManagement extends Component {
 				) }
 				{ showCommentList && (
 					<CommentList
+						key={ `${ siteId }-${ status }` }
 						changePage={ changePage }
 						order={ order }
 						page={ page }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `CommentList`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to `/comments/all/:site`
* Switch between comment states (Unapproved, Spam, etc) and change your currently active site
* Verify this works well and exactly as on prod
* Now go to a site which has at least 2 comment pages, go to a page other than the first and change the `page` param in the address bar manually to something higher than the total of pages. Hit Enter and verify the param gets updated to the last page number.

Related to #58453 
