### PR TITLE
Jetpack Cloud: Add new FAQ about how to get started with Jetpack to Pricing page.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -9,6 +9,19 @@ import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
 import './style.scss';
 
+const jetpackGettingStartedLink = () => {
+	return (
+		<a
+			href="https://jetpack.com/support/getting-started-with-jetpack/"
+			target="_blank"
+			rel="noopener noreferrer"
+			onClick={ () => {
+				recordTracksEvent( 'calypso_jetpack_faq_getting_started_click' );
+			} }
+		/>
+	);
+};
+
 const JetpackFAQ: React.FC = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -37,6 +50,18 @@ const JetpackFAQ: React.FC = () => {
 		<>
 			<section className="jetpack-faq">
 				<h2 className="jetpack-faq__heading">{ translate( 'Frequently Asked Questions' ) }</h2>
+				<FoldableFAQ
+					id="priority-support"
+					question={ translate( 'How do I start using Jetpack on my website?' ) }
+					onToggle={ onFaqToggle }
+				>
+					{ translate(
+						'Learn everything you need to know about getting started with Jetpack {{gettingStartedLink}}here{{/gettingStartedLink}}.',
+						{
+							components: { gettingStartedLink: jetpackGettingStartedLink() },
+						}
+					) }
+				</FoldableFAQ>
 				<FoldableFAQ
 					id="priority-support"
 					question={ translate( 'Is priority support included in all plans?' ) }


### PR DESCRIPTION
Fixes Automattic/jetpack/issues/23269

#### Changes proposed in this Pull Request

* Adds new FAQ entry "How do I start using Jetpack on my website?" to the Jetpack Plans FAQ component.
<img width="962" alt="image" src="https://user-images.githubusercontent.com/746152/157045366-2dfbcc76-80f3-45c3-ab0b-efb4535143ff.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Start Jetpack Cloud (AKA Calypso Green) with `yarn start-jetpack-cloud`
* Visit `http://jetpack.cloud.localhost/pricing`
* Scroll to the bottom
* Confirm you see the new questions at the top of the list

