### PR TITLE
Checkout: Separate validation endpoint response type into true and false

### DIFF
--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -596,6 +596,9 @@ export function getSignupValidationErrorResponse(
 export function formatDomainContactValidationResponse(
 	response: DomainContactValidationResponse
 ): ManagedContactDetailsErrors {
+	if ( response.success ) {
+		return {};
+	}
 	return {
 		firstName: response.messages?.first_name,
 		lastName: response.messages?.last_name,

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -446,6 +446,24 @@ export type DomainContactValidationRequestExtraFields = {
 	};
 };
 
+export type ContactValidationResponseMessagesExtra = {
+	ca?: {
+		lang?: string[];
+		legal_type?: string[];
+		cira_agreement_accepted?: string[];
+	};
+	uk?: {
+		registrant_type?: string[];
+		registration_number?: string[];
+		trading_name?: string[];
+	};
+	fr?: {
+		registrant_type?: string[];
+		trademark_number?: string[];
+		siren_siret?: string[];
+	};
+};
+
 /**
  * Response format of the domain contact validation endpoint.
  */
@@ -465,36 +483,24 @@ export type ContactValidationResponseMessages = {
 	country_code?: string[];
 	fax?: string[];
 	vat_id?: string[];
-	extra?: {
-		ca?: {
-			lang?: string[];
-			legal_type?: string[];
-			cira_agreement_accepted?: string[];
-		};
-		uk?: {
-			registrant_type?: string[];
-			registration_number?: string[];
-			trading_name?: string[];
-		};
-		fr?: {
-			registrant_type?: string[];
-			trademark_number?: string[];
-			siren_siret?: string[];
-		};
-	};
+	extra?: ContactValidationResponseMessagesExtra;
 };
 
 export type RawContactValidationResponseMessages = Record< string, string[] >;
 
-export type DomainContactValidationResponse = {
-	success: boolean;
-	messages?: ContactValidationResponseMessages;
-};
+export type DomainContactValidationResponse =
+	| { success: true }
+	| {
+			success: false;
+			messages: ContactValidationResponseMessages;
+	  };
 
-export type RawDomainContactValidationResponse = {
-	success: boolean;
-	messages?: RawContactValidationResponseMessages;
-};
+export type RawDomainContactValidationResponse =
+	| { success: true }
+	| {
+			success: false;
+			messages: RawContactValidationResponseMessages;
+	  };
 
 export interface CountryListItem {
 	code: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The validation endpoints for contact information (domain, tax, and Google Apps) return a value which has a `success: boolean` property; if the property is false, it will also contain a `messages: Record<string, string[]>` property.

This diff alters the TypeScript types for the response to clarify that `success: false` is always paired with `messages` and `success: true` with no other properties.

Extracted from https://github.com/Automattic/wp-calypso/pull/61862

#### Testing instructions

- Add a product to the cart and visit checkout.
- In the contact step, enter an invalid postal code.
- Try to complete the contact step and verify that you get a validation error.
- Change to a valid postal code and verify that you can complete the step successfully.