### PR TITLE
Checkout: Do not try to update cart location if cart is loading

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -184,7 +184,6 @@ export default function CompositeCheckout( {
 	const cartKey = useCartKey();
 	const {
 		applyCoupon,
-		updateLocation,
 		replaceProductInCart,
 		replaceProductsInCart,
 		isLoading: isLoadingCart,
@@ -249,7 +248,7 @@ export default function CompositeCheckout( {
 	useWpcomStore( emptyManagedContactDetails, updateContactDetailsCache );
 
 	useDetectedCountryCode();
-	useCachedDomainContactDetails( updateLocation, countriesList );
+	useCachedDomainContactDetails( countriesList );
 
 	// Record errors adding products to the cart
 	useActOnceOnStrings( [ cartProductPrepError ].filter( isValueTruthy ), ( messages ) => {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -1,21 +1,25 @@
+import { useShoppingCart } from '@automattic/shopping-cart';
 import { getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
 import { useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useEffect, useRef } from 'react';
 import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { requestContactDetailsCache } from 'calypso/state/domains/management/actions';
 import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-cache';
-import type { UpdateTaxLocationInCart } from '@automattic/shopping-cart';
 import type { CountryListItem } from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-cached-domain-contact-details' );
 
-export default function useCachedDomainContactDetails(
-	updateCartLocation: UpdateTaxLocationInCart,
-	countriesList: CountryListItem[]
-): void {
+export default function useCachedDomainContactDetails( countriesList: CountryListItem[] ): void {
 	const reduxDispatch = useReduxDispatch();
 	const haveRequestedCachedDetails = useRef( false );
+	const cartKey = useCartKey();
+	const {
+		updateLocation: updateCartLocation,
+		isLoading: isLoadingCart,
+		loadingError: cartLoadingError,
+	} = useShoppingCart( cartKey );
 
 	useEffect( () => {
 		if ( ! haveRequestedCachedDetails.current ) {
@@ -33,6 +37,8 @@ export default function useCachedDomainContactDetails(
 
 	const { loadDomainContactDetailsFromCache } = useDispatch( 'wpcom-checkout' );
 
+	// When we have fetched or loaded contact details, send them to the
+	// `wpcom-checkout` data store for use by the checkout contact form.
 	useEffect( () => {
 		if ( cachedContactDetails ) {
 			debug( 'using fetched cached domain contact details', cachedContactDetails );
@@ -40,6 +46,14 @@ export default function useCachedDomainContactDetails(
 				...cachedContactDetails,
 				postalCode: arePostalCodesSupported ? cachedContactDetails.postalCode : undefined,
 			} );
+		}
+	}, [ cachedContactDetails, arePostalCodesSupported, loadDomainContactDetailsFromCache ] );
+
+	// When we have fetched or loaded contact details, send them to the
+	// to the shopping cart for calculating taxes.
+	useEffect( () => {
+		if ( isLoadingCart || cartLoadingError ) {
+			return;
 		}
 		if (
 			cachedContactDetails?.countryCode ||
@@ -53,9 +67,10 @@ export default function useCachedDomainContactDetails(
 			} );
 		}
 	}, [
+		cartLoadingError,
+		isLoadingCart,
 		cachedContactDetails,
 		updateCartLocation,
 		arePostalCodesSupported,
-		loadDomainContactDetailsFromCache,
 	] );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When checkout loads, it queries the domain contact details endpoint and then saves that data to the current contact form and to the shopping cart (for tax purposes). However, it's possible that the cart may still be loading when the domain contact information becomes available, which will cause an error (you'll only see it in the console) of `Cart actions cannot be taken without a cart key`.

In this PR, we modify the code that performs the actions with the contact details so that it will wait for the cart to be loaded before trying to update its location.

#### Testing instructions

- Use an account which has saved contact details (typically this is because you've made a purchase before).
- Add a product to your cart and visit checkout with your developer console open.
- Verify that checkout loads, and that the contact details are pre-filled in the contact step.
- Verify that you see no errors like `Cart actions cannot be taken without a cart key` in the console.