### PR TITLE
Add pre-purchase notices for Jetpack Anti-Spam and Scan

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -1,8 +1,12 @@
 import {
 	getProductFromSlug,
+	isJetpackAntiSpam,
+	isJetpackAntiSpamSlug,
 	isJetpackBackup,
 	isJetpackBackupSlug,
 	isJetpackPlanSlug,
+	isJetpackScan,
+	isJetpackScanSlug,
 } from '@automattic/calypso-products';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useEffect } from 'react';
@@ -13,6 +17,10 @@ import { requestRewindCapabilities } from 'calypso/state/rewind/capabilities/act
 import {
 	isPlanIncludingSiteBackup,
 	isBackupProductIncludedInSitePlan,
+	isPlanIncludingSiteAntiSpam,
+	isAntiSpamProductIncludedInSitePlan,
+	isPlanIncludingSiteScan,
+	isScanProductIncludedInSitePlan,
 } from 'calypso/state/sites/products/conflicts';
 import {
 	getSitePlan,
@@ -41,6 +49,9 @@ const PrePurchaseNotices = () => {
 	const { responseCart } = useShoppingCart( cartKey );
 	const cartItemSlugs = responseCart.products.map( ( item ) => item.product_slug );
 
+	/**
+	 * Ensure site rewind capabilities are loaded, for use by isPlanIncludingSiteBackup().
+	 */
 	useEffect( () => {
 		if ( ! siteId ) return;
 		dispatch( requestRewindCapabilities( siteId ) );
@@ -53,6 +64,7 @@ const PrePurchaseNotices = () => {
 
 		return getSitePlan( state, siteId );
 	} );
+
 	const currentSiteProducts = useSelector( ( state ) => {
 		if ( ! siteId ) {
 			return null;
@@ -62,18 +74,57 @@ const PrePurchaseNotices = () => {
 		return products.filter( ( p ) => ! p.expired );
 	} );
 
-	const backupSlugInCart = cartItemSlugs.find( isJetpackBackupSlug );
-
-	const cartPlanOverlapsSiteBackupPurchase = useSelector( ( state ) => {
+	/**
+	 * The active product on the current site that overlaps/conflicts with the plan currently in the cart.
+	 */
+	const siteProductThatOverlapsCartPlan = useSelector( ( state ) => {
 		const planSlugInCart = cartItemSlugs.find( isJetpackPlanSlug );
 
-		return planSlugInCart && isPlanIncludingSiteBackup( state, siteId, planSlugInCart );
+		if ( ! planSlugInCart ) return null;
+
+		if ( isPlanIncludingSiteBackup( state, siteId, planSlugInCart ) ) {
+			return currentSiteProducts.find( isJetpackBackup );
+		}
+
+		if ( isPlanIncludingSiteAntiSpam( state, siteId, planSlugInCart ) ) {
+			return currentSiteProducts.find( isJetpackAntiSpam );
+		}
+
+		if ( isPlanIncludingSiteScan( state, siteId, planSlugInCart ) ) {
+			return currentSiteProducts.find( isJetpackScan );
+		}
+
+		return null;
 	} );
 
-	const sitePlanIncludesCartBackupProduct = useSelector(
-		( state ) =>
-			backupSlugInCart && isBackupProductIncludedInSitePlan( state, siteId, backupSlugInCart )
-	);
+	/**
+	 * The product currently in the cart that overlaps/conflicts with the current active site plan.
+	 */
+	const cartProductThatOverlapsSitePlan = useSelector( ( state ) => {
+		const backupSlugInCart = cartItemSlugs.find( isJetpackBackupSlug );
+		const antiSpamSlugInCart = cartItemSlugs.find( isJetpackAntiSpamSlug );
+		const scanSlugInCart = cartItemSlugs.find( isJetpackScanSlug );
+
+		if (
+			backupSlugInCart &&
+			isBackupProductIncludedInSitePlan( state, siteId, backupSlugInCart )
+		) {
+			return getProductFromSlug( backupSlugInCart );
+		}
+
+		if (
+			antiSpamSlugInCart &&
+			isAntiSpamProductIncludedInSitePlan( state, siteId, antiSpamSlugInCart )
+		) {
+			return getProductFromSlug( antiSpamSlugInCart );
+		}
+
+		if ( scanSlugInCart && isScanProductIncludedInSitePlan( state, siteId, scanSlugInCart ) ) {
+			return getProductFromSlug( scanSlugInCart );
+		}
+
+		return null;
+	} );
 
 	const BACKUP_MINIMUM_JETPACK_VERSION = '8.5';
 	const siteHasBackupMinimumPluginVersion = useSelector( ( state ) => {
@@ -99,38 +150,36 @@ const PrePurchaseNotices = () => {
 		return null;
 	}
 
-	// This site has an active Jetpack Backup product purchase,
-	// but we're attempting to buy a plan that includes one as well
-	const siteBackupProduct = currentSiteProducts.find( isJetpackBackup );
-	if ( cartPlanOverlapsSiteBackupPurchase && siteBackupProduct ) {
+	// This site has an active Jetpack product purchase, but we're
+	// attempting to buy a plan that includes the same one as well.
+	// i.e. User owns a Jetpack Backup product, and is attempting
+	// to purchase Jetpack Security.
+	if ( siteProductThatOverlapsCartPlan ) {
 		return (
 			<CartPlanOverlapsOwnedProductNotice
-				product={ siteBackupProduct }
+				product={ siteProductThatOverlapsCartPlan }
 				selectedSite={ selectedSite }
 			/>
 		);
 	}
-
-	// Notices after this point require a Backup product to be in the cart
-	if ( ! backupSlugInCart ) {
-		return null;
-	}
-
-	const backupProductInCart = getProductFromSlug( backupSlugInCart );
 
 	// We're attempting to buy Jetpack Backup individually,
 	// but this site already has a plan that includes it
-	if ( sitePlanIncludesCartBackupProduct && currentSitePlan ) {
+	if ( currentSitePlan && cartProductThatOverlapsSitePlan ) {
 		return (
 			<SitePlanIncludesCartProductNotice
 				plan={ currentSitePlan }
-				product={ backupProductInCart }
+				product={ cartProductThatOverlapsSitePlan }
 				selectedSite={ selectedSite }
 			/>
 		);
 	}
 
-	if ( ! siteHasBackupMinimumPluginVersion ) {
+	// We're attempting to buy a Jetpack Backup product,
+	// but this site does not have the minimum plugin version.
+	const backupSlugInCart = cartItemSlugs.find( isJetpackBackupSlug );
+	const backupProductInCart = getProductFromSlug( backupSlugInCart );
+	if ( ! siteHasBackupMinimumPluginVersion && backupProductInCart ) {
 		return (
 			<JetpackPluginRequiredVersionNotice
 				product={ backupProductInCart }

--- a/client/state/sites/products/conflicts.ts
+++ b/client/state/sites/products/conflicts.ts
@@ -1,15 +1,23 @@
 import {
-	planHasAtLeastOneFeature,
-	planHasSuperiorFeature,
-	JETPACK_PLANS,
-	FEATURE_JETPACK_BACKUP_REALTIME,
+	FEATURE_JETPACK_ANTI_SPAM,
+	FEATURE_JETPACK_ANTI_SPAM_MONTHLY,
 	FEATURE_JETPACK_BACKUP_DAILY,
 	FEATURE_JETPACK_BACKUP_DAILY_MONTHLY,
+	FEATURE_JETPACK_BACKUP_REALTIME,
 	FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY,
 	FEATURE_JETPACK_BACKUP_T1_MONTHLY,
 	FEATURE_JETPACK_BACKUP_T1_YEARLY,
 	FEATURE_JETPACK_BACKUP_T2_MONTHLY,
 	FEATURE_JETPACK_BACKUP_T2_YEARLY,
+	FEATURE_JETPACK_SCAN_DAILY,
+	FEATURE_JETPACK_SCAN_DAILY_MONTHLY,
+	isJetpackAntiSpam,
+	isJetpackScan,
+	JETPACK_PLANS,
+	JETPACK_ANTI_SPAM_PRODUCTS,
+	JETPACK_SCAN_PRODUCTS,
+	planHasAtLeastOneFeature,
+	planHasSuperiorFeature,
 	PRODUCT_JETPACK_BACKUP_DAILY,
 	PRODUCT_JETPACK_BACKUP_REALTIME,
 	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
@@ -21,7 +29,7 @@ import {
 } from '@automattic/calypso-products';
 import { createSelector } from '@automattic/state-utils';
 import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
-import { getSitePlanSlug } from 'calypso/state/sites/selectors';
+import { getSiteProducts, getSitePlanSlug } from 'calypso/state/sites/selectors';
 import type { AppState } from 'calypso/types';
 
 const DAILY_BACKUP_FEATURES = [
@@ -52,6 +60,10 @@ const REALTIME_BACKUP_PRODUCTS = [
 	PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
 ];
 
+const ANTI_SPAM_FEATURES = [ FEATURE_JETPACK_ANTI_SPAM, FEATURE_JETPACK_ANTI_SPAM_MONTHLY ];
+
+const SCAN_FEATURES = [ FEATURE_JETPACK_SCAN_DAILY, FEATURE_JETPACK_SCAN_DAILY_MONTHLY ];
+
 /**
  * Check is a Jetpack plan is including a daily backup feature.
  *
@@ -78,6 +90,38 @@ export const planHasDailyBackup = ( planSlug: string, orSuperior = false ): bool
 export const planHasRealTimeBackup = ( planSlug: string, orSuperior = false ): boolean => {
 	const hasFeature = planHasAtLeastOneFeature( planSlug, REALTIME_BACKUP_FEATURES );
 	const hasSuperiorFeature = REALTIME_BACKUP_FEATURES.some( ( feature ) =>
+		planHasSuperiorFeature( planSlug, feature )
+	);
+
+	return orSuperior ? hasFeature || hasSuperiorFeature : hasFeature;
+};
+
+/**
+ * Check is a Jetpack plan is including an anti-spam feature.
+ *
+ * @param {string} planSlug The plan slug.
+ * @param {boolean} orSuperior When true, also checks plan for superior features.
+ * @returns {boolean} True if the plan includes an anti-spam feature.
+ */
+export const planHasAntiSpam = ( planSlug: string, orSuperior = false ): boolean => {
+	const hasFeature = planHasAtLeastOneFeature( planSlug, ANTI_SPAM_FEATURES );
+	const hasSuperiorFeature = ANTI_SPAM_FEATURES.some( ( feature ) =>
+		planHasSuperiorFeature( planSlug, feature )
+	);
+
+	return orSuperior ? hasFeature || hasSuperiorFeature : hasFeature;
+};
+
+/**
+ * Check is a Jetpack plan is including a scan feature.
+ *
+ * @param {string} planSlug The plan slug.
+ * @param {boolean} orSuperior When true, also checks plan for superior features.
+ * @returns {boolean} True if the plan includes a scan feature.
+ */
+export const planHasScan = ( planSlug: string, orSuperior = false ): boolean => {
+	const hasFeature = planHasAtLeastOneFeature( planSlug, SCAN_FEATURES );
+	const hasSuperiorFeature = SCAN_FEATURES.some( ( feature ) =>
 		planHasSuperiorFeature( planSlug, feature )
 	);
 
@@ -155,6 +199,150 @@ export const isBackupProductIncludedInSitePlan = createSelector(
 
 		if ( REALTIME_BACKUP_PRODUCTS.includes( productSlug ) ) {
 			return planHasRealTimeBackup( sitePlanSlug, true );
+		}
+
+		return null;
+	},
+	[
+		( state: AppState, siteId: number | null, productSlug: string ) => [
+			siteId,
+			productSlug,
+			getSitePlanSlug( state, siteId ),
+		],
+	]
+);
+
+/**
+ * Check if a Jetpack plan is including an Anti-Spam product a site might already have.
+ *
+ * @param {AppState} state The redux state.
+ * @param {number} siteId The site ID.
+ * @param {string} planSlug The plan slug.
+ * @returns {boolean|null} True if the plan includes the Anti-Spam product, or null when it's unable to be determined.
+ */
+export const isPlanIncludingSiteAntiSpam = createSelector(
+	( state: AppState, siteId: number | null, planSlug: string ): boolean | null => {
+		if ( ! siteId || ! ( JETPACK_PLANS as ReadonlyArray< string > ).includes( planSlug ) ) {
+			return null;
+		}
+
+		const products = getSiteProducts( state, siteId ) || [];
+		const siteProducts = products.filter( ( p ) => ! p.expired );
+
+		const sitePlanSlug = getSitePlanSlug( state, siteId );
+		const siteHasAntiSpam = Boolean(
+			( sitePlanSlug && planHasAntiSpam( sitePlanSlug ) ) || siteProducts.find( isJetpackAntiSpam )
+		);
+
+		return siteHasAntiSpam && planHasAntiSpam( planSlug );
+	},
+	[
+		( state: AppState, siteId: number | null, planSlug: string ) => [
+			siteId,
+			planSlug,
+			getSitePlanSlug( state, siteId ),
+			getSiteProducts( state, siteId ),
+		],
+	]
+);
+
+/**
+ * Check if an Anti-Spam product is already included in a site plan.
+ *
+ * @param {AppState} state The redux state.
+ * @param {number} siteId The site ID.
+ * @param {string} productSlug The product slug.
+ * @returns {boolean|null} True if the product is already included in a plan, or null when it's unable to be determined.
+ */
+export const isAntiSpamProductIncludedInSitePlan = createSelector(
+	( state: AppState, siteId: number | null, productSlug: string ): boolean | null => {
+		if ( ! siteId ) {
+			return null;
+		}
+
+		const sitePlanSlug = getSitePlanSlug( state, siteId );
+
+		if (
+			! sitePlanSlug ||
+			! ( JETPACK_PLANS as ReadonlyArray< string > ).includes( sitePlanSlug )
+		) {
+			return null;
+		}
+
+		if ( ( JETPACK_ANTI_SPAM_PRODUCTS as ReadonlyArray< string > ).includes( productSlug ) ) {
+			return planHasAntiSpam( sitePlanSlug, true );
+		}
+
+		return null;
+	},
+	[
+		( state: AppState, siteId: number | null, productSlug: string ) => [
+			siteId,
+			productSlug,
+			getSitePlanSlug( state, siteId ),
+		],
+	]
+);
+
+/**
+ * Check if a Jetpack plan is including a Scan product a site might already have.
+ *
+ * @param {AppState} state The redux state.
+ * @param {number} siteId The site ID.
+ * @param {string} planSlug The plan slug.
+ * @returns {boolean|null} True if the plan includes the Scan product, or null when it's unable to be determined.
+ */
+export const isPlanIncludingSiteScan = createSelector(
+	( state: AppState, siteId: number | null, planSlug: string ): boolean | null => {
+		if ( ! siteId || ! ( JETPACK_PLANS as ReadonlyArray< string > ).includes( planSlug ) ) {
+			return null;
+		}
+
+		const products = getSiteProducts( state, siteId ) || [];
+		const siteProducts = products.filter( ( p ) => ! p.expired );
+
+		const sitePlanSlug = getSitePlanSlug( state, siteId );
+		const siteHasScan = Boolean(
+			( !! sitePlanSlug && planHasScan( sitePlanSlug ) ) || siteProducts.find( isJetpackScan )
+		);
+
+		return siteHasScan && planHasScan( planSlug );
+	},
+	[
+		( state: AppState, siteId: number | null, planSlug: string ) => [
+			siteId,
+			planSlug,
+			getSitePlanSlug( state, siteId ),
+			getSiteProducts( state, siteId ),
+		],
+	]
+);
+
+/**
+ * Check if a Scan product is already included in a site plan.
+ *
+ * @param {AppState} state The redux state.
+ * @param {number} siteId The site ID.
+ * @param {string} productSlug The product slug.
+ * @returns {boolean|null} True if the product is already included in a plan, or null when it's unable to be determined.
+ */
+export const isScanProductIncludedInSitePlan = createSelector(
+	( state: AppState, siteId: number | null, productSlug: string ): boolean | null => {
+		if ( ! siteId ) {
+			return null;
+		}
+
+		const sitePlanSlug = getSitePlanSlug( state, siteId );
+
+		if (
+			! sitePlanSlug ||
+			! ( JETPACK_PLANS as ReadonlyArray< string > ).includes( sitePlanSlug )
+		) {
+			return null;
+		}
+
+		if ( ( JETPACK_SCAN_PRODUCTS as ReadonlyArray< string > ).includes( productSlug ) ) {
+			return planHasScan( sitePlanSlug, true );
 		}
 
 		return null;

--- a/client/state/sites/products/test/conflicts.ts
+++ b/client/state/sites/products/test/conflicts.ts
@@ -16,7 +16,12 @@ import {
 	PLAN_JETPACK_SECURITY_T2_MONTHLY,
 	PLAN_JETPACK_SECURITY_T2_YEARLY,
 } from '@automattic/calypso-products';
-import { planHasDailyBackup, planHasRealTimeBackup } from '../conflicts';
+import {
+	planHasAntiSpam,
+	planHasDailyBackup,
+	planHasRealTimeBackup,
+	planHasScan,
+} from '../conflicts';
 
 const plansWithDailyBackup = [
 	PLAN_JETPACK_PERSONAL,
@@ -40,6 +45,46 @@ const plansWithRealTimeBackup = [
 	PLAN_JETPACK_SECURITY_T2_YEARLY,
 ];
 
+const plansWithAntiSpam = [
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_YEARLY,
+	PLAN_JETPACK_SECURITY_T2_MONTHLY,
+	PLAN_JETPACK_SECURITY_T2_YEARLY,
+	PLAN_JETPACK_SECURITY_DAILY,
+	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+];
+
+const plansWithScan = [
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_YEARLY,
+	PLAN_JETPACK_SECURITY_T2_MONTHLY,
+	PLAN_JETPACK_SECURITY_T2_YEARLY,
+	PLAN_JETPACK_SECURITY_DAILY,
+	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+];
+
 describe( 'conflicts', () => {
 	test( 'Plans and products that have daily backups return true for plansWithDailyBackup', () => {
 		plansWithDailyBackup.forEach( ( plan ) => {
@@ -50,6 +95,18 @@ describe( 'conflicts', () => {
 	test( 'Plans and products that have real-time backups return true for plansWithRealTimeBackup', () => {
 		plansWithRealTimeBackup.forEach( ( plan ) => {
 			expect( planHasRealTimeBackup( plan ) ).toBe( true );
+		} );
+	} );
+
+	test( 'Plans and products that have anti-spam return true for plansWithAntiSpam', () => {
+		plansWithAntiSpam.forEach( ( plan ) => {
+			expect( planHasAntiSpam( plan ) ).toBe( true );
+		} );
+	} );
+
+	test( 'Plans and products that have scan return true for plansWithScan', () => {
+		plansWithScan.forEach( ( plan ) => {
+			expect( planHasScan( plan ) ).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds support for pre-purchase notices surrounding anti-spam and scan overlaps. 
  * If a user already has Jetpack Anti-Spam/Scan, and attempts to purchase another plan that includes Anti-Spam/Scan, they will be shown a notice.
  * If a user already has a plan with anti-spam/scan, and attempts to directly purchase a Jetpack Anti-Spam/Scan, they will be shown a notice.
* This is achieved by implementing the same logic as the backup-related pre-purchase notices, except with anti-spam and scan product and feature slugs.
* Combines product-specific pre-purchase notice checks into `siteProductThatOverlapsCartPlan` and `cartProductThatOverlapsSitePlan`, allowing a single render case for each of these variables instead of checking against and rendering a unique output for each potential pre-purchase notice.
* Adds a few additional comments for clarity.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a WordPress site with Jetpack.
* Purchase Jetpack Anti-Spam.
* Add a plan that also includes anti-spam to the cart, such as Jetpack Security.
* Verify the notice is displayed:

<img width="585" alt="Screen Shot 2022-03-03 at 4 33 50 PM" src="https://user-images.githubusercontent.com/10933065/156671106-259236a4-4656-4e0e-b3a3-45cc3fa06ccb.png">

* Remove your Anti-Spam product.
* Purchase a plan that includes Anti-Spam, such as Jetpack Security.
* Add Jetpack Anti-Spam to the cart.
  (You can force this by opening http://calypso.localhost:3000/checkout/[YOUR_SITE]/jetpack_anti_spam)
* Verify the notice is displayed:

<img width="586" alt="Screen Shot 2022-03-03 at 4 35 23 PM" src="https://user-images.githubusercontent.com/10933065/156671123-9f313247-2eb1-4b10-87cc-2608ed58ce21.png">

* Remove all purchased plans/products
* Purchase Jetpack Scan.
* Add a plan that also includes scan to the cart, such as Jetpack Security.
* Verify the notice is displayed:

<img width="585" alt="Screen Shot 2022-03-04 at 11 04 15 AM" src="https://user-images.githubusercontent.com/10933065/156817670-e937b3b4-1b56-4ef8-9467-710111d35b27.png">

* Remove your Scan product.
* Purchase a plan that includes Scan, such as Jetpack Security.
* Add Jetpack Scan to the cart.
  (You can force this by opening [http://calypso.localhost:3000/checkout/[YOUR_SITE]/jetpack_scan](http://calypso.localhost:3000/checkout/%5BYOUR_SITE%5D/jetpack_anti_scan))
* Verify the notice is displayed:

<img width="585" alt="Screen Shot 2022-03-04 at 10 52 10 AM" src="https://user-images.githubusercontent.com/10933065/156817661-8993bc26-35dd-46da-ac91-75abd11914e2.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #61577
