### PR TITLE
`OrgRemoteCredentials`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/state/jetpack-remote-install/reducer.js
+++ b/client/state/jetpack-remote-install/reducer.js
@@ -6,6 +6,18 @@ import {
 } from 'calypso/state/action-types';
 import { combineReducers, keyedReducer } from 'calypso/state/utils';
 
+export const isRemoteInstallingJetpack = keyedReducer( 'url', ( state = false, { type } ) => {
+	switch ( type ) {
+		case JETPACK_REMOTE_INSTALL:
+			return true;
+		case JETPACK_REMOTE_INSTALL_SUCCESS:
+		case JETPACK_REMOTE_INSTALL_FAILURE:
+			return false;
+		default:
+			return state;
+	}
+} );
+
 export const isComplete = keyedReducer( 'url', ( state = false, { type } ) => {
 	switch ( type ) {
 		case JETPACK_REMOTE_INSTALL_SUCCESS:
@@ -48,6 +60,7 @@ const combinedReducer = combineReducers( {
 	errorCode: errorCodeReducer,
 	errorMessage: errorMessageReducer,
 	isComplete,
+	isRemoteInstallingJetpack,
 } );
 
 export default withStorageKey( 'jetpackRemoteInstall', combinedReducer );

--- a/client/state/selectors/is-remote-installing-jetpack.js
+++ b/client/state/selectors/is-remote-installing-jetpack.js
@@ -9,5 +9,5 @@ import 'calypso/state/jetpack-remote-install/init';
  * @returns {boolean} True if installation is currently in progress
  */
 export default function isRemoteInstallingJetpack( state, url ) {
-	return state.jetpackRemoteInstall.isRemoteInstallingJetpack?.[ url ] ?? false;
+	return state.jetpackRemoteInstall.isRemoteInstallingJetpack[ url ] ?? false;
 }

--- a/client/state/selectors/is-remote-installing-jetpack.js
+++ b/client/state/selectors/is-remote-installing-jetpack.js
@@ -1,0 +1,13 @@
+import 'calypso/state/jetpack-remote-install/init';
+
+/**
+ * Returns whether remote installation of the jetpack plugin to the .org siteat
+ * is currently in progress at the given url.
+ *
+ * @param {object} state Global state tree
+ * @param {string} url .org site URL
+ * @returns {boolean} True if installation is currently in progress
+ */
+export default function isRemoteInstallingJetpack( state, url ) {
+	return state.jetpackRemoteInstall.isRemoteInstallingJetpack?.[ url ] ?? false;
+}

--- a/client/state/selectors/is-remote-installing-jetpack.js
+++ b/client/state/selectors/is-remote-installing-jetpack.js
@@ -1,7 +1,7 @@
 import 'calypso/state/jetpack-remote-install/init';
 
 /**
- * Returns whether remote installation of the jetpack plugin to the .org siteat
+ * Returns whether the remote installation of the jetpack plugin to the .org site
  * is currently in progress at the given url.
  *
  * @param {object} state Global state tree


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `OrgRemoteCredentials`: refactor away from `UNSAFE_*`

Please note that I added an additional reducer which takes care of the `isSubmitting` flag, which previously was kept in component state, to prevent having different approaches for managing related state. Eventually we should move the request to use `wpcom.req` directly without the Redux part (or React Query).

#### Testing instructions

* Go to `/jetpack/connect/install`
* Enter the URL of a org site which doesn't have Jetpack installed, go to the next step
* Enter credentials and hit "Install Jetpack"
* While the request is processing the form should behave exactly like on prod

Related to #58453 
