### PR TITLE
Fix module path in 'Register section' of the Hello World example

### DIFF
--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -101,7 +101,7 @@ if ( config.isEnabled( 'hello-world' ) ) {
 	sections.push( {
 		name: 'hello-world',
 		paths: [ '/hello-world' ],
-		module: 'my-sites/hello-world',
+		module: 'calypso/my-sites/hello-world',
 	} );
 }
 ```


### PR DESCRIPTION
Related to #61344

#### Changes proposed in this Pull Request

The current code-base expects the section modules paths to start with
`calypso/`.

Setting the module path to `my-sites/hello-world` as per the tutorial
causes the following error:

> Module not found: Error: Can't resolve 'my-sites/hello-world'

This corrects the module path to `calypso/my-sites/hello-world`.

#### Testing instructions

1. Follow the initial guide steps 1 - 4 to setup the "Hello World" section controller and route.
2. Add the following to the end of the `sections` array in [section.js](https://github.com/Automattic/wp-calypso/blob/trunk/client/sections.js#L507)

{
        name: 'hello-world',
        paths: [ '/hello-world' ],
        module: 'calypso/my-sites/hello-world',
    }
3. Run yarn start

The local environment should start without errors.
