### PR TITLE
Plugin Installed badge: use a plugin specific selector that also checks isEqualSlugOrId.

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -14,10 +14,7 @@ import { PluginPrice } from 'calypso/my-sites/plugins/plugin-price';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
-import {
-	getSitesWithPlugin,
-	getPlugins as getInstalledPlugins,
-} from 'calypso/state/plugins/installed/selectors';
+import { getSitesWithPlugin, getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -194,20 +191,16 @@ const InstalledInOrPricing = ( {
 } ) => {
 	const translate = useTranslate();
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const installedPlugins =
-		useSelector( ( state ) => getInstalledPlugins( state, [ selectedSiteId ] ) ) || [];
-	const activePlugins = selectedSiteId
-		? installedPlugins.filter( ( activePlugin ) => activePlugin.sites[ selectedSiteId ]?.active )
-		: [];
+	const isPluginAtive = useSelector( ( state ) =>
+		getPluginOnSites( state, [ selectedSiteId ], plugin.slug )
+	)?.active;
 
 	let checkmarkColorClass = 'checkmark--active';
 
 	if ( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) || isWpcomPreinstalled ) {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
-
-		const isActive = !! activePlugins.find( ( activePlugin ) => activePlugin.slug === plugin.slug );
 		if ( selectedSiteId ) {
-			checkmarkColorClass = isActive ? 'checkmark--active' : 'checkmark--inactive';
+			checkmarkColorClass = isPluginAtive ? 'checkmark--active' : 'checkmark--inactive';
 		}
 		return (
 			<div className="plugins-browser-item__installed-and-active-container">
@@ -222,8 +215,8 @@ const InstalledInOrPricing = ( {
 				</div>
 				{ selectedSiteId && (
 					<div className="plugins-browser-item__active">
-						<Badge type={ isActive ? 'success' : 'info' }>
-							{ isActive ? translate( 'Active' ) : translate( 'Inactive' ) }
+						<Badge type={ isPluginAtive ? 'success' : 'info' }>
+							{ isPluginAtive ? translate( 'Active' ) : translate( 'Inactive' ) }
 						</Badge>
 					</div>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`getInstalledPlugins` didn't work properly due to some plugins mismatch in slugs. We resolved a same problem in the past too https://github.com/Automattic/wp-calypso/pull/60627

- I have used `getPluginOnSites` which contains `isEqualSlugOrId` and properly matches the current plugin with the installed.

https://github.com/Automattic/wp-calypso/blob/bbe31df69fea04abd0b7d3df71aabb4fa597d693/client/state/plugins/installed/selectors.js#L108-L110


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a site with free and paid plugins installed and all of them being active
* Make sure that no free / paid plugin is reported as inactive.
* Visit `/plugins` make sure there are no regressions.
* Observe the console for errors.

|Before | After|
|-------|------|
|<img width="1093" alt="CleanShot 2022-02-25 at 15 48 43@2x" src="https://user-images.githubusercontent.com/12430020/155726215-e89a2abd-f1e7-48e2-968b-01b2f8fe56e7.png">|<img width="1098" alt="CleanShot 2022-02-25 at 15 49 04@2x" src="https://user-images.githubusercontent.com/12430020/155726274-27d5a775-a494-4549-abfc-90f4e3f4ec09.png">|

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/pull/61389
