### PR TITLE
Update Cart Line Item Design

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker.tsx
@@ -101,7 +101,7 @@ function ProductVariant( {
 
 const TermOptions = styled.ul`
 	flex-basis: 100%;
-	margin: 12px 0 0;
+	margin: 20px 0 0;
 	padding: 0;
 `;
 

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -7,7 +7,6 @@ import {
 	isGSuiteOrExtraLicenseProductSlug,
 	isTitanMail,
 	isP2Plus,
-	isJetpackSearch,
 	isJetpackProductSlug,
 } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
@@ -17,11 +16,6 @@ import type { ResponseCartProduct } from '@automattic/shopping-cart';
 export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 	const isRenewalItem = isRenewal( serverCartItem );
 	const { meta, product_name: productName, product_slug: productSlug } = serverCartItem;
-
-	// Jetpack Search has its own special sublabel
-	if ( ! isRenewalItem && isJetpackSearch( serverCartItem ) ) {
-		return '';
-	}
 
 	if ( isDotComPlan( serverCartItem ) ) {
 		if ( isRenewalItem ) {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -546,12 +546,7 @@ function returnModalCopy(
 }
 
 function JetpackSearchMeta( { product }: { product: ResponseCartProduct } ): JSX.Element {
-	return (
-		<>
-			<ProductTier product={ product } />
-			<RenewalFrequency product={ product } />
-		</>
-	);
+	return <ProductTier product={ product } />;
 }
 
 function ProductTier( { product }: { product: ResponseCartProduct } ): JSX.Element | null {
@@ -574,22 +569,6 @@ function ProductTier( { product }: { product: ResponseCartProduct } ): JSX.Eleme
 				</LineItemMeta>
 			);
 		}
-	}
-	return null;
-}
-
-function RenewalFrequency( { product }: { product: ResponseCartProduct } ): JSX.Element | null {
-	const translate = useTranslate();
-	if ( isMonthlyProduct( product ) ) {
-		return <LineItemMeta>{ translate( 'Renews monthly' ) }</LineItemMeta>;
-	}
-
-	if ( isYearly( product ) ) {
-		return <LineItemMeta>{ translate( 'Renews annually' ) }</LineItemMeta>;
-	}
-
-	if ( isBiennially( product ) ) {
-		return <LineItemMeta>{ translate( 'Renews every two years' ) }</LineItemMeta>;
 	}
 	return null;
 }

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -103,18 +103,24 @@ const LineItemMeta = styled.div< { theme?: Theme } >`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 	font-size: 14px;
 	width: 100%;
+	display: flex;
+	flex-direction: row;
+	align-content: center;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	> {
+		margin: 2px 0;
+	}
 `;
 
 const DiscountCallout = styled.div< { theme?: Theme } >`
 	color: ${ ( props ) => props.theme.colors.success };
 	display: block;
-	margin: 2px 0;
 `;
 
 const NotApplicableCallout = styled.div< { theme?: Theme } >`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 	display: block;
-	margin: 2px 0;
 	font-size: 12px;
 `;
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -108,9 +108,7 @@ const LineItemMeta = styled.div< { theme?: Theme } >`
 	align-content: center;
 	justify-content: space-between;
 	flex-wrap: wrap;
-	> {
-		margin: 2px 0;
-	}
+	gap: 2px 10px;
 `;
 
 const DiscountCallout = styled.div< { theme?: Theme } >`
@@ -121,7 +119,6 @@ const DiscountCallout = styled.div< { theme?: Theme } >`
 const NotApplicableCallout = styled.div< { theme?: Theme } >`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 	display: block;
-	font-size: 12px;
 `;
 
 const LineItemTitle = styled.div< { theme?: Theme; isSummary?: boolean } >`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Increase top margin for between variant picker and line
* Allow special meta info to collapse to single lines
 - This prevents the UI from increasing in height for most common cases
* Remove special ( but redundant ) Jetpack Search meta info

##### Before/After

| What  | Before | After |
| ----- | ------ | ----- |
| Item Info Collapsing | <img width="565" alt="Screen Shot 2022-03-07 at 13 09 42" src="https://user-images.githubusercontent.com/2810519/157118648-bedb3203-f36a-40d8-a1bc-8b45df7092e6.png"> | <img width="568" alt="Screen Shot 2022-03-07 at 13 09 51" src="https://user-images.githubusercontent.com/2810519/157118675-e957c959-320e-4ee6-9fc4-98f271f33283.png"> |
| Jetpack Search Extra | <img width="568" alt="Screen Shot 2022-03-07 at 13 09 10" src="https://user-images.githubusercontent.com/2810519/157118706-a603e362-e67b-4f54-8fbb-3f91934fd6c3.png"> | <img width="564" alt="Screen Shot 2022-03-07 at 13 08 45" src="https://user-images.githubusercontent.com/2810519/157118736-60b36b0f-23a2-4ddb-93aa-dc744892a8a3.png"> |

##### Height stable across the monthly and yearly variant selection
 https://user-images.githubusercontent.com/2810519/157117508-922ae51b-e773-4dc4-a0ba-e592ed8f0e41.mov

#### Testing instructions

1. Boot branch on Calypso Blue or use Calypso Live link
2. Add a Jetpack product eligible for an intro offer ( i.e. a yearly product that has not yet been purchased for a site, or with a "siteless" cart )
3. Verify that the "Plan Subscription" and "Discount for first year" lines only take up one line with desktop widths, and break into two lines at narrow widths
4. Repeat for Jetpack Search, verifying that only the extra line "Up to X records" appears
