### PR TITLE
Add 'jetpack/backup-messaging-i3' feature-flags for production

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -34,6 +34,7 @@
 		"checkout/google-pay": false,
 		"fullstory": true,
 		"i18n/community-translator": false,
+		"jetpack/backup-messaging-i3": true,
 		"jetpack-cloud": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,

--- a/config/production.json
+++ b/config/production.json
@@ -42,6 +42,7 @@
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": false,
+		"jetpack/backup-messaging-i3": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/features-section/atomic": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a '`jetpack/backup-messaging-i3`' feature flag to production environment for both WordPress.com (Calypso blue) and Jetpack Cloud (Calypso green).

#### Testing instructions

Verify that the '`jetpack/backup-messaging-i3`' flag has been added and set to `true` in:
 
- `production.json`
- `jetpack-cloud-production.json`

