### PR TITLE
Licensing Portal: Fix mobile style of license assignment page header

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
@@ -71,3 +71,12 @@ p.assign-license-form__description {
 	font-weight: 700;
 	text-decoration: underline;
 }
+
+@include breakpoint-deprecated( '<960px' ) {
+	.assign-license-form {
+		&__top {
+			flex-direction: column;
+			margin-top: 0;
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
@@ -53,9 +53,12 @@
 
 p.assign-license-form__description {
 	margin-bottom: 0;
-	align-self: flex-end;
 	font-size: 0.875rem;
 	color: #333;
+
+	@include break-large {
+		align-self: flex-end;
+	}
 }
 
 .assign-license-form__site-card {

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
@@ -1,3 +1,4 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
 
 .assign-license-form {
@@ -30,16 +31,19 @@
 .assign-license-form__top {
 	display: flex;
 	justify-content: space-between;
-}
-
-.assign-license-form__top > div {
-	align-self: flex-end;
-	margin-bottom: 0;
-}
-
-.assign-license-form__top {
+	flex-direction: column;
+	margin-top: 0;
 	margin-bottom: 1rem;
-	margin-top: -1.5rem;
+
+	> div {
+		align-self: flex-end;
+		margin-bottom: 0;
+	}
+
+	@include break-large {
+		flex-direction: row;
+		margin-top: -1.5rem;
+	}
 }
 
 .assign-license-form__bottom {
@@ -70,13 +74,4 @@ p.assign-license-form__description {
 	margin-right: 1rem;
 	font-weight: 700;
 	text-decoration: underline;
-}
-
-@include breakpoint-deprecated( '<960px' ) {
-	.assign-license-form {
-		&__top {
-			flex-direction: column;
-			margin-top: 0;
-		}
-	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Properly display the header on mobile license assignment

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure to have a Partner Account 👉🏻 PCYsg-zPi-p2
* Issue some license
* Click on "Assign license" on the list of licenses to start the flow, you will be taken to a list of your sites to assign that license to
* The header should be better looking on mobile

**Previous header look**
![image](https://user-images.githubusercontent.com/5550190/154985878-7092957f-1939-427e-98fc-a12f829c28f3.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

#### Screenshots
![image](https://user-images.githubusercontent.com/5550190/154984809-524b0a33-bc91-44a3-885b-e51feba89927.png)
![image](https://user-images.githubusercontent.com/5550190/154985184-5b120285-5650-483c-9dfd-ea96f8da31fb.png)

![image](https://user-images.githubusercontent.com/5550190/154984883-d016d10d-bb2d-4aa2-a61a-66ea4a5a99ee.png)
