### PR TITLE
Fix the regex for plugin slug.

### DIFF
--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -44,7 +44,7 @@ async function getRequest( url, query ) {
 export function fetchPluginInformation( pluginSlug, locale ) {
 	const query = {
 		action: 'plugin_information',
-		'request[slug]': pluginSlug.replace( new RegExp( '.php$' ), '' ),
+		'request[slug]': pluginSlug.replace( new RegExp( '\\.php$' ), '' ),
 		'request[locale]': getWporgLocaleCode( locale ),
 		'request[fields]': 'icons,short_description,contributors,-added,-donate_link,-homepage',
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fix the regex for plugin slug.

Before this change, it was picking everything ending in php with any character before it.
After this change, it is picking everything ending with `.php`.

Depends on D75879-code

#### Testing instructions
* Go to plugin  the details page of a plugin ending with `php`. Ex: **hide-wp-admin-wp-login-php** on `/plugins/hide-wp-admin-wp-login-php`
* Select a site and click to install
* Check if the entire process goes well.

#### Demo
<img width="1062" alt="Screen Shot 2022-03-01 at 16 29 37" src="https://user-images.githubusercontent.com/5039531/156235755-6de97eee-8396-4ca2-ba6c-0d1c08bd039c.png">

---
Fixes #61343