### PR TITLE
Checkout: Fix and Improve Jetpack Pre-Purchase Notices

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/cart-plan-overlaps-owned-product-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/cart-plan-overlaps-owned-product-notice.tsx
@@ -1,6 +1,6 @@
 import { getJetpackProductDisplayName } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, FunctionComponent } from 'react';
+import { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import PrePurchaseNotice from './prepurchase-notice';
@@ -38,7 +38,7 @@ const CartPlanOverlapsOwnedProductNotice: FunctionComponent< Props > = ( {
 			comment: 'The `product` variable refers to the product the customer owns already',
 			components: {
 				link: <a href={ subscriptionUrl } />,
-				product: getJetpackProductDisplayName( product ) as ReactElement,
+				product: <>{ getJetpackProductDisplayName( product ) }</>,
 			},
 		}
 	);

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -1,8 +1,12 @@
 import {
 	getProductFromSlug,
+	isJetpackAntiSpam,
+	isJetpackAntiSpamSlug,
 	isJetpackBackup,
 	isJetpackBackupSlug,
 	isJetpackPlanSlug,
+	isJetpackScan,
+	isJetpackScanSlug,
 } from '@automattic/calypso-products';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useEffect } from 'react';
@@ -13,6 +17,10 @@ import { requestRewindCapabilities } from 'calypso/state/rewind/capabilities/act
 import {
 	isPlanIncludingSiteBackup,
 	isBackupProductIncludedInSitePlan,
+	isPlanIncludingSiteAntiSpam,
+	isAntiSpamProductIncludedInSitePlan,
+	isPlanIncludingSiteScan,
+	isScanProductIncludedInSitePlan,
 } from 'calypso/state/sites/products/conflicts';
 import {
 	getSitePlan,
@@ -41,6 +49,9 @@ const PrePurchaseNotices = () => {
 	const { responseCart } = useShoppingCart( cartKey );
 	const cartItemSlugs = responseCart.products.map( ( item ) => item.product_slug );
 
+	/**
+	 * Ensure site rewind capabilities are loaded, for use by isPlanIncludingSiteBackup().
+	 */
 	useEffect( () => {
 		if ( ! siteId ) return;
 		dispatch( requestRewindCapabilities( siteId ) );
@@ -53,6 +64,7 @@ const PrePurchaseNotices = () => {
 
 		return getSitePlan( state, siteId );
 	} );
+
 	const currentSiteProducts = useSelector( ( state ) => {
 		if ( ! siteId ) {
 			return null;
@@ -62,18 +74,57 @@ const PrePurchaseNotices = () => {
 		return products.filter( ( p ) => ! p.expired );
 	} );
 
-	const backupSlugInCart = cartItemSlugs.find( isJetpackBackupSlug );
-
-	const cartPlanOverlapsSiteBackupPurchase = useSelector( ( state ) => {
+	/**
+	 * The active product on the current site that overlaps/conflicts with the plan currently in the cart.
+	 */
+	const siteProductThatOverlapsCartPlan = useSelector( ( state ) => {
 		const planSlugInCart = cartItemSlugs.find( isJetpackPlanSlug );
 
-		return planSlugInCart && isPlanIncludingSiteBackup( state, siteId, planSlugInCart );
+		if ( ! planSlugInCart ) return null;
+
+		if ( isPlanIncludingSiteBackup( state, siteId, planSlugInCart ) ) {
+			return currentSiteProducts.find( isJetpackBackup );
+		}
+
+		if ( isPlanIncludingSiteAntiSpam( state, siteId, planSlugInCart ) ) {
+			return currentSiteProducts.find( isJetpackAntiSpam );
+		}
+
+		if ( isPlanIncludingSiteScan( state, siteId, planSlugInCart ) ) {
+			return currentSiteProducts.find( isJetpackScan );
+		}
+
+		return null;
 	} );
 
-	const sitePlanIncludesCartBackupProduct = useSelector(
-		( state ) =>
-			backupSlugInCart && isBackupProductIncludedInSitePlan( state, siteId, backupSlugInCart )
-	);
+	/**
+	 * The product currently in the cart that overlaps/conflicts with the current active site plan.
+	 */
+	const cartProductThatOverlapsSitePlan = useSelector( ( state ) => {
+		const backupSlugInCart = cartItemSlugs.find( isJetpackBackupSlug );
+		const antiSpamSlugInCart = cartItemSlugs.find( isJetpackAntiSpamSlug );
+		const scanSlugInCart = cartItemSlugs.find( isJetpackScanSlug );
+
+		if (
+			backupSlugInCart &&
+			isBackupProductIncludedInSitePlan( state, siteId, backupSlugInCart )
+		) {
+			return getProductFromSlug( backupSlugInCart );
+		}
+
+		if (
+			antiSpamSlugInCart &&
+			isAntiSpamProductIncludedInSitePlan( state, siteId, antiSpamSlugInCart )
+		) {
+			return getProductFromSlug( antiSpamSlugInCart );
+		}
+
+		if ( scanSlugInCart && isScanProductIncludedInSitePlan( state, siteId, scanSlugInCart ) ) {
+			return getProductFromSlug( scanSlugInCart );
+		}
+
+		return null;
+	} );
 
 	const BACKUP_MINIMUM_JETPACK_VERSION = '8.5';
 	const siteHasBackupMinimumPluginVersion = useSelector( ( state ) => {
@@ -99,38 +150,36 @@ const PrePurchaseNotices = () => {
 		return null;
 	}
 
-	// This site has an active Jetpack Backup product purchase,
-	// but we're attempting to buy a plan that includes one as well
-	const siteBackupProduct = currentSiteProducts.find( isJetpackBackup );
-	if ( cartPlanOverlapsSiteBackupPurchase && siteBackupProduct ) {
+	// This site has an active Jetpack product purchase, but we're
+	// attempting to buy a plan that includes the same one as well.
+	// i.e. User owns a Jetpack Backup product, and is attempting
+	// to purchase Jetpack Security.
+	if ( siteProductThatOverlapsCartPlan ) {
 		return (
 			<CartPlanOverlapsOwnedProductNotice
-				product={ siteBackupProduct }
+				product={ siteProductThatOverlapsCartPlan }
 				selectedSite={ selectedSite }
 			/>
 		);
 	}
-
-	// Notices after this point require a Backup product to be in the cart
-	if ( ! backupSlugInCart ) {
-		return null;
-	}
-
-	const backupProductInCart = getProductFromSlug( backupSlugInCart );
 
 	// We're attempting to buy Jetpack Backup individually,
 	// but this site already has a plan that includes it
-	if ( sitePlanIncludesCartBackupProduct && currentSitePlan ) {
+	if ( currentSitePlan && cartProductThatOverlapsSitePlan ) {
 		return (
 			<SitePlanIncludesCartProductNotice
 				plan={ currentSitePlan }
-				product={ backupProductInCart }
+				product={ cartProductThatOverlapsSitePlan }
 				selectedSite={ selectedSite }
 			/>
 		);
 	}
 
-	if ( ! siteHasBackupMinimumPluginVersion ) {
+	// We're attempting to buy a Jetpack Backup product,
+	// but this site does not have the minimum plugin version.
+	const backupSlugInCart = cartItemSlugs.find( isJetpackBackupSlug );
+	const backupProductInCart = getProductFromSlug( backupSlugInCart );
+	if ( ! siteHasBackupMinimumPluginVersion && backupProductInCart ) {
 		return (
 			<JetpackPluginRequiredVersionNotice
 				product={ backupProductInCart }

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -5,9 +5,11 @@ import {
 	isJetpackPlanSlug,
 } from '@automattic/calypso-products';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import { useSelector } from 'react-redux';
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { requestRewindCapabilities } from 'calypso/state/rewind/capabilities/actions';
 import {
 	isPlanIncludingSiteBackup,
 	isBackupProductIncludedInSitePlan,
@@ -30,12 +32,19 @@ import './style.scss';
  * from a range of possible options.
  */
 const PrePurchaseNotices = () => {
+	const dispatch = useDispatch();
+
 	const selectedSite = useSelector( getSelectedSite );
 	const siteId = selectedSite?.ID;
 
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const cartItemSlugs = responseCart.products.map( ( item ) => item.product_slug );
+
+	useEffect( () => {
+		if ( ! siteId ) return;
+		dispatch( requestRewindCapabilities( siteId ) );
+	}, [ dispatch, siteId ] );
 
 	const currentSitePlan = useSelector( ( state ) => {
 		if ( ! siteId ) {

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/site-plan-includes-cart-product-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/site-plan-includes-cart-product-notice.tsx
@@ -1,6 +1,6 @@
 import { getJetpackProductDisplayName } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, FunctionComponent } from 'react';
+import { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import PrePurchaseNotice from './prepurchase-notice';
@@ -40,7 +40,7 @@ const SitePlanIncludesCartProductNotice: FunctionComponent< Props > = ( {
 				plan: plan.product_name_short,
 			},
 			components: {
-				product: getJetpackProductDisplayName( product ) as ReactElement,
+				product: <>{ getJetpackProductDisplayName( product ) }</>,
 			},
 			comment:
 				'The `plan` variable refers to the short name of the plan the customer owns already. `product` refers to the product in the cart that is already included in the plan.',

--- a/client/state/sites/products/conflicts.ts
+++ b/client/state/sites/products/conflicts.ts
@@ -1,15 +1,23 @@
 import {
-	planHasAtLeastOneFeature,
-	planHasSuperiorFeature,
-	JETPACK_PLANS,
-	FEATURE_JETPACK_BACKUP_REALTIME,
+	FEATURE_JETPACK_ANTI_SPAM,
+	FEATURE_JETPACK_ANTI_SPAM_MONTHLY,
 	FEATURE_JETPACK_BACKUP_DAILY,
 	FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
+	FEATURE_JETPACK_BACKUP_REALTIME,
 	FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
 	FEATURE_JETPACK_BACKUP_T1_MONTHLY,
 	FEATURE_JETPACK_BACKUP_T1_YEARLY,
 	FEATURE_JETPACK_BACKUP_T2_MONTHLY,
 	FEATURE_JETPACK_BACKUP_T2_YEARLY,
+	FEATURE_JETPACK_SCAN_DAILY,
+	FEATURE_JETPACK_SCAN_DAILY_MONTHLY,
+	isJetpackAntiSpam,
+	isJetpackScan,
+	JETPACK_PLANS,
+	JETPACK_ANTI_SPAM_PRODUCTS,
+	JETPACK_SCAN_PRODUCTS,
+	planHasAtLeastOneFeature,
+	planHasSuperiorFeature,
 	PRODUCT_JETPACK_BACKUP_DAILY,
 	PRODUCT_JETPACK_BACKUP_REALTIME,
 	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
@@ -21,7 +29,7 @@ import {
 } from '@automattic/calypso-products';
 import { createSelector } from '@automattic/state-utils';
 import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
-import { getSitePlanSlug } from 'calypso/state/sites/selectors';
+import { getSiteProducts, getSitePlanSlug } from 'calypso/state/sites/selectors';
 import type { AppState } from 'calypso/types';
 
 const DAILY_BACKUP_FEATURES = [
@@ -52,6 +60,10 @@ const REALTIME_BACKUP_PRODUCTS = [
 	PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
 ];
 
+const ANTI_SPAM_FEATURES = [ FEATURE_JETPACK_ANTI_SPAM, FEATURE_JETPACK_ANTI_SPAM_MONTHLY ];
+
+const SCAN_FEATURES = [ FEATURE_JETPACK_SCAN_DAILY, FEATURE_JETPACK_SCAN_DAILY_MONTHLY ];
+
 /**
  * Check is a Jetpack plan is including a daily backup feature.
  *
@@ -78,6 +90,38 @@ export const planHasDailyBackup = ( planSlug: string, orSuperior = false ): bool
 export const planHasRealTimeBackup = ( planSlug: string, orSuperior = false ): boolean => {
 	const hasFeature = planHasAtLeastOneFeature( planSlug, REALTIME_BACKUP_FEATURES );
 	const hasSuperiorFeature = REALTIME_BACKUP_FEATURES.some( ( feature ) =>
+		planHasSuperiorFeature( planSlug, feature )
+	);
+
+	return orSuperior ? hasFeature || hasSuperiorFeature : hasFeature;
+};
+
+/**
+ * Check is a Jetpack plan is including an anti-spam feature.
+ *
+ * @param {string} planSlug The plan slug.
+ * @param {boolean} orSuperior When true, also checks plan for superior features.
+ * @returns {boolean} True if the plan includes an anti-spam feature.
+ */
+export const planHasAntiSpam = ( planSlug: string, orSuperior = false ): boolean => {
+	const hasFeature = planHasAtLeastOneFeature( planSlug, ANTI_SPAM_FEATURES );
+	const hasSuperiorFeature = ANTI_SPAM_FEATURES.some( ( feature ) =>
+		planHasSuperiorFeature( planSlug, feature )
+	);
+
+	return orSuperior ? hasFeature || hasSuperiorFeature : hasFeature;
+};
+
+/**
+ * Check is a Jetpack plan is including a scan feature.
+ *
+ * @param {string} planSlug The plan slug.
+ * @param {boolean} orSuperior When true, also checks plan for superior features.
+ * @returns {boolean} True if the plan includes a scan feature.
+ */
+export const planHasScan = ( planSlug: string, orSuperior = false ): boolean => {
+	const hasFeature = planHasAtLeastOneFeature( planSlug, SCAN_FEATURES );
+	const hasSuperiorFeature = SCAN_FEATURES.some( ( feature ) =>
 		planHasSuperiorFeature( planSlug, feature )
 	);
 
@@ -155,6 +199,150 @@ export const isBackupProductIncludedInSitePlan = createSelector(
 
 		if ( REALTIME_BACKUP_PRODUCTS.includes( productSlug ) ) {
 			return planHasRealTimeBackup( sitePlanSlug, true );
+		}
+
+		return null;
+	},
+	[
+		( state: AppState, siteId: number | null, productSlug: string ) => [
+			siteId,
+			productSlug,
+			getSitePlanSlug( state, siteId ),
+		],
+	]
+);
+
+/**
+ * Check if a Jetpack plan is including an Anti-Spam product a site might already have.
+ *
+ * @param {AppState} state The redux state.
+ * @param {number} siteId The site ID.
+ * @param {string} planSlug The plan slug.
+ * @returns {boolean|null} True if the plan includes the Anti-Spam product, or null when it's unable to be determined.
+ */
+export const isPlanIncludingSiteAntiSpam = createSelector(
+	( state: AppState, siteId: number | null, planSlug: string ): boolean | null => {
+		if ( ! siteId || ! ( JETPACK_PLANS as ReadonlyArray< string > ).includes( planSlug ) ) {
+			return null;
+		}
+
+		const products = getSiteProducts( state, siteId ) || [];
+		const siteProducts = products.filter( ( p ) => ! p.expired );
+
+		const sitePlanSlug = getSitePlanSlug( state, siteId );
+		const siteHasAntiSpam = Boolean(
+			( sitePlanSlug && planHasAntiSpam( sitePlanSlug ) ) || siteProducts.find( isJetpackAntiSpam )
+		);
+
+		return siteHasAntiSpam && planHasAntiSpam( planSlug );
+	},
+	[
+		( state: AppState, siteId: number | null, planSlug: string ) => [
+			siteId,
+			planSlug,
+			getSitePlanSlug( state, siteId ),
+			getSiteProducts( state, siteId ),
+		],
+	]
+);
+
+/**
+ * Check if an Anti-Spam product is already included in a site plan.
+ *
+ * @param {AppState} state The redux state.
+ * @param {number} siteId The site ID.
+ * @param {string} productSlug The product slug.
+ * @returns {boolean|null} True if the product is already included in a plan, or null when it's unable to be determined.
+ */
+export const isAntiSpamProductIncludedInSitePlan = createSelector(
+	( state: AppState, siteId: number | null, productSlug: string ): boolean | null => {
+		if ( ! siteId ) {
+			return null;
+		}
+
+		const sitePlanSlug = getSitePlanSlug( state, siteId );
+
+		if (
+			! sitePlanSlug ||
+			! ( JETPACK_PLANS as ReadonlyArray< string > ).includes( sitePlanSlug )
+		) {
+			return null;
+		}
+
+		if ( ( JETPACK_ANTI_SPAM_PRODUCTS as ReadonlyArray< string > ).includes( productSlug ) ) {
+			return planHasAntiSpam( sitePlanSlug, true );
+		}
+
+		return null;
+	},
+	[
+		( state: AppState, siteId: number | null, productSlug: string ) => [
+			siteId,
+			productSlug,
+			getSitePlanSlug( state, siteId ),
+		],
+	]
+);
+
+/**
+ * Check if a Jetpack plan is including a Scan product a site might already have.
+ *
+ * @param {AppState} state The redux state.
+ * @param {number} siteId The site ID.
+ * @param {string} planSlug The plan slug.
+ * @returns {boolean|null} True if the plan includes the Scan product, or null when it's unable to be determined.
+ */
+export const isPlanIncludingSiteScan = createSelector(
+	( state: AppState, siteId: number | null, planSlug: string ): boolean | null => {
+		if ( ! siteId || ! ( JETPACK_PLANS as ReadonlyArray< string > ).includes( planSlug ) ) {
+			return null;
+		}
+
+		const products = getSiteProducts( state, siteId ) || [];
+		const siteProducts = products.filter( ( p ) => ! p.expired );
+
+		const sitePlanSlug = getSitePlanSlug( state, siteId );
+		const siteHasScan = Boolean(
+			( !! sitePlanSlug && planHasScan( sitePlanSlug ) ) || siteProducts.find( isJetpackScan )
+		);
+
+		return siteHasScan && planHasScan( planSlug );
+	},
+	[
+		( state: AppState, siteId: number | null, planSlug: string ) => [
+			siteId,
+			planSlug,
+			getSitePlanSlug( state, siteId ),
+			getSiteProducts( state, siteId ),
+		],
+	]
+);
+
+/**
+ * Check if a Scan product is already included in a site plan.
+ *
+ * @param {AppState} state The redux state.
+ * @param {number} siteId The site ID.
+ * @param {string} productSlug The product slug.
+ * @returns {boolean|null} True if the product is already included in a plan, or null when it's unable to be determined.
+ */
+export const isScanProductIncludedInSitePlan = createSelector(
+	( state: AppState, siteId: number | null, productSlug: string ): boolean | null => {
+		if ( ! siteId ) {
+			return null;
+		}
+
+		const sitePlanSlug = getSitePlanSlug( state, siteId );
+
+		if (
+			! sitePlanSlug ||
+			! ( JETPACK_PLANS as ReadonlyArray< string > ).includes( sitePlanSlug )
+		) {
+			return null;
+		}
+
+		if ( ( JETPACK_SCAN_PRODUCTS as ReadonlyArray< string > ).includes( productSlug ) ) {
+			return planHasScan( sitePlanSlug, true );
 		}
 
 		return null;

--- a/client/state/sites/products/conflicts.ts
+++ b/client/state/sites/products/conflicts.ts
@@ -1,20 +1,23 @@
 import {
-	planHasFeature,
 	planHasAtLeastOneFeature,
 	planHasSuperiorFeature,
+	JETPACK_PLANS,
 	FEATURE_JETPACK_BACKUP_REALTIME,
 	FEATURE_JETPACK_BACKUP_DAILY,
-	JETPACK_PLANS,
-	PRODUCT_JETPACK_BACKUP_DAILY,
-	PRODUCT_JETPACK_BACKUP_REALTIME,
-	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
-	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
 	FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
 	FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
 	FEATURE_JETPACK_BACKUP_T1_MONTHLY,
 	FEATURE_JETPACK_BACKUP_T1_YEARLY,
 	FEATURE_JETPACK_BACKUP_T2_MONTHLY,
 	FEATURE_JETPACK_BACKUP_T2_YEARLY,
+	PRODUCT_JETPACK_BACKUP_DAILY,
+	PRODUCT_JETPACK_BACKUP_REALTIME,
+	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+	PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_T2_YEARLY,
 } from '@automattic/calypso-products';
 import { createSelector } from '@automattic/state-utils';
 import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
@@ -26,6 +29,11 @@ const DAILY_BACKUP_FEATURES = [
 	FEATURE_JETPACK_BACKUP_DAILY,
 ];
 
+const DAILY_BACKUP_PRODUCTS = [
+	PRODUCT_JETPACK_BACKUP_DAILY,
+	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+];
+
 const REALTIME_BACKUP_FEATURES = [
 	FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
 	FEATURE_JETPACK_BACKUP_REALTIME,
@@ -35,23 +43,46 @@ const REALTIME_BACKUP_FEATURES = [
 	FEATURE_JETPACK_BACKUP_T2_YEARLY,
 ];
 
+const REALTIME_BACKUP_PRODUCTS = [
+	PRODUCT_JETPACK_BACKUP_REALTIME,
+	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+	PRODUCT_JETPACK_BACKUP_T2_YEARLY,
+	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
+];
+
 /**
  * Check is a Jetpack plan is including a daily backup feature.
  *
  * @param {string} planSlug The plan slug.
+ * @param {boolean} orSuperior When true, also checks plan for superior features.
  * @returns {boolean} True if the plan includes a daily backup feature.
  */
-export const planHasDailyBackup = ( planSlug: string ): boolean =>
-	planHasAtLeastOneFeature( planSlug, DAILY_BACKUP_FEATURES );
+export const planHasDailyBackup = ( planSlug: string, orSuperior = false ): boolean => {
+	const hasFeature = planHasAtLeastOneFeature( planSlug, DAILY_BACKUP_FEATURES );
+	const hasSuperiorFeature = DAILY_BACKUP_FEATURES.some( ( feature ) =>
+		planHasSuperiorFeature( planSlug, feature )
+	);
+
+	return orSuperior ? hasFeature || hasSuperiorFeature : hasFeature;
+};
 
 /**
  * Check is a Jetpack plan is including a real-time backup feature.
  *
  * @param {string} planSlug The plan slug.
+ * @param {boolean} orSuperior When true, also checks plan for superior features.
  * @returns {boolean} True if the plan includes a real-time backup feature.
  */
-export const planHasRealTimeBackup = ( planSlug: string ): boolean =>
-	planHasAtLeastOneFeature( planSlug, REALTIME_BACKUP_FEATURES );
+export const planHasRealTimeBackup = ( planSlug: string, orSuperior = false ): boolean => {
+	const hasFeature = planHasAtLeastOneFeature( planSlug, REALTIME_BACKUP_FEATURES );
+	const hasSuperiorFeature = REALTIME_BACKUP_FEATURES.some( ( feature ) =>
+		planHasSuperiorFeature( planSlug, feature )
+	);
+
+	return orSuperior ? hasFeature || hasSuperiorFeature : hasFeature;
+};
 
 /**
  * Check if a Jetpack plan is including a Backup product a site might already have.
@@ -118,25 +149,15 @@ export const isBackupProductIncludedInSitePlan = createSelector(
 			return null;
 		}
 
-		let feature;
-
-		if (
-			[ PRODUCT_JETPACK_BACKUP_DAILY, PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ].includes( productSlug )
-		) {
-			feature = FEATURE_JETPACK_BACKUP_DAILY;
-		} else if (
-			[ PRODUCT_JETPACK_BACKUP_REALTIME, PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ].includes(
-				productSlug
-			)
-		) {
-			feature = FEATURE_JETPACK_BACKUP_REALTIME;
-		} else {
-			return null;
+		if ( DAILY_BACKUP_PRODUCTS.includes( productSlug ) ) {
+			return planHasDailyBackup( sitePlanSlug, true );
 		}
 
-		return (
-			planHasFeature( sitePlanSlug, feature ) || planHasSuperiorFeature( sitePlanSlug, feature )
-		);
+		if ( REALTIME_BACKUP_PRODUCTS.includes( productSlug ) ) {
+			return planHasRealTimeBackup( sitePlanSlug, true );
+		}
+
+		return null;
 	},
 	[
 		( state: AppState, siteId: number | null, productSlug: string ) => [

--- a/client/state/sites/products/test/conflicts.ts
+++ b/client/state/sites/products/test/conflicts.ts
@@ -16,7 +16,12 @@ import {
 	PLAN_JETPACK_SECURITY_T2_MONTHLY,
 	PLAN_JETPACK_SECURITY_T2_YEARLY,
 } from '@automattic/calypso-products';
-import { planHasDailyBackup, planHasRealTimeBackup } from '../conflicts';
+import {
+	planHasAntiSpam,
+	planHasDailyBackup,
+	planHasRealTimeBackup,
+	planHasScan,
+} from '../conflicts';
 
 const plansWithDailyBackup = [
 	PLAN_JETPACK_PERSONAL,
@@ -40,6 +45,46 @@ const plansWithRealTimeBackup = [
 	PLAN_JETPACK_SECURITY_T2_YEARLY,
 ];
 
+const plansWithAntiSpam = [
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_YEARLY,
+	PLAN_JETPACK_SECURITY_T2_MONTHLY,
+	PLAN_JETPACK_SECURITY_T2_YEARLY,
+	PLAN_JETPACK_SECURITY_DAILY,
+	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+];
+
+const plansWithScan = [
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_YEARLY,
+	PLAN_JETPACK_SECURITY_T2_MONTHLY,
+	PLAN_JETPACK_SECURITY_T2_YEARLY,
+	PLAN_JETPACK_SECURITY_DAILY,
+	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+];
+
 describe( 'conflicts', () => {
 	test( 'Plans and products that have daily backups return true for plansWithDailyBackup', () => {
 		plansWithDailyBackup.forEach( ( plan ) => {
@@ -50,6 +95,18 @@ describe( 'conflicts', () => {
 	test( 'Plans and products that have real-time backups return true for plansWithRealTimeBackup', () => {
 		plansWithRealTimeBackup.forEach( ( plan ) => {
 			expect( planHasRealTimeBackup( plan ) ).toBe( true );
+		} );
+	} );
+
+	test( 'Plans and products that have anti-spam return true for plansWithAntiSpam', () => {
+		plansWithAntiSpam.forEach( ( plan ) => {
+			expect( planHasAntiSpam( plan ) ).toBe( true );
+		} );
+	} );
+
+	test( 'Plans and products that have scan return true for plansWithScan', () => {
+		plansWithScan.forEach( ( plan ) => {
+			expect( planHasScan( plan ) ).toBe( true );
 		} );
 	} );
 } );

--- a/client/state/sites/products/test/conflicts.ts
+++ b/client/state/sites/products/test/conflicts.ts
@@ -1,0 +1,55 @@
+import {
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_SECURITY_DAILY,
+	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_YEARLY,
+	PLAN_JETPACK_SECURITY_T2_MONTHLY,
+	PLAN_JETPACK_SECURITY_T2_YEARLY,
+} from '@automattic/calypso-products';
+import { planHasDailyBackup, planHasRealTimeBackup } from '../conflicts';
+
+const plansWithDailyBackup = [
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_SECURITY_DAILY,
+	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+];
+
+const plansWithRealTimeBackup = [
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_YEARLY,
+	PLAN_JETPACK_SECURITY_T2_MONTHLY,
+	PLAN_JETPACK_SECURITY_T2_YEARLY,
+];
+
+describe( 'conflicts', () => {
+	test( 'Plans and products that have daily backups return true for plansWithDailyBackup', () => {
+		plansWithDailyBackup.forEach( ( plan ) => {
+			expect( planHasDailyBackup( plan ) ).toBe( true );
+		} );
+	} );
+
+	test( 'Plans and products that have real-time backups return true for plansWithRealTimeBackup', () => {
+		plansWithRealTimeBackup.forEach( ( plan ) => {
+			expect( planHasRealTimeBackup( plan ) ).toBe( true );
+		} );
+	} );
+} );


### PR DESCRIPTION
The `<PrePurchaseNotices />` component declared in `client/my-sites/checkout/composite-checkout/components/prepurchase-notices.jsx` has fallen out of date with the current offering of Jetpack plans and their features, causing the notices to not display when they should. 

For example, when a user already has a Jetpack Backup product, and attempts to purchase a Jetpack plan that includes the equivalent backup feature (i.e. real-time backups), the `<PrePurchaseNotices />` component should render to let them know that they have an overlapping product.

There is also a need for the pre-purchase notices to cover additional cases, such as for scan and anti-spam features (1164141197617539-as-1201857762851565).

This PR serves as a main branch for the assorted fixes and improvements required to get pre-purchase notices back in action.

| Issue | PR | Status |
| ----- | -- | ------- |
| isPlanIncludingSiteBackup() is inaccurate | #61525 | 🟢 Merged |
| isBackupProductIncludedInSitePlan() is inaccurate | #61582 | 🟢 Merged |
| Pre-purchase notice message translation is broken | #61525 | 🟢 Merged |
| Show pre-purchase notices for feature overlaps of Anti-Spam | #61716 | 🟢 Merged |
| Show pre-purchase notices for feature overlaps of Scan |  #61716 | 🟢 Merged |
