### PR TITLE
Adds DIFM options step

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -390,7 +390,7 @@ export function generateFlows( {
 						'user',
 						'new-or-existing-site',
 						'difm-site-picker',
-						'site-info-collection',
+						'difm-options',
 						'difm-design-setup-site',
 				  ]
 				: [

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -70,6 +70,7 @@ const stepNameToModuleName = {
 	'new-or-existing-site': 'new-or-existing-site',
 	'difm-site-picker': 'difm-site-picker',
 	'difm-design-setup-site': 'design-picker',
+	'difm-options': 'site-options',
 	'site-info-collection': 'site-info-collection',
 	'website-content': 'website-content',
 	intent: 'intent',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -714,6 +714,13 @@ export function generateSteps( {
 				hideDesignTitle: true,
 			},
 		},
+		'difm-options': {
+			stepName: 'site-options',
+			providesDependencies: [ 'siteTitle', 'tagline' ],
+			props: {
+				hideSkip: true,
+			},
+		},
 		'site-info-collection': {
 			stepName: 'site-info-collection',
 			dependencies: [ 'newOrExistingSiteChoice' ],

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -101,7 +101,7 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 		} else {
 			dispatch( removeSiteSlugDependency() );
 			dispatch( submitSignupStep( { stepName: 'difm-site-picker', wasSkipped: true } ) );
-			props.goToStep( 'site-info-collection' );
+			props.goToStep( 'difm-options' );
 		}
 	};
 

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_DIFM_LITE } from '@automattic/calypso-products';
 import { IntentScreen } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
@@ -101,7 +102,9 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 		} else {
 			dispatch( removeSiteSlugDependency() );
 			dispatch( submitSignupStep( { stepName: 'difm-site-picker', wasSkipped: true } ) );
-			props.goToStep( 'difm-options' );
+			props.goToStep(
+				isEnabled( 'signup/redesigned-difm-flow' ) ? 'difm-options' : 'site-info-collection'
+			);
 		}
 	};
 

--- a/client/signup/steps/site-options/index.scss
+++ b/client/signup/steps/site-options/index.scss
@@ -2,7 +2,7 @@
 @import '@wordpress/base-styles/_mixins.scss';
 
 .signup__step .is-site-options,
-.is-difm-options {
+.signup__step .is-difm-options {
 	.step-wrapper__header {
 		@include break-small {
 			flex-basis: 34%;

--- a/client/signup/steps/site-options/index.scss
+++ b/client/signup/steps/site-options/index.scss
@@ -1,7 +1,8 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
 
-.signup__step .is-site-options {
+.signup__step .is-site-options,
+.is-difm-options {
 	.step-wrapper__header {
 		@include break-small {
 			flex-basis: 34%;

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -33,6 +33,14 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 					siteTitleLabel: translate( 'Store name' ),
 					taglineExplanation: translate( 'In a few words, explain what your store is about.' ),
 				};
+			case 'difm-options':
+				return {
+					headerText: translate( "First, let's give your site a name" ),
+					headerImage: siteOptionsImage,
+					siteTitleLabel: translate( 'Site title' ),
+					taglineExplanation: translate( 'In a few words, explain what your site is about.' ),
+					isSiteTitleRequired: true,
+				};
 
 			// Regular blog
 			default:
@@ -45,7 +53,13 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 		}
 	};
 
-	const { headerText, headerImage, siteTitleLabel, taglineExplanation } = getStepText( stepName );
+	const {
+		headerText,
+		headerImage,
+		siteTitleLabel,
+		taglineExplanation,
+		isSiteTitleRequired,
+	} = getStepText( stepName );
 
 	const submitSiteOptions = ( { siteTitle, tagline }: SiteOptionsFormValues ) => {
 		recordTracksEvent( 'calypso_signup_site_options_submit', {
@@ -74,6 +88,7 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 					defaultTagline={ tagline }
 					siteTitleLabel={ siteTitleLabel }
 					taglineExplanation={ taglineExplanation }
+					isSiteTitleRequired={ isSiteTitleRequired }
 					onSubmit={ submitSiteOptions }
 				/>
 			}

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -24,7 +24,7 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 	const { stepName, signupDependencies, goToNextStep } = props;
 	const { siteTitle, tagline } = signupDependencies;
 
-	const getStepText = ( stepName: string ) => {
+	const getSiteOptionsProps = ( stepName: string ) => {
 		switch ( stepName ) {
 			case 'store-options':
 				return {
@@ -59,7 +59,7 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 		siteTitleLabel,
 		taglineExplanation,
 		isSiteTitleRequired,
-	} = getStepText( stepName );
+	} = getSiteOptionsProps( stepName );
 
 	const submitSiteOptions = ( { siteTitle, tagline }: SiteOptionsFormValues ) => {
 		recordTracksEvent( 'calypso_signup_site_options_submit', {

--- a/client/signup/steps/site-options/site-options.scss
+++ b/client/signup/steps/site-options/site-options.scss
@@ -59,6 +59,14 @@
 			margin-right: 8px;
 		}
 	}
+
+	.form-input-validation {
+		span {
+			display: flex;
+			align-items: center;
+			gap: 10px;
+		}
+	}
 }
 
 .button.site-options__submit-button.is-primary {

--- a/client/signup/steps/site-options/site-options.tsx
+++ b/client/signup/steps/site-options/site-options.tsx
@@ -1,13 +1,15 @@
 import { Button } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import React, { ReactChild } from 'react';
+import React, { ReactChild, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
 import { tip } from '../../icons';
 import type { SiteOptionsFormValues } from './types';
+import type { TranslateResult } from 'i18n-calypso';
 import './site-options.scss';
 
 interface Props {
@@ -15,6 +17,8 @@ interface Props {
 	defaultTagline: string;
 	siteTitleLabel: ReactChild;
 	taglineExplanation: ReactChild;
+	isSiteTitleRequired?: boolean;
+	isTaglineRequired?: boolean;
 	onSubmit: ( siteOptionsFormValues: SiteOptionsFormValues ) => void;
 	translate: LocalizeProps[ 'translate' ];
 }
@@ -24,6 +28,8 @@ const SiteOptions: React.FC< Props > = ( {
 	defaultTagline = '',
 	siteTitleLabel,
 	taglineExplanation,
+	isSiteTitleRequired,
+	isTaglineRequired,
 	onSubmit,
 	translate,
 } ) => {
@@ -32,22 +38,35 @@ const SiteOptions: React.FC< Props > = ( {
 		tagline: defaultTagline,
 	} );
 
+	const [ siteTitleError, setSiteTitleError ] = useState< TranslateResult | null >( null );
+	const [ taglineError, setTaglineError ] = useState< TranslateResult | null >( null );
+
 	const onChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		setFormValues( ( value ) => ( {
 			...value,
 			[ event.target.name ]: event.target.value,
 		} ) );
+		setSiteTitleError( null );
+		setTaglineError( null );
 	};
 
 	const handleSubmit = ( event: React.FormEvent ) => {
 		event.preventDefault();
+		if ( isSiteTitleRequired && ! formValues.siteTitle?.trim().length ) {
+			setSiteTitleError( translate( 'A valid site title is required.' ) );
+			return;
+		}
+		if ( isTaglineRequired && ! formValues.tagline?.trim().length ) {
+			setTaglineError( translate( 'A valid tagline is required.' ) );
+			return;
+		}
 		onSubmit( formValues );
 	};
 
 	return (
 		<form className="site-options__form" onSubmit={ handleSubmit }>
 			<FormFieldset className="site-options__form-fieldset">
-				<FormLabel htmlFor="siteTitle" optional>
+				<FormLabel htmlFor="siteTitle" optional={ ! isSiteTitleRequired }>
 					{ siteTitleLabel }
 				</FormLabel>
 				<FormInput
@@ -56,12 +75,14 @@ const SiteOptions: React.FC< Props > = ( {
 					value={ formValues.siteTitle }
 					onChange={ onChange }
 				/>
+				{ siteTitleError && <FormInputValidation isError text={ siteTitleError } /> }
 			</FormFieldset>
 			<FormFieldset className="site-options__form-fieldset">
-				<FormLabel htmlFor="tagline" optional>
+				<FormLabel htmlFor="tagline" optional={ ! isTaglineRequired }>
 					{ translate( 'Tagline' ) }
 				</FormLabel>
 				<FormInput name="tagline" id="tagline" value={ formValues.tagline } onChange={ onChange } />
+				{ taglineError && <FormInputValidation isError text={ taglineError } /> }
 				<FormSettingExplanation>
 					<Icon className="site-options__form-icon" icon={ tip } size={ 20 } />
 					{ taglineExplanation }

--- a/client/signup/steps/site-options/site-options.tsx
+++ b/client/signup/steps/site-options/site-options.tsx
@@ -73,6 +73,7 @@ const SiteOptions: React.FC< Props > = ( {
 					name="siteTitle"
 					id="siteTitle"
 					value={ formValues.siteTitle }
+					isError={ siteTitleError }
 					onChange={ onChange }
 				/>
 				{ siteTitleError && <FormInputValidation isError text={ siteTitleError } /> }
@@ -81,7 +82,13 @@ const SiteOptions: React.FC< Props > = ( {
 				<FormLabel htmlFor="tagline" optional={ ! isTaglineRequired }>
 					{ translate( 'Tagline' ) }
 				</FormLabel>
-				<FormInput name="tagline" id="tagline" value={ formValues.tagline } onChange={ onChange } />
+				<FormInput
+					name="tagline"
+					id="tagline"
+					value={ formValues.tagline }
+					isError={ taglineError }
+					onChange={ onChange }
+				/>
 				{ taglineError && <FormInputValidation isError text={ taglineError } /> }
 				<FormSettingExplanation>
 					<Icon className="site-options__form-icon" icon={ tip } size={ 20 } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds the `difm-options` step to the `do-it-for-me` signup flow. The new step is accessible when the `signup/redesigned-difm-flow` feature flag is enabled. However, the end-to-end flow will not be testable.
* Site title is a required field and should be added before proceeding.
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/5436027/158157216-5507490d-a755-4302-9df0-13ff928e4508.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me/?flags=signup/redesigned-difm-flow`
* Click on "New Site".
* Confirm that the UI matches the screenshot shared above.
* Click on the continue button without entering a site title. Confirm that you can see the validation error.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
