### PR TITLE
Use startsWith instead of includes to check the author profile.

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -306,7 +306,7 @@ export const WPORG_PROFILE_URL = 'https://profiles.wordpress.org/';
  * @returns {string|null} the author keyword
  */
 export function getPluginAuthorProfileKeyword( plugin ) {
-	if ( ! plugin?.author_profile?.includes( WPORG_PROFILE_URL ) ) {
+	if ( ! plugin?.author_profile?.startsWith( WPORG_PROFILE_URL ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use `startsWith` instead of `includes` to check the author's profile.

---

Related to https://github.com/Automattic/wp-calypso/pull/60977#discussion_r815819440
