### PR TITLE
Settings: Adjust copy used for the support link on Jetpack Backup credentials page

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -158,7 +158,7 @@ export class RewindCredentialsForm extends Component {
 				{ showNotices && (
 					<div className="rewind-credentials-form__instructions">
 						{ translate(
-							'Your server credentials can be found with your hosting provider. Their website should explain how to get the credentials you need. {{link}}Check out our handy guide for more info{{/link}}.',
+							'Your server credentials can be found with your hosting provider. Their website should explain how to get the credentials you need. {{link}}Learn how to find and enter your credentials{{/link}}.',
 							{
 								components: {
 									link: <a href="https://jetpack.com/support/activating-jetpack-backups/" />,


### PR DESCRIPTION
Closes Automattic/jetpack/issues/23327

#### Changes proposed in this Pull Request

* Adjusts the copy used for the support link on Jetpack Backup credentials page from _Check out our handy guide for more info_ to _Learn how to find and enter your credentials_.

#### After

<img width="942" alt="image" src="https://user-images.githubusercontent.com/746152/157461208-ce6b364a-8dd7-4ead-a742-31ceef6599e2.png">

#### Before

<img width="800" alt="image" src="https://user-images.githubusercontent.com/746152/157461972-c29e1da4-c0fd-4e53-bf3f-897265ae3c79.png">


#### Testing instructions
* Checkout this branch
* Start the dev env with `yarn start`
Visit `http://calypso.localhost:3000/settings/jetpack/:a-given-site-with-a-plan#credentials
*Confirm you see the new updated text on the support link reading _Learn how to find and enter your credentials_

