### PR TITLE
Full Site Editing: use correct `wp-admin` url and params

### DIFF
--- a/client/data/block-editor/use-block-editor-settings-query.ts
+++ b/client/data/block-editor/use-block-editor-settings-query.ts
@@ -3,9 +3,15 @@ import { useSelector } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
 import { getActiveTheme } from 'calypso/state/themes/selectors';
 
+type HomeTemplateSettings = {
+	postType: string | null;
+	postId: number | null;
+};
+
 export type BlockEditorSettings = {
 	is_fse_eligible: boolean;
 	is_fse_active: boolean;
+	home_template: HomeTemplateSettings;
 };
 
 export const useBlockEditorSettingsQuery = (

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -818,7 +818,7 @@ const mapStateToProps = (
 
 	const siteAdminUrl =
 		editorType === 'site'
-			? getSiteAdminUrl( state, siteId, 'admin.php?page=gutenberg-edit-site' )
+			? getSiteAdminUrl( state, siteId, 'themes.php?page=gutenberg-edit-site' )
 			: getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' );
 
 	const iframeUrl = addQueryArgs( queryArgs, siteAdminUrl ?? '' );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -10,6 +10,8 @@ import { Component, Fragment } from 'react';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
+import { BlockEditorSettings } from 'calypso/data/block-editor/use-block-editor-settings-query';
+import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import memoizeLast from 'calypso/lib/memoize-last';
@@ -80,6 +82,7 @@ interface Props {
 	parentPostId: T.PostId;
 	stripeConnectSuccess: 'gutenberg' | null;
 	showDraftPostModal: boolean;
+	blockEditorSettings: BlockEditorSettings;
 }
 
 interface CheckoutModalOptions extends RequestCart {
@@ -779,6 +782,7 @@ const mapStateToProps = (
 		anchorFmData,
 		showDraftPostModal,
 		pressThisData,
+		blockEditorSettings,
 	}: Props
 ) => {
 	const siteId = getSelectedSiteId( state );
@@ -814,6 +818,12 @@ const mapStateToProps = (
 	// Pass through to iframed editor if user is in editor deprecation group.
 	if ( 'classic' === getSelectedEditor( state, siteId ?? 0 ) ) {
 		queryArgs[ 'in-editor-deprecation-group' ] = 1;
+	}
+
+	// Add new Site Editor params introduced in https://github.com/WordPress/gutenberg/pull/38817.
+	if ( 'site' === editorType && blockEditorSettings?.home_template?.postType ) {
+		queryArgs.postType = blockEditorSettings.home_template.postType;
+		queryArgs.postId = blockEditorSettings.home_template.postId;
 	}
 
 	const siteAdminUrl =
@@ -879,6 +889,7 @@ type ConnectedProps = ReturnType< typeof mapStateToProps > & typeof mapDispatchT
 
 export default flowRight(
 	withStopPerformanceTrackingProp,
+	withBlockEditorSettings,
 	connect( mapStateToProps, mapDispatchToProps ),
 	localize,
 	protectForm

--- a/client/state/selectors/get-site-editor-url.js
+++ b/client/state/selectors/get-site-editor-url.js
@@ -12,7 +12,7 @@ export const getSiteEditorUrl = ( state, siteId ) => {
 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
 
 	if ( ! shouldLoadGutenframe( state, siteId ) ) {
-		return `${ siteAdminUrl }admin.php?page=gutenberg-edit-site`;
+		return `${ siteAdminUrl }themes.php?page=gutenberg-edit-site`;
 	}
 
 	const siteSlug = getSiteSlug( state, siteId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the correct `wp-admin` URL and params for the site editor.

https://github.com/WordPress/gutenberg/pull/38817 introduced a redirect to ensure that homepage editing works properly. Unfortunately this scrambled a lot of our (fragile!) site editor integration code on the backend.

#### Testing instructions

You need D76621-code on your sandbox. Sandbox a site with FSE active and also `public-api`.

Try to load the site editor. It should work with both `prod` and `edge` gutenberg versions. But, lacking either the backend patch, or this branch, the site editor redirects on `edge` to the `wp-admin` URL at the top level.

Related to #61776 #61858