### PR TITLE
Try renovate schedules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -99,6 +99,10 @@
 			"matchPackagePrefixes": [ "d3-" ]
 		}
 	],
+	"major": {
+		"schedule": [ "every 3 months on the first day of the month" ]
+	},
+	"schedule": [ "every weekend" ],
 	"dependencyDashboardTitle": "Renovate Dependency Updates",
 	"rangeStrategy": "bump",
 	"ignoreDeps": [ "electron-builder" ],
@@ -108,5 +112,7 @@
 	"prHourlyLimit": 10,
 	"semanticCommits": true,
 	"semanticCommitType": "chore",
-	"reviewers": [ "team:team-calypso-platform" ]
+	"reviewers": [ "team:team-calypso-platform" ],
+	"stabilityDays": 10,
+	"prCreation": "not-pending"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -100,7 +100,7 @@
 		}
 	],
 	"major": {
-		"schedule": [ "every 3 months on the first day of the month" ]
+		"schedule": [ "on the first day of the month" ]
 	},
 	"schedule": [ "every weekend" ],
 	"dependencyDashboardTitle": "Renovate Dependency Updates",
@@ -114,5 +114,6 @@
 	"semanticCommitType": "chore",
 	"reviewers": [ "team:team-calypso-platform" ],
 	"stabilityDays": 10,
-	"prCreation": "not-pending"
+	"prCreation": "not-pending",
+	"timezone": "America/Los_Angeles"
 }


### PR DESCRIPTION
A few ideas for reducing dependency noise:

- Major updates every three months
- Other updates every weekend
- Updates are only opened if they are at least 10 days old

We can also easily update anything earlier by using the dependency dashboard as needed. We could also not schedule major updates at all and only open them by approval via the dependency dashboard.

