### PR TITLE
Use the right property to retrieve the isLoading state from useWPCOMPlugins

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -141,7 +141,9 @@ const PluginsBrowser = ( {
 	const hasBusinessPlan =
 		sitePlan && ( isBusiness( sitePlan ) || isEnterprise( sitePlan ) || isEcommerce( sitePlan ) );
 
-	const { data: paidPluginsRawList = [], isFetchingPaidPlugins } = useWPCOMPlugins( 'featured' );
+	const { data: paidPluginsRawList = [], isLoading: isFetchingPaidPlugins } = useWPCOMPlugins(
+		'featured'
+	);
 	const paidPlugins = useMemo( () => paidPluginsRawList.map( updateWpComRating ), [
 		paidPluginsRawList,
 	] );
@@ -398,7 +400,7 @@ const SearchListView = ( {
 	);
 	const {
 		data: paidPluginsBySearchTermRaw = [],
-		isFetchingPaidPluginsBySearchTerm,
+		isLoading: isFetchingPaidPluginsBySearchTerm,
 	} = useWPCOMPlugins( 'all', searchTerm, {
 		enabled: !! searchTerm,
 	} );


### PR DESCRIPTION


#### Changes proposed in this Pull Request
Use the right property to retrieve the isLoading state from useWPCOMPlugins.

Before this change, the loading variables (`isFetchingPaidPlugins` and `isFetchingPaidPluginsBySearchTerm`) were always returning `undefined` as they are not being returned by `useWPCOMPlugins`.

After this change, the variables are receiving the value from `isLoading` which is returned by `useWPCOMPlugins`.
