### PR TITLE
Jetpack Cloud: Backup - Introduce support links at the bottom of the "Backup Failed" card (aka Alert view) 

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
@@ -9,6 +9,7 @@ import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-valu
 import getSiteUrl from 'calypso/state/sites/selectors/get-site-url';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import useGetDisplayDate from '../use-get-display-date';
+import BackupSupportLinks from './backup-support-links';
 import cloudErrorIcon from './icons/cloud-error.svg';
 
 import './style.scss';
@@ -96,6 +97,7 @@ const BackupFailed = ( { backup } ) => {
 					{ translate( 'Contact support' ) }
 				</Button>
 			</div>
+			<BackupSupportLinks siteUrl={ siteUrl } />
 		</>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/status-card/backup-support-links.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-support-links.jsx
@@ -1,0 +1,41 @@
+import { useTranslate } from 'i18n-calypso';
+import ExternalLink from 'calypso/components/external-link';
+import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
+
+const BackupSupportLinks = ( { siteUrl } ) => {
+	const translate = useTranslate();
+	const troubleshootingLink = 'https://jetpack.com/support/backup/troubleshooting-jetpack-backup/';
+	const fixConnectionIssuesLink =
+		'https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/';
+
+	return (
+		<div className="backup-support-links__wrapper">
+			<div>
+				<b>{ translate( 'Do you need any help?' ) }</b>
+			</div>
+			<div className="backup-support-links__links">
+				<div>
+					<ExternalLink href={ troubleshootingLink } target="_blank" rel="noopener noreferrer">
+						{ translate( 'Troubleshooting tips' ) }
+					</ExternalLink>
+				</div>
+				<div>
+					<ExternalLink href={ fixConnectionIssuesLink } target="_blank" rel="noopener noreferrer">
+						{ translate( 'How to fix connection issues' ) }
+					</ExternalLink>
+				</div>
+				<div>
+					<ExternalLink
+						href={ contactSupportUrl( siteUrl ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ translate( 'Contact Jetpack support' ) }
+					</ExternalLink>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default BackupSupportLinks;

--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -229,3 +229,15 @@
 	padding-top: 1.5rem;
 	margin-top: 1.5rem;
 }
+
+.backup-support-links__wrapper {
+	border-top: 1px solid var( --color-neutral-5 );
+	margin-top: 1.5rem;
+	padding-top: 1.5rem;
+}
+
+.backup-support-links__links {
+	margin-top: 1rem;
+	display: grid;
+	grid-auto-flow: column;
+}


### PR DESCRIPTION
Fixes Automattic/jetpack/issues/23270
<img width="739" alt="image" src="https://user-images.githubusercontent.com/746152/157858862-6d5851a7-4270-4ba4-8a46-d60bc2d1a137.png">


#### Changes proposed in this Pull Request

* Introduces component `BackupSupportLinks/>` under `client/components/jetpack/daily-backup-status/`
  * Showing three links.   
     * _Troubleshooting tips_ linking to https://jetpack.com/support/backup/troubleshooting-jetpack-backup/.
      * _How to fix connection issues_ linking to https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/ 
     * _Contact Jetpack support_ linking to https://jetpack.com/contact-support/?rel=support&url=

#### Testing instructions

* For a previously ephemeral connected site that you know has experied (e.g. Jurassic Ninja or Atomic Ephemeral), visit the following URL
* http://jetpack.cloud.localhost:3000/backup/:site-slug
* Confirm you see the failed card with the links on its footer
