### PR TITLE
Marketplace: Advertise the discount on annual plans

### DIFF
--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -1,9 +1,14 @@
 import { PlansIntervalToggle } from '@automattic/plans-grid/src';
 import styled from '@emotion/styled';
+import { sprintf } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import SelectDropdown from 'calypso/components/select-dropdown';
+import { PluginAnnualSaving } from 'calypso/my-sites/plugins/plugin-saving';
 import { IntervalLength } from './constants';
 
+type PluginAnnualSavingLabelProps = {
+	isSelected: boolean;
+};
 const Container = styled.div`
 	.plans-interval-toggle {
 		display: inline-flex;
@@ -16,16 +21,28 @@ const PlansIntervalToggleLabel = styled.span`
 	margin-right: 10px;
 `;
 
+const PluginAnnualSavingLabelMobile = styled.span< PluginAnnualSavingLabelProps >`
+	color: ${ ( props ) =>
+		props.isSelected ? 'var( --studio-white-100 )' : 'var( --studio-green-60 )' };
+`;
+
+const PluginAnnualSavingLabelDesktop = styled.span`
+	font-size: 12px;
+	color: var( --studio-green-60 );
+`;
+
 type Props = {
 	onChange: ( selectedValue: 'MONTHLY' | 'ANNUALLY' ) => void;
 	billingPeriod: IntervalLength;
 	compact: boolean;
+	plugin?: object;
 };
 
 const BillingIntervalSwitcher: React.FunctionComponent< Props > = ( {
 	billingPeriod,
 	onChange,
 	compact,
+	plugin,
 } ) => {
 	const translate = useTranslate();
 	const monthlyLabel = translate( 'Monthly price' );
@@ -48,6 +65,21 @@ const BillingIntervalSwitcher: React.FunctionComponent< Props > = ( {
 						onClick={ () => onChange( IntervalLength.ANNUALLY ) }
 					>
 						{ annualLabel }
+						{ plugin ? (
+							<PluginAnnualSaving plugin={ plugin }>
+								{ ( annualSaving: { saving: any } ) =>
+									annualSaving.saving ? (
+										<>
+											<PluginAnnualSavingLabelMobile
+												isSelected={ billingPeriod === IntervalLength.ANNUALLY }
+											>
+												-{ annualSaving.saving }
+											</PluginAnnualSavingLabelMobile>
+										</>
+									) : null
+								}
+							</PluginAnnualSaving>
+						) : null }
 					</SelectDropdown.Item>
 				</SelectDropdown>
 			</Container>
@@ -57,7 +89,25 @@ const BillingIntervalSwitcher: React.FunctionComponent< Props > = ( {
 	return (
 		<Container>
 			<PlansIntervalToggleLabel>{ translate( 'Price' ) }</PlansIntervalToggleLabel>
-			<PlansIntervalToggle intervalType={ billingPeriod } onChange={ onChange } />
+			<PlansIntervalToggle intervalType={ billingPeriod } onChange={ onChange }>
+				{ plugin ? (
+					<PluginAnnualSaving plugin={ plugin }>
+						{ ( annualSaving: { saving: any } ) =>
+							annualSaving.saving ? (
+								<>
+									<PluginAnnualSavingLabelDesktop>
+										(
+										{ sprintf( 'Save %(save)s', {
+											save: annualSaving.saving,
+										} ) }
+										)
+									</PluginAnnualSavingLabelDesktop>
+								</>
+							) : null
+						}
+					</PluginAnnualSaving>
+				) : null }
+			</PlansIntervalToggle>
 		</Container>
 	);
 };

--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -96,11 +96,11 @@ const BillingIntervalSwitcher: React.FunctionComponent< Props > = ( {
 							annualSaving.saving ? (
 								<>
 									<PluginAnnualSavingLabelDesktop>
-										(
-										{ sprintf( 'Save %(save)s', {
-											save: annualSaving.saving,
+										&nbsp;
+										{ translate( 'Save %(save)s', {
+											comment: 'Sale price label, ex: Save $51',
+											args: { save: annualSaving.saving },
 										} ) }
-										)
 									</PluginAnnualSavingLabelDesktop>
 								</>
 							) : null

--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -67,7 +67,7 @@ const BillingIntervalSwitcher: FunctionComponent< Props > = ( {
 						{ annualLabel }
 						{ plugin && (
 							<PluginAnnualSaving plugin={ plugin }>
-								{ ( annualSaving: { saving: never } ) =>
+								{ ( annualSaving: { saving: string | null } ) =>
 									annualSaving.saving && (
 										<PluginAnnualSavingLabelMobile
 											isSelected={ billingPeriod === IntervalLength.ANNUALLY }

--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -1,7 +1,7 @@
 import { PlansIntervalToggle } from '@automattic/plans-grid/src';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import { FunctionComponent } from 'react';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { PluginAnnualSaving } from 'calypso/my-sites/plugins/plugin-saving';
 import { IntervalLength } from './constants';
@@ -38,7 +38,7 @@ type Props = {
 	plugin?: object;
 };
 
-const BillingIntervalSwitcher: React.FunctionComponent< Props > = ( {
+const BillingIntervalSwitcher: FunctionComponent< Props > = ( {
 	billingPeriod,
 	onChange,
 	compact,

--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -1,7 +1,7 @@
 import { PlansIntervalToggle } from '@automattic/plans-grid/src';
 import styled from '@emotion/styled';
-import { sprintf } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
+import React from 'react';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { PluginAnnualSaving } from 'calypso/my-sites/plugins/plugin-saving';
 import { IntervalLength } from './constants';
@@ -65,21 +65,19 @@ const BillingIntervalSwitcher: React.FunctionComponent< Props > = ( {
 						onClick={ () => onChange( IntervalLength.ANNUALLY ) }
 					>
 						{ annualLabel }
-						{ plugin ? (
+						{ plugin && (
 							<PluginAnnualSaving plugin={ plugin }>
-								{ ( annualSaving: { saving: any } ) =>
-									annualSaving.saving ? (
-										<>
-											<PluginAnnualSavingLabelMobile
-												isSelected={ billingPeriod === IntervalLength.ANNUALLY }
-											>
-												-{ annualSaving.saving }
-											</PluginAnnualSavingLabelMobile>
-										</>
-									) : null
+								{ ( annualSaving: { saving: never } ) =>
+									annualSaving.saving && (
+										<PluginAnnualSavingLabelMobile
+											isSelected={ billingPeriod === IntervalLength.ANNUALLY }
+										>
+											&nbsp;-{ annualSaving.saving }
+										</PluginAnnualSavingLabelMobile>
+									)
 								}
 							</PluginAnnualSaving>
-						) : null }
+						) }
 					</SelectDropdown.Item>
 				</SelectDropdown>
 			</Container>
@@ -90,23 +88,21 @@ const BillingIntervalSwitcher: React.FunctionComponent< Props > = ( {
 		<Container>
 			<PlansIntervalToggleLabel>{ translate( 'Price' ) }</PlansIntervalToggleLabel>
 			<PlansIntervalToggle intervalType={ billingPeriod } onChange={ onChange }>
-				{ plugin ? (
+				{ plugin && (
 					<PluginAnnualSaving plugin={ plugin }>
-						{ ( annualSaving: { saving: any } ) =>
-							annualSaving.saving ? (
-								<>
-									<PluginAnnualSavingLabelDesktop>
-										&nbsp;
-										{ translate( 'Save %(save)s', {
-											comment: 'Sale price label, ex: Save $51',
-											args: { save: annualSaving.saving },
-										} ) }
-									</PluginAnnualSavingLabelDesktop>
-								</>
-							) : null
+						{ ( annualSaving: { saving: never } ) =>
+							annualSaving.saving && (
+								<PluginAnnualSavingLabelDesktop>
+									&nbsp;
+									{ translate( 'Save %(save)s', {
+										comment: 'Sale price label, ex: Save $51',
+										args: { save: annualSaving.saving },
+									} ) }
+								</PluginAnnualSavingLabelDesktop>
+							)
 						}
 					</PluginAnnualSaving>
-				) : null }
+				) }
 			</PlansIntervalToggle>
 		</Container>
 	);

--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -35,7 +35,7 @@ type Props = {
 	onChange: ( selectedValue: 'MONTHLY' | 'ANNUALLY' ) => void;
 	billingPeriod: IntervalLength;
 	compact: boolean;
-	plugin?: object;
+	plugin?: { variations?: { yearly?: { product_slug: string }; monthly?: { product_slug: string } } };
 };
 
 const BillingIntervalSwitcher: FunctionComponent< Props > = ( {

--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -1,10 +1,10 @@
 import { PlansIntervalToggle } from '@automattic/plans-grid/src';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import type { FunctionComponent } from 'react';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { PluginAnnualSaving } from 'calypso/my-sites/plugins/plugin-saving';
 import { IntervalLength } from './constants';
+import type { FunctionComponent } from 'react';
 
 type PluginAnnualSavingLabelProps = {
 	isSelected: boolean;
@@ -35,7 +35,9 @@ type Props = {
 	onChange: ( selectedValue: 'MONTHLY' | 'ANNUALLY' ) => void;
 	billingPeriod: IntervalLength;
 	compact: boolean;
-	plugin?: { variations?: { yearly?: { product_slug: string }; monthly?: { product_slug: string } } };
+	plugin?: {
+		variations?: { yearly?: { product_slug: string }; monthly?: { product_slug: string } };
+	};
 };
 
 const BillingIntervalSwitcher: FunctionComponent< Props > = ( {
@@ -90,7 +92,7 @@ const BillingIntervalSwitcher: FunctionComponent< Props > = ( {
 			<PlansIntervalToggle intervalType={ billingPeriod } onChange={ onChange }>
 				{ plugin && (
 					<PluginAnnualSaving plugin={ plugin }>
-						{ ( annualSaving: { saving: never } ) =>
+						{ ( annualSaving: { saving: string | null } ) =>
 							annualSaving.saving && (
 								<PluginAnnualSavingLabelDesktop>
 									&nbsp;

--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -1,7 +1,7 @@
 import { PlansIntervalToggle } from '@automattic/plans-grid/src';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
+import type { FunctionComponent } from 'react';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { PluginAnnualSaving } from 'calypso/my-sites/plugins/plugin-saving';
 import { IntervalLength } from './constants';

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -253,6 +253,7 @@ function PluginDetails( props ) {
 							billingPeriod={ billingPeriod }
 							onChange={ ( interval ) => dispatch( setBillingInterval( interval ) ) }
 							compact={ ! isWide }
+							plugin={ fullPlugin }
 						/>
 					) }
 			</FixedNavigationHeader>

--- a/client/my-sites/plugins/plugin-saving/index.jsx
+++ b/client/my-sites/plugins/plugin-saving/index.jsx
@@ -23,22 +23,3 @@ export const PluginAnnualSaving = ( { plugin, children } ) => {
 		saving: getAnnualPriceSavingText(),
 	} );
 };
-
-export const PluginAnnualSavingPercent = ( { plugin, children } ) => {
-	const priceSlugYearly = plugin?.variations?.yearly?.product_slug;
-	const productYearly = useSelector( ( state ) => getProductBySlug( state, priceSlugYearly ) );
-	const priceSlugMonthly = plugin?.variations?.monthly?.product_slug;
-	const productMonthly = useSelector( ( state ) => getProductBySlug( state, priceSlugMonthly ) );
-	const isFetching = useSelector( isProductsListFetching );
-
-	const getAnnualPriceSavingText = () => {
-		return productMonthly && productYearly
-			? Math.floor( 100 - ( productYearly.cost * 100 ) / ( productMonthly.cost * 12 ) )
-			: null;
-	};
-
-	return children( {
-		isFetching,
-		saving: getAnnualPriceSavingText(),
-	} );
-};

--- a/client/my-sites/plugins/plugin-saving/index.jsx
+++ b/client/my-sites/plugins/plugin-saving/index.jsx
@@ -1,0 +1,44 @@
+import formatCurrency from '@automattic/format-currency';
+import { useSelector } from 'react-redux';
+import { getProductBySlug, isProductsListFetching } from 'calypso/state/products-list/selectors';
+
+export const PluginAnnualSaving = ( { plugin, children } ) => {
+	const priceSlugYearly = plugin?.variations?.yearly?.product_slug;
+	const productYearly = useSelector( ( state ) => getProductBySlug( state, priceSlugYearly ) );
+	const priceSlugMonthly = plugin?.variations?.monthly?.product_slug;
+	const productMonthly = useSelector( ( state ) => getProductBySlug( state, priceSlugMonthly ) );
+	const isFetching = useSelector( isProductsListFetching );
+
+	const getAnnualPriceSavingText = () => {
+		return productMonthly && productYearly
+			? formatCurrency(
+					Math.round( productMonthly.cost * 12 - productYearly.cost ),
+					productYearly.currency_code
+			  )
+			: null;
+	};
+
+	return children( {
+		isFetching,
+		saving: getAnnualPriceSavingText(),
+	} );
+};
+
+export const PluginAnnualSavingPercent = ( { plugin, children } ) => {
+	const priceSlugYearly = plugin?.variations?.yearly?.product_slug;
+	const productYearly = useSelector( ( state ) => getProductBySlug( state, priceSlugYearly ) );
+	const priceSlugMonthly = plugin?.variations?.monthly?.product_slug;
+	const productMonthly = useSelector( ( state ) => getProductBySlug( state, priceSlugMonthly ) );
+	const isFetching = useSelector( isProductsListFetching );
+
+	const getAnnualPriceSavingText = () => {
+		return productMonthly && productYearly
+			? Math.floor( 100 - ( productYearly.cost * 100 ) / ( productMonthly.cost * 12 ) )
+			: null;
+	};
+
+	return children( {
+		isFetching,
+		saving: getAnnualPriceSavingText(),
+	} );
+};

--- a/client/my-sites/plugins/plugin-saving/index.jsx
+++ b/client/my-sites/plugins/plugin-saving/index.jsx
@@ -14,7 +14,7 @@ export const PluginAnnualSaving = ( { plugin, children } ) => {
 			productMonthly && productYearly
 				? Math.round( productMonthly.cost * 12 - productYearly.cost )
 				: null;
-		return totalDiscount > 0 ? formatCurrency( totalDiscount, productYearly.currency_code ) : null;
+		return totalDiscount > 0 && formatCurrency( totalDiscount, productYearly.currency_code );
 	};
 
 	return children( {

--- a/client/my-sites/plugins/plugin-saving/index.jsx
+++ b/client/my-sites/plugins/plugin-saving/index.jsx
@@ -10,12 +10,11 @@ export const PluginAnnualSaving = ( { plugin, children } ) => {
 	const isFetching = useSelector( isProductsListFetching );
 
 	const getAnnualPriceSavingText = () => {
-		return productMonthly && productYearly
-			? formatCurrency(
-					Math.round( productMonthly.cost * 12 - productYearly.cost ),
-					productYearly.currency_code
-			  )
-			: null;
+		const totalDiscount =
+			productMonthly && productYearly
+				? Math.round( productMonthly.cost * 12 - productYearly.cost )
+				: null;
+		return totalDiscount > 0 ? formatCurrency( totalDiscount, productYearly.currency_code ) : null;
 	};
 
 	return children( {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -260,3 +260,7 @@ body.is-section-plugins:not( .is-nav-unification ) {
 		padding: 0 24px;
 	}
 }
+
+body.is-section-plugins header .select-dropdown__item {
+	padding: 0 0 0 16px !important;
+}

--- a/packages/plans-grid/src/plans-interval-toggle/index.tsx
+++ b/packages/plans-grid/src/plans-interval-toggle/index.tsx
@@ -46,6 +46,7 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 	intervalType,
 	maxMonthlyDiscountPercentage,
 	className = '',
+	children,
 } ) => {
 	const { __, _x, hasTranslation } = useI18n();
 	const locale = useLocale();
@@ -88,7 +89,10 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 					selected={ intervalType === 'ANNUALLY' }
 					onClick={ () => onChange( 'ANNUALLY' ) }
 				>
-					<span className="plans-interval-toggle__label">{ annuallyLabel }</span>
+					<span className="plans-interval-toggle__label">
+						{ annuallyLabel } { children }
+					</span>
+
 					{ /*
 					 * Check covers both cases of maxMonthlyDiscountPercentage
 					 * not being undefined and not being 0


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- Create a component to get the discount price on annual plans
- Use the component in monthly/yearly selector when in plugin view
- Add styles to match [this requirements](https://github.com/Automattic/wp-calypso/issues/59397#issuecomment-1039792675)
- Had to modify the [`billing-interval-switcher`](https://github.com/Automattic/wp-calypso/tree/trunk/client/my-sites/marketplace/components/billing-interval-switcher) component in order to receive the plugin to get the discount

#### Testing instructions
- Visit /plugins page and select a paid plugin.
- You should see the discount price in the annual selector

#### Screenshots Desktop
Before
<img width="1064" alt="image" src="https://user-images.githubusercontent.com/402286/155017939-61cb0b59-54e2-4a8c-b483-024855864f9f.png">

After
<img width="1056" alt="image" src="https://user-images.githubusercontent.com/402286/155018112-b766898f-8292-4d42-ad79-9f91ade80dd8.png">

#### Screenshots Mobile
Before
<img width="264" alt="image" src="https://user-images.githubusercontent.com/402286/155018010-5a6a5a81-0585-4ca1-b2bd-99876f1357a9.png">

After
<img width="266" alt="image" src="https://user-images.githubusercontent.com/402286/155018232-cd2287c3-9071-4d56-97b3-35aaa6eeacca.png">

Related to #59397
