### PR TITLE
Media: Optimize selected items selector when empty

### DIFF
--- a/client/state/selectors/get-media-library-selected-items.js
+++ b/client/state/selectors/get-media-library-selected-items.js
@@ -2,6 +2,8 @@ import getMediaItem from 'calypso/state/selectors/get-media-item';
 
 import 'calypso/state/media/init';
 
+const EMPTY_ARRAY = [];
+
 /**
  * Retrieves the currently selected media library items for a specified site.
  *
@@ -11,13 +13,13 @@ import 'calypso/state/media/init';
  */
 export default ( state, siteId ) => {
 	if ( ! siteId ) {
-		return [];
+		return EMPTY_ARRAY;
 	}
 
 	const selectedMediaIds = state.media.selectedItems[ siteId ];
 
 	if ( ! selectedMediaIds ) {
-		return [];
+		return EMPTY_ARRAY;
 	}
 
 	return selectedMediaIds


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When profiling Calypso's editor initial page load, I noticed that we'll trigger additional re-renders because when there are no selected items in the media library / media modal, we create a new array on every call.

This PR updates the `getMediaLibrarySelectedItems()` selector to return the same empty array when there are no selected items, in order to avoid excess rerenders.

This PR is part of a series that aims to decrease the number of unnecessary re-renders on the Calypso editor by over 50%:

* #61702
* #61703
* #61704
* #61706
* #61707
* #61708

#### Testing instructions

* Verify that the editor in Calypso still works well.
* Verify that the media modal in a post still works well, specifically the selected items there.