### PR TITLE
Seller experience: Add payments pattern to non-eCommerce themes

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -647,20 +647,8 @@ export function generateSteps( {
 			apiRequestFunction: setDesignOnSite,
 			delayApiRequestUntilComplete: true,
 			dependencies: [ 'siteSlug' ],
-			providesDependencies: [
-				'isFSEActive',
-				'selectedDesign',
-				'selectedSiteCategory',
-				'intent',
-				'storeType',
-			],
-			optionalDependencies: [
-				'isFSEActive',
-				'selectedDesign',
-				'selectedSiteCategory',
-				'intent',
-				'storeType',
-			],
+			providesDependencies: [ 'isFSEActive', 'selectedDesign', 'selectedSiteCategory', 'intent' ],
+			optionalDependencies: [ 'isFSEActive', 'selectedDesign', 'selectedSiteCategory', 'intent' ],
 			props: {
 				showDesignPickerCategories: config.isEnabled( 'signup/design-picker-categories' ),
 				showDesignPickerCategoriesAllFilter: config.isEnabled( 'signup/design-picker-categories' ),

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -647,8 +647,20 @@ export function generateSteps( {
 			apiRequestFunction: setDesignOnSite,
 			delayApiRequestUntilComplete: true,
 			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'isFSEActive', 'selectedDesign', 'selectedSiteCategory' ],
-			optionalDependencies: [ 'isFSEActive', 'selectedDesign', 'selectedSiteCategory' ],
+			providesDependencies: [
+				'isFSEActive',
+				'selectedDesign',
+				'selectedSiteCategory',
+				'intent',
+				'storeType',
+			],
+			optionalDependencies: [
+				'isFSEActive',
+				'selectedDesign',
+				'selectedSiteCategory',
+				'intent',
+				'storeType',
+			],
 			props: {
 				showDesignPickerCategories: config.isEnabled( 'signup/design-picker-categories' ),
 				showDesignPickerCategoriesAllFilter: config.isEnabled( 'signup/design-picker-categories' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `setDesignOnSite` to account for cases where someone with the `sell` intent chooses a non-ecommerce theme.
* Instead of running theme setup in these cases, create a new home page with a Payments block pattern
* TODO: Fetch the eComm themes from a query rather than manual array
* TODO: This still doesn't always work 🤔  For some reason the Twenty Twenty Two themes don't take the block pattern, but other themes do. 

**Video demo**

TBD

#### Testing instructions

* Switch to this PR, navigate to `/start`
* Create a new site with the Sell intent; at the design selection step, choose a non-eCommerce theme (like Bennett)
* You should be brought to the site editor with a page called "Available now!" that includes a payment block pattern
* Create another new site from `/start` with the Sell intent; this time, choose one of the eCommerce themes (like Hari)
* You should be brought to the site editor with the full demo site content loaded
* Make sure other intents/flows are working as expected

Fixes #61651 
