### PR TITLE
Remove disabled actions from `DnsRecordsListItem`

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -21,6 +21,7 @@ export const DOMAIN_EXPIRATION_AUCTION = `${ root }/domains/domain-expiration/#e
 export const DOMAIN_EXPIRATION_REDEMPTION = `${ root }/domains/domain-expiration/#renewing-a-domain-in-the-redemption-period`;
 export const DOMAIN_RECENTLY_REGISTERED = `${ root }/domains/register-domain/#waiting-for-domain-changes`;
 export const DOMAIN_PRICING_AND_AVAILABLE_TLDS = `${ root }/domains/domain-pricing-and-available-tlds`;
+export const DNS_RECORDS_EDITING_OR_DELETING = `${ root }/domains/custom-dns/#editing-or-deleting-dns-records`;
 export const DNS_TXT_RECORD_CHAR_LIMIT = `${ root }/domains/custom-dns/#txt-record-character-limit`;
 export const ECOMMERCE = `${ root }/ecommerce`;
 export const INCOMING_DOMAIN_TRANSFER_STATUSES = `${ root }/move-domain/incoming-domain-transfer/#checking-your-transfer-status-and-failed-transfers`;

--- a/client/my-sites/domains/domain-management/dns/dns-record-data.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-record-data.jsx
@@ -1,6 +1,8 @@
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
+import ExternalLink from 'calypso/components/external-link';
+import { DNS_RECORDS_EDITING_OR_DELETING } from 'calypso/lib/url/support';
 import DnsRecordsListItem from './dns-records-list-item';
 
 class DnsRecordData extends Component {
@@ -24,10 +26,29 @@ class DnsRecordData extends Component {
 		// TODO: Remove this once we stop displaying the protected records
 		if ( dnsRecord.protected_field ) {
 			if ( 'MX' === type ) {
-				return translate( 'Mail handled by WordPress.com email forwarding' );
+				return translate(
+					'Mail handled by WordPress.com email forwarding. {{supportLink}}Learn more{{/supportLink}}.',
+					{
+						components: {
+							supportLink: (
+								<ExternalLink
+									href={ DNS_RECORDS_EDITING_OR_DELETING }
+									target="_blank"
+									icon={ false }
+								/>
+							),
+						},
+					}
+				);
 			}
 
-			return translate( 'Handled by WordPress.com' );
+			return translate( 'Handled by WordPress.com. {{supportLink}}Learn more{{/supportLink}}.', {
+				components: {
+					supportLink: (
+						<ExternalLink href={ DNS_RECORDS_EDITING_OR_DELETING } target="_blank" icon={ false } />
+					),
+				},
+			} );
 		}
 
 		switch ( type ) {

--- a/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
@@ -18,18 +18,16 @@ function DnsRecordsListItem( { type, name, value, actions, disabled, isHeader, r
 			popoverClassName="dns-records-list-item__action-menu-popover"
 			position="bottom left"
 		>
-			{ actions.map( ( action ) => {
-				return action.disabled ? null : (
-					<PopoverMenuItem
-						disabled={ action.disabled }
-						key={ key++ }
-						onClick={ () => action.callback( record ) }
-					>
-						{ action.icon }
-						{ action.title }
-					</PopoverMenuItem>
-				);
-			} ) }
+			{ actions.map( ( action ) => (
+				<PopoverMenuItem
+					disabled={ action.disabled }
+					key={ key++ }
+					onClick={ () => action.callback( record ) }
+				>
+					{ action.icon }
+					{ action.title }
+				</PopoverMenuItem>
+			) ) }
 		</EllipsisMenu>
 	);
 

--- a/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
@@ -6,7 +6,6 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 
 function DnsRecordsListItem( { type, name, value, actions, disabled, isHeader, record } ) {
 	let key = 0;
-	let enabledActions = 0;
 	const menu = actions && (
 		<EllipsisMenu
 			icon={
@@ -20,9 +19,6 @@ function DnsRecordsListItem( { type, name, value, actions, disabled, isHeader, r
 			position="bottom left"
 		>
 			{ actions.map( ( action ) => {
-				if ( ! action.disabled ) {
-					enabledActions++;
-				}
 				return action.disabled ? null : (
 					<PopoverMenuItem
 						disabled={ action.disabled }
@@ -56,7 +52,7 @@ function DnsRecordsListItem( { type, name, value, actions, disabled, isHeader, r
 					<span>{ value }</span>
 				</div>
 				<div className="dns-records-list-item__data dns-records-list-item__menu">
-					{ ! isHeader && enabledActions > 0 && menu }
+					{ ! isHeader && actions.length > 0 && menu }
 				</div>
 			</div>
 		</div>

--- a/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
@@ -6,6 +6,7 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 
 function DnsRecordsListItem( { type, name, value, actions, disabled, isHeader, record } ) {
 	let key = 0;
+	let enabledActions = 0;
 	const menu = actions && (
 		<EllipsisMenu
 			icon={
@@ -19,7 +20,10 @@ function DnsRecordsListItem( { type, name, value, actions, disabled, isHeader, r
 			position="bottom left"
 		>
 			{ actions.map( ( action ) => {
-				return (
+				if ( ! action.disabled ) {
+					enabledActions++;
+				}
+				return action.disabled ? null : (
 					<PopoverMenuItem
 						disabled={ action.disabled }
 						key={ key++ }
@@ -52,7 +56,7 @@ function DnsRecordsListItem( { type, name, value, actions, disabled, isHeader, r
 					<span>{ value }</span>
 				</div>
 				<div className="dns-records-list-item__data dns-records-list-item__menu">
-					{ ! isHeader && menu }
+					{ ! isHeader && enabledActions > 0 && menu }
 				</div>
 			</div>
 		</div>

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -27,7 +27,6 @@ class DnsRecordsList extends Component {
 	};
 
 	disableRecordAction = {
-		disabled: false,
 		icon: (
 			<MaterialIcon
 				icon="do_not_disturb"
@@ -40,7 +39,6 @@ class DnsRecordsList extends Component {
 	};
 
 	enableRecordAction = {
-		disabled: false,
 		icon: (
 			<Icon
 				icon={ redo }
@@ -53,7 +51,6 @@ class DnsRecordsList extends Component {
 	};
 
 	recordInfoAction = {
-		disabled: false,
 		icon: (
 			<Icon
 				icon={ info }
@@ -66,7 +63,6 @@ class DnsRecordsList extends Component {
 	};
 
 	editRecordAction = {
-		disabled: false,
 		icon: (
 			<Icon
 				icon={ edit }
@@ -80,7 +76,6 @@ class DnsRecordsList extends Component {
 	};
 
 	deleteRecordAction = {
-		disabled: false,
 		icon: (
 			<Icon
 				icon={ trash }
@@ -199,10 +194,10 @@ class DnsRecordsList extends Component {
 		const actions = [];
 
 		if ( ! record.protected_field ) {
-			actions.push( { ...this.editRecordAction, disabled: false } );
+			actions.push( { ...this.editRecordAction } );
 		}
 		if ( ! ( record.protected_field && 'MX' !== record.type ) ) {
-			actions.push( { ...this.deleteRecordAction, disabled: false } );
+			actions.push( { ...this.deleteRecordAction } );
 		}
 		return actions;
 	}

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -196,10 +196,15 @@ class DnsRecordsList extends Component {
 			];
 		}
 
-		return [
-			{ ...this.editRecordAction, disabled: record.protected_field },
-			{ ...this.deleteRecordAction, disabled: record.protected_field && 'MX' !== record.type },
-		];
+		const actions = [];
+
+		if ( ! record.protected_field ) {
+			actions.push( { ...this.editRecordAction, disabled: false } );
+		}
+		if ( ! ( record.protected_field && 'MX' !== record.type ) ) {
+			actions.push( { ...this.deleteRecordAction, disabled: false } );
+		}
+		return actions;
 	}
 
 	getDomainConnectDnsRecord( enabled ) {


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR remove disabled actions from the popover menu, in domain dns record list item, and hide the entire menu if no actions are available.

It also add a link to support documentation to better explain the role of default CNAME, A and MX records.

![dns-records](https://user-images.githubusercontent.com/2797601/157904212-811223a0-72ae-44ef-a652-726b07fce2e6.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- Select a owned domain, with default DNS record (with email forwarding service enabled) a go to DNS record page (Upgrade->Domains-> DNS record card -> "Manage")
- Verify that
  - Default A record doesn't have popover menu
  - Default CNAME record doesn't have popover menu
  - Default MX record has only Delete action in popover menu
  - All the default records has a Learn more link pointing to [Editing or deleting DNS records](https://wordpress.com/support/domains/custom-dns/#editing-or-deleting-dns-records)

Related to #60680 
