### PR TITLE
Jetpack Cloud | Disable navigation to back in time on initial backup screen

### DIFF
--- a/client/my-sites/backup/backup-date-picker/hooks.ts
+++ b/client/my-sites/backup/backup-date-picker/hooks.ts
@@ -7,10 +7,16 @@ import { useIsDateVisible, useFirstMatchingBackupAttempt } from '../hooks';
 type CanGoToDateHook = (
 	siteId: number,
 	selectedDate: Moment,
-	oldestDateAvailable?: Moment
+	oldestDateAvailable?: Moment,
+	hasNoBackups?: boolean
 ) => ( desiredDate: Moment ) => boolean;
 
-export const useCanGoToDate: CanGoToDateHook = ( siteId, selectedDate, oldestDateAvailable ) => {
+export const useCanGoToDate: CanGoToDateHook = (
+	siteId,
+	selectedDate,
+	oldestDateAvailable,
+	hasNoBackups
+) => {
 	const moment = useLocalizedMoment();
 	const today = useDateWithOffset( moment() );
 	const selectedDateIsVisible = useIsDateVisible( siteId )( selectedDate );
@@ -28,6 +34,11 @@ export const useCanGoToDate: CanGoToDateHook = ( siteId, selectedDate, oldestDat
 				// past the limit of visible days, so we can show eligible
 				// users the opportunity to upgrade
 				if ( ! selectedDateIsVisible ) {
+					return false;
+				}
+
+				// If there are no backups, we won't show the navigation
+				if ( hasNoBackups ) {
 					return false;
 				}
 
@@ -51,7 +62,7 @@ export const useCanGoToDate: CanGoToDateHook = ( siteId, selectedDate, oldestDat
 			// then everything's fine (this should never happen)
 			return true;
 		},
-		[ selectedDateIsVisible, selectedDate, today, oldestDateAvailable ]
+		[ selectedDateIsVisible, selectedDate, today, oldestDateAvailable, hasNoBackups ]
 	);
 };
 

--- a/client/my-sites/backup/backup-date-picker/test/index.jsx
+++ b/client/my-sites/backup/backup-date-picker/test/index.jsx
@@ -26,6 +26,7 @@ jest.mock( '../hooks', () => ( {
 	...jest.requireActual( '../hooks' ),
 	useCanGoToDate: jest.fn(),
 } ) );
+jest.mock( 'calypso/state/selectors/get-rewind-backups' );
 
 import { shallow } from 'enzyme';
 import { useTranslate } from 'i18n-calypso';

--- a/client/my-sites/backup/status/index.jsx
+++ b/client/my-sites/backup/status/index.jsx
@@ -5,7 +5,7 @@ import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
 import MostRecentStatus from 'calypso/components/jetpack/daily-backup-status';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
-import isRewindBackupsInitialized from 'calypso/state/rewind/selectors/is-rewind-backups-initialized.ts';
+import isRewindBackupsInitialized from 'calypso/state/rewind/selectors/is-rewind-backups-initialized';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import { useIsDateVisible } from '../hooks';
 import { useDailyBackupStatus, useRealtimeBackupStatus } from './hooks';


### PR DESCRIPTION
Addresses 1164141197617539-as-1201605708683813/f

#### Changes proposed in this Pull Request

* This PR disables the navigation to older dates on Backup section of Jetpack Cloud on the initial backup.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot up this PR and run `yarn start` before running `yarn start-jetpack-cloud-p`
* Spin up a JN site and set up Jetpack with Backup plan
* Quickly goto `http://jetpack.cloud.localhost:3001/backup/:site`
* Confirm that you don't Date Navigation (Yesterday) button is disabled.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes 7185-gh-Automattic/jpop-issues


<img width="781" alt="Screenshot 2022-02-28 at 3 24 22 PM" src="https://user-images.githubusercontent.com/18226415/155973052-3cde30ec-72cc-4bdf-bdf6-d1c3665e14d2.png">