### PR TITLE
Payment Methods: Re-throw errors in fetchStoredCards/deleteStoredCard

### DIFF
--- a/client/state/stored-cards/actions.js
+++ b/client/state/stored-cards/actions.js
@@ -51,6 +51,8 @@ export const fetchStoredCards = () => ( dispatch ) => {
 				type: STORED_CARDS_FETCH_FAILED,
 				error: error.message || i18n.translate( 'There was a problem retrieving stored cards.' ),
 			} );
+			// Re-throw the rejection so whatever uses this Promise can see the failure too.
+			return Promise.reject( error );
 		} );
 };
 
@@ -77,6 +79,8 @@ export const deleteStoredCard = ( card ) => ( dispatch ) => {
 				card,
 				error: error.message || i18n.translate( 'There was a problem deleting the stored card.' ),
 			} );
+			// Re-throw the rejection so whatever uses this Promise can see the failure too.
+			return Promise.reject( error );
 		} );
 };
 

--- a/client/state/stored-cards/test/actions.js
+++ b/client/state/stored-cards/test/actions.js
@@ -83,18 +83,25 @@ describe( 'actions', () => {
 					.reply( 403, error );
 			} );
 
-			test( 'should dispatch fetch/fail actions', () => {
+			test( 'should dispatch fetch/fail actions', async () => {
 				const promise = fetchStoredCards()( spy );
 
 				expect( spy ).to.have.been.calledWith( {
 					type: STORED_CARDS_FETCH,
 				} );
 
-				return promise.then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: STORED_CARDS_FETCH_FAILED,
-						error: error.message,
-					} );
+				let didFail = false;
+				try {
+					await promise;
+				} catch {
+					didFail = true;
+				}
+
+				expect( didFail ).to.be.true;
+
+				expect( spy ).to.have.been.calledWith( {
+					type: STORED_CARDS_FETCH_FAILED,
+					error: error.message,
 				} );
 			} );
 		} );
@@ -147,7 +154,7 @@ describe( 'actions', () => {
 					.reply( 403, error );
 			} );
 
-			test( 'should dispatch fetch/fail actions', () => {
+			test( 'should dispatch fetch/fail actions', async () => {
 				const promise = deleteStoredCard( card )( spy );
 
 				expect( spy ).to.have.been.calledWith( {
@@ -155,12 +162,19 @@ describe( 'actions', () => {
 					card,
 				} );
 
-				return promise.then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: STORED_CARDS_DELETE_FAILED,
-						card,
-						error: error.message,
-					} );
+				let didFail = false;
+				try {
+					await promise;
+				} catch {
+					didFail = true;
+				}
+
+				expect( didFail ).to.be.true;
+
+				expect( spy ).to.have.been.calledWith( {
+					type: STORED_CARDS_DELETE_FAILED,
+					card,
+					error: error.message,
 				} );
 			} );
 		} );


### PR DESCRIPTION
The Redux action creators `fetchStoredCards` and `deleteStoredCard` are Thunks, and they return a Promise that resolves to the result of the respective endpoint request. This is then returned by the Redux dispatcher that dispatches the Thunk and can be used to chain on additional behavior.

However, in the case of an endpoint failure, both functions would still return a resolved Promise because they have their own `catch()` handlers. This is counterintuitive and can create bugs if the caller expects the Promise to reject on error (as is the case with deleteStoredCard).

With this change, both functions will reject if there is an error.

Co-authored-by: vitozev <vitozev@gmail.com>

#### Testing instructions

- Apply D76114-code to break the stored-cards deletion endpoint.
- Visit `/me/purchases/payment-methods`.
- If you do not already have a payment method listed, add one.
- Click the "Delete" button next to a payment method.
- Click to confirm the dialog.
- Verify that you see an error message appear.