### PR TITLE
Run full eslint when eslint packages update

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -244,6 +244,11 @@ object CheckCodeStyle : BuildType({
 			triggerBuild = always()
 			withPendingChangesOnly = false
 		}
+		vcs {
+			branchFilter = """
+				+:renovate/eslint-packages
+			""".trimIndent()
+		}
 	}
 
 	failureConditions {
@@ -267,6 +272,24 @@ object CheckCodeStyle : BuildType({
 			param("xmlReportParsing.verboseOutput", "true")
 		}
 		perfmon {
+		}
+		pullRequests {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			provider = github {
+				authType = token {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
+			}
+		}
+		commitStatusPublisher {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			publisher = github {
+				githubUrl = "https://api.github.com"
+				authType = personalToken {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+			}
 		}
 	}
 })


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since we know the branch name Renovate uses for eslint updates, we can use that the trigger the full linter build. This should make it easier to see if eslint updates introduce any lint issues.

#### Testing instructions
TC