### PR TITLE
Guided Tours: Refactor `GuidedToursComponent` away from `UNSAFE_` methods

### DIFF
--- a/client/layout/guided-tours/component.jsx
+++ b/client/layout/guided-tours/component.jsx
@@ -4,13 +4,8 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryPreferences from 'calypso/components/data/query-preferences';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import {
-	nextGuidedTourStep,
-	quitGuidedTour,
-	resetGuidedToursHistory,
-} from 'calypso/state/guided-tours/actions';
+import { nextGuidedTourStep, quitGuidedTour } from 'calypso/state/guided-tours/actions';
 import { getGuidedTourState } from 'calypso/state/guided-tours/selectors';
-import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import { getLastAction } from 'calypso/state/ui/action-log/selectors';
 import { getSectionName, isSectionLoading } from 'calypso/state/ui/selectors';
 import AllTours from './all-tours';
@@ -19,13 +14,6 @@ import './style.scss';
 class GuidedToursComponent extends Component {
 	shouldComponentUpdate( nextProps ) {
 		return this.props.tourState !== nextProps.tourState;
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.requestedTour === 'reset' && this.props.requestedTour !== 'reset' ) {
-			this.props.dispatch( resetGuidedToursHistory() );
-		}
 	}
 
 	start = ( { step, tour, tourVersion: tour_version } ) => {
@@ -107,6 +95,5 @@ export default connect( ( state ) => {
 		tourState,
 		isValid: getTourWhenState( state ),
 		lastAction: getLastAction( state ),
-		requestedTour: getInitialQueryArguments( state ).tour,
 	};
 } )( GuidedToursComponent );

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -1,8 +1,22 @@
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
+import { resetGuidedToursHistory } from 'calypso/state/guided-tours/actions';
 import { getGuidedTourState } from 'calypso/state/guided-tours/selectors';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 
-function GuidedTours( { shouldShow } ) {
+function GuidedTours() {
+	const dispatch = useDispatch();
+	const tourState = useSelector( getGuidedTourState );
+	const shouldShow = tourState && tourState.shouldShow;
+	const requestedTour = useSelector( getInitialQueryArguments ).tour;
+
+	useEffect( () => {
+		if ( requestedTour === 'reset' ) {
+			dispatch( resetGuidedToursHistory() );
+		}
+	}, [ dispatch, requestedTour ] );
+
 	if ( ! shouldShow ) {
 		return null;
 	}
@@ -10,9 +24,4 @@ function GuidedTours( { shouldShow } ) {
 	return <AsyncLoad require="calypso/layout/guided-tours/component" />;
 }
 
-export default connect( ( state ) => {
-	const tourState = getGuidedTourState( state );
-	return {
-		shouldShow: tourState && tourState.shouldShow,
-	};
-} )( GuidedTours );
+export default GuidedTours;

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -9,7 +9,7 @@ function GuidedTours() {
 	const dispatch = useDispatch();
 	const tourState = useSelector( getGuidedTourState );
 	const shouldShow = tourState && tourState.shouldShow;
-	const requestedTour = useSelector( getInitialQueryArguments ).tour;
+	const requestedTour = useSelector( getInitialQueryArguments )?.tour;
 
 	useEffect( () => {
 		if ( requestedTour === 'reset' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `GuidedToursComponent` component away from the `UNSAFE_` deprecated React component methods.

It also uses the opportunity to fix the guided tours resetting that was broken. Seems like we broke it in #31805, and it was introduced in #17740 - so more info on how it's supposed to work can be found in #17740.

Part of #58453.

#### Testing instructions
* Type `localStorage.setItem( 'debug', 'calypso:guided-tours' )` in your browser console.
* Go to `/settings/security/:site` where `:site` is a Jetpack site.
* Verify the main toggle under "WordPress.com sign in" is disabled.
* Now go to `/settings/security/:site?tour=jetpackSignIn` where `:site` is your Jetpack site.
* Enable the toggle.
* Refresh the page.
* Verify you can see at least `jetpackSignIn` in the array of seen tours in the console.
* Now go to `/settings/security/:site?tour=reset`
* Verify that the array is now empty.
* Smoke test that guided tour and verify it still works as it did before.