### PR TITLE
Seller Experience: Add new themes to the design picker

### DIFF
--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -173,7 +173,7 @@
 				{ "slug": "store", "name": "Store" }
 			],
 			"is_premium": false,
-			"is_fse": false,
+			"is_fse": true,
 			"preview": "static",
 			"features": []
 		},
@@ -187,7 +187,7 @@
 				{ "slug": "store", "name": "Store" }
 			],
 			"is_premium": false,
-			"is_fse": false,
+			"is_fse": true,
 			"preview": "static",
 			"features": []
 		},
@@ -201,7 +201,7 @@
 				{ "slug": "store", "name": "Store" }
 			],
 			"is_premium": false,
-			"is_fse": false,
+			"is_fse": true,
 			"preview": "static",
 			"features": []
 		},
@@ -215,7 +215,7 @@
 				{ "slug": "store", "name": "Store" }
 			],
 			"is_premium": false,
-			"is_fse": false,
+			"is_fse": true,
 			"preview": "static",
 			"features": []
 		},
@@ -229,7 +229,7 @@
 				{ "slug": "store", "name": "Store" }
 			],
 			"is_premium": false,
-			"is_fse": false,
+			"is_fse": true,
 			"preview": "static",
 			"features": []
 		},

--- a/packages/design-picker/src/available-designs-config.json
+++ b/packages/design-picker/src/available-designs-config.json
@@ -164,6 +164,76 @@
 			"features": []
 		},
 		{
+			"title": "Marl",
+			"slug": "marl",
+			"template": "blockbase",
+			"theme": "marl",
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "store", "name": "Store" }
+			],
+			"is_premium": false,
+			"is_fse": false,
+			"preview": "static",
+			"features": []
+		},
+		{
+			"title": "Attar",
+			"slug": "attar",
+			"template": "blockbase",
+			"theme": "attar",
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "store", "name": "Store" }
+			],
+			"is_premium": false,
+			"is_fse": false,
+			"preview": "static",
+			"features": []
+		},
+		{
+			"title": "Hari",
+			"slug": "hari",
+			"template": "blockbase",
+			"theme": "hari",
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "store", "name": "Store" }
+			],
+			"is_premium": false,
+			"is_fse": false,
+			"preview": "static",
+			"features": []
+		},
+		{
+			"title": "Winkel",
+			"slug": "winkel",
+			"template": "blockbase",
+			"theme": "winkel",
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "store", "name": "Store" }
+			],
+			"is_premium": false,
+			"is_fse": false,
+			"preview": "static",
+			"features": []
+		},
+		{
+			"title": "Dorna",
+			"slug": "dorna",
+			"template": "blockbase",
+			"theme": "dorna",
+			"categories": [
+				{ "slug": "featured", "name": "Featured" },
+				{ "slug": "store", "name": "Store" }
+			],
+			"is_premium": false,
+			"is_fse": false,
+			"preview": "static",
+			"features": []
+		},
+		{
 			"title": "Russell",
 			"slug": "russell",
 			"template": "russell",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds new themes _Attar_, _Marl_, _Hari_, _Dorna_, and _Winkel_ to signup with a `store` tag/category.
* TODO: This does not add the "Store" category in the design picker yet.

#### Testing instructions

* Switch to this PR
* Navigate to `/start` and create a new free site
* At the design picker step, make sure the above themes are included in the options
* Make sure choosing the themes works correctly and looks like the site demo

Related to #61470