### PR TITLE
Editor: Cache default and empty media data sources

### DIFF
--- a/client/gutenberg/editor/media-utils.js
+++ b/client/gutenberg/editor/media-utils.js
@@ -1,6 +1,9 @@
 import { parseWithAttributeSchema } from '@wordpress/blocks';
 import { get, includes, reduce } from 'lodash';
 
+const EMPTY_ARRAY = [];
+const DEFAULT_DISABLED_DATA_SOURCES = [ 'google_photos', 'pexels' ];
+
 /**
  * Convert the Calypso Media Modal output to the format expected by Gutenberg
  *
@@ -48,9 +51,9 @@ export const getDisabledDataSources = ( allowedTypes ) => {
 		( Array.isArray( allowedTypes ) && ! allowedTypes.length ) ||
 		includes( allowedTypes, 'image' )
 	) {
-		return [];
+		return EMPTY_ARRAY;
 	}
-	return [ 'google_photos', 'pexels' ];
+	return DEFAULT_DISABLED_DATA_SOURCES;
 };
 
 const enabledFiltersMap = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When profiling Calypso's editor initial page load, I noticed that we'll trigger additional re-renders because when rendering the media modal, we generate a new empty array if there are no media data sources, and a new array with the default data sources too. 

This PR updates the cases when we return an empty array or return the default set of media data sources, to use a constant array in order to avoid unnecessary re-renders.

This PR is part of a series that aims to decrease the number of unnecessary re-renders on the Calypso editor by over 50% in total:

* #61702
* #61703
* #61704
* #61706
* #61707
* #61708

#### Testing instructions

* Smoke test the editor in Calypso.
* Verify that the media modal in a post still works well.