### PR TITLE
WoA sites always use WordPress.com plans

### DIFF
--- a/client/state/selectors/get-sites-items.ts
+++ b/client/state/selectors/get-sites-items.ts
@@ -21,6 +21,7 @@ export interface SitesItem {
 	is_vip?: boolean;
 	options?: Record< string, unknown >;
 	plan?: SitePlan;
+	is_wpcom_atomic?: boolean;
 }
 
 /**

--- a/client/state/selectors/is-eligible-for-wpcom-monthly-plan.js
+++ b/client/state/selectors/is-eligible-for-wpcom-monthly-plan.js
@@ -21,11 +21,7 @@ export default createSelector(
 			return true;
 		}
 
-		return (
-			( isAtomicSite( state, siteId ) && currentPlanSlug === 'jetpack_free' ) ||
-			isWpComMonthlyPlan( currentPlanSlug ) ||
-			isWpComFreePlan( currentPlanSlug )
-		);
+		return isWpComMonthlyPlan( currentPlanSlug ) || isWpComFreePlan( currentPlanSlug );
 	},
 	( state, siteId = getSelectedSiteId( state ) ) => [
 		isAtomicSite( state, siteId ),

--- a/client/state/sites/selectors/get-site-plan.ts
+++ b/client/state/sites/selectors/get-site-plan.ts
@@ -36,6 +36,16 @@ export default function getSitePlan(
 	}
 
 	if ( site.plan?.expired ) {
+		if ( site.jetpack && ! site.is_wpcom_atomic ) {
+			return {
+				product_id: 2002,
+				product_slug: 'jetpack_free',
+				product_name_short: 'Free',
+				free_trial: false,
+				expired: false,
+			};
+		}
+
 		return {
 			product_id: 1,
 			product_slug: 'free_plan',

--- a/client/state/sites/selectors/get-site-plan.ts
+++ b/client/state/sites/selectors/get-site-plan.ts
@@ -36,16 +36,6 @@ export default function getSitePlan(
 	}
 
 	if ( site.plan?.expired ) {
-		if ( site.jetpack ) {
-			return {
-				product_id: 2002,
-				product_slug: 'jetpack_free',
-				product_name_short: 'Free',
-				free_trial: false,
-				expired: false,
-			};
-		}
-
 		return {
 			product_id: 1,
 			product_slug: 'free_plan',

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1878,7 +1878,7 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		test( 'it should return jetpack free plan if expired', () => {
+		test( 'it should return free plan if expired and site is atomic', () => {
 			const sitePlan = getSitePlan(
 				{
 					sites: {
@@ -1886,6 +1886,7 @@ describe( 'selectors', () => {
 							77203074: {
 								ID: 77203074,
 								jetpack: true,
+								is_wpcom_atomic: true,
 								plan: {
 									product_id: 1234,
 									product_slug: 'fake-plan',
@@ -1903,6 +1904,38 @@ describe( 'selectors', () => {
 			chaiExpect( sitePlan ).to.eql( {
 				product_id: 1,
 				product_slug: 'free_plan',
+				product_name_short: 'Free',
+				free_trial: false,
+				expired: false,
+			} );
+		} );
+
+		test( 'it should return jetpack free plan if expired and site is not atomic', () => {
+			const sitePlan = getSitePlan(
+				{
+					sites: {
+						items: {
+							77203074: {
+								ID: 77203074,
+								jetpack: true,
+								is_wpcom_atomic: false,
+								plan: {
+									product_id: 1234,
+									product_slug: 'fake-plan',
+									product_name_short: 'Fake Plan',
+									free_trial: false,
+									expired: true,
+								},
+							},
+						},
+					},
+				},
+				77203074
+			);
+
+			chaiExpect( sitePlan ).to.eql( {
+				product_id: 2002,
+				product_slug: 'jetpack_free',
 				product_name_short: 'Free',
 				free_trial: false,
 				expired: false,

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1901,8 +1901,8 @@ describe( 'selectors', () => {
 			);
 
 			chaiExpect( sitePlan ).to.eql( {
-				product_id: 2002,
-				product_slug: 'jetpack_free',
+				product_id: 1,
+				product_slug: 'free_plan',
 				product_name_short: 'Free',
 				free_trial: false,
 				expired: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR ensures that the free Atomic site is reported as a WordPress.com free plan site instead of reporting as a jetpack free site. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This PR doesn't require explicit test instructions. We just need to make sure that none of the unit tests are failing. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55488 
