### PR TITLE
Domains: Restrict the visualization of domain transfer pages for domains that are past redemption

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
@@ -14,7 +14,7 @@ const DomainTransferInfoCard = ( {
 
 	if (
 		! domain.currentUserIsOwner ||
-		( ! domain.isRenewable && ! domain.isRedeemable ) ||
+		( domain.expired && ! domain.isRenewable && ! domain.isRedeemable ) ||
 		typesUnableToTransfer.includes( domain.type ) ||
 		domain.aftermarketAuction
 	) {

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
@@ -1,6 +1,5 @@
 import { Icon, lock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { isDomainInGracePeriod } from 'calypso/lib/domains';
 import { type as domainType } from 'calypso/lib/domains/constants';
 import { domainManagementTransfer } from 'calypso/my-sites/domains/paths';
 import DomainInfoCard from '..';
@@ -15,7 +14,7 @@ const DomainTransferInfoCard = ( {
 
 	if (
 		! domain.currentUserIsOwner ||
-		( domain.expired && ! isDomainInGracePeriod( domain ) ) ||
+		( ! domain.isRenewable && ! domain.isRedeemable ) ||
 		typesUnableToTransfer.includes( domain.type ) ||
 		domain.aftermarketAuction
 	) {

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
@@ -14,7 +14,7 @@ const DomainTransferInfoCard = ( {
 
 	if (
 		! domain.currentUserIsOwner ||
-		( domain.expired && ! domain.isRenewable && ! domain.isRedeemable ) ||
+		( domain.expired && ! domain.isRenewable ) ||
 		typesUnableToTransfer.includes( domain.type ) ||
 		domain.aftermarketAuction
 	) {

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
@@ -14,7 +14,7 @@ const DomainTransferInfoCard = ( {
 
 	if (
 		! domain.currentUserIsOwner ||
-		( domain.expired && ! domain.isRenewable ) ||
+		domain.isRedeemable ||
 		typesUnableToTransfer.includes( domain.type ) ||
 		domain.aftermarketAuction
 	) {

--- a/client/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice.tsx
@@ -1,0 +1,17 @@
+import { useTranslate } from 'i18n-calypso';
+import Notice from 'calypso/components/notice';
+
+const NonTransferrableDomainNotice = ( { domainName }: { domainName: string } ): JSX.Element => {
+	const translate = useTranslate();
+	const text = translate(
+		"{{strong}}%(domain)s{{/strong}} is already past its redemption period so it's not possible to transfer it.",
+		{
+			components: { strong: <strong /> },
+			args: { domain: domainName },
+		}
+	);
+
+	return <Notice text={ text } status="is-warning" showDismiss={ false } />;
+};
+
+export default NonTransferrableDomainNotice;

--- a/client/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice.tsx
@@ -4,7 +4,7 @@ import Notice from 'calypso/components/notice';
 const NonTransferrableDomainNotice = ( { domainName }: { domainName: string } ): JSX.Element => {
 	const translate = useTranslate();
 	const text = translate(
-		"{{strong}}%(domain)s{{/strong}} is already past its redemption period so it's not possible to transfer it.",
+		"{{strong}}%(domain)s{{/strong}} is in redemption so it's not possible to transfer it.",
 		{
 			components: { strong: <strong /> },
 			args: { domain: domainName },

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -348,7 +348,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
 		}
 
-		if ( domain.expired && ! domain.isRenewable && ! domain.isRedeemable ) {
+		if ( domain.expired && ! domain.isRenewable ) {
 			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -23,6 +23,7 @@ import wpcom from 'calypso/lib/wp';
 import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/breadcrumbs';
 import AftermarketAutcionNotice from 'calypso/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
+import NonTransferrableDomainNotice from 'calypso/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice';
 import SelectIpsTag from 'calypso/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag';
 import {
 	domainManagementEdit,
@@ -341,6 +342,10 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 
 		if ( ! domain.currentUserIsOwner ) {
 			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
+		}
+
+		if ( ! domain.isRenewable && ! domain.isRedeemable ) {
+			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 
 		if ( domain.aftermarketAuction ) {

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -344,12 +344,12 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
 		}
 
-		if ( ! domain.isRenewable && ! domain.isRedeemable ) {
-			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
-		}
-
 		if ( domain.aftermarketAuction ) {
 			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
+		}
+
+		if ( domain.expired && ! domain.isRenewable && ! domain.isRedeemable ) {
+			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 
 		return (

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -348,7 +348,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
 		}
 
-		if ( domain.expired && ! domain.isRenewable ) {
+		if ( domain.isRedeemable ) {
 			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -190,12 +190,12 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 			return <NonOwnerCard { ...propsWithoutChildren } />;
 		}
 
-		if ( ! domain.isRenewable && ! domain.isRedeemable ) {
-			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
-		}
-
 		if ( aftermarketAuction ) {
 			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
+		}
+
+		if ( domain.expired && ! domain.isRenewable && ! domain.isRedeemable ) {
+			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 
 		return (

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -194,7 +194,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
 		}
 
-		if ( domain.expired && ! domain.isRenewable ) {
+		if ( domain && domain.expired && ! domain.isRenewable ) {
 			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 
@@ -227,7 +227,10 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 
 export default connect(
 	( state, ownProps: TransferDomainToOtherSitePassedProps ) => {
-		const domain = ! ownProps.isRequestingSiteDomains && getSelectedDomain( ownProps );
+		let domain;
+		if ( ! ownProps.isRequestingSiteDomains ) {
+			domain = getSelectedDomain( ownProps );
+		}
 		const siteId = getSelectedSiteId( state );
 		return {
 			currentRoute: getCurrentRoute( state ),

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -13,6 +13,7 @@ import Breadcrumbs from 'calypso/my-sites/domains/domain-management/components/b
 import AftermarketAutcionNotice from 'calypso/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
+import NonTransferrableDomainNotice from 'calypso/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice';
 import {
 	domainManagementEdit,
 	domainManagementList,
@@ -183,10 +184,14 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 	};
 
 	renderSection(): JSX.Element {
-		const { currentUserCanManage, selectedDomainName, aftermarketAuction } = this.props;
+		const { currentUserCanManage, selectedDomainName, aftermarketAuction, domain } = this.props;
 		const { children, ...propsWithoutChildren } = this.props;
 		if ( ! currentUserCanManage ) {
 			return <NonOwnerCard { ...propsWithoutChildren } />;
+		}
+
+		if ( ! domain.isRenewable && ! domain.isRedeemable ) {
+			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 
 		if ( aftermarketAuction ) {
@@ -227,6 +232,7 @@ export default connect(
 		return {
 			currentRoute: getCurrentRoute( state ),
 			currentUserCanManage: typeof domain === 'object' && domain.currentUserCanManage,
+			domain,
 			aftermarketAuction: typeof domain === 'object' && domain.aftermarketAuction,
 			hasSiteDomainsLoaded: hasLoadedSiteDomains( state, siteId ),
 			isDomainOnly: isDomainOnlySite( state, siteId ),

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -194,7 +194,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
 		}
 
-		if ( domain.expired && ! domain.isRenewable && ! domain.isRedeemable ) {
+		if ( domain.expired && ! domain.isRenewable ) {
 			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -194,7 +194,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
 		}
 
-		if ( domain && domain.expired && ! domain.isRenewable ) {
+		if ( domain && domain.isRedeemable ) {
 			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
@@ -29,7 +29,7 @@ export type TransferDomainToOtherSiteStateProps = {
 	aftermarketAuction: boolean;
 	currentRoute: string;
 	currentUserCanManage: boolean;
-	domain: ResponseDomain;
+	domain?: ResponseDomain;
 	hasSiteDomainsLoaded: boolean;
 	isDomainOnly: Maybe< boolean >;
 	isMapping: boolean;

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
@@ -29,6 +29,7 @@ export type TransferDomainToOtherSiteStateProps = {
 	aftermarketAuction: boolean;
 	currentRoute: string;
 	currentUserCanManage: boolean;
+	domain: ResponseDomain;
 	hasSiteDomainsLoaded: boolean;
 	isDomainOnly: Maybe< boolean >;
 	isMapping: boolean;

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -251,6 +251,7 @@ class TransferDomainToOtherUser extends Component {
 			currentUserCanManage,
 			domainRegistrationAgreementUrl,
 			aftermarketAuction,
+			expired,
 			isRenewable,
 			isRedeemable,
 		} = getSelectedDomain( this.props );
@@ -260,12 +261,12 @@ class TransferDomainToOtherUser extends Component {
 			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
 		}
 
-		if ( ! isRenewable && ! isRedeemable ) {
-			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
-		}
-
 		if ( aftermarketAuction ) {
 			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
+		}
+
+		if ( expired && ! isRenewable && ! isRedeemable ) {
+			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 
 		const { isMapping, translate, users } = this.props;

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -253,7 +253,6 @@ class TransferDomainToOtherUser extends Component {
 			aftermarketAuction,
 			expired,
 			isRenewable,
-			isRedeemable,
 		} = getSelectedDomain( this.props );
 		const { domains, selectedDomainName } = this.props;
 
@@ -265,7 +264,7 @@ class TransferDomainToOtherUser extends Component {
 			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
 		}
 
-		if ( expired && ! isRenewable && ! isRedeemable ) {
+		if ( expired && ! isRenewable ) {
 			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -19,6 +19,7 @@ import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/co
 import AftermarketAutcionNotice from 'calypso/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
+import NonTransferrableDomainNotice from 'calypso/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice';
 import {
 	domainManagementEdit,
 	domainManagementList,
@@ -250,11 +251,17 @@ class TransferDomainToOtherUser extends Component {
 			currentUserCanManage,
 			domainRegistrationAgreementUrl,
 			aftermarketAuction,
+			isRenewable,
+			isRedeemable,
 		} = getSelectedDomain( this.props );
 		const { domains, selectedDomainName } = this.props;
 
 		if ( ! currentUserCanManage ) {
 			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
+		}
+
+		if ( ! isRenewable && ! isRedeemable ) {
+			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 
 		if ( aftermarketAuction ) {

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -251,8 +251,7 @@ class TransferDomainToOtherUser extends Component {
 			currentUserCanManage,
 			domainRegistrationAgreementUrl,
 			aftermarketAuction,
-			expired,
-			isRenewable,
+			isRedeemable,
 		} = getSelectedDomain( this.props );
 		const { domains, selectedDomainName } = this.props;
 
@@ -264,7 +263,7 @@ class TransferDomainToOtherUser extends Component {
 			return <AftermarketAutcionNotice domainName={ selectedDomainName } />;
 		}
 
-		if ( expired && ! isRenewable ) {
+		if ( isRedeemable ) {
 			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR prevents domain transfer pages from being displayed for domains which are past their redemption date. It also updates the condition in which the domain transfer card is shown in the domain management page.

#### Screenshots

| Before | After |
| --- | --- |
| <img width="1071" alt="Screen Shot 2022-03-10 at 19 33 22" src="https://user-images.githubusercontent.com/5324818/157767697-ecf848c1-c88e-4544-a1d9-c0691f9bb3e6.png"> | <img width="1063" alt="Screen Shot 2022-03-10 at 19 48 12" src="https://user-images.githubusercontent.com/5324818/157767956-2dcb96ba-5467-4784-9ace-d2c7651fd475.png"> |
| <img width="1070" alt="Screen Shot 2022-03-10 at 19 44 40" src="https://user-images.githubusercontent.com/5324818/157767710-664d8940-b0e1-40e3-9b9a-63420d3629b5.png"> | <img width="1071" alt="Screen Shot 2022-03-10 at 19 22 12" src="https://user-images.githubusercontent.com/5324818/157767973-8e14aefd-d7ec-4968-bcbd-297db9e5cbf1.png"> |
| <img width="1078" alt="Screen Shot 2022-03-10 at 19 45 11" src="https://user-images.githubusercontent.com/5324818/157767717-35dc9649-392e-4169-a3ec-955e48af66a6.png"> | <img width="1072" alt="Screen Shot 2022-03-10 at 19 22 43" src="https://user-images.githubusercontent.com/5324818/157767975-761f4636-41bd-447c-a2d4-5e71076ed4bc.png"> |
| <img width="886" alt="Screen Shot 2022-03-10 at 19 45 39" src="https://user-images.githubusercontent.com/5324818/157767719-c63fbfb2-72dc-4486-ac8c-0955f7ad31a3.png"> | <img width="939" alt="Screen Shot 2022-03-10 at 19 23 10" src="https://user-images.githubusercontent.com/5324818/157767977-ae561781-8049-463a-ba81-fe0cfcaaa1fd.png"> |

### Testing instructions

The best way to test this would be if you have an expired domain that is in redemption. If you don't have a domain in that state, you can sandbox your `public-api` and hack your backend to force the `is_redeemable` domain property to always be `true`.

- Build this branch locally or open the live Calypso link
- Go to the domain management page (Upgrades > Domains) of a a domain that's past its redemption grace period
- Ensure that the transfer card is not shown
- Visit these three pages directly via their URL (as they won't be accessible via the UI normally) and ensure only the "domain cannot be transferred" notice is shown, like in the screenshots above:
  - `/domains/manage/<domain>/transfer/<site_slug>` - main transfer page
  - `/domains/manage/<domain>/transfer/other-user/<site_slug>` - transfer to another user
  - `/domains/manage/<domain>/transfer/other-site/<site_slug>` - transfer to another site
