### PR TITLE
Fix Sidebar Scroll synchronizer

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -45,9 +45,9 @@ import { handleScroll } from './utils';
 import 'calypso/components/environment-badge/style.scss';
 import './style.scss';
 
-function SidebarScrollSynchronizer( { enabled } ) {
+function SidebarScrollSynchronizer() {
 	const isNarrow = useBreakpoint( '<660px' );
-	const active = enabled && ! isNarrow && ! config.isEnabled( 'jetpack-cloud' ); // Jetpack cloud hasn't yet aligned with WPCOM.
+	const active = ! isNarrow && ! config.isEnabled( 'jetpack-cloud' ); // Jetpack cloud hasn't yet aligned with WPCOM.
 
 	useEffect( () => {
 		if ( active ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a regression introduced by https://github.com/Automattic/wp-calypso/pull/61901 which was preventing the sidebar from being scrollable.

More info: p1647260885084749-slack-C03TY6J1A

#### Testing instructions

- Use the Calypso live link below.
- Adjust the browser size so the sidebar doesn't fit in the window.
- Make sure you can scroll the sidebar.