### PR TITLE
Full importer: Improved logic of showing install Jetpack button

### DIFF
--- a/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
+++ b/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
@@ -2,7 +2,6 @@ import { NextButton, SelectItems } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import React, { useEffect, useState } from 'react';
-import { connect } from 'react-redux';
 import ActionCard from 'calypso/components/action-card';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -128,6 +127,4 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 	);
 };
 
-export default connect( () => {
-	return {};
-} )( ContentChooser );
+export default ContentChooser;

--- a/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
+++ b/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
@@ -36,20 +36,23 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 	 */
 	const showJetpackConnectionBlock = !! fromSite;
 	const [ hasOriginSiteJetpackConnected, setHasOriginSiteJetpackConnected ] = useState( false );
-	const [ isFetchingSite, setIsFetchingSite ] = useState( false );
+	const [ initialFetching, setInitialFetching ] = useState( true );
 
 	/**
 	 ↓ Effects
 	 */
-	useEffect( checkOriginSiteJetpackConnection, [ fromSite ] );
+	useEffect( () => {
+		checkOriginSiteJetpackConnection();
+		const interval = setInterval( checkOriginSiteJetpackConnection, 5000 );
+
+		return () => clearInterval( interval );
+	}, [] );
 
 	/**
 	 ↓ Methods
 	 */
 	function checkOriginSiteJetpackConnection() {
 		if ( ! fromSite ) return;
-
-		setIsFetchingSite( true );
 
 		wpcom
 			.site( fromSite )
@@ -58,7 +61,7 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 				setHasOriginSiteJetpackConnected( !! ( site && site.capabilities ) )
 			)
 			.catch( () => setHasOriginSiteJetpackConnected( false ) )
-			.finally( () => setIsFetchingSite( false ) );
+			.finally( () => setInitialFetching( false ) );
 	}
 
 	return (
@@ -83,13 +86,13 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 						mainText={ __( "All your site's content, themes, plugins, users and settings" ) }
 					>
 						<NextButton
-							disabled={ ! hasOriginSiteJetpackConnected || isFetchingSite }
+							disabled={ ! hasOriginSiteJetpackConnected || initialFetching }
 							onClick={ onContentEverythingSelection }
 						>
 							{ __( 'Continue' ) }
 						</NextButton>
 					</ActionCard>
-					{ showJetpackConnectionBlock && ! hasOriginSiteJetpackConnected && ! isFetchingSite && (
+					{ showJetpackConnectionBlock && ! hasOriginSiteJetpackConnected && ! initialFetching && (
 						<SelectItems
 							onSelect={ onJetpackSelection }
 							items={ [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The change improves the UX of showing the Jetpack install button by adding a connection check interval of 5 seconds.

#### Testing instructions

* Go to `/start/from/importing/wordpress?from={NINJA_SLUG}&to={SLUG}.wordpress.com`
( jurassic.ninja slug should be without jetpack connection )
* Press on the `Install jetpack` button
( the process of Jetpack connection will be started in the new tab )
* Approve Jetpack
* Come back to the previous tab
* Check if the Jetpack install button is disappeared
( it should disappear in a period of 5 seconds )

Closes https://github.com/Automattic/wp-calypso/issues/61799
