### PR TITLE
Playwright: refactor `EditorSettingsSidebarComponent` to use FrameLocator.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -302,7 +302,6 @@ export class EditorSettingsSidebarComponent {
 	 * Clicks on the Revisions section in the sidebar to show a revisions modal.
 	 */
 	async showRevisions(): Promise< void > {
-		await this.page.pause();
 		const locator = this.frameLocator.locator(
 			`${ selectors.sectionHeader }:has-text("Revisions")`
 		);

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -22,7 +22,7 @@ const panel = '[aria-label="Editor settings"]';
 
 const selectors = {
 	// Close button for mobile
-	mobileCloseSidebarButton: `${ panel } [aria-label="Close settings"]:visible`, // there's a hidden copy in there
+	mobileCloseSidebarButton: `${ panel } [aria-label="Close settings"]:visible`,
 
 	// Tab
 	tabButton: ( tabName: EditorSidebarTab ) => `${ panel } button[data-label="${ tabName }"]`,
@@ -56,8 +56,6 @@ const selectors = {
 
 	// Tag
 	tagInput: `${ panel } .components-form-token-field:has-text("Add New Tag") input`,
-	// addedTag: ( tagName: string ) =>
-	// `${ panel } .components-form-token-field:has-text("Add New Tag") .components-form-token-field__token:has-text("${ tagName }")`,
 	addedTag: ( tag: string ) =>
 		`${ panel } .components-form-token-field__token-text:has-text("${ tag }")`,
 };

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -1,4 +1,5 @@
 import { FrameLocator, Page } from 'playwright';
+import envVariables from '../../env-variables';
 
 export type EditorSidebarTab = 'Post' | 'Block' | 'Page';
 export type ArticleSections =
@@ -79,9 +80,13 @@ export class EditorSettingsSidebarComponent {
 	}
 
 	/**
-	 *
+	 * Closes the sidebar only for Mobile viewport.
 	 */
 	async closeSidebarForMobile(): Promise< void > {
+		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
+			return;
+		}
+
 		const locator = this.frameLocator.locator( selectors.mobileCloseSidebarButton );
 		await locator.click();
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -5,7 +5,7 @@ export type PreviewOptions = 'Desktop' | 'Mobile' | 'Tablet';
 const panel = 'div.interface-interface-skeleton__header';
 const selectors = {
 	// Block Inserter
-	blockInserterButton: `${ panel } button[aria-label="Toggle block inserter"]`,
+	blockInserterButton: `${ panel } button.edit-post-header-toolbar__inserter-toggle`,
 
 	// Draft
 	saveDraftButton: ( state: 'disabled' | 'enabled' ) => {

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -27,7 +27,7 @@ const selectors = {
 	},
 
 	// Editor settings
-	settingsButton: `${ panel } button[aria-label="Settings"]`,
+	settingsButton: `${ panel } .edit-post-header__settings .interface-pinned-items button:first-child`,
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -391,12 +391,70 @@ export class GutenbergEditorPage {
 		visibility: PrivacyOptions,
 		{ password }: { password?: string }
 	): Promise< void > {
+		await Promise.race( [
+			this.editorSettingsSidebarComponent.clickTab( 'Page' ),
+			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
+		] );
+
 		await this.editorSettingsSidebarComponent.expandSection( 'Status & Visibility' );
 		await this.editorSettingsSidebarComponent.openVisibilityOptions();
 		await this.editorSettingsSidebarComponent.selectVisibility( visibility, {
 			password: password,
 		} );
 		await this.editorSettingsSidebarComponent.closeVisibilityOptions();
+	}
+
+	/**
+	 * View revisions for the article.
+	 */
+	async viewRevisions(): Promise< void > {
+		await Promise.race( [
+			this.editorSettingsSidebarComponent.clickTab( 'Page' ),
+			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
+		] );
+		await this.editorSettingsSidebarComponent.showRevisions();
+	}
+
+	/**
+	 * Select a category for the article.
+	 *
+	 * @param {string} name Name of the category.
+	 */
+	async selectCategory( name: string ): Promise< void > {
+		await Promise.race( [
+			this.editorSettingsSidebarComponent.clickTab( 'Page' ),
+			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
+		] );
+		await this.editorSettingsSidebarComponent.expandSection( 'Categories' );
+		await this.editorSettingsSidebarComponent.checkCategory( name );
+	}
+
+	/**
+	 * Adds the given tag to the article.
+	 *
+	 * @param {string} tag Tag to be added to article.
+	 */
+	async addTag( tag: string ): Promise< void > {
+		await Promise.race( [
+			this.editorSettingsSidebarComponent.clickTab( 'Page' ),
+			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
+		] );
+		await this.editorSettingsSidebarComponent.expandSection( 'Tags' );
+		await this.editorSettingsSidebarComponent.enterTag( tag );
+	}
+
+	/**
+	 * Sets the URL slug.
+	 *
+	 * @param {string} slug Desired URL slug.
+	 */
+	async setURLSlug( slug: string ): Promise< void > {
+		await Promise.race( [
+			this.editorSettingsSidebarComponent.clickTab( 'Page' ),
+			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
+		] );
+		await this.editorSettingsSidebarComponent.expandSection( 'Permalink' );
+		await this.editorSettingsSidebarComponent.enterUrlSlug( slug );
 	}
 
 	/* Publish, Draft & Schedule */

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -61,8 +61,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	it( 'Open setting sidebar', async function () {
 		await gutenbergEditorPage.openSettings();
-		editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( editorIframe, page );
-		await editorSettingsSidebarComponent.clickTab( 'Page' );
+		await gutenbergEditorPage.clickSettingsTab( 'Page' );
 	} );
 
 	it( 'Set custom URL slug', async function () {

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -61,7 +61,6 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	it( 'Open setting sidebar', async function () {
 		await gutenbergEditorPage.openSettings();
-		await gutenbergEditorPage.clickSettingsTab( 'Page' );
 	} );
 
 	it( 'Set custom URL slug', async function () {

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -1,6 +1,5 @@
 import {
 	DataHelper,
-	EditorSettingsSidebarComponent,
 	envVariables,
 	GutenbergEditorPage,
 	PublishedPostPage,
@@ -25,7 +24,6 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	let gutenbergEditorPage: GutenbergEditorPage;
 	let editorIframe: Frame;
 	let pagesPage: PagesPage;
-	let editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
 	let publishedUrl: URL;
 	const accountName = envVariables.GUTENBERG_EDGE
 		? 'gutenbergSimpleSiteEdgeUser'
@@ -49,13 +47,15 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	it( 'Select page template', async function () {
 		gutenbergEditorPage = new GutenbergEditorPage( page );
+		// @TODO Consider moving this to GutenbergEditorPage.
 		editorIframe = await gutenbergEditorPage.waitUntilLoaded();
-		const pageTemplateComponent = new PageTemplateModalComponent( editorIframe, page );
-		await pageTemplateComponent.selectTemplateCatagory( pageTemplateCategory );
-		await pageTemplateComponent.selectTemplate( pageTemplateLable );
+		const pageTemplateModalComponent = new PageTemplateModalComponent( editorIframe, page );
+		await pageTemplateModalComponent.selectTemplateCatagory( pageTemplateCategory );
+		await pageTemplateModalComponent.selectTemplate( pageTemplateLable );
 	} );
 
 	it( 'Template content loads into editor', async function () {
+		// @TODO Consider moving this to GutenbergEditorPage.
 		await editorIframe.waitForSelector( `text=${ expectedTemplateText }` );
 	} );
 
@@ -65,13 +65,12 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Set custom URL slug', async function () {
-		await editorSettingsSidebarComponent.expandSection( 'Permalink' );
-		await editorSettingsSidebarComponent.enterUrlSlug( customUrlSlug );
+		await gutenbergEditorPage.setURLSlug( customUrlSlug );
 	} );
 
 	// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional.
 	it( 'Close settings sidebar', async function () {
-		await editorSettingsSidebarComponent.closeSidebar();
+		await gutenbergEditorPage.closeSettings();
 	} );
 
 	it( 'Publish page', async function () {

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -5,7 +5,6 @@
 import {
 	DataHelper,
 	GutenbergEditorPage,
-	EditorSettingsSidebarComponent,
 	PublishedPostPage,
 	skipItIf,
 	TestAccount,
@@ -24,7 +23,6 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
 	let page: Page;
 	let gutenbergEditorPage: GutenbergEditorPage;
-	let editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
 	let publishedPostPage: PublishedPostPage;
 	const accountName = envVariables.GUTENBERG_EDGE
 		? 'gutenbergSimpleSiteEdgeUser'
@@ -61,21 +59,16 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Categories and Tags', function () {
-		it( 'Open editor settings sidebar for post', async function () {
+		it( 'Open settings', async function () {
 			await gutenbergEditorPage.openSettings();
-			const frame = await gutenbergEditorPage.getEditorFrame();
-			editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
-			await editorSettingsSidebarComponent.clickTab( 'Post' );
 		} );
 
 		it( 'Add post category', async function () {
-			await editorSettingsSidebarComponent.expandSection( 'Categories' );
-			await editorSettingsSidebarComponent.clickCategory( category );
+			await gutenbergEditorPage.selectCategory( category );
 		} );
 
 		it( 'Add post tag', async function () {
-			await editorSettingsSidebarComponent.expandSection( 'Tags' );
-			await editorSettingsSidebarComponent.enterTag( tag );
+			await gutenbergEditorPage.addTag( tag );
 		} );
 	} );
 
@@ -84,7 +77,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional.
 		it( 'Close settings sidebar', async function () {
-			await editorSettingsSidebarComponent.closeSidebar();
+			await gutenbergEditorPage.closeSettings();
 		} );
 
 		it( 'Launch preview', async function () {

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -8,7 +8,6 @@ import {
 	TestAccount,
 	envVariables,
 	GutenbergEditorPage,
-	EditorSettingsSidebarComponent,
 	RevisionsComponent,
 	ParagraphBlock,
 } from '@automattic/calypso-e2e';
@@ -21,7 +20,6 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 		? 'gutenbergSimpleSiteEdgeUser'
 		: 'simpleSitePersonalPlanUser';
 	let gutenbergEditorPage: GutenbergEditorPage;
-	let editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
 	let revisionsComponent: RevisionsComponent;
 	let page: Page;
 
@@ -51,11 +49,8 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 	);
 
 	it( 'View revisions', async function () {
-		const frame = await gutenbergEditorPage.getEditorFrame();
 		await gutenbergEditorPage.openSettings();
-		editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
-		await editorSettingsSidebarComponent.clickTab( 'Post' );
-		await editorSettingsSidebarComponent.showRevisions();
+		await gutenbergEditorPage.viewRevisions();
 	} );
 
 	it( 'Revision 1 displays expected diff', async function () {

--- a/test/e2e/specs/editor/editor__schedule.ts
+++ b/test/e2e/specs/editor/editor__schedule.ts
@@ -7,7 +7,6 @@ import {
 	TestAccount,
 	envVariables,
 	GutenbergEditorPage,
-	EditorSettingsSidebarComponent,
 	PublishedPostPage,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
@@ -46,21 +45,15 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 	} );
 
 	describe( 'Schedule: future', function () {
-		let editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
-
-		it( 'Open scheduler', async function () {
-			const frame = await gutenbergEditorPage.getEditorFrame();
+		it( 'Open settings', async function () {
 			await gutenbergEditorPage.openSettings();
-			editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
-			await editorSettingsSidebarComponent.clickTab( 'Post' );
-			await editorSettingsSidebarComponent.openSchedule();
 		} );
 
 		it( 'Schedule the post for next year', async function () {
 			const date = new Date();
 			date.setUTCFullYear( date.getFullYear() + 1 );
 
-			await editorSettingsSidebarComponent.schedule( {
+			await gutenbergEditorPage.schedule( {
 				year: date.getUTCFullYear(),
 				month: date.getUTCMonth(),
 				date: date.getUTCDate(),
@@ -69,7 +62,8 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 				meridian: 'am',
 			} );
 			// On mobile, the sidebar covers all of the screen.
-			await editorSettingsSidebarComponent.closeSidebar();
+			// Dismiss it so publish buttons are available.
+			await gutenbergEditorPage.closeSettings();
 		} );
 
 		it( 'Publish post', async function () {
@@ -102,22 +96,15 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 	} );
 
 	describe( 'Schedule: past', function () {
-		let editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
-
-		it( 'Open scheduler', async function () {
-			const frame = await gutenbergEditorPage.getEditorFrame();
+		it( 'Open settings', async function () {
 			await gutenbergEditorPage.openSettings();
-			editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
-
-			await editorSettingsSidebarComponent.clickTab( 'Post' );
-			await editorSettingsSidebarComponent.openSchedule();
 		} );
 
 		it( 'Schedule post to fist of the current month of last year', async function () {
 			const date = new Date();
 			date.setUTCFullYear( date.getUTCFullYear() - 1 );
 
-			await editorSettingsSidebarComponent.schedule( {
+			await gutenbergEditorPage.schedule( {
 				year: date.getUTCFullYear(),
 				date: 1,
 				month: date.getUTCMonth(),
@@ -125,7 +112,9 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 				minutes: 59,
 				meridian: 'pm',
 			} );
-			await editorSettingsSidebarComponent.closeSidebar();
+			// On mobile, the sidebar covers all of the screen.
+			// Dismiss it so publish buttons are available.
+			await gutenbergEditorPage.closeSettings();
 		} );
 
 		it( 'Publish post', async function () {

--- a/test/e2e/specs/editor/shared/privacy-testing.ts
+++ b/test/e2e/specs/editor/shared/privacy-testing.ts
@@ -5,7 +5,6 @@ import {
 	envVariables,
 	PrivacyOptions,
 	PublishedPostPage,
-	EditorSettingsSidebarComponent,
 	PageTemplateModalComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
@@ -32,7 +31,6 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 		let page: Page;
 		let url: URL;
 		let gutenbergEditorPage: GutenbergEditorPage;
-		let editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
 
 		describe( `Create a ${ visibility } page`, function () {
 			beforeAll( async function () {
@@ -62,15 +60,10 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 			} );
 
 			it( `Set page visibility to ${ visibility }`, async function () {
-				const frame = await gutenbergEditorPage.getEditorFrame();
 				await gutenbergEditorPage.openSettings();
-
-				editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( frame, page );
-				await editorSettingsSidebarComponent.clickTab( 'Page' );
-				await editorSettingsSidebarComponent.setVisibility( visibility as PrivacyOptions, {
+				await gutenbergEditorPage.setArticleVisibility( visibility as PrivacyOptions, {
 					password: pagePassword,
 				} );
-
 				await gutenbergEditorPage.closeSettings();
 			} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the EditorSettingsSidebarComponent to work with `FrameLocator`.

Key changes:
- change EditorSettingsSidebarComponent to accept a FrameLocator instead of Frame.
- modify CSS selectors and selector names where necessary.
- refactor methods to perform piecemeal actions in EditorSettingsSidebarComponent instead, relying on the calling class (in this case GutenbergEditorPage) to handle piecing together the actions.

#### Testing instructions

Ensure the following:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [x] i18n E2E

Related to #60868