### PR TITLE
Add default site suggestion when creating a new P2

### DIFF
--- a/client/assets/stylesheets/_p2-vars.scss
+++ b/client/assets/stylesheets/_p2-vars.scss
@@ -7,6 +7,7 @@
 	--p2-color-link: #0267ff;
 	--p2-color-link-dark: #004cbf;
 
+	--p2-color-border-light: #e7e9ea;
 	--p2-color-border: #d8dbdd;
 	--p2-color-border-medium: #9ea4a8;
 
@@ -20,7 +21,8 @@
 	--p2-color-hover-dark: #061925;
 	--p2-color-separator-light: #4d5860;
 
-	--p2-font-inter: 'Inter', -apple-system, system-ui, blinkmacsystemfont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+	--p2-font-inter: 'Inter', -apple-system, system-ui, blinkmacsystemfont, 'Segoe UI', 'Roboto',
+		'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
 
 	--p2-font-size-form-xxs: 14px;
 	--p2-font-size-form-xs: 15px;

--- a/client/my-sites/email/inbox/mailbox-selection-list/style.scss
+++ b/client/my-sites/email/inbox/mailbox-selection-list/style.scss
@@ -199,7 +199,7 @@ body.is-section-inbox .layout.is-section-inbox > .layout__content {
 
 		.mailbox-selection-list__item {
 			align-items: center;
-			border-color: #e7e9ea;
+			border-color: var( --p2-color-border-light );
 			border-style: solid;
 			border-width: 1px 0 0;
 			box-shadow: none;

--- a/client/signup/p2-step-wrapper/index.jsx
+++ b/client/signup/p2-step-wrapper/index.jsx
@@ -1,4 +1,3 @@
-import { Path, SVG } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -20,26 +19,6 @@ function P2StepWrapper( {
 	return (
 		<div className={ classnames( 'p2-step-wrapper', className ) }>
 			<div className="p2-step-wrapper__header">
-				<div className="p2-step-wrapper__header-logo">
-					<SVG xmlns="http://www.w3.org/2000/svg" width="67" height="32" viewBox="0 0 67 32">
-						<Path
-							fillRule="evenodd"
-							clipRule="evenodd"
-							d="M1.99451 0C0.892972 0 0 0.895431 0 2V30C0 31.1046 0.892973 32 1.99451 32H30.0055C31.107 32 32 31.1046 32 30V2C32 0.895431 31.107 0 30.0055 0H1.99451ZM22.1177 7.52942H9.41177V16H22.1177V7.52942ZM9.41177 18.8235H17.8824V24.4706H9.41177V18.8235Z"
-							fill="none"
-						/>
-						<Path
-							d="M54.7535 24.4461H66.8161V21.5213H59.7107V21.4057L62.1811 18.9849C65.6594 15.8123 66.593 14.226 66.593 12.3009C66.593 9.3679 64.197 7.29413 60.57 7.29413C57.0173 7.29413 54.58 9.41747 54.5883 12.7388H57.984C57.9757 11.1194 59.0002 10.128 60.5452 10.128C62.0324 10.128 63.1395 11.0534 63.1395 12.5405C63.1395 13.8872 62.3133 14.8126 60.7765 16.2915L54.7535 21.8684V24.4461Z"
-							fill="none"
-						/>
-						<Path
-							fillRule="evenodd"
-							clipRule="evenodd"
-							d="M39.5294 24.4706H43.0973V18.9779H46.0966C49.9776 18.9779 52.2353 16.6535 52.2353 13.2702C52.2353 9.9035 50.0188 7.52942 46.1872 7.52942H39.5294V24.4706ZM43.0973 16.1075V10.4577H45.5033C47.5633 10.4577 48.5603 11.5827 48.5603 13.2702C48.5603 14.9495 47.5633 16.1075 45.5198 16.1075H43.0973Z"
-							fill="none"
-						/>
-					</SVG>
-				</div>
 				{ headerIcon && (
 					<div className="p2-step-wrapper__header-icon">
 						<Icon icon={ headerIcon } />

--- a/client/signup/p2-step-wrapper/style.scss
+++ b/client/signup/p2-step-wrapper/style.scss
@@ -9,14 +9,24 @@
 	height: 100vh;
 	display: flex;
 	flex-direction: column;
-	padding: 96px 1.5em 24px;
 	font-family: var( --p2-font-inter );
 	line-height: 1.8;
+	padding: 10px 20px;
 
 	@include break-mobile {
-		padding-left: 20px;
-		padding-right: 20px;
 		max-width: 440px;
+	}
+
+	input {
+		font-family: var( --p2-font-inter );
+	}
+
+	a {
+		@extend %p2-link;
+	}
+
+	.p2-step-wrapper__header-text {
+		margin-bottom: 0.5em;
 	}
 }
 
@@ -45,6 +55,7 @@
 
 .p2-step-wrapper__subheader-text {
 	text-align: center;
+	margin-bottom: 48px;
 }
 
 .p2-step-wrapper__header-logo {
@@ -72,10 +83,6 @@
 
 .p2-step-wrapper__footer-text {
 	font-size: var( --p2-font-size-form-xxs );
-}
-
-.p2-step-wrapper button {
-	@extend %p2-form-button;
 }
 
 /* Step-specific overrides */

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -1,12 +1,17 @@
 import config from '@automattic/calypso-config';
+import { Gridicon } from '@automattic/components';
 import { getLanguage } from '@automattic/i18n-utils';
+import { Path, SVG } from '@wordpress/components';
+import { createRef } from '@wordpress/element';
+import { reusableBlock, Icon } from '@wordpress/icons';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
-import { includes, isEmpty, map, deburr, get } from 'lodash';
+import { includes, isEmpty, map, deburr, get, debounce } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
 import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
@@ -92,14 +97,18 @@ class P2Site extends Component {
 		this.state = {
 			form: this.formStateController.getInitialState(),
 			submitting: false,
-			suggestedSubdomains: [],
+			lastSuggestionSuffixIndex: 0,
 			lastInvalidSite: '',
+			isFetchingDefaultSuggestion: false,
+			showCustomSiteAddressInput: false,
 		};
 	}
 
 	componentWillUnmount() {
 		this.save();
 	}
+
+	customizeSiteInput = createRef();
 
 	sanitizeSubdomain = ( domain ) => {
 		if ( ! domain ) {
@@ -128,6 +137,58 @@ class P2Site extends Component {
 			},
 		} );
 	};
+
+	fetchSuggestion = async () => {
+		const nextSuggestionSuffixIndex =
+			( this.state.lastSuggestionSuffixIndex + 1 ) % WPCOM_SUBDOMAIN_SUFFIX_SUGGESTIONS.length;
+
+		this.setState( { lastSuggestionSuffixIndex: nextSuggestionSuffixIndex } );
+		const suggestionSuffix = WPCOM_SUBDOMAIN_SUFFIX_SUGGESTIONS[ nextSuggestionSuffixIndex ];
+		const currentTitle = formState.getFieldValue( this.state.form, 'siteTitle' );
+		const suggestionQuery = `${ currentTitle }${ suggestionSuffix }`;
+
+		const suggestionObjects = await wpcom.domains().suggestions( {
+			quantity: 1,
+			query: suggestionQuery,
+			only_wordpressdotcom: true,
+		} );
+
+		const suggestion = get( suggestionObjects, '0.domain_name', null );
+
+		if ( ! formState.getFieldValue( this.state.form, 'siteTitle' ) ) {
+			this.formStateController.handleFieldChange( {
+				name: 'site',
+				value: '',
+			} );
+			return;
+		}
+
+		if ( suggestion ) {
+			const [ subdomain ] = suggestion.split( '.' );
+			this.formStateController.handleFieldChange( {
+				name: 'site',
+				value: subdomain,
+			} );
+		}
+	};
+
+	suggestDefaultSubdomain = async () => {
+		this.formStateController.handleFieldChange( {
+			name: 'site',
+			value: '',
+		} );
+		if ( this.state.isFetchingDefaultSuggestion ) {
+			return;
+		}
+		try {
+			this.setState( { isFetchingDefaultSuggestion: true } );
+			await this.fetchSuggestion();
+		} finally {
+			this.setState( { isFetchingDefaultSuggestion: false } );
+		}
+	};
+
+	debouncedSuggestDefaultSubdomain = debounce( this.suggestDefaultSubdomain, 600 );
 
 	validate = ( fields, onComplete ) => {
 		const messages = {};
@@ -162,10 +223,6 @@ class P2Site extends Component {
 				( error, response ) => {
 					debug( error, response );
 
-					if ( this.state.lastInvalidSite !== fields.site ) {
-						this.setState( { suggestedSubdomains: [] } );
-					}
-
 					this.setState( { lastInvalidSite: fields.site } );
 
 					if ( error && error.message ) {
@@ -194,7 +251,7 @@ class P2Site extends Component {
 							if ( SITE_TAKEN_ERROR_CODES.includes( error.error ) ) {
 								messages.site = {
 									[ ERROR_CODE_TAKEN_SITE ]: this.props.translate(
-										'Sorry, that site already exists! Here are some available alternatives:'
+										'Sorry, that site already exists! Please, try a different one'
 									),
 								};
 							} else {
@@ -206,29 +263,6 @@ class P2Site extends Component {
 							// We want to log the real error code and message. The above is formatted for the end user
 							// only.
 							this.logValidationErrorToLogstash( error.error, error.message );
-						}
-
-						if ( error.error && SITE_TAKEN_ERROR_CODES.includes( error.error ) ) {
-							WPCOM_SUBDOMAIN_SUFFIX_SUGGESTIONS.forEach( ( suffix ) => {
-								const suggestedSubdomain = `${ fields.site }${ suffix }`;
-
-								wpcom
-									.domains()
-									.suggestions( {
-										quantity: 1,
-										query: suggestedSubdomain,
-										only_wordpressdotcom: true,
-									} )
-									.then( ( suggestionObjects ) => {
-										this.setState( {
-											suggestedSubdomains: [
-												...this.state.suggestedSubdomains,
-												get( suggestionObjects, '0.domain_name', null ),
-											],
-										} );
-									} )
-									.catch( () => {} );
-							} );
 						}
 					}
 
@@ -327,8 +361,8 @@ class P2Site extends Component {
 			value: event.target.value,
 		} );
 
-		if ( event.target.name === 'site' ) {
-			this.setState( { suggestedSubdomains: [] } );
+		if ( event.target.name === 'site-title' && ! this.state.showCustomSiteAddressInput ) {
+			this.debouncedSuggestDefaultSubdomain();
 		}
 	};
 
@@ -376,14 +410,132 @@ class P2Site extends Component {
 			name: 'site',
 			value: site,
 		} );
+	};
 
-		this.setState( {
-			suggestedSubdomains: [],
-		} );
+	renderDefaultSite = () => {
+		const site = formState.getFieldValue( this.state.form, 'site' );
+		const handleMouseLeave = ( event ) => {
+			event.currentTarget.scrollLeft = 0;
+		};
+		const { isFetchingDefaultSuggestion } = this.state;
+
+		return (
+			<span
+				className="p2-site__wordpress-domain-default"
+				title={ site ? `https://${ site }.wordpress.com` : '' }
+			>
+				<span onMouseLeave={ handleMouseLeave } className="p2-site__site-wordpress-domain">
+					{ site }
+				</span>
+				<span className="p2-site__site-wordpress-suffix">
+					{ site ? '.wordpress.com' : '' }&nbsp;
+				</span>
+				<button
+					type="button"
+					disabled={ isFetchingDefaultSuggestion }
+					className="p2-site__site-wordpress-domain-refresh"
+					onClick={ this.suggestDefaultSubdomain }
+				>
+					<Icon size={ 24 } icon={ reusableBlock } />
+				</button>
+			</span>
+		);
+	};
+
+	showCustomSiteAddressInput = () => {
+		this.setState( { showCustomSiteAddressInput: true } );
+		setTimeout( () => {
+			this.customizeSiteInput?.current?.focus();
+		}, 0 );
+	};
+
+	hideSiteCustomizer = () => {
+		this.suggestDefaultSubdomain();
+		this.setState( { showCustomSiteAddressInput: false } );
+	};
+
+	renderSuggestedSiteAddressInput = () => {
+		const { form } = this.state;
+		const site = formState.getFieldValue( form, 'site' );
+
+		return (
+			<>
+				<FormTextInput
+					id="site-address-input"
+					autoCapitalize={ 'off' }
+					className="p2-site__site-suggested-url"
+					disabled={ true }
+					name="suggested-site"
+					value={ site ? `https://${ site }.wordpress.com` : '' }
+				/>
+				<FormSettingExplanation className="p2-site__workspace-form-input-explanation">
+					{ this.props.translate(
+						'We suggest this URL, but you can {{a}}choose manually{{/a}} too',
+						{
+							components: {
+								a: <a href="#" onClick={ this.showCustomSiteAddressInput } />, // eslint-disable-line jsx-a11y/anchor-is-valid
+							},
+						}
+					) }
+				</FormSettingExplanation>
+				{ this.renderDefaultSite() }
+			</>
+		);
+	};
+
+	renderCustomSiteAddressInput = () => {
+		const { submitting, form } = this.state;
+		const site = formState.getFieldValue( form, 'site' );
+		return (
+			<>
+				<FormTextInput
+					id="site-address-input"
+					ref={ this.customizeSiteInput }
+					autoCapitalize={ 'off' }
+					className="p2-site__site-url"
+					disabled={ submitting }
+					name="site"
+					value={ site }
+					isError={ formState.isFieldInvalid( form, 'site' ) }
+					isValid={ formState.isFieldValid( form, 'site' ) }
+					onBlur={ this.handleBlur }
+					onChange={ this.handleChangeEvent }
+				/>
+				<FormSettingExplanation className="p2-site__workspace-form-input-explanation">
+					{ this.props.translate( 'Enter an address, or {{a}}choose a suggestion{{/a}}', {
+						components: {
+							a: <a href="#" onClick={ this.hideSiteCustomizer } />, // eslint-disable-line jsx-a11y/anchor-is-valid
+						},
+					} ) }
+				</FormSettingExplanation>
+				<span className="p2-site__wordpress-domain-suffix">.wordpress.com</span>
+			</>
+		);
+	};
+
+	renderSubdomainInput = () => {
+		const { showCustomSiteAddressInput } = this.state;
+		return (
+			<ValidationFieldset
+				errorMessages={ this.getErrorMessagesWithLogin( 'site' ) }
+				className="p2-site__validation-site"
+			>
+				<FormLabel htmlFor="site-address-input">
+					{ this.props.translate( 'Workspace address' ) }
+				</FormLabel>
+				<div className="p2-site__site-url-container">
+					{ ! showCustomSiteAddressInput && this.renderSuggestedSiteAddressInput() }
+					{ showCustomSiteAddressInput && this.renderCustomSiteAddressInput() }
+				</div>
+			</ValidationFieldset>
+		);
 	};
 
 	formFields = () => {
-		const fieldDisabled = this.state.submitting;
+		const { submitting, form } = this.state;
+		const siteTitle = formState.getFieldValue( form, 'siteTitle' );
+		const site = formState.getFieldValue( form, 'site' );
+		const showSubdomainInput = !! siteTitle || !! site;
 
 		return (
 			<>
@@ -392,45 +544,27 @@ class P2Site extends Component {
 					className="p2-site__validation-site-title"
 				>
 					<FormLabel htmlFor="site-title-input">
-						{ this.props.translate( 'Name your workspace' ) }
+						{ this.props.translate( 'Workspace name' ) }
 					</FormLabel>
 					<FormTextInput
 						id="site-title-input"
 						autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 						autoCapitalize={ 'off' }
 						className="p2-site__site-title"
-						disabled={ fieldDisabled }
+						disabled={ submitting }
 						name="site-title"
-						value={ formState.getFieldValue( this.state.form, 'siteTitle' ) }
-						isError={ formState.isFieldInvalid( this.state.form, 'siteTitle' ) }
-						isValid={ formState.isFieldValid( this.state.form, 'siteTitle' ) }
+						value={ siteTitle }
+						isError={ formState.isFieldInvalid( form, 'siteTitle' ) }
+						isValid={ formState.isFieldValid( form, 'siteTitle' ) }
 						onBlur={ this.handleBlur }
 						onChange={ this.handleChangeEvent }
 					/>
+					<FormSettingExplanation className="p2-site__workspace-form-input-explanation">
+						{ this.props.translate( 'This is usually the name of your company or organization' ) }
+					</FormSettingExplanation>
 				</ValidationFieldset>
-				<ValidationFieldset
-					errorMessages={ this.getErrorMessagesWithLogin( 'site' ) }
-					className="p2-site__validation-site"
-				>
-					<FormLabel htmlFor="site-address-input">
-						{ this.props.translate( 'Choose an address for your workspace' ) }
-					</FormLabel>
-					<div className="p2-site__site-url-container">
-						<FormTextInput
-							id="site-address-input"
-							autoCapitalize={ 'off' }
-							className="p2-site__site-url"
-							disabled={ fieldDisabled }
-							name="site"
-							value={ formState.getFieldValue( this.state.form, 'site' ) }
-							isError={ formState.isFieldInvalid( this.state.form, 'site' ) }
-							isValid={ formState.isFieldValid( this.state.form, 'site' ) }
-							onBlur={ this.handleBlur }
-							onChange={ this.handleChangeEvent }
-						/>
-						<span className="p2-site__wordpress-domain-suffix">.wordpress.com</span>
-					</div>
-				</ValidationFieldset>
+				{ showSubdomainInput && this.renderSubdomainInput() }
+				{ this.renderFormNotice() }
 			</>
 		);
 	};
@@ -440,61 +574,86 @@ class P2Site extends Component {
 			return this.props.translate( 'Site created - Go to next step' );
 		}
 
-		return this.props.translate( 'Continue' );
+		return this.props.translate( 'Create workspace' );
 	};
 
-	renderSubdomainSuggestions() {
-		const { suggestedSubdomains } = this.state;
-
-		if ( isEmpty( suggestedSubdomains ) ) {
-			return null;
-		}
-
+	renderFormNotice = () => {
 		return (
-			<div className="p2-site__subdomain-suggestions">
-				{ map( suggestedSubdomains, ( suggestion, index ) => {
-					return (
-						<button
-							key={ index }
-							className="p2-site__subdomain-suggestions-item"
-							onClick={ () => this.handleSubdomainSuggestionClick( suggestion ) }
-						>
-							{ suggestion }
-						</button>
-					);
-				} ) }
+			<div className="p2-site__workspace-form-notice-wrapper">
+				<hr />
+				<div className="p2-site__workspace-form-notice">
+					<div className="p2-site__workspace-form-notice-icon">
+						<Gridicon size={ 24 } icon="info-outline" />
+					</div>
+					<p>
+						{ this.props.translate(
+							"The first P2 in your workspace will be created automatically for you, so you can focus on getting started. You'll be able to customize it at any time!"
+						) }
+					</p>
+				</div>
+				<hr />
 			</div>
 		);
-	}
+	};
 
 	render() {
+		const { submitting, form } = this.state;
+		const siteTitle = formState.getFieldValue( form, 'siteTitle' );
+		const site = formState.getFieldValue( form, 'site' );
+		const submitDisabled = submitting || ! site || ! siteTitle;
 		return (
-			<P2StepWrapper
-				className="p2-site__create"
-				flowName={ this.props.flowName }
-				stepName={ this.props.stepName }
-				positionInFlow={ this.props.positionInFlow }
-				headerText={ this.props.translate( 'Create a workspace' ) }
-				subHeaderText={ this.props.translate(
-					'Your workspace is where you will create all the different P2s for teams, projects, topics, etc.'
-				) }
-			>
-				<form className="p2-site__form" onSubmit={ this.handleSubmit } noValidate>
-					{ this.formFields() }
-					{ this.renderSubdomainSuggestions() }
-					<div className="p2-site__form-footer">
-						<FormButton disabled={ this.state.submitting } className="p2-site__form-submit-btn">
-							{ this.buttonText() }
-						</FormButton>
-					</div>
-				</form>
-
-				<div className="p2-site__learn-more">
-					<a href="https://wordpress.com/p2" className="p2-site__learn-more-link">
-						{ this.props.translate( 'Learn more about P2' ) }
-					</a>
+			<>
+				<div className="p2-site__header-logo">
+					<SVG xmlns="http://www.w3.org/2000/svg" width="67" height="32" viewBox="0 0 67 32">
+						<Path
+							fillRule="evenodd"
+							clipRule="evenodd"
+							d="M1.99451 0C0.892972 0 0 0.895431 0 2V30C0 31.1046 0.892973 32 1.99451 32H30.0055C31.107 32 32 31.1046 32 30V2C32 0.895431 31.107 0 30.0055 0H1.99451ZM22.1177 7.52942H9.41177V16H22.1177V7.52942ZM9.41177 18.8235H17.8824V24.4706H9.41177V18.8235Z"
+							fill="none"
+						/>
+						<Path
+							d="M54.7535 24.4461H66.8161V21.5213H59.7107V21.4057L62.1811 18.9849C65.6594 15.8123 66.593 14.226 66.593 12.3009C66.593 9.3679 64.197 7.29413 60.57 7.29413C57.0173 7.29413 54.58 9.41747 54.5883 12.7388H57.984C57.9757 11.1194 59.0002 10.128 60.5452 10.128C62.0324 10.128 63.1395 11.0534 63.1395 12.5405C63.1395 13.8872 62.3133 14.8126 60.7765 16.2915L54.7535 21.8684V24.4461Z"
+							fill="none"
+						/>
+						<Path
+							fillRule="evenodd"
+							clipRule="evenodd"
+							d="M39.5294 24.4706H43.0973V18.9779H46.0966C49.9776 18.9779 52.2353 16.6535 52.2353 13.2702C52.2353 9.9035 50.0188 7.52942 46.1872 7.52942H39.5294V24.4706ZM43.0973 16.1075V10.4577H45.5033C47.5633 10.4577 48.5603 11.5827 48.5603 13.2702C48.5603 14.9495 47.5633 16.1075 45.5198 16.1075H43.0973Z"
+							fill="none"
+						/>
+					</SVG>
 				</div>
-			</P2StepWrapper>
+				<P2StepWrapper
+					className="p2-site__create"
+					flowName={ this.props.flowName }
+					stepName={ this.props.stepName }
+					positionInFlow={ this.props.positionInFlow }
+					headerText={ this.props.translate( 'Create a workspace' ) }
+					subHeaderText={ this.props.translate(
+						"Your {{b}}workspace{{/b}} is where you'll create all the different P2s for teams, projects, topics, etc.",
+						{
+							components: {
+								b: <b />,
+							},
+						}
+					) }
+				>
+					<form className="p2-site__form" onSubmit={ this.handleSubmit } noValidate>
+						{ this.formFields() }
+						<div className="p2-site__form-footer">
+							<FormButton disabled={ submitDisabled } className="p2-site__form-submit-btn">
+								{ this.buttonText() }
+							</FormButton>
+						</div>
+					</form>
+
+					<div className="p2-site__learn-more">
+						<a href="https://wordpress.com/p2" className="p2-site__learn-more-link">
+							{ this.props.translate( 'Learn more about P2' ) }
+						</a>
+					</div>
+				</P2StepWrapper>
+			</>
 		);
 	}
 }

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -1,22 +1,111 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .p2-site__create {
+	flex: 1;
 	.p2-step-wrapper__header-text {
-		font-size: var( --p2-font-size-form-xl );
+		font-size: var( --p2-font-size-form-xxl );
 		font-weight: 700;
+		text-align: center;
 	}
 }
 
-.p2-site__site-url-container {
-	position: relative;
+.p2-site__header-logo {
+	svg path {
+		fill: inherit;
+	}
+	margin: 24px 0 8px 32px;
+}
+
+.signup__step.is-p-2-site {
+	display: flex;
+	flex-direction: column;
 }
 
 .p2-site__wordpress-domain-suffix {
-	color: var( --p2-color-link );
+	color: var( --p2-color-text-light );
 	line-height: 22px;
 	pointer-events: none;
-	position: absolute;
+	position: relative;
 	font-size: var( --p2-font-size-form );
-	top: 19px;
-	right: 24px;
+	top: -62px;
+	display: block;
+	width: 100%;
+	text-align: right;
+	padding-right: 16px;
+	box-sizing: border-box;
+}
+
+.p2-site__wordpress-domain-default {
+	color: var( --p2-color-text );
+	position: relative;
+	font-size: var( --p2-font-size-form );
+	top: -66px;
+	display: flex;
+	align-items: center;
+	max-width: 400px;
+}
+
+.p2-site__site-wordpress-domain {
+	font-weight: 600;
+	margin-left: 16px;
+	text-overflow: ellipsis;
+	overflow-x: auto;
+	white-space: nowrap;
+	flex-basis: auto;
+	&:hover {
+		text-overflow: clip;
+	}
+}
+
+.p2-site__site-wordpress-suffix {
+	flex: 2 1 auto;
+}
+
+.p2-site__site-wordpress-domain-refresh {
+	flex: 0 0 50px;
+	min-width: 50px;
+	cursor: pointer;
+	&:disabled {
+		cursor: not-allowed;
+		fill: var( --p2-color-text-light );
+	}
+
+	svg {
+		display: inline-block;
+		vertical-align: middle;
+	}
+}
+
+.p2-step-wrapper__subheader-text {
+	text-align: center;
+}
+
+.p2-site__workspace-form-input-explanation {
+	font-style: normal;
+}
+
+.p2-site__workspace-form-notice {
+	display: flex;
+	font-size: var( --p2-font-size-form-xxs );
+}
+
+.p2-site__workspace-form-notice-wrapper {
+	margin-top: 40px;
+	hr {
+		margin: 10px 0;
+	}
+
+	p {
+		margin: 0;
+	}
+}
+
+.p2-site__workspace-form-notice-icon {
+	margin-right: 16px;
+	svg {
+		vertical-align: middle;
+	}
 }
 
 .p2-site__validation-site,
@@ -31,13 +120,13 @@
 }
 
 .p2-site__form-footer {
-	margin-top: 48px;
+	margin-top: 40px;
 }
 
 .p2-site__form-submit-btn.is-primary {
 	float: none;
 	margin: 0;
-	padding: 1em 2em;
+	padding: 14px;
 	width: 100%;
 	background-color: var( --p2-color-link );
 	border: none;
@@ -71,7 +160,7 @@
 }
 
 .p2-site__form input[type='text'].form-text-input {
-	padding: 18px 24px;
+	padding: 14px 16px;
 	line-height: 1;
 	border-radius: 2px;
 	font-size: var( --p2-font-size-form );
@@ -117,7 +206,15 @@
 }
 
 .p2-site__form input[type='text'].p2-site__site-url.form-text-input {
+	padding-right: 150px;
+	text-overflow: ellipsis;
+}
+
+.p2-site__form input[type='text'].p2-site__site-suggested-url.form-text-input {
 	padding-right: 160px;
+	color: transparent;
+	border-color: var( --p2-color-border-light );
+	-webkit-text-fill-color: transparent;
 }
 
 .p2-site__form .form-input-validation {
@@ -149,42 +246,4 @@
 	line-height: 1.5;
 	border-bottom: 1px solid currentColor;
 	padding-bottom: 2px;
-}
-
-.p2-site__subdomain-suggestions {
-	display: flex;
-	flex-direction: column;
-	margin-top: 24px;
-}
-
-.p2-site__subdomain-suggestions button.p2-site__subdomain-suggestions-item {
-	background: var( --p2-color-white );
-	border: 1px solid var( --p2-color-border-medium );
-	border-radius: 0;
-	justify-content: flex-start;
-	padding: 18px 24px;
-	margin-bottom: 0;
-	transition: border 0.2s ease;
-	margin-top: -1px;
-	position: relative;
-	font-size: 15px; /* stylelint-disable-line */
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-
-	&:first-child {
-		border-radius: 2px 2px 0 0;
-	}
-
-	&:last-child {
-		border-radius: 0 0 2px 2px;
-	}
-
-	&:hover,
-	&:focus {
-		cursor: pointer;
-		border-color: var( --p2-color-link );
-		z-index: 1;
-		background: var( --p2-color-white );
-	}
 }


### PR DESCRIPTION
resolves  4796-gh-Automattic/p2 

#### Changes proposed in this Pull Request

This pull request adapts the P2's "Create Workspace" form to the new design we have for it (see linked issue). One of the biggest changes is the suggestion of an available domain name by default.


Before:


https://user-images.githubusercontent.com/1574407/158603315-03bb1eba-89fe-48d2-b660-94bc9e59c31e.mov


After:



https://user-images.githubusercontent.com/1574407/158613555-614a7aa1-d098-462d-9842-28495f68fa3a.mov






#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via the Calypso live branch
* Navigate to /start/p2/p2-site
* Fill in a workspace name
* Ensure a workspace address is automatically suggested
* Click the double arrow icon to request a new suggestion
* Ensure the new suggestion is different to the previous one
* Click on "choose a suggestion" to enter a custom domain
* Enter an existing custom domain, ensure an error is shown and more suggestions to pick from are displayed below
* Enter a non-existing custom domain
* Go back and forth between suggestions and custom domains and look for any odd behaviour you can think of.
* Click on create workspace and ensure the new workspace is created with the final name and domains entered in the form.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

