### PR TITLE
Notice: Optimize notices selector default values

### DIFF
--- a/client/state/notices/selectors.js
+++ b/client/state/notices/selectors.js
@@ -2,6 +2,8 @@ import { createSelector } from '@automattic/state-utils';
 
 import 'calypso/state/notices/init';
 
+const EMPTY_ARRAY = [];
+
 /**
  * Returns array value of notice item state
  *
@@ -9,7 +11,13 @@ import 'calypso/state/notices/init';
  * @returns {Array}        Notice objects as array
  */
 export const getNotices = createSelector(
-	( state ) => Object.values( state.notices.items ),
+	( state ) => {
+		const notices = Object.values( state.notices.items );
+		if ( ! notices.length ) {
+			return EMPTY_ARRAY;
+		}
+		return notices;
+	},
 	( state ) => state.notices.items
 );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When profiling Calypso's editor initial page load, I noticed that we'll trigger additional re-renders because when deciding whether to display any global notices, we create a new object every time when there are no notices.

This PR updates the `getNotices()` selector to return the same empty array when there are no notices, in order to avoid excess rerenders.

This PR is part of a series that aims to decrease the number of unnecessary re-renders on the Calypso editor by over 50%:

* #61702
* #61703
* #61704
* #61706
* #61707
* #61708

#### Testing instructions

* Verify that the editor in Calypso still works well.
* Verify that notices in Calypso still work well.