### PR TITLE
Seller Experience: Fix bug returning from Woo seller flow back to simple 

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -532,10 +532,12 @@ class Signup extends Component {
 		const nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
 
 		if ( nextFlowName !== this.props.flowName ) {
-			this.setState( { previousFlowName: this.props.flowName } );
+			this.setState( { previousFlowName: this.props.flowName }, () => {
+				this.goToStep( nextStepName, nextStepSection, nextFlowName );
+			} );
+		} else {
+			this.goToStep( nextStepName, nextStepSection, nextFlowName );
 		}
-
-		this.goToStep( nextStepName, nextStepSection, nextFlowName );
 	};
 
 	goToFirstInvalidStep = ( progress = this.props.progress ) => {

--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -18,7 +18,7 @@ import type { Dependencies } from 'calypso/signup/types';
 import './index.scss';
 
 interface Props {
-	goToNextStep: () => void;
+	goToNextStep: ( nextFlow?: string ) => void;
 	isReskinned: boolean;
 	signupDependencies: any;
 	stepName: string;
@@ -60,7 +60,17 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 			store_feature: storeType,
 		} );
 		dispatch( submitSignupStep( { stepName }, providedDependencies ) );
-		goToNextStep();
+
+		if ( 'simple' === storeType ) {
+			goToNextStep();
+		} else {
+			/**
+			 * When moving to the WooCommerce flow, we need to explicitly set the next step name.
+			 * This ensures that the currentFlow and previousFlow are set properly in the store
+			 * which is necessary for the "Back" button to work.
+			 */
+			goToNextStep( 'woocommerce-install' );
+		}
 	};
 
 	const sitePlanSlug = useSelector( ( state ) => getSite( state, siteSlug )?.plan?.product_slug );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes the issue where a user is unable to continue with the "Start simple" path after clicking through on the "More power" store setup option.

@sixhours figured out that `goToNextStep` takes an optional argument of the next
flow name. If this argument isn't provided, it defaults to the current flow name.

We now explicitly pass `woocommerce-install` to `goToNextStep`. This lets the signup process know that we've moved between flows so it keeps the state properly and the Back button will work.

#### Testing instructions

1. Create a new site via `wordpress.com/start`.
2. Choose the "Sell" intent.
3. Select the "More power" option.
4. Click "Back" (the nav button, not the browser back-button), then chose the "Start simple" option.
5. You should continue through the simple flow.

Fixes #61436
