### PR TITLE
CI: upgrade Playwright to 1.19.

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -44,7 +44,7 @@
 		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",
-		"playwright": "1.19",
+		"playwright": "^1.19.2",
 		"postcss": "^8.4.5",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -44,7 +44,7 @@
 		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",
-		"playwright": "^1.18",
+		"playwright": "1.19",
 		"postcss": "^8.4.5",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -21,7 +21,7 @@
 		"@types/totp-generator": "^0.0.3",
 		"config": "^3.3.6",
 		"mailosaur": "^7.3.1",
-		"playwright": "^1.18",
+		"playwright": "1.19",
 		"totp-generator": "^0.0.12"
 	},
 	"devDependencies": {

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -21,7 +21,7 @@
 		"@types/totp-generator": "^0.0.3",
 		"config": "^3.3.6",
 		"mailosaur": "^7.3.1",
-		"playwright": "1.19",
+		"playwright": "^1.19.2",
 		"totp-generator": "^0.0.12"
 	},
 	"devDependencies": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -62,7 +62,7 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"mocha-teamcity-reporter": "^3.0.0",
 		"node-fetch": "^2.6.1",
-		"playwright": "^1.18",
+		"playwright": "1.19",
 		"png-itxt": "^1.3.0",
 		"push-receiver": "^2.0.0",
 		"react": "^17.0.2",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -62,7 +62,7 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"mocha-teamcity-reporter": "^3.0.0",
 		"node-fetch": "^2.6.1",
-		"playwright": "1.19",
+		"playwright": "^1.19.2",
 		"png-itxt": "^1.3.0",
 		"push-receiver": "^2.0.0",
 		"react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34360,7 +34360,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"stack-utils@npm:2.0.5":
+"stack-utils@npm:2.0.5, stack-utils@npm:^2.0.2, stack-utils@npm:^2.0.3":
   version: 2.0.5
   resolution: "stack-utils@npm:2.0.5"
   dependencies:
@@ -34373,15 +34373,6 @@ resolve@^2.0.0-next.3:
   version: 1.0.2
   resolution: "stack-utils@npm:1.0.2"
   checksum: 41b714acbb8d887ef7801010adf430a60db64e03e37953652ecbd17d5e67d59854691816baa7ad3bf8f1bb1863b8af083762fd1a560da68ee9151e81b122f77e
-  languageName: node
-  linkType: hard
-
-"stack-utils@npm:^2.0.2, stack-utils@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "stack-utils@npm:2.0.3"
-  dependencies:
-    escape-string-regexp: ^2.0.0
-  checksum: b5391171b11024c7a092bbdb818b1784cd77ec9b91ed17fa2cc5f2391457db4aa2186567df097ae1579f75abcdd929bc6f72df57a20d19db4d20f07d9d98bb46
   languageName: node
   linkType: hard
 
@@ -38605,7 +38596,7 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"ws@npm:8.4.2":
+"ws@npm:8.4.2, ws@npm:^8.1.0, ws@npm:^8.2.3":
   version: 8.4.2
   resolution: "ws@npm:8.4.2"
   peerDependencies:
@@ -38671,21 +38662,6 @@ testarmada-magellan@11.0.10:
     utf-8-validate:
       optional: true
   checksum: ca1674eb90923c1b67a7df99709119c38b39b20db7595255dc146fae6f0cdf513311714a314a30819cf6bbe06bb31378bb4722d0a3025c161ef556281077e5ec
-  languageName: node
-  linkType: hard
-
-"ws@npm:^8.1.0, ws@npm:^8.2.3":
-  version: 8.3.0
-  resolution: "ws@npm:8.3.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 3e9d2faf128435f0b8ab272d731d8460c6c23d126503a920f14f81f9ae4a213624bfc2ca79e891b87ae84fe45b187754048df93b46c3ce55f8501528790380ee
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,7 +237,7 @@ __metadata:
     config: ^3.3.6
     mailosaur: ^7.3.1
     node-fetch: ^2.6.6
-    playwright: 1.19
+    playwright: ^1.19.2
     totp-generator: ^0.0.12
     typescript: ^4.5.5
   languageName: unknown
@@ -10302,7 +10302,7 @@ __metadata:
     keytar: ^7.7.0
     lodash: ^4.17.21
     make-dir: ^3.1.0
-    playwright: 1.19
+    playwright: ^1.19.2
     postcss: ^8.4.5
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -28708,7 +28708,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"playwright@npm:1.19":
+"playwright@npm:^1.19.2":
   version: 1.19.2
   resolution: "playwright@npm:1.19.2"
   dependencies:
@@ -38395,7 +38395,7 @@ testarmada-magellan@11.0.10:
     mocha-multi-reporters: ^1.5.1
     mocha-teamcity-reporter: ^3.0.0
     node-fetch: ^2.6.1
-    playwright: 1.19
+    playwright: ^1.19.2
     png-itxt: ^1.3.0
     postcss: ^8.3.11
     push-receiver: ^2.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,7 +237,7 @@ __metadata:
     config: ^3.3.6
     mailosaur: ^7.3.1
     node-fetch: ^2.6.6
-    playwright: ^1.18
+    playwright: 1.19
     totp-generator: ^0.0.12
     typescript: ^4.5.5
   languageName: unknown
@@ -10302,7 +10302,7 @@ __metadata:
     keytar: ^7.7.0
     lodash: ^4.17.21
     make-dir: ^3.1.0
-    playwright: ^1.18
+    playwright: 1.19
     postcss: ^8.4.5
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -13999,6 +13999,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:8.3.0":
+  version: 8.3.0
+  resolution: "commander@npm:8.3.0"
+  checksum: 8b043bb8322ea1c39664a1598a95e0495bfe4ca2fad0d84a92d7d1d8d213e2a155b441d2470c8e08de7c4a28cf2bc6e169211c49e1b21d9f7edc6ae4d9356060
+  languageName: node
+  linkType: hard
+
 "commander@npm:^2.15.1, commander@npm:^2.19.0, commander@npm:^2.20.0, commander@npm:^2.9.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
@@ -14038,13 +14045,6 @@ __metadata:
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
   checksum: 8d690ff13b0356df7e0ebbe6c59b4712f754f4b724d4f473d3cc5b3fdcf978e3a5dc3078717858a2ceb50b0f84d0660a7f22a96cdc50fb877d0c9bb31593d23a
-  languageName: node
-  linkType: hard
-
-"commander@npm:^8.2.0":
-  version: 8.3.0
-  resolution: "commander@npm:8.3.0"
-  checksum: 8b043bb8322ea1c39664a1598a95e0495bfe4ca2fad0d84a92d7d1d8d213e2a155b441d2470c8e08de7c4a28cf2bc6e169211c49e1b21d9f7edc6ae4d9356060
   languageName: node
   linkType: hard
 
@@ -15482,7 +15482,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3":
+"debug@npm:4, debug@npm:4.3.3, debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3":
   version: 4.3.3
   resolution: "debug@npm:4.3.3"
   dependencies:
@@ -23628,7 +23628,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"jpeg-js@npm:^0.4.2":
+"jpeg-js@npm:0.4.3":
   version: 0.4.3
   resolution: "jpeg-js@npm:0.4.3"
   checksum: f1d6f38e5250e80f0ff9020f09f216f1493d4bd1ce091fff1ae361fcdab199df5df03a6d81a418964074b572b8f6ecfad3cf4ea807e5aa96477c092b3d247a12
@@ -26146,6 +26146,15 @@ fsevents@~2.1.2:
   bin:
     mime: cli.js
   checksum: b92cd0adc44888c7135a185bfd0dddc42c32606401c72896a842ae15da71eb88858f17669af41e498b463cd7eb998f7b48939a25b08374c7924a9c8a6f8a81b0
+  languageName: node
+  linkType: hard
+
+"mime@npm:3.0.0":
+  version: 3.0.0
+  resolution: "mime@npm:3.0.0"
+  bin:
+    mime: cli.js
+  checksum: 402e792a8df1b2cc41cb77f0dcc46472b7944b7ec29cb5bbcd398624b6b97096728f1239766d3fdeb20551dd8d94738344c195a6ea10c4f906eb0356323b0531
   languageName: node
   linkType: hard
 
@@ -28673,40 +28682,40 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:=1.18.1":
-  version: 1.18.1
-  resolution: "playwright-core@npm:1.18.1"
+"playwright-core@npm:1.19.2":
+  version: 1.19.2
+  resolution: "playwright-core@npm:1.19.2"
   dependencies:
-    commander: ^8.2.0
-    debug: ^4.1.1
-    extract-zip: ^2.0.1
-    https-proxy-agent: ^5.0.0
-    jpeg-js: ^0.4.2
-    mime: ^2.4.6
-    pngjs: ^5.0.0
-    progress: ^2.0.3
-    proper-lockfile: ^4.1.1
-    proxy-from-env: ^1.1.0
-    rimraf: ^3.0.2
-    socks-proxy-agent: ^6.1.0
-    stack-utils: ^2.0.3
-    ws: ^7.4.6
-    yauzl: ^2.10.0
-    yazl: ^2.5.1
+    commander: 8.3.0
+    debug: 4.3.3
+    extract-zip: 2.0.1
+    https-proxy-agent: 5.0.0
+    jpeg-js: 0.4.3
+    mime: 3.0.0
+    pngjs: 6.0.0
+    progress: 2.0.3
+    proper-lockfile: 4.1.2
+    proxy-from-env: 1.1.0
+    rimraf: 3.0.2
+    socks-proxy-agent: 6.1.1
+    stack-utils: 2.0.5
+    ws: 8.4.2
+    yauzl: 2.10.0
+    yazl: 2.5.1
   bin:
     playwright: cli.js
-  checksum: e64581928d9a42dce66f623b3af8ff8774ab2b09518756eb72449b3c5988cbe7336e898926b0bf3a56c8f317e4419f7aaa2ca3d826e9b705e8912738ffb3d9c0
+  checksum: ba2f402cd538a4b89b1ff084c32a21994eed4c5efff68017f3f79838a74e65e70d3cc53ba8a08c963ffd3f493d4818c0b7c7c1717b513892df53dafb56b2d6d1
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.18":
-  version: 1.18.1
-  resolution: "playwright@npm:1.18.1"
+"playwright@npm:1.19":
+  version: 1.19.2
+  resolution: "playwright@npm:1.19.2"
   dependencies:
-    playwright-core: =1.18.1
+    playwright-core: 1.19.2
   bin:
     playwright: cli.js
-  checksum: 5a24f4b10abe6f1f1262d6e5fa269cc18a8254e192787995b9d6ea8e19e8d92c9d5cdea92839022fcf2c41c5727f89a88ea84c168a9fea8ef074e2d14e18e1d5
+  checksum: 16262c6955be5542215393ca25b5fdedad0a4943a9f1a1ed2ce560ba1404b7783e53517dea33716a8943283d5a48795f925b59a91de86877b1382f8fce7c916d
   languageName: node
   linkType: hard
 
@@ -28777,17 +28786,17 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"pngjs@npm:6.0.0":
+  version: 6.0.0
+  resolution: "pngjs@npm:6.0.0"
+  checksum: ac23ea329b1881d1a10575aff58116dc27b894ec3f5b84ba15c7f527d21e609fbce7ba16d48f8ccb86c7ce45ceed622472765476ab2875949d4bec55e153f87a
+  languageName: node
+  linkType: hard
+
 "pngjs@npm:^3.0.0, pngjs@npm:^3.3.3":
   version: 3.4.0
   resolution: "pngjs@npm:3.4.0"
   checksum: 88ee73e2ad3f736e0b2573722309eb80bd2aa28916f0862379b4fd0f904751b4f61bb6bd1ecd7d4242d331f2b5c28c13309dd4b7d89a9b78306e35122fdc5011
-  languageName: node
-  linkType: hard
-
-"pngjs@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "pngjs@npm:5.0.0"
-  checksum: c074d8a94fb75e2defa8021e85356bf7849688af7d8ce9995b7394d57cd1a777b272cfb7c4bce08b8d10e71e708e7717c81fd553a413f21840c548ec9d4893c6
   languageName: node
   linkType: hard
 
@@ -29734,7 +29743,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"progress@npm:^2.0.0, progress@npm:^2.0.1, progress@npm:^2.0.3":
+"progress@npm:2.0.3, progress@npm:^2.0.0, progress@npm:^2.0.1, progress@npm:^2.0.3":
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
   checksum: 1697e07cb1068055dbe9fe858d242368ff5d2073639e652b75a7eb1f2a1a8d4afd404d719de23c7b48481a6aa0040686310e2dac2f53d776daa2176d3f96369c
@@ -29846,7 +29855,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"proper-lockfile@npm:^4.1.1":
+"proper-lockfile@npm:4.1.2":
   version: 4.1.2
   resolution: "proper-lockfile@npm:4.1.2"
   dependencies:
@@ -34008,6 +34017,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"socks-proxy-agent@npm:6.1.1":
+  version: 6.1.1
+  resolution: "socks-proxy-agent@npm:6.1.1"
+  dependencies:
+    agent-base: ^6.0.2
+    debug: ^4.3.1
+    socks: ^2.6.1
+  checksum: 4d2ff6af0a4c49aa0f5aa3847468a75667795bc72c8271f85ee4c0a121f13f610674da43a6cbe77275e51596022f59da744d58f57d722dafbd1f54208cfa427d
+  languageName: node
+  linkType: hard
+
 "socks-proxy-agent@npm:^5.0.0":
   version: 5.0.0
   resolution: "socks-proxy-agent@npm:5.0.0"
@@ -34016,17 +34036,6 @@ resolve@^2.0.0-next.3:
     debug: 4
     socks: ^2.3.3
   checksum: 2cf4c67b124bc298673b4c5f83ebdfb48e647841c4b3bfd0d1a1201388aaae02a57fc0f8c58e64b83eb5fd7426cef7544d4482b9f9b7674ca7fe6f85db2a935c
-  languageName: node
-  linkType: hard
-
-"socks-proxy-agent@npm:^6.1.0":
-  version: 6.1.1
-  resolution: "socks-proxy-agent@npm:6.1.1"
-  dependencies:
-    agent-base: ^6.0.2
-    debug: ^4.3.1
-    socks: ^2.6.1
-  checksum: 4d2ff6af0a4c49aa0f5aa3847468a75667795bc72c8271f85ee4c0a121f13f610674da43a6cbe77275e51596022f59da744d58f57d722dafbd1f54208cfa427d
   languageName: node
   linkType: hard
 
@@ -34348,6 +34357,15 @@ resolve@^2.0.0-next.3:
   version: 0.0.10
   resolution: "stack-trace@npm:0.0.10"
   checksum: 9ff3dabfad4049b635a85456f927a075c9d0c210e3ea336412d18220b2a86cbb9b13ec46d6c37b70a302a4ea4d49e30e5d4944dd60ae784073f1cde778ac8f4b
+  languageName: node
+  linkType: hard
+
+"stack-utils@npm:2.0.5":
+  version: 2.0.5
+  resolution: "stack-utils@npm:2.0.5"
+  dependencies:
+    escape-string-regexp: ^2.0.0
+  checksum: 059f828eed5b03b963e8200529c27bd92b105f2cac9dffc9edcbc739ea8fa108e4ec45d0da257d8e0f7b5ac98db5643a0787e5c25ceab1396f7123e1ee15a086
   languageName: node
   linkType: hard
 
@@ -38386,7 +38404,7 @@ testarmada-magellan@11.0.10:
     mocha-multi-reporters: ^1.5.1
     mocha-teamcity-reporter: ^3.0.0
     node-fetch: ^2.6.1
-    playwright: ^1.18
+    playwright: 1.19
     png-itxt: ^1.3.0
     postcss: ^8.3.11
     push-receiver: ^2.0.0
@@ -38587,6 +38605,21 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
+"ws@npm:8.4.2":
+  version: 8.4.2
+  resolution: "ws@npm:8.4.2"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 6ce80cc740f00103611918147ca486938b1f9080216b8c251e8f07378d23eecf187255ed857cdf673c0757e0f1999a91dd4bcbcc18e0073bb7b1f86033eafd8d
+  languageName: node
+  linkType: hard
+
 "ws@npm:^1.1.0, ws@npm:^1.1.5":
   version: 1.1.5
   resolution: "ws@npm:1.1.5"
@@ -38626,7 +38659,7 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"ws@npm:^7, ws@npm:^7.2.3, ws@npm:^7.3.1, ws@npm:^7.4.5, ws@npm:^7.4.6":
+"ws@npm:^7, ws@npm:^7.2.3, ws@npm:^7.3.1, ws@npm:^7.4.5":
   version: 7.5.5
   resolution: "ws@npm:7.5.5"
   peerDependencies:
@@ -39118,7 +39151,7 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"yauzl@npm:^2.10.0":
+"yauzl@npm:2.10.0, yauzl@npm:^2.10.0":
   version: 2.10.0
   resolution: "yauzl@npm:2.10.0"
   dependencies:
@@ -39128,7 +39161,7 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
-"yazl@npm:^2.5.1":
+"yazl@npm:2.5.1":
   version: 2.5.1
   resolution: "yazl@npm:2.5.1"
   dependencies:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR keeps our version of Playwright up to date with latest release, 1.19.2.

#### Testing instructions

Ensure the following:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [ ] i18n E2E
  - [x] Desktop E2E
  - [x] Unit tests