### PR TITLE
Concierge: Refactor `CalendarStep` away from `UNSAFE_` methods

### DIFF
--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -55,7 +55,6 @@ class CalendarStep extends Component {
 			this.props.onComplete();
 		} else if ( this.props.signupForm.status === CONCIERGE_STATUS_BOOKING_ERROR ) {
 			// request new available times
-			alert( 'error' );
 			this.props.requestConciergeInitial( this.props.scheduleId );
 		}
 	}

--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -49,13 +49,13 @@ class CalendarStep extends Component {
 		this.props.recordTracksEvent( 'calypso_concierge_book_calendar_step' );
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillUpdate( nextProps ) {
-		if ( nextProps.signupForm.status === CONCIERGE_STATUS_BOOKED ) {
-			// go to confirmation page if booking was successfull
+	componentDidUpdate() {
+		if ( this.props.signupForm.status === CONCIERGE_STATUS_BOOKED ) {
+			// go to confirmation page if booking was successful
 			this.props.onComplete();
-		} else if ( nextProps.signupForm.status === CONCIERGE_STATUS_BOOKING_ERROR ) {
+		} else if ( this.props.signupForm.status === CONCIERGE_STATUS_BOOKING_ERROR ) {
 			// request new available times
+			alert( 'error' );
 			this.props.requestConciergeInitial( this.props.scheduleId );
 		}
 	}

--- a/client/me/concierge/reschedule/calendar-step.js
+++ b/client/me/concierge/reschedule/calendar-step.js
@@ -64,9 +64,8 @@ class CalendarStep extends Component {
 		this.props.recordTracksEvent( 'calypso_concierge_reschedule_calendar_step' );
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillUpdate( nextProps ) {
-		if ( nextProps.signupForm.status === CONCIERGE_STATUS_BOOKED ) {
+	componentDidUpdate() {
+		if ( this.props.signupForm.status === CONCIERGE_STATUS_BOOKED ) {
 			// go to confirmation page if booking was successful
 			this.props.onComplete();
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor`CalenderStep` component away from the `UNSAFE_` deprecated React component methods (worked with @flootr on this one). 

Part of: https://github.com/Automattic/wp-calypso/issues/58453.

#### Testing instructions

If you have a quick start session (concierge session) available on a site already, you can skip these first two steps and go to 'Test steps' below: 

* Go to SA for your account
* Click on the product dropdown and select 'Quick Start Session' for your test site and then click 'Add Subscription.'

**Test steps for booking a session:** 

* Go to `/me/quickstart/TEST_SITE_ADDRESS/book`
* Fill out info and click 'Continue to Calendar' 
* Select a date and click on 'Book this session'
* See confirmation page that session has been booked (proceed to next steps to test rescheduling)

**Test steps for rescheduling a session:** 

* Click on 'View Support Sessions' after booking or go back to `/me/quickstart/TEST_SITE_ADDRESS/book`
* Click on 'Reschedule or Cancel' 
* Choose 'Reschedule session' 
*  Select a date and click on 'Book this session'
* See confirmation page that session has been booked

_**Please make sure to cancel quick start session after testing is complete**_