### PR TITLE
Hide variation picker for partner coupons

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -92,7 +92,8 @@ export function WPOrderReviewLineItems( {
 				const shouldShowVariantSelector =
 					onChangePlanLength &&
 					! isRenewal &&
-					! isPremiumPlanWithDIFMInTheCart( product, responseCart );
+					! isPremiumPlanWithDIFMInTheCart( product, responseCart ) &&
+					! hasPartnerCoupon;
 				return (
 					<WPOrderReviewListItem key={ product.uuid }>
 						<LineItem


### PR DESCRIPTION
Partner coupons are currently only aimed towards specific product variations (1 year duration) so presenting the toggle selector might break the flow, which means partner pay us for a full year license but the customer only gets a discount on the first month (it they select "monthly").

#### Changes proposed in this Pull Request

* Hide the Variation/interval picker for partner coupons.

#### Related links

* 1201801459945917-as-1201771509585206

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up branch (feel free to use the [Calypso Live direct link](https://calypso.live/?image=registry.a8c.com/calypso/app:commit-feefa952c887f05409662aff430f989ca1e5640f))
* Go to `/checkout/jetpack/jetpack_backup_daily?coupon={COUPON}`
  * Replace `{COUPON}` with the coupon found here: 2bdb2-pb
* The "Monthly / Yearly" selector should now be **hidden** (see "With partner coupon" screenshot below)
* Go to `/checkout/jetpack/jetpack_backup_daily` (so, without the coupon)
* The "Monthly / Yearly" selector should now be **shown** (see "Without partner coupon" screenshot below)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

**Without partner coupon**

![Screenshot 2022-03-04 at 17 57 20](https://user-images.githubusercontent.com/3846700/156806853-214b4c15-66ad-43fd-96c0-78233fd658c3.png)

**With partner coupon**

![Screenshot 2022-03-04 at 17 57 44](https://user-images.githubusercontent.com/3846700/156806911-bf8589df-0a5b-4ff0-a8a0-8554348efea5.png)