### PR TITLE
[E2E][GB 12.7.x] Test fix for Gutenberg 

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -426,13 +426,10 @@ export class GutenbergEditorPage {
 	async unpublish(): Promise< void > {
 		const frame = await this.getEditorFrame();
 
-		// Add handler to handle dialog that must be accepted for the post
-		// to be unpublished.
-		this.page.once( 'dialog', async ( dialog ) => {
-			await dialog.accept();
-		} );
-
 		await frame.click( selectors.switchToDraftButton );
+
+		// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
+		await frame.click( `div[role="dialog"] button:has-text("OK")` );
 		// Similar to Save Draft, the publish button temporarily becomes disabled
 		// while the unpublish process takes place. This waits for the publish button
 		// to again become enabled.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  Fix for failing e2e test, in preparation for upcoming 12.7.x release on WPcom. Test failed due to `ConfirmDialog` migration. Added similar fix seen in #61376

#### Testing instructions

1. Run test `editor__post-advanced-flow.ts`
2. All tests should pass 

To be merged **after** 12.7.0 is released to production WPCOM.

Tracking issue: https://github.com/Automattic/wp-calypso/issues/61456
