### PR TITLE
Refactor account email handling into dedicated component

### DIFF
--- a/client/me/account/account-email-field.tsx
+++ b/client/me/account/account-email-field.tsx
@@ -154,7 +154,7 @@ const AccountEmailPendingEmailChangeNotice = ( {
 	);
 };
 
-const AccountEmailFragment = ( {
+const AccountEmailField = ( {
 	emailInputId = 'user_email',
 	emailInputName = 'user_email',
 	emailValidationHandler,
@@ -170,6 +170,13 @@ const AccountEmailFragment = ( {
 	const [ emailInvalidReason, setEmailInvalidReason ] = useState< AccountEmailValidationReason >(
 		EMAIL_VALIDATION_REASON_IS_VALID
 	);
+
+	useEffect( () => {
+		// Ensure that we remove any unsaved changes to the email address when we unmount
+		return (): void => {
+			dispatch( removeUnsavedUserSetting( 'user_email' ) );
+		};
+	}, [ dispatch ] );
 
 	const emailAddress = getUserSetting( {
 		settingName: isEmailChangePending ? 'new_user_email' : 'user_email',
@@ -193,13 +200,6 @@ const AccountEmailFragment = ( {
 
 		dispatch( setUserSetting( 'user_email', value ) );
 	};
-
-	useEffect( () => {
-		// Ensure that we remove any unsaved changes to the email address when we unmount
-		return (): void => {
-			dispatch( removeUnsavedUserSetting( 'user_email' ) );
-		};
-	}, [ dispatch ] );
 
 	return (
 		<>
@@ -235,4 +235,4 @@ const AccountEmailFragment = ( {
 	);
 };
 
-export default AccountEmailFragment;
+export default AccountEmailField;

--- a/client/me/account/account-email-fragment.tsx
+++ b/client/me/account/account-email-fragment.tsx
@@ -30,8 +30,8 @@ export type AccountEmailFragmentProps = {
 	emailInputId?: string;
 	emailInputName?: string;
 	emailValidationHandler?: ( isEmailValid: boolean ) => void;
-	getFocusHandler?: ( focusName: string ) => () => void;
 	isEmailControlDisabled?: boolean;
+	onFocus?: () => void;
 	unsavedUserSettings?: UserSettingsType;
 	userSettings?: UserSettingsType;
 };
@@ -55,12 +55,6 @@ const getUserSetting = ( {
 	userSettings: UserSettingsType;
 } ) => {
 	return unsavedUserSettings?.[ settingName ] ?? userSettings?.[ settingName ] ?? '';
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const noopFocusHandler = ( focusName: string ) => {
-	// eslint-disable-next-line @typescript-eslint/no-empty-function
-	return () => {};
 };
 
 const AccountEmailValidationNotice = ( {
@@ -164,8 +158,8 @@ const AccountEmailFragment = ( {
 	emailInputId = 'user_email',
 	emailInputName = 'user_email',
 	emailValidationHandler,
-	getFocusHandler = noopFocusHandler,
 	isEmailControlDisabled = false,
+	onFocus,
 	unsavedUserSettings = {},
 	userSettings = {},
 }: AccountEmailFragmentProps ): JSX.Element => {
@@ -180,7 +174,7 @@ const AccountEmailFragment = ( {
 	const emailAddress = getUserSetting( {
 		settingName: isEmailChangePending ? 'new_user_email' : 'user_email',
 		unsavedUserSettings,
-		userSettings
+		userSettings,
 	} );
 
 	const onEmailAddressChange = ( event: ChangeEvent< HTMLInputElement > ): void => {
@@ -217,7 +211,7 @@ const AccountEmailFragment = ( {
 					id={ emailInputId }
 					name={ emailInputName }
 					isError={ emailInvalidReason !== EMAIL_VALIDATION_REASON_IS_VALID }
-					onFocus={ getFocusHandler( 'Email Address Field' ) }
+					onFocus={ onFocus }
 					value={ emailAddress }
 					onChange={ onEmailAddressChange }
 				/>

--- a/client/me/account/account-email-fragment.tsx
+++ b/client/me/account/account-email-fragment.tsx
@@ -1,0 +1,242 @@
+import emailValidator from 'email-validator';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import QueryAllDomains from 'calypso/components/data/query-all-domains';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import { type as domainTypes } from 'calypso/lib/domains/constants';
+import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
+import isRequestingAllDomains from 'calypso/state/selectors/is-requesting-all-domains';
+import { getFlatDomainsList } from 'calypso/state/sites/domains/selectors';
+import {
+	cancelPendingEmailChange,
+	removeUnsavedUserSetting,
+	setUserSetting,
+} from 'calypso/state/user-settings/actions';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { ChangeEvent } from 'react';
+
+export type UserSettingValue = boolean | number | string;
+
+export type UserSettingsType = Record< string, UserSettingValue >;
+
+export type AccountEmailFragmentProps = {
+	emailInputId?: string;
+	emailInputName?: string;
+	emailValidationHandler?: ( isEmailValid: boolean ) => void;
+	getFocusHandler?: ( focusName: string ) => () => void;
+	isEmailControlDisabled?: boolean;
+	unsavedUserSettings?: UserSettingsType;
+	userSettings?: UserSettingsType;
+};
+
+const EMAIL_VALIDATION_REASON_EMPTY = 'empty';
+const EMAIL_VALIDATION_REASON_INVALID = 'invalid';
+const EMAIL_VALIDATION_REASON_IS_VALID = null;
+
+type AccountEmailValidationReason =
+	| typeof EMAIL_VALIDATION_REASON_EMPTY
+	| typeof EMAIL_VALIDATION_REASON_INVALID
+	| typeof EMAIL_VALIDATION_REASON_IS_VALID;
+
+const getUserSetting = ( {
+	settingName,
+	unsavedUserSettings,
+	userSettings,
+}: {
+	settingName: string;
+	unsavedUserSettings: UserSettingsType;
+	userSettings: UserSettingsType;
+} ) => {
+	return unsavedUserSettings?.[ settingName ] ?? userSettings?.[ settingName ] ?? '';
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const noopFocusHandler = ( focusName: string ) => {
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	return () => {};
+};
+
+const AccountEmailValidationNotice = ( {
+	emailInvalidReason,
+	unsavedUserSettings,
+	userSettings,
+}: {
+	emailInvalidReason: AccountEmailValidationReason;
+	unsavedUserSettings: UserSettingsType;
+	userSettings: UserSettingsType;
+} ): JSX.Element | null => {
+	const translate = useTranslate();
+
+	if ( unsavedUserSettings?.user_email === null || unsavedUserSettings?.user_email === undefined ) {
+		return null;
+	}
+
+	if ( emailInvalidReason === EMAIL_VALIDATION_REASON_IS_VALID ) {
+		return null;
+	}
+
+	let noticeText;
+
+	if ( emailInvalidReason === EMAIL_VALIDATION_REASON_EMPTY ) {
+		noticeText = translate( 'Email address can not be empty.' );
+	} else if ( emailInvalidReason === EMAIL_VALIDATION_REASON_INVALID ) {
+		noticeText = translate( '%(email)s is not a valid email address.', {
+			args: {
+				email: getUserSetting( {
+					settingName: 'user_email',
+					unsavedUserSettings,
+					userSettings,
+				} ),
+			},
+		} );
+	}
+
+	return <FormInputValidation isError={ true } text={ noticeText } />;
+};
+
+const AccountEmailPendingEmailChangeNotice = ( {
+	unsavedUserSettings,
+	userSettings,
+}: {
+	unsavedUserSettings: UserSettingsType;
+	userSettings: UserSettingsType;
+} ): JSX.Element | null => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const domainsList: ResponseDomain[] = useSelector( getFlatDomainsList );
+	const isRequestingDomainList = useSelector( isRequestingAllDomains );
+	const isEmailChangePending = useSelector( isPendingEmailChange );
+
+	if ( ! isEmailChangePending ) {
+		return null;
+	}
+
+	const editContactInfoInBulkUrl = `/domains/manage?site=all&action=edit-contact-email`;
+	const email = getUserSetting( {
+		settingName: 'new_user_email',
+		unsavedUserSettings,
+		userSettings,
+	} );
+
+	const hasCustomDomainRegistration = domainsList.some( ( domain ) => {
+		return domainTypes.REGISTERED === domain.type;
+	} );
+
+	const noticeText =
+		isRequestingDomainList || ! hasCustomDomainRegistration
+			? translate(
+					'Your email change is pending. Please take a moment to check %(email)s for an email with the subject "[WordPress.com] New Email Address" to confirm your change.',
+					{
+						args: { email },
+					}
+			  )
+			: translate(
+					'Your email change is pending. Please take a moment to:{{br/}}1. Check %(email)s for an email with the subject "[WordPress.com] New Email Address" to confirm your change.{{br/}}2. Update contact information on your domain names if necessary {{link}}here{{/link}}.',
+					{
+						args: {
+							email,
+						},
+						components: {
+							br: <br />,
+							link: <a href={ editContactInfoInBulkUrl } />,
+						},
+					}
+			  );
+
+	return (
+		<Notice showDismiss={ false } status="is-info" text={ noticeText }>
+			<NoticeAction onClick={ () => dispatch( cancelPendingEmailChange() ) }>
+				{ translate( 'Cancel' ) }
+			</NoticeAction>
+		</Notice>
+	);
+};
+
+const AccountEmailFragment = ( {
+	emailInputId = 'user_email',
+	emailInputName = 'user_email',
+	emailValidationHandler,
+	getFocusHandler = noopFocusHandler,
+	isEmailControlDisabled = false,
+	unsavedUserSettings = {},
+	userSettings = {},
+}: AccountEmailFragmentProps ): JSX.Element => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const isEmailChangePending = useSelector( isPendingEmailChange );
+
+	const [ emailInvalidReason, setEmailInvalidReason ] = useState< AccountEmailValidationReason >(
+		EMAIL_VALIDATION_REASON_IS_VALID
+	);
+
+	const emailAddress = isEmailChangePending
+		? getUserSetting( { settingName: 'new_user_email', unsavedUserSettings, userSettings } )
+		: getUserSetting( { settingName: 'user_email', unsavedUserSettings, userSettings } );
+
+	const onEmailAddressChange = ( event: ChangeEvent< HTMLInputElement > ): void => {
+		const { value } = event.target;
+
+		let emailValidationReason: AccountEmailValidationReason = EMAIL_VALIDATION_REASON_IS_VALID;
+
+		if ( value === '' ) {
+			emailValidationReason = EMAIL_VALIDATION_REASON_EMPTY;
+		} else if ( ! emailValidator.validate( value ) ) {
+			emailValidationReason = EMAIL_VALIDATION_REASON_INVALID;
+		}
+
+		setEmailInvalidReason( emailValidationReason );
+		emailValidationHandler?.( emailValidationReason === EMAIL_VALIDATION_REASON_IS_VALID );
+
+		dispatch( setUserSetting( 'user_email', value ) );
+	};
+
+	useEffect( () => {
+		// Ensure that we remove any unsaved changes to the email address when we unmount
+		return (): void => {
+			dispatch( removeUnsavedUserSetting( 'user_email' ) );
+		};
+	}, [ dispatch ] );
+
+	return (
+		<>
+			<QueryAllDomains />
+			<FormFieldset>
+				<FormLabel htmlFor={ emailInputId }>{ translate( 'Email address' ) }</FormLabel>
+				<FormTextInput
+					disabled={ isEmailControlDisabled || isEmailChangePending }
+					id={ emailInputId }
+					name={ emailInputName }
+					isError={ emailInvalidReason !== EMAIL_VALIDATION_REASON_IS_VALID }
+					onFocus={ getFocusHandler( 'Email Address Field' ) }
+					value={ emailAddress }
+					onChange={ onEmailAddressChange }
+				/>
+
+				<AccountEmailValidationNotice
+					emailInvalidReason={ emailInvalidReason }
+					unsavedUserSettings={ unsavedUserSettings }
+					userSettings={ userSettings }
+				/>
+
+				<FormSettingExplanation>
+					{ translate( 'Will not be publicly displayed' ) }
+				</FormSettingExplanation>
+
+				<AccountEmailPendingEmailChangeNotice
+					unsavedUserSettings={ unsavedUserSettings }
+					userSettings={ userSettings }
+				/>
+			</FormFieldset>
+		</>
+	);
+};
+
+export default AccountEmailFragment;

--- a/client/me/account/account-email-fragment.tsx
+++ b/client/me/account/account-email-fragment.tsx
@@ -177,9 +177,11 @@ const AccountEmailFragment = ( {
 		EMAIL_VALIDATION_REASON_IS_VALID
 	);
 
-	const emailAddress = isEmailChangePending
-		? getUserSetting( { settingName: 'new_user_email', unsavedUserSettings, userSettings } )
-		: getUserSetting( { settingName: 'user_email', unsavedUserSettings, userSettings } );
+	const emailAddress = getUserSetting( {
+		settingName: isEmailChangePending ? 'new_user_email' : 'user_email',
+		unsavedUserSettings,
+		userSettings
+	} );
 
 	const onEmailAddressChange = ( event: ChangeEvent< HTMLInputElement > ): void => {
 		const { value } = event.target;

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -671,8 +671,8 @@ class Account extends Component {
 					emailValidationHandler={ ( isEmailValid ) =>
 						this.setState( { emailValidationError: ! isEmailValid } )
 					}
-					getFocusHandler={ ( focusName ) => this.getFocusHandler( focusName ) }
 					isEmailControlDisabled={ this.getDisabledState( ACCOUNT_FORM_NAME ) }
+					onFocus={ this.getFocusHandler( 'Email Address Field' ) }
 					unsavedUserSettings={ this.props.unsavedUserSettings }
 					userSettings={ this.props.userSettings }
 				/>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -36,7 +36,7 @@ import { protectForm } from 'calypso/lib/protect-form';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import { clearStore } from 'calypso/lib/user/store';
 import wpcom from 'calypso/lib/wp';
-import AccountEmailFragment from 'calypso/me/account/account-email-fragment';
+import AccountEmailField from 'calypso/me/account/account-email-field';
 import ReauthRequired from 'calypso/me/reauth-required';
 import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import { recordGoogleEvent, recordTracksEvent, bumpStat } from 'calypso/state/analytics/actions';
@@ -665,7 +665,7 @@ class Account extends Component {
 
 		return (
 			<div className="account__settings-form" key="settingsForm">
-				<AccountEmailFragment
+				<AccountEmailField
 					emailInputId="user_email"
 					emailInputName="user_email"
 					emailValidationHandler={ ( isEmailValid ) =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR extracts the form fields and logic for updating a user's account email address into a dedicated component. This is the first step in allowing this field to be updated from a dedicated page under `/me/security`, as part of a broader effort to have `/me/security` function as a security checklist.

It is worth noting that the goal of this refactor is not to introduce any new or changed behaviour.

#### Testing instructions

* Run this branch locally or via the Calypso live branch
* Navigate to `/me/account`
* Modify the "Email address" field so you have an invalid email address
* Verify that you see an error message below the input field about the email address being invalid
* Verify that the "Save account settings" button is disabled
* Update the "Email address" field so it is a valid email address again (which should be different from the initial email address)
* Verify that the error message is removed
* Verify that the "Save account settings" button is enabled
* Click on the "Save account settings" button
* Verify that the save operation succeeds, and that you see a "Your email change is pending." notice below the "Email address" field. If you have any domains for your account, the notice should include a link to updating your contact information. If the link for updating contact information is visible, open it in a new tab/window, and verify that it takes you to a screen where you can bulk edit contact information.
* Verify that you receive an email trying to confirm the email address change. Don't click on any links in the email for now.
* Click on the "Cancel" option at the right end of the notice.
* Verify that the email change operation is cancelled and the form is displayed with your original email address and the "Save account settings" button disabled
* Modify the "Email address" field so it is empty
* Verify that you get a "Email address can not be empty" error for the email address
* Verify that the "Save account settings" button is disabled
* Update the "Email address" field so it is a valid email address  that is different from the initial email address
* Verify that the error message is removed and the "Save account settings" button is enabled
* Modify the "Email address" field to match the original email address
* Verify that the "Save account settings" button is disabled