### PR TITLE
Sign Up: Remove mobile social login first experiment

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { isMobile } from '@automattic/viewport';
 import { isEmpty } from 'lodash';
 import page from 'page';
 import { createElement } from 'react';

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -342,10 +342,6 @@ export default {
 			loadExperimentAssignment( 'calypso_signup_monthly_plans_default_202201_v2' );
 		}
 
-		if ( isMobile() && 'wpcc' !== flowName ) {
-			loadExperimentAssignment( 'registration_social_login_first_on_mobile_v3' );
-		}
-
 		context.primary = createElement( SignupComponent, {
 			store: context.store,
 			path: context.path,

--- a/client/signup/steps/user/style.scss
+++ b/client/signup/steps/user/style.scss
@@ -27,33 +27,3 @@ body.is-section-signup.is-white-signup .signup {
 		}
 	}
 }
-
-.user__simpler-mobile-form {
-
-	.signup-form {
-		flex-direction: column-reverse !important;
-
-		.signup-form__social-buttons-tos {
-			display: none;
-		}
-	}
-
-	.signup-form__terms-of-service-link {
-		margin-bottom: 0 !important;
-	}
-
-	p.signup-form__social-buttons-tos {
-		font-size: 0.75rem;
-		text-align: left;
-		padding: 0 16px;
-		max-width: 408px;
-		color: var( --studio-gray-40 );
-		font-weight: 400;
-		margin-top: -60px;
-		margin-bottom: 80px;
-
-		a {
-			color: var( --studio-gray-40 );
-		}
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reverts the Mobile only social login first experiment pbxNRc-1a4-p2
* Related PR that introduced it https://github.com/Automattic/wp-calypso/pull/57940


#### Testing instructions

* Navigate to /start/user on a smaller screen.
* Are you able to complete the signup flow? 
