### PR TITLE
Fix grammar in backup messaging date and time

### DIFF
--- a/client/components/jetpack/daily-backup-status/use-get-display-date.js
+++ b/client/components/jetpack/daily-backup-status/use-get-display-date.js
@@ -35,7 +35,7 @@ export default function useGetDisplayDate() {
 
 		if ( withLatest ) {
 			return isToday
-				? translate( 'Latest: Today %s', {
+				? translate( 'Latest: Today, %s', {
 						args: [ formattedDateTime ],
 						comment: '',
 				  } )
@@ -46,7 +46,7 @@ export default function useGetDisplayDate() {
 		}
 
 		return isToday
-			? translate( 'Today %s', {
+			? translate( 'Today, %s', {
 					args: [ formattedDateTime ],
 					comment: '',
 			  } )


### PR DESCRIPTION
Addresses pbtFFM-17s-p2#comment-2365 and 1201868942120840-as-1201927633828839/f

#### Changes proposed in this Pull Request

* Add a comma between "Today" and the backup time to make it consistent with other dates.

#### Testing instructions

* Spin up a JN site and setup Jetpack Backup
* Boot up this PR
* Goto Calypso Green - `http://jetpack.cloud.localhost:3001/backup/:site`
* If the backup is not in progress, please queue one from Rewind Debugger
* Confirm that there is a comma after "today" in the backup-in-progress card label
* Let the backup finish and confirm that there is a comma after "today" in backup-just-completed card
* Confirm the same in Calypso Blue


<img width="735" alt="Screenshot 2022-03-08 at 11 04 19 AM" src="https://user-images.githubusercontent.com/18226415/157177668-2d73d3db-ba2a-49f1-97a6-7a874a55a960.png">
<img width="733" alt="Screenshot 2022-03-08 at 11 11 56 AM" src="https://user-images.githubusercontent.com/18226415/157177686-b1856d4e-6c8b-4246-a4c9-ddcfa23387d9.png">
