### PR TITLE
Licensing Portal: Add an error notice when product families fail to load

### DIFF
--- a/client/state/partner-portal/licenses/hooks/use-products-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-products-query.ts
@@ -1,6 +1,9 @@
+import { useTranslate } from 'i18n-calypso';
 import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { useDispatch } from 'react-redux';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import { APIProductFamily } from 'calypso/state/partner-portal/types';
+import { errorNotice } from '../../../notices/actions';
 
 function queryProducts(): Promise< APIProductFamily[] > {
 	return wpcomJpl.req
@@ -29,9 +32,26 @@ function queryProducts(): Promise< APIProductFamily[] > {
 export default function useProductsQuery< TError = unknown, TData = unknown >(
 	options?: UseQueryOptions< APIProductFamily[], TError, TData >
 ): UseQueryResult< TData, TError > {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
 	return useQuery< APIProductFamily[], TError, TData >(
 		[ 'partner-portal', 'licenses', 'products' ],
 		queryProducts,
-		options
+		{
+			onError: () => {
+				dispatch(
+					errorNotice(
+						translate(
+							'We were unable to retrieve your latest product details. Please try again later.'
+						),
+						{
+							id: 'partner-portal-product-families-failure',
+						}
+					)
+				);
+			},
+			...options,
+		}
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Licensing Portal: Add an error notice when product families fail to load.

#### Testing instructions

* Requires a Jetpack partner account - please reach out to team Avalon for information on how to acquire one.
* Follow the testing instructions in D75652-code to trigger a false error.
* Apply patch, run Jetpack Cloud and open up http://jetpack.cloud.localhost:3000/partner-portal/issue-license.
* You should see a loading animation and 4 ajax requests attempting to load products but failing with 500.
* After the 4th request ends an error notice should appear:
![Screen Shot 2022-02-24 at 20 23 43](https://user-images.githubusercontent.com/22746396/155584433-aa01b4a8-7d92-4b37-a553-6a2f0b8fa96b.png)

Note that you may still see products being listed if they are already cached locally.