### PR TITLE
Seller Experience: Enable seller experience feature flag across WP.com

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -72,7 +72,7 @@
 		"reader": true,
 		"reader/list-management": true,
 		"safari-idb-mitigation": true,
-		"seller-experience": false,
+		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,

--- a/config/production.json
+++ b/config/production.json
@@ -77,7 +77,7 @@
 		"reader/list-management": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
-		"seller-experience": false,
+		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -78,7 +78,7 @@
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
 		"security/security-checkup": false,
-		"seller-experience": false,
+		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,

--- a/config/test.json
+++ b/config/test.json
@@ -67,7 +67,7 @@
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"rum-tracking/logstash": false,
-		"seller-experience": false,
+		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"signup/social": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,7 +91,7 @@
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
 		"security/security-checkup": false,
-		"seller-experience": false,
+		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable seller experience flow for all WP.com environments including production.

#### Testing instructions

* Switch to this PR, navigate to `/start`
* Make sure both seller experience flows work as expected.
* Make sure other signup flows continue to work as expected.
