### PR TITLE
Jetpack Licensing Portal: License assignment step progress component

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -1,0 +1,30 @@
+import { Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { ReactElement } from 'react';
+import './style.scss';
+
+export default function (): ReactElement {
+	const translate = useTranslate();
+
+	return (
+		<div className="assign-license-step-progress">
+			<div className="assign-license-step-progress__step-complete">
+				<span className="assign-license-step-progress__step-circle">
+					<Gridicon icon="checkmark" />
+				</span>
+				<span className="assign-license-step-progress__step-name">
+					{ translate( 'Issue new license' ) }
+				</span>
+			</div>
+			<div className="assign-license-step-progress__step-separator" />
+			<div className="assign-license-step-progress__step-current">
+				<span className="assign-license-step-progress__step-circle">
+					<span>2</span>
+				</span>
+				<span className="assign-license-step-progress__step-name">
+					{ translate( 'Assign license' ) }
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -3,12 +3,25 @@ import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
 import './style.scss';
 
-export default function (): ReactElement {
+function getStepClassName( currentStep: number, step: number ): any {
+	switch ( true ) {
+		case currentStep === step:
+			return 'step-current';
+		case currentStep < step:
+			return 'step-next';
+		case currentStep > step:
+			return 'step-complete';
+	}
+}
+
+export default function ( { currentStep }: { currentStep: number } ): ReactElement {
 	const translate = useTranslate();
 
 	return (
 		<div className="assign-license-step-progress">
-			<div className="assign-license-step-progress__step-complete">
+			<div
+				className={ `assign-license-step-progress__step ${ getStepClassName( currentStep, 1 ) }` }
+			>
 				<span className="assign-license-step-progress__step-circle">
 					<Gridicon icon="checkmark" />
 				</span>
@@ -17,7 +30,9 @@ export default function (): ReactElement {
 				</span>
 			</div>
 			<div className="assign-license-step-progress__step-separator" />
-			<div className="assign-license-step-progress__step-current">
+			<div
+				className={ `assign-license-step-progress__step ${ getStepClassName( currentStep, 2 ) }` }
+			>
 				<span className="assign-license-step-progress__step-circle">
 					<span>2</span>
 				</span>

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -1,17 +1,15 @@
 import { Gridicon } from '@automattic/components';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
 import './style.scss';
 
 function getStepClassName( currentStep: number, step: number ): any {
-	switch ( true ) {
-		case currentStep === step:
-			return 'step-current';
-		case currentStep < step:
-			return 'step-next';
-		case currentStep > step:
-			return 'step-complete';
-	}
+	return classnames( {
+		'step-current': currentStep === step,
+		'step-next': currentStep < step,
+		'step-complete': currentStep > step,
+	} );
 }
 
 export default function ( { currentStep }: { currentStep: number } ): ReactElement {

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
@@ -11,33 +11,25 @@
         justify-content: flex-start;
     }
 
-    &__step-complete, &__step-current {
+    &__step {
         display: flex;
         flex-direction: row;
         align-items: center;
-    }
-
-    &__step-separator,
-    &__step-current {
-        @include break-medium {
-            margin-left: 1.25rem;
-        }
     }
 
     &__step-separator {
         border: 1px solid var( --studio-gray-80 );
         width: 20px;
         height: 0;
+        margin: 0 0.75rem;
 
         @include break-medium {
             width: 40px;
+            margin: 0 1.25rem;
         }
     }
 
     &__step-circle {
-        background-color: var( --studio-gray-80 );
-        border: 2px solid var( --studio-gray-80 );
-        color: var( --studio-white );
         width: 20px;
         height: 20px;
         display: flex;
@@ -45,20 +37,28 @@
         justify-content: center;
         align-content: center;
         align-items: center;
+        font-size: 0.75rem;
     }
 
     &__step-name {
         margin-left: 1.125rem;
+        white-space: nowrap;
     }
 
-    &__step-complete:nth-child( 1 ) > &__step-circle {
+    &__step.step-current > &__step-circle {
+        background-color: var( --studio-gray-80 );
+        border: 2px solid var( --studio-gray-80 );
+        color: var( --studio-white );
+    }
+
+    &__step.step-next > &__step-circle {
+        border: 2px solid var( --studio-gray-80 );
+        color: var( --studio-gray-80 );
+    }
+
+    &__step.step-complete > &__step-circle {
         background-color: var( --studio-jetpack-green-50 );
         border: 2px solid var( --studio-jetpack-green-50 );
         color: var( --studio-white );
     }
-
-    &__step-current > &__step-circle {
-        font-size: 0.75rem;
-    }
-
 }

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
@@ -1,0 +1,50 @@
+.assign-license-step-progress {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    margin-bottom: 40px;
+
+    &__step-complete, &__step-current {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+    }
+
+    &__step-separator,
+    &__step-current {
+        margin-left: 1.25rem;
+    }
+
+    &__step-circle {
+        background-color: var( --studio-gray-80 );
+        border: 2px solid var( --studio-gray-80 );
+        color: var( --studio-white );
+        width: 20px;
+        height: 20px;
+        display: flex;
+        border-radius: 50%; /* stylelint-disable */
+        justify-content: center;
+        align-content: center;
+        align-items: center;
+    }
+
+    &__step-name {
+        margin-left: 1.125rem;
+    }
+
+    &__step-complete:nth-child( 1 ) > &__step-circle {
+        background-color: var( --studio-jetpack-green-50 );
+        border: 2px solid var( --studio-jetpack-green-50 );
+        color: var( --studio-white );
+    }
+
+    &__step-current > &__step-circle {
+        font-size: 0.75rem;
+    }
+
+    &__step-separator {
+        border: 1px solid var( --studio-gray-80 );
+        width: 40px;
+        height: 0;
+    }
+}

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
@@ -1,8 +1,15 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .assign-license-step-progress {
     display: flex;
-    justify-content: flex-start;
+    justify-content: space-between;
     align-items: center;
     margin-bottom: 40px;
+
+    @include break-medium {
+        justify-content: flex-start;
+    }
 
     &__step-complete, &__step-current {
         display: flex;
@@ -12,7 +19,19 @@
 
     &__step-separator,
     &__step-current {
-        margin-left: 1.25rem;
+        @include break-medium {
+            margin-left: 1.25rem;
+        }
+    }
+
+    &__step-separator {
+        border: 1px solid var( --studio-gray-80 );
+        width: 20px;
+        height: 0;
+
+        @include break-medium {
+            width: 40px;
+        }
     }
 
     &__step-circle {
@@ -42,9 +61,4 @@
         font-size: 0.75rem;
     }
 
-    &__step-separator {
-        border: 1px solid var( --studio-gray-80 );
-        width: 40px;
-        height: 0;
-    }
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -33,7 +33,7 @@ export default function AssignLicense( {
 		<Main wideLayout className="assign-license">
 			<DocumentHead title={ translate( 'Assign your License' ) } />
 			<SidebarNavigation />
-			<AssignLicenseStepProgress />
+			<AssignLicenseStepProgress currentStep={ 2 } />
 			<CardHeading size={ 36 }>{ translate( 'Assign your License' ) }</CardHeading>
 
 			<AssignLicenseForm sites={ sites } currentPage={ currentPage } search={ search } />

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -31,9 +31,9 @@ export default function AssignLicense( {
 
 	return (
 		<Main wideLayout className="assign-license">
-			<AssignLicenseStepProgress />
 			<DocumentHead title={ translate( 'Assign your License' ) } />
 			<SidebarNavigation />
+			<AssignLicenseStepProgress />
 			<CardHeading size={ 36 }>{ translate( 'Assign your License' ) }</CardHeading>
 
 			<AssignLicenseForm sites={ sites } currentPage={ currentPage } search={ search } />

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -5,6 +5,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import AssignLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-form';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
+import AssignLicenseStepProgress from '../../assign-license-step-progress';
 
 export default function AssignLicense( {
 	sites,
@@ -30,6 +31,7 @@ export default function AssignLicense( {
 
 	return (
 		<Main wideLayout className="assign-license">
+			<AssignLicenseStepProgress />
 			<DocumentHead title={ translate( 'Assign your License' ) } />
 			<SidebarNavigation />
 			<CardHeading size={ 36 }>{ translate( 'Assign your License' ) }</CardHeading>

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -5,6 +5,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import IssueLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/issue-license-form';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
+import AssignLicenseStepProgress from '../../assign-license-step-progress';
 
 export default function IssueLicense(): ReactElement {
 	const translate = useTranslate();
@@ -24,6 +25,7 @@ export default function IssueLicense(): ReactElement {
 		<Main wideLayout className="issue-license">
 			<DocumentHead title={ translate( 'Issue a new License' ) } />
 			<SidebarNavigation />
+			<AssignLicenseStepProgress currentStep={ 1 } />
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
 			<IssueLicenseForm />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Completes this 👉🏻 1201801459945917-as-1201809041277064/f
* Adds a step progress component for the license assignment step

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure to have a Partner Account 👉🏻 PCYsg-zPi-p2
* Issue some license
* You should see the flow header (a.k.a. step progress)
* Following for the next step, license assignment, you should see that the header reflects the progress through the processes' steps

> This component is purely informative and cosmetic and holds no actionable elements

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Screenshots
**Desktop - Steps 1 & 2**
![image](https://user-images.githubusercontent.com/5550190/157678729-8c836320-7498-4951-b523-ab53d58fc0ae.png)

![image](https://user-images.githubusercontent.com/5550190/157293271-d9dd99a7-5ff7-449d-92fa-2872d801d664.png)

**Mobile - Product selection - Step 1**
![image](https://user-images.githubusercontent.com/5550190/157678221-8cfa4a28-46bf-4814-9fef-f1a374b4106d.png)
![image](https://user-images.githubusercontent.com/5550190/157678290-93c93d00-2216-4a65-9615-52be4c021024.png)
![image](https://user-images.githubusercontent.com/5550190/157678395-8008fbe0-cc8f-4545-a8da-48d346230f93.png)

**Mobile - Site selection - Step 2**
![image](https://user-images.githubusercontent.com/5550190/157678593-0fae54a5-c8cb-4dc4-96ed-4ee26cecac9d.png)
![image](https://user-images.githubusercontent.com/5550190/157678640-719401f5-6e0b-45a3-a835-03e07127afdc.png)
![image](https://user-images.githubusercontent.com/5550190/157678669-e11d05fa-dbb4-4c4d-ad84-dd3f4adc2c89.png)
