### PR TITLE
Settings: Fix typo in SSO SupportInfo link - 1 min review

### DIFF
--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -35,7 +35,7 @@ const Sso = ( {
 						) }
 						link={
 							isAtomic
-								? 'https://wordpress.com/en/support/wordpress-com-secure-sign-on-sso/'
+								? 'https://wordpress.com/support/wordpress-com-secure-sign-on-sso/'
 								: 'https://jetpack.com/support/sso/'
 						}
 						privacyLink={ ! isAtomic }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Had a typo in my previous PR that caused the link to only work in English. This fix removes the hardcoded language in the support link.

<img width="1197" alt="Markup 2022-02-25 at 11 01 09" src="https://user-images.githubusercontent.com/33258733/155696414-c556d9c8-dcae-4da3-8163-7ca7fead54b9.png">

#### Testing instructions

1. Load branch and `yarn start`
2. Change account language to Spanish or any other supported languages
3. Go to Settings ⇢ Security and click the `( i )` next to SSO settings
4. Verify the support link takes you to the correct support page and not 404


Fixes #59975 