### PR TITLE
Admin bar: update colors to show support for Ukraine

### DIFF
--- a/client/layout/masterbar/masterbar.jsx
+++ b/client/layout/masterbar/masterbar.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import './style.scss';
 
 const Masterbar = ( { children, className } ) => (
-	<header id="header" className={ classNames( 'masterbar', className ) }>
+	<header id="header" className={ classNames( 'masterbar ukraine', className ) }>
 		{ children }
 	</header>
 );

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -97,12 +97,13 @@ $autobar-height: 20px;
 		#ffd700 50%
 	);
 
-	> .masterbar__item:not( .masterbar__item-title ),
+	> .masterbar__item,
+	> .masterbar__section--center,
+	> .masterbar__section--right,
 	> .masterbar__notifications,
 	> .masterbar__login-links a {
-		&:not( .is-active ) {
-			background: rgba( var( --color-primary-rgb ), 0.85 );
-		}
+		background-color: #0057b7 !important;
+		color: var( --color-masterbar-text ) !important;
 
 		&:hover {
 			background: var( --color-primary );
@@ -115,6 +116,21 @@ $autobar-height: 20px;
 				box-shadow: inset 0 0 0 2px var( --color-primary-light );
 			}
 		}
+	}
+
+	> .masterbar__section--left {
+		> button,
+		> a {
+			background-color: #0057b7;
+
+			&:hover {
+				background: var( --color-masterbar-item-hover-background );
+			}
+		}
+	}
+
+	> .masterbar__item-content {
+		color: var( --color-masterbar-text );
 	}
 }
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -90,6 +90,34 @@ $autobar-height: 20px;
 	}
 }
 
+.ukraine.masterbar {
+	background: linear-gradient(
+		-180deg,
+		#0057b7 50%,
+		#ffd700 50%
+	);
+
+	> .masterbar__item:not( .masterbar__item-title ),
+	> .masterbar__notifications,
+	> .masterbar__login-links a {
+		&:not( .is-active ) {
+			background: rgba( var( --color-primary-rgb ), 0.85 );
+		}
+
+		&:hover {
+			background: var( --color-primary );
+		}
+
+		&:focus {
+			outline: none;
+
+			.accessible-focus & {
+				box-shadow: inset 0 0 0 2px var( --color-primary-light );
+			}
+		}
+	}
+}
+
 .masterbar__item-bubble {
 	border: solid 2px var( --color-masterbar-background );
 	// stylelint-disable-next-line declaration-property-unit-allowed-list


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the colors of the logged in admin bar to show support for Ukraine.

<img width="1496" alt="Screenshot 2022-03-14 at 11 23 18" src="https://user-images.githubusercontent.com/426388/158153659-7b2dac70-f80c-4a76-b043-69b1b9fda8cf.png">

I could use some help finding a way to keep a good contrast around the buttons / links in the admin bar :)

#### Testing instructions

* Run this branch and Open [`calypso.localhost:3000`](http://calypso.localhost:3000/) in your browser.
* Check the admin bar in different browsers.`

#### References

- pb6Nl-eP1-p2