### PR TITLE
Guided Tours: Refactor `Quit` away from `UNSAFE_` lifecycle methods

### DIFF
--- a/client/layout/guided-tours/config-elements/quit.js
+++ b/client/layout/guided-tours/config-elements/quit.js
@@ -28,8 +28,8 @@ export default class Quit extends Component {
 	}
 
 	componentDidUpdate() {
-		this.addTargetListener();
 		this.removeTargetListener();
+		this.addTargetListener();
 	}
 
 	addTargetListener() {

--- a/client/layout/guided-tours/config-elements/quit.js
+++ b/client/layout/guided-tours/config-elements/quit.js
@@ -27,13 +27,9 @@ export default class Quit extends Component {
 		this.removeTargetListener();
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillUpdate() {
-		this.removeTargetListener();
-	}
-
 	componentDidUpdate() {
 		this.addTargetListener();
+		this.removeTargetListener();
 	}
 
 	addTargetListener() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `Quit` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/settings/security/:site` where `:site` is a Jetpack site.
* Verify the main toggle under "WordPress.com sign in" is disabled.
* Now go to `/settings/security/:site?tour=jetpackSignIn` where `:site` is your Jetpack site.
* Enable the toggle.
* On the next step, click "No thanks"
* Verify the guided tour quits and there are no errors in the console. 