### PR TITLE
Marketplace: fix plugin slug in product details

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -163,7 +163,7 @@ class ActivityLog extends Component {
 	}
 
 	initializeBreadcrumbs() {
-		this.props.updateBreadcrumbs( [
+		this.props.updateBreadcrumbs( this.props.siteId, [
 			{
 				label: this.props.translate( 'Activity Log' ),
 				href: `/activity-log/${ this.props.slug || '' }`,

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -66,10 +66,9 @@ function PluginDetails( props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const breadcrumbs = useSelector( getBreadcrumbs );
-
 	// Site information.
 	const selectedSite = useSelector( getSelectedSite );
+	const breadcrumbs = useSelector( ( state ) => getBreadcrumbs( state, selectedSite?.ID ) );
 	const sitesWithPlugins = useSelector( getSelectedOrAllSitesWithPlugins );
 	const sites = useSelector( getSelectedOrAllSitesWithPlugins );
 	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
@@ -199,7 +198,7 @@ function PluginDetails( props ) {
 	useEffect( () => {
 		if ( breadcrumbs.length === 0 ) {
 			dispatch(
-				appendBreadcrumb( {
+				appendBreadcrumb( selectedSite?.ID, {
 					label: translate( 'Plugins' ),
 					href: `/plugins/${ selectedSite?.slug || '' }`,
 					id: 'plugins',
@@ -209,7 +208,7 @@ function PluginDetails( props ) {
 
 		if ( fullPlugin.name && props.pluginSlug ) {
 			dispatch(
-				appendBreadcrumb( {
+				appendBreadcrumb( selectedSite?.ID, {
 					label: fullPlugin.name,
 					href: `/plugins/${ props.pluginSlug }/${ selectedSite?.slug || '' }`,
 					id: `plugin-${ props.pluginSlug }`,

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -121,9 +121,8 @@ const PluginsBrowser = ( {
 	hideHeader,
 	doSearch,
 } ) => {
-	const breadcrumbs = useSelector( getBreadcrumbs );
-
 	const selectedSite = useSelector( getSelectedSite );
+	const breadcrumbs = useSelector( ( state ) => getBreadcrumbs( state, selectedSite?.ID ) );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 
 	// Billing period switcher.
@@ -194,6 +193,10 @@ const PluginsBrowser = ( {
 	}, [ isJetpack, selectedSite, hasJetpack ] );
 
 	useEffect( () => {
+		if ( ! selectedSite?.ID ) {
+			return;
+		}
+
 		const items = [
 			{ label: translate( 'Plugins' ), href: `/plugins/${ siteSlug || '' }`, id: 'plugins' },
 		];
@@ -212,8 +215,8 @@ const PluginsBrowser = ( {
 			} );
 		}
 
-		dispatch( updateBreadcrumbs( items ) );
-	}, [ siteSlug, search, category, dispatch, translate ] );
+		dispatch( updateBreadcrumbs( selectedSite?.ID, items ) );
+	}, [ siteSlug, search, category, dispatch, translate, selectedSite?.ID ] );
 
 	const trackSiteDisconnect = () =>
 		composeAnalytics(


### PR DESCRIPTION
While navigating in Calypso, I have noticed two bugs in breadcrumbs:
1. On some cases Plugin Title appears multiple times
<img width="1582" alt="CleanShot 2022-02-28 at 10 12 44@2x" src="https://user-images.githubusercontent.com/12430020/155947715-87b5d533-cb88-47ba-8dd6-133cea430f57.png">

2. When in Plugin Details and you switch sites, the breadcrumb will contain references to the previous site. Example:
- Go to `https://wordpress.com/plugins/woocommerce/Site1`
- Switch to `Site2` from the sidebar
- Click `Plugins` from the Fixed Header breadcrumb
- You will land to Plugins page of `Site1`, `https://wordpress.com/plugins/Site1`

#### Changes proposed in this Pull Request

* Correctly adds `slug` to `fullPlugin`. It will either be the wpcom or the wporg `slug`. `slug` returned from the WordPress `plugins` endpoint might be slightly altered (p9o2xV-1Of-p2#comment-5485)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #