### PR TITLE
Add dedicated page for changing account email below `/me/security`

### DIFF
--- a/client/me/account/account-email-field.scss
+++ b/client/me/account/account-email-field.scss
@@ -1,0 +1,8 @@
+.account-email-field__change-pending.notice {
+	/* 
+	Override negative bottom margin from FormSettingExplanation 
+	and large margin below default notice
+	*/
+	margin-bottom: 5px;
+	margin-top: 5px;
+}

--- a/client/me/account/account-email-field.tsx
+++ b/client/me/account/account-email-field.tsx
@@ -23,11 +23,14 @@ import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { UserSettingsType } from 'calypso/state/selectors/get-user-settings';
 import type { ChangeEvent } from 'react';
 
-export type AccountEmailFragmentProps = {
+import './account-email-field.scss';
+
+export type AccountEmailFieldProps = {
 	emailInputId?: string;
 	emailInputName?: string;
 	emailValidationHandler?: ( isEmailValid: boolean ) => void;
 	isEmailControlDisabled?: boolean;
+	onEmailChange?: ( isEmailModified: boolean ) => void;
 	onFocus?: () => void;
 	unsavedUserSettings?: UserSettingsType;
 	userSettings?: UserSettingsType;
@@ -143,7 +146,12 @@ const AccountEmailPendingEmailChangeNotice = ( {
 			  );
 
 	return (
-		<Notice showDismiss={ false } status="is-info" text={ noticeText }>
+		<Notice
+			className="account-email-field__change-pending"
+			showDismiss={ false }
+			status="is-info"
+			text={ noticeText }
+		>
 			<NoticeAction onClick={ () => dispatch( cancelPendingEmailChange() ) }>
 				{ translate( 'Cancel' ) }
 			</NoticeAction>
@@ -156,10 +164,11 @@ const AccountEmailField = ( {
 	emailInputName = 'user_email',
 	emailValidationHandler,
 	isEmailControlDisabled = false,
+	onEmailChange,
 	onFocus,
 	unsavedUserSettings = {},
 	userSettings = {},
-}: AccountEmailFragmentProps ): JSX.Element => {
+}: AccountEmailFieldProps ): JSX.Element => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const isEmailChangePending = useSelector( isPendingEmailChange );
@@ -194,6 +203,8 @@ const AccountEmailField = ( {
 
 		setEmailInvalidReason( emailValidationReason );
 		emailValidationHandler?.( emailValidationReason === EMAIL_VALIDATION_REASON_IS_VALID );
+
+		onEmailChange?.( value !== userSettings.user_email );
 
 		dispatch( setUserSetting( 'user_email', value ) );
 	};

--- a/client/me/security-account-email/index.tsx
+++ b/client/me/security-account-email/index.tsx
@@ -1,0 +1,128 @@
+import { Button, Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useProtectForm } from 'calypso/lib/protect-form';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import AccountEmailField from 'calypso/me/account/account-email-field';
+import ReauthRequired from 'calypso/me/reauth-required';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import getUnsavedUserSettings from 'calypso/state/selectors/get-unsaved-user-settings';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
+import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
+import type { NoticeId, NoticeOptions } from 'calypso/state/notices/types';
+import type { CalypsoDispatch } from 'calypso/state/types';
+
+const noticeId: NoticeId = 'me-security-account-email-notice';
+
+const noticeOptions: NoticeOptions = {
+	id: noticeId,
+};
+
+const SecurityAccountEmail = ( { path }: { path: string } ): JSX.Element => {
+	const dispatch: CalypsoDispatch = useDispatch();
+	const { markChanged, markSaved } = useProtectForm();
+	const translate = useTranslate();
+
+	const [ isNewEmailValid, setIsNewEmailValid ] = useState( true );
+	const emailValidationHandler = ( emailIsValid: boolean ): void =>
+		setIsNewEmailValid( emailIsValid );
+
+	const emailChangeIsPending = useSelector( isPendingEmailChange );
+
+	const unsavedUserSettings = useSelector( getUnsavedUserSettings ) ?? {};
+	const userSettings = useSelector( getUserSettings ) ?? {};
+
+	const isEmailModified = null !== ( unsavedUserSettings.user_email ?? null );
+
+	const [ isSubmittingUpdate, setIsSubmittingUpdate ] = useState( false );
+
+	const maybeMarkFormAsSaved = () => {
+		if ( null === ( unsavedUserSettings.user_email ?? null ) ) {
+			markSaved();
+		}
+	};
+
+	const submitEmailUpdate = (): void => {
+		dispatch( saveUnsavedUserSettings( [ 'user_email' ] ) )
+			.then( () => {
+				maybeMarkFormAsSaved();
+
+				dispatch(
+					successNotice(
+						translate( 'Your account email address was updated successfully.' ),
+						noticeOptions
+					)
+				);
+			} )
+			.catch( ( error ) => {
+				const noticeText =
+					error?.message ?? translate( 'There was a problem updating your account email.' );
+
+				dispatch( errorNotice( noticeText, noticeOptions ) );
+			} )
+			.finally( () => {
+				setIsSubmittingUpdate( false );
+			} );
+	};
+
+	return (
+		<Main wideLayout className="security-account-email">
+			<PageViewTracker path={ path } title="Me > Security > Account Email " />
+
+			<DocumentHead title={ translate( 'Account Email' ) } />
+
+			<MeSidebarNavigation />
+
+			<FormattedHeader brandFont headerText={ translate( 'Account Email' ) } align="left" />
+
+			<HeaderCake backText={ translate( 'Back' ) } backHref="/me/security">
+				{ translate( 'Account Email' ) }
+			</HeaderCake>
+
+			<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+
+			<Card className="security-account-email__content">
+				<p>
+					{ translate(
+						'To update your account email enter a new email address below. ' +
+							'You will need to confirm the new email address before the change will take effect.'
+					) }
+				</p>
+
+				<AccountEmailField
+					emailValidationHandler={ emailValidationHandler }
+					onEmailChange={ ( emailIsModified: boolean ): void => {
+						if ( emailIsModified ) {
+							markChanged();
+						} else {
+							markSaved();
+						}
+					} }
+					unsavedUserSettings={ unsavedUserSettings }
+					userSettings={ userSettings }
+				/>
+
+				<Button
+					busy={ isSubmittingUpdate }
+					disabled={
+						isSubmittingUpdate || emailChangeIsPending || ! isEmailModified || ! isNewEmailValid
+					}
+					onClick={ submitEmailUpdate }
+					primary
+				>
+					{ translate( 'Update account email' ) }
+				</Button>
+			</Card>
+		</Main>
+	);
+};
+
+export default SecurityAccountEmail;

--- a/client/me/security-account-email/index.tsx
+++ b/client/me/security-account-email/index.tsx
@@ -44,16 +44,10 @@ const SecurityAccountEmail = ( { path }: { path: string } ): JSX.Element => {
 
 	const [ isSubmittingUpdate, setIsSubmittingUpdate ] = useState( false );
 
-	const maybeMarkFormAsSaved = () => {
-		if ( null === ( unsavedUserSettings.user_email ?? null ) ) {
-			markSaved();
-		}
-	};
-
 	const submitEmailUpdate = (): void => {
 		dispatch( saveUnsavedUserSettings( [ 'user_email' ] ) )
 			.then( () => {
-				maybeMarkFormAsSaved();
+				markSaved();
 
 				dispatch(
 					successNotice(

--- a/client/me/security-account-email/index.tsx
+++ b/client/me/security-account-email/index.tsx
@@ -75,7 +75,7 @@ const SecurityAccountEmail = ( { path }: { path: string } ): JSX.Element => {
 
 			<MeSidebarNavigation />
 
-			<FormattedHeader brandFont headerText={ translate( 'Account Email' ) } align="left" />
+			<FormattedHeader brandFont headerText={ translate( 'Security' ) } align="left" />
 
 			<HeaderCake backText={ translate( 'Back' ) } backHref="/me/security">
 				{ translate( 'Account Email' ) }

--- a/client/me/security-checkup/account-email.jsx
+++ b/client/me/security-checkup/account-email.jsx
@@ -6,18 +6,28 @@ import {
 	getCurrentUserEmail,
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
 import { getOKIcon, getWarningIcon } from './icons.js';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupAccountEmail extends Component {
 	static propTypes = {
+		emailChangePending: PropTypes.bool,
 		primaryEmail: PropTypes.string,
 		primaryEmailVerified: PropTypes.bool,
 		translate: PropTypes.func.isRequired,
+		userSettings: PropTypes.object,
 	};
 
 	render() {
-		const { primaryEmail, primaryEmailVerified, translate } = this.props;
+		const {
+			emailChangePending,
+			primaryEmail,
+			primaryEmailVerified,
+			translate,
+			userSettings,
+		} = this.props;
 
 		let icon;
 		let description;
@@ -29,6 +39,19 @@ class SecurityCheckupAccountEmail extends Component {
 				{
 					args: {
 						emailAddress: primaryEmail,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else if ( emailChangePending ) {
+			icon = getWarningIcon();
+			description = translate(
+				'You are in the process of changing your account email address to {{strong}}%(newEmailAddress)s{{/strong}}, but still need to confirm the change.',
+				{
+					args: {
+						newEmailAddress: userSettings.new_user_email,
 					},
 					components: {
 						strong: <strong />,
@@ -52,7 +75,7 @@ class SecurityCheckupAccountEmail extends Component {
 
 		return (
 			<SecurityCheckupNavigationItem
-				path={ '/me/account' }
+				path={ '/me/security/account-email' }
 				materialIcon={ icon }
 				text={ translate( 'Account Email' ) }
 				description={ description }
@@ -62,6 +85,8 @@ class SecurityCheckupAccountEmail extends Component {
 }
 
 export default connect( ( state ) => ( {
+	emailChangePending: isPendingEmailChange( state ),
 	primaryEmail: getCurrentUserEmail( state ),
 	primaryEmailVerified: isCurrentUserEmailVerified( state ),
+	userSettings: getUserSettings( state ),
 } ) )( localize( SecurityCheckupAccountEmail ) );

--- a/client/me/security-checkup/account-email.jsx
+++ b/client/me/security-checkup/account-email.jsx
@@ -48,7 +48,7 @@ class SecurityCheckupAccountEmail extends Component {
 		} else if ( emailChangePending ) {
 			icon = getWarningIcon();
 			description = translate(
-				'You are in the process of changing your account email address to {{strong}}%(newEmailAddress)s{{/strong}}, but still need to confirm the change.',
+				'You are in the process of changing your account email address to {{strong}}%(newEmailAddress)s{{/strong}}, but you still need to confirm the change.',
 				{
 					args: {
 						newEmailAddress: userSettings.new_user_email,

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -3,6 +3,7 @@ import page from 'page';
 import { createElement } from 'react';
 import { getSocialServiceFromClientId } from 'calypso/lib/login';
 import ConnectedAppsComponent from 'calypso/me/connected-applications';
+import SecurityAccountEmail from 'calypso/me/security-account-email';
 import AccountRecoveryComponent from 'calypso/me/security-account-recovery';
 import SecurityCheckupComponent from 'calypso/me/security-checkup';
 import PasswordComponent from 'calypso/me/security/main';
@@ -46,6 +47,12 @@ export function accountRecovery( context, next ) {
 	context.primary = createElement( AccountRecoveryComponent, {
 		path: context.path,
 	} );
+	next();
+}
+
+export function securityAccountEmail( context, next ) {
+	context.primary = <SecurityAccountEmail path={ context.path } />;
+
 	next();
 }
 

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -6,6 +6,7 @@ import {
 	accountRecovery,
 	connectedApplications,
 	password,
+	securityAccountEmail,
 	securityCheckup,
 	socialLogin,
 	twoStep,
@@ -18,6 +19,8 @@ export default function () {
 	page( '/me/security', sidebar, mainPageFunction, makeLayout, clientRender );
 
 	if ( useCheckupMenu ) {
+		page( '/me/security/account-email', sidebar, securityAccountEmail, makeLayout, clientRender );
+
 		page( '/me/security/password', sidebar, password, makeLayout, clientRender );
 	}
 

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -1,4 +1,4 @@
-import config from '@automattic/calypso-config';
+import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/me/controller';
@@ -13,16 +13,12 @@ import {
 } from './controller';
 
 export default function () {
-	const useCheckupMenu = config.isEnabled( 'security/security-checkup' );
-
-	const mainPageFunction = useCheckupMenu ? securityCheckup : password;
+	const mainPageFunction = isEnabled( 'security/security-checkup' ) ? securityCheckup : password;
 	page( '/me/security', sidebar, mainPageFunction, makeLayout, clientRender );
 
-	if ( useCheckupMenu ) {
-		page( '/me/security/account-email', sidebar, securityAccountEmail, makeLayout, clientRender );
+	page( '/me/security/account-email', sidebar, securityAccountEmail, makeLayout, clientRender );
 
-		page( '/me/security/password', sidebar, password, makeLayout, clientRender );
-	}
+	page( '/me/security/password', sidebar, password, makeLayout, clientRender );
 
 	page( '/me/security/social-login', sidebar, socialLogin, makeLayout, clientRender );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR creates a new `SecurityAccountEmail` component intended to run under `/me/security/account-email` as part of our security checkup approach to `/me/security`
* The PR also updates some of the routing logic so we always display some of the new routes regardless of the state of the `security/security-checkup` feature flag
* Finally, the PR also updates the account email checklist item to flag pending email changes as a warning

#### Testing instructions

* Run this branch locally or via [the calypso.live branch](https://github.com/Automattic/wp-calypso/pull/61768#issuecomment-1063017681)
* Navigate to `/me/security?flags=security/security-checkup`
* Click on the Account Email menu item
* Verify that you are taken to `/me/security/account-email` and can see the page to edit your account email
* Make some changes to the "Email address" field and ensure that when the email is invalid (i.e. not a valid email address or empty), we disable the "Update account email" button and show a validation error message, and the button is re-enabled when the email is valid (and not the same as the original)
* Change the email address to another email address you can receive email at, and click on the "Update account email" button
* Verify that the update is processed, and you see a notice mentioning that you need to confirm the new email address. At this stage the "Update account email" button should be disabled.
* Click on the "Back" button in the top left to bring you back to the main security menu -- you may need to add `?flags=security/security-checkup` to the URL to re-enable the feature flag
* Verify that the Account Email item has a warning for the pending email change
* Click on the Account Email item again
* Click on Cancel in the notice to stop the email change from proceeding

##### Screenshot

<img width="1073" alt="Screenshot 2022-03-09 at 16 57 41" src="https://user-images.githubusercontent.com/3376401/157468967-4f1ab307-fccb-4280-8460-5926c7db77eb.png">


Related to #61734 , which added the `AccountEmailField` component that this PR depends on
