### PR TITLE
Payment Methods: Change getPaymentMethodSummary into a component

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/index.tsx
@@ -2,7 +2,7 @@ import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useRecentPaymentMethodsQuery } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import PaymentMethodDeletePrimaryConfirmation from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation';
-import { getPaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
+import { PaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 import type { FunctionComponent } from 'react';
 
@@ -23,11 +23,9 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 
-	const paymentMethodSummary = getPaymentMethodSummary( {
-		translate,
-		type: paymentMethod?.card.brand,
-		digits: paymentMethod?.card.last4,
-	} );
+	const paymentMethodSummary = (
+		<PaymentMethodSummary type={ paymentMethod?.card.brand } digits={ paymentMethod?.card.last4 } />
+	);
 
 	const { isFetching: isFetchingRecentPaymentMethods } = useRecentPaymentMethodsQuery( {
 		enabled: paymentMethod.is_default,

--- a/client/lib/checkout/payment-methods.tsx
+++ b/client/lib/checkout/payment-methods.tsx
@@ -65,19 +65,18 @@ export const getPaymentMethodImageURL = ( type: string ): string => {
 	return `${ imagePath }`;
 };
 
-export const getPaymentMethodSummary = ( {
-	translate,
+export const PaymentMethodSummary = ( {
 	type,
 	digits,
 	email,
 }: {
-	translate: ReturnType< typeof useTranslate >;
 	type: string;
 	digits?: string;
 	email?: string;
-} ): TranslateResult => {
+} ): JSX.Element => {
+	const translate = useTranslate();
 	if ( type === PARTNER_PAYPAL_EXPRESS ) {
-		return email || '';
+		return <>{ email || '' }</>;
 	}
 	let displayType: TranslateResult;
 	switch ( type && type.toLocaleLowerCase() ) {
@@ -115,10 +114,14 @@ export const getPaymentMethodSummary = ( {
 	}
 
 	if ( ! digits ) {
-		return displayType;
+		return <>{ displayType }</>;
 	}
 
-	return translate( '%(displayType)s ****%(digits)s', {
-		args: { displayType, digits },
-	} );
+	return (
+		<>
+			{ translate( '%(displayType)s ****%(digits)s', {
+				args: { displayType, digits },
+			} ) }
+		</>
+	);
 };

--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	isPaymentAgreement,
-	getPaymentMethodSummary,
+	PaymentMethodSummary,
 	PaymentMethod,
 } from 'calypso/lib/checkout/payment-methods';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -57,12 +57,13 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 	return (
 		<>
 			<PaymentMethodDeleteDialog
-				paymentMethodSummary={ getPaymentMethodSummary( {
-					translate,
-					type: card.card_type || card.payment_partner,
-					digits: card.card,
-					email: card.email,
-				} ) }
+				paymentMethodSummary={
+					<PaymentMethodSummary
+						type={ card.card_type || card.payment_partner }
+						digits={ card.card }
+						email={ card.email }
+					/>
+				}
 				isVisible={ isDialogVisible }
 				onClose={ closeDialog }
 				onConfirm={ handleDelete }

--- a/client/me/purchases/payment-methods/payment-method-details.tsx
+++ b/client/me/purchases/payment-methods/payment-method-details.tsx
@@ -5,7 +5,7 @@ import { FunctionComponent } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	getPaymentMethodImageURL,
-	getPaymentMethodSummary,
+	PaymentMethodSummary,
 } from 'calypso/lib/checkout/payment-methods';
 
 import 'calypso/me/purchases/payment-methods/style.scss';
@@ -22,10 +22,10 @@ interface Props {
 }
 
 const PaymentMethodDetails: FunctionComponent< Props > = ( {
-	cardType,
-	expiry,
 	lastDigits,
+	cardType,
 	name,
+	expiry,
 	email,
 	paymentPartner,
 	isExpired,
@@ -48,12 +48,7 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 			/>
 			<div className="payment-method-details__details">
 				<span className="payment-method-details__number">
-					{ getPaymentMethodSummary( {
-						translate,
-						type,
-						digits: lastDigits,
-						email,
-					} ) }
+					<PaymentMethodSummary type={ type } digits={ lastDigits } email={ email } />
 				</span>
 
 				{ displayExpirationDate && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a change extracted from https://github.com/Automattic/wp-calypso/pull/57807 which modifies the function `getPaymentMethodSummary` so that it is a component called `PaymentMethodSummary` instead. The advantage is that it can now get its own `translate` function from a hook, rather than relying on it being passed in as an argument.


Co-authored by: @chrisfromthelc 

<img width="894" alt="Screen Shot 2022-03-11 at 12 12 40 PM" src="https://user-images.githubusercontent.com/2036909/157914942-a4d13df4-46c8-4445-bea8-316a1694ae66.png">

#### Testing instructions

- Add a payment method to an account if one does not already exist.
- Visit `/me/purchases/payment-methods` and click on the Delete button next to the payment method.
- Verify that the confirmation dialog reads `The payment method XXXXXX will be removed...` where `XXXXXX` is the card type (eg: `VISA`) and last four digits.