### PR TITLE
Remove more divided dependencies from client directory

### DIFF
--- a/client/lib/fse-beta/send-site-editor-beta-feedback.js
+++ b/client/lib/fse-beta/send-site-editor-beta-feedback.js
@@ -1,10 +1,4 @@
-/**
- * External dependencies
- */
 import config from '@automattic/calypso-config';
-/**
- * Internal dependencies
- */
 import wpcom from 'calypso/lib/wp';
 
 const noop = () => {};

--- a/client/signup/steps/p2-get-started/index.jsx
+++ b/client/signup/steps/p2-get-started/index.jsx
@@ -1,11 +1,5 @@
-/**
- * External dependencies
- */
 import { Button } from '@wordpress/components';
 import { Icon, chevronRight } from '@wordpress/icons';
-/**
- * Internal dependencies
- */
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { login } from 'calypso/lib/paths';

--- a/client/state/data-layer/wpcom/sites/rewind/size/from-api.ts
+++ b/client/state/data-layer/wpcom/sites/rewind/size/from-api.ts
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import type { RewindSizeInfo } from 'calypso/state/rewind/size/types';
 
 type ApiResponse = {


### PR DESCRIPTION
About a year ago, (see https://github.com/Automattic/wp-calypso/issues/54448) all imports in calypso's `client` directory were migrated from the `wpcalypso/import-docblock` eslint rule, which divided them into "External" and "Internal" sections, to the `import/order` rule, which has a hierarchical order based on many factors. The new order is automatically applied by `eslint --fix` which is run on commit.

#### Changes proposed in this Pull Request

A few files ended up with the divided imports, and this change removes them. (It looks like the imports are actually in the correct order otherwise, though.)

I thought I got them all in https://github.com/Automattic/wp-calypso/pull/61414 but I had missed some due to different capitalization.

#### Testing instructions

None; this just removes comments.