### PR TITLE
Fix: Product/Plan Management URL in Overlap Notice

### DIFF
--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -11,7 +11,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Notice from 'calypso/components/notice';
-import { managePurchase } from 'calypso/me/purchases/paths';
+import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
@@ -109,7 +109,7 @@ class ProductPlanOverlapNotices extends Component {
 		return (
 			<li key={ productSlug }>
 				<a
-					href={ managePurchase( productPurchase.domain, productPurchase.id ) }
+					href={ getManagePurchaseUrlFor( productPurchase.domain, productPurchase.id ) }
 					onClick={ () => this.clickPurchaseHandler( productSlug ) }
 				>
 					{ this.getProductName( productSlug ) }


### PR DESCRIPTION
This PR addresses a bug in Jetpack Cloud where the plan/product overlap notice would link to an invalid/404 page. This was due to the URL using the `/me` structure from calypso blue, which is valid in the context of WordPress.com but not Jetpack Cloud.

![Screen Shot 2022-02-27 at 10 25 51 AM](https://user-images.githubusercontent.com/10933065/155892825-1d217e2d-a40a-4113-a382-bf3212efb8c5.jpg)

#### Changes proposed in this Pull Request

* Changes the manage plan/product URL from `/me/purchases/{siteName}/{purchaseId}` to `/purchases/subscriptions/{siteName}/{purchaseId}` by replacing the usage of `managePurchase()` from `client/me/purchases/paths.js` with `getManagePurchaseUrlFor()` from `client/my-sites/purchases/paths`.

#### Additional Notes

* This is my first PR dealing with shared paths between calypso blue and green, so extra scrutiny is very welcome. I there any issue with pulling paths from `/my-sites` for use in `/blocks`?

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a new WordPress installation with Jetpack installed.
* Connect Jetpack and purchase two overlapping products. 
  i.e. purchase Jetpack Backup (10 GB) and then upgrade to Jetpack Security (10GB).
* Run `yarn start` and `yarn-start-jetpack-cloud-p` in two separate terminals.
* Open http://calypso.localhost:3000/purchases/ and select your newly created site.
* Verify the overlap notice appears, and that the link to the redundant product or plan works.
* Open http://jetpack.cloud.localhost:3001/purchases and select your newly created site.
* Verify the overlap notice appears, and that the link to the redundant plan leads to a 404 page.
* `git checkout fix/overlap-notice-manage-url`
* Verify the link works in both calypso and jetpack cloud.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1164141197617539-as-1201857762851565