### PR TITLE
Fix domain settings header notices

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@automattic/components';
-import { Purchase } from '@automattic/wpcom-checkout';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { isExpiringSoon } from 'calypso/lib/domains/utils/is-expiring-soon';
@@ -18,6 +17,7 @@ import {
 } from 'calypso/my-sites/domains/paths';
 import { transferStatus, type as domainTypes, gdprConsentStatus } from './constants';
 import type { ResponseDomain } from './types';
+import type { Purchase } from 'calypso/lib/purchases/types';
 import type { ReactChild } from 'react';
 
 export type ResolveDomainStatusReturn =

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -415,7 +415,7 @@ const Settings = ( {
 			{ selectedSite.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderBreadcrumbs() }
-			<SettingsHeader domain={ domain } site={ selectedSite } />
+			<SettingsHeader domain={ domain } site={ selectedSite } purchase={ purchase } />
 			<TwoColumnsLayout content={ renderMainContent() } sidebar={ renderSettingsCards() } />
 		</Main>
 	);

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -120,8 +120,8 @@ const SettingsHeader = ( props: SettingsHeaderProps ): JSX.Element => {
 	};
 
 	const renderNotices = () => {
-		const { domain, site } = props;
-		const { noticeText, statusClass } = resolveDomainStatus( domain, null, {
+		const { domain, site, purchase } = props;
+		const { noticeText, statusClass } = resolveDomainStatus( domain, purchase, {
 			siteSlug: site?.slug,
 			getMappingErrors: true,
 		} );

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -52,6 +52,7 @@ export type SettingsPageConnectedDispatchProps = {
 export type SettingsHeaderOwnProps = {
 	domain: ResponseDomain;
 	site: SiteData;
+	purchase: Purchase | null;
 };
 
 export type SettingsHeaderConnectedProps = {


### PR DESCRIPTION
## Changes proposed in this Pull Request

We are not passing Purchase obj to Settings Header and this causes the correct notice to not always be shown for domain owner (see screenshots).

![purchase-before](https://user-images.githubusercontent.com/2797601/155298330-d1c138a6-e8a2-4b86-b49b-b460d68863ea.png)

![purchase-after](https://user-images.githubusercontent.com/2797601/155298348-5992bd18-45c5-42e5-a212-be46b0ecd6eb.png)

## Testing instructions
- Build this branch locally or open the live Calypso link
- Select a site, then an expired domain owned by you
- Verify that correct notice is displayed (see screenshot above)
