### PR TITLE
Plugins: Use Breadcrumb component from Domains

### DIFF
--- a/client/components/breadcrumb/README.md
+++ b/client/components/breadcrumb/README.md
@@ -15,10 +15,9 @@ const navigationItems = [
 
 const mobileItem = {
 	label: 'Back',
-	href: '/plugins'
+	href: '/plugins',
 	showBackArrow: true,
 };
-
 
 function render() {
 	return <Breadcrumb items={ navigationItems } mobileItem={ mobileItem } />;

--- a/client/components/breadcrumb/README.md
+++ b/client/components/breadcrumb/README.md
@@ -13,12 +13,19 @@ const navigationItems = [
 	{ label: 'Search', href: `/plugins?s=woo` },
 ];
 
+const mobileItem = {
+	label: 'Back',
+	href: '/plugins'
+	showBackArrow: true,
+};
+
+
 function render() {
-	return <Breadcrumb items={ navigationItems } />;
+	return <Breadcrumb items={ navigationItems } mobileItem={ mobileItem } />;
 }
 ```
 
 ## Props
 
 - `items` (`{ label: string; href?: string }[]`) - The Navigations items to be shown
-- `compact` (`boolean`) - Displays only the previous item URL reading "Back" (optional)
+- `mobileItem` (`{ label: string; href?: string, showBackArrow?: boolean }`) - Displays this value on the mobile view

--- a/client/components/breadcrumb/docs/example.jsx
+++ b/client/components/breadcrumb/docs/example.jsx
@@ -6,7 +6,13 @@ const BreadcrumbExample = () => {
 		{ label: 'Search', href: `/plugins?s=woo` },
 		{ label: 'Woocommerce' },
 	];
-	return <Breadcrumb items={ navigationItems } />;
+	const mobileItem = {
+		label: 'Back',
+		href: navigationItems[ navigationItems.length - 2 ].href,
+		showBackArrow: true,
+	};
+
+	return <Breadcrumb items={ navigationItems } mobileItem={ mobileItem } />;
 };
 
 BreadcrumbExample.displayName = 'Breadcrumb';

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -1,77 +1,173 @@
 import { Gridicon } from '@automattic/components';
-import styled from '@emotion/styled';
-import { useTranslate } from 'i18n-calypso';
-import { Key } from 'react';
+import { Icon, chevronLeft } from '@wordpress/icons';
+import classNames from 'classnames';
+import React from 'react';
+import InfoPopover from 'calypso/components/info-popover';
 
-const StyledUl = styled.ul`
-	display: flex;
-	align-items: center;
-	list-style-type: none;
-	margin: 0;
-`;
+import './style.scss';
 
-const StyledLi = styled.li`
-	display: flex;
-	align-items: center;
-	font-size: 13px;
-	font-weight: 500;
-	--color-link: var( --studio-gray-100 );
+/**
+ * The required `items` property is an array of strings or objects that correspond to each item in the
+ * Breadcrumb component. If an item is a string, it'll be rendered as text. If it's an object, it must
+ * follow the structure:
+ *
+ * {
+ *   label (required): string,
+ *   href (optional): string,
+ *   helpBubble (optional): string|JSX element,
+ * }
+ *
+ * `label` is the text that will be rendered for that item. If `href` is present, it will render the
+ * label as a link. If `helpBubble` is present, a help bubble with a popover containing the informed
+ * text or element will be rendered besides that item's label.
+ *
+ * `mobileItem` is a required object and follows the same structure as an item of the `items` array
+ * described earlier. It can also have a "showBackArrow" boolean property which, if true, will render
+ * a back arrow before the item label when in mobile view.
+ *
+ * The `buttons` property is optional and can contain an array of Buttons that will be rendered on the
+ * right end of the breadcrumb. `mobileButtons` is also optional and contains an array of components
+ * that will be shown on the right end of the breadcrumb section in mobile view.
+ */
 
-	:first-of-type {
-		font-size: 16px;
-		font-weight: 600;
-		--color-link: var( --studio-gray-80 );
-	}
-
-	:last-of-type:not( :first-of-type ) {
-		--color-link: var( --studio-gray-50 );
-	}
-`;
-
-const StyledGridicon = styled( Gridicon )`
-	margin: 0 7px;
-	fill: var( --studio-gray-50 );
-`;
+type Item = {
+	label: string;
+	href?: string;
+	helpBubble?: string | JSX.Element;
+	showBackArrow?: boolean;
+};
 
 interface Props {
-	items: { label: string; href?: string }[];
-	compact?: boolean;
+	items: Item[];
+	mobileItem: Item;
+	buttons?: JSX.Element[];
+	mobileButtons?: JSX.Element[];
 }
+/*
+Breadcrumbs.propTypes = {
+	items: PropTypes.array.isRequired,
+	mobileItem: PropTypes.object.isRequired,
+	buttons: PropTypes.array,
+	mobileButtons: PropTypes.array,
+	className: PropTypes.string,
+};
+*/
+const Breadcrumbs: React.FunctionComponent< Props > = ( {
+	items,
+	mobileItem,
+	buttons,
+	mobileButtons,
+} ) => {
+	const renderItemLabel = ( item: Item ) => {
+		if ( item.href ) {
+			return (
+				<a className="breadcrumb__item-label" href={ item.href }>
+					{ item.label }
+				</a>
+			);
+		}
+		return <span className="breadcrumb__item-label">{ item.label || item }</span>;
+	};
 
-const Breadcrumb: React.FunctionComponent< Props > = ( { items, compact = false } ) => {
-	const translate = useTranslate();
+	const renderHelpBubble = ( item: Item ) => {
+		if ( ! item.helpBubble ) {
+			return null;
+		}
+		return (
+			<InfoPopover
+				className="breadcrumb__help-bubble"
+				icon="help-outline"
+				position={ 'right' }
+				screenReaderText={ 'Learn more' }
+			>
+				{ item.helpBubble }
+			</InfoPopover>
+		);
+	};
+
+	const renderSeparator = ( index: number ) => {
+		if ( index === items.length - 1 ) {
+			return null;
+		}
+		/* eslint-disable wpcalypso/jsx-gridicon-size */
+		return <Gridicon className="breadcrumb__separator" icon="chevron-right" size={ 14 } />;
+		/* eslint-enable wpcalypso/jsx-gridicon-size */
+	};
+
+	const renderItem = ( item: Item, index: number ) => {
+		const classes = classNames( 'breadcrumb__item', {
+			'is-last-item': index === items.length - 1,
+			'is-only-item': items.length === 1,
+		} );
+		return (
+			<React.Fragment key={ `breadcrumb${ index }` }>
+				<span className={ classes }>{ renderItemLabel( item ) }</span>
+				{ renderHelpBubble( item ) }
+				{ renderSeparator( index ) }
+			</React.Fragment>
+		);
+	};
+
+	const renderBackArrow = () => {
+		if ( mobileItem.showBackArrow && mobileItem.href ) {
+			/* eslint-disable wpcalypso/jsx-gridicon-size */
+			return (
+				<a className="breadcrumb__item" href={ mobileItem.href }>
+					<Icon className="breadcrumb__back-arrow" icon={ chevronLeft } size={ 20 } />
+				</a>
+			);
+			/* eslint-enable wpcalypso/jsx-gridicon-size */
+		}
+		return null;
+	};
+
+	const renderMobileItem = () => {
+		return (
+			<>
+				{ renderBackArrow() }
+				<span className="breadcrumb__item breadcrumb__item--mobile">
+					{ renderItemLabel( mobileItem ) }
+				</span>
+				{ renderHelpBubble( mobileItem ) }
+			</>
+		);
+	};
+
+	const renderItems = () => {
+		return (
+			<>
+				<div className="breadcrumb__items">
+					{ items.map( ( item, i ) => renderItem( item, i ) ) }
+				</div>
+				<div className="breadcrumb__items-mobile">{ renderMobileItem() }</div>
+			</>
+		);
+	};
+
+	const renderButtons = () => (
+		<>
+			{ buttons && (
+				<div className="breadcrumb__buttons">{ buttons.map( ( button ) => button ) }</div>
+			) }
+			{ mobileButtons && (
+				<div className="breadcrumb__buttons-mobile">
+					{ mobileButtons.map( ( button ) => button ) }
+				</div>
+			) }
+		</>
+	);
 
 	return (
-		<StyledUl>
-			{ compact && items.length > 1 ? (
-				<StyledLi>
-					<StyledGridicon icon="chevron-left" size={ 18 } />
-					{ /*  Show the exactly previous page with items[ items.length - 2 ] */ }
-					<a href={ items[ items.length - 2 ].href }>{ translate( 'Back' ) }</a>
-				</StyledLi>
-			) : (
-				<>
-					{ items.map( ( item: { href?: string; label: string }, index: Key ) => {
-						return (
-							<StyledLi key={ index }>
-								{ compact && <StyledGridicon icon="chevron-left" size={ 18 } /> }
-								{ index !== 0 && <StyledGridicon icon="chevron-right" size={ 18 } /> }
-								{ item.href ? (
-									<a href={ item.href }>{ item.label }</a>
-								) : (
-									<span>{ item.label }</span>
-								) }
-							</StyledLi>
-						);
-					} ) }
-				</>
-			) }
-		</StyledUl>
+		<div className="breadcrumb">
+			<div>
+				<div className="breadcrumb__content">
+					{ renderItems() }
+					{ renderButtons() }
+				</div>
+			</div>
+			<div className="breadcrumb__spacer"></div>
+		</div>
 	);
 };
 
-Breadcrumb.defaultProps = {
-	items: [],
-};
-
-export default Breadcrumb;
+export default Breadcrumbs;

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -31,7 +31,7 @@ import './style.scss';
  */
 
 type Item = {
-	label: string;
+	label: React.ReactChild;
 	href?: string;
 	helpBubble?: string | JSX.Element;
 	showBackArrow?: boolean;
@@ -43,15 +43,7 @@ interface Props {
 	buttons?: JSX.Element[];
 	mobileButtons?: JSX.Element[];
 }
-/*
-Breadcrumbs.propTypes = {
-	items: PropTypes.array.isRequired,
-	mobileItem: PropTypes.object.isRequired,
-	buttons: PropTypes.array,
-	mobileButtons: PropTypes.array,
-	className: PropTypes.string,
-};
-*/
+
 const Breadcrumbs: React.FunctionComponent< Props > = ( {
 	items,
 	mobileItem,
@@ -165,7 +157,6 @@ const Breadcrumbs: React.FunctionComponent< Props > = ( {
 					{ renderButtons() }
 				</div>
 			</div>
-			<div className="breadcrumb__spacer"></div>
 		</div>
 	);
 };

--- a/client/components/breadcrumb/style.scss
+++ b/client/components/breadcrumb/style.scss
@@ -3,14 +3,7 @@
 
 .breadcrumb {
 	> div:first-child {
-		position: fixed;
-		margin: 0;
-		z-index: -10;
-		background-color: white;
-		top: var( --masterbar-height );
 		padding: 0 16px;
-		left: 0;
-		right: 0;
 		border-bottom: 1px solid var( --studio-gray-5 );
 
 		@include breakpoint-deprecated( '>660px' ) {

--- a/client/components/breadcrumb/style.scss
+++ b/client/components/breadcrumb/style.scss
@@ -1,0 +1,194 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.breadcrumb {
+	> div:first-child {
+		position: fixed;
+		margin: 0;
+		z-index: 10;
+		background-color: white;
+		top: var( --masterbar-height );
+		padding: 0 16px;
+		left: 0;
+		right: 0;
+		border-bottom: 1px solid var( --studio-gray-5 );
+
+		@include breakpoint-deprecated( '>660px' ) {
+			padding: 0 24px;
+		}
+
+		@media screen and ( min-width: #{ ( $break-medium + 1 ) } ) {
+			left: var( --sidebar-width-min );
+		}
+
+		@media screen and ( min-width: #{ ( $break-large + 1 ) } ) {
+			padding: 0 32px;
+		}
+
+		@include break-large {
+			left: var( --sidebar-width-max );
+		}
+	}
+
+	.select-dropdown__separator {
+		border-top: 1px solid var( --color-neutral-10 );
+		display: block;
+		margin: 8px 0 0;
+	}
+}
+
+.breadcrumb__content {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	height: 60px;
+	max-width: 1040px;
+	margin: 0 auto;
+
+	@include break-mobile {
+		height: 70px;
+	}
+}
+
+.breadcrumb__items {
+	display: none;
+
+	@include break-mobile {
+		display: flex;
+		align-items: center;
+		font-size: 13px; /* stylelint-disable-line */
+		font-weight: 400;
+
+		& .breadcrumb__item {
+			.breadcrumb__item-label {
+				color: var( --color-neutral-50 );
+
+				&:hover {
+					color: var( --color-neutral-80 );
+				}
+			}
+
+			&.is-last-item {
+				.breadcrumb__item-label {
+					font-weight: 500; /* stylelint-disable-line */
+					color: var( --color-neutral-80 );
+				}
+			}
+
+			&.is-only-item {
+				.breadcrumb__item-label {
+					font-weight: 600;
+					font-size: $font-body;
+					color: var( --color-neutral-80 );
+				}
+			}
+		}
+	}
+}
+
+.breadcrumb__items-mobile {
+	display: flex;
+	align-items: center;
+	font-size: 13px; /* stylelint-disable-line */
+	font-weight: 400;
+
+	& .breadcrumb__item {
+		display: flex;
+		align-items: center;
+
+		.breadcrumb__item-label {
+			color: var( --color-neutral-80 );
+		}
+
+		/* This rule applies when there's no back arrow present */
+		span:first-child {
+			font-weight: 600;
+			font-size: $font-body;
+		}
+	}
+
+	@include break-mobile {
+		display: none;
+	}
+}
+
+.breadcrumb__back-arrow {
+	margin-right: 4px;
+	color: var( --color-neutral-80 );
+}
+
+.breadcrumb__help-bubble {
+	margin-left: 7px;
+
+	&.info-popover .gridicon {
+		color: var( --studio-gray-30 );
+	}
+}
+
+.breadcrumb__separator {
+	margin: 0 12px;
+	color: var( --color-neutral-10 );
+}
+
+.breadcrumb__buttons,
+.breadcrumb__buttons-mobile {
+	align-items: center;
+
+	> * + * {
+		margin-left: 16px;
+	}
+
+	& button,
+	& .select-dropdown {
+		height: 40px;
+
+		.select-dropdown__header {
+			height: 40px;
+		}
+	}
+
+	@include break-mobile {
+		.options-domain-button.ellipsis {
+			padding-right: 0;
+		}
+	}
+}
+
+.breadcrumb__buttons-mobile {
+	display: flex;
+
+	> * + * {
+		margin-left: 8px;
+	}
+
+	@include break-mobile {
+		display: none;
+	}
+}
+
+.breadcrumb__buttons {
+	display: none;
+
+	@include break-mobile {
+		display: flex;
+	}
+}
+
+.breadcrumb__spacer {
+	height: 58px;
+
+	@include breakpoint-deprecated( '<960px' ) {
+		height: 66px;
+	}
+
+	@include breakpoint-deprecated( '<660px' ) {
+		height: 76px;
+	}
+}
+
+/* This prevents breadcrumb component from being partially hidden when happychat is open */
+.has-docked-chat .breadcrumb > div:first-child {
+	@include breakpoint-deprecated( '>1040px' ) {
+		right: var( --sidebar-width-max );
+	}
+}

--- a/client/components/breadcrumb/style.scss
+++ b/client/components/breadcrumb/style.scss
@@ -5,7 +5,7 @@
 	> div:first-child {
 		position: fixed;
 		margin: 0;
-		z-index: 10;
+		z-index: -10;
 		background-color: white;
 		top: var( --masterbar-height );
 		padding: 0 16px;

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -96,7 +96,19 @@ const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
 		};
 	}, [ contentRef ] );
 
-	const [ mobileItem = { label: 'Back' } ] = navigationItems.splice( navigationItems.length - 2 );
+	let mobileItem: { label: string; href?: string; showBackArrow?: boolean } = {
+		label: 'Back',
+	};
+	if ( navigationItems.length > 1 ) {
+		mobileItem = {
+			href: navigationItems[ navigationItems.length - 2 ].href,
+			label: 'Back',
+			showBackArrow: true,
+		};
+		navigationItems[ navigationItems.length - 1 ].href = undefined;
+	} else if ( navigationItems.length > 0 ) {
+		mobileItem = { ...navigationItems[ 0 ], href: undefined, showBackArrow: false };
+	}
 
 	return (
 		<Header id={ id } className={ className } ref={ headerRef }>

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { useEffect, useRef } from '@wordpress/element';
+import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import Breadcrumb from 'calypso/components/breadcrumb';
 
@@ -64,6 +65,7 @@ const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
 	const { id, className, children, navigationItems, contentRef } = props;
 	const actionsRef = useRef< HTMLDivElement >( null );
 	const headerRef = useRef< HTMLElement >( null );
+	const translate = useTranslate();
 
 	useEffect( () => {
 		if ( ! contentRef ) {
@@ -96,18 +98,18 @@ const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
 		};
 	}, [ contentRef ] );
 
-	let mobileItem: { label: string; href?: string; showBackArrow?: boolean } = {
-		label: 'Back',
+	let mobileItem: { label: React.ReactChild; href?: string; showBackArrow?: boolean } = {
+		label: translate( 'Back' ),
 	};
 	if ( navigationItems.length > 1 ) {
 		mobileItem = {
 			href: navigationItems[ navigationItems.length - 2 ].href,
-			label: 'Back',
+			label: translate( 'Back' ),
 			showBackArrow: true,
 		};
 		navigationItems[ navigationItems.length - 1 ].href = undefined;
 	} else if ( navigationItems.length > 0 ) {
-		mobileItem = { ...navigationItems[ 0 ], href: undefined, showBackArrow: false };
+		mobileItem = { ...navigationItems[ 0 ], showBackArrow: false };
 	}
 
 	return (

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -96,7 +96,7 @@ const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
 		};
 	}, [ contentRef ] );
 
-	const [ mobileItem = { label: '' } ] = navigationItems.splice( navigationItems.length - 2 );
+	const [ mobileItem = { label: 'Back' } ] = navigationItems.splice( navigationItems.length - 2 );
 
 	return (
 		<Header id={ id } className={ className } ref={ headerRef }>

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -61,7 +61,7 @@ interface Props {
 }
 
 const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
-	const { id, className, children, navigationItems, contentRef, compactBreadcrumb = false } = props;
+	const { id, className, children, navigationItems, contentRef } = props;
 	const actionsRef = useRef< HTMLDivElement >( null );
 	const headerRef = useRef< HTMLElement >( null );
 
@@ -96,10 +96,12 @@ const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
 		};
 	}, [ contentRef ] );
 
+	const [ mobileItem = { label: '' } ] = navigationItems.splice( navigationItems.length - 2 );
+
 	return (
 		<Header id={ id } className={ className } ref={ headerRef }>
 			<Container>
-				<Breadcrumb items={ navigationItems } compact={ compactBreadcrumb } />
+				<Breadcrumb items={ navigationItems } mobileItem={ mobileItem } />
 				<ActionsContainer ref={ actionsRef }>{ children }</ActionsContainer>
 			</Container>
 		</Header>

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -6,7 +6,7 @@ const selectors = {
 	sectionTitle: ( section: string ) => `.plugins-browser-list__title:text("${ section }")`,
 	sectionTitles: '.plugins-browser-list__title',
 	browseAllPopular: 'a[href^="/plugins/popular"]',
-	breadcrumb: ( section: string ) => `.plugins-browser__header li a:text("${ section }") `,
+	breadcrumb: ( section: string ) => `.plugins-browser__header span a:text("${ section }") `,
 	pricingToggle: ':text("Monthly Price"), :text("Annual Price")',
 	monthlyPricingSelect: 'a[data-bold-text^="Monthly price"]',
 	annualPricingSelect: 'a[data-bold-text^="Annual price"]',


### PR DESCRIPTION
The Breadcrumb will be taken from the Domains component and it will be
added to generic components and used it in other areas.

Remaining things to do:
- [x] ~Use the common component in all the domains code~ -> https://github.com/Automattic/wp-calypso/issues/61952
- [x] Ensure the compact functionality works as expected
- [x] ~Decide if using external styles or styled components~ -> https://github.com/Automattic/wp-calypso/issues/61917
- [x] Update documentation


#### Changes proposed in this Pull Request

The style **and functionality** of the breadcrumb component from the Domains page has been migrated to the common Breadcrumb component currently used in Plugins but meant to be used in most of the pages.

|Before | After|
|-------|------|
|<img width="470" alt="CleanShot 2022-03-15 at 12 20 53@2x" src="https://user-images.githubusercontent.com/3519124/158367193-813ac16b-d277-4c80-b6ac-b62400bd64dc.png">|<img width="543" alt="image" src="https://user-images.githubusercontent.com/3519124/158367270-723cb450-0c12-4506-b0c4-3fc0facf73a7.png">|
|**Domains**|<img width="490" alt="image" src="https://user-images.githubusercontent.com/3519124/158367401-22aeff94-03ae-4dd6-8a21-b465ff96a705.png">|

##### Responsive behaviour
|Before | After|
|-------|------|
|![CleanShot 2022-03-15 at 12 26 38](https://user-images.githubusercontent.com/3519124/158368323-80200c98-efb7-4035-92e8-eaadea8cfd3c.gif)|![CleanShot 2022-03-15 at 12 27 22](https://user-images.githubusercontent.com/3519124/158368358-15c9ffaf-42b0-4fac-9c1b-5f34e4370d59.gif)|
|**Domains**|![CleanShot 2022-03-15 at 12 24 31](https://user-images.githubusercontent.com/3519124/158368296-93e4fce5-ef5e-41f2-b045-89aa3643ea4e.gif)|

#### Testing instructions

* Open plugins and select one plugin
* Check the styles and compare them against the breadcrumb in the Domains page. The Domains page can be accessed by navigating to Upgrades -> Domains and selecting one domain.
* Check that the responsive behaviour works as expected resizing the window.

Fixes #61143
