### PR TITLE
HackWeek: Add a banner in Stats page when the user has its site set to private

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -6,9 +6,11 @@ import { parse as parseQs, stringify as stringifyQs } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
+import rocketImage from 'calypso/assets/images/customer-home/illustration--rocket.svg';
 import parselyIcon from 'calypso/assets/images/icons/parsely-logo.svg';
 import JetpackBackupCredsBanner from 'calypso/blocks/jetpack-backup-creds-banner';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
+import Banner from 'calypso/components/banner';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
@@ -32,6 +34,7 @@ import {
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
+import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import ChartTabs from './stats-chart-tabs';
@@ -144,8 +147,29 @@ class StatsSite extends Component {
 		this.props.recordTracksEvent( 'calypso_stats_parsely_banner_click' );
 	};
 
+	buildPrivateSiteBanner() {
+		return (
+			<Banner
+				callToAction={ translate( 'Launch your site' ) }
+				className="stats__private-site-banner"
+				description={ translate(
+					'Changing your site from private to public helps people find you and get more visitors. Don’t worry, you can keep iterating on your site.'
+				) }
+				disableCircle="true"
+				event="calypso_stats_private_site_banner"
+				dismissTemporary="true"
+				dismissPreferenceName="dismiss"
+				href="/settings/general"
+				iconPath={ rocketImage }
+				title={ translate( 'Launch your site public to drive more visitors' ) }
+				tracksClickName="calypso_stats_private_site_banner_click"
+				tracksImpressionName="calypso_stats_private_site_banner_view"
+			/>
+		);
+	}
+
 	renderStats() {
-		const { date, siteId, slug, isJetpack } = this.props;
+		const { date, siteId, slug, isJetpack, isPrivate } = this.props;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
@@ -168,6 +192,8 @@ class StatsSite extends Component {
 				/>
 			);
 		}
+
+		const privateSiteBanner = isPrivate ? this.buildPrivateSiteBanner() : null;
 
 		return (
 			<>
@@ -193,7 +219,7 @@ class StatsSite extends Component {
 					siteId={ siteId }
 					slug={ slug }
 				/>
-
+				{ privateSiteBanner }
 				<div id="my-stats-content">
 					<ChartTabs
 						activeTab={ getActiveTab( this.props.chartTab ) }
@@ -382,6 +408,7 @@ export default connect(
 			siteId && isJetpack && isJetpackModuleActive( state, siteId, 'stats' ) === false;
 		return {
 			isJetpack,
+			isPrivate: isPrivateSite( state, siteId ),
 			siteId,
 			slug: getSelectedSiteSlug( state ),
 			showEnableStatsModule,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -157,7 +157,6 @@ class StatsSite extends Component {
 				) }
 				disableCircle="true"
 				event="calypso_stats_private_site_banner"
-				dismissTemporary="false"
 				dismissPreferenceName="stats-launch-private-site"
 				href={ `/settings/general/${ slug }` }
 				iconPath={ rocketImage }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -147,21 +147,21 @@ class StatsSite extends Component {
 		this.props.recordTracksEvent( 'calypso_stats_parsely_banner_click' );
 	};
 
-	buildPrivateSiteBanner() {
+	renderPrivateSiteBanner( slug ) {
 		return (
 			<Banner
 				callToAction={ translate( 'Launch your site' ) }
 				className="stats__private-site-banner"
 				description={ translate(
-					'Changing your site from private to public helps people find you and get more visitors. Don’t worry, you can keep iterating on your site.'
+					'Changing your site from private to public helps people find you and get more visitors. Don’t worry, you can keep working on your site.'
 				) }
 				disableCircle="true"
 				event="calypso_stats_private_site_banner"
-				dismissTemporary="true"
-				dismissPreferenceName="dismiss"
-				href="/settings/general"
+				dismissTemporary="false"
+				dismissPreferenceName="stats-launch-private-site"
+				href={ `/settings/general/${ slug }` }
 				iconPath={ rocketImage }
-				title={ translate( 'Launch your site public to drive more visitors' ) }
+				title={ translate( 'Launch your site to drive more visitors' ) }
 				tracksClickName="calypso_stats_private_site_banner_click"
 				tracksDismissName="calypso_stats_private_site_banner_dismiss"
 				tracksImpressionName="calypso_stats_private_site_banner_view"
@@ -170,7 +170,7 @@ class StatsSite extends Component {
 	}
 
 	renderStats() {
-		const { date, siteId, slug, isJetpack, isPrivate } = this.props;
+		const { date, siteId, slug, isJetpack, isSitePrivate } = this.props;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
@@ -193,8 +193,6 @@ class StatsSite extends Component {
 				/>
 			);
 		}
-
-		const privateSiteBanner = isPrivate ? this.buildPrivateSiteBanner() : null;
 
 		return (
 			<>
@@ -220,7 +218,9 @@ class StatsSite extends Component {
 					siteId={ siteId }
 					slug={ slug }
 				/>
-				{ privateSiteBanner }
+
+				{ isSitePrivate ? this.renderPrivateSiteBanner( slug ) : null }
+
 				<div id="my-stats-content">
 					<ChartTabs
 						activeTab={ getActiveTab( this.props.chartTab ) }
@@ -409,7 +409,7 @@ export default connect(
 			siteId && isJetpack && isJetpackModuleActive( state, siteId, 'stats' ) === false;
 		return {
 			isJetpack,
-			isPrivate: isPrivateSite( state, siteId ),
+			isSitePrivate: isPrivateSite( state, siteId ),
 			siteId,
 			slug: getSelectedSiteSlug( state ),
 			showEnableStatsModule,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -163,6 +163,7 @@ class StatsSite extends Component {
 				iconPath={ rocketImage }
 				title={ translate( 'Launch your site public to drive more visitors' ) }
 				tracksClickName="calypso_stats_private_site_banner_click"
+				tracksDismissName="calypso_stats_private_site_banner_dismiss"
 				tracksImpressionName="calypso_stats_private_site_banner_view"
 			/>
 		);

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -147,7 +147,7 @@ class StatsSite extends Component {
 		this.props.recordTracksEvent( 'calypso_stats_parsely_banner_click' );
 	};
 
-	renderPrivateSiteBanner( slug ) {
+	renderPrivateSiteBanner( siteId, siteSlug ) {
 		return (
 			<Banner
 				callToAction={ translate( 'Launch your site' ) }
@@ -158,11 +158,11 @@ class StatsSite extends Component {
 				disableCircle="true"
 				event="calypso_stats_private_site_banner"
 				dismissPreferenceName="stats-launch-private-site"
-				href={ `/settings/general/${ slug }` }
+				href={ `/settings/general/${ siteSlug }` }
 				iconPath={ rocketImage }
 				title={ translate( 'Launch your site to drive more visitors' ) }
 				tracksClickName="calypso_stats_private_site_banner_click"
-				tracksDismissName="calypso_stats_private_site_banner_dismiss"
+				tracksDismissName={ `stats-launch-private-site-${ siteId }` }
 				tracksImpressionName="calypso_stats_private_site_banner_view"
 			/>
 		);
@@ -218,7 +218,7 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 
-				{ isSitePrivate ? this.renderPrivateSiteBanner( slug ) : null }
+				{ isSitePrivate ? this.renderPrivateSiteBanner( siteId, slug ) : null }
 
 				<div id="my-stats-content">
 					<ChartTabs

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -157,12 +157,12 @@ class StatsSite extends Component {
 				) }
 				disableCircle="true"
 				event="calypso_stats_private_site_banner"
-				dismissPreferenceName="stats-launch-private-site"
+				dismissPreferenceName={ `stats-launch-private-site-${ siteId }` }
 				href={ `/settings/general/${ siteSlug }` }
 				iconPath={ rocketImage }
 				title={ translate( 'Launch your site to drive more visitors' ) }
 				tracksClickName="calypso_stats_private_site_banner_click"
-				tracksDismissName={ `stats-launch-private-site-${ siteId }` }
+				tracksDismissName="calypso_stats_private_site_banner_dismiss"
 				tracksImpressionName="calypso_stats_private_site_banner_view"
 			/>
 		);

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -123,6 +123,46 @@
 	}
 }
 
+.stats__private-site-banner {
+	.banner__content {
+		.banner__action {
+			margin-top: 14px;
+			margin-right: 0;
+			@include breakpoint-deprecated( '>480px' ) {
+				margin-right: 40px;
+
+				a {
+					width: 140px;
+					margin-left: 10px;
+				}
+			}
+		}
+	}
+
+	.dismissible-card__close-icon {
+		transform: translateY( -50% );
+		-webkit-transform: translateY( -50% );
+		top: 50%;
+		@include breakpoint-deprecated( '>480px' ) {
+			top: unset;
+			transform: unset;
+			-webkit-transform: unset;
+		}
+	}
+	.banner__icons {
+		.banner__icon {
+			display: none;
+		}
+		.banner__icon-no-circle {
+			max-width: 48px;
+			max-height: 48px;
+			min-width: 48px;
+			min-height: 48px;
+		}
+	}
+}
+
+
 .stats__parsely-banner {
 	display: flex;
 	font-size: $font-body-small;

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -130,7 +130,7 @@
 			margin-right: 0;
 			@include breakpoint-deprecated( '>480px' ) {
 				margin-right: 40px;
-
+				margin-top: 0;
 				a {
 					width: 140px;
 					margin-left: 10px;

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -131,6 +131,7 @@
 			@include breakpoint-deprecated( '>480px' ) {
 				margin-right: 40px;
 				margin-top: 0;
+
 				a {
 					width: 140px;
 					margin-left: 10px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request aims to add a new Banner in the Stats page when the user has its site set to private.

#### Testing instructions

1. Run this branch locally or use the [Calypso Live Branch](https://github.com/Automattic/wp-calypso/pull/61796#issuecomment-1064017812)!
2. Set your site to private
3. Go to Stats and assert that you see a new banner on the top side of the page (see screenshots)
4. Assert that we are sending the following Tracks Events (you can use [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) to ease this task), also leave the dismiss action as the last step for testing this PR, otherwise you'll have to test the next steps with a different site:

      calypso_stats_private_site_banner_view
      calypso_stats_private_site_banner_view_click (when we click on "Launch your site")
      calypso_stats_private_site_banner_view_dismiss (When we click on the dismissal icon)

5. Assert that when you set your site to be public the Banner is not presented anymore

NOTE
Assert that once you click on the dismiss icon, the banner is not showing up anymore even if the site is still private.

### Screenshots

![image](https://user-images.githubusercontent.com/5689927/157701117-b10ea1e9-0a28-41cc-a96f-fe9deb2746fa.png)

| Mobile View  | Desktop View |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/5689927/157664300-6ee087e7-8c11-464a-8ac4-3a6595bd8f71.png) | ![image](https://user-images.githubusercontent.com/5689927/157673856-82ad785a-125a-4a7a-b512-d092bb1b4687.png) |
