### PR TITLE
Seller experience: Replace tip icon with shopping cart

### DIFF
--- a/client/signup/icons/index.tsx
+++ b/client/signup/icons/index.tsx
@@ -191,3 +191,29 @@ export const shoppingBag: ReactElement = (
 		/>
 	</svg>
 );
+
+export const shoppingCart: ReactElement = (
+	<svg fill="none" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+		<path
+			d="m9 22c.55228 0 1-.4477 1-1s-.44772-1-1-1-1 .4477-1 1 .44772 1 1 1z"
+			stroke="#8c8f94"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width="2"
+		/>
+		<path
+			d="m20 22c.5523 0 1-.4477 1-1s-.4477-1-1-1-1 .4477-1 1 .4477 1 1 1z"
+			stroke="#8c8f94"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width="2"
+		/>
+		<path
+			d="m1 1h4l2.68 13.39c.09144.4604.34191.874.70755 1.1683.36563.2943.82315.4507 1.29245.4417h9.72c.4693.009.9268-.1474 1.2925-.4417.3656-.2943.6161-.7079.7075-1.1683l1.6-8.39h-17"
+			stroke="#8c8f94"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width="2"
+		/>
+	</svg>
+);

--- a/client/signup/steps/intent/intents.tsx
+++ b/client/signup/steps/intent/intents.tsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { SelectItem, SelectAltItem } from '@automattic/onboarding-components';
 import { useTranslate } from 'i18n-calypso';
-import { build, write, tip } from '../../icons';
+import { build, write, shoppingCart } from '../../icons';
 import type { IntentFlag } from './types';
 
 type Intent = SelectItem< IntentFlag >;
@@ -34,7 +34,7 @@ export const useIntents = (): Intent[] => {
 			key: 'sell',
 			title: translate( 'Sell' ),
 			description: <p>{ translate( 'Set up an online store' ) }</p>,
-			icon: tip,
+			icon: shoppingCart,
 			value: 'sell',
 			actionText: translate( 'Start selling' ),
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace `tip` icon with custom shopping cart svg.

**Before**
<img width="694" alt="Screen Shot 2022-02-24 at 9 11 01 AM" src="https://user-images.githubusercontent.com/2124984/155539912-8f1ba20d-671e-4d52-a461-99b0d4183cb4.png">

**After**
<img width="612" alt="Screen Shot 2022-02-24 at 9 11 36 AM" src="https://user-images.githubusercontent.com/2124984/155540038-dc401245-5f79-4937-86ba-89de6720ddb9.png">


#### Testing instructions

* Switch to this PR, navigate to `/start`
* Create a new site and check for the icon change on the intent screen; the icon next to Sell should now be a shopping cart.


Fixes #61429
