### PR TITLE
Follow up for #61222: handle undefined `pageEntity`

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
@@ -47,10 +47,11 @@ const SellerCelebrationModal = () => {
 			const pageId = parseInt( page?.context?.postId );
 			const isSavingEntity = select( 'core' ).isSavingEntityRecord( 'postType', 'page', pageId );
 			const pageEntity = select( 'core' ).getEntityRecord( 'postType', 'page', pageId );
-			const rawContent = pageEntity.content.raw;
+			const paymentsBlock =
+				pageEntity?.content?.includes( '<!-- wp:jetpack/recurring-payments -->' ) ?? false;
 			return {
 				isEditorSaving: isSavingSite || isSavingEntity,
-				hasPaymentsBlock: rawContent.includes( '<!-- wp:jetpack/recurring-payments -->' ),
+				hasPaymentsBlock: paymentsBlock,
 				linkUrl: pageEntity.link,
 			};
 		}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
@@ -52,7 +52,7 @@ const SellerCelebrationModal = () => {
 			return {
 				isEditorSaving: isSavingSite || isSavingEntity,
 				hasPaymentsBlock: paymentsBlock,
-				linkUrl: pageEntity.link,
+				linkUrl: pageEntity?.link,
 			};
 		}
 		const currentPost = select( 'core/editor' ).getCurrentPost();

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
@@ -48,7 +48,7 @@ const SellerCelebrationModal = () => {
 			const isSavingEntity = select( 'core' ).isSavingEntityRecord( 'postType', 'page', pageId );
 			const pageEntity = select( 'core' ).getEntityRecord( 'postType', 'page', pageId );
 			const paymentsBlock =
-				pageEntity?.content?.includes( '<!-- wp:jetpack/recurring-payments -->' ) ?? false;
+				pageEntity?.content?.raw?.includes( '<!-- wp:jetpack/recurring-payments -->' ) ?? false;
 			return {
 				isEditorSaving: isSavingSite || isSavingEntity,
 				hasPaymentsBlock: paymentsBlock,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is follow up PR to #61222 to handle when `pageEntity` is undefined. 

#### Testing instructions

1. Checkout this branch.
2. In Calypso, cd to `apps/editing-toolkit`, run `yarn dev --sync`.
3. Sandbox a new FSE site and verify that [this issue](https://github.com/Automattic/wp-calypso/issues/61754) is not reproducible. 
4. Bonus point: verify that you can see the issue on trunk.

Fixes https://github.com/Automattic/wp-calypso/issues/61754
