### PR TITLE
WIP: Add email to Google Ads gtag.js for enhanced conversions

### DIFF
--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -444,6 +444,10 @@ function recordOrderInGoogleAds( cart, orderId, wpcomJetpackCartInfo ) {
 	// MCC-level event.
 	// @TODO Separate WPCOM from Jetpack events.
 	if ( isWpcomGoogleAdsGtagEnabled ) {
+		window.gtag( 'set', 'user_data', {
+			email: user_email,
+		} );
+
 		const params = [
 			'event',
 			'conversion',
@@ -452,9 +456,6 @@ function recordOrderInGoogleAds( cart, orderId, wpcomJetpackCartInfo ) {
 				value: cart.total_cost,
 				currency: cart.currency,
 				transaction_id: orderId,
-				user_data: {
-					email: user_email,
-				},
 			},
 		];
 		debug( 'recordOrderInGoogleAds: Record WPCom Purchase', params );

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -433,6 +433,14 @@ function recordOrderInGoogleAds( cart, orderId, wpcomJetpackCartInfo ) {
 		return;
 	}
 
+	/**
+	 * Enhanced conversion tracking by supplying hashed email to gtag.
+	 * It's hashed locally before reaching Google.
+	 */
+
+	const current_user = getCurrentUser();
+	const user_email = current_user.email ?? '';
+
 	// MCC-level event.
 	// @TODO Separate WPCOM from Jetpack events.
 	if ( isWpcomGoogleAdsGtagEnabled ) {
@@ -444,6 +452,9 @@ function recordOrderInGoogleAds( cart, orderId, wpcomJetpackCartInfo ) {
 				value: cart.total_cost,
 				currency: cart.currency,
 				transaction_id: orderId,
+				user_data: {
+					email: user_email,
+				},
 			},
 		];
 		debug( 'recordOrderInGoogleAds: Record WPCom Purchase', params );

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -199,7 +199,9 @@ function setupAdRollGlobal() {
 
 function setupWpcomGoogleAdsGtag() {
 	setupGtag();
-	window.gtag( 'config', TRACKING_IDS.wpcomGoogleAdsGtag );
+	window.gtag( 'config', TRACKING_IDS.wpcomGoogleAdsGtag, {
+		allow_enhanced_conversions: true,
+	} );
 }
 
 function setupWpcomFloodlightGtag() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adding email to gtag.js. This value will be hashed before it's sent to Google. 

#### Testing instructions
TBD

From Google Ads documentation:
```
Right click on your web page.
Select Inspect.
Select the Network tab.
Enter your conversion ID or conversion label into the search bar.
Find the network request that's going to "googleadservices.com/pagead/conversion/" (or "google.com/pagead/1p-conversion/" on some browsers).
In the Headers part of the Network request, scroll to “Query String Parameters”. Here, you should find that there is a parameter “em” with a hashed string as the value. If you see the "em" parameter, this means that the enhanced conversions tag is correctly picking up and hashing the enhanced_conversion_data object.```