### PR TITLE
Update Cart Variant Price Calculation Logic

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -18,7 +18,6 @@ import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useEffect, useState, useMemo, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { getJetpackCouponDiscountMap } from 'calypso/state/marketing/selectors';
 import { requestPlans } from 'calypso/state/plans/actions';
 import { requestProductsList } from 'calypso/state/products-list/actions';
 import { computeProductsWithPrices } from 'calypso/state/products-list/selectors';
@@ -87,8 +86,6 @@ export function useGetProductVariants(
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 
-	const jetpackCouponDiscountMap = useSelector( getJetpackCouponDiscountMap );
-
 	const sitePlans: SitesPlansResult | null = useSelector( ( state ) =>
 		siteId ? getPlansBySiteId( state, siteId ) : null
 	);
@@ -101,13 +98,7 @@ export function useGetProductVariants(
 	debug( 'variantProductSlugs', variantProductSlugs );
 
 	const variantsWithPrices: AvailableProductVariant[] = useSelector( ( state ) => {
-		return computeProductsWithPrices(
-			state,
-			siteId,
-			variantProductSlugs,
-			0,
-			jetpackCouponDiscountMap
-		);
+		return computeProductsWithPrices( state, siteId, variantProductSlugs );
 	} );
 
 	const [ haveFetchedProducts, setHaveFetchedProducts ] = useState( false );
@@ -240,25 +231,16 @@ function VariantPriceDiscount( { variant }: { variant: AvailableProductVariantAn
 	const discountPercentage = Math.floor(
 		100 - ( maybeFinalPrice / variant.priceFullBeforeDiscount ) * 100
 	);
-	let message = '';
-	if ( variant.introductoryOfferPrice ) {
-		message = String(
-			translate( 'Eligible orders save %(percent)s%%', {
+
+	return (
+		<Discount>
+			{ translate( 'Save %(percent)s%%', {
 				args: {
 					percent: discountPercentage,
 				},
-			} )
-		);
-	} else {
-		message = String(
-			translate( 'Save %(percent)s%%', {
-				args: {
-					percent: discountPercentage,
-				},
-			} )
-		);
-	}
-	return <Discount>{ message }</Discount>;
+			} ) }
+		</Discount>
+	);
 }
 
 function getVariantPlanProductSlugs( productSlug: string | undefined ): string[] {

--- a/client/state/marketing/selectors.ts
+++ b/client/state/marketing/selectors.ts
@@ -1,8 +1,3 @@
-import {
-	JETPACK_PRODUCTS_BY_TERM,
-	JETPACK_RESET_PLANS_BY_TERM,
-	PRODUCT_JETPACK_SEARCH,
-} from '@automattic/calypso-products';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import type { AppState } from 'calypso/types';
 import 'calypso/state/marketing/init';
@@ -39,27 +34,4 @@ export function getJetpackSaleCouponDiscountRatio( state: AppState ): number {
 export function getFullJetpackSaleCouponDiscountRatio( state: AppState ): number {
 	const discount = getJetpackSaleCoupon( state )?.final_discount || 0;
 	return discount / 100;
-}
-
-interface DiscountMap {
-	[ productSlug: string ]: number;
-}
-
-export function getJetpackCouponDiscountMap( state: AppState ): DiscountMap {
-	// discountedPricePercentage is 1 - discountPercentage.
-	const discountedPricePercentage =
-		( 100 - ( getJetpackSaleCoupon( state )?.discount || 0 ) ) / 100;
-	const discountMap: DiscountMap = {};
-
-	//  outside of sales ( when the discountedPricePercentage is 100% or full price ) there is no need to build this object
-	if ( discountedPricePercentage < 1 ) {
-		[ ...JETPACK_RESET_PLANS_BY_TERM, ...JETPACK_PRODUCTS_BY_TERM ].forEach( ( { yearly } ) => {
-			// search requires special discount support since it does not have an introductory offer
-			if ( yearly !== PRODUCT_JETPACK_SEARCH ) {
-				discountMap[ yearly ] = discountedPricePercentage;
-			}
-		} );
-	}
-
-	return discountMap;
 }

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -24,7 +24,7 @@ export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) 
 		? getProductCost( state, planObject.getStoreSlug() )
 		: getPlanPrice( state, siteId, planObject, false );
 	const introOfferIsEligible = getIntroOfferIsEligible( state, planObject.getProductId(), siteId );
-	const saleCouponDiscount = getProductSaleCouponDiscount( state, planObject.getStoreSlug() ) || 1;
+	const saleCouponDiscount = getProductSaleCouponDiscount( state, planObject.getStoreSlug() ) || 0;
 	const introductoryOfferPrice = introOfferIsEligible
 		? getIntroOfferPrice( state, planObject.getProductId(), siteId )
 		: null;
@@ -34,7 +34,7 @@ export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) 
 		priceFull: planOrProductPrice,
 		priceFinal: saleCouponCost || planOrProductPrice,
 		introductoryOfferPrice:
-			introductoryOfferPrice !== null ? introductoryOfferPrice * saleCouponDiscount : null,
+			introductoryOfferPrice !== null ? introductoryOfferPrice * ( 1 - saleCouponDiscount ) : null,
 	};
 };
 

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -4,6 +4,7 @@ import getIntroOfferIsEligible from 'calypso/state/selectors/get-intro-offer-is-
 import getIntroOfferPrice from 'calypso/state/selectors/get-intro-offer-price';
 import { getPlanPrice } from './get-plan-price';
 import { getProductCost } from './get-product-cost';
+import { getProductSaleCouponCost } from './get-product-sale-coupon-cost';
 import { getProductSaleCouponDiscount } from './get-product-sale-coupon-discount';
 
 /**
@@ -23,18 +24,17 @@ export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) 
 		? getProductCost( state, planObject.getStoreSlug() )
 		: getPlanPrice( state, siteId, planObject, false );
 	const introOfferIsEligible = getIntroOfferIsEligible( state, planObject.getProductId(), siteId );
+	const saleCouponDiscount = getProductSaleCouponDiscount( state, planObject.getStoreSlug() ) || 1;
 	const introductoryOfferPrice = introOfferIsEligible
 		? getIntroOfferPrice( state, planObject.getProductId(), siteId )
 		: null;
-	const saleCouponDiscount = getProductSaleCouponDiscount( state, planObject.getStoreSlug() ) || 1;
+	const saleCouponCost = getProductSaleCouponCost( state, planObject.getStoreSlug() );
 
 	return {
 		priceFull: planOrProductPrice,
-		priceFinal: Math.max( planOrProductPrice, 0 ),
+		priceFinal: saleCouponCost || planOrProductPrice,
 		introductoryOfferPrice:
-			introductoryOfferPrice !== null
-				? Math.max( introductoryOfferPrice * saleCouponDiscount, 0 )
-				: introductoryOfferPrice,
+			introductoryOfferPrice !== null ? introductoryOfferPrice * saleCouponDiscount : null,
 	};
 };
 

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -4,6 +4,7 @@ import getIntroOfferIsEligible from 'calypso/state/selectors/get-intro-offer-is-
 import getIntroOfferPrice from 'calypso/state/selectors/get-intro-offer-price';
 import { getPlanPrice } from './get-plan-price';
 import { getProductCost } from './get-product-cost';
+import { getProductSaleCouponDiscount } from './get-product-sale-coupon-discount';
 
 /**
  * Computes a full and monthly price for a given plan, based on it's slug/constant
@@ -25,13 +26,14 @@ export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) 
 	const introductoryOfferPrice = introOfferIsEligible
 		? getIntroOfferPrice( state, planObject.getProductId(), siteId )
 		: null;
+	const saleCouponDiscount = getProductSaleCouponDiscount( state, planObject.getStoreSlug() ) || 1;
 
 	return {
 		priceFull: planOrProductPrice,
 		priceFinal: Math.max( planOrProductPrice, 0 ),
 		introductoryOfferPrice:
 			introductoryOfferPrice !== null
-				? Math.max( introductoryOfferPrice, 0 )
+				? Math.max( introductoryOfferPrice * saleCouponDiscount, 0 )
 				: introductoryOfferPrice,
 	};
 };

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -16,6 +16,10 @@ import { getProductSaleCouponDiscount } from './get-product-sale-coupon-discount
  * @returns {object} Object with a full and monthly price
  */
 export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) => {
+	if ( planObject.group === GROUP_WPCOM ) {
+		return computePricesForWpComPlan( state, siteId, planObject );
+	}
+
 	const planOrProductPrice = ! getPlanPrice( state, siteId, planObject, false )
 		? getProductCost( state, planObject.getStoreSlug() )
 		: getPlanPrice( state, siteId, planObject, false );
@@ -33,3 +37,21 @@ export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) 
 			introductoryOfferPrice !== null ? introductoryOfferPrice * saleCouponDiscount : null,
 	};
 };
+
+/**
+ * Compute a full and monthly price for a given wpcom plan.
+ *
+ * @param {object} state Current redux state
+ * @param {number} siteId Site ID to consider
+ * @param {object} planObject Plan object returned by getPlan() from @automattic/calypso-products
+ */
+function computePricesForWpComPlan( state, siteId, planObject ) {
+	const priceFull = getPlanRawPrice( state, planObject.getProductId(), false ) || 0;
+	const introductoryOfferPrice = getIntroOfferPrice( state, planObject.getProductId(), siteId );
+
+	return {
+		priceFull,
+		priceFinal: priceFull,
+		introductoryOfferPrice,
+	};
+}

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -16,10 +16,6 @@ import { getProductSaleCouponDiscount } from './get-product-sale-coupon-discount
  * @returns {object} Object with a full and monthly price
  */
 export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) => {
-	if ( planObject.group === GROUP_WPCOM ) {
-		return computePricesForWpComPlan( state, siteId, planObject );
-	}
-
 	const planOrProductPrice = ! getPlanPrice( state, siteId, planObject, false )
 		? getProductCost( state, planObject.getStoreSlug() )
 		: getPlanPrice( state, siteId, planObject, false );
@@ -37,21 +33,3 @@ export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) 
 			introductoryOfferPrice !== null ? introductoryOfferPrice * saleCouponDiscount : null,
 	};
 };
-
-/**
- * Compute a full and monthly price for a given wpcom plan.
- *
- * @param {object} state Current redux state
- * @param {number} siteId Site ID to consider
- * @param {object} planObject Plan object returned by getPlan() from @automattic/calypso-products
- */
-function computePricesForWpComPlan( state, siteId, planObject ) {
-	const priceFull = getPlanRawPrice( state, planObject.getProductId(), false ) || 0;
-	const introductoryOfferPrice = getIntroOfferPrice( state, planObject.getProductId(), siteId );
-
-	return {
-		priceFull,
-		priceFinal: priceFull,
-		introductoryOfferPrice,
-	};
-}

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -11,19 +11,9 @@ import { getProductCost } from './get-product-cost';
  * @param {object} state Current redux state
  * @param {number} siteId Site ID to consider
  * @param {object} planObject Plan object returned by getPlan() from @automattic/calypso-products
- * @param {number} credits The number of free credits in cart
- * @param {object} couponDiscounts Absolute values of any discounts coming from a discount coupon
  * @returns {object} Object with a full and monthly price
  */
-export const computeFullAndMonthlyPricesForPlan = (
-	state,
-	siteId,
-	planObject,
-	credits,
-	couponDiscounts
-) => {
-	const couponDiscount = couponDiscounts[ planObject.getStoreSlug() ] || 1;
-
+export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) => {
 	if ( planObject.group === GROUP_WPCOM ) {
 		return computePricesForWpComPlan( state, siteId, planObject );
 	}
@@ -38,10 +28,10 @@ export const computeFullAndMonthlyPricesForPlan = (
 
 	return {
 		priceFull: planOrProductPrice,
-		priceFinal: Math.max( planOrProductPrice * couponDiscount - credits, 0 ),
+		priceFinal: Math.max( planOrProductPrice, 0 ),
 		introductoryOfferPrice:
 			introductoryOfferPrice !== null
-				? Math.max( introductoryOfferPrice * couponDiscount - credits, 0 )
+				? Math.max( introductoryOfferPrice, 0 )
 				: introductoryOfferPrice,
 	};
 };

--- a/client/state/products-list/selectors/compute-products-with-prices.js
+++ b/client/state/products-list/selectors/compute-products-with-prices.js
@@ -11,11 +11,9 @@ import { planSlugToPlanProduct } from './plan-slug-to-plan-product';
  * @param {object} state Current redux state
  * @param {number|undefined} siteId Site ID to consider
  * @param {string[]} planSlugs Plans constants
- * @param {number} credits The number of free credits in cart
- * @param {object} couponDiscounts Absolute values of any discounts coming from a discount coupon
  * @returns {Array} A list of objects as described above
  */
-export const computeProductsWithPrices = ( state, siteId, planSlugs, credits, couponDiscounts ) => {
+export const computeProductsWithPrices = ( state, siteId, planSlugs ) => {
 	const products = getProductsList( state );
 
 	return planSlugs
@@ -23,13 +21,7 @@ export const computeProductsWithPrices = ( state, siteId, planSlugs, credits, co
 		.filter( ( planProduct ) => planProduct.plan && get( planProduct, [ 'product', 'available' ] ) )
 		.map( ( availablePlanProduct ) => ( {
 			...availablePlanProduct,
-			...computeFullAndMonthlyPricesForPlan(
-				state,
-				siteId,
-				availablePlanProduct.plan,
-				credits,
-				couponDiscounts
-			),
+			...computeFullAndMonthlyPricesForPlan( state, siteId, availablePlanProduct.plan ),
 		} ) )
 		.filter( ( availablePlanProduct ) => availablePlanProduct.priceFull )
 		.sort( ( a, b ) => getTermDuration( a.plan.term ) - getTermDuration( b.plan.term ) );

--- a/client/state/products-list/selectors/get-product-sale-coupon-cost.ts
+++ b/client/state/products-list/selectors/get-product-sale-coupon-cost.ts
@@ -1,0 +1,21 @@
+import { getProductBySlug } from './get-product-by-slug';
+import type { AppState } from 'calypso/types';
+
+import 'calypso/state/products-list/init';
+
+/**
+ * Returns the product cost with a sale coupon, or null if there is no sale coupon.
+ *
+ * @param {object} state - global state tree
+ * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
+ * @returns {number|null} - the product cost with a sale coupon, or null if there is no sale coupon.
+ */
+export function getProductSaleCouponCost( state: AppState, productSlug: string ): number | null {
+	const product = getProductBySlug( state, productSlug );
+
+	if ( ! product || product.sale_cost === undefined ) {
+		return null;
+	}
+
+	return product.sale_cost;
+}

--- a/client/state/products-list/selectors/get-product-sale-coupon-discount.ts
+++ b/client/state/products-list/selectors/get-product-sale-coupon-discount.ts
@@ -23,6 +23,6 @@ export function getProductSaleCouponDiscount(
 	) {
 		return null;
 	}
-
-	return product.sale_coupon.discount;
+	// the sale_coupon is returned in integer form i.e. a 20% discount is `20`
+	return product.sale_coupon.discount / 100;
 }

--- a/client/state/products-list/selectors/get-product-sale-coupon-discount.ts
+++ b/client/state/products-list/selectors/get-product-sale-coupon-discount.ts
@@ -4,11 +4,11 @@ import type { AppState } from 'calypso/types';
 import 'calypso/state/products-list/init';
 
 /**
- * Returns the discount percentage of a sale coupon, or null if there is none.
+ * Returns the discount percentage of a sale coupon, or null if there is no sale coupon.
  *
  * @param {object} state - global state tree
  * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
- * @returns {number|null} - the discount percentage of a sale coupon, or null if there is none..
+ * @returns {number|null} - the discount percentage of a sale coupon, or null if there is no sale coupon.
  */
 export function getProductSaleCouponDiscount(
 	state: AppState,

--- a/client/state/products-list/selectors/get-product-sale-coupon-discount.ts
+++ b/client/state/products-list/selectors/get-product-sale-coupon-discount.ts
@@ -1,0 +1,28 @@
+import { getProductBySlug } from './get-product-by-slug';
+import type { AppState } from 'calypso/types';
+
+import 'calypso/state/products-list/init';
+
+/**
+ * Returns the discount percentage of a sale coupon, or null if there is none.
+ *
+ * @param {object} state - global state tree
+ * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
+ * @returns {number|null} - the discount percentage of a sale coupon, or null if there is none..
+ */
+export function getProductSaleCouponDiscount(
+	state: AppState,
+	productSlug: string
+): number | null {
+	const product = getProductBySlug( state, productSlug );
+
+	if (
+		! product ||
+		product.sale_coupon === undefined ||
+		product.sale_coupon.discount === undefined
+	) {
+		return null;
+	}
+
+	return product.sale_coupon.discount;
+}

--- a/client/state/products-list/selectors/index.js
+++ b/client/state/products-list/selectors/index.js
@@ -13,3 +13,5 @@ export { getProductsListType } from './get-products-list-type';
 export { isProductsListFetching } from './is-products-list-fetching';
 export { planSlugToPlanProduct } from './plan-slug-to-plan-product';
 export { isMarketplaceProduct } from './is-marketplace-product';
+export { getProductSaleCouponCost } from './get-product-sale-coupon-cost';
+export { getProductSaleCouponDiscount } from './get-product-sale-coupon-discount';

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -137,19 +137,10 @@ describe( 'selectors', () => {
 			getPlanRawPrice.mockImplementation( () => 150 );
 
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
-			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0, {} ) ).toEqual( {
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan ) ).toEqual( {
 				introductoryOfferPrice: null,
 				priceFull: 120,
 				priceFinal: 120,
-			} );
-		} );
-
-		test( 'Should return proper priceFinal if couponDiscounts are provided', () => {
-			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
-			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0, { abc: 0.5 } ) ).toEqual( {
-				introductoryOfferPrice: null,
-				priceFull: 120,
-				priceFinal: 60,
 			} );
 		} );
 
@@ -157,7 +148,7 @@ describe( 'selectors', () => {
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
 			getIntroOfferPrice.mockImplementation( () => 60 );
 			getIntroOfferIsEligible.mockImplementation( () => true );
-			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0, {} ) ).toEqual( {
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan ) ).toEqual( {
 				introductoryOfferPrice: 60,
 				priceFull: 120,
 				priceFinal: 120,
@@ -168,7 +159,7 @@ describe( 'selectors', () => {
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
 			getIntroOfferPrice.mockImplementation( () => 60 );
 			getIntroOfferIsEligible.mockImplementation( () => false );
-			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0, {} ) ).toEqual( {
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan ) ).toEqual( {
 				introductoryOfferPrice: null,
 				priceFull: 120,
 				priceFinal: 120,
@@ -219,7 +210,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0, {} ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
 				{
 					planSlug: 'plan1',
 					plan: testPlans.plan1,
@@ -239,37 +230,37 @@ describe( 'selectors', () => {
 			] );
 		} );
 
-		test( 'couponDiscount should discount priceFinal', () => {
-			const state = {
-				productsList: {
-					items: {
-						plan1: { available: true },
-						plan2: { available: true },
-					},
-				},
-			};
+		// test( 'couponDiscount should discount priceFinal', () => {
+		// 	const state = {
+		// 		productsList: {
+		// 			items: {
+		// 				plan1: { available: true },
+		// 				plan2: { available: true },
+		// 			},
+		// 		},
+		// 	};
 
-			expect(
-				computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0, { abc: 0.5, jkl: 0.8 } )
-			).toEqual( [
-				{
-					planSlug: 'plan1',
-					plan: testPlans.plan1,
-					product: state.productsList.items.plan1,
-					priceFull: 120,
-					priceFinal: 60,
-					introductoryOfferPrice: null,
-				},
-				{
-					planSlug: 'plan2',
-					plan: testPlans.plan2,
-					product: state.productsList.items.plan2,
-					priceFull: 240,
-					priceFinal: 192,
-					introductoryOfferPrice: null,
-				},
-			] );
-		} );
+		// 	expect(
+		// 		computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0, { abc: 0.5, jkl: 0.8 } )
+		// 	).toEqual( [
+		// 		{
+		// 			planSlug: 'plan1',
+		// 			plan: testPlans.plan1,
+		// 			product: state.productsList.items.plan1,
+		// 			priceFull: 120,
+		// 			priceFinal: 60,
+		// 			introductoryOfferPrice: null,
+		// 		},
+		// 		{
+		// 			planSlug: 'plan2',
+		// 			plan: testPlans.plan2,
+		// 			product: state.productsList.items.plan2,
+		// 			priceFull: 240,
+		// 			priceFinal: 192,
+		// 			introductoryOfferPrice: null,
+		// 		},
+		// 	] );
+		// } );
 
 		test( 'Should filter out unavailable products', () => {
 			const state = {
@@ -281,7 +272,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0, {} ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
 				{
 					planSlug: 'plan1',
 					plan: testPlans.plan1,
@@ -302,7 +293,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0, {} ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
 				{
 					planSlug: 'plan1',
 					plan: testPlans.plan1,
@@ -335,7 +326,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0, {} ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
 				{
 					planSlug: 'plan1',
 					plan: testPlans.plan1,

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -5,16 +5,23 @@ import getIntroOfferIsEligible from 'calypso/state/selectors/get-intro-offer-is-
 import getIntroOfferPrice from 'calypso/state/selectors/get-intro-offer-price';
 import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
 import {
-	getProductDisplayCost,
-	isProductsListFetching,
-	getPlanPrice,
-	planSlugToPlanProduct,
 	computeFullAndMonthlyPricesForPlan,
 	computeProductsWithPrices,
+	getPlanPrice,
+	getProductDisplayCost,
+	getProductSaleCouponCost,
+	getProductSaleCouponDiscount,
+	isProductsListFetching,
+	planSlugToPlanProduct,
 } from '../selectors';
 
 jest.mock( 'calypso/state/selectors/get-intro-offer-price', () => jest.fn() );
 jest.mock( 'calypso/state/selectors/get-intro-offer-is-eligible', () => jest.fn() );
+jest.mock( 'calypso/state/selectors/get-intro-offer-is-eligible', () => jest.fn() );
+jest.mock( 'calypso/state/product-list/selectors/get-product-sale-coupon-cost', () => jest.fn() );
+jest.mock( 'calypso/state/product-list/selectors/get-product-sale-coupon-discount', () =>
+	jest.fn()
+);
 
 jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
 	getPlanDiscountedRawPrice: jest.fn(),
@@ -129,6 +136,10 @@ describe( 'selectors', () => {
 			getIntroOfferPrice.mockImplementation( () => null );
 			getIntroOfferIsEligible.mockReset();
 			getIntroOfferIsEligible.mockImplementation( () => false );
+			getProductSaleCouponCost.mockReset();
+			getProductSaleCouponCost.mockImplementation( () => false );
+			getProductSaleCouponDiscount.mockReset();
+			getProductSaleCouponDiscount.mockImplementation( () => false );
 		} );
 		test( 'Should return shape { priceFull }', () => {
 			getPlanDiscountedRawPrice.mockImplementation( ( a, b, c, { isMonthly } ) =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Add new selectors for retrieving sales coupon prices and discounts from a product
- Remove credits and coupon arguments from `computeFullAndMonthlyPricesForPlan` and `computeProductsWithPrices`
- Use sales coupon prices and discounts to help calculate the prices returned by `computeFullAndMonthlyPricesForPlan` and `computeProductsWithPrices`
- Remove 'Eligible orders save X%' disclaimer from the variant pickers
- Update tests for `computeFullAndMonthlyPricesForPlan` and `computeProductsWithPrices`

#### Testing instructions

1. Load branch as Calypso Blue and sandbox `public-api.wordpress.com` and enable the store sandbox.
   - I have added a pair of temporary sales coupons for testing.
2. Add the following products to a Jetpack Cart
  - VideoPress Yearly
  - Search Yearly
  - Another Yearly Jetpack Plan or Product ( I used Anti-Spam in the example )
3. Verify the following: <img width="455" alt="Screen Shot 2022-03-07 at 09 02 31" src="https://user-images.githubusercontent.com/2810519/157082721-aeb55b00-baea-46f6-94dc-c89bd33a3635.png">
   1. The VideoPress Variant Selector shows 60% off ( 50% intro offer + 20% sales coupon )
   2. The Search Variant Selector shows 60% off ( 60% sales coupon )
   3. The other product shows 50% ( 50% intro offer )
4. Verify the new unit test pass on the branch `yarn test-client client/state/products-list/test/selectors.js`
