### PR TITLE
Disable domain actions for domains at auction

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice.tsx
@@ -5,7 +5,7 @@ import { DOMAIN_EXPIRATION_AUCTION } from 'calypso/lib/url/support';
 const AftermarketAutcionNotice = ( { domainName }: { domainName: string } ): JSX.Element => {
 	const translate = useTranslate();
 	const text = translate(
-		'{{strong}}%(domain)s{{/strong}} has been placed at auction. Currently it is not possible to renew it. {{a}}Learn more{{/a}}',
+		'{{strong}}%(domain)s{{/strong}} expired over 30 days ago and has been offered for sale at auction. Currently it is not possible to renew it. {{a}}Learn more{{/a}}',
 
 		{
 			components: {

--- a/client/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice.tsx
@@ -1,0 +1,24 @@
+import { useTranslate } from 'i18n-calypso';
+import Notice from 'calypso/components/notice';
+import { DOMAIN_EXPIRATION_AUCTION } from 'calypso/lib/url/support';
+
+const AftermarketAutcionNotice = ( { domainName }: { domainName: string } ): JSX.Element => {
+	const translate = useTranslate();
+	const text = translate(
+		'{{strong}}%(domain)s{{/strong}} has been placed at auction. Currently it is not possible to renew it. {{a}}Learn more{{/a}}',
+
+		{
+			components: {
+				a: <a href={ DOMAIN_EXPIRATION_AUCTION } target="_blank" rel="noopener noreferrer" />,
+				strong: <strong />,
+			},
+			args: {
+				domain: domainName,
+			},
+		}
+	);
+
+	return <Notice text={ text } status="is-warning" showDismiss={ false } />;
+};
+
+export default AftermarketAutcionNotice;

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
@@ -16,7 +16,8 @@ const DomainTransferInfoCard = ( {
 	if (
 		! domain.currentUserIsOwner ||
 		( domain.expired && ! isDomainInGracePeriod( domain ) ) ||
-		typesUnableToTransfer.includes( domain.type )
+		typesUnableToTransfer.includes( domain.type ) ||
+		domain.aftermarketAuction
 	) {
 		return null;
 	}

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -213,7 +213,11 @@ class DomainRow extends PureComponent {
 
 	shouldShowAutoRenewStatus = () => {
 		const { domain } = this.props;
-		if ( domain?.type === domainTypes.WPCOM || domain?.type === domainTypes.TRANSFER ) {
+		if (
+			domain?.type === domainTypes.WPCOM ||
+			domain?.type === domainTypes.TRANSFER ||
+			domain?.aftermarketAuction
+		) {
 			return false;
 		}
 		return ! domain?.bundledPlanSubscriptionId && domain.currentUserCanManage;

--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -50,7 +50,11 @@ const RegisteredDomainDetails = ( {
 	};
 
 	const shouldNotRenderAutoRenewToggle = () => {
-		return ! domain.currentUserCanManage || ( ! isLoadingPurchase && ! purchase );
+		return (
+			! domain.currentUserCanManage ||
+			( ! isLoadingPurchase && ! purchase ) ||
+			domain.aftermarketAuction
+		);
 	};
 
 	const renderAutoRenewToggle = () => {
@@ -104,7 +108,8 @@ const RegisteredDomainDetails = ( {
 			! domain.currentUserCanManage ||
 			domain.expired ||
 			isExpiringSoon( domain, 30 ) || // from `registered-domain-type` and `mapped-domain-type`
-			( ! isLoadingPurchase && ! purchase )
+			( ! isLoadingPurchase && ! purchase ) ||
+			domain.aftermarketAuction
 		);
 	};
 

--- a/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
@@ -60,7 +60,8 @@ const SetAsPrimary = ( props: SetAsPrimaryProps ): JSX.Element | null => {
 			domain &&
 			domain.canSetAsPrimary &&
 			! domain.isPrimary &&
-			! shouldUpgradeToMakeDomainPrimary()
+			! shouldUpgradeToMakeDomainPrimary() &&
+			! domain.aftermarketAuction
 		);
 	};
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -21,6 +21,7 @@ import { getSelectedDomain, getTopLevelOfTld, isMappedDomain } from 'calypso/lib
 import { DESIGNATED_AGENT, TRANSFER_DOMAIN_REGISTRATION } from 'calypso/lib/url/support';
 import wpcom from 'calypso/lib/wp';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
+import AftermarketAutcionNotice from 'calypso/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import SelectIpsTag from 'calypso/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag';
 import {
@@ -340,6 +341,10 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 
 		if ( ! domain.currentUserIsOwner ) {
 			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
+		}
+
+		if ( domain.aftermarketAuction ) {
+			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
 		}
 
 		return (

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -10,6 +10,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
 import wpcom from 'calypso/lib/wp';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
+import AftermarketAutcionNotice from 'calypso/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import {
@@ -182,10 +183,14 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 	};
 
 	renderSection(): JSX.Element {
-		const { currentUserCanManage, selectedDomainName } = this.props;
+		const { currentUserCanManage, selectedDomainName, aftermarketAuction } = this.props;
 		const { children, ...propsWithoutChildren } = this.props;
 		if ( ! currentUserCanManage ) {
 			return <NonOwnerCard { ...propsWithoutChildren } />;
+		}
+
+		if ( aftermarketAuction ) {
+			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
 		}
 
 		return (
@@ -222,6 +227,7 @@ export default connect(
 		return {
 			currentRoute: getCurrentRoute( state ),
 			currentUserCanManage: typeof domain === 'object' && domain.currentUserCanManage,
+			aftermarketAuction: typeof domain === 'object' && domain.aftermarketAuction,
 			hasSiteDomainsLoaded: hasLoadedSiteDomains( state, siteId ),
 			isDomainOnly: isDomainOnlySite( state, siteId ),
 			isMapping: Boolean( domain ) && isMappedDomain( domain ),

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
@@ -26,6 +26,7 @@ export type TransferDomainToOtherSitePassedProps = {
 
 // state props
 export type TransferDomainToOtherSiteStateProps = {
+	aftermarketAuction: boolean;
 	currentRoute: string;
 	currentUserCanManage: boolean;
 	hasSiteDomainsLoaded: boolean;

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -16,6 +16,7 @@ import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
 import wpcom from 'calypso/lib/wp';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/components/designated-agent-notice';
+import AftermarketAutcionNotice from 'calypso/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import {
@@ -245,13 +246,19 @@ class TransferDomainToOtherUser extends Component {
 	}
 
 	renderSection() {
-		const { currentUserCanManage, domainRegistrationAgreementUrl } = getSelectedDomain(
-			this.props
-		);
+		const {
+			currentUserCanManage,
+			domainRegistrationAgreementUrl,
+			aftermarketAuction,
+		} = getSelectedDomain( this.props );
+		const { domains, selectedDomainName } = this.props;
 
 		if ( ! currentUserCanManage ) {
-			const { domains, selectedDomainName } = this.props;
 			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
+		}
+
+		if ( aftermarketAuction ) {
+			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
 		}
 
 		const { isMapping, translate, users } = this.props;


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR disables some actions for domain in `aftermarketAuction` state.

You can apply this patch in your sandbox to get a domain in auction (D75409-code).

| ![settings](https://user-images.githubusercontent.com/2797601/155700217-c0a59619-7bdc-4dc4-a72a-9289974f761e.png) |
|:--:|
| <b>Domain settings</b> |

| ![transfer](https://user-images.githubusercontent.com/2797601/155700225-0d20595e-4d97-4de4-b520-6a09f5fb6c8b.png) |
|:--:|
| <b>Transfer page</b> |

| ![transfer-to-other-site](https://user-images.githubusercontent.com/2797601/155700239-089a0e73-dfb0-4023-9640-716271b75176.png) |
|:--:|
| <b>Transfer to another site</b> |

| ![transfer-to-other-user](https://user-images.githubusercontent.com/2797601/155700256-26a8deb0-8c4e-484a-b901-2deb411d4b80.png) |
|:--:|
| <b>Transfer to another user</b> |

## Testing instructions

- Build this branch locally or open the live Calypso link
- Select a domain that has `aftermarketAuction` property set to `true`
  - In _Settings page_, verify that the Renew button and the Auto-renew toggle are not displayed
  - In _Settings page_, verify that the transfer card (right column) is not displayed
  - In _Transfer page_, verify that the notice is displayed
  - In _Transfer page_ (to another user), verify that the notice is displayed
  - In _Transfer page_ (to another site), verify that the notice is displayed
