### PR TITLE
Marketplace: Spotlight JITM Integration

### DIFF
--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -34,6 +34,14 @@ function renderTemplate( template, props ) {
 					placeholder={ null }
 				/>
 			);
+		case 'spotlight':
+			return (
+				<AsyncLoad
+					{ ...props }
+					require="calypso/blocks/jitm/templates/spotlight"
+					placeholder={ null }
+				/>
+			);
 		case 'invisible':
 			return <>{ props.trackImpression && props.trackImpression() }</>;
 		case 'modal':

--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -116,7 +116,6 @@ export function JITM( props ) {
 	}
 
 	debug( `siteId: %d, messagePath: %s, message: `, currentSite.ID, messagePath, jitm );
-
 	// 'jetpack' icon is only allowed to Jetpack sites
 	if ( jitm?.content?.icon === 'jetpack' && ! isJetpack ) {
 		jitm.content.icon = '';

--- a/client/blocks/jitm/templates/spotlight.jsx
+++ b/client/blocks/jitm/templates/spotlight.jsx
@@ -1,12 +1,18 @@
 import Spotlight from 'calypso/components/spotlight';
 
 export default function SpotlightTemplate( props ) {
-	const { trackImpression } = props;
+	const { trackImpression, message, CTA, description, icon } = props;
 
 	return (
 		<>
 			{ trackImpression && trackImpression() }
-			<Spotlight />
+			<Spotlight
+				taglineText={ message }
+				illustrationSrc={ icon }
+				onClick
+				titleText={ description }
+				ctaText={ CTA.message }
+			/>
 		</>
 	);
 }

--- a/client/blocks/jitm/templates/spotlight.jsx
+++ b/client/blocks/jitm/templates/spotlight.jsx
@@ -1,7 +1,14 @@
+import page from 'page';
 import Spotlight from 'calypso/components/spotlight';
 
 export default function SpotlightTemplate( props ) {
-	const { trackImpression, message, CTA, description, icon } = props;
+	const { trackImpression, message, CTA, description, icon, onClick } = props;
+
+	const spotlightOnClick = () => {
+		onClick();
+
+		page( CTA.link );
+	};
 
 	return (
 		<>
@@ -9,7 +16,7 @@ export default function SpotlightTemplate( props ) {
 			<Spotlight
 				taglineText={ message }
 				illustrationSrc={ icon }
-				onClick
+				onClick={ spotlightOnClick }
 				titleText={ description }
 				ctaText={ CTA.message }
 			/>

--- a/client/blocks/jitm/templates/spotlight.jsx
+++ b/client/blocks/jitm/templates/spotlight.jsx
@@ -1,0 +1,12 @@
+import Spotlight from 'calypso/components/spotlight';
+
+export default function SpotlightTemplate( props ) {
+	const { trackImpression } = props;
+
+	return (
+		<>
+			{ trackImpression && trackImpression() }
+			<Spotlight />
+		</>
+	);
+}

--- a/client/components/spotlight/index.tsx
+++ b/client/components/spotlight/index.tsx
@@ -8,7 +8,7 @@ const SpotlightContainer = styled.div`
 	align-items: center;
 	padding: 30px;
 	border: 1px solid var( --studio-gray-5 );
-	border-radius: var( --radius-2 );
+	border-radius: 5px;
 `;
 
 const SpotlightContent = styled.div`

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -113,7 +113,7 @@ const PluginsBrowserList = ( {
 					require="calypso/blocks/jitm"
 					template="spotlight"
 					placeholder={ null }
-					messagePath="calypso:spotlight:sidebar_notice"
+					messagePath="calypso:plugins:spotlight"
 				/>
 			) }
 			<Card className="plugins-browser-list__elements">{ renderViews() }</Card>

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -4,14 +4,11 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { times } from 'lodash';
-import page from 'page';
 import PropTypes from 'prop-types';
-import { useDispatch } from 'react-redux';
-import Spotlight from 'calypso/components/spotlight';
+import AsyncLoad from 'calypso/components/async-load';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
 import PluginBrowserItem from 'calypso/my-sites/plugins/plugins-browser-item';
 import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { PluginsBrowserListVariant } from './types';
 
 import './style.scss';
@@ -32,12 +29,9 @@ const PluginsBrowserList = ( {
 	listName,
 	expandedListLink,
 	size,
-	spotlightPlugin,
-	spotlightPluginFetched,
 } ) => {
 	const isWide = useBreakpoint( '>1280px' );
 	const { __ } = useI18n();
-	const dispatch = useDispatch();
 
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {
@@ -91,17 +85,6 @@ const PluginsBrowserList = ( {
 		}
 	};
 
-	const spotlightOnClick = () => {
-		dispatch(
-			recordTracksEvent( 'calypso_marketplace_spotlight_click', {
-				type: 'plugin',
-				slug: spotlightPlugin.slug,
-				id: spotlightPlugin.id,
-				site: site,
-			} )
-		);
-		page( `/plugins/${ spotlightPlugin.slug }/${ site || '' }` );
-	};
 	return (
 		<div className="plugins-browser-list">
 			<div className="plugins-browser-list__header">
@@ -125,18 +108,14 @@ const PluginsBrowserList = ( {
 					) }
 				</div>
 			</div>
-			{ listName === 'paid' &&
-				isEnabled( 'marketplace-spotlight' ) &&
-				spotlightPluginFetched &&
-				spotlightPlugin && (
-					<Spotlight
-						taglineText={ __( 'Drive more traffic with Yoast SEO Premium' ) }
-						titleText={ __( 'Under the Spotlight' ) }
-						ctaText={ __( 'View Details' ) }
-						illustrationSrc={ spotlightPlugin?.icon ?? '' }
-						onClick={ () => spotlightOnClick() }
-					/>
-				) }
+			{ listName === 'paid' && isEnabled( 'marketplace-spotlight' ) && (
+				<AsyncLoad
+					require="calypso/blocks/jitm"
+					template="spotlight"
+					placeholder={ null }
+					messagePath="calypso:spotlight:sidebar_notice"
+				/>
+			) }
 			<Card className="plugins-browser-list__elements">{ renderViews() }</Card>
 		</div>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `Spotlight` template to JITM block.
* Integrates Marketplace Spotlight with JITM.

#### Screenshots
![Screen Shot 2022-03-15 at 2 54 52 PM](https://user-images.githubusercontent.com/1035546/158460548-06f17cd8-21d0-496b-afd4-f4c125d5adec.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
First Apply D76242-code

##### Showcase Yoast Premium when not installed
* On a simple site and an atomic site without yoast premium installed Navigate into `http://calypso.localhost:3000/plugins/:siteSlug?flags=marketplace-spotlight`.
* Spotlight component should correctly show Yoast Premium. (Icon is not showing yet and will be addressed on a backend follow-up)
* Click on it, it should navigate to the plugin page.
* It should also send the following track event `jitm-spotlight-calypso-yoast`

##### Doesn't show Yoast Premium when installed
* On a atomic site with Yoast Premium installed Navigate into `http://calypso.localhost:3000/plugins/:siteSlug?flags=marketplace-spotlight`.
* Spotlight component should not show.

##### Shows sensei pro when sensei is installed
* On a atomic site with Sensei installed Navigate into `http://calypso.localhost:3000/plugins/:siteSlug?flags=marketplace-spotlight`.
* Spotlight component should show with sensei pro content.
* Click on it, it should navigate to the plugin page.
* It should also send the following track event `jitm-spotlight-calypso-senseipro`

##### Hide spotlight when sensei, sensei pro and yoast premium are installed
can't be tested because still we can't install sensei pro - https://github.com/Automattic/wp-calypso/issues/61882

Related to #61492