### PR TITLE
G Suite: Update Email Comparison page to show badge for Google Workspace free trial

### DIFF
--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -43,8 +43,8 @@ const AdditionalPriceInformation = ( {
 		return null;
 	}
 
-	const standardPriceForIntervalLength = formatPrice( product?.cost ?? 0, currencyCode ?? '' );
-	const salePriceForIntervalLength = formatPrice( product?.sale_cost ?? 0, currencyCode ?? '' );
+	const standardPrice = formatPrice( product?.cost ?? 0, currencyCode ?? '' );
+	const discountedPrice = formatPrice( product?.sale_cost ?? 0, currencyCode ?? '' );
 
 	return (
 		<div className="google-workspace-price__discount">
@@ -53,8 +53,8 @@ const AdditionalPriceInformation = ( {
 				{
 					args: {
 						discount: product?.sale_coupon?.discount,
-						discountedPrice: salePriceForIntervalLength,
-						standardPrice: standardPriceForIntervalLength,
+						discountedPrice,
+						standardPrice,
 					},
 					comment:
 						"%(discount)d is a numeric percentage discount (e.g. '50'), " +

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -8,7 +8,11 @@ import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import InfoPopover from 'calypso/components/info-popover';
-import { hasGSuiteSupportedDomain, getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import {
+	getGoogleMailServiceFamily,
+	hasGSuiteSupportedDomain,
+	isDomainEligibleForGoogleWorkspaceFreeTrial,
+} from 'calypso/lib/gsuite';
 import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import PriceBadge from 'calypso/my-sites/email/email-providers-comparison/price-badge';
@@ -16,6 +20,7 @@ import PriceWithInterval from 'calypso/my-sites/email/email-providers-comparison
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
+import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import type { SiteDomain } from 'calypso/state/sites/domains/types';
 import type { ReactElement } from 'react';
 
@@ -25,6 +30,55 @@ const getGoogleWorkspaceProductSlug = ( intervalLength: IntervalLength ): string
 	return intervalLength === IntervalLength.MONTHLY
 		? GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY
 		: GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY;
+};
+
+const AdditionalPriceInformation = ( {
+	currencyCode,
+	product,
+}: {
+	currencyCode: string | null;
+	product: ProductListItem | null;
+} ): ReactElement | null => {
+	if ( ! hasDiscount( product ) ) {
+		return null;
+	}
+
+	const standardPriceForIntervalLength = formatPrice( product?.cost ?? 0, currencyCode ?? '' );
+	const salePriceForIntervalLength = formatPrice( product?.sale_cost ?? 0, currencyCode ?? '' );
+
+	return (
+		<div className="google-workspace-price__discount">
+			{ translate(
+				'%(discount)d%% off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
+				{
+					args: {
+						discount: product?.sale_coupon?.discount,
+						discountedPrice: salePriceForIntervalLength,
+						standardPrice: standardPriceForIntervalLength,
+					},
+					comment:
+						"%(discount)d is a numeric percentage discount (e.g. '50'), " +
+						"%(discountedPrice)s is a formatted, discounted price that the user will pay today (e.g. '$3'), " +
+						"%(standardPrice)s is a formatted price (e.g. '$5')",
+					components: {
+						span: <span />,
+					},
+				}
+			) }
+
+			<InfoPopover position="right" showOnHover>
+				{ translate(
+					'This discount is only available the first time you purchase a %(googleMailService)s account, any additional mailboxes purchased after that will be at the regular price.',
+					{
+						args: {
+							googleMailService: getGoogleMailServiceFamily( product?.product_slug ),
+						},
+						comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+					}
+				) }
+			</InfoPopover>
+		</div>
+	);
 };
 
 type GoogleWorkspacePriceProps = {
@@ -65,60 +119,35 @@ const GoogleWorkspacePrice = ( {
 		);
 	}
 
-	const productIsDiscounted = hasDiscount( product );
-
-	const standardPriceForIntervalLength = formatPrice( product?.cost ?? 0, currencyCode ?? '' );
-	const salePriceForIntervalLength = formatPrice( product?.sale_cost ?? 0, currencyCode ?? '' );
-
-	const discount = productIsDiscounted ? (
-		<div className="google-workspace-price__discount">
-			{ translate(
-				'%(discount)d%% off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
-				{
-					args: {
-						discount: product?.sale_coupon?.discount,
-						discountedPrice: salePriceForIntervalLength,
-						standardPrice: standardPriceForIntervalLength,
-					},
-					comment:
-						"%(discount)d is a numeric percentage discount (e.g. '50'), " +
-						"%(discountedPrice)s is a formatted, discounted price that the user will pay today (e.g. '$3'), " +
-						"%(standardPrice)s is a formatted price (e.g. '$5')",
-					components: {
-						span: <span />,
-					},
-				}
-			) }
-
-			<InfoPopover position="right" showOnHover>
-				{ translate(
-					'This discount is only available the first time you purchase a %(googleMailService)s account, any additional mailboxes purchased after that will be at the regular price.',
-					{
-						args: {
-							googleMailService: getGoogleMailServiceFamily( productSlug ),
-						},
-						comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
-					}
-				) }
-			</InfoPopover>
-		</div>
-	) : null;
+	const isEligibleForFreeTrial = isDomainEligibleForGoogleWorkspaceFreeTrial( domain );
 
 	const priceWithInterval = (
 		<PriceWithInterval
 			cost={ product?.cost ?? 0 }
 			currencyCode={ currencyCode ?? '' }
-			hasDiscount={ productIsDiscounted }
+			hasDiscount={ isEligibleForFreeTrial || hasDiscount( product ) }
 			intervalLength={ intervalLength }
 			sale={ product?.sale_cost ?? null }
 		/>
 	);
 
+	const additionalPriceInformation = (
+		<AdditionalPriceInformation currencyCode={ currencyCode } product={ product } />
+	);
+
 	return (
-		<PriceBadge
-			additionalPriceInformationComponent={ discount }
-			priceComponent={ priceWithInterval }
-		/>
+		<>
+			{ isEligibleForFreeTrial && (
+				<div className="google-workspace-price__discount badge badge--info-green">
+					{ translate( '1 month free' ) }
+				</div>
+			) }
+
+			<PriceBadge
+				additionalPriceInformationComponent={ additionalPriceInformation }
+				priceComponent={ priceWithInterval }
+			/>
+		</>
 	);
 };
 


### PR DESCRIPTION
This pull request updates the `Email Comparison` page to show a `1 month free` badge for Google Workspace when it is eligible for a free trial. The price is also crossed out in that case:

![image](https://user-images.githubusercontent.com/594356/155551393-e1e59916-2007-44f3-bf03-4c07342da58f.png)

#### Testing instructions

1. Run `git checkout update/email-comparison-page` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/61416#issuecomment-1049074413)
2. Apply D75632-code to your sandbox
3. Point `public-api.wordpress.com` to your sandbox
4. Make sure you are proxied
5. Make sure your currency is set to `EUR` or `USD`
6. Log into a WordPress.com account that has a domain without emails
7. Open the [`Emails` page](http://calypso.localhost:3000/email)
8. Click the `Add Email` button for that domain
9. Assert that the badge and price for Google Workspace looks like in the screenshot above