### PR TITLE
Marketplace plugin install: skip eligibility check for Atomic sites

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -74,7 +74,7 @@ const PluginDetailsCTA = ( {
 		isEligibleForAutomatedTransfer( state, selectedSite?.ID )
 	);
 	const hasEligibilityMessages =
-		! isJetpack && ( eligibilityHolds || eligibilityWarnings || isEligible );
+		! isAtomic && ! isJetpack && ( eligibilityHolds || eligibilityWarnings || isEligible );
 
 	if ( isPlaceholder ) {
 		return <PluginDetailsCTAPlaceholder />;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Don't show eligibility warnings if the site already has the `is_automated_transfer` option. This check previously relied solely on the `jetpack` property, which gets set a while later than the automated transfer finishes:
![image](https://user-images.githubusercontent.com/11555574/157263145-c519ee2a-8e92-4d9a-9b5e-e93e45d157a2.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate or create a Simple site. Make sure it is not a Jetpack site.
- Upgrade the plan to a Business site and _quickly_ 
- Purchase a plugin.
  ⚠️ Please note that the time between upgrading the plan and purchasing a plugin is crucial here as, during that short period, the site is considered non-Jetpack site.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #58923
