### PR TITLE
Fix for "My Themes" tab on Atomic Business & eCommerce Plans.

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -1,3 +1,4 @@
+import { FEATURE_PREMIUM_THEMES, planHasFeature } from '@automattic/calypso-products';
 import { compact, isEqual, property, snakeCase } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -8,7 +9,7 @@ import ThemesList from 'calypso/components/themes-list';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer.js';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite, getSitePlanSlug } from 'calypso/state/sites/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
 import {
 	arePremiumThemesEnabled,
@@ -210,12 +211,18 @@ export const ConnectedThemesSelection = connect(
 		const isJetpack = isJetpackSite( state, siteId );
 		const isAtomic = isSiteAutomatedTransfer( state, siteId );
 		const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
+		const sitePlanSlug = getSitePlanSlug( state, siteId );
+		const hasUnlimitedPremiumThemes = planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES );
 
 		let sourceSiteId;
 		if ( source === 'wpcom' || source === 'wporg' ) {
 			sourceSiteId = source;
 		} else {
-			sourceSiteId = siteId && isJetpack && ! isAtomic ? siteId : 'wpcom';
+			sourceSiteId = siteId && isJetpack ? siteId : 'wpcom';
+		}
+
+		if ( isAtomic && ! hasUnlimitedPremiumThemes ) {
+			sourceSiteId = 'wpcom';
 		}
 
 		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes ["My Themes" tab](https://wordpress.com/themes/) showing all themes, not just the installed themes, on Atomic business and eCommerce plans.

<table>
<tr>
<td>
<h3>Before</h3>

![atomic-business-mythemes-before](https://user-images.githubusercontent.com/140841/155620202-6b5f3265-5cc9-4c81-977e-39aecee3b23f.png)

</td>
<td>
<h3>After</h3>

![atomic-business-mythemes-after](https://user-images.githubusercontent.com/140841/155620238-09b9be6c-7cec-493f-82dd-e62b7047e18b.png)

</td>
</tr>
</table>

#### Testing instructions

* Checkout the PR.
* Visit the "My Themes" tab on an Atomic business, Atomic eCommerce, and Jetpack site. It should display the correct themes, NOT all themes. (See pictures above.)
   * Note: Atomic sites with plans below business will still show all themes on the "My Themes" tab. However, those plans should not have a "My Themes" tab. That tab can be [removed in a follow up issue](https://github.com/Automattic/wp-calypso/issues/61509).
* Regression test: The Premium Theme purchase nudge should still be viewable on sites below Premium and not on Business and above sites.

<table>
<tr>
<td>
<h3>Atomic Free</h3>

![atomic-free-recommended](https://user-images.githubusercontent.com/140841/155621288-dcc03c4d-4997-4918-b91c-7d47fa01d616.png)

</td>
<td>
<h3>Atomic Business</h3>

![atomic-business-recommended](https://user-images.githubusercontent.com/140841/155621319-dd56bb86-6376-477a-b7ab-a446d07272a3.png)

</td>
<td>
<h3>Jetpack</h3>

![jetpack-recommended](https://user-images.githubusercontent.com/140841/155621389-9fc98d8c-84b4-4faf-afe2-87beb786cc30.png)

</td>
</tr>
</table>

Related to https://github.com/Automattic/wp-calypso/issues/61213
