### PR TITLE
Payment Methods: Add tax contact details validation to assignNewCardProcessor

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -91,11 +91,11 @@ export async function assignNewCardProcessor(
 			},
 		} );
 		if ( ! contactValidationResponse.success ) {
-			throw new Error(
-				contactValidationResponse.messages?.country_code?.[ 0 ] ??
-					contactValidationResponse.messages?.postal_code?.[ 0 ] ??
-					'Unknown validation error'
-			);
+			const errorMessage =
+				contactValidationResponse.messages_flat.length > 0
+					? contactValidationResponse.messages_flat[ 0 ]
+					: 'Unknown error validating location information';
+			throw new Error( errorMessage );
 		}
 
 		reduxDispatch( recordFormSubmitEvent( { purchase, useForAllSubscriptions } ) );

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -92,8 +92,8 @@ export async function assignNewCardProcessor(
 		} );
 		if ( ! contactValidationResponse.success ) {
 			const errorMessage =
-				contactValidationResponse.messages_flat.length > 0
-					? contactValidationResponse.messages_flat[ 0 ]
+				contactValidationResponse.messages_simple.length > 0
+					? contactValidationResponse.messages_simple[ 0 ]
 					: 'Unknown error validating location information';
 			throw new Error( errorMessage );
 		}

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -177,7 +177,7 @@ async function createStripeSetupIntentAsync(
 
 function isNewCardDataValid( data: unknown ): data is NewCardSubmitData {
 	const newCardData = data as NewCardSubmitData;
-	return newCardData.countryCode === undefined;
+	return newCardData.countryCode !== undefined;
 }
 
 interface NewCardSubmitData {

--- a/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
@@ -281,6 +281,7 @@ function convertValidationResponse( rawResponse: unknown ): DomainContactValidat
 	return {
 		success: false,
 		messages: convertValidationMessages( rawResponse.messages ),
+		messages_flat: rawResponse.messages_flat,
 	};
 }
 

--- a/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
@@ -99,7 +99,7 @@ async function runContactValidationCheck(
 		default:
 			return isCompleteAndValid( contactInfo )
 				? { success: true }
-				: { success: false, messages: {} };
+				: { success: false, messages: {}, messages_flat: [] };
 	}
 }
 

--- a/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
@@ -99,7 +99,7 @@ async function runContactValidationCheck(
 		default:
 			return isCompleteAndValid( contactInfo )
 				? { success: true }
-				: { success: false, messages: {}, messages_flat: [] };
+				: { success: false, messages: {}, messages_simple: [] };
 	}
 }
 
@@ -281,7 +281,7 @@ function convertValidationResponse( rawResponse: unknown ): DomainContactValidat
 	return {
 		success: false,
 		messages: convertValidationMessages( rawResponse.messages ),
-		messages_flat: rawResponse.messages_flat,
+		messages_simple: rawResponse.messages_simple,
 	};
 }
 

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -44,8 +44,8 @@ export default function CreditCardPayButton( {
 							stripeConfiguration,
 							cardNumberElement,
 							paymentPartner,
-							countryCode: fields?.countryCode?.value,
-							postalCode: fields?.postalCode?.value,
+							countryCode: fields?.countryCode?.value ?? '',
+							postalCode: fields?.postalCode?.value ?? '',
 							useForAllSubscriptions,
 							eventSource: 'checkout',
 						} );

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -493,6 +493,7 @@ export type DomainContactValidationResponse =
 	| {
 			success: false;
 			messages: ContactValidationResponseMessages;
+			messages_flat: string[];
 	  };
 
 export type RawDomainContactValidationResponse =
@@ -500,6 +501,7 @@ export type RawDomainContactValidationResponse =
 	| {
 			success: false;
 			messages: RawContactValidationResponseMessages;
+			messages_flat: string[];
 	  };
 
 export interface CountryListItem {

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -493,7 +493,7 @@ export type DomainContactValidationResponse =
 	| {
 			success: false;
 			messages: ContactValidationResponseMessages;
-			messages_flat: string[];
+			messages_simple: string[];
 	  };
 
 export type RawDomainContactValidationResponse =
@@ -501,7 +501,7 @@ export type RawDomainContactValidationResponse =
 	| {
 			success: false;
 			messages: RawContactValidationResponseMessages;
-			messages_flat: string[];
+			messages_simple: string[];
 	  };
 
 export interface CountryListItem {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When assigning a new card to an existing subscription, the form asks for country code and postal code for tax purposes (currently sent only to Stripe); however, that data is not validated.

This PR adds contact details validation to the submit flow when assigning a new card to a subscription.

Requires D76634-code in order to get the proper error messages.

<img width="1054" alt="Screen Shot 2022-03-14 at 3 35 04 PM" src="https://user-images.githubusercontent.com/2036909/158247663-e1c33b46-5161-44b9-906e-2aafce968520.png">


#### Testing instructions

1. Use an account with at least one active subscription.
1. Visit `/me/purchases` and click on an active subscription.
1. Click "Change Payment Method" or "Add Payment Method".

To test for invalid data:

1. Select the "Credit or debit card" payment method option, and fill in the form, but **leave country and postal code blank**.
1. Press the submit button and verify that you receive an error mentioning invalid contact info.
1. Add a valid postal code, but **do not select a country**.
1. Press the submit button and verify that you receive an error mentioning invalid contact info.
1. Select a valid country (which has postal codes), but **leave the postal code blank**.
1. Press the submit button and verify that you receive an error mentioning invalid contact info.
1. Select a valid country (which has postal codes), and **enter an invalid postal code**.
1. Press the submit button and verify that you receive an error mentioning invalid contact info.

To test that valid data works:

1. Select a valid country (which has postal codes), and **enter a valid postal code**.
1. Press the submit button and verify that the form submits successfully.

To test valid data for countries with no postal code:

1. Click "Change Payment Method" to return to the form.
1. Add another new card, but this time select a country that has no postal code (eg: Macau) and verify that the form submits successfully.
