### PR TITLE
Checkout: Fix display of plan overlap notices for backup-related plans

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/cart-plan-overlaps-owned-product-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/cart-plan-overlaps-owned-product-notice.tsx
@@ -1,6 +1,6 @@
 import { getJetpackProductDisplayName } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, FunctionComponent } from 'react';
+import { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import PrePurchaseNotice from './prepurchase-notice';
@@ -38,7 +38,7 @@ const CartPlanOverlapsOwnedProductNotice: FunctionComponent< Props > = ( {
 			comment: 'The `product` variable refers to the product the customer owns already',
 			components: {
 				link: <a href={ subscriptionUrl } />,
-				product: getJetpackProductDisplayName( product ) as ReactElement,
+				product: <>{ getJetpackProductDisplayName( product ) }</>,
 			},
 		}
 	);

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -5,9 +5,11 @@ import {
 	isJetpackPlanSlug,
 } from '@automattic/calypso-products';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import { useSelector } from 'react-redux';
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { requestRewindCapabilities } from 'calypso/state/rewind/capabilities/actions';
 import {
 	isPlanIncludingSiteBackup,
 	isBackupProductIncludedInSitePlan,
@@ -30,12 +32,19 @@ import './style.scss';
  * from a range of possible options.
  */
 const PrePurchaseNotices = () => {
+	const dispatch = useDispatch();
+
 	const selectedSite = useSelector( getSelectedSite );
 	const siteId = selectedSite?.ID;
 
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const cartItemSlugs = responseCart.products.map( ( item ) => item.product_slug );
+
+	useEffect( () => {
+		if ( ! siteId ) return;
+		dispatch( requestRewindCapabilities( siteId ) );
+	}, [ dispatch, siteId ] );
 
 	const currentSitePlan = useSelector( ( state ) => {
 		if ( ! siteId ) {

--- a/client/state/sites/products/conflicts.ts
+++ b/client/state/sites/products/conflicts.ts
@@ -21,20 +21,28 @@ import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabiliti
 import { getSitePlanSlug } from 'calypso/state/sites/selectors';
 import type { AppState } from 'calypso/types';
 
+const DAILY_BACKUP_FEATURES = [
+	FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
+	FEATURE_JETPACK_BACKUP_DAILY,
+];
+
+const REALTIME_BACKUP_FEATURES = [
+	FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
+	FEATURE_JETPACK_BACKUP_REALTIME,
+	FEATURE_JETPACK_BACKUP_T1_MONTHLY,
+	FEATURE_JETPACK_BACKUP_T1_YEARLY,
+	FEATURE_JETPACK_BACKUP_T2_MONTHLY,
+	FEATURE_JETPACK_BACKUP_T2_YEARLY,
+];
+
 /**
  * Check is a Jetpack plan is including a daily backup feature.
  *
  * @param {string} planSlug The plan slug.
  * @returns {boolean} True if the plan includes a daily backup feature.
  */
-export const planHasDailyBackup = ( planSlug: string ): boolean => {
-	const DAILY_BACKUP_FEATURES = [
-		FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
-		FEATURE_JETPACK_BACKUP_DAILY,
-	];
-
-	return planHasAtLeastOneFeature( planSlug, DAILY_BACKUP_FEATURES );
-};
+export const planHasDailyBackup = ( planSlug: string ): boolean =>
+	planHasAtLeastOneFeature( planSlug, DAILY_BACKUP_FEATURES );
 
 /**
  * Check is a Jetpack plan is including a real-time backup feature.
@@ -42,18 +50,8 @@ export const planHasDailyBackup = ( planSlug: string ): boolean => {
  * @param {string} planSlug The plan slug.
  * @returns {boolean} True if the plan includes a real-time backup feature.
  */
-export const planHasRealTimeBackup = ( planSlug: string ): boolean => {
-	const REALTIME_BACKUP_FEATURES = [
-		FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
-		FEATURE_JETPACK_BACKUP_REALTIME,
-		FEATURE_JETPACK_BACKUP_T1_MONTHLY,
-		FEATURE_JETPACK_BACKUP_T1_YEARLY,
-		FEATURE_JETPACK_BACKUP_T2_MONTHLY,
-		FEATURE_JETPACK_BACKUP_T2_YEARLY,
-	];
-
-	return planHasAtLeastOneFeature( planSlug, REALTIME_BACKUP_FEATURES );
-};
+export const planHasRealTimeBackup = ( planSlug: string ): boolean =>
+	planHasAtLeastOneFeature( planSlug, REALTIME_BACKUP_FEATURES );
 
 /**
  * Check if a Jetpack plan is including a Backup product a site might already have.

--- a/client/state/sites/products/conflicts.ts
+++ b/client/state/sites/products/conflicts.ts
@@ -22,12 +22,10 @@ import {
 	PRODUCT_JETPACK_BACKUP_REALTIME,
 	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
-	PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
-	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
-	PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
-	PRODUCT_JETPACK_BACKUP_T2_YEARLY,
 } from '@automattic/calypso-products';
 import { createSelector } from '@automattic/state-utils';
+import { useSelector } from 'react-redux';
+import { siteHasRealtimeBackups } from 'calypso/state/rewind/selectors';
 import { hasSiteProduct, getSitePlanSlug } from 'calypso/state/sites/selectors';
 import type { AppState } from 'calypso/types';
 
@@ -46,14 +44,7 @@ export const isPlanIncludingSiteBackup = createSelector(
 		}
 
 		const hasBackup = hasSiteProduct( state, siteId, [ ...JETPACK_BACKUP_PRODUCTS ] );
-		const hasRealTimeBackup = hasSiteProduct( state, siteId, [
-			PRODUCT_JETPACK_BACKUP_REALTIME,
-			PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
-			PRODUCT_JETPACK_BACKUP_T1_YEARLY,
-			PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
-			PRODUCT_JETPACK_BACKUP_T2_YEARLY,
-			PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
-		] );
+		const hasRealTimeBackup = useSelector( ( state ) => siteHasRealtimeBackups( state, siteId ) );
 
 		if ( ! hasBackup ) {
 			return false;

--- a/client/state/sites/products/conflicts.ts
+++ b/client/state/sites/products/conflicts.ts
@@ -3,6 +3,7 @@ import {
 	planHasSuperiorFeature,
 	FEATURE_JETPACK_BACKUP_REALTIME,
 	FEATURE_JETPACK_BACKUP_DAILY,
+	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_PLANS,
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_BUSINESS,
@@ -21,6 +22,10 @@ import {
 	PRODUCT_JETPACK_BACKUP_REALTIME,
 	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+	PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_T2_YEARLY,
 } from '@automattic/calypso-products';
 import { createSelector } from '@automattic/state-utils';
 import { hasSiteProduct, getSitePlanSlug } from 'calypso/state/sites/selectors';
@@ -40,16 +45,17 @@ export const isPlanIncludingSiteBackup = createSelector(
 			return null;
 		}
 
-		const hasDailyBackup = hasSiteProduct( state, siteId, [
-			PRODUCT_JETPACK_BACKUP_DAILY,
-			PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
-		] );
+		const hasBackup = hasSiteProduct( state, siteId, [ ...JETPACK_BACKUP_PRODUCTS ] );
 		const hasRealTimeBackup = hasSiteProduct( state, siteId, [
 			PRODUCT_JETPACK_BACKUP_REALTIME,
 			PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+			PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+			PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
+			PRODUCT_JETPACK_BACKUP_T2_YEARLY,
+			PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
 		] );
 
-		if ( ! hasDailyBackup && ! hasRealTimeBackup ) {
+		if ( ! hasBackup ) {
 			return false;
 		}
 

--- a/client/state/sites/products/conflicts.ts
+++ b/client/state/sites/products/conflicts.ts
@@ -1,33 +1,59 @@
 import {
 	planHasFeature,
+	planHasAtLeastOneFeature,
 	planHasSuperiorFeature,
 	FEATURE_JETPACK_BACKUP_REALTIME,
 	FEATURE_JETPACK_BACKUP_DAILY,
-	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_PLANS,
-	PLAN_JETPACK_FREE,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_SECURITY_DAILY,
-	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
-	PLAN_JETPACK_SECURITY_REALTIME,
-	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
-	PLAN_JETPACK_COMPLETE,
-	PLAN_JETPACK_COMPLETE_MONTHLY,
 	PRODUCT_JETPACK_BACKUP_DAILY,
 	PRODUCT_JETPACK_BACKUP_REALTIME,
 	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+	FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
+	FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
+	FEATURE_JETPACK_BACKUP_T1_MONTHLY,
+	FEATURE_JETPACK_BACKUP_T1_YEARLY,
+	FEATURE_JETPACK_BACKUP_T2_MONTHLY,
+	FEATURE_JETPACK_BACKUP_T2_YEARLY,
 } from '@automattic/calypso-products';
 import { createSelector } from '@automattic/state-utils';
-import { useSelector } from 'react-redux';
-import { siteHasRealtimeBackups } from 'calypso/state/rewind/selectors';
-import { hasSiteProduct, getSitePlanSlug } from 'calypso/state/sites/selectors';
+import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
+import { getSitePlanSlug } from 'calypso/state/sites/selectors';
 import type { AppState } from 'calypso/types';
+
+/**
+ * Check is a Jetpack plan is including a daily backup feature.
+ *
+ * @param {string} planSlug The plan slug.
+ * @returns {boolean} True if the plan includes a daily backup feature.
+ */
+export const planHasDailyBackup = ( planSlug: string ): boolean => {
+	const DAILY_BACKUP_FEATURES = [
+		FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
+		FEATURE_JETPACK_BACKUP_DAILY,
+	];
+
+	return planHasAtLeastOneFeature( planSlug, DAILY_BACKUP_FEATURES );
+};
+
+/**
+ * Check is a Jetpack plan is including a real-time backup feature.
+ *
+ * @param {string} planSlug The plan slug.
+ * @returns {boolean} True if the plan includes a real-time backup feature.
+ */
+export const planHasRealTimeBackup = ( planSlug: string ): boolean => {
+	const REALTIME_BACKUP_FEATURES = [
+		FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
+		FEATURE_JETPACK_BACKUP_REALTIME,
+		FEATURE_JETPACK_BACKUP_T1_MONTHLY,
+		FEATURE_JETPACK_BACKUP_T1_YEARLY,
+		FEATURE_JETPACK_BACKUP_T2_MONTHLY,
+		FEATURE_JETPACK_BACKUP_T2_YEARLY,
+	];
+
+	return planHasAtLeastOneFeature( planSlug, REALTIME_BACKUP_FEATURES );
+};
 
 /**
  * Check if a Jetpack plan is including a Backup product a site might already have.
@@ -43,33 +69,21 @@ export const isPlanIncludingSiteBackup = createSelector(
 			return null;
 		}
 
-		const hasBackup = hasSiteProduct( state, siteId, [ ...JETPACK_BACKUP_PRODUCTS ] );
-		const hasRealTimeBackup = useSelector( ( state ) => siteHasRealtimeBackups( state, siteId ) );
+		const capabilities = getRewindCapabilities( state, siteId );
+		const siteHasBackup = Array.isArray( capabilities ) && capabilities.includes( 'backup' );
+		const siteHasRealTimeBackup =
+			Array.isArray( capabilities ) && capabilities.includes( 'backup-realtime' );
 
-		if ( ! hasBackup ) {
+		if ( ! siteHasBackup && ! siteHasRealTimeBackup ) {
 			return false;
 		}
 
-		switch ( planSlug ) {
-			case PLAN_JETPACK_FREE:
-				return false;
-			case PLAN_JETPACK_PERSONAL:
-			case PLAN_JETPACK_PERSONAL_MONTHLY:
-			case PLAN_JETPACK_PREMIUM:
-			case PLAN_JETPACK_PREMIUM_MONTHLY:
-			case PLAN_JETPACK_SECURITY_DAILY:
-			case PLAN_JETPACK_SECURITY_DAILY_MONTHLY:
-				if ( hasRealTimeBackup ) {
-					return false;
-				}
-				return true;
-			case PLAN_JETPACK_BUSINESS:
-			case PLAN_JETPACK_BUSINESS_MONTHLY:
-			case PLAN_JETPACK_SECURITY_REALTIME:
-			case PLAN_JETPACK_SECURITY_REALTIME_MONTHLY:
-			case PLAN_JETPACK_COMPLETE:
-			case PLAN_JETPACK_COMPLETE_MONTHLY:
-				return true;
+		if ( siteHasRealTimeBackup && planHasRealTimeBackup( planSlug ) ) {
+			return true;
+		}
+
+		if ( siteHasBackup && ! siteHasRealTimeBackup && planHasDailyBackup( planSlug ) ) {
+			return true;
 		}
 
 		return false;
@@ -78,14 +92,7 @@ export const isPlanIncludingSiteBackup = createSelector(
 		( state: AppState, siteId: number | null, planSlug: string ) => [
 			siteId,
 			planSlug,
-			hasSiteProduct( state, siteId, [
-				PRODUCT_JETPACK_BACKUP_DAILY,
-				PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
-			] ),
-			hasSiteProduct( state, siteId, [
-				PRODUCT_JETPACK_BACKUP_REALTIME,
-				PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
-			] ),
+			getRewindCapabilities( state, siteId ),
 		],
 	]
 );

--- a/client/state/sites/products/test/conflicts.ts
+++ b/client/state/sites/products/test/conflicts.ts
@@ -1,0 +1,55 @@
+import {
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_SECURITY_DAILY,
+	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_YEARLY,
+	PLAN_JETPACK_SECURITY_T2_MONTHLY,
+	PLAN_JETPACK_SECURITY_T2_YEARLY,
+} from '@automattic/calypso-products';
+import { planHasDailyBackup, planHasRealTimeBackup } from '../conflicts';
+
+const plansWithDailyBackup = [
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_SECURITY_DAILY,
+	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+];
+
+const plansWithRealTimeBackup = [
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_YEARLY,
+	PLAN_JETPACK_SECURITY_T2_MONTHLY,
+	PLAN_JETPACK_SECURITY_T2_YEARLY,
+];
+
+describe( 'conflicts', () => {
+	test( 'Plans and products that have daily backups return true for plansWithDailyBackup', () => {
+		plansWithDailyBackup.forEach( ( plan ) => {
+			expect( planHasDailyBackup( plan ) ).toBe( true );
+		} );
+	} );
+
+	test( 'Plans and products that have real-time backups return true for plansWithRealTimeBackup', () => {
+		plansWithRealTimeBackup.forEach( ( plan ) => {
+			expect( planHasRealTimeBackup( plan ) ).toBe( true );
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR addresses a bug where the `<CartPlanOverlapsOwnedProductNotice />` component was not being displayed when a user has a plan in their cart that overlaps with an existing plan active on their site that already contains equivalent backup features.
  * The previous code used fixed lists of Jetpack products to compare the current cart plan against the existing site plan when checking for potential overlaps. These lists have become outdated after the addition of new Jetpack plans during the shift to offering real-time backup on all plans. 
  * The new approach suggested by this PR is to use the site's rewind capabilities, and the cart plan's available features, to determine if there is an overlap in backup functionality.
  * This new approach identifies an overlap when the cart and site plan both include real-time backup, or both include daily backup. If a cart item includes daily backup, and the site plan includes real-time backup, it will not consider that an overlap.
  * This requires an additional API call via `requestRewindCapabilities()`.
* This PR also addresses a bug where the `translate()` used in the `<CartPlanOverlapsOwnedProductNotice />` was not injecting the components into the final string.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a new JN site, activate Jetpack and purchase Jetpack Backup (10GB).
* Add Jetpack Security to your cart.
* Verify the pre-purchase notice is displayed:

<img width="593" alt="Screen Shot 2022-03-02 at 2 05 24 PM" src="https://user-images.githubusercontent.com/10933065/156449565-127369ca-8172-4778-9a85-0cf185a68774.png">

* Verify tests pass: `yarn test-client client/state/sites/products/test/conflicts.ts`


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1164141197617539-as-1201857762851565