### PR TITLE
Improve mobile styles for security checkup menu

### DIFF
--- a/client/me/security-checkup/style.scss
+++ b/client/me/security-checkup/style.scss
@@ -5,6 +5,10 @@
 }
 
 .security-checkup__nav-item {
+	&.card.is-compact {
+		padding-right: 24px;
+	}
+
 	span {
 		display: flex;
 		align-items: center;
@@ -12,6 +16,7 @@
 			fill: var( --color-neutral-90 );
 			height: 32px;
 			margin-right: 16px;
+			min-width: 32px;
 			width: 32px;
 			&.material-icon-check_circle {
 				fill: var( --color-success );

--- a/client/me/security-checkup/style.scss
+++ b/client/me/security-checkup/style.scss
@@ -17,7 +17,7 @@
 			height: 32px;
 			margin-right: 16px;
 			min-width: 32px;
-			width: 32px;
+
 			&.material-icon-check_circle {
 				fill: var( --color-success );
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the CSS for the security checkup menu to ensure that we use consistent widths for the icons on the left, and leave enough room for the chevron icon on the right

#### Testing instructions

* Run this branch locally or via the calypso.live branch
* Ensure your browser (or device) is set to render content at the width of a mobile device (you can use your developer tools to emulate this)
* Navigate to `/me/security?flags=security/security-checkup`
* Verify that all the icons on the left are the same size
* Verify that none of the text overlaps with the chevron icons on the right

##### Screenshots

| Before | After |
|--------|-------|
| <img width="374" alt="Screenshot 2022-03-10 at 16 34 06" src="https://user-images.githubusercontent.com/3376401/157684499-09ca0708-f36a-4418-89b1-4145a086c70a.png"> | <img width="374" alt="Screenshot 2022-03-10 at 16 33 25" src="https://user-images.githubusercontent.com/3376401/157684469-2a16bbd4-b6ba-45e3-b3e6-154bc389b915.png"> |
