### PR TITLE
Emails: Update old domain upsell page with the Google one month free trial

### DIFF
--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -10,6 +10,7 @@ export type DomainType = keyof typeof domainType;
 interface EmailSubscription {
 	expiryDate?: string;
 	hasExpectedDnsRecords?: boolean | null;
+	isEligibleForIntroductoryOffer?: boolean;
 	ownedByUserId?: number;
 	purchaseCostPerMailbox?: EmailCost | null;
 	renewalCostPerMailbox?: EmailCost | null;
@@ -31,12 +32,10 @@ export type GoogleEmailSubscription = EmailSubscription & {
 	subscribedDate?: string;
 	subscriptionId?: string;
 	totalUserCount?: number;
-	isEligibleForIntroductoryOffer?: boolean;
 };
 
 export type TitanEmailSubscription = EmailSubscription & {
 	appsUrl?: string;
-	isEligibleForIntroductoryOffer?: boolean;
 	maximumMailboxCount?: number;
 	numberOfMailboxes?: number;
 	orderId?: number;

--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -31,6 +31,7 @@ export type GoogleEmailSubscription = EmailSubscription & {
 	subscribedDate?: string;
 	subscriptionId?: string;
 	totalUserCount?: number;
+	isEligibleForIntroductoryOffer?: boolean;
 };
 
 export type TitanEmailSubscription = EmailSubscription & {

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -33,4 +33,4 @@ export { getGSuiteExpiryDate } from './get-gsuite-expiry-date';
 export { getGSuiteMailboxPurchaseCost } from './get-gsuite-mailbox-purchase-cost';
 export { getGSuiteMailboxRenewalCost } from './get-gsuite-mailbox-renewal.cost';
 export { isPendingGSuiteTOSAcceptance } from './is-pending-gsuite-tos-acceptance';
-export { isDomainEligibleForGoogleWorkspaceFreeTrial } from './is-domain-eligible-for-google-free-trial';
+export { isDomainEligibleForGoogleWorkspaceFreeTrial } from './is-domain-eligible-for-google-workspace-free-trial';

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -33,3 +33,4 @@ export { getGSuiteExpiryDate } from './get-gsuite-expiry-date';
 export { getGSuiteMailboxPurchaseCost } from './get-gsuite-mailbox-purchase-cost';
 export { getGSuiteMailboxRenewalCost } from './get-gsuite-mailbox-renewal.cost';
 export { isPendingGSuiteTOSAcceptance } from './is-pending-gsuite-tos-acceptance';
+export { isDomainEligibleForGoogleFreeTrial } from './is-domain-eligible-for-google-free-trial';

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -33,4 +33,4 @@ export { getGSuiteExpiryDate } from './get-gsuite-expiry-date';
 export { getGSuiteMailboxPurchaseCost } from './get-gsuite-mailbox-purchase-cost';
 export { getGSuiteMailboxRenewalCost } from './get-gsuite-mailbox-renewal.cost';
 export { isPendingGSuiteTOSAcceptance } from './is-pending-gsuite-tos-acceptance';
-export { isDomainEligibleForGoogleFreeTrial } from './is-domain-eligible-for-google-free-trial';
+export { isDomainEligibleForGoogleWorkspaceFreeTrial } from './is-domain-eligible-for-google-free-trial';

--- a/client/lib/gsuite/is-domain-eligible-for-google-free-trial.ts
+++ b/client/lib/gsuite/is-domain-eligible-for-google-free-trial.ts
@@ -1,11 +1,5 @@
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
-/**
- * Determines if the specified domain is eligible for the Google 1-month free trial.
- *
- * @param {ResponseDomain|undefined} domain - domain object
- * @returns {boolean} whether the domain is eligible or not
- */
 export function isDomainEligibleForGoogleFreeTrial( domain: ResponseDomain ) {
 	return domain?.googleAppsSubscription?.isEligibleForIntroductoryOffer ?? false;
 }

--- a/client/lib/gsuite/is-domain-eligible-for-google-free-trial.ts
+++ b/client/lib/gsuite/is-domain-eligible-for-google-free-trial.ts
@@ -1,5 +1,5 @@
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
-export function isDomainEligibleForGoogleWorkspaceFreeTrial( domain: ResponseDomain ) : boolean {
+export function isDomainEligibleForGoogleWorkspaceFreeTrial( domain: ResponseDomain ): boolean {
 	return domain?.googleAppsSubscription?.isEligibleForIntroductoryOffer ?? false;
 }

--- a/client/lib/gsuite/is-domain-eligible-for-google-free-trial.ts
+++ b/client/lib/gsuite/is-domain-eligible-for-google-free-trial.ts
@@ -1,5 +1,5 @@
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
-export function isDomainEligibleForGoogleFreeTrial( domain: ResponseDomain ) {
+export function isDomainEligibleForGoogleWorkspaceFreeTrial( domain: ResponseDomain ) {
 	return domain?.googleAppsSubscription?.isEligibleForIntroductoryOffer ?? false;
 }

--- a/client/lib/gsuite/is-domain-eligible-for-google-free-trial.ts
+++ b/client/lib/gsuite/is-domain-eligible-for-google-free-trial.ts
@@ -1,5 +1,5 @@
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
-export function isDomainEligibleForGoogleWorkspaceFreeTrial( domain: ResponseDomain ) {
+export function isDomainEligibleForGoogleWorkspaceFreeTrial( domain: ResponseDomain ) : boolean {
 	return domain?.googleAppsSubscription?.isEligibleForIntroductoryOffer ?? false;
 }

--- a/client/lib/gsuite/is-domain-eligible-for-google-free-trial.ts
+++ b/client/lib/gsuite/is-domain-eligible-for-google-free-trial.ts
@@ -1,0 +1,11 @@
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
+/**
+ * Determines if the specified domain is eligible for the Google 1-month free trial.
+ *
+ * @param {ResponseDomain|undefined} domain - domain object
+ * @returns {boolean} whether the domain is eligible or not
+ */
+export function isDomainEligibleForGoogleFreeTrial( domain: ResponseDomain ) {
+	return domain?.googleAppsSubscription?.isEligibleForIntroductoryOffer ?? false;
+}

--- a/client/lib/gsuite/is-domain-eligible-for-google-free-trial.ts
+++ b/client/lib/gsuite/is-domain-eligible-for-google-free-trial.ts
@@ -1,5 +1,0 @@
-import type { ResponseDomain } from 'calypso/lib/domains/types';
-
-export function isDomainEligibleForGoogleWorkspaceFreeTrial( domain: ResponseDomain ): boolean {
-	return domain?.googleAppsSubscription?.isEligibleForIntroductoryOffer ?? false;
-}

--- a/client/lib/gsuite/is-domain-eligible-for-google-workspace-free-trial.ts
+++ b/client/lib/gsuite/is-domain-eligible-for-google-workspace-free-trial.ts
@@ -1,0 +1,8 @@
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
+
+export function isDomainEligibleForGoogleWorkspaceFreeTrial(
+	domain: ResponseDomain | SiteDomain | undefined
+): boolean {
+	return domain?.googleAppsSubscription?.isEligibleForIntroductoryOffer ?? false;
+}

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -371,7 +371,8 @@ class EmailProvidersComparison extends Component {
 
 		const { validatedMailboxUuids } = this.state;
 
-		const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForGoogleWorkspaceFreeTrial( domain );
+		const isEligibleForFreeTrial =
+			hasCartDomain || isDomainEligibleForGoogleWorkspaceFreeTrial( domain );
 
 		// TODO: Improve handling of this case
 		if ( ! isGSuiteSupported ) {

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -380,7 +380,7 @@ class EmailProvidersComparison extends Component {
 								"%(discountedPrice)s is a formatted, discounted price that the user will pay today (e.g. '$3'), " +
 								"%(standardPrice)s is a formatted price (e.g. '$5')",
 							components: {
-								span: <span className={ 'email-providers-comparison__google_discount' }/>,
+								span: <span className={ 'email-providers-comparison__google-discount' } />,
 							},
 						}
 					) }

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -470,7 +470,6 @@ class EmailProvidersComparison extends Component {
 			return null;
 		}
 
-		// Note that when we have a discount, we include all renewal information in the discount content
 		const discount = getAvailableDiscountForGoogle();
 
 		const starLabel = productIsDiscounted

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -38,7 +38,7 @@ import {
 	getGoogleMailServiceFamily,
 	getMonthlyPrice,
 	hasGSuiteSupportedDomain,
-	isDomainEligibleForGoogleFreeTrial,
+	isDomainEligibleForGoogleWorkspaceFreeTrial,
 } from 'calypso/lib/gsuite';
 import {
 	GOOGLE_PROVIDER_NAME,
@@ -371,7 +371,7 @@ class EmailProvidersComparison extends Component {
 
 		const { validatedMailboxUuids } = this.state;
 
-		const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForGoogleFreeTrial( domain );
+		const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForGoogleWorkspaceFreeTrial( domain );
 
 		// TODO: Improve handling of this case
 		if ( ! isGSuiteSupported ) {

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -401,42 +401,70 @@ class EmailProvidersComparison extends Component {
 
 		const standardPrice = getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode );
 
-		// Note that when we have a discount, we include all renewal information in the discount content
-		const discount = ! isEligibleForFreeTrial ? null : (
-			<>
-				{ translate( '1 month free' ) }
-				<span className="email-providers-comparison__discount-with-renewal">
-					<span>
+		function getAvailableDiscountForGoogle() {
+			if ( productIsDiscounted ) {
+				return (
+					<span className="email-providers-comparison__discount-with-renewal">
 						{ translate(
-							'%(firstRenewalPrice)s/mailbox billed in 1 month, renews at %(standardPrice)s/mailbox',
+							'%(discount)d%% off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
 							{
 								args: {
-									firstRenewalPrice: formatCurrency(
-										( ( gSuiteProduct?.cost ?? 0 ) * 11 ) / 12,
-										currencyCode
-									),
+									discount: gSuiteProduct.sale_coupon.discount,
+									discountedPrice: getAnnualPrice( gSuiteProduct.sale_cost, currencyCode ),
 									standardPrice,
 								},
 								comment:
-									"%(firstRenewalPrice)s is a formatted, reduced price that the user will pay in three months (e.g. '$3'), " +
+									"%(discount)d is a numeric percentage discount (e.g. '50'), " +
+									"%(discountedPrice)s is a formatted, discounted price that the user will pay today (e.g. '$3'), " +
 									"%(standardPrice)s is a formatted price (e.g. '$5')",
-							}
-						) }
-					</span>
-					<InfoPopover position="right" showOnHover>
-						{ translate(
-							'This discount is only available the first time you purchase a %(googleMailService)s account, any additional mailboxes purchased after that will be at the regular price.',
-							{
-								args: {
-									googleMailService: getGoogleMailServiceFamily(),
+								components: {
+									span: <span />,
 								},
-								comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
 							}
 						) }
-					</InfoPopover>
-				</span>
-			</>
-		);
+
+						<InfoPopover position="right" showOnHover>
+							{ translate(
+								'This discount is only available the first time you purchase a %(googleMailService)s account, any additional mailboxes purchased after that will be at the regular price.',
+								{
+									args: {
+										googleMailService: getGoogleMailServiceFamily(),
+									},
+									comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+								}
+							) }
+						</InfoPopover>
+					</span>
+				);
+			}
+			return ! isEligibleForFreeTrial ? null : (
+				<>
+					{ translate( '1 month free' ) }
+					<span className="email-providers-comparison__discount-with-renewal">
+						<span>
+							{ translate(
+								'%(firstRenewalPrice)s/mailbox billed in 1 month, renews at %(standardPrice)s/mailbox',
+								{
+									args: {
+										firstRenewalPrice: formatCurrency(
+											( ( gSuiteProduct?.cost ?? 0 ) * 11 ) / 12,
+											currencyCode
+										),
+										standardPrice,
+									},
+									comment:
+										"%(firstRenewalPrice)s is a formatted, reduced price that the user will pay in three months (e.g. '$3'), " +
+										"%(standardPrice)s is a formatted price (e.g. '$5')",
+								}
+							) }
+						</span>
+					</span>
+				</>
+			);
+		}
+
+		// Note that when we have a discount, we include all renewal information in the discount content
+		const discount = getAvailableDiscountForGoogle();
 
 		const starLabel = productIsDiscounted
 			? translate( '%(discount)d%% off!', {

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -437,30 +437,35 @@ class EmailProvidersComparison extends Component {
 					</span>
 				);
 			}
-			return ! isEligibleForFreeTrial ? null : (
-				<>
-					{ translate( '1 month free' ) }
-					<span className="email-providers-comparison__discount-with-renewal">
-						<span>
-							{ translate(
-								'%(firstRenewalPrice)s/mailbox billed in 1 month, renews at %(standardPrice)s/mailbox',
-								{
-									args: {
-										firstRenewalPrice: formatCurrency(
-											( ( gSuiteProduct?.cost ?? 0 ) * 11 ) / 12,
-											currencyCode
-										),
-										standardPrice,
-									},
-									comment:
-										"%(firstRenewalPrice)s is a formatted, reduced price that the user will pay in three months (e.g. '$3'), " +
-										"%(standardPrice)s is a formatted price (e.g. '$5')",
-								}
-							) }
+
+			if ( isEligibleForFreeTrial ) {
+				return (
+					<>
+						{ translate( '1 month free' ) }
+						<span className="email-providers-comparison__discount-with-renewal">
+							<span>
+								{ translate(
+									'%(firstRenewalPrice)s/mailbox billed in 1 month, renews at %(standardPrice)s/mailbox',
+									{
+										args: {
+											firstRenewalPrice: formatCurrency(
+												( ( gSuiteProduct?.cost ?? 0 ) * 11 ) / 12,
+												currencyCode
+											),
+											standardPrice,
+										},
+										comment:
+											"%(firstRenewalPrice)s is a formatted, reduced price that the user will pay in one month (e.g. '$3'), " +
+											"%(standardPrice)s is a formatted price (e.g. '$5')",
+									}
+								) }
+							</span>
 						</span>
-					</span>
-				</>
-			);
+					</>
+				);
+			}
+
+			return null;
 		}
 
 		// Note that when we have a discount, we include all renewal information in the discount content

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -370,6 +370,8 @@ class EmailProvidersComparison extends Component {
 
 		const { validatedMailboxUuids } = this.state;
 
+		const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForTitanFreeTrial( domain );
+
 		// TODO: Improve handling of this case
 		if ( ! isGSuiteSupported ) {
 			return null;
@@ -400,39 +402,41 @@ class EmailProvidersComparison extends Component {
 		const standardPrice = getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode );
 
 		// Note that when we have a discount, we include all renewal information in the discount content
-		const discount = productIsDiscounted ? (
-			<span className="email-providers-comparison__discount-with-renewal">
-				{ translate(
-					'%(discount)d%% off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
-					{
-						args: {
-							discount: gSuiteProduct.sale_coupon.discount,
-							discountedPrice: getAnnualPrice( gSuiteProduct.sale_cost, currencyCode ),
-							standardPrice,
-						},
-						comment:
-							"%(discount)d is a numeric percentage discount (e.g. '50'), " +
-							"%(discountedPrice)s is a formatted, discounted price that the user will pay today (e.g. '$3'), " +
-							"%(standardPrice)s is a formatted price (e.g. '$5')",
-						components: {
-							span: <span />,
-						},
-					}
-				) }
-
-				<InfoPopover position="right" showOnHover>
-					{ translate(
-						'This discount is only available the first time you purchase a %(googleMailService)s account, any additional mailboxes purchased after that will be at the regular price.',
-						{
-							args: {
-								googleMailService: getGoogleMailServiceFamily(),
-							},
-							comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
-						}
-					) }
-				</InfoPopover>
-			</span>
-		) : null;
+		const discount = ! isEligibleForFreeTrial ? null : (
+			<>
+				{ translate( '1 month free' ) }
+				<span className="email-providers-comparison__discount-with-renewal">
+					<span>
+						{ translate(
+							'%(firstRenewalPrice)s/mailbox billed in 1 month, renews at %(standardPrice)s/mailbox',
+							{
+								args: {
+									firstRenewalPrice: formatCurrency(
+										( ( gSuiteProduct?.cost ?? 0 ) * 11 ) / 12,
+										currencyCode
+									),
+									standardPrice,
+								},
+								comment:
+									"%(firstRenewalPrice)s is a formatted, reduced price that the user will pay in three months (e.g. '$3'), " +
+									"%(standardPrice)s is a formatted price (e.g. '$5')",
+							}
+						) }
+					</span>
+					<InfoPopover position="right" showOnHover>
+						{ translate(
+							'This discount is only available the first time you purchase a %(googleMailService)s account, any additional mailboxes purchased after that will be at the regular price.',
+							{
+								args: {
+									googleMailService: getGoogleMailServiceFamily(),
+								},
+								comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+							}
+						) }
+					</InfoPopover>
+				</span>
+			</>
+		);
 
 		const starLabel = productIsDiscounted
 			? translate( '%(discount)d%% off!', {

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -364,6 +364,7 @@ class EmailProvidersComparison extends Component {
 		standardPrice
 	) {
 		const { translate } = this.props;
+
 		if ( productIsDiscounted ) {
 			return (
 				<span className="email-providers-comparison__discount-with-renewal">
@@ -380,7 +381,7 @@ class EmailProvidersComparison extends Component {
 								"%(discountedPrice)s is a formatted, discounted price that the user will pay today (e.g. '$3'), " +
 								"%(standardPrice)s is a formatted price (e.g. '$5')",
 							components: {
-								span: <span />,
+								span: <span className={ 'email-providers-comparison__google_discount' }/>,
 							},
 						}
 					) }
@@ -452,8 +453,7 @@ class EmailProvidersComparison extends Component {
 		}
 
 		const isEligibleForFreeTrial =
-			config.isEnabled( 'emails/google-workspace-1-month-trial' ) &&
-			( hasCartDomain || isDomainEligibleForGoogleWorkspaceFreeTrial( domain ) );
+			config.isEnabled( 'emails/google-workspace-1-month-trial' ) && hasCartDomain;
 
 		const productIsDiscounted = hasDiscount( gSuiteProduct );
 		const monthlyPrice = getMonthlyPrice( gSuiteProduct?.cost ?? null, currencyCode );

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -39,7 +39,6 @@ import {
 	getGoogleMailServiceFamily,
 	getMonthlyPrice,
 	hasGSuiteSupportedDomain,
-	isDomainEligibleForGoogleWorkspaceFreeTrial,
 } from 'calypso/lib/gsuite';
 import {
 	GOOGLE_PROVIDER_NAME,

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -38,6 +38,7 @@ import {
 	getGoogleMailServiceFamily,
 	getMonthlyPrice,
 	hasGSuiteSupportedDomain,
+	isDomainEligibleForGoogleFreeTrial,
 } from 'calypso/lib/gsuite';
 import {
 	GOOGLE_PROVIDER_NAME,
@@ -370,7 +371,7 @@ class EmailProvidersComparison extends Component {
 
 		const { validatedMailboxUuids } = this.state;
 
-		const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForTitanFreeTrial( domain );
+		const isEligibleForFreeTrial = hasCartDomain || isDomainEligibleForGoogleFreeTrial( domain );
 
 		// TODO: Improve handling of this case
 		if ( ! isGSuiteSupported ) {

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -205,6 +205,10 @@
 				margin-left: 0.5em;
 			}
 
+			span.email-providers-comparison__google_discount {
+				margin-left: 0;
+			}
+
 			.email-providers-comparison__discount-with-renewal .info-popover {
 				margin-left: 2px;
 				vertical-align: text-top;

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -205,7 +205,7 @@
 				margin-left: 0.5em;
 			}
 
-			span.email-providers-comparison__google_discount {
+			span.email-providers-comparison__google-discount {
 				margin-left: 0;
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**_Important:_** This patch can't go live before adding the necessary changes in backend to add the `isEligibleForIntroductoryOffer` in the `google_apps_subscription` object within the domain object.

This code updates the Google Email Provider card to offer a one month free trial when it is eligible for that.

#### Testing instructions

1. Go to Upgrades -> Domains
2. Add a domain to your cart
3. Check that you are presented with the upsell page that prompts you to add an email provider.
4. Add the feature flag: emails/google-workspace-1-month-trial
5. Check that it offers you a free month for Google Workspace

![image](https://user-images.githubusercontent.com/5689927/154983115-bf340f3a-cd58-49e5-8ed3-4ed518dc6435.png)


### Extra Test

1. Sandbox your WordPress API.
2. Enable the store sandbox
3. Repeat the first test, but add the Google Workspace to your cart and go to the checkout screen.
4. Check that you see the following information:

![image](https://user-images.githubusercontent.com/5689927/154983314-23d50714-d581-4578-9889-42ed856d136e.png)


Related to {1200182182542585-as-1201837520922119}
