### PR TITLE
Fix infinite loop in post comment list

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -152,6 +152,7 @@ class PostCommentList extends Component {
 			// in this case we can't just load the exact comment in question because
 			// we could create a gap in the list.
 			if ( this.props.commentsTree ) {
+				// view earlier...
 				this.viewEarlierCommentsHandler();
 			} else {
 				this.props.requestComment( { siteId, commentId: this.props.startingCommentId } );
@@ -171,7 +172,11 @@ class PostCommentList extends Component {
 		this.resetActiveReplyComment();
 	}
 
-	componentDidUpdate( prevProps ) {
+	componentDidUpdate( prevProps, prevState ) {
+		// If only the state is changing, do nothing. (Avoids setState loops.)
+		if ( prevState !== this.state && prevProps === this.props ) {
+			return;
+		}
 		this.initialFetches();
 		if (
 			prevProps.siteId !== this.props.siteId ||


### PR DESCRIPTION
#### Changes proposed in this Pull Request
There was a race condition in the comments list after refactoring away from the UNSAFE lifecycle methods:
 
- `componentDidUpdate` calls `initialFetches`.
- `initialFetches` triggers `viewEarlierCommentsHandler` if comments haven't loaded yet.
- `viewEarlierCommentsHandler` calls `setState` before it requests more comments
- This triggers another render, which then triggers another `componentDidUpdate`. Since the comments still haven't loaded, we get stuck in a loop and `setState` is called again.
- This results in a WSOD after React detects we've gotten stuck in an infinite render loop.

This was not an issue previously because `setState` was called during `componentWillReceiveProps`, meaning the state was set _before_ the render. Additionally, it would not have been called again because just the state was changing and not the props.

The root problem is that any `setState` call inside `componentDidUpdate` must be wrapped with a conditional which stops it from triggering again. The previous code under willReceiveProps would have never been triggered by a state change, so the existing logic never took state changes into account when checking "should I do this fetch?"

I've solved the problem in this PR by doing a reference check on state changes. If the state has changed but the props have not, then we will not trigger any of the didUpdate logic. This should more closely match the previous code.

That said, I think the code for "should I fetch new comments" is pretty convoluted, spread across two lifecycle methods and several functions. I wonder if a refactor would be helpful -- but that's out of scope for now :)

#### Testing instructions
Load this URL in calypso.live: `/read/blogs/19734/posts/46156#comment-53943`. If it crashes, this fix did not work. If it loads, the fix did work.

