### PR TITLE
Signup: Link to My Home rather than wp-admin for "Start from scratch"

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -119,10 +119,6 @@ function getDestinationFromIntent( dependencies ) {
 		return `/post/${ siteSlug }`;
 	}
 
-	if ( intent === 'wpadmin' ) {
-		return `https://${ siteSlug }/wp-admin`;
-	}
-
 	if ( intent === 'sell' && storeType === 'woocommerce' ) {
 		return addQueryArgs(
 			{

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -31,6 +31,14 @@ export const EXCLUDED_STEPS: { [ key: string ]: string[] } = {
 	write: [ 'store-options', 'store-features' ],
 	build: [ 'site-options', 'starting-point', 'courses', 'store-options', 'store-features' ],
 	sell: [ 'site-options', 'starting-point', 'courses', 'design-setup-site' ],
+	wpadmin: [
+		'store-options',
+		'store-features',
+		'site-options',
+		'starting-point',
+		'courses',
+		'design-setup-site',
+	],
 };
 
 const EXTERNAL_FLOW: { [ key: string ]: string } = {
@@ -47,7 +55,6 @@ export default function IntentStep( props: Props ): React.ReactNode {
 	const headerText = translate( 'Where will you start?' );
 	const subHeaderText = translate( 'You can change your mind at any time.' );
 	const branchSteps = useBranchSteps( stepName, getExcludedSteps );
-	const siteSlug = props.signupDependencies.siteSlug;
 
 	const siteId = useSelector( ( state ) => getSiteId( state, queryObject.siteSlug as string ) );
 	const canImport = useSelector( ( state ) =>
@@ -65,9 +72,6 @@ export default function IntentStep( props: Props ): React.ReactNode {
 		if ( EXTERNAL_FLOW[ intent ] ) {
 			dispatch( submitSignupStep( { stepName }, providedDependencies ) );
 			page( getStepUrl( EXTERNAL_FLOW[ intent ], '', '', '', queryObject ) );
-		} else if ( 'wpadmin' === intent ) {
-			//Bail from site setup if we're going directly to wp-admin
-			window.location.href = `https://${ siteSlug }/wp-admin/`;
 		} else {
 			branchSteps( providedDependencies );
 			dispatch( submitSignupStep( { stepName }, providedDependencies ) );

--- a/client/signup/steps/intent/intents.tsx
+++ b/client/signup/steps/intent/intents.tsx
@@ -54,7 +54,7 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 			value: 'wpadmin',
 			disable: false,
 			disableText: '',
-			actionText: translate( 'Start from scratch / wp-admin' ),
+			actionText: translate( 'Start from scratch' ),
 		},
 		{
 			show: isEnabled( 'onboarding/import' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Redirect to My Home rather than `/wp-admin` when starting from scratching from the intent step

**Before**

<img width="566" alt="Screen Shot 2022-03-01 at 3 58 48 PM" src="https://user-images.githubusercontent.com/2124984/156247853-d7ad7bc0-8731-4949-88f7-292e1b84b98a.png">

**After**

<img width="549" alt="Screen Shot 2022-03-01 at 3 54 31 PM" src="https://user-images.githubusercontent.com/2124984/156247699-79c66dff-e531-4903-8da6-0d09173793e5.png">


#### Testing instructions

* Switch to this PR, navigate to `/start`
* Create a new site 
* On the Intent step, select "Know what you're doing? Start from scratch"
* You should be redirected to My Home
* Other signup flows should work as expected.


Related to #61543
