### PR TITLE
Lib: Optimize route modal to avoid extra object recreation

### DIFF
--- a/client/lib/route-modal/use-route-modal.tsx
+++ b/client/lib/route-modal/use-route-modal.tsx
@@ -19,10 +19,8 @@ export interface RouteModalData {
  * React hook providing utils to control opening and closing modal via query string.
  */
 const useRouteModal = ( queryKey: string, defaultValue: unknown = '' ): RouteModalData => {
-	const { currentQuery, previousRoute } = useSelector( ( state ) => ( {
-		currentQuery: getCurrentQueryArguments( state ),
-		previousRoute: getPreviousRoute( state ),
-	} ) );
+	const currentQuery = useSelector( getCurrentQueryArguments );
+	const previousRoute = useSelector( getPreviousRoute );
 
 	const value = currentQuery?.[ queryKey ];
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When profiling Calypso's editor initial page load, I noticed that we'll trigger additional re-renders because when using the route modal for the support article dialog, we unnecessarily create a new object just to destructure from it every time. 

This PR updates the `useRouteModal` hook to directly use `useSelector` instead of creating an object and destructuring afterward.

This PR is part of a series that aims to decrease the number of unnecessary re-renders on the Calypso editor by over 50%:

* #61702
* #61703
* #61704
* #61706
* #61707
* #61708

#### Testing instructions

* Verify that the editor in Calypso still works well.
* Verify test instructions of #61199 work well.