### PR TITLE
Experiment: Remove `calypso_mobile_plans_page_with_billing` experiment

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -128,7 +128,6 @@ export class PlanFeaturesHeader extends Component {
 			title,
 			audience,
 			translate,
-			isBillingWordingExperiment,
 		} = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
@@ -154,7 +153,7 @@ export class PlanFeaturesHeader extends Component {
 				</header>
 				<div className="plan-features__pricing">
 					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }
-					{ isBillingWordingExperiment && this.getDiscountInfo() }
+					{ this.getDiscountInfo() }
 					{ this.getIntervalDiscount() }
 				</div>
 			</span>
@@ -278,7 +277,6 @@ export class PlanFeaturesHeader extends Component {
 			isMonthlyPlan,
 			relatedYearlyPlan,
 			isLoggedInMonthlyPricing,
-			isBillingWordingExperiment,
 		} = this.props;
 
 		if ( ( isInSignup || isLoggedInMonthlyPricing ) && isMonthlyPlan && relatedYearlyPlan ) {
@@ -293,12 +291,9 @@ export class PlanFeaturesHeader extends Component {
 			planMatches( planType, { group: GROUP_WPCOM, term: TERM_ANNUALLY } ) &&
 			relatedYearlyPlan
 		) {
-			if ( isBillingWordingExperiment ) {
-				return translate( 'billed as %(price)s annually', {
-					args: { price: relatedYearlyPlan.formatted_price },
-				} );
-			}
-			return translate( 'billed annually' );
+			return translate( 'billed as %(price)s annually', {
+				args: { price: relatedYearlyPlan.formatted_price },
+			} );
 		}
 
 		if (

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -313,7 +313,6 @@ export class PlanFeatures extends Component {
 			showPlanCreditsApplied,
 			isLaunchPage,
 			isInVerticalScrollingPlansExperiment,
-			isBillingWordingExperiment,
 		} = this.props;
 
 		// move any free plan to last place in mobile view
@@ -399,7 +398,6 @@ export class PlanFeatures extends Component {
 						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 						isLoggedInMonthlyPricing={ this.props.isLoggedInMonthlyPricing }
 						isInSignup={ isInSignup }
-						isBillingWordingExperiment={ isBillingWordingExperiment }
 					/>
 					<p className="plan-features__description">{ planDescription }</p>
 					<PlanFeaturesActions

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -172,7 +172,6 @@ export class PlansFeaturesMain extends Component {
 			siteId,
 			plansWithScroll,
 			isInVerticalScrollingPlansExperiment,
-			isBillingWordingExperiment,
 			isProfessionalEmailPromotionAvailable,
 			redirectToAddDomainFlow,
 			translate,
@@ -228,7 +227,6 @@ export class PlansFeaturesMain extends Component {
 					} ) }
 					siteId={ siteId }
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
-					isBillingWordingExperiment={ isBillingWordingExperiment }
 					kindOfPlanTypeSelector={ this.getKindOfPlanTypeSelector( this.props ) }
 				/>
 			</div>

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -341,9 +341,6 @@ export default {
 		if ( flowName === 'onboarding' || flowName === 'launch-site' ) {
 			loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v2' );
 		}
-		if ( isMobile() && 'onboarding' === flowName ) {
-			loadExperimentAssignment( 'calypso_mobile_plans_page_with_billing' );
-		}
 
 		if ( isMobile() && 'wpcc' !== flowName ) {
 			loadExperimentAssignment( 'registration_social_login_first_on_mobile_v3' );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
-import { isDesktop, subscribeIsDesktop, isMobile } from '@automattic/viewport';
+import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -166,53 +166,6 @@ export class PlansStep extends Component {
 			);
 		}
 
-		return (
-			// 
-			if ( ! isMobile() ) {
-				return this.renderSignUpMonthlyPlansExperiment( errorDisplay );
-			}
-
-			return (
-				<div>
-					{ errorDisplay }
-					<PlansFeaturesMain
-						site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
-						hideFreePlan={ hideFreePlan }
-						isInSignup={ true }
-						isLaunchPage={ isLaunchPage }
-						intervalType={ this.getIntervalType( false ) }
-						onUpgradeClick={ this.onSelectPlan }
-						showFAQ={ false }
-						domainName={ this.getDomainName() }
-						customerType={ this.getCustomerType() }
-						disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
-						plansWithScroll={ this.state.isDesktop }
-						planTypes={ planTypes }
-						flowName={ flowName }
-						showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
-						isAllPaidPlansShown={ true }
-						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
-						shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
-						isReskinned={ isReskinned }
-						disableMonthlyExperiment={ false }
-					/>
-				</div>
-			);
-		);
-	}
-
-	renderSignUpMonthlyPlansExperiment( errorDisplay ) {
-		const {
-			disableBloggerPlanWithNonBlogDomain,
-			hideFreePlan,
-			isLaunchPage,
-			selectedSite,
-			planTypes,
-			flowName,
-			showTreatmentPlansReorderTest,
-			isInVerticalScrollingPlansExperiment,
-			isReskinned,
-		} = this.props;
 		return (
 			<ProvideExperimentData
 				name="calypso_signup_monthly_plans_default_202201_v2"

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -167,49 +167,37 @@ export class PlansStep extends Component {
 		}
 
 		return (
-			<ProvideExperimentData
-				name="calypso_mobile_plans_page_with_billing"
-				options={ { isEligible: isMobile() && 'onboarding' === this.props.flowName } }
-			>
-				{ ( isLoading, experimentAssignment ) => {
-					if ( isLoading ) {
-						return this.renderLoading();
-					}
+			// 
+			if ( ! isMobile() ) {
+				return this.renderSignUpMonthlyPlansExperiment( errorDisplay );
+			}
 
-					// This allows us to continue with the other experiments.
-					if ( ! experimentAssignment?.variationName ) {
-						return this.renderSignUpMonthlyPlansExperiment( errorDisplay );
-					}
-
-					return (
-						<div>
-							{ errorDisplay }
-							<PlansFeaturesMain
-								site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
-								hideFreePlan={ hideFreePlan }
-								isInSignup={ true }
-								isLaunchPage={ isLaunchPage }
-								intervalType={ this.getIntervalType( false ) }
-								isBillingWordingExperiment={ experimentAssignment?.variationName !== null }
-								onUpgradeClick={ this.onSelectPlan }
-								showFAQ={ false }
-								domainName={ this.getDomainName() }
-								customerType={ this.getCustomerType() }
-								disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
-								plansWithScroll={ this.state.isDesktop }
-								planTypes={ planTypes }
-								flowName={ flowName }
-								showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
-								isAllPaidPlansShown={ true }
-								isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
-								shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
-								isReskinned={ isReskinned }
-								disableMonthlyExperiment={ false }
-							/>
-						</div>
-					);
-				} }
-			</ProvideExperimentData>
+			return (
+				<div>
+					{ errorDisplay }
+					<PlansFeaturesMain
+						site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
+						hideFreePlan={ hideFreePlan }
+						isInSignup={ true }
+						isLaunchPage={ isLaunchPage }
+						intervalType={ this.getIntervalType( false ) }
+						onUpgradeClick={ this.onSelectPlan }
+						showFAQ={ false }
+						domainName={ this.getDomainName() }
+						customerType={ this.getCustomerType() }
+						disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+						plansWithScroll={ this.state.isDesktop }
+						planTypes={ planTypes }
+						flowName={ flowName }
+						showTreatmentPlansReorderTest={ showTreatmentPlansReorderTest }
+						isAllPaidPlansShown={ true }
+						isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
+						shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
+						isReskinned={ isReskinned }
+						disableMonthlyExperiment={ false }
+					/>
+				</div>
+			);
 		);
 	}
 
@@ -247,7 +235,6 @@ export class PlansStep extends Component {
 								isInSignup={ true }
 								isLaunchPage={ isLaunchPage }
 								intervalType={ this.getIntervalType( isTreatmentMonthlyDefault ) }
-								isBillingWordingExperiment={ false }
 								onUpgradeClick={ this.onSelectPlan }
 								showFAQ={ false }
 								domainName={ this.getDomainName() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `calypso_mobile_plans_page_with_billing` experiemnt. 
Related: pbxNRc-1fu-p2

The experiment didn't conclude to go eather way but since the changes align things more with the destop version. 
I think it would be good to follow that example. 

#### Testing instructions
* Go though the sign up flow on mobile.
* Do you see the new wording.
<img src="https://user-images.githubusercontent.com/115071/156630563-cc2b08b2-829c-477f-aac3-dc8a212a6fd1.png" width="300" />

if you encounter the new plans page. You can use the following query parameter in your url. 
`?flags=-plans/managed-plan` to remove it. 


Related to #