### PR TITLE
Plugins: Unsubscribe breakpoint observer on unmount

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -88,6 +88,10 @@ export class PluginsMain extends Component {
 		} );
 	}
 
+	componentWillUnmount() {
+		this.unsubscribe();
+	}
+
 	getCurrentPlugins() {
 		const { currentPlugins, currentPluginsOnVisibleSites, search, selectedSiteSlug } = this.props;
 		let plugins = selectedSiteSlug ? currentPlugins : currentPluginsOnVisibleSites;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As @flootr observed in https://github.com/Automattic/wp-calypso/pull/61571#discussion_r817474739, we're not cleaning up the breakpoint observer from the `PluginsMain` component on unmount, which might be causing memory leaks.

This PR updates the component to unsubscribe from the breakpoint observer on unmount.

#### Testing instructions

Verify test instructions from #61571 still work well.