### PR TITLE
Licensing Portal: Use the new API endpoint for fetching payment methods from Stripe

### DIFF
--- a/client/components/data/query-jetpack-partner-portal-stored-cards/index.ts
+++ b/client/components/data/query-jetpack-partner-portal-stored-cards/index.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { fetchStoredCards } from 'calypso/state/partner-portal/stored-cards/actions';
+import { isFetchingStoredCards } from 'calypso/state/partner-portal/stored-cards/selectors';
+import type { CalypsoDispatch } from 'calypso/state/types';
+import type { AppState } from 'calypso/types';
+
+const request = () => ( dispatch: CalypsoDispatch, getState: AppState ) => {
+	if ( ! isFetchingStoredCards( getState() ) ) {
+		dispatch( fetchStoredCards() );
+	}
+};
+
+function QueryJetpackPartnerPortalStoredCards() {
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		dispatch( request() );
+	}, [ dispatch ] );
+
+	return null;
+}
+
+export default QueryJetpackPartnerPortalStoredCards;

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
@@ -2,7 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import { PaymentMethod } from 'calypso/lib/checkout/payment-methods';
+import { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 
 import './style.scss';
 

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/index.ts
@@ -1,0 +1,13 @@
+export interface PaymentMethod {
+	id: string;
+	card: PaymentMethodCard;
+	name: string;
+	created: string;
+}
+
+export interface PaymentMethodCard {
+	brand: string;
+	exp_month: number;
+	exp_year: number;
+	last4: string;
+}

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/index.ts
@@ -1,6 +1,7 @@
 export interface PaymentMethod {
 	id: string;
 	card: PaymentMethodCard;
+	is_default: boolean;
 	name: string;
 	created: string;
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
@@ -3,22 +3,30 @@ import { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
-import QueryStoredCards from 'calypso/components/data/query-stored-cards';
+import QueryJetpackPartnerPortalStoredCards from 'calypso/components/data/query-jetpack-partner-portal-stored-cards';
 import Main from 'calypso/components/main';
 import AddStoredCreditCard from 'calypso/jetpack-cloud/sections/partner-portal/add-stored-credit-card';
+import { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import StoredCreditCard from 'calypso/jetpack-cloud/sections/partner-portal/stored-credit-card';
-import { getAllStoredCards } from 'calypso/state/stored-cards/selectors';
+import StoredCreditCardLoading from 'calypso/jetpack-cloud/sections/partner-portal/stored-credit-card/stored-credit-card-loading';
+import {
+	getAllStoredCards,
+	isFetchingStoredCards,
+} from 'calypso/state/partner-portal/stored-cards/selectors';
 import './style.scss';
 
 export default function PaymentMethodList(): ReactElement {
 	const translate = useTranslate();
 	const storedCards = useSelector( getAllStoredCards );
-	const cards = storedCards.map( ( card ) => <StoredCreditCard key={ card.card } card={ card } /> );
+	const isFetching = useSelector( isFetchingStoredCards );
+	const cards = storedCards.map( ( card: PaymentMethod ) => (
+		<StoredCreditCard key={ card.id } card={ card } />
+	) );
 
 	return (
 		<Main wideLayout className="payment-method-list">
-			<QueryStoredCards />
+			<QueryJetpackPartnerPortalStoredCards />
 			<DocumentHead title={ translate( 'Payment Methods' ) } />
 			<SidebarNavigation />
 
@@ -27,7 +35,10 @@ export default function PaymentMethodList(): ReactElement {
 			</div>
 
 			<div className="payment-method-list__body">
-				{ cards }
+				{ isFetching && <StoredCreditCardLoading /> }
+
+				{ ! isFetching && cards }
+
 				<AddStoredCreditCard />
 			</div>
 		</Main>

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card/index.tsx
@@ -2,22 +2,22 @@ import { PaymentLogo } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
 import PaymentMethodActions from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-actions';
-import { PaymentMethod } from 'calypso/lib/checkout/payment-methods';
+import { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 import './style.scss';
 
 export default function StoredCreditCard( props: { card: PaymentMethod } ): ReactElement {
 	const translate = useTranslate();
 	const creditCard = props.card;
 
-	const [ year, expiryMonth ] = creditCard.expiry.split( '-' );
-	const expiryYear = year.substr( 2, 2 );
+	const expiryMonth = creditCard?.card.exp_month;
+	const expiryYear = creditCard?.card.exp_year;
 
 	return (
 		<div className="stored-credit-card">
 			<div className="stored-credit-card__header">
 				<div className="stored-credit-card__labels">
 					<div className="stored-credit-card__payment-logo">
-						<PaymentLogo brand={ creditCard.card_type } isSummary={ true } />
+						<PaymentLogo brand={ creditCard?.card.brand } isSummary={ true } />
 					</div>
 
 					<div className="stored-credit-card__primary">{ translate( 'Primary' ) }</div>
@@ -29,8 +29,10 @@ export default function StoredCreditCard( props: { card: PaymentMethod } ): Reac
 			</div>
 			<div className="stored-credit-card__footer">
 				<div className="stored-credit-card__footer-left">
-					<div className="stored-credit-card__name">{ creditCard.name }</div>
-					<div className="stored-credit-card__number">**** **** **** { creditCard.card }</div>
+					<div className="stored-credit-card__name">{ creditCard?.name }</div>
+					<div className="stored-credit-card__number">
+						**** **** **** { creditCard?.card.last4 }
+					</div>
 				</div>
 
 				<div className="stored-credit-card__footer-right">

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card/stored-credit-card-loading.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card/stored-credit-card-loading.tsx
@@ -3,10 +3,10 @@ import './style.scss';
 export default function StoredCreditCardLoading(): JSX.Element {
 	return (
 		<div className="stored-credit-card stored-credit-card-loading">
-			<div className="stored-credit-card-loading__top stored-credit-card-loading--placeholder" />
+			<div className="stored-credit-card-loading__content" />
 			<div className="stored-credit-card-loading__bottom">
-				<div className="stored-credit-card-loading__cardholder stored-credit-card-loading--placeholder" />
-				<div className="stored-credit-card-loading__card stored-credit-card-loading--placeholder" />
+				<div className="stored-credit-card-loading__content" />
+				<div className="stored-credit-card-loading__content" />
 			</div>
 		</div>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card/stored-credit-card-loading.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card/stored-credit-card-loading.tsx
@@ -1,0 +1,13 @@
+import './style.scss';
+
+export default function StoredCreditCardLoading(): JSX.Element {
+	return (
+		<div className="stored-credit-card stored-credit-card-loading">
+			<div className="stored-credit-card-loading__top stored-credit-card-loading--placeholder" />
+			<div className="stored-credit-card-loading__bottom">
+				<div className="stored-credit-card-loading__cardholder stored-credit-card-loading--placeholder" />
+				<div className="stored-credit-card-loading__card stored-credit-card-loading--placeholder" />
+			</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card/style.scss
@@ -8,6 +8,32 @@
 	padding: 1rem;
 }
 
+.stored-credit-card-loading {
+	display: flex;
+	align-content: space-between;
+
+	&--placeholder {
+		@include placeholder( --color-neutral-10 );
+	}
+
+	&__top {
+		width: 100%;
+		height: 30px;
+	}
+
+	&__bottom {
+		width: 100%;
+
+		> div {
+			&:first-child {
+				margin-bottom: 1rem;
+			}
+
+			height: 30px;
+		}
+	}
+}
+
 .stored-credit-card__primary {
 	padding: 2px 4px;
 	line-height: 1.25rem;

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card/style.scss
@@ -12,13 +12,11 @@
 	display: flex;
 	align-content: space-between;
 
-	&--placeholder {
-		@include placeholder( --color-neutral-10 );
-	}
-
-	&__top {
+	&__content {
 		width: 100%;
-		height: 30px;
+		height: 27px;
+
+		@include placeholder( --color-neutral-10 );
 	}
 
 	&__bottom {
@@ -28,8 +26,6 @@
 			&:first-child {
 				margin-bottom: 1rem;
 			}
-
-			height: 30px;
 		}
 	}
 }

--- a/client/state/partner-portal/reducer.js
+++ b/client/state/partner-portal/reducer.js
@@ -1,11 +1,13 @@
 import { withStorageKey } from '@automattic/state-utils';
 import licenses from 'calypso/state/partner-portal/licenses/reducer';
 import partner from 'calypso/state/partner-portal/partner/reducer';
+import storedCards from 'calypso/state/partner-portal/stored-cards/reducer';
 import { combineReducers } from 'calypso/state/utils';
 
 const combinedReducer = combineReducers( {
 	partner,
 	licenses,
+	storedCards,
 } );
 
 export default withStorageKey( 'partnerPortal', combinedReducer );

--- a/client/state/partner-portal/stored-cards/actions.ts
+++ b/client/state/partner-portal/stored-cards/actions.ts
@@ -1,0 +1,30 @@
+import i18n from 'i18n-calypso';
+import { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import type { AnyAction, Dispatch } from 'redux';
+
+import 'calypso/state/partner-portal/stored-cards/init';
+
+export const fetchStoredCards = () => ( dispatch: Dispatch< AnyAction > ) => {
+	dispatch( {
+		type: 'STORED_CARDS_FETCH',
+	} );
+
+	return wpcomJpl.req
+		.get( {
+			apiNamespace: 'wpcom/v2',
+			path: '/jetpack-licensing/stripe/payment-methods',
+		} )
+		.then( ( data: PaymentMethod[] ) => {
+			dispatch( {
+				type: 'STORED_CARDS_FETCH_COMPLETED',
+				list: data,
+			} );
+		} )
+		.catch( ( error: { message: string } ) => {
+			dispatch( {
+				type: 'STORED_CARDS_FETCH_FAILED',
+				error: error.message || i18n.translate( 'There was a problem retrieving stored cards.' ),
+			} );
+		} );
+};

--- a/client/state/partner-portal/stored-cards/init.ts
+++ b/client/state/partner-portal/stored-cards/init.ts
@@ -1,0 +1,4 @@
+import { registerReducer } from 'calypso/state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'storedCards' ], reducer );

--- a/client/state/partner-portal/stored-cards/reducer.ts
+++ b/client/state/partner-portal/stored-cards/reducer.ts
@@ -1,8 +1,19 @@
 import { withStorageKey } from '@automattic/state-utils';
+import { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 import { combineReducers } from 'calypso/state/utils';
-import type { AnyAction } from 'redux';
+import type { Reducer, Action } from 'redux';
 
-export const items = ( state = [], action: AnyAction ) => {
+type ItemsAction =
+	| {
+			type: 'STORED_CARDS_ADD_COMPLETED';
+			item: PaymentMethod;
+	  }
+	| {
+			type: 'STORED_CARDS_FETCH_COMPLETED';
+			list: PaymentMethod[];
+	  };
+
+export const items: Reducer< PaymentMethod[], ItemsAction > = ( state = [], action ) => {
 	switch ( action.type ) {
 		case 'STORED_CARDS_ADD_COMPLETED': {
 			const { item } = action;
@@ -17,7 +28,11 @@ export const items = ( state = [], action: AnyAction ) => {
 	return state;
 };
 
-export const isFetching = ( state = false, action: AnyAction ) => {
+type IsFetchingAction = Action<
+	'STORED_CARDS_FETCH' | 'STORED_CARDS_FETCH_COMPLETED' | 'STORED_CARDS_FETCH_FAILED'
+>;
+
+export const isFetching: Reducer< boolean, IsFetchingAction > = ( state = false, action ) => {
 	switch ( action.type ) {
 		case 'STORED_CARDS_FETCH':
 			return true;
@@ -31,8 +46,8 @@ export const isFetching = ( state = false, action: AnyAction ) => {
 };
 
 const combinedReducer = combineReducers( {
+	items: items as Reducer,
 	isFetching,
-	items,
 } );
 
 export default withStorageKey( 'storedCards', combinedReducer );

--- a/client/state/partner-portal/stored-cards/reducer.ts
+++ b/client/state/partner-portal/stored-cards/reducer.ts
@@ -1,0 +1,38 @@
+import { withStorageKey } from '@automattic/state-utils';
+import { combineReducers } from 'calypso/state/utils';
+import type { AnyAction } from 'redux';
+
+export const items = ( state = [], action: AnyAction ) => {
+	switch ( action.type ) {
+		case 'STORED_CARDS_ADD_COMPLETED': {
+			const { item } = action;
+			return [ ...state, item ];
+		}
+		case 'STORED_CARDS_FETCH_COMPLETED': {
+			const { list } = action;
+			return list;
+		}
+	}
+
+	return state;
+};
+
+export const isFetching = ( state = false, action: AnyAction ) => {
+	switch ( action.type ) {
+		case 'STORED_CARDS_FETCH':
+			return true;
+
+		case 'STORED_CARDS_FETCH_COMPLETED':
+		case 'STORED_CARDS_FETCH_FAILED':
+			return false;
+	}
+
+	return state;
+};
+
+const combinedReducer = combineReducers( {
+	isFetching,
+	items,
+} );
+
+export default withStorageKey( 'storedCards', combinedReducer );

--- a/client/state/partner-portal/stored-cards/selectors.ts
+++ b/client/state/partner-portal/stored-cards/selectors.ts
@@ -1,0 +1,8 @@
+import 'calypso/state/partner-portal/stored-cards/init';
+import type { AppState } from 'calypso/types';
+
+export const getAllStoredCards = ( state: AppState ) =>
+	state?.partnerPortal?.storedCards?.items ?? [];
+
+export const isFetchingStoredCards = ( state: AppState ) =>
+	Boolean( state?.partnerPortal?.storedCards?.isFetching );

--- a/client/state/partner-portal/stored-cards/selectors.ts
+++ b/client/state/partner-portal/stored-cards/selectors.ts
@@ -1,7 +1,8 @@
 import 'calypso/state/partner-portal/stored-cards/init';
+import { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 import type { AppState } from 'calypso/types';
 
-export const getAllStoredCards = ( state: AppState ) =>
+export const getAllStoredCards = ( state: AppState ): PaymentMethod[] =>
 	state?.partnerPortal?.storedCards?.items ?? [];
 
 export const isFetchingStoredCards = ( state: AppState ) =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR uses the new REST API endpoints for fetching the available payment methods in the licensing portal. The current implementation shows payment methods available in Calypso.

#### Testing instructions

**Prerequisites**
- See pbtFFM-1v8-p2

**Notes**
- The duplicated "primary" label in all cards will be fixed in a different PR.

**Instructions**
- If you do not have a partner key, please get in touch with Avalon for one, or you will be unable to view the UI.
- Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
- Visit http://jetpack.cloud.localhost:3000/partner-portal/payment-methods and select your partner key, if prompted.
- Verify that:
  - Payment methods from your Stripe account are listed. You can use the "add credit card" flow to add new payment methods (make sure you have read the prerequisites).
  - The loading placeholder is looking good on different screen resolutions.
  - No regression is introduced by this PR.


Related to 1201734780767770-as-1201734867345390