### PR TITLE
Clear existing error notices on re-submit add payment method

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -25,7 +25,7 @@ import { useCreateStoredCreditCardMethod } from 'calypso/jetpack-cloud/sections/
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 
 import './style.scss';
 
@@ -62,7 +62,8 @@ function PaymentMethodAdd(): ReactElement {
 			reduxDispatch(
 				errorNotice(
 					transactionError ||
-						translate( 'There was a problem assigning that payment method. Please try again.' )
+						translate( 'There was a problem assigning that payment method. Please try again.' ),
+					{ id: 'payment-method-failure' }
 				)
 			);
 			// We need to regenerate the setup intent if the form was submitted.
@@ -115,8 +116,9 @@ function PaymentMethodAdd(): ReactElement {
 				onPaymentError={ handleChangeError }
 				paymentMethods={ paymentMethods }
 				paymentProcessors={ {
-					card: ( data: unknown ) =>
-						assignNewCardProcessor(
+					card: ( data: unknown ) => {
+						reduxDispatch( removeNotice( 'payment-method-failure' ) );
+						return assignNewCardProcessor(
 							{
 								useAsPrimaryPaymentMethod,
 								translate,
@@ -127,7 +129,8 @@ function PaymentMethodAdd(): ReactElement {
 								reduxDispatch,
 							},
 							data
-						),
+						);
+					},
 				} }
 				initiallySelectedPaymentMethodId="card"
 				isLoading={ isStripeLoading }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change will clear out the existing/previous error notice which shows up during add payment method failure when re-submitting the form so that the error notices for the same submit don't stack up. 

#### Testing instructions

- Checkout to `update/clear-existing-error-notices-for-payment-method` branch and take a pull
- Start Calypso green with `yarn start-jetpack-cloud`.
- Go to http://jetpack.cloud.localhost:3000/partner-portal/payment-methods/add
- Enter all the details. You can use the test card - `4000 0027 6000 3184` and enter any value for the other fields.
- Click `Save payment method` and an error message will show up.
- Click `Save payment method` again, the previous error message should disappear and the new error message should show up. 
- Every time you click on Submit, the previous error message should disappear

**Before the change**

<img width="1222" alt="Screenshot 2022-03-03 at 11 47 58 AM" src="https://user-images.githubusercontent.com/10586875/156515975-fca9dd1c-2e93-424d-b321-d37f25a5c818.png">

**After the change**

https://user-images.githubusercontent.com/10586875/156516089-2d1c8b13-7ee5-45d8-ab2d-4a55b4b4effd.mov

Related to 1201734780767770-as-1201871638662037