### PR TITLE
Update the displaying of compact breadcrumbs

### DIFF
--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -40,23 +40,32 @@ interface Props {
 
 const Breadcrumb: React.FunctionComponent< Props > = ( { items, compact = false } ) => {
 	const translate = useTranslate();
-	const back = translate( 'Back' ) as string;
-	if ( compact && items.length > 1 ) {
-		// Show only the exactly previous page
-		items = items.slice( -2, -1 );
-		items[ 0 ].label = back;
-	}
+
 	return (
 		<StyledUl>
-			{ items.map( ( item: { href?: string; label: string }, index: Key ) => {
-				return (
-					<StyledLi key={ index }>
-						{ compact && <StyledGridicon icon="chevron-left" size={ 18 } /> }
-						{ index !== 0 && <StyledGridicon icon="chevron-right" size={ 18 } /> }
-						{ item.href ? <a href={ item.href }>{ item.label }</a> : <span>{ item.label }</span> }
-					</StyledLi>
-				);
-			} ) }
+			{ compact && items.length > 1 ? (
+				<StyledLi>
+					<StyledGridicon icon="chevron-left" size={ 18 } />
+					{ /*  Show the exactly previous page with items[ items.length - 2 ] */ }
+					<a href={ items[ items.length - 2 ].href }>{ translate( 'Back' ) }</a>
+				</StyledLi>
+			) : (
+				<>
+					{ items.map( ( item: { href?: string; label: string }, index: Key ) => {
+						return (
+							<StyledLi key={ index }>
+								{ compact && <StyledGridicon icon="chevron-left" size={ 18 } /> }
+								{ index !== 0 && <StyledGridicon icon="chevron-right" size={ 18 } /> }
+								{ item.href ? (
+									<a href={ item.href }>{ item.label }</a>
+								) : (
+									<span>{ item.label }</span>
+								) }
+							</StyledLi>
+						);
+					} ) }
+				</>
+			) }
 		</StyledUl>
 	);
 };

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -208,16 +208,16 @@ function PluginDetails( props ) {
 			);
 		}
 
-		if ( fullPlugin.name && fullPlugin.slug ) {
+		if ( fullPlugin.name && props.pluginSlug ) {
 			dispatch(
 				appendBreadcrumb( {
 					label: fullPlugin.name,
-					href: `/plugins/${ fullPlugin.slug }/${ selectedSite?.slug || '' }`,
-					id: `plugin-${ fullPlugin.slug }`,
+					href: `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }`,
+					id: `plugin-${ props.pluginSlug }`,
 				} )
 			);
 		}
-	}, [ fullPlugin.name, fullPlugin.slug, selectedSite ] );
+	}, [ fullPlugin.name, props.pluginSlug, selectedSite ] );
 
 	const getPageTitle = () => {
 		return translate( '%(pluginName)s Plugin', {


### PR DESCRIPTION
### Changes proposed in this Pull Request

**Compact Breadcrumbs**
Before this change, the items property was being updated, not allowing it to go back to its original value when resizing to wider screen size.

After this change, the back link is displayed on the screen but the items property remains untouched allowing it to returns to its original value.

**Plugin Details breadcrumb slug**
Before this change, the breadcrumb was based on the slug from the fullPlugin property. This property is mounted by different sources (WP.org, WP.com, etc) which can cause it receive different values, creating a new breadcrumb for the same page.

After this change, the breadcrumb is based on the slug from the url, which shouldn't change.

### Testing instructions

| Before  | After |
| ------------- | ------------- |
|![Kapture 2022-03-02 at 17 10 35](https://user-images.githubusercontent.com/5039531/156441725-cbf0ea43-8971-43bb-8290-ac6fbe504344.gif)| ![Kapture 2022-03-02 at 17 07 59](https://user-images.githubusercontent.com/5039531/156441507-7e040024-8bd2-4d7b-9f2e-85e7c8b83f8e.gif)|

---

Related to #61218
