### PR TITLE
Add warning when a domain already has paid email service

### DIFF
--- a/client/lib/gsuite/get-gsuite-subscription-status.js
+++ b/client/lib/gsuite/get-gsuite-subscription-status.js
@@ -1,9 +1,0 @@
-/**
- * Gets Google Workspace subscription status for a given domain object.
- *
- * @param {undefined|{googleAppsSubscription?:{status?: string}}} domain - Domain object
- * @returns {string} - Subscription status or empty string for null/undefined values
- */
-export function getGSuiteSubscriptionStatus( domain ) {
-	return domain?.googleAppsSubscription?.status ?? '';
-}

--- a/client/lib/gsuite/get-gsuite-subscription-status.ts
+++ b/client/lib/gsuite/get-gsuite-subscription-status.ts
@@ -1,0 +1,13 @@
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
+
+/**
+ * Gets Google Workspace subscription status for a given domain object.
+ *
+ * @returns {string} - Subscription status or empty string for null/undefined values
+ */
+export function getGSuiteSubscriptionStatus(
+	domain: ResponseDomain | SiteDomain | undefined
+): string {
+	return domain?.googleAppsSubscription?.status ?? '';
+}

--- a/client/lib/gsuite/has-gsuite-with-another-provider.ts
+++ b/client/lib/gsuite/has-gsuite-with-another-provider.ts
@@ -1,12 +1,13 @@
 import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite/get-gsuite-subscription-status';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
 
 /**
  * Given a domain object, does that domain have G Suite with another provider.
  *
- * @param {import('../domains/types').ResponseDomain | undefined } domain - domain object
  * @returns {boolean} - true if the domain is with another provider, false otherwise
  */
-export function hasGSuiteWithAnotherProvider( domain ) {
+export function hasGSuiteWithAnotherProvider( domain: ResponseDomain | SiteDomain | undefined ): boolean {
 	const status = getGSuiteSubscriptionStatus( domain );
 
 	return 'other_provider' === status;

--- a/client/lib/gsuite/has-gsuite-with-another-provider.ts
+++ b/client/lib/gsuite/has-gsuite-with-another-provider.ts
@@ -7,7 +7,9 @@ import type { SiteDomain } from 'calypso/state/sites/domains/types';
  *
  * @returns {boolean} - true if the domain is with another provider, false otherwise
  */
-export function hasGSuiteWithAnotherProvider( domain: ResponseDomain | SiteDomain | undefined ): boolean {
+export function hasGSuiteWithAnotherProvider(
+	domain: ResponseDomain | SiteDomain | undefined
+): boolean {
 	const status = getGSuiteSubscriptionStatus( domain );
 
 	return 'other_provider' === status;

--- a/client/lib/gsuite/has-gsuite-with-us.ts
+++ b/client/lib/gsuite/has-gsuite-with-us.ts
@@ -1,12 +1,13 @@
 import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite/get-gsuite-subscription-status';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
 
 /**
  * Given a domain object, does that domain have G Suite with us.
  *
- * @param {undefined|{googleAppsSubscription?:{status?: string}}|import('calypso/lib/domains/types').ResponseDomain|import('calypso/state/sites/domains/types').SiteDomain} domain - Domain object
  * @returns {boolean} - true if the domain is under our management, false otherwise
  */
-export function hasGSuiteWithUs( domain ) {
+export function hasGSuiteWithUs( domain: ResponseDomain | SiteDomain | undefined ): boolean {
 	const status = getGSuiteSubscriptionStatus( domain );
 
 	return ! [ '', 'no_subscription', 'other_provider' ].includes( status );

--- a/client/lib/titan/has-titan-mail-with-us.js
+++ b/client/lib/titan/has-titan-mail-with-us.js
@@ -1,5 +1,0 @@
-export function hasTitanMailWithUs( domain ) {
-	const subscriptionStatus = domain?.titanMailSubscription?.status ?? '';
-
-	return subscriptionStatus === 'active' || subscriptionStatus === 'suspended';
-}

--- a/client/lib/titan/has-titan-mail-with-us.ts
+++ b/client/lib/titan/has-titan-mail-with-us.ts
@@ -1,0 +1,8 @@
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
+
+export function hasTitanMailWithUs( domain: ResponseDomain | SiteDomain | undefined ): boolean {
+	const subscriptionStatus = domain?.titanMailSubscription?.status ?? '';
+
+	return subscriptionStatus === 'active' || subscriptionStatus === 'suspended';
+}

--- a/client/my-sites/email/email-existing-paid-service-notice/index.tsx
+++ b/client/my-sites/email/email-existing-paid-service-notice/index.tsx
@@ -1,0 +1,60 @@
+import { useTranslate } from 'i18n-calypso';
+import Notice from 'calypso/components/notice';
+import { hasGSuiteWithAnotherProvider, hasGSuiteWithUs } from 'calypso/lib/gsuite';
+import { hasTitanMailWithUs } from 'calypso/lib/titan';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
+
+const EmailExistingPaidServiceNotice = ( {
+	domain,
+}: {
+	domain: ResponseDomain | SiteDomain;
+} ): JSX.Element | null => {
+	const translate = useTranslate();
+
+	const hasGoogleWithAnotherProvider = hasGSuiteWithAnotherProvider( domain );
+	const hasGoogleWithUs = hasGSuiteWithUs( domain );
+	const hasProfessionalEmailWithUs = hasTitanMailWithUs( domain );
+
+	const showWarning = hasGoogleWithAnotherProvider || hasGoogleWithUs || hasProfessionalEmailWithUs;
+
+	if ( ! showWarning ) {
+		return null;
+	}
+
+	let message = null;
+
+	if ( hasGoogleWithAnotherProvider || hasGoogleWithUs ) {
+		message = translate(
+			'You already have Google email set up for the domain %(domainName)s. Please check if you really want a different email service, as changing email providers may disrupt your existing service.',
+			{
+				args: {
+					domainName: domain.domain,
+				},
+				comment: "%(domainName)s is a domain name, such as 'example.com' or 'yourgroovydomain.com'",
+			}
+		);
+	} else if ( hasProfessionalEmailWithUs ) {
+		message = translate(
+			'You already have Professional Email set up for the domain %(domainName)s. Please check if you really want a different email service, as changing email providers may disrupt your existing service.',
+			{
+				args: {
+					domainName: domain.domain,
+				},
+				comment: "%(domainName)s is a domain name, such as 'example.com' or 'yourgroovydomain.com'",
+			}
+		);
+	}
+
+	if ( null === message ) {
+		return null;
+	}
+
+	return (
+		<Notice showDismiss={ false } status="is-warning">
+			{ message }
+		</Notice>
+	);
+};
+
+export default EmailExistingPaidServiceNotice;

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -43,7 +43,7 @@ const EmailProvidersStackedComparison = ( {
 	selectedEmailProviderSlug,
 	selectedIntervalLength = IntervalLength.ANNUALLY,
 	source,
-}: EmailProvidersStackedComparisonProps ): JSX.Element => {
+}: EmailProvidersStackedComparisonProps ): JSX.Element | null => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -73,7 +73,7 @@ const EmailProvidersStackedComparison = ( {
 	const domainsWithForwards = useSelector( ( state ) => getDomainsWithForwards( state, domains ) );
 
 	if ( ! domain ) {
-		return <></>;
+		return null;
 	}
 
 	const changeExpandedState = ( providerKey: string, isCurrentlyExpanded: boolean ) => {
@@ -178,7 +178,7 @@ const EmailProvidersStackedComparison = ( {
 				/>
 			) }
 
-			{ domain && <EmailExistingPaidServiceNotice domain={ domain } /> }
+			<EmailExistingPaidServiceNotice domain={ domain } />
 
 			<ProfessionalEmailCard
 				comparisonContext={ comparisonContext }

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -11,6 +11,7 @@ import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-forwards-notice';
+import EmailExistingPaidServiceNotice from 'calypso/my-sites/email/email-existing-paid-service-notice';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
 import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparison/email-forwarding-link';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
@@ -25,7 +26,6 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwards';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -43,7 +43,7 @@ const EmailProvidersStackedComparison = ( {
 	selectedEmailProviderSlug,
 	selectedIntervalLength = IntervalLength.ANNUALLY,
 	source,
-}: EmailProvidersStackedComparisonProps ): ReactElement => {
+}: EmailProvidersStackedComparisonProps ): JSX.Element => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -177,6 +177,8 @@ const EmailProvidersStackedComparison = ( {
 					selectedDomainName={ selectedDomainName }
 				/>
 			) }
+
+			{ domain && <EmailExistingPaidServiceNotice domain={ domain } /> }
 
 			<ProfessionalEmailCard
 				comparisonContext={ comparisonContext }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a warning to the email comparison component when we can detect that a user already has paid email service. We currently detect when the user has Google Workspace/G Suite service with us or another provider, and when the user has Professional Email service with us.
* The PR also converts some of our library functions across to TypeScript.

#### Testing instructions

* Run this branch locally or via [the Calypso live branch](https://github.com/Automattic/wp-calypso/pull/61638#issuecomment-1058070667)
* For domains that have a Professional Email subscription, a Google Workspace subscription, and a G Suite subscription, run the following steps:
  1. Navigate to **Upgrades** -> **Emails**, and click on your domain
  2. Change the URL in your browser so you replace `/manage/` with `/purchase/`
  3. Verify that you see a warning mentioning that you already have service for your current provider (either Google or Professional Email)
* Navigate to **Upgrades** -> **Emails** for a site that has a domain without any paid email service
* Click on "Add Email" for that domain without email service
* Verify that you do not see the notice for this domain

_Note: I am not sure how to effectively test for the case where billing is with Google or another provider. It should just work, but I am not sure how to verify that effectively._

#### Screenshots

##### Domain with existing Professional Email subscription

<img width="1141" alt="Screenshot 2022-03-03 at 15 57 56" src="https://user-images.githubusercontent.com/3376401/156579308-34fee928-6bf8-4428-b878-7a2c451d2b05.png">

##### Domain with existing Google Workspace/G Suite subscription
<img width="1141" alt="Screenshot 2022-03-03 at 15 56 59" src="https://user-images.githubusercontent.com/3376401/156579298-5fbe4d9e-daf4-41fd-b5b1-c68c65387fa3.png">