### PR TITLE
Seller Experience v2: Add initial translations for the Woo upsell banner on My Home

### DIFF
--- a/client/my-sites/customer-home/translations/woo-upsell-banner.js
+++ b/client/my-sites/customer-home/translations/woo-upsell-banner.js
@@ -1,0 +1,6 @@
+import { translate } from 'i18n-calypso';
+
+translate( 'Need more from your store?' );
+translate(
+	'Upgrade to our premium plan to gain access to all the tools you need to run an online ecommerce store, from marketing to shipping.'
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This contains the `translate` calls for all of the new copy for the Woo upsell banner on My Home.

<img width="775" alt="image" src="https://user-images.githubusercontent.com/917632/156474931-9637cbb6-eca7-4b89-bd76-109fa5116491.png">


Related to #61471
