### PR TITLE
Licensing Portal: Update assign license actions UI to better match designs

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -79,7 +79,12 @@ export default function AssignLicenseForm( { sites }: any ): ReactElement {
 					>
 						{ translate( 'Assign later' ) }
 					</Button>
-					<Button primary onClick={ onAssignLicense } busy={ isSubmitting }>
+					<Button
+						primary
+						className="assign-license-form__assign-now"
+						busy={ isSubmitting }
+						onClick={ onAssignLicense }
+					>
 						{ translate( 'Assign to website' ) }
 					</Button>
 				</div>

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
@@ -132,9 +132,21 @@ p.assign-license-form__description {
 }
 
 .assign-license-form__assign-later.button {
-	margin-right: 1rem;
+	margin-right: 0;
 	font-weight: 700;
 	text-decoration: underline;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-right: 1rem;
+	}
+
+	@include break-medium {
+		margin-right: 0;
+	}
+
+	@include break-xlarge {
+		margin-right: 1rem;
+	}
 }
 
 .assign-license-form__assign-now.button {

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
@@ -33,21 +33,18 @@
 	flex-wrap: nowrap;
 	justify-content: space-between;
 	align-items: center;
-	margin-bottom: 1rem;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		flex-wrap: wrap;
-	}
-
-	@include break-medium {
-		flex-wrap: nowrap;
 	}
 }
 
 .assign-license-form__controls {
 	display: flex;
 	flex-direction: column-reverse;
+	justify-content: stretch;
 	align-items: center;
+	flex-wrap: wrap;
 	flex-grow: 1;
 	position: fixed;
 	left: 0;
@@ -61,14 +58,15 @@
 		width: 100%;
 		padding: 8px 24px;
 		font-size: 1rem;
-		white-space: nowrap;
 	}
 
 	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
-		flex-wrap: nowrap;
+		flex-grow: 1;
+		justify-content: flex-end;
 		position: static;
 		padding: 0;
+		margin-bottom: 1rem;
 		background: transparent;
 		box-shadow: none;
 
@@ -79,18 +77,14 @@
 	}
 
 	@include break-medium {
-		flex-wrap: wrap;
-		flex-direction: column-reverse;
-		flex-grow: 0;
-
 		.button {
 			flex-grow: 0;
 		}
 	}
 
 	@include break-xlarge {
-		flex-wrap: nowrap;
 		flex-direction: row;
+		flex-grow: 0;
 	}
 }
 
@@ -101,21 +95,14 @@
 
 p.assign-license-form__description {
 	flex: 1 0 100%;
-	margin: 0;
+	align-self: flex-end;
+	margin: 0 0 1rem;
 	font-size: 0.875rem;
 	color: #333;
 
-	@include breakpoint-deprecated( '>660px' ) {
-		margin: 0 0 1rem;
-	}
-
 	@include break-medium {
 		flex: 1 1 auto;
-		margin: 0 1rem 0 0;
-	}
-
-	@include break-xlarge {
-		align-self: flex-end;
+		margin-right: 1rem;
 	}
 }
 
@@ -135,32 +122,18 @@ p.assign-license-form__description {
 	margin-right: 0;
 	font-weight: 700;
 	text-decoration: underline;
+	white-space: nowrap;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		margin-right: 1rem;
-	}
-
-	@include break-medium {
-		margin-right: 0;
-	}
-
-	@include break-xlarge {
 		margin-right: 1rem;
 	}
 }
 
 .assign-license-form__assign-now.button {
 	margin-bottom: 0.5rem;
+	white-space: nowrap;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		margin-bottom: 0;
-	}
-
-	@include break-medium {
-		margin-bottom: 0.5rem;
-	}
-
-	@include break-xlarge {
 		margin-bottom: 0;
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
@@ -1,3 +1,4 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
 
 .assign-license-form {
@@ -29,17 +30,68 @@
 
 .assign-license-form__top {
 	display: flex;
+	flex-wrap: nowrap;
 	justify-content: space-between;
-}
-
-.assign-license-form__top > div {
-	align-self: flex-end;
-	margin-bottom: 0;
-}
-
-.assign-license-form__top {
+	align-items: center;
 	margin-bottom: 1rem;
-	margin-top: -1.5rem;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		flex-wrap: wrap;
+	}
+
+	@include break-medium {
+		flex-wrap: nowrap;
+	}
+}
+
+.assign-license-form__controls {
+	display: flex;
+	flex-direction: column-reverse;
+	align-items: center;
+	flex-grow: 1;
+	position: fixed;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	padding: 0.875rem 0.875rem 1.5rem;
+	background: white;
+	box-shadow: 0 -1px 2px rgba( 0, 0, 0, 0.12 );
+
+	.button {
+		width: 100%;
+		padding: 8px 24px;
+		font-size: 1rem;
+		white-space: nowrap;
+	}
+
+	@include breakpoint-deprecated( '>660px' ) {
+		flex-direction: row;
+		flex-wrap: nowrap;
+		position: static;
+		padding: 0;
+		background: transparent;
+		box-shadow: none;
+
+		.button {
+			flex-grow: 1;
+			width: auto;
+		}
+	}
+
+	@include break-medium {
+		flex-wrap: wrap;
+		flex-direction: column-reverse;
+		flex-grow: 0;
+
+		.button {
+			flex-grow: 0;
+		}
+	}
+
+	@include break-xlarge {
+		flex-wrap: nowrap;
+		flex-direction: row;
+	}
 }
 
 .assign-license-form__bottom {
@@ -48,10 +100,23 @@
 }
 
 p.assign-license-form__description {
-	margin-bottom: 0;
-	align-self: flex-end;
+	flex: 1 0 100%;
+	margin: 0;
 	font-size: 0.875rem;
 	color: #333;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin: 0 0 1rem;
+	}
+
+	@include break-medium {
+		flex: 1 1 auto;
+		margin: 0 1rem 0 0;
+	}
+
+	@include break-xlarge {
+		align-self: flex-end;
+	}
 }
 
 .assign-license-form__site-card {
@@ -70,4 +135,20 @@ p.assign-license-form__description {
 	margin-right: 1rem;
 	font-weight: 700;
 	text-decoration: underline;
+}
+
+.assign-license-form__assign-now.button {
+	margin-bottom: 0.5rem;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-bottom: 0;
+	}
+
+	@include break-medium {
+		margin-bottom: 0.5rem;
+	}
+
+	@include break-xlarge {
+		margin-bottom: 0;
+	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
@@ -1,5 +1,19 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
+@import '../mixins.scss';
+
+.main.assign-license {
+	// Make sure there's sufficient space for the floating action bar on mobile.
+	padding-bottom: 148px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		padding-bottom: 88px;
+	}
+
+	@include breakpoint-deprecated( '>1400px' ) {
+		padding-bottom: 0;
+	}
+}
 
 .assign-license-form {
 
@@ -40,39 +54,23 @@
 }
 
 .assign-license-form__controls {
+	@include licensing-portal-bottom-action-bar;
+
 	display: flex;
 	flex-direction: column-reverse;
 	justify-content: stretch;
 	align-items: center;
 	flex-wrap: wrap;
 	flex-grow: 1;
-	position: fixed;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	padding: 0.875rem 0.875rem 1.5rem;
-	background: white;
-	box-shadow: 0 -1px 2px rgba( 0, 0, 0, 0.12 );
-
-	.button {
-		width: 100%;
-		padding: 8px 24px;
-		font-size: 1rem;
-	}
 
 	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 		flex-grow: 1;
 		justify-content: flex-end;
-		position: static;
-		padding: 0;
 		margin-bottom: 1rem;
-		background: transparent;
-		box-shadow: none;
 
 		.button {
 			flex-grow: 1;
-			width: auto;
 		}
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/style.scss
@@ -1,5 +1,6 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
+@import '../mixins.scss';
 
 .issue-license-form {
 
@@ -29,31 +30,7 @@
 }
 
 .issue-license-form__controls {
-	position: fixed;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	padding: 0.875rem 0.875rem 1.5rem;
-	background: white;
-	box-shadow: 0 -1px 2px rgba( 0, 0, 0, 0.12 );
-
-	.button {
-		width: 100%;
-		padding: 8px 24px;
-		font-size: 1rem;
-		white-space: nowrap;
-	}
-
-	@include breakpoint-deprecated( '>660px' ) {
-		position: static;
-		padding: 0;
-		background: transparent;
-		box-shadow: none;
-
-		.button {
-			width: auto;
-		}
-	}
+	@include licensing-portal-bottom-action-bar;
 }
 
 .issue-license-form__top {

--- a/client/jetpack-cloud/sections/partner-portal/mixins.scss
+++ b/client/jetpack-cloud/sections/partner-portal/mixins.scss
@@ -1,0 +1,31 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+@mixin licensing-portal-bottom-action-bar() {
+	position: fixed;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	padding: 0.875rem 0.875rem 1.5rem;
+	background: white;
+	box-shadow: 0 -1px 2px rgba( 0, 0, 0, 0.12 );
+	z-index: 20;
+
+	.button {
+		width: 100%;
+		padding: 8px 24px;
+		font-size: 1rem;
+		white-space: nowrap;
+	}
+
+	@include breakpoint-deprecated( '>660px' ) {
+		position: static;
+		padding: 0;
+		background: transparent;
+		box-shadow: none;
+
+		.button {
+			width: auto;
+		}
+	}
+}


### PR DESCRIPTION
PT: pdpAdu-95-p2

#### Changes proposed in this Pull Request

* Licensing Portal: Update assign license actions UI to better match designs

#### Testing instructions

* Requires a Jetpack partner account - please reach out to team Avalon for information on how to acquire one.
* Apply patch and run Jetpack Cloud.
* Issue a new license and move to the Assign License step.
* Confirm the header/actions UI looks good on various screen sizes and matches designs (the actual site selection list is out of scope for this PR).

| Mobile | Desktop |
| - | - |
| ![jetpack cloud localhost_3000_partner-portal_assign-license_key=jetpack-scan_Tn4mp67eYf8DAFDMn1m5jI0kO](https://user-images.githubusercontent.com/22746396/155344226-050aadc8-a6a4-4b7c-bb67-6d3ead59cd0e.png) | ![jetpack cloud localhost_3000_partner-portal_assign-license_key=jetpack-scan_Tn4mp67eYf8DAFDMn1m5jI0kO (1)](https://user-images.githubusercontent.com/22746396/155344230-b2bc6270-fe32-4cc2-8b10-35e913cfd2ec.png) |