### PR TITLE
Fix breadcrumb state

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -163,7 +163,7 @@ class ActivityLog extends Component {
 	}
 
 	initializeBreadcrumbs() {
-		this.props.updateBreadcrumbs( [
+		this.props.updateBreadcrumbs( this.props.siteId, [
 			{
 				label: this.props.translate( 'Activity Log' ),
 				href: `/activity-log/${ this.props.slug || '' }`,

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -222,7 +222,7 @@ function PluginDetails( props ) {
 				} )
 			);
 		}
-	}, [ fullPlugin.name, props.pluginSlug, selectedSite ] );
+	}, [ fullPlugin?.name, fullPlugin?.slug, selectedSite?.ID ] );
 
 	const getPageTitle = () => {
 		return translate( '%(pluginName)s Plugin', {

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -159,6 +159,7 @@ function PluginDetails( props ) {
 			...wpcomPlugin,
 			...wporgPlugin,
 			...plugin,
+			slug: wpcomPlugin?.slug || wporgPlugin?.slug,
 			fetched: wpcomPlugin?.fetched || wporgPlugin?.fetched,
 			isMarketplaceProduct,
 		};

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -197,10 +197,6 @@ function PluginDetails( props ) {
 	] );
 
 	useEffect( () => {
-		if ( ! selectedSite ) {
-			return;
-		}
-
 		// If no breadcrumb set (eg directly loading this page), add the first breadcrumb part.
 		if ( breadcrumbs.length === 0 ) {
 			dispatch(

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -197,6 +197,11 @@ function PluginDetails( props ) {
 	] );
 
 	useEffect( () => {
+		if ( ! selectedSite ) {
+			return;
+		}
+
+		// If no breadcrumb set (eg directly loading this page), add the first breadcrumb part.
 		if ( breadcrumbs.length === 0 ) {
 			dispatch(
 				appendBreadcrumb( selectedSite?.ID, {
@@ -207,12 +212,13 @@ function PluginDetails( props ) {
 			);
 		}
 
-		if ( fullPlugin.name && props.pluginSlug ) {
+		// When plugin data are loaded, add the next breadrumb part.
+		if ( fullPlugin.name && fullPlugin.slug ) {
 			dispatch(
 				appendBreadcrumb( selectedSite?.ID, {
 					label: fullPlugin.name,
-					href: `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }`,
-					id: `plugin-${ props.pluginSlug }`,
+					href: `/plugins/${ fullPlugin.slug }/${ selectedSite?.slug || '' }`,
+					id: 'plugin',
 				} )
 			);
 		}

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -66,10 +66,9 @@ function PluginDetails( props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const breadcrumbs = useSelector( getBreadcrumbs );
-
 	// Site information.
 	const selectedSite = useSelector( getSelectedSite );
+	const breadcrumbs = useSelector( ( state ) => getBreadcrumbs( state, selectedSite?.ID ) );
 	const sitesWithPlugins = useSelector( getSelectedOrAllSitesWithPlugins );
 	const sites = useSelector( getSelectedOrAllSitesWithPlugins );
 	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
@@ -200,7 +199,7 @@ function PluginDetails( props ) {
 	useEffect( () => {
 		if ( breadcrumbs.length === 0 ) {
 			dispatch(
-				appendBreadcrumb( {
+				appendBreadcrumb( selectedSite?.ID, {
 					label: translate( 'Plugins' ),
 					href: `/plugins/${ selectedSite?.slug || '' }`,
 					id: 'plugins',
@@ -210,7 +209,7 @@ function PluginDetails( props ) {
 
 		if ( fullPlugin.name && props.pluginSlug ) {
 			dispatch(
-				appendBreadcrumb( {
+				appendBreadcrumb( selectedSite?.ID, {
 					label: fullPlugin.name,
 					href: `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }`,
 					id: `plugin-${ props.pluginSlug }`,

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -193,10 +193,6 @@ const PluginsBrowser = ( {
 	}, [ isJetpack, selectedSite, hasJetpack ] );
 
 	useEffect( () => {
-		if ( ! selectedSite?.ID ) {
-			return;
-		}
-
 		const items = [
 			{ label: translate( 'Plugins' ), href: `/plugins/${ siteSlug || '' }`, id: 'plugins' },
 		];

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -121,9 +121,8 @@ const PluginsBrowser = ( {
 	hideHeader,
 	doSearch,
 } ) => {
-	const breadcrumbs = useSelector( getBreadcrumbs );
-
 	const selectedSite = useSelector( getSelectedSite );
+	const breadcrumbs = useSelector( ( state ) => getBreadcrumbs( state, selectedSite?.ID ) );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 
 	// Billing period switcher.
@@ -194,6 +193,10 @@ const PluginsBrowser = ( {
 	}, [ isJetpack, selectedSite, hasJetpack ] );
 
 	useEffect( () => {
+		if ( ! selectedSite?.ID ) {
+			return;
+		}
+
 		const items = [
 			{ label: translate( 'Plugins' ), href: `/plugins/${ siteSlug || '' }`, id: 'plugins' },
 		];
@@ -212,8 +215,8 @@ const PluginsBrowser = ( {
 			} );
 		}
 
-		dispatch( updateBreadcrumbs( items ) );
-	}, [ siteSlug, search, category, dispatch, translate ] );
+		dispatch( updateBreadcrumbs( selectedSite?.ID, items ) );
+	}, [ siteSlug, search, category, dispatch, translate, selectedSite?.ID ] );
 
 	const trackSiteDisconnect = () =>
 		composeAnalytics(

--- a/client/state/breadcrumb/actions.js
+++ b/client/state/breadcrumb/actions.js
@@ -6,22 +6,25 @@ import {
 
 import 'calypso/state/breadcrumb/init';
 
-export function resetBreadcrumbs() {
+export function resetBreadcrumbs( siteId ) {
 	return {
 		type: BREADCRUMB_RESET_LIST,
+		siteId,
 	};
 }
 
-export function updateBreadcrumbs( items ) {
+export function updateBreadcrumbs( siteId, items ) {
 	return {
 		type: BREADCRUMB_UPDATE_LIST,
+		siteId,
 		items,
 	};
 }
 
-export function appendBreadcrumb( item ) {
+export function appendBreadcrumb( siteId, item ) {
 	return {
 		type: BREADCRUMB_APPEND_ITEM,
+		siteId,
 		item,
 	};
 }

--- a/client/state/breadcrumb/actions.js
+++ b/client/state/breadcrumb/actions.js
@@ -6,14 +6,14 @@ import {
 
 import 'calypso/state/breadcrumb/init';
 
-export function resetBreadcrumbs( siteId ) {
+export function resetBreadcrumbs( siteId = 0 ) {
 	return {
 		type: BREADCRUMB_RESET_LIST,
 		siteId,
 	};
 }
 
-export function updateBreadcrumbs( siteId, items ) {
+export function updateBreadcrumbs( siteId = 0, items ) {
 	return {
 		type: BREADCRUMB_UPDATE_LIST,
 		siteId,
@@ -21,7 +21,7 @@ export function updateBreadcrumbs( siteId, items ) {
 	};
 }
 
-export function appendBreadcrumb( siteId, item ) {
+export function appendBreadcrumb( siteId = 0, item ) {
 	return {
 		type: BREADCRUMB_APPEND_ITEM,
 		siteId,

--- a/client/state/breadcrumb/reducer.js
+++ b/client/state/breadcrumb/reducer.js
@@ -3,9 +3,10 @@ import {
 	BREADCRUMB_UPDATE_LIST,
 	BREADCRUMB_APPEND_ITEM,
 } from 'calypso/state/action-types';
+import { keyedReducer } from 'calypso/state/utils';
 
 // Stores the complete list of breadcrumbs in an array,
-export default ( state = [], action ) => {
+const breadcrumbs = ( state = [], action ) => {
 	switch ( action.type ) {
 		case BREADCRUMB_RESET_LIST:
 			return [];
@@ -24,3 +25,5 @@ export default ( state = [], action ) => {
 
 	return state;
 };
+
+export default keyedReducer( 'siteId', breadcrumbs );

--- a/client/state/breadcrumb/selectors.js
+++ b/client/state/breadcrumb/selectors.js
@@ -1,5 +1,5 @@
 import 'calypso/state/breadcrumb/init';
 
-export const getBreadcrumbs = ( state ) => {
-	return state.breadcrumbs;
+export const getBreadcrumbs = ( state, siteId ) => {
+	return state.breadcrumbs?.[ siteId ] || [];
 };

--- a/client/state/breadcrumb/selectors.js
+++ b/client/state/breadcrumb/selectors.js
@@ -1,5 +1,5 @@
 import 'calypso/state/breadcrumb/init';
 
-export const getBreadcrumbs = ( state, siteId ) => {
+export const getBreadcrumbs = ( state, siteId = 0 ) => {
 	return state.breadcrumbs?.[ siteId ] || [];
 };


### PR DESCRIPTION
While navigating in Calypso, I have noticed two bugs in breadcrumbs:
1. On some cases Plugin Title appears multiple times
<img width="1582" alt="CleanShot 2022-02-28 at 10 12 44@2x" src="https://user-images.githubusercontent.com/12430020/155947715-87b5d533-cb88-47ba-8dd6-133cea430f57.png">

2. When in Plugin Details and you switch sites, the breadcrumb will contain references to the previous site. Example:
- Go to `https://wordpress.com/plugins/woocommerce/Site1`
- Switch to `Site2` from the sidebar
- Click `Plugins` from the Fixed Header breadcrumb
- You will land to Plugins page of `Site1`, `https://wordpress.com/plugins/Site1`

#### Changes proposed in this Pull Request

1. Correctly adds `slug` to `fullPlugin`. It will either be the wpcom or the wporg `slug`. `slug` returned from the WordPress `plugins` endpoint might be slightly altered (p9o2xV-1Of-p2#comment-5485)
2. Use a `keyedReducer` with `siteId` as key so that sites have their own breadcrumb

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The first (1) issue has been resolved in #61625 just updated the implementation to use `fullPlugin` as source of truth (as we do in the rest of the file) rather than `pluginSlug` from `props`.

Follow the steps of issue (2) and make sure that navigating to a breadcrumb after switching site navigates you to the new site rather than the previous one. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->