### PR TITLE
Simplify Pricing For Jetpack Backup Storage Pricing Page

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -1,4 +1,3 @@
-import { TERM_ANNUALLY } from '@automattic/calypso-products';
 import { TranslateResult } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import PlanPrice from 'calypso/my-sites/plan-price';
@@ -40,8 +39,6 @@ const Paid: React.FC< OwnProps > = ( {
 		);
 	}
 
-	const couponOriginalPrice = parseFloat( ( discountedPrice ?? originalPrice ).toFixed( 2 ) );
-
 	const renderDiscountedPrice = () => {
 		return (
 			<>
@@ -55,9 +52,7 @@ const Paid: React.FC< OwnProps > = ( {
 					<PlanPrice
 						original
 						className="display-price__original-price"
-						rawPrice={
-							( billingTerm === TERM_ANNUALLY ? originalPrice : couponOriginalPrice ) as number
-						}
+						rawPrice={ originalPrice as number }
 						currencyCode={ currencyCode }
 					/>
 				</span>
@@ -70,18 +65,12 @@ const Paid: React.FC< OwnProps > = ( {
 
 	const renderNonDiscountedPrice = () => (
 		<span dir="ltr">
-			<PlanPrice
-				discounted
-				rawPrice={
-					( billingTerm === TERM_ANNUALLY ? originalPrice : couponOriginalPrice ) as number
-				}
-				currencyCode={ currencyCode }
-			/>
+			<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
 		</span>
 	);
 
 	const renderPrice = () =>
-		billingTerm === TERM_ANNUALLY ? renderDiscountedPrice() : renderNonDiscountedPrice();
+		finalPrice && finalPrice < originalPrice ? renderDiscountedPrice() : renderNonDiscountedPrice();
 
 	return (
 		<>

--- a/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
@@ -60,8 +60,8 @@ export const StoragePricing: React.FC< Props > = ( {
 					urlQueryArgs={ urlQueryArgs }
 					siteSlug={ siteSlug }
 				/>
-				{ footer }
 			</Main>
+			{ footer }
 		</>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
@@ -3,6 +3,7 @@ import { TERM_ANNUALLY } from '@automattic/calypso-products';
 import { ReactNode, useState } from 'react';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
+import QueryIntroOffers from 'calypso/components/data/query-intro-offers';
 import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Main from 'calypso/components/main';
@@ -50,6 +51,7 @@ export const StoragePricing: React.FC< Props > = ( {
 		<>
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 			{ siteId && <QuerySiteProducts siteId={ siteId } /> }
+			{ siteId && <QueryIntroOffers siteId={ siteId } /> }
 
 			{ nav }
 			<Main className="storage-pricing__main" wideLayout>

--- a/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { TERM_ANNUALLY } from '@automattic/calypso-products';
 import { ReactNode, useState } from 'react';
 import * as React from 'react';
@@ -31,6 +32,19 @@ export const StoragePricing: React.FC< Props > = ( {
 } ) => {
 	const [ duration, setDuration ] = useState< Duration >( defaultDuration );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const showAnnualPlansOnly = config.isEnabled( 'jetpack/pricing-page-annual-only' );
+
+	const filterBar = React.useMemo(
+		() =>
+			showAnnualPlansOnly ? null : (
+				<PlansFilterBar
+					showDiscountMessage
+					duration={ duration }
+					onDurationChange={ setDuration }
+				/>
+			),
+		[ duration, showAnnualPlansOnly ]
+	);
 
 	return (
 		<>
@@ -40,11 +54,7 @@ export const StoragePricing: React.FC< Props > = ( {
 			{ nav }
 			<Main className="storage-pricing__main" wideLayout>
 				{ header }
-				<PlansFilterBar
-					showDiscountMessage
-					duration={ duration }
-					onDurationChange={ setDuration }
-				/>
+				{ filterBar }
 				<StorageTierUpgrade
 					duration={ duration }
 					urlQueryArgs={ urlQueryArgs }


### PR DESCRIPTION
This PR applies the recent changes made to the `/pricing` page on Jetpack Cloud to the `/pricing/storage/:site` page.

#### Changes proposed in this Pull Request

* Prevents the plan term length toggle from being displayed when the `jetpack/pricing-page-annual-only` config flag is `true` (Copied logic from #59088).
* Loads the introductory offers via `<QueryIntroOffers />`.
* Updates the `<Paid />` component to render strike-through prices based on the presence of a difference between `finalPrice` and `originalPrice`, instead of using the selected term length. I made this change prior to loading introductory offers, when each product card was showing a duplicate struck-through and real price (i.e. ~~$9.95~~ $9.95). Loading the introductory offers negates the immediate need for this, but refactoring the `<Paid />` component to do this was on the to-do list already, so I've kept it in this PR. 
* Moves the page footer outside of the `<Main>` component, so that it spans the full width of the page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `git checkout fix/simplify-backup-storage-pricing` && `yarn start-jetpack-cloud`
* Open http://jetpack.cloud.localhost:3000/pricing/storage/[SITE_URL_HERE]
* Verify the plan term length toggle is not displayed.
* Verify the introductory offers are applied to each plan.
* Comment out line 54 of `client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx` and verify no strike-through price is shown when there is no discount loaded/available.
* Verify the footer is full width.
* Check for regressions against the live page: https://cloud.jetpack.com/pricing/storage/[SITE_URL_HERE]

#### Screenshots

**Before:**

![jetpack cloud localhost_3001_pricing_storage_odd-shrew jurassic ninja (1)](https://user-images.githubusercontent.com/10933065/157098828-a36fbb36-f3c4-4ec5-a3ba-12ff9f2ba372.png)

**After:**

![jetpack cloud localhost_3001_pricing_storage_odd-shrew jurassic ninja](https://user-images.githubusercontent.com/10933065/157098838-218eb655-7790-4e1e-ae0d-bb329a0a2d3d.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1164141197617539-as-1201922198916077 and 1201295898168937-as-1201731047136547.