### PR TITLE
Stepper: make step CSS reusable

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -1,6 +1,7 @@
 export { default as domain } from './domain';
 export { default as design } from './design';
 export { default as intent } from './intent-step';
+export { default as options } from './site-options';
 export { default as build } from './build';
 export { default as sell } from './sell';
 export { default as write } from './write';
@@ -12,6 +13,7 @@ export type StepPath =
 	| 'design'
 	| 'intent'
 	| 'build'
+	| 'options'
 	| 'sell'
 	| 'write'
 	| 'import'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 import IntentScreen from '@automattic/onboarding-components';
 import { useTranslate } from 'i18n-calypso';
 import intentImageUrl from 'calypso/assets/images/onboarding/intent.svg';
@@ -7,6 +8,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { useIntents, useIntentsAlt } from './intents';
 import type { StepPath } from '../';
 import type { Step } from '../../types';
+import '../step-layouts/horizontal-layout.scss';
 import './style.scss';
 
 /**
@@ -30,8 +32,8 @@ const IntentStep: Step = function IntentStep( { navigation } ) {
 	};
 
 	return (
-		<div className="intent-step">
-			<div className="intent-step__header">
+		<div className="step-horizontal-layout intent-step">
+			<div className="step__header">
 				<FormattedHeader
 					id={ 'intent-header' }
 					headerText={ headerText }
@@ -39,7 +41,7 @@ const IntentStep: Step = function IntentStep( { navigation } ) {
 					align={ 'left' }
 				/>
 				{ intentImageUrl && (
-					<div className="intent-step__header-image">
+					<div className="step__header-image">
 						<img src={ intentImageUrl } alt="" />
 					</div>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/intents.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/intents.tsx
@@ -12,11 +12,11 @@ export const useIntents = (): Intent[] => {
 
 	const intents: Intent[] = [
 		{
-			key: 'write',
+			key: 'options',
 			title: translate( 'Write' ),
 			description: <p>{ translate( 'Share your ideas with the world' ) }</p>,
 			icon: write,
-			value: 'write',
+			value: 'options',
 			actionText: translate( 'Start writing' ),
 		},
 		{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/style.scss
@@ -6,94 +6,22 @@ $gray-100: #101517;
 $gray-60: #50575e;
 
 .intent-step {
-    align-items: flex-start;
-    justify-content: space-between;
-    max-width: 1024px;
-    padding: 0 20px;
-	margin: 0 auto;
-    margin-top: 44px;
+	.onboarding-components-select-items__item {
+		.onboarding-components-select-items__item-title {
+			font-weight: 400;
+			margin: 0;
+		}
 
-    @include break-small {
-        display: flex;
-        margin-top: 25vh;
-    }
+		.onboarding-components-select-items__item-button {
+			box-shadow: rgba( 0, 0, 0, 0.05 ) 0 1px 2px 0;
+			border-radius: 4px;
+			border: 1px solid rgb( 195, 196, 199 );
+		}
+	}
 
-    .intent-step__header {
-        display: block;
-        justify-content: space-between;
-        align-items: center;
-		margin-bottom: 40px;
-
-        @include breakpoint-deprecated( '<660px' ) {
-            flex-wrap: wrap;
-            margin-top: 24px;
-        }
-
-        @include break-small {
-            padding-right: 20px;
-        }
-
-    }
-
-    .intent-step__header-image {
-        margin-top: 64px;
-        display: none;
-    
-        @include break-small {
-            display: block;
-        }
-    }
-
-    .formatted-header {
-        margin: 0;
-        flex-grow: 1;
-        text-align: left;
-
-        .formatted-header__title {
-            @include onboarding-font-recoleta;
-			color: $gray-100;
-			letter-spacing: 0.2px;
-			font-size: 2.15rem; /* stylelint-disable-line */
-            font-weight: 400;
-            padding: 0;
-            text-align: left;
-            margin: 0;
-
-			@include break-xlarge {
-				font-size: 2.75rem; /* stylelint-disable-line */
-			}
-        }
-
-        .formatted-header__subtitle {
-            padding: 0;
-            text-align: left;
-            color: $gray-60;
-			font-size: 1rem;
-            margin: 8px 0 0;
-            line-height: 24px;
-
-			@include breakpoint-deprecated( '<660px' ) {
-				margin-top: 16px;
-			}
-        }
-    }
-
-    .onboarding-components-select-items__item {
-        .onboarding-components-select-items__item-title {
-            font-weight: 400;
-            margin: 0;
-        }
-        
-        .onboarding-components-select-items__item-button {
-            box-shadow: rgba( 0, 0, 0, 0.05 ) 0 1px 2px 0;
-            border-radius: 4px;
-            border: 1px solid rgb( 195, 196, 199 );
-        }
-    }
-
-    .onboarding-components-select-items-alt__item {
-        .onboarding-components-select-items-alt__item-description {
-            margin: 0;
-        }
-    }
+	.onboarding-components-select-items-alt__item {
+		.onboarding-components-select-items-alt__item-description {
+			margin: 0;
+		}
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/style.scss
@@ -12,7 +12,7 @@ $gray-60: #50575e;
 			margin: 0;
 		}
 
-		.onboarding-components-select-items__item-button {
+		button.onboarding-components-select-items__item-button {
 			box-shadow: rgba( 0, 0, 0, 0.05 ) 0 1px 2px 0;
 			border-radius: 4px;
 			border: 1px solid rgb( 195, 196, 199 );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/types.ts
@@ -1,1 +1,1 @@
-export type IntentFlag = 'build' | 'write' | 'import' | 'sell' | 'wpadmin';
+export type IntentFlag = 'build' | 'options' | 'import' | 'sell' | 'wpadmin';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -1,0 +1,31 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { useTranslate } from 'i18n-calypso';
+import siteOptionsURL from 'calypso/assets/images/onboarding/site-options.svg';
+import FormattedHeader from 'calypso/components/formatted-header';
+import type { Step } from '../../types';
+import './style.scss';
+import '../step-layouts/horizontal-layout.scss';
+
+/**
+ * The intent capture step
+ */
+const SiteOptionsStep: Step = function SiteOptionsStep() {
+	const translate = useTranslate();
+	const headerText = translate( "First, let's give your blog a name" );
+
+	return (
+		<div className="step-horizontal-layout">
+			<div className="site-options__header">
+				<FormattedHeader id={ 'site-options-header' } headerText={ headerText } align={ 'left' } />
+				<div className="step__header-image">
+					<img src={ siteOptionsURL } alt="" />
+				</div>
+			</div>
+			<div>{ /*
+				options form should be here
+				*/ }</div>
+		</div>
+	);
+};
+
+export default SiteOptionsStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/style.scss
@@ -1,0 +1,9 @@
+@import '@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
+/*
+.site-options {
+	
+}
+*/

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/step-layouts/horizontal-layout.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/step-layouts/horizontal-layout.scss
@@ -42,6 +42,7 @@ $gray-60: #50575e;
 			display: block;
 		}
 	}
+
 	.formatted-header {
 		margin: 0;
 		flex-grow: 1;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/step-layouts/horizontal-layout.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/step-layouts/horizontal-layout.scss
@@ -1,0 +1,78 @@
+@import '@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
+$gray-100: #101517;
+$gray-60: #50575e;
+
+.step-horizontal-layout {
+	align-items: flex-start;
+	justify-content: space-between;
+	max-width: 1024px;
+	padding: 0 20px;
+	margin: 0 auto;
+	margin-top: 44px;
+
+	@include break-small {
+		display: flex;
+		margin-top: 25vh;
+	}
+
+	.step__header {
+		display: block;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 40px;
+
+		@include breakpoint-deprecated( '<660px' ) {
+			flex-wrap: wrap;
+			margin-top: 24px;
+		}
+
+		@include break-small {
+			padding-right: 20px;
+		}
+	}
+
+	.step__header-image {
+		margin-top: 64px;
+		display: none;
+
+		@include break-small {
+			display: block;
+		}
+	}
+	.formatted-header {
+		margin: 0;
+		flex-grow: 1;
+		text-align: left;
+
+		.formatted-header__title {
+			@include onboarding-font-recoleta;
+			color: $gray-100;
+			letter-spacing: 0.2px;
+			font-size: 2.15rem; /* stylelint-disable-line */
+			font-weight: 400;
+			padding: 0;
+			text-align: left;
+			margin: 0;
+
+			@include break-xlarge {
+				font-size: 2.75rem; /* stylelint-disable-line */
+			}
+		}
+
+		.formatted-header__subtitle {
+			padding: 0;
+			text-align: left;
+			color: $gray-60;
+			font-size: 1rem;
+			margin: 8px 0 0;
+			line-height: 24px;
+
+			@include breakpoint-deprecated( '<660px' ) {
+				margin-top: 16px;
+			}
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -3,12 +3,12 @@ import type { Flow } from './internals/types';
 
 export const siteSetupFlow: Flow = {
 	useSteps() {
-		return [ 'intent', 'write', 'build', 'sell', 'import' ];
+		return [ 'intent', 'options', 'build', 'sell', 'import' ];
 	},
 	useStepNavigation( currentStep, navigate ) {
 		const goBack = () => {
 			if (
-				currentStep === 'write' ||
+				currentStep === 'options' ||
 				currentStep === 'build' ||
 				currentStep === 'sell' ||
 				currentStep === 'import'

--- a/packages/onboarding-components/src/components/onboarding-components-select-items/style.scss
+++ b/packages/onboarding-components/src/components/onboarding-components-select-items/style.scss
@@ -70,7 +70,7 @@
 		}
 	}
 
-	&-button {
+	button.onboarding-components-select-items__item-button {
 		margin-top: 24px;
 		border-radius: 4px; /* stylelint-disable-line */
 		min-width: 130px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This just moves CSS around to make it more modular so all steps could use it. 
* Adds a new step called `options` just to test the CSS.

#### Testing instructions

1. start.
2. Go to `/stepper/`
3. Click on `Write`

