### PR TITLE
Consolidate data fetching in SecurityCheckup component

### DIFF
--- a/client/me/security-checkup/account-email.jsx
+++ b/client/me/security-checkup/account-email.jsx
@@ -7,12 +7,14 @@ import {
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import hasUserSettings from 'calypso/state/selectors/has-user-settings';
 import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
 import { getOKIcon, getWarningIcon } from './icons.js';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupAccountEmail extends Component {
 	static propTypes = {
+		areUserSettingsLoaded: PropTypes.bool,
 		emailChangePending: PropTypes.bool,
 		primaryEmail: PropTypes.string,
 		primaryEmailVerified: PropTypes.bool,
@@ -22,12 +24,17 @@ class SecurityCheckupAccountEmail extends Component {
 
 	render() {
 		const {
+			areUserSettingsLoaded,
 			emailChangePending,
 			primaryEmail,
 			primaryEmailVerified,
 			translate,
 			userSettings,
 		} = this.props;
+
+		if ( ! areUserSettingsLoaded ) {
+			return <SecurityCheckupNavigationItem isPlaceholder />;
+		}
 
 		let icon;
 		let description;
@@ -85,6 +92,7 @@ class SecurityCheckupAccountEmail extends Component {
 }
 
 export default connect( ( state ) => ( {
+	areUserSettingsLoaded: hasUserSettings( state ),
 	emailChangePending: isPendingEmailChange( state ),
 	primaryEmail: getCurrentUserEmail( state ),
 	primaryEmailVerified: isCurrentUserEmailVerified( state ),

--- a/client/me/security-checkup/account-recovery-email.jsx
+++ b/client/me/security-checkup/account-recovery-email.jsx
@@ -1,8 +1,7 @@
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component, Fragment } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
-import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
 import {
 	getAccountRecoveryEmail,
 	isAccountRecoveryEmailActionInProgress,
@@ -28,12 +27,7 @@ class SecurityCheckupAccountRecoveryEmail extends Component {
 		} = this.props;
 
 		if ( accountRecoveryEmailActionInProgress ) {
-			return (
-				<Fragment>
-					<QueryAccountRecoverySettings />
-					<SecurityCheckupNavigationItem isPlaceholder={ true } />
-				</Fragment>
-			);
+			return <SecurityCheckupNavigationItem isPlaceholder={ true } />;
 		}
 
 		let icon;

--- a/client/me/security-checkup/account-recovery-phone.jsx
+++ b/client/me/security-checkup/account-recovery-phone.jsx
@@ -1,8 +1,7 @@
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component, Fragment } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
-import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
 import {
 	getAccountRecoveryPhone,
 	isAccountRecoveryPhoneActionInProgress,
@@ -28,12 +27,7 @@ class SecurityCheckupAccountRecoveryPhone extends Component {
 		} = this.props;
 
 		if ( accountRecoveryPhoneActionInProgress ) {
-			return (
-				<Fragment>
-					<QueryAccountRecoverySettings />
-					<SecurityCheckupNavigationItem isPlaceholder={ true } />
-				</Fragment>
-			);
+			return <SecurityCheckupNavigationItem isPlaceholder={ true } />;
 		}
 
 		let icon;

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -2,6 +2,8 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import SectionHeader from 'calypso/components/section-header';
@@ -35,6 +37,9 @@ class SecurityCheckupComponent extends Component {
 				<PageViewTracker path={ path } title="Me > Security Checkup" />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<MeSidebarNavigation />
+
+				<QueryAccountRecoverySettings />
+				<QueryUserSettings />
 
 				<DocumentHead title={ translate( 'Security' ) } />
 

--- a/client/me/security-checkup/two-factor-authentication.jsx
+++ b/client/me/security-checkup/two-factor-authentication.jsx
@@ -1,8 +1,7 @@
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component, Fragment } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
-import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import hasUserSettings from 'calypso/state/selectors/has-user-settings';
 import isTwoStepEnabled from 'calypso/state/selectors/is-two-step-enabled';
@@ -29,12 +28,7 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 		} = this.props;
 
 		if ( ! areUserSettingsLoaded ) {
-			return (
-				<Fragment>
-					<QueryUserSettings />
-					<SecurityCheckupNavigationItem isPlaceholder={ true } />
-				</Fragment>
-			);
+			return <SecurityCheckupNavigationItem isPlaceholder={ true } />;
 		}
 
 		let icon;
@@ -69,15 +63,12 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 		}
 
 		return (
-			<Fragment>
-				<QueryUserSettings />
-				<SecurityCheckupNavigationItem
-					path={ '/me/security/two-step' }
-					materialIcon={ icon }
-					text={ translate( 'Two-Step Authentication' ) }
-					description={ description }
-				/>
-			</Fragment>
+			<SecurityCheckupNavigationItem
+				path={ '/me/security/two-step' }
+				materialIcon={ icon }
+				text={ translate( 'Two-Step Authentication' ) }
+				description={ description }
+			/>
 		);
 	}
 }

--- a/client/me/security-checkup/two-factor-backup-codes.jsx
+++ b/client/me/security-checkup/two-factor-backup-codes.jsx
@@ -1,8 +1,7 @@
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component, Fragment } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
-import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import hasUserSettings from 'calypso/state/selectors/has-user-settings';
 import isTwoStepEnabled from 'calypso/state/selectors/is-two-step-enabled';
@@ -26,12 +25,7 @@ class SecurityCheckupTwoFactorBackupCodes extends Component {
 		} = this.props;
 
 		if ( ! areUserSettingsLoaded ) {
-			return (
-				<Fragment>
-					<QueryUserSettings />
-					<SecurityCheckupNavigationItem isPlaceholder={ true } />
-				</Fragment>
-			);
+			return <SecurityCheckupNavigationItem isPlaceholder={ true } />;
 		}
 
 		// Don't show this item if the user doesn't have 2FA enabled.
@@ -58,15 +52,12 @@ class SecurityCheckupTwoFactorBackupCodes extends Component {
 		}
 
 		return (
-			<Fragment>
-				<QueryUserSettings />
-				<SecurityCheckupNavigationItem
-					path={ '/me/security/two-step' }
-					materialIcon={ icon }
-					text={ translate( 'Two-Step Backup Codes' ) }
-					description={ description }
-				/>
-			</Fragment>
+			<SecurityCheckupNavigationItem
+				path={ '/me/security/two-step' }
+				materialIcon={ icon }
+				text={ translate( 'Two-Step Backup Codes' ) }
+				description={ description }
+			/>
 		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR refactors the `SecurityCheckup` component and some of its subsidiary menu item components so that data fetching for account recovery settings and user settings is always triggered by `SecurityCheckup` component rather than having multiple menu items request the same data. This work was spurred by [this discussion](https://github.com/Automattic/wp-calypso/pull/61768#issuecomment-1063766252) on #61768.

#### Testing instructions

* Run this branch locally or via [the calypso.live branch](https://github.com/Automattic/wp-calypso/pull/61791#issuecomment-1063889872)
* Open the network tab of your browser's developer tools, and optionally filter the calls to XMLHttpRequests (aka XHR for Chrome and Firefox)
* Navigate to `/me/security?flags=security/security-checkup`
* Verify that you see calls to the following `public-api.wordpress.com` endpoints:
  - `/rest/v1.1/me/account-recovery`
  - `/rest/v1.1/me/settings`
* Click on any one of the "Recovery" or "Two Factor" menu items
* Clear your network history, and then click on the "Back" link in the page
* Verify that you see API calls the following `public-api.wordpress.com` endpoints:
  - `/rest/v1.1/me/account-recovery`
  - `/rest/v1.1/me/settings`

Related to #61768
