### PR TITLE
P2: no success notice after accepting invites

### DIFF
--- a/client/components/logged-out-form/link-item.scss
+++ b/client/components/logged-out-form/link-item.scss
@@ -10,10 +10,17 @@
 	.is-p2-invite.invite-accept &,
 	.is-p2-signup .signup__step.is-user & {
 		padding: 0;
+		width: fit-content;
+		margin-left: auto;
+		margin-right: auto;
 	}
 
-	body.is-section-signup:not( .is-section-jetpack-connect ):not( .is-section-settings ) .layout:not( .dops ):not( .is-wccom-oauth-flow ) &,
-	body.is-section-signup:not( .is-section-jetpack-connect ):not( .is-section-settings ) .layout.gravatar & {
+	body.is-section-signup:not( .is-section-jetpack-connect ):not( .is-section-settings )
+		.layout:not( .dops ):not( .is-wccom-oauth-flow )
+		&,
+	body.is-section-signup:not( .is-section-jetpack-connect ):not( .is-section-settings )
+		.layout.gravatar
+		& {
 		color: var( --color-text-inverted );
 
 		&:hover {

--- a/client/my-sites/invites/p2/invite-accept-logged-in.jsx
+++ b/client/my-sites/invites/p2/invite-accept-logged-in.jsx
@@ -14,17 +14,7 @@ const P2InviteAcceptLoggedIn = ( props ) => {
 				{ P2InviteAcceptHeader( { site: props.invite.site, translate: props.translate } ) }
 				<div className="invite-accept-logged-in__join-as">
 					<Gravatar user={ props.user } size={ 72 } />
-					<div className="invite-accept-logged-in__join-as-text">
-						{ /* { props.translate( "You'll join as {{usernameWrap}}%(username)s{{/usernameWrap}}", {
-							components: {
-								usernameWrap: <span className="invite-accept-logged-in__join-as-username" />,
-							},
-							args: {
-								username: props.user && props.user.display_name,
-							},
-						} ) } */ }
-						{ props.joinAsText }
-					</div>
+					<div className="invite-accept-logged-in__join-as-text">{ props.joinAsText }</div>
 					<LoggedOutFormLinks>
 						<LoggedOutFormLinkItem onClick={ props.signIn } href={ props.signInLink }>
 							{ props.translate( 'Sign in as a different user' ) }

--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -233,7 +233,7 @@ export function acceptInvite( invite ) {
 				await dispatch( fetchCurrentUser() );
 			}
 
-			if ( ! invite.site.is_vip ) {
+			if ( ! invite.site.is_vip && ! invite.site.is_wpforteams_site ) {
 				dispatch( successNotice( ...acceptedNotice( invite ) ) );
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For P2s, the user is redirected to the workspace hub after accepting an invite. For this reason, we should skip the success notice displayed in Calypso, as the user does not have enough time to actually read it before the redirect happens.
* Drive-by cleanup of commented-out code, and minor CSS tweak for the "Sign in as a different user" link in the Accept Invite page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Send your test user an email invite, or generate an invite link for a P2 site.
2. Accept the invite.
3. The Accept page should look okay, and upon accepting, you should not see a success banner flash on the top right corner. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 4597-gh-Automattic/p2