### PR TITLE
Playwright: Reduce cookie freshness definition to <2 days.

### DIFF
--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -109,7 +109,7 @@ export class TestAccount {
 		try {
 			const { birthtimeMs } = await fs.stat( this.getAuthCookiesPath() );
 			const nowMs = Date.now();
-			const threeDaysMs = 3 * 24 * 60 * 60 * 1000;
+			const threeDaysMs = 2 * 24 * 60 * 60 * 1000;
 
 			return nowMs < birthtimeMs + threeDaysMs;
 		} catch {

--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -109,9 +109,9 @@ export class TestAccount {
 		try {
 			const { birthtimeMs } = await fs.stat( this.getAuthCookiesPath() );
 			const nowMs = Date.now();
-			const threeDaysMs = 2 * 24 * 60 * 60 * 1000;
+			const twoDaysMs = 2 * 24 * 60 * 60 * 1000;
 
-			return nowMs < birthtimeMs + threeDaysMs;
+			return nowMs < birthtimeMs + twoDaysMs;
 		} catch {
 			return false;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reduces the definition of a 'fresh cookie' to less than 2 days, down from the current definition of less than 3 days.

Details:
When testing locally with either the `AUTHENTICATE_ACCOUNTS` or `COOKIE_PATH` environment variable set, the authentication cookies are saved for the account. This expires after ~2 days locally, but the definition of a fresh cookie in the framework is set at _less than 3 days_. This causes issues on the third day where user is unable to have their sessions automatically authenticated and the framework enters an odd in-between state.

#### Testing instructions



Related to #60630