### PR TITLE
change page title to Available now!

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -519,7 +519,7 @@ export async function setStoreFeatures( callback, { siteSlug }, stepProvidedItem
 			apiNamespace: 'wp/v2',
 			body: {
 				content: singleProductPattern.html,
-				title: translate( 'Home' ),
+				title: translate( 'Available now!' ),
 				status: 'publish',
 				template: 'header-footer-only',
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

| Before  | After |
| ------------- | ------------- |
|![image](https://user-images.githubusercontent.com/375980/155005739-fbde100e-0d82-411f-bdad-c9165f91ec44.png)  | ![image](https://user-images.githubusercontent.com/375980/155005779-946c75fa-f226-4c91-a6e3-36d9f3b16e93.png) |


#### Testing instructions
* Switch to this PR, navigate to `/start?flags=seller-experience`
* Create a new free site
* Choose Sell at the intent step
* Choose the Simple option
* Go to: `http://calypso.localhost:3000/pages/[YOUR_SITE]` and verify that the page created is called 'Available now!' 

Closes https://github.com/Automattic/wp-calypso/issues/61214
