### PR TITLE
Add backup tips to "backup in progress" and "backup just completed" cards

### DIFF
--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -79,7 +79,7 @@ export const DotPager = ( {
 	showControlLabels = false,
 	hasDynamicHeight = false,
 	children,
-	className,
+	className = '',
 	onPageSelected = null,
 	...props
 } ) => {

--- a/client/components/jetpack/daily-backup-status/status-card/backup-in-progress.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-in-progress.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { ProgressBar } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { Moment } from 'moment';
@@ -9,6 +10,7 @@ import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import { backupMainPath } from 'calypso/my-sites/backup/paths';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import useGetDisplayDate from '../use-get-display-date';
+import BackupTips from './backup-tips';
 import cloudScheduleIcon from './icons/cloud-schedule.svg';
 
 import './style.scss';
@@ -66,6 +68,7 @@ const BackupInProgress: React.FC< Props > = ( { percent, inProgressDate, lastBac
 					} ) }
 				</div>
 			) }
+			{ isEnabled( 'jetpack/backup-messaging-i3' ) && <BackupTips location="IN_PROGRESS" /> }
 		</>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/status-card/backup-just-completed.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-just-completed.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { Moment } from 'moment';
 import * as React from 'react';
@@ -8,6 +9,7 @@ import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import { backupMainPath } from 'calypso/my-sites/backup/paths';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import useGetDisplayDate from '../use-get-display-date';
+import BackupTips from './backup-tips';
 import cloudScheduleIcon from './icons/cloud-schedule.svg';
 
 import './style.scss';
@@ -49,6 +51,8 @@ const BackupJustCompleted: React.FC< Props > = ( { justCompletedBackupDate, last
 					} ) }
 				</div>
 			) }
+
+			{ isEnabled( 'jetpack/backup-messaging-i3' ) && <BackupTips location="COMPLETED" /> }
 		</>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/status-card/backup-tips.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-tips.tsx
@@ -8,7 +8,7 @@ type BackupTipsProps = {
 };
 
 // locations where the message about the initial backup should be shown
-const LOCATIONS_4_INITIAL_BACKUP_TIP: Array< BackupTipsProps[ 'location' ] > = [
+const LOCATIONS_FOR_INITIAL_BACKUP_TIP: Array< BackupTipsProps[ 'location' ] > = [
 	'IN_PROGRESS',
 	'COMPLETED',
 ];
@@ -21,7 +21,7 @@ const BackupTips: React.FC< BackupTipsProps > = ( { location } ) => {
 			<DotPager>
 				{
 					// Tip about initial backup should be shown only at the given locations
-					LOCATIONS_4_INITIAL_BACKUP_TIP.includes( location ) && (
+					LOCATIONS_FOR_INITIAL_BACKUP_TIP.includes( location ) && (
 						<div>
 							<div>
 								<b>{ translate( 'Did you know' ) }</b>

--- a/client/components/jetpack/daily-backup-status/status-card/backup-tips.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-tips.tsx
@@ -1,0 +1,59 @@
+import { useTranslate } from 'i18n-calypso';
+import DotPager from 'calypso/components/dot-pager';
+
+import './style.scss';
+
+type BackupTipsProps = {
+	location: 'IN_PROGRESS' | 'SCHEDULED' | 'COMPLETED' | 'NO_BACKUPS';
+};
+
+// locations where the message about the initial backup should be shown
+const LOCATIONS_4_INITIAL_BACKUP_TIP: Array< BackupTipsProps[ 'location' ] > = [
+	'IN_PROGRESS',
+	'COMPLETED',
+];
+
+const BackupTips: React.FC< BackupTipsProps > = ( { location } ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="backup-tips__wrapper">
+			<DotPager>
+				{
+					// Tip about initial backup should be shown only at the given locations
+					LOCATIONS_4_INITIAL_BACKUP_TIP.includes( location ) && (
+						<div>
+							<div>
+								<b>{ translate( 'Did you know' ) }</b>
+							</div>
+							{ translate(
+								'The initial backup time depends on the size of your site and the stability of the connection. Subsequent backups are usually faster! {{link}}Learn more{{/link}}',
+								{
+									components: {
+										link: (
+											<a
+												href="https://jetpack.com/support/backup/"
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								}
+							) }
+						</div>
+					)
+				}
+				<div>
+					<div>
+						<b>{ translate( 'Did you know' ) }</b>
+					</div>
+					{ translate(
+						`If there are issues with your backup, we will automatically try again. You'll also get an email if something goes wrong.`
+					) }
+				</div>
+			</DotPager>
+		</div>
+	);
+};
+
+export default BackupTips;

--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -223,3 +223,8 @@
 	font-size: 0.875rem;
 	color: var( --studio-gray-40 );
 }
+
+.backup-tips__wrapper {
+	border-top: 1px solid var( --color-neutral-5 );
+	padding-top: 1.5rem;
+}


### PR DESCRIPTION
Completes 1201868942120840-as-1201868942120855/
f
#### Changes proposed in this Pull Request

* Add backup tips to "backup in progress" and "backup just completed" cards

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot up this PR and run `yarn start` before running `yarn start-jetpack-cloud-p`
* Setup a JN site and add Jetpack Backup
* Queue a Backup from Rewind Debugger if one is not in progress
* Goto `http://calypso.localhost:3000/backup/:site` and `http://jetpack.cloud.localhost:3001/backup/:site`
* Confirm that the tips are shown as Dot Paper carousel at the bottom of the "backup in progress" card
* Confirm that the tips are shown as Dot Paper carousel at the bottom of the "backup just completed" card
* Confirm that the dots and nav arrows work
* Confirm that Swipe on mobile devices works

💡 Tip: To manually show the "backup in progress" and "backup just completed" UIs, you can change (by hard-coding) the if conditions inside `client/components/jetpack/daily-backup-status/index.jsx`


<img width="759" alt="Screenshot 2022-02-25 at 1 11 46 PM" src="https://user-images.githubusercontent.com/18226415/155675004-c8cf1706-ec56-4705-b2ce-d78228257771.png">
<img width="749" alt="Screenshot 2022-02-25 at 3 47 21 PM" src="https://user-images.githubusercontent.com/18226415/155697859-ab46f4f6-12eb-48da-a548-f79b6cae47c9.png">

