### PR TITLE
Guided Tours: Refactor `Continue` away from `UNSAFE_` methods

### DIFF
--- a/client/layout/guided-tours/config-elements/continue.js
+++ b/client/layout/guided-tours/config-elements/continue.js
@@ -31,17 +31,10 @@ export default class Continue extends Component {
 		this.removeTargetListener();
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps, nextContext ) {
-		nextProps.when && nextContext.isValid( nextProps.when ) && this.onContinue();
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillUpdate() {
-		this.removeTargetListener();
-	}
-
 	componentDidUpdate() {
+		this.props.when && this.context.isValid( this.props.when ) && this.onContinue();
+
+		this.removeTargetListener();
 		this.addTargetListener();
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `Continue` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/settings/general/:site?tour=checklistSiteTitle` where `:site` is one of your sites.
* Go through the tour and verify it works the same way as it does on production.
* Keep an eye on the browser console for errors.

#### Notes

ESLint error is pre-existing, and it's expected that the Code Style build is failing.