### PR TITLE
Purchases: Refactor `CancelPurchase` away from `UNSAFE_` methods

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -61,14 +61,14 @@ class CancelPurchase extends Component {
 
 	componentDidMount() {
 		if ( ! this.isDataValid() ) {
-			this.redirect( this.props );
+			this.redirect();
 			return;
 		}
 	}
 
 	componentDidUpdate( prevProps ) {
 		if ( this.isDataValid( prevProps ) && ! this.isDataValid() ) {
-			this.redirect( this.props );
+			this.redirect();
 			return;
 		}
 	}
@@ -90,8 +90,8 @@ class CancelPurchase extends Component {
 		return isCancelable( purchase ) && isDomainTransferCancelable;
 	};
 
-	redirect = ( props ) => {
-		const { purchase, siteSlug } = props;
+	redirect = () => {
+		const { purchase, siteSlug } = this.props;
 		let redirectPath = this.props.purchaseListUrl;
 
 		if ( siteSlug && purchase && ( ! isCancelable( purchase ) || isDomainTransfer( purchase ) ) ) {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -59,18 +59,16 @@ class CancelPurchase extends Component {
 		purchaseListUrl: purchasesRoot,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		if ( ! this.isDataValid() ) {
 			this.redirect( this.props );
 			return;
 		}
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.isDataValid() && ! this.isDataValid( nextProps ) ) {
-			this.redirect( nextProps );
+	componentDidUpdate( prevProps ) {
+		if ( this.isDataValid( prevProps ) && ! this.isDataValid() ) {
+			this.redirect( this.props );
 			return;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor concierge booking step `CancelPurchase` component away from the `UNSAFE_` deprecated React component methods.

Part of: https://github.com/Automattic/wp-calypso/issues/58453.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start at `/me/purchases` and click on a purchase
* Enable auto-renew 
* Add payment method if there is none 
* Click on 'Cancel Subscription'
* In the URL `/me/purchases/SITE_ADDRESS/PURCHASE_ID/cancel`, edit `PURCHASE_ID` to a random number that does not match one of your purchase IDs.
* Verify you're redirected to `/me/purchases`



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

