### PR TITLE
Comments: Fix `CommentPostLink` post querying

### DIFF
--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -21,7 +21,7 @@ const CommentPostLink = ( {
 	translate,
 } ) => (
 	<div className="comment__post-link">
-		{ ! isPostTitleLoaded && <QueryPosts siteId={ siteId } postId={ postId } /> }
+		{ ! isPostTitleLoaded && postId && <QueryPosts siteId={ siteId } postId={ postId } /> }
 
 		<Gridicon icon={ isBulkMode ? 'chevron-right' : 'posts' } size={ 18 } />
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While testing #61311 I noticed that when viewing type of comments page for a site for a WP.org site, we're getting this request:

![](https://cldup.com/LjGfP1OP5s.png)

This PR fixes that error.

#### Testing instructions

* Go to `/comments/approved/:site` where `:site` is a site with many comments.
* Switch between different types of comments.
* Verify the error no longer appears in your console.