### PR TITLE
Jetpack Connection: Remove userless connection option in coupon flow

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -498,6 +498,8 @@ export class LoginForm extends Component {
 			return this.renderWooCommerce();
 		}
 
+		const inPartnerCouponFlow = currentQuery?.redirect_after_auth?.includes( 'partnerCoupon' );
+
 		return (
 			<form onSubmit={ this.onSubmitForm } method="post">
 				{ isCrowdsignalOAuth2Client( oauth2Client ) && (
@@ -651,13 +653,14 @@ export class LoginForm extends Component {
 					</Fragment>
 				) }
 
-				{ ( currentQuery?.skip_user || currentQuery?.allow_site_connection ) && (
-					<JetpackConnectSiteOnly
-						homeUrl={ currentQuery?.site }
-						redirectAfterAuth={ currentQuery?.redirect_after_auth }
-						source="login"
-					/>
-				) }
+				{ ( currentQuery?.skip_user || currentQuery?.allow_site_connection ) &&
+					! inPartnerCouponFlow && (
+						<JetpackConnectSiteOnly
+							homeUrl={ currentQuery?.site }
+							redirectAfterAuth={ currentQuery?.redirect_after_auth }
+							source="login"
+						/>
+					) }
 			</form>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the "Continue without user account" option during login during Jetpack connection, if a `partnerCoupon` is present in the redirect URI. This will ensure that partner users who are connecting and redeeming a coupon cannot end up down a dead end.

#### Testing instructions

1. In an incognito window, connect a new JN site using the coupon flow.
2. You should get to the wpcom login screen, and the option to "Continue without a user account" at the bottom should not be present.
