### PR TITLE
Plugins: Display live chat support only for annual plans

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -54,7 +54,8 @@ const USPS: React.FC< Props > = ( {
 	const currentPlan = useSelector(
 		( state ) => selectedSiteId && getCurrentPlan( state, selectedSiteId )
 	);
-	const isAnnualPlan = currentPlan && ! isMonthly( currentPlan.productSlug );
+	const isAnnualPlan =
+		( currentPlan && ! isMonthly( currentPlan.productSlug ) && ! shouldUpgrade ) || isAnnualPeriod;
 
 	const planDisplayCost = useSelector( ( state ) =>
 		getProductDisplayCost( state, isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY )

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -55,7 +55,8 @@ const USPS: React.FC< Props > = ( {
 		( state ) => selectedSiteId && getCurrentPlan( state, selectedSiteId )
 	);
 	const isAnnualPlan =
-		( currentPlan && ! isMonthly( currentPlan.productSlug ) && ! shouldUpgrade ) || isAnnualPeriod;
+		( ! shouldUpgrade && currentPlan && ! isMonthly( currentPlan.productSlug ) ) ||
+		( shouldUpgrade && isAnnualPeriod );
 
 	const planDisplayCost = useSelector( ( state ) =>
 		getProductDisplayCost( state, isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY )

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -51,8 +51,8 @@ const USPS: React.FC< Props > = ( {
 	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const currentPlan = useSelector( ( state ) =>
-		selectedSiteId && getCurrentPlan( state, selectedSiteId )
+	const currentPlan = useSelector(
+		( state ) => selectedSiteId && getCurrentPlan( state, selectedSiteId )
 	);
 	const isAnnualPlan = currentPlan && ! isMonthly( currentPlan.productSlug );
 

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -1,10 +1,12 @@
-import { PLAN_BUSINESS_MONTHLY, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { PLAN_BUSINESS_MONTHLY, PLAN_BUSINESS, isMonthly } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const StyledUl = styled.ul`
 	margin-top: 20px;
@@ -47,6 +49,12 @@ const USPS: React.FC< Props > = ( {
 	const translate = useTranslate();
 
 	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
+
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const currentPlan = useSelector( ( state ) =>
+		selectedSiteId ? getCurrentPlan( state, selectedSiteId ) : undefined
+	);
+	const isAnnualPlan = currentPlan && ! isMonthly( currentPlan.productSlug );
 
 	const planDisplayCost = useSelector( ( state ) =>
 		getProductDisplayCost( state, isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY )
@@ -112,7 +120,7 @@ const USPS: React.FC< Props > = ( {
 					{
 						id: 'support',
 						image: <Gridicon icon="chat" size={ 16 } />,
-						text: isAnnualPeriod
+						text: isAnnualPlan
 							? translate( 'Live chat support 24x7' )
 							: translate( 'Unlimited Email Support' ),
 						eligibilities: [ 'needs-upgrade', 'marketplace' ],

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -1,12 +1,11 @@
-import { PLAN_BUSINESS_MONTHLY, PLAN_BUSINESS, isMonthly } from '@automattic/calypso-products';
+import { PLAN_BUSINESS_MONTHLY, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
+import { isAnnualPlanOrUpgradeableAnnualPeriod } from 'calypso/state/marketplace/selectors';
 import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const StyledUl = styled.ul`
 	margin-top: 20px;
@@ -48,16 +47,9 @@ const USPS: React.FC< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 
+	const isAnnualPlan = useSelector( isAnnualPlanOrUpgradeableAnnualPeriod );
+
 	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
-
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const currentPlan = useSelector(
-		( state ) => selectedSiteId && getCurrentPlan( state, selectedSiteId )
-	);
-	const isAnnualPlan =
-		( ! shouldUpgrade && currentPlan && ! isMonthly( currentPlan.productSlug ) ) ||
-		( shouldUpgrade && isAnnualPeriod );
-
 	const planDisplayCost = useSelector( ( state ) =>
 		getProductDisplayCost( state, isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY )
 	);

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -52,7 +52,7 @@ const USPS: React.FC< Props > = ( {
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const currentPlan = useSelector( ( state ) =>
-		selectedSiteId ? getCurrentPlan( state, selectedSiteId ) : undefined
+		selectedSiteId && getCurrentPlan( state, selectedSiteId )
 	);
 	const isAnnualPlan = currentPlan && ! isMonthly( currentPlan.productSlug );
 

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -1,4 +1,3 @@
-import { isMonthly } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
 import { useSelector } from 'react-redux';
@@ -6,12 +5,8 @@ import eye from 'calypso/assets/images/marketplace/eye.svg';
 import support from 'calypso/assets/images/marketplace/support.svg';
 import wooLogo from 'calypso/assets/images/marketplace/woo-logo.svg';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
-import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
-import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
-import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { getSelectedSiteId, getSelectedSite } from 'calypso/state/ui/selectors';
+import { isAnnualPlanOrUpgradeableAnnualPeriod } from 'calypso/state/marketplace/selectors';
 
 const PluginDetailsSidebar = ( {
 	plugin: {
@@ -24,21 +19,7 @@ const PluginDetailsSidebar = ( {
 } ) => {
 	const translate = useTranslate();
 
-	const billingPeriod = useSelector( getBillingInterval );
-	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
-
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const selectedSite = useSelector( getSelectedSite );
-
-	const currentPlan = useSelector(
-		( state ) => selectedSiteId && getCurrentPlan( state, selectedSiteId )
-	);
-
-	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );
-
-	const isAnnualPlan =
-		( ! shouldUpgrade && currentPlan && ! isMonthly( currentPlan.productSlug ) ) ||
-		( shouldUpgrade && isAnnualPeriod );
+	const isAnnualPlan = useSelector( isAnnualPlanOrUpgradeableAnnualPeriod );
 
 	if ( ! isMarketplaceProduct ) {
 		return (

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -23,7 +23,7 @@ const PluginDetailsSidebar = ( {
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const currentPlan = useSelector( ( state ) =>
-		selectedSiteId ? getCurrentPlan( state, selectedSiteId ) : undefined
+		selectedSiteId && getCurrentPlan( state, selectedSiteId )
 	);
 	const isAnnualPlan = currentPlan && ! isMonthly( currentPlan.productSlug );
 

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -22,8 +22,8 @@ const PluginDetailsSidebar = ( {
 	const translate = useTranslate();
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const currentPlan = useSelector( ( state ) =>
-		selectedSiteId && getCurrentPlan( state, selectedSiteId )
+	const currentPlan = useSelector(
+		( state ) => selectedSiteId && getCurrentPlan( state, selectedSiteId )
 	);
 	const isAnnualPlan = currentPlan && ! isMonthly( currentPlan.productSlug );
 

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -1,3 +1,4 @@
+import { isMonthly } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
 import { useSelector } from 'react-redux';
@@ -5,9 +6,9 @@ import eye from 'calypso/assets/images/marketplace/eye.svg';
 import support from 'calypso/assets/images/marketplace/support.svg';
 import wooLogo from 'calypso/assets/images/marketplace/woo-logo.svg';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
-import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
-import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const PluginDetailsSidebar = ( {
 	plugin: {
@@ -19,8 +20,12 @@ const PluginDetailsSidebar = ( {
 	},
 } ) => {
 	const translate = useTranslate();
-	const billingPeriod = useSelector( getBillingInterval );
-	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
+
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const currentPlan = useSelector( ( state ) =>
+		selectedSiteId ? getCurrentPlan( state, selectedSiteId ) : undefined
+	);
+	const isAnnualPlan = currentPlan && ! isMonthly( currentPlan.productSlug );
 
 	if ( ! isMarketplaceProduct ) {
 		return (
@@ -97,7 +102,7 @@ const PluginDetailsSidebar = ( {
 				icon={ { src: support } }
 				title={ translate( 'Support' ) }
 				description={
-					isAnnualPeriod
+					isAnnualPlan
 						? translate( 'Live chat support 24x7' )
 						: translate( 'Unlimited Email Support' )
 				}

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -6,9 +6,12 @@ import eye from 'calypso/assets/images/marketplace/eye.svg';
 import support from 'calypso/assets/images/marketplace/support.svg';
 import wooLogo from 'calypso/assets/images/marketplace/woo-logo.svg';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
+import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
+import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'calypso/state/ui/selectors';
 
 const PluginDetailsSidebar = ( {
 	plugin: {
@@ -21,11 +24,21 @@ const PluginDetailsSidebar = ( {
 } ) => {
 	const translate = useTranslate();
 
+	const billingPeriod = useSelector( getBillingInterval );
+	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
+
 	const selectedSiteId = useSelector( getSelectedSiteId );
+	const selectedSite = useSelector( getSelectedSite );
+
 	const currentPlan = useSelector(
 		( state ) => selectedSiteId && getCurrentPlan( state, selectedSiteId )
 	);
-	const isAnnualPlan = currentPlan && ! isMonthly( currentPlan.productSlug );
+
+	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );
+
+	const isAnnualPlan =
+		( ! shouldUpgrade && currentPlan && ! isMonthly( currentPlan.productSlug ) ) ||
+		( shouldUpgrade && isAnnualPeriod );
 
 	if ( ! isMarketplaceProduct ) {
 		return (

--- a/client/state/marketplace/selectors.ts
+++ b/client/state/marketplace/selectors.ts
@@ -1,7 +1,11 @@
-import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
+import { isBusiness, isEcommerce, isEnterprise, isMonthly } from '@automattic/calypso-products';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
+import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import { default as isVipSite } from 'calypso/state/selectors/is-vip-site';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { IAppState } from 'calypso/state/types';
+import { getSelectedSiteId, getSelectedSite } from 'calypso/state/ui/selectors';
 import type { WithCamelCaseSlug, WithSnakeCaseSlug } from '@automattic/calypso-products';
 
 const shouldUpgradeCheck = (
@@ -17,6 +21,20 @@ const shouldUpgradeCheck = (
 				isVipSite( state, selectedSite?.ID )
 		  )
 		: null;
+};
+
+export const isAnnualPlanOrUpgradeableAnnualPeriod = ( state: IAppState ) => {
+	const selectedSiteId = getSelectedSiteId( state );
+	const currentPlan = selectedSiteId && getCurrentPlan( state, selectedSiteId );
+	const isAnnualPlan = currentPlan && ! isMonthly( currentPlan.productSlug );
+
+	const selectedSite = getSelectedSite( state );
+	const shouldUpgrade = selectedSite && shouldUpgradeCheck( state, selectedSite );
+
+	const billingPeriod = getBillingInterval( state );
+	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
+
+	return ( ! shouldUpgrade && isAnnualPlan ) || ( shouldUpgrade && isAnnualPeriod );
 };
 
 export default shouldUpgradeCheck;


### PR DESCRIPTION
The live chat support message when purchasing a plugin will only be
displayed for annual plans regardless of the billing period of the
plugin.

#### Changes proposed in this Pull Request

* Displays `Live chat support` message only for annual plans
* For monthly plans is displayed the message `Unlimited email support`

|Before | After|
|-------|------|
|![CleanShot 2022-02-22 at 18 06 04@2x](https://user-images.githubusercontent.com/3519124/155182231-1075cf1d-261f-4466-9408-5474937d2ae0.png)|![CleanShot 2022-02-22 at 18 14 24@2x](https://user-images.githubusercontent.com/3519124/155183559-990d74b5-d988-44f4-9b69-10aaa622f272.png)|
|![CleanShot 2022-02-22 at 18 07 17@2x](https://user-images.githubusercontent.com/3519124/155182414-bd8f7565-f082-4872-bc64-b02445f706d2.png)|![CleanShot 2022-02-22 at 18 16 35@2x](https://user-images.githubusercontent.com/3519124/155183933-1ac5a036-c42b-43ae-9dab-989d1b6318ef.png)|
|![CleanShot 2022-02-22 at 18 11 04@2x](https://user-images.githubusercontent.com/3519124/155183047-e35c83b1-4c31-4cb4-8d06-ef6ca0aa8038.png)|![CleanShot 2022-02-22 at 18 17 47@2x](https://user-images.githubusercontent.com/3519124/155184165-69292d5c-0050-4b87-a25c-77f1f0d6f1f1.png)|
|![CleanShot 2022-02-22 at 18 12 09@2x](https://user-images.githubusercontent.com/3519124/155183183-c2fc5913-1ab2-484e-8e83-e5945f01c009.png)|![CleanShot 2022-02-22 at 18 18 36@2x](https://user-images.githubusercontent.com/3519124/155184294-b649c135-3d69-4a2a-be72-959ab9445d00.png)|

#### Testing instructions

##### Scenario 1
* In a site with either Annual Business or eCommerce plan which is paid **Monthly**
* Add a paid plugin
* Select Monthly billing for the plugin
  * The details of the Purchase and the Support details on the right should include `Unlimited email support`
* Select Annually billing for the plugin
  * The details of the Purchase and the Support details on the right should include `Unlimited email support`

##### Scenario 2
* In a site with either Annual Business or eCommerce plan which is paid **Annually**
* Add a paid plugin
* Select Monthly billing for the plugin
  * The details of the Purchase and the Support details on the right should include `Live chat support 24x7` 
* Select Annually billing for the plugin
  * The details of the Purchase and the Support details on the right should include `Live chat support 24x7`

##### Screenshots
|Monthly Plan|Annual Plan|
|---|---|
|![CleanShot 2022-02-23 at 09 12 51@2x](https://user-images.githubusercontent.com/3519124/155282086-faed9ae1-be51-49d6-b2d8-80663909a7bf.png)|![CleanShot 2022-02-23 at 09 10 56@2x](https://user-images.githubusercontent.com/3519124/155281868-1843d5de-0393-4f06-bba1-6f121f586ca0.png)|

Fixes #61365