### PR TITLE
Update/hello world tutorial config

### DIFF
--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -77,10 +77,15 @@ import { navigation, siteSelection } from 'calypso/my-sites/controller';
 import { helloWorld } from './controller';
 
 export default () => {
-	page( '/hello-world/:site?', siteSelection, navigation, helloWorld, makeLayout, clientRender );
+	if ( config.isEnabled( 'hello-world' ) ) {
+		page( '/hello-world/:site?', siteSelection, navigation, helloWorld, makeLayout, clientRender );
+	} else {
+		page.redirect( '/' );
+	}
 };
 ```
 
+- First we check to make sure our hello-world feature flag is enabled. If not, we skip setting up the route and redirect to the homepage.
 - `page()` will set up the route `/hello-world` and run some functions when it's matched.
 - The `:site?` is because we want to support site specific pages for our hello-world route.
 - Each function is invoked with `context` and `next` arguments.
@@ -94,29 +99,30 @@ You can read more about ES6 modules from Axel Rauschmayer's "[_ECMAScript 6 modu
 
 ### 5. Register section
 
-Now it's time to configure our section. Open `client/sections.js` and add the following code:
+Now it's time to configure our section. Open `client/sections.js` and add the following code to the end of the `sections` array:
 
 ```javascript
-if ( config.isEnabled( 'hello-world' ) ) {
-	sections.push( {
+	{
 		name: 'hello-world',
 		paths: [ '/hello-world' ],
 		module: 'calypso/my-sites/hello-world',
-	} );
-}
+	},
 ```
 
-This checks for our feature in the current environment to figure out whether it needs to register a new section. The section is defined by a name, an array with the relevant paths, and the main module.
-
-You also need to `require` the `config` module at the top of the `client/sections.js` file (in case the `require` statement is not already there):
-
-```js
-const config = require( '@automattic/calypso-config' ).default;
+The array should look something like:
+```
+const sections = [
+	// All of the other sections are here
+	// ...
+	{
+		name: 'hello-world',
+		paths: [ '/hello-world' ],
+		module: 'calypso/my-sites/hello-world',
+	},
+];
 ```
 
-The `sections.js` module needs to be a CommonJS module that uses `require` calls, because it's run by Node.js. ESM imports won't work there at this moment.
-
-Through the use of the `config` module, we are conditionally loading our section only in development environment. All existing sections in `client/sections.js` will load in all environments.
+We always add our section to the list, even if the feature flag is disabled. In the event that our feature flag is turned off, our route won't be registered (per the code in Step 4).
 
 ## Run the server!
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
    
The original documentation had us calling `config.isEnabled` in `client/sections.js`. This no longer works with the current codebase(see [this discussion](https://github.com/Automattic/wp-calypso/issues/61347#issuecomment-1047764063) for more details).
    
This change updates the documentation to always add the hello-world section in `sections.js` and do the `config.isEnabled` check in the hello-world controller.

Related to #

Fixes #61347