### PR TITLE
Editor: Cache page view stats properties by props

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -11,6 +11,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import memoizeLast from 'calypso/lib/memoize-last';
 import { navigate } from 'calypso/lib/navigate';
 import {
 	withStopPerformanceTrackingProp,
@@ -611,8 +612,12 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 
 	getStatsProps = () => {
 		const { postId, postType } = this.props;
-		return postId ? { post_type: postType, post_id: postId } : { post_type: postType };
+		return this.getStatsPropertiesForProps( postId, postType );
 	};
+
+	getStatsPropertiesForProps = memoizeLast( ( postId, postType ) =>
+		postId ? { post_type: postType, post_id: postId } : { post_type: postType }
+	);
 
 	getStatsTitle = () => {
 		const { postId, postType } = this.props;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When profiling Calypso's editor initial page load, I noticed that we'll trigger additional re-renders because when generating the `properties` prop for `<PageViewTracker />`, we create a new object every time, although the data is almost always the same. 

This PR updates the `getStatsProps()` method to use an internal `getStatsPropertiesForProps()` method that will cache and return the same objects for when the same arguments are passed. 

This PR is part of a series that aims to decrease the number of unnecessary re-renders on the Calypso editor by over 50% in total:

* #61702
* #61703
* #61704
* #61706
* #61707
* #61708

#### Testing instructions

* Verify that the editor in Calypso still works well.
* Input `localStorage.setItem('debug', 'calypso:analytics*');` in your browser console and refresh the editor page.
* Verify you still see this in your console:

![](https://cldup.com/8BoassTMQl.png)

