### PR TITLE
Jetpack Pricing: remove custom padding from compare all button

### DIFF
--- a/client/my-sites/plans/jetpack-plans/more-info-box/style.scss
+++ b/client/my-sites/plans/jetpack-plans/more-info-box/style.scss
@@ -6,14 +6,14 @@
 
 	margin: 24px 0;
 	padding: 30px 15px 26px;
-	border-radius: 8px;
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
 
 	text-align: center;
 
 	@include break-small {
 		margin: 0 30px;
 
-		border-radius: 0 0 8px 8px;
+		border-radius: 0 0 8px 8px; /* stylelint-disable-line scales/radii */
 	}
 }
 
@@ -29,7 +29,6 @@
 	align-items: center;
 
 	margin: 0 auto;
-	padding: 10px 16px 10px 40px;
 
 	border: solid 2px currentColor;
 	border-radius: 4px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes custom padding from the “Compare all product bundles” button in the Jetpack pricing page, for a uniform look.

#### Testing instructions

* Fire up this PR.
* Head to http://jetpack.cloud.localhost:3000/pricing
* Confirm the button now has uniform padding all around.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/157848759-fb9e19b3-2bbc-49b2-824b-f86d40299623.png) | ![image](https://user-images.githubusercontent.com/390760/157848740-1769c831-073b-44ad-bc9c-815e7d679186.png)
