### PR TITLE
Add tracking events to the Spotlight component

### DIFF
--- a/client/components/spotlight/index.tsx
+++ b/client/components/spotlight/index.tsx
@@ -56,12 +56,8 @@ interface SpotlightProps {
 const Spotlight: React.FunctionComponent< SpotlightProps > = ( props: SpotlightProps ) => {
 	const { taglineText, illustrationSrc, onClick, titleText, ctaText } = props;
 
-	const handleClick = () => {
-		onClick();
-	};
-
 	return (
-		<SpotlightContainer onClick={ handleClick }>
+		<SpotlightContainer onClick={ onClick }>
 			<SpotlightContent>
 				<SpotlightIllustration alt="Spotlight Logo" src={ illustrationSrc } />
 				<SpotlightTextContainer>

--- a/client/components/spotlight/index.tsx
+++ b/client/components/spotlight/index.tsx
@@ -46,7 +46,7 @@ const SpotlightCta = styled.div`
 	max-height: 32px;
 `;
 interface SpotlightProps {
-	url: string;
+	onClick: () => void;
 	taglineText: string;
 	illustrationSrc: string;
 	titleText: string;
@@ -54,23 +54,25 @@ interface SpotlightProps {
 }
 
 const Spotlight: React.FunctionComponent< SpotlightProps > = ( props: SpotlightProps ) => {
-	const { taglineText, illustrationSrc, url, titleText, ctaText } = props;
+	const { taglineText, illustrationSrc, onClick, titleText, ctaText } = props;
+
+	const handleClick = () => {
+		onClick();
+	};
 
 	return (
-		<a href={ url }>
-			<SpotlightContainer>
-				<SpotlightContent>
-					<SpotlightIllustration alt="Spotlight Logo" src={ illustrationSrc } />
-					<SpotlightTextContainer>
-						<SpotlightTitle>{ titleText }</SpotlightTitle>
-						<SpotlightTagline>{ taglineText }</SpotlightTagline>
-					</SpotlightTextContainer>
-				</SpotlightContent>
-				<SpotlightCta>
-					<Button>{ ctaText }</Button>
-				</SpotlightCta>
-			</SpotlightContainer>
-		</a>
+		<SpotlightContainer onClick={ handleClick }>
+			<SpotlightContent>
+				<SpotlightIllustration alt="Spotlight Logo" src={ illustrationSrc } />
+				<SpotlightTextContainer>
+					<SpotlightTitle>{ titleText }</SpotlightTitle>
+					<SpotlightTagline>{ taglineText }</SpotlightTagline>
+				</SpotlightTextContainer>
+			</SpotlightContent>
+			<SpotlightCta>
+				<Button>{ ctaText }</Button>
+			</SpotlightCta>
+		</SpotlightContainer>
 	);
 };
 

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -100,7 +100,7 @@ const PluginsBrowserList = ( {
 				site: site,
 			} )
 		);
-		page( `/plugins/${ spotlightPlugin.slug }/${ site }` );
+		page( `/plugins/${ spotlightPlugin.slug }/${ site || '' }` );
 	};
 	return (
 		<div className="plugins-browser-list">

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -6,10 +6,12 @@ import classnames from 'classnames';
 import { times } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
 import Spotlight from 'calypso/components/spotlight';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
 import PluginBrowserItem from 'calypso/my-sites/plugins/plugins-browser-item';
 import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { PluginsBrowserListVariant } from './types';
 
 import './style.scss';
@@ -35,6 +37,7 @@ const PluginsBrowserList = ( {
 } ) => {
 	const isWide = useBreakpoint( '>1280px' );
 	const { __ } = useI18n();
+	const dispatch = useDispatch();
 
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {
@@ -88,6 +91,17 @@ const PluginsBrowserList = ( {
 		}
 	};
 
+	const spotlightOnClick = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_marketplace_spotlight_click', {
+				type: 'plugin',
+				slug: spotlightPlugin.slug,
+				id: spotlightPlugin.id,
+				site: site,
+			} )
+		);
+		page( `/plugins/${ spotlightPlugin.slug }/${ site }` );
+	};
 	return (
 		<div className="plugins-browser-list">
 			<div className="plugins-browser-list__header">
@@ -120,7 +134,7 @@ const PluginsBrowserList = ( {
 						titleText={ __( 'Under the Spotlight' ) }
 						ctaText={ __( 'View Details' ) }
 						illustrationSrc={ spotlightPlugin?.icon ?? '' }
-						onClick={ () => page( `/plugins/${ spotlightPlugin.slug }/${ site }` ) }
+						onClick={ () => spotlightOnClick() }
 					/>
 				) }
 			<Card className="plugins-browser-list__elements">{ renderViews() }</Card>

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -4,6 +4,7 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { times } from 'lodash';
+import page from 'page';
 import PropTypes from 'prop-types';
 import Spotlight from 'calypso/components/spotlight';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
@@ -119,7 +120,7 @@ const PluginsBrowserList = ( {
 						titleText={ __( 'Under the Spotlight' ) }
 						ctaText={ __( 'View Details' ) }
 						illustrationSrc={ spotlightPlugin?.icon ?? '' }
-						url={ `/plugins/${ spotlightPlugin.slug }/${ site }` }
+						onClick={ () => page( `/plugins/${ spotlightPlugin.slug }/${ site }` ) }
 					/>
 				) }
 			<Card className="plugins-browser-list__elements">{ renderViews() }</Card>

--- a/client/my-sites/plugins/plugins-browser-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/test/index.jsx
@@ -6,6 +6,10 @@ jest.mock( 'i18n-calypso', () => ( {
 	localize: ( c ) => c,
 	translate: ( s ) => s,
 } ) );
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useDispatch: jest.fn().mockImplementation( () => {} ),
+} ) );
 
 import { PLAN_FREE } from '@automattic/calypso-products';
 import { shallow } from 'enzyme';
@@ -20,6 +24,7 @@ const plugins = [
 
 const props = {
 	plugins,
+	variant: PluginsBrowserListVariant.Fixed,
 	listName: 'woocommerce',
 	title: 'woocommerce',
 	subtitle: '100 plugins',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Track events to the Spotlight component.

#### Testing instructions
* Show tracking in your browser: PCYsg-cae-p2
* Start with a site on a < Business plan
* Go to /plugins/< site id >?flags=marketplace-spotlight
* Go through the flow and check that the `calypso_marketplace_spotlight_click` track event is logged with the site domain, type, plugin slug, and plugin id after the confirm step.

Related to #61266 
