### PR TITLE
Update switch to advanced message

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
@@ -39,7 +39,7 @@ export default function ConnectDomainStepSuggestedStart( {
 
 	const message = isSubdomain( domain )
 		? __(
-				'The easiest way to connect your subdomain is by changing name servers. But if you are unable to do this, then switch to our <a>advanced setup</a>, using A & CNAME records.'
+				'The easiest way to connect your subdomain is by changing NS records. But if you are unable to do this, then switch to our <a>advanced setup</a>, using A & CNAME records.'
 		  )
 		: __(
 				'This is the easiest way to connect your domain, using name servers. If needed you can also use our <a>advanced setup</a>, using root A & CNAME records.'
@@ -70,7 +70,7 @@ export default function ConnectDomainStepSuggestedStart( {
 				header={
 					<div>
 						<Icon icon={ info } size={ 24 } />
-						{ __( 'Any services connected to this domain?' ) }
+						{ __( 'Do you have email or other services connected to this domain?' ) }
 					</div>
 				}
 				/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
@@ -39,7 +39,7 @@ export default function ConnectDomainStepSuggestedStart( {
 
 	const message = isSubdomain( domain )
 		? __(
-				"This is the easiest way to connect your subdomain, using NS records. Can't set NS records on your subdomain? Switch to our <a>advanced setup</a>, using A & CNAME records."
+				'The easiest way to connect your subdomain is by changing name servers. But if you are unable to do this, then switch to our <a>advanced setup</a>, using A & CNAME records.'
 		  )
 		: __(
 				'This is the easiest way to connect your domain, using name servers. If needed you can also use our <a>advanced setup</a>, using root A & CNAME records.'

--- a/client/components/domains/connect-domain-step/connect-domain-step-switch-setup-info-link.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-switch-setup-info-link.jsx
@@ -26,7 +26,7 @@ export default function ConnectDomainStepSwitchSetupInfoLink( {
 		setPage( isSubdomain ? stepSlug.SUBDOMAIN_SUGGESTED_START : stepSlug.SUGGESTED_START );
 
 	const switchToAdvancedSetupMessage = isSubdomain
-		? __( "Can't set NS records on your subdomain? Switch to our <a>advanced setup</a>." )
+		? __( "Can't set NS records for your subdomain? Switch to our <a>advanced setup</a>." )
 		: __( 'Switch to our <a>advanced setup</a>.' );
 
 	const message =

--- a/client/components/domains/connect-domain-step/connect-domain-step-switch-setup-info-link.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-switch-setup-info-link.jsx
@@ -25,6 +25,10 @@ export default function ConnectDomainStepSwitchSetupInfoLink( {
 	const switchToSuggestedSetup = () =>
 		setPage( isSubdomain ? stepSlug.SUBDOMAIN_SUGGESTED_START : stepSlug.SUGGESTED_START );
 
+	const switchToAdvancedSetupMessage = isSubdomain
+		? __( "Can't set NS records on your subdomain? Switch to our <a>advanced setup</a>." )
+		: __( 'Switch to our <a>advanced setup</a>.' );
+
 	const message =
 		modeType.ADVANCED === currentMode ? (
 			<span className={ baseClassName + '__text' }>
@@ -34,7 +38,7 @@ export default function ConnectDomainStepSwitchSetupInfoLink( {
 			</span>
 		) : (
 			<span className={ baseClassName + '__text' }>
-				{ createInterpolateElement( __( 'Switch to our <a>advanced setup</a>.' ), {
+				{ createInterpolateElement( switchToAdvancedSetupMessage, {
 					a: createElement( 'a', { onClick: switchToAdvancedSetup } ),
 				} ) }
 			</span>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Attempt to clarify when a user may want to switch to the advanced domain connection setup. 

#### Testing instructions

Attempt to connect a subdomain to a site. Make sure you see the following messages on the first screen of the connect a domain flow page.

<img width="1125" alt="Connect_a_Domain_Setup_‹_A8C_Test_Site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/155803306-d10e5e1b-3d49-48a0-9090-f13c9048ef35.png">


Also, try clicking on the "Please try this setup again" link on the domains list page for  a connected subdomain that isn't pointing to WPCOM.  Make sure that the message switch to the advanced setup at the bottom of the page includes the question about the name servers.

<img width="896" alt="Connect_a_Domain_Setup_‹_A8C_Test_Site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/155803163-566f2259-eabc-474b-85e0-c52d0caa1e14.png">

When setting up a second-level domain, make sure that the footer text doesn't show the info about name servers.

<img width="1139" alt="Connect_a_Domain_Setup_‹_A8C_Test_Site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/155793708-bb91eb9b-370b-4cb7-95cb-5d7337c6263e.png">

