### PR TITLE
Fix Tab Order in Cart

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -136,7 +136,6 @@ const LineItemPriceWrapper = styled.span< { theme?: Theme; isSummary?: boolean }
 
 const DeleteButtonWrapper = styled.div`
 	width: 100%;
-	order: 1;
 `;
 
 const DeleteButton = styled( Button )< { theme?: Theme } >`
@@ -929,6 +928,30 @@ function WPLineItem( {
 					isSummary={ isSummary }
 				/>
 			</span>
+
+			{ product && ! containsPartnerCoupon && (
+				<LineItemMeta>
+					<LineItemSublabelAndPrice product={ product } />
+					<DomainDiscountCallout product={ product } />
+					<FirstTermDiscountCallout product={ product } />
+					<CouponDiscountCallout product={ product } />
+					<IntroductoryOfferCallout product={ product } />
+				</LineItemMeta>
+			) }
+
+			{ product && containsPartnerCoupon && (
+				<LineItemMeta>
+					<LineItemSublabelAndPrice product={ product } />
+					<CouponDiscountCallout product={ product } />
+				</LineItemMeta>
+			) }
+
+			{ isJetpackSearch( product ) && <JetpackSearchMeta product={ product } /> }
+
+			{ isEmail && <EmailMeta product={ product } isRenewal={ isRenewal } /> }
+
+			{ children }
+
 			{ hasDeleteButton && removeProductFromCart && (
 				<>
 					<DeleteButtonWrapper>
@@ -971,29 +994,6 @@ function WPLineItem( {
 					/>
 				</>
 			) }
-
-			{ product && ! containsPartnerCoupon && (
-				<LineItemMeta>
-					<LineItemSublabelAndPrice product={ product } />
-					<DomainDiscountCallout product={ product } />
-					<FirstTermDiscountCallout product={ product } />
-					<CouponDiscountCallout product={ product } />
-					<IntroductoryOfferCallout product={ product } />
-				</LineItemMeta>
-			) }
-
-			{ product && containsPartnerCoupon && (
-				<LineItemMeta>
-					<LineItemSublabelAndPrice product={ product } />
-					<CouponDiscountCallout product={ product } />
-				</LineItemMeta>
-			) }
-
-			{ isJetpackSearch( product ) && <JetpackSearchMeta product={ product } /> }
-
-			{ isEmail && <EmailMeta product={ product } isRenewal={ isRenewal } /> }
-
-			{ children }
 		</div>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reorder cart components so that when tabbing through controls the order is as expected
<img width="588" alt="Screen Shot 2022-03-04 at 08 59 12" src="https://user-images.githubusercontent.com/2810519/156806989-beec175b-7bd0-44b1-990a-072ce88ae530.png">



#### Testing instructions

1. Boot or goto live branch as calypso blue
2. Either
   - Add a Jetpack Product to the cart
   - Add a WordPress.com Product to the cart, and click the "Edit" button in the upper right hand
3. Verify there are no design changes vs. Production
4. Tab through the controls, verifying that the controls are focused in the correct order
