### PR TITLE
Update the Jetpack connection support link

### DIFF
--- a/client/components/jetpack/jetpack-disconnected-wpcom/index.tsx
+++ b/client/components/jetpack/jetpack-disconnected-wpcom/index.tsx
@@ -7,7 +7,7 @@ import ExternalLink from 'calypso/components/external-link';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import { preventWidows } from 'calypso/lib/formatting';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
-import { JETPACK_SUPPORT } from 'calypso/lib/url/support';
+import { JETPACK_SUPPORT_CONNECTION_ISSUES } from 'calypso/lib/url/support';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -54,7 +54,7 @@ const JetpackDisconnectedWPCOM: FunctionComponent = () => {
 				</Button>
 				<Button
 					className="jetpack-disconnected-wpcom__cta"
-					href={ JETPACK_SUPPORT }
+					href={ JETPACK_SUPPORT_CONNECTION_ISSUES }
 					onClick={ onSupportClick }
 				>
 					{ translate( 'I need help' ) }

--- a/client/components/jetpack/jetpack-disconnected/index.tsx
+++ b/client/components/jetpack/jetpack-disconnected/index.tsx
@@ -5,7 +5,7 @@ import JetpackDisconnectedSVG from 'calypso/assets/images/jetpack/disconnected-g
 import ExternalLink from 'calypso/components/external-link';
 import Upsell from 'calypso/components/jetpack/upsell';
 import { preventWidows } from 'calypso/lib/formatting';
-import { JETPACK_SUPPORT } from 'calypso/lib/url/support';
+import { JETPACK_SUPPORT_CONNECTION_ISSUES } from 'calypso/lib/url/support';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
@@ -50,7 +50,7 @@ const JetpackDisconnected: FunctionComponent = () => {
 			buttonText={ translate( 'Reconnect Jetpack' ) }
 			onClick={ () => dispatch( recordTracksEvent( 'calypso_jetpack_backup_reconnect_click' ) ) }
 			iconComponent={ <JetpackDisconnectedIcon /> }
-			secondaryButtonLink={ JETPACK_SUPPORT }
+			secondaryButtonLink={ JETPACK_SUPPORT_CONNECTION_ISSUES }
 			secondaryButtonText={ translate( 'I need help' ) }
 			secondaryOnClick={ () =>
 				dispatch( recordTracksEvent( 'calypso_jetpack_backup_support_click' ) )

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -39,6 +39,8 @@ export const GDPR_POLICIES = `${ root }/your-site-and-the-gdpr`;
 export const GSUITE_LEARNING_CENTER = 'https://workspace.google.com/learning-center/';
 export const HTTPS_SSL = `${ root }/https-ssl`;
 export const JETPACK_SUPPORT = 'https://jetpack.com/support/';
+export const JETPACK_SUPPORT_CONNECTION_ISSUES =
+	'https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/';
 export const JETPACK_CONTACT_SUPPORT = 'https://jetpack.com/contact-support/?rel=support';
 export const JETPACK_PRICING_PAGE = 'https://jetpack.com/pricing/';
 export const JETPACK_SERVICE_VAULTPRESS = 'https://help.vaultpress.com/install-vaultpress/';


### PR DESCRIPTION
Addresses 1201868942120840-as-1201868942120865/f

#### Changes proposed in this Pull Request

* This PR updates the support link for Jetpack connection issues to https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/

#### Testing instructions

* Create a JN site and set up Jetpack Backup
* Deactivate Jetpack plugin from wp-admin
* Boot up this PR and run `yarn start-jetpack-cloud-p`
* Goto `http://jetpack.cloud.localhost:3001/backup/:site`
* Check the connection link