### PR TITLE
Remove lodash from `getTimezones` selector

### DIFF
--- a/client/components/data/query-timezones/index.jsx
+++ b/client/components/data/query-timezones/index.jsx
@@ -1,20 +1,15 @@
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { requestTimezones } from 'calypso/state/timezones/actions';
 
-export class QueryTimezones extends Component {
-	static propTypes = {
-		requestTimezones: PropTypes.func,
-	};
+function QueryTimezones() {
+	const dispatch = useDispatch();
 
-	componentDidMount() {
-		this.props.requestTimezones();
-	}
+	useEffect( () => {
+		dispatch( requestTimezones() );
+	}, [ dispatch ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
 
-export default connect( null, { requestTimezones } )( QueryTimezones );
+export default QueryTimezones;

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -48,6 +48,10 @@ const initialReduxState = {
 	editor: {
 		imageEditor: {},
 	},
+	timezones: {
+		labels: {},
+		byContinents: {},
+	},
 	ui: {},
 };
 

--- a/client/state/selectors/get-timezones-labels.js
+++ b/client/state/selectors/get-timezones-labels.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 import 'calypso/state/timezones/init';
 
 /**
@@ -12,5 +10,5 @@ import 'calypso/state/timezones/init';
  * @returns {object} An object of timezones labels
  */
 export default function getTimezonesLabels( state ) {
-	return get( state, 'timezones.labels', {} );
+	return state.timezones.labels;
 }

--- a/client/state/selectors/get-timezones.js
+++ b/client/state/selectors/get-timezones.js
@@ -18,13 +18,7 @@ import 'calypso/state/timezones/init';
  * @returns {Array} Timezones arrays
  */
 export default function getTimezones( state ) {
-	const continents = state.timezones?.byContinents ?? null;
-
-	if ( ! continents ) {
-		return null;
-	}
-
-	return Object.entries( continents ).map( ( zones ) => [
+	return Object.entries( state.timezones.byContinents ).map( ( zones ) => [
 		zones[ 0 ],
 		zones[ 1 ].map( ( value ) => [ value, getTimezonesLabel( state, value ) ] ),
 	] );

--- a/client/state/selectors/get-timezones.js
+++ b/client/state/selectors/get-timezones.js
@@ -1,4 +1,3 @@
-import { get, map } from 'lodash';
 import getTimezonesLabel from 'calypso/state/selectors/get-timezones-label';
 
 import 'calypso/state/timezones/init';
@@ -19,14 +18,14 @@ import 'calypso/state/timezones/init';
  * @returns {Array} Timezones arrays
  */
 export default function getTimezones( state ) {
-	const continents = get( state, 'timezones.byContinents', null );
+	const continents = state.timezones?.byContinents ?? null;
 
 	if ( ! continents ) {
 		return null;
 	}
 
-	return map( Object.entries( continents ), ( zones ) => [
+	return Object.entries( continents ).map( ( zones ) => [
 		zones[ 0 ],
-		map( zones[ 1 ], ( value ) => [ value, getTimezonesLabel( state, value ) ] ),
+		zones[ 1 ].map( ( value ) => [ value, getTimezonesLabel( state, value ) ] ),
 	] );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove lodash from `getTimezones` selector
* Remove lodash from `getTimezonesLabels` selector
* Refactor `QueryTimezones` to FC (drive by)

#### Testing instructions

* Go to e.g. `/settings/general/:site`
* Verify the _Site timezone_ dropdown still works as expected

Related to #58453 
