### PR TITLE
Show next steps for DIFM in Checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
@@ -79,7 +79,10 @@ const NextStepIcon = styled( BaseIcon )`
 	background-color: ${ ( props ) => props.theme.colors.surface };
 `;
 
-export default function CheckoutNextSteps( { responseCart, headerText }: Props ): JSX.Element {
+export default function CheckoutNextSteps( {
+	responseCart,
+	headerText,
+}: Props ): JSX.Element | null {
 	const translate = useTranslate();
 
 	const steps: NextStepsStep[] = useMemo( () => {
@@ -124,7 +127,5 @@ export default function CheckoutNextSteps( { responseCart, headerText }: Props )
 				) ) }
 			</CheckoutNextStepsListWrapper>
 		</CheckoutNextStepsWrapper>
-	) : (
-		<></>
-	);
+	) : null;
 }

--- a/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
@@ -1,10 +1,11 @@
 import { Gridicon } from '@automattic/components';
-import { ResponseCart } from '@automattic/shopping-cart';
 import styled from '@emotion/styled';
-import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { ReactChild, useMemo } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
-
+import type { ResponseCart } from '@automattic/shopping-cart';
+import type { TranslateResult } from 'i18n-calypso';
+import type { ReactChild } from 'react';
 interface Props {
 	responseCart: ResponseCart;
 	headerText?: TranslateResult;

--- a/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
@@ -100,7 +100,9 @@ export default function CheckoutNextSteps( {
 					icon: <NextStepIcon />,
 				},
 				{
-					text: translate( 'Receive your finished site in under 4 business days!' ),
+					text: translate( 'Receive your finished site in under %d business days!', {
+						args: [ 4 ],
+					} ),
 					icon: <NextStepIcon />,
 				},
 			];

--- a/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
@@ -116,8 +116,8 @@ export default function CheckoutNextSteps( { responseCart, headerText }: Props )
 				{ headerText || translate( "What's Next" ) }
 			</CheckoutNextStepsHeader>
 			<CheckoutNextStepsListWrapper>
-				{ steps.map( ( step ) => (
-					<CheckoutNextStepsListItem>
+				{ steps.map( ( step, index ) => (
+					<CheckoutNextStepsListItem key={ index.toString() }>
 						{ step.icon }
 						{ step.text }
 					</CheckoutNextStepsListItem>

--- a/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
@@ -1,0 +1,129 @@
+import { Gridicon } from '@automattic/components';
+import { ResponseCart } from '@automattic/shopping-cart';
+import styled from '@emotion/styled';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { ReactChild, useMemo } from 'react';
+import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
+
+interface Props {
+	responseCart: ResponseCart;
+	headerText?: TranslateResult;
+}
+
+interface NextStepsStep {
+	text: ReactChild;
+	icon: JSX.Element;
+}
+
+const CheckoutNextStepsWrapper = styled.div`
+	background: ${ ( props ) => props.theme.colors.surface };
+	border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+	margin: 0;
+	padding: 20px;
+`;
+
+const CheckoutNextStepsHeader = styled.h3`
+	font-size: 14px;
+	font-weight: ${ ( props ) => props.theme.weights.bold };
+	margin-bottom: 16px;
+`;
+
+const CheckoutNextStepsListWrapper = styled.ul`
+	margin: 0;
+	list-style: none;
+	font-size: 14px;
+`;
+
+const CheckoutNextStepsListItem = styled( 'li' )`
+	margin-bottom: 4px;
+	overflow-wrap: break-word;
+	display: flex;
+	align-items: flex-start;
+	margin-bottom: 12px;
+
+	.rtl & {
+		padding-right: 24px;
+		padding-left: 0;
+	}
+`;
+
+const BaseIcon = styled.div`
+	background: ${ ( props ) => props.theme.colors.success };
+	border-radius: 50%;
+	border: 1px solid;
+	border-color: ${ ( props ) => props.theme.colors.success };
+	height: 18px;
+	width: 18px;
+	text-align: center;
+	flex-shrink: 0;
+	margin-right: 8px;
+
+	.gridicon {
+		fill: ${ ( props ) => props.theme.colors.surface };
+	}
+`;
+
+const CompletedStepIcon = () => (
+	<BaseIcon>
+		<Gridicon icon="checkmark" size={ 12 } />
+	</BaseIcon>
+);
+
+const CurrentStepIcon = styled( BaseIcon )`
+	background: ${ ( props ) =>
+		`linear-gradient(0, ${ props.theme.colors.success } 50%, ${ props.theme.colors.surface } 50%)` };
+`;
+
+const NextStepIcon = styled( BaseIcon )`
+	background-color: ${ ( props ) => props.theme.colors.surface };
+`;
+
+export default function CheckoutNextSteps( { responseCart, headerText }: Props ): JSX.Element {
+	const translate = useTranslate();
+
+	const steps: NextStepsStep[] = useMemo( () => {
+		if ( hasDIFMProduct( responseCart ) ) {
+			return [
+				{
+					text: translate( 'Submit business information' ),
+					icon: <CompletedStepIcon />,
+				},
+				{
+					text: translate( 'Choose a design' ),
+					icon: <CompletedStepIcon />,
+				},
+				{
+					text: <b>{ translate( 'Checkout' ) }</b>,
+					icon: <CurrentStepIcon />,
+				},
+				{
+					text: translate( 'Submit content for new site' ),
+					icon: <NextStepIcon />,
+				},
+				{
+					text: translate( 'Receive your finished site in under 4 business days!' ),
+					icon: <NextStepIcon />,
+				},
+			];
+		}
+		return [];
+	}, [ responseCart, translate ] );
+
+	return steps && steps.length ? (
+		<CheckoutNextStepsWrapper>
+			<CheckoutNextStepsHeader>
+				{ headerText || translate( "What's Next" ) }
+			</CheckoutNextStepsHeader>
+			<CheckoutNextStepsListWrapper>
+				{ steps.map( ( step ) => (
+					<CheckoutNextStepsListItem>
+						{ step.icon }
+						{ step.text }
+					</CheckoutNextStepsListItem>
+				) ) }
+			</CheckoutNextStepsListWrapper>
+		</CheckoutNextStepsWrapper>
+	) : (
+		<></>
+	);
+}

--- a/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
@@ -41,11 +41,7 @@ const CheckoutNextStepsListItem = styled( 'li' )`
 	display: flex;
 	align-items: flex-start;
 	margin-bottom: 12px;
-
-	.rtl & {
-		padding-right: 24px;
-		padding-left: 0;
-	}
+	gap: 8px;
 `;
 
 const BaseIcon = styled.div`
@@ -57,7 +53,6 @@ const BaseIcon = styled.div`
 	width: 18px;
 	text-align: center;
 	flex-shrink: 0;
-	margin-right: 8px;
 
 	.gridicon {
 		fill: ${ ( props ) => props.theme.colors.surface };

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -48,6 +48,7 @@ import badge7Src from './assets/icons/badge-7.svg';
 import badgeGenericSrc from './assets/icons/badge-generic.svg';
 import { CheckoutCompleteRedirecting } from './checkout-complete-redirecting';
 import CheckoutHelpLink from './checkout-help-link';
+import CheckoutNextSteps from './checkout-next-steps';
 import { EmptyCart, shouldShowEmptyCartPage } from './empty-cart';
 import PaymentMethodStep from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
@@ -371,6 +372,7 @@ export default function WPCheckout( {
 							isCartPendingUpdate={ isCartPendingUpdate }
 						/>
 						<CheckoutHelpLink />
+						<CheckoutNextSteps responseCart={ responseCart } />
 					</CheckoutSummaryBody>
 				</CheckoutErrorBoundary>
 			</CheckoutSummaryArea>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Context: pdh1Xd-tJ-p2#comment-881
* Adds a "What's Next" box to checkout describing the next steps in the DIFM flow.
* The next steps are shown only if the DIFM product is in the cart. However, we can also use the component to display the next steps for other products with a little modification.
<img width="993" alt="image" src="https://user-images.githubusercontent.com/5436027/156166986-326e0c67-923d-4082-9e70-9425aa0d1ba6.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add the DIFM product to the cart by starting from the flow at `/start/do-it-for-me`.
* Confirm that you see the "What's Next" box as shown in the screenshot.
* Confirm that it is displayed correctly in mobile & tablet resolutions: [Mobile GIF](https://user-images.githubusercontent.com/5436027/156167913-9a896722-c1cb-40cc-9063-40f7d819fcbb.gif)
* Confirm that it is displayed correctly for an RTL lang. 
<img width="756" alt="image" src="https://user-images.githubusercontent.com/5436027/156307983-025f822c-c3a1-4fb8-8e20-939680c84901.png">

* Remove the DIFM product. Confirm that the "What's Next" box is no longer shown.


Related to 0-as-1201857306873589/f