### PR TITLE
Fix countdown block on iOS

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/event-countdown.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/event-countdown.js
@@ -16,11 +16,11 @@
 			continue;
 		}
 
-		const dtstr = eventDateElem[ 0 ].innerHTML;
+		const dtstr = eventDateElem[ 0 ].textContent;
 
 		let eventTime;
 		if ( isUnixTimestamp( dtstr ) ) {
-			eventTime = eventDateElem[ 0 ].innerHTML * 1000;
+			eventTime = dtstr * 1000;
 		} else {
 			// backwards compatibility, event date was stored as YYYY-MM-DDTHH:mm:ss
 			// parse date into unix time (but in ms)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* iOS Safari adds a clickable anchor inside any element containing a number that looks like a phone number, to make the number clickable. This PR works around that.

#### Testing instructions

1. `cd apps/editing-toolkit`.
2. Run `yarn dev --sync`.
3. Sandbox ffff680239952.wordpress.com
4. Visit pd2Siy-2g-p2 on iOS. 
5. Countdown should work.

Fixes: 211-gh-Automattic/wpcom-blocks