### PR TITLE
Experiment: Integrate Olark chat in the signup flow

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -726,6 +726,8 @@ class Signup extends Component {
 
 		const isReskinned = isReskinnedFlow( this.props.flowName );
 		const olarkIdentity = config( 'olark_chat_identity' );
+		const isEligibleForOlarkChat =
+			'onboarding' === this.props.flowName && 'en' === this.props.localeSlug;
 
 		return (
 			<>
@@ -755,7 +757,7 @@ class Signup extends Component {
 						/>
 					) }
 				</div>
-				{ 'onboarding' === this.props.flowName && <OlarkChat identity={ olarkIdentity } /> }
+				{ isEligibleForOlarkChat && <OlarkChat identity={ olarkIdentity } /> }
 			</>
 		);
 	}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -27,6 +27,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
+import OlarkChat from 'calypso/components/olark-chat';
 import {
 	recordSignupStart,
 	recordSignupComplete,
@@ -724,34 +725,38 @@ class Signup extends Component {
 		}
 
 		const isReskinned = isReskinnedFlow( this.props.flowName );
+		const olarkIdentity = config( 'olark_chat_identity' );
 
 		return (
-			<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>
-				<DocumentHead title={ this.props.pageTitle } />
-				{ ! isP2Flow( this.props.flowName ) && (
-					<SignupHeader
-						shouldShowLoadingScreen={ this.state.shouldShowLoadingScreen }
-						isReskinned={ isReskinned }
-						rightComponent={
-							showProgressIndicator( this.props.flowName ) && (
-								<FlowProgressIndicator
-									positionInFlow={ this.getPositionInFlow() }
-									flowLength={ this.getInteractiveStepsCount() }
-									flowName={ this.props.flowName }
-								/>
-							)
-						}
-					/>
-				) }
-				<div className="signup__steps">{ this.renderCurrentStep( isReskinned ) }</div>
-				{ this.state.bearerToken && (
-					<WpcomLoginForm
-						authorization={ 'Bearer ' + this.state.bearerToken }
-						log={ this.state.username }
-						redirectTo={ this.state.redirectTo }
-					/>
-				) }
-			</div>
+			<>
+				<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>
+					<DocumentHead title={ this.props.pageTitle } />
+					{ ! isP2Flow( this.props.flowName ) && (
+						<SignupHeader
+							shouldShowLoadingScreen={ this.state.shouldShowLoadingScreen }
+							isReskinned={ isReskinned }
+							rightComponent={
+								showProgressIndicator( this.props.flowName ) && (
+									<FlowProgressIndicator
+										positionInFlow={ this.getPositionInFlow() }
+										flowLength={ this.getInteractiveStepsCount() }
+										flowName={ this.props.flowName }
+									/>
+								)
+							}
+						/>
+					) }
+					<div className="signup__steps">{ this.renderCurrentStep( isReskinned ) }</div>
+					{ this.state.bearerToken && (
+						<WpcomLoginForm
+							authorization={ 'Bearer ' + this.state.bearerToken }
+							log={ this.state.username }
+							redirectTo={ this.state.redirectTo }
+						/>
+					) }
+				</div>
+				{ 'onboarding' === this.props.flowName && <OlarkChat identity={ olarkIdentity } /> }
+			</>
 		);
 	}
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -38,6 +38,7 @@
 	"google_oauth_client_id": "108380595987-j91sm1alavcdgd81i2655kp8q1lbtvrc.apps.googleusercontent.com",
 	"facebook_app_id": "611241942420191",
 	"livechat_support_locales": [ "en", "en-gb" ],
+	"olark_chat_identity": false,
 	"upwork_support_locales": [
 		"de",
 		"de-at",

--- a/config/development.json
+++ b/config/development.json
@@ -25,6 +25,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
+	"olark_chat_identity": "2503-569-10-2205",
 	"features": {
 		"ad-tracking": false,
 		"calypsoify/plugins": true,

--- a/config/development.json
+++ b/config/development.json
@@ -25,7 +25,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
-	"olark_chat_identity": "2503-569-10-2205",
+	"olark_chat_identity": "7089-503-10-5123",
 	"features": {
 		"ad-tracking": false,
 		"calypsoify/plugins": true,

--- a/config/production.json
+++ b/config/production.json
@@ -13,6 +13,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"facebook_app_id": "2373049596",
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
+	"olark_chat_identity": "2503-569-10-2205",
 	"features": {
 		"ad-tracking": true,
 		"bilmur-script": true,

--- a/config/production.json
+++ b/config/production.json
@@ -13,7 +13,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"facebook_app_id": "2373049596",
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
-	"olark_chat_identity": "2503-569-10-2205",
+	"olark_chat_identity": "7089-503-10-5123",
 	"features": {
 		"ad-tracking": true,
 		"bilmur-script": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -12,6 +12,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
+	"olark_chat_identity": "2503-569-10-2205",
 	"features": {
 		"ad-tracking": false,
 		"calypsoify/plugins": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -12,7 +12,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
-	"olark_chat_identity": "2503-569-10-2205",
+	"olark_chat_identity": "7089-503-10-5123",
 	"features": {
 		"ad-tracking": false,
 		"calypsoify/plugins": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -13,6 +13,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
+	"olark_chat_identity": "2503-569-10-2205",
 	"features": {
 		"ad-tracking": false,
 		"calypsoify/plugins": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -13,7 +13,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
-	"olark_chat_identity": "2503-569-10-2205",
+	"olark_chat_identity": "7089-503-10-5123",
 	"features": {
 		"ad-tracking": false,
 		"calypsoify/plugins": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This integrates Olark chat in the `onboarding` signup flow. The chat window will appear in the registration step, domains step, and plans step of the `onboarding` flow for `en` users.
* Read more in pau2Xa-40L-p2.
* The chat icon and window design could change (it's controlled in Olark's admin dashboard), but this is how things look now:

### When agents are offline

<img width="1454" alt="Screenshot 2022-03-22 at 12 30 14 PM" src="https://user-images.githubusercontent.com/1269602/159439643-af438b40-8926-479d-b1a0-a0d0c2e065f4.png">

<img width="1539" alt="Screenshot 2022-03-22 at 12 30 25 PM" src="https://user-images.githubusercontent.com/1269602/159439658-107bd834-bdfe-4beb-a031-d5413d5f3dcc.png">

### When agents are online

<img width="1577" alt="Screenshot 2022-03-22 at 12 22 27 PM" src="https://user-images.githubusercontent.com/1269602/159439687-a27810df-5ff7-457c-a263-cb9ad44a6aae.png">

<img width="1586" alt="Screenshot 2022-03-22 at 12 24 19 PM" src="https://user-images.githubusercontent.com/1269602/159439715-4c66a0fd-ecd4-45ae-adce-938f993363fc.png">

### Mobile

<img width="408" alt="Screenshot 2022-03-22 at 12 25 48 PM" src="https://user-images.githubusercontent.com/1269602/159439754-eae177fa-2433-4c44-b8e2-ba853f579677.png">
<img width="399" alt="Screenshot 2022-03-22 at 12 25 57 PM" src="https://user-images.githubusercontent.com/1269602/159439764-b99624d5-8800-4c4c-943c-d6632728cd1e.png">




### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Go to `/start` in `en` locale and verify that you can see the chat widget. 
2. On the Olark agent dashboard, set yourself online and observe that the chat widget on `/start` shows the available-to-chat window. Set yourself offline in Olark agent dashboard, and observe that the chat widget on `/start` shows the offline chat window.
3. Confirm that the chat window does not show in non-en locales. Also it shouldn't show in other signup flows such as `/start/domain` or `/start/premium`.
4. While logged in to an account, add a new site and verify that the chat widget shows for existing users too.
5. Verify in mobile viewport that the widget shows properly. 