### PR TITLE
DIFM: Updates subheader copy for the new/existing site step

### DIFF
--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -38,31 +38,15 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 
 	const headerText = translate( 'Do It For Me' );
 
-	const subHeaderTextWithPlaceHolder = translate(
-		'Get a professionally designed, mobile-optimized website in %(fulfillmentDays)d business days or less for a one-time fee of {{Placeholder}}{{/Placeholder}}',
-		{
-			args: {
-				fulfillmentDays: 4,
-			},
-			components: {
-				Placeholder: <Placeholder />,
-			},
-		}
-	);
-
 	const subHeaderText = translate(
-		'Get a professionally designed, mobile-optimized website in %(fulfillmentDays)d business days or less for a one-time fee of {{strong}}%(displayCost)s{{/strong}}*.' +
-			'{{br}}{{/br}}{{br}}{{/br}}' +
-			'{{small}}* Plus a one year subscription of the Premium plan.{{/small}}',
+		'Get a professionally designed, mobile-optimized website in %(fulfillmentDays)d business days or less for a one-time fee of {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}} plus a one year subscription of the Premium plan.',
 		{
 			args: {
 				displayCost,
 				fulfillmentDays: 4,
 			},
 			components: {
-				strong: <strong />,
-				br: <br />,
-				small: <small />,
+				PriceWrapper: isLoading ? <Placeholder /> : <strong />,
 			},
 		}
 	);
@@ -123,12 +107,12 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 
 	return (
 		<>
-			<QueryProductsList />
+			<QueryProductsList persist />
 			<StepWrapper
 				headerText={ headerText }
 				fallbackHeaderText={ headerText }
-				subHeaderText={ isLoading ? subHeaderTextWithPlaceHolder : subHeaderText }
-				fallbackSubHeaderText={ isLoading ? subHeaderTextWithPlaceHolder : subHeaderText }
+				subHeaderText={ subHeaderText }
+				fallbackSubHeaderText={ subHeaderText }
 				stepContent={
 					<IntentScreen
 						intents={ intents }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the  subheader copy for the new/existing site step. Context: p1646924073231129/1646912673.898539-slack-C028NRBP2AU

<img width="1920" alt="image" src="https://user-images.githubusercontent.com/5436027/157811104-a413e78b-aa41-4f5a-b65b-8745c53dd02b.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 
* Log in as a user who has more than 1 existing site.
* Go to `/start/do-it-for-me?flags=force-sympathy`. (`flags=force-sympathy` ensures that local browser storage is cleared)
* Confirm that you can see the placeholder while the product list is loading.
* Confirm that the screen matches the design shared in the link above.
* Confirm that the price for the DIFM product is displayed correctly according to the user currency.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
