### PR TITLE
Licensing Portal: Add pricing info to license issuing UI

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -9,21 +9,11 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 import useIssueLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-issue-license-mutation';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
-import { APIProductFamily } from 'calypso/state/partner-portal/types';
+import { APIProductFamily, APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import './style.scss';
 
-interface ProductOption {
-	value: string;
-	label: string;
-}
-
-function selectProductOptions( families: APIProductFamily[] ): ProductOption[] {
-	return families.flatMap( ( family ) =>
-		family.products.map( ( product ) => ( {
-			value: product.slug,
-			label: product.name,
-		} ) )
-	);
+function selectProductOptions( families: APIProductFamily[] ): APIProductFamilyProduct[] {
+	return families.flatMap( ( family ) => family.products );
 }
 
 export default function IssueLicenseForm(): ReactElement {
@@ -46,26 +36,26 @@ export default function IssueLicenseForm(): ReactElement {
 	const [ product, setProduct ] = useState( '' );
 
 	const onSelectProduct = useCallback(
-		( option ) => {
+		( value ) => {
 			dispatch(
 				recordTracksEvent( 'calypso_partner_portal_issue_license_product_select', {
-					product: option.value,
+					product: value,
 				} )
 			);
-			setProduct( option.value );
+			setProduct( value );
 		},
 		[ setProduct ]
 	);
 
 	const productCards =
 		products.data &&
-		products.data.map( ( prod, i ) => (
+		products.data.map( ( productOption, i ) => (
 			<LicenseProductCard
-				key={ prod.value }
-				product={ prod }
+				key={ productOption.slug }
+				product={ productOption }
 				onSelectProduct={ onSelectProduct }
-				isSelected={ prod.value === product }
-				orderIndex={ i }
+				isSelected={ productOption.slug === product }
+				tabIndex={ 100 + i }
 			/>
 		) );
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/style.scss
@@ -29,46 +29,57 @@
 }
 
 .issue-license-form__controls {
-	text-align: right;
+	position: fixed;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	padding: 0.875rem 0.875rem 1.5rem;
+	background: white;
+	box-shadow: 0 -1px 2px rgba( 0, 0, 0, 0.12 );
 
-	@include break-large {
-		text-align: left;
+	.button {
+		width: 100%;
+		padding: 8px 24px;
+		font-size: 1rem;
+		white-space: nowrap;
+	}
+
+	@include breakpoint-deprecated( '>660px' ) {
+		position: static;
+		padding: 0;
+		background: transparent;
+		box-shadow: none;
+
+		.button {
+			width: auto;
+		}
 	}
 }
 
 .issue-license-form__top {
-	margin-bottom: 1rem;
-	margin-top: -1.5rem;
-	display: block;
-
-	@include break-large {
-		display: flex;
-		justify-content: space-between;
-	}
-
-	& > div {
-		align-self: flex-end;
-		margin-bottom: 0;
-	}
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: 0.5rem;
 }
 
 .issue-license-form__bottom {
 	display: flex;
 	flex-wrap: wrap;
 
-	@include break-wide {
+	@include break-xlarge {
 		margin-left: -0.5rem;
 		margin-right: -0.5rem;
 	}
 }
 
 p.issue-license-form__description {
-	margin: 2rem 0 1rem;
+	flex: 1 1 auto;
 	align-self: flex-end;
+	margin: 0;
 	font-size: 0.875rem;
 	color: #333;
 
-	@include break-large {
-		margin: 0;
+	@include breakpoint-deprecated( '>660px' ) {
+		margin: 0 1rem 0 0;
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -1,39 +1,61 @@
 import { Gridicon } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
-import { ReactElement } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { ReactElement, useCallback } from 'react';
+import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
 import './style.scss';
 
-export default function LicenseProductCard( props: any ): ReactElement {
-	const {
-		product: { label },
-		orderIndex,
-	} = props;
-	const productTitle = label.replace( 'Jetpack ', '' ).replace( '(', '' ).replace( ')', '' );
+interface Props {
+	tabIndex: number;
+	product: APIProductFamilyProduct;
+	isSelected: boolean;
+	onSelectProduct: ( value: string ) => void | null;
+}
 
-	function handleKeyDown( e: any ) {
-		if ( 32 === e.keyCode ) {
-			props.onSelectProduct( props.product );
-		}
-	}
+export default function LicenseProductCard( props: Props ): ReactElement {
+	const { tabIndex, product, isSelected, onSelectProduct } = props;
+	const productTitle = product.name.replace( 'Jetpack ', '' ).replace( '(', '' ).replace( ')', '' );
+	const translate = useTranslate();
+
+	const onSelect = useCallback( () => {
+		onSelectProduct?.( product.slug );
+	}, [ onSelectProduct ] );
+
+	const onKeyDown = useCallback(
+		( e: any ) => {
+			// Spacebar
+			if ( 32 === e.keyCode ) {
+				onSelect();
+			}
+		},
+		[ onSelect ]
+	);
 
 	return (
 		<div
-			onClick={ () => props.onSelectProduct( props.product ) }
-			onKeyDown={ ( e ) => handleKeyDown( e ) }
+			onClick={ onSelect }
+			onKeyDown={ onKeyDown }
 			role="radio"
-			tabIndex={ orderIndex + 100 }
-			aria-checked={ props.isSelected }
+			tabIndex={ tabIndex }
+			aria-checked={ isSelected }
 			className={ classNames( {
 				'license-product-card': true,
-				selected: props.isSelected,
+				selected: isSelected,
 			} ) }
 		>
 			<div className="license-product-card__inner">
 				<div className="license-product-card__details">
-					<div className="license-product-card__top">
-						<h3 className="license-product-card__title">{ productTitle }</h3>
-						<div className="license-product-card__radio">
-							{ props.isSelected && <Gridicon icon="checkmark" /> }
+					<h3 className="license-product-card__title">{ productTitle }</h3>
+					<div className="license-product-card__radio">
+						{ isSelected && <Gridicon icon="checkmark" /> }
+					</div>
+					<div className="license-product-card__pricing">
+						<div className="license-product-card__price">
+							{ formatCurrency( product.amount, product.currency ) }
+						</div>
+						<div className="license-product-card__price-interval">
+							{ translate( '/per site per month' ) }
 						</div>
 					</div>
 				</div>
@@ -41,3 +63,7 @@ export default function LicenseProductCard( props: any ): ReactElement {
 		</div>
 	);
 }
+
+LicenseProductCard.defaultProps = {
+	onSelectProduct: null,
+};

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -4,6 +4,10 @@
 .license-product-card {
 	width: 100%;
 
+	@include break-xlarge {
+		width: 50%;
+	}
+
 	@include break-wide {
 		width: 33.33%;
 	}
@@ -12,43 +16,79 @@
 .license-product-card__inner {
 	margin: 0.5rem 0;
 	padding: 1.5rem;
-	border: 1px solid #ddd;
-	border-radius: 2px;
+	border: 1px solid var( --studio-gray-10 );
+	border-radius: 4px;
 	cursor: pointer;
 	user-select: none;
 
-	@include break-wide {
+	@include break-xlarge {
 		margin: 0.5rem;
+		padding: 1.75rem;
 	}
 }
 
 .license-product-card.selected .license-product-card__inner {
 	border: 1px solid #fff;
 	background: #fff;
-	box-shadow: 0 0 12px #ddd;
+	box-shadow: 0 0 40px rgba( 0, 0, 0, 0.08 );
+}
+
+.license-product-card__details {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: stretch;
+	align-items: center;
 }
 
 .license-product-card__title {
+	flex: 1 0 auto;
+	white-space: nowrap;
 	font-size: 1.5rem;
-	margin-bottom: 1rem;
-	color: #444;
-	display: inline-block;
+	line-height: 1.5rem;
+	color: var( --studio-gray-80 );
+}
+
+@mixin license-product-card-block__radio {
+	order: initial;
+	margin-right: 0;
+}
+
+@mixin license-product-card-line__radio {
+	order: -1;
+	margin-right: 1rem;
 }
 
 .license-product-card__radio {
-	border: 2px solid #444;
-	width: 16px;
-	height: 16px;
-	display: inline-block;
-	float: right;
-	border-radius: 10px; /* stylelint-disable-line */
+	width: 20px;
+	height: 20px;
+	border: 2px solid var( --studio-black );
+	border-radius: 12px; /* stylelint-disable-line */
+	text-align: center;
+
+	@include license-product-card-block__radio;
+
+	@include break-mobile {
+		@include license-product-card-line__radio;
+	}
+
+	@include breakpoint-deprecated( '>660px' ) {
+		@include license-product-card-block__radio;
+	}
+
+	@include break-medium {
+		@include license-product-card-line__radio;
+	}
+
+	@include break-xlarge {
+		@include license-product-card-block__radio;
+	}
 }
 
 .license-product-card__radio .gridicon {
 	color: #fff;
 	position: relative;
-	top: -4px;
-	left: 1px;
+	top: -2px;
+	left: 0;
 	width: 14px;
 }
 
@@ -57,12 +97,58 @@
 	background: var( --studio-jetpack-green-50 );
 }
 
-/*
- * This is currently not being used, but should remain because it will be
- * added back in when we show prices for licenses.
- */
-p.license-product-card__text {
+@mixin license-product-card-block__pricing {
+	flex-basis: 100%;
+	margin: 1rem 0 0;
+	text-align: left;
+}
+
+@mixin license-product-card-line__pricing {
+	flex-basis: auto;
+	margin: 0 0 0 1rem;
+	text-align: right;
+}
+
+.license-product-card__pricing {
+	white-space: nowrap;
+	@include license-product-card-block__pricing;
+
+	@include break-mobile {
+		@include license-product-card-line__pricing;
+	}
+
+	@include breakpoint-deprecated( '>660px' ) {
+		@include license-product-card-block__pricing;
+	}
+
+	@include break-medium {
+		@include license-product-card-line__pricing;
+	}
+
+	@include break-xlarge {
+		@include license-product-card-block__pricing;
+	}
+}
+
+.license-product-card__price {
+	margin-bottom: 0.25rem;
+	font-size: 1.25rem;
+	line-height: 1.5rem;
+	font-weight: 600;
+	color: var( --studio-gray-80 );
+
+	@include break-xlarge {
+		margin-bottom: 0.5rem;
+		font-size: 1.5rem;
+		line-height: 1.75rem;
+		font-weight: 700;
+		color: var( --studio-black );
+	}
+}
+
+.license-product-card__price-interval {
 	font-size: 0.75rem;
-	color: #777;
-	margin-bottom: 0;
+	line-height: 0.875rem;
+	font-weight: 400;
+	color: var( --studio-gray-60 );
 }

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -76,6 +76,8 @@ export interface APIProductFamilyProduct {
 	name: string;
 	slug: string;
 	product_id: number;
+	currency: string;
+	amount: number;
 }
 
 export interface APIProductFamily {


### PR DESCRIPTION
PT: pdpAdu-95-p2

#### Changes proposed in this Pull Request

* Licensing Portal: Add pricing info to license issuing UI

#### Testing instructions

Note that the product layout will switch between multi-line and single-line multiple times depending on the screen size because our product names are longer than what can fit in the original designs.

* Requires a Jetpack partner account - please reach out to team Avalon for information on how to acquire one.
* Apply patch and run Jetpack Cloud.
* Open up http://jetpack.cloud.localhost:3000/partner-portal/issue-license and confirm products are shown as expected based on the screen size:

|  |  |
| - | - |
| ![jetpack cloud localhost_3000_partner-portal_issue-license](https://user-images.githubusercontent.com/22746396/155195199-e5d6085b-1f18-4448-a985-0dac566a15ac.png) | ![jetpack cloud localhost_3000_partner-portal_issue-license (1)](https://user-images.githubusercontent.com/22746396/155195204-7228a622-e396-41f9-8cdd-4135ee3a091b.png) |
| ![jetpack cloud localhost_3000_partner-portal_issue-license (2)](https://user-images.githubusercontent.com/22746396/155195214-33475d0c-15a1-4bf7-b3ad-3faa643d4be1.png) | ![jetpack cloud localhost_3000_partner-portal_issue-license (3)](https://user-images.githubusercontent.com/22746396/155195219-0386f3d1-4556-4102-a3f0-e6aa8b69a241.png) |

Note: Ignore the "Need to refresh" thingy.
Note 2: Ignore the prices you see - they are test ones for my account. Also, you will most likely get $0 prices for every product.