### PR TITLE
Marketplace: Education Footer Background Change and Hover State

### DIFF
--- a/client/components/link-card/index.tsx
+++ b/client/components/link-card/index.tsx
@@ -16,6 +16,10 @@ interface LinkCardProps {
 }
 
 const LinkCardContainer = styled.div< LinkCardContainerProps >`
+	:hover {
+		filter: brightness( 120% );
+	}
+
 	border-radius: 5px;
 	padding: 24px;
 	background: var( --${ ( props ) => props.background || 'studio-white' } );

--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -12,7 +12,7 @@ const SectionContainer = styled.div`
 	::before {
 		box-sizing: border-box;
 		content: '';
-		background-color: #fafafa;
+		background-color: var( --studio-gray-0 );
 		position: absolute;
 		height: 100%;
 		width: 200vw;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes footer background to use `gray-0`.
* Adds hover state via lightening the background color of cards.

#### Video
https://user-images.githubusercontent.com/1035546/157542398-9e8ef111-970d-4637-a83e-73dfe68c29fe.mp4

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `http://calypso.localhost:3000/plugins/:siteId`.
* Scroll down to the bottom.
* Footer background should be `gray-0`.
* Hovering on cards should lighten the background.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #61491