### PR TITLE
Adds feature flag for the redesigned DIFM flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -394,7 +394,6 @@ export function generateFlows( {
 			destination: getDIFMSignupDestination,
 			description: 'A flow for DIFM Lite leads',
 			excludeFromManageSiteFlows: true,
-			enableBranchSteps: true,
 			lastModified: '2022-03-10',
 		},
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -375,17 +375,27 @@ export function generateFlows( {
 		},
 		{
 			name: 'do-it-for-me',
-			steps: [
-				'user',
-				'new-or-existing-site',
-				'difm-site-picker',
-				'site-info-collection',
-				'difm-design-setup-site',
-			],
+			steps: isEnabled( 'signup/redesigned-difm-flow' )
+				? [
+						// Add or replace new steps here
+						'user',
+						'new-or-existing-site',
+						'difm-site-picker',
+						'site-info-collection',
+						'difm-design-setup-site',
+				  ]
+				: [
+						'user',
+						'new-or-existing-site',
+						'difm-site-picker',
+						'site-info-collection',
+						'difm-design-setup-site',
+				  ],
 			destination: getDIFMSignupDestination,
 			description: 'A flow for DIFM Lite leads',
 			excludeFromManageSiteFlows: true,
-			lastModified: '2021-09-30',
+			enableBranchSteps: true,
+			lastModified: '2022-03-10',
 		},
 
 		{

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -6,12 +6,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import difmImage from 'calypso/assets/images/difm/difm.svg';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { preventWidows } from 'calypso/lib/formatting';
+import useBranchSteps from 'calypso/signup/hooks/use-branch-steps';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import {
 	getProductDisplayCost,
 	isProductsListFetching,
 } from 'calypso/state/products-list/selectors';
-import { removeSiteSlugDependency } from 'calypso/state/signup/actions';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { award, headset } from '../../icons';
 import { ChoiceType } from './types';
@@ -102,7 +102,13 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 		dispatch( saveSignupStep( { stepName: props.stepName } ) );
 	}, [ dispatch, props.stepName ] );
 
+	// If 'new-site' is selected, skip the `difm-site-picker` step.
+	const branchSteps = useBranchSteps( props.stepName, ( dependencies ) =>
+		dependencies?.choiceType === 'new-site' ? [ 'difm-site-picker' ] : []
+	);
+
 	const newOrExistingSiteSelected = ( value: ChoiceType ) => {
+		branchSteps( { choiceType: value } );
 		dispatch(
 			submitSignupStep(
 				{ stepName: props.stepName },
@@ -112,13 +118,7 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 				}
 			)
 		);
-		if ( 'existing-site' === value ) {
-			props.goToNextStep();
-		} else {
-			dispatch( removeSiteSlugDependency() );
-			dispatch( submitSignupStep( { stepName: 'difm-site-picker', wasSkipped: true } ) );
-			props.goToStep( 'site-info-collection' );
-		}
+		props.goToNextStep();
 	};
 
 	return (

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -6,12 +6,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import difmImage from 'calypso/assets/images/difm/difm.svg';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { preventWidows } from 'calypso/lib/formatting';
-import useBranchSteps from 'calypso/signup/hooks/use-branch-steps';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import {
 	getProductDisplayCost,
 	isProductsListFetching,
 } from 'calypso/state/products-list/selectors';
+import { removeSiteSlugDependency } from 'calypso/state/signup/actions';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { award, headset } from '../../icons';
 import { ChoiceType } from './types';
@@ -102,13 +102,7 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 		dispatch( saveSignupStep( { stepName: props.stepName } ) );
 	}, [ dispatch, props.stepName ] );
 
-	// If 'new-site' is selected, skip the `difm-site-picker` step.
-	const branchSteps = useBranchSteps( props.stepName, ( dependencies ) =>
-		dependencies?.choiceType === 'new-site' ? [ 'difm-site-picker' ] : []
-	);
-
 	const newOrExistingSiteSelected = ( value: ChoiceType ) => {
-		branchSteps( { choiceType: value } );
 		dispatch(
 			submitSignupStep(
 				{ stepName: props.stepName },
@@ -118,7 +112,13 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 				}
 			)
 		);
-		props.goToNextStep();
+		if ( 'existing-site' === value ) {
+			props.goToNextStep();
+		} else {
+			dispatch( removeSiteSlugDependency() );
+			dispatch( submitSignupStep( { stepName: 'difm-site-picker', wasSkipped: true } ) );
+			props.goToStep( 'site-info-collection' );
+		}
 	};
 
 	return (

--- a/config/development.json
+++ b/config/development.json
@@ -133,7 +133,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
-		"signup/redesigned-difm-flow": false,
+		"signup/redesigned-difm-flow": true,
 		"site-indicator": true,
 		"themes/premium": true,
 		"titan/iframe-control-panel": false,

--- a/config/development.json
+++ b/config/development.json
@@ -133,6 +133,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
+		"signup/redesigned-difm-flow": false,
 		"site-indicator": true,
 		"themes/premium": true,
 		"titan/iframe-control-panel": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -86,6 +86,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
+		"signup/redesigned-difm-flow": false,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,
 		"themes/premium": true,

--- a/config/production.json
+++ b/config/production.json
@@ -91,6 +91,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
+		"signup/redesigned-difm-flow": false,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -92,6 +92,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
+		"signup/redesigned-difm-flow": false,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,
 		"themes/premium": true,

--- a/config/test.json
+++ b/config/test.json
@@ -72,6 +72,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"signup/social": true,
+		"signup/redesigned-difm-flow": false,
 		"site-indicator": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -104,6 +104,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
+		"signup/redesigned-difm-flow": false,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,
 		"themes/premium": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a new feature flag `signup/redesigned-difm-flow`, which will be used to enable the new steps in the DIFM flow. Any new steps can be added to `flows-pure.js`.
* The flag has been set as `false` in all environments. To enable the flag, add `?flags=signup/redesigned-difm-flow` to the URL.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There should be no functional changes. Testing for regressions:
* Go to `/start/do-it-for-me`. Choose "Existing Site" and complete the flow. 
* Go to `/start/do-it-for-me`. Choose "New Site" and complete the flow.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 0-as-1201933307121199/f