### PR TITLE
Domains: Update conditions to show domain renew elements

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -321,11 +321,9 @@ export function resolveDomainStatus(
 			}
 
 			if ( domain.expired ) {
-				const daysSinceExpiration = moment.utc().diff( moment.utc( domain.expiry ), 'days' );
-
 				let renewCta;
 
-				if ( daysSinceExpiration >= 1 && daysSinceExpiration <= 43 ) {
+				if ( domain.isRenewable ) {
 					const renewableUntil = moment.utc( domain.renewableUntil ).format( 'LL' );
 
 					renewCta =
@@ -351,9 +349,7 @@ export function resolveDomainStatus(
 										args: { renewableUntil },
 									}
 							  );
-				}
-
-				if ( daysSinceExpiration > 43 ) {
+				} else if ( domain.isRedeemable ) {
 					const redeemableUntil = moment.utc( domain.redeemableUntil ).format( 'LL' );
 
 					renewCta =

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -220,7 +220,7 @@ class DomainRow extends PureComponent {
 		) {
 			return false;
 		}
-		return ! domain?.bundledPlanSubscriptionId && domain.currentUserCanManage;
+		return ! domain?.bundledPlanSubscriptionId && domain.currentUserIsOwner;
 	};
 
 	renderEmail() {

--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -51,7 +51,7 @@ const RegisteredDomainDetails = ( {
 
 	const shouldNotRenderAutoRenewToggle = () => {
 		return (
-			! domain.currentUserCanManage ||
+			! domain.currentUserIsOwner ||
 			( ! isLoadingPurchase && ! purchase ) ||
 			domain.aftermarketAuction
 		);

--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -5,7 +5,6 @@ import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { isExpiringSoon } from 'calypso/lib/domains/utils';
 import { getRenewalPrice, isExpiring } from 'calypso/lib/purchases';
 import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
 import RenewButton from 'calypso/my-sites/domains/domain-management/edit/card/renew-button';
@@ -106,8 +105,7 @@ const RegisteredDomainDetails = ( {
 			! domain.subscriptionId ||
 			domain.isPendingRenewal ||
 			! domain.currentUserCanManage ||
-			domain.expired ||
-			isExpiringSoon( domain, 30 ) || // from `registered-domain-type` and `mapped-domain-type`
+			( domain.expired && ! domain.isRenewable && ! domain.isRedeemable ) ||
 			( ! isLoadingPurchase && ! purchase ) ||
 			domain.aftermarketAuction
 		);
@@ -124,7 +122,11 @@ const RegisteredDomainDetails = ( {
 				selectedSite={ selectedSite }
 				subscriptionId={ parseInt( domain.subscriptionId!, 10 ) }
 				tracksProps={ { source: 'registered-domain-status', domain_status: 'active' } }
-				customLabel={ translate( 'Renew now' ) }
+				customLabel={
+					! domain.expired || domain.isRenewable
+						? translate( 'Renew now' )
+						: translate( 'Redeem now' )
+				}
 				disabled={ isLoadingPurchase }
 			/>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the conditions to show the auto-renew toggle and renew button for registered domains. This is part of an effort to fix and standardize the conditions in which some domain actions are shown or hidden in the domain management pages in Calypso.

Two places were updated:

- Domains list

The auto-renew toggle should only appear if you're the owner of the domain and the renew/redeem notices should appear only if the domain has the `isRenewable`/`isRedeemable` properties. Until now, the renew notice would appear if the domain had expired between 1 and 43 days ago and the redemption notice if the domain expired more than 43 days ago, regardless of the actual renewal and redemption periods for the domain's specific TLD (some TLDs have different grace periods).

<img width="1083" alt="Screen Shot 2022-03-11 at 20 32 11" src="https://user-images.githubusercontent.com/5324818/157988308-2958ca22-26b2-4a7d-a401-4333d7d4d808.png">

![Markup on 2022-03-11 at 20:25:09](https://user-images.githubusercontent.com/5324818/157987837-837497a1-a5df-4a72-ae09-f2d5e8687bae.png)

- Domain management page

The renew/redeem notices and the auto-renew toggle here should follow the same logic as in the domains list, as described above. The renew button should appear while the domain is still renewable or redeemable - when a domain enters the redemption grace period, the button should have the "Redeem now" label.

![Markup on 2022-03-11 at 20:29:19](https://user-images.githubusercontent.com/5324818/157988129-02ef30ef-0393-4c98-ba12-2e19e31aec79.png)

![Markup on 2022-03-11 at 20:20:20](https://user-images.githubusercontent.com/5324818/157987989-bcac9598-f34f-4847-a6d5-f4f03e647941.png)

#### Testing instructions

The best way to test this would be to have expired domains, one in the renewal period and one in the redemption period. If you don't, you can follow the instructions in D70509-code to enable mocked domains.

- Build this branch locally or open the live Calypso link
- Visit the domains list page (Upgrades > Domains) and ensure the domains in renewal and redemption periods are showing the correct notices and auto-renew toggle
- Visit the domain management pages for these domains and ensure the renew/redemption notice is correct, the auto-renew toggle is shown and the "Renew now" button works as expected
- For the domain in redemption, ensure the "Redeem now" button works as expected: it should take you to the checkout page with the registration + redemption products in the cart