### PR TITLE
Add pre-purchase notices for anti-spam overlaps

### DIFF
--- a/client/state/sites/products/conflicts.ts
+++ b/client/state/sites/products/conflicts.ts
@@ -3,8 +3,7 @@ import {
 	FEATURE_JETPACK_BACKUP_REALTIME,
 	FEATURE_JETPACK_BACKUP_DAILY,
 	JETPACK_PLANS,
-	PRODUCT_JETPACK_ANTI_SPAM,
-	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
+	JETPACK_ANTI_SPAM_PRODUCTS,
 	PRODUCT_JETPACK_BACKUP_DAILY,
 	PRODUCT_JETPACK_BACKUP_REALTIME,
 	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
@@ -58,8 +57,6 @@ const REALTIME_BACKUP_PRODUCTS = [
 ];
 
 const ANTI_SPAM_FEATURES = [ FEATURE_JETPACK_ANTI_SPAM, FEATURE_JETPACK_ANTI_SPAM_MONTHLY ];
-
-const ANTI_SPAM_PRODUCTS = [ PRODUCT_JETPACK_ANTI_SPAM, PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ];
 
 /**
  * Check is a Jetpack plan is including a daily backup feature.
@@ -250,7 +247,7 @@ export const isAntiSpamProductIncludedInSitePlan = createSelector(
 			return null;
 		}
 
-		if ( ANTI_SPAM_PRODUCTS.includes( productSlug ) ) {
+		if ( ( JETPACK_ANTI_SPAM_PRODUCTS as ReadonlyArray< string > ).includes( productSlug ) ) {
 			return planHasAntiSpam( sitePlanSlug, true );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds support for pre-purchase notices surrounding anti-spam overlaps. 
  * If a user already has Jetpack Anti-Spam, and attempts to purchase another plan that includes Anti-Spam, they will be shown a notice.
  * If a user already has a plan with anti-spam, and attempts to directly purchase a Jetpack Anti-Spam, they will be shown a notice.
* This is achieved by implementing the same logic as the backup-related pre-purchase notices, except with anti-spam product and feature slugs.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a WordPress site with Jetpack.
* Purchase Jetpack Anti-Spam.
* Add a plan that also includes anti-spam to the cart, such as Jetpack Security.
* Verify the notice is displayed:

<img width="585" alt="Screen Shot 2022-03-03 at 4 33 50 PM" src="https://user-images.githubusercontent.com/10933065/156671106-259236a4-4656-4e0e-b3a3-45cc3fa06ccb.png">

* Remove your Anti-Spam product.
* Purchase a plan that includes Anti-Spam, such as Jetpack Security.
* Add Jetpack Anti-Spam to the cart.
  (You can force this by opening http://calypso.localhost:3000/checkout/[YOUR_SITE]/jetpack_anti_spam)
* Verify the notice is displayed:

<img width="586" alt="Screen Shot 2022-03-03 at 4 35 23 PM" src="https://user-images.githubusercontent.com/10933065/156671123-9f313247-2eb1-4b10-87cc-2608ed58ce21.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #61577
