### PR TITLE
Playwright: update selectors and name for updated Payments block.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/payments.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/payments.ts
@@ -4,7 +4,7 @@ interface ConfigurationData {
 	buttonText: string;
 }
 
-const blockParentSelector = '[aria-label="Block: Payments"]';
+const blockParentSelector = '[aria-label="Block: Payment Button"]';
 const selectors = {
 	buttonText: `${ blockParentSelector } [role=textbox]`,
 };
@@ -24,7 +24,7 @@ export class PaymentsBlockFlow implements BlockFlow {
 		this.configurationData = configurationData;
 	}
 
-	blockSidebarName = 'Payments';
+	blockSidebarName = 'Payment Button';
 	blockEditorSelector = blockParentSelector;
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the selectors and block name used for Payments block (now known as Payments Button) as of https://github.com/Automattic/jetpack/pull/22491.

#### Testing instructions

Ensure that:
  - [x] WPCOM E2E (mobile)
  - [x] WPCOM E2E (desktop)

Related to #61458.
