### PR TITLE
Emails: Fix ToS styling on email upsell page after adding Professional email

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -121,7 +121,8 @@ $left-margin: 36px;
  */
 .purchase-modal .checkout__terms,
 .purchase-modal .checkout__concierge-refund-policy,
-.purchase-modal .checkout__bundled-domain-notice {
+.purchase-modal .checkout__bundled-domain-notice,
+.purchase-modal .checkout__titan-terms-of-service {
 	margin: 4px 0;
 	padding-left: $left-margin;
 	position: relative;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

During the upsell nudge once we have purchased a plan, we are presented with a monthly subscription for Professional Email. This code matches the billing term for the Professional Email with the billing term that the user has purchased. But the ToS has some styling issues as shown in this [Pull Request](https://github.com/Automattic/wp-calypso/pull/61120).

![image](https://user-images.githubusercontent.com/5689927/154079277-b3585167-f572-4599-8ecc-26d12fe160b6.png)

#### Testing instructions

Scenario 1: Monthly billing
Run this branch locally or use the calypso live branch.
Build the following URL: (append it to the base AKA http://wordpress.com/ or your Calypso local branch) checkout/offer-professional-email/{domain}/{receipt-id}/{site-slug}

Check that you are presented with the following information:
![image](https://user-images.githubusercontent.com/5689927/154078309-1291b029-b57f-4763-9bfd-7c780322512b.png)

Check that once you click on "Add Professional Email" you are presented with the following information:
![image](https://user-images.githubusercontent.com/5689927/156145168-84b97b65-85f8-4596-9372-c3b5c07fab5d.png)

Please, note that the dates in the blue box should be different, ideally 3 months ahead of today the date of renewal attempt for Professional Email.

Related to {1200182182542585-as-1201815195387520} and {1200182182542585-as-1201890118162562}
