### PR TITLE
Avoid resolving server logger in calypso apps

### DIFF
--- a/apps/happychat/webpack.config.js
+++ b/apps/happychat/webpack.config.js
@@ -79,6 +79,13 @@ module.exports = {
 			filename: 'build.min.css',
 			minify: ! isDevelopment,
 		} ),
+		/*
+		 * ExPlat: Don't import the server logger when we are in the browser
+		 */
+		new webpack.NormalModuleReplacementPlugin(
+			/^calypso\/server\/lib\/logger$/,
+			'calypso/lib/explat/internals/logger-browser-replacement'
+		),
 		new HtmlWebpackPlugin( {
 			filename: path.join( outputPath, 'index.html' ),
 			template: path.join( __dirname, 'src', 'index.ejs' ),

--- a/apps/inline-help/webpack.config.js
+++ b/apps/inline-help/webpack.config.js
@@ -79,6 +79,13 @@ module.exports = {
 			filename: 'build.min.css',
 			minify: ! isDevelopment,
 		} ),
+		/*
+		 * ExPlat: Don't import the server logger when we are in the browser
+		 */
+		new webpack.NormalModuleReplacementPlugin(
+			/^calypso\/server\/lib\/logger$/,
+			'calypso/lib/explat/internals/logger-browser-replacement'
+		),
 		new HtmlWebpackPlugin( {
 			filename: path.join( outputPath, 'index.html' ),
 			template: path.join( __dirname, 'src', 'index.ejs' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #60795, explat was included in certain files which occur in the tree of files imported by `inline-help`. This was problematic because `explat` utilizes the calypso server logger, which includes calls to nodejs libraries which don't exist in the browser. The fix is to update the webpack config for `inline-help`and `happychat` to include the fix which already exists in the client's webpack config:

https://github.com/Automattic/wp-calypso/blob/b57297fac00a56cf103f3235e33f6636ddca1f49/client/webpack.config.js#L322-L328

We haven't run into this problem before because none of the Calypso apps have imported enough things from the Calypso client for code like `explat` to be processed by any calypso app webpack configs. With inline help and happychat now, this sort of error can happen more frequently.

#### Testing instructions
- TeamCity