### PR TITLE
Revert "Seller Experience: Enable seller experience feature flag across WP.com"

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -72,7 +72,7 @@
 		"reader": true,
 		"reader/list-management": true,
 		"safari-idb-mitigation": true,
-		"seller-experience": true,
+		"seller-experience": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,

--- a/config/production.json
+++ b/config/production.json
@@ -77,7 +77,7 @@
 		"reader/list-management": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
-		"seller-experience": true,
+		"seller-experience": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -78,7 +78,7 @@
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
 		"security/security-checkup": false,
-		"seller-experience": true,
+		"seller-experience": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,

--- a/config/test.json
+++ b/config/test.json
@@ -67,7 +67,7 @@
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"rum-tracking/logstash": false,
-		"seller-experience": true,
+		"seller-experience": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"signup/social": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,7 +91,7 @@
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
 		"security/security-checkup": false,
-		"seller-experience": true,
+		"seller-experience": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,


### PR DESCRIPTION
DO NOT MERGE unless we need to revert the seller experience flow launch. Reverts Automattic/wp-calypso#61330