### PR TITLE
Earn: Add a Tracks event to the Connect Stripe button

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -27,6 +27,7 @@ import SectionHeader from 'calypso/components/section-header';
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { userCan } from 'calypso/lib/site/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getEarningsWithDefaultsForSiteId } from 'calypso/state/memberships/earnings/selectors';
 import { requestDisconnectStripeAccount } from 'calypso/state/memberships/settings/actions';
 import {
@@ -587,7 +588,13 @@ class MembershipsSection extends Component {
 					/>
 				) }
 				{ this.renderOnboarding(
-					<Button primary={ true } href={ this.props.connectUrl }>
+					<Button
+						primary={ true }
+						href={ this.props.connectUrl }
+						onClick={ () =>
+							this.props.recordTracksEvent( 'calypso_memberships_stripe_connect_click' )
+						}
+					>
 						{ this.props.translate( 'Connect Stripe to Get Started' ) }{ ' ' }
 						<Gridicon size={ 18 } icon={ 'external' } />
 					</Button>
@@ -657,6 +664,7 @@ const mapStateToProps = ( state ) => {
 };
 
 export default connect( mapStateToProps, {
+	recordTracksEvent,
 	requestSubscribers,
 	requestDisconnectStripeAccount,
 	requestSubscriptionStop,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the new `calypso_memberships_stripe_connect_click` Tracks event to the Connect Stripe button in the Earn section.

![image-10](https://user-images.githubusercontent.com/2070010/155728472-ae691afa-c092-4f61-8ecf-2225e63c2d36.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up Calypso and select a site with a paid plan without a pre-existing Stripe connection.
* Enter `localStorage.setItem( 'debug', 'calypso:analytics*' );` in the console and reload; filter the console by `calypso_memberships_stripe_connect_click`.
* Navigate to Tools -> Earn -> Collect Payments.
* Click on the "Connect Stripe to Get Started" button.
* Check the console and make sure the `calypso_memberships_stripe_connect_click` is recorded (you might need to enable "preserve log" since the button will navigate away from Calypso.

Related to https://github.com/Automattic/wp-calypso/issues/61487
