### PR TITLE
Writing Settings: Hide infinite scroll toggle if theme does not support it

### DIFF
--- a/client/data/theme-supports/use-theme-supports-query.ts
+++ b/client/data/theme-supports/use-theme-supports-query.ts
@@ -1,0 +1,18 @@
+import { useQuery } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+export type ThemeSupports = {
+	[ 'align-wide' ]: boolean;
+	gutenberg: boolean;
+	[ 'infinite-scroll' ]: boolean;
+};
+
+export const useThemeSupportsQuery = ( siteId: number ) => {
+	const queryKey = [ 'themeSupports', siteId ];
+	return useQuery< ThemeSupports >( queryKey, () => {
+		return wpcom.req.get( {
+			path: `/sites/${ siteId }/theme-support`,
+			apiNamespace: 'wpcom/v2',
+		} );
+	} );
+};

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -67,92 +67,89 @@ function ThemeEnhancements( {
 
 	if ( siteIsJetpack ) {
 		content = (
-			<Card>
-				{ themeSupportsInfiniteScroll ? (
-					<>
-						<FormLegend>{ translate( 'Infinite Scroll' ) }</FormLegend>
-						<SupportInfo
-							text={ translate(
-								'Loads the next posts automatically when the reader approaches the bottom of the page.'
-							) }
-							link={
-								isAtomic
-									? 'https://wordpress.com/support/infinite-scroll/'
-									: 'https://jetpack.com/support/infinite-scroll/'
-							}
-							privacyLink={ ! isAtomic }
-						/>
-						<FormSettingExplanation>
-							{ translate(
-								'Create a smooth, uninterrupted reading experience by loading more content as visitors scroll to the bottom of your archive pages.'
-							) }
-						</FormSettingExplanation>
-						<RadioOptions />
-						<hr />{ ' ' }
-					</>
-				) : null }
-				<SupportInfo
-					text={ translate(
-						"Adds names for CSS preprocessor use, disabling the theme's CSS, or custom image width."
-					) }
-					link={
-						isAtomic
-							? 'https://wordpress.com/support/editing-css/'
-							: 'https://jetpack.com/support/custom-css/'
-					}
-					privacyLink={ ! isAtomic }
-				/>
-				<JetpackModuleToggle
-					siteId={ siteId }
-					moduleSlug="custom-css"
-					label={ translate( 'Enhance CSS customization panel' ) }
-					disabled={ isFormPending }
-				/>
-			</Card>
-		);
-	} else {
-		content = (
 			<>
-				{ themeSupportsInfiniteScroll ? (
-					<Card>
-						<FormLegend>{ translate( 'Infinite scroll' ) }</FormLegend>
-						<SupportInfo
-							text={ translate( 'Control how additional posts are loaded.' ) }
-							link="https://wordpress.com/support/infinite-scroll/"
-							privacyLink={ false }
-						/>
-						<ToggleControl
-							checked={ !! fields[ name ] }
-							disabled={ isFormPending || blockedByFooter }
-							onChange={ handleAutosavingToggle( name ) }
-							label={ translate(
-								'Load posts as you scroll. Disable to show a clickable button to load posts.'
-							) }
-						/>
-						{ blockedByFooter && (
-							<FormSettingExplanation isIndented>
+				<SettingsSectionHeader title={ translate( 'Theme enhancements' ) } />
+				<Card>
+					{ themeSupportsInfiniteScroll ? (
+						<>
+							<FormLegend>{ translate( 'Infinite Scroll' ) }</FormLegend>
+							<SupportInfo
+								text={ translate(
+									'Loads the next posts automatically when the reader approaches the bottom of the page.'
+								) }
+								link={
+									isAtomic
+										? 'https://wordpress.com/support/infinite-scroll/'
+										: 'https://jetpack.com/support/infinite-scroll/'
+								}
+								privacyLink={ ! isAtomic }
+							/>
+							<FormSettingExplanation>
 								{ translate(
-									'Your site has a "footer" widget enabled so buttons will always be used. {{link}}Customize your site{{/link}}',
-									{
-										components: {
-											link: <a href={ customizeUrl } />,
-										},
-									}
+									'Create a smooth, uninterrupted reading experience by loading more content as visitors scroll to the bottom of your archive pages.'
 								) }
 							</FormSettingExplanation>
+							<RadioOptions />
+							<hr />{ ' ' }
+						</>
+					) : null }
+					<SupportInfo
+						text={ translate(
+							"Adds names for CSS preprocessor use, disabling the theme's CSS, or custom image width."
 						) }
-					</Card>
-				) : null }
+						link={
+							isAtomic
+								? 'https://wordpress.com/support/editing-css/'
+								: 'https://jetpack.com/support/custom-css/'
+						}
+						privacyLink={ ! isAtomic }
+					/>
+					<JetpackModuleToggle
+						siteId={ siteId }
+						moduleSlug="custom-css"
+						label={ translate( 'Enhance CSS customization panel' ) }
+						disabled={ isFormPending }
+					/>
+				</Card>
 			</>
 		);
+	} else {
+		content = themeSupportsInfiniteScroll ? (
+			<>
+				<SettingsSectionHeader title={ translate( 'Theme enhancements' ) } />
+				<Card>
+					<FormLegend>{ translate( 'Infinite scroll' ) }</FormLegend>
+					<SupportInfo
+						text={ translate( 'Control how additional posts are loaded.' ) }
+						link="https://wordpress.com/support/infinite-scroll/"
+						privacyLink={ false }
+					/>
+					<ToggleControl
+						checked={ !! fields[ name ] }
+						disabled={ isFormPending || blockedByFooter }
+						onChange={ handleAutosavingToggle( name ) }
+						label={ translate(
+							'Load posts as you scroll. Disable to show a clickable button to load posts.'
+						) }
+					/>
+					{ blockedByFooter && (
+						<FormSettingExplanation isIndented>
+							{ translate(
+								'Your site has a "footer" widget enabled so buttons will always be used. {{link}}Customize your site{{/link}}',
+								{
+									components: {
+										link: <a href={ customizeUrl } />,
+									},
+								}
+							) }
+						</FormSettingExplanation>
+					) }
+				</Card>
+			</>
+		) : null;
 	}
 
-	return (
-		<div>
-			<SettingsSectionHeader title={ translate( 'Theme enhancements' ) } />
-			{ content }
-		</div>
-	);
+	return { content };
 }
 
 ThemeEnhancements.defaultProps = {

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -9,15 +9,14 @@ import FormLegend from 'calypso/components/forms/form-legend';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import SupportInfo from 'calypso/components/support-info';
+import { useThemeSupportsQuery } from 'calypso/data/theme-supports/use-theme-supports-query';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { getCustomizerUrl } from 'calypso/state/sites/selectors';
-import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 function ThemeEnhancements( {
 	isAtomic,
-	currentTheme,
 	siteIsJetpack,
 	handleAutosavingToggle,
 	handleAutosavingRadio,
@@ -31,8 +30,9 @@ function ThemeEnhancements( {
 	const translate = useTranslate();
 	const blockedByFooter = 'footer' === get( fields, 'infinite_scroll_blocked' );
 	const name = 'infinite_scroll';
+	const { data } = useThemeSupportsQuery( siteId );
 	const themeSupportsInfiniteScroll =
-		currentTheme?.tags && currentTheme.tags.some( ( tag ) => tag === 'infinite-scroll' );
+		data?.theme_support && data.theme_support[ 'infinite-scroll' ];
 
 	function RadioOptions() {
 		const options = [
@@ -90,7 +90,7 @@ function ThemeEnhancements( {
 								) }
 							</FormSettingExplanation>
 							<RadioOptions />
-							<hr />{ ' ' }
+							<hr />
 						</>
 					) : null }
 					<SupportInfo
@@ -149,7 +149,7 @@ function ThemeEnhancements( {
 		) : null;
 	}
 
-	return { content };
+	return content;
 }
 
 ThemeEnhancements.defaultProps = {
@@ -173,12 +173,8 @@ ThemeEnhancements.propTypes = {
 export default connect( ( state ) => {
 	const site = getSelectedSite( state );
 	const selectedSiteId = get( site, 'ID' );
-	const currentThemeId = getActiveTheme( state, selectedSiteId );
-	const currentTheme = getCanonicalTheme( state, selectedSiteId, currentThemeId );
 
 	return {
-		currentTheme,
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
-		selectedSiteId,
 	};
 } )( localize( ThemeEnhancements ) );


### PR DESCRIPTION
### Description

Calypso would always display the infinite scroll setting, regardless of whether or not the theme actually supported infinite scroll. We refactored underlying code to evaluate theme tags before rendering an infinite scroll toggle.

### Changes proposed in this Pull Request
* Evaluate the current theme tags and ensure that infinite scroll is supported before rendering an infinite scroll toggle.

### Screenshots
#### Before
<img width="642" alt="Screen Shot 2022-03-02 at 11 54 59 AM" src="https://user-images.githubusercontent.com/5414230/156439589-dc2e2ee5-bc90-47b7-9aab-0fc68f6bff60.png">

#### After
<img width="642" alt="Screen Shot 2022-03-02 at 11 55 54 AM" src="https://user-images.githubusercontent.com/5414230/156439606-22f2c622-5360-457c-adb8-ca840513aed0.png">

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* In a local dev environment, navigate to Appearance > Themes and select a full site editing theme without the `infinite-scroll` tag ( Ex. Blockbase, Bennett, Twenty-Twenty-Two, etc. )
* Navigate to Settings > Writing and confirm that the infinite scroll toggle is rendered
* Check out this branch
* Spin up a local calypso dev environment
* Navigate to Settings > Writing and confirm that the infinite scroll toggle is no longer rendered
* Now, activate an infinite-scroll enabled theme ( Ex. Dara )
* Navigate back to Settings > Writing and confirm that the infinite scroll toggle is rendered again
* Follow the same instructions for a jetpack site

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/61202
