### PR TITLE
Playwright: auto-expand the sidebar as part of the loading process.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -35,7 +35,7 @@ export class SidebarComponent {
 	async waitForSidebarInitialization(): Promise< void > {
 		await this.page.waitForLoadState( 'load' );
 		const sidebarLocator = this.page.locator( selectors.sidebar );
-		await sidebarLocator.waitFor( { state: 'visible' } );
+		await sidebarLocator.waitFor();
 
 		// If the sidebar is collapsed (via the Collapse Menu toggle),
 		// re-expand the sidebar.
@@ -158,7 +158,7 @@ export class SidebarComponent {
 		const navbarComponent = new NavbarComponent( this.page );
 		await navbarComponent.clickMySites();
 
-		// `focus-sidebar` attribute is added is added to the main screen.
+		// `focus-sidebar` attribute is added to the main layout screen.
 		const layoutElement = await this.page.waitForSelector( selectors.focusedLayout( 'Sidebar' ) );
 		await layoutElement.waitForElementState( 'stable' );
 	}

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -7,6 +7,7 @@ type FocusType = 'Sites' | 'Sidebar';
 
 const selectors = {
 	sidebar: '.sidebar',
+	collapsedSidebar: '.is-sidebar-collapsed',
 	focusedLayout: ( focus: FocusType ) => `.layout.focus-${ focus.toLowerCase() }`,
 
 	// Buttons and links within Sidebar
@@ -41,11 +42,11 @@ export class SidebarComponent {
 		// re-expand the sidebar.
 		if ( await this.sidebarIsCollapsed() ) {
 			const sidebarCollapseToggle = this.page.locator( selectors.linkWithText( 'Collapse menu' ) );
-			await sidebarCollapseToggle.dispatchEvent( 'click' );
-
-			if ( await this.sidebarIsCollapsed() ) {
-				throw new Error( 'Unable to expand sidebar.' );
-			}
+			// Wait until the collapsed sidebar CSS is detached from DOM, ie. it is no longer collapsed.
+			await Promise.all( [
+				this.page.waitForSelector( selectors.collapsedSidebar, { state: 'detached' } ),
+				sidebarCollapseToggle.dispatchEvent( 'click' ),
+			] );
 		}
 	}
 
@@ -141,7 +142,7 @@ export class SidebarComponent {
 	 * state.
 	 */
 	private async sidebarIsCollapsed(): Promise< boolean > {
-		const collapsedSidebarLocator = this.page.locator( '.is-sidebar-collapsed' );
+		const collapsedSidebarLocator = this.page.locator( selectors.collapsedSidebar );
 		return ( await collapsedSidebarLocator.count() ) > 0;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reverts the changes in #61322 and applies appropriate fixes to ensure the Sidebar is always in expanded mode.

Key changes:
- wholly reverts the changes in #61322.
- implement a new method, `sidebarIsCollapsed` which returns a Boolean value based on the presence of the CSS selector `.is-sidebar-collapsed`.
- unrelated minor refactor of other supporting methods, including selectors.

#### Testing instructions

Ensure that all of the following are green/passing:
  - [x] WPCOM E2E (desktop)
  - [x] WPCOM E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release Tests

Closes #61387.
