### PR TITLE
Licensing Portal: Update position of the placeholder card for adding new payment method

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
@@ -80,11 +80,11 @@ export default function PaymentMethodList(): ReactElement {
 			</div>
 
 			<div className="payment-method-list__body">
+				<AddStoredCreditCard />
+
 				{ isFetching && <StoredCreditCardLoading /> }
 
 				{ ! isFetching && cards }
-
-				<AddStoredCreditCard />
 			</div>
 
 			{ showPagination && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Discussion: https://github.com/Automattic/wp-calypso/pull/61679

We want to move the placeholder card for adding a new payment method to the first position instead of the last one.

**Screenshots:**

Before | After
--- | ---
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/1749918/157930474-2df73a4f-9198-49bb-8a9b-50b08a18f548.png"> | <img width="1170" alt="image" src="https://user-images.githubusercontent.com/1749918/157930094-e17a6c1d-7620-4a86-9246-2a810eda03a7.png">

#### Testing instructions

- If you do not have a partner key, please get in touch with Avalon for one, or you will be unable to view the UI.
- Checkout PR locally, run yarn && yarn start-jetpack-cloud.
- Visit http://jetpack.cloud.localhost:3000/partner-portal/payment-methods and select your partner key, if prompted.
- Verify that the placeholder card is displayed in the first position.

Related to 1201734780767770-as-1201956195880287