### PR TITLE
Settings: add support link to Performance page

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -137,6 +137,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/manage-purchases/',
 		post_id: 111349,
 	},
+	'site-speed': {
+		link: 'https://wordpress.com/support/site-speed/',
+		post_id: 150474,
+	},
 	'site-verification': {
 		link: 'https://wordpress.com/support/site-verification-services/',
 		post_id: 5022,

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { pick } from 'lodash';
 import { Component, Fragment } from 'react';
@@ -7,6 +8,7 @@ import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import AmpJetpack from 'calypso/my-sites/site-settings/amp/jetpack';
 import AmpWpcom from 'calypso/my-sites/site-settings/amp/wpcom';
@@ -127,6 +129,14 @@ class SiteSettingsPerformance extends Component {
 						isRequestingSettings={ isRequestingSettings }
 						fields={ fields }
 					/>
+				) }
+
+				{ ( ! siteIsJetpack || siteIsAtomic ) && (
+					<CompactCard>
+						<InlineSupportLink supportContext="site-speed" showIcon={ false }>
+							Learn more about site speed and performance
+						</InlineSupportLink>
+					</CompactCard>
 				) }
 			</Main>
 		);


### PR DESCRIPTION
## Changes proposed in this Pull Request

To help users learn more about how to make their site faster and minimize support contact it was suggested to add a support link to the [Site Speed and Performance](https://wordpress.com/en/support/site-speed/) page. This uses the `InlineSupportLink` component and adds the link to the bottom of the Performance Setting page.

This only applies to Simple and Atomic sites. Jetpack-connected sites should not see this.

| Simple | Atomic | Jetpack |
| - | - | - |
| <img width="760" alt="Markup 2022-03-13 at 21 35 31" src="https://user-images.githubusercontent.com/33258733/158078218-da4597f6-90ed-4046-9df2-d6f1bcbd1dd6.png"> | <img width="760" alt="Markup 2022-03-13 at 21 36 40" src="https://user-images.githubusercontent.com/33258733/158078245-4f9f4258-e9ee-40c2-8b4f-3bf5499ff96b.png"> | <img width="760" alt="Markup 2022-03-13 at 21 37 39" src="https://user-images.githubusercontent.com/33258733/158078302-1afce81d-fd41-4303-96ab-24cd6c7ca74e.png"> |

## Testing instructions

1. Pull branch & `yarn start`
2. Navigate to Settings ⇢ Performance
3. Verify the link is appearing and working
4. Repeat this against Jetpack, Atomic, and Simple site

Fixes #56355 