### PR TITLE
Add managed signup flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -50,6 +50,14 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
+			name: 'managed',
+			steps: [ 'user', 'domains', 'plans-managed' ],
+			destination: getSignupDestination,
+			description: 'Create an account and a blog and then add the managed plan to the users cart.',
+			lastModified: '2022-03-08',
+			showRecaptcha: true,
+		},
+		{
 			name: 'free',
 			steps: [ 'user', 'domains' ],
 			destination: getSignupDestination,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -25,6 +25,7 @@ const stepNameToModuleName = {
 	'plans-new': 'plans',
 	'plans-business': 'plans',
 	'plans-ecommerce': 'plans',
+	'plans-managed': 'plans',
 	'plans-import': 'plans',
 	'plans-launch': 'plans',
 	'plans-personal': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -8,6 +8,7 @@ import {
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_ECOMMERCE_MONTHLY,
+	PLAN_WPCOM_MANAGED,
 	TYPE_FREE,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
@@ -276,6 +277,17 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 			defaultDependencies: {
 				cartItem: PLAN_BUSINESS,
+			},
+		},
+
+		'plans-managed': {
+			stepName: 'plans-managed',
+			apiRequestFunction: addPlanToCart,
+			fulfilledStepCallback: isPlanFulfilled,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+			defaultDependencies: {
+				cartItem: PLAN_WPCOM_MANAGED,
 			},
 		},
 

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -199,6 +199,7 @@
 		"business-monthly",
 		"ecommerce",
 		"ecommerce-monthly",
+		"managed",
 		"domain"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There's a link on /pricing that leads to the Business signup flow. There were two options to resolve this - to add another flow or to point the link to the default signup flow. Proposing that we add a new signup flow.

#### Testing instructions

1. With a new user, go to /start/managed and proceed
2. You should be able to see the checkout with Managed added

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
