### PR TITLE
Open 'Powered by' links on the 'Set up your store intent' in new windows

### DIFF
--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -98,6 +98,8 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 										href={ localizeUrl(
 											'https://wordpress.com/support/wordpress-editor/blocks/payments/'
 										) }
+										target="_blank"
+										rel="noopener noreferrer"
 									/>
 								),
 							},
@@ -144,6 +146,8 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 										href={ localizeUrl(
 											'https://wordpress.com/support/introduction-to-woocommerce/'
 										) }
+										target="_blank"
+										rel="noopener noreferrer"
 									/>
 								),
 							},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a user visits the "Set up your store" intent, there are two links (Power by Payment Blocks and Powered by WooCommerce). This changes makes it so those links open in new windows.

#### Testing instructions

1. Go to https://calypso.localhost:3000/start/
2. Choose a domain and select the "Free" version for that domain
3. On "Choose a plan", select "start with a free site"
4. Click "Start selling"
5. Click "Continue" (no need to fill in store name or tagline)
6. Click "Payment Blocks" and verify it opens in a new window.
7. Click "WooCommerce" and verify it opens in a new window.

Related to #
Fixes: #61373