### PR TITLE
DIFM Lite: Changes product name

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -197,7 +197,7 @@ class Site extends Component {
 						) }
 						{ site.options && site.options.is_difm_lite_in_progress && (
 							<span className="site__badge site__badge-domain-only">
-								{ translate( 'Do It For Me (Lite)' ) }
+								{ translate( 'Do It For Me' ) }
 							</span>
 						) }
 						{ shouldShowPublicComingSoonSiteBadge && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: pdh1Xd-xv-p2#comment-906

* This change removes "Lite" from the product name for Do It For Me.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase the DIFM product for a site or toggle the `difm-lite-in-progress` sticker via the Blog RC.
* Switch to the site and confirm that in the sidebar, the site has a "Do It For Me" badge.
<img width="257" alt="image" src="https://user-images.githubusercontent.com/5436027/155986498-cb92111d-eb91-4aeb-b8fd-51ab0657ad9a.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 0-as-1201857306873590/f