### PR TITLE
Marketplace: Yoast Premium warns of "Huge SEO issue" on sites with coming soon mode

### DIFF
--- a/apps/editing-toolkit/bin/sync-newspack-blocks.sh
+++ b/apps/editing-toolkit/bin/sync-newspack-blocks.sh
@@ -130,7 +130,7 @@ echo -n "eslint --fix: "
 npx eslint . --fix > /dev/null 2>&1
 echo "done"
 echo -n "phpcbf: "
-../../vendor/bin/phpcbf -q $TARGET | grep "A TOTAL OF" || PHPCBF_ERRORED=1
+../../vendor/bin/phpcbf -q $TARGET | grep "A TOTAL OF\|No fixable errors were found" || PHPCBF_ERRORED=1
 
 if [ "$PHPCBF_ERRORED" = 1 ] ; then
 	echo '!! There was an error executing phpcbf!'

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -92,6 +92,35 @@ function add_public_coming_soon_to_settings_endpoint_post( $input, $unfiltered_i
 add_filter( 'rest_api_update_site_settings', __NAMESPACE__ . '\add_public_coming_soon_to_settings_endpoint_post', 10, 2 );
 
 /**
+ * Replace Yoast SEO notice when `wpcom_public_coming_soon` changes to coming soon.
+ * 
+ * @param $old_value int|NULL The previous value of wpcom_public_coming_soon
+ * @param $value     int|NULL The current value of wpcom_public_coming_soon
+ * @return           bool     Whether the blog option was updated
+ */
+function wpcom_public_coming_soon_handle_seo_notice( $old_value, $value ) {
+	if ( $value === 0 ) {
+		// Do nothing if coming soon is not being enabled
+		return false;
+	}
+
+	$site_id = get_current_blog_id();
+
+	$wpseo_options = get_blog_option( $site_id, 'wpseo', false );
+	if ( ! $wpseo_options ) {
+		// Do nothing if Yoast is not installed
+		return false;
+	}
+
+	// Hide the Yoast SEO notice
+	$wpseo_options['ignore_search_engines_discouraged_notice'] = true;
+	update_blog_option( $site_id, 'wpseo', $wpseo_options );
+
+	return true;
+}
+add_action( 'update_option_wpcom_public_coming_soon', __NAMESPACE__ . '\wpcom_public_coming_soon_handle_seo_notice', 10, 2 );
+
+/**
  * Launch the site when the privacy mode changes from public-not-indexed
  * This can happen due to clicking the launch button from the banner
  * Or due to manually updating the setting in wp-admin or calypso settings page.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide Yoast SEO problem notice when Coming Soon mode is enabled on a site
* Show a new SEO notice that's specific to the Coming Soon mode

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #60714
