### PR TITLE
Jetpack: update primary button colors

### DIFF
--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -3,8 +3,8 @@
 @import '@automattic/typography/styles/fonts';
 
 .is-group-jetpack-cloud.is-section-jetpack-cloud-pricing {
-	--color-accent: var( --studio-jetpack-green-40 );
-	--color-primary: var( --studio-jetpack-green-40 );
+	--color-accent: var( --studio-jetpack-green-50 );
+	--color-primary: var( --studio-jetpack-green-50 );
 
 	background-color: var( --color-surface );
 
@@ -13,7 +13,7 @@
 	h2 {
 		line-height: inherit;
 	}
-	#header {
+	#header { /* stylelint-disable-line selector-max-id */
 		display: none;
 	}
 	.header {
@@ -43,7 +43,7 @@
 	}
 
 	.layout__content {
-		padding: 0;	
+		padding: 0;
 	}
 
 	.foldable-card {

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -6,6 +6,8 @@
 	--color-accent: var( --studio-jetpack-green-50 );
 	--color-primary: var( --studio-jetpack-green-50 );
 
+	--color-accent-60: var( --studio-jetpack-green-70 );
+
 	background-color: var( --color-surface );
 
 	font-family: 'Inter', $sans;

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -25,6 +25,7 @@
 	border-radius: var( --jetpack-corners-soft );
 	box-sizing: border-box;
 	font-weight: 500; /* stylelint-disable-line scales/font-weights */
+	transition: background-color 0.1s;
 
 	&:hover {
 		background-color: var( --color-accent-0 );

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -54,8 +54,8 @@
 	border-color: var( --studio-jetpack-green-50 );
 
 	&:hover {
-		background-color: var( --studio-jetpack-green-60 );
-		border-color: var( --studio-jetpack-green-60 );
+		background-color: var( --studio-jetpack-green-70 );
+		border-color: var( --studio-jetpack-green-70 );
 	}
 
 	&:focus {
@@ -65,8 +65,8 @@
 	}
 
 	&:active {
-		background: var( --studio-jetpack-green-60 );
-		border-color: var( --studio-jetpack-green-60 );
+		background: var( --studio-jetpack-green-70 );
+		border-color: var( --studio-jetpack-green-70 );
 	}
 
 	&[disabled],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR brings the primary buttons in Calypso Green in line with Jetpack.com by doing two minor changes:
  * Update the primary and accent colors in the pricing stylesheet.
  * Update the hover and focus colors in the Jetpack Cloud stylesheet.

All buttons should now have this styling:
- Resting: Jetpack Green 50
- Hover/Focus: Jetpack Green 70

![image](https://user-images.githubusercontent.com/390760/157859153-d09156e4-b726-405c-9cc8-013948319566.png)


#### Testing instructions

* Fire up this PR.
* Head to http://jetpack.cloud.localhost:3000/pricing and ensure the buttons have the correct colors.
* Head to http://jetpack.cloud.localhost:3000/, select a site, and ensure the buttons across the entire suite of product have the correct colors.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/157859581-97310b66-0928-4a35-86b9-f3760745fb6b.png)| ![image](https://user-images.githubusercontent.com/390760/157859589-fa15000b-21fa-4710-8e22-582cf477f8e9.png)
![image](https://user-images.githubusercontent.com/390760/157859603-12011069-60c9-4bed-b4a4-58250ee3c65b.png) | ![image](https://user-images.githubusercontent.com/390760/157859615-b79e28eb-7530-4df9-9ddf-160c182ddddc.png)
![image](https://user-images.githubusercontent.com/390760/157859902-11b071be-0f66-45be-87e1-244ffd511b20.png) | ![image](https://user-images.githubusercontent.com/390760/157859914-5a85563d-4994-4589-8f04-394a41c1e03b.png)

#### Demo

![buttons](https://user-images.githubusercontent.com/390760/157860032-c1ff51dc-34e9-4fb2-b4b3-0c804739ac70.gif)

