### PR TITLE
Fixed CSS margins for the Jetpack notice banner

### DIFF
--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -34,9 +34,11 @@ body.is-section-plugins:not( .is-nav-unification ) {
 
 .upsell-nudge.is-jetpack {
 	margin-top: 51px;
+	margin-bottom: -20px;
 
 	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 86px;
+		margin-bottom: -50px;
 	}
 }
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -32,6 +32,14 @@ body.is-section-plugins:not( .is-nav-unification ) {
 	}
 }
 
+.upsell-nudge.is-jetpack {
+	margin-top: 51px;
+
+	@include breakpoint-deprecated( '<660px' ) {
+		margin-top: 86px;
+	}
+}
+
 .upsell-nudge {
 	margin-top: 16px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixed Jetpack notices spacing:

![Screenshot 2022-02-16 at 15-23-36 Plugins ‹ test — WordPress com](https://user-images.githubusercontent.com/811776/154195867-a1c411a4-6be8-4113-bf8d-b740ff9ae392.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the plugin screen with a Jetpack (non atomic) site, likely needs a free plan. [Jurassic.ninja](https://jurassic.ninja/) sites work. You should see the top spacing between Jetpack notice banner and Header:

![image](https://user-images.githubusercontent.com/1044309/157453681-16fdbe6d-2f4f-46b6-8301-622a1ba0e45b.png)

The space should match our other notices:

![Screenshot 2022-02-16 at 16-38-22 Plugins ‹ test — WordPress com](https://user-images.githubusercontent.com/811776/154203104-5098aee9-ab9e-434c-a8ba-0fc6ca8ac53e.png)


2. Please test on mobile too. You should see the following result:

![image](https://user-images.githubusercontent.com/1044309/157453995-e08103d4-200e-499c-8e97-63db3324d959.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/61142
