### PR TITLE
Update list of Jetpack coupon partners and presets

### DIFF
--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -15,8 +15,13 @@ export const REMOTE_PATH_INSTALL =
 	'/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
 export const ALLOWED_MOBILE_APP_REDIRECT_URL_LIST = [ /^wordpress:\/\// ];
 export const JPC_PATH_CHECKOUT = '/checkout';
-export const JETPACK_COUPON_PARTNERS = [ 'JPTST', 'IONOS' ];
+export const JETPACK_COUPON_PARTNERS = [ 'JPTST', 'IONOS', 'APK', 'AAD', 'RDCO', 'HMOU' ];
 export const JETPACK_COUPON_PRESET_MAPPING = {
 	IONA: 'jetpack_backup_daily',
 	JPTA: 'jetpack_backup_daily',
+	APKA: 'jetpack_backup_daily',
+	APKB: 'jetpack_backup_daily',
+	AADA: 'jetpack_backup_daily',
+	RDCA: 'jetpack_backup_daily',
+	HMOA: 'jetpack_backup_daily',
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the list of recognised Jetpack coupon partners and presets (coupon types) to avoid using real coupon to test functionality.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this branch locally
* Start up the Jetpack plugin locally or power up a JN site
* Issue a coupon through the [Jetpack Partner Coupon API](https://github.com/Automattic/jetpack-partner-api/tree/master/coupon) or through the MC tool.
* Define `define( 'CALYPSO_ENV', 'development' );` on the WordPress site so we redirect to your local Calypso instance.
* Add the code snippet below to make the Jetpack plugin recognise your test coupon.
* Go to `/wp-admin/admin.php?jetpack-partner-coupon={YOUR_COUPON}`
* Follow the flow and you should hopefully end up in checkout with your test coupon applied.

**Recognise test coupon in Jetpack plugin**
```php
add_filter( 'jetpack_partner_coupon_supported_partners', static function ( $partners ) {
	// Replace "PARTNER_SLUG".
	$partners['PARTNER_SLUG'] = [ 'name' => 'Company name' ];

	return $partners;
} );

add_filter( 'jetpack_partner_coupon_supported_presets', static function ( $presets ) {
	// Replace "COUPON_PRESET".
	$presets['COUPON_PRESET'] = 'jetpack_backup_daily';

	return $presets;
} );
```

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->