### PR TITLE
ETK Error Reporting: Add the crossorigin attribute to tags only

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -52,7 +52,7 @@ function head_error_handler() {
 function add_crossorigin_to_script_els( $tag ) {
 	// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	if ( preg_match( '/<script\s.*src=.*(s0\.wp\.com|stats\.wp\.com|widgets\.wp\.com).*>/', $tag ) ) {
-		return str_replace( ' src', ' crossorigin="anonymous" src', $tag );
+		return str_replace( ' src=', ' crossorigin="anonymous" src=', $tag );
 	};
 	return $tag;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, the implementation in `add_crossorigin_to_script_els` function targets whole elemenents in it's `str_replace` function call, where ` src` is being looked for.

However, the ` src:` may be used by inline scripts (eg.: fo CSS' font-family), and after we make sure that a script is being loaded from expected host; by checking the `src` attribute in script tag, all instances of ` src` in whole element are being replaced.

This is causing issues with widgets customizer in classic themes.

This changed makes the `str_replace` more targeted, and only acts on the opening `script` tags.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure URLs are being staticized in your testing environment
* try to reproduce the issue described in #61397
* apply the patch, the issue should be fixed.
* check whether `crossorigin="anonymous"` is still being added to scripts served from expected hosts (s0.wp.com, stats.wp.com, widgets.wp.com).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #61397
