### PR TITLE
Experiment: Domains mobile add domain description

### DIFF
--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -141,7 +141,11 @@
 	color: var( --studio-gray-40 );
 	display: flex;
 	align-items: center;
-	margin: 0 20px;
+	margin: 0;
+
+	@include break-small {
+		margin: 0 20px;
+	}
 
 	svg {
 		fill: #a7aaad;

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -342,8 +342,8 @@ export default {
 			loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v2' );
 		}
 
-		if ( isMobile() && 'onboarding' === flowName ) {
-			loadExperimentAssignment( 'calypso_signup_domain_mobile_browser_chrome_added_v2' );
+		if ( isMobile() && [ 'onboarding', 'launch-site', 'free', 'pro' ].includes( flowName ) ) {
+			loadExperimentAssignment( 'calypso_signup_domain_mobile_browser_chrome_added_v3' );
 		}
 
 		context.primary = createElement( SignupComponent, {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -341,6 +341,10 @@ export default {
 			loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v2' );
 		}
 
+		if ( isMobile() && 'onboarding' === flowName ) {
+			loadExperimentAssignment( 'calypso_mobile_domains_sidebar_explainer' );
+		}
+
 		context.primary = createElement( SignupComponent, {
 			store: context.store,
 			path: context.path,

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { isMobile } from '@automattic/viewport';
 import { isEmpty } from 'lodash';
 import page from 'page';
 import { createElement } from 'react';

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -343,7 +343,7 @@ export default {
 		}
 
 		if ( isMobile() && 'onboarding' === flowName ) {
-			loadExperimentAssignment( 'calypso_signup_domain_mobile_brower_chrome_added' );
+			loadExperimentAssignment( 'calypso_signup_domain_mobile_browser_chrome_added_v2' );
 		}
 
 		context.primary = createElement( SignupComponent, {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -342,7 +342,7 @@ export default {
 		}
 
 		if ( isMobile() && 'onboarding' === flowName ) {
-			loadExperimentAssignment( 'calypso_mobile_domains_sidebar_explainer' );
+			loadExperimentAssignment( 'calypso_signup_domain_mobile_brower_chrome_added' );
 		}
 
 		context.primary = createElement( SignupComponent, {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -343,7 +343,7 @@ export default {
 		}
 
 		if ( isMobile() && [ 'onboarding', 'launch-site', 'free', 'pro' ].includes( flowName ) ) {
-			loadExperimentAssignment( 'calypso_signup_domain_mobile_browser_chrome_added_v3' );
+			loadExperimentAssignment( 'calypso_signup_domain_mobile_browser_chrome_added_v4' );
 		}
 
 		context.primary = createElement( SignupComponent, {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -438,7 +438,7 @@ class DomainsStep extends Component {
 
 		return (
 			<ProvideExperimentData
-				name="calypso_signup_domain_mobile_brower_chrome_added"
+				name="calypso_signup_domain_mobile_browser_chrome_added_v2"
 				options={ {
 					isEligible: isMobile() && 'onboarding' === this.props.flowName,
 				} }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -438,9 +438,11 @@ class DomainsStep extends Component {
 
 		return (
 			<ProvideExperimentData
-				name="calypso_signup_domain_mobile_browser_chrome_added_v2"
+				name="calypso_signup_domain_mobile_browser_chrome_added_v3"
 				options={ {
-					isEligible: isMobile() && 'onboarding' === this.props.flowName,
+					isEligible:
+						isMobile() &&
+						[ 'onboarding', 'launch-site', 'free', 'pro' ].includes( this.props.flowName ),
 				} }
 			>
 				{ ( isLoading, experimentAssignment ) => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -438,9 +438,9 @@ class DomainsStep extends Component {
 
 		return (
 			<ProvideExperimentData
-				name="calypso_mobile_domains_sidebar_explainer"
+				name="calypso_signup_domain_mobile_brower_chrome_added"
 				options={ {
-					isEligible: isMobile() && 'wpcc' !== this.props.flowName,
+					isEligible: isMobile() && 'onboarding' === this.props.flowName,
 				} }
 			>
 				{ ( isLoading, experimentAssignment ) => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -459,7 +459,7 @@ class DomainsStep extends Component {
 									<span className="domains__domain-side-content-container-browser-chrome-url">
 										https://
 										{ this.props.translate( 'yoursitename', {
-											comment: 'xample url used to explain what a domain is.',
+											comment: 'example url used to explain what a domain is.',
 										} ) }
 										.com
 									</span>
@@ -490,14 +490,7 @@ class DomainsStep extends Component {
 										/>
 									</div>
 								) }
-							{ ! this.shouldHideUseYourDomain() && (
-								<div className="domains__domain-side-content">
-									<ReskinSideExplainer
-										onClick={ this.handleUseYourDomainClick }
-										type={ 'use-your-domain' }
-									/>
-								</div>
-							) }
+							{ useYourDomain }
 							{ this.shouldDisplayDomainOnlyExplainer() && (
 								<div className="domains__domain-side-content">
 									<ReskinSideExplainer

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -463,6 +463,15 @@ class DomainsStep extends Component {
 									</span>
 									<span></span>
 								</div>
+								{ ! this.shouldHideDomainExplainer() &&
+									this.props.isPlanSelectionAvailableLaterInFlow && (
+										<div className="domains__domain-side-content domains__free-domain">
+											<ReskinSideExplainer
+												onClick={ this.handleDomainExplainerClick }
+												type={ 'free-domain-explainer' }
+											/>
+										</div>
+									) }
 								{ useYourDomain }
 							</div>
 						);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -455,7 +455,11 @@ class DomainsStep extends Component {
 									<span></span>
 									<span></span>
 									<span className="domains__domain-side-content-container-browser-chrome-url">
-										https://{ this.props.translate( 'yoursitename.com' ) }
+										https://
+										{ this.props.translate( 'yoursitename', {
+											comment: 'xample url used to explain what a domain is.',
+										} ) }
+										.com
 									</span>
 									<span></span>
 								</div>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -438,7 +438,7 @@ class DomainsStep extends Component {
 
 		return (
 			<ProvideExperimentData
-				name="calypso_signup_domain_mobile_browser_chrome_added_v3"
+				name="calypso_signup_domain_mobile_browser_chrome_added_v4"
 				options={ {
 					isEligible:
 						isMobile() &&

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -123,11 +123,33 @@ body.is-section-signup.is-white-signup {
 			}
 		}
 
+		.register-domain-step .domains__domain-side-content-container-mobile-experiment {
+			display: flex;
+			height: 100%;
+			justify-content: space-between;
+			flex-direction: column;
+			
+			.domains__domain-side-content {
+				border-top: 1px solid var( --studio-gray-5 );
+				border-bottom: 0;
+				padding: 16px 0 0;
+				margin: 0;
+
+				@include break-large {
+					display: none;
+				}
+			}
+		}
+
 		.domains__domain-side-content {
 			border-bottom: 1px solid;
 			border-bottom-color: var( --studio-gray-5 );
 			padding: 20px 0;
-			margin: 0 20px;
+			margin: 0;
+
+			@include break-small {
+				margin: 0 20px;
+			}
 
 			@include break-large {
 				margin: 0 20px 0 40px;
@@ -155,7 +177,16 @@ body.is-section-signup.is-white-signup {
 			background: var( --color-surface );
 			box-shadow: none;
 			border-radius: 4px; /* stylelint-disable-line */
-			margin: 20px 20px 0;
+			margin: 20px 0 0;
+			border: 1px solid #a7aaad;
+
+			@include break-small {
+				margin: 20px 20px 0;
+			}
+
+			.search-component.is-open {
+				border: none;
+			}
 
 			@include break-large {
 				margin: 0;
@@ -285,4 +316,48 @@ body.is-section-signup:not( .is-white-signup ) {
 
 	}
 
+}
+
+/* The domain browser chrome used in the domain mobile experiement */
+.domains__domain-side-content-container-browser-chrome {
+	position: relative;
+	background-color: #d9d8da;
+	border-top-right-radius: 4px;
+	border-top-left-radius: 4px;
+	display: flex;
+	padding: 10px 5px 30px;
+	justify-content: space-between;
+
+	@include break-large {
+		display: none;
+	}
+
+	&::after {
+		content: '';
+		width: auto;
+		height: 20px;
+		background-color:  #f5f5f5;
+		position: absolute;
+		border-top-right-radius: 4px;
+		border-top-left-radius: 4px;
+		bottom: 0;
+		left: 10px;
+		right: 10px;
+	}
+
+	span {
+		width: 32px;
+		height: 32px;
+		background: #fff;
+		border-radius: 4px;
+		margin: 3px 6px;
+	}
+}
+.domains__domain-side-content-container-browser-chrome-url {
+	flex-grow: 2;
+	padding: 0 10px;
+	line-height: 32px;
+	font-size: $font-body-extra-small;
+	text-overflow: ellipsis;
+	overflow: hidden;
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -125,19 +125,23 @@ body.is-section-signup.is-white-signup {
 
 		.register-domain-step .domains__domain-side-content-container-mobile-experiment {
 			display: flex;
-			height: 100%;
+			
 			justify-content: space-between;
 			flex-direction: column;
 			
 			.domains__domain-side-content {
 				border-top: 1px solid var( --studio-gray-5 );
 				border-bottom: 0;
-				padding: 16px 0 0;
+				padding: 16px 0;
 				margin: 0;
 
 				@include break-large {
 					display: none;
 				}
+			}
+
+			.domains__free-domain .reskin-side-explainer__subtitle {
+				display: none;
 			}
 		}
 
@@ -327,6 +331,7 @@ body.is-section-signup:not( .is-white-signup ) {
 	display: flex;
 	padding: 10px 5px 30px;
 	justify-content: space-between;
+	margin-bottom: 20px;
 
 	@include break-large {
 		display: none;

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -140,7 +140,7 @@ body.is-section-signup.is-white-signup {
 				}
 			}
 
-			.domains__free-domain .reskin-side-explainer__subtitle {
+			.domains__free-domain .reskin-side-explainer__subtitle-2 {
 				display: none;
 			}
 		}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -261,7 +261,7 @@ body.is-section-signup.is-white-signup {
 			display: none;
 		}
 	}
-
+	.signup__step.is-domain-only,
 	.signup__step.is-domains {
 		padding: 0 20px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is an experiment on the mobile web that shows the browser chrome instead of explaining what the domain is to the user in words. 
More info: pbxNRc-1t7-p2

<table>
<tr>
<td>
Control

![Screen Shot 2022-04-11 at 14 48 40](https://user-images.githubusercontent.com/115071/162839740-e08a6f95-c778-4e99-80c5-57b8fb4b78ea.png)


</td>
<td>
Treatment

![Screen Shot 2022-04-11 at 14 45 46](https://user-images.githubusercontent.com/115071/162839724-0b621436-041e-4717-a18e-ec7ea57568ad.png)

</td>
</tr>
</table>

#### Testing instructions

* Set your user to have the control assigned. 
Visit /start/domains - does it look as expected?

* Set your user to have the treatment assigned. 
Visit /start/domains- does it look as expected?