### PR TITLE
Plugins Browser: Use react query to search plugins on WPORG

### DIFF
--- a/client/data/marketplace/use-wporg-plugin-query.ts
+++ b/client/data/marketplace/use-wporg-plugin-query.ts
@@ -40,7 +40,7 @@ export const useWPORGPlugins = (
 				author,
 			} ),
 		{
-			select: ( { plugins = {}, info = {} } ) => ( {
+			select: ( { plugins = [], info = {} } ) => ( {
 				plugins: normalizePluginsList( plugins ),
 				pagination: info,
 			} ),

--- a/client/data/marketplace/use-wporg-plugin-query.ts
+++ b/client/data/marketplace/use-wporg-plugin-query.ts
@@ -1,0 +1,52 @@
+import { useQuery, UseQueryResult, UseQueryOptions, QueryKey } from 'react-query';
+import { useSelector } from 'react-redux';
+import { extractSearchInformation, normalizePluginsList } from 'calypso/lib/plugins/utils';
+import { fetchPluginsList } from 'calypso/lib/wporg';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+
+type WPORGOptionsType = {
+	pageSize?: number;
+	page?: number;
+	category?: string;
+	searchTerm?: string;
+	locale: string;
+};
+
+const getCacheKey = ( key: string ): QueryKey => [ 'wporg-plugins', key ];
+
+const getPluginsListKey = ( options: WPORGOptionsType ): QueryKey =>
+	getCacheKey(
+		`${ options.category || '' }_${ options.searchTerm || '' }_${ options.page || '' }_${
+			options.pageSize || ''
+		}_${ options.locale || '' }`
+	);
+
+export const useWPORGPlugins = (
+	options: WPORGOptionsType,
+	{ enabled = true, staleTime = 1000 * 60 * 60 * 2, refetchOnMount = true }: UseQueryOptions = {}
+): UseQueryResult => {
+	const [ search, author ] = extractSearchInformation( options.searchTerm );
+	const locale = useSelector( getCurrentUserLocale );
+
+	return useQuery(
+		getPluginsListKey( options ),
+		() =>
+			fetchPluginsList( {
+				pageSize: options.pageSize,
+				page: options.page,
+				category: options.category,
+				locale: options.locale || locale,
+				search,
+				author,
+			} ),
+		{
+			select: ( { plugins = {}, info = {} } ) => ( {
+				plugins: normalizePluginsList( plugins ),
+				pagination: info,
+			} ),
+			enabled: enabled,
+			staleTime: staleTime,
+			refetchOnMount: refetchOnMount,
+		}
+	);
+};

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -398,14 +398,14 @@ const SearchListView = ( {
 	);
 	const translate = useTranslate();
 
-	const pluginItemsFeatch = ( currentPage ) => {
+	const pluginItemsFetch = ( currentPage ) => {
 		return currentPage === 1
 			? SEARCH_RESULTS_LIST_LENGTH + ( paidPluginsBySearchTerm?.length % 2 )
 			: SEARCH_RESULTS_LIST_LENGTH;
 	};
 
 	useEffect( () => {
-		setPageSize( pluginItemsFeatch( page ) );
+		setPageSize( pluginItemsFetch( page ) );
 	}, [ paidPluginsBySearchTerm ] );
 
 	if (
@@ -458,11 +458,11 @@ const SearchListView = ( {
 				{ pluginsPagination && (
 					<Pagination
 						page={ pluginsPagination.page }
-						perPage={ pluginItemsFeatch( pluginsPagination?.page ) }
+						perPage={ pluginItemsFetch( pluginsPagination?.page ) }
 						total={ pluginsPagination.results }
 						pageClick={ ( clickedPage ) => {
 							setPage( clickedPage );
-							setPageSize( pluginItemsFeatch( clickedPage ) );
+							setPageSize( pluginItemsFetch( clickedPage ) );
 						} }
 						variant={ PaginationVariant.minimal }
 					/>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -20,7 +20,6 @@ import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
-import QueryWporgPlugins from 'calypso/components/data/query-wporg-plugins';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import MainComponent from 'calypso/components/main';
@@ -29,6 +28,7 @@ import NoticeAction from 'calypso/components/notice/notice-action';
 import Pagination from 'calypso/components/pagination';
 import { PaginationVariant } from 'calypso/components/pagination/constants';
 import { useWPCOMPlugin, useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import { useWPORGPlugins } from 'calypso/data/marketplace/use-wporg-plugin-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import UrlSearch from 'calypso/lib/url-search';
 import NoResults from 'calypso/my-sites/no-results';
@@ -47,16 +47,7 @@ import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
-import {
-	fetchPluginsCategoryNextPage,
-	fetchPluginsList,
-} from 'calypso/state/plugins/wporg/actions';
-import {
-	getPluginsListByCategory,
-	getPluginsListBySearchTerm,
-	isFetchingPluginsList,
-	getPluginsListPagination,
-} from 'calypso/state/plugins/wporg/selectors';
+import { fetchPluginsCategoryNextPage } from 'calypso/state/plugins/wporg/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
@@ -147,7 +138,6 @@ const PluginsBrowser = ( {
 	const paidPlugins = useMemo( () => paidPluginsRawList.map( updateWpComRating ), [
 		paidPluginsRawList,
 	] );
-	const popularPlugins = useSelector( ( state ) => getPluginsListByCategory( state, 'popular' ) );
 
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
 	const jetpackNonAtomic = useSelector(
@@ -167,26 +157,26 @@ const PluginsBrowser = ( {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const sites = useSelector( getSelectedOrAllSitesJetpackCanManage );
 	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
-	const pluginsByCategory = useSelector( ( state ) => getPluginsListByCategory( state, category ) );
-	const pluginsByCategoryNew = useSelector( ( state ) => getPluginsListByCategory( state, 'new' ) );
-	const pluginsByCategoryFeatured = useSelector( ( state ) =>
-		getPluginsListByCategory( state, 'featured' )
-	);
+	const {
+		data: { plugins: pluginsByCategory = [] } = {},
+		isLoading: isFetchingPluginsByCategory,
+	} = useWPORGPlugins( { category } );
+	const {
+		data: { plugins: pluginsByCategoryNew = [] } = {},
+		isLoading: isFetchingPluginsByCategoryNew,
+	} = useWPORGPlugins( { category: 'new' } );
+	const {
+		data: pluginsByCategoryFeatured = [],
+		isLoading: isFetchingPluginsByCategoryFeatured,
+	} = useWPCOMPlugins( 'featured' );
+
+	const {
+		data: { plugins: popularPlugins = [] } = {},
+		isLoading: isFetchingPluginsByCategoryPopular,
+	} = useWPORGPlugins( { category: 'popular' } );
 	const pluginsByCategoryPopular = filterPopularPlugins(
 		popularPlugins,
 		pluginsByCategoryFeatured
-	);
-	const isFetchingPluginsByCategory = useSelector( ( state ) =>
-		isFetchingPluginsList( state, category )
-	);
-	const isFetchingPluginsByCategoryNew = useSelector( ( state ) =>
-		isFetchingPluginsList( state, 'new' )
-	);
-	const isFetchingPluginsByCategoryPopular = useSelector( ( state ) =>
-		isFetchingPluginsList( state, 'popular' )
-	);
-	const isFetchingPluginsByCategoryFeatured = useSelector( ( state ) =>
-		isFetchingPluginsList( state, 'featured' )
 	);
 
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, selectedSite?.ID ) );
@@ -285,15 +275,6 @@ const PluginsBrowser = ( {
 
 	return (
 		<MainComponent wideLayout>
-			{ category && <QueryWporgPlugins category={ category } /> }
-			{ search && <QueryWporgPlugins searchTerm={ search } /> }
-			{ ! category && ! search && (
-				<>
-					<QueryWporgPlugins category="new" />
-					<QueryWporgPlugins category="popular" />
-					<QueryWporgPlugins category="featured" />
-				</>
-			) }
 			<QueryProductsList persist />
 			<QueryJetpackPlugins siteIds={ siteIds } />
 			<PageViewTrackerWrapper
@@ -389,14 +370,21 @@ const SearchListView = ( {
 	sites,
 	billingPeriod,
 } ) => {
-	const pluginsBySearchTerm = useSelector( ( state ) =>
-		getPluginsListBySearchTerm( state, searchTerm )
-	);
-	const isFetchingPluginsBySearchTerm = useSelector( ( state ) =>
-		isFetchingPluginsList( state, null, searchTerm )
-	);
-	const pluginsPagination = useSelector( ( state ) =>
-		getPluginsListPagination( state, searchTerm )
+	const [ page, setPage ] = useState( 1 );
+	const [ pageSize, setPageSize ] = useState( SEARCH_RESULTS_LIST_LENGTH );
+
+	useEffect( () => {
+		setPage( 1 );
+	}, [ searchTerm ] );
+
+	const {
+		data: { plugins: pluginsBySearchTerm = [], pagination: pluginsPagination } = {},
+		isLoading: isFetchingPluginsBySearchTerm,
+	} = useWPORGPlugins(
+		{ searchTerm, page, pageSize },
+		{
+			enabled: !! searchTerm,
+		}
 	);
 	const {
 		data: paidPluginsBySearchTermRaw = [],
@@ -409,7 +397,16 @@ const SearchListView = ( {
 		[ paidPluginsBySearchTermRaw ]
 	);
 	const translate = useTranslate();
-	const dispatch = useDispatch();
+
+	const pluginItemsFeatch = ( currentPage ) => {
+		return currentPage === 1
+			? SEARCH_RESULTS_LIST_LENGTH + ( paidPluginsBySearchTerm?.length % 2 )
+			: SEARCH_RESULTS_LIST_LENGTH;
+	};
+
+	useEffect( () => {
+		setPageSize( pluginItemsFeatch( page ) );
+	}, [ paidPluginsBySearchTerm ] );
 
 	if (
 		pluginsBySearchTerm.length > 0 ||
@@ -439,23 +436,6 @@ const SearchListView = ( {
 				},
 			} );
 
-		let pageSize = SEARCH_RESULTS_LIST_LENGTH;
-		if ( pluginsPagination?.page === 1 ) {
-			// Paid results appear only in the first page.
-			// Since the wporg results will always be an even number and paid results might be odd
-			// append one more wporg result if needed to fill the grid.
-			pageSize =
-				SEARCH_RESULTS_LIST_LENGTH +
-				paidPluginsBySearchTerm?.length +
-				( paidPluginsBySearchTerm?.length % 2 );
-		}
-
-		const pluginItemsFeatch = ( page ) => {
-			return page === 1
-				? SEARCH_RESULTS_LIST_LENGTH + ( paidPluginsBySearchTerm?.length % 2 )
-				: SEARCH_RESULTS_LIST_LENGTH;
-		};
-
 		return (
 			<>
 				<PluginsBrowserList
@@ -480,8 +460,9 @@ const SearchListView = ( {
 						page={ pluginsPagination.page }
 						perPage={ pluginItemsFeatch( pluginsPagination?.page ) }
 						total={ pluginsPagination.results }
-						pageClick={ ( page ) => {
-							dispatch( fetchPluginsList( null, page, searchTerm, pluginItemsFeatch( page ) ) );
+						pageClick={ ( clickedPage ) => {
+							setPage( clickedPage );
+							setPageSize( pluginItemsFeatch( clickedPage ) );
 						} }
 						variant={ PaginationVariant.minimal }
 					/>

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -11,6 +11,11 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/blocks/upsell-nudge', () => 'upsell-nudge' );
 
+let mockPlugins = [];
+jest.mock( 'calypso/data/marketplace/use-wporg-plugin-query', () => ( {
+	useWPORGPlugins: jest.fn( () => ( { data: { plugins: mockPlugins } } ) ),
+} ) );
+
 jest.mock( '@automattic/languages', () => [
 	{
 		value: 1,
@@ -97,9 +102,8 @@ describe( 'Search view', () => {
 		expect( comp.find( 'NoResults' ).length ).toBe( 1 );
 	} );
 	test( 'should show plugin list when there are results', () => {
-		const comp = mountWithRedux( <PluginsBrowser { ...myProps } />, {
-			plugins: { wporg: { lists: { search: { searchterm: [ {} ] } } } },
-		} );
+		mockPlugins = [ {} ];
+		const comp = mountWithRedux( <PluginsBrowser { ...myProps } /> );
 		expect( comp.find( 'PluginsBrowserList' ).length ).toBe( 1 );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add useWPORGPlugins to fetch plugins list with react query
* Use the plugin useWPORGPlugins to retrieve data on Plugins Browser

#### Testing instructions
1. Check if the `/plugins` page is working properly (without a selected site)
2. Check if the `/plugins/:site` page is working (with a selected site)
3. Test the search functionality with a keyword for paid and free plugins. ex: `woo` and `yoast`
4. Verify if the pagination is working properly
5. Verify if new API requests are not being done when the same page and same term are requested.

![Kapture 2022-02-25 at 16 23 30](https://user-images.githubusercontent.com/5039531/155780542-27e39ea8-c716-452a-8c8c-25eb6c636644.gif)

