### PR TITLE
Update calypso-products utility functions to cover the Managed plan cases.

### DIFF
--- a/packages/calypso-products/src/is-managed.ts
+++ b/packages/calypso-products/src/is-managed.ts
@@ -1,0 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
+import { isManagedPlan } from './main';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isManaged( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	return isManagedPlan( camelOrSnakeSlug( product ) );
+}

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -26,6 +26,7 @@ import {
 	isBusiness,
 	isEnterprise,
 	isEcommerce,
+	isManaged,
 	isVipPlan,
 	getProductFromSlug,
 } from '.';
@@ -668,7 +669,7 @@ export function planHasJetpackClassicSearch(
 			isBusiness( plan ) ||
 			isEnterprise( plan ) ||
 			isEcommerce( plan ) ||
-			isManagedPlan( plan ) ||
+			isManaged( plan ) ||
 			isVipPlan( plan ) )
 	);
 }

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -6,6 +6,7 @@ import {
 	TYPE_ECOMMERCE,
 	TYPE_MANAGED,
 	TYPE_FREE,
+	TYPE_FLEXIBLE,
 	TYPE_BLOGGER,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
@@ -73,6 +74,10 @@ export function getPlanPath( plan: string ): string | undefined {
 export function getPlanClass( planKey: string ): string {
 	if ( isFreePlan( planKey ) ) {
 		return 'is-free-plan';
+	}
+
+	if ( isFlexiblePlan( planKey ) ) {
+		return 'is-flexible-plan';
 	}
 
 	if ( isBloggerPlan( planKey ) ) {
@@ -257,6 +262,10 @@ export function isBloggerPlan( planSlug: string ): boolean {
 
 export function isFreePlan( planSlug: string ): boolean {
 	return planMatches( planSlug, { type: TYPE_FREE } );
+}
+
+export function isFlexiblePlan( planSlug: string ): boolean {
+	return planMatches( planSlug, { type: TYPE_FLEXIBLE } );
 }
 
 export function isSecurityDailyPlan( planSlug: string ): boolean {

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -4,6 +4,7 @@ import {
 	TERM_BIENNIALLY,
 	TYPE_BUSINESS,
 	TYPE_ECOMMERCE,
+	TYPE_MANAGED,
 	TYPE_FREE,
 	TYPE_BLOGGER,
 	TYPE_PERSONAL,
@@ -92,6 +93,10 @@ export function getPlanClass( planKey: string ): string {
 
 	if ( isEcommercePlan( planKey ) ) {
 		return 'is-ecommerce-plan';
+	}
+
+	if ( isManagedPlan( planKey ) ) {
+		return 'is-managed-plan';
 	}
 
 	if ( isSecurityDailyPlan( planKey ) ) {
@@ -230,6 +235,10 @@ export function isEcommercePlan( planSlug: string ): boolean {
 	return planMatches( planSlug, { type: TYPE_ECOMMERCE } );
 }
 
+export function isManagedPlan( planSlug: string ): boolean {
+	return planMatches( planSlug, { type: TYPE_MANAGED } );
+}
+
 export function isBusinessPlan( planSlug: string ): boolean {
 	return planMatches( planSlug, { type: TYPE_BUSINESS } );
 }
@@ -272,6 +281,10 @@ export function isWpComBusinessPlan( planSlug: string ): boolean {
 
 export function isWpComEcommercePlan( planSlug: string ): boolean {
 	return planMatches( planSlug, { type: TYPE_ECOMMERCE, group: GROUP_WPCOM } );
+}
+
+export function isWpComManagedPlan( planSlug: string ): boolean {
+	return planMatches( planSlug, { TYPE: TYPE_MANAGED, group: GROUP_WPCOM } );
 }
 
 export function isWpComPremiumPlan( planSlug: string ): boolean {
@@ -609,6 +622,8 @@ export const chooseDefaultCustomerType = ( {
 		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_BUSINESS } )[ 0 ],
 		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_ECOMMERCE } )[ 0 ],
 		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_ECOMMERCE } )[ 0 ],
+		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_MANAGED } )[ 0 ],
+		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_MANAGED } )[ 0 ],
 	]
 		.map( ( planKey ) => getPlan( planKey ) )
 		.filter( isValueTruthy )
@@ -644,6 +659,7 @@ export function planHasJetpackClassicSearch(
 			isBusiness( plan ) ||
 			isEnterprise( plan ) ||
 			isEcommerce( plan ) ||
+			isManagedPlan( plan ) ||
 			isVipPlan( plan ) )
 	);
 }

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -284,7 +284,7 @@ export function isWpComEcommercePlan( planSlug: string ): boolean {
 }
 
 export function isWpComManagedPlan( planSlug: string ): boolean {
-	return planMatches( planSlug, { TYPE: TYPE_MANAGED, group: GROUP_WPCOM } );
+	return planMatches( planSlug, { type: TYPE_MANAGED, group: GROUP_WPCOM } );
 }
 
 export function isWpComPremiumPlan( planSlug: string ): boolean {

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -14,6 +14,7 @@ export { isBiennially } from './is-biennially';
 export { isBlogger } from './is-blogger';
 export { isBundled } from './is-bundled';
 export { isBusiness } from './is-business';
+export { isManaged } from './is-managed';
 export { isChargeback } from './is-chargeback';
 export { isConciergeSession } from './is-concierge-session';
 export { isCredits } from './is-credits';

--- a/packages/calypso-products/test/choose-default-customer-type.js
+++ b/packages/calypso-products/test/choose-default-customer-type.js
@@ -4,7 +4,7 @@ import {
 	PLAN_PREMIUM,
 	PLAN_FREE,
 	PLAN_PERSONAL,
-	PLAN_MANAGED,
+	PLAN_WPCOM_MANAGED,
 } from '../src/constants';
 
 describe( 'chooseDefaultCustomerType', () => {
@@ -44,7 +44,7 @@ describe( 'chooseDefaultCustomerType', () => {
 
 	test( 'chooses "business" either if site on the Managed plan', () => {
 		const currentPlan = {
-			product_slug: PLAN_MANAGED,
+			product_slug: PLAN_WPCOM_MANAGED,
 		};
 		expect( chooseDefaultCustomerType( { currentPlan } ) ).toBe( 'business' );
 	} );

--- a/packages/calypso-products/test/choose-default-customer-type.js
+++ b/packages/calypso-products/test/choose-default-customer-type.js
@@ -3,6 +3,7 @@ import {
 	PLAN_ECOMMERCE_2_YEARS,
 	PLAN_PREMIUM,
 	PLAN_FREE,
+	PLAN_WPCOM_FLEXIBLE,
 	PLAN_PERSONAL,
 	PLAN_WPCOM_MANAGED,
 } from '../src/constants';
@@ -42,10 +43,17 @@ describe( 'chooseDefaultCustomerType', () => {
 		expect( chooseDefaultCustomerType( { currentPlan } ) ).toBe( 'business' );
 	} );
 
-	test( 'chooses "business" either if site on the Managed plan', () => {
+	test( 'chooses "business" if the site is on the Managed plan', () => {
 		const currentPlan = {
 			product_slug: PLAN_WPCOM_MANAGED,
 		};
 		expect( chooseDefaultCustomerType( { currentPlan } ) ).toBe( 'business' );
+	} );
+
+	test( 'chooses "personal" if the site is on the Flexible plan', () => {
+		const currentPlan = {
+			product_slug: PLAN_WPCOM_FLEXIBLE,
+		};
+		expect( chooseDefaultCustomerType( { currentPlan } ) ).toBe( 'personal' );
 	} );
 } );

--- a/packages/calypso-products/test/choose-default-customer-type.js
+++ b/packages/calypso-products/test/choose-default-customer-type.js
@@ -1,5 +1,11 @@
 import { chooseDefaultCustomerType } from '../src';
-import { PLAN_ECOMMERCE_2_YEARS, PLAN_PREMIUM, PLAN_FREE, PLAN_PERSONAL } from '../src/constants';
+import {
+	PLAN_ECOMMERCE_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_FREE,
+	PLAN_PERSONAL,
+	PLAN_MANAGED,
+} from '../src/constants';
 
 describe( 'chooseDefaultCustomerType', () => {
 	test( 'chooses "personal" if current site type is "personal"', () => {
@@ -33,6 +39,13 @@ describe( 'chooseDefaultCustomerType', () => {
 		expect( chooseDefaultCustomerType( { currentPlan } ) ).toBe( 'business' );
 
 		currentPlan.product_slug = PLAN_ECOMMERCE_2_YEARS;
+		expect( chooseDefaultCustomerType( { currentPlan } ) ).toBe( 'business' );
+	} );
+
+	test( 'chooses "business" either if site on the Managed plan', () => {
+		const currentPlan = {
+			product_slug: PLAN_MANAGED,
+		};
 		expect( chooseDefaultCustomerType( { currentPlan } ) ).toBe( 'business' );
 	} );
 } );

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -59,6 +59,7 @@ import {
 	getPlan,
 	getPlans,
 	getPlanClass,
+	isManagedPlan,
 	isBusinessPlan,
 	isPersonalPlan,
 	isPremiumPlan,
@@ -175,6 +176,22 @@ describe( 'isBusinessPlan', () => {
 		expect( isBusinessPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
 		expect( isBusinessPlan( PLAN_ECOMMERCE ) ).to.equal( false );
 		expect( isBusinessPlan( 'non-existing plan' ) ).to.equal( false );
+	} );
+} );
+
+describe( 'isManagedPlan', () => {
+	test( 'should return true for the Managed plan', () => {
+		expect( isManagedPlan( PLAN_WPCOM_MANAGED ) ).to.equal( true );
+	} );
+	test( 'should return false for non-managed plans', () => {
+		expect( isManagedPlan( PLAN_PERSONAL ) ).to.equal( false );
+		expect( isManagedPlan( PLAN_PERSONAL_2_YEARS ) ).to.equal( false );
+		expect( isManagedPlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
+		expect( isManagedPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
+		expect( isManagedPlan( PLAN_PREMIUM ) ).to.equal( false );
+		expect( isManagedPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
+		expect( isManagedPlan( PLAN_ECOMMERCE ) ).to.equal( false );
+		expect( isManagedPlan( 'non-existing plan' ) ).to.equal( false );
 	} );
 } );
 

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -65,6 +65,7 @@ import {
 	isPremiumPlan,
 	isBloggerPlan,
 	isFreePlan,
+	isFlexiblePlan,
 	isJetpackBusinessPlan,
 	isJetpackPersonalPlan,
 	isJetpackPremiumPlan,
@@ -102,6 +103,25 @@ describe( 'isFreePlan', () => {
 		expect( isFreePlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
 		expect( isFreePlan( PLAN_ECOMMERCE ) ).to.equal( false );
 		expect( isFreePlan( 'non-existing plan' ) ).to.equal( false );
+	} );
+} );
+
+describe( 'isFlexiblePlan', () => {
+	test( 'should return true for flexible plans', () => {
+		expect( isFlexiblePlan( PLAN_WPCOM_FLEXIBLE ) ).to.equal( true );
+	} );
+	test( 'should return false for non-flexible plans', () => {
+		expect( isFlexiblePlan( PLAN_FREE ) ).to.equal( false );
+		expect( isFlexiblePlan( PLAN_JETPACK_FREE ) ).to.equal( false );
+		expect( isFlexiblePlan( PLAN_PERSONAL ) ).to.equal( false );
+		expect( isFlexiblePlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
+		expect( isFlexiblePlan( PLAN_PREMIUM ) ).to.equal( false );
+		expect( isFlexiblePlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
+		expect( isFlexiblePlan( PLAN_BUSINESS ) ).to.equal( false );
+		expect( isFlexiblePlan( PLAN_WPCOM_MANAGED ) ).to.equal( false );
+		expect( isFlexiblePlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
+		expect( isFlexiblePlan( PLAN_ECOMMERCE ) ).to.equal( false );
+		expect( isFlexiblePlan( 'non-existing plan' ) ).to.equal( false );
 	} );
 } );
 

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -68,6 +68,7 @@ import {
 	isJetpackPersonalPlan,
 	isJetpackPremiumPlan,
 	isJetpackFreePlan,
+	isWpComManagedPlan,
 	isWpComEcommercePlan,
 	isWpComBusinessPlan,
 	isWpComPersonalPlan,
@@ -285,6 +286,25 @@ describe( 'isWpComEcommercePlan', () => {
 		expect( isWpComEcommercePlan( PLAN_BUSINESS ) ).to.equal( false );
 		expect( isWpComEcommercePlan( PLAN_BUSINESS_2_YEARS ) ).to.equal( false );
 		expect( isWpComEcommercePlan( 'non-exisWpComting plan' ) ).to.equal( false );
+	} );
+} );
+
+describe( 'isWpComManagedPlan', () => {
+	test( 'should return true for the Managed plan', () => {
+		expect( isWpComManagedPlan( PLAN_WPCOM_MANAGED ) ).to.equal( true );
+	} );
+	test( 'should return false for non-business plans', () => {
+		expect( isWpComManagedPlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
+		expect( isWpComManagedPlan( PLAN_JETPACK_BUSINESS_MONTHLY ) ).to.equal( false );
+		expect( isWpComManagedPlan( PLAN_PERSONAL ) ).to.equal( false );
+		expect( isWpComManagedPlan( PLAN_PERSONAL_2_YEARS ) ).to.equal( false );
+		expect( isWpComManagedPlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
+		expect( isWpComManagedPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
+		expect( isWpComManagedPlan( PLAN_PREMIUM ) ).to.equal( false );
+		expect( isWpComManagedPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
+		expect( isWpComManagedPlan( PLAN_BUSINESS ) ).to.equal( false );
+		expect( isWpComManagedPlan( PLAN_BUSINESS_2_YEARS ) ).to.equal( false );
+		expect( isWpComManagedPlan( 'non-exisWpComting plan' ) ).to.equal( false );
 	} );
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR extends several product checking utility functions defined in `calypso-products` to cover the Managed and Flexible plan cases.

#### Testing instructions
`yarn run test-packages packages/calypso-products/test/` should pass.