### PR TITLE
Nav Unification: Remove old sidebar (part 2)

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -8,9 +8,9 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import SiteIndicator from 'calypso/my-sites/site-indicator';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
-import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
@@ -104,14 +104,12 @@ class Site extends Component {
 		const { site, homeLink, translate } = this.props;
 		return (
 			<div className="site__domain">
-				{ /* eslint-disable-next-line no-nested-ternary */ }
-				{ this.props.isNavUnificationEnabled && ! isEnabled( 'jetpack-cloud' )
-					? site.domain
-					: homeLink
-					? translate( 'View %(domain)s', {
-							args: { domain: site.domain },
-					  } )
-					: site.domain }
+				{ isJetpackCloud() &&
+					homeLink &&
+					translate( 'View %(domain)s', {
+						args: { domain: site.domain },
+					} ) }
+				{ ( ! isJetpackCloud() || ! homeLink ) && site.domain }
 			</div>
 		);
 	};
@@ -238,7 +236,6 @@ function mapStateToProps( state, ownProps ) {
 		isPreviewable: isSitePreviewable( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 		isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
-		isNavUnificationEnabled: isNavUnificationEnabled( state ),
 		isSiteP2: isSiteWPForTeams( state, siteId ),
 		isP2Hub: isSiteP2Hub( state, siteId ),
 	};

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -17,7 +17,6 @@ import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getSiteMigrationStatus from 'calypso/state/selectors/get-site-migration-status';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
-import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
@@ -51,9 +50,7 @@ class MasterbarLoggedIn extends Component {
 	};
 
 	handleLayoutFocus = ( currentSection ) => {
-		if ( ! this.props.isNavUnificationEnabled ) {
-			this.props.setNextLayoutFocus( 'sidebar' );
-		} else if ( currentSection !== this.props.section ) {
+		if ( currentSection !== this.props.section ) {
 			// When current section is not focused then open the sidebar.
 			this.props.setNextLayoutFocus( 'sidebar' );
 		} else {
@@ -184,7 +181,7 @@ class MasterbarLoggedIn extends Component {
 			: getStatsPathForTab( 'day', siteSlug );
 
 		let mySitesUrl = domainOnlySite ? domainManagementList( siteSlug ) : homeUrl;
-		if ( this.props.isNavUnificationEnabled && 'sites' === section ) {
+		if ( 'sites' === section ) {
 			mySitesUrl = '';
 		}
 		return (
@@ -364,7 +361,6 @@ export default connect(
 			previousPath: getPreviousRoute( state ),
 			isJetpackNotAtomic: isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ),
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
-			isNavUnificationEnabled: isNavUnificationEnabled( state ),
 		};
 	},
 	{ setNextLayoutFocus, recordTracksEvent, updateSiteMigrationMeta, activateNextLayoutFocus }

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -1,13 +1,11 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { Children, createRef, useMemo, useState, useRef, useLayoutEffect } from 'react';
-import { useSelector } from 'react-redux';
 import { v4 as uuid } from 'uuid';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import HoverIntent from 'calypso/lib/hover-intent';
 import { hasTouch } from 'calypso/lib/touch-detect';
-import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import ExpandableSidebarHeading from './expandable-heading';
 
 const isTouch = hasTouch();
@@ -56,7 +54,6 @@ export const ExpandableSidebarMenu = ( {
 	const menu = createRef(); // Needed for HoverIntent.
 	const submenu = useRef();
 	const [ submenuHovered, setSubmenuHovered ] = useState( false );
-	const isUnifiedMenuEnabled = useSelector( isNavUnificationEnabled );
 
 	if ( submenu.current ) {
 		// Sets flyout to expand towards bottom.
@@ -75,7 +72,7 @@ export const ExpandableSidebarMenu = ( {
 	} );
 
 	const onEnter = () => {
-		if ( disableFlyout || expanded || isTouch || ! isUnifiedMenuEnabled ) {
+		if ( disableFlyout || expanded || isTouch ) {
 			return;
 		}
 
@@ -84,7 +81,7 @@ export const ExpandableSidebarMenu = ( {
 
 	const onLeave = () => {
 		// Remove "hovered" state even if menu is expanded.
-		if ( isTouch || ! isUnifiedMenuEnabled ) {
+		if ( isTouch ) {
 			return;
 		}
 

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -51,7 +51,6 @@ import canDisplayCommunityTranslator from 'calypso/state/selectors/can-display-c
 import getOnboardingUrl from 'calypso/state/selectors/get-onboarding-url';
 import getUnsavedUserSettings from 'calypso/state/selectors/get-unsaved-user-settings';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
-import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import isRequestingMissingSites from 'calypso/state/selectors/is-requesting-missing-sites';
 import {
 	clearUnsavedUserSettings,
@@ -953,9 +952,7 @@ class Account extends Component {
 									<ColorSchemePicker
 										temporarySelection
 										disabled={ this.getDisabledState( INTERFACE_FORM_NAME ) }
-										defaultSelection={
-											this.props.isNavUnificationEnabled ? 'classic-dark' : 'classic-bright'
-										}
+										defaultSelection="classic-dark"
 										onSelection={ this.updateColorScheme }
 									/>
 								</FormFieldset>
@@ -985,7 +982,6 @@ export default compose(
 			unsavedUserSettings: getUnsavedUserSettings( state ),
 			visibleSiteCount: getCurrentUserVisibleSiteCount( state ),
 			onboardingUrl: getOnboardingUrl( state ),
-			isNavUnificationEnabled: isNavUnificationEnabled( state ),
 		} ),
 		{
 			bumpStat,

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Button, Card, Gridicon } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { localize, withRtl } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -12,7 +12,6 @@ import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
-import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import { hasAllSitesList } from 'calypso/state/sites/selectors';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -27,7 +26,6 @@ class CurrentSite extends Component {
 		translate: PropTypes.func.isRequired,
 		anySiteSelected: PropTypes.array,
 		forceAllSitesView: PropTypes.bool,
-		isNavUnificationEnabled: PropTypes.bool.isRequired,
 		isRtl: PropTypes.bool,
 	};
 
@@ -66,14 +64,10 @@ class CurrentSite extends Component {
 					{ this.props.siteCount > 1 && (
 						<span className="current-site__switch-sites">
 							<Button borderless onClick={ this.switchSites }>
-								{ this.props.isNavUnificationEnabled ? (
+								<span
 									// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-									<span
-										className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
-									></span>
-								) : (
-									<Gridicon icon={ `chevron-${ arrowDirection }` } />
-								) }
+									className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
+								></span>
 								<span className="current-site__switch-sites-label">
 									{ translate( 'Switch Site' ) }
 								</span>
@@ -121,7 +115,6 @@ export default connect(
 		anySiteSelected: getSelectedOrAllSites( state ),
 		siteCount: getCurrentUserSiteCount( state ),
 		hasAllSitesList: hasAllSitesList( state ),
-		isNavUnificationEnabled: isNavUnificationEnabled( state ),
 	} ),
 	{
 		recordGoogleEvent,

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -13,7 +13,6 @@ import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
-import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import {
@@ -54,7 +53,6 @@ export const QuickLinks = ( {
 	trackExplorePluginsAction,
 	isExpanded,
 	updateHomeQuickLinksToggleStatus,
-	isUnifiedNavEnabled,
 	siteAdminUrl,
 	editHomePageUrl,
 	siteSlug,
@@ -167,7 +165,7 @@ export const QuickLinks = ( {
 					) }
 				</>
 			) }
-			{ isUnifiedNavEnabled && siteAdminUrl && (
+			{ siteAdminUrl && (
 				<ActionBox
 					href={ siteAdminUrl }
 					hideLinkIndicator
@@ -402,7 +400,6 @@ const mapStateToProps = ( state ) => {
 		editHomePageUrl,
 		isAtomic: isSiteAtomic( state, siteId ),
 		isExpanded: getPreference( state, 'homeQuickLinksToggleStatus' ) !== 'collapsed',
-		isUnifiedNavEnabled: isNavUnificationEnabled,
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 	};
 };

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -10,10 +10,6 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/my-sites/themes/theme-preview', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'calypso/state/selectors/is-nav-unification-enabled', () => ( {
-	__esModule: true,
-	default: () => true,
-} ) );
 
 const themeData = {
 	name: 'Twenty Sixteen',

--- a/client/state/selectors/get-preferred-editor-view.js
+++ b/client/state/selectors/get-preferred-editor-view.js
@@ -1,11 +1,6 @@
 import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
-import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 
 export const getPreferredEditorView = ( state, siteId, postType = 'post' ) => {
-	if ( ! isNavUnificationEnabled( state ) ) {
-		return 'default';
-	}
-
 	const menu = getAdminMenu( state, siteId );
 	if ( ! menu ) {
 		return 'default';


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/47051.

#### Changes proposed in this Pull Request

This PR removes several usages of the `isNavUnificationEnabled` selector as part of a bigger cleanup task which seeks to remove no longer used code as of the Nav Unification launch.

<details>
<summary><strong>Context</strong></summary>

Last year, we introduced new components for the navigation sidebar as part of the Nav Unification project. However, we've been falling back to the old sidebar components in these scenarios:
- As an escape hatch using [the `?disable-nav-unification` query param](https://github.com/Automattic/wp-calypso/blob/c7e06d5e2fe1ca94643d16855209704c39452f30/client/state/selectors/is-nav-unification-enabled.js#L9-L12).
- For self-hosted Jetpack sites [not updated to Jetpack 9.8](https://github.com/Automattic/wp-calypso/blob/c7e06d5e2fe1ca94643d16855209704c39452f30/client/state/selectors/is-nav-unification-enabled.js#L14-L19).
- [In Jetpack Cloud](https://github.com/Automattic/wp-calypso/blob/c7e06d5e2fe1ca94643d16855209704c39452f30/client/my-sites/navigation/index.jsx#L24-L25).

We no longer need to support the first two scenarios, since the escape hatch was meant to be temporary and Calypso does not need to support lower Jetpack versions than 9.8 anymore.

As for the third scenario, Jetpack Cloud only needs a small subset of the old components.

That gives us a good opportunity to remove a lot of unused code which would simplify the overall Calypso codebase.
</details>

#### Testing instructions

- Use the Calypso live link below.
- Make sure the site domain is visible in the sidebar: 
<img width="200" alt="Screen Shot 2022-02-28 at 12 52 57" src="https://user-images.githubusercontent.com/1233880/155985268-81cb469b-9abe-4c62-9ec8-6db6ac4f462e.png">

- Make sure you can open the sidebar by clicking on the "W" button on mobile viewports.
- Make sure submenus are visible as usual (hovering the parent menu on desktop viewports, touching the parent menu on mobile viewports).
- Make sure the "Switch site" button continues to work as always:
<img width="200" alt="Screen Shot 2022-02-28 at 13 07 26" src="https://user-images.githubusercontent.com/1233880/155985848-0055a8a8-7aa4-4099-9f4c-17477913b6cb.png">

- Make sure the "WP Admin Dashboard" quick link is still visible in My Home:
<img width="200" alt="Screen Shot 2022-02-28 at 13 09 43" src="https://user-images.githubusercontent.com/1233880/155985903-541b6e3c-31aa-4324-bc71-36bc0ecc824b.png">

- Make sure that visiting `/post/:site` redirects you to your preferred view for Posts. It's Calypso by default, but can you change it to WP Admin using the screen switcher in the `/posts/:site` page: 
<img width="600" alt="Screen Shot 2022-02-28 at 13 50 52" src="https://user-images.githubusercontent.com/1233880/155986402-a713345c-a271-4aa9-ba9e-fdd4e4a6a290.png">

- Use the Jetpack Cloud live link below.
- Make sure the site domain is visible in the sidebar using a `View <domain>` format:
<img width="404" alt="Screen Shot 2022-02-28 at 12 53 36" src="https://user-images.githubusercontent.com/1233880/155986795-0fb0129a-83d7-475b-b394-be2e188a5313.png">


 