### PR TITLE
Domains: Fix a typo in the copy-DNS suggestion

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
@@ -92,7 +92,7 @@ export default function ConnectDomainStepSuggestedStart( {
 				<p>
 					{ createInterpolateElement(
 						__(
-							'If you have any email or services other than web hosting connected to this domain, we recommend you copy over your DNS records before proceeding with this setup to avoid distruptions. You can then start the setup again by going back to <em>Upgrades > Domains</em>.'
+							'If you have any email or services other than web hosting connected to this domain, we recommend you copy over your DNS records before proceeding with this setup to avoid disruptions. You can then start the setup again by going back to <em>Upgrades > Domains</em>.'
 						),
 						{
 							em: createElement( 'em' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This fixes a typo (`distruptions` to `disruptions`) in the suggestion to copy over DNS records while connecting an existing domain.

![image](https://user-images.githubusercontent.com/75777864/156138780-d1dffa1b-5ca0-421a-a0ef-8d7324168866.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change your WordPress.com user interface language to English.
* Go to Upgrades > Domains, click "+ Add a domain" and then "Use a domain I own".
* Type a domain name, click "Next", then click "Select" in the "Connect your domain" box.
* Expand the "Do you have email or other services..." box and verify that the typo is gone.
* Go back to Upgrades > Domains and remove the domain connection that was created.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->