### PR TITLE
Plugins: Refactor `PluginsMain` away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -52,8 +52,13 @@ export class PluginsMain extends Component {
 		};
 	}
 
-	componentDidUpdate() {
-		const { currentPlugins } = this.props;
+	componentDidUpdate( prevProps ) {
+		const {
+			currentPlugins,
+			hasJetpackSites: hasJpSites,
+			selectedSiteIsJetpack,
+			selectedSiteSlug,
+		} = this.props;
 
 		currentPlugins.map( ( plugin ) => {
 			const pluginData = this.props.wporgPlugins?.[ plugin.slug ];
@@ -61,20 +66,8 @@ export class PluginsMain extends Component {
 				this.props.wporgFetchPluginData( plugin.slug );
 			}
 		} );
-	}
 
-	componentDidMount() {
-		// Change the isMobile state when the size of the browser changes.
-		this.unsubscribe = subscribeIsWithinBreakpoint( '<960px', ( isMobile ) => {
-			this.setState( { isMobile } );
-		} );
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const { hasJetpackSites: hasJpSites, selectedSiteIsJetpack, selectedSiteSlug } = nextProps;
-
-		if ( this.props.isRequestingSites && ! nextProps.isRequestingSites ) {
+		if ( prevProps.isRequestingSites && ! this.props.isRequestingSites ) {
 			// Selected site is not a Jetpack site
 			if ( selectedSiteSlug && ! selectedSiteIsJetpack ) {
 				page.redirect( `/plugins/${ selectedSiteSlug }` );
@@ -87,6 +80,13 @@ export class PluginsMain extends Component {
 				return;
 			}
 		}
+	}
+
+	componentDidMount() {
+		// Change the isMobile state when the size of the browser changes.
+		this.unsubscribe = subscribeIsWithinBreakpoint( '<960px', ( isMobile ) => {
+			this.setState( { isMobile } );
+		} );
 	}
 
 	getCurrentPlugins() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `PluginsMain` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/plugins/manage/:site` where `:site` is a WP.com simple site.
* Verify that shortly you're still redirected to `/plugins/:site`
* Verify that the redirect doesn't happen for Jetpack sites.