### PR TITLE
Ensure we refetch account recovery data after reauthorizing

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -6,6 +6,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import emitter from 'calypso/lib/mixins/emitter';
 import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import wp from 'calypso/lib/wp';
+import { accountRecoverySettingsFetch } from 'calypso/state/account-recovery/settings/actions';
 import { requestConnectedApplications } from 'calypso/state/connected-applications/actions';
 import { requestUserProfileLinks } from 'calypso/state/profile-links/actions';
 import { fetchUserSettings } from 'calypso/state/user-settings/actions';
@@ -88,6 +89,7 @@ TwoStepAuthorization.prototype.refreshDataOnSuccessfulAuth = function () {
 	// If the validation was successful AND re-auth was required, fetch
 	// data from the following modules.
 	if ( this.isReauthRequired() ) {
+		reduxDispatch( accountRecoverySettingsFetch() );
 		reduxDispatch( fetchUserSettings() );
 		reduxDispatch( requestConnectedApplications() );
 		reduxDispatch( requestUserProfileLinks() );

--- a/client/state/account-recovery/settings/actions.js
+++ b/client/state/account-recovery/settings/actions.js
@@ -60,7 +60,7 @@ export const accountRecoverySettingsFetch = () => ( dispatch ) => {
 
 			// Only trigger the default handling for errors other than reauthorization.
 			// We don't want to show a generic error if we need to reauthorize.
-			if ( error?.statusCode !== 401 || error?.error !== 'reauthorization_required' ) {
+			if ( error.statusCode !== 401 || error.error !== 'reauthorization_required' ) {
 				dispatch( onAccountRecoverySettingsFetchFailed() );
 			}
 		} );

--- a/client/state/account-recovery/settings/actions.js
+++ b/client/state/account-recovery/settings/actions.js
@@ -57,7 +57,12 @@ export const accountRecoverySettingsFetch = () => ( dispatch ) => {
 		)
 		.catch( ( error ) => {
 			dispatch( accountRecoverySettingsFetchFailed( error ) );
-			dispatch( onAccountRecoverySettingsFetchFailed() );
+
+			// Only trigger the default handling for errors other than reauthorization.
+			// We don't want to show a generic error if we need to reauthorize.
+			if ( error?.statusCode !== 401 || error?.error !== 'reauthorization_required' ) {
+				dispatch( onAccountRecoverySettingsFetchFailed() );
+			}
 		} );
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR ensures that when we successfully complete Two Factor Authentication, we trigger a refetch of the user's account recovery details (which are dependent on 2FA)
* The PR also ensures that when we receive an error fetching data from the `/me/account-recovery` endpoint, we no longer trigger a generic error message if the error was because the user needs to reauthorize

#### Testing instructions

First, ensure you are logged in and testing with a WordPress.com account that has 2FA enabled.

##### Illustrating the error on WordPress.com

* Navigate directly to `/me/security/account-recovery` on WordPress.com
  -  If you are _not_ presented with the 2FA dialog to authenticate, then open your developer tools and remove the `twostep_auth` cookie set against `public-api.wordpress.com`. Then reload the page and proceed with testing.
* Complete the 2FA process by entering your 2FA code (and requesting it if needed)
* Verify that you see the following error in the top right of the screen: `An error occurred while fetching your account recovery settings.`
* Verify that the main content of the screen remains in a loading state (and doesn't load)

##### Verifying the fix

* Run this branch locally or via [the calypso.live branch](https://github.com/Automattic/wp-calypso/pull/61766#issuecomment-1062974676)
* Ensure you delete the `twostep_auth` cookie for `public-api.wordpress.com`
* Navigate directly to `/me/security/account-recovery`, and verify that you see the 2FA dialog
  - As before, if you don't see the 2FA dialog, delete the `twostep_auth` cookie for `public-api.wordpress.com`, and then reload the page
* Complete the 2FA process
* Verify that you don't see an error message in the top right of the page
* Verify that the main content for the page loads

For bonus points, you can also test the fix by navigating to `/me/security?flags=security/security-checkup`, which also attempts to load this data.