### PR TITLE
Marketplace: Fixes Education Footer Links

### DIFF
--- a/client/components/link-card/index.tsx
+++ b/client/components/link-card/index.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { ReactChild } from 'react';
+import ExternalLink from 'calypso/components/external-link';
 
 import './style.scss';
 
@@ -13,6 +14,7 @@ interface LinkCardProps {
 	cta?: ReactChild;
 	background?: string;
 	url: string;
+	external?: boolean;
 }
 
 const LinkCardContainer = styled.div< LinkCardContainerProps >`
@@ -58,16 +60,18 @@ const LinkCardCta = styled.div`
 `;
 
 const LinkCard = ( props: LinkCardProps ) => {
-	const { label, title, cta, background, url } = props;
+	const { label, title, cta, background, url, external } = props;
+
+	const Link = external ? ExternalLink : 'a';
 
 	return (
-		<a href={ url }>
+		<Link href={ url }>
 			<LinkCardContainer background={ background }>
 				<LinkCardLabel>{ label }</LinkCardLabel>
 				<LinkCardTitle>{ title }</LinkCardTitle>
 				<LinkCardCta>{ cta }</LinkCardCta>
 			</LinkCardContainer>
-		</a>
+		</Link>
 	);
 };
 

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -27,6 +27,7 @@ const EducationFooter = () => {
 		<Section header={ __( 'Learn more' ) }>
 			<ArticleLinksContainer>
 				<LinkCard
+					external
 					label={ __( 'Website Building' ) }
 					title={ __( 'What Are WordPress Plugins and Themes? (A Beginner’s Guide)' ) }
 					cta={ __( 'Read More' ) }
@@ -36,6 +37,7 @@ const EducationFooter = () => {
 					background="studio-celadon-60"
 				/>
 				<LinkCard
+					external
 					label={ __( 'Customization' ) }
 					title={ __( 'How to Choose WordPress Plugins for Your Website (7 Tips)' ) }
 					cta={ __( 'Read More' ) }
@@ -45,6 +47,7 @@ const EducationFooter = () => {
 					background="studio-purple-80"
 				/>
 				<LinkCard
+					external
 					label={ __( 'SEO' ) }
 					title={ __( 'Do You Need to Use SEO Plugins on Your WordPress.com Site?' ) }
 					cta={ __( 'Read More' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the `external` prop to the `CardLink` component for external links.
* Makes Education Footer link cards external.

#### Testing instructions
* Navigate to `http://calypso.localhost:3000/plugins/:siteId`.
* Scroll to the bottom and click the links, they should link to the correct site.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #61491
