### PR TITLE
Fix rounding errors in calculation of Jetpack discount percentages

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/use-coupon-discount.ts
+++ b/client/components/jetpack/card/jetpack-product-card/use-coupon-discount.ts
@@ -15,7 +15,7 @@ export default function useCouponDiscount(
 	}
 
 	const finalPrice =
-		Math.floor( ( discountedPrice ?? originalPrice ) * ( 1 - jetpackSaleDiscountRatio ) * 100 ) /
+		Math.ceil( ( discountedPrice ?? originalPrice ) * ( 1 - jetpackSaleDiscountRatio ) * 100 ) /
 		100;
 
 	const finalDiscount = Math.floor( ( ( originalPrice - finalPrice ) / originalPrice ) * 100 );

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -113,9 +113,6 @@ const useIntroductoryOfferPrices = (
 	};
 };
 
-const getMonthlyPrice = ( yearlyPrice: number ): number =>
-	Math.ceil( ( yearlyPrice / 12 ) * 100 ) / 100;
-
 const useItemPrice = (
 	siteId: number | null,
 	item: SelectorProduct | null,
@@ -150,9 +147,9 @@ const useItemPrice = (
 	if ( item && itemCost ) {
 		originalPrice = itemCost;
 		if ( item.term !== TERM_MONTHLY ) {
-			originalPrice = monthlyItemCost ?? getMonthlyPrice( itemCost );
+			originalPrice = monthlyItemCost ?? itemCost / 12;
 			discountedPrice = introductoryOfferPrices.introOfferCost
-				? getMonthlyPrice( introductoryOfferPrices.introOfferCost )
+				? introductoryOfferPrices.introOfferCost / 12
 				: undefined;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR moves the rounding of the monthly price from `useItemPrice` into `useCouponDiscount`. This change prevents the `discountedPrice` value from being rounded up prior to the calculation of the discount percentages, which was causing errors (1164141197617539-as-1201823541344205).
* This also ensures the price from an introductory offer is not rounded before a secondary discount (i.e. Valentine's Day Sale) is applied.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

(I reproduced the rounding issue by overriding the `/sale-coupon` endpoint response, however you may know of a better or easier method. The objective is to trigger a discount amount where the percentages displayed on the product cards are inconsistent.)

- `git checkout trunk`
- `yarn start-jetpack-cloud`
- Sandbox `public-api.wordpress.com`
- In your wpcom sandbox, override the `/sale-coupon` endpoint by adding the following at `/wp-content/lib/jetpack-marketing/holiday-sale.php:35`:

   ```
   return [
       'coupon' => [
           'discount' => 5,
           'start_date' => '01-01-2022',
           'expiry_date' => null,
           'sale_title' => 'TEST SALE',
           'final_discount' => 52
       ]
   ];
   ```
- Open http://jetpack.cloud.localhost:3000/pricing and observe the inconsistent discount percentages (52% and 53%).

<img width="1026" alt="Screen Shot 2022-02-22 at 2 08 27 PM" src="https://user-images.githubusercontent.com/10933065/155219844-4bbd404f-7683-4b1d-bae4-fb8ff3bf9265.png">

* `git checkout fix/jetpack-pricing-discount-rounding`
* Refresh the page and verify that:
   *  the discount percentages are correct and consistent 
   * the monthly prices are correctly rounded up to the nearest cent

<img width="1026" alt="Screen Shot 2022-02-22 at 2 08 04 PM" src="https://user-images.githubusercontent.com/10933065/155219874-d3b3973f-552d-42ef-9629-4a628b6d3d70.png">

Related to https://github.com/Automattic/wp-calypso/pull/60212