### PR TITLE
Styled site delete confirmation

### DIFF
--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -1,14 +1,15 @@
-import { Button, Card, Dialog } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormTextInput from 'calypso/components/forms/form-text-input';
 import SiteSelector from 'calypso/components/site-selector';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { getSiteDomain, getSiteSlug, getSiteTitle } from 'calypso/state/sites/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { SiteData } from 'calypso/state/ui/selectors/get-selected-site';
+import SiteDeleteConfirmationDialog from './site-delete-confirmation-dialog';
+
+import './styles.scss';
 
 interface Props {
 	stepSectionName: string | null;
@@ -36,10 +37,7 @@ export default function DIFMSitePickerStep( props: Props ): React.ReactElement {
 	const dispatch = useDispatch();
 	const { goToNextStep } = props;
 	const [ siteId, setSiteId ] = useState< number | null >( null );
-	const [ confirmDomain, setConfirmDomain ] = useState( '' );
-	const siteDomain = useSelector( ( state ) => getSiteDomain( state, siteId ?? 0 ) );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
-	const siteTitle = useSelector( ( state ) => getSiteTitle( state, siteId ) );
 	const headerText = translate( 'Choose where you want us to build your site.' );
 	const subHeaderText = translate( 'Some unsupported sites may be hidden.' );
 
@@ -96,99 +94,24 @@ export default function DIFMSitePickerStep( props: Props ): React.ReactElement {
 		goToNextStep();
 	};
 
-	if ( siteId ) {
-		const deleteDisabled =
-			typeof confirmDomain !== 'string' ||
-			confirmDomain.toLowerCase().replace( /\s/g, '' ) !== siteDomain;
-		const buttons = [
-			<Button onClick={ onCloseDialog }>{ translate( 'Cancel' ) }</Button>,
-			<Button primary scary disabled={ deleteDisabled } onClick={ onConfirmDelete }>
-				{ translate( 'Delete site content' ) }
-			</Button>,
-		];
-
-		return (
-			<Dialog isVisible={ true } buttons={ buttons } onClose={ onCloseDialog }>
-				<h1>{ translate( 'Site Reset Confirmation' ) }</h1>
-				<p>{ translate( 'After completing your purchase:' ) }</p>
-				<ul>
-					<li>
-						{ translate(
-							'The current content of your website {{strong}}%(siteTitle)s{{/strong}} (%(siteAddress)s) will be deleted, so we can start your website build on an empty site. ' +
-								'This includes pages, posts, media, and comments.',
-							{
-								components: {
-									strong: <strong />,
-								},
-								args: {
-									siteTitle,
-									siteAddress: siteDomain,
-								},
-							}
-						) }
-					</li>
-					<li>
-						{ translate(
-							'Any WordPress.com subscriptions on your site such as custom domains and emails will not be affected.'
-						) }
-					</li>
-					<li>
-						{ translate(
-							'Your site will be inaccessible in {{i}}Coming Soon{{/i}} mode while we build your new site.',
-							{
-								components: {
-									i: <i />,
-								},
-							}
-						) }
-					</li>
-				</ul>
-				<p>
-					{ translate(
-						'If you don’t want your site content to be deleted, we can instead create a new site on your account for the website build. ' +
-							'You can then transfer the existing content to the new site once it’s complete. ' +
-							'Click {{a}}here{{/a}} to go back and choose "New Site".',
-						{
-							components: {
-								a: <a href="/start/do-it-for-me" />,
-							},
-						}
-					) }
-				</p>
-				<FormLabel htmlFor="confirmDomainChangeInput">
-					{ translate(
-						"Please type {{warn}}%(siteAddress)s{{/warn}} to acknowledge that after purchase all of your site's content will be permanently deleted.",
-						{
-							components: {
-								warn: <span />,
-							},
-							args: {
-								siteAddress: siteDomain,
-							},
-						}
-					) }
-				</FormLabel>
-
-				<FormTextInput
-					autoCapitalize="off"
-					onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-						setConfirmDomain( event.target.value )
-					}
-					value={ confirmDomain }
-					aria-required="true"
-					id="confirmDomainChangeInput"
-				/>
-			</Dialog>
-		);
-	}
-
 	return (
 		<StepWrapper
 			headerText={ headerText }
 			fallbackHeaderText={ headerText }
 			subHeaderText={ subHeaderText }
 			fallbackSubHeaderText={ subHeaderText }
-			stepContent={ <DIFMSitePicker filter={ filterSites } onSiteSelect={ handleSiteSelect } /> }
+			stepContent={
+				<>
+					<DIFMSitePicker filter={ filterSites } onSiteSelect={ handleSiteSelect } />
+					{ siteId && (
+						<SiteDeleteConfirmationDialog
+							onClose={ onCloseDialog }
+							onConfirm={ onConfirmDelete }
+							siteId={ siteId }
+						/>
+					) }
+				</>
+			}
 			hideSkip
 			{ ...props }
 		/>

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -1,15 +1,10 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import SiteSelector from 'calypso/components/site-selector';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import {
-	removeStep,
-	saveSignupStep,
-	submitSignupStep,
-} from 'calypso/state/signup/progress/actions';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { SiteData } from 'calypso/state/ui/selectors/get-selected-site';
 import SiteDeleteConfirmationDialog from './site-delete-confirmation-dialog';
@@ -98,18 +93,6 @@ export default function DIFMSitePickerStep( props: Props ): React.ReactElement {
 		goToNextStep();
 	};
 
-	const onRedirectToNewSite = () => {
-		dispatch(
-			removeStep( {
-				stepName: 'domains',
-				wasSkipped: true,
-			} )
-		);
-
-		// We do not redirect to the site title step because it might confuse the user
-		page( '/start/do-it-for-me' );
-	};
-
 	return (
 		<StepWrapper
 			headerText={ headerText }
@@ -121,7 +104,6 @@ export default function DIFMSitePickerStep( props: Props ): React.ReactElement {
 					<DIFMSitePicker filter={ filterSites } onSiteSelect={ handleSiteSelect } />
 					{ siteId && (
 						<SiteDeleteConfirmationDialog
-							onRedirectToNewSite={ onRedirectToNewSite }
 							onClose={ onCloseDialog }
 							onConfirm={ onConfirmDelete }
 							siteId={ siteId }

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -1,14 +1,18 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import SiteSelector from 'calypso/components/site-selector';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
+import {
+	removeStep,
+	saveSignupStep,
+	submitSignupStep,
+} from 'calypso/state/signup/progress/actions';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { SiteData } from 'calypso/state/ui/selectors/get-selected-site';
 import SiteDeleteConfirmationDialog from './site-delete-confirmation-dialog';
-
 import './styles.scss';
 
 interface Props {
@@ -94,6 +98,18 @@ export default function DIFMSitePickerStep( props: Props ): React.ReactElement {
 		goToNextStep();
 	};
 
+	const onRedirectToNewSite = () => {
+		dispatch(
+			removeStep( {
+				stepName: 'domains',
+				wasSkipped: true,
+			} )
+		);
+
+		// We do not redirect to the site title step because it might confuse the user
+		page( '/start/do-it-for-me' );
+	};
+
 	return (
 		<StepWrapper
 			headerText={ headerText }
@@ -105,6 +121,7 @@ export default function DIFMSitePickerStep( props: Props ): React.ReactElement {
 					<DIFMSitePicker filter={ filterSites } onSiteSelect={ handleSiteSelect } />
 					{ siteId && (
 						<SiteDeleteConfirmationDialog
+							onRedirectToNewSite={ onRedirectToNewSite }
 							onClose={ onCloseDialog }
 							onConfirm={ onConfirmDelete }
 							siteId={ siteId }

--- a/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
+++ b/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
@@ -42,7 +42,6 @@ const DialogContainer = styled.div`
 
 const DialogButton = styled( Button )`
 	border-radius: 5px;
-	width: 152px;
 	--color-accent: #117ac9;
 	--color-accent-60: #0e64a5;
 	.gridicon {

--- a/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
+++ b/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
@@ -6,8 +6,7 @@ import { useSelector } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { getSiteTitle } from 'calypso/state/signup/steps/site-title/selectors';
-import { getSiteDomain } from 'calypso/state/sites/selectors';
+import { getSiteDomain, getSiteTitle } from 'calypso/state/sites/selectors';
 
 const ExclamationIcon = () => (
 	<svg xmlns="http://www.w3.org/2000/svg" width="90" height="89" fill="none" viewBox="0 0 90 89">
@@ -30,8 +29,13 @@ const ExclamationIcon = () => (
 	</svg>
 );
 
+const Row = styled.div`
+	display: flex;
+	justify-content: center;
+`;
+
 const DialogContainer = styled.div`
-	text-align: center;
+	text-align: left;
 	width: 600px;
 	padding: 65px 65px 0 65px;
 `;
@@ -45,22 +49,34 @@ const DialogButton = styled( Button )`
 		margin-left: 10px;
 	}
 `;
+const AnchorButton = styled( Button )`
+	background: none;
+	border: none;
+	color: var( --color-primary-light );
+	padding: 0;
+`;
+const Subtitle = styled.p`
+	color: var( --color-neutral-50 );
+	font-size: 0.875rem;
+`;
 
 function SiteDeleteConfirmationDialog( {
 	onClose,
 	onConfirm,
 	siteId,
+	onRedirectToNewSite,
 }: {
 	onClose: () => void;
 	onConfirm: () => void;
+	onRedirectToNewSite: () => void;
 	siteId: number;
 } ) {
 	const [ confirmText, setConfirmText ] = useState( '' );
 	const siteDomain = useSelector( ( state ) => getSiteDomain( state, siteId ?? 0 ) );
-	const siteTitle = useSelector( ( state ) => getSiteTitle( state ) );
+	const siteTitle = useSelector( ( state ) => getSiteTitle( state, siteId ) );
 
 	const translate = useTranslate();
-	const deleteDisabled = confirmText.toUpperCase().replace( /\s/g, '' ) !== 'DELETE';
+	const deleteDisabled = confirmText !== 'DELETE';
 
 	return (
 		<Dialog
@@ -75,26 +91,57 @@ function SiteDeleteConfirmationDialog( {
 			onClose={ onClose }
 		>
 			<DialogContainer>
-				<ExclamationIcon />
+				<Row>
+					<ExclamationIcon />
+				</Row>
 				<FormattedHeader
 					align="center"
 					brandFont
 					headerText={ translate( 'Site Reset Confirmation' ) }
-					subHeaderText={ translate(
-						'The current content of your website {{strong}}%(siteTitle)s{{/strong}} (%(siteAddress)s) will be deleted. ' +
-							'This includes pages, posts, media, comments, third party plugins and themes. Any WordPress.com subscriptions ' +
-							'on your site such as custom domains and emails will not be affected',
-						{
-							components: {
-								strong: <strong />,
-							},
-							args: {
-								siteTitle,
-								siteAddress: siteDomain,
-							},
-						}
-					) }
 				/>
+				<Subtitle>
+					<ul>
+						<li>
+							{ translate(
+								'The current content of your website {{strong}}%(siteTitle)s{{/strong}} (%(siteAddress)s) will be deleted. ' +
+									'This includes pages, posts, media, comments, third party plugins and themes.',
+								{
+									components: {
+										strong: <strong />,
+									},
+									args: {
+										siteTitle,
+										siteAddress: siteDomain,
+									},
+								}
+							) }
+						</li>
+						<li>
+							{ translate(
+								'Any WordPress.com subscriptions on your site such as custom domains and emails will not be affected.',
+								{
+									components: {
+										strong: <strong />,
+									},
+									args: {
+										siteTitle,
+										siteAddress: siteDomain,
+									},
+								}
+							) }
+						</li>
+						<li>
+							{ translate(
+								"If you don't want your site content to be deleted you can create a {{a}}new site{{/a}} instead.",
+								{
+									components: {
+										a: <AnchorButton onClick={ onRedirectToNewSite } />,
+									},
+								}
+							) }
+						</li>
+					</ul>
+				</Subtitle>
 				<FormLabel htmlFor="confirmTextChangeInput">
 					{ translate(
 						'Type DELETE to confirm that your site’s current content will be deleted.'

--- a/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
+++ b/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
@@ -1,0 +1,118 @@
+import { Button, Dialog } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import { getSiteTitle } from 'calypso/state/signup/steps/site-title/selectors';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+
+const ExclamationIcon = () => (
+	<svg xmlns="http://www.w3.org/2000/svg" width="90" height="89" fill="none" viewBox="0 0 90 89">
+		<path
+			fill="#FFA555"
+			d="M39.18 83.895c19.46 0 35.237-15.776 35.237-35.237 0-19.462-15.776-35.238-35.238-35.238-19.46 0-35.237 15.776-35.237 35.237 0 19.462 15.776 35.238 35.237 35.238z"
+		></path>
+		<path
+			fill="#003C65"
+			d="M40.78 73.049c-1.067-1.05-1.6-2.344-1.6-3.896 0-1.535.533-2.844 1.6-3.895 1.066-1.05 2.392-1.584 3.96-1.584s2.893.533 3.96 1.584c1.067 1.05 1.6 2.344 1.6 3.895 0 1.536-.533 2.845-1.6 3.896-1.067 1.05-2.392 1.584-3.96 1.584-1.584-.016-2.894-.533-3.96-1.584zm-.76-59.63h9.424l-.712 40.492H40.7L40.02 13.42z"
+		></path>
+		<path
+			stroke="#003C65"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			strokeMiterlimit="10"
+			strokeWidth="1.8"
+			d="M88.884 44.31c-.986 57.753-86.898 57.753-87.884 0 1.002-57.755 86.914-57.738 87.884 0z"
+		></path>
+	</svg>
+);
+
+const DialogContainer = styled.div`
+	text-align: center;
+	width: 600px;
+	padding: 65px 65px 0 65px;
+`;
+
+const DialogButton = styled( Button )`
+	border-radius: 5px;
+	width: 152px;
+	--color-accent: #117ac9;
+	--color-accent-60: #0e64a5;
+	.gridicon {
+		margin-left: 10px;
+	}
+`;
+
+function SiteDeleteConfirmationDialog( {
+	onClose,
+	onConfirm,
+	siteId,
+}: {
+	onClose: () => void;
+	onConfirm: () => void;
+	siteId: number;
+} ) {
+	const [ confirmText, setConfirmText ] = useState( '' );
+	const siteDomain = useSelector( ( state ) => getSiteDomain( state, siteId ?? 0 ) );
+	const siteTitle = useSelector( ( state ) => getSiteTitle( state ) );
+
+	const translate = useTranslate();
+	const deleteDisabled = confirmText.toUpperCase().replace( /\s/g, '' ) !== 'DELETE';
+
+	return (
+		<Dialog
+			isBackdropVisible={ true }
+			isVisible={ true }
+			buttons={ [
+				<DialogButton onClick={ onClose }>{ translate( 'Cancel' ) }</DialogButton>,
+				<DialogButton primary disabled={ deleteDisabled } onClick={ onConfirm }>
+					{ translate( 'Delete site content' ) }
+				</DialogButton>,
+			] }
+			onClose={ onClose }
+		>
+			<DialogContainer>
+				<ExclamationIcon />
+				<FormattedHeader
+					align="center"
+					brandFont
+					headerText={ translate( 'Site Reset Confirmation' ) }
+					subHeaderText={ translate(
+						'The current content of your website {{strong}}%(siteTitle)s{{/strong}} (%(siteAddress)s) will be deleted. ' +
+							'This includes pages, posts, media, comments, third party plugins and themes. Any WordPress.com subscriptions ' +
+							'on your site such as custom domains and emails will not be affected',
+						{
+							components: {
+								strong: <strong />,
+							},
+							args: {
+								siteTitle,
+								siteAddress: siteDomain,
+							},
+						}
+					) }
+				/>
+				<FormLabel htmlFor="confirmTextChangeInput">
+					{ translate(
+						'Type DELETE to confirm that your site’s current content will be deleted.'
+					) }
+				</FormLabel>
+
+				<FormTextInput
+					autoCapitalize="off"
+					onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+						setConfirmText( event.target.value )
+					}
+					value={ confirmText }
+					aria-required="true"
+					id="confirmTextChangeInput"
+				/>
+			</DialogContainer>
+		</Dialog>
+	);
+}
+
+export default SiteDeleteConfirmationDialog;

--- a/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
+++ b/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
@@ -35,9 +35,11 @@ const Row = styled.div`
 `;
 
 const DialogContainer = styled.div`
-	text-align: left;
-	width: 600px;
-	padding: 65px 65px 0 65px;
+	max-width: 600px;
+	padding: 50px 50px 0 50px;
+	@media ( max-width: 425px ) {
+		padding: 30px 0 10px 0;
+	}
 `;
 
 const DialogButton = styled( Button )`

--- a/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
+++ b/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
@@ -49,12 +49,7 @@ const DialogButton = styled( Button )`
 		margin-left: 10px;
 	}
 `;
-const AnchorButton = styled( Button )`
-	background: none;
-	border: none;
-	color: var( --color-primary-light );
-	padding: 0;
-`;
+
 const Subtitle = styled.p`
 	color: var( --color-neutral-50 );
 	font-size: 0.875rem;
@@ -64,22 +59,21 @@ function SiteDeleteConfirmationDialog( {
 	onClose,
 	onConfirm,
 	siteId,
-	onRedirectToNewSite,
 }: {
 	onClose: () => void;
 	onConfirm: () => void;
-	onRedirectToNewSite: () => void;
 	siteId: number;
 } ) {
 	const [ confirmText, setConfirmText ] = useState( '' );
 	const siteDomain = useSelector( ( state ) => getSiteDomain( state, siteId ?? 0 ) );
 	const siteTitle = useSelector( ( state ) => getSiteTitle( state, siteId ) );
-
 	const translate = useTranslate();
-	const deleteDisabled = confirmText !== 'DELETE';
+	const TRANSLATED_DELETE_WORD = translate( 'DELETE' );
+	const deleteDisabled = confirmText !== TRANSLATED_DELETE_WORD;
 
 	return (
 		<Dialog
+			additionalClassNames="difm-site-delete-confirmation"
 			isBackdropVisible={ true }
 			isVisible={ true }
 			buttons={ [
@@ -118,16 +112,7 @@ function SiteDeleteConfirmationDialog( {
 						</li>
 						<li>
 							{ translate(
-								'Any WordPress.com subscriptions on your site such as custom domains and emails will not be affected.',
-								{
-									components: {
-										strong: <strong />,
-									},
-									args: {
-										siteTitle,
-										siteAddress: siteDomain,
-									},
-								}
+								'Any WordPress.com subscriptions on your site such as custom domains and emails will not be affected.'
 							) }
 						</li>
 						<li>
@@ -135,7 +120,7 @@ function SiteDeleteConfirmationDialog( {
 								"If you don't want your site content to be deleted you can create a {{a}}new site{{/a}} instead.",
 								{
 									components: {
-										a: <AnchorButton onClick={ onRedirectToNewSite } />,
+										a: <a href="/start/do-it-for-me" />,
 									},
 								}
 							) }
@@ -144,7 +129,15 @@ function SiteDeleteConfirmationDialog( {
 				</Subtitle>
 				<FormLabel htmlFor="confirmTextChangeInput">
 					{ translate(
-						'Type DELETE to confirm that your site’s current content will be deleted.'
+						'Type {{strong}}%(deleteWord)s{{/strong}} to confirm that your site’s current content will be deleted after purchase.',
+						{
+							components: {
+								strong: <strong />,
+							},
+							args: {
+								deleteWord: TRANSLATED_DELETE_WORD,
+							},
+						}
 					) }
 				</FormLabel>
 

--- a/client/signup/steps/difm-site-picker/styles.scss
+++ b/client/signup/steps/difm-site-picker/styles.scss
@@ -1,5 +1,5 @@
 .ReactModalPortal {
-	.dialog__action-buttons {
+	.difm-site-delete-confirmation {
 		text-align: center;
 		padding: 40px 0 50px;
 	}

--- a/client/signup/steps/difm-site-picker/styles.scss
+++ b/client/signup/steps/difm-site-picker/styles.scss
@@ -2,7 +2,7 @@
 	.difm-site-delete-confirmation {
 		.dialog__action-buttons {
 			text-align: center;
-			padding: 40px 0 50px;
+			padding: 40px 16px 50px;
 			.button {
 				min-width: 152px;
 			}

--- a/client/signup/steps/difm-site-picker/styles.scss
+++ b/client/signup/steps/difm-site-picker/styles.scss
@@ -1,0 +1,6 @@
+.ReactModalPortal {
+	.dialog__action-buttons {
+		text-align: center;
+		padding: 40px 0 50px;
+	}
+}

--- a/client/signup/steps/difm-site-picker/styles.scss
+++ b/client/signup/steps/difm-site-picker/styles.scss
@@ -1,6 +1,11 @@
 .ReactModalPortal {
 	.difm-site-delete-confirmation {
-		text-align: center;
-		padding: 40px 0 50px;
+		.dialog__action-buttons {
+			text-align: center;
+			padding: 40px 0 50px;
+			.button {
+				min-width: 152px;
+			}
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Restyled the site confirmation for the difm onboarding flow.
More context : pdh1Xd-xv-p2#comment-894
<img width="1367" alt="image" src="https://user-images.githubusercontent.com/3422709/156560872-21236cf2-371a-4d7f-862e-a0e9599b8eb5.png">


#### Testing instructions
* Go through the DIFM flow `/start/do-it-for-me`
* Select existing site
* Select the site
* The dialog above should be shown

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #