### PR TITLE
Seller-experience: Adding new Payments block step

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-plan/use-site-plan.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-plan/use-site-plan.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from '@wordpress/element';
+import { useCallback } from 'react';
+import request from 'wpcom-proxy-request';
+
+const useSitePlan = ( siteIdOrSlug ) => {
+	const [ sitePlan, setSitePlan ] = useState();
+
+	const fetchSite = useCallback( async () => {
+		const siteObj = await request( {
+			path: `/sites/${ siteIdOrSlug }?http_envelope=1`,
+			apiNamespace: 'rest/v1.1',
+		} );
+		if ( siteObj?.plan ) {
+			setSitePlan( siteObj.plan );
+		}
+	}, [ siteIdOrSlug ] );
+
+	useEffect( () => {
+		fetchSite();
+	}, [ fetchSite ] );
+
+	return sitePlan;
+};
+export default useSitePlan;

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-plan/use-site-plan.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-plan/use-site-plan.ts
@@ -1,14 +1,16 @@
+import { SiteDetails } from '@automattic/data-stores/src/site';
+import { SiteDetailsPlan } from '@automattic/launch/src/stores';
 import { useState, useEffect } from '@wordpress/element';
 import { useCallback } from 'react';
 import request from 'wpcom-proxy-request';
 
-const useSitePlan = ( siteIdOrSlug ) => {
-	const [ sitePlan, setSitePlan ] = useState();
+const useSitePlan = ( siteIdOrSlug: string | number ) => {
+	const [ sitePlan, setSitePlan ] = useState( {} as SiteDetailsPlan );
 
 	const fetchSite = useCallback( async () => {
-		const siteObj = await request( {
+		const siteObj: SiteDetails = await request( {
 			path: `/sites/${ siteIdOrSlug }?http_envelope=1`,
-			apiNamespace: 'rest/v1.1',
+			apiVersion: '1.1',
 		} );
 		if ( siteObj?.plan ) {
 			setSitePlan( siteObj.plan );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -44,6 +44,7 @@ function getTourAssets( key: string ): TourAsset | undefined {
 function getTourSteps( localeSlug: string, referencePositioning = false ): WpcomStep[] {
 	return [
 		{
+			slug: 'welcome',
 			meta: {
 				heading: __( 'Welcome to WordPress!', 'full-site-editing' ),
 				descriptions: {
@@ -63,6 +64,7 @@ function getTourSteps( localeSlug: string, referencePositioning = false ): Wpcom
 			},
 		},
 		{
+			slug: 'everything-is-a-block',
 			meta: {
 				heading: __( 'Everything is a block', 'full-site-editing' ),
 				descriptions: {
@@ -82,6 +84,7 @@ function getTourSteps( localeSlug: string, referencePositioning = false ): Wpcom
 			},
 		},
 		{
+			slug: 'add-block',
 			...( referencePositioning && {
 				referenceElements: {
 					mobile:
@@ -112,6 +115,7 @@ function getTourSteps( localeSlug: string, referencePositioning = false ): Wpcom
 			},
 		},
 		{
+			slug: 'edit-block',
 			meta: {
 				heading: __( 'Click a block to change it', 'full-site-editing' ),
 				descriptions: {
@@ -131,6 +135,7 @@ function getTourSteps( localeSlug: string, referencePositioning = false ): Wpcom
 			},
 		},
 		{
+			slug: 'settings',
 			...( referencePositioning && {
 				referenceElements: {
 					mobile:
@@ -157,6 +162,7 @@ function getTourSteps( localeSlug: string, referencePositioning = false ): Wpcom
 		...( ! isMobile()
 			? [
 					{
+						slug: 'find-your-way',
 						meta: {
 							heading: __( 'Find your way', 'full-site-editing' ),
 							descriptions: {
@@ -180,6 +186,7 @@ function getTourSteps( localeSlug: string, referencePositioning = false ): Wpcom
 		...( ! isMobile()
 			? [
 					{
+						slug: 'undo',
 						...( referencePositioning && {
 							referenceElements: {
 								desktop:
@@ -207,6 +214,7 @@ function getTourSteps( localeSlug: string, referencePositioning = false ): Wpcom
 			  ]
 			: [] ),
 		{
+			slug: 'drag-drop',
 			meta: {
 				heading: __( 'Drag & drop', 'full-site-editing' ),
 				descriptions: {
@@ -259,6 +267,7 @@ function getTourSteps( localeSlug: string, referencePositioning = false ): Wpcom
 			},
 		},
 		{
+			slug: 'congratulations',
 			meta: {
 				heading: __( 'Congratulations!', 'full-site-editing' ),
 				descriptions: {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -257,7 +257,6 @@ function getTourSteps( localeSlug: string, referencePositioning = false ): Wpcom
 					mobile: null,
 				},
 				imgSrc: getTourAssets( 'welcome' ),
-				animation: null,
 			},
 			options: {
 				classNames: {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -223,6 +223,42 @@ function getTourSteps( localeSlug: string, referencePositioning = false ): Wpcom
 			},
 		},
 		{
+			slug: 'payment-block',
+			meta: {
+				heading: __( 'The Payments block', 'full-site-editing' ),
+				descriptions: {
+					desktop: (
+						<>
+							{ __(
+								'The Payments block allows you to accept payments for one-time, monthly recurring, or annual payments on your website',
+								'full-site-editing'
+							) }
+							<br />
+							<ExternalLink
+								href={ localizeUrl(
+									'https://wordpress.com/support/video-tutorials-add-payments-features-to-your-site-with-our-guides/#how-to-use-the-payments-block-video',
+									localeSlug
+								) }
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{ __( 'Learn more', 'full-site-editing' ) }
+							</ExternalLink>
+						</>
+					),
+					mobile: null,
+				},
+				imgSrc: getTourAssets( 'welcome' ),
+				animation: null,
+			},
+			options: {
+				classNames: {
+					desktop: 'wpcom-editor-welcome-tour__step',
+					mobile: 'wpcom-editor-welcome-tour__step',
+				},
+			},
+		},
+		{
 			meta: {
 				heading: __( 'Congratulations!', 'full-site-editing' ),
 				descriptions: {

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import type { Modifier } from 'react-popper';
 
 export interface Step {
+	slug?: string;
 	referenceElements?: {
 		desktop?: string;
 		mobile?: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add new 'Payment block' step to editor welcome tour

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To see the new step:

* [Sync](https://github.com/Automattic/wp-calypso/tree/trunk/apps) calypso's `editing-toolkit` app to your sandbox
* Sandbox a new site url
* Create this new site using the simple seller flow
* Its editor should open on the end of the flow `https://wordpress.com/site-editor/<your-site>`
* There should be a "Payments block" step (the second-to-last step)
* If you follow any other flow, you shouldn't get the Payments step.

![image](https://user-images.githubusercontent.com/3801502/156362884-81dfa06d-2112-45e6-a3e2-18fcd40a9200.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #61466 
