### PR TITLE
E2E: fix permanently failing tests in WPCOM/Gutenberg.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -9,7 +9,7 @@ export * from './blog-posts';
 export * from './post-carousel';
 export * from './timeline';
 export * from './premium-content';
-export * from './subscription-form';
+export * from './subscribe';
 export * from './payments';
 export * from './contact-info';
 export * from './star-rating';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/subscribe.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/subscribe.ts
@@ -1,6 +1,6 @@
 import { BlockFlow, PublishedPostContext } from '..';
 
-const blockParentSelector = '[aria-label="Block: Subscription Form"]';
+const blockParentSelector = '[aria-label="Block: Subscribe"]';
 const selectors = {
 	emailInput: 'input[name=email]',
 	subscribeButton: 'button:has-text("Subscribe")',
@@ -9,8 +9,8 @@ const selectors = {
 /**
  * Class representing the flow of using a Subscription Form block in the editor.
  */
-export class SubscriptionFormBlockFlow implements BlockFlow {
-	blockSidebarName = 'Subscription Form';
+export class SubscribeFlow implements BlockFlow {
+	blockSidebarName = 'Subscribe';
 	blockEditorSelector = blockParentSelector;
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -120,13 +120,13 @@ export class EditorSettingsSidebarComponent {
 		// will not be actionable until then.
 		const popoverHandle = await this.frame.waitForSelector( selectors.visibilityPopover );
 		await popoverHandle.waitForElementState( 'stable' );
+		await this.page.pause();
 
-		// Private posts display a dialog that when accepted will publish the post.
-		// For non-Private posts, this handler has no effect.
-		await Promise.all( [
-			this.page.once( 'dialog', ( dialog ) => dialog.accept() ),
-			this.frame.click( selectors.visibilityOption( visibility ) ),
-		] );
+		if ( visibility === 'Private' ) {
+			await this.frame.click( selectors.visibilityOption( visibility ) );
+			// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
+			await this.frame.click( `div[role="dialog"] button:has-text("OK")` );
+		}
 
 		// For Password-protected posts, the password field needs to be filled.
 		if ( visibility === 'Password' ) {

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -120,7 +120,6 @@ export class EditorSettingsSidebarComponent {
 		// will not be actionable until then.
 		const popoverHandle = await this.frame.waitForSelector( selectors.visibilityPopover );
 		await popoverHandle.waitForElementState( 'stable' );
-		await this.page.pause();
 
 		if ( visibility === 'Private' ) {
 			await this.frame.click( selectors.visibilityOption( visibility ) );

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -120,9 +120,9 @@ export class EditorSettingsSidebarComponent {
 		// will not be actionable until then.
 		const popoverHandle = await this.frame.waitForSelector( selectors.visibilityPopover );
 		await popoverHandle.waitForElementState( 'stable' );
+		await this.frame.click( selectors.visibilityOption( visibility ) );
 
 		if ( visibility === 'Private' ) {
-			await this.frame.click( selectors.visibilityOption( visibility ) );
 			// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
 			await this.frame.click( `div[role="dialog"] button:has-text("OK")` );
 		}

--- a/test/e2e/specs/blocks/blocks__jetpack-grow.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-grow.ts
@@ -7,7 +7,7 @@ import {
 	WhatsAppButtonFlow,
 	ContactFormFlow,
 	PremiumContentBlockFlow,
-	SubscriptionFormBlockFlow,
+	SubscribeFlow,
 	ContactInfoBlockFlow,
 	DataHelper,
 	envVariables,
@@ -18,7 +18,7 @@ const blockFlows: BlockFlow[] = [
 	new BusinessHoursFlow( { day: 'Sat' } ),
 	new WhatsAppButtonFlow( { phoneNumber: 1234567890, buttonText: 'Porpoises swim happily' } ),
 	new ContactFormFlow( { nameLabel: 'Angry dolphins flip swiftly' } ),
-	new SubscriptionFormBlockFlow(),
+	new SubscribeFlow(),
 	new ContactInfoBlockFlow( { email: 'foo@example.com', phoneNumber: '(213) 621-0002' } ),
 ];
 

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -7,12 +7,11 @@ import {
 	GutenbergEditorPage,
 	EditorSettingsSidebarComponent,
 	PublishedPostPage,
-	ImageBlock,
 	skipItIf,
 	TestAccount,
 	envVariables,
 } from '@automattic/calypso-e2e';
-import { Page, ElementHandle, Browser } from 'playwright';
+import { Page, Browser } from 'playwright';
 
 const quote =
 	'The problem with quotes on the Internet is that it is hard to verify their authenticity. \n— Abraham Lincoln';
@@ -44,8 +43,6 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Blocks', function () {
-		let blockHandle: ElementHandle;
-
 		it( 'Enter post title', async function () {
 			await gutenbergEditorPage.enterTitle( title );
 		} );
@@ -53,23 +50,12 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		it( 'Enter post text', async function () {
 			await gutenbergEditorPage.enterText( quote );
 		} );
-
-		it( 'Add image block', async function () {
-			blockHandle = await gutenbergEditorPage.addBlock(
-				ImageBlock.blockName,
-				ImageBlock.blockEditorSelector
-			);
-		} );
-
-		it( 'Remove image block', async function () {
-			await gutenbergEditorPage.removeBlock( blockHandle );
-		} );
 	} );
 
 	describe( 'Patterns', function () {
-		const patternName = 'Heading';
+		const patternName = 'About Me';
 
-		it( `Add ${ patternName }`, async function () {
+		it( `Add ${ patternName } pattern`, async function () {
 			await gutenbergEditorPage.addPattern( patternName );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes permanent failing tests in WPCOM/Gutenberg E2E tests.

Permanent failures:
- Editor: Privacy (updated modal) (https://github.com/WordPress/gutenberg/pull/37602)
- Editor: Basic Post Flow (new pattern) 
- Jetpack: Grow (Subscription Form) (https://github.com/Automattic/jetpack/pull/22694)

#### Testing instructions

- [x] Ensure these pass:
  - [x] WPCOM desktop
  - [x] WPCOM mobile
  - [x] Calypso desktop
  - [x] Calypso mobile

Related to #
