### PR TITLE
Add runtime introductory offer checks to email upsell in domain flow

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { withShoppingCart } from '@automattic/shopping-cart';
@@ -76,7 +75,10 @@ import { emailManagement } from 'calypso/my-sites/email/paths';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
-import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import {
+	getProductBySlug,
+	getProductIntroductoryOffer,
+} from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import {
 	getDomainsWithForwards,
@@ -111,6 +113,7 @@ class EmailProvidersComparison extends Component {
 		currencyCode: PropTypes.string,
 		domain: PropTypes.object,
 		domainName: PropTypes.string,
+		gSuiteIntroductoryOffer: PropTypes.object,
 		gSuiteProduct: PropTypes.object,
 		hasCartDomain: PropTypes.bool,
 		isGSuiteSupported: PropTypes.bool.isRequired,
@@ -355,13 +358,13 @@ class EmailProvidersComparison extends Component {
 		);
 	}
 
-	getAvailableDiscountForGoogle(
+	getAvailableDiscountForGoogle( {
 		currencyCode,
 		isEligibleForFreeTrial,
 		gSuiteProduct,
 		productIsDiscounted,
-		standardPrice
-	) {
+		standardPrice,
+	} ) {
 		const { translate } = this.props;
 
 		if ( productIsDiscounted ) {
@@ -434,6 +437,7 @@ class EmailProvidersComparison extends Component {
 		const {
 			currencyCode,
 			domain,
+			gSuiteIntroductoryOffer,
 			gSuiteProduct,
 			hasCartDomain,
 			isGSuiteSupported,
@@ -451,8 +455,7 @@ class EmailProvidersComparison extends Component {
 			return null;
 		}
 
-		const isEligibleForFreeTrial =
-			config.isEnabled( 'emails/google-workspace-1-month-trial' ) && hasCartDomain;
+		const isEligibleForFreeTrial = gSuiteIntroductoryOffer && hasCartDomain;
 
 		const productIsDiscounted = hasDiscount( gSuiteProduct );
 		const monthlyPrice = getMonthlyPrice( gSuiteProduct?.cost ?? null, currencyCode );
@@ -481,13 +484,13 @@ class EmailProvidersComparison extends Component {
 				? formatCurrency( gSuiteProduct?.cost ?? null, currencyCode )
 				: getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode );
 
-		const discount = this.getAvailableDiscountForGoogle(
+		const discount = this.getAvailableDiscountForGoogle( {
 			currencyCode,
 			isEligibleForFreeTrial,
 			gSuiteProduct,
 			productIsDiscounted,
-			standardPrice
-		);
+			standardPrice,
+		} );
 
 		const starLabel = productIsDiscounted
 			? translate( '%(discount)d%% off!', {
@@ -934,6 +937,10 @@ export default connect(
 			domain,
 			domainName,
 			domainsWithForwards: getDomainsWithForwards( state, domains ),
+			gSuiteIntroductoryOffer: getProductIntroductoryOffer(
+				state,
+				GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+			),
 			gSuiteProduct,
 			hasCartDomain,
 			isSubmittingEmailForward: isAddingEmailForward( state, ownProps.selectedDomainName ),

--- a/client/state/products-list/selectors/get-product-introductory-offer.ts
+++ b/client/state/products-list/selectors/get-product-introductory-offer.ts
@@ -9,7 +9,6 @@ import type { AppState } from 'calypso/types';
  * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
  * @returns {import('./get-products-list').ProductIntroductoryOffer|null} - introductory offer details for the product, or null if no offer exists
  */
-
 export function getProductIntroductoryOffer(
 	state: AppState,
 	productSlug: string

--- a/client/state/products-list/selectors/get-product-introductory-offer.ts
+++ b/client/state/products-list/selectors/get-product-introductory-offer.ts
@@ -1,0 +1,18 @@
+import 'calypso/state/products-list/init';
+import type { ProductIntroductoryOffer } from './get-products-list';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Retrieves an introductory offer for the product with the specified slug.
+ *
+ * @param {object} state - global state tree
+ * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
+ * @returns {import('./get-products-list').ProductIntroductoryOffer|null} - introductory offer details for the product, or null if no offer exists
+ */
+
+export function getProductIntroductoryOffer(
+	state: AppState,
+	productSlug: string
+): ProductIntroductoryOffer | null {
+	return state.productsList?.items?.[ productSlug ]?.introductory_offer ?? null;
+}

--- a/client/state/products-list/selectors/get-products-list.ts
+++ b/client/state/products-list/selectors/get-products-list.ts
@@ -2,6 +2,17 @@ import type { PriceTierEntry } from '@automattic/calypso-products';
 import type { AppState } from 'calypso/types';
 import 'calypso/state/products-list/init';
 
+export type IntroductoryOfferTimeUnit = 'day' | 'week' | 'month' | 'year';
+
+export interface ProductIntroductoryOffer {
+	cost_per_interval: number;
+	interval_count: number;
+	interval_unit: IntroductoryOfferTimeUnit;
+	should_prorate_when_offer_ends: boolean;
+	transition_after_renewal_count: number;
+	usage_limit: number | null;
+}
+
 export interface ProductListItem {
 	product_id: number;
 	product_name: string;
@@ -13,6 +24,7 @@ export interface ProductListItem {
 	cost_display: string;
 	cost: number;
 	currency_code: string;
+	introductory_offer?: ProductIntroductoryOffer;
 	price_tier_list: PriceTierEntry[];
 	price_tier_usage_quantity: null | number;
 	price_tier_slug: string;

--- a/client/state/products-list/selectors/index.js
+++ b/client/state/products-list/selectors/index.js
@@ -4,6 +4,7 @@ export { getAvailableProductsList } from './get-available-products-list';
 export { getPlanPrice } from './get-plan-price';
 export { getProductBySlug } from './get-product-by-slug';
 export { getProductCost } from './get-product-cost';
+export { getProductIntroductoryOffer } from './get-product-introductory-offer';
 export { getProductName } from './get-product-name';
 export { getProductDisplayCost } from './get-product-display-cost';
 export { getProductPriceTierList } from './get-product-price-tiers';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR tackles a few items:
* It defines a new `ProductIntroductoryOffer` type and documents it as an optional property on the `ProductListItem` object returned from the `getProductBySlug()` and related selectors
* It adds a new `getProductIntroductoryOffer()` selector to return the introductory offer defined for a product slug
* It updates the `EmailProvidersComparison` component to rely on the presence of an introductory offer for the Google Workspace product instead of a feature flag

The combined goal of these changes is to make it possible for this page to dynamically detect when an introductory offer is available for Google Workspace, and then show the appropriate pricing details. This will mean this page will automatically switch to the correct pricing details when we make free trials for Google Workspace available in production.

#### Testing instructions

* Run this branch locally or via the [calypso.live branch](https://github.com/Automattic/wp-calypso/pull/61418#issuecomment-1049152298)
* Ensure you have store sandbox disabled
* Navigate to Upgrades -> Domains, and click on the "Add a domain" button in the top right corner
* Select "Search for a domain" from the dropdown
* Search for a domain name, and select a paid domain name from the list of suggestions
* Verify that you see the standard pricing for Google Workspace in the next page, without an indication of the free trial
* Click on one of the "Skip" options on the page
* Remove all products from your cart in the checkout page
* Enable store sandbox mode
* Ensure that the Calypso data store is empty by opening the developer tools, and ensuring that the IndexedDB data for Calypso is cleared (this is under the Application tab in Chrome, under `IndexedDB` -> `calypso - {hostname}` -> `calypso_store`, and you can clear the contents by right clicking on "calypso_store" and selecting the "Clear" option
* Navigate to Upgrades -> Domains and follow the same steps to add a domain to your cart
* Verify that when you get to the email upsell page, we now show the details for the Google Workspace 1 month free trial -- this is expected because we have enabled the free trial in the store sandbox

Related to #61324