### PR TITLE
Marketplace: Feature additional plugins in Spotlight without JITM

### DIFF
--- a/client/my-sites/plugins/plugin-spotlight/README.md
+++ b/client/my-sites/plugins/plugin-spotlight/README.md
@@ -1,0 +1,21 @@
+# Plugin Spotlight
+
+This component renders a plugin spotlight on the top of the list browser.
+## How to use
+
+```js
+import PluginSpotlight from 'calypso/my-sites/plugins/plugin-spotlight';
+
+function render() {
+	return (
+		<div>
+			<PluginSpotlight eligiblePlugins={ eligiblePlugins } currentSites={ currentSites } />
+		</div>
+	);
+}
+```
+
+## Props
+
+- `eligiblePlugins`: a list with the plugins that are eligible to be featured on the spolight and its marketing copy.
+- `currentSites`: a list of sites that are currenly selected.

--- a/client/my-sites/plugins/plugin-spotlight/index.tsx
+++ b/client/my-sites/plugins/plugin-spotlight/index.tsx
@@ -1,0 +1,66 @@
+import page from 'page';
+import { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import Spotlight from 'calypso/components/spotlight';
+import { useWPCOMPlugin, useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+const useRandomPlugin = ( eligiblePlugins: any[] ) => {
+	const [ eligiblePlugin, setEligiblePlugin ] = useState();
+
+	useEffect( () => {
+		setEligiblePlugin( eligiblePlugins[ Math.floor( Math.random() * eligiblePlugins.length ) ] );
+	}, [ JSON.stringify( eligiblePlugins ) ] );
+
+	return eligiblePlugin;
+};
+
+const PluginSpotlight = ( { eligiblePlugins, site } ) => {
+	const { data: spotlightPlugin, isFetched: spotlightPluginFetched } = useWPCOMPlugin(
+		'wordpress-seo-premium'
+	);
+	const { data: plugins = [], isFetched: pluginsFetched } = useWPCOMPlugins( 'featured' );
+
+	const eligiblePlugin = useRandomPlugin( eligiblePlugins );
+
+	const dispatch = useDispatch();
+
+	// #TODO: remove this and combinedPlugins when wordpress seo premium is enabled
+	if ( ! spotlightPluginFetched || ! pluginsFetched ) {
+		return <></>;
+	}
+
+	const combinedPlugins = [ ...plugins, spotlightPlugin ];
+
+	const selectedPlugin = combinedPlugins.find(
+		( plugin ) => plugin.slug === eligiblePlugin?.pluginSlug
+	);
+
+	const spotlightOnClick = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_marketplace_spotlight_click', {
+				type: 'plugin',
+				slug: selectedPlugin.slug,
+				id: selectedPlugin.id,
+				site: site,
+			} )
+		);
+		page( `/plugins/${ selectedPlugin.slug }/${ site || '' }` );
+	};
+
+	return (
+		<>
+			{ selectedPlugin && eligiblePlugin && (
+				<Spotlight
+					onClick={ spotlightOnClick }
+					taglineText={ eligiblePlugin.tagline }
+					titleText={ eligiblePlugin.title }
+					ctaText={ eligiblePlugin.cta }
+					illustrationSrc={ selectedPlugin?.icon ?? '' }
+				/>
+			) }
+		</>
+	);
+};
+
+export default PluginSpotlight;

--- a/client/my-sites/plugins/plugin-spotlight/index.tsx
+++ b/client/my-sites/plugins/plugin-spotlight/index.tsx
@@ -15,19 +15,17 @@ export interface EligiblePlugins {
 
 export interface PluginSpotlightProps {
 	eligiblePlugins: EligiblePlugins[];
-	site: string;
 	currentSites: any[];
 }
 
-const PluginSpotlight = ( { eligiblePlugins, site, currentSites }: PluginSpotlightProps ) => {
+const PluginSpotlight = ( { eligiblePlugins, currentSites }: PluginSpotlightProps ) => {
+	const site = currentSites[ 0 ];
 	const dispatch = useDispatch();
 	const sitePlugins = useSelector( ( state ) =>
 		getPlugins( state, siteObjectsToSiteIds( currentSites ) )
 	);
 
-	const isFetchingInstalledPlugins = useSelector( ( state ) =>
-		isRequesting( state, currentSites[ 0 ].ID )
-	);
+	const isFetchingInstalledPlugins = useSelector( ( state ) => isRequesting( state, site.ID ) );
 
 	// When we are in plugins/:siteId select the first plugin that is not installed, otherwise always showcase
 	// the first in the list.
@@ -58,10 +56,10 @@ const PluginSpotlight = ( { eligiblePlugins, site, currentSites }: PluginSpotlig
 				type: 'plugin',
 				slug: spotlightPlugin.slug,
 				id: spotlightPlugin.id,
-				site: site,
+				site: site.slug,
 			} )
 		);
-		page( `/plugins/${ spotlightPlugin.slug }/${ site || '' }` );
+		page( `/plugins/${ spotlightPlugin.slug }/${ site.slug }` );
 	};
 
 	return (

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -4,14 +4,11 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { times } from 'lodash';
-import page from 'page';
 import PropTypes from 'prop-types';
-import { useDispatch } from 'react-redux';
-import Spotlight from 'calypso/components/spotlight';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
+import PluginSpotlight from 'calypso/my-sites/plugins/plugin-spotlight';
 import PluginBrowserItem from 'calypso/my-sites/plugins/plugins-browser-item';
 import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { PluginsBrowserListVariant } from './types';
 
 import './style.scss';
@@ -32,12 +29,9 @@ const PluginsBrowserList = ( {
 	listName,
 	expandedListLink,
 	size,
-	spotlightPlugin,
-	spotlightPluginFetched,
 } ) => {
 	const isWide = useBreakpoint( '>1280px' );
 	const { __ } = useI18n();
-	const dispatch = useDispatch();
 
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {
@@ -91,17 +85,21 @@ const PluginsBrowserList = ( {
 		}
 	};
 
-	const spotlightOnClick = () => {
-		dispatch(
-			recordTracksEvent( 'calypso_marketplace_spotlight_click', {
-				type: 'plugin',
-				slug: spotlightPlugin.slug,
-				id: spotlightPlugin.id,
-				site: site,
-			} )
-		);
-		page( `/plugins/${ spotlightPlugin.slug }/${ site || '' }` );
-	};
+	const eligiblePlugins = [
+		{
+			pluginSlug: 'wordpress-seo-premium',
+			tagline: __( 'Drive more traffic with Yoast SEO Premium' ),
+			title: __( 'Under the Spotlight' ),
+			cta: __( 'View Details' ),
+		},
+		{
+			pluginSlug: 'woocommerce-subscriptions',
+			tagline: __( 'Let your customer subscribe to your plans' ),
+			title: __( 'Under the Spotlight' ),
+			cta: __( 'Start now' ),
+		},
+	];
+
 	return (
 		<div className="plugins-browser-list">
 			<div className="plugins-browser-list__header">
@@ -125,18 +123,9 @@ const PluginsBrowserList = ( {
 					) }
 				</div>
 			</div>
-			{ listName === 'paid' &&
-				isEnabled( 'marketplace-spotlight' ) &&
-				spotlightPluginFetched &&
-				spotlightPlugin && (
-					<Spotlight
-						taglineText={ __( 'Drive more traffic with Yoast SEO Premium' ) }
-						titleText={ __( 'Under the Spotlight' ) }
-						ctaText={ __( 'View Details' ) }
-						illustrationSrc={ spotlightPlugin?.icon ?? '' }
-						onClick={ () => spotlightOnClick() }
-					/>
-				) }
+			{ listName === 'paid' && isEnabled( 'marketplace-spotlight' ) && (
+				<PluginSpotlight site={ site } eligiblePlugins={ eligiblePlugins } />
+			) }
 			<Card className="plugins-browser-list__elements">{ renderViews() }</Card>
 		</div>
 	);

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -87,14 +87,21 @@ const PluginsBrowserList = ( {
 
 	const eligiblePlugins = [
 		{
-			pluginSlug: 'wordpress-seo-premium',
+			slug: 'wordpress-seo-premium',
 			tagline: __( 'Drive more traffic with Yoast SEO Premium' ),
 			title: __( 'Under the Spotlight' ),
 			cta: __( 'View Details' ),
 		},
+		// delete everything below this and replace with Sensei Pro this is being used as a proof of concept
 		{
-			pluginSlug: 'woocommerce-subscriptions',
-			tagline: __( 'Let your customer subscribe to your plans' ),
+			slug: 'woocommerce-subscriptions',
+			tagline: __( 'Let your customer subscribe with Woocommerce Subscriptions' ),
+			title: __( 'Under the Spotlight' ),
+			cta: __( 'Start now' ),
+		},
+		{
+			slug: 'woocommerce-bookings',
+			tagline: __( 'Let your customer book with WooCommerce Bookings' ),
 			title: __( 'Under the Spotlight' ),
 			cta: __( 'Start now' ),
 		},
@@ -124,7 +131,11 @@ const PluginsBrowserList = ( {
 				</div>
 			</div>
 			{ listName === 'paid' && isEnabled( 'marketplace-spotlight' ) && (
-				<PluginSpotlight site={ site } eligiblePlugins={ eligiblePlugins } />
+				<PluginSpotlight
+					site={ site }
+					eligiblePlugins={ eligiblePlugins }
+					currentSites={ currentSites }
+				/>
 			) }
 			<Card className="plugins-browser-list__elements">{ renderViews() }</Card>
 		</div>

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -131,11 +131,7 @@ const PluginsBrowserList = ( {
 				</div>
 			</div>
 			{ listName === 'paid' && isEnabled( 'marketplace-spotlight' ) && (
-				<PluginSpotlight
-					site={ site }
-					eligiblePlugins={ eligiblePlugins }
-					currentSites={ currentSites }
-				/>
+				<PluginSpotlight eligiblePlugins={ eligiblePlugins } currentSites={ currentSites } />
 			) }
 			<Card className="plugins-browser-list__elements">{ renderViews() }</Card>
 		</div>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	isBusiness,
 	isEcommerce,
@@ -27,7 +26,7 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import Pagination from 'calypso/components/pagination';
 import { PaginationVariant } from 'calypso/components/pagination/constants';
-import { useWPCOMPlugin, useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import { useWPORGPlugins } from 'calypso/data/marketplace/use-wporg-plugin-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import UrlSearch from 'calypso/lib/url-search';
@@ -536,9 +535,6 @@ const PluginSingleListView = ( {
 
 	const siteId = useSelector( getSelectedSiteId );
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
-	const { data: spotlightPlugin, isFetched: spotlightPluginFetched } =
-		useWPCOMPlugin( 'wordpress-seo-premium', { enabled: isEnabled( 'marketplace-spotlight' ) } ) ||
-		{};
 
 	let plugins;
 	let isFetching;
@@ -575,8 +571,6 @@ const PluginSingleListView = ( {
 			variant={ PluginsBrowserListVariant.Fixed }
 			billingPeriod={ billingPeriod }
 			setBillingPeriod={ category === 'paid' && setBillingPeriod }
-			spotlightPlugin={ spotlightPlugin }
-			spotlightPluginFetched={ spotlightPluginFetched }
 			extended
 		/>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds additional plugins to the marketplace spotlight.
* Renders them conditionally depending on site installed plugins.
* Adds some plugins to the component for a PoC and testing.
* Adds a fallback where it doesn't render if all the plugins in the list are installed for that site.

#### Screenshot
<img width="1512" alt="Screen Shot 2022-03-04 at 8 15 42 AM" src="https://user-images.githubusercontent.com/1035546/156770123-7e37ff57-343f-4293-9b25-15f31cc073d5.png">

**Note:** The plugin in the image is just a PoC/test plugin we can configure the following list to showcase Yoast Premium and Sensei Pro (when is merged).

#### Testing instructions
* On a site without Yoast Premium installed navigate to `http://calypso.localhost:3000/plugins/<siteSlug>?flags=marketplace-spotlight`.
* It should showcase Yoast Premium.
* Click on the Spotlight and install Yoast Premium.
* Navigate back when installation finished and it should show the WooCommerce Bookings PoC one.
* Navigate into `http://calypso.localhost:3000/plugins?flags=marketplace-spotlight` it should always show Yoast Premium.

Related to #61549
