### PR TITLE
Guided Tours: Optimize defaults in selectors

### DIFF
--- a/client/state/guided-tours/selectors/index.js
+++ b/client/state/guided-tours/selectors/index.js
@@ -170,9 +170,10 @@ export const findEligibleTour = createSelector(
  */
 const getRawGuidedTourState = ( state ) => state.guidedTours;
 
+const EMPTY_STATE = { shouldShow: false };
+
 export const getGuidedTourState = createSelector(
 	( state ) => {
-		const emptyState = { shouldShow: false };
 		const tourState = getRawGuidedTourState( state );
 		const tour = findEligibleTour( state );
 		const isGutenberg = getSectionGroup( state ) === 'gutenberg';
@@ -189,7 +190,7 @@ export const getGuidedTourState = createSelector(
 		);
 
 		if ( ! tour ) {
-			return { ...tourState, ...emptyState };
+			return EMPTY_STATE;
 		}
 
 		return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When profiling Calypso's editor initial page load, I noticed that we'll trigger additional re-renders because when checking whether we have guided tours, we'll always return a new object, even if it will contain a flag that there are no guided tours.

This PR updates the `getGuidedTourState()` selector to return the same empty state when there is no tour available.

This PR is part of a series that aims to decrease the number of unnecessary re-renders on the Calypso editor by over 50%:

* #61702
* #61703
* #61704
* #61706
* #61707
* #61708

#### Testing instructions

* Verify that the editor in Calypso still works well.
* Verify that guided tours still work well.