### PR TITLE
Plans overhaul Phase 1: apply new plans mix

### DIFF
--- a/client/my-sites/plans-comparison/is-eligible-for-managed-plan.ts
+++ b/client/my-sites/plans-comparison/is-eligible-for-managed-plan.ts
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { isE2ETest } from 'calypso/lib/e2e';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import type { AppState } from 'calypso/types';
 
@@ -8,7 +9,7 @@ export function isEligibleForManagedPlan( state: AppState, siteId?: number ): bo
 		return false;
 	}
 
-	if ( siteId && isJetpackSite( state, siteId ) ) {
+	if ( siteId && ( isJetpackSite( state, siteId ) || isSiteWPForTeams( state, siteId ) ) ) {
 		return false;
 	}
 

--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -1,12 +1,16 @@
-import { isFreePlanProduct } from '@automattic/calypso-products';
+import { isFreePlanProduct, isFlexiblePlanProduct } from '@automattic/calypso-products';
 import page from 'page';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { isEligibleForManagedPlan } from 'calypso/my-sites/plans-comparison';
+import { getSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CurrentPlan from './';
 
 export function currentPlan( context, next ) {
 	const state = context.store.getState();
 
-	const selectedSite = getSelectedSite( state );
+	const siteId = getSelectedSiteId( state );
+	const selectedSite = getSite( state, siteId );
+	const eligibleForManagedPlan = isEligibleForManagedPlan( state, siteId );
 
 	if ( ! selectedSite ) {
 		page.redirect( '/plans/' );
@@ -14,7 +18,10 @@ export function currentPlan( context, next ) {
 		return null;
 	}
 
-	if ( isFreePlanProduct( selectedSite.plan ) ) {
+	if (
+		eligibleForManagedPlan &&
+		( isFreePlanProduct( selectedSite.plan ) || isFlexiblePlanProduct( selectedSite.plan ) )
+	) {
 		page.redirect( `/plans/${ selectedSite.slug }` );
 
 		return null;

--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -19,8 +19,8 @@ export function currentPlan( context, next ) {
 	}
 
 	if (
-		eligibleForManagedPlan &&
-		( isFreePlanProduct( selectedSite.plan ) || isFlexiblePlanProduct( selectedSite.plan ) )
+		isFreePlanProduct( selectedSite.plan ) ||
+		( eligibleForManagedPlan && isFlexiblePlanProduct( selectedSite.plan ) )
 	) {
 		page.redirect( `/plans/${ selectedSite.slug }` );
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -259,9 +259,9 @@ class CurrentPlan extends Component {
 				{ showLegacyPlanNotice && (
 					<Notice
 						status="is-info"
-						text={ translate(
+						text={
 							'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer ut felis et orci fringilla pretium. Consectura elit et orci fel.'
-						) }
+						}
 						showDismiss={ false }
 					></Notice>
 				) }

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -1,3 +1,4 @@
+import { isFreePlanProduct, isFlexiblePlanProduct } from '@automattic/calypso-products';
 import { isMobile } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -7,8 +8,10 @@ import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { sectionify } from 'calypso/lib/route';
+import { isEligibleForManagedPlan } from 'calypso/my-sites/plans-comparison';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -36,7 +39,7 @@ class PlansNavigation extends Component {
 	}
 
 	render() {
-		const { site, shouldShowMyPlan, translate } = this.props;
+		const { site, shouldShowMyPlan, shouldShowPlans, translate } = this.props;
 		const path = sectionify( this.props.path );
 		const sectionTitle = this.getSectionTitle( path );
 		const hasPinnedItems = isMobile() && site;
@@ -53,14 +56,16 @@ class PlansNavigation extends Component {
 								{ translate( 'My Plan' ) }
 							</NavItem>
 						) }
-						<NavItem
-							path={ `/plans/${ site.slug }` }
-							selected={
-								path === '/plans' || path === '/plans/monthly' || path === '/plans/yearly'
-							}
-						>
-							{ translate( 'Plans' ) }
-						</NavItem>
+						{ shouldShowPlans && (
+							<NavItem
+								path={ `/plans/${ site.slug }` }
+								selected={
+									path === '/plans' || path === '/plans/monthly' || path === '/plans/yearly'
+								}
+							>
+								{ translate( 'Plans' ) }
+							</NavItem>
+						) }
 					</NavTabs>
 				</SectionNav>
 			)
@@ -74,9 +79,22 @@ export default connect( ( state ) => {
 	const isJetpack = isJetpackSite( state, siteId );
 	const isOnFreePlan = isSiteOnFreePlan( state, siteId );
 	const isAtomic = isAtomicSite( state, siteId );
+	const eligibleForManagedPlan = isEligibleForManagedPlan( state, siteId );
+	const currentPlan = getCurrentPlan( state, siteId );
+	let shouldShowMyPlan = ! isOnFreePlan || ( isJetpack && ! isAtomic );
+	let shouldShowPlans = true;
+
+	if ( eligibleForManagedPlan && currentPlan ) {
+		const isFreeOrFlexible =
+			isFreePlanProduct( currentPlan ) || isFlexiblePlanProduct( currentPlan );
+		shouldShowMyPlan = isFreeOrFlexible ? false : true;
+		shouldShowPlans = isFreeOrFlexible ? true : false;
+	}
 	return {
 		isJetpack,
-		shouldShowMyPlan: ! isOnFreePlan || ( isJetpack && ! isAtomic ),
+		shouldShowMyPlan,
+		shouldShowPlans,
 		site,
+		eligibleForManagedPlan,
 	};
 } )( localize( PlansNavigation ) );

--- a/packages/calypso-products/src/is-flexible-plan.ts
+++ b/packages/calypso-products/src/is-flexible-plan.ts
@@ -1,0 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
+import { PLAN_WPCOM_FLEXIBLE } from './constants';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isFlexiblePlanProduct( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	return camelOrSnakeSlug( product ) === PLAN_WPCOM_FLEXIBLE;
+}

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -32,6 +32,7 @@ export { isEcommerce } from './is-ecommerce';
 export { isEnterprise } from './is-enterprise';
 export { isFreeJetpackPlan } from './is-free-jetpack-plan';
 export { isFreePlanProduct } from './is-free-plan';
+export { isFlexiblePlanProduct } from './is-flexible-plan';
 export { isFreeWordPressComDomain } from './is-free-wordpress-com-domain';
 export {
 	isGoogleWorkspace,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adjusts the behavior of the /plans pages based on pdgrnI-kt#comment-612-p2:
* Free Plan users (old and new): only show the "Plans" tab
* Paid Plan users (old and new): only show the "My Plan" tab. Old Plan users should also see a notification

#### Testing instructions
* checkout this branch to enable the Plans overhaul

##### Free Plans
* go to the /plans page on a new Free plan site
* it should only show the `Plans` tab
<img width="320" alt="Screenshot on 2022-03-04 at 11-12-43 (1)" src="https://user-images.githubusercontent.com/2749938/156735787-5e491afe-8b85-452e-976a-15f420abb17c.png">

* accessing the /plans/my-plan page should redirect to /plans
* similar behavior is expected with an old Free Plan site

##### Paid Plans
* go to the /plans page on a new Managed plan site
* it should only show the `My Plan` tab
* accessing the /plans page should redirect to /plans/my-plan
<img width="320" alt="Screenshot on 2022-03-04 at 11-18-27" src="https://user-images.githubusercontent.com/2749938/156735732-93939d4e-fa66-49a6-961f-c664b7d93f77.png">

* similar behavior is expected with an old Plan site (ex. eCommerce)
* here, you should see a notice with a placeholder text which will indicate your using a legacy plan.
<img width="320" alt="Screenshot on 2022-03-04 at 11-11-47 (2)" src="https://user-images.githubusercontent.com/2749938/156735824-91cc39be-1319-485e-94a7-386e59cb1dd8.png">


##### Staging
* you should not see any changes in any non-development environments