### PR TITLE
Emails: Add Google Workspace Pricing Notice component

### DIFF
--- a/client/my-sites/email/gsuite-add-users/google-workspace-pricing-notice.tsx
+++ b/client/my-sites/email/gsuite-add-users/google-workspace-pricing-notice.tsx
@@ -1,0 +1,182 @@
+import { translate as originalTranslate, useTranslate } from 'i18n-calypso';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import Notice from 'calypso/components/notice';
+import {
+	getGSuiteExpiryDate,
+	getGSuiteMailboxPurchaseCost,
+	getGSuiteMailboxRenewalCost,
+	hasGSuiteWithUs,
+} from 'calypso/lib/gsuite';
+import type { EmailCost, ResponseDomain } from 'calypso/lib/domains/types';
+import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+import type { TranslateResult } from 'i18n-calypso';
+import type { ReactElement } from 'react';
+
+const doesAdditionalPriceMatchStandardPrice = (
+	domain: ResponseDomain,
+	googleMailProduct: ProductListItem
+): boolean => {
+	if ( ! domain || ! hasGSuiteWithUs( domain ) ) {
+		return true;
+	}
+	const costPerAdditionalMailbox = getGSuiteMailboxPurchaseCost( domain );
+	if ( ! costPerAdditionalMailbox ) {
+		return true;
+	}
+
+	return (
+		costPerAdditionalMailbox.amount === googleMailProduct.cost &&
+		costPerAdditionalMailbox.currency === googleMailProduct.currency_code
+	);
+};
+
+function getPriceMessage( {
+	purchaseCost,
+	translate,
+}: {
+	purchaseCost: EmailCost | null;
+	translate: typeof originalTranslate;
+} ): TranslateResult {
+	if ( purchaseCost === null ) {
+		return '';
+	}
+	return purchaseCost.amount === 0
+		? translate( 'You can add new mailboxes for free until the end of your trial period.' )
+		: translate(
+				'You can purchase new mailboxes at the prorated price of {{strong}}%(proratedPrice)s{{/strong}} per mailbox.',
+				{
+					args: {
+						proratedPrice: purchaseCost.text,
+					},
+					components: {
+						strong: <strong />,
+					},
+					comment:
+						'%(proratedPrice)s is a formatted price for an email subscription (e.g. $3.50, €3.75, or PLN 4.50)',
+				}
+		  );
+}
+
+function getPriceMessageExplanation( {
+	purchaseCost,
+	renewalCost,
+	translate,
+}: {
+	purchaseCost: EmailCost | null;
+	renewalCost: EmailCost | null;
+	googleMailProduct: ProductListItem;
+	translate: typeof originalTranslate;
+} ): TranslateResult {
+	if ( purchaseCost === null || renewalCost === null ) {
+		return '';
+	}
+
+	// We don't need any explanation of the price at this point, because we have already handled it previously.
+	if ( purchaseCost.amount === 0 ) {
+		return '';
+	}
+
+	if ( purchaseCost.amount < renewalCost.amount ) {
+		return translate(
+			'This is less than the regular price because you are only charged for the remainder of the current year.'
+		);
+	}
+
+	return translate(
+		'This is more than the regular price because you are charged for the remainder of the current year plus any additional year until renewal.'
+	);
+}
+
+function getPriceMessageRenewal( {
+	expiryDate,
+	renewalCost,
+	translate,
+}: {
+	expiryDate: string;
+	renewalCost: EmailCost | null;
+	translate: typeof originalTranslate;
+} ): TranslateResult {
+	if ( renewalCost === null ) {
+		return '';
+	}
+
+	return translate(
+		'All of your mailboxes are due to renew at the regular price of {{strong}}%(fullPrice)s{{/strong}} per mailbox when your subscription renews on {{strong}}%(expiryDate)s{{/strong}}.',
+		{
+			args: {
+				fullPrice: renewalCost.text,
+				expiryDate: expiryDate,
+			},
+			components: {
+				strong: <strong />,
+			},
+			comment:
+				'%(fullPrice)s is a formatted price for an email subscription (e.g. $3.50, €3.75, or PLN 4.50), ' +
+				'%(expiryDate)s is a localized date (e.g. February 17, 2021)',
+		}
+	);
+}
+
+const GoogleMailboxPricingNotice = ( {
+	domain,
+	googleMailProduct,
+}: {
+	domain: ResponseDomain;
+	googleMailProduct: ProductListItem;
+} ): ReactElement | null => {
+	const moment = useLocalizedMoment();
+	const translate = useTranslate();
+
+	if ( ! hasGSuiteWithUs( domain ) ) {
+		return null;
+	}
+
+	const purchaseCost = getGSuiteMailboxPurchaseCost( domain );
+
+	if ( doesAdditionalPriceMatchStandardPrice( domain, googleMailProduct ) ) {
+		const translateArgs = {
+			args: {
+				price: purchaseCost?.text,
+			},
+			components: {
+				strong: <strong />,
+			},
+			comment:
+				'%(price)s is a formatted price for an email subscription (e.g. $3.50, €3.75, or PLN 4.50)',
+		};
+
+		return (
+			<Notice icon="info-outline" showDismiss={ false } status="is-success">
+				{ translate(
+					'You can purchase new mailboxes at the regular price of {{strong}}%(price)s{{/strong}} per mailbox per year.',
+					translateArgs
+				) }
+			</Notice>
+		);
+	}
+
+	const renewalCost = getGSuiteMailboxRenewalCost( domain );
+	const expiryDate = getGSuiteExpiryDate( domain );
+	const priceMessage = getPriceMessage( { purchaseCost, translate } );
+	const priceMessageExplanation = getPriceMessageExplanation( {
+		purchaseCost,
+		renewalCost,
+		googleMailProduct,
+		translate,
+	} );
+	const priceMessageRenewal = getPriceMessageRenewal( {
+		expiryDate: moment( expiryDate ).format( 'LL' ),
+		renewalCost,
+		translate,
+	} );
+
+	return (
+		<Notice icon="info-outline" showDismiss={ false } status="is-success">
+			<>
+				{ priceMessage } { priceMessageExplanation } { priceMessageRenewal }
+			</>
+		</Notice>
+	);
+};
+
+export default GoogleMailboxPricingNotice;

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -7,6 +7,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryGSuiteUsers from 'calypso/components/data/query-gsuite-users';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
@@ -38,6 +39,7 @@ import EmailHeader from 'calypso/my-sites/email/email-header';
 import GoogleMailboxPricingNotice from 'calypso/my-sites/email/gsuite-add-users/google-workspace-pricing-notice';
 import { emailManagementAddGSuiteUsers, emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getGSuiteUsers from 'calypso/state/selectors/get-gsuite-users';
@@ -237,10 +239,11 @@ class GSuiteAddUsers extends Component {
 		const {
 			currentRoute,
 			domains,
+			googleMailProduct,
 			productType,
-			translate,
 			selectedDomainName,
 			selectedSite,
+			translate,
 		} = this.props;
 
 		const selectedDomain = getSelectedDomain( {
@@ -260,6 +263,8 @@ class GSuiteAddUsers extends Component {
 		return (
 			<>
 				<PageViewTracker path={ analyticsPath } title="Email Management > Add Google Users" />
+
+				<QueryProductsList />
 
 				{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
@@ -284,7 +289,7 @@ class GSuiteAddUsers extends Component {
 						{ selectedDomainName && (
 							<GoogleMailboxPricingNotice
 								domain={ selectedDomain }
-								googleMailProduct={ productType }
+								googleMailProduct={ googleMailProduct }
 							/>
 						) }
 						{ this.renderAddGSuite() }
@@ -298,6 +303,7 @@ class GSuiteAddUsers extends Component {
 GSuiteAddUsers.propTypes = {
 	currentRoute: PropTypes.string,
 	domains: PropTypes.array.isRequired,
+	googleMailProduct: PropTypes.object.isRequired,
 	gsuiteUsers: PropTypes.array,
 	isRequestingDomains: PropTypes.bool.isRequired,
 	productType: PropTypes.oneOf( [ GOOGLE_WORKSPACE_PRODUCT_TYPE, GSUITE_PRODUCT_TYPE ] ),
@@ -310,14 +316,16 @@ GSuiteAddUsers.propTypes = {
 };
 
 export default connect(
-	( state ) => {
+	( state, ownProps ) => {
 		const selectedSite = getSelectedSite( state );
 		const selectedSiteId = getSelectedSiteId( state );
 		const domains = getDomainsBySiteId( state, selectedSiteId );
+		const productSlug = getProductSlug( ownProps.productType );
 
 		return {
 			currentRoute: getCurrentRoute( state ),
 			domains,
+			googleMailProduct: productSlug ? getProductBySlug( state, productSlug ) : null,
 			gsuiteUsers: getGSuiteUsers( state, selectedSiteId ),
 			isRequestingDomains: isRequestingSiteDomains( state, selectedSiteId ),
 			selectedSite,

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -14,6 +14,7 @@ import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getSelectedDomain } from 'calypso/lib/domains';
 import {
 	getEligibleGSuiteDomain,
 	getGoogleMailServiceFamily,
@@ -34,6 +35,7 @@ import {
 } from 'calypso/lib/gsuite/new-users';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import EmailHeader from 'calypso/my-sites/email/email-header';
+import GoogleMailboxPricingNotice from 'calypso/my-sites/email/gsuite-add-users/google-workspace-pricing-notice';
 import { emailManagementAddGSuiteUsers, emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
@@ -232,7 +234,19 @@ class GSuiteAddUsers extends Component {
 	}
 
 	render() {
-		const { currentRoute, productType, translate, selectedDomainName, selectedSite } = this.props;
+		const {
+			currentRoute,
+			domains,
+			productType,
+			translate,
+			selectedDomainName,
+			selectedSite,
+		} = this.props;
+
+		const selectedDomain = getSelectedDomain( {
+			domains,
+			selectedDomainName: selectedDomainName,
+		} );
 
 		const analyticsPath = emailManagementAddGSuiteUsers(
 			':site',
@@ -267,6 +281,12 @@ class GSuiteAddUsers extends Component {
 						} ) }
 						noticeStatus="is-info"
 					>
+						{ selectedDomainName && (
+							<GoogleMailboxPricingNotice
+								domain={ selectedDomain }
+								googleMailProduct={ productType }
+							/>
+						) }
 						{ this.renderAddGSuite() }
 					</EmailVerificationGate>
 				</Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull requests adds a new component to the add mailbox screen for Google Workspace.

We can later refactor the component to a common one, passing the needed parameters. But! As the Google Workspace subscription does not support monthly billing yet, the code was going to be longer than it should. I want to keep things easier to review.

#### Testing instructions

1. Apply this patch locally or use the calypso live branch
2. Go to Upgrades -> Email and add a mailbox to a current Google Workspace subscription (if you don't have you should add a subscription to a domain)
3. Check that you are presented with the following screen, with a notice in the top of the form.

![image](https://user-images.githubusercontent.com/5689927/155703022-faa85275-fd01-49b2-a5ef-a7762083a250.png)

Related to {1200182182542585-as-1201814087051103}
