### PR TITLE
Remove divided dependencies in preapproved-domains

### DIFF
--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -1,15 +1,9 @@
-/**
- * External Dependencies
- */
 import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import classNames from 'classnames';
 import { includes, pickBy, filter } from 'lodash';
 import { useSelector } from 'react-redux';
-/**
- * Internal Dependencies
- */
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';


### PR DESCRIPTION
About a year ago, (see https://github.com/Automattic/wp-calypso/issues/54448) all imports in calypso's `client` directory were migrated from the `wpcalypso/import-docblock` eslint rule, which divided them into "External" and "Internal" sections, to the `import/order` rule, which has a hierarchical order based on many factors. The new order is automatically applied by `eslint --fix` which is run on commit.

#### Changes proposed in this Pull Request

One new file ended up with the divided imports, and this change removes them. (It looks like the imports are actually in the correct order otherwise, though.)

Discovered by @kallehauge in https://github.com/Automattic/wp-calypso/pull/61001#discussion_r812829142

#### Testing instructions

None; this just removes comments.