### PR TITLE
Show Pricing & Packaging Hotjar survey for eligible users

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -82,7 +82,7 @@ const Home = ( {
 			return;
 		}
 
-		if ( ! [ 'US', 'UK', 'AU', 'JP' ].includes( detectedCountryCode ) ) {
+		if ( ! [ 'US', 'GB', 'AU', 'JP' ].includes( detectedCountryCode ) ) {
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Implement the survey described in pdgrnI-oQ-p2.
* Show the survey to users from US, AU, and JP seven days after signup.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Proxy through US, JP, and AU and verify that the survey is visible in Customer Home seven days after signup.
* Without submitting a response, any number of reloads of Customer Home should always show the poll.
* Submit a response on the popover poll, and reload Customer Home. You should not be prompted again for the poll. Verify that your response is captured on Hotjar for the survey "Pricing Research Survey EN - COPY".
* The survey should not be visible if signup was less than seven days before.
* Survey should not show for users from other countries.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


