### PR TITLE
Licensing Portal: Replace the public product families endpoint used

### DIFF
--- a/client/state/partner-portal/licenses/hooks/use-products-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-products-query.ts
@@ -1,12 +1,12 @@
 import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
-import wpcom from 'calypso/lib/wp';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import { APIProductFamily } from 'calypso/state/partner-portal/types';
 
 function queryProducts(): Promise< APIProductFamily[] > {
-	return wpcom.req
+	return wpcomJpl.req
 		.get( {
 			apiNamespace: 'wpcom/v2',
-			path: '/jetpack-licensing/product-families',
+			path: '/jetpack-licensing/partner/product-families',
 		} )
 		.then( ( data: APIProductFamily[] ) => {
 			const exclude = [ 'free', 'personal', 'premium', 'professional' ];

--- a/client/state/partner-portal/licenses/test/hooks.js
+++ b/client/state/partner-portal/licenses/test/hooks.js
@@ -111,6 +111,8 @@ describe( 'useProductsQuery', () => {
 						name: 'Jetpack Scan Daily',
 						product_id: 2106,
 						slug: 'jetpack-scan',
+						currency: 'us',
+						amount: 1,
 					},
 				],
 			},
@@ -122,18 +124,22 @@ describe( 'useProductsQuery', () => {
 						name: 'Jetpack Backup (Daily)',
 						product_id: 2100,
 						slug: 'jetpack-backup-daily',
+						currency: 'us',
+						amount: 1.99,
 					},
 					{
 						name: 'Jetpack Backup (Real-time)',
 						product_id: 2102,
 						slug: 'jetpack-backup-realtime',
+						currency: 'us',
+						amount: 3.49,
 					},
 				],
 			},
 		];
 
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/jetpack-licensing/product-families' )
+			.get( '/wpcom/v2/jetpack-licensing/partner/product-families' )
 			.reply( 200, [ ...unexpected, ...expected ] );
 
 		const { result, waitFor } = renderHook( () => useProductsQuery(), {


### PR DESCRIPTION
The new endpoint is identical but servers partner-specific products and includes their partner-specific product pricing information which can later be used in the UI.

#### Changes proposed in this Pull Request

* Replace the `/jetpack-licensing/product-families` endpoint used with `/jetpack-licensing/partner/product-families` which is identical but requires authentication and servers partner-specific product data.

#### Testing instructions

* Requires a Jetpack partner account - please reach out to team Avalon for information on how to acquire one.
* Requires D75203-code.
* Apply patch and run Jetpack Cloud.
* Open up http://jetpack.cloud.localhost:3000/partner-portal/issue-license and confirm products are shown as expected
![Screen Shot 2022-02-21 at 19 26 29](https://user-images.githubusercontent.com/22746396/155002564-9cfbfd3c-5079-4f04-a31f-acbff30e8acb.png)