### PR TITLE
Remove the Add new credit card button from add card

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
 import { useDispatch } from 'react-redux';
@@ -25,10 +25,8 @@ export default function AddStoredCreditCard(): ReactElement {
 			<div className="add-stored-credit-card__content">
 				<CardHeading className="add-stored-credit-card__title" tagName="h3">
 					<Gridicon key="add-card-icon" icon="add-outline" size={ 24 } />
-					<span key="add-card-text">{ translate( 'New Credit Card' ) }</span>
+					<span key="add-card-text">{ translate( 'New credit card' ) }</span>
 				</CardHeading>
-
-				<Button>{ translate( 'Add new credit card' ) }</Button>
 			</div>
 		</a>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/style.scss
@@ -10,10 +10,13 @@
 		transition: all 0.2s ease-in-out;
 	}
 
-	&:hover, &:active {
+	&:hover, &:active, &:focus {
 		background-color: var( --studio-white );
 		border-color: var( --studio-white );
 		box-shadow: 0 0 40px rgba( 0, 0, 0, 0.08 );
+	}
+	&:focus {
+		outline: none;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR will remove the `Add new credit card` button from the add card flow.
* Adds the styles to focus on cards similar to hover styles.
* Rename `New Credit Card` to `New credit card`.

#### Testing instructions

* Switch to `update/remove-add-new-credit-card-button` branch and take a pull
* Start Calypso green with `yarn start-jetpack-cloud`.
* Go to http://jetpack.cloud.localhost:3000/partner-portal/payment-methods
* Make sure the empty card to add a new credit card doesn't have the button `Add new credit card` and only shows `+ New credit card` as shown in the screenshot below


<img width="1582" alt="Screenshot 2022-02-25 at 3 38 58 PM" src="https://user-images.githubusercontent.com/10586875/155707025-ea1f80fa-9bdc-4db9-b561-f257b48a76a7.png">


* To test the focus state, the best way is to force the focus state. To do that, click on Inspect -> Select the card -> Right-click -> click Force State & Select `focus` or click Focus[TIL], The card should have a style similar to hover styles


<img width="930" alt="Screenshot 2022-02-25 at 4 38 05 PM" src="https://user-images.githubusercontent.com/10586875/155705698-0dbd9422-72fa-4e94-92f9-3a21c56d65a1.png">


Card after focus

<img width="475" alt="Screenshot 2022-02-25 at 4 42 14 PM" src="https://user-images.githubusercontent.com/10586875/155705777-b154faaf-dd24-4d8d-8d19-730203cef8a3.png">

Related to 1201734780767770-as-1201735329399944