### PR TITLE
Fix masterbar title on the Plugin install page

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -10,7 +10,6 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import EmptyContent from 'calypso/components/empty-content';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
 import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
-import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
@@ -402,8 +401,12 @@ const MarketplacePluginInstall = ( {
 			/>
 			{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 			<Masterbar>
-				<WordPressWordmark className="marketplace-plugin-install__wpcom-wordmark" />
-				<Item>{ translate( 'Plugin Installation' ) }</Item>
+				<div className="marketplace-plugin-install__masterbar">
+					<WordPressWordmark className="marketplace-plugin-install__wpcom-wordmark" />
+					<span className="marketplace-plugin-install__plugin-installation-text">
+						{ translate( 'Plugin installation' ) }
+					</span>
+				</div>
 			</Masterbar>
 			<div className="marketplace-plugin-install__root">
 				{ renderError() || <MarketplaceProgressBar steps={ steps } currentStep={ currentStep } /> }

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -10,6 +10,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import EmptyContent from 'calypso/components/empty-content';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
 import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
@@ -400,13 +401,9 @@ const MarketplacePluginInstall = ( {
 				title="Plugins > Installing"
 			/>
 			{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
-			<Masterbar>
-				<div className="marketplace-plugin-install__masterbar">
-					<WordPressWordmark className="marketplace-plugin-install__wpcom-wordmark" />
-					<span className="marketplace-plugin-install__plugin-installation-text">
-						{ translate( 'Plugin installation' ) }
-					</span>
-				</div>
+			<Masterbar className="marketplace-plugin-install__masterbar">
+				<WordPressWordmark className="marketplace-plugin-install__wpcom-wordmark" />
+				<Item>{ translate( 'Plugin installation' ) }</Item>
 			</Masterbar>
 			<div className="marketplace-plugin-install__root">
 				{ renderError() || <MarketplaceProgressBar steps={ steps } currentStep={ currentStep } /> }

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/style.scss
@@ -17,6 +17,29 @@ body.is-section-marketplace.theme-default.color-scheme {
 	}
 }
 
+.marketplace-plugin-install__masterbar {
+	display: flex;
+	align-items: center;
+
+	.marketplace-plugin-install__wpcom-wordmark {
+		margin-right: 5px;
+	}
+
+	.marketplace-plugin-install__plugin-installation-text {
+		color: var( --color-primary-5 );
+		transform: translateY( 1px );
+		line-height: 1.2em;
+		font-size: 0.75rem;
+		margin-left: 5px;
+
+		@include breakpoint-deprecated( '>480px' ) {
+			// stylelint-disable-next-line declaration-property-unit-allowed-list
+			font-size: 100%;
+			margin-left: 0;
+		}
+	}
+}
+
 .marketplace-plugin-install__wpcom-wordmark {
 	align-self: center;
 	margin-left: 10px;

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/style.scss
@@ -19,30 +19,20 @@ body.is-section-marketplace.theme-default.color-scheme {
 
 .marketplace-plugin-install__masterbar {
 	display: flex;
-	align-items: center;
+	align-items: baseline;
+	justify-content: flex-start;
 
 	.marketplace-plugin-install__wpcom-wordmark {
-		margin-right: 5px;
+		align-self: center;
+		margin-left: 10px;
 	}
 
-	.marketplace-plugin-install__plugin-installation-text {
+	.masterbar__item,
+	.masterbar__item:hover {
 		color: var( --color-primary-5 );
-		transform: translateY( 1px );
-		line-height: 1.2em;
-		font-size: 0.75rem;
-		margin-left: 5px;
-
-		@include breakpoint-deprecated( '>480px' ) {
-			// stylelint-disable-next-line declaration-property-unit-allowed-list
-			font-size: 100%;
-			margin-left: 0;
-		}
+		flex-grow: 0;
+		background: var( --color-masterbar-background );
 	}
-}
-
-.marketplace-plugin-install__wpcom-wordmark {
-	align-self: center;
-	margin-left: 10px;
 }
 
 .marketplace-plugin-install__root {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Applied styling from the checkout masterbar
* Moved the title to the left to align with Figma and other instances of the masterbar

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try installing any plugin, or visit the plugin install page directly (`/marketplace/<productSlug>/install/<siteUrl>`)
* Verify that the masterbar layout looks like this:
  | Before | After | 
  | --- | --- |
  | ![calypso localhost_3000_marketplace_mailpoet_install_gcsecseysimplebusiness wpcomstaging com](https://user-images.githubusercontent.com/11555574/157888904-70111f7d-db89-4b5c-b46b-d36b1016d768.png) | ![calypso localhost_3000_marketplace_mailpoet_install_gcsecseysimplebusiness wpcomstaging com (1)](https://user-images.githubusercontent.com/11555574/157888934-3c0a1769-0809-43ef-82f8-5e9d3a0b7fed.png) |

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #61836
