### PR TITLE
Hero flow: Add option to move to `/wp-admin` for intents step

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -116,6 +116,10 @@ function getDestinationFromIntent( dependencies ) {
 		return `/post/${ siteSlug }`;
 	}
 
+	if ( intent === 'wpadmin' ) {
+		return `https://${ siteSlug }/wp-admin`;
+	}
+
 	if ( intent === 'sell' && storeType === 'woocommerce' ) {
 		return addQueryArgs(
 			{

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -47,6 +47,7 @@ export default function IntentStep( props: Props ): React.ReactNode {
 	const headerText = translate( 'Where will you start?' );
 	const subHeaderText = translate( 'You can change your mind at any time.' );
 	const branchSteps = useBranchSteps( stepName, getExcludedSteps );
+	const siteSlug = props.signupDependencies.siteSlug;
 
 	const siteId = useSelector( ( state ) => getSiteId( state, queryObject.siteSlug as string ) );
 	const canImport = useSelector( ( state ) =>
@@ -64,6 +65,9 @@ export default function IntentStep( props: Props ): React.ReactNode {
 		if ( EXTERNAL_FLOW[ intent ] ) {
 			dispatch( submitSignupStep( { stepName }, providedDependencies ) );
 			page( getStepUrl( EXTERNAL_FLOW[ intent ], '', '', '', queryObject ) );
+		} else if ( 'wpadmin' === intent ) {
+			//Bail from site setup if we're going directly to wp-admin
+			window.location.href = `https://${ siteSlug }/wp-admin/`;
 		} else {
 			branchSteps( providedDependencies );
 			dispatch( submitSignupStep( { stepName }, providedDependencies ) );

--- a/client/signup/steps/intent/intents.tsx
+++ b/client/signup/steps/intent/intents.tsx
@@ -48,6 +48,13 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 
 	return [
 		{
+			show: true,
+			key: 'wpadmin',
+			description: translate( "Know what you're doing?" ),
+			value: 'wpadmin',
+			actionText: translate( 'Start from scratch / wp-admin' ),
+		},
+		{
 			show: isEnabled( 'onboarding/import' ),
 			key: 'import',
 			description: translate( 'Already have an existing website?' ),

--- a/client/signup/steps/intent/intents.tsx
+++ b/client/signup/steps/intent/intents.tsx
@@ -52,6 +52,8 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 			key: 'wpadmin',
 			description: translate( "Know what you're doing?" ),
 			value: 'wpadmin',
+			disable: false,
+			disableText: null,
 			actionText: translate( 'Start from scratch / wp-admin' ),
 		},
 		{

--- a/client/signup/steps/intent/intents.tsx
+++ b/client/signup/steps/intent/intents.tsx
@@ -53,7 +53,7 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 			description: translate( "Know what you're doing?" ),
 			value: 'wpadmin',
 			disable: false,
-			disableText: null,
+			disableText: '',
 			actionText: translate( 'Start from scratch / wp-admin' ),
 		},
 		{

--- a/client/signup/steps/intent/types.ts
+++ b/client/signup/steps/intent/types.ts
@@ -1,1 +1,1 @@
-export type IntentFlag = 'build' | 'write' | 'import' | 'sell';
+export type IntentFlag = 'build' | 'write' | 'import' | 'sell' | 'wpadmin';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add value for `wpadmin` to possible alternative intents
* Do a manual redirect with `window.location.href` since we're moving outside Calypso and bailing on signup

**Visual**

<img width="1276" alt="Screen Shot 2022-02-21 at 2 03 34 PM" src="https://user-images.githubusercontent.com/2124984/155013538-62cf51dc-6850-496d-8fc0-ea4398a740b1.png">


#### Testing instructions

* Switch to this PR and navigate to `/start`
* At the site intent step, choose "Know what you're doing?"
* You should be redirected to your new site's `/wp-admin`
* Other flows should continue to work as expected
* You should be able to hit "Back" to go back to the signup intent if you want to continue it.

Fixes #61216
