### PR TITLE
Add backup tip to 'Backup scheduled' and 'No backups yet' cards

### DIFF
--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -83,9 +83,12 @@ export const DotPager = ( {
 	onPageSelected = null,
 	...props
 } ) => {
+	// Filter out the empty children
+	const normalizedChildren = Children.toArray( children ).filter( Boolean );
+
 	const [ currentPage, setCurrentPage ] = useState( 0 );
 
-	const numPages = Children.count( children );
+	const numPages = Children.count( normalizedChildren );
 
 	useEffect( () => {
 		if ( currentPage >= numPages ) {
@@ -113,7 +116,7 @@ export const DotPager = ( {
 				pageClassName="dot-pager__page"
 				containerClassName="dot-pager__pages"
 			>
-				{ children }
+				{ normalizedChildren }
 			</Swipeable>
 		</div>
 	);

--- a/client/components/jetpack/daily-backup-status/status-card/backup-scheduled.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-scheduled.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -8,6 +9,7 @@ import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import ActionButtons from '../action-buttons';
+import BackupTips from './backup-tips';
 import cloudScheduleIcon from './icons/cloud-schedule.svg';
 
 import './style.scss';
@@ -70,6 +72,7 @@ const BackupScheduled = ( { lastBackupDate } ) => {
 				} ) }
 			</div>
 			<ActionButtons disabled />
+			{ isEnabled( 'jetpack/backup-messaging-i3' ) && <BackupTips location="SCHEDULED" /> }
 		</>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/status-card/no-backups-on-selected-date.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/no-backups-on-selected-date.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import Button from 'calypso/components/forms/form-button';
@@ -6,6 +7,7 @@ import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
 import { backupMainPath } from 'calypso/my-sites/backup/paths';
 import getSiteUrl from 'calypso/state/sites/selectors/get-site-url';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import BackupTips from './backup-tips';
 import cloudWarningIcon from './icons/cloud-warning.svg';
 
 import './style.scss';
@@ -62,6 +64,7 @@ const NoBackupsOnSelectedDate = ( { selectedDate } ) => {
 			>
 				{ translate( 'Contact support' ) }
 			</Button>
+			{ isEnabled( 'jetpack/backup-messaging-i3' ) && <BackupTips location="NO_BACKUPS" /> }
 		</>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/status-card/no-backups-yet.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/no-backups-yet.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -10,6 +11,7 @@ import getRawSite from 'calypso/state/selectors/get-raw-site';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import getSiteUrl from 'calypso/state/sites/selectors/get-site-url';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import BackupTips from './backup-tips';
 import cloudPendingIcon from './icons/cloud-pending.svg';
 
 import './style.scss';
@@ -72,6 +74,7 @@ const NoBackupsYet = () => {
 					<ExternalLink href={ adminUrl }>{ translate( 'Manage your website' ) }</ExternalLink>
 				</li>
 			</ul>
+			{ isEnabled( 'jetpack/backup-messaging-i3' ) && <BackupTips location="NO_BACKUPS" /> }
 		</>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -227,4 +227,5 @@
 .backup-tips__wrapper {
 	border-top: 1px solid var( --color-neutral-5 );
 	padding-top: 1.5rem;
+	margin-top: 1.5rem;
 }


### PR DESCRIPTION
Completes 1201868942120840-as-1201868942120861/f and 1201868942120840-as-1201868942120859/f

#### Changes proposed in this Pull Request

* Add backup tips to 'Backup scheduled' and 'No backups yet' cards

#### Testing instructions

* Boot up this PR and run `yarn start` before running `yarn start-jetpack-cloud-p`
* Setup a JN site and add Jetpack Backup
* Goto `http://calypso.localhost:3000/backup/:site` and `http://jetpack.cloud.localhost:3001/backup/:site`
* Confirm that the tip is shown at the bottom of the 'Backup scheduled' card
* Confirm that the tip is shown at the bottom of the 'No backups yet' card

💡 Tip: To manually show the "Backup scheduled" and "No backups yet" UIs, you can change (by hard-coding) the `if` conditions inside `client/components/jetpack/daily-backup-status/index.jsx`

<img width="757" alt="Screenshot 2022-02-25 at 3 01 43 PM" src="https://user-images.githubusercontent.com/18226415/155695581-1bfd6318-1f96-4c62-916e-063ee32074dd.png">
<img width="767" alt="Screenshot 2022-02-25 at 3 04 34 PM" src="https://user-images.githubusercontent.com/18226415/155695599-85782bf0-a372-43f8-a8b4-e2c5abb71b01.png">
<img width="749" alt="Screenshot 2022-02-25 at 3 23 24 PM" src="https://user-images.githubusercontent.com/18226415/155695600-1fb462d1-31fb-459e-a911-c196ed75fa5f.png">
