### PR TITLE
Full importer: WP Import Everything flow - Add plan upgrade screen

### DIFF
--- a/client/signup/steps/import-from/wordpress/import-everything/confirm-upgrade-plan.tsx
+++ b/client/signup/steps/import-from/wordpress/import-everything/confirm-upgrade-plan.tsx
@@ -1,6 +1,7 @@
 import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
-import { NextButton } from '@automattic/onboarding';
+import { sprintf } from '@wordpress/i18n';
 import { check, Icon } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import React from 'react';
 import { useSelector } from 'react-redux';
@@ -17,6 +18,8 @@ interface Props {
 }
 
 export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
+	const { __ } = useI18n();
+
 	const { sourceSite } = props;
 	const plan = getPlan( PLAN_BUSINESS );
 	const planId = plan?.getProductId();
@@ -44,8 +47,13 @@ export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
 		<div className={ classnames( 'import__upgrade-plan' ) }>
 			<QueryPlans />
 			<p>
-				To import your themes, plugins, users, and settings from { sourceSite?.slug } we need to
-				upgrade your WordPress.com site. Select a plan below:
+				{ sprintf(
+					/* translators: the website could be any domain (eg: "yourname.com") */
+					__(
+						'To import your themes, plugins, users, and settings from %(website)s we need to upgrade your WordPress.com site. Select a plan below:'
+					),
+					{ website: sourceSite?.slug }
+				) }
 			</p>
 
 			<div className={ classnames( 'import__upgrade-plan-container' ) }>
@@ -62,8 +70,6 @@ export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
 					{ renderFeatureList() }
 				</div>
 			</div>
-
-			<NextButton>Upgrade</NextButton>
 		</div>
 	);
 };

--- a/client/signup/steps/import-from/wordpress/import-everything/confirm-upgrade-plan.tsx
+++ b/client/signup/steps/import-from/wordpress/import-everything/confirm-upgrade-plan.tsx
@@ -1,0 +1,71 @@
+import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { NextButton } from '@automattic/onboarding';
+import { check, Icon } from '@wordpress/icons';
+import classnames from 'classnames';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import QueryPlans from 'calypso/components/data/query-plans';
+import { getFeatureByKey } from 'calypso/lib/plans/features-list';
+import PlanPrice from 'calypso/my-sites/plan-price';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import { getPlanRawPrice } from 'calypso/state/plans/selectors';
+import { SitesItem } from 'calypso/state/selectors/get-sites-items';
+import type { FunctionComponent } from 'react';
+
+interface Props {
+	sourceSite: SitesItem | null;
+}
+
+export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
+	const { sourceSite } = props;
+	const plan = getPlan( PLAN_BUSINESS );
+	const planId = plan?.getProductId();
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	const promotedFeatures: string[] = plan?.getPromotedFeatures() ? plan?.getPromotedFeatures() : [];
+
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const rawPrice = useSelector( ( state ) => getPlanRawPrice( state, planId as number, true ) );
+
+	function renderFeatureList() {
+		return (
+			<ul className={ classnames( 'import__details-list' ) }>
+				{ promotedFeatures.map( ( feature, i ) => (
+					<li className={ classnames( 'import__upgrade-plan-feature' ) } key={ i }>
+						<Icon size={ 20 } icon={ check } />
+						<span>{ getFeatureByKey( feature ).getTitle() }</span>
+					</li>
+				) ) }
+			</ul>
+		);
+	}
+
+	return (
+		<div className={ classnames( 'import__upgrade-plan' ) }>
+			<QueryPlans />
+			<p>
+				To import your themes, plugins, users, and settings from { sourceSite?.slug } we need to
+				upgrade your WordPress.com site. Select a plan below:
+			</p>
+
+			<div className={ classnames( 'import__upgrade-plan-container' ) }>
+				<div className={ classnames( 'import__upgrade-plan-price' ) }>
+					<h3 className={ classnames( 'plan-title' ) }>
+						WordPress.com { getPlan( PLAN_BUSINESS )?.getTitle() }
+					</h3>
+					<PlanPrice rawPrice={ rawPrice } currency={ currencyCode } />
+					<span className={ classnames( 'plan-time-frame' ) }>
+						{ getPlan( PLAN_BUSINESS )?.getBillingTimeFrame() }
+					</span>
+				</div>
+				<div className={ classnames( 'import__upgrade-plan-details' ) }>
+					{ renderFeatureList() }
+				</div>
+			</div>
+
+			<NextButton>Upgrade</NextButton>
+		</div>
+	);
+};
+
+export default ConfirmUpgradePlan;

--- a/client/signup/steps/import-from/wordpress/import-everything/confirm-upgrade-plan.tsx
+++ b/client/signup/steps/import-from/wordpress/import-everything/confirm-upgrade-plan.tsx
@@ -25,7 +25,7 @@ export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
 	const planId = plan?.getProductId();
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
-	const promotedFeatures: string[] = plan?.getPromotedFeatures() ? plan?.getPromotedFeatures() : [];
+	const promotedFeatures: string[] = plan?.getPromotedFeatures() ?? [];
 
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const rawPrice = useSelector( ( state ) => getPlanRawPrice( state, planId as number, true ) );

--- a/client/signup/steps/import-from/wordpress/import-everything/confirm.tsx
+++ b/client/signup/steps/import-from/wordpress/import-everything/confirm.tsx
@@ -8,6 +8,7 @@ import SiteIcon from 'calypso/blocks/site-icon';
 import { UrlData } from 'calypso/signup/steps/import/types';
 import { convertToFriendlyWebsiteName } from 'calypso/signup/steps/import/util';
 import ConfirmModal from './confirm-modal';
+import ConfirmUpgradePlan from './confirm-upgrade-plan';
 import type { SitesItem } from 'calypso/state/selectors/get-sites-items';
 
 import './style.scss';
@@ -38,6 +39,7 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 		startImport,
 	} = props;
 	const [ isModalDetailsOpen, setIsModalDetailsOpen ] = useState( false );
+	const [ showUpgradePlanScreen, setShowUpgradePlanScreen ] = useState( false );
 
 	return (
 		<>
@@ -78,46 +80,62 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 					</div>
 				</div>
 
-				<Title>
-					{ sprintf(
-						/* translators: the `from` and `to` fields could be any site URL (eg: "yourname.com") */
-						__( 'Import everything from %(from)s and overwrite everything on %(to)s?' ),
-						{
-							from: convertToFriendlyWebsiteName( sourceSiteUrl ),
-							to: convertToFriendlyWebsiteName( targetSiteSlug ),
-						}
-					) }
-				</Title>
-
-				<ul className={ classnames( 'import__details-list' ) }>
-					<li>
-						<Icon size={ 20 } icon={ check } /> { __( 'All posts, pages, comments, and media' ) }
-					</li>
-					<li>
-						<Icon size={ 20 } icon={ check } /> { __( 'Add users and roles' ) }
-					</li>
-					<li>
-						<Icon size={ 20 } icon={ check } /> { __( 'Theme, plugins, and settings' ) }
-					</li>
-				</ul>
-
-				<SubTitle>
-					{ __(
-						'Your site will keep working, but your WordPress.com dashboard will be locked during importing.'
-					) }
-				</SubTitle>
-
-				{ ! isTargetSitePlanCompatible && (
+				{ ! showUpgradePlanScreen && (
 					<>
-						<Notice>{ __( 'You need to upgrade your account to import everything.' ) }</Notice>
-						<NextButton onClick={ startImport }>{ __( 'See plans' ) }</NextButton>
+						<Title>
+							{ sprintf(
+								/* translators: the `from` and `to` fields could be any site URL (eg: "yourname.com") */
+								__( 'Import everything from %(from)s and overwrite everything on %(to)s?' ),
+								{
+									from: convertToFriendlyWebsiteName( sourceSiteUrl ),
+									to: convertToFriendlyWebsiteName( targetSiteSlug ),
+								}
+							) }
+						</Title>
+
+						<ul className={ classnames( 'import__details-list' ) }>
+							<li>
+								<Icon size={ 20 } icon={ check } />{ ' ' }
+								{ __( 'All posts, pages, comments, and media' ) }
+							</li>
+							<li>
+								<Icon size={ 20 } icon={ check } /> { __( 'Add users and roles' ) }
+							</li>
+							<li>
+								<Icon size={ 20 } icon={ check } /> { __( 'Theme, plugins, and settings' ) }
+							</li>
+						</ul>
+
+						<SubTitle>
+							{ __(
+								'Your site will keep working, but your WordPress.com dashboard will be locked during importing.'
+							) }
+						</SubTitle>
+
+						{ ! isTargetSitePlanCompatible && (
+							<>
+								<Notice>{ __( 'You need to upgrade your account to import everything.' ) }</Notice>
+								<NextButton onClick={ () => setShowUpgradePlanScreen( true ) }>
+									{ __( 'See plans' ) }
+								</NextButton>
+							</>
+						) }
+
+						{ isTargetSitePlanCompatible && (
+							<NextButton onClick={ () => setIsModalDetailsOpen( true ) }>
+								{ __( 'Start import' ) }
+							</NextButton>
+						) }
 					</>
 				) }
 
-				{ isTargetSitePlanCompatible && (
-					<NextButton onClick={ () => setIsModalDetailsOpen( true ) }>
-						{ __( 'Start import' ) }
-					</NextButton>
+				{ showUpgradePlanScreen && (
+					<>
+						<ConfirmUpgradePlan sourceSite={ sourceSite } />
+						<NextButton onClick={ () => setIsModalDetailsOpen( true ) }>
+							{ __( 'Upgrade and import' ) }
+						</NextButton>
+					</>
 				) }
 			</div>
 

--- a/client/signup/steps/import-from/wordpress/import-everything/style.scss
+++ b/client/signup/steps/import-from/wordpress/import-everything/style.scss
@@ -25,8 +25,8 @@
 	}
 
 	.action_buttons__button {
-		padding: initial !important;
 		min-width: 120px !important;
+		margin-bottom: 1em;
 	}
 
 	.import__site-mapper {

--- a/client/signup/steps/import-from/wordpress/import-everything/style.scss
+++ b/client/signup/steps/import-from/wordpress/import-everything/style.scss
@@ -137,9 +137,13 @@
 		}
 
 		.import__upgrade-plan-feature {
-			flex-basis: 50%;
 			padding-left: 25px;
 			color: var( --studio-gray-40 );
+			flex-basis: 100%;
+
+			@include break-small {
+				flex-basis: 50%;
+			}
 
 			span {
 				margin: 0;

--- a/client/signup/steps/import-from/wordpress/import-everything/style.scss
+++ b/client/signup/steps/import-from/wordpress/import-everything/style.scss
@@ -76,6 +76,82 @@
 	}
 }
 
+.import__upgrade-plan {
+	p {
+		color: var( --studio-gray-40 );
+	}
+
+	.import__upgrade-plan-container {
+		border: solid var( --studio-gray-5 ) 1px;
+		border-radius: 4px;
+		padding: 1.75em;
+		margin-bottom: 2em;
+		display: flex;
+		gap: 1.5rem;
+		flex-direction: column;
+
+		@include break-medium {
+			flex-direction: row;
+		}
+	}
+
+	.import__upgrade-plan-price,
+	.import__upgrade-plan-details {
+		display: flex;
+	}
+
+	.import__upgrade-plan-price {
+		min-width: 150px;
+		flex-direction: column;
+
+		.plan-title {
+			font-weight: 500;
+			font-size: 1.25em; /* stylelint-disable-line */
+			line-height: 1.25em;
+			color: var( --studio-gray-60 );
+		}
+
+		.plan-price {
+			font-weight: 500;
+		}
+
+		.plan-price__currency-symbol {
+			font-size: inherit;
+			color: inherit;
+			vertical-align: unset;
+		}
+
+		.plan-price__integer {
+			font-weight: inherit;
+		}
+
+		.plan-time-frame {
+			font-size: 0.75em; /* stylelint-disable-line */
+			color: var( --studio-gray-40 );
+		}
+	}
+
+	.import__upgrade-plan-details {
+		ul {
+			margin: 0;
+		}
+
+		.import__upgrade-plan-feature {
+			flex-basis: 50%;
+			padding-left: 25px;
+			color: var( --studio-gray-40 );
+
+			span {
+				margin: 0;
+			}
+
+			svg {
+				fill: var( --color-success );
+			}
+		}
+	}
+}
+
 .components-modal__frame.components-modal-new__frame {
 	&.import__confirm-modal {
 		@include break-medium {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Added missing plan upgrade screen.

#### Testing instructions

* Go to `/start/setup-site/intent?siteSlug={SIMPLE_SITE_SLUG}`
* Enter any Jetpack connected WordPress site
* Press `Import your content`
* Select `Everything` option
* Press `See plans`
* Check if Business plan details are there

#### Screenshots
<img width="793" alt="Screenshot 2022-03-11 at 14 56 28" src="https://user-images.githubusercontent.com/1241413/157882611-2c979c9b-66c8-4119-9ac5-69d9d22b5ccd.png">
<img width="374" alt="Screenshot 2022-03-11 at 14 57 48" src="https://user-images.githubusercontent.com/1241413/157882634-5b8da0c4-3ff0-4440-ae6f-0872f265908a.png">


Relates to https://github.com/Automattic/wp-calypso/issues/57131
Closes #61797 #60238
