### PR TITLE
DIFM Lite: Contact page section improvements

### DIFF
--- a/client/signup/steps/website-content/page-details.tsx
+++ b/client/signup/steps/website-content/page-details.tsx
@@ -1,4 +1,4 @@
-import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
@@ -13,10 +13,11 @@ import {
 	imageUploadInitiated,
 	textChanged,
 } from 'calypso/state/signup/steps/website-content/actions';
-import { PageData } from 'calypso/state/signup/steps/website-content/schema';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { SiteData } from 'calypso/state/ui/selectors/get-selected-site';
 import { MediaUploadData, WordpressMediaUpload } from './wordpress-media-upload';
+import type { PageData } from 'calypso/state/signup/steps/website-content/schema';
+import type { SiteData } from 'calypso/state/ui/selectors/get-selected-site';
+import type { TranslateResult } from 'i18n-calypso';
 
 export const CONTENT_SUFFIX = 'Content';
 export const IMAGE_PREFIX = 'Image';

--- a/client/signup/steps/website-content/page-details.tsx
+++ b/client/signup/steps/website-content/page-details.tsx
@@ -1,4 +1,4 @@
-import { useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { ChangeEvent } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
@@ -24,10 +24,12 @@ export const IMAGE_PREFIX = 'Image';
 export function PageDetails( {
 	page,
 	formErrors,
+	label,
 	onChangeField,
 }: {
 	page: PageData;
 	formErrors: ValidationErrors;
+	label: TranslateResult | undefined;
 	onChangeField?: ( { target: { name, value } }: ChangeEvent< HTMLInputElement > ) => void;
 } ) {
 	const translate = useTranslate();
@@ -88,12 +90,12 @@ export function PageDetails( {
 				onChange={ onContentChange }
 				value={ page.content }
 				error={ formErrors[ fieldName ] }
-				label={ translate(
-					'Please provide the text you want to appear on your %(pageTitle)s page.',
-					{
+				label={
+					label ||
+					translate( 'Please provide the text you want to appear on your %(pageTitle)s page.', {
 						args: { pageTitle },
-					}
-				) }
+					} )
+				}
 			/>
 			<Label>
 				{ translate( 'Upload up to 3 images to be used on your %(pageTitle)s page.', {

--- a/client/signup/steps/website-content/section-generator.tsx
+++ b/client/signup/steps/website-content/section-generator.tsx
@@ -1,11 +1,11 @@
-import { TranslateResult } from 'i18n-calypso';
-import {
-	AccordionSectionProps,
-	SectionGeneratorReturnType,
-} from 'calypso/signup/accordion-form/types';
 import { WebsiteContent } from 'calypso/state/signup/steps/website-content/schema';
 import { LogoUploadSection } from './logo-upload-section';
 import { CONTENT_SUFFIX, PageDetails } from './page-details';
+import type {
+	AccordionSectionProps,
+	SectionGeneratorReturnType,
+} from 'calypso/signup/accordion-form/types';
+import type { TranslateResult } from 'i18n-calypso';
 
 const generateWebsiteContentSections = (
 	params: SectionGeneratorReturnType< WebsiteContent >,

--- a/client/signup/steps/website-content/section-generator.tsx
+++ b/client/signup/steps/website-content/section-generator.tsx
@@ -1,3 +1,4 @@
+import { TranslateResult } from 'i18n-calypso';
 import {
 	AccordionSectionProps,
 	SectionGeneratorReturnType,
@@ -11,6 +12,15 @@ const generateWebsiteContentSections = (
 	elapsedSections = 0
 ) => {
 	const { translate, formValues, formErrors, onChangeField } = params;
+
+	const OPTIONAL_PAGES: Record< string, boolean > = { Contact: true };
+	const PAGE_LABELS: Record< string, TranslateResult > = {
+		Contact: translate(
+			"We'll add a standard contact form on this page, plus a comment box. " +
+				'If you would like text to appear above this form, please enter it below.'
+		),
+	};
+
 	const websiteContentSections = formValues.pages.map( ( page, index ) => {
 		const fieldNumber = elapsedSections + index + 1;
 		const { title: pageTitle } = page;
@@ -24,11 +34,16 @@ const generateWebsiteContentSections = (
 			} ),
 			summary: page.content,
 			component: (
-				<PageDetails page={ page } formErrors={ formErrors } onChangeField={ onChangeField } />
+				<PageDetails
+					page={ page }
+					formErrors={ formErrors }
+					label={ PAGE_LABELS[ page.id ] || undefined }
+					onChangeField={ onChangeField }
+				/>
 			),
-			showSkip: false,
+			showSkip: !! OPTIONAL_PAGES[ page.id ],
 			validate: () => {
-				const isValid = Boolean( page.content?.length );
+				const isValid = OPTIONAL_PAGES[ page.id ] || Boolean( page.content?.length );
 				return {
 					result: isValid,
 					errors: {

--- a/client/signup/steps/website-content/section-generator.tsx
+++ b/client/signup/steps/website-content/section-generator.tsx
@@ -37,7 +37,7 @@ const generateWebsiteContentSections = (
 				<PageDetails
 					page={ page }
 					formErrors={ formErrors }
-					label={ PAGE_LABELS[ page.id ] || undefined }
+					label={ PAGE_LABELS[ page.id ] }
 					onChangeField={ onChangeField }
 				/>
 			),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: pdh1Xd-xv-p2#comment-869

On the Website Content step of the DIFM Lite flow, this PR:
* Makes the "Contact" page section optional.
* Changes the copy of the label for the text area.

<img width="1343" alt="image" src="https://user-images.githubusercontent.com/5436027/155533217-3b39a2ef-4095-4829-b3a1-48d2b186751e.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the DIFM Lite flow at `/start/do-it-for-me` and complete the purchase.
* On the Website Content form, open the section for the "Contact" page.
* Confirm that the copy matches the one shared here: pdh1Xd-xv-p2#comment-889
* Confirm that you can proceed to the next section without entering any text in the text area. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 0-as-1201848051283171/f