### PR TITLE
Check if Simple flow before creating new homepage

### DIFF
--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -167,7 +167,7 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 				break;
 
 			case 'simple': {
-				dispatch( submitSignupStep( { stepName } ) );
+				dispatch( submitSignupStep( { stepName }, { storeType: 'payment_block' } ) );
 			}
 		}
 		goToNextStep();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added store type choice information to the dispatch call and a check before creating a new homepage.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to `/start`
* Create a new free site
* Choose Sell at the intent step
* Choose the Simple option => it should create a new homepage with the payment block
* Create a new free site
* This time choose the More Power option => it should _not_ create a new homepage

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #61215
