### PR TITLE
languages: Update languages-meta.json to reflect Norwegian locale changes on WP.com

### DIFF
--- a/packages/languages/src/language-slug.ts
+++ b/packages/languages/src/language-slug.ts
@@ -94,7 +94,7 @@ export type LanguageSlug =
 	| 'ne'
 	| 'nl'
 	| 'nn'
-	| 'no'
+	| 'nb'
 	| 'non'
 	| 'nv'
 	| 'oci'

--- a/packages/languages/src/languages-meta.json
+++ b/packages/languages/src/languages-meta.json
@@ -1,1786 +1,1496 @@
 {
-    "af": {
-        "value": 2,
-        "langSlug": "af",
-        "name": "Afrikaans",
-        "wpLocale": "af",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 5,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "002"
-        ]
-    },
-    "als": {
-        "value": 418,
-        "langSlug": "als",
-        "name": "Alemannisch",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "155"
-        ]
-    },
-    "am": {
-        "value": 481,
-        "langSlug": "am",
-        "name": "\u12a0\u121b\u122d\u129b",
-        "wpLocale": "am",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 1,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "002"
-        ]
-    },
-    "an": {
-        "value": 485,
-        "langSlug": "an",
-        "name": "Aragon\u00e9s",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 2,
-        "isTranslatedIncompletely": true,
-        "territories": []
-    },
-    "ar": {
-        "value": 3,
-        "langSlug": "ar",
-        "name": "\u0627\u0644\u0639\u0631\u0628\u064a\u0629",
-        "wpLocale": "ar",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 99,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "145",
-            "002"
-        ],
-        "rtl": true,
-        "popular": 16
-    },
-    "arc": {
-        "value": 419,
-        "langSlug": "arc",
-        "name": "\u0715\u0725\u0712\u072a\u0738\u071d\u071b",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "145"
-        ]
-    },
-    "as": {
-        "value": 4,
-        "langSlug": "as",
-        "name": "\u0985\u09b8\u09ae\u09c0\u09af\u09bc\u09be",
-        "wpLocale": "as",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 4,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "ast": {
-        "value": 420,
-        "langSlug": "ast",
-        "name": "Asturianu",
-        "wpLocale": "ast",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 4,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "av": {
-        "value": 421,
-        "langSlug": "av",
-        "name": "\u0430\u0432\u0430\u0440 \u043c\u0430\u0446\u04c0",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "ay": {
-        "value": 422,
-        "langSlug": "ay",
-        "name": "aymar aru",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "019"
-        ]
-    },
-    "az": {
-        "value": 79,
-        "langSlug": "az",
-        "name": "Az\u0259rbaycan dili",
-        "wpLocale": "az",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 21,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "145"
-        ]
-    },
-    "ba": {
-        "value": 423,
-        "langSlug": "ba",
-        "name": "\u0431\u0430\u0448\u04a1\u043e\u0440\u0442 \u0442\u0435\u043b\u0435",
-        "wpLocale": "ba",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "bel": {
-        "value": 5,
-        "langSlug": "bel",
-        "name": "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u043a\u0430\u044f \u043c\u043e\u0432\u0430",
-        "wpLocale": "bel",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 4,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "bg": {
-        "value": 6,
-        "langSlug": "bg",
-        "name": "\u0411\u044a\u043b\u0433\u0430\u0440\u0441\u043a\u0438",
-        "wpLocale": "bg_BG",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 18,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "bm": {
-        "value": 7,
-        "langSlug": "bm",
-        "name": "Bamanankan",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "002"
-        ]
-    },
-    "bn": {
-        "value": 8,
-        "langSlug": "bn",
-        "name": "\u09ac\u09be\u0982\u09b2\u09be",
-        "wpLocale": "bn_BD",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 5,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "bo": {
-        "value": 9,
-        "langSlug": "bo",
-        "name": "\u0f56\u0f7c\u0f51\u0f0b\u0f66\u0f90\u0f51",
-        "wpLocale": "bo",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 4,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "030"
-        ]
-    },
-    "br": {
-        "value": 424,
-        "langSlug": "br",
-        "name": "Brezhoneg",
-        "wpLocale": "bre",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 5,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "155"
-        ]
-    },
-    "bs": {
-        "value": 454,
-        "langSlug": "bs",
-        "name": "Bosanski",
-        "wpLocale": "bs_BA",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 9,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "ca": {
-        "value": 10,
-        "langSlug": "ca",
-        "name": "Catal\u00e0",
-        "wpLocale": "ca",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 12,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "ce": {
-        "value": 425,
-        "langSlug": "ce",
-        "name": "\u041d\u043e\u0445\u0447\u0438\u0439\u043d \u043c\u043e\u0442\u0442",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "ckb": {
-        "value": 41,
-        "langSlug": "ckb",
-        "name": "\u0643\u0648\u0631\u062f\u06cc\u200e",
-        "wpLocale": "ckb",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 6,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "145",
-            "034"
-        ],
-        "rtl": true
-    },
-    "cs": {
-        "value": 11,
-        "langSlug": "cs",
-        "name": "\u010ce\u0161tina",
-        "wpLocale": "cs_CZ",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 36,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "csb": {
-        "value": 12,
-        "langSlug": "csb",
-        "name": "Kasz\u00ebbsczi",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "cv": {
-        "value": 426,
-        "langSlug": "cv",
-        "name": "\u0447\u04d1\u0432\u0430\u0448 \u0447\u04d7\u043b\u0445\u0438",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 28,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "cy": {
-        "value": 13,
-        "langSlug": "cy",
-        "name": "Cymraeg",
-        "wpLocale": "cy",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 12,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "154"
-        ]
-    },
-    "da": {
-        "value": 14,
-        "langSlug": "da",
-        "name": "Dansk",
-        "wpLocale": "da_DK",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 9,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "154"
-        ]
-    },
-    "de": {
-        "value": 15,
-        "langSlug": "de",
-        "name": "Deutsch",
-        "wpLocale": "de_DE",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 99,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "155"
-        ],
-        "popular": 4
-    },
-    "de-ch": {
-        "value": 903,
-        "langSlug": "de-ch",
-        "name": "Deutsch (Schweiz)",
-        "wpLocale": "de_CH",
-        "parentLangSlug": "de",
-        "calypsoPercentTranslated": 99,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "155"
-        ]
-    },
-    "de_formal": {
-        "value": 900,
-        "langSlug": "de_formal",
-        "name": "Deutsch (Sie)",
-        "wpLocale": "de",
-        "parentLangSlug": "de",
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "155"
-        ]
-    },
-    "dv": {
-        "value": 427,
-        "langSlug": "dv",
-        "name": "\u078b\u07a8\u0788\u07ac\u0780\u07a8",
-        "wpLocale": "dv",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 1,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ],
-        "rtl": true
-    },
-    "dz": {
-        "value": 16,
-        "langSlug": "dz",
-        "name": "\u0f47\u0f7c\u0f44\u0f0b\u0f41",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "el": {
-        "value": 17,
-        "langSlug": "el",
-        "name": "\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac",
-        "wpLocale": "el",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 23,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "el-po": {
-        "value": 468,
-        "langSlug": "el-po",
-        "name": "Greek (Polytonic)",
-        "wpLocale": "el",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 56,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "en": {
-        "value": 1,
-        "langSlug": "en",
-        "name": "English",
-        "wpLocale": "en_US",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 100,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "019"
-        ],
-        "popular": 1
-    },
-    "en-gb": {
-        "value": 482,
-        "langSlug": "en-gb",
-        "name": "English (UK)",
-        "wpLocale": "en_GB",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 15,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "154"
-        ]
-    },
-    "eo": {
-        "value": 18,
-        "langSlug": "eo",
-        "name": "Esperanto",
-        "wpLocale": "eo",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 11,
-        "isTranslatedIncompletely": true,
-        "territories": []
-    },
-    "es": {
-        "value": 19,
-        "langSlug": "es",
-        "name": "Espa\u00f1ol",
-        "wpLocale": "es_ES",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 99,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "019",
-            "039"
-        ],
-        "popular": 2
-    },
-    "es-cl": {
-        "value": 484,
-        "langSlug": "es-cl",
-        "name": "Espa\u00f1ol de Chile",
-        "wpLocale": "es_CL",
-        "parentLangSlug": "es",
-        "calypsoPercentTranslated": 99,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "019"
-        ]
-    },
-    "es-mx": {
-        "value": 902,
-        "langSlug": "es-mx",
-        "name": "Espa\u00f1ol de M\u00e9xico",
-        "wpLocale": "es_MX",
-        "parentLangSlug": "es",
-        "calypsoPercentTranslated": 99,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "019"
-        ]
-    },
-    "et": {
-        "value": 20,
-        "langSlug": "et",
-        "name": "Eesti",
-        "wpLocale": "et",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 9,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "154"
-        ]
-    },
-    "eu": {
-        "value": 429,
-        "langSlug": "eu",
-        "name": "Euskara",
-        "wpLocale": "eu",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 6,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "fa": {
-        "value": 21,
-        "langSlug": "fa",
-        "name": "\u0641\u0627\u0631\u0633\u06cc",
-        "wpLocale": "fa_IR",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 38,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ],
-        "rtl": true
-    },
-    "fi": {
-        "value": 22,
-        "langSlug": "fi",
-        "name": "Suomi",
-        "wpLocale": "fi",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 15,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "154"
-        ]
-    },
-    "fo": {
-        "value": 23,
-        "langSlug": "fo",
-        "name": "F\u00f8royskt",
-        "wpLocale": "fo",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 3,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "154"
-        ]
-    },
-    "fr": {
-        "value": 24,
-        "langSlug": "fr",
-        "name": "Fran\u00e7ais",
-        "wpLocale": "fr_FR",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 98,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "155"
-        ],
-        "popular": 5
-    },
-    "fr-be": {
-        "value": 478,
-        "langSlug": "fr-be",
-        "name": "Fran\u00e7ais de Belgique",
-        "wpLocale": "fr_BE",
-        "parentLangSlug": "fr",
-        "calypsoPercentTranslated": 98,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "155"
-        ]
-    },
-    "fr-ca": {
-        "value": 475,
-        "langSlug": "fr-ca",
-        "name": "Fran\u00e7ais du Canada",
-        "wpLocale": "fr_CA",
-        "parentLangSlug": "fr",
-        "calypsoPercentTranslated": 98,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "019"
-        ]
-    },
-    "fr-ch": {
-        "value": 474,
-        "langSlug": "fr-ch",
-        "name": "Fran\u00e7ais de Suisse",
-        "wpLocale": "",
-        "parentLangSlug": "fr",
-        "calypsoPercentTranslated": 98,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "155"
-        ]
-    },
-    "fur": {
-        "value": 25,
-        "langSlug": "fur",
-        "name": "Friulian",
-        "wpLocale": "fur",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "fy": {
-        "value": 26,
-        "langSlug": "fy",
-        "name": "Frysk",
-        "wpLocale": "fy",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "155"
-        ]
-    },
-    "ga": {
-        "value": 27,
-        "langSlug": "ga",
-        "name": "Gaelige",
-        "wpLocale": "ga",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 12,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "154"
-        ]
-    },
-    "gd": {
-        "value": 476,
-        "langSlug": "gd",
-        "name": "G\u00e0idhlig",
-        "wpLocale": "gd",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 12,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "154"
-        ]
-    },
-    "gl": {
-        "value": 457,
-        "langSlug": "gl",
-        "name": "Galego",
-        "wpLocale": "gl_ES",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 13,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "gn": {
-        "value": 430,
-        "langSlug": "gn",
-        "name": "Ava\u00f1e'\u1ebd",
-        "wpLocale": "gn",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "019"
-        ]
-    },
-    "gu": {
-        "value": 28,
-        "langSlug": "gu",
-        "name": "\u0a97\u0ac1\u0a9c\u0ab0\u0abe\u0aa4\u0ac0",
-        "wpLocale": "gu",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 5,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "he": {
-        "value": 29,
-        "langSlug": "he",
-        "name": "\u05e2\u05b4\u05d1\u05b0\u05e8\u05b4\u05d9\u05ea",
-        "wpLocale": "he_IL",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 97,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "145"
-        ],
-        "rtl": true,
-        "popular": 6
-    },
-    "hi": {
-        "value": 30,
-        "langSlug": "hi",
-        "name": "\u0939\u093f\u0928\u094d\u0926\u0940",
-        "wpLocale": "hi_IN",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 9,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "hr": {
-        "value": 431,
-        "langSlug": "hr",
-        "name": "Hrvatski",
-        "wpLocale": "hr",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 15,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "hu": {
-        "value": 31,
-        "langSlug": "hu",
-        "name": "Magyar",
-        "wpLocale": "hu_HU",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 26,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "hy": {
-        "value": 467,
-        "langSlug": "hy",
-        "name": "\u0540\u0561\u0575\u0565\u0580\u0565\u0576",
-        "wpLocale": "hy",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 5,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "145"
-        ]
-    },
-    "ia": {
-        "value": 32,
-        "langSlug": "ia",
-        "name": "Interlingua",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": []
-    },
-    "id": {
-        "value": 33,
-        "langSlug": "id",
-        "name": "Bahasa Indonesia",
-        "wpLocale": "id_ID",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 99,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "035"
-        ],
-        "popular": 12
-    },
-    "ii": {
-        "value": 432,
-        "langSlug": "ii",
-        "name": "\ua187\ua259",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "030"
-        ]
-    },
-    "ilo": {
-        "value": 469,
-        "langSlug": "ilo",
-        "name": "Pagsasao nga Iloko",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "035"
-        ]
-    },
-    "is": {
-        "value": 34,
-        "langSlug": "is",
-        "name": "\u00cdslenska",
-        "wpLocale": "is_IS",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 14,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "154"
-        ]
-    },
-    "it": {
-        "value": 35,
-        "langSlug": "it",
-        "name": "Italiano",
-        "wpLocale": "it_IT",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 99,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "039"
-        ],
-        "popular": 8
-    },
-    "ja": {
-        "value": 36,
-        "langSlug": "ja",
-        "name": "\u65e5\u672c\u8a9e",
-        "wpLocale": "ja",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 98,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "030"
-        ],
-        "popular": 7
-    },
-    "ka": {
-        "value": 37,
-        "langSlug": "ka",
-        "name": "\u10e5\u10d0\u10e0\u10d7\u10e3\u10da\u10d8",
-        "wpLocale": "ka_GE",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 6,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "145"
-        ]
-    },
-    "kab": {
-        "value": 488,
-        "langSlug": "kab",
-        "name": "Taqbaylit",
-        "wpLocale": "kab",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 24,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "002"
-        ]
-    },
-    "kir": {
-        "value": 479,
-        "langSlug": "kir",
-        "name": "\u041a\u044b\u0440\u0433\u044b\u0437\u0447\u0430",
-        "wpLocale": "kir",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 3,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "143"
-        ]
-    },
-    "kk": {
-        "value": 462,
-        "langSlug": "kk",
-        "name": "\u049a\u0430\u0437\u0430\u049b \u0442\u0456\u043b\u0456",
-        "wpLocale": "kk",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 4,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "143"
-        ]
-    },
-    "km": {
-        "value": 38,
-        "langSlug": "km",
-        "name": "\u1797\u17b6\u179f\u17b6\u1781\u17d2\u1798\u17c2\u179a",
-        "wpLocale": "km",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 7,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "035"
-        ]
-    },
-    "kn": {
-        "value": 39,
-        "langSlug": "kn",
-        "name": "\u0c95\u0ca8\u0ccd\u0ca8\u0ca1",
-        "wpLocale": "kn",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 2,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "ko": {
-        "value": 40,
-        "langSlug": "ko",
-        "name": "\ud55c\uad6d\uc5b4",
-        "wpLocale": "ko_KR",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 99,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "030"
-        ],
-        "popular": 15
-    },
-    "ks": {
-        "value": 433,
-        "langSlug": "ks",
-        "name": "\u0915\u0936\u094d\u092e\u0940\u0930\u0940",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "kv": {
-        "value": 434,
-        "langSlug": "kv",
-        "name": "\u041a\u043e\u043c\u0438",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "la": {
-        "value": 42,
-        "langSlug": "la",
-        "name": "Latine",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "li": {
-        "value": 43,
-        "langSlug": "li",
-        "name": "Limburgs",
-        "wpLocale": "li",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "155"
-        ]
-    },
-    "lo": {
-        "value": 44,
-        "langSlug": "lo",
-        "name": "\u0e9e\u0eb2\u0eaa\u0eb2\u0ea5\u0eb2\u0ea7",
-        "wpLocale": "lo",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 3,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "035"
-        ]
-    },
-    "lt": {
-        "value": 45,
-        "langSlug": "lt",
-        "name": "Lietuvi\u0173 kalba",
-        "wpLocale": "lt_LT",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 20,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "154"
-        ]
-    },
-    "lv": {
-        "value": 453,
-        "langSlug": "lv",
-        "name": "Latvie\u0161u valoda",
-        "wpLocale": "lv",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 15,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "154"
-        ]
-    },
-    "mk": {
-        "value": 435,
-        "langSlug": "mk",
-        "name": "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0441\u043a\u0438 \u0458\u0430\u0437\u0438\u043a",
-        "wpLocale": "mk_MK",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 6,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "ml": {
-        "value": 46,
-        "langSlug": "ml",
-        "name": "\u0d2e\u0d32\u0d2f\u0d3e\u0d33\u0d02",
-        "wpLocale": "ml_IN",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 4,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "mn": {
-        "value": 472,
-        "langSlug": "mn",
-        "name": "\u041c\u043e\u043d\u0433\u043e\u043b",
-        "wpLocale": "mn",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 23,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "030"
-        ]
-    },
-    "mr": {
-        "value": 461,
-        "langSlug": "mr",
-        "name": "\u092e\u0930\u093e\u0920\u0940",
-        "wpLocale": "mr",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 5,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "ms": {
-        "value": 47,
-        "langSlug": "ms",
-        "name": "Bahasa Melayu",
-        "wpLocale": "ms_MY",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 6,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "035"
-        ]
-    },
-    "mt": {
-        "value": 465,
-        "langSlug": "mt",
-        "name": "Malti",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "mwl": {
-        "value": 464,
-        "langSlug": "mwl",
-        "name": "Mirand\u00e9s",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 2,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "nah": {
-        "value": 436,
-        "langSlug": "nah",
-        "name": "Nahuatl",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "019"
-        ]
-    },
-    "nap": {
-        "value": 437,
-        "langSlug": "nap",
-        "name": "Nnapulitano",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "nds": {
-        "value": 48,
-        "langSlug": "nds",
-        "name": "Plattd\u00fc\u00fctsch",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "155"
-        ]
-    },
-    "ne": {
-        "value": 456,
-        "langSlug": "ne",
-        "name": "\u0928\u0947\u092a\u093e\u0932\u0940",
-        "wpLocale": "ne_NP",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 4,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "nl": {
-        "value": 49,
-        "langSlug": "nl",
-        "name": "Nederlands",
-        "wpLocale": "nl_NL",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 98,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "155"
-        ],
-        "popular": 9
-    },
-    "nl_formal": {
-        "value": 904,
-        "langSlug": "nl_formal",
-        "name": "Nederlands (U)",
-        "wpLocale": "nl",
-        "parentLangSlug": "nl",
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "155"
-        ]
-    },
-    "nn": {
-        "value": 50,
-        "langSlug": "nn",
-        "name": "Norsk nynorsk",
-        "wpLocale": "nn_NO",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 13,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "154"
-        ]
-    },
-    "no": {
-        "value": 51,
-        "langSlug": "no",
-        "name": "Norsk",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 53,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "154"
-        ]
-    },
-    "non": {
-        "value": 52,
-        "langSlug": "non",
-        "name": "Norr\u01ffna",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "154"
-        ]
-    },
-    "nv": {
-        "value": 53,
-        "langSlug": "nv",
-        "name": "Din\u00e9 bizaad",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "019"
-        ]
-    },
-    "oci": {
-        "value": 54,
-        "langSlug": "oci",
-        "name": "Occitan",
-        "wpLocale": "oci",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 5,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "155"
-        ]
-    },
-    "or": {
-        "value": 55,
-        "langSlug": "or",
-        "name": "\u0b13\u0b21\u0b3c\u0b3f\u0b06",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "os": {
-        "value": 56,
-        "langSlug": "os",
-        "name": "\u0418\u0440\u043e\u043d",
-        "wpLocale": "os",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "145"
-        ]
-    },
-    "pa": {
-        "value": 57,
-        "langSlug": "pa",
-        "name": "\u0a2a\u0a70\u0a1c\u0a3e\u0a2c\u0a40",
-        "wpLocale": "pa_IN",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 22,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "pl": {
-        "value": 58,
-        "langSlug": "pl",
-        "name": "Polski",
-        "wpLocale": "pl_PL",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 26,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "ps": {
-        "value": 59,
-        "langSlug": "ps",
-        "name": "\u067e\u069a\u062a\u0648",
-        "wpLocale": "ps",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 3,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ],
-        "rtl": true
-    },
-    "pt": {
-        "value": 60,
-        "langSlug": "pt",
-        "name": "Portugu\u00eas",
-        "wpLocale": "pt_PT",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 19,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "pt-br": {
-        "value": 438,
-        "langSlug": "pt-br",
-        "name": "Portugu\u00eas do Brasil",
-        "wpLocale": "pt_BR",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 99,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "019"
-        ],
-        "popular": 3
-    },
-    "qu": {
-        "value": 439,
-        "langSlug": "qu",
-        "name": "Runa Simi",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "019"
-        ]
-    },
-    "ro": {
-        "value": 61,
-        "langSlug": "ro",
-        "name": "Rom\u00e2n\u0103",
-        "wpLocale": "ro_RO",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 100,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "151"
-        ]
-    },
-    "ru": {
-        "value": 62,
-        "langSlug": "ru",
-        "name": "\u0420\u0443\u0441\u0441\u043a\u0438\u0439",
-        "wpLocale": "ru_RU",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 99,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "151"
-        ],
-        "popular": 10
-    },
-    "rup": {
-        "value": 483,
-        "langSlug": "rup",
-        "name": "Arm\u00e3neashce",
-        "wpLocale": "rup_MK",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 1,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "sc": {
-        "value": 63,
-        "langSlug": "sc",
-        "name": "Sardu",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "si": {
-        "value": 471,
-        "langSlug": "si",
-        "name": "\u0dc3\u0dd2\u0d82\u0dc4\u0dbd",
-        "wpLocale": "si_LK",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 5,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "sk": {
-        "value": 64,
-        "langSlug": "sk",
-        "name": "Sloven\u010dina",
-        "wpLocale": "sk_SK",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 10,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "skr": {
-        "value": 486,
-        "langSlug": "skr",
-        "name": "Saraiki",
-        "wpLocale": "skr",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 68,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "sl": {
-        "value": 65,
-        "langSlug": "sl",
-        "name": "Sloven\u0161\u010dina",
-        "wpLocale": "sl_SI",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 8,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "snd": {
-        "value": 440,
-        "langSlug": "snd",
-        "name": "\u0633\u0646\u068c\u064a",
-        "wpLocale": "snd",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 5,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "so": {
-        "value": 459,
-        "langSlug": "so",
-        "name": "Afsoomaali",
-        "wpLocale": "so_SO",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 3,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "002"
-        ]
-    },
-    "sq": {
-        "value": 66,
-        "langSlug": "sq",
-        "name": "Shqip",
-        "wpLocale": "sq",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 50,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "sr": {
-        "value": 67,
-        "langSlug": "sr",
-        "name": "\u0421\u0440\u043f\u0441\u043a\u0438 \u0458\u0435\u0437\u0438\u043a",
-        "wpLocale": "sr_RS",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 10,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "sr_latin": {
-        "value": 901,
-        "langSlug": "sr_latin",
-        "name": "Srpski (latinica)",
-        "wpLocale": "sr",
-        "parentLangSlug": "sr",
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "su": {
-        "value": 441,
-        "langSlug": "su",
-        "name": "Basa Sunda",
-        "wpLocale": "su_ID",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 3,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "035"
-        ]
-    },
-    "sv": {
-        "value": 68,
-        "langSlug": "sv",
-        "name": "Svenska",
-        "wpLocale": "sv_SE",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 99,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "154"
-        ],
-        "popular": 17
-    },
-    "ta": {
-        "value": 69,
-        "langSlug": "ta",
-        "name": "\u0ba4\u0bae\u0bbf\u0bb4\u0bcd",
-        "wpLocale": "ta_IN",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 5,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034",
-            "035"
-        ]
-    },
-    "te": {
-        "value": 70,
-        "langSlug": "te",
-        "name": "\u0c24\u0c46\u0c32\u0c41\u0c17\u0c41",
-        "wpLocale": "te",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 16,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ]
-    },
-    "th": {
-        "value": 71,
-        "langSlug": "th",
-        "name": "\u0e44\u0e17\u0e22",
-        "wpLocale": "th",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 9,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "035"
-        ]
-    },
-    "tir": {
-        "value": 480,
-        "langSlug": "tir",
-        "name": "\u1275\u130d\u122d\u129b",
-        "wpLocale": "tir",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "002"
-        ]
-    },
-    "tl": {
-        "value": 455,
-        "langSlug": "tl",
-        "name": "Tagalog",
-        "wpLocale": "tl",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 6,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "035"
-        ]
-    },
-    "tr": {
-        "value": 78,
-        "langSlug": "tr",
-        "name": "T\u00fcrk\u00e7e",
-        "wpLocale": "tr_TR",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 99,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "145"
-        ],
-        "popular": 11
-    },
-    "tt": {
-        "value": 72,
-        "langSlug": "tt",
-        "name": "\u0422\u0430\u0442\u0430\u0440 \u0442\u0435\u043b\u0435",
-        "wpLocale": "tt_RU",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "ty": {
-        "value": 442,
-        "langSlug": "ty",
-        "name": "Reo M\u0101`ohi",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "009"
-        ]
-    },
-    "udm": {
-        "value": 443,
-        "langSlug": "udm",
-        "name": "\u0423\u0434\u043c\u0443\u0440\u0442 \u043a\u044b\u043b",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "ug": {
-        "value": 444,
-        "langSlug": "ug",
-        "name": "Uy\u01a3urq\u0259",
-        "wpLocale": "ug_CN",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 6,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "030"
-        ]
-    },
-    "uk": {
-        "value": 73,
-        "langSlug": "uk",
-        "name": "\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430",
-        "wpLocale": "uk",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 16,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "151"
-        ]
-    },
-    "ur": {
-        "value": 74,
-        "langSlug": "ur",
-        "name": "\u0627\u0631\u062f\u0648",
-        "wpLocale": "ur",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 12,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "034"
-        ],
-        "rtl": true
-    },
-    "uz": {
-        "value": 458,
-        "langSlug": "uz",
-        "name": "O\u2018zbekcha",
-        "wpLocale": "uz_UZ",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 5,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "143"
-        ]
-    },
-    "vec": {
-        "value": 445,
-        "langSlug": "vec",
-        "name": "V\u00e8neta",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "039"
-        ]
-    },
-    "vi": {
-        "value": 446,
-        "langSlug": "vi",
-        "name": "Ti\u1ebfng Vi\u1ec7t",
-        "wpLocale": "vi",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 23,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "035"
-        ]
-    },
-    "wa": {
-        "value": 75,
-        "langSlug": "wa",
-        "name": "Walon",
-        "wpLocale": "wa",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "155"
-        ]
-    },
-    "xal": {
-        "value": 447,
-        "langSlug": "xal",
-        "name": "\u0425\u0430\u043b\u044c\u043c\u0433",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "143"
-        ]
-    },
-    "yi": {
-        "value": 76,
-        "langSlug": "yi",
-        "name": "\u05d9\u05d9\u05b4\u05d3\u05d9\u05e9",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": []
-    },
-    "yo": {
-        "value": 477,
-        "langSlug": "yo",
-        "name": "\u00e8d\u00e8 Yor\u00f9b\u00e1",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "002"
-        ]
-    },
-    "za": {
-        "value": 448,
-        "langSlug": "za",
-        "name": "(Cuengh)",
-        "wpLocale": "",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 0,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "030"
-        ]
-    },
-    "zh-cn": {
-        "value": 449,
-        "langSlug": "zh-cn",
-        "name": "\u7b80\u4f53\u4e2d\u6587",
-        "wpLocale": "zh_CN",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 98,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "030"
-        ],
-        "popular": 13
-    },
-    "zh-hk": {
-        "value": 487,
-        "langSlug": "zh-hk",
-        "name": "\u9999\u6e2f\u4e2d\u6587\u7248",
-        "wpLocale": "zh_HK",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 70,
-        "isTranslatedIncompletely": true,
-        "territories": [
-            "030"
-        ]
-    },
-    "zh-sg": {
-        "value": 489,
-        "langSlug": "zh-sg",
-        "name": "\u4e2d\u6587",
-        "wpLocale": "zh_SG",
-        "parentLangSlug": "zh-cn",
-        "calypsoPercentTranslated": 98,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "035"
-        ]
-    },
-    "zh-tw": {
-        "value": 452,
-        "langSlug": "zh-tw",
-        "name": "\u7e41\u9ad4\u4e2d\u6587",
-        "wpLocale": "zh_TW",
-        "parentLangSlug": null,
-        "calypsoPercentTranslated": 98,
-        "isTranslatedIncompletely": false,
-        "territories": [
-            "030"
-        ],
-        "popular": 14
-    }
+	"af": {
+		"value": 2,
+		"langSlug": "af",
+		"name": "Afrikaans",
+		"wpLocale": "af",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 5,
+		"isTranslatedIncompletely": true,
+		"territories": [ "002" ]
+	},
+	"als": {
+		"value": 418,
+		"langSlug": "als",
+		"name": "Alemannisch",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "155" ]
+	},
+	"am": {
+		"value": 481,
+		"langSlug": "am",
+		"name": "\u12a0\u121b\u122d\u129b",
+		"wpLocale": "am",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 1,
+		"isTranslatedIncompletely": true,
+		"territories": [ "002" ]
+	},
+	"an": {
+		"value": 485,
+		"langSlug": "an",
+		"name": "Aragon\u00e9s",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 2,
+		"isTranslatedIncompletely": true,
+		"territories": []
+	},
+	"ar": {
+		"value": 3,
+		"langSlug": "ar",
+		"name": "\u0627\u0644\u0639\u0631\u0628\u064a\u0629",
+		"wpLocale": "ar",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 99,
+		"isTranslatedIncompletely": false,
+		"territories": [ "145", "002" ],
+		"rtl": true,
+		"popular": 16
+	},
+	"arc": {
+		"value": 419,
+		"langSlug": "arc",
+		"name": "\u0715\u0725\u0712\u072a\u0738\u071d\u071b",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "145" ]
+	},
+	"as": {
+		"value": 4,
+		"langSlug": "as",
+		"name": "\u0985\u09b8\u09ae\u09c0\u09af\u09bc\u09be",
+		"wpLocale": "as",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 4,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"ast": {
+		"value": 420,
+		"langSlug": "ast",
+		"name": "Asturianu",
+		"wpLocale": "ast",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 4,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"av": {
+		"value": 421,
+		"langSlug": "av",
+		"name": "\u0430\u0432\u0430\u0440 \u043c\u0430\u0446\u04c0",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"ay": {
+		"value": 422,
+		"langSlug": "ay",
+		"name": "aymar aru",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "019" ]
+	},
+	"az": {
+		"value": 79,
+		"langSlug": "az",
+		"name": "Az\u0259rbaycan dili",
+		"wpLocale": "az",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 21,
+		"isTranslatedIncompletely": true,
+		"territories": [ "145" ]
+	},
+	"ba": {
+		"value": 423,
+		"langSlug": "ba",
+		"name": "\u0431\u0430\u0448\u04a1\u043e\u0440\u0442 \u0442\u0435\u043b\u0435",
+		"wpLocale": "ba",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"bel": {
+		"value": 5,
+		"langSlug": "bel",
+		"name": "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u043a\u0430\u044f \u043c\u043e\u0432\u0430",
+		"wpLocale": "bel",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 4,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"bg": {
+		"value": 6,
+		"langSlug": "bg",
+		"name": "\u0411\u044a\u043b\u0433\u0430\u0440\u0441\u043a\u0438",
+		"wpLocale": "bg_BG",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 18,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"bm": {
+		"value": 7,
+		"langSlug": "bm",
+		"name": "Bamanankan",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "002" ]
+	},
+	"bn": {
+		"value": 8,
+		"langSlug": "bn",
+		"name": "\u09ac\u09be\u0982\u09b2\u09be",
+		"wpLocale": "bn_BD",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 5,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"bo": {
+		"value": 9,
+		"langSlug": "bo",
+		"name": "\u0f56\u0f7c\u0f51\u0f0b\u0f66\u0f90\u0f51",
+		"wpLocale": "bo",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 4,
+		"isTranslatedIncompletely": true,
+		"territories": [ "030" ]
+	},
+	"br": {
+		"value": 424,
+		"langSlug": "br",
+		"name": "Brezhoneg",
+		"wpLocale": "bre",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 5,
+		"isTranslatedIncompletely": true,
+		"territories": [ "155" ]
+	},
+	"bs": {
+		"value": 454,
+		"langSlug": "bs",
+		"name": "Bosanski",
+		"wpLocale": "bs_BA",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 9,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"ca": {
+		"value": 10,
+		"langSlug": "ca",
+		"name": "Catal\u00e0",
+		"wpLocale": "ca",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 12,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"ce": {
+		"value": 425,
+		"langSlug": "ce",
+		"name": "\u041d\u043e\u0445\u0447\u0438\u0439\u043d \u043c\u043e\u0442\u0442",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"ckb": {
+		"value": 41,
+		"langSlug": "ckb",
+		"name": "\u0643\u0648\u0631\u062f\u06cc\u200e",
+		"wpLocale": "ckb",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 6,
+		"isTranslatedIncompletely": true,
+		"territories": [ "145", "034" ],
+		"rtl": true
+	},
+	"cs": {
+		"value": 11,
+		"langSlug": "cs",
+		"name": "\u010ce\u0161tina",
+		"wpLocale": "cs_CZ",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 36,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"csb": {
+		"value": 12,
+		"langSlug": "csb",
+		"name": "Kasz\u00ebbsczi",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"cv": {
+		"value": 426,
+		"langSlug": "cv",
+		"name": "\u0447\u04d1\u0432\u0430\u0448 \u0447\u04d7\u043b\u0445\u0438",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 28,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"cy": {
+		"value": 13,
+		"langSlug": "cy",
+		"name": "Cymraeg",
+		"wpLocale": "cy",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 12,
+		"isTranslatedIncompletely": true,
+		"territories": [ "154" ]
+	},
+	"da": {
+		"value": 14,
+		"langSlug": "da",
+		"name": "Dansk",
+		"wpLocale": "da_DK",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 9,
+		"isTranslatedIncompletely": true,
+		"territories": [ "154" ]
+	},
+	"de": {
+		"value": 15,
+		"langSlug": "de",
+		"name": "Deutsch",
+		"wpLocale": "de_DE",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 99,
+		"isTranslatedIncompletely": false,
+		"territories": [ "155" ],
+		"popular": 4
+	},
+	"de-ch": {
+		"value": 903,
+		"langSlug": "de-ch",
+		"name": "Deutsch (Schweiz)",
+		"wpLocale": "de_CH",
+		"parentLangSlug": "de",
+		"calypsoPercentTranslated": 99,
+		"isTranslatedIncompletely": false,
+		"territories": [ "155" ]
+	},
+	"de_formal": {
+		"value": 900,
+		"langSlug": "de_formal",
+		"name": "Deutsch (Sie)",
+		"wpLocale": "de",
+		"parentLangSlug": "de",
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "155" ]
+	},
+	"dv": {
+		"value": 427,
+		"langSlug": "dv",
+		"name": "\u078b\u07a8\u0788\u07ac\u0780\u07a8",
+		"wpLocale": "dv",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 1,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ],
+		"rtl": true
+	},
+	"dz": {
+		"value": 16,
+		"langSlug": "dz",
+		"name": "\u0f47\u0f7c\u0f44\u0f0b\u0f41",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"el": {
+		"value": 17,
+		"langSlug": "el",
+		"name": "\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac",
+		"wpLocale": "el",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 23,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"el-po": {
+		"value": 468,
+		"langSlug": "el-po",
+		"name": "Greek (Polytonic)",
+		"wpLocale": "el",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 56,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"en": {
+		"value": 1,
+		"langSlug": "en",
+		"name": "English",
+		"wpLocale": "en_US",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 100,
+		"isTranslatedIncompletely": false,
+		"territories": [ "019" ],
+		"popular": 1
+	},
+	"en-gb": {
+		"value": 482,
+		"langSlug": "en-gb",
+		"name": "English (UK)",
+		"wpLocale": "en_GB",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 15,
+		"isTranslatedIncompletely": false,
+		"territories": [ "154" ]
+	},
+	"eo": {
+		"value": 18,
+		"langSlug": "eo",
+		"name": "Esperanto",
+		"wpLocale": "eo",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 11,
+		"isTranslatedIncompletely": true,
+		"territories": []
+	},
+	"es": {
+		"value": 19,
+		"langSlug": "es",
+		"name": "Espa\u00f1ol",
+		"wpLocale": "es_ES",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 99,
+		"isTranslatedIncompletely": false,
+		"territories": [ "019", "039" ],
+		"popular": 2
+	},
+	"es-cl": {
+		"value": 484,
+		"langSlug": "es-cl",
+		"name": "Espa\u00f1ol de Chile",
+		"wpLocale": "es_CL",
+		"parentLangSlug": "es",
+		"calypsoPercentTranslated": 99,
+		"isTranslatedIncompletely": false,
+		"territories": [ "019" ]
+	},
+	"es-mx": {
+		"value": 902,
+		"langSlug": "es-mx",
+		"name": "Espa\u00f1ol de M\u00e9xico",
+		"wpLocale": "es_MX",
+		"parentLangSlug": "es",
+		"calypsoPercentTranslated": 99,
+		"isTranslatedIncompletely": false,
+		"territories": [ "019" ]
+	},
+	"et": {
+		"value": 20,
+		"langSlug": "et",
+		"name": "Eesti",
+		"wpLocale": "et",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 9,
+		"isTranslatedIncompletely": true,
+		"territories": [ "154" ]
+	},
+	"eu": {
+		"value": 429,
+		"langSlug": "eu",
+		"name": "Euskara",
+		"wpLocale": "eu",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 6,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"fa": {
+		"value": 21,
+		"langSlug": "fa",
+		"name": "\u0641\u0627\u0631\u0633\u06cc",
+		"wpLocale": "fa_IR",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 38,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ],
+		"rtl": true
+	},
+	"fi": {
+		"value": 22,
+		"langSlug": "fi",
+		"name": "Suomi",
+		"wpLocale": "fi",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 15,
+		"isTranslatedIncompletely": true,
+		"territories": [ "154" ]
+	},
+	"fo": {
+		"value": 23,
+		"langSlug": "fo",
+		"name": "F\u00f8royskt",
+		"wpLocale": "fo",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 3,
+		"isTranslatedIncompletely": true,
+		"territories": [ "154" ]
+	},
+	"fr": {
+		"value": 24,
+		"langSlug": "fr",
+		"name": "Fran\u00e7ais",
+		"wpLocale": "fr_FR",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 98,
+		"isTranslatedIncompletely": false,
+		"territories": [ "155" ],
+		"popular": 5
+	},
+	"fr-be": {
+		"value": 478,
+		"langSlug": "fr-be",
+		"name": "Fran\u00e7ais de Belgique",
+		"wpLocale": "fr_BE",
+		"parentLangSlug": "fr",
+		"calypsoPercentTranslated": 98,
+		"isTranslatedIncompletely": false,
+		"territories": [ "155" ]
+	},
+	"fr-ca": {
+		"value": 475,
+		"langSlug": "fr-ca",
+		"name": "Fran\u00e7ais du Canada",
+		"wpLocale": "fr_CA",
+		"parentLangSlug": "fr",
+		"calypsoPercentTranslated": 98,
+		"isTranslatedIncompletely": false,
+		"territories": [ "019" ]
+	},
+	"fr-ch": {
+		"value": 474,
+		"langSlug": "fr-ch",
+		"name": "Fran\u00e7ais de Suisse",
+		"wpLocale": "",
+		"parentLangSlug": "fr",
+		"calypsoPercentTranslated": 98,
+		"isTranslatedIncompletely": false,
+		"territories": [ "155" ]
+	},
+	"fur": {
+		"value": 25,
+		"langSlug": "fur",
+		"name": "Friulian",
+		"wpLocale": "fur",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"fy": {
+		"value": 26,
+		"langSlug": "fy",
+		"name": "Frysk",
+		"wpLocale": "fy",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "155" ]
+	},
+	"ga": {
+		"value": 27,
+		"langSlug": "ga",
+		"name": "Gaelige",
+		"wpLocale": "ga",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 12,
+		"isTranslatedIncompletely": true,
+		"territories": [ "154" ]
+	},
+	"gd": {
+		"value": 476,
+		"langSlug": "gd",
+		"name": "G\u00e0idhlig",
+		"wpLocale": "gd",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 12,
+		"isTranslatedIncompletely": true,
+		"territories": [ "154" ]
+	},
+	"gl": {
+		"value": 457,
+		"langSlug": "gl",
+		"name": "Galego",
+		"wpLocale": "gl_ES",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 13,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"gn": {
+		"value": 430,
+		"langSlug": "gn",
+		"name": "Ava\u00f1e'\u1ebd",
+		"wpLocale": "gn",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "019" ]
+	},
+	"gu": {
+		"value": 28,
+		"langSlug": "gu",
+		"name": "\u0a97\u0ac1\u0a9c\u0ab0\u0abe\u0aa4\u0ac0",
+		"wpLocale": "gu",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 5,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"he": {
+		"value": 29,
+		"langSlug": "he",
+		"name": "\u05e2\u05b4\u05d1\u05b0\u05e8\u05b4\u05d9\u05ea",
+		"wpLocale": "he_IL",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 97,
+		"isTranslatedIncompletely": false,
+		"territories": [ "145" ],
+		"rtl": true,
+		"popular": 6
+	},
+	"hi": {
+		"value": 30,
+		"langSlug": "hi",
+		"name": "\u0939\u093f\u0928\u094d\u0926\u0940",
+		"wpLocale": "hi_IN",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 9,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"hr": {
+		"value": 431,
+		"langSlug": "hr",
+		"name": "Hrvatski",
+		"wpLocale": "hr",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 15,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"hu": {
+		"value": 31,
+		"langSlug": "hu",
+		"name": "Magyar",
+		"wpLocale": "hu_HU",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 26,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"hy": {
+		"value": 467,
+		"langSlug": "hy",
+		"name": "\u0540\u0561\u0575\u0565\u0580\u0565\u0576",
+		"wpLocale": "hy",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 5,
+		"isTranslatedIncompletely": true,
+		"territories": [ "145" ]
+	},
+	"ia": {
+		"value": 32,
+		"langSlug": "ia",
+		"name": "Interlingua",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": []
+	},
+	"id": {
+		"value": 33,
+		"langSlug": "id",
+		"name": "Bahasa Indonesia",
+		"wpLocale": "id_ID",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 99,
+		"isTranslatedIncompletely": false,
+		"territories": [ "035" ],
+		"popular": 12
+	},
+	"ii": {
+		"value": 432,
+		"langSlug": "ii",
+		"name": "\ua187\ua259",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "030" ]
+	},
+	"ilo": {
+		"value": 469,
+		"langSlug": "ilo",
+		"name": "Pagsasao nga Iloko",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "035" ]
+	},
+	"is": {
+		"value": 34,
+		"langSlug": "is",
+		"name": "\u00cdslenska",
+		"wpLocale": "is_IS",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 14,
+		"isTranslatedIncompletely": true,
+		"territories": [ "154" ]
+	},
+	"it": {
+		"value": 35,
+		"langSlug": "it",
+		"name": "Italiano",
+		"wpLocale": "it_IT",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 99,
+		"isTranslatedIncompletely": false,
+		"territories": [ "039" ],
+		"popular": 8
+	},
+	"ja": {
+		"value": 36,
+		"langSlug": "ja",
+		"name": "\u65e5\u672c\u8a9e",
+		"wpLocale": "ja",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 98,
+		"isTranslatedIncompletely": false,
+		"territories": [ "030" ],
+		"popular": 7
+	},
+	"ka": {
+		"value": 37,
+		"langSlug": "ka",
+		"name": "\u10e5\u10d0\u10e0\u10d7\u10e3\u10da\u10d8",
+		"wpLocale": "ka_GE",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 6,
+		"isTranslatedIncompletely": true,
+		"territories": [ "145" ]
+	},
+	"kab": {
+		"value": 488,
+		"langSlug": "kab",
+		"name": "Taqbaylit",
+		"wpLocale": "kab",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 24,
+		"isTranslatedIncompletely": true,
+		"territories": [ "002" ]
+	},
+	"kir": {
+		"value": 479,
+		"langSlug": "kir",
+		"name": "\u041a\u044b\u0440\u0433\u044b\u0437\u0447\u0430",
+		"wpLocale": "kir",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 3,
+		"isTranslatedIncompletely": true,
+		"territories": [ "143" ]
+	},
+	"kk": {
+		"value": 462,
+		"langSlug": "kk",
+		"name": "\u049a\u0430\u0437\u0430\u049b \u0442\u0456\u043b\u0456",
+		"wpLocale": "kk",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 4,
+		"isTranslatedIncompletely": true,
+		"territories": [ "143" ]
+	},
+	"km": {
+		"value": 38,
+		"langSlug": "km",
+		"name": "\u1797\u17b6\u179f\u17b6\u1781\u17d2\u1798\u17c2\u179a",
+		"wpLocale": "km",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 7,
+		"isTranslatedIncompletely": true,
+		"territories": [ "035" ]
+	},
+	"kn": {
+		"value": 39,
+		"langSlug": "kn",
+		"name": "\u0c95\u0ca8\u0ccd\u0ca8\u0ca1",
+		"wpLocale": "kn",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 2,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"ko": {
+		"value": 40,
+		"langSlug": "ko",
+		"name": "\ud55c\uad6d\uc5b4",
+		"wpLocale": "ko_KR",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 99,
+		"isTranslatedIncompletely": false,
+		"territories": [ "030" ],
+		"popular": 15
+	},
+	"ks": {
+		"value": 433,
+		"langSlug": "ks",
+		"name": "\u0915\u0936\u094d\u092e\u0940\u0930\u0940",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"kv": {
+		"value": 434,
+		"langSlug": "kv",
+		"name": "\u041a\u043e\u043c\u0438",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"la": {
+		"value": 42,
+		"langSlug": "la",
+		"name": "Latine",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"li": {
+		"value": 43,
+		"langSlug": "li",
+		"name": "Limburgs",
+		"wpLocale": "li",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "155" ]
+	},
+	"lo": {
+		"value": 44,
+		"langSlug": "lo",
+		"name": "\u0e9e\u0eb2\u0eaa\u0eb2\u0ea5\u0eb2\u0ea7",
+		"wpLocale": "lo",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 3,
+		"isTranslatedIncompletely": true,
+		"territories": [ "035" ]
+	},
+	"lt": {
+		"value": 45,
+		"langSlug": "lt",
+		"name": "Lietuvi\u0173 kalba",
+		"wpLocale": "lt_LT",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 20,
+		"isTranslatedIncompletely": true,
+		"territories": [ "154" ]
+	},
+	"lv": {
+		"value": 453,
+		"langSlug": "lv",
+		"name": "Latvie\u0161u valoda",
+		"wpLocale": "lv",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 15,
+		"isTranslatedIncompletely": true,
+		"territories": [ "154" ]
+	},
+	"mk": {
+		"value": 435,
+		"langSlug": "mk",
+		"name": "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0441\u043a\u0438 \u0458\u0430\u0437\u0438\u043a",
+		"wpLocale": "mk_MK",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 6,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"ml": {
+		"value": 46,
+		"langSlug": "ml",
+		"name": "\u0d2e\u0d32\u0d2f\u0d3e\u0d33\u0d02",
+		"wpLocale": "ml_IN",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 4,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"mn": {
+		"value": 472,
+		"langSlug": "mn",
+		"name": "\u041c\u043e\u043d\u0433\u043e\u043b",
+		"wpLocale": "mn",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 23,
+		"isTranslatedIncompletely": true,
+		"territories": [ "030" ]
+	},
+	"mr": {
+		"value": 461,
+		"langSlug": "mr",
+		"name": "\u092e\u0930\u093e\u0920\u0940",
+		"wpLocale": "mr",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 5,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"ms": {
+		"value": 47,
+		"langSlug": "ms",
+		"name": "Bahasa Melayu",
+		"wpLocale": "ms_MY",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 6,
+		"isTranslatedIncompletely": true,
+		"territories": [ "035" ]
+	},
+	"mt": {
+		"value": 465,
+		"langSlug": "mt",
+		"name": "Malti",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"mwl": {
+		"value": 464,
+		"langSlug": "mwl",
+		"name": "Mirand\u00e9s",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 2,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"nah": {
+		"value": 436,
+		"langSlug": "nah",
+		"name": "Nahuatl",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "019" ]
+	},
+	"nap": {
+		"value": 437,
+		"langSlug": "nap",
+		"name": "Nnapulitano",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"nds": {
+		"value": 48,
+		"langSlug": "nds",
+		"name": "Plattd\u00fc\u00fctsch",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "155" ]
+	},
+	"ne": {
+		"value": 456,
+		"langSlug": "ne",
+		"name": "\u0928\u0947\u092a\u093e\u0932\u0940",
+		"wpLocale": "ne_NP",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 4,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"nl": {
+		"value": 49,
+		"langSlug": "nl",
+		"name": "Nederlands",
+		"wpLocale": "nl_NL",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 98,
+		"isTranslatedIncompletely": false,
+		"territories": [ "155" ],
+		"popular": 9
+	},
+	"nl_formal": {
+		"value": 904,
+		"langSlug": "nl_formal",
+		"name": "Nederlands (U)",
+		"wpLocale": "nl",
+		"parentLangSlug": "nl",
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "155" ]
+	},
+	"nn": {
+		"value": 50,
+		"langSlug": "nn",
+		"name": "Norsk nynorsk",
+		"wpLocale": "nn_NO",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 13,
+		"isTranslatedIncompletely": true,
+		"territories": [ "154" ]
+	},
+	"no": {
+		"value": 51,
+		"langSlug": "nb",
+		"name": "Norwegian (Bokm\u00e5l)",
+		"wpLocale": "nb_NO",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 53,
+		"isTranslatedIncompletely": true,
+		"territories": [ "154" ]
+	},
+	"non": {
+		"value": 52,
+		"langSlug": "non",
+		"name": "Norr\u01ffna",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "154" ]
+	},
+	"nv": {
+		"value": 53,
+		"langSlug": "nv",
+		"name": "Din\u00e9 bizaad",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "019" ]
+	},
+	"oci": {
+		"value": 54,
+		"langSlug": "oci",
+		"name": "Occitan",
+		"wpLocale": "oci",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 5,
+		"isTranslatedIncompletely": true,
+		"territories": [ "155" ]
+	},
+	"or": {
+		"value": 55,
+		"langSlug": "or",
+		"name": "\u0b13\u0b21\u0b3c\u0b3f\u0b06",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"os": {
+		"value": 56,
+		"langSlug": "os",
+		"name": "\u0418\u0440\u043e\u043d",
+		"wpLocale": "os",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "145" ]
+	},
+	"pa": {
+		"value": 57,
+		"langSlug": "pa",
+		"name": "\u0a2a\u0a70\u0a1c\u0a3e\u0a2c\u0a40",
+		"wpLocale": "pa_IN",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 22,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"pl": {
+		"value": 58,
+		"langSlug": "pl",
+		"name": "Polski",
+		"wpLocale": "pl_PL",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 26,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"ps": {
+		"value": 59,
+		"langSlug": "ps",
+		"name": "\u067e\u069a\u062a\u0648",
+		"wpLocale": "ps",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 3,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ],
+		"rtl": true
+	},
+	"pt": {
+		"value": 60,
+		"langSlug": "pt",
+		"name": "Portugu\u00eas",
+		"wpLocale": "pt_PT",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 19,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"pt-br": {
+		"value": 438,
+		"langSlug": "pt-br",
+		"name": "Portugu\u00eas do Brasil",
+		"wpLocale": "pt_BR",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 99,
+		"isTranslatedIncompletely": false,
+		"territories": [ "019" ],
+		"popular": 3
+	},
+	"qu": {
+		"value": 439,
+		"langSlug": "qu",
+		"name": "Runa Simi",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "019" ]
+	},
+	"ro": {
+		"value": 61,
+		"langSlug": "ro",
+		"name": "Rom\u00e2n\u0103",
+		"wpLocale": "ro_RO",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 100,
+		"isTranslatedIncompletely": false,
+		"territories": [ "151" ]
+	},
+	"ru": {
+		"value": 62,
+		"langSlug": "ru",
+		"name": "\u0420\u0443\u0441\u0441\u043a\u0438\u0439",
+		"wpLocale": "ru_RU",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 99,
+		"isTranslatedIncompletely": false,
+		"territories": [ "151" ],
+		"popular": 10
+	},
+	"rup": {
+		"value": 483,
+		"langSlug": "rup",
+		"name": "Arm\u00e3neashce",
+		"wpLocale": "rup_MK",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 1,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"sc": {
+		"value": 63,
+		"langSlug": "sc",
+		"name": "Sardu",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"si": {
+		"value": 471,
+		"langSlug": "si",
+		"name": "\u0dc3\u0dd2\u0d82\u0dc4\u0dbd",
+		"wpLocale": "si_LK",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 5,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"sk": {
+		"value": 64,
+		"langSlug": "sk",
+		"name": "Sloven\u010dina",
+		"wpLocale": "sk_SK",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 10,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"skr": {
+		"value": 486,
+		"langSlug": "skr",
+		"name": "Saraiki",
+		"wpLocale": "skr",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 68,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"sl": {
+		"value": 65,
+		"langSlug": "sl",
+		"name": "Sloven\u0161\u010dina",
+		"wpLocale": "sl_SI",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 8,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"snd": {
+		"value": 440,
+		"langSlug": "snd",
+		"name": "\u0633\u0646\u068c\u064a",
+		"wpLocale": "snd",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 5,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"so": {
+		"value": 459,
+		"langSlug": "so",
+		"name": "Afsoomaali",
+		"wpLocale": "so_SO",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 3,
+		"isTranslatedIncompletely": true,
+		"territories": [ "002" ]
+	},
+	"sq": {
+		"value": 66,
+		"langSlug": "sq",
+		"name": "Shqip",
+		"wpLocale": "sq",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 50,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"sr": {
+		"value": 67,
+		"langSlug": "sr",
+		"name": "\u0421\u0440\u043f\u0441\u043a\u0438 \u0458\u0435\u0437\u0438\u043a",
+		"wpLocale": "sr_RS",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 10,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"sr_latin": {
+		"value": 901,
+		"langSlug": "sr_latin",
+		"name": "Srpski (latinica)",
+		"wpLocale": "sr",
+		"parentLangSlug": "sr",
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"su": {
+		"value": 441,
+		"langSlug": "su",
+		"name": "Basa Sunda",
+		"wpLocale": "su_ID",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 3,
+		"isTranslatedIncompletely": true,
+		"territories": [ "035" ]
+	},
+	"sv": {
+		"value": 68,
+		"langSlug": "sv",
+		"name": "Svenska",
+		"wpLocale": "sv_SE",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 99,
+		"isTranslatedIncompletely": false,
+		"territories": [ "154" ],
+		"popular": 17
+	},
+	"ta": {
+		"value": 69,
+		"langSlug": "ta",
+		"name": "\u0ba4\u0bae\u0bbf\u0bb4\u0bcd",
+		"wpLocale": "ta_IN",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 5,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034", "035" ]
+	},
+	"te": {
+		"value": 70,
+		"langSlug": "te",
+		"name": "\u0c24\u0c46\u0c32\u0c41\u0c17\u0c41",
+		"wpLocale": "te",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 16,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ]
+	},
+	"th": {
+		"value": 71,
+		"langSlug": "th",
+		"name": "\u0e44\u0e17\u0e22",
+		"wpLocale": "th",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 9,
+		"isTranslatedIncompletely": true,
+		"territories": [ "035" ]
+	},
+	"tir": {
+		"value": 480,
+		"langSlug": "tir",
+		"name": "\u1275\u130d\u122d\u129b",
+		"wpLocale": "tir",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "002" ]
+	},
+	"tl": {
+		"value": 455,
+		"langSlug": "tl",
+		"name": "Tagalog",
+		"wpLocale": "tl",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 6,
+		"isTranslatedIncompletely": true,
+		"territories": [ "035" ]
+	},
+	"tr": {
+		"value": 78,
+		"langSlug": "tr",
+		"name": "T\u00fcrk\u00e7e",
+		"wpLocale": "tr_TR",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 99,
+		"isTranslatedIncompletely": false,
+		"territories": [ "145" ],
+		"popular": 11
+	},
+	"tt": {
+		"value": 72,
+		"langSlug": "tt",
+		"name": "\u0422\u0430\u0442\u0430\u0440 \u0442\u0435\u043b\u0435",
+		"wpLocale": "tt_RU",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"ty": {
+		"value": 442,
+		"langSlug": "ty",
+		"name": "Reo M\u0101`ohi",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "009" ]
+	},
+	"udm": {
+		"value": 443,
+		"langSlug": "udm",
+		"name": "\u0423\u0434\u043c\u0443\u0440\u0442 \u043a\u044b\u043b",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"ug": {
+		"value": 444,
+		"langSlug": "ug",
+		"name": "Uy\u01a3urq\u0259",
+		"wpLocale": "ug_CN",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 6,
+		"isTranslatedIncompletely": true,
+		"territories": [ "030" ]
+	},
+	"uk": {
+		"value": 73,
+		"langSlug": "uk",
+		"name": "\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430",
+		"wpLocale": "uk",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 16,
+		"isTranslatedIncompletely": true,
+		"territories": [ "151" ]
+	},
+	"ur": {
+		"value": 74,
+		"langSlug": "ur",
+		"name": "\u0627\u0631\u062f\u0648",
+		"wpLocale": "ur",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 12,
+		"isTranslatedIncompletely": true,
+		"territories": [ "034" ],
+		"rtl": true
+	},
+	"uz": {
+		"value": 458,
+		"langSlug": "uz",
+		"name": "O\u2018zbekcha",
+		"wpLocale": "uz_UZ",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 5,
+		"isTranslatedIncompletely": true,
+		"territories": [ "143" ]
+	},
+	"vec": {
+		"value": 445,
+		"langSlug": "vec",
+		"name": "V\u00e8neta",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "039" ]
+	},
+	"vi": {
+		"value": 446,
+		"langSlug": "vi",
+		"name": "Ti\u1ebfng Vi\u1ec7t",
+		"wpLocale": "vi",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 23,
+		"isTranslatedIncompletely": true,
+		"territories": [ "035" ]
+	},
+	"wa": {
+		"value": 75,
+		"langSlug": "wa",
+		"name": "Walon",
+		"wpLocale": "wa",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "155" ]
+	},
+	"xal": {
+		"value": 447,
+		"langSlug": "xal",
+		"name": "\u0425\u0430\u043b\u044c\u043c\u0433",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "143" ]
+	},
+	"yi": {
+		"value": 76,
+		"langSlug": "yi",
+		"name": "\u05d9\u05d9\u05b4\u05d3\u05d9\u05e9",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": []
+	},
+	"yo": {
+		"value": 477,
+		"langSlug": "yo",
+		"name": "\u00e8d\u00e8 Yor\u00f9b\u00e1",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "002" ]
+	},
+	"za": {
+		"value": 448,
+		"langSlug": "za",
+		"name": "(Cuengh)",
+		"wpLocale": "",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 0,
+		"isTranslatedIncompletely": true,
+		"territories": [ "030" ]
+	},
+	"zh-cn": {
+		"value": 449,
+		"langSlug": "zh-cn",
+		"name": "\u7b80\u4f53\u4e2d\u6587",
+		"wpLocale": "zh_CN",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 98,
+		"isTranslatedIncompletely": false,
+		"territories": [ "030" ],
+		"popular": 13
+	},
+	"zh-hk": {
+		"value": 487,
+		"langSlug": "zh-hk",
+		"name": "\u9999\u6e2f\u4e2d\u6587\u7248",
+		"wpLocale": "zh_HK",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 70,
+		"isTranslatedIncompletely": true,
+		"territories": [ "030" ]
+	},
+	"zh-sg": {
+		"value": 489,
+		"langSlug": "zh-sg",
+		"name": "\u4e2d\u6587",
+		"wpLocale": "zh_SG",
+		"parentLangSlug": "zh-cn",
+		"calypsoPercentTranslated": 98,
+		"isTranslatedIncompletely": false,
+		"territories": [ "035" ]
+	},
+	"zh-tw": {
+		"value": 452,
+		"langSlug": "zh-tw",
+		"name": "\u7e41\u9ad4\u4e2d\u6587",
+		"wpLocale": "zh_TW",
+		"parentLangSlug": null,
+		"calypsoPercentTranslated": 98,
+		"isTranslatedIncompletely": false,
+		"territories": [ "030" ],
+		"popular": 14
+	}
 }

--- a/packages/languages/src/languages-meta.json
+++ b/packages/languages/src/languages-meta.json
@@ -975,10 +975,10 @@
 		"isTranslatedIncompletely": true,
 		"territories": [ "154" ]
 	},
-	"no": {
+	"nb": {
 		"value": 51,
 		"langSlug": "nb",
-		"name": "Norwegian (Bokm\u00e5l)",
+		"name": "Norsk bokm\u00e5l",
 		"wpLocale": "nb_NO",
 		"parentLangSlug": null,
 		"calypsoPercentTranslated": 53,

--- a/packages/languages/src/languages-meta.json
+++ b/packages/languages/src/languages-meta.json
@@ -1,1621 +1,1786 @@
 {
-	"af": {
-		"value": 2,
-		"langSlug": "af",
-		"name": "Afrikaans",
-		"wpLocale": "af",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 6,
-		"isTranslatedIncompletely": true,
-		"territories": [ "002" ],
-		"revision": 60516
-	},
-	"als": {
-		"value": 418,
-		"langSlug": "als",
-		"name": "Alemannisch",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "155" ],
-		"revision": null
-	},
-	"am": {
-		"value": 481,
-		"langSlug": "am",
-		"name": "\u12a0\u121b\u122d\u129b",
-		"wpLocale": "am",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 2,
-		"isTranslatedIncompletely": true,
-		"territories": [ "002" ],
-		"revision": 59811
-	},
-	"an": {
-		"value": 485,
-		"langSlug": "an",
-		"name": "Aragon\u00e9s",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 3,
-		"isTranslatedIncompletely": true,
-		"territories": [],
-		"revision": 59594
-	},
-	"ar": {
-		"value": 3,
-		"langSlug": "ar",
-		"name": "\u0627\u0644\u0639\u0631\u0628\u064a\u0629",
-		"wpLocale": "ar",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "145", "002" ],
-		"revision": 60531,
-		"rtl": true,
-		"popular": 16
-	},
-	"arc": {
-		"value": 419,
-		"langSlug": "arc",
-		"name": "\u0715\u0725\u0712\u072a\u0738\u071d\u071b",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "145" ],
-		"revision": null
-	},
-	"as": {
-		"value": 4,
-		"langSlug": "as",
-		"name": "\u0985\u09b8\u09ae\u09c0\u09af\u09bc\u09be",
-		"wpLocale": "as",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 5,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59815
-	},
-	"ast": {
-		"value": 420,
-		"langSlug": "ast",
-		"name": "Asturianu",
-		"wpLocale": "ast",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 5,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 59816
-	},
-	"av": {
-		"value": 421,
-		"langSlug": "av",
-		"name": "\u0430\u0432\u0430\u0440 \u043c\u0430\u0446\u04c0",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": null
-	},
-	"ay": {
-		"value": 422,
-		"langSlug": "ay",
-		"name": "aymar aru",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "019" ],
-		"revision": null
-	},
-	"az": {
-		"value": 79,
-		"langSlug": "az",
-		"name": "Az\u0259rbaycan dili",
-		"wpLocale": "az",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 25,
-		"isTranslatedIncompletely": true,
-		"territories": [ "145" ],
-		"revision": 59537
-	},
-	"ba": {
-		"value": 423,
-		"langSlug": "ba",
-		"name": "\u0431\u0430\u0448\u04a1\u043e\u0440\u0442 \u0442\u0435\u043b\u0435",
-		"wpLocale": "ba",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": null
-	},
-	"bel": {
-		"value": 5,
-		"langSlug": "bel",
-		"name": "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u043a\u0430\u044f \u043c\u043e\u0432\u0430",
-		"wpLocale": "bel",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 5,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": 59819
-	},
-	"bg": {
-		"value": 6,
-		"langSlug": "bg",
-		"name": "\u0411\u044a\u043b\u0433\u0430\u0440\u0441\u043a\u0438",
-		"wpLocale": "bg_BG",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 22,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": 59927
-	},
-	"bm": {
-		"value": 7,
-		"langSlug": "bm",
-		"name": "Bamanankan",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "002" ],
-		"revision": null
-	},
-	"bn": {
-		"value": 8,
-		"langSlug": "bn",
-		"name": "\u09ac\u09be\u0982\u09b2\u09be",
-		"wpLocale": "bn_BD",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 6,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59685
-	},
-	"bo": {
-		"value": 9,
-		"langSlug": "bo",
-		"name": "\u0f56\u0f7c\u0f51\u0f0b\u0f66\u0f90\u0f51",
-		"wpLocale": "bo",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 5,
-		"isTranslatedIncompletely": true,
-		"territories": [ "030" ],
-		"revision": 59820
-	},
-	"br": {
-		"value": 424,
-		"langSlug": "br",
-		"name": "Brezhoneg",
-		"wpLocale": "bre",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 6,
-		"isTranslatedIncompletely": true,
-		"territories": [ "155" ],
-		"revision": 59687
-	},
-	"bs": {
-		"value": 454,
-		"langSlug": "bs",
-		"name": "Bosanski",
-		"wpLocale": "bs_BA",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 10,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 59689
-	},
-	"ca": {
-		"value": 10,
-		"langSlug": "ca",
-		"name": "Catal\u00e0",
-		"wpLocale": "ca",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 15,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 60078
-	},
-	"ce": {
-		"value": 425,
-		"langSlug": "ce",
-		"name": "\u041d\u043e\u0445\u0447\u0438\u0439\u043d \u043c\u043e\u0442\u0442",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": null
-	},
-	"ckb": {
-		"value": 41,
-		"langSlug": "ckb",
-		"name": "\u0643\u0648\u0631\u062f\u06cc\u200e",
-		"wpLocale": "ckb",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 7,
-		"isTranslatedIncompletely": true,
-		"territories": [ "145", "034" ],
-		"revision": 59691,
-		"rtl": true
-	},
-	"cs": {
-		"value": 11,
-		"langSlug": "cs",
-		"name": "\u010ce\u0161tina",
-		"wpLocale": "cs_CZ",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 32,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": 60176
-	},
-	"csb": {
-		"value": 12,
-		"langSlug": "csb",
-		"name": "Kasz\u00ebbsczi",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": null
-	},
-	"cv": {
-		"value": 426,
-		"langSlug": "cv",
-		"name": "\u0447\u04d1\u0432\u0430\u0448 \u0447\u04d7\u043b\u0445\u0438",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 24,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": null
-	},
-	"cy": {
-		"value": 13,
-		"langSlug": "cy",
-		"name": "Cymraeg",
-		"wpLocale": "cy",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 14,
-		"isTranslatedIncompletely": true,
-		"territories": [ "154" ],
-		"revision": 59678
-	},
-	"da": {
-		"value": 14,
-		"langSlug": "da",
-		"name": "Dansk",
-		"wpLocale": "da_DK",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 10,
-		"isTranslatedIncompletely": true,
-		"territories": [ "154" ],
-		"revision": 60333
-	},
-	"de": {
-		"value": 15,
-		"langSlug": "de",
-		"name": "Deutsch",
-		"wpLocale": "de_DE",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "155" ],
-		"revision": 60515,
-		"popular": 4
-	},
-	"de-ch": {
-		"value": 903,
-		"langSlug": "de-ch",
-		"name": "Deutsch (Schweiz)",
-		"wpLocale": "de_CH",
-		"parentLangSlug": "de",
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "155" ],
-		"revision": 58348
-	},
-	"de_formal": {
-		"value": 900,
-		"langSlug": "de_formal",
-		"name": "Deutsch (Sie)",
-		"wpLocale": "de",
-		"parentLangSlug": "de",
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "155" ],
-		"revision": 60520
-	},
-	"dv": {
-		"value": 427,
-		"langSlug": "dv",
-		"name": "\u078b\u07a8\u0788\u07ac\u0780\u07a8",
-		"wpLocale": "dv",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 1,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59823,
-		"rtl": true
-	},
-	"dz": {
-		"value": 16,
-		"langSlug": "dz",
-		"name": "\u0f47\u0f7c\u0f44\u0f0b\u0f41",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": null
-	},
-	"el": {
-		"value": 17,
-		"langSlug": "el",
-		"name": "\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac",
-		"wpLocale": "el",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 27,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 59694
-	},
-	"el-po": {
-		"value": 468,
-		"langSlug": "el-po",
-		"name": "Greek (Polytonic)",
-		"wpLocale": "el",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 44,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 60444
-	},
-	"en": {
-		"value": 1,
-		"langSlug": "en",
-		"name": "English",
-		"wpLocale": "en_US",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 100,
-		"isTranslatedIncompletely": false,
-		"territories": [ "019" ],
-		"revision": null,
-		"popular": 1
-	},
-	"en-gb": {
-		"value": 482,
-		"langSlug": "en-gb",
-		"name": "English (UK)",
-		"wpLocale": "en_GB",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 18,
-		"isTranslatedIncompletely": false,
-		"territories": [ "154" ],
-		"revision": 60220
-	},
-	"eo": {
-		"value": 18,
-		"langSlug": "eo",
-		"name": "Esperanto",
-		"wpLocale": "eo",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 13,
-		"isTranslatedIncompletely": true,
-		"territories": [],
-		"revision": 60406
-	},
-	"es": {
-		"value": 19,
-		"langSlug": "es",
-		"name": "Espa\u00f1ol",
-		"wpLocale": "es_ES",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "019", "039" ],
-		"revision": 60530,
-		"popular": 2
-	},
-	"es-cl": {
-		"value": 484,
-		"langSlug": "es-cl",
-		"name": "Espa\u00f1ol de Chile",
-		"wpLocale": "es_CL",
-		"parentLangSlug": "es",
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "019" ],
-		"revision": 60533
-	},
-	"es-mx": {
-		"value": 902,
-		"langSlug": "es-mx",
-		"name": "Espa\u00f1ol de M\u00e9xico",
-		"wpLocale": "es_MX",
-		"parentLangSlug": "es",
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "019" ],
-		"revision": 60534
-	},
-	"et": {
-		"value": 20,
-		"langSlug": "et",
-		"name": "Eesti",
-		"wpLocale": "et",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 10,
-		"isTranslatedIncompletely": true,
-		"territories": [ "154" ],
-		"revision": 59550
-	},
-	"eu": {
-		"value": 429,
-		"langSlug": "eu",
-		"name": "Euskara",
-		"wpLocale": "eu",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 7,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 59827
-	},
-	"fa": {
-		"value": 21,
-		"langSlug": "fa",
-		"name": "\u0641\u0627\u0631\u0633\u06cc",
-		"wpLocale": "fa_IR",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 46,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 60419,
-		"rtl": true
-	},
-	"fi": {
-		"value": 22,
-		"langSlug": "fi",
-		"name": "Suomi",
-		"wpLocale": "fi",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 17,
-		"isTranslatedIncompletely": true,
-		"territories": [ "154" ],
-		"revision": 60407
-	},
-	"fo": {
-		"value": 23,
-		"langSlug": "fo",
-		"name": "F\u00f8royskt",
-		"wpLocale": "fo",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 3,
-		"isTranslatedIncompletely": true,
-		"territories": [ "154" ],
-		"revision": 59605
-	},
-	"fr": {
-		"value": 24,
-		"langSlug": "fr",
-		"name": "Fran\u00e7ais",
-		"wpLocale": "fr_FR",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "155" ],
-		"revision": 60505,
-		"popular": 5
-	},
-	"fr-be": {
-		"value": 478,
-		"langSlug": "fr-be",
-		"name": "Fran\u00e7ais de Belgique",
-		"wpLocale": "fr_BE",
-		"parentLangSlug": "fr",
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "155" ],
-		"revision": 60524
-	},
-	"fr-ca": {
-		"value": 475,
-		"langSlug": "fr-ca",
-		"name": "Fran\u00e7ais du Canada",
-		"wpLocale": "fr_CA",
-		"parentLangSlug": "fr",
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "019" ],
-		"revision": 60526
-	},
-	"fr-ch": {
-		"value": 474,
-		"langSlug": "fr-ch",
-		"name": "Fran\u00e7ais de Suisse",
-		"wpLocale": "",
-		"parentLangSlug": "fr",
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "155" ],
-		"revision": 60527
-	},
-	"fur": {
-		"value": 25,
-		"langSlug": "fur",
-		"name": "Friulian",
-		"wpLocale": "fur",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": null
-	},
-	"fy": {
-		"value": 26,
-		"langSlug": "fy",
-		"name": "Frysk",
-		"wpLocale": "fy",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "155" ],
-		"revision": null
-	},
-	"ga": {
-		"value": 27,
-		"langSlug": "ga",
-		"name": "Gaelige",
-		"wpLocale": "ga",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 15,
-		"isTranslatedIncompletely": true,
-		"territories": [ "154" ],
-		"revision": 59557
-	},
-	"gd": {
-		"value": 476,
-		"langSlug": "gd",
-		"name": "G\u00e0idhlig",
-		"wpLocale": "gd",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 15,
-		"isTranslatedIncompletely": true,
-		"territories": [ "154" ],
-		"revision": 59558
-	},
-	"gl": {
-		"value": 457,
-		"langSlug": "gl",
-		"name": "Galego",
-		"wpLocale": "gl_ES",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 15,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 59701
-	},
-	"gn": {
-		"value": 430,
-		"langSlug": "gn",
-		"name": "Ava\u00f1e'\u1ebd",
-		"wpLocale": "gn",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "019" ],
-		"revision": null
-	},
-	"gu": {
-		"value": 28,
-		"langSlug": "gu",
-		"name": "\u0a97\u0ac1\u0a9c\u0ab0\u0abe\u0aa4\u0ac0",
-		"wpLocale": "gu",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 6,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59831
-	},
-	"he": {
-		"value": 29,
-		"langSlug": "he",
-		"name": "\u05e2\u05b4\u05d1\u05b0\u05e8\u05b4\u05d9\u05ea",
-		"wpLocale": "he_IL",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 98,
-		"isTranslatedIncompletely": false,
-		"territories": [ "145" ],
-		"revision": 60477,
-		"rtl": true,
-		"popular": 6
-	},
-	"hi": {
-		"value": 30,
-		"langSlug": "hi",
-		"name": "\u0939\u093f\u0928\u094d\u0926\u0940",
-		"wpLocale": "hi_IN",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 10,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59832
-	},
-	"hr": {
-		"value": 431,
-		"langSlug": "hr",
-		"name": "Hrvatski",
-		"wpLocale": "hr",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 17,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 59705
-	},
-	"hu": {
-		"value": 31,
-		"langSlug": "hu",
-		"name": "Magyar",
-		"wpLocale": "hu_HU",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 33,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": 60084
-	},
-	"hy": {
-		"value": 467,
-		"langSlug": "hy",
-		"name": "\u0540\u0561\u0575\u0565\u0580\u0565\u0576",
-		"wpLocale": "hy",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 6,
-		"isTranslatedIncompletely": true,
-		"territories": [ "145" ],
-		"revision": 59833
-	},
-	"ia": {
-		"value": 32,
-		"langSlug": "ia",
-		"name": "Interlingua",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [],
-		"revision": null
-	},
-	"id": {
-		"value": 33,
-		"langSlug": "id",
-		"name": "Bahasa Indonesia",
-		"wpLocale": "id_ID",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "035" ],
-		"revision": 60507,
-		"popular": 12
-	},
-	"ii": {
-		"value": 432,
-		"langSlug": "ii",
-		"name": "\ua187\ua259",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "030" ],
-		"revision": null
-	},
-	"ilo": {
-		"value": 469,
-		"langSlug": "ilo",
-		"name": "Pagsasao nga Iloko",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "035" ],
-		"revision": null
-	},
-	"is": {
-		"value": 34,
-		"langSlug": "is",
-		"name": "\u00cdslenska",
-		"wpLocale": "is_IS",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 18,
-		"isTranslatedIncompletely": true,
-		"territories": [ "154" ],
-		"revision": 59563
-	},
-	"it": {
-		"value": 35,
-		"langSlug": "it",
-		"name": "Italiano",
-		"wpLocale": "it_IT",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "039" ],
-		"revision": 60479,
-		"popular": 8
-	},
-	"ja": {
-		"value": 36,
-		"langSlug": "ja",
-		"name": "\u65e5\u672c\u8a9e",
-		"wpLocale": "ja",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 98,
-		"isTranslatedIncompletely": false,
-		"territories": [ "030" ],
-		"revision": 60511,
-		"popular": 7
-	},
-	"ka": {
-		"value": 37,
-		"langSlug": "ka",
-		"name": "\u10e5\u10d0\u10e0\u10d7\u10e3\u10da\u10d8",
-		"wpLocale": "ka_GE",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 8,
-		"isTranslatedIncompletely": true,
-		"territories": [ "145" ],
-		"revision": 59835
-	},
-	"kab": {
-		"value": 488,
-		"langSlug": "kab",
-		"name": "Taqbaylit",
-		"wpLocale": "kab",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 29,
-		"isTranslatedIncompletely": true,
-		"territories": [ "002" ],
-		"revision": null
-	},
-	"kir": {
-		"value": 479,
-		"langSlug": "kir",
-		"name": "\u041a\u044b\u0440\u0433\u044b\u0437\u0447\u0430",
-		"wpLocale": "kir",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 4,
-		"isTranslatedIncompletely": true,
-		"territories": [ "143" ],
-		"revision": 59836
-	},
-	"kk": {
-		"value": 462,
-		"langSlug": "kk",
-		"name": "\u049a\u0430\u0437\u0430\u049b \u0442\u0456\u043b\u0456",
-		"wpLocale": "kk",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 5,
-		"isTranslatedIncompletely": true,
-		"territories": [ "143" ],
-		"revision": 59837
-	},
-	"km": {
-		"value": 38,
-		"langSlug": "km",
-		"name": "\u1797\u17b6\u179f\u17b6\u1781\u17d2\u1798\u17c2\u179a",
-		"wpLocale": "km",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 8,
-		"isTranslatedIncompletely": true,
-		"territories": [ "035" ],
-		"revision": 59567
-	},
-	"kn": {
-		"value": 39,
-		"langSlug": "kn",
-		"name": "\u0c95\u0ca8\u0ccd\u0ca8\u0ca1",
-		"wpLocale": "kn",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 3,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59613
-	},
-	"ko": {
-		"value": 40,
-		"langSlug": "ko",
-		"name": "\ud55c\uad6d\uc5b4",
-		"wpLocale": "ko_KR",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "030" ],
-		"revision": 60502,
-		"popular": 15
-	},
-	"ks": {
-		"value": 433,
-		"langSlug": "ks",
-		"name": "\u0915\u0936\u094d\u092e\u0940\u0930\u0940",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": null
-	},
-	"kv": {
-		"value": 434,
-		"langSlug": "kv",
-		"name": "\u041a\u043e\u043c\u0438",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": null
-	},
-	"la": {
-		"value": 42,
-		"langSlug": "la",
-		"name": "Latine",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": null
-	},
-	"li": {
-		"value": 43,
-		"langSlug": "li",
-		"name": "Limburgs",
-		"wpLocale": "li",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "155" ],
-		"revision": null
-	},
-	"lo": {
-		"value": 44,
-		"langSlug": "lo",
-		"name": "\u0e9e\u0eb2\u0eaa\u0eb2\u0ea5\u0eb2\u0ea7",
-		"wpLocale": "lo",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 4,
-		"isTranslatedIncompletely": true,
-		"territories": [ "035" ],
-		"revision": 59841
-	},
-	"lt": {
-		"value": 45,
-		"langSlug": "lt",
-		"name": "Lietuvi\u0173 kalba",
-		"wpLocale": "lt_LT",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 25,
-		"isTranslatedIncompletely": true,
-		"territories": [ "154" ],
-		"revision": 60090
-	},
-	"lv": {
-		"value": 453,
-		"langSlug": "lv",
-		"name": "Latvie\u0161u valoda",
-		"wpLocale": "lv",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 18,
-		"isTranslatedIncompletely": true,
-		"territories": [ "154" ],
-		"revision": 60408
-	},
-	"mk": {
-		"value": 435,
-		"langSlug": "mk",
-		"name": "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0441\u043a\u0438 \u0458\u0430\u0437\u0438\u043a",
-		"wpLocale": "mk_MK",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 7,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 59710
-	},
-	"ml": {
-		"value": 46,
-		"langSlug": "ml",
-		"name": "\u0d2e\u0d32\u0d2f\u0d3e\u0d33\u0d02",
-		"wpLocale": "ml_IN",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 5,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59845
-	},
-	"mn": {
-		"value": 472,
-		"langSlug": "mn",
-		"name": "\u041c\u043e\u043d\u0433\u043e\u043b",
-		"wpLocale": "mn",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 21,
-		"isTranslatedIncompletely": true,
-		"territories": [ "030" ],
-		"revision": 60334
-	},
-	"mr": {
-		"value": 461,
-		"langSlug": "mr",
-		"name": "\u092e\u0930\u093e\u0920\u0940",
-		"wpLocale": "mr",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 6,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59847
-	},
-	"ms": {
-		"value": 47,
-		"langSlug": "ms",
-		"name": "Bahasa Melayu",
-		"wpLocale": "ms_MY",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 7,
-		"isTranslatedIncompletely": true,
-		"territories": [ "035" ],
-		"revision": 59574
-	},
-	"mt": {
-		"value": 465,
-		"langSlug": "mt",
-		"name": "Malti",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": null
-	},
-	"mwl": {
-		"value": 464,
-		"langSlug": "mwl",
-		"name": "Mirand\u00e9s",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 2,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 58731
-	},
-	"nah": {
-		"value": 436,
-		"langSlug": "nah",
-		"name": "Nahuatl",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "019" ],
-		"revision": null
-	},
-	"nap": {
-		"value": 437,
-		"langSlug": "nap",
-		"name": "Nnapulitano",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": null
-	},
-	"nds": {
-		"value": 48,
-		"langSlug": "nds",
-		"name": "Plattd\u00fc\u00fctsch",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "155" ],
-		"revision": null
-	},
-	"ne": {
-		"value": 456,
-		"langSlug": "ne",
-		"name": "\u0928\u0947\u092a\u093e\u0932\u0940",
-		"wpLocale": "ne_NP",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 5,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59848
-	},
-	"nl": {
-		"value": 49,
-		"langSlug": "nl",
-		"name": "Nederlands",
-		"wpLocale": "nl_NL",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "155" ],
-		"revision": 60509,
-		"popular": 9
-	},
-	"nn": {
-		"value": 50,
-		"langSlug": "nn",
-		"name": "Norsk nynorsk",
-		"wpLocale": "nn_NO",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 16,
-		"isTranslatedIncompletely": true,
-		"territories": [ "154" ],
-		"revision": 59715
-	},
-	"no": {
-		"value": 51,
-		"langSlug": "no",
-		"name": "Norsk",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 65,
-		"isTranslatedIncompletely": true,
-		"territories": [ "154" ],
-		"revision": 60437
-	},
-	"non": {
-		"value": 52,
-		"langSlug": "non",
-		"name": "Norr\u01ffna",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "154" ],
-		"revision": null
-	},
-	"nv": {
-		"value": 53,
-		"langSlug": "nv",
-		"name": "Din\u00e9 bizaad",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "019" ],
-		"revision": null
-	},
-	"oci": {
-		"value": 54,
-		"langSlug": "oci",
-		"name": "Occitan",
-		"wpLocale": "oci",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 6,
-		"isTranslatedIncompletely": true,
-		"territories": [ "155" ],
-		"revision": 59849
-	},
-	"or": {
-		"value": 55,
-		"langSlug": "or",
-		"name": "\u0b13\u0b21\u0b3c\u0b3f\u0b06",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": null
-	},
-	"os": {
-		"value": 56,
-		"langSlug": "os",
-		"name": "\u0418\u0440\u043e\u043d",
-		"wpLocale": "os",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "145" ],
-		"revision": null
-	},
-	"pa": {
-		"value": 57,
-		"langSlug": "pa",
-		"name": "\u0a2a\u0a70\u0a1c\u0a3e\u0a2c\u0a40",
-		"wpLocale": "pa_IN",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 24,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 60410
-	},
-	"pl": {
-		"value": 58,
-		"langSlug": "pl",
-		"name": "Polski",
-		"wpLocale": "pl_PL",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 33,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": 60518
-	},
-	"ps": {
-		"value": 59,
-		"langSlug": "ps",
-		"name": "\u067e\u069a\u062a\u0648",
-		"wpLocale": "ps",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 4,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59852,
-		"rtl": true
-	},
-	"pt": {
-		"value": 60,
-		"langSlug": "pt",
-		"name": "Portugu\u00eas",
-		"wpLocale": "pt_PT",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 25,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 60452
-	},
-	"pt-br": {
-		"value": 438,
-		"langSlug": "pt-br",
-		"name": "Portugu\u00eas do Brasil",
-		"wpLocale": "pt_BR",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 98,
-		"isTranslatedIncompletely": false,
-		"territories": [ "019" ],
-		"revision": 60442,
-		"popular": 3
-	},
-	"qu": {
-		"value": 439,
-		"langSlug": "qu",
-		"name": "Runa Simi",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "019" ],
-		"revision": null
-	},
-	"ro": {
-		"value": 61,
-		"langSlug": "ro",
-		"name": "Rom\u00e2n\u0103",
-		"wpLocale": "ro_RO",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "151" ],
-		"revision": 60506
-	},
-	"ru": {
-		"value": 62,
-		"langSlug": "ru",
-		"name": "\u0420\u0443\u0441\u0441\u043a\u0438\u0439",
-		"wpLocale": "ru_RU",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "151" ],
-		"revision": 60529,
-		"popular": 10
-	},
-	"rup": {
-		"value": 483,
-		"langSlug": "rup",
-		"name": "Arm\u00e3neashce",
-		"wpLocale": "rup_MK",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 1,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": 59855
-	},
-	"sc": {
-		"value": 63,
-		"langSlug": "sc",
-		"name": "Sardu",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": null
-	},
-	"si": {
-		"value": 471,
-		"langSlug": "si",
-		"name": "\u0dc3\u0dd2\u0d82\u0dc4\u0dbd",
-		"wpLocale": "si_LK",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 6,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59579
-	},
-	"sk": {
-		"value": 64,
-		"langSlug": "sk",
-		"name": "Sloven\u010dina",
-		"wpLocale": "sk_SK",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 12,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": 59718
-	},
-	"skr": {
-		"value": 486,
-		"langSlug": "skr",
-		"name": "Saraiki",
-		"wpLocale": "skr",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 87,
-		"isTranslatedIncompletely": false,
-		"territories": [ "034" ],
-		"revision": 58230
-	},
-	"sl": {
-		"value": 65,
-		"langSlug": "sl",
-		"name": "Sloven\u0161\u010dina",
-		"wpLocale": "sl_SI",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 10,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 59582
-	},
-	"snd": {
-		"value": 440,
-		"langSlug": "snd",
-		"name": "\u0633\u0646\u068c\u064a",
-		"wpLocale": "snd",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 7,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59857
-	},
-	"so": {
-		"value": 459,
-		"langSlug": "so",
-		"name": "Afsoomaali",
-		"wpLocale": "so_SO",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 3,
-		"isTranslatedIncompletely": true,
-		"territories": [ "002" ],
-		"revision": 59722
-	},
-	"sq": {
-		"value": 66,
-		"langSlug": "sq",
-		"name": "Shqip",
-		"wpLocale": "sq",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 58,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 60412
-	},
-	"sr": {
-		"value": 67,
-		"langSlug": "sr",
-		"name": "\u0421\u0440\u043f\u0441\u043a\u0438 \u0458\u0435\u0437\u0438\u043a",
-		"wpLocale": "sr_RS",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 12,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 59725
-	},
-	"sr_latin": {
-		"value": 901,
-		"langSlug": "sr_latin",
-		"name": "Srpski (latinica)",
-		"wpLocale": "sr",
-		"parentLangSlug": "sr",
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": 59742
-	},
-	"su": {
-		"value": 441,
-		"langSlug": "su",
-		"name": "Basa Sunda",
-		"wpLocale": "su_ID",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 4,
-		"isTranslatedIncompletely": true,
-		"territories": [ "035" ],
-		"revision": 59625
-	},
-	"sv": {
-		"value": 68,
-		"langSlug": "sv",
-		"name": "Svenska",
-		"wpLocale": "sv_SE",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "154" ],
-		"revision": 60501,
-		"popular": 17
-	},
-	"ta": {
-		"value": 69,
-		"langSlug": "ta",
-		"name": "\u0ba4\u0bae\u0bbf\u0bb4\u0bcd",
-		"wpLocale": "ta_IN",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 6,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034", "035" ],
-		"revision": 59726
-	},
-	"te": {
-		"value": 70,
-		"langSlug": "te",
-		"name": "\u0c24\u0c46\u0c32\u0c41\u0c17\u0c41",
-		"wpLocale": "te",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 20,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59793
-	},
-	"th": {
-		"value": 71,
-		"langSlug": "th",
-		"name": "\u0e44\u0e17\u0e22",
-		"wpLocale": "th",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 10,
-		"isTranslatedIncompletely": true,
-		"territories": [ "035" ],
-		"revision": 59587
-	},
-	"tir": {
-		"value": 480,
-		"langSlug": "tir",
-		"name": "\u1275\u130d\u122d\u129b",
-		"wpLocale": "tir",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "002" ],
-		"revision": 43820
-	},
-	"tl": {
-		"value": 455,
-		"langSlug": "tl",
-		"name": "Tagalog",
-		"wpLocale": "tl",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 7,
-		"isTranslatedIncompletely": true,
-		"territories": [ "035" ],
-		"revision": 59589
-	},
-	"tr": {
-		"value": 78,
-		"langSlug": "tr",
-		"name": "T\u00fcrk\u00e7e",
-		"wpLocale": "tr_TR",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "145" ],
-		"revision": 60514,
-		"popular": 11
-	},
-	"tt": {
-		"value": 72,
-		"langSlug": "tt",
-		"name": "\u0422\u0430\u0442\u0430\u0440 \u0442\u0435\u043b\u0435",
-		"wpLocale": "tt_RU",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": null
-	},
-	"ty": {
-		"value": 442,
-		"langSlug": "ty",
-		"name": "Reo M\u0101`ohi",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "009" ],
-		"revision": null
-	},
-	"udm": {
-		"value": 443,
-		"langSlug": "udm",
-		"name": "\u0423\u0434\u043c\u0443\u0440\u0442 \u043a\u044b\u043b",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": null
-	},
-	"ug": {
-		"value": 444,
-		"langSlug": "ug",
-		"name": "Uy\u01a3urq\u0259",
-		"wpLocale": "ug_CN",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 7,
-		"isTranslatedIncompletely": true,
-		"territories": [ "030" ],
-		"revision": 59727
-	},
-	"uk": {
-		"value": 73,
-		"langSlug": "uk",
-		"name": "\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430",
-		"wpLocale": "uk",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 19,
-		"isTranslatedIncompletely": true,
-		"territories": [ "151" ],
-		"revision": 59729
-	},
-	"ur": {
-		"value": 74,
-		"langSlug": "ur",
-		"name": "\u0627\u0631\u062f\u0648",
-		"wpLocale": "ur",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 14,
-		"isTranslatedIncompletely": true,
-		"territories": [ "034" ],
-		"revision": 59730,
-		"rtl": true
-	},
-	"uz": {
-		"value": 458,
-		"langSlug": "uz",
-		"name": "O\u2018zbekcha",
-		"wpLocale": "uz_UZ",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 6,
-		"isTranslatedIncompletely": true,
-		"territories": [ "143" ],
-		"revision": 59861
-	},
-	"vec": {
-		"value": 445,
-		"langSlug": "vec",
-		"name": "V\u00e8neta",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "039" ],
-		"revision": null
-	},
-	"vi": {
-		"value": 446,
-		"langSlug": "vi",
-		"name": "Ti\u1ebfng Vi\u1ec7t",
-		"wpLocale": "vi",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 11,
-		"isTranslatedIncompletely": true,
-		"territories": [ "035" ],
-		"revision": 59733
-	},
-	"wa": {
-		"value": 75,
-		"langSlug": "wa",
-		"name": "Walon",
-		"wpLocale": "wa",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "155" ],
-		"revision": null
-	},
-	"xal": {
-		"value": 447,
-		"langSlug": "xal",
-		"name": "\u0425\u0430\u043b\u044c\u043c\u0433",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "143" ],
-		"revision": null
-	},
-	"yi": {
-		"value": 76,
-		"langSlug": "yi",
-		"name": "\u05d9\u05d9\u05b4\u05d3\u05d9\u05e9",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [],
-		"revision": 43826
-	},
-	"yo": {
-		"value": 477,
-		"langSlug": "yo",
-		"name": "\u00e8d\u00e8 Yor\u00f9b\u00e1",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "002" ],
-		"revision": null
-	},
-	"za": {
-		"value": 448,
-		"langSlug": "za",
-		"name": "(Cuengh)",
-		"wpLocale": "",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 0,
-		"isTranslatedIncompletely": true,
-		"territories": [ "030" ],
-		"revision": null
-	},
-	"zh-cn": {
-		"value": 449,
-		"langSlug": "zh-cn",
-		"name": "\u7b80\u4f53\u4e2d\u6587",
-		"wpLocale": "zh_CN",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 99,
-		"isTranslatedIncompletely": false,
-		"territories": [ "030" ],
-		"revision": 60441,
-		"popular": 13
-	},
-	"zh-hk": {
-		"value": 487,
-		"langSlug": "zh-hk",
-		"name": "\u9999\u6e2f\u4e2d\u6587\u7248",
-		"wpLocale": "zh_HK",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 93,
-		"isTranslatedIncompletely": false,
-		"territories": [ "030" ],
-		"revision": 60415
-	},
-	"zh-tw": {
-		"value": 452,
-		"langSlug": "zh-tw",
-		"name": "\u7e41\u9ad4\u4e2d\u6587",
-		"wpLocale": "zh_TW",
-		"parentLangSlug": null,
-		"calypsoPercentTranslated": 98,
-		"isTranslatedIncompletely": false,
-		"territories": [ "030" ],
-		"revision": 60436,
-		"popular": 14
-	}
+    "af": {
+        "value": 2,
+        "langSlug": "af",
+        "name": "Afrikaans",
+        "wpLocale": "af",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 5,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "002"
+        ]
+    },
+    "als": {
+        "value": 418,
+        "langSlug": "als",
+        "name": "Alemannisch",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "155"
+        ]
+    },
+    "am": {
+        "value": 481,
+        "langSlug": "am",
+        "name": "\u12a0\u121b\u122d\u129b",
+        "wpLocale": "am",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 1,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "002"
+        ]
+    },
+    "an": {
+        "value": 485,
+        "langSlug": "an",
+        "name": "Aragon\u00e9s",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 2,
+        "isTranslatedIncompletely": true,
+        "territories": []
+    },
+    "ar": {
+        "value": 3,
+        "langSlug": "ar",
+        "name": "\u0627\u0644\u0639\u0631\u0628\u064a\u0629",
+        "wpLocale": "ar",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 99,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "145",
+            "002"
+        ],
+        "rtl": true,
+        "popular": 16
+    },
+    "arc": {
+        "value": 419,
+        "langSlug": "arc",
+        "name": "\u0715\u0725\u0712\u072a\u0738\u071d\u071b",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "145"
+        ]
+    },
+    "as": {
+        "value": 4,
+        "langSlug": "as",
+        "name": "\u0985\u09b8\u09ae\u09c0\u09af\u09bc\u09be",
+        "wpLocale": "as",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 4,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "ast": {
+        "value": 420,
+        "langSlug": "ast",
+        "name": "Asturianu",
+        "wpLocale": "ast",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 4,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "av": {
+        "value": 421,
+        "langSlug": "av",
+        "name": "\u0430\u0432\u0430\u0440 \u043c\u0430\u0446\u04c0",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "ay": {
+        "value": 422,
+        "langSlug": "ay",
+        "name": "aymar aru",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "019"
+        ]
+    },
+    "az": {
+        "value": 79,
+        "langSlug": "az",
+        "name": "Az\u0259rbaycan dili",
+        "wpLocale": "az",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 21,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "145"
+        ]
+    },
+    "ba": {
+        "value": 423,
+        "langSlug": "ba",
+        "name": "\u0431\u0430\u0448\u04a1\u043e\u0440\u0442 \u0442\u0435\u043b\u0435",
+        "wpLocale": "ba",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "bel": {
+        "value": 5,
+        "langSlug": "bel",
+        "name": "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u043a\u0430\u044f \u043c\u043e\u0432\u0430",
+        "wpLocale": "bel",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 4,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "bg": {
+        "value": 6,
+        "langSlug": "bg",
+        "name": "\u0411\u044a\u043b\u0433\u0430\u0440\u0441\u043a\u0438",
+        "wpLocale": "bg_BG",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 18,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "bm": {
+        "value": 7,
+        "langSlug": "bm",
+        "name": "Bamanankan",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "002"
+        ]
+    },
+    "bn": {
+        "value": 8,
+        "langSlug": "bn",
+        "name": "\u09ac\u09be\u0982\u09b2\u09be",
+        "wpLocale": "bn_BD",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 5,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "bo": {
+        "value": 9,
+        "langSlug": "bo",
+        "name": "\u0f56\u0f7c\u0f51\u0f0b\u0f66\u0f90\u0f51",
+        "wpLocale": "bo",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 4,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "030"
+        ]
+    },
+    "br": {
+        "value": 424,
+        "langSlug": "br",
+        "name": "Brezhoneg",
+        "wpLocale": "bre",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 5,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "155"
+        ]
+    },
+    "bs": {
+        "value": 454,
+        "langSlug": "bs",
+        "name": "Bosanski",
+        "wpLocale": "bs_BA",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 9,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "ca": {
+        "value": 10,
+        "langSlug": "ca",
+        "name": "Catal\u00e0",
+        "wpLocale": "ca",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 12,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "ce": {
+        "value": 425,
+        "langSlug": "ce",
+        "name": "\u041d\u043e\u0445\u0447\u0438\u0439\u043d \u043c\u043e\u0442\u0442",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "ckb": {
+        "value": 41,
+        "langSlug": "ckb",
+        "name": "\u0643\u0648\u0631\u062f\u06cc\u200e",
+        "wpLocale": "ckb",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 6,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "145",
+            "034"
+        ],
+        "rtl": true
+    },
+    "cs": {
+        "value": 11,
+        "langSlug": "cs",
+        "name": "\u010ce\u0161tina",
+        "wpLocale": "cs_CZ",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 36,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "csb": {
+        "value": 12,
+        "langSlug": "csb",
+        "name": "Kasz\u00ebbsczi",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "cv": {
+        "value": 426,
+        "langSlug": "cv",
+        "name": "\u0447\u04d1\u0432\u0430\u0448 \u0447\u04d7\u043b\u0445\u0438",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 28,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "cy": {
+        "value": 13,
+        "langSlug": "cy",
+        "name": "Cymraeg",
+        "wpLocale": "cy",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 12,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "154"
+        ]
+    },
+    "da": {
+        "value": 14,
+        "langSlug": "da",
+        "name": "Dansk",
+        "wpLocale": "da_DK",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 9,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "154"
+        ]
+    },
+    "de": {
+        "value": 15,
+        "langSlug": "de",
+        "name": "Deutsch",
+        "wpLocale": "de_DE",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 99,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "155"
+        ],
+        "popular": 4
+    },
+    "de-ch": {
+        "value": 903,
+        "langSlug": "de-ch",
+        "name": "Deutsch (Schweiz)",
+        "wpLocale": "de_CH",
+        "parentLangSlug": "de",
+        "calypsoPercentTranslated": 99,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "155"
+        ]
+    },
+    "de_formal": {
+        "value": 900,
+        "langSlug": "de_formal",
+        "name": "Deutsch (Sie)",
+        "wpLocale": "de",
+        "parentLangSlug": "de",
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "155"
+        ]
+    },
+    "dv": {
+        "value": 427,
+        "langSlug": "dv",
+        "name": "\u078b\u07a8\u0788\u07ac\u0780\u07a8",
+        "wpLocale": "dv",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 1,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ],
+        "rtl": true
+    },
+    "dz": {
+        "value": 16,
+        "langSlug": "dz",
+        "name": "\u0f47\u0f7c\u0f44\u0f0b\u0f41",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "el": {
+        "value": 17,
+        "langSlug": "el",
+        "name": "\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac",
+        "wpLocale": "el",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 23,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "el-po": {
+        "value": 468,
+        "langSlug": "el-po",
+        "name": "Greek (Polytonic)",
+        "wpLocale": "el",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 56,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "en": {
+        "value": 1,
+        "langSlug": "en",
+        "name": "English",
+        "wpLocale": "en_US",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 100,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "019"
+        ],
+        "popular": 1
+    },
+    "en-gb": {
+        "value": 482,
+        "langSlug": "en-gb",
+        "name": "English (UK)",
+        "wpLocale": "en_GB",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 15,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "154"
+        ]
+    },
+    "eo": {
+        "value": 18,
+        "langSlug": "eo",
+        "name": "Esperanto",
+        "wpLocale": "eo",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 11,
+        "isTranslatedIncompletely": true,
+        "territories": []
+    },
+    "es": {
+        "value": 19,
+        "langSlug": "es",
+        "name": "Espa\u00f1ol",
+        "wpLocale": "es_ES",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 99,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "019",
+            "039"
+        ],
+        "popular": 2
+    },
+    "es-cl": {
+        "value": 484,
+        "langSlug": "es-cl",
+        "name": "Espa\u00f1ol de Chile",
+        "wpLocale": "es_CL",
+        "parentLangSlug": "es",
+        "calypsoPercentTranslated": 99,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "019"
+        ]
+    },
+    "es-mx": {
+        "value": 902,
+        "langSlug": "es-mx",
+        "name": "Espa\u00f1ol de M\u00e9xico",
+        "wpLocale": "es_MX",
+        "parentLangSlug": "es",
+        "calypsoPercentTranslated": 99,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "019"
+        ]
+    },
+    "et": {
+        "value": 20,
+        "langSlug": "et",
+        "name": "Eesti",
+        "wpLocale": "et",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 9,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "154"
+        ]
+    },
+    "eu": {
+        "value": 429,
+        "langSlug": "eu",
+        "name": "Euskara",
+        "wpLocale": "eu",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 6,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "fa": {
+        "value": 21,
+        "langSlug": "fa",
+        "name": "\u0641\u0627\u0631\u0633\u06cc",
+        "wpLocale": "fa_IR",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 38,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ],
+        "rtl": true
+    },
+    "fi": {
+        "value": 22,
+        "langSlug": "fi",
+        "name": "Suomi",
+        "wpLocale": "fi",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 15,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "154"
+        ]
+    },
+    "fo": {
+        "value": 23,
+        "langSlug": "fo",
+        "name": "F\u00f8royskt",
+        "wpLocale": "fo",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 3,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "154"
+        ]
+    },
+    "fr": {
+        "value": 24,
+        "langSlug": "fr",
+        "name": "Fran\u00e7ais",
+        "wpLocale": "fr_FR",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 98,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "155"
+        ],
+        "popular": 5
+    },
+    "fr-be": {
+        "value": 478,
+        "langSlug": "fr-be",
+        "name": "Fran\u00e7ais de Belgique",
+        "wpLocale": "fr_BE",
+        "parentLangSlug": "fr",
+        "calypsoPercentTranslated": 98,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "155"
+        ]
+    },
+    "fr-ca": {
+        "value": 475,
+        "langSlug": "fr-ca",
+        "name": "Fran\u00e7ais du Canada",
+        "wpLocale": "fr_CA",
+        "parentLangSlug": "fr",
+        "calypsoPercentTranslated": 98,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "019"
+        ]
+    },
+    "fr-ch": {
+        "value": 474,
+        "langSlug": "fr-ch",
+        "name": "Fran\u00e7ais de Suisse",
+        "wpLocale": "",
+        "parentLangSlug": "fr",
+        "calypsoPercentTranslated": 98,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "155"
+        ]
+    },
+    "fur": {
+        "value": 25,
+        "langSlug": "fur",
+        "name": "Friulian",
+        "wpLocale": "fur",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "fy": {
+        "value": 26,
+        "langSlug": "fy",
+        "name": "Frysk",
+        "wpLocale": "fy",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "155"
+        ]
+    },
+    "ga": {
+        "value": 27,
+        "langSlug": "ga",
+        "name": "Gaelige",
+        "wpLocale": "ga",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 12,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "154"
+        ]
+    },
+    "gd": {
+        "value": 476,
+        "langSlug": "gd",
+        "name": "G\u00e0idhlig",
+        "wpLocale": "gd",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 12,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "154"
+        ]
+    },
+    "gl": {
+        "value": 457,
+        "langSlug": "gl",
+        "name": "Galego",
+        "wpLocale": "gl_ES",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 13,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "gn": {
+        "value": 430,
+        "langSlug": "gn",
+        "name": "Ava\u00f1e'\u1ebd",
+        "wpLocale": "gn",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "019"
+        ]
+    },
+    "gu": {
+        "value": 28,
+        "langSlug": "gu",
+        "name": "\u0a97\u0ac1\u0a9c\u0ab0\u0abe\u0aa4\u0ac0",
+        "wpLocale": "gu",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 5,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "he": {
+        "value": 29,
+        "langSlug": "he",
+        "name": "\u05e2\u05b4\u05d1\u05b0\u05e8\u05b4\u05d9\u05ea",
+        "wpLocale": "he_IL",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 97,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "145"
+        ],
+        "rtl": true,
+        "popular": 6
+    },
+    "hi": {
+        "value": 30,
+        "langSlug": "hi",
+        "name": "\u0939\u093f\u0928\u094d\u0926\u0940",
+        "wpLocale": "hi_IN",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 9,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "hr": {
+        "value": 431,
+        "langSlug": "hr",
+        "name": "Hrvatski",
+        "wpLocale": "hr",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 15,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "hu": {
+        "value": 31,
+        "langSlug": "hu",
+        "name": "Magyar",
+        "wpLocale": "hu_HU",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 26,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "hy": {
+        "value": 467,
+        "langSlug": "hy",
+        "name": "\u0540\u0561\u0575\u0565\u0580\u0565\u0576",
+        "wpLocale": "hy",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 5,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "145"
+        ]
+    },
+    "ia": {
+        "value": 32,
+        "langSlug": "ia",
+        "name": "Interlingua",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": []
+    },
+    "id": {
+        "value": 33,
+        "langSlug": "id",
+        "name": "Bahasa Indonesia",
+        "wpLocale": "id_ID",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 99,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "035"
+        ],
+        "popular": 12
+    },
+    "ii": {
+        "value": 432,
+        "langSlug": "ii",
+        "name": "\ua187\ua259",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "030"
+        ]
+    },
+    "ilo": {
+        "value": 469,
+        "langSlug": "ilo",
+        "name": "Pagsasao nga Iloko",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "035"
+        ]
+    },
+    "is": {
+        "value": 34,
+        "langSlug": "is",
+        "name": "\u00cdslenska",
+        "wpLocale": "is_IS",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 14,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "154"
+        ]
+    },
+    "it": {
+        "value": 35,
+        "langSlug": "it",
+        "name": "Italiano",
+        "wpLocale": "it_IT",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 99,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "039"
+        ],
+        "popular": 8
+    },
+    "ja": {
+        "value": 36,
+        "langSlug": "ja",
+        "name": "\u65e5\u672c\u8a9e",
+        "wpLocale": "ja",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 98,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "030"
+        ],
+        "popular": 7
+    },
+    "ka": {
+        "value": 37,
+        "langSlug": "ka",
+        "name": "\u10e5\u10d0\u10e0\u10d7\u10e3\u10da\u10d8",
+        "wpLocale": "ka_GE",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 6,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "145"
+        ]
+    },
+    "kab": {
+        "value": 488,
+        "langSlug": "kab",
+        "name": "Taqbaylit",
+        "wpLocale": "kab",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 24,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "002"
+        ]
+    },
+    "kir": {
+        "value": 479,
+        "langSlug": "kir",
+        "name": "\u041a\u044b\u0440\u0433\u044b\u0437\u0447\u0430",
+        "wpLocale": "kir",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 3,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "143"
+        ]
+    },
+    "kk": {
+        "value": 462,
+        "langSlug": "kk",
+        "name": "\u049a\u0430\u0437\u0430\u049b \u0442\u0456\u043b\u0456",
+        "wpLocale": "kk",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 4,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "143"
+        ]
+    },
+    "km": {
+        "value": 38,
+        "langSlug": "km",
+        "name": "\u1797\u17b6\u179f\u17b6\u1781\u17d2\u1798\u17c2\u179a",
+        "wpLocale": "km",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 7,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "035"
+        ]
+    },
+    "kn": {
+        "value": 39,
+        "langSlug": "kn",
+        "name": "\u0c95\u0ca8\u0ccd\u0ca8\u0ca1",
+        "wpLocale": "kn",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 2,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "ko": {
+        "value": 40,
+        "langSlug": "ko",
+        "name": "\ud55c\uad6d\uc5b4",
+        "wpLocale": "ko_KR",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 99,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "030"
+        ],
+        "popular": 15
+    },
+    "ks": {
+        "value": 433,
+        "langSlug": "ks",
+        "name": "\u0915\u0936\u094d\u092e\u0940\u0930\u0940",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "kv": {
+        "value": 434,
+        "langSlug": "kv",
+        "name": "\u041a\u043e\u043c\u0438",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "la": {
+        "value": 42,
+        "langSlug": "la",
+        "name": "Latine",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "li": {
+        "value": 43,
+        "langSlug": "li",
+        "name": "Limburgs",
+        "wpLocale": "li",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "155"
+        ]
+    },
+    "lo": {
+        "value": 44,
+        "langSlug": "lo",
+        "name": "\u0e9e\u0eb2\u0eaa\u0eb2\u0ea5\u0eb2\u0ea7",
+        "wpLocale": "lo",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 3,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "035"
+        ]
+    },
+    "lt": {
+        "value": 45,
+        "langSlug": "lt",
+        "name": "Lietuvi\u0173 kalba",
+        "wpLocale": "lt_LT",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 20,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "154"
+        ]
+    },
+    "lv": {
+        "value": 453,
+        "langSlug": "lv",
+        "name": "Latvie\u0161u valoda",
+        "wpLocale": "lv",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 15,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "154"
+        ]
+    },
+    "mk": {
+        "value": 435,
+        "langSlug": "mk",
+        "name": "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0441\u043a\u0438 \u0458\u0430\u0437\u0438\u043a",
+        "wpLocale": "mk_MK",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 6,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "ml": {
+        "value": 46,
+        "langSlug": "ml",
+        "name": "\u0d2e\u0d32\u0d2f\u0d3e\u0d33\u0d02",
+        "wpLocale": "ml_IN",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 4,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "mn": {
+        "value": 472,
+        "langSlug": "mn",
+        "name": "\u041c\u043e\u043d\u0433\u043e\u043b",
+        "wpLocale": "mn",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 23,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "030"
+        ]
+    },
+    "mr": {
+        "value": 461,
+        "langSlug": "mr",
+        "name": "\u092e\u0930\u093e\u0920\u0940",
+        "wpLocale": "mr",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 5,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "ms": {
+        "value": 47,
+        "langSlug": "ms",
+        "name": "Bahasa Melayu",
+        "wpLocale": "ms_MY",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 6,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "035"
+        ]
+    },
+    "mt": {
+        "value": 465,
+        "langSlug": "mt",
+        "name": "Malti",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "mwl": {
+        "value": 464,
+        "langSlug": "mwl",
+        "name": "Mirand\u00e9s",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 2,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "nah": {
+        "value": 436,
+        "langSlug": "nah",
+        "name": "Nahuatl",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "019"
+        ]
+    },
+    "nap": {
+        "value": 437,
+        "langSlug": "nap",
+        "name": "Nnapulitano",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "nds": {
+        "value": 48,
+        "langSlug": "nds",
+        "name": "Plattd\u00fc\u00fctsch",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "155"
+        ]
+    },
+    "ne": {
+        "value": 456,
+        "langSlug": "ne",
+        "name": "\u0928\u0947\u092a\u093e\u0932\u0940",
+        "wpLocale": "ne_NP",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 4,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "nl": {
+        "value": 49,
+        "langSlug": "nl",
+        "name": "Nederlands",
+        "wpLocale": "nl_NL",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 98,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "155"
+        ],
+        "popular": 9
+    },
+    "nl_formal": {
+        "value": 904,
+        "langSlug": "nl_formal",
+        "name": "Nederlands (U)",
+        "wpLocale": "nl",
+        "parentLangSlug": "nl",
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "155"
+        ]
+    },
+    "nn": {
+        "value": 50,
+        "langSlug": "nn",
+        "name": "Norsk nynorsk",
+        "wpLocale": "nn_NO",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 13,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "154"
+        ]
+    },
+    "no": {
+        "value": 51,
+        "langSlug": "no",
+        "name": "Norsk",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 53,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "154"
+        ]
+    },
+    "non": {
+        "value": 52,
+        "langSlug": "non",
+        "name": "Norr\u01ffna",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "154"
+        ]
+    },
+    "nv": {
+        "value": 53,
+        "langSlug": "nv",
+        "name": "Din\u00e9 bizaad",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "019"
+        ]
+    },
+    "oci": {
+        "value": 54,
+        "langSlug": "oci",
+        "name": "Occitan",
+        "wpLocale": "oci",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 5,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "155"
+        ]
+    },
+    "or": {
+        "value": 55,
+        "langSlug": "or",
+        "name": "\u0b13\u0b21\u0b3c\u0b3f\u0b06",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "os": {
+        "value": 56,
+        "langSlug": "os",
+        "name": "\u0418\u0440\u043e\u043d",
+        "wpLocale": "os",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "145"
+        ]
+    },
+    "pa": {
+        "value": 57,
+        "langSlug": "pa",
+        "name": "\u0a2a\u0a70\u0a1c\u0a3e\u0a2c\u0a40",
+        "wpLocale": "pa_IN",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 22,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "pl": {
+        "value": 58,
+        "langSlug": "pl",
+        "name": "Polski",
+        "wpLocale": "pl_PL",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 26,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "ps": {
+        "value": 59,
+        "langSlug": "ps",
+        "name": "\u067e\u069a\u062a\u0648",
+        "wpLocale": "ps",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 3,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ],
+        "rtl": true
+    },
+    "pt": {
+        "value": 60,
+        "langSlug": "pt",
+        "name": "Portugu\u00eas",
+        "wpLocale": "pt_PT",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 19,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "pt-br": {
+        "value": 438,
+        "langSlug": "pt-br",
+        "name": "Portugu\u00eas do Brasil",
+        "wpLocale": "pt_BR",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 99,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "019"
+        ],
+        "popular": 3
+    },
+    "qu": {
+        "value": 439,
+        "langSlug": "qu",
+        "name": "Runa Simi",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "019"
+        ]
+    },
+    "ro": {
+        "value": 61,
+        "langSlug": "ro",
+        "name": "Rom\u00e2n\u0103",
+        "wpLocale": "ro_RO",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 100,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "151"
+        ]
+    },
+    "ru": {
+        "value": 62,
+        "langSlug": "ru",
+        "name": "\u0420\u0443\u0441\u0441\u043a\u0438\u0439",
+        "wpLocale": "ru_RU",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 99,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "151"
+        ],
+        "popular": 10
+    },
+    "rup": {
+        "value": 483,
+        "langSlug": "rup",
+        "name": "Arm\u00e3neashce",
+        "wpLocale": "rup_MK",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 1,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "sc": {
+        "value": 63,
+        "langSlug": "sc",
+        "name": "Sardu",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "si": {
+        "value": 471,
+        "langSlug": "si",
+        "name": "\u0dc3\u0dd2\u0d82\u0dc4\u0dbd",
+        "wpLocale": "si_LK",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 5,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "sk": {
+        "value": 64,
+        "langSlug": "sk",
+        "name": "Sloven\u010dina",
+        "wpLocale": "sk_SK",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 10,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "skr": {
+        "value": 486,
+        "langSlug": "skr",
+        "name": "Saraiki",
+        "wpLocale": "skr",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 68,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "sl": {
+        "value": 65,
+        "langSlug": "sl",
+        "name": "Sloven\u0161\u010dina",
+        "wpLocale": "sl_SI",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 8,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "snd": {
+        "value": 440,
+        "langSlug": "snd",
+        "name": "\u0633\u0646\u068c\u064a",
+        "wpLocale": "snd",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 5,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "so": {
+        "value": 459,
+        "langSlug": "so",
+        "name": "Afsoomaali",
+        "wpLocale": "so_SO",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 3,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "002"
+        ]
+    },
+    "sq": {
+        "value": 66,
+        "langSlug": "sq",
+        "name": "Shqip",
+        "wpLocale": "sq",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 50,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "sr": {
+        "value": 67,
+        "langSlug": "sr",
+        "name": "\u0421\u0440\u043f\u0441\u043a\u0438 \u0458\u0435\u0437\u0438\u043a",
+        "wpLocale": "sr_RS",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 10,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "sr_latin": {
+        "value": 901,
+        "langSlug": "sr_latin",
+        "name": "Srpski (latinica)",
+        "wpLocale": "sr",
+        "parentLangSlug": "sr",
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "su": {
+        "value": 441,
+        "langSlug": "su",
+        "name": "Basa Sunda",
+        "wpLocale": "su_ID",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 3,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "035"
+        ]
+    },
+    "sv": {
+        "value": 68,
+        "langSlug": "sv",
+        "name": "Svenska",
+        "wpLocale": "sv_SE",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 99,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "154"
+        ],
+        "popular": 17
+    },
+    "ta": {
+        "value": 69,
+        "langSlug": "ta",
+        "name": "\u0ba4\u0bae\u0bbf\u0bb4\u0bcd",
+        "wpLocale": "ta_IN",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 5,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034",
+            "035"
+        ]
+    },
+    "te": {
+        "value": 70,
+        "langSlug": "te",
+        "name": "\u0c24\u0c46\u0c32\u0c41\u0c17\u0c41",
+        "wpLocale": "te",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 16,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ]
+    },
+    "th": {
+        "value": 71,
+        "langSlug": "th",
+        "name": "\u0e44\u0e17\u0e22",
+        "wpLocale": "th",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 9,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "035"
+        ]
+    },
+    "tir": {
+        "value": 480,
+        "langSlug": "tir",
+        "name": "\u1275\u130d\u122d\u129b",
+        "wpLocale": "tir",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "002"
+        ]
+    },
+    "tl": {
+        "value": 455,
+        "langSlug": "tl",
+        "name": "Tagalog",
+        "wpLocale": "tl",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 6,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "035"
+        ]
+    },
+    "tr": {
+        "value": 78,
+        "langSlug": "tr",
+        "name": "T\u00fcrk\u00e7e",
+        "wpLocale": "tr_TR",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 99,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "145"
+        ],
+        "popular": 11
+    },
+    "tt": {
+        "value": 72,
+        "langSlug": "tt",
+        "name": "\u0422\u0430\u0442\u0430\u0440 \u0442\u0435\u043b\u0435",
+        "wpLocale": "tt_RU",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "ty": {
+        "value": 442,
+        "langSlug": "ty",
+        "name": "Reo M\u0101`ohi",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "009"
+        ]
+    },
+    "udm": {
+        "value": 443,
+        "langSlug": "udm",
+        "name": "\u0423\u0434\u043c\u0443\u0440\u0442 \u043a\u044b\u043b",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "ug": {
+        "value": 444,
+        "langSlug": "ug",
+        "name": "Uy\u01a3urq\u0259",
+        "wpLocale": "ug_CN",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 6,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "030"
+        ]
+    },
+    "uk": {
+        "value": 73,
+        "langSlug": "uk",
+        "name": "\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430",
+        "wpLocale": "uk",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 16,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "151"
+        ]
+    },
+    "ur": {
+        "value": 74,
+        "langSlug": "ur",
+        "name": "\u0627\u0631\u062f\u0648",
+        "wpLocale": "ur",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 12,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "034"
+        ],
+        "rtl": true
+    },
+    "uz": {
+        "value": 458,
+        "langSlug": "uz",
+        "name": "O\u2018zbekcha",
+        "wpLocale": "uz_UZ",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 5,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "143"
+        ]
+    },
+    "vec": {
+        "value": 445,
+        "langSlug": "vec",
+        "name": "V\u00e8neta",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "039"
+        ]
+    },
+    "vi": {
+        "value": 446,
+        "langSlug": "vi",
+        "name": "Ti\u1ebfng Vi\u1ec7t",
+        "wpLocale": "vi",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 23,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "035"
+        ]
+    },
+    "wa": {
+        "value": 75,
+        "langSlug": "wa",
+        "name": "Walon",
+        "wpLocale": "wa",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "155"
+        ]
+    },
+    "xal": {
+        "value": 447,
+        "langSlug": "xal",
+        "name": "\u0425\u0430\u043b\u044c\u043c\u0433",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "143"
+        ]
+    },
+    "yi": {
+        "value": 76,
+        "langSlug": "yi",
+        "name": "\u05d9\u05d9\u05b4\u05d3\u05d9\u05e9",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": []
+    },
+    "yo": {
+        "value": 477,
+        "langSlug": "yo",
+        "name": "\u00e8d\u00e8 Yor\u00f9b\u00e1",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "002"
+        ]
+    },
+    "za": {
+        "value": 448,
+        "langSlug": "za",
+        "name": "(Cuengh)",
+        "wpLocale": "",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 0,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "030"
+        ]
+    },
+    "zh-cn": {
+        "value": 449,
+        "langSlug": "zh-cn",
+        "name": "\u7b80\u4f53\u4e2d\u6587",
+        "wpLocale": "zh_CN",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 98,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "030"
+        ],
+        "popular": 13
+    },
+    "zh-hk": {
+        "value": 487,
+        "langSlug": "zh-hk",
+        "name": "\u9999\u6e2f\u4e2d\u6587\u7248",
+        "wpLocale": "zh_HK",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 70,
+        "isTranslatedIncompletely": true,
+        "territories": [
+            "030"
+        ]
+    },
+    "zh-sg": {
+        "value": 489,
+        "langSlug": "zh-sg",
+        "name": "\u4e2d\u6587",
+        "wpLocale": "zh_SG",
+        "parentLangSlug": "zh-cn",
+        "calypsoPercentTranslated": 98,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "035"
+        ]
+    },
+    "zh-tw": {
+        "value": 452,
+        "langSlug": "zh-tw",
+        "name": "\u7e41\u9ad4\u4e2d\u6587",
+        "wpLocale": "zh_TW",
+        "parentLangSlug": null,
+        "calypsoPercentTranslated": 98,
+        "isTranslatedIncompletely": false,
+        "territories": [
+            "030"
+        ],
+        "popular": 14
+    }
 }

--- a/packages/languages/test/index.js
+++ b/packages/languages/test/index.js
@@ -15,7 +15,6 @@ describe( 'languages', () => {
 					name: 'English',
 					parentLangSlug: null,
 					popular: 1,
-					revision: null,
 					territories: [ '019' ],
 					value: 1,
 					wpLocale: 'en_US',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the languages-meta.json in `@automattic/languages` to reflect the locale changes in D76578.
* The updated languages-meta.json has the `revisions` property removed from the entries, since it's no longer used.

#### Testing instructions

* Open Calypso.live build
* Go to Account Settings and open the language switcher
* Confirm `Norsk bokmål` option is available.

Related to 394-gh-Automattic/i18n-issues
