### PR TITLE
Checkout: Show permission error if cart will not load due to permissions

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -42,6 +42,7 @@ import useCreatePaymentMethods from './hooks/use-create-payment-methods';
 import useDetectedCountryCode from './hooks/use-detected-country-code';
 import useGetThankYouUrl from './hooks/use-get-thank-you-url';
 import usePrepareProductsForCart from './hooks/use-prepare-products-for-cart';
+import { usePurchasePermissionsCheck } from './hooks/use-purchase-permissions-check';
 import useRecordCartLoaded from './hooks/use-record-cart-loaded';
 import useRecordCheckoutLoaded from './hooks/use-record-checkout-loaded';
 import useRemoveFromCartAndRedirect from './hooks/use-remove-from-cart-and-redirect';
@@ -193,6 +194,8 @@ export default function CompositeCheckout( {
 		loadingErrorType: cartLoadingErrorType,
 		addProductsToCart,
 	} = useShoppingCart( cartKey );
+
+	usePurchasePermissionsCheck();
 
 	const updatedSiteId = isJetpackCheckout ? parseInt( String( responseCart.blog_id ), 10 ) : siteId;
 

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -184,7 +184,6 @@ export default function CompositeCheckout( {
 	const cartKey = useCartKey();
 	const {
 		applyCoupon,
-		updateLocation,
 		replaceProductInCart,
 		replaceProductsInCart,
 		isLoading: isLoadingCart,
@@ -249,7 +248,7 @@ export default function CompositeCheckout( {
 	useWpcomStore( emptyManagedContactDetails, updateContactDetailsCache );
 
 	useDetectedCountryCode();
-	useCachedDomainContactDetails( updateLocation, countriesList );
+	useCachedDomainContactDetails( countriesList );
 
 	// Record errors adding products to the cart
 	useActOnceOnStrings( [ cartProductPrepError ].filter( isValueTruthy ), ( messages ) => {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -1,21 +1,25 @@
+import { useShoppingCart } from '@automattic/shopping-cart';
 import { getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
 import { useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useEffect, useRef } from 'react';
 import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { requestContactDetailsCache } from 'calypso/state/domains/management/actions';
 import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-cache';
-import type { UpdateTaxLocationInCart } from '@automattic/shopping-cart';
 import type { CountryListItem } from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-cached-domain-contact-details' );
 
-export default function useCachedDomainContactDetails(
-	updateCartLocation: UpdateTaxLocationInCart,
-	countriesList: CountryListItem[]
-): void {
+export default function useCachedDomainContactDetails( countriesList: CountryListItem[] ): void {
 	const reduxDispatch = useReduxDispatch();
 	const haveRequestedCachedDetails = useRef( false );
+	const cartKey = useCartKey();
+	const {
+		updateLocation: updateCartLocation,
+		isLoading: isLoadingCart,
+		loadingError: cartLoadingError,
+	} = useShoppingCart( cartKey );
 
 	useEffect( () => {
 		if ( ! haveRequestedCachedDetails.current ) {
@@ -33,6 +37,8 @@ export default function useCachedDomainContactDetails(
 
 	const { loadDomainContactDetailsFromCache } = useDispatch( 'wpcom-checkout' );
 
+	// When we have fetched or loaded contact details, send them to the
+	// `wpcom-checkout` data store for use by the checkout contact form.
 	useEffect( () => {
 		if ( cachedContactDetails ) {
 			debug( 'using fetched cached domain contact details', cachedContactDetails );
@@ -40,6 +46,14 @@ export default function useCachedDomainContactDetails(
 				...cachedContactDetails,
 				postalCode: arePostalCodesSupported ? cachedContactDetails.postalCode : undefined,
 			} );
+		}
+	}, [ cachedContactDetails, arePostalCodesSupported, loadDomainContactDetailsFromCache ] );
+
+	// When we have fetched or loaded contact details, send them to the
+	// to the shopping cart for calculating taxes.
+	useEffect( () => {
+		if ( isLoadingCart || cartLoadingError ) {
+			return;
 		}
 		if (
 			cachedContactDetails?.countryCode ||
@@ -53,9 +67,10 @@ export default function useCachedDomainContactDetails(
 			} );
 		}
 	}, [
+		cartLoadingError,
+		isLoadingCart,
 		cachedContactDetails,
 		updateCartLocation,
 		arePostalCodesSupported,
-		loadDomainContactDetailsFromCache,
 	] );
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-purchase-permissions-check.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-purchase-permissions-check.ts
@@ -1,0 +1,30 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+export function usePurchasePermissionsCheck() {
+	const selectedSite = useSelector( getSelectedSite );
+	const reduxDispatch = useDispatch();
+	const cartKey = useCartKey();
+	const translate = useTranslate();
+	const doesUserHavePermission = useSelector( ( state ) => {
+		if ( cartKey ) {
+			return true;
+		}
+		if ( ! selectedSite?.ID ) {
+			return undefined;
+		}
+		return canCurrentUser( state, selectedSite.ID, 'manage_options' );
+	} );
+	useEffect( () => {
+		if ( doesUserHavePermission === false ) {
+			reduxDispatch(
+				errorNotice( translate( 'You do not have permssion to make purchases on this site.' ) )
+			);
+		}
+	}, [ reduxDispatch, translate, doesUserHavePermission ] );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/61267 we modified the `useCartKey` hook so that it will not return a site ID if the user does not have permission to make purchases on that site. This will prevent the shopping cart package from loading.

The downside of this is that the user will have no notification that the permissions check has failed. This is partially intentional because different uses of the cart API may want to handle this situation differently. In checkout, however, the effect is that the page appears to hang in a loading state forever.

In this PR we add a notification to checkout so that the user is notified if their permissions check has failed.

<img width="833" alt="Screen Shot 2022-03-04 at 4 06 08 PM" src="https://user-images.githubusercontent.com/2036909/156844397-81c71f99-c1d7-480f-a399-efc764c7dddd.png">

Fixes https://github.com/Automattic/wp-calypso/issues/61644

#### Testing instructions

- Invite user A as an Editor to a site own by user B and have user A accept the role.
- Visit SA on the backend for user A and add a plan subscription to the site owned by user B.
- Have user A visit `/me/purchases` in calypso, select the newly added subscription, and click "Renew now".
- Verify that you see a permissions error message.