### PR TITLE
Payments Inserter Tracking: Added support for Payment Inserter block 

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -71,7 +71,7 @@ const getTypeForBlockId = ( blockId ) => {
  * Guess which inserter was used to insert/replace blocks.
  *
  * @param {string[]} originalBlockIds ids or blocks that are being replaced
- * @returns {'header-inserter'|'slash-inserter'|'quick-inserter'|'block-switcher'|undefined} ID representing the insertion method that was used
+ * @returns {'header-inserter'|'slash-inserter'|'quick-inserter'|'block-switcher'|'payments_intro_block'|undefined} ID representing the insertion method that was used
  */
 const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 	// Check if the main inserter (opened using the [+] button in the header) is open.
@@ -125,6 +125,13 @@ const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 		document.querySelector( '.block-editor-inserter__block-list' )
 	) {
 		return 'quick-inserter';
+	}
+
+	// This checks validates if we are inserting a block from the Payments Inserter block.
+	if (
+		select( 'core/block-editor' ).getBlockName( originalBlockIds[ 0 ] ) === 'jetpack/payments-intro'
+	) {
+		return 'payments_intro_block';
 	}
 
 	return undefined;

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -71,7 +71,7 @@ const getTypeForBlockId = ( blockId ) => {
  * Guess which inserter was used to insert/replace blocks.
  *
  * @param {string[]} originalBlockIds ids or blocks that are being replaced
- * @returns {'header-inserter'|'slash-inserter'|'quick-inserter'|'block-switcher'|'payments_intro_block'|undefined} ID representing the insertion method that was used
+ * @returns {'header-inserter'|'slash-inserter'|'quick-inserter'|'block-switcher'|'payments-intro-block'|undefined} ID representing the insertion method that was used
  */
 const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 	// Check if the main inserter (opened using the [+] button in the header) is open.
@@ -129,9 +129,10 @@ const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 
 	// This checks validates if we are inserting a block from the Payments Inserter block.
 	if (
+		originalBlockIds.length === 1 &&
 		select( 'core/block-editor' ).getBlockName( originalBlockIds[ 0 ] ) === 'jetpack/payments-intro'
 	) {
-		return 'payments_intro_block';
+		return 'payments-intro-block';
 	}
 
 	return undefined;

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -70,10 +70,11 @@ const getTypeForBlockId = ( blockId ) => {
 /**
  * Guess which inserter was used to insert/replace blocks.
  *
- * @param {string[]} originalBlockIds ids or blocks that are being replaced
+ * @param {string[]|string} originalBlockIds ids or blocks that are being replaced
  * @returns {'header-inserter'|'slash-inserter'|'quick-inserter'|'block-switcher'|'payments-intro-block'|undefined} ID representing the insertion method that was used
  */
 const getBlockInserterUsed = ( originalBlockIds = [] ) => {
+	const clientIds = Array.isArray( originalBlockIds ) ? originalBlockIds : [ originalBlockIds ];
 	// Check if the main inserter (opened using the [+] button in the header) is open.
 	// If it is then the block was inserted using this menu. This inserter closes
 	// automatically when the user tries to use another form of block insertion
@@ -92,10 +93,7 @@ const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 	// The block switcher open state is not stored in Redux, it's component state
 	// inside a <Dropdown>, so we can't access it. Work around this by checking if
 	// the DOM elements are present on the page while the block is being replaced.
-	if (
-		originalBlockIds.length &&
-		document.querySelector( '.block-editor-block-switcher__container' )
-	) {
+	if ( clientIds.length && document.querySelector( '.block-editor-block-switcher__container' ) ) {
 		return 'block-switcher';
 	}
 
@@ -106,11 +104,9 @@ const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 	// then use the block switcher, and the following tests would incorrectly capture
 	// that case too.
 	if (
-		originalBlockIds.length === 1 &&
-		select( 'core/block-editor' ).getBlockName( originalBlockIds[ 0 ] ) === 'core/paragraph' &&
-		select( 'core/block-editor' )
-			.getBlockAttributes( originalBlockIds[ 0 ] )
-			.content.startsWith( '/' )
+		clientIds.length === 1 &&
+		select( 'core/block-editor' ).getBlockName( clientIds[ 0 ] ) === 'core/paragraph' &&
+		select( 'core/block-editor' ).getBlockAttributes( clientIds[ 0 ] ).content.startsWith( '/' )
 	) {
 		return 'slash-inserter';
 	}
@@ -129,8 +125,8 @@ const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 
 	// This checks validates if we are inserting a block from the Payments Inserter block.
 	if (
-		originalBlockIds.length === 1 &&
-		select( 'core/block-editor' ).getBlockName( originalBlockIds[ 0 ] ) === 'jetpack/payments-intro'
+		clientIds.length === 1 &&
+		select( 'core/block-editor' ).getBlockName( clientIds[ 0 ] ) === 'jetpack/payments-intro'
 	) {
 		return 'payments-intro-block';
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We added an exception to the tracking file so that we can determine if we are replacing a block from the Payments inserter before sending the tracking pixel.
* Also fixed a bug caused by not casting the block ids to an array when the argument is a string. [The replaceBlock function accepts both an array and a string](https://github.com/WordPress/gutenberg/blob/d5915916abc45e6682f4bdb70888aa41e98aa395/packages/block-editor/src/store/actions.js#L358).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You might need to sandbox widgets.wp.com
* Create or edit a new Post.
* Add a Payments block.
* Open Chrome's inspector.
* Navigate to the Network tab and filter by "t.gif"
* Click on any/all the options available inside the Payments block.
* You should see a pixel that includes the information of the replaced block and the inserter should be of type: nsert_method=payments-intro-block

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#23139](https://github.com/Automattic/jetpack/issues/23139)

#### Test evidence

https://user-images.githubusercontent.com/1989914/157860362-bd4ff207-9e18-4447-8aac-d46d6544f833.mp4

