### PR TITLE
Licensing Portal: Use "per_page" count from the payment methods API response

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
@@ -14,14 +14,13 @@ import StoredCreditCard from 'calypso/jetpack-cloud/sections/partner-portal/stor
 import StoredCreditCardLoading from 'calypso/jetpack-cloud/sections/partner-portal/stored-credit-card/stored-credit-card-loading';
 import {
 	getAllStoredCards,
+	getStoredCardsPerPage,
 	isFetchingStoredCards,
 	hasMoreStoredCards,
 } from 'calypso/state/partner-portal/stored-cards/selectors';
 import type { ReactElement } from 'react';
 
 import './style.scss';
-
-const ITEMS_PER_PAGE = 8;
 
 const preparePagingCursor = (
 	direction: 'next' | 'prev',
@@ -45,6 +44,7 @@ export default function PaymentMethodList(): ReactElement {
 	const translate = useTranslate();
 	const storedCards = useSelector( getAllStoredCards );
 	const isFetching = useSelector( isFetchingStoredCards );
+	const perPage = useSelector( getStoredCardsPerPage );
 	const hasMoreItems = useSelector( hasMoreStoredCards );
 	const cards = storedCards.map( ( card: PaymentMethod ) => (
 		<StoredCreditCard key={ card.id } card={ card } />
@@ -95,7 +95,7 @@ export default function PaymentMethodList(): ReactElement {
 					} ) }
 					pageClick={ onPageClick }
 					page={ currentPage }
-					perPage={ ITEMS_PER_PAGE }
+					perPage={ perPage }
 				/>
 			) }
 		</Main>

--- a/client/state/partner-portal/stored-cards/actions.ts
+++ b/client/state/partner-portal/stored-cards/actions.ts
@@ -20,10 +20,15 @@ export const fetchStoredCards = ( paging: { startingAfter: string; endingBefore:
 			},
 			{ starting_after: paging.startingAfter, ending_before: paging.endingBefore }
 		)
-		.then( ( data: { items: PaymentMethod[]; has_more: boolean } ) => {
+		.then( ( data: { items: PaymentMethod[]; has_more: boolean; per_page: number } ) => {
 			dispatch( {
 				type: 'STORED_CARDS_HAS_MORE_ITEMS',
 				hasMore: data.has_more,
+			} );
+
+			dispatch( {
+				type: 'STORED_CARDS_ITEMS_PER_PAGE',
+				perPage: data.per_page,
 			} );
 
 			dispatch( {

--- a/client/state/partner-portal/stored-cards/reducer.ts
+++ b/client/state/partner-portal/stored-cards/reducer.ts
@@ -46,7 +46,7 @@ type ItemsPerPageAction = {
 	perPage: number;
 };
 
-export const itemsPerPage: Reducer< number, ItemsPerPageAction > = ( state = 8, action ) => {
+export const itemsPerPage: Reducer< number, ItemsPerPageAction > = ( state = 30, action ) => {
 	switch ( action?.type ) {
 		case 'STORED_CARDS_ITEMS_PER_PAGE': {
 			const { perPage } = action;

--- a/client/state/partner-portal/stored-cards/reducer.ts
+++ b/client/state/partner-portal/stored-cards/reducer.ts
@@ -41,6 +41,21 @@ export const items: Reducer< PaymentMethod[], ItemsAction > = ( state = [], acti
 	return state;
 };
 
+type ItemsPerPageAction = {
+	type: 'STORED_CARDS_ITEMS_PER_PAGE';
+	perPage: number;
+};
+
+export const itemsPerPage: Reducer< number, ItemsPerPageAction > = ( state = 8, action ) => {
+	switch ( action?.type ) {
+		case 'STORED_CARDS_ITEMS_PER_PAGE': {
+			const { perPage } = action;
+			return perPage;
+		}
+	}
+	return state;
+};
+
 type MoreItemsAction = {
 	type: 'STORED_CARDS_HAS_MORE_ITEMS';
 	hasMore: boolean;
@@ -112,6 +127,7 @@ export const isDeleting: Reducer< { [ key: string ]: boolean }, DeletingActionSt
 
 const combinedReducer = combineReducers( {
 	items: items as Reducer,
+	itemsPerPage: itemsPerPage as Reducer,
 	isDeleting: isDeleting as Reducer,
 	isFetching,
 	hasMoreItems: hasMoreItems as Reducer,

--- a/client/state/partner-portal/stored-cards/selectors.ts
+++ b/client/state/partner-portal/stored-cards/selectors.ts
@@ -2,11 +2,13 @@ import 'calypso/state/partner-portal/stored-cards/init';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 import type { AppState } from 'calypso/types';
 
+const DEFAULT_CARDS_PER_PAGE = 30;
+
 export const getAllStoredCards = ( state: AppState ): PaymentMethod[] =>
 	state?.partnerPortal?.storedCards?.items ?? [];
 
 export const getStoredCardsPerPage = ( state: AppState ): number =>
-	Number( state?.partnerPortal?.storedCards?.itemsPerPage );
+	parseInt( state?.partnerPortal?.storedCards?.itemsPerPage ) || DEFAULT_CARDS_PER_PAGE;
 
 export const isFetchingStoredCards = ( state: AppState ) =>
 	Boolean( state?.partnerPortal?.storedCards?.isFetching );

--- a/client/state/partner-portal/stored-cards/selectors.ts
+++ b/client/state/partner-portal/stored-cards/selectors.ts
@@ -6,7 +6,7 @@ export const getAllStoredCards = ( state: AppState ): PaymentMethod[] =>
 	state?.partnerPortal?.storedCards?.items ?? [];
 
 export const getStoredCardsPerPage = ( state: AppState ): number =>
-	state?.partnerPortal?.storedCards?.perPage ?? 8;
+	Number( state?.partnerPortal?.storedCards?.itemsPerPage );
 
 export const isFetchingStoredCards = ( state: AppState ) =>
 	Boolean( state?.partnerPortal?.storedCards?.isFetching );

--- a/client/state/partner-portal/stored-cards/selectors.ts
+++ b/client/state/partner-portal/stored-cards/selectors.ts
@@ -5,6 +5,9 @@ import type { AppState } from 'calypso/types';
 export const getAllStoredCards = ( state: AppState ): PaymentMethod[] =>
 	state?.partnerPortal?.storedCards?.items ?? [];
 
+export const getStoredCardsPerPage = ( state: AppState ): number =>
+	state?.partnerPortal?.storedCards?.perPage ?? 8;
+
 export const isFetchingStoredCards = ( state: AppState ) =>
 	Boolean( state?.partnerPortal?.storedCards?.isFetching );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `per_page` property returned from the server instead of duplicating the value in Calypso.

#### Testing instructions
- ~Apply D76607-code~ (this patch has already been merged)
- See https://github.com/Automattic/wp-calypso/pull/61679 for detailed testing instructions.
- Verify the payment methods are displayed correctly.

Related to 1201734780767770-as-1201956558991730