### PR TITLE
Plugins: Fix word break in plugins sections

### DIFF
--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -40,7 +40,7 @@
 		margin-bottom: 8px;
 	}
 	a {
-		word-break: break-all;
+		word-break: normal;
 	}
 	blockquote {
 		padding: 10px;


### PR DESCRIPTION
Hyperlinks were cut mid-word when being split into different lines

#### Changes proposed in this Pull Request

* Change the `word-break` css property for `PluginSections`

|Before | After|
|-------|------|
| ![CleanShot 2022-03-01 at 20 20 44](https://user-images.githubusercontent.com/3519124/156234702-e3d80d99-c68a-4715-adbb-5f852fcdb547.gif) | ![CleanShot 2022-03-01 at 20 17 08](https://user-images.githubusercontent.com/3519124/156234707-1323228f-e899-46bd-b4a8-4e292df61800.gif) |

#### Testing instructions

* Visit https://wordpress.com/plugins/wordpress-seo
* Click FAQs and/or Description
* Resize the width of the screen, narrow it and widen it.
* Check that there are no hyperlinks that are incorrectly split by mid-word.

Fixes #61352 

Thanks @WBerredo for the suggested fix