### PR TITLE
Licensing Portal: Update/licensing portal issue assign button behavior

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -82,6 +82,7 @@ export default function AssignLicenseForm( { sites }: any ): ReactElement {
 					<Button
 						primary
 						className="assign-license-form__assign-now"
+						disabled={ ! selectedSite }
 						busy={ isSubmitting }
 						onClick={ onAssignLicense }
 					>

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
@@ -131,6 +131,10 @@ p.assign-license-form__description {
 	margin-bottom: 0.5rem;
 	white-space: nowrap;
 
+	// :active introduces a 1px border but :focus introduces a 1.5px border which causes the button to move around.
+	border-width: 1.5px !important;
+	border-color: transparent;
+
 	@include breakpoint-deprecated( '>660px' ) {
 		margin-bottom: 0;
 	}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -77,7 +77,13 @@ export default function IssueLicenseForm(): ReactElement {
 							) }
 						</p>
 						<div className="issue-license-form__controls">
-							<Button primary onClick={ onIssueLicense }>
+							<Button
+								primary
+								className="issue-license-form__select-license"
+								disabled={ ! product }
+								busy={ issueLicense.isLoading }
+								onClick={ onIssueLicense }
+							>
 								{ translate( 'Select License' ) }
 							</Button>
 						</div>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/style.scss
@@ -60,3 +60,9 @@ p.issue-license-form__description {
 		margin: 0 1rem 0 0;
 	}
 }
+
+.issue-license-form__select-license {
+	// :active introduces a 1px border but :focus introduces a 1.5px border which causes the button to move around.
+	border-width: 1.5px !important;
+	border-color: transparent;
+}


### PR DESCRIPTION
PT: pdpAdu-95-p2

#### Changes proposed in this Pull Request

* Licensing Portal: Update licensing portal issue and assign buttons behavior to include disabled and busy states.

#### Testing instructions

* Requires a Jetpack partner account - please reach out to team Avalon for information on how to acquire one.
* Apply patch and run Jetpack Cloud.
* Try to issue a new license without selecting a product - the "Select License" button should be disabled.
* Select a product. The button should now be enabled and clicking it should switch it to a busy state with the appropriate animation.
* You will now be redirected to the Assign license state. Repeat the same tests but with the "Assign to website" button.
