### PR TITLE
Try add missing learn more links

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -47,6 +47,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/export/#exporting-the-media-library',
 		post_id: 2087,
 	},
+	followers: {
+		link: 'https://wordpress.com/support/followers/',
+		post_id: 5444,
+	},
 	'getting-started-video': {
 		link:
 			'https://wordpress.com/support/getting-started-with-wordpress-com/#video-getting-started-with-word-press-com',

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -89,6 +89,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/moving-from-self-hosted-wordpress-to-wordpress-com/',
 		post_id: 102755,
 	},
+	invites: {
+		link: 'https://wordpress.com/support/user-roles/#adding-users-to-your-site',
+		post_id: 1221,
+	},
 	media: {
 		link: 'https://wordpress.com/support/media/',
 		post_id: 853,

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -125,6 +125,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/payment/#using-a-payment-method-for-all-subscriptions',
 		post_id: 76237,
 	},
+	performance: {
+		link: 'https://wordpress.com/support/settings/performance-settings/',
+		post_id: 179952,
+	},
 	plugins: {
 		link: 'https://wordpress.com/support/plugins/',
 		post_id: 2108,

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -49,7 +49,14 @@ class People extends Component {
 		switch ( filter ) {
 			case 'followers':
 				return translate(
-					'People who have subscribed to your site using their WordPress.com account.'
+					'People who have subscribed to your site using their WordPress.com account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: (
+								<InlineSupportLink key="learnMore" supportContext="followers" showIcon={ false } />
+							),
+						},
+					}
 				);
 			case 'email-followers':
 				return translate( 'People who have subscribed to your site using their email address.' );

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -59,7 +59,16 @@ class People extends Component {
 					}
 				);
 			case 'email-followers':
-				return translate( 'People who have subscribed to your site using their email address.' );
+				return translate(
+					'People who have subscribed to your site using their email address. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: (
+								<InlineSupportLink key="learnMore" supportContext="followers" showIcon={ false } />
+							),
+						},
+					}
+				);
 			default:
 				return isWPForTeamsSite
 					? this.getSubheaderTextForP2()

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -53,7 +53,11 @@ class People extends Component {
 					{
 						components: {
 							learnMoreLink: (
-								<InlineSupportLink key="learnMore" supportContext="followers" showIcon={ false } />
+								<InlineSupportLink
+									key="learnMoreFollowers"
+									supportContext="followers"
+									showIcon={ false }
+								/>
 							),
 						},
 					}
@@ -64,7 +68,11 @@ class People extends Component {
 					{
 						components: {
 							learnMoreLink: (
-								<InlineSupportLink key="learnMore" supportContext="followers" showIcon={ false } />
+								<InlineSupportLink
+									key="learnMoreFollowers"
+									supportContext="followers"
+									showIcon={ false }
+								/>
 							),
 						},
 					}
@@ -77,7 +85,11 @@ class People extends Component {
 							{
 								components: {
 									learnMoreLink: (
-										<InlineSupportLink key="learnMore" supportContext="team" showIcon={ false } />
+										<InlineSupportLink
+											key="learnMoreTeam"
+											supportContext="team"
+											showIcon={ false }
+										/>
 									),
 								},
 							}

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import QuerySiteInvites from 'calypso/components/data/query-site-invites';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
@@ -81,7 +82,16 @@ class PeopleInvites extends PureComponent {
 					brandFont
 					className="people-invites__page-heading"
 					headerText={ translate( 'Users' ) }
-					subHeaderText={ translate( 'View and manage the invites to your site.' ) }
+					subHeaderText={ translate(
+						'View and Manage the invites to your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: (
+									<InlineSupportLink key="learnMore" supportContext="invites" showIcon={ false } />
+								),
+							},
+						}
+					) }
 					align="left"
 				/>
 				<PeopleSectionNav

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -7,6 +7,7 @@ import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import AmpJetpack from 'calypso/my-sites/site-settings/amp/jetpack';
 import AmpWpcom from 'calypso/my-sites/site-settings/amp/wpcom';
@@ -57,7 +58,20 @@ class SiteSettingsPerformance extends Component {
 					brandFont
 					className="settings-performance__page-heading"
 					headerText={ translate( 'Performance Settings' ) }
-					subHeaderText={ translate( "Explore settings to improve your site's performance." ) }
+					subHeaderText={ translate(
+						"Explore settings to improve your site's performance. {{learnMoreLink}}Learn more{{/learnMoreLink}}.",
+						{
+							components: {
+								learnMoreLink: (
+									<InlineSupportLink
+										key="learnMore"
+										supportContext="performance"
+										showIcon={ false }
+									/>
+								),
+							},
+						}
+					) }
 					align="left"
 				/>
 				<SiteSettingsNavigation site={ site } section="performance" />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds 'Read More' links to the following Calypso page subheads

 * Settings > [Performance](https://wordpress.com/settings/performance)
 * Users > [Followers](https://wordpress.com/people/followers)
 * Users> [Email Followers](https://wordpress.com/people/email-followers)
 * Users > [Invites](https://wordpress.com/people/invites/)

#### Testing instructions

* Check each page listed above and confirm there is a 'Read More' link in the subhead - linking to a relevant document,

Related to #60876 
