### PR TITLE
Emails: Refactor GoogleMailboxPricingNotice into MailboxPricingNotice

### DIFF
--- a/client/my-sites/email/email-pricing-notice/index.tsx
+++ b/client/my-sites/email/email-pricing-notice/index.tsx
@@ -1,0 +1,176 @@
+import { translate as originalTranslate, useTranslate } from 'i18n-calypso';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import Notice from 'calypso/components/notice';
+import type { EmailCost, ResponseDomain } from 'calypso/lib/domains/types';
+import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+import type { TranslateResult } from 'i18n-calypso';
+import type { ReactElement } from 'react';
+
+const doesAdditionalPriceMatchStandardPrice = (
+	domain: ResponseDomain,
+	mailProduct: ProductListItem,
+	purchaseCost: EmailCost | null
+): boolean => {
+	if ( ! domain ) {
+		return true;
+	}
+
+	if ( ! purchaseCost ) {
+		return true;
+	}
+
+	return (
+		purchaseCost.amount === mailProduct.cost && purchaseCost.currency === mailProduct.currency_code
+	);
+};
+
+function getPriceMessage( {
+	mailboxPurchaseCost,
+	translate,
+}: {
+	mailboxPurchaseCost: EmailCost | null;
+	translate: typeof originalTranslate;
+} ): TranslateResult {
+	if ( mailboxPurchaseCost === null ) {
+		return '';
+	}
+	return mailboxPurchaseCost.amount === 0
+		? translate( 'You can add new mailboxes for free until the end of your trial period.' )
+		: translate(
+				'You can purchase new mailboxes at the prorated price of {{strong}}%(proratedPrice)s{{/strong}} per mailbox.',
+				{
+					args: {
+						proratedPrice: mailboxPurchaseCost.text,
+					},
+					components: {
+						strong: <strong />,
+					},
+					comment:
+						'%(proratedPrice)s is a formatted price for an email subscription (e.g. $3.50, €3.75, or PLN 4.50)',
+				}
+		  );
+}
+
+function getPriceMessageExplanation( {
+	mailboxPurchaseCost,
+	mailboxRenewalCost,
+	translate,
+}: {
+	mailboxPurchaseCost: EmailCost | null;
+	mailboxRenewalCost: EmailCost | null;
+	mailProduct: ProductListItem;
+	translate: typeof originalTranslate;
+} ): TranslateResult {
+	if ( mailboxPurchaseCost === null || mailboxRenewalCost === null ) {
+		return '';
+	}
+
+	// We don't need any explanation of the price at this point, because we have already handled it previously.
+	if ( mailboxPurchaseCost.amount === 0 ) {
+		return '';
+	}
+
+	if ( mailboxPurchaseCost.amount < mailboxRenewalCost.amount ) {
+		return translate(
+			'This is less than the regular price because you are only charged for the remainder of the current year.'
+		);
+	}
+
+	return translate(
+		'This is more than the regular price because you are charged for the remainder of the current year plus any additional year until renewal.'
+	);
+}
+
+function getPriceMessageRenewal( {
+	expiryDate,
+	mailboxRenewalCost,
+	translate,
+}: {
+	expiryDate: string;
+	mailboxRenewalCost: EmailCost | null;
+	translate: typeof originalTranslate;
+} ): TranslateResult {
+	if ( mailboxRenewalCost === null ) {
+		return '';
+	}
+
+	return translate(
+		'All of your mailboxes are due to renew at the regular price of {{strong}}%(fullPrice)s{{/strong}} per mailbox when your subscription renews on {{strong}}%(expiryDate)s{{/strong}}.',
+		{
+			args: {
+				fullPrice: mailboxRenewalCost.text,
+				expiryDate: expiryDate,
+			},
+			components: {
+				strong: <strong />,
+			},
+			comment:
+				'%(fullPrice)s is a formatted price for an email subscription (e.g. $3.50, €3.75, or PLN 4.50), ' +
+				'%(expiryDate)s is a localized date (e.g. February 17, 2021)',
+		}
+	);
+}
+
+interface MailboxPricingNoticeProps {
+	domain: ResponseDomain;
+	expiryDate: string | null;
+	mailProduct: ProductListItem;
+	mailboxPurchaseCost: EmailCost | null;
+	mailboxRenewalCost: EmailCost | null;
+}
+
+const MailboxPricingNotice = ( {
+	domain,
+	expiryDate,
+	mailProduct,
+	mailboxPurchaseCost,
+	mailboxRenewalCost,
+}: MailboxPricingNoticeProps ): ReactElement | null => {
+	const moment = useLocalizedMoment();
+	const translate = useTranslate();
+
+	if ( doesAdditionalPriceMatchStandardPrice( domain, mailProduct, mailboxPurchaseCost ) ) {
+		const translateArgs = {
+			args: {
+				price: mailboxPurchaseCost?.text,
+			},
+			components: {
+				strong: <strong />,
+			},
+			comment:
+				'%(price)s is a formatted price for an email subscription (e.g. $3.50, €3.75, or PLN 4.50)',
+		};
+
+		return (
+			<Notice icon="info-outline" showDismiss={ false } status="is-success">
+				{ translate(
+					'You can purchase new mailboxes at the regular price of {{strong}}%(price)s{{/strong}} per mailbox per year.',
+					translateArgs
+				) }
+			</Notice>
+		);
+	}
+
+	const priceMessage = getPriceMessage( { mailboxPurchaseCost, translate } );
+	const priceMessageExplanation = getPriceMessageExplanation( {
+		mailboxPurchaseCost,
+		mailboxRenewalCost,
+		mailProduct,
+		translate,
+	} );
+	const priceMessageRenewal = getPriceMessageRenewal( {
+		expiryDate: moment( expiryDate ).format( 'LL' ),
+		mailboxRenewalCost,
+		translate,
+	} );
+
+	return (
+		<Notice icon="info-outline" showDismiss={ false } status="is-success">
+			<>
+				{ priceMessage } { priceMessageExplanation } { priceMessageRenewal }
+			</>
+		</Notice>
+	);
+};
+
+export default MailboxPricingNotice;

--- a/client/my-sites/email/email-pricing-notice/index.tsx
+++ b/client/my-sites/email/email-pricing-notice/index.tsx
@@ -58,7 +58,6 @@ function getPriceMessageExplanation( {
 }: {
 	mailboxPurchaseCost: EmailCost | null;
 	mailboxRenewalCost: EmailCost | null;
-	mailProduct: ProductListItem;
 	translate: typeof originalTranslate;
 } ): TranslateResult {
 	if ( mailboxPurchaseCost === null || mailboxRenewalCost === null ) {
@@ -114,22 +113,22 @@ function getPriceMessageRenewal( {
 interface MailboxPricingNoticeProps {
 	domain: ResponseDomain;
 	expiryDate: string | null;
-	mailProduct: ProductListItem;
 	mailboxPurchaseCost: EmailCost | null;
 	mailboxRenewalCost: EmailCost | null;
+	product: ProductListItem;
 }
 
 const MailboxPricingNotice = ( {
 	domain,
 	expiryDate,
-	mailProduct,
 	mailboxPurchaseCost,
 	mailboxRenewalCost,
+	product,
 }: MailboxPricingNoticeProps ): ReactElement | null => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 
-	if ( doesAdditionalPriceMatchStandardPrice( domain, mailProduct, mailboxPurchaseCost ) ) {
+	if ( doesAdditionalPriceMatchStandardPrice( domain, product, mailboxPurchaseCost ) ) {
 		const translateArgs = {
 			args: {
 				price: mailboxPurchaseCost?.text,
@@ -155,7 +154,6 @@ const MailboxPricingNotice = ( {
 	const priceMessageExplanation = getPriceMessageExplanation( {
 		mailboxPurchaseCost,
 		mailboxRenewalCost,
-		mailProduct,
 		translate,
 	} );
 	const priceMessageRenewal = getPriceMessageRenewal( {

--- a/client/my-sites/email/email-pricing-notice/index.tsx
+++ b/client/my-sites/email/email-pricing-notice/index.tsx
@@ -3,11 +3,11 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Notice from 'calypso/components/notice';
 import type { EmailCost, ResponseDomain } from 'calypso/lib/domains/types';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
 import type { TranslateResult } from 'i18n-calypso';
-import type { ReactElement } from 'react';
 
 const doesAdditionalPriceMatchStandardPrice = (
-	domain: ResponseDomain,
+	domain: ResponseDomain | SiteDomain | null,
 	mailProduct: ProductListItem,
 	purchaseCost: EmailCost | null
 ): boolean => {
@@ -111,20 +111,20 @@ function getPriceMessageRenewal( {
 }
 
 interface MailboxPricingNoticeProps {
-	domain: ResponseDomain;
+	domain: ResponseDomain | SiteDomain | null;
 	expiryDate: string | null;
 	mailboxPurchaseCost: EmailCost | null;
 	mailboxRenewalCost: EmailCost | null;
 	product: ProductListItem;
 }
 
-const MailboxPricingNotice = ( {
+const EmailPricingNotice = ( {
 	domain,
 	expiryDate,
 	mailboxPurchaseCost,
 	mailboxRenewalCost,
 	product,
-}: MailboxPricingNoticeProps ): ReactElement | null => {
+}: MailboxPricingNoticeProps ): JSX.Element | null => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 
@@ -171,4 +171,4 @@ const MailboxPricingNotice = ( {
 	);
 };
 
-export default MailboxPricingNotice;
+export default EmailPricingNotice;

--- a/client/my-sites/email/email-pricing-notice/index.tsx
+++ b/client/my-sites/email/email-pricing-notice/index.tsx
@@ -7,18 +7,10 @@ import type { SiteDomain } from 'calypso/state/sites/domains/types';
 import type { TranslateResult } from 'i18n-calypso';
 
 const doesAdditionalPriceMatchStandardPrice = (
-	domain: ResponseDomain | SiteDomain | null,
+	domain: ResponseDomain | SiteDomain,
 	mailProduct: ProductListItem,
-	purchaseCost: EmailCost | null
+	purchaseCost: EmailCost
 ): boolean => {
-	if ( ! domain ) {
-		return true;
-	}
-
-	if ( ! purchaseCost ) {
-		return true;
-	}
-
 	return (
 		purchaseCost.amount === mailProduct.cost && purchaseCost.currency === mailProduct.currency_code
 	);
@@ -115,7 +107,7 @@ interface MailboxPricingNoticeProps {
 	expiryDate: string | null;
 	mailboxPurchaseCost: EmailCost | null;
 	mailboxRenewalCost: EmailCost | null;
-	product: ProductListItem;
+	product: ProductListItem | null;
 }
 
 const EmailPricingNotice = ( {
@@ -127,6 +119,10 @@ const EmailPricingNotice = ( {
 }: MailboxPricingNoticeProps ): JSX.Element | null => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
+
+	if ( ! domain || ! mailboxPurchaseCost || ! product ) {
+		return null;
+	}
 
 	if ( doesAdditionalPriceMatchStandardPrice( domain, product, mailboxPurchaseCost ) ) {
 		const translateArgs = {

--- a/client/my-sites/email/email-pricing-notice/index.tsx
+++ b/client/my-sites/email/email-pricing-notice/index.tsx
@@ -7,7 +7,6 @@ import type { SiteDomain } from 'calypso/state/sites/domains/types';
 import type { TranslateResult } from 'i18n-calypso';
 
 const doesAdditionalPriceMatchStandardPrice = (
-	domain: ResponseDomain | SiteDomain,
 	mailProduct: ProductListItem,
 	purchaseCost: EmailCost
 ): boolean => {
@@ -124,7 +123,7 @@ const EmailPricingNotice = ( {
 		return null;
 	}
 
-	if ( doesAdditionalPriceMatchStandardPrice( domain, product, mailboxPurchaseCost ) ) {
+	if ( doesAdditionalPriceMatchStandardPrice( product, mailboxPurchaseCost ) ) {
 		const translateArgs = {
 			args: {
 				price: mailboxPurchaseCost?.text,

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -296,7 +296,7 @@ class GSuiteAddUsers extends Component {
 								expiryDate={ getGSuiteExpiryDate( selectedDomain ) }
 								mailboxRenewalCost={ getGSuiteMailboxRenewalCost( selectedDomain ) }
 								mailboxPurchaseCost={ getGSuiteMailboxPurchaseCost( selectedDomain ) }
-								mailProduct={ googleMailProduct }
+								product={ googleMailProduct }
 							/>
 						) }
 						{ this.renderAddGSuite() }

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -19,8 +19,12 @@ import { getSelectedDomain } from 'calypso/lib/domains';
 import {
 	getEligibleGSuiteDomain,
 	getGoogleMailServiceFamily,
+	getGSuiteExpiryDate,
+	getGSuiteMailboxPurchaseCost,
+	getGSuiteMailboxRenewalCost,
 	getGSuiteSupportedDomains,
 	getProductSlug,
+	hasGSuiteWithUs,
 } from 'calypso/lib/gsuite';
 import {
 	GOOGLE_PROVIDER_NAME,
@@ -36,7 +40,7 @@ import {
 } from 'calypso/lib/gsuite/new-users';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import EmailHeader from 'calypso/my-sites/email/email-header';
-import GoogleMailboxPricingNotice from 'calypso/my-sites/email/gsuite-add-users/google-workspace-pricing-notice';
+import MailboxPricingNotice from 'calypso/my-sites/email/email-pricing-notice';
 import { emailManagementAddGSuiteUsers, emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
@@ -286,10 +290,13 @@ class GSuiteAddUsers extends Component {
 						} ) }
 						noticeStatus="is-info"
 					>
-						{ selectedDomainName && (
-							<GoogleMailboxPricingNotice
+						{ selectedDomainName && hasGSuiteWithUs( selectedDomain ) && (
+							<MailboxPricingNotice
 								domain={ selectedDomain }
-								googleMailProduct={ googleMailProduct }
+								expiryDate={ getGSuiteExpiryDate( selectedDomain ) }
+								mailboxRenewalCost={ getGSuiteMailboxRenewalCost( selectedDomain ) }
+								mailboxPurchaseCost={ getGSuiteMailboxPurchaseCost( selectedDomain ) }
+								mailProduct={ googleMailProduct }
 							/>
 						) }
 						{ this.renderAddGSuite() }

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -40,7 +40,7 @@ import {
 } from 'calypso/lib/gsuite/new-users';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import EmailHeader from 'calypso/my-sites/email/email-header';
-import MailboxPricingNotice from 'calypso/my-sites/email/email-pricing-notice';
+import EmailPricingNotice from 'calypso/my-sites/email/email-pricing-notice';
 import { emailManagementAddGSuiteUsers, emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
@@ -291,7 +291,7 @@ class GSuiteAddUsers extends Component {
 						noticeStatus="is-info"
 					>
 						{ selectedDomainName && hasGSuiteWithUs( selectedDomain ) && (
-							<MailboxPricingNotice
+							<EmailPricingNotice
 								domain={ selectedDomain }
 								expiryDate={ getGSuiteExpiryDate( selectedDomain ) }
 								mailboxRenewalCost={ getGSuiteMailboxRenewalCost( selectedDomain ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is the first step to unify the GoogleMailboxPricingNotice and TitanMailboxPricingNotice into one single component called EmailPricingNotice.

As a first step it will **ONLY** refactor the GoogleMailboxPricingNotice as is the simplest (does not support yet monthly billing) so the review is smaller and divided into smaller tasks & chunks. I recon that I could even make the PR smaller, but then there were no way to easily test this change.

The next PR will refactor the Titan component and _probably_ will modify the props for this new component added (not sure yet, just guessing based on its current behaviour of showing different translates for yearly/monthly

#### Testing instructions

1. Apply this patch locally or use the calypso live branch
2. Go to Upgrades -> Email and add a mailbox to a current Google Workspace subscription (if you don't have you should add a subscription to a domain)
3. Check that you are presented with the following screen, with a notice in the top of the form.

You should be presented with this screen:
![image](https://user-images.githubusercontent.com/5689927/156172874-d0067f0b-9c92-4d20-a198-3ee5d1d119ea.png)


*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to {1200182182542585-as-1201892594134559}
