### PR TITLE
Change Scan review-prompt to display after 3 visits to Scan page.

### DIFF
--- a/client/blocks/jetpack-review-prompt/index.tsx
+++ b/client/blocks/jetpack-review-prompt/index.tsx
@@ -3,7 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QueryPreferences from 'calypso/components/data/query-preferences';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { dismiss } from 'calypso/state/jetpack-review-prompt/actions';
@@ -20,7 +19,6 @@ interface Props {
 const JetpackReviewPrompt: FunctionComponent< Props > = ( { align = 'center', type } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const moment = useLocalizedMoment();
 
 	// dismiss count is stored in a preference, make sure we have that before rendering
 	const hasReceivedRemotePreferences = useSelector( ( state ) =>
@@ -76,15 +74,6 @@ const JetpackReviewPrompt: FunctionComponent< Props > = ( { align = 'center', ty
 			default:
 				return (
 					<p>
-						{ translate( 'Scan fixed all threats {{strong}}%s{{/strong}}. Your site looks great!', {
-							args: [ moment.utc( validFrom ).fromNow() ],
-							components: {
-								strong: <strong />,
-							},
-						} ) }
-
-						<br />
-
 						{ preventWidows(
 							translate(
 								'Are you happy with Jetpack Scan? Leave us a review and help spread the word.'

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -71,12 +71,11 @@ const SCAN_VISIT_COUNTER_NAME = 'scan-page-visit';
 class ScanPage extends Component< Props > {
 	componentDidMount() {
 		const { scanState, dispatchIncrementCounter } = this.props;
-		if ( ! scanState?.state || scanState?.state === 'unavailable' ) {
-			return;
+		if ( scanState?.state && scanState?.state !== 'unavailable' ) {
+			// Counting visits to the scan page for the Jetpack (Scan) Review Prompt.
+			// Review Prompt should appear after 3 visits (not including same day visits)
+			dispatchIncrementCounter( SCAN_VISIT_COUNTER_NAME, false, false );
 		}
-		// Counting visits to the scan page for the Jetpack (Scan) Review Prompt.
-		// Review Prompt should appear after 3 visits (not including same day visits)
-		dispatchIncrementCounter( SCAN_VISIT_COUNTER_NAME, false, false );
 	}
 
 	componentDidUpdate( prevProps: Props ) {

--- a/client/state/data-layer/wpcom/sites/alerts/fix-status.js
+++ b/client/state/data-layer/wpcom/sites/alerts/fix-status.js
@@ -3,7 +3,6 @@ import { JETPACK_SCAN_THREATS_GET_FIX_STATUS } from 'calypso/state/action-types'
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
-import { setValidFrom } from 'calypso/state/jetpack-review-prompt/actions.ts';
 import { requestScanStatus } from 'calypso/state/jetpack-scan/actions';
 import { requestJetpackScanHistory } from 'calypso/state/jetpack-scan/history/actions';
 import { getFixThreatsStatus } from 'calypso/state/jetpack-scan/threats/actions';
@@ -54,10 +53,6 @@ export const success = ( action, fixer_state ) => {
 					duration: 4000,
 				}
 			),
-			// Make the 'jetpack-review-prompt' (calypso preference) valid, triggering a
-			// user prompt to submit a review of the Jetpack plugin on the /scan/:site page.
-			setValidFrom( 'scan', Date.now() ),
-
 			requestScanStatus( action.siteId ),
 			// Since we can fix threats from the History section, we need to update that
 			// information as well.

--- a/client/state/jetpack-review-prompt/actions.ts
+++ b/client/state/jetpack-review-prompt/actions.ts
@@ -14,28 +14,15 @@ const combineDismissPreference = (
 	const fullPref = getPreference( state, PREFERENCE_NAME ) ?? {};
 	const previousPref = getExistingPreference( state, type );
 
-	return type === 'scan'
-		? {
-				...fullPref,
-				scan: {
-					...fullPref.scan,
-					[ state.ui.selectedSiteId ]: {
-						...previousPref,
-						dismissCount: previousPref.dismissCount + ( reviewed ? 0 : 1 ),
-						dismissedAt,
-						reviewed,
-					},
-				},
-		  }
-		: {
-				...fullPref,
-				[ type ]: {
-					...previousPref,
-					dismissCount: previousPref.dismissCount + ( reviewed ? 0 : 1 ),
-					dismissedAt,
-					reviewed,
-				},
-		  };
+	return {
+		...fullPref,
+		[ type ]: {
+			...previousPref,
+			dismissCount: previousPref.dismissCount + ( reviewed ? 0 : 1 ),
+			dismissedAt,
+			reviewed,
+		},
+	};
 };
 
 const dismiss = (
@@ -58,24 +45,13 @@ const combineValidPreference = (
 	const fullPref = getPreference( state, PREFERENCE_NAME ) ?? {};
 	const previousPref = getExistingPreference( state, type );
 
-	return type === 'scan'
-		? {
-				...fullPref,
-				scan: {
-					...fullPref.scan,
-					[ state.ui.selectedSiteId ]: {
-						...previousPref,
-						validFrom: validFrom ?? Date.now(),
-					},
-				},
-		  }
-		: {
-				...fullPref,
-				[ type ]: {
-					...previousPref,
-					validFrom: validFrom ?? Date.now(),
-				},
-		  };
+	return {
+		...fullPref,
+		[ type ]: {
+			...previousPref,
+			validFrom: validFrom ?? Date.now(),
+		},
+	};
 };
 
 const setValidFrom = ( type: 'restore' | 'scan', validFrom: number | null = null ) => (

--- a/client/state/jetpack-review-prompt/constants.ts
+++ b/client/state/jetpack-review-prompt/constants.ts
@@ -8,12 +8,8 @@ export interface SinglePreferenceType {
 }
 
 export interface PreferenceType {
-	scan?: ScanPreferenceType;
+	scan?: SinglePreferenceType;
 	restore?: SinglePreferenceType;
-}
-
-export interface ScanPreferenceType {
-	[ siteId: string ]: SinglePreferenceType;
 }
 
 export const emptyPreference: SinglePreferenceType = {

--- a/client/state/jetpack-review-prompt/selectors.ts
+++ b/client/state/jetpack-review-prompt/selectors.ts
@@ -6,7 +6,6 @@ import {
 	PreferenceType,
 	TIME_BETWEEN_PROMPTS,
 	SinglePreferenceType,
-	ScanPreferenceType,
 } from './constants';
 import type { AppState } from 'calypso/types';
 
@@ -15,11 +14,8 @@ const getExistingPreference = (
 	type: 'scan' | 'restore'
 ): SinglePreferenceType => {
 	const pref = ( getPreference( state, PREFERENCE_NAME ) as PreferenceType ) || {};
-	if ( type === 'scan' && pref?.scan ) {
-		const scanKey = state.ui.selectedSiteId as keyof ScanPreferenceType;
-		return pref.scan[ scanKey ] ?? emptyPreference;
-	}
-	return pref.restore ?? emptyPreference;
+
+	return pref[ type ] ?? emptyPreference;
 };
 
 const getIsDismissed = ( state: AppState, type: 'scan' | 'restore' ): boolean => {

--- a/client/state/jetpack-review-prompt/test/actions.ts
+++ b/client/state/jetpack-review-prompt/test/actions.ts
@@ -1,9 +1,5 @@
 import { expect } from 'chai';
-// import { getIsDismissed, getIsValid } from '../selectors';
-// import { TIME_BETWEEN_PROMPTS } from '../constants';
 import { combineDismissPreference, combineValidPreference } from '../actions';
-
-const TEST_SITE_ID = 123456789;
 
 describe( 'actions', () => {
 	describe( 'Scan Review Prompt:', () => {
@@ -14,15 +10,12 @@ describe( 'actions', () => {
 				expect(
 					combineDismissPreference(
 						{
-							ui: {
-								selectedSiteId: TEST_SITE_ID,
-							},
 							preferences: {},
 						},
 						'scan',
 						dismissDate,
 						false
-					).scan[ TEST_SITE_ID ]
+					).scan
 				).to.have.property( 'dismissedAt', dismissDate );
 			} );
 
@@ -30,15 +23,12 @@ describe( 'actions', () => {
 				expect(
 					combineDismissPreference(
 						{
-							ui: {
-								selectedSiteId: TEST_SITE_ID,
-							},
 							preferences: {},
 						},
 						'scan',
 						Date.now(),
 						false
-					).scan[ TEST_SITE_ID ]
+					).scan
 				).to.have.property( 'dismissCount', 1 );
 			} );
 
@@ -46,19 +36,14 @@ describe( 'actions', () => {
 				expect(
 					combineDismissPreference(
 						{
-							ui: {
-								selectedSiteId: TEST_SITE_ID,
-							},
 							preferences: {
 								localValues: {
 									'jetpack-review-prompt': {
 										scan: {
-											[ TEST_SITE_ID ]: {
-												dismissCount: 1,
-												dismissedAt: Date.now(),
-												validFrom: null,
-												reviewed: false,
-											},
+											dismissCount: 1,
+											dismissedAt: Date.now(),
+											validFrom: null,
+											reviewed: false,
 										},
 									},
 								},
@@ -67,7 +52,7 @@ describe( 'actions', () => {
 						'scan',
 						Date.now(),
 						false
-					).scan[ TEST_SITE_ID ]
+					).scan
 				).to.have.property( 'dismissCount', 2 );
 			} );
 
@@ -75,15 +60,12 @@ describe( 'actions', () => {
 				expect(
 					combineDismissPreference(
 						{
-							ui: {
-								selectedSiteId: TEST_SITE_ID,
-							},
 							preferences: {},
 						},
 						'scan',
 						Date.now(),
 						true
-					).scan[ TEST_SITE_ID ]
+					).scan
 				).to.have.property( 'reviewed', true );
 			} );
 
@@ -94,14 +76,11 @@ describe( 'actions', () => {
 					expect(
 						combineValidPreference(
 							{
-								ui: {
-									selectedSiteId: TEST_SITE_ID,
-								},
 								preferences: {},
 							},
 							'scan',
 							validFrom
-						).scan[ TEST_SITE_ID ]
+						).scan
 					).to.have.property( 'validFrom', validFrom );
 				} );
 			} );

--- a/client/state/jetpack-review-prompt/test/selectors.ts
+++ b/client/state/jetpack-review-prompt/test/selectors.ts
@@ -2,57 +2,25 @@ import { expect } from 'chai';
 import { TIME_BETWEEN_PROMPTS } from '../constants';
 import { getIsDismissed, getIsValid } from '../selectors';
 
-const TEST_SITE_ID = 123456789;
-const reduxState = {
-	ui: {
-		selectedSiteId: TEST_SITE_ID,
-	},
-};
-
 describe( 'selectors', () => {
 	describe( 'Scan Review Prompt:', () => {
 		describe( 'getIsDismissed()', () => {
 			test( 'should return false if no preference saved', () => {
 				const state = {
-					...reduxState,
 					preferences: {},
-				};
-				expect( getIsDismissed( state, 'scan' ) ).to.be.false;
-			} );
-			test( 'should return false if no preference saved for the currently selectedSiteId', () => {
-				const state = {
-					...reduxState,
-					preferences: {
-						localValues: {
-							'jetpack-review-prompt': {
-								scan: {
-									// not the currently selectedSiteId
-									[ 3458899 ]: {
-										dismissCount: 1,
-										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
-										reviewed: true,
-										validFrom: null,
-									},
-								},
-							},
-						},
-					},
 				};
 				expect( getIsDismissed( state, 'scan' ) ).to.be.false;
 			} );
 			test( 'should return true if reviewed', () => {
 				const state = {
-					...reduxState,
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
 								scan: {
-									[ TEST_SITE_ID ]: {
-										dismissCount: 1,
-										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
-										reviewed: true,
-										validFrom: null,
-									},
+									dismissCount: 1,
+									dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+									reviewed: true,
+									validFrom: null,
 								},
 							},
 						},
@@ -62,17 +30,14 @@ describe( 'selectors', () => {
 			} );
 			test( 'should return false if dismissed just now', () => {
 				const state = {
-					...reduxState,
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
 								scan: {
-									[ TEST_SITE_ID ]: {
-										dismissCount: 1,
-										dismissedAt: Date.now() /* - TIME_BETWEEN_PROMPTS * 2*/,
-										reviewed: true,
-										validFrom: null,
-									},
+									dismissCount: 1,
+									dismissedAt: Date.now() /* - TIME_BETWEEN_PROMPTS * 2*/,
+									reviewed: true,
+									validFrom: null,
 								},
 							},
 						},
@@ -82,17 +47,14 @@ describe( 'selectors', () => {
 			} );
 			test( 'should return true if dismissed longer than TIME_BETWEEN_PROMPTS', () => {
 				const state = {
-					...reduxState,
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
 								scan: {
-									[ TEST_SITE_ID ]: {
-										dismissCount: 1,
-										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
-										reviewed: true,
-										validFrom: null,
-									},
+									dismissCount: 1,
+									dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+									reviewed: true,
+									validFrom: null,
 								},
 							},
 						},
@@ -102,17 +64,14 @@ describe( 'selectors', () => {
 			} );
 			test( 'should return true if dismissed twice', () => {
 				const state = {
-					...reduxState,
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
 								scan: {
-									[ TEST_SITE_ID ]: {
-										dismissCount: 2,
-										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
-										reviewed: true,
-										validFrom: null,
-									},
+									dismissCount: 2,
+									dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+									reviewed: true,
+									validFrom: null,
 								},
 							},
 						},
@@ -125,24 +84,20 @@ describe( 'selectors', () => {
 		describe( 'getIsValid()', () => {
 			test( 'should return false if preference is empty', () => {
 				const state = {
-					...reduxState,
 					preferences: {},
 				};
 				expect( getIsValid( state, 'scan' ) ).to.be.false;
 			} );
 			test( 'should return false if isValid has not been set', () => {
 				const state = {
-					...reduxState,
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
 								scan: {
-									[ TEST_SITE_ID ]: {
-										dismissCount: 1,
-										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
-										reviewed: true,
-										validFrom: null,
-									},
+									dismissCount: 1,
+									dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+									reviewed: true,
+									validFrom: null,
 								},
 							},
 						},
@@ -152,17 +107,14 @@ describe( 'selectors', () => {
 			} );
 			test( 'should return true if isValid has been set', () => {
 				const state = {
-					...reduxState,
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
 								scan: {
-									[ TEST_SITE_ID ]: {
-										dismissCount: 1,
-										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
-										reviewed: true,
-										validFrom: Date.now() - 1,
-									},
+									dismissCount: 1,
+									dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+									reviewed: true,
+									validFrom: Date.now() - 1,
 								},
 							},
 						},
@@ -170,22 +122,16 @@ describe( 'selectors', () => {
 				};
 				expect( getIsValid( state, 'scan' ) ).to.be.true;
 			} );
-			test( 'should return false if isValid is not set on the currently selectedSiteId', () => {
+			test( 'should return false if isValid is not set', () => {
 				const state = {
-					ui: {
-						selectedSiteId: TEST_SITE_ID,
-					},
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
 								scan: {
-									// not the currently selected site ID.
-									[ 56723451 ]: {
-										dismissCount: 1,
-										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
-										reviewed: true,
-										validFrom: null,
-									},
+									dismissCount: 1,
+									dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+									reviewed: true,
+									validFrom: null,
 								},
 								restore: {
 									dismissCount: 0,
@@ -205,14 +151,12 @@ describe( 'selectors', () => {
 		describe( 'getIsDismissed()', () => {
 			test( 'should return false if no preference saved', () => {
 				const state = {
-					...reduxState,
 					preferences: {},
 				};
 				expect( getIsDismissed( state, 'restore' ) ).to.be.false;
 			} );
 			test( 'should return true if reviewed', () => {
 				const state = {
-					...reduxState,
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
@@ -230,7 +174,6 @@ describe( 'selectors', () => {
 			} );
 			test( 'should return false if dismissed just now', () => {
 				const state = {
-					...reduxState,
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
@@ -248,7 +191,6 @@ describe( 'selectors', () => {
 			} );
 			test( 'should return true if dismissed longer than TIME_BETWEEN_PROMPTS', () => {
 				const state = {
-					...reduxState,
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
@@ -266,7 +208,6 @@ describe( 'selectors', () => {
 			} );
 			test( 'should return true if dismissed twice', () => {
 				const state = {
-					...reduxState,
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
@@ -287,14 +228,12 @@ describe( 'selectors', () => {
 		describe( 'getIsValid()', () => {
 			test( 'should return false if preference is empty', () => {
 				const state = {
-					...reduxState,
 					preferences: {},
 				};
 				expect( getIsValid( state, 'restore' ) ).to.be.false;
 			} );
 			test( 'should return false if isValid has not been set', () => {
 				const state = {
-					...reduxState,
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
@@ -312,7 +251,6 @@ describe( 'selectors', () => {
 			} );
 			test( 'should return true if isValid has been set', () => {
 				const state = {
-					...reduxState,
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
@@ -330,17 +268,14 @@ describe( 'selectors', () => {
 			} );
 			test( 'should return true if isValid has been set on correct sub-property', () => {
 				const state = {
-					...reduxState,
 					preferences: {
 						localValues: {
 							'jetpack-review-prompt': {
 								scan: {
-									[ TEST_SITE_ID ]: {
-										dismissCount: 1,
-										dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
-										reviewed: true,
-										validFrom: Date.now() - 1,
-									},
+									dismissCount: 1,
+									dismissedAt: Date.now() - TIME_BETWEEN_PROMPTS * 2,
+									reviewed: true,
+									validFrom: Date.now() - 1,
 								},
 								restore: {
 									dismissCount: 0,

--- a/client/state/persistent-counter/README.md
+++ b/client/state/persistent-counter/README.md
@@ -1,0 +1,51 @@
+# Persistent Counter
+
+This is a basic counter that can be used to count any sort of Calypso event or action persistently using [Calypso Preferences](https://github.com/Automattic/wp-calypso/tree/trunk/client/state/preferences). (Preferences are saved to `me/settings` and available in Redux state).
+
+### Usage:
+
+To create the counter and increment:
+
+```
+import { useDispatch } from 'react-redux';
+import { incrementCounter } from 'calypso/state/persistent-counter/actions';
+const dispatch = useDispatch();
+
+const MY_COUNTER_NAME = 'my-counter-name';
+
+dispatch( incrementCounter( MY_COUNTER_NAME ) );
+```
+
+### More info:
+
+`incrementCounter`, `decrementCounter`, and `resetCounter` are redux actions that can be dispatched. Thier argument signature is as follows:
+
+`incrementCounter( counterName, keyedToSiteId = false, countSameDay = true );`
+
+`counterName` - a unique slug/name that will be used to reference the counter.
+`keyedToSiteId` - if true, the counter will be keyed to the currently selected siteId and therefore a counter will be created and incremented/decremented per each currently selected siteId.
+`countSameDay` - if false, the counter will only increment, at most, once per day.
+
+**The counter keyed by siteId:**
+
+`dispatch( incrementCounter( MY_COUNTER_NAME, true ) );`
+
+**The counter will only increment at most, once per day (ie- not allow incrementing on the same day):**
+
+`dispatch( incrementCounter( MY_COUNTER_NAME, false, false ) );`
+
+##### getCount:
+
+To retrieve a counter's current count, call the `getCount()` selector:
+
+```
+import { useSelector } from 'react-redux';
+
+const currentCount = useSelector( state => getCount( MY_COUNTER_NAME, false ) );
+```
+
+##### Other selectors:
+
+`counterExists( state, counterName, keyedToSiteId )`
+
+`getCounter( state, counterName, keyedToSiteId )`

--- a/client/state/persistent-counter/README.md
+++ b/client/state/persistent-counter/README.md
@@ -2,7 +2,7 @@
 
 This is a basic counter that can be used to count any sort of Calypso event or action persistently using [Calypso Preferences](https://github.com/Automattic/wp-calypso/tree/trunk/client/state/preferences). (Preferences are saved to `me/settings` and available in Redux state).
 
-### Usage:
+## Usage
 
 To create the counter and increment:
 
@@ -16,7 +16,7 @@ const MY_COUNTER_NAME = 'my-counter-name';
 dispatch( incrementCounter( MY_COUNTER_NAME ) );
 ```
 
-### More info:
+### More info
 
 `incrementCounter`, `decrementCounter`, and `resetCounter` are redux actions that can be dispatched. Thier argument signature is as follows:
 
@@ -26,15 +26,15 @@ dispatch( incrementCounter( MY_COUNTER_NAME ) );
 `keyedToSiteId` - if true, the counter will be keyed to the currently selected siteId and therefore a counter will be created and incremented/decremented per each currently selected siteId.
 `countSameDay` - if false, the counter will only increment, at most, once per day.
 
-**The counter keyed by siteId:**
+#### The counter keyed by siteId
 
 `dispatch( incrementCounter( MY_COUNTER_NAME, true ) );`
 
-**The counter will only increment at most, once per day (ie- not allow incrementing on the same day):**
+#### The counter will only increment at most, once per day (ie- not allow incrementing on the same day)
 
 `dispatch( incrementCounter( MY_COUNTER_NAME, false, false ) );`
 
-##### getCount:
+##### getCount
 
 To retrieve a counter's current count, call the `getCount()` selector:
 
@@ -44,7 +44,7 @@ import { useSelector } from 'react-redux';
 const currentCount = useSelector( state => getCount( MY_COUNTER_NAME, false ) );
 ```
 
-##### Other selectors:
+##### Other selectors
 
 `counterExists( state, counterName, keyedToSiteId )`
 

--- a/client/state/persistent-counter/actions.ts
+++ b/client/state/persistent-counter/actions.ts
@@ -1,0 +1,56 @@
+import { savePreference } from 'calypso/state/preferences/actions';
+import { PREFERENCE_BASE_NAME } from './constants';
+import { incrementPreference, decrementPreference, resetPreference } from './helpers';
+import { lastUpdatedIsToday, counterExists } from './selectors';
+import type { CalypsoDispatch } from '../types';
+import type { AppState } from 'calypso/types';
+
+export const incrementCounter = (
+	counterName: string,
+	keyedToSiteId = false,
+	countSameDay = true
+) => ( dispatch: CalypsoDispatch, getState: () => AppState ) => {
+	if ( ! countSameDay && lastUpdatedIsToday( getState(), counterName, keyedToSiteId ) ) {
+		return;
+	}
+
+	dispatch(
+		savePreference(
+			PREFERENCE_BASE_NAME,
+			incrementPreference( getState(), counterName, keyedToSiteId )
+		)
+	);
+};
+
+export const decrementCounter = (
+	counterName: string,
+	keyedToSiteId = false,
+	countSameDay = true
+) => ( dispatch: CalypsoDispatch, getState: () => AppState ) => {
+	if ( ! countSameDay && lastUpdatedIsToday( getState(), counterName, keyedToSiteId ) ) {
+		return;
+	}
+
+	dispatch(
+		savePreference(
+			PREFERENCE_BASE_NAME,
+			decrementPreference( getState(), counterName, keyedToSiteId )
+		)
+	);
+};
+
+export const resetCounter = ( counterName: string, keyedToSiteId = false ) => (
+	dispatch: CalypsoDispatch,
+	getState: () => AppState
+) => {
+	if ( ! counterExists( getState(), counterName, keyedToSiteId ) ) {
+		return;
+	}
+
+	dispatch(
+		savePreference(
+			PREFERENCE_BASE_NAME,
+			resetPreference( getState(), counterName, keyedToSiteId )
+		)
+	);
+};

--- a/client/state/persistent-counter/constants.ts
+++ b/client/state/persistent-counter/constants.ts
@@ -1,0 +1,15 @@
+export const PREFERENCE_BASE_NAME = 'persistent-counter';
+
+export interface SingleCounterType {
+	count: number;
+	lastUpdated: number | null;
+}
+
+export interface CounterType {
+	[ counterName: string ]: SingleCounterType;
+}
+
+export const initialCount: SingleCounterType = {
+	count: 0,
+	lastUpdated: null,
+};

--- a/client/state/persistent-counter/helpers.ts
+++ b/client/state/persistent-counter/helpers.ts
@@ -1,0 +1,64 @@
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { PREFERENCE_BASE_NAME, CounterType, initialCount } from './constants';
+import { getCounter, getCounterName } from './selectors';
+import type { AppState } from 'calypso/types';
+
+export const isSameDay = ( unixTimestamp1: number, unixTimestamp2: number ): boolean => {
+	const millisecondsInDay = 24 * 60 * 60 * 1000;
+	return (
+		Math.floor( unixTimestamp1 / millisecondsInDay ) ===
+		Math.floor( unixTimestamp2 / millisecondsInDay )
+	);
+};
+
+export const incrementPreference = (
+	state: AppState,
+	counterName: string,
+	keyedToSiteId = false
+): CounterType => {
+	const fullPref = getPreference( state, PREFERENCE_BASE_NAME ) ?? {};
+	const thisCounter = getCounter( state, counterName, keyedToSiteId );
+	const keyedCounterName = getCounterName( state, counterName, keyedToSiteId );
+
+	return {
+		...fullPref,
+		[ keyedCounterName ]: {
+			count: thisCounter.count + 1,
+			lastUpdated: Date.now(),
+		},
+	};
+};
+
+export const decrementPreference = (
+	state: AppState,
+	counterName: string,
+	keyedToSiteId = false
+): CounterType => {
+	const fullPref = getPreference( state, PREFERENCE_BASE_NAME ) ?? {};
+	const thisCounter = getCounter( state, counterName, keyedToSiteId );
+	const keyedCounterName = getCounterName( state, counterName, keyedToSiteId );
+
+	return {
+		...fullPref,
+		[ keyedCounterName ]: {
+			count: thisCounter.count <= 0 ? 0 : thisCounter.count - 1,
+			lastUpdated: Date.now(),
+		},
+	};
+};
+
+export const resetPreference = (
+	state: AppState,
+	counterName: string,
+	keyedToSiteId = false
+): CounterType => {
+	const fullPref = getPreference( state, PREFERENCE_BASE_NAME ) ?? {};
+	const keyedCounterName = getCounterName( state, counterName, keyedToSiteId );
+
+	return {
+		...fullPref,
+		[ keyedCounterName ]: {
+			...initialCount,
+		},
+	};
+};

--- a/client/state/persistent-counter/selectors.ts
+++ b/client/state/persistent-counter/selectors.ts
@@ -1,0 +1,56 @@
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { initialCount, PREFERENCE_BASE_NAME, SingleCounterType, CounterType } from './constants';
+import { isSameDay } from './helpers';
+import type { AppState } from 'calypso/types';
+
+export const getCounterName = (
+	state: AppState,
+	counterName: string,
+	keyedToSiteId = false
+): keyof CounterType => {
+	if ( keyedToSiteId ) {
+		return `${ counterName }-${ state.ui.selectedSiteId }`;
+	}
+	return counterName;
+};
+
+export const getCounter = (
+	state: AppState,
+	counterName: string,
+	keyedToSiteId = false
+): SingleCounterType => {
+	const keyedCounterName: keyof CounterType = getCounterName( state, counterName, keyedToSiteId );
+	const pref = ( getPreference( state, PREFERENCE_BASE_NAME ) as CounterType ) || {};
+
+	return pref[ keyedCounterName ] ?? initialCount;
+};
+
+export const lastUpdatedIsToday = (
+	state: AppState,
+	counterName: string,
+	keyedToSiteId = false
+): boolean => {
+	const thisPref = getCounter( state, counterName, keyedToSiteId );
+	const { lastUpdated } = thisPref;
+	const lastUpdatedDate = lastUpdated || 0;
+
+	return isSameDay( lastUpdatedDate, Date.now() );
+};
+
+export const counterExists = (
+	state: AppState,
+	counterName: string,
+	keyedToSiteId = false
+): boolean => {
+	const pref = ( getPreference( state, PREFERENCE_BASE_NAME ) as CounterType ) || {};
+	const keyedCounterName: keyof CounterType = getCounterName( state, counterName, keyedToSiteId );
+
+	return !! pref[ keyedCounterName ];
+};
+
+export const getCount = ( state: AppState, counterName: string, keyedToSiteId = false ): number => {
+	const keyedCounterName: keyof CounterType = getCounterName( state, counterName, keyedToSiteId );
+	const pref = ( getPreference( state, PREFERENCE_BASE_NAME ) as CounterType ) || {};
+
+	return pref[ keyedCounterName ]?.count;
+};

--- a/client/state/persistent-counter/test/actions.ts
+++ b/client/state/persistent-counter/test/actions.ts
@@ -1,0 +1,231 @@
+import { expect } from 'chai';
+import { PREFERENCE_BASE_NAME } from '../constants';
+import { isSameDay, incrementPreference, decrementPreference, resetPreference } from '../helpers';
+
+const TEST_SITE_ID = 123456789;
+const COUNTER_NAME = 'my-test-counter';
+
+describe( 'actions', () => {
+	describe( 'isSameDay()', () => {
+		test( 'Should return true if 2 timestamps are on the same day', () => {
+			const timestamp1 = Date.parse( '2022-03-09 07:47:05' );
+			const timestamp2 = Date.parse( '2022-03-09 01:00:02' );
+			expect( isSameDay( timestamp1, timestamp2 ) ).to.be.true;
+		} );
+
+		test( 'Should return false if 2 timestamps are on different days', () => {
+			const timestamp1 = Date.now();
+			const timestamp2 = Date.parse( '2022-03-08 01:00:02' );
+			expect( isSameDay( timestamp1, timestamp2 ) ).to.be.false;
+		} );
+	} );
+
+	describe( 'incrementPreference()', () => {
+		test( "should create new counter property if counter preference doesn't exist", () => {
+			const result = incrementPreference(
+				{
+					ui: {
+						selectedSiteId: TEST_SITE_ID,
+					},
+					preferences: {
+						localValues: {
+							[ PREFERENCE_BASE_NAME ]: {
+								'some-other-counter': {
+									count: 99,
+									lastUpdated: 1646844419200,
+								},
+							},
+						},
+					},
+				},
+				'my-test-counter',
+				false
+			);
+
+			expect( result ).to.have.deep.own.property( 'my-test-counter' );
+		} );
+
+		test( 'should cleanly update the preferences object without affecting other values', () => {
+			jest.spyOn( Date, 'now' ).mockReturnValueOnce( 9999 );
+
+			const result = incrementPreference(
+				{
+					ui: {
+						selectedSiteId: TEST_SITE_ID,
+					},
+					preferences: {
+						localValues: {
+							[ PREFERENCE_BASE_NAME ]: {
+								'some-other-counter': {
+									count: 99,
+									lastUpdated: 1646844419200,
+								},
+							},
+						},
+					},
+				},
+				'my-test-counter',
+				false
+			);
+
+			expect( result ).to.deep.eql( {
+				'some-other-counter': {
+					count: 99,
+					lastUpdated: 1646844419200,
+				},
+				'my-test-counter': {
+					count: 1,
+					lastUpdated: 9999,
+				},
+			} );
+		} );
+
+		test( 'should increment count to 1 on initial increment/creation', () => {
+			const result = incrementPreference(
+				{
+					ui: {
+						selectedSiteId: TEST_SITE_ID,
+					},
+					preferences: {},
+				},
+				'my-test-counter',
+				false
+			);
+			expect( result[ COUNTER_NAME ] ).to.have.own.property( 'count', 1 );
+		} );
+
+		test( 'should update lastUpdated on increment', () => {
+			jest.spyOn( Date, 'now' ).mockReturnValueOnce( 9999 );
+
+			const result = incrementPreference(
+				{
+					ui: {
+						selectedSiteId: TEST_SITE_ID,
+					},
+					preferences: {
+						localValues: {
+							[ PREFERENCE_BASE_NAME ]: {
+								'my-test-counter': {
+									count: 1,
+									lastUpdated: 1646844419200,
+								},
+							},
+						},
+					},
+				},
+				'my-test-counter',
+				false
+			);
+			expect( result[ COUNTER_NAME ] ).to.deep.eql( {
+				count: 2,
+				lastUpdated: 9999,
+			} );
+			expect( result[ COUNTER_NAME ] ).to.have.own.property( 'lastUpdated', 9999 );
+		} );
+	} );
+
+	describe( 'decrementPreference()', () => {
+		test( "should create new counter property if counter preference doesn't exist and set count to 0", () => {
+			jest.spyOn( Date, 'now' ).mockReturnValueOnce( 9999 );
+			const result = decrementPreference(
+				{
+					ui: {
+						selectedSiteId: TEST_SITE_ID,
+					},
+					preferences: {},
+				},
+				'my-test-counter',
+				false
+			);
+			expect( result ).to.have.deep.own.property( 'my-test-counter' );
+			expect( result[ COUNTER_NAME ] ).to.deep.eql( {
+				count: 0,
+				lastUpdated: 9999,
+			} );
+		} );
+
+		test( 'counter should not decrement to negative. should force minimum 0', () => {
+			jest.spyOn( Date, 'now' ).mockReturnValueOnce( 9999 );
+			const result = decrementPreference(
+				{
+					ui: {
+						selectedSiteId: TEST_SITE_ID,
+					},
+					preferences: {
+						localValues: {
+							[ PREFERENCE_BASE_NAME ]: {
+								'my-test-counter': {
+									count: 0,
+									lastUpdated: 1646844419200,
+								},
+							},
+						},
+					},
+				},
+				'my-test-counter',
+				false
+			);
+			expect( result[ COUNTER_NAME ] ).to.deep.eql( {
+				count: 0,
+				lastUpdated: 9999,
+			} );
+		} );
+
+		test( 'should update lastUpdated on decrement', () => {
+			jest.spyOn( Date, 'now' ).mockReturnValueOnce( 9999 );
+
+			const result = decrementPreference(
+				{
+					ui: {
+						selectedSiteId: TEST_SITE_ID,
+					},
+					preferences: {
+						localValues: {
+							[ PREFERENCE_BASE_NAME ]: {
+								'my-test-counter': {
+									count: 1,
+									lastUpdated: 1646844419200,
+								},
+							},
+						},
+					},
+				},
+				'my-test-counter',
+				false
+			);
+			expect( result[ COUNTER_NAME ] ).to.deep.eql( {
+				count: 0,
+				lastUpdated: 9999,
+			} );
+			expect( result[ COUNTER_NAME ] ).to.have.own.property( 'lastUpdated', 9999 );
+		} );
+	} );
+
+	describe( 'resetPreference()', () => {
+		test( 'should reset the counter preference to count: 0 and lastUpdated: null', () => {
+			const result = resetPreference(
+				{
+					ui: {
+						selectedSiteId: TEST_SITE_ID,
+					},
+					preferences: {
+						localValues: {
+							[ PREFERENCE_BASE_NAME ]: {
+								'my-test-counter': {
+									count: 8,
+									lastUpdated: 1646844419200,
+								},
+							},
+						},
+					},
+				},
+				'my-test-counter',
+				false
+			);
+			expect( result[ COUNTER_NAME ] ).to.deep.eql( {
+				count: 0,
+				lastUpdated: null,
+			} );
+		} );
+	} );
+} );

--- a/client/state/persistent-counter/test/selectors.ts
+++ b/client/state/persistent-counter/test/selectors.ts
@@ -1,0 +1,212 @@
+import { expect } from 'chai';
+import { PREFERENCE_BASE_NAME } from '../constants';
+import {
+	getCounterName,
+	getCounter,
+	getCount,
+	lastUpdatedIsToday,
+	counterExists,
+} from '../selectors';
+
+const TEST_SITE_ID = 123456789;
+const COUNTER_NAME = 'my-test-counter';
+
+const reduxState = {
+	ui: {
+		selectedSiteId: TEST_SITE_ID,
+	},
+};
+
+describe( 'selectors', () => {
+	describe( 'getCounterName:', () => {
+		test( 'should return counter name with siteId suffixed when keyedToSiteId arg is true', () => {
+			const state = {
+				...reduxState,
+				preferences: {},
+			};
+			expect( getCounterName( state, COUNTER_NAME, true ) ).to.equal(
+				`${ COUNTER_NAME }-${ TEST_SITE_ID }`
+			);
+		} );
+
+		test( 'should return counter name without siteId suffixed when keyedToSiteId arg is false', () => {
+			const state = {
+				...reduxState,
+				preferences: {},
+			};
+			expect( getCounterName( state, COUNTER_NAME, false ) ).to.equal( `${ COUNTER_NAME }` );
+		} );
+	} );
+
+	describe( 'getCounter:', () => {
+		test( "should return an initial counter object (count: 0, lastUpdated: null) if counter doesn't exist", () => {
+			const state = {
+				...reduxState,
+				preferences: {},
+			};
+			expect( getCounter( state, COUNTER_NAME, false ) ).to.deep.equal( {
+				count: 0,
+				lastUpdated: null,
+			} );
+		} );
+
+		test( 'should return the preference value when the preference exists', () => {
+			const state = {
+				...reduxState,
+				preferences: {
+					localValues: {
+						[ PREFERENCE_BASE_NAME ]: {
+							[ COUNTER_NAME ]: {
+								count: 5,
+								lastUpdated: 1646852413406,
+							},
+						},
+					},
+				},
+			};
+			expect( getCounter( state, COUNTER_NAME, false ) ).to.deep.equal( {
+				count: 5,
+				lastUpdated: 1646852413406,
+			} );
+		} );
+
+		test( 'should return the preference value when exists and keyedToSiteId arg is true', () => {
+			const state = {
+				...reduxState,
+				preferences: {
+					localValues: {
+						[ PREFERENCE_BASE_NAME ]: {
+							[ `${ COUNTER_NAME }-${ TEST_SITE_ID }` ]: {
+								count: 11,
+								lastUpdated: 1646852413406,
+							},
+						},
+					},
+				},
+			};
+			expect( getCounter( state, COUNTER_NAME, true ) ).to.deep.equal( {
+				count: 11,
+				lastUpdated: 1646852413406,
+			} );
+		} );
+	} );
+
+	describe( 'getCount:', () => {
+		test( "should return undefined if preference doesn't exist", () => {
+			const state = {
+				...reduxState,
+				preferences: {},
+			};
+			expect( getCount( state, COUNTER_NAME, false ) ).to.be.undefined;
+		} );
+
+		test( 'should return the correct count value if preference exist and keyedToSiteId arg is false', () => {
+			const state = {
+				...reduxState,
+				preferences: {
+					localValues: {
+						[ PREFERENCE_BASE_NAME ]: {
+							[ COUNTER_NAME ]: {
+								count: 7,
+								lastUpdated: 1646852413406,
+							},
+						},
+					},
+				},
+			};
+			expect( getCount( state, COUNTER_NAME, false ) ).to.equal( 7 );
+		} );
+
+		test( 'should return the correct count value if counter exist and keyedToSiteId arg is true', () => {
+			const state = {
+				...reduxState,
+				preferences: {
+					localValues: {
+						[ PREFERENCE_BASE_NAME ]: {
+							[ `${ COUNTER_NAME }-${ TEST_SITE_ID }` ]: {
+								count: 3,
+								lastUpdated: 1646852413406,
+							},
+						},
+					},
+				},
+			};
+			expect( getCount( state, COUNTER_NAME, true ) ).to.equal( 3 );
+		} );
+	} );
+
+	describe( 'lastUpdatedIsToday:', () => {
+		test( 'should return true if counter was updated today', () => {
+			const today = Date.now();
+			const state = {
+				...reduxState,
+				preferences: {
+					localValues: {
+						[ PREFERENCE_BASE_NAME ]: {
+							[ COUNTER_NAME ]: {
+								count: 7,
+								lastUpdated: today,
+							},
+						},
+					},
+				},
+			};
+			expect( lastUpdatedIsToday( state, COUNTER_NAME, false ) ).to.be.true;
+		} );
+
+		test( 'should return false if counter was not updated today', () => {
+			const notToday = Date.parse( '2022-03-09 07:47:05' );
+			const state = {
+				...reduxState,
+				preferences: {
+					localValues: {
+						[ PREFERENCE_BASE_NAME ]: {
+							[ COUNTER_NAME ]: {
+								count: 7,
+								lastUpdated: notToday,
+							},
+						},
+					},
+				},
+			};
+			expect( lastUpdatedIsToday( state, COUNTER_NAME, false ) ).to.be.false;
+		} );
+	} );
+
+	describe( 'counterExists:', () => {
+		test( 'should return true if the counter preference key exists', () => {
+			const state = {
+				...reduxState,
+				preferences: {
+					localValues: {
+						[ PREFERENCE_BASE_NAME ]: {
+							'my-counter-name': {
+								count: 7,
+								lastUpdated: 1646852413406,
+							},
+						},
+					},
+				},
+			};
+			expect( counterExists( state, 'my-counter-name', false ) ).to.be.true;
+		} );
+
+		test( 'should return false if counter preference key does not exist', () => {
+			const notToday = Date.parse( '2022-03-09 07:47:05' );
+			const state = {
+				...reduxState,
+				preferences: {
+					localValues: {
+						[ PREFERENCE_BASE_NAME ]: {
+							'my-counter-name': {
+								count: 7,
+								lastUpdated: notToday,
+							},
+						},
+					},
+				},
+			};
+			expect( lastUpdatedIsToday( state, 'wrong-counter-name', false ) ).to.be.false;
+		} );
+	} );
+} );

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -72,18 +72,26 @@ export const remoteValuesSchema = {
 		'jetpack-review-prompt': {
 			type: 'object',
 			properties: {
-				scan: {
-					type: 'object',
-					properties: {
-						'/[0-9]+/': { $ref: '#/definitions/dismissiblePrompt' },
-					},
-				},
+				scan: { $ref: '#/definitions/dismissiblePrompt' },
 				restore: { $ref: '#/definitions/dismissiblePrompt' },
 			},
 		},
 		homeQuickLinksToggleStatus: {
 			type: 'string',
 			enum: [ 'collapsed', 'expanded' ],
+		},
+		'persistent-counter': {
+			type: 'object',
+			properties: {
+				// counter-name (possibly suffixed with siteId)
+				'^[a-z0-9-]+$': {
+					type: 'object',
+					properties: {
+						count: { type: 'number', minimum: 0 },
+						lastCountDate: { type: [ 'number', 'null' ] },
+					},
+				},
+			},
 		},
 	},
 	definitions: {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the Jetpack-Review-Prompt for Jetpack Scan to display after 3 visits to the Scan page (not on the same day), instead of after a Scan threat is successfully "auto-fixed". 

Related to: 1164141197617539-as-1201731270035137

**Jetpack Review Prompt context:**
The Jetpack Review Prompt is a UI component that displays to users, prompting them to leave a review for Jetpack on the WordPress plugin repository.  There is a review prompt for Backup and for Scan. The Backup one displays after the user initiates a site restore. The Scan one, prior to this PR, displays after the user successfully "auto-fixes" a detected scan threat.
The way the Review Prompts dismiss behavior works is: After the prompt has been triggered to display, the user can dismiss the prompt by either clicking the (X) button in the top right corner, or by clicking the "Leave a review" button. If the "Leave a review" button is clicked, the prompt is dismissed permanently. If the prompt is dismissed using the (X) button, the prompt will dismiss initially, but will appear again in 2 weeks. When the prompt is dismissed the second time, it will then dismiss permanently.

Instead of triggering the Scan Review Prompt after a scan threat has been auto-fixed, this PR will trigger the Scan Review prompt after 3 visits (on separate days) to the main Scan page.



**Additional implementation notes:**
- Created a new "persistent-counter" [preference](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/preferences/README.md), and uses this to _persistently_ count each Scan page visit. I tried to make the persistent-counter extensible so it can be reused for persistently counting any other events or actions within Calypso, if needed.
- Created unit tests for the "persistent-counter".
- Updated the existing Jetpack Review Prompt (for Scan) to display after 3 visits (on different days) to the main Scan page, instead of after a scan threat is auto-fixed.
- Updated the existing Jetpack Review Prompt (for Scan) to **no longer** store the review prompt preferences values **per each user's site**. This is no longer needed because the review prompt is no longer based on the scan threat auto-fix of _each site_.

### Testing instructions

1. Spin up this PR in Calypso green (`yarn start-jetpack-cloud`). (or green and blue concurrently)
1. Open up file `client/my-sites/scan/main.tsx`, line 79, and change `dispatchIncrementCounter( SCAN_VISIT_COUNTER_NAME, false, false );` to:
```
dispatchIncrementCounter( SCAN_VISIT_COUNTER_NAME, false, true ); // last argument, set to true.
```
(This change will allow the page counter to count on every visit (for testing purposes), instead of only counting once per day).
1. Select a Jetpack site that has an active Scan subscription (or purchase a new Scan product)
1. Visit `http://jetpack.cloud.localhost:3000/scan/:site` (replace :site with your site slug)
1. If interested you can open Redux DevTools, and inspect the global state object. Go to: preferences -> remoteValues -> persistent-counter -> scan-page-visit, to view the counter increment on every scan page visit.
1. <img width="614" alt="Markup 2022-03-10 at 17 08 41" src="https://user-images.githubusercontent.com/11078128/157774342-e16c31bf-7191-4d54-9c21-076604631afc.png">
1. Reload the scan page (or navigate away and back again) _2 more times_. Upon **3 total visits** you should see the Jetpack Review Prompt (see screenshot):
1. ![Markup 2022-03-10 at 17 12 42](https://user-images.githubusercontent.com/11078128/157774386-55855377-173d-4444-b3d3-aacee77b9a56.png)
1. Dismiss the Jetpack Review Prompt by clicking the (X) close button in the top right corner. The prompt should disappear.
1. Now set your computer's clock forward 2+ weeks. For Mac go to System Preferences -> Date & Time -> Manually set date forward 2 weeks and 1 day (15 days) or more.
1. Reload the scan page, you should see the Jetpack Review Prompt again.
1. Dismiss the Review Prompt again clicking the (X) close button. The prompt should disappear.
1. Manually set your computer clock again to an additional 15 or more days forward.
1. Reload the scan page again and verify the Review Prompt **does not** appear again.
1. And that's it.
1. Reset your computer's clock back to the correct date.
1. To reset the counter and review prompt Preferences settings back to default, Open up the Environment badge thingy in the lower right corner: 
![Markup 2022-03-10 at 17 58 37](https://user-images.githubusercontent.com/11078128/157774586-2519a593-b673-45dc-920d-f7776e91dd78.png)
1. hover over "Preferences" and click the (X) button on the "persistent-counter" and "jetpack-review-prompt" preferences properties.  This will delete/reset the counter and review-prompt values. (See video below).

https://user-images.githubusercontent.com/11078128/157774619-da48eacc-447a-49dd-b2ed-77b584ba934c.mp4

#### Run unit tests:

Run:

` yarn test-client client/state/persistent-counter`

`yarn test-client client/state/jetpack-review-prompt`