### PR TITLE
Licensing Portal: Add ellipsis menu for actions specific to each payment method

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
@@ -14,7 +14,7 @@ const PaymentMethodActions: FunctionComponent< Props > = () => {
 	const translate = useTranslate();
 
 	const renderDeleteAction = () => {
-		return <PopoverMenuItem>{ translate( 'Delete' ) }</PopoverMenuItem>;
+		return <PopoverMenuItem key="delete">{ translate( 'Delete' ) }</PopoverMenuItem>;
 	};
 
 	const renderActions = () => {

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
@@ -1,0 +1,50 @@
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { PaymentMethod } from 'calypso/lib/checkout/payment-methods';
+
+import './style.scss';
+
+interface Props {
+	card: PaymentMethod;
+}
+
+const PaymentMethodActions: FunctionComponent< Props > = () => {
+	const translate = useTranslate();
+
+	const renderDeleteAction = () => {
+		return <PopoverMenuItem>{ translate( 'Delete' ) }</PopoverMenuItem>;
+	};
+
+	const renderActions = () => {
+		const actions = [];
+
+		actions.push( renderDeleteAction() );
+
+		return actions;
+	};
+
+	return (
+		<EllipsisMenu
+			icon={
+				<svg
+					width="24"
+					height="24"
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 24 24"
+					aria-hidden="true"
+					focusable="false"
+				>
+					<path d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"></path>
+				</svg>
+			}
+			className="payment-method-actions"
+			popoverClassName="payment-method-actions__popover"
+		>
+			{ renderActions() }
+		</EllipsisMenu>
+	);
+};
+
+export default PaymentMethodActions;

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-actions/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-actions/style.scss
@@ -1,0 +1,18 @@
+.payment-method-actions {
+	&__popover {
+
+		.popover__menu-item {
+			margin: 8px 0;
+		}
+		
+		.popover__menu-item.is-selected,
+		.popover__menu-item:hover,
+		.popover__menu-item:focus,
+		.popover__menu-item.button.is-selected,
+		.popover__menu-item.button:hover,
+		.popover__menu-item.button:focus {
+			background-color: var( --studio-gray-5 );
+			color: var( --studio-black );
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card/index.tsx
@@ -1,6 +1,7 @@
 import { PaymentLogo } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
+import PaymentMethodActions from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-actions';
 import { PaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import './style.scss';
 
@@ -14,11 +15,17 @@ export default function StoredCreditCard( props: { card: PaymentMethod } ): Reac
 	return (
 		<div className="stored-credit-card">
 			<div className="stored-credit-card__header">
-				<div className="stored-credit-card__payment-logo">
-					<PaymentLogo brand={ creditCard.card_type } isSummary={ true } />
+				<div className="stored-credit-card__labels">
+					<div className="stored-credit-card__payment-logo">
+						<PaymentLogo brand={ creditCard.card_type } isSummary={ true } />
+					</div>
+
+					<div className="stored-credit-card__primary">{ translate( 'Primary' ) }</div>
 				</div>
 
-				<div className="stored-credit-card__primary">{ translate( 'Primary' ) }</div>
+				<div className="stored-credit-card__actions">
+					<PaymentMethodActions card={ creditCard } />
+				</div>
 			</div>
 			<div className="stored-credit-card__footer">
 				<div className="stored-credit-card__footer-left">

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card/style.scss
@@ -20,9 +20,32 @@
 
 .stored-credit-card__header {
 	display: flex;
-	justify-content: space-between;
-	flex-grow: 1;
-	margin-bottom: auto;
+	align-items: flex-start;
+	flex-basis: 100%;
+}
+
+.stored-credit-card__labels {
+	display: flex;
+
+	> div {
+		&:first-child {
+			margin-left: 0;
+		}
+
+		margin-left: 10px;
+		margin-right: 10px;
+	}
+}
+
+.stored-credit-card__actions {
+	width: 28px;
+	height: 28px;
+
+	margin-left: auto;
+
+	.button.ellipsis-menu__toggle {
+		padding: 0;
+	}
 }
 
 .stored-credit-card__payment-logo svg {


### PR DESCRIPTION
#### Context 
- P2: pbtFFM-1wG-p2

#### Changes proposed in this Pull Request

* Provides a way to perform various actions (e.g., delete) for each payment method in the list by implementing [an ellipsis menu](https://github.com/Automattic/wp-calypso/tree/trunk/client/components/ellipsis-menu). **This diff contains only the UI, without any logic implemented.**

Here's a short video overview:

https://user-images.githubusercontent.com/1749918/154970673-043c5513-079b-4fd3-be87-a6b6ae3dd6b8.mp4

#### Testing instructions

- If you do not have a partner key, please get in touch with Avalon for one, or you will be unable to view the UI.
- Checkout PR locally, run `yarn && yarn start-jetpack-cloud`
- Visit http://jetpack.cloud.localhost:3000/partner-portal/payment-methods and select your partner key, if prompted.
- The payment methods list will show all payment methods added in [Calypso](https://wordpress.com/me/purchases/payment-methods). This will be changed in another PR, but for now, this means that you could enable the store sandbox and use test payment methods provided by Stripe.
- Verify that the ellipsis menu is displayed correctly on various resolutions.
- Verify that the implementation matches the design (see the P2 above for more context).

Related to 1201734780767770-as-1201735329399981