### PR TITLE
E2E: Expand sidebar before accessing items

### DIFF
--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -77,8 +77,7 @@ export class SidebarComponent {
 			await this.page.dispatchEvent( itemSelector, 'click' );
 		} else {
 			//  only hover on Desktop when the goal is accessing a subitem
-			await this.page.locator( itemSelector ).scrollIntoViewIfNeeded();
-			await this.page.locator( itemSelector ).hover();
+			await this.page.dispatchEvent( itemSelector, 'mouseover' );
 		}
 
 		// Sub-level menu item selector.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates e2e tests to handle a collapsed sidebar gracefully.

1. `Sidebar.navigate` expands it now before looking for an item.
2. It'll also only hover the main item if a subitem is meant to be clicked on Desktop. This makes the tests less flaky because it removes one navigation step before running the test. 
3. It waits for promotions to render in the sidebar because they change every item position once they do.

#### Testing instructions
- Green checks.

Related to all PRs in the past couple days.
