### PR TITLE
Comments: Refactor `AddLinkDialog` away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/comments/comment/comment-html-editor/add-link-dialog.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/add-link-dialog.jsx
@@ -11,6 +11,15 @@ const REGEXP_EMAIL = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i;
 const REGEXP_URL = /^(https?|ftp):\/\/[A-Z0-9.-]+\.[A-Z]{2,4}[^ "]*$/i;
 const REGEXP_STANDALONE_URL = /^(?:[a-z]+:|#|\?|\.|\/)/;
 
+function inferUrl( selectedText ) {
+	if ( REGEXP_EMAIL.test( selectedText ) ) {
+		return 'mailto:' + selectedText;
+	} else if ( REGEXP_URL.test( selectedText ) ) {
+		return selectedText.replace( /&amp;|&#0?38;/gi, '&' );
+	}
+	return '';
+}
+
 export class AddLinkDialog extends Component {
 	static propTypes = {
 		onClose: PropTypes.func,
@@ -26,12 +35,11 @@ export class AddLinkDialog extends Component {
 		linkUrl: '',
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( newProps ) {
-		this.setState( {
-			linkUrl: this.inferUrl( newProps.selectedText ),
-			linkText: newProps.selectedText,
-		} );
+	static getDerivedStateFromProps( { selectedText } ) {
+		return {
+			linkUrl: inferUrl( selectedText ),
+			linkText: selectedText,
+		};
 	}
 
 	correctUrl() {
@@ -43,15 +51,6 @@ export class AddLinkDialog extends Component {
 			return `http://${ url }`;
 		}
 		return url;
-	}
-
-	inferUrl( selectedText ) {
-		if ( REGEXP_EMAIL.test( selectedText ) ) {
-			return 'mailto:' + selectedText;
-		} else if ( REGEXP_URL.test( selectedText ) ) {
-			return selectedText.replace( /&amp;|&#0?38;/gi, '&' );
-		}
-		return '';
 	}
 
 	setLinkUrl = ( event ) => this.setState( { linkUrl: event.target.value } );

--- a/client/my-sites/comments/comment/comment-html-editor/add-link-dialog.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/add-link-dialog.jsx
@@ -31,16 +31,9 @@ export class AddLinkDialog extends Component {
 
 	state = {
 		linkNewTab: false,
-		linkText: '',
-		linkUrl: '',
+		linkUrl: inferUrl( this.props.selectedText ),
+		linkText: this.props.selectedText,
 	};
-
-	static getDerivedStateFromProps( { selectedText } ) {
-		return {
-			linkUrl: inferUrl( selectedText ),
-			linkText: selectedText,
-		};
-	}
 
 	correctUrl() {
 		const url = this.state.linkUrl.trim();

--- a/client/my-sites/comments/comment/comment-html-editor/index.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/index.jsx
@@ -231,6 +231,7 @@ export class CommentHtmlEditor extends Component {
 				/>
 
 				<AddLinkDialog
+					key={ `add-link-dialog-${ selectedText }` }
 					onClose={ this.closeLinkDialog }
 					onInsert={ this.insertATag }
 					selectedText={ selectedText }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `AddLinkDialog` component away from the `UNSAFE_` deprecated React component methods.

We use the `key` approach for resetting the component in order to be able to benefit from the component state management without any unintended side effects.

Part of #58453.

#### Testing instructions
* Go to `/comments/all/:site`
* Edit a comment
* Select some text.
* Click "link" and add a link to the selected text.
* Smoke test link adding functionality and verify it still works as it did before.