### PR TITLE
Removing the days since signup from the Fiverr logo maker links.

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -12,7 +12,6 @@ import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/ana
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import getCurrentUserTimeSinceSignup from 'calypso/state/selectors/get-current-user-time-since-signup';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import isNavUnificationEnabled from 'calypso/state/selectors/is-nav-unification-enabled';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
@@ -61,7 +60,6 @@ export const QuickLinks = ( {
 	siteSlug,
 	blockEditorSettings,
 	areBlockEditorSettingsLoading,
-	daysSinceSignup,
 } ) => {
 	const isFSEActive = blockEditorSettings?.is_fse_active ?? false;
 
@@ -187,7 +185,7 @@ export const QuickLinks = ( {
 						gridicon="plugins"
 					/>
 					<ActionBox
-						href={ 'https://wp.me/logo-maker/?utm_campaign=my_home_' + daysSinceSignup + 'd' }
+						href="https://wp.me/logo-maker/?utm_campaign=my_home"
 						onClick={ trackDesignLogoAction }
 						target="_blank"
 						label={
@@ -406,7 +404,6 @@ const mapStateToProps = ( state ) => {
 		isExpanded: getPreference( state, 'homeQuickLinksToggleStatus' ) !== 'collapsed',
 		isUnifiedNavEnabled: isNavUnificationEnabled,
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
-		daysSinceSignup: getCurrentUserTimeSinceSignup( state ),
 	};
 };
 

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -23,7 +23,6 @@ import {
 import { hasTrafficGuidePurchase } from 'calypso/my-sites/marketing/ultimate-traffic-guide';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
-import getCurrentUserTimeSinceSignup from 'calypso/state/selectors/get-current-user-time-since-signup';
 import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import * as T from 'calypso/types';
@@ -44,7 +43,6 @@ export const MarketingTools: FunctionComponent = () => {
 	const showFacebookUpsell = [ 'value_bundle', 'personal-bundle', 'free_plan' ].includes(
 		sitePlan
 	);
-	const daysSinceSignup = useSelector( getCurrentUserTimeSinceSignup );
 
 	const handleBusinessToolsClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_business_tools_button_click' );
@@ -114,7 +112,7 @@ export const MarketingTools: FunctionComponent = () => {
 				>
 					<Button
 						onClick={ handleCreateALogoClick }
-						href={ 'https://wp.me/logo-maker/?utm_campaign=marketing_tab_' + daysSinceSignup + 'd' }
+						href="https://wp.me/logo-maker/?utm_campaign=marketing_tab"
 						target="_blank"
 					>
 						{ translate( 'Create a logo' ) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -25,7 +25,6 @@ import guessTimezone from 'calypso/lib/i18n-utils/guess-timezone';
 import scrollTo from 'calypso/lib/scroll-to';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import getCurrentUserTimeSinceSignup from 'calypso/state/selectors/get-current-user-time-since-signup';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -94,7 +93,6 @@ export class SiteSettingsFormGeneral extends Component {
 			eventTracker,
 			onChangeField,
 			uniqueEventTracker,
-			daysSinceSignup,
 		} = this.props;
 
 		return (
@@ -152,9 +150,7 @@ export class SiteSettingsFormGeneral extends Component {
 					<div className="site-settings__fiver-cta-button">
 						<Button
 							target="_blank"
-							href={
-								'https://wp.me/logo-maker/?utm_campaign=general_settings_' + daysSinceSignup + 'd'
-							}
+							href="https://wp.me/logo-maker/?utm_campaign=general_settings"
 							onClick={ this.trackFiverrLogoMakerClick }
 						>
 							<Gridicon icon="external" />
@@ -718,7 +714,6 @@ const connectComponent = connect( ( state ) => {
 		isAtomicAndEditingToolkitDeactivated:
 			isAtomicSite( state, siteId ) &&
 			getSiteOption( state, siteId, 'editing_toolkit_is_active' ) === false,
-		daysSinceSignup: getCurrentUserTimeSinceSignup( state ),
 	};
 }, mapDispatchToProps );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the account age from the logo maker links. We have the data we need for now. Ref p5uIfZ-bQD-p2#comment-17404. This tracking parameter was added in PR: https://github.com/Automattic/wp-calypso/pull/60664

#### Testing instructions
* Check on "My Home" 
* Check the logo maker CTA in tools>marketing (should be similar to above)
* Check the logo maker CTA under settings>general (should be similar to above)
* Confirm the account age parameter is not present in the link href on links going to `wp.me/logo-maker`.

The selector and associated tests will be removed after this PR is merged.