### PR TITLE
CI: update list of pre-authenticated accounts for WPCOM tests.

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -244,6 +244,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String ): E2E
 				checked = "true",
 				unchecked = "false"
 			)
+			param("env.AUTHENTICATE_ACCOUNTS", "gutenbergSimpleSiteEdgeUser,gutenbergSimpleSiteUser,coBlocksSimpleSiteEdgeUser,simpleSitePersonalPlanUser")
 			param("env.VIEWPORT_NAME", "$targetDevice")
 		},
 		buildFeatures = {
@@ -300,6 +301,7 @@ fun coblocksPlaywrightBuildType( targetDevice: String, buildUuid: String ): E2EB
 				checked = "true",
 				unchecked = "false"
 			)
+			param("env.AUTHENTICATE_ACCOUNTS", "gutenbergSimpleSiteEdgeUser,gutenbergSimpleSiteUser,coBlocksSimpleSiteEdgeUser")
 			param("env.VIEWPORT_NAME", "$targetDevice")
 		},
 		buildFeatures = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to add a list of accounts to be pre-authenticated for WPCOM tests.

Precedent for this is established with Calypso E2E tests, which use a different list of pre-authenticated accounts tailored for the Calypso E2E tests.

Key changes:
- specify the pre-authentication of all accounts used for WPCOM/Gutenberg E2E tests.

#### Testing instructions

Ensure that account authentication and cookie storage step are observed in the build log.

