### PR TITLE
Seller Experience: Add initial translations for updated Woo landing page

### DIFF
--- a/client/my-sites/customer-home/translations/woo-upsell-banner.js
+++ b/client/my-sites/customer-home/translations/woo-upsell-banner.js
@@ -4,3 +4,8 @@ translate( 'Need more from your store?' );
 translate(
 	'Upgrade to our premium plan to gain access to all the tools you need to run an online ecommerce store, from marketing to shipping.'
 );
+
+translate( 'Upgrade your store' );
+translate(
+	'Need more out of your store? Unlock the tools needed to manage products, orders, shipping, and more.'
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This contains the `translate` calls for all of the new copy on the Woo landing page.

![image](https://user-images.githubusercontent.com/917632/157064080-5c4809f7-b4a4-43fe-9e5f-f5455a143429.png)


Related to #61472
