### PR TITLE
Component SupportInfo: replace link-less uses with InfoPopover

### DIFF
--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -3,6 +3,7 @@ import { numberFormat, translate } from 'i18n-calypso';
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import FoldableCard from 'calypso/components/foldable-card';
+import InfoPopover from 'calypso/components/info-popover';
 import FixAllThreatsDialog from 'calypso/components/jetpack/fix-all-threats-dialog';
 import SecurityIcon from 'calypso/components/jetpack/security-icon';
 import ThreatDialog from 'calypso/components/jetpack/threat-dialog';
@@ -10,7 +11,6 @@ import ThreatItem from 'calypso/components/jetpack/threat-item';
 import { FixableThreat, Threat, ThreatAction } from 'calypso/components/jetpack/threat-item/types';
 import ThreatListHeader from 'calypso/components/jetpack/threat-list-header';
 import ThreatLowRiskItemHeader from 'calypso/components/jetpack/threat-low-risk-item-header';
-import SupportInfo from 'calypso/components/support-info';
 import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
 import { triggerScanRun } from 'calypso/lib/jetpack/trigger-scan-run';
 import { useThreats } from 'calypso/lib/jetpack/use-threats';
@@ -234,12 +234,11 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 				<p className="scan-threats__header-message">
 					{ headerSummary }{ ' ' }
 					{ maxSeverity < 3 && (
-						<SupportInfo
-							position="top"
-							text={ translate(
+						<InfoPopover position="top" screenReaderText={ translate( 'Learn more' ) }>
+							{ translate(
 								"Low risk items don't have a negative impact on your site and can be safely ignored."
 							) }
-						/>
+						</InfoPopover>
 					) }
 				</p>
 				{ hasFixableThreats && (

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -3,6 +3,10 @@
 
 	&__threats {
 		margin: 0;
+
+		.info-popover {
+			margin: 0 0 0 20px;
+		}
 	}
 
 	&__card-header {
@@ -29,7 +33,7 @@
 		}
 
 		.foldable-card.is-expanded .foldable-card__content {
-				padding: 0;
+			padding: 0;
 		}
 	}
 
@@ -42,7 +46,7 @@
 		text-align: center;
 		font-size: $font-body-small;
 		line-height: 20px;
-		color: var( --studio-gray-40 );
+		color: var(--studio-gray-40);
 		margin-top: 24px;
 	}
 
@@ -51,7 +55,7 @@
 		display: flex;
 		flex-direction: column;
 
-		@include breakpoint-deprecated( '>800px' ) {
+		@include breakpoint-deprecated('>800px') {
 			flex-direction: row;
 		}
 
@@ -60,7 +64,7 @@
 			line-height: 21px;
 			font-style: normal;
 			font-weight: normal;
-			color: var( --studio-gray-60 );
+			color: var(--studio-gray-60);
 			text-align: center;
 			letter-spacing: -0.01em;
 			max-width: 576px;
@@ -68,7 +72,7 @@
 			margin-left: 72px;
 			margin-right: 72px;
 
-			@include breakpoint-deprecated( '>800px' ) {
+			@include breakpoint-deprecated('>800px') {
 				margin-bottom: 0;
 			}
 		}
@@ -77,7 +81,7 @@
 			flex: 1 1 40%;
 			padding: 10px 30px;
 
-			@include breakpoint-deprecated( '>800px' ) {
+			@include breakpoint-deprecated('>800px') {
 				flex: 0 0 170px;
 				margin-left: 8px;
 			}
@@ -95,7 +99,7 @@
 		&:active,
 		&:focus {
 			background: initial;
-			color: var( --color-link-dark );
+			color: var(--color-link-dark);
 		}
 
 		&:hover,
@@ -112,13 +116,13 @@
 
 	&__buttons {
 		display: flex;
-		border-top: 1px solid var( --studio-gray-5 );
+		border-top: 1px solid var(--studio-gray-5);
 		padding-top: 32px;
 		flex-direction: space-between;
 		flex-wrap: wrap;
 		align-items: center;
 
-		@include breakpoint-deprecated( '>800px' ) {
+		@include breakpoint-deprecated('>800px') {
 			flex-direction: row;
 		}
 
@@ -127,7 +131,7 @@
 			font-weight: normal;
 			// line-height: 24px;
 
-			@include breakpoint-deprecated( '>800px' ) {
+			@include breakpoint-deprecated('>800px') {
 				flex-grow: 1;
 				margin: 0 !important;
 			}
@@ -139,7 +143,8 @@
 		height: 40px;
 		border-radius: 2px;
 		font-weight: 600;
-		@include breakpoint-deprecated( '<800px' ) {
+
+		@include breakpoint-deprecated('<800px') {
 			flex-grow: 1;
 		}
 	}

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -33,7 +33,7 @@
 		}
 
 		.foldable-card.is-expanded .foldable-card__content {
-			padding: 0;
+				padding: 0;
 		}
 	}
 
@@ -46,7 +46,7 @@
 		text-align: center;
 		font-size: $font-body-small;
 		line-height: 20px;
-		color: var(--studio-gray-40);
+		color: var( --studio-gray-40 );
 		margin-top: 24px;
 	}
 
@@ -55,7 +55,7 @@
 		display: flex;
 		flex-direction: column;
 
-		@include breakpoint-deprecated('>800px') {
+		@include breakpoint-deprecated( '>800px' ) {
 			flex-direction: row;
 		}
 
@@ -64,7 +64,7 @@
 			line-height: 21px;
 			font-style: normal;
 			font-weight: normal;
-			color: var(--studio-gray-60);
+			color: var( --studio-gray-60 );
 			text-align: center;
 			letter-spacing: -0.01em;
 			max-width: 576px;
@@ -72,7 +72,7 @@
 			margin-left: 72px;
 			margin-right: 72px;
 
-			@include breakpoint-deprecated('>800px') {
+			@include breakpoint-deprecated( '>800px' ) {
 				margin-bottom: 0;
 			}
 		}
@@ -81,7 +81,7 @@
 			flex: 1 1 40%;
 			padding: 10px 30px;
 
-			@include breakpoint-deprecated('>800px') {
+			@include breakpoint-deprecated( '>800px' ) {
 				flex: 0 0 170px;
 				margin-left: 8px;
 			}
@@ -99,7 +99,7 @@
 		&:active,
 		&:focus {
 			background: initial;
-			color: var(--color-link-dark);
+			color: var( --color-link-dark );
 		}
 
 		&:hover,
@@ -116,13 +116,13 @@
 
 	&__buttons {
 		display: flex;
-		border-top: 1px solid var(--studio-gray-5);
+		border-top: 1px solid var( --studio-gray-5 );
 		padding-top: 32px;
 		flex-direction: space-between;
 		flex-wrap: wrap;
 		align-items: center;
 
-		@include breakpoint-deprecated('>800px') {
+		@include breakpoint-deprecated( '>800px' ) {
 			flex-direction: row;
 		}
 
@@ -131,7 +131,7 @@
 			font-weight: normal;
 			// line-height: 24px;
 
-			@include breakpoint-deprecated('>800px') {
+			@include breakpoint-deprecated( '>800px' ) {
 				flex-grow: 1;
 				margin: 0 !important;
 			}
@@ -143,8 +143,7 @@
 		height: 40px;
 		border-radius: 2px;
 		font-weight: 600;
-
-		@include breakpoint-deprecated('<800px') {
+		@include breakpoint-deprecated( '<800px' ) {
 			flex-grow: 1;
 		}
 	}

--- a/client/components/jetpack/threat-low-risk-item-header/index.tsx
+++ b/client/components/jetpack/threat-low-risk-item-header/index.tsx
@@ -1,6 +1,6 @@
 import { translate } from 'i18n-calypso';
 import * as React from 'react';
-import SupportInfo from 'calypso/components/support-info';
+import InfoPopover from 'calypso/components/info-popover';
 
 interface Props {
 	threatCount: number;
@@ -14,12 +14,11 @@ const ThreatLowRiskItemHeader: React.FC< Props > = ( { threatCount } ) => {
 				'Review %(threatCount)s low risk items',
 				{ args: { threatCount: threatCount }, count: threatCount }
 			) }
-			<SupportInfo
-				position="top"
-				text={ translate(
+			<InfoPopover position="top" screenReaderText={ translate( 'Learn more' ) }>
+				{ translate(
 					"Low risk items don't have a negative impact on your site and can be safely ignored."
 				) }
-			/>
+			</InfoPopover>
 		</>
 	);
 };

--- a/client/my-sites/people/contractor-select/index.tsx
+++ b/client/my-sites/people/contractor-select/index.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
-import SupportInfo from 'calypso/components/support-info';
+import InfoPopover from 'calypso/components/info-popover';
 import type { ChangeEventHandler } from 'react';
 
 interface Props {
@@ -29,12 +29,11 @@ const ContractorSelect: FunctionComponent< Props > = ( { id, checked, onChange, 
 				/>
 				<span>
 					{ translate( 'This user is a contractor, freelancer, consultant, or agency.' ) }
-					<SupportInfo
-						position="top right"
-						text={ translate(
+					<InfoPopover position="top right" screenReaderText={ translate( 'Learn more' ) }>
+						{ translate(
 							'Use this checkbox to flag users who are not a part of your organization.'
 						) }
-					/>
+					</InfoPopover>
 				</span>
 			</FormLabel>
 		</FormFieldset>

--- a/client/my-sites/people/contractor-select/style.scss
+++ b/client/my-sites/people/contractor-select/style.scss
@@ -2,7 +2,7 @@
 	margin-top: 3px;
 }
 
-.contractor-select .support-info {
+.contractor-select .info-popover {
 	display: inline-block;
 	float: none;
 	margin: 0 0 0 10px;


### PR DESCRIPTION
## Changes proposed in this Pull Request
While attempting to update the SupportInfo component there were tests failing due to some occurrences not using all the props. Because the occurrences were not even using the link option I thought it best to replace it with the correct component `InfoPopover`. InfoPopover is the core element that is used in the SupportInfo component and when there is no `link` or `privacyLink` given then an InfoPopover is all that is returned. The two occurrences were in the Jetpack Scan threat list and the Add users setting page when creating a contractor. [Failing tests](https://teamcity.a8c.com/viewLog.html?buildId=7441652&buildTypeId=calypso_RunAllUnitTests)

### People
| **Before** | **After** |
| ------ | ----- |
| <img width="751" alt="Markup 2022-02-21 at 22 21 02" src="https://user-images.githubusercontent.com/33258733/155031948-1ac2e829-2a64-4853-b7f5-16560bc85b58.png"> | <img width="768" alt="Markup 2022-02-21 at 22 21 17" src="https://user-images.githubusercontent.com/33258733/155031990-42a0f468-6efc-46d0-91c0-5a0f5161ec6a.png"> |

### Jetpack Scan
| **Before** | **After** |
| -------|------|
| <img width="652" alt="Markup 2022-02-21 at 22 47 17" src="https://user-images.githubusercontent.com/33258733/155032113-cfacbac0-bd81-46ed-ac40-7572153de5ff.png"> | <img width="534" alt="Markup 2022-02-21 at 22 47 03" src="https://user-images.githubusercontent.com/33258733/155032144-97b32e78-7418-4212-aebd-a64ca93ba14a.png"> |

Related to #61260 
