### PR TITLE
Reimport the useState hook.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -12,7 +12,7 @@ import Search from '@automattic/search';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Icon, upload } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import announcementImage from 'calypso/assets/images/marketplace/diamond.svg';
 import AnnouncementModal from 'calypso/blocks/announcement-modal';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reimport the `useState` hook which is used on the search view.

#### Testing instructions
* Go to the `/plugins` page
* Search for a plugin on the topbar
* You should be able to see the results of this search

PS: Before this change, an error was being triggered.


---

Related to #61657
