### PR TITLE
Export types in @automattic/explat-client-react-helpers that are used in consumers

### DIFF
--- a/packages/explat-client-react-helpers/CHANGELOG.md
+++ b/packages/explat-client-react-helpers/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.0.4
+
+- Added ExperimentOptions and ExPlatClientReactHelpers Typescript interfaces to export
 
 ## 0.0.3
 

--- a/packages/explat-client-react-helpers/package.json
+++ b/packages/explat-client-react-helpers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/explat-client-react-helpers",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"description": "Standalone ExPlat Client: React Helpers.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",

--- a/packages/explat-client-react-helpers/src/index.tsx
+++ b/packages/explat-client-react-helpers/src/index.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import * as React from 'react';
 import type { ExPlatClient, ExperimentAssignment } from '@automattic/explat-client';
-export { ExPlatClient, ExperimentAssignment };
 
 export interface ExperimentOptions {
 	/**

--- a/packages/explat-client-react-helpers/src/index.tsx
+++ b/packages/explat-client-react-helpers/src/index.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 import * as React from 'react';
 import type { ExPlatClient, ExperimentAssignment } from '@automattic/explat-client';
+export { ExPlatClient, ExperimentAssignment };
 
-interface ExperimentOptions {
+export interface ExperimentOptions {
 	/**
 	 * Determines whether a participant is currenlty eligible for an assignment.
 	 * - Only loads the experimentAssignment if isEligible is true.
@@ -15,7 +16,7 @@ const defaultExperimentOptions = {
 	isEligible: true,
 };
 
-interface ExPlatClientReactHelpers {
+export interface ExPlatClientReactHelpers {
 	/**
 	 * An ExPlat useExperiment hook.
 	 *


### PR DESCRIPTION
Howdy!

We are experiencing some Typescript error when using @automattic/explat-client-react-helpers in WooCommerce Admin.
woocommerce/woocommerce#32147

There are two separate sets of errors:

```
> tsc --build ./tsconfig.json ./tsconfig-cjs.json

src/index.ts(43,2): error TS4023: Exported variable 'useExperiment' has or is using name 'ExperimentOptions' from external module "~/Projects/automattic/Automattic/wp-calypso/packages/explat-client-react-helpers/dist/types/index" but cannot be named.
src/index.ts(44,2): error TS4023: Exported variable 'Experiment' has or is using name 'ExperimentOptions' from external module "~/Projects/automattic/Automattic/wp-calypso/packages/explat-client-react-helpers/dist/types/index" but cannot be named.
src/index.ts(45,2): error TS4023: Exported variable 'ProvideExperimentData' has or is using name 'ExperimentOptions' from external module "~/Projects/automattic/Automattic/wp-calypso/packages/explat-client-react-helpers/dist/types/index" but cannot be named.
```

And 

```
> tsc --build ./tsconfig.json ./tsconfig-cjs.json

src/index.ts(43,2): error TS2742: The inferred type of 'useExperiment' cannot be named without a reference to '../../../../../Automattic/wp-calypso/node_modules/@automattic/explat-client/dist/types'. This is likely not portable. A type annotation is necessary.
src/index.ts(45,2): error TS2742: The inferred type of 'ProvideExperimentData' cannot be named without a reference to '../../../../../Automattic/wp-calypso/node_modules/@automattic/explat-client/dist/types'. This is likely not portable. A type annotation is necessary.
```

These errors are fixed by the changes proposed in this pull request:
- Export ExperimentOptions and ExPlatClientReactHelper interfaces
- Re-export ExPlatClient and ExperimentAssignment types from @automattic/explat-client


#### Testing instructions

There are no material changes so the only expected change in output are the built d.ts files for the @automattic/explat-client-react-helpers package.

cc @jessie-ross 
