### PR TITLE
Add common checkout terms component

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -38,14 +38,7 @@ export default function AdditionalTermsOfServiceInCart(): JSX.Element | null {
 					return null;
 				}
 
-				return (
-					<CheckoutTermsItem
-						className="checkout__titan-terms-of-service"
-						key={ termsOfServiceRecord.key }
-					>
-						{ message }
-					</CheckoutTermsItem>
-				);
+				return <CheckoutTermsItem key={ termsOfServiceRecord.key }>{ message }</CheckoutTermsItem>;
 			} ) }
 		</>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { TermsOfServiceRecord, useShoppingCart } from '@automattic/shopping-cart';
 import debugFactory from 'debug';
@@ -6,6 +5,7 @@ import i18n, { useTranslate, TranslateResult } from 'i18n-calypso';
 import moment from 'moment';
 import { useSelector } from 'react-redux';
 import { EDIT_PAYMENT_DETAILS } from 'calypso/lib/url/support';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -39,10 +39,12 @@ export default function AdditionalTermsOfServiceInCart(): JSX.Element | null {
 				}
 
 				return (
-					<div className="checkout__titan-terms-of-service" key={ termsOfServiceRecord.key }>
-						<Gridicon icon="info-outline" size={ 18 } />
-						<p>{ message }</p>
-					</div>
+					<CheckoutTermsItem
+						className="checkout__titan-terms-of-service"
+						key={ termsOfServiceRecord.key }
+					>
+						{ message }
+					</CheckoutTermsItem>
 				);
 			} ) }
 		</>

--- a/client/my-sites/checkout/composite-checkout/components/bundled-domain-notice.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/bundled-domain-notice.jsx
@@ -1,5 +1,4 @@
 import { isMonthly, getPlan, getBillingMonthsForTerm } from '@automattic/calypso-products';
-import { Gridicon } from '@automattic/components';
 import { localizeUrl, translationExists } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import {
@@ -10,6 +9,7 @@ import {
 	hasP2PlusPlan,
 } from 'calypso/lib/cart-values/cart-items';
 import { REGISTER_DOMAIN } from 'calypso/lib/url/support';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -84,13 +84,10 @@ export default function BundledDomainNotice( { cart } ) {
 	);
 
 	return (
-		<div className="checkout__bundled-domain-notice">
-			<Gridicon icon="info-outline" size={ 18 } />
-			<p>
-				{ hasBiennialPlan( cart ) ? twoYearCopy : oneYearCopy }{ ' ' }
-				{ hasDomainRegistration( cart ) ? null : registrationLink }{ ' ' }
-				{ hasBiennialPlan( cart ) ? afterFirstYear : null }
-			</p>
-		</div>
+		<CheckoutTermsItem className="checkout__bundled-domain-notice">
+			{ hasBiennialPlan( cart ) ? twoYearCopy : oneYearCopy }{ ' ' }
+			{ hasDomainRegistration( cart ) ? null : registrationLink }{ ' ' }
+			{ hasBiennialPlan( cart ) ? afterFirstYear : null }
+		</CheckoutTermsItem>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/bundled-domain-notice.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/bundled-domain-notice.jsx
@@ -84,7 +84,7 @@ export default function BundledDomainNotice( { cart } ) {
 	);
 
 	return (
-		<CheckoutTermsItem className="checkout__bundled-domain-notice">
+		<CheckoutTermsItem>
 			{ hasBiennialPlan( cart ) ? twoYearCopy : oneYearCopy }{ ' ' }
 			{ hasDomainRegistration( cart ) ? null : registrationLink }{ ' ' }
 			{ hasBiennialPlan( cart ) ? afterFirstYear : null }

--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms-item.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms-item.tsx
@@ -1,0 +1,27 @@
+import { Gridicon } from '@automattic/components';
+import classNames from 'classnames';
+
+const CheckoutTermsItem = ( {
+	children,
+	className,
+	onClick,
+	wrapChildren = true,
+}: {
+	children: React.ReactNode;
+	className?: string;
+	onClick?: () => void;
+	wrapChildren?: boolean;
+} ): JSX.Element => {
+	return (
+		<div
+			className={ classNames( 'checkout-terms-item', className ) }
+			onClick={ onClick }
+			role="presentation"
+		>
+			<Gridicon icon="info-outline" size={ 18 } />
+			{ wrapChildren ? <p>{ children }</p> : children }
+		</div>
+	);
+};
+
+export default CheckoutTermsItem;

--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms-item.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms-item.tsx
@@ -1,5 +1,31 @@
 import { Gridicon } from '@automattic/components';
+import styled from '@emotion/styled';
 import classNames from 'classnames';
+
+const Wrapper = styled.div`
+	padding-left: 24px;
+	position: relative;
+	font-size: 12px;
+
+	> svg {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 16px;
+		height: 16px;
+
+		.rtl & {
+			left: auto;
+			right: 0;
+		}
+	}
+
+	p {
+		font-size: 12px;
+		margin: 0;
+		word-break: break-word;
+	}
+`;
 
 const CheckoutTermsItem = ( {
 	children,
@@ -13,14 +39,14 @@ const CheckoutTermsItem = ( {
 	wrapChildren?: boolean;
 } ): JSX.Element => {
 	return (
-		<div
-			className={ classNames( 'checkout-terms-item', className ) }
+		<Wrapper
+			className={ classNames( 'checkout__terms-item', className ) }
 			onClick={ onClick }
 			role="presentation"
 		>
 			<Gridicon icon="info-outline" size={ 18 } />
 			{ wrapChildren ? <p>{ children }</p> : children }
-		</div>
+		</Wrapper>
 	);
 };
 

--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms-item.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms-item.tsx
@@ -31,21 +31,17 @@ const CheckoutTermsItem = ( {
 	children,
 	className,
 	onClick,
-	prewrappedChildren,
+	isPrewrappedChildren,
 }: {
 	children: React.ReactNode;
 	className?: string;
 	onClick?: React.MouseEventHandler< HTMLDivElement >;
-	prewrappedChildren?: boolean;
+	isPrewrappedChildren?: boolean;
 } ): JSX.Element => {
 	return (
-		<Wrapper
-			className={ classNames( 'checkout__terms-item', className ) }
-			onClick={ onClick }
-			role="presentation"
-		>
+		<Wrapper className={ classNames( 'checkout__terms-item', className ) } onClick={ onClick }>
 			<Gridicon icon="info-outline" size={ 18 } />
-			{ prewrappedChildren ? children : <p>{ children }</p> }
+			{ isPrewrappedChildren ? children : <p>{ children }</p> }
 		</Wrapper>
 	);
 };

--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms-item.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms-item.tsx
@@ -31,12 +31,12 @@ const CheckoutTermsItem = ( {
 	children,
 	className,
 	onClick,
-	wrapChildren = true,
+	prewrappedChildren,
 }: {
 	children: React.ReactNode;
 	className?: string;
-	onClick?: () => void;
-	wrapChildren?: boolean;
+	onClick?: React.MouseEventHandler< HTMLDivElement >;
+	prewrappedChildren?: boolean;
 } ): JSX.Element => {
 	return (
 		<Wrapper
@@ -45,7 +45,7 @@ const CheckoutTermsItem = ( {
 			role="presentation"
 		>
 			<Gridicon icon="info-outline" size={ 18 } />
-			{ wrapChildren ? <p>{ children }</p> : children }
+			{ prewrappedChildren ? children : <p>{ children }</p> }
 		</Wrapper>
 	);
 };

--- a/client/my-sites/checkout/composite-checkout/components/concierge-refund-policy.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/concierge-refund-policy.jsx
@@ -1,10 +1,10 @@
-import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { hasConciergeSession } from 'calypso/lib/cart-values/cart-items';
 import { REFUNDS } from 'calypso/lib/url/support';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -42,10 +42,9 @@ class ConciergeRefundPolicy extends Component {
 		}
 
 		return (
-			<div className="checkout__concierge-refund-policy">
-				<Gridicon icon="info-outline" size={ 18 } />
-				<p>{ this.renderPolicy() }</p>
-			</div>
+			<CheckoutTermsItem className="checkout__concierge-refund-policy">
+				{ this.renderPolicy() }
+			</CheckoutTermsItem>
 		);
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/components/concierge-refund-policy.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/concierge-refund-policy.jsx
@@ -41,11 +41,7 @@ class ConciergeRefundPolicy extends Component {
 			return null;
 		}
 
-		return (
-			<CheckoutTermsItem className="checkout__concierge-refund-policy">
-				{ this.renderPolicy() }
-			</CheckoutTermsItem>
-		);
+		return <CheckoutTermsItem>{ this.renderPolicy() }</CheckoutTermsItem>;
 	}
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/domain-refund-policy.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-refund-policy.jsx
@@ -106,12 +106,7 @@ class DomainRefundPolicy extends Component {
 		const policies = this.getApplicablePolicies();
 
 		return Object.entries( policies ).map( ( [ name, message ] ) => (
-			<CheckoutTermsItem
-				className="checkout__domain-refund-policy"
-				key={ 'domain-refund-policy-' + name }
-			>
-				{ message }
-			</CheckoutTermsItem>
+			<CheckoutTermsItem key={ 'domain-refund-policy-' + name }>{ message }</CheckoutTermsItem>
 		) );
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/components/domain-refund-policy.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-refund-policy.jsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
@@ -10,6 +9,7 @@ import {
 	hasNewDomainRegistration,
 } from 'calypso/lib/cart-values/cart-items';
 import { DOMAIN_CANCEL, REFUNDS } from 'calypso/lib/url/support';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -106,10 +106,12 @@ class DomainRefundPolicy extends Component {
 		const policies = this.getApplicablePolicies();
 
 		return Object.entries( policies ).map( ( [ name, message ] ) => (
-			<div className="checkout__domain-refund-policy" key={ 'domain-refund-policy-' + name }>
-				<Gridicon icon="info-outline" size={ 18 } />
-				<p>{ message }</p>
-			</div>
+			<CheckoutTermsItem
+				className="checkout__domain-refund-policy"
+				key={ 'domain-refund-policy-' + name }
+			>
+				{ message }
+			</CheckoutTermsItem>
 		) );
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/components/domain-registration-agreement.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-registration-agreement.jsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get, map, reduce } from 'lodash';
 import { Component, Fragment } from 'react';
@@ -9,6 +8,7 @@ import {
 	hasDomainRegistration,
 	hasTransferProduct,
 } from 'calypso/lib/cart-values/cart-items';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -129,10 +129,12 @@ class DomainRegistrationAgreement extends Component {
 		}
 
 		return (
-			<div className="checkout__domain-registration-agreement-link">
-				<Gridicon icon="info-outline" size={ 18 } />
+			<CheckoutTermsItem
+				className="checkout__domain-registration-agreement-link"
+				wrapChildren={ false }
+			>
 				{ this.renderAgreements() }
-			</div>
+			</CheckoutTermsItem>
 		);
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/components/domain-registration-agreement.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-registration-agreement.jsx
@@ -128,7 +128,7 @@ class DomainRegistrationAgreement extends Component {
 			return null;
 		}
 
-		return <CheckoutTermsItem prewrappedChildren>{ this.renderAgreements() }</CheckoutTermsItem>;
+		return <CheckoutTermsItem isPrewrappedChildren>{ this.renderAgreements() }</CheckoutTermsItem>;
 	}
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/domain-registration-agreement.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-registration-agreement.jsx
@@ -128,9 +128,7 @@ class DomainRegistrationAgreement extends Component {
 			return null;
 		}
 
-		return (
-			<CheckoutTermsItem wrapChildren={ false }>{ this.renderAgreements() }</CheckoutTermsItem>
-		);
+		return <CheckoutTermsItem prewrappedChildren>{ this.renderAgreements() }</CheckoutTermsItem>;
 	}
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/domain-registration-agreement.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-registration-agreement.jsx
@@ -129,12 +129,7 @@ class DomainRegistrationAgreement extends Component {
 		}
 
 		return (
-			<CheckoutTermsItem
-				className="checkout__domain-registration-agreement-link"
-				wrapChildren={ false }
-			>
-				{ this.renderAgreements() }
-			</CheckoutTermsItem>
+			<CheckoutTermsItem wrapChildren={ false }>{ this.renderAgreements() }</CheckoutTermsItem>
 		);
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/components/domain-registration-hsts.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-registration-hsts.jsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { isEmpty, merge, reduce } from 'lodash';
@@ -7,6 +6,7 @@ import { connect } from 'react-redux';
 import { getDomainRegistrations, getDomainTransfers } from 'calypso/lib/cart-values/cart-items';
 import { getTld, isHstsRequired } from 'calypso/lib/domains';
 import { HTTPS_SSL } from 'calypso/lib/url/support';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -49,27 +49,22 @@ class DomainRegistrationHsts extends PureComponent {
 		const { translate } = this.props;
 
 		return (
-			<div className="checkout__domain-registration-hsts">
-				<Gridicon icon="info-outline" size={ 18 } />
-				<p>
-					{ translate(
-						'All domains ending in {{strong}}%(tld)s{{/strong}} require an SSL certificate ' +
-							'to host a website. When you host this domain at WordPress.com an SSL ' +
-							'certificate is included. {{a}}Learn more{{/a}}.',
-						{
-							args: {
-								tld: tlds,
-							},
-							components: {
-								a: (
-									<a href={ localizeUrl( HTTPS_SSL ) } target="_blank" rel="noopener noreferrer" />
-								),
-								strong: <strong />,
-							},
-						}
-					) }
-				</p>
-			</div>
+			<CheckoutTermsItem className="checkout__domain-registration-hsts">
+				{ translate(
+					'All domains ending in {{strong}}%(tld)s{{/strong}} require an SSL certificate ' +
+						'to host a website. When you host this domain at WordPress.com an SSL ' +
+						'certificate is included. {{a}}Learn more{{/a}}.',
+					{
+						args: {
+							tld: tlds,
+						},
+						components: {
+							a: <a href={ localizeUrl( HTTPS_SSL ) } target="_blank" rel="noopener noreferrer" />,
+							strong: <strong />,
+						},
+					}
+				) }
+			</CheckoutTermsItem>
 		);
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/components/domain-registration-hsts.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-registration-hsts.jsx
@@ -49,7 +49,7 @@ class DomainRegistrationHsts extends PureComponent {
 		const { translate } = this.props;
 
 		return (
-			<CheckoutTermsItem className="checkout__domain-registration-hsts">
+			<CheckoutTermsItem>
 				{ translate(
 					'All domains ending in {{strong}}%(tld)s{{/strong}} require an SSL certificate ' +
 						'to host a website. When you host this domain at WordPress.com an SSL ' +

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-step.tsx
@@ -33,25 +33,6 @@ const CheckoutTermsWrapper = styled.div`
 		margin-top: 32px;
 	}
 
-	svg {
-		width: 16px;
-		height: 16px;
-		position: absolute;
-		top: 0;
-		left: 0;
-
-		.rtl & {
-			left: auto;
-			right: 0;
-		}
-	}
-
-	p {
-		font-size: 12px;
-		margin: 0;
-		word-break: break-word;
-	}
-
 	a {
 		text-decoration: underline;
 	}

--- a/client/my-sites/checkout/composite-checkout/components/terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/terms-of-service.jsx
@@ -37,7 +37,7 @@ class TermsOfService extends Component {
 
 	render() {
 		return (
-			<CheckoutTermsItem className="checkout__terms" onClick={ this.recordTermsAndConditionsClick }>
+			<CheckoutTermsItem onClick={ this.recordTermsAndConditionsClick }>
 				{ this.renderTerms() }
 			</CheckoutTermsItem>
 		);

--- a/client/my-sites/checkout/composite-checkout/components/terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/terms-of-service.jsx
@@ -1,9 +1,9 @@
-import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import TosText from 'calypso/me/purchases/manage-purchase/payment-method-selector/tos-text';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -37,14 +37,9 @@ class TermsOfService extends Component {
 
 	render() {
 		return (
-			<div
-				className="checkout__terms"
-				role="presentation"
-				onClick={ this.recordTermsAndConditionsClick }
-			>
-				<Gridicon icon="info-outline" size={ 18 } />
-				<p>{ this.renderTerms() }</p>
-			</div>
+			<CheckoutTermsItem className="checkout__terms" onClick={ this.recordTermsAndConditionsClick }>
+				{ this.renderTerms() }
+			</CheckoutTermsItem>
 		);
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/components/third-party-plugins-terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/third-party-plugins-terms-of-service.jsx
@@ -1,6 +1,6 @@
-import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -29,12 +29,7 @@ function ThirdPartyPluginsTermsOfService( { cart, translate } ) {
 		}
 	);
 
-	return (
-		<div className="checkout__terms">
-			<Gridicon icon="info-outline" size={ 18 } />
-			<p>{ thirdPartyPluginsTerms }</p>
-		</div>
-	);
+	return <CheckoutTermsItem>{ thirdPartyPluginsTerms }</CheckoutTermsItem>;
 }
 
 export default localize( ThirdPartyPluginsTermsOfService );

--- a/client/my-sites/checkout/composite-checkout/components/titan-terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/titan-terms-of-service.jsx
@@ -1,7 +1,7 @@
-import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { hasTitanMail } from 'calypso/lib/cart-values/cart-items';
 import { getTitanProductName } from 'calypso/lib/titan';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -45,10 +45,9 @@ function TitanTermsOfService( { cart, translate } ) {
 	);
 
 	return (
-		<div className="checkout__titan-terms-of-service">
-			<Gridicon icon="info-outline" size={ 18 } />
-			<p>{ titanTerms }</p>
-		</div>
+		<CheckoutTermsItem className="checkout__titan-terms-of-service">
+			{ titanTerms }
+		</CheckoutTermsItem>
 	);
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/titan-terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/titan-terms-of-service.jsx
@@ -44,11 +44,7 @@ function TitanTermsOfService( { cart, translate } ) {
 		}
 	);
 
-	return (
-		<CheckoutTermsItem className="checkout__titan-terms-of-service">
-			{ titanTerms }
-		</CheckoutTermsItem>
-	);
+	return <CheckoutTermsItem>{ titanTerms }</CheckoutTermsItem>;
 }
 
 export default localize( TitanTermsOfService );

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -119,32 +119,15 @@ $left-margin: 36px;
 /**
  * Checkout Terms
  */
-.purchase-modal .checkout__terms,
-.purchase-modal .checkout__concierge-refund-policy,
-.purchase-modal .checkout__bundled-domain-notice,
-.purchase-modal .checkout__titan-terms-of-service {
-	margin: 4px 0;
+.purchase-modal .checkout__terms {
+	margin: 1em 0 4px;
 	padding-left: $left-margin;
-	position: relative;
 	font-size: $font-body-extra-small;
-
-	.purchase-modal__step + & {
-		margin-top: 1em;
-	}
-
-	> svg {
-		position: absolute;
-		top: 0;
-		left: ( $left-margin - 24px );
-		width: 16px;
-		height: 16px;
-	}
-
-	p {
-		font-size: $font-body-extra-small;
-		margin: 0;
-		word-break: break-word;
-	}
+}
+.purchase-modal .checkout__terms-item {
+	margin-bottom: 4px;
+	margin-left: 12px;
+	margin-top: 4px;
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a new `CheckoutTermsItem` component to provide more consistent behaviour for terms that we may need to show in checkout.
* Even though `client/my-sites/checkout/composite-checkout` is separate from `@automattic/composite-checkout`, there seems to be a practice of using CSS in JS in both places. Therefore, I moved the styles for the `CheckoutTermsItem` component into the JS component itself.
* I minimised the amount of styling for the checkout terms in `client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss`. To be clear, we still need that little bit of CSS here to preserve the differences in styling between the checkout page and the upsell nudge.
* I removed unused CSS classes for checkout terms items. Since we're standardising the styles for this new component, it makes sense to not unnecessarily use separate (and unstyled) CSS classes for the same component.

#### Testing instructions

Note that the `CheckoutTermsItem` component is used for other products than just domains. There seems to be only two visually distinct scenarios where terms are displayed however: the checkout page and the upsell nudge. Therefore, my thinking is that it should suffice to test both of these scenarios.

To test the changes on the **checkout page**:
1. Add e.g. a domain to your cart.
1. Proceed to /checkout.

To test the changes in the **upsell nudge**:
1. Have a connected custom domain
1. Go to `/purchases/billing-history/{site-slug}`
1. Find a domain purchase, open it, copy the receipt ID
1. Go to `/checkout/offer-professional-email/{domain}/{receiptId}/{siteSlug}`
1. Fill out the input fields and click "Add professional email"

#### Screenshots of the changes

<img width="1419" alt="Screenshot 2022-04-28 at 15 35 48" src="https://user-images.githubusercontent.com/1101677/166216156-67ba1c36-39cf-455e-9cb6-5de22bd4c726.png">
<img width="1426" alt="Screenshot 2022-04-28 at 16 31 15" src="https://user-images.githubusercontent.com/1101677/166216163-264b8377-6fd4-412a-a9c0-53c81871ccae.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1200182182542585-as-1201900052374140