### PR TITLE
Licensing Portal: Remove primary payment methods confirmation modal

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks.ts
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.ts
@@ -1,8 +1,9 @@
 import { getQueryArg } from '@wordpress/url';
 import page from 'page';
 import { useEffect } from 'react';
+import { useQuery } from 'react-query';
 import { ensurePartnerPortalReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
-
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 /**
  * Redirect to the partner portal or a present "return" GET parameter given a certain condition.
  *
@@ -18,4 +19,17 @@ export function useReturnUrl( redirect: boolean ): void {
 			page.redirect( returnUrl );
 		}
 	}, [ redirect ] );
+}
+
+/**
+ * Returns the recent payment methods from the Jetpack Stripe account.
+ *
+ */
+export function useRecentPaymentMethodsQuery() {
+	return useQuery( [ 'jetpack-cloud', 'partner-portal', 'recent-cards' ], () =>
+		wpcomJpl.req.get( {
+			apiNamespace: 'wpcom/v2',
+			path: '/jetpack-licensing/stripe/payment-methods',
+		} )
+	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/hooks.ts
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.ts
@@ -1,7 +1,7 @@
 import { getQueryArg } from '@wordpress/url';
 import page from 'page';
 import { useEffect } from 'react';
-import { useQuery } from 'react-query';
+import { useQuery, UseQueryOptions } from 'react-query';
 import { ensurePartnerPortalReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 /**
@@ -25,11 +25,16 @@ export function useReturnUrl( redirect: boolean ): void {
  * Returns the recent payment methods from the Jetpack Stripe account.
  *
  */
-export function useRecentPaymentMethodsQuery() {
-	return useQuery( [ 'jetpack-cloud', 'partner-portal', 'recent-cards' ], () =>
-		wpcomJpl.req.get( {
-			apiNamespace: 'wpcom/v2',
-			path: '/jetpack-licensing/stripe/payment-methods',
-		} )
+export function useRecentPaymentMethodsQuery( { enabled = true }: UseQueryOptions = {} ) {
+	return useQuery(
+		[ 'jetpack-cloud', 'partner-portal', 'recent-cards' ],
+		() =>
+			wpcomJpl.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: '/jetpack-licensing/stripe/payment-methods',
+			} ),
+		{
+			enabled: enabled,
+		}
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { useRecentPaymentMethodsQuery } from 'calypso/jetpack-cloud/sections/partner-portal//hooks';
 import PaymentMethodDeleteDialog from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -24,11 +25,11 @@ const PaymentMethodActions: FunctionComponent< Props > = ( { card } ) => {
 	const [ isDeleteDialogVisible, setIsDeleteDialogVisible ] = useState( false );
 	const closeDialog = useCallback( () => setIsDeleteDialogVisible( false ), [] );
 
-	// Defines the next primary payment method shown in the confirmation UI.
-	const [
-		nextPrimaryPaymentMethod,
-		setNextPrimaryPaymentMethod,
-	] = useState< PaymentMethod | null >( null );
+	const { data: recentCards } = useRecentPaymentMethodsQuery();
+
+	const nextPrimaryPaymentMethod = ( recentCards?.items || [] ).find(
+		( currCard: PaymentMethod ) => currCard.id !== card.id
+	);
 
 	const handleDelete = useCallback( () => {
 		closeDialog();
@@ -58,7 +59,6 @@ const PaymentMethodActions: FunctionComponent< Props > = ( { card } ) => {
 				isVisible={ isDeleteDialogVisible }
 				onClose={ closeDialog }
 				onConfirm={ handleDelete }
-				setNextPrimaryPaymentMethod={ setNextPrimaryPaymentMethod }
 			/>
 
 			<EllipsisMenu

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
@@ -24,9 +24,15 @@ const PaymentMethodActions: FunctionComponent< Props > = ( { card } ) => {
 	const [ isDeleteDialogVisible, setIsDeleteDialogVisible ] = useState( false );
 	const closeDialog = useCallback( () => setIsDeleteDialogVisible( false ), [] );
 
+	// Defines the next primary payment method shown in the confirmation UI.
+	const [
+		nextPrimaryPaymentMethod,
+		setNextPrimaryPaymentMethod,
+	] = useState< PaymentMethod | null >( null );
+
 	const handleDelete = useCallback( () => {
 		closeDialog();
-		reduxDispatch( deleteStoredCard( card ) )
+		reduxDispatch( deleteStoredCard( card, nextPrimaryPaymentMethod?.id ) )
 			.then( () => {
 				reduxDispatch( successNotice( translate( 'Payment method deleted successfully' ) ) );
 
@@ -35,7 +41,7 @@ const PaymentMethodActions: FunctionComponent< Props > = ( { card } ) => {
 			.catch( ( error: Error ) => {
 				reduxDispatch( errorNotice( error.message ) );
 			} );
-	}, [ closeDialog, card, translate, reduxDispatch ] );
+	}, [ closeDialog, card, translate, reduxDispatch, nextPrimaryPaymentMethod ] );
 
 	const renderActions = () => {
 		return [
@@ -52,6 +58,7 @@ const PaymentMethodActions: FunctionComponent< Props > = ( { card } ) => {
 				isVisible={ isDeleteDialogVisible }
 				onClose={ closeDialog }
 				onConfirm={ handleDelete }
+				setNextPrimaryPaymentMethod={ setNextPrimaryPaymentMethod }
 			/>
 
 			<EllipsisMenu

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import { useRecentPaymentMethodsQuery } from 'calypso/jetpack-cloud/sections/partner-portal//hooks';
+import { useRecentPaymentMethodsQuery } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import PaymentMethodDeleteDialog from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -33,7 +33,7 @@ const PaymentMethodActions: FunctionComponent< Props > = ( { card } ) => {
 
 	const handleDelete = useCallback( () => {
 		closeDialog();
-		reduxDispatch( deleteStoredCard( card, nextPrimaryPaymentMethod?.id ) )
+		reduxDispatch( deleteStoredCard( card, nextPrimaryPaymentMethod.id ) )
 			.then( () => {
 				reduxDispatch( successNotice( translate( 'Payment method deleted successfully' ) ) );
 
@@ -42,7 +42,7 @@ const PaymentMethodActions: FunctionComponent< Props > = ( { card } ) => {
 			.catch( ( error: Error ) => {
 				reduxDispatch( errorNotice( error.message ) );
 			} );
-	}, [ closeDialog, card, translate, reduxDispatch, nextPrimaryPaymentMethod ] );
+	}, [ closeDialog, card, translate, reduxDispatch, nextPrimaryPaymentMethod?.id ] );
 
 	const renderActions = () => {
 		return [

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/index.tsx
@@ -1,9 +1,9 @@
 import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
 import PaymentMethodDeletePrimaryConfirmation from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation';
 import { getPaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
+import type { Dispatch, FunctionComponent, SetStateAction } from 'react';
 
 import './style.scss';
 
@@ -12,6 +12,7 @@ interface Props {
 	isVisible: boolean;
 	onClose: () => void;
 	onConfirm: () => void;
+	setNextPrimaryPaymentMethod: Dispatch< SetStateAction< PaymentMethod | null > >;
 }
 
 const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
@@ -19,6 +20,7 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 	isVisible,
 	onClose,
 	onConfirm,
+	setNextPrimaryPaymentMethod,
 } ) => {
 	const translate = useTranslate();
 
@@ -58,7 +60,10 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 			</p>
 
 			{ paymentMethod.is_default && (
-				<PaymentMethodDeletePrimaryConfirmation paymentMethod={ paymentMethod } />
+				<PaymentMethodDeletePrimaryConfirmation
+					paymentMethod={ paymentMethod }
+					setNextPrimaryPaymentMethod={ setNextPrimaryPaymentMethod }
+				/>
 			) }
 		</Dialog>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/index.tsx
@@ -1,9 +1,10 @@
 import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useRecentPaymentMethodsQuery } from 'calypso/jetpack-cloud/sections/partner-portal//hooks';
 import PaymentMethodDeletePrimaryConfirmation from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation';
 import { getPaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
-import type { Dispatch, FunctionComponent, SetStateAction } from 'react';
+import type { FunctionComponent } from 'react';
 
 import './style.scss';
 
@@ -12,7 +13,6 @@ interface Props {
 	isVisible: boolean;
 	onClose: () => void;
 	onConfirm: () => void;
-	setNextPrimaryPaymentMethod: Dispatch< SetStateAction< PaymentMethod | null > >;
 }
 
 const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
@@ -20,7 +20,6 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 	isVisible,
 	onClose,
 	onConfirm,
-	setNextPrimaryPaymentMethod,
 } ) => {
 	const translate = useTranslate();
 
@@ -29,6 +28,8 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 		type: paymentMethod?.card.brand,
 		digits: paymentMethod?.card.last4,
 	} );
+
+	const { isFetching: isFetchingRecentPaymentMethods } = useRecentPaymentMethodsQuery();
 
 	return (
 		<Dialog
@@ -40,7 +41,7 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 					{ translate( 'Go back' ) }
 				</Button>,
 
-				<Button onClick={ onConfirm } primary scary>
+				<Button disabled={ isFetchingRecentPaymentMethods } onClick={ onConfirm } primary scary>
 					{ translate( 'Delete payment method' ) }
 				</Button>,
 			] }
@@ -60,10 +61,7 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 			</p>
 
 			{ paymentMethod.is_default && (
-				<PaymentMethodDeletePrimaryConfirmation
-					paymentMethod={ paymentMethod }
-					setNextPrimaryPaymentMethod={ setNextPrimaryPaymentMethod }
-				/>
+				<PaymentMethodDeletePrimaryConfirmation paymentMethod={ paymentMethod } />
 			) }
 		</Dialog>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useRecentPaymentMethodsQuery } from 'calypso/jetpack-cloud/sections/partner-portal//hooks';
+import { useRecentPaymentMethodsQuery } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import PaymentMethodDeletePrimaryConfirmation from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation';
 import { getPaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
@@ -29,7 +29,9 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 		digits: paymentMethod?.card.last4,
 	} );
 
-	const { isFetching: isFetchingRecentPaymentMethods } = useRecentPaymentMethodsQuery();
+	const { isFetching: isFetchingRecentPaymentMethods } = useRecentPaymentMethodsQuery( {
+		enabled: paymentMethod.is_default,
+	} );
 
 	return (
 		<Dialog

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/index.tsx
@@ -1,8 +1,9 @@
 import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import PaymentMethodDeletePrimaryConfirmation from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation';
 import { getPaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
-import type { FunctionComponent } from 'react';
 
 import './style.scss';
 
@@ -55,6 +56,10 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 					}
 				) }
 			</p>
+
+			{ paymentMethod.is_default && (
+				<PaymentMethodDeletePrimaryConfirmation paymentMethod={ paymentMethod } />
+			) }
 		</Dialog>
 	);
 };

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/index.tsx
@@ -33,9 +33,6 @@ const PaymentMethodDeletePrimaryConfirmation: FunctionComponent< Props > = ( {
 	);
 
 	useEffect( () => {
-		if ( ! nextPrimaryPaymentMethod ) {
-			return;
-		}
 		setNextPrimaryPaymentMethod( nextPrimaryPaymentMethod );
 	}, [ nextPrimaryPaymentMethod, setNextPrimaryPaymentMethod ] );
 

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/index.tsx
@@ -1,0 +1,74 @@
+import { PaymentLogo } from '@automattic/composite-checkout';
+import { useTranslate } from 'i18n-calypso';
+import { QueryKey, useQuery } from 'react-query';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
+import type { FunctionComponent } from 'react';
+
+import './style.scss';
+
+const getCacheKey = ( key: string ): QueryKey => [ 'jetpack_cloud', 'partner_portal', key ];
+
+interface Props {
+	paymentMethod: PaymentMethod;
+}
+
+const PaymentMethodDeletePrimaryConfirmation: FunctionComponent< Props > = ( {
+	paymentMethod,
+} ) => {
+	const translate = useTranslate();
+
+	const { data: recentCards, isFetching } = useQuery( getCacheKey( 'recent_cards' ), () =>
+		wpcomJpl.req.get( {
+			apiNamespace: 'wpcom/v2',
+			path: '/jetpack-licensing/stripe/payment-methods',
+		} )
+	);
+
+	const nextPrimaryPaymentMethod = ( recentCards || [] ).find(
+		( card: PaymentMethod ) => card.id !== paymentMethod.id
+	);
+
+	return (
+		<div className="payment-method-delete-primary-confirmation">
+			<div className="payment-method-delete-primary-confirmation__card">
+				<div className="payment-method-delete-primary-confirmation__card-title">
+					{ translate( 'Deleting' ) }
+				</div>
+				<div className="payment-method-delete-primary-confirmation__card-details">
+					<div className="payment-method-delete-primary-confirmation__card-details-logo">
+						<PaymentLogo brand={ paymentMethod?.card.brand } isSummary={ true } />
+					</div>
+					<div>**** **** **** { paymentMethod?.card.last4 }</div>
+					<div>{ `${ paymentMethod?.card.exp_month }/${ paymentMethod?.card.exp_year }` }</div>
+				</div>
+			</div>
+
+			<hr className="payment-method-delete-primary-confirmation__separator" />
+
+			<div className="payment-method-delete-primary-confirmation__card">
+				<div className="payment-method-delete-primary-confirmation__card-title">
+					{ translate( 'Your primary payment method will automatically switch to' ) }
+				</div>
+
+				<div className="payment-method-delete-primary-confirmation__card-details">
+					{ isFetching && (
+						<div className="payment-method-delete-primary-confirmation__card-details-loader" />
+					) }
+
+					{ ! isFetching && (
+						<>
+							<div className="payment-method-delete-primary-confirmation__card-details-logo">
+								<PaymentLogo brand={ nextPrimaryPaymentMethod?.card.brand } isSummary={ true } />
+							</div>
+							<div>**** **** **** { nextPrimaryPaymentMethod?.card.last4 }</div>
+							<div>{ `${ nextPrimaryPaymentMethod?.card.exp_month }/${ nextPrimaryPaymentMethod?.card.exp_year }` }</div>
+						</>
+					) }
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default PaymentMethodDeletePrimaryConfirmation;

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/index.tsx
@@ -1,43 +1,28 @@
 import { PaymentLogo } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
-import { QueryKey, useQuery } from 'react-query';
-import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import { useRecentPaymentMethodsQuery } from 'calypso/jetpack-cloud/sections/partner-portal//hooks';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
-import type { Dispatch, FunctionComponent, SetStateAction } from 'react';
+import type { FunctionComponent } from 'react';
 
 import './style.scss';
 
-const getCacheKey = ( key: string ): QueryKey => [ 'jetpack-cloud', 'partner-portal', key ];
-
 interface Props {
 	paymentMethod: PaymentMethod;
-	setNextPrimaryPaymentMethod: Dispatch< SetStateAction< PaymentMethod | null > >;
 }
 
 const PaymentMethodDeletePrimaryConfirmation: FunctionComponent< Props > = ( {
 	paymentMethod,
-	setNextPrimaryPaymentMethod,
 } ) => {
 	const translate = useTranslate();
 
-	const { data: recentCards, isFetching } = useQuery( getCacheKey( 'recent-cards' ), () =>
-		wpcomJpl.req.get( {
-			apiNamespace: 'wpcom/v2',
-			path: '/jetpack-licensing/stripe/payment-methods',
-		} )
-	);
+	const { data: recentCards, isFetching } = useRecentPaymentMethodsQuery();
 
 	const nextPrimaryPaymentMethod = ( recentCards?.items || [] ).find(
 		( card: PaymentMethod ) => card.id !== paymentMethod.id
 	);
 
-	useEffect( () => {
-		setNextPrimaryPaymentMethod( nextPrimaryPaymentMethod );
-	}, [ nextPrimaryPaymentMethod, setNextPrimaryPaymentMethod ] );
-
 	if ( ! isFetching && ! nextPrimaryPaymentMethod ) {
-		return <></>;
+		return null;
 	}
 
 	return (

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/index.tsx
@@ -36,7 +36,7 @@ const PaymentMethodDeletePrimaryConfirmation: FunctionComponent< Props > = ( {
 		setNextPrimaryPaymentMethod( nextPrimaryPaymentMethod );
 	}, [ nextPrimaryPaymentMethod, setNextPrimaryPaymentMethod ] );
 
-	if ( ! nextPrimaryPaymentMethod ) {
+	if ( ! isFetching && ! nextPrimaryPaymentMethod ) {
 		return <></>;
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/index.tsx
@@ -33,7 +33,7 @@ const PaymentMethodDeletePrimaryConfirmation: FunctionComponent< Props > = ( {
 	);
 
 	useEffect( () => {
-		if ( ! nextPrimaryPaymentMethod?.id ) {
+		if ( ! nextPrimaryPaymentMethod ) {
 			return;
 		}
 		setNextPrimaryPaymentMethod( nextPrimaryPaymentMethod );

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/style.scss
@@ -1,0 +1,36 @@
+.payment-method-delete-primary-confirmation {
+	&__separator {
+		margin: 24px 0;
+	}
+
+	&__card {
+		font-size: 0.875rem;
+
+		&-title {
+			font-weight: bold;
+		}
+
+		&-details {
+			display: flex;
+			margin-top: 1rem;
+	
+			& > div {
+				margin-right: 32px;
+			}
+
+			&-loader {
+				width: 50%;
+				height: 30px;
+
+				@include placeholder();
+			}
+
+			&-logo {
+				svg {
+					filter: grayscale( 100% );
+				}
+			}
+		}
+	}
+
+}

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
 .payment-method-delete-primary-confirmation {
 	&__separator {
 		margin: 24px 0;
@@ -19,10 +22,14 @@
 			}
 
 			&-loader {
-				width: 50%;
+				width: 100%;
 				height: 30px;
 
-				@include placeholder();
+				@include placeholder( --color-neutral-10 );
+
+				@include break-mobile {
+					width: 50%;
+				}
 			}
 
 			&-logo {

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card/index.tsx
@@ -29,8 +29,9 @@ export default function StoredCreditCard( props: { card: PaymentMethod } ): Reac
 					<div className="stored-credit-card__payment-logo">
 						<PaymentLogo brand={ creditCard?.card.brand } isSummary={ true } />
 					</div>
-
-					<div className="stored-credit-card__primary">{ translate( 'Primary' ) }</div>
+					{ creditCard?.is_default && (
+						<div className="stored-credit-card__primary">{ translate( 'Primary' ) }</div>
+					) }
 				</div>
 
 				<div className="stored-credit-card__actions">

--- a/client/state/partner-portal/stored-cards/actions.ts
+++ b/client/state/partner-portal/stored-cards/actions.ts
@@ -41,7 +41,9 @@ export const fetchStoredCards = ( paging: { startingAfter: string; endingBefore:
 		} );
 };
 
-export const deleteStoredCard = ( card: PaymentMethod ) => ( dispatch: Dispatch< AnyAction > ) => {
+export const deleteStoredCard = ( card: PaymentMethod, primary_payment_method_id?: string ) => (
+	dispatch: Dispatch< AnyAction >
+) => {
 	dispatch( {
 		type: 'STORED_CARDS_DELETE',
 		card,
@@ -52,12 +54,17 @@ export const deleteStoredCard = ( card: PaymentMethod ) => ( dispatch: Dispatch<
 			method: 'DELETE',
 			apiNamespace: 'wpcom/v2',
 			path: '/jetpack-licensing/stripe/payment-method',
-			body: { payment_method_id: card.id },
+			body: { payment_method_id: card.id, primary_payment_method_id: primary_payment_method_id },
 		} )
-		.then( () => {
+		.then( ( response: { success: boolean; primary_payment_method_id: string } ) => {
 			dispatch( {
 				type: 'STORED_CARDS_DELETE_COMPLETED',
 				card,
+			} );
+
+			dispatch( {
+				type: 'STORED_CARDS_UPDATE_IS_PRIMARY_COMPLETED',
+				payment_method_id: response.primary_payment_method_id,
 			} );
 		} )
 		.catch( ( error: Error ) => {

--- a/client/state/partner-portal/stored-cards/actions.ts
+++ b/client/state/partner-portal/stored-cards/actions.ts
@@ -41,7 +41,7 @@ export const fetchStoredCards = ( paging: { startingAfter: string; endingBefore:
 		} );
 };
 
-export const deleteStoredCard = ( card: PaymentMethod, primary_payment_method_id?: string ) => (
+export const deleteStoredCard = ( card: PaymentMethod, primaryPaymentMethodId?: string ) => (
 	dispatch: Dispatch< AnyAction >
 ) => {
 	dispatch( {
@@ -54,7 +54,7 @@ export const deleteStoredCard = ( card: PaymentMethod, primary_payment_method_id
 			method: 'DELETE',
 			apiNamespace: 'wpcom/v2',
 			path: '/jetpack-licensing/stripe/payment-method',
-			body: { payment_method_id: card.id, primary_payment_method_id: primary_payment_method_id },
+			body: { payment_method_id: card.id, primary_payment_method_id: primaryPaymentMethodId },
 		} )
 		.then( ( response: { success: boolean; primary_payment_method_id: string } ) => {
 			dispatch( {

--- a/client/state/partner-portal/stored-cards/reducer.ts
+++ b/client/state/partner-portal/stored-cards/reducer.ts
@@ -9,6 +9,10 @@ type ItemsAction =
 			card: PaymentMethod;
 	  }
 	| {
+			type: 'STORED_CARDS_UPDATE_IS_PRIMARY_COMPLETED';
+			payment_method_id: string;
+	  }
+	| {
 			type: 'STORED_CARDS_FETCH_COMPLETED';
 			list: PaymentMethod[];
 	  };
@@ -22,6 +26,15 @@ export const items: Reducer< PaymentMethod[], ItemsAction > = ( state = [], acti
 		case 'STORED_CARDS_DELETE_COMPLETED': {
 			const { card } = action;
 			return state.filter( ( item ) => item.id !== card.id );
+		}
+		case 'STORED_CARDS_UPDATE_IS_PRIMARY_COMPLETED': {
+			const { payment_method_id } = action;
+			return state.map( ( item ) => {
+				if ( item.id === payment_method_id ) {
+					return { ...item, is_default: true };
+				}
+				return item;
+			} );
 		}
 	}
 
@@ -45,11 +58,11 @@ export const hasMoreItems: Reducer< boolean, MoreItemsAction > = ( state = false
 	return state;
 };
 
-type IsFetchingAction = Action<
+type FetchingActionStatus = Action<
 	'STORED_CARDS_FETCH' | 'STORED_CARDS_FETCH_COMPLETED' | 'STORED_CARDS_FETCH_FAILED'
 >;
 
-export const isFetching: Reducer< boolean, IsFetchingAction > = ( state = false, action ) => {
+export const isFetching: Reducer< boolean, FetchingActionStatus > = ( state = false, action ) => {
 	switch ( action.type ) {
 		case 'STORED_CARDS_FETCH':
 			return true;
@@ -62,7 +75,7 @@ export const isFetching: Reducer< boolean, IsFetchingAction > = ( state = false,
 	return state;
 };
 
-type IsDeletingAction =
+type DeletingActionStatus =
 	| {
 			type: 'STORED_CARDS_DELETE';
 			card: PaymentMethod;
@@ -76,7 +89,7 @@ type IsDeletingAction =
 			card: PaymentMethod;
 	  };
 
-export const isDeleting: Reducer< { [ key: string ]: boolean }, IsDeletingAction > = (
+export const isDeleting: Reducer< { [ key: string ]: boolean }, DeletingActionStatus > = (
 	state = {},
 	action
 ) => {

--- a/client/state/partner-portal/stored-cards/reducer.ts
+++ b/client/state/partner-portal/stored-cards/reducer.ts
@@ -44,7 +44,6 @@ export const items: Reducer< PaymentMethod[], ItemsAction > = ( state = [], acti
 type MoreItemsAction = {
 	type: 'STORED_CARDS_HAS_MORE_ITEMS';
 	hasMore: boolean;
-	hasBeenSet: boolean;
 };
 
 export const hasMoreItems: Reducer< boolean, MoreItemsAction > = ( state = false, action ) => {


### PR DESCRIPTION
#### Context 

- Design: JVpmiQH74FKEIrPLjqv8p7-fi-1262%3A12746

#### Changes proposed in this Pull Request

* This PR implements the confirmation UI when deleting a primary payment method from Stripe. 

#### Implementation

* By design, when a primary payment method is removed from Stripe, they will set the most recent one as a primary payment method. We fetch the most current payment methods in the confirmation UI and display confirmation to the user as the next primary payment method. In addition, this payment method will be sent to our API endpoint, so the next payment method will be what the user saw in the confirmation screen.

**Screenshot:**

![image](https://user-images.githubusercontent.com/1749918/157466427-fb9ae274-f931-47ff-96a3-cb741e770cd3.png)


#### Testing instructions

**Prerequisites**
- See pbtFFM-1v8-p2
- Open Dev Tools during the testing and make sure that there are no JS errors.

**Instructions**
- Apply D76361-code
- If you do not have a partner key, please get in touch with Avalon for one, or you will be unable to view the UI.
- Checkout PR locally, run `yarn && yarn start-jetpack-cloud`.
- Visit http://jetpack.cloud.localhost:3000/partner-portal/payment-methods and select your partner key, if prompted.
- Add multiple payment methods (by reading the prerequisites, you should be able to use Stripe's [test cards available](https://stripe.com/docs/testing))
- Test different flows:
  - Delete single payment method.
  - Delete primary payment method when there are multiple payment methods available.
  - Delete non-primary payment method.
 - Also verify that: 
   - The "Primary" label is shown on the right (displayed in the confirmation UI) payment method after removal.
   - The implementation matches the design.
   - The UI is looking good on different resolutions.
   - No regression is introduced by this PR.


Related to 1201734780767770-as-1201735329399991