### PR TITLE
Plugins Browser: Use compact breadcrumbs when on mobile layout

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -312,7 +312,11 @@ const PluginsBrowser = ( {
 				/>
 			) }
 			{ ! hideHeader && (
-				<FixedNavigationHeader className="plugins-browser__header" navigationItems={ breadcrumbs }>
+				<FixedNavigationHeader
+					className="plugins-browser__header"
+					navigationItems={ breadcrumbs }
+					compactBreadcrumb={ isMobile }
+				>
 					<div className="plugins-browser__main-buttons">
 						<ManageButton
 							shouldShowManageButton={ shouldShowManageButton }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -9,10 +9,10 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import Search from '@automattic/search';
-import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/viewport';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { Icon, upload } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useEffect, useCallback, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import announcementImage from 'calypso/assets/images/marketplace/diamond.svg';
 import AnnouncementModal from 'calypso/blocks/announcement-modal';
@@ -194,7 +194,7 @@ const PluginsBrowser = ( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const [ isMobile, setIsMobile ] = useState();
+	const isMobile = useBreakpoint( '<960px' );
 
 	const shouldShowManageButton = useMemo( () => {
 		if ( isJetpack ) {
@@ -249,21 +249,6 @@ const PluginsBrowser = ( {
 				} )
 			);
 		}
-	}, [] );
-
-	useEffect( () => {
-		if ( isWithinBreakpoint( '<960px' ) ) {
-			setIsMobile( true );
-		}
-		const unsubscribe = subscribeIsWithinBreakpoint( '<960px', ( isMobileLayout ) =>
-			setIsMobile( isMobileLayout )
-		);
-
-		return () => {
-			if ( typeof unsubscribe === 'function' ) {
-				unsubscribe();
-			}
-		};
 	}, [] );
 
 	const fetchNextPagePlugins = useCallback( () => {

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -74,6 +74,13 @@ export class PluginsPage {
 	}
 
 	/**
+	 * Click the Back breadcrumb
+	 */
+	async clickBackBreadcrumb(): Promise< void > {
+		await this.page.click( selectors.breadcrumb( 'Back' ) );
+	}
+
+	/**
 	 * Click the Plugins breadcrumb
 	 */
 	async clickPluginsBreadcrumb(): Promise< void > {

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -2,7 +2,7 @@
  * @group calypso-pr
  */
 
-import { DataHelper, TestAccount, PluginsPage } from '@automattic/calypso-e2e';
+import { DataHelper, TestAccount, PluginsPage, envVariables } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
@@ -35,7 +35,11 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins' ), function () {
 	} );
 
 	it( 'Can return via breadcrumb', async function () {
-		await pluginsPage.clickPluginsBreadcrumb();
+		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
+			await pluginsPage.clickPluginsBreadcrumb();
+		} else {
+			await pluginsPage.clickBackBreadcrumb();
+		}
 		await pluginsPage.validateHasSection( 'Premium' );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Use compact breadcrumbs on Plugins Browser screen when on mobile layout

#### Testing instructions
* Go to `/plugins` page
* Open your browser dev tools
* Enable the resizing screen tool
* Switch from larger screens to smaller screens (< 960px)
* Check if the breadcrumbs are updated
* Click on one of the *Browse All* options
* Apply the same tests as above

![Kapture 2022-03-02 at 10 43 22](https://user-images.githubusercontent.com/5039531/156373538-bd4e0f60-8894-4d71-8221-e00701370478.gif)

---
Fixes #61218
