### PR TITLE
Enable Security Checkup feature in development, horizon, and wpcalypso

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -119,7 +119,7 @@
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
-		"security/security-checkup": false,
+		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -74,6 +74,7 @@
 		"reader": true,
 		"reader/list-management": true,
 		"safari-idb-mitigation": true,
+		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,7 +91,7 @@
 		"recommend-plugins": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
-		"security/security-checkup": false,
+		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR enables the `security/security-checkup` feature flag in the development, horizon, and wpcalypso environments to support internal testing before we roll the feature out to all users

#### Testing instructions

* Run this branch locally or via the calypso.live branch
* Navigate to `/me/security`
* Verify that you see a vertical checklist-style menu