### PR TITLE
Plugin Browser: Prevent yost premium WPCOM plugin network call for non a11n

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	isBusiness,
 	isEcommerce,
@@ -563,9 +564,9 @@ const PluginSingleListView = ( {
 
 	const siteId = useSelector( getSelectedSiteId );
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
-	const { data: spotlightPlugin, isFetched: spotlightPluginFetched } = useWPCOMPlugin(
-		'wordpress-seo-premium'
-	);
+	const { data: spotlightPlugin, isFetched: spotlightPluginFetched } =
+		useWPCOMPlugin( 'wordpress-seo-premium', { enabled: isEnabled( 'marketplace-spotlight' ) } ) ||
+		{};
 
 	let plugins;
 	let isFetching;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Conditionally fetches the `wordpress-premium-seo` plugin depending on the `marketplace-spotlight` feature flag.

#### Testing instructions
* On a non-a11n account navigate to `http://calypso.localhost:3000/plugins/<siteId>?flags=marketplace-spotlight`
* It should work and don't show the `NotFoundError: Product Not Found`.


Related to #61323
