### PR TITLE
My Profile: add sub-header with inline support link

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -1,4 +1,8 @@
 const contextLinks = {
+	'account-settings': {
+		link: 'https://wordpress.com/support/account-settings/',
+		post_id: 80368,
+	},
 	autorenewal: {
 		link: 'https://wordpress.com/support/manage-purchases/#automatic-renewal',
 		post_id: 111349,
@@ -84,6 +88,10 @@ const contextLinks = {
 	media: {
 		link: 'https://wordpress.com/support/media/',
 		post_id: 853,
+	},
+	'manage-profile': {
+		link: 'https://wordpress.com/support/manage-my-profile/',
+		post_id: 19775,
 	},
 	menus: {
 		link: 'https://wordpress.com/support/menus/',

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -21,6 +21,7 @@ import FormRadio from 'calypso/components/forms/form-radio';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import LanguagePicker from 'calypso/components/language-picker';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
@@ -873,7 +874,21 @@ class Account extends Component {
 				<QueryUserSettings />
 				<PageViewTracker path="/me/account" title="Me > Account Settings" />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
-				<FormattedHeader brandFont headerText={ translate( 'Account settings' ) } align="left" />
+				<FormattedHeader
+					brandFont
+					headerText={ translate( 'Account settings' ) }
+					align="left"
+					subHeaderText={ translate(
+						'Adjust your account information and interface settings. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: (
+									<InlineSupportLink supportContext="account-settings" showIcon={ false } />
+								),
+							},
+						}
+					) }
+				/>
 
 				<SectionHeader label={ translate( 'Account Information' ) } />
 				<Card className="account__settings">

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -11,6 +11,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -46,6 +47,16 @@ class Profile extends Component {
 				<FormattedHeader
 					brandFont
 					headerText={ this.props.translate( 'My Profile' ) }
+					subHeaderText={ this.props.translate(
+						'Set your name, bio, and other public-facing information. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: (
+									<InlineSupportLink supportContext="manage-profile" showIcon={ false } />
+								),
+							},
+						}
+					) }
 					align="left"
 				/>
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Update pages to include a subheader with link to relevant support guide. The `FormattedHeader` already existed so I only added a `subHeaderText` prop and updated the `context-links.js` for the new links.

#### My Profile
<img width="621" alt="Markup 2022-03-13 at 22 06 09" src="https://user-images.githubusercontent.com/33258733/158079250-cb31b88d-36b2-457a-88a8-baa8be960409.png">

#### Account Settings
<img width="604" alt="Markup 2022-03-13 at 22 05 57" src="https://user-images.githubusercontent.com/33258733/158079254-41a0d7a2-8725-496a-a1f3-89dc2a2d05c5.png">

## Testing instructions

1. Pull branch and `yarn start`
2. Go to your profile section and verify the My Profile and Account Settings tabs now have subheaders with working links.

Related to #60876 
