### PR TITLE
Revert the code changes introduced for the domain copy test

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1290,13 +1290,11 @@ class RegisterDomainStep extends Component {
 	}
 
 	renderBestNamesPrompt() {
-		const { isCopyExperiment, translate } = this.props;
+		const { translate } = this.props;
 		return (
 			<div className="register-domain-step__example-prompt">
 				<Icon icon={ tip } size={ 20 } />
-				{ isCopyExperiment
-					? 'You’ll see many options below. Or, you can choose a domain later and start with a free wordpress.com address.'
-					: translate( 'The best names are short and memorable' ) }
+				{ translate( 'The best names are short and memorable' ) }
 			</div>
 		);
 	}

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -349,23 +349,6 @@ export default {
 			loadExperimentAssignment( 'registration_social_login_first_on_mobile_v3' );
 		}
 
-		const signupFlows = [
-			'onboarding',
-			'launch-site',
-			'free',
-			'personal',
-			'premium',
-			'business',
-			'ecommerce',
-			'personal-monthly',
-			'premium-monthly',
-			'business-monthly',
-			'ecommerce-monthly',
-		];
-		if ( signupFlows.includes( flowName ) ) {
-			loadExperimentAssignment( 'calypso_signup_domain_step_copy_test_202201_v2' );
-		}
-
 		context.primary = createElement( SignupComponent, {
 			store: context.store,
 			path: context.path,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -11,7 +11,6 @@ import RegisterDomainStep from 'calypso/components/domains/register-domain-step'
 import { recordUseYourDomainButtonClick } from 'calypso/components/domains/register-domain-step/analytics';
 import ReskinSideExplainer from 'calypso/components/domains/reskin-side-explainer';
 import UseMyDomain from 'calypso/components/domains/use-my-domain';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Notice from 'calypso/components/notice';
 import {
 	domainRegistration,
@@ -21,7 +20,6 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { getDomainProductSlug, TRUENAME_COUPONS, TRUENAME_TLDS } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { ProvideExperimentData } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -459,7 +457,7 @@ class DomainsStep extends Component {
 		);
 	};
 
-	domainForm = ( isDomainStepCopyTreatment ) => {
+	domainForm = () => {
 		let initialState = {};
 		if ( this.props.step ) {
 			initialState = this.props.step.domainForm;
@@ -539,20 +537,11 @@ class DomainsStep extends Component {
 						this.props.forceHideFreeDomainExplainerAndStrikeoutUi
 					}
 					isReskinned={ this.props.isReskinned }
-					isCopyExperiment={ isDomainStepCopyTreatment }
 					reskinSideContent={ this.getSideContent() }
 				/>
 			</CalypsoShoppingCartProvider>
 		);
 	};
-
-	renderLoading() {
-		return (
-			<div className="domains__loading">
-				<LoadingEllipsis active />
-			</div>
-		);
-	}
 
 	onUseMyDomainConnect = ( { domain } ) => {
 		this.handleAddMapping( 'useYourDomainForm', domain );
@@ -603,7 +592,7 @@ class DomainsStep extends Component {
 		);
 	};
 
-	getSubHeaderText( isDomainStepCopyTreatment ) {
+	getSubHeaderText() {
 		const {
 			flowName,
 			isAllDomains,
@@ -618,14 +607,7 @@ class DomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
-			if ( ! stepSectionName && isDomainStepCopyTreatment ) {
-				return 'A domain name is a first step in branding your website, and helps you choose your web address, too.';
-			}
-
-			return (
-				! stepSectionName &&
-				translate( "Enter your site's name or some descriptive keywords to get started" )
-			);
+			return ! stepSectionName && translate( 'Enter some descriptive keywords to get started' );
 		}
 
 		const subHeaderPropertyName = 'signUpFlowDomainsStepSubheader';
@@ -643,7 +625,7 @@ class DomainsStep extends Component {
 			: translate( "Enter your site's name or some keywords that describe it to get started." );
 	}
 
-	getHeaderText( isDomainStepCopyTreatment ) {
+	getHeaderText() {
 		const {
 			headerText,
 			isAllDomains,
@@ -658,9 +640,6 @@ class DomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
-			if ( isDomainStepCopyTreatment && ! stepSectionName ) {
-				return 'Find a domain';
-			}
 			return ! stepSectionName && translate( 'Choose a domain' );
 		}
 
@@ -673,7 +652,7 @@ class DomainsStep extends Component {
 		return this.props.isDomainOnly ? 'domain-first' : 'signup';
 	}
 
-	renderContent( isDomainStepCopyTreatment ) {
+	renderContent() {
 		let content;
 		let sideContent;
 
@@ -682,7 +661,7 @@ class DomainsStep extends Component {
 		}
 
 		if ( ! this.props.stepSectionName || this.props.isDomainOnly ) {
-			content = this.domainForm( isDomainStepCopyTreatment );
+			content = this.domainForm();
 		}
 
 		if ( ! this.props.stepSectionName && this.props.isReskinned ) {
@@ -783,62 +762,33 @@ class DomainsStep extends Component {
 			}
 		}
 
-		const domainTestEligibleSignupFlows = [
-			'onboarding',
-			'launch-site',
-			'free',
-			'personal',
-			'premium',
-			'business',
-			'ecommerce',
-			'personal-monthly',
-			'premium-monthly',
-			'business-monthly',
-			'ecommerce-monthly',
-		];
+		const headerText = this.getHeaderText();
+		const fallbackSubHeaderText = this.getSubHeaderText();
 
 		return (
-			<ProvideExperimentData
-				name="calypso_signup_domain_step_copy_test_202201_v2"
-				options={ {
-					isEligible: domainTestEligibleSignupFlows.includes( this.props.flowName ),
-				} }
-			>
-				{ ( isLoading, experimentAssignment ) => {
-					if ( isLoading ) {
-						return this.renderLoading();
-					}
-					const isDomainStepCopyTreatment = experimentAssignment?.variationName === 'treatment';
-					const headerText = this.getHeaderText( isDomainStepCopyTreatment );
-					const fallbackSubHeaderText = this.getSubHeaderText( isDomainStepCopyTreatment );
-
-					return (
-						<StepWrapper
-							flowName={ this.props.flowName }
-							stepName={ this.props.stepName }
-							backUrl={ backUrl }
-							positionInFlow={ this.props.positionInFlow }
-							headerText={ headerText }
-							subHeaderText={ fallbackSubHeaderText }
-							isExternalBackUrl={ isExternalBackUrl }
-							fallbackHeaderText={ headerText }
-							fallbackSubHeaderText={ fallbackSubHeaderText }
-							stepContent={
-								<div>
-									{ ! this.props.productsLoaded && <QueryProductsList /> }
-									{ this.renderContent( isDomainStepCopyTreatment ) }
-								</div>
-							}
-							allowBackFirstStep={ !! backUrl }
-							backLabelText={ backLabelText }
-							hideSkip={ true }
-							goToNextStep={ this.handleSkip }
-							align={ isReskinned ? 'left' : 'center' }
-							isWideLayout={ isReskinned }
-						/>
-					);
-				} }
-			</ProvideExperimentData>
+			<StepWrapper
+				flowName={ this.props.flowName }
+				stepName={ this.props.stepName }
+				backUrl={ backUrl }
+				positionInFlow={ this.props.positionInFlow }
+				headerText={ headerText }
+				subHeaderText={ fallbackSubHeaderText }
+				isExternalBackUrl={ isExternalBackUrl }
+				fallbackHeaderText={ headerText }
+				fallbackSubHeaderText={ fallbackSubHeaderText }
+				stepContent={
+					<div>
+						{ ! this.props.productsLoaded && <QueryProductsList /> }
+						{ this.renderContent() }
+					</div>
+				}
+				allowBackFirstStep={ !! backUrl }
+				backLabelText={ backLabelText }
+				hideSkip={ true }
+				goToNextStep={ this.handleSkip }
+				align={ isReskinned ? 'left' : 'center' }
+				isWideLayout={ isReskinned }
+			/>
 		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Per the results posted in pbxNRc-18T-p2#comment-3073, we're deploying control for the domain copy experiment introduced in https://github.com/Automattic/wp-calypso/pull/59310. This PR wraps up the experiment.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that in the domain step of signup, `control` version copy is retained and that all experiment related code introduced in https://github.com/Automattic/wp-calypso/pull/59310 is removed.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


