### PR TITLE
Playwright: refactor EditorToolbarComponent and EditorNavSidebarComponent out of GutenbergEditorPage.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
@@ -1,6 +1,5 @@
 import { Page, FrameLocator } from 'playwright';
 import envVariables from '../../env-variables';
-import { NavbarComponent } from '.';
 
 const panel = 'div.wpcom-block-editor-nav-sidebar-nav-sidebar__container';
 const selectors = {
@@ -63,29 +62,15 @@ export class EditorNavSidebarComponent {
 	 * Exits the editor.
 	 *
 	 * For Desktop viewports, the sidebar is used to exit.
-	 * For Mobile viewports, My Sites button is used to exit.
+	 * For Mobile viewports, nothing happens.
 	 */
 	async exitEditor(): Promise< void > {
-		// There are three different places to return to,
-		// depending on how the editor was entered.
-		const navigationPromise = Promise.race( [
-			this.page.waitForNavigation( { url: '**/home/**' } ),
-			this.page.waitForNavigation( { url: '**/posts/**' } ),
-			this.page.waitForNavigation( { url: '**/pages/**' } ),
-		] );
-		const actions: Promise< unknown >[] = [ navigationPromise ];
-
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			// Mobile viewports do not use a sidebar.
-			const navbarComponent = new NavbarComponent( this.page );
-			actions.push( navbarComponent.clickMySites() );
-		} else {
-			const exitLinkLocator = this.frameLocator.locator( selectors.exitLink );
-			actions.push( exitLinkLocator.click() );
+			return;
 		}
 
-		// Perform the actions and resolve promises.
-		await Promise.all( actions );
+		const exitLinkLocator = this.frameLocator.locator( selectors.exitLink );
+		await exitLinkLocator.click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
@@ -1,0 +1,85 @@
+import { Page, FrameLocator } from 'playwright';
+import envVariables from '../../env-variables';
+import { NavbarComponent } from '.';
+
+const panel = 'div.wpcom-block-editor-nav-sidebar-nav-sidebar__container';
+const selectors = {
+	sidebarButton: `${ panel } button.wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button`,
+	exitLink: `${ panel } a.wpcom-block-editor-nav-sidebar-nav-sidebar__home-button`,
+};
+
+/**
+ * Represents an instance of the WordPress.com Editor's navigation sidebar.
+ * The component is available only in the Desktop viewport.
+ */
+export class EditorNavSidebarComponent {
+	private page: Page;
+	private frameLocator: FrameLocator;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 * @param {FrameLocator} frameLocator Locator of the editor iframe.
+	 */
+	constructor( page: Page, frameLocator: FrameLocator ) {
+		this.page = page;
+		this.frameLocator = frameLocator;
+	}
+
+	/**
+	 * Exits the editor.
+	 *
+	 * For Desktop viewports, the sidebar is used to exit.
+	 * For Mobile viewports, My Sites button is used to exit.
+	 */
+	async exitEditor(): Promise< void > {
+		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
+			await this.openSidebar();
+		}
+
+		// There are three different places to return to,
+		// depending on how the editor was entered.
+		const navigationPromise = Promise.race( [
+			this.page.waitForNavigation( { url: '**/home/**' } ),
+			this.page.waitForNavigation( { url: '**/posts/**' } ),
+			this.page.waitForNavigation( { url: '**/pages/**' } ),
+		] );
+		const actions: Promise< unknown >[] = [ navigationPromise ];
+
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// Mobile viewports do not use a sidebar.
+			const navbarComponent = new NavbarComponent( this.page );
+			actions.push( navbarComponent.clickMySites() );
+		} else {
+			const exitLinkLocator = this.frameLocator.locator( selectors.exitLink );
+			actions.push( exitLinkLocator.click() );
+		}
+
+		// Perform the actions and resolve promises.
+		await Promise.all( actions );
+	}
+
+	/**
+	 * Returns whether the sidebar is open.
+	 *
+	 * @returns {boolean} True if the sidebar is open. False otherwise.
+	 */
+	private async sidebarIsOpen(): Promise< boolean > {
+		const locator = this.frameLocator.locator( selectors.sidebarButton );
+
+		const status = await locator.getAttribute( 'aria-expanded' );
+
+		return status === 'true';
+	}
+
+	/**
+	 * Opens the sidebar if not already open.
+	 */
+	async openSidebar(): Promise< void > {
+		if ( ! ( await this.sidebarIsOpen() ) ) {
+			const locator = this.frameLocator.locator( selectors.sidebarButton );
+			await locator.click();
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
@@ -28,16 +28,26 @@ export class EditorNavSidebarComponent {
 	}
 
 	/**
+	 * Opens the sidebar if not already open.
+	 */
+	async openSidebar(): Promise< void > {
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			return;
+		}
+
+		if ( ! ( await this.sidebarIsOpen() ) ) {
+			const locator = this.frameLocator.locator( selectors.sidebarButton );
+			await locator.click();
+		}
+	}
+
+	/**
 	 * Exits the editor.
 	 *
 	 * For Desktop viewports, the sidebar is used to exit.
 	 * For Mobile viewports, My Sites button is used to exit.
 	 */
 	async exitEditor(): Promise< void > {
-		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
-			await this.openSidebar();
-		}
-
 		// There are three different places to return to,
 		// depending on how the editor was entered.
 		const navigationPromise = Promise.race( [
@@ -69,15 +79,5 @@ export class EditorNavSidebarComponent {
 		const locator = this.frameLocator.locator( selectors.sidebarButton );
 		const status = await locator.getAttribute( 'aria-expanded' );
 		return status === 'true';
-	}
-
-	/**
-	 * Opens the sidebar if not already open.
-	 */
-	async openSidebar(): Promise< void > {
-		if ( ! ( await this.sidebarIsOpen() ) ) {
-			const locator = this.frameLocator.locator( selectors.sidebarButton );
-			await locator.click();
-		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
@@ -3,8 +3,8 @@ import envVariables from '../../env-variables';
 
 const panel = 'div.wpcom-block-editor-nav-sidebar-nav-sidebar__container';
 const selectors = {
-	sidebarButton: `button.wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button`,
-	exitLink: `${ panel } a.wpcom-block-editor-nav-sidebar-nav-sidebar__home-button`,
+	sidebarButton: `button[aria-label="Block editor sidebar"]`,
+	exitLink: `${ panel } a[aria-description="Returns to the dashboard"]`,
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
@@ -4,7 +4,7 @@ import { NavbarComponent } from '.';
 
 const panel = 'div.wpcom-block-editor-nav-sidebar-nav-sidebar__container';
 const selectors = {
-	sidebarButton: `${ panel } button.wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button`,
+	sidebarButton: `button.wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button`,
 	exitLink: `${ panel } a.wpcom-block-editor-nav-sidebar-nav-sidebar__home-button`,
 };
 
@@ -67,7 +67,6 @@ export class EditorNavSidebarComponent {
 	 */
 	private async sidebarIsOpen(): Promise< boolean > {
 		const locator = this.frameLocator.locator( selectors.sidebarButton );
-
 		const status = await locator.getAttribute( 'aria-expanded' );
 
 		return status === 'true';

--- a/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
@@ -35,10 +35,28 @@ export class EditorNavSidebarComponent {
 			return;
 		}
 
-		if ( ! ( await this.sidebarIsOpen() ) ) {
-			const locator = this.frameLocator.locator( selectors.sidebarButton );
-			await locator.click();
+		if ( await this.sidebarIsOpen() ) {
+			return;
 		}
+
+		const locator = this.frameLocator.locator( selectors.sidebarButton );
+		await locator.click();
+	}
+
+	/**
+	 * Closes the sidebar if open.
+	 */
+	async closeSidebar(): Promise< void > {
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			return;
+		}
+
+		if ( ! ( await this.sidebarIsOpen() ) ) {
+			return;
+		}
+
+		const locator = this.frameLocator.locator( selectors.sidebarButton );
+		await locator.click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
@@ -68,7 +68,6 @@ export class EditorNavSidebarComponent {
 	private async sidebarIsOpen(): Promise< boolean > {
 		const locator = this.frameLocator.locator( selectors.sidebarButton );
 		const status = await locator.getAttribute( 'aria-expanded' );
-
 		return status === 'true';
 	}
 

--- a/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
@@ -58,6 +58,9 @@ export class EditorPublishPanelComponent {
 	 */
 	async closePanel(): Promise< void > {
 		// Construct a comma-separated list of CSS selectors so that one of them will match.
+		if ( ! ( await this.panelIsOpen() ) ) {
+			return;
+		}
 		const selector = `${ selectors.cancelPublishButton }, ${ selectors.postPublishClosePanelButton }`;
 		const locator = this.frameLocator.locator( selector );
 		await locator.click();

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -1,11 +1,29 @@
 import { Page, FrameLocator } from 'playwright';
 
+export type PreviewOptions = 'Desktop' | 'Mobile' | 'Tablet';
+
 const panel = 'div.interface-interface-skeleton__header';
 const selectors = {
+	// Block Inserter
+	blockInserterButton: `${ panel } button.edit-post-header-toolbar__inserter-toggle`,
+
+	// Draft
 	saveDraftButton: `${ panel } button.editor-post-save-draft[aria-disabled="false"]`,
 	saveDraftDisabledButton: `${ panel } button.editor-post-saved-state.is-saved[aria-disabled="true"]`,
 	switchToDraftButton: `${ panel } button.editor-post-switch-to-draft`,
+
+	// Preview
+	mobilePreviewButton: `${ panel } a.editor-post-preview`,
+	desktopPreviewButton: `${ panel } button.block-editor-post-preview__button-toggle`,
+	desktopPreviewMenuItem: ( target: PreviewOptions ) =>
+		`button[role="menuitem"] span:text("${ target }")`,
+	previewPane: ( target: PreviewOptions ) => `.is-${ target.toLowerCase() }-preview`,
+
+	// Publish
 	publishButton: `${ panel } button.editor-post-publish-button__button[aria-disabled="false"]`,
+
+	// Editor settings
+	settingsButton: `${ panel } .interface-pinned-items > button:first-child`,
 };
 
 /**
@@ -27,6 +45,49 @@ export class EditorToolbarComponent {
 		this.frameLocator = frameLocator;
 	}
 
+	/* General helper */
+
+	/**
+	 * Given a selector, determines whether the target button/toggle is
+	 * in an expanded state.
+	 *
+	 * If the toggle is in the on state or otherwise in an expanded
+	 * state, this method will return true. Otherwise, false.
+	 *
+	 * @param {string} selector Target selector.
+	 * @returns {Promise<boolean>} True if target is in an expanded state. False otherwise.
+	 */
+	async targetIsOpen( selector: string ): Promise< boolean > {
+		const locator = this.frameLocator.locator( selector );
+		const pressed = await locator.getAttribute( 'aria-pressed' );
+		const expanded = await locator.getAttribute( 'aria-expanded' );
+		return pressed === 'true' || expanded === 'true';
+	}
+
+	/* Block Inserter */
+
+	/**
+	 * Opens the block inserter.
+	 */
+	async openBlockInserter(): Promise< void > {
+		if ( ! ( await this.targetIsOpen( selectors.blockInserterButton ) ) ) {
+			const locator = this.frameLocator.locator( selectors.blockInserterButton );
+			await locator.click();
+		}
+	}
+
+	/**
+	 * Closes the block inserter.
+	 */
+	async closeBlockInserter(): Promise< void > {
+		if ( await this.targetIsOpen( selectors.blockInserterButton ) ) {
+			const locator = this.frameLocator.locator( selectors.blockInserterButton );
+			await locator.click();
+		}
+	}
+
+	/* Draft */
+
 	/**
 	 * Clicks on the 'Save Draft' button on the editor.
 	 *
@@ -45,6 +106,73 @@ export class EditorToolbarComponent {
 		const savedButtonLocator = this.frameLocator.locator( selectors.saveDraftDisabledButton );
 		await savedButtonLocator.waitFor();
 	}
+
+	/* Preview */
+
+	/**
+	 * Launches the Preview when in mobile mode.
+	 *
+	 * @returns {Page} Handler for the new page object.
+	 */
+	async openMobilePreview(): Promise< Page > {
+		const mobilePreviewButtonLocator = this.frameLocator.locator( selectors.mobilePreviewButton );
+
+		const [ popup ] = await Promise.all( [
+			this.page.waitForEvent( 'popup' ),
+			mobilePreviewButtonLocator.click(),
+		] );
+		return popup;
+	}
+
+	/**
+	 * Launches the Preview when in Desktop mode, then selects the
+	 * target preview option.
+	 */
+	async openDesktopPreview( target: PreviewOptions ): Promise< void > {
+		// Click on the Preview button to open the menu.
+		await this.openDesktopPreviewMenu();
+
+		// Locate and click on the intended preview target.
+		const desktopPreviewMenuItemLocator = this.frameLocator.locator(
+			selectors.desktopPreviewMenuItem( target )
+		);
+		await desktopPreviewMenuItemLocator.click();
+
+		// Verify the editor panel is resized and stable.
+		const desktopPreviewPaneLocator = this.frameLocator.locator( selectors.previewPane( target ) );
+		await desktopPreviewPaneLocator.waitFor();
+		const elementHandle = await desktopPreviewPaneLocator.elementHandle();
+		await elementHandle?.waitForElementState( 'stable' );
+
+		// Click on the Preview button to close the menu.
+		await this.closeDesktopPreviewMenu();
+	}
+
+	/**
+	 * Opens the Preview menu for Desktop viewport.
+	 */
+	async openDesktopPreviewMenu(): Promise< void > {
+		if ( ! ( await this.targetIsOpen( selectors.desktopPreviewButton ) ) ) {
+			const desktopPreviewButtonLocator = this.frameLocator.locator(
+				selectors.desktopPreviewButton
+			);
+			await desktopPreviewButtonLocator.click();
+		}
+	}
+
+	/**
+	 * Closes the Preview menu for the Desktop viewport.
+	 */
+	async closeDesktopPreviewMenu(): Promise< void > {
+		if ( await this.targetIsOpen( selectors.desktopPreviewButton ) ) {
+			const desktopPreviewButtonLocator = this.frameLocator.locator(
+				selectors.desktopPreviewButton
+			);
+			await desktopPreviewButtonLocator.click();
+		}
+	}
+
+	/* Publish and unpublish */
 
 	/**
 	 * Clicks on the primary button to publish the article.
@@ -74,5 +202,27 @@ export class EditorToolbarComponent {
 		// Publish button will become enabled upon completion.
 		const publishButtonLocator = this.frameLocator.locator( selectors.publishButton );
 		await publishButtonLocator.waitFor();
+	}
+
+	/* Editor Settings sidebar */
+
+	/**
+	 * Opens the editor settings.
+	 */
+	async openSettings(): Promise< void > {
+		if ( ! ( await this.targetIsOpen( selectors.settingsButton ) ) ) {
+			const locator = this.frameLocator.locator( selectors.settingsButton );
+			await locator.click();
+		}
+	}
+
+	/**
+	 * Closes the editor settings.
+	 */
+	async closeSettings(): Promise< void > {
+		if ( await this.targetIsOpen( selectors.settingsButton ) ) {
+			const locator = this.frameLocator.locator( selectors.settingsButton );
+			await locator.click();
+		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -191,16 +191,8 @@ export class EditorToolbarComponent {
 	 * the article.
 	 */
 	async switchToDraft(): Promise< void > {
-		this.page.once( 'dialog', async ( dialog ) => {
-			await dialog.accept();
-		} );
-
 		const swithcToDraftLocator = this.frameLocator.locator( selectors.switchToDraftButton );
 		await swithcToDraftLocator.click();
-
-		// Publish button will become enabled upon completion.
-		const publishButtonLocator = this.frameLocator.locator( selectors.publishButton );
-		await publishButtonLocator.waitFor();
 	}
 
 	/* Editor Settings sidebar */

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -21,7 +21,10 @@ const selectors = {
 	previewPane: ( target: PreviewOptions ) => `.is-${ target.toLowerCase() }-preview`,
 
 	// Publish
-	publishButton: `${ panel } button.editor-post-publish-button__button[aria-disabled="false"]`,
+	publishButton: ( state: 'disabled' | 'enabled' ) => {
+		const buttonState = state === 'disabled' ? 'true' : 'false';
+		return `${ panel } button.editor-post-publish-button__button[aria-disabled="${ buttonState }"]`;
+	},
 
 	// Editor settings
 	settingsButton: `${ panel } button[aria-label="Settings"]`,
@@ -182,7 +185,7 @@ export class EditorToolbarComponent {
 	 * 	- schedule a post (Schedule)
 	 */
 	async clickPublish(): Promise< void > {
-		const publishButtonLocator = this.frameLocator.locator( selectors.publishButton );
+		const publishButtonLocator = this.frameLocator.locator( selectors.publishButton( 'enabled' ) );
 		await publishButtonLocator.click();
 	}
 

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -57,7 +57,7 @@ export class EditorToolbarComponent {
 	 * @param {string} selector Target selector.
 	 * @returns {Promise<boolean>} True if target is in an expanded state. False otherwise.
 	 */
-	async targetIsOpen( selector: string ): Promise< boolean > {
+	private async targetIsOpen( selector: string ): Promise< boolean > {
 		const locator = this.frameLocator.locator( selector );
 		const pressed = await locator.getAttribute( 'aria-pressed' );
 		const expanded = await locator.getAttribute( 'aria-expanded' );
@@ -96,7 +96,9 @@ export class EditorToolbarComponent {
 	async saveDraft(): Promise< void > {
 		const saveButtonLocator = this.frameLocator.locator( selectors.saveDraftButton );
 
-		if ( ! saveButtonLocator.waitFor( { timeout: 5 * 1000 } ) ) {
+		try {
+			await saveButtonLocator.waitFor( { timeout: 5 * 1000 } );
+		} catch {
 			return;
 		}
 

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -1,0 +1,78 @@
+import { Page, FrameLocator } from 'playwright';
+
+const panel = 'div.interface-interface-skeleton__header';
+const selectors = {
+	saveDraftButton: `${ panel } button.editor-post-save-draft[aria-disabled="false"]`,
+	saveDraftDisabledButton: `${ panel } button.editor-post-saved-state.is-saved[aria-disabled="true"]`,
+	switchToDraftButton: `${ panel } button.editor-post-switch-to-draft`,
+	publishButton: `${ panel } button.editor-post-publish-button__button[aria-disabled="false"]`,
+};
+
+/**
+ * Represents an instance of the WordPress.com Editor's navigation sidebar.
+ * The component is available only in the Desktop viewport.
+ */
+export class EditorToolbarComponent {
+	private page: Page;
+	private frameLocator: FrameLocator;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 * @param {FrameLocator} frameLocator Locator of the editor iframe.
+	 */
+	constructor( page: Page, frameLocator: FrameLocator ) {
+		this.page = page;
+		this.frameLocator = frameLocator;
+	}
+
+	/**
+	 * Clicks on the 'Save Draft' button on the editor.
+	 *
+	 * If the button cannot be clicked, the method short-circuits.
+	 */
+	async saveDraft(): Promise< void > {
+		const saveButtonLocator = this.frameLocator.locator( selectors.saveDraftButton );
+
+		if ( ! saveButtonLocator.waitFor( { timeout: 5 * 1000 } ) ) {
+			return;
+		}
+
+		await saveButtonLocator.click();
+
+		// Ensure the Save Draft button is disabled after successful save.
+		const savedButtonLocator = this.frameLocator.locator( selectors.saveDraftDisabledButton );
+		await savedButtonLocator.waitFor();
+	}
+
+	/**
+	 * Clicks on the primary button to publish the article.
+	 *
+	 * This is applicable for the following scenarios:
+	 * 	- publish of a new article (Publish)
+	 * 	- update an existing article (Update)
+	 * 	- schedule a post (Schedule)
+	 */
+	async clickPublish(): Promise< void > {
+		const publishButtonLocator = this.frameLocator.locator( selectors.publishButton );
+		await publishButtonLocator.click();
+	}
+
+	/**
+	 * Clicks on the `Switch to Draft` button and unpublish
+	 * the article.
+	 */
+	async switchToDraft(): Promise< void > {
+		this.page.once( 'dialog', async ( dialog ) => {
+			await dialog.accept();
+		} );
+
+		const swithcToDraftLocator = this.frameLocator.locator( selectors.switchToDraftButton );
+		await swithcToDraftLocator.click();
+
+		// Publish button will become enabled upon completion.
+		const publishButtonLocator = this.frameLocator.locator( selectors.publishButton );
+		await publishButtonLocator.waitFor();
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -5,16 +5,17 @@ export type PreviewOptions = 'Desktop' | 'Mobile' | 'Tablet';
 const panel = 'div.interface-interface-skeleton__header';
 const selectors = {
 	// Block Inserter
-	blockInserterButton: `${ panel } button.edit-post-header-toolbar__inserter-toggle`,
+	blockInserterButton: `${ panel } button[aria-label="Toggle block inserter"]`,
 
 	// Draft
-	saveDraftButton: `${ panel } button.editor-post-save-draft[aria-disabled="false"]`,
-	saveDraftDisabledButton: `${ panel } button.editor-post-saved-state.is-saved[aria-disabled="true"]`,
+	saveDraftButton: ( state: 'disabled' | 'enabled' ) => {
+		const buttonState = state === 'disabled' ? 'true' : 'false';
+		return `${ panel } button[aria-label="Save draft"][aria-disabled="${ buttonState }"]`;
+	},
 	switchToDraftButton: `${ panel } button.editor-post-switch-to-draft`,
 
 	// Preview
-	mobilePreviewButton: `${ panel } a.editor-post-preview`,
-	desktopPreviewButton: `${ panel } button.block-editor-post-preview__button-toggle`,
+	previewButton: `${ panel } :text("Preview"):visible`,
 	desktopPreviewMenuItem: ( target: PreviewOptions ) =>
 		`button[role="menuitem"] span:text("${ target }")`,
 	previewPane: ( target: PreviewOptions ) => `.is-${ target.toLowerCase() }-preview`,
@@ -23,7 +24,7 @@ const selectors = {
 	publishButton: `${ panel } button.editor-post-publish-button__button[aria-disabled="false"]`,
 
 	// Editor settings
-	settingsButton: `${ panel } .interface-pinned-items > button:first-child`,
+	settingsButton: `${ panel } button[aria-label="Settings"]`,
 };
 
 /**
@@ -94,7 +95,7 @@ export class EditorToolbarComponent {
 	 * If the button cannot be clicked, the method short-circuits.
 	 */
 	async saveDraft(): Promise< void > {
-		const saveButtonLocator = this.frameLocator.locator( selectors.saveDraftButton );
+		const saveButtonLocator = this.frameLocator.locator( selectors.saveDraftButton( 'enabled' ) );
 
 		try {
 			await saveButtonLocator.waitFor( { timeout: 5 * 1000 } );
@@ -105,7 +106,7 @@ export class EditorToolbarComponent {
 		await saveButtonLocator.click();
 
 		// Ensure the Save Draft button is disabled after successful save.
-		const savedButtonLocator = this.frameLocator.locator( selectors.saveDraftDisabledButton );
+		const savedButtonLocator = this.frameLocator.locator( selectors.saveDraftButton( 'disabled' ) );
 		await savedButtonLocator.waitFor();
 	}
 
@@ -117,7 +118,7 @@ export class EditorToolbarComponent {
 	 * @returns {Page} Handler for the new page object.
 	 */
 	async openMobilePreview(): Promise< Page > {
-		const mobilePreviewButtonLocator = this.frameLocator.locator( selectors.mobilePreviewButton );
+		const mobilePreviewButtonLocator = this.frameLocator.locator( selectors.previewButton );
 
 		const [ popup ] = await Promise.all( [
 			this.page.waitForEvent( 'popup' ),
@@ -154,10 +155,8 @@ export class EditorToolbarComponent {
 	 * Opens the Preview menu for Desktop viewport.
 	 */
 	async openDesktopPreviewMenu(): Promise< void > {
-		if ( ! ( await this.targetIsOpen( selectors.desktopPreviewButton ) ) ) {
-			const desktopPreviewButtonLocator = this.frameLocator.locator(
-				selectors.desktopPreviewButton
-			);
+		if ( ! ( await this.targetIsOpen( selectors.previewButton ) ) ) {
+			const desktopPreviewButtonLocator = this.frameLocator.locator( selectors.previewButton );
 			await desktopPreviewButtonLocator.click();
 		}
 	}
@@ -166,10 +165,8 @@ export class EditorToolbarComponent {
 	 * Closes the Preview menu for the Desktop viewport.
 	 */
 	async closeDesktopPreviewMenu(): Promise< void > {
-		if ( await this.targetIsOpen( selectors.desktopPreviewButton ) ) {
-			const desktopPreviewButtonLocator = this.frameLocator.locator(
-				selectors.desktopPreviewButton
-			);
+		if ( await this.targetIsOpen( selectors.previewButton ) ) {
+			const desktopPreviewButtonLocator = this.frameLocator.locator( selectors.previewButton );
 			await desktopPreviewButtonLocator.click();
 		}
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -210,19 +210,21 @@ export class EditorToolbarComponent {
 	 * Opens the editor settings.
 	 */
 	async openSettings(): Promise< void > {
-		if ( ! ( await this.targetIsOpen( selectors.settingsButton ) ) ) {
-			const locator = this.frameLocator.locator( selectors.settingsButton );
-			await locator.click();
+		if ( await this.targetIsOpen( selectors.settingsButton ) ) {
+			return;
 		}
+		const locator = this.frameLocator.locator( selectors.settingsButton );
+		await locator.click();
 	}
 
 	/**
 	 * Closes the editor settings.
 	 */
 	async closeSettings(): Promise< void > {
-		if ( await this.targetIsOpen( selectors.settingsButton ) ) {
-			const locator = this.frameLocator.locator( selectors.settingsButton );
-			await locator.click();
+		if ( ! ( await this.targetIsOpen( selectors.settingsButton ) ) ) {
+			return;
 		}
+		const locator = this.frameLocator.locator( selectors.settingsButton );
+		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -17,5 +17,6 @@ export * from './page-template-modal-component';
 export * from './react-modal-component';
 export * from './popover-block-inserter-component';
 export * from './editor-publish-panel-component';
+export * from './editor-nav-sidebar-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -18,5 +18,6 @@ export * from './react-modal-component';
 export * from './popover-block-inserter-component';
 export * from './editor-publish-panel-component';
 export * from './editor-nav-sidebar-component';
+export * from './editor-toolbar-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -257,21 +257,11 @@ export class GutenbergEditorPage {
 	 * 	- Editor Navigation Sidebar
 	 */
 	async closeAllPanels(): Promise< void > {
-		try {
-			await this.editorPublishPanelComponent.closePanel();
-		} catch {
-			// noop
-		}
-		try {
-			await this.editorNavSidebarComponent.closeSidebar();
-		} catch {
-			// noop
-		}
-		try {
-			await this.editorToolbarComponent.closeSettings();
-		} catch {
-			// noop
-		}
+		await Promise.allSettled( [
+			this.editorPublishPanelComponent.closePanel(),
+			this.editorNavSidebarComponent.closeSidebar(),
+			this.editorToolbarComponent.closeSettings(),
+		] );
 	}
 
 	/**
@@ -416,6 +406,10 @@ export class GutenbergEditorPage {
 	 */
 	async unpublish(): Promise< void > {
 		await this.editorToolbarComponent.switchToDraft();
+
+		const frame = await this.getEditorFrame();
+		// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
+		await frame.click( `div[role="dialog"] button:has-text("OK")` );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -248,6 +248,32 @@ export class GutenbergEditorPage {
 	}
 
 	/**
+	 * Closes all panels that can be opened in the editor.
+	 *
+	 * This method will attempt to close the following panels:
+	 * 	- Publish Panel (including pre-publish checklist)
+	 * 	- Editor Settings Panel
+	 * 	- Editor Navigation Sidebar
+	 */
+	async closeAllPanels(): Promise< void > {
+		try {
+			await this.editorPublishPanelComponent.closePanel();
+		} catch {
+			// noop
+		}
+		try {
+			await this.editorNavSidebarComponent.closeSidebar();
+		} catch {
+			// noop
+		}
+		try {
+			await this.editorToolbarComponent.closeSettings();
+		} catch {
+			// noop
+		}
+	}
+
+	/**
 	 * Adds a Gutenberg block from the block inserter panel.
 	 *
 	 * The name is expected to be formatted in the same manner as it

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -411,7 +411,9 @@ export class GutenbergEditorPage {
 		// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
 		await frame.click( `div[role="dialog"] button:has-text("OK")` );
 		// @TODO: eventually refactor this out to a EditorToastNotificationComponent.
-		await frame.waitForSelector( '.components-snackbar__content :text("Post reverted to draft.")' );
+		await frame.waitForSelector(
+			'.components-editor-notices__snackbar :has-text("Post reverted to draft.")'
+		);
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -410,6 +410,8 @@ export class GutenbergEditorPage {
 		const frame = await this.getEditorFrame();
 		// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
 		await frame.click( `div[role="dialog"] button:has-text("OK")` );
+		// @TODO: eventually refactor this out to a EditorToastNotificationComponent.
+		await frame.waitForSelector( '.components-snackbar__content :text("Post reverted to draft.")' );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -532,21 +532,39 @@ export class GutenbergEditorPage {
 	/* Previews */
 
 	/**
-	 * Launches the Preview.
+	 * Launches the Preview as mobile viewport.
 	 *
-	 * For Desktop viewports, this method will not return any value.
 	 * For Mobile viewports, this method will return a reference to a popup Page.
+	 * For Desktop and Tablet viewports, an error is thrown.
 	 *
-	 * @returns {Page|void} Handler for the Page object on mobile. Void otherwise.
+	 * @returns {Promise<Page>} Handler for the popup page.
+	 * @throws {Error} If the current viewport is not of Mobile.
 	 */
-	async preview( target?: PreviewOptions ): Promise< Page | void > {
-		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			return await this.editorToolbarComponent.openMobilePreview();
+	async previewAsMobile(): Promise< Page > {
+		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
+			throw new Error(
+				`This method only works in mobile viewport, current viewport: ${ envVariables.VIEWPORT_NAME } `
+			);
 		}
-		if ( ! target ) {
-			throw new Error( 'Preview target must be defined.' );
-		}
+		return await this.editorToolbarComponent.openMobilePreview();
+	}
 
+	/**
+	 * Launches the Preview as non-mobile viewport.
+	 *
+	 * For Desktop and Tablet viewports, this method will not return any value.
+	 * For Mobile viewport, an error is thrown.
+	 *
+	 * @param {PreviewOptions} target Target preview size.
+	 * @returns {Page|void} Handler for the Page object on mobile. Void otherwise.
+	 * @throws {Error} If the current viewport is not of Desktop or Tablet.
+	 */
+	async previewAsDesktop( target: PreviewOptions ): Promise< void > {
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			throw new Error(
+				`This method only works in non-mobile viewport, current viewport: ${ envVariables.VIEWPORT_NAME } `
+			);
+		}
 		await this.editorToolbarComponent.openDesktopPreview( target );
 	}
 

--- a/test/e2e/specs/blocks/blocks__jetpack-grow.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-grow.ts
@@ -16,10 +16,10 @@ import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
 	new BusinessHoursFlow( { day: 'Sat' } ),
-	new WhatsAppButtonFlow( { phoneNumber: 1234567890, buttonText: 'Porpoises swim happily' } ),
 	new ContactFormFlow( { nameLabel: 'Angry dolphins flip swiftly' } ),
 	new SubscribeFlow(),
 	new ContactInfoBlockFlow( { email: 'foo@example.com', phoneNumber: '(213) 621-0002' } ),
+	new WhatsAppButtonFlow( { phoneNumber: 1234567890, buttonText: 'Porpoises swim happily' } ),
 ];
 
 // Interacting with the Premium Content toolbar is currently broken on mobile, so only adding for desktop:

--- a/test/e2e/specs/editor/editor__navbar.ts
+++ b/test/e2e/specs/editor/editor__navbar.ts
@@ -15,6 +15,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
 	beforeAll( async () => {
 		page = await browser.newPage();
 		gutenbergEditorPage = new GutenbergEditorPage( page );
+
 		const testAccount = new TestAccount( 'simpleSitePersonalPlanUser' );
 		await testAccount.authenticate( page );
 	} );
@@ -24,7 +25,6 @@ describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
 	} );
 
 	it( 'Return to Calypso dashboard', async function () {
-		const gutenbergEditorPage = new GutenbergEditorPage( page );
-		await gutenbergEditorPage.returnToCalypsoDashboard();
+		await gutenbergEditorPage.exitEditor();
 	} );
 } );

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -80,31 +80,23 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Preview', function () {
-		let previewPage: Page;
+		let previewPage: Page | void;
 
 		// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional.
 		it( 'Close settings sidebar', async function () {
 			await editorSettingsSidebarComponent.closeSidebar();
 		} );
 
-		// The following two steps have conditiionals inside them, as how the
-		// Editor Preview behaves depends on the device type.
-		// On desktop and tablet, preview applies CSS attributes to modify the preview in-editor.
-		// On mobile web, preview button opens a new tab.
 		it( 'Launch preview', async function () {
-			if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-				previewPage = await gutenbergEditorPage.openPreviewAsMobile();
-			} else {
-				await gutenbergEditorPage.openPreviewAsDesktop( 'Mobile' );
-			}
+			previewPage = await gutenbergEditorPage.preview( 'Mobile' );
 		} );
 
-		skipItIf( envVariables.VIEWPORT_NAME === 'desktop' )( 'Close preview', async function () {
-			// Mobile path.
+		it( 'Close preview', async function () {
 			if ( previewPage ) {
+				// Mobile path - close the new page.
 				await previewPage.close();
-				// Desktop path.
 			} else {
+				// Desktop path - restore the Desktop view.
 				await gutenbergEditorPage.closePreview();
 			}
 		} );

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -80,7 +80,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Preview', function () {
-		let previewPage: Page | void;
+		let previewPage: Page;
 
 		// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional.
 		it( 'Close settings sidebar', async function () {
@@ -88,7 +88,11 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		} );
 
 		it( 'Launch preview', async function () {
-			previewPage = await gutenbergEditorPage.preview( 'Mobile' );
+			if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+				previewPage = await gutenbergEditorPage.previewAsMobile();
+			} else {
+				await gutenbergEditorPage.previewAsDesktop( 'Mobile' );
+			}
 		} );
 
 		it( 'Close preview', async function () {

--- a/test/e2e/specs/editor/editor__schedule.ts
+++ b/test/e2e/specs/editor/editor__schedule.ts
@@ -74,7 +74,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 
 		it( 'Publish post', async function () {
 			postURL = await gutenbergEditorPage.publish();
-			await gutenbergEditorPage.editorPublishPanelComponent.closePanel();
+			await gutenbergEditorPage.closeAllPanels();
 		} );
 
 		it( `View post as ${ accountName }`, async function () {

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -121,7 +121,7 @@ skipDescribeIf( isStagingOrProd )(
 		describe( 'Validate site metadata', function () {
 			it( 'Return to Calypso dashboard', async function () {
 				gutenbergEditorPage = new GutenbergEditorPage( page );
-				await gutenbergEditorPage.returnToCalypsoDashboard();
+				await gutenbergEditorPage.exitEditor();
 			} );
 
 			it( 'Navigate to settings', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors two new components out of GutenbergEditorPage:
- EditorToolbarComponent
- EditorNavSidebarComponent

Handling the top toolbar interactions and the editor navigation sidebar respectively.

Key changes:
- extract methods related to toolbar and navigation sidebar out of GutenbergEditorPage.
- update existing methods in GutenbergEditorPage to point to the extracted classes.

#### Testing instructions

Ensure that all following builds are green:
  - [x] WPCOM E2E (desktop)
  - [x] WPCOM E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release

Related to https://github.com/Automattic/wp-calypso/issues/60868.
Depends on https://github.com/Automattic/wp-calypso/pull/61431.
