### PR TITLE
Configure ICFY action to retain uploaded stats only for 7 days

### DIFF
--- a/.github/workflows/icfy-stats.yml
+++ b/.github/workflows/icfy-stats.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           name: icfy
           path: icfy-stats
+          retention-days: 7
       - name: Upload build artifact
         env:
           ICFY_SECRET: ${{ secrets.ICFY_SECRET }}


### PR DESCRIPTION
These artifact are quite big and most of the time we need them only for a few minutes: until the ICFY server receives a webhook notification and downloads the artifact from GitHub.

Only when the ICFY server crashes, and unprocessed builds start queueing up, then we need artifacts that are hours or even days old to be still available when the server restarts, so that nothing gets lost.

See also: https://href.li/?https://github.com/actions/upload-artifact#retention-period