### PR TITLE
Seller Experience: Add context to Woo landing page translations

### DIFF
--- a/client/my-sites/customer-home/translations/woo-upsell-banner.js
+++ b/client/my-sites/customer-home/translations/woo-upsell-banner.js
@@ -5,7 +5,12 @@ translate(
 	'Upgrade to our premium plan to gain access to all the tools you need to run an online ecommerce store, from marketing to shipping.'
 );
 
-translate( 'Upgrade your store' );
+translate( 'Upgrade your store', {
+	context: 'Header text',
+} );
+translate( 'Upgrade your store', {
+	context: 'Button text',
+} );
 translate(
 	'Need more out of your store? Unlock the tools needed to manage products, orders, shipping, and more.'
 );

--- a/client/my-sites/woocommerce/landing-page.tsx
+++ b/client/my-sites/woocommerce/landing-page.tsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useRef } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
+import { sprintf, _x } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import page from 'page';
@@ -134,21 +134,21 @@ const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 
 	if ( simpleSeller ) {
 		displayData = {
-			title: __( 'Upgrade your store' ),
+			title: _x( 'Upgrade your store', 'Header text' ),
 			illustration: '/calypso/images/illustrations/illustration-seller.svg',
 			line: __(
 				'Need more out of your store? Unlock the tools needed to manage products, orders, shipping, and more.'
 			),
-			action: __( 'Upgrade your store' ),
+			action: _x( 'Upgrade your store', 'Button text' ),
 		};
 	} else {
 		displayData = {
-			title: __( 'Set up a store and start selling online' ),
+			title: _x( 'Set up a store and start selling online', 'Header text' ),
 			illustration: '/calypso/images/illustrations/illustration-shopping-bags.svg',
 			line: __(
 				'Set up a new store in minutes. Get secure payments, configurable shipping options, and more, out of the box.'
 			),
-			action: __( 'Start a new store' ),
+			action: _x( 'Start a new store', 'Button text' ),
 		};
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Per https://github.com/Automattic/wp-calypso/pull/61700#issuecomment-1061857285, added context to one of our translation strings.

![image](https://user-images.githubusercontent.com/917632/157268063-ca565d21-0dea-4f52-aad0-297788b0dd82.png)
