### PR TITLE
Experiment: Add Upgrade button to Masterbar

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -21,7 +21,9 @@ import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { updateSiteMigrationMeta } from 'calypso/state/sites/actions';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
 import { isSupportSession } from 'calypso/state/support/selectors';
@@ -115,6 +117,12 @@ class MasterbarLoggedIn extends Component {
 	clickReader = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_reader_clicked' );
 		this.handleLayoutFocus( 'reader' );
+	};
+
+	clickPlanUpsell = () => {
+		this.props.recordTracksEvent( 'calypso_masterbar_click', {
+			clicked: 'plan_upsell_button',
+		} );
 	};
 
 	clickMe = () => {
@@ -213,8 +221,11 @@ class MasterbarLoggedIn extends Component {
 			siteSlug,
 			isJetpackNotAtomic,
 			title,
+			isP2,
+			isJetpack,
 			currentSelectedSiteSlug,
 			currentSelectedSiteId,
+			currentPlan,
 		} = this.props;
 
 		const { isActionSearchVisible } = this.state;
@@ -232,6 +243,21 @@ class MasterbarLoggedIn extends Component {
 				/>
 			);
 		}
+		const planSlug = currentPlan?.productSlug || '';
+
+		const plansUpsells = [
+			'free_plan',
+			'personal-bundle-monthly',
+			'value_bundle_monthly',
+			'business-bundle-monthly',
+			'ecommerce-bundle-monthly',
+
+			'personal-bundle',
+			'value_bundle',
+			'business-bundle',
+		];
+		const showPlanUpsell = ! isP2 && ! isJetpack && plansUpsells.includes( planSlug );
+		const plansUpsellPath = '/plans/' + siteSlug;
 
 		return (
 			<>
@@ -275,6 +301,17 @@ class MasterbarLoggedIn extends Component {
 						) }
 					</div>
 					<div className="masterbar__section masterbar__section--center">
+						{ showPlanUpsell && (
+							<Item
+								tipTarget="Upgrade Plan"
+								url={ plansUpsellPath }
+								onClick={ this.clickPlanUpsell }
+								className="masterbar__item masterbar__item-upsell button is-primary"
+								tooltip={ translate( 'Upgrade your plan' ) }
+							>
+								{ translate( 'Upgrade' ) }
+							</Item>
+						) }
 						{ ! domainOnlySite && ! isMigrationInProgress && (
 							<AsyncLoad
 								require="./publish"
@@ -352,7 +389,10 @@ export default connect(
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
 			user: getCurrentUser( state ),
 			isSupportSession: isSupportSession( state ),
+			currentPlan: getCurrentPlan( state, siteId ),
 			isMigrationInProgress,
+			isP2: isSiteWPForTeams( state, siteId ),
+			isJetpack: isJetpackSite( state, siteId ),
 			migrationStatus: getSiteMigrationStatus( state, currentSelectedSiteId ),
 			currentSelectedSiteId,
 			currentSelectedSiteSlug: currentSelectedSiteId

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -7,6 +7,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
+import { ProvideExperimentData } from 'calypso/lib/explat';
 import { getStatsPathForTab } from 'calypso/lib/route';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
@@ -301,17 +302,33 @@ class MasterbarLoggedIn extends Component {
 						) }
 					</div>
 					<div className="masterbar__section masterbar__section--center">
-						{ showPlanUpsell && (
-							<Item
-								tipTarget="Upgrade Plan"
-								url={ plansUpsellPath }
-								onClick={ this.clickPlanUpsell }
-								className="masterbar__item masterbar__item-upsell button is-primary"
-								tooltip={ translate( 'Upgrade your plan' ) }
-							>
-								{ translate( 'Upgrade' ) }
-							</Item>
-						) }
+						<ProvideExperimentData
+							name="masterbar_plan_upsell_202202_v1"
+							options={ {
+								isEligible: showPlanUpsell,
+							} }
+						>
+							{ ( isLoading, experimentAssignment ) => {
+								if ( isLoading ) {
+									return null;
+								}
+
+								const variation = experimentAssignment?.variationName;
+								return (
+									'treatment' === variation && (
+										<Item
+											tipTarget={ translate( 'Upgrade your plan' ) }
+											url={ plansUpsellPath }
+											onClick={ this.clickPlanUpsell }
+											className="masterbar__item masterbar__item-upsell button is-primary"
+											tooltip={ translate( 'Upgrade your plan' ) }
+										>
+											{ translate( 'Upgrade' ) }
+										</Item>
+									)
+								);
+							} }
+						</ProvideExperimentData>
 						{ ! domainOnlySite && ! isMigrationInProgress && (
 							<AsyncLoad
 								require="./publish"

--- a/client/layout/masterbar/plan-upsell.jsx
+++ b/client/layout/masterbar/plan-upsell.jsx
@@ -1,0 +1,96 @@
+import PropTypes from 'prop-types';
+import { createRef, Component } from 'react';
+import { connect } from 'react-redux';
+import TranslatableString from 'calypso/components/translatable/proptype';
+import { ProvideExperimentData } from 'calypso/lib/explat';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import MasterbarItem from './item';
+
+class MasterbarItemPlanUpsell extends Component {
+	static propTypes = {
+		className: PropTypes.string,
+		tooltip: TranslatableString,
+	};
+
+	planUpsellButtonRef = createRef();
+
+	clickPlanUpsell = () => {
+		this.props.recordTracksEvent( 'calypso_masterbar_click', {
+			clicked: 'plan_upsell_button',
+		} );
+	};
+
+	render() {
+		const { siteSlug, isP2, className, isJetpack, tooltip, planSlug } = this.props;
+
+		const plansUpsells = [
+			'free_plan',
+			'personal-bundle-monthly',
+			'value_bundle_monthly',
+			'business-bundle-monthly',
+			'ecommerce-bundle-monthly',
+
+			'personal-bundle',
+			'value_bundle',
+			'business-bundle',
+		];
+		const showPlanUpsell = ! isP2 && ! isJetpack && plansUpsells.includes( planSlug );
+		const plansUpsellPath = '/plans/' + siteSlug;
+
+		if ( ! showPlanUpsell ) {
+			return null;
+		}
+
+		return (
+			<ProvideExperimentData
+				name="masterbar_plan_upsell_202202_v1"
+				options={ {
+					isEligible: showPlanUpsell,
+				} }
+			>
+				{ ( isLoading, experimentAssignment ) => {
+					if ( isLoading ) {
+						return null;
+					}
+
+					const variation = experimentAssignment?.variationName;
+					return (
+						'treatment' === variation && (
+							<MasterbarItem
+								ref={ this.planUpsellButtonRef }
+								url={ plansUpsellPath }
+								onClick={ this.clickPlanUpsell }
+								className={ className }
+								tooltip={ tooltip }
+							>
+								{ this.props.children }
+							</MasterbarItem>
+						)
+					);
+				} }
+			</ProvideExperimentData>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+		const siteId = selectedSiteId || getPrimarySiteId( state );
+		const currentPlan = getCurrentPlan( state, siteId );
+		const planSlug = currentPlan?.productSlug || '';
+
+		return {
+			siteSlug: getSiteSlug( state, siteId ),
+			isP2: isSiteWPForTeams( state, siteId ),
+			isJetpack: isJetpackSite( state, siteId ),
+			planSlug,
+		};
+	},
+	{ recordTracksEvent }
+)( MasterbarItemPlanUpsell );

--- a/client/layout/masterbar/plan-upsell.jsx
+++ b/client/layout/masterbar/plan-upsell.jsx
@@ -1,4 +1,5 @@
 import { withMobileBreakpoint } from '@automattic/viewport-react';
+import cookie from 'cookie';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
@@ -19,6 +20,7 @@ import {
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import MasterbarItem from './item';
 
+const THREE_WEEKS = 3 * 7 * 24 * 60 * 60;
 class MasterbarItemPlanUpsell extends Component {
 	static propTypes = {
 		className: PropTypes.string,
@@ -31,20 +33,32 @@ class MasterbarItemPlanUpsell extends Component {
 		this.props.recordTracksEvent( 'calypso_masterbar_click', {
 			clicked: 'plan_upsell_button',
 		} );
+		document.cookie = cookie.serialize(
+			'masterbar_plan_upsell_' + this.props.siteId,
+			'button_clicked',
+			{
+				path: '/',
+				domain: '.wordpress.com',
+			}
+		);
 	};
 
-	render() {
-		const {
-			plansPath,
-			currentRoute,
-			isP2,
-			className,
-			isJetpackNotAtomic,
-			tooltip,
-			isMobile,
-			planSlug,
-		} = this.props;
+	checkIsRestrictedRoute = ( siteSlug, currentRoute ) => {
+		const restrictedRoutes = [
+			`/plans/${ siteSlug }`,
+			'/plans/monthly',
+			'/plans/yearly',
+			'/checkout',
+		];
+		return -1 !== restrictedRoutes.findIndex( ( route ) => currentRoute.startsWith( route ) );
+	};
 
+	checkIsPurchased = ( siteSlug, currentRoute ) => {
+		const thankYouPages = [ '/checkout/thank-you', `/checkout/${ siteSlug }/offer-plan-upgrade` ];
+		return -1 !== thankYouPages.findIndex( ( route ) => currentRoute.startsWith( route ) );
+	};
+
+	checkIsSupportedPlan = ( planSlug ) => {
 		const plansUpsells = [
 			'free_plan',
 			'personal-bundle-monthly',
@@ -57,16 +71,46 @@ class MasterbarItemPlanUpsell extends Component {
 			'business-bundle',
 		];
 
-		const restrictedRoutes = [ '/plans', '/checkout' ];
-		const isRestrictedRoute =
-			-1 !== restrictedRoutes.findIndex( ( route ) => currentRoute.startsWith( route ) );
+		return plansUpsells.includes( planSlug );
+	};
+
+	render() {
+		const {
+			plansPath,
+			currentRoute,
+			isP2,
+			className,
+			isJetpackNotAtomic,
+			tooltip,
+			isMobile,
+			planSlug,
+			siteId,
+			siteSlug,
+		} = this.props;
+
+		const cookies = cookie.parse( document.cookie );
+		const isPurchased = this.checkIsPurchased( siteSlug, currentRoute );
+		const isRestrictedRoute = this.checkIsRestrictedRoute( siteSlug, currentRoute );
+
+		const cookieKey = 'masterbar_plan_upsell_' + siteId;
+		if ( isPurchased && 'button_clicked' === cookies[ cookieKey ] ) {
+			document.cookie = cookie.serialize( cookieKey, 'purchased', {
+				path: '/',
+				domain: '.wordpress.com',
+				maxAge: THREE_WEEKS,
+			} );
+		}
+
+		const isFlowCompleted = 'purchased' === cookies[ cookieKey ];
+		const isSupportedPlan = this.checkIsSupportedPlan( planSlug );
 
 		const showPlanUpsell =
 			! isRestrictedRoute &&
 			! isMobile &&
+			! isFlowCompleted &&
 			! isP2 &&
 			! isJetpackNotAtomic &&
-			plansUpsells.includes( planSlug );
+			isSupportedPlan;
 
 		if ( ! showPlanUpsell ) {
 			return null;
@@ -115,20 +159,24 @@ export default withMobileBreakpoint(
 			}
 
 			const planSlug = getSitePlanSlug( state, siteId ) || '';
+			const siteSlug = getSiteSlug( state, siteId );
+			const currentRoute = getCurrentRoute( state );
 
 			let plansPath = '/plans/';
 			if ( 'ecommerce-bundle-monthly' === planSlug ) {
 				plansPath += 'yearly/';
 			}
-			plansPath += getSiteSlug( state, siteId );
+			plansPath += siteSlug;
 
 			return {
 				isP2: isSiteWPForTeams( state, siteId ),
 				isJetpackNotAtomic: isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ),
 				planSlug,
+				siteSlug,
 				isMobile: ownProps.isBreakpointActive,
 				plansPath,
-				currentRoute: getCurrentRoute( state ),
+				currentRoute,
+				siteId,
 			};
 		},
 		{ recordTracksEvent }

--- a/client/layout/masterbar/plan-upsell.jsx
+++ b/client/layout/masterbar/plan-upsell.jsx
@@ -33,6 +33,11 @@ class MasterbarItemPlanUpsell extends Component {
 		} );
 	};
 
+	checkIsRestrictedRoute = ( currentRoute ) => {
+		const restrictedRoutes = [ `/plans`, '/checkout' ];
+		return -1 !== restrictedRoutes.findIndex( ( route ) => currentRoute.startsWith( route ) );
+	};
+
 	render() {
 		const {
 			plansPath,
@@ -45,32 +50,14 @@ class MasterbarItemPlanUpsell extends Component {
 			planSlug,
 		} = this.props;
 
-		const plansUpsells = [
-			'free_plan',
-			'personal-bundle-monthly',
-			'value_bundle_monthly',
-			'business-bundle-monthly',
-			'ecommerce-bundle-monthly',
-
-			'personal-bundle',
-			'value_bundle',
-			'business-bundle',
-		];
-
-		const restrictedRoutes = [ '/plans', '/checkout' ];
-		const isRestrictedRoute =
-			-1 !== restrictedRoutes.findIndex( ( route ) => currentRoute.startsWith( route ) );
+		const isRestrictedRoute = this.checkIsRestrictedRoute( currentRoute );
 
 		const showPlanUpsell =
 			! isRestrictedRoute &&
 			! isMobile &&
 			! isP2 &&
 			! isJetpackNotAtomic &&
-			plansUpsells.includes( planSlug );
-
-		if ( ! showPlanUpsell ) {
-			return null;
-		}
+			'free_plan' === planSlug;
 
 		return (
 			<ProvideExperimentData
@@ -113,14 +100,9 @@ export default withMobileBreakpoint(
 			if ( ! userCan( 'manage_options', site ) ) {
 				siteId = getPrimarySiteId( state );
 			}
-
+			const siteSlug = getSiteSlug( state, siteId );
 			const planSlug = getSitePlanSlug( state, siteId ) || '';
-
-			let plansPath = '/plans/';
-			if ( 'ecommerce-bundle-monthly' === planSlug ) {
-				plansPath += 'yearly/';
-			}
-			plansPath += getSiteSlug( state, siteId );
+			const plansPath = '/plans/' + siteSlug;
 
 			return {
 				isP2: isSiteWPForTeams( state, siteId ),

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -457,6 +457,20 @@ $autobar-height: 20px;
 	}
 }
 
+.masterbar__item-upsell {
+	height: 24px;
+    margin-top: 4px;
+
+	@media only screen and ( max-width: 782px ) {
+		height: 34px;
+		margin-top: 6px;
+	}
+
+	@include breakpoint-deprecated( '<480px' ) {
+		display: none;
+	}
+}
+
 .masterbar__item-me {
 	.gravatar {
 		position: absolute;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -465,10 +465,6 @@ $autobar-height: 20px;
 		height: 34px;
 		margin-top: 6px;
 	}
-
-	@include breakpoint-deprecated( '<480px' ) {
-		display: none;
-	}
 }
 
 .masterbar__item-me {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements the experiment defined in  pbxNRc-1qR-p2 which adds a plan Upgrade button in the Masterbar, next to the Write button. It will appear for current free and any upgradeable plans. 
The button redirects to the Calypso Plans page for the viewed site if it is owned by the users, or the primary site if not (similar to the Write button).

<img width="480" alt="Screenshot on 2022-02-21 at 17-24-16" src="https://user-images.githubusercontent.com/2749938/155132237-9c1178a7-8396-47f6-b3f0-c60682c75a91.png">


#### Testing instructions

##### Treatment 
* Assign yourself to `treatment` variation using the bookmarklet for the experiment `masterbar_plan_upsell_202202_v1`
* Go to a Free site
* Verify that the `Upgrade` button is visible in the Masterbar, next to the `Write` button

<img width="480" alt="Screenshot on 2022-02-22 at 14-48-45" src="https://user-images.githubusercontent.com/2749938/155135784-666e8a14-7888-460f-a6b1-01c4b28c3f95.png">

* Make sure it looks ok on smaller screens and RTL locales. It should be hidden on mobile screens for lack of space.
* Clicking it should open the Plans page.
* A tracks event should also fire when clicking the button:
<img width="480" alt="Screenshot on 2022-02-22 at 14-46-17" src="https://user-images.githubusercontent.com/2749938/155135265-70e3575e-676f-420f-9b56-d9cce46cf20a.png">

* The button should not be visible on the Plans and Checkout page
* Upgrade or go to a paid site
* Make sure the button is not shown

##### Control

* Assign yourself to `control` variation using the bookmarklet for the experiment `masterbar_plan_upsell_202202_v1`.
* Go to a Free site
* Verify that the `Upgrade` button is not visible any longer in the Masterbar.