### PR TITLE
Rename track event for domain-only upsell carousel card impression

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-only-upsell-carousel.tsx
+++ b/client/my-sites/domains/domain-management/list/domain-only-upsell-carousel.tsx
@@ -222,7 +222,7 @@ const DomainOnlyUpsellCarousel = ( props: DomainOnlyUpsellCarouselProps ): JSX.E
 				buttonLabel: translate( 'Create site' ),
 				cardName: 'create-site',
 				cardNoticeType: UpsellCardNoticeType.HIDE_CREATE_SITE_CARD,
-				eventTrackViewName: 'calypso_domain_only_upsell_carousel_impression_create_site_card',
+				eventTrackViewName: 'calypso_domain_only_upsell_carousel_card_impression',
 				areHideOptionsVisible: areHideSiteCardOptionsVisible,
 				setHideOptionsVisible: setHideSiteCardOptionsVisible,
 			} )
@@ -244,7 +244,7 @@ const DomainOnlyUpsellCarousel = ( props: DomainOnlyUpsellCarouselProps ): JSX.E
 				buttonLabel: translate( 'Add professional email' ),
 				cardName: 'add-email',
 				cardNoticeType: UpsellCardNoticeType.HIDE_ADD_EMAIL_CARD,
-				eventTrackViewName: 'calypso_domain_only_upsell_carousel_impression_add_email_card',
+				eventTrackViewName: 'calypso_domain_only_upsell_carousel_card_impression',
 				areHideOptionsVisible: areHideEmailCardOptionsVisible,
 				setHideOptionsVisible: setHideEmailCardOptionsVisible,
 			} )


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR rename tracks event sent when a card is showed in domain-only upsell carousel.

Before:
- `calypso_domain_only_upsell_carousel_impression_create_site_card`
- `calypso_domain_only_upsell_carousel_impression_add_email_card`

After:
- `calypso_domain_only_upsell_carousel_card_impression` (_content_type_: `create-site`)
- `calypso_domain_only_upsell_carousel_card_impression` (_content_type_: `add-email`)

All these events are not registered yet in Tracks, so this PR should not mess up with existing funnel.

## Testing instructions

Nothing to test, actually.