### PR TITLE
LicesingPortal: Added license assignment button to mobile view on licenses list

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -5,6 +5,7 @@ import { useDispatch } from 'react-redux';
 import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
 import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 interface Props {
@@ -42,6 +43,12 @@ export default function LicenseDetailsActions( {
 			{ licenseState !== LicenseState.Revoked && (
 				<Button onClick={ openRevokeDialog } scary>
 					{ translate( 'Revoke License' ) }
+				</Button>
+			) }
+
+			{ licenseState === LicenseState.Detached && (
+				<Button href={ addQueryArgs( { key: licenseKey }, '/partner-portal/assign-license' ) }>
+					{ translate( 'Assign License' ) }
 				</Button>
 			) }
 

--- a/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
@@ -1,6 +1,8 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
 
+$action-assign: 2;
+
 .license-details {
 	margin: 0;
 
@@ -65,6 +67,13 @@
 	&__actions {
 		margin-top: 42px;
 		display: flex;
-		justify-content: flex-end;
+		flex-direction: row-reverse;
+		justify-content: space-between;
+
+		@include break-large {
+			> *:nth-child(#{$action-assign}) {
+				display: none;
+			}
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Completes 1201801459945917-as-1201855787240336/f
* Fix for showing the license assignment button on mobile on licensing portal

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure to have a Partner Account 👉🏻 PCYsg-zPi-p2
* Issue some licenses

1️⃣  **License is not yet assigned**
* On a mobile viewport, check if the license assignment button shows in the license details
* On a desktop viewport, you should not see the license assignment button in the license details (bottom line next to "revoke license" button)

2️⃣  **License is already assigned**
* You should not see the license assignment button for already assigned licenses

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Screenshots
> **Not assigned**
![image](https://user-images.githubusercontent.com/5550190/155212555-77f085b4-1aeb-4a0b-b253-790fc3f1f4bf.png)
![image](https://user-images.githubusercontent.com/5550190/155212646-8462a422-7a38-42c5-aaa1-b144a648495c.png)
![image](https://user-images.githubusercontent.com/5550190/155212710-800a0d33-9ed7-44b9-b27f-2679ed6f4eef.png)

> **Assigned**
![image](https://user-images.githubusercontent.com/5550190/155212348-f4441767-91ad-478c-bba9-af0c14ac0b30.png)
![image](https://user-images.githubusercontent.com/5550190/155212459-c519bb98-2688-45af-bee8-6eafa71c5fc3.png)