### PR TITLE
FSE: add theme activation notice

### DIFF
--- a/client/my-sites/themes/test/thanks-modal.jsx
+++ b/client/my-sites/themes/test/thanks-modal.jsx
@@ -4,9 +4,7 @@
 
 import '@testing-library/jest-dom/extend-expect';
 import { render, screen, waitFor } from '@testing-library/react';
-import nock from 'nock';
 import ReactModal from 'react-modal';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
@@ -19,12 +17,9 @@ import ThanksModal from '../thanks-modal';
 ReactModal.setAppElement( '*' ); // suppresses modal-related test warnings.
 
 const TestComponent = ( { store } ) => {
-	const queryClient = new QueryClient();
 	return (
 		<ReduxProvider store={ store }>
-			<QueryClientProvider client={ queryClient }>
-				<ThanksModal source="details" />
-			</QueryClientProvider>
+			<ThanksModal source="details" />
 		</ReduxProvider>
 	);
 };
@@ -36,18 +31,8 @@ const userId = 456;
 const source = 'unknown';
 const purchased = false;
 
-/**
- * The `is_fse_active` flag depends on the theme that just
- * got activated on the back-end, so we need to refetch
- * that flag whenever the theme changes.
- */
-const setupAPIResponse = ( { is_fse_active } ) => {
-	return nock( 'https://public-api.wordpress.com:443' )
-		.get( `/wpcom/v2/sites/${ siteId }/block-editor` )
-		.reply( 200, {
-			is_fse_eligible: true,
-			is_fse_active,
-		} );
+const fseThemeFeature = {
+	slug: 'full-site-editing',
 };
 
 const defaultSite = { ID: siteId, name: 'Example site', URL: 'https://example.com' };
@@ -81,12 +66,15 @@ const setupStore = ( { site = defaultSite, theme = defaultTheme } = {} ) => {
 
 describe( 'thanks-modal', () => {
 	describe( 'when activating an FSE theme', () => {
-		beforeEach( () => {
-			setupAPIResponse( { is_fse_active: true } );
-		} );
-
 		test( 'displays the "Edit site" call to action and links it to the site editor', async () => {
-			const store = setupStore();
+			const store = setupStore( {
+				theme: {
+					...defaultTheme,
+					taxonomies: {
+						theme_feature: [ fseThemeFeature ],
+					},
+				},
+			} );
 
 			render( <TestComponent store={ store } /> );
 
@@ -103,10 +91,6 @@ describe( 'thanks-modal', () => {
 	} );
 
 	describe( 'when activating a non-FSE theme that has a front page', () => {
-		beforeEach( () => {
-			setupAPIResponse( { is_fse_active: false } );
-		} );
-
 		test( 'displays the "Edit homepage" call to action and links it to the page editor', async () => {
 			const store = setupStore( {
 				site: {
@@ -140,10 +124,6 @@ describe( 'thanks-modal', () => {
 	} );
 
 	describe( 'when activating a non-FSE theme that does not have a front page', () => {
-		beforeEach( () => {
-			setupAPIResponse( { is_fse_active: false } );
-		} );
-
 		test( 'displays the "Customize site" call to action and links it to the customizer', async () => {
 			const store = setupStore();
 
@@ -157,25 +137,6 @@ describe( 'thanks-modal', () => {
 					'href',
 					'/customize/example.com'
 				);
-			} );
-		} );
-	} );
-
-	describe( 'when activating a theme', () => {
-		beforeEach( () => {
-			setupAPIResponse( { is_fse_active: false } );
-		} );
-
-		test( 'waits for isFSEActive response before displaying content', async () => {
-			const store = setupStore();
-
-			render( <TestComponent store={ store } /> );
-
-			expect( screen.getByTestId( 'loadingThanksModalContent' ) ).toBeInTheDocument();
-			expect( screen.queryByText( 'Customize site' ) ).not.toBeInTheDocument();
-
-			await waitFor( () => {
-				expect( screen.getByText( 'Customize site' ) ).toBeInTheDocument();
 			} );
 		} );
 	} );

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import PulsingDot from 'calypso/components/pulsing-dot';
-import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
 import { addQueryArgs } from 'calypso/lib/route';
 import getCustomizeOrEditFrontPageUrl from 'calypso/state/selectors/get-customize-or-edit-front-page-url';
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
@@ -25,6 +24,7 @@ import {
 import { themeHasAutoLoadingHomepage } from 'calypso/state/themes/selectors/theme-has-auto-loading-homepage';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { trackClick } from './helpers';
+import { isFullSiteEditingTheme } from './is-full-site-editing-theme';
 
 import './thanks-modal.scss';
 
@@ -49,7 +49,6 @@ class ThanksModal extends Component {
 		isThemeWpcom: PropTypes.bool.isRequired,
 		siteId: PropTypes.number,
 		isFSEActive: PropTypes.bool,
-		areBlockEditorSettingsLoading: PropTypes.bool.isRequired,
 	};
 
 	componentDidUpdate( prevProps ) {
@@ -185,14 +184,9 @@ class ThanksModal extends Component {
 	};
 
 	getEditSiteLabel = () => {
-		const {
-			shouldEditHomepageWithGutenberg,
-			hasActivated,
-			isFSEActive,
-			areBlockEditorSettingsLoading,
-		} = this.props;
+		const { shouldEditHomepageWithGutenberg, hasActivated, isFSEActive } = this.props;
 
-		if ( ! hasActivated || areBlockEditorSettingsLoading ) {
+		if ( ! hasActivated ) {
 			return this.props.translate( 'Activating theme…' );
 		}
 
@@ -263,9 +257,9 @@ class ThanksModal extends Component {
 	};
 
 	render() {
-		const { currentTheme, hasActivated, isActivating, areBlockEditorSettingsLoading } = this.props;
+		const { currentTheme, hasActivated, isActivating } = this.props;
 
-		const shouldDisplayContent = hasActivated && currentTheme && ! areBlockEditorSettingsLoading;
+		const shouldDisplayContent = hasActivated && currentTheme;
 
 		return (
 			<Dialog
@@ -281,15 +275,12 @@ class ThanksModal extends Component {
 }
 
 const ConnectedThanksModal = connect(
-	( state, props ) => {
-		const { blockEditorSettings } = props;
-
-		const isFSEActive = blockEditorSettings?.is_fse_active ?? false;
-
+	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const siteUrl = getSiteUrl( state, siteId );
 		const currentThemeId = getActiveTheme( state, siteId );
 		const currentTheme = currentThemeId && getCanonicalTheme( state, siteId, currentThemeId );
+		const isFSEActive = isFullSiteEditingTheme( currentTheme );
 
 		// Note: Gutenberg buttons will only show if the homepage is a page.
 		const shouldEditHomepageWithGutenberg = shouldCustomizeHomepageWithGutenberg( state, siteId );
@@ -327,4 +318,4 @@ const ConnectedThanksModal = connect(
 	}
 )( localize( ThanksModal ) );
 
-export default withBlockEditorSettings( ConnectedThanksModal );
+export default ConnectedThanksModal;

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -165,6 +165,13 @@ class ThanksModal extends Component {
 						args: { themeAuthor },
 					} ) }
 				</span>
+				{ this.props.isFSEActive && (
+					<p className="themes__thanks-modal-fse-notice">
+						{ this.props.translate(
+							'This theme uses Full Site Editing to allow you to edit every aspect of your site all in one place, making it easier than ever to create exactly what you want!'
+						) }
+					</p>
+				) }
 			</div>
 		);
 	};

--- a/client/my-sites/themes/thanks-modal.scss
+++ b/client/my-sites/themes/thanks-modal.scss
@@ -56,7 +56,7 @@
 	&-fse-notice {
 		margin: 1rem auto;
 		color: var( --color-text-subtle );
-		font-size: 0.875rem;
+		font-size: $font-body-small;
 		max-width: 300px;
 	}
 

--- a/client/my-sites/themes/thanks-modal.scss
+++ b/client/my-sites/themes/thanks-modal.scss
@@ -60,12 +60,6 @@
 		max-width: 300px;
 	}
 
-	.thanks-modal__gutenberg-prompt {
-		color: var( --color-text-subtle );
-		font-size: 14px;
-		margin-top: 12px;
-	}
-
 	ul {
 		display: block;
 		margin-left: 10px;

--- a/client/my-sites/themes/thanks-modal.scss
+++ b/client/my-sites/themes/thanks-modal.scss
@@ -53,6 +53,13 @@
 		}
 	}
 
+	&-fse-notice {
+		margin: 1rem auto;
+		color: var( --color-text-subtle );
+		font-size: 0.875rem;
+		max-width: 300px;
+	}
+
 	.thanks-modal__gutenberg-prompt {
 		color: var( --color-text-subtle );
 		font-size: 14px;


### PR DESCRIPTION
Fixes #61119.

#### Changes proposed in this Pull Request

We want to display a message indicating the capabilities of FSE upon theme activation.

![image](https://user-images.githubusercontent.com/26530524/156627472-7a08c6bc-99ad-43af-8718-de90573aa3d4.png)

#### Testing instructions

- Open Themes page;
- Activate one FSE theme;
- Check the notice in the Thanks modal.