### PR TITLE
Woo landing page: Remove 100% width on wide-layout

### DIFF
--- a/client/my-sites/woocommerce/style.scss
+++ b/client/my-sites/woocommerce/style.scss
@@ -16,13 +16,6 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 		@include breakpoint-deprecated( '>660px' ) {
 			padding-top: 35px;
 		}
-
-		&.is-wide-layout {
-			width: 100%;
-			padding-bottom: 0;
-			max-width: 100%;
-			margin: 0;
-		}
 	}
 
 	.woocommerce-colophon {
@@ -77,9 +70,6 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 		padding-top: 60px;
 		padding-bottom: 40px;
 
-		padding-left: 10%;
-		padding-right: 5%;
-
 		.formatted-header .formatted-header__title {
 			@include onboarding-font-recoleta;
 			text-align: left;
@@ -103,7 +93,7 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 					@media ( min-width: $break-wide ) {
 						width: calc( 30% );
 						padding-left: 0;
-						padding-right: 20px;
+						padding-right: 10px;
 					}
 					.action-panel__title {
 						justify-content: normal;

--- a/client/my-sites/woocommerce/style.scss
+++ b/client/my-sites/woocommerce/style.scss
@@ -16,6 +16,11 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 		@include breakpoint-deprecated( '>660px' ) {
 			padding-top: 35px;
 		}
+
+		@media ( max-width: 660px ) {
+			padding-left: 15px;
+			padding-right: 15px;
+		}
 	}
 
 	.woocommerce-colophon {
@@ -48,8 +53,6 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 		max-width: 540px;
 		margin: 0 auto;
 		padding-top: 3em;
-		padding-left: 15px;
-		padding-right: 15px;
 
 		.empty-content__title {
 			@include onboarding-heading-text;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Align the page width with the rest of calypso.

#### Testing instructions

* http://calypso.localhost:3000/woocommerce-installation/

Before
![Screenshot 2022-03-01 at 14-17-36 WooCommerce — WordPress com](https://user-images.githubusercontent.com/811776/156098337-5b64a6dd-2cee-4ded-b2d0-688e925d66d8.png)

After
![Screenshot 2022-03-01 at 14-17-12 WooCommerce — WordPress com](https://user-images.githubusercontent.com/811776/156098348-8f68f767-1f5c-4ae8-b07d-7bc9741f9d40.png)

Fixes https://github.com/Automattic/wp-calypso/issues/61345
