### PR TITLE
Seller Experience: Adding payment contextual help

### DIFF
--- a/client/blocks/inline-help/constants.js
+++ b/client/blocks/inline-help/constants.js
@@ -9,3 +9,5 @@ export const SUPPORT_BLOG_ID = 9619154;
 export const SUPPORT_TYPE_CONTEXTUAL_HELP = 'contextual_help';
 export const SUPPORT_TYPE_API_HELP = 'api_help';
 export const SUPPORT_TYPE_ADMIN_SECTION = 'admin_section';
+
+export const SELL_INTENT_ARTICLE = 'sell_intent_article';

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -1,6 +1,6 @@
 import { translate } from 'i18n-calypso';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { RESULT_TOUR, RESULT_VIDEO } from './constants';
+import { RESULT_TOUR, RESULT_VIDEO, SELL_INTENT_ARTICLE } from './constants';
 
 /**
  * Module variables
@@ -1310,6 +1310,23 @@ const contextLinksForSection = {
 			},
 		},
 		{
+			type: SELL_INTENT_ARTICLE,
+			get link() {
+				return localizeUrl(
+					'https://wordpress.com/support/video-tutorials-add-payments-features-to-your-site-with-our-guides/'
+				);
+			},
+			post_id: 175999,
+			get title() {
+				return translate( 'The Payments Block' );
+			},
+			get description() {
+				return translate(
+					"The Payments block is one of WordPress.com's payment blocks that allows you to accept payments for one-time, monthly recurring, or annual payments on your website."
+				);
+			},
+		},
+		{
 			get link() {
 				return localizeUrl( 'https://wordpress.com/support/xml-rpc/' );
 			},
@@ -2257,12 +2274,19 @@ export function getContextResults( section, siteIntent ) {
 	// `first` is a safe-guard in case that fails
 	const video = videosForSection[ section ]?.[ 0 ];
 	const tour = toursForSection[ section ]?.[ 0 ];
-	const links = contextLinksForSection[ section ] ?? fallbackLinks;
+	let links = contextLinksForSection[ section ] ?? fallbackLinks;
 
 	// If true, still display fallback links in addition (as opposed to instead
 	// of) the other context links.
 	if ( section === 'home' ) {
 		return [ tour, video, ...fallbackLinks, ...links ].filter( Boolean );
+	}
+
+	// Remove sell docs if not on a site with the 'sell' intent.
+	if ( section === 'gutenberg-editor' && siteIntent !== 'sell' ) {
+		links = links.filter( ( link ) => {
+			return link.type !== SELL_INTENT_ARTICLE;
+		} );
 	}
 
 	return [ tour, video, ...links ].filter( Boolean );


### PR DESCRIPTION
Adds payments docs on editor if the site has the `sell` intent.

#### Testing instructions
1. Open the calypso.live link in the comments.
2. Create or open a site that has the `sell` intent.
3. Click on the question mark & verify you see the payments documentation. <img width="338" alt="image" src="https://user-images.githubusercontent.com/375980/157094416-e3cd9514-5f8b-4518-8596-c918f6777551.png">
4. Create or open a site that does not have the `sell` intent.
5. Verify the payments documentation is not there. 
<img width="341" alt="image" src="https://user-images.githubusercontent.com/375980/157094924-62d297ca-2f3f-4dd2-a291-f5847b705713.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/61469
