### PR TITLE
Add Error Notice when an Introductory Offers Request Fails

### DIFF
--- a/client/state/data-layer/wpcom/introductory-offers/index.tsx
+++ b/client/state/data-layer/wpcom/introductory-offers/index.tsx
@@ -1,3 +1,4 @@
+import { translate } from 'i18n-calypso';
 import {
 	SITE_INTRO_OFFER_RECEIVE,
 	SITE_INTRO_OFFER_REQUEST,
@@ -7,6 +8,7 @@ import {
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
+import { errorNotice } from 'calypso/state/notices/actions';
 
 const fetchIntroOffers = ( action: { siteId: number | 'none' } ) => {
 	return http(
@@ -39,11 +41,15 @@ const onUpdateSuccess = ( action: { siteId: number | 'none' }, response: unknown
 	];
 };
 
-const onUpdateError = () => {
+const onUpdateError = ( action: { siteId: number | 'none' } ) => {
 	return [
 		{
 			type: SITE_INTRO_OFFER_REQUEST_FAILURE,
+			siteId: action.siteId,
 		},
+		errorNotice(
+			translate( 'Error loading introductory discounts. Some displayed prices may be incorrect.' )
+		),
 	];
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add an error notice when an intro offers request fails, to explain possible price mismatches.
* Fix an error with intro offers request error handler

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Rig the `https://public-api.wordpress.com/wpcom/v2/introductory-offers` endpoint to fail
2. Navigate to the cart on the branch
3. Verify you see the following notice:<img width="1126" alt="Screen Shot 2022-03-04 at 15 11 04" src="https://user-images.githubusercontent.com/2810519/156854393-d3637d27-2d0f-4361-9505-03570ceb3358.png">
4. Visit `/pricing` on the Calypso Green version of the branch
5. Verify you eventually see the same notice

