### PR TITLE
Guided Tours: Fix `UNSAFE_` methods in docs

### DIFF
--- a/client/layout/guided-tours/docs/patch/clean-history.patch
+++ b/client/layout/guided-tours/docs/patch/clean-history.patch
@@ -6,7 +6,7 @@ index 9dadd4e6a6..d442d108fd 100644
  } from 'state/ui/guided-tours/actions';
  
  class GuidedTours extends Component {
-+	UNSAFE_componentWillMount() {
++	componentDidMount() {
 +		this.quit( {} );
 +	}
 +


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the `UNSAFE` deprecated React component methods references in guided tours documentation.

Part of #58453.

#### Testing instructions
Not needed, this is a docs change.