### PR TITLE
adds icon to plugin page header

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -23,7 +23,7 @@
 	font-family: $brand-serif;
 	font-size: $font-title-large;
 	color: var( --studio-gray-100 );
-	margin: 16px 0;
+	margin: 32px 0 16px;
 	min-height: 48px;
 	display: flex;
 	align-items: baseline;

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -18,11 +18,16 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 
 	return (
 		<>
-			<div className="plugin-details-header__tags">{ tags }</div>
 			<div className="plugin-details-header__container">
-				<div className="plugin-details-header__name">{ plugin.name }</div>
-				<div className="plugin-details-header__description">
-					{ preventWidows( plugin.short_description || plugin.description ) }
+				<div className="plugin-details-header__tags">{ tags }</div>
+				<div className="plugin-details-header__main-info">
+					<img className="plugin-details-header__icon" src={ plugin.icon } alt="Plugin Icon" />
+					<div className="plugin-details-header__title-container">
+						<div className="plugin-details-header__name">{ plugin.name }</div>
+						<div className="plugin-details-header__description">
+							{ preventWidows( plugin.short_description || plugin.description ) }
+						</div>
+					</div>
 				</div>
 				<div className="plugin-details-header__additional-info">
 					<div className="plugin-details-header__info">

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -21,7 +21,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 			<div className="plugin-details-header__container">
 				<div className="plugin-details-header__tags">{ tags }</div>
 				<div className="plugin-details-header__main-info">
-					<img className="plugin-details-header__icon" src={ plugin.icon } alt="Plugin Icon" />
+					<img className="plugin-details-header__icon" src={ plugin.icon } alt="" />
 					<div className="plugin-details-header__title-container">
 						<div className="plugin-details-header__name">{ plugin.name }</div>
 						<div className="plugin-details-header__description">

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -1,22 +1,59 @@
 @use '../variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 $plugin-details-header-padding: 100px;
+$mobile-icon-height: 175px;
 
 .plugin-details-header__container {
+	display: block;
     @extend %plugin-header;
+}
+
+.plugin-details-header__main-info {
+	margin-top: 16px;
+	margin-bottom: 30px;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+
+	@include break-mobile {
+		flex-wrap: nowrap;
+		align-items: center;
+		justify-content: flex-start;
+	}
+	
+	.plugin-details-header__icon {
+		@include break-mobile {
+			width: 88px;
+			height: 88px;
+			margin-right: 20px;
+			margin-bottom: 0;
+		}
+
+		margin-bottom: 15px;
+		width: $mobile-icon-height;
+		height: $mobile-icon-height;
+	}
+}
+
+.plugin-details-header__title-container {
+	margin-top: 30px;
+
+	@include break-mobile {
+		margin-top: 0;
+	}
 }
 
 .plugin-details-header__name {
 	font-family: $brand-serif;
 	font-size: $font-title-large;
 	color: var( --studio-gray-100 );
-	margin: 16px 0;
 }
 
 .plugin-details-header__description {
 	font-size: $font-title-small;
 	color: var( --studio-gray-70 );
-	margin-bottom: 30px;
 }
 
 .plugin-details-header__additional-info {
@@ -48,13 +85,13 @@ $plugin-details-header-padding: 100px;
 
 .plugin-details-header__tags {
 	position: absolute;
+    top: calc( $mobile-icon-height + 25px );
 	font-size: $font-body-extra-small;
 	color: var( --studio-gray-60 );
-	top: calc( $plugin-details-header-padding - 15px );
-	left: 0;
 
-	@media screen and ( max-width: 1040px ) {
-		top: -5px;
+	@include break-mobile {
+		position: relative;
+		top: 0;
 	}
 }
 

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -30,7 +30,7 @@ $mobile-icon-height: 175px;
 			margin-right: 20px;
 			margin-bottom: 0;
 		}
-
+		border-radius: 4px;
 		margin-bottom: 15px;
 		width: $mobile-icon-height;
 		height: $mobile-icon-height;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Adds the plugin logo to the plugin page header

#### Testing instructions
* Navigate into `http://calypso.localhost:3000/plugins/<pluginSlug>/<siteSlug>`
* Logo should appear

#### Screenshots
|  Large Laptop Screen | Large Screen| Mobile Screen|  
|---------------|-----------------| -----------------|
|<img width="1081" alt="Screen Shot 2022-02-21 at 1 11 51 PM" src="https://user-images.githubusercontent.com/1035546/155007933-4f7e264b-fcfa-466e-a0f7-1f0599d9a651.png">|<img width="1024" alt="Screen Shot 2022-02-21 at 12 59 03 PM" src="https://user-images.githubusercontent.com/1035546/155007598-d00653fa-5e8b-4806-8377-9e24f034af7e.png">|<img width="425" alt="Screen Shot 2022-02-21 at 12 58 46 PM" src="https://user-images.githubusercontent.com/1035546/155007569-ff3a836a-b5e3-4eeb-8854-6fbb22257409.png">|

Related to #58296 
