### PR TITLE
`VerificationCodeForm`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/blocks/login/two-factor-authentication/two-factor-content.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-content.jsx
@@ -32,6 +32,7 @@ export default function TwoFactorContent( {
 			<div>
 				{ poller }
 				<VerificationCodeForm
+					key={ twoFactorAuthType }
 					onSuccess={ handleValid2FACode }
 					twoFactorAuthType={ twoFactorAuthType }
 					switchTwoFactorAuthType={ switchTwoFactorAuthType }

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -56,14 +56,6 @@ class VerificationCodeForm extends Component {
 		}
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps = ( nextProps ) => {
-		// Resets the verification code input field when switching pages
-		if ( this.props.twoFactorAuthType !== nextProps.twoFactorAuthType ) {
-			this.setState( { twoStepCode: '' } );
-		}
-	};
-
 	onChangeField = ( event ) => {
 		const { name, value = '' } = event.target;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `VerificationCodeForm`: refactor away from `UNSAFE_*`

#### Testing instructions

* Start logged out and use WP.com account which has both SMS and OTP for 2FA enabled
* Attempt to log in and choose either SMS or OTP for 2FA
* When shown the verification code input, click the button to change the method
* Verify you get a new input component (either by looking at the `key` prop in devtools or by typing something into the form before switching)

Related to #58453 
