### PR TITLE
Update Jetpack Pricing Page For Price Update

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -5,12 +5,13 @@ import { useSelector } from 'react-redux';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 import { preventWidows } from 'calypso/lib/formatting';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { INTRO_PRICING_DISCOUNT_PERCENTAGE } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { isConnectStore } from 'calypso/my-sites/plans/jetpack-plans/product-grid/utils';
 import {
 	getFullJetpackSaleCouponDiscountRatio,
 	getHasRequestedJetpackSaleCoupon,
 } from 'calypso/state/marketing/selectors';
+import getBestIntroOfferDiscount from 'calypso/state/selectors/get-best-intro-offer-discount';
+import getIsRequestingIntroOffers from 'calypso/state/selectors/get-is-requesting-into-offers';
 import './style.scss';
 import guaranteeBadge from './14-day-badge.svg';
 import rocket from './rocket.svg';
@@ -18,11 +19,22 @@ import rocket from './rocket.svg';
 // since this amount is backed into the badge above we make it a const
 const GUARANTEE_DAYS = 14;
 
-const IntroPricingBanner: FunctionComponent = () => {
+interface Props {
+	productSlugs: string[];
+	siteId: number | 'none';
+}
+
+const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId = 'none' } ) => {
 	const translate = useTranslate();
 	const isNotNarrow = useViewportMatch( 'medium', '>=' );
 	const fullJetpackSaleDiscount = useSelector( getFullJetpackSaleCouponDiscountRatio ) * 100;
 	const hasRequestedCoupon = useSelector( getHasRequestedJetpackSaleCoupon );
+	const isRequestingIntroOffers = useSelector( ( state ) =>
+		getIsRequestingIntroOffers( state, siteId )
+	);
+	const highestDiscount = useSelector( ( state ) =>
+		getBestIntroOfferDiscount( state, productSlugs, siteId )
+	);
 
 	const CALYPSO_MASTERBAR_HEIGHT = 47;
 	const CLOUD_MASTERBAR_HEIGHT = 0;
@@ -38,10 +50,10 @@ const IntroPricingBanner: FunctionComponent = () => {
 
 	const outerDivProps = barRef ? { ref: barRef as React.RefObject< HTMLDivElement > } : {};
 
-	const isLoading = ! hasRequestedCoupon;
+	const isLoading = ! hasRequestedCoupon || isRequestingIntroOffers;
 
 	const discountPercentage =
-		fullJetpackSaleDiscount > 0 ? fullJetpackSaleDiscount : INTRO_PRICING_DISCOUNT_PERCENTAGE;
+		fullJetpackSaleDiscount > 0 ? fullJetpackSaleDiscount : highestDiscount;
 
 	let className;
 
@@ -67,7 +79,7 @@ const IntroPricingBanner: FunctionComponent = () => {
 					/>
 					<span>
 						{ preventWidows(
-							translate( 'Get %(percent)d%% off your first year.', {
+							translate( 'Get up to %(percent)d%% off your first year.', {
 								args: {
 									percent: discountPercentage,
 								},

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -69,25 +69,27 @@ const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId 
 		<>
 			<div className="intro-pricing-banner__viewport-sentinel" { ...outerDivProps }></div>
 			<div className={ className }>
-				<div className="intro-pricing-banner__discount">
-					<img
-						src={ rocket }
-						alt={ translate( 'Rocket representing %(percent)d%% sale', {
-							args: { percent: discountPercentage },
-							textOnly: true,
-						} ) }
-					/>
-					<span>
-						{ preventWidows(
-							translate( 'Get up to %(percent)d%% off your first year.', {
-								args: {
-									percent: discountPercentage,
-								},
-							} )
-						) }
-					</span>
-				</div>
-				{ isNotNarrow && (
+				{ ( discountPercentage > 0 || isLoading ) && (
+					<div className="intro-pricing-banner__discount">
+						<img
+							src={ rocket }
+							alt={ translate( 'Rocket representing %(percent)d%% sale', {
+								args: { percent: discountPercentage },
+								textOnly: true,
+							} ) }
+						/>
+						<span>
+							{ preventWidows(
+								translate( 'Get up to %(percent)d%% off your first year.', {
+									args: {
+										percent: discountPercentage,
+									},
+								} )
+							) }
+						</span>
+					</div>
+				) }
+				{ ( isNotNarrow || ( discountPercentage <= 0 && ! isLoading ) ) && (
 					<div className="intro-pricing-banner__guarantee">
 						<img
 							src={ guaranteeBadge }

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -216,7 +216,13 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 			<ProductGridSection>
 				{ ! planRecommendation && filterBar }
 				<div className="product-grid__pricing-banner">
-					<IntroPricingBanner />
+					<IntroPricingBanner
+						productSlugs={ [
+							...popularItems.map( ( { productSlug } ) => productSlug ),
+							...otherItems.map( ( { productSlug } ) => productSlug ),
+						] }
+						siteId={ siteId ?? 'none' }
+					/>
 				</div>
 				<ul
 					className={ classNames( 'product-grid__plan-grid', {

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -149,7 +149,7 @@ const useItemPrice = (
 		if ( item.term !== TERM_MONTHLY ) {
 			originalPrice = monthlyItemCost ?? itemCost / 12;
 			discountedPrice = introductoryOfferPrices.introOfferCost
-				? introductoryOfferPrices.introOfferCost / 12
+				? ( introductoryOfferPrices.introOfferCost * 100 ) / 12 / 100
 				: undefined;
 		}
 	}

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -113,6 +113,8 @@ const useIntroductoryOfferPrices = (
 	};
 };
 
+const getMonthlyPrice = ( yearlyPrice: number ): number => ( yearlyPrice * 100 ) / 12 / 100;
+
 const useItemPrice = (
 	siteId: number | null,
 	item: SelectorProduct | null,
@@ -147,9 +149,9 @@ const useItemPrice = (
 	if ( item && itemCost ) {
 		originalPrice = itemCost;
 		if ( item.term !== TERM_MONTHLY ) {
-			originalPrice = monthlyItemCost ?? itemCost / 12;
+			originalPrice = monthlyItemCost ?? getMonthlyPrice( itemCost );
 			discountedPrice = introductoryOfferPrices.introOfferCost
-				? ( introductoryOfferPrices.introOfferCost * 100 ) / 12 / 100
+				? getMonthlyPrice( introductoryOfferPrices.introOfferCost )
 				: undefined;
 		}
 	}

--- a/client/state/selectors/get-best-intro-offer-discount.ts
+++ b/client/state/selectors/get-best-intro-offer-discount.ts
@@ -1,0 +1,27 @@
+import type { IntroOffer } from 'calypso/state/sites/intro-offers/types';
+import type { AppState } from 'calypso/types';
+
+/**
+ * @param  {object}  state       Global state tree
+ * @param  {number}  productSlugs   The productSlugs to check for a best intro offer discount
+ * @param  {number|null}  siteId      The ID of the site we're querying
+ * @returns {number|null}        The best intro offer discount ( may be zero if no intro offers are found)
+ */
+export default function getBestIntroOfferDiscount(
+	state: AppState,
+	productSlugs: string[],
+	siteId: number | null | 'none'
+): number {
+	const siteIdKey = siteId && typeof siteId === 'number' && siteId > 0 ? siteId : 'none';
+
+	return ( Object.values(
+		state.sites?.introOffers?.items?.[ siteIdKey ] || {}
+	) as IntroOffer[] ).reduce(
+		( previousBest, currentOffer ) =>
+			currentOffer.discountPercentage > previousBest &&
+			productSlugs.includes( currentOffer.productSlug )
+				? currentOffer.discountPercentage
+				: previousBest,
+		0
+	);
+}

--- a/client/state/selectors/get-is-requesting-into-offers.ts
+++ b/client/state/selectors/get-is-requesting-into-offers.ts
@@ -9,6 +9,9 @@ import type { AppState } from 'calypso/types';
  * @param  {number?}  siteId    The ID of the site we're querying
  * @returns {string}            true if request is in-progress, false otherwise
  */
-export default function getIsIntroOfferRequesting( state: AppState, siteId?: number ): boolean {
+export default function getIsIntroOfferRequesting(
+	state: AppState,
+	siteId?: number | 'none'
+): boolean {
 	return getIntroOfferRequestStatus( state, siteId ) === RequestStatus.Pending;
 }

--- a/client/state/sites/intro-offers/reducer.ts
+++ b/client/state/sites/intro-offers/reducer.ts
@@ -17,19 +17,21 @@ interface IntroOfferItemsState {
 }
 
 const mapResponseObject = ( {
+	currency_code,
+	discount_percentage,
+	formatted_price,
+	ineligible_reason,
 	product_id,
 	product_slug,
-	currency_code,
-	formatted_price,
 	raw_price,
-	ineligible_reason,
 }: ResponseIntroOffer ): IntroOffer => ( {
+	currencyCode: currency_code,
+	discountPercentage: discount_percentage,
+	formattedPrice: formatted_price,
+	ineligibleReason: ineligible_reason,
 	productId: product_id,
 	productSlug: product_slug,
-	currencyCode: currency_code,
-	formattedPrice: formatted_price,
 	rawPrice: raw_price,
-	ineligibleReason: ineligible_reason,
 } );
 
 const createIntroOfferMap = ( payload: ResponseIntroOffer[] ) => {

--- a/client/state/sites/intro-offers/test/reducer.ts
+++ b/client/state/sites/intro-offers/test/reducer.ts
@@ -23,6 +23,7 @@ describe( 'reducer', () => {
 							formatted_price: '$149',
 							raw_price: 149,
 							ineligible_reason: null,
+							discount_percentage: 50,
 						},
 					],
 				} as IntroOfferReceiveAction );
@@ -36,6 +37,7 @@ describe( 'reducer', () => {
 							formattedPrice: '$149',
 							rawPrice: 149,
 							ineligibleReason: null,
+							discountPercentage: 50,
 						},
 					},
 				} );
@@ -53,6 +55,7 @@ describe( 'reducer', () => {
 							formatted_price: '$149',
 							raw_price: 149,
 							ineligible_reason: null,
+							discount_percentage: 50,
 						},
 					],
 				} as IntroOfferReceiveAction );
@@ -66,6 +69,7 @@ describe( 'reducer', () => {
 							formattedPrice: '$149',
 							rawPrice: 149,
 							ineligibleReason: null,
+							discountPercentage: 50,
 						},
 					},
 				} );

--- a/client/state/sites/intro-offers/types.ts
+++ b/client/state/sites/intro-offers/types.ts
@@ -1,19 +1,21 @@
 export interface IntroOffer {
+	currencyCode: string;
+	discountPercentage: number;
+	formattedPrice: string;
+	ineligibleReason: string[] | null;
 	productId: number;
 	productSlug: string;
-	currencyCode: string;
-	formattedPrice: string;
 	rawPrice: number;
-	ineligibleReason: string[] | null;
 }
 
 export interface ResponseIntroOffer {
+	currency_code: string;
+	discount_percentage: number;
+	formatted_price: string;
+	ineligible_reason: string[] | null;
 	product_id: number;
 	product_slug: string;
-	currency_code: string;
-	formatted_price: string;
 	raw_price: number;
-	ineligible_reason: string[] | null;
 }
 
 export enum RequestStatus {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update Pricing Intro Banner to say "Up to X% off"
   * Support new discount percentage in intro offer endpoint ( requires D76437-code )
   * Create new "getBestIntroOfferDiscount" selector
* Fix floating pointing point error when dividing annual prices by 12 by multiplying and dividing by 100.

<img width="981" alt="Screen Shot 2022-03-09 at 21 34 58" src="https://user-images.githubusercontent.com/2810519/157596625-d63da2c5-5181-4d1b-a317-1ddc25d00495.png">

#### Testing instructions

1. Sandbox `public-api.wordpress.com`, use store sandbox, and apply D76437-code if it has not yet been merged.
2. Boot branch as Calypso Green and navigate to `/pricing`
3. Verify monthly prices are all `X.95` in USD.
4. Verify the Intro Banner now says "Up to 70% off

