### PR TITLE
Checkout: Allow non-admins to access the shopping cart for a site

### DIFF
--- a/client/my-sites/checkout/get-cart-key.ts
+++ b/client/my-sites/checkout/get-cart-key.ts
@@ -5,21 +5,16 @@ export default function getCartKey( {
 	selectedSite,
 	isLoggedOutCart,
 	isNoSiteCart,
-	doesUserHavePermission,
 }: {
 	selectedSite: SiteData | undefined | null;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
-	doesUserHavePermission?: boolean;
 } ): CartKey | undefined {
 	if ( ! selectedSite?.slug && ( isLoggedOutCart || isNoSiteCart ) ) {
 		return 'no-user';
 	}
 	if ( ! selectedSite?.slug && ! isLoggedOutCart && ! isNoSiteCart ) {
 		return 'no-site';
-	}
-	if ( selectedSite?.ID && ! doesUserHavePermission ) {
-		return undefined;
 	}
 	if ( selectedSite?.ID ) {
 		return selectedSite.ID;

--- a/client/my-sites/checkout/use-cart-key.ts
+++ b/client/my-sites/checkout/use-cart-key.ts
@@ -1,7 +1,6 @@
 import { useDebugValue } from 'react';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import getCartKey from './get-cart-key';
 
@@ -21,18 +20,13 @@ export default function useCartKey(): ReturnType< typeof getCartKey > {
 		( ! isLoggedOutCart &&
 			currentUrlPath.includes( '/checkout/no-site' ) &&
 			'no-user' === searchParams.get( 'cart' ) );
-	const doesUserHavePermission = useSelector(
-		( state ) => !! selectedSite?.ID && canCurrentUser( state, selectedSite.ID, 'manage_options' )
-	);
 
 	const cartKey = getCartKey( {
 		selectedSite,
 		isLoggedOutCart,
 		isNoSiteCart,
-		doesUserHavePermission,
 	} );
 	useDebugValue( `cart key is ${ cartKey }` );
 	useDebugValue( `site ID ${ selectedSite?.ID }` );
-	useDebugValue( `does user have permission? ${ doesUserHavePermission }` );
 	return cartKey;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This mostly reverts the changes from https://github.com/Automattic/wp-calypso/pull/61267, once again allowing non-admins to make requests to the `/me/shopping-cart` endpoint. The endpoint itself can block such users if it needs to.

Originally that PR was meant to help track down some invalid access we had been seeing, but it did not actually help with that. With the change reverted, we can have less logic on the client and we don't need to keep it in sync with the matching logic on the server. (Indeed, the server has several exceptions to the rule. I'm not sure if they're valid any more, but having such guards in one place is easier to manage.)

#### Testing instructions

This mostly just reverts changes so there's not a lot to review. 