### PR TITLE
Managed Plan: Allow sites to be moved to Atomic

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -1,4 +1,4 @@
-import { isBusiness, isEcommerce, isEnterprise } from '@automattic/calypso-products';
+import { isBusiness, isEcommerce, isEnterprise, isManaged } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { ThemeProvider } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
@@ -126,7 +126,8 @@ const MarketplacePluginInstall = ( {
 	useEffect( () => {
 		supportsAtomicUpgrade.current =
 			selectedSite?.plan &&
-			( isBusiness( selectedSite.plan ) ||
+			( isManaged( selectedSite.plan ) ||
+				isBusiness( selectedSite.plan ) ||
 				isEnterprise( selectedSite.plan ) ||
 				isEcommerce( selectedSite.plan ) );
 	}, [ selectedSite ] );

--- a/client/state/marketplace/selectors.ts
+++ b/client/state/marketplace/selectors.ts
@@ -1,4 +1,10 @@
-import { isBusiness, isEcommerce, isEnterprise, isMonthly } from '@automattic/calypso-products';
+import {
+	isBusiness,
+	isEcommerce,
+	isEnterprise,
+	isManaged,
+	isMonthly,
+} from '@automattic/calypso-products';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import { default as isVipSite } from 'calypso/state/selectors/is-vip-site';
@@ -14,6 +20,7 @@ const shouldUpgradeCheck = (
 ) => {
 	return selectedSite
 		? ! (
+				isManaged( selectedSite?.plan ) ||
 				isBusiness( selectedSite?.plan ) ||
 				isEnterprise( selectedSite?.plan ) ||
 				isEcommerce( selectedSite?.plan ) ||

--- a/client/state/purchases/selectors/should-revert-atomic-site-before-deactivation.js
+++ b/client/state/purchases/selectors/should-revert-atomic-site-before-deactivation.js
@@ -1,4 +1,8 @@
-import { isWpComBusinessPlan, isWpComEcommercePlan } from '@automattic/calypso-products';
+import {
+	isWpComBusinessPlan,
+	isWpComEcommercePlan,
+	isWpComManagedPlan,
+} from '@automattic/calypso-products';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getByPurchaseId } from './get-by-purchase-id';
@@ -21,6 +25,7 @@ export const shouldRevertAtomicSiteBeforeDeactivation = ( state, purchaseId ) =>
 	const purchase = getByPurchaseId( state, purchaseId );
 
 	const isAtomicSupportedProduct = ( productSlug ) =>
+		isWpComManagedPlan( productSlug ) ||
 		isWpComBusinessPlan( productSlug ) ||
 		isWpComEcommercePlan( productSlug ) ||
 		isMarketplaceProduct( state, productSlug );

--- a/client/state/selectors/is-site-on-atomic-plan.js
+++ b/client/state/selectors/is-site-on-atomic-plan.js
@@ -1,4 +1,4 @@
-import { isEcommercePlan, isBusinessPlan } from '@automattic/calypso-products';
+import { isEcommercePlan, isBusinessPlan, isManagedPlan } from '@automattic/calypso-products';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 
 /**
@@ -16,7 +16,11 @@ const isSiteOnAtomicPlan = ( state, siteId ) => {
 		return false;
 	}
 
-	return isEcommercePlan( currentPlan.productSlug ) || isBusinessPlan( currentPlan.productSlug );
+	return (
+		isEcommercePlan( currentPlan.productSlug ) ||
+		isBusinessPlan( currentPlan.productSlug ) ||
+		isManagedPlan( currentPlan.productSlug )
+	);
 };
 
 export default isSiteOnAtomicPlan;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request adds basic functionality to enable the new Managed plan to be moved to Atomic and reverted.

#### Testing instructions

1. Apply D76435-code on the server
2. In store sandbox mode, purchase the Managed plan, e.g. at http://calypso.localhost:3000/checkout/managed
3. Go to the Plugins page (e.g. http://calypso.localhost:3000/plugins) and install a plugin.
4. Ensure that it takes you through the process of moving to Atomic (i.e., a `wpcomstaging` domain and everything else).
5. Go to cancel the Managed plan. After confirming the revert, it should (eventually) put you back to a normal non-Atomic site.

Note: This pull request is just designed to get the basics working.  The plugin itself won't actually be installed (that will probably require other server-side code to actually be deployed) and there may be text on the screen incorrectly telling you that you need a Business plan, etc.

If you want, you can also test the above process for a site with a Business plan too, and make sure that it continues to work OK.