### PR TITLE
Show site disconnection error message from the API error response

### DIFF
--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -176,11 +176,12 @@ class DisconnectJetpack extends PureComponent {
 				);
 				this.props.recordGoogleEvent( 'Jetpack', 'Successfully Disconnected' );
 			},
-			() => {
+			( err ) => {
 				removeInfoNotice( notice.noticeId );
-				showErrorNotice(
-					translate( '%(siteName)s failed to disconnect', { args: { siteName: siteTitle } } )
-				);
+				const errorMessage =
+					( err && err.message ) ||
+					translate( '%(siteName)s failed to disconnect', { args: { siteName: siteTitle } } );
+				showErrorNotice( errorMessage );
 				this.props.recordGoogleEvent( 'Jetpack', 'Failed Disconnected Site' );
 			}
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show site disconnection failure error message from the API response instead of showing a generic hard-coded message.

#### Testing instructions

* Create a JN site
* Go to wp-admin -> Plugins and deactivate Jetpack plugin
* Download Jetpack backup plugin from [here](https://github.com/Automattic/jetpack/tree/master/projects/plugins/backup) and install and activate it.
* Connect Jetpack
* Go to Settings -> Manage Connection
* Try to disconnect the site, it should now show an error - `Please login to {{Site}} directly to disconnect it from your account.` as shown in the screenshot below.
* The text coming from the endpoint is already translated ✅ 

<img width="748" alt="Screenshot 2022-02-28 at 11 40 12 AM" src="https://user-images.githubusercontent.com/10586875/155936485-103852ce-4968-4905-809a-7acb76ce9673.png">

Related to 1164141197617539-as-1201726523088193