### PR TITLE
Emails: Exploration to show existing mailboxes on the add new mailboxes form

### DIFF
--- a/client/my-sites/email/titan-add-mailboxes/index.jsx
+++ b/client/my-sites/email/titan-add-mailboxes/index.jsx
@@ -10,7 +10,6 @@ import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import HeaderCake from 'calypso/components/header-cake';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
-import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { titanMailMonthly, titanMailYearly } from 'calypso/lib/cart-values/cart-items';
 import { getSelectedDomain } from 'calypso/lib/domains';
@@ -42,6 +41,7 @@ import {
 	emailManagementTitanSetUpMailbox,
 } from 'calypso/my-sites/email/paths';
 import TitanUnusedMailboxesNotice from 'calypso/my-sites/email/titan-add-mailboxes/titan-unused-mailbox-notice';
+import { TitanExistingMailboxes } from 'calypso/my-sites/email/titan-existing-mailboxes/titan-existing-mailboxes';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
@@ -205,7 +205,13 @@ class TitanAddMailboxes extends Component {
 	};
 
 	renderForm() {
-		const { isLoadingDomains, selectedDomainName, titanMailProduct, translate } = this.props;
+		const {
+			isLoadingDomains,
+			selectedDomainName,
+			selectedSite,
+			titanMailProduct,
+			translate,
+		} = this.props;
 
 		if ( isLoadingDomains || ! titanMailProduct ) {
 			return <AddEmailAddressesCardPlaceholder />;
@@ -213,8 +219,13 @@ class TitanAddMailboxes extends Component {
 
 		return (
 			<>
-				<SectionHeader label={ translate( 'Add New Mailboxes' ) } />
-
+				<TitanExistingMailboxes
+					selectedDomainName={ selectedDomainName }
+					selectedSiteId={ selectedSite.ID }
+					title={ translate( 'Add New Mailboxes', {
+						textOnly: true,
+					} ) }
+				/>
 				<Card>
 					<TitanNewMailboxList
 						selectedDomainName={ selectedDomainName }

--- a/client/my-sites/email/titan-existing-mailboxes/style.scss
+++ b/client/my-sites/email/titan-existing-mailboxes/style.scss
@@ -10,8 +10,14 @@ div.titan-existing-mailboxes__header.is-expanded.is-compact {
 
 		ul {
 			font-size: $font-body-small;
-			line-height: 1em;
+			line-height: 1.5em;
 		}
+	}
+}
+
+.titan-existing-mailboxes__header {
+	.titan-existing-mailboxes__existing-mailboxes {
+		margin-bottom: 16px;
 	}
 }
 

--- a/client/my-sites/email/titan-existing-mailboxes/style.scss
+++ b/client/my-sites/email/titan-existing-mailboxes/style.scss
@@ -1,0 +1,17 @@
+div.titan-existing-mailboxes__header.is-expanded.is-compact {
+	margin-bottom: 0;
+	margin-top: 0;
+
+	.foldable-card__content {
+		max-height: 200px;
+		overflow: scroll;
+		overflow-x: hidden;
+		overflow-y: visible;
+
+		ul {
+			font-size: $font-body-small;
+			line-height: 1em;
+		}
+	}
+}
+

--- a/client/my-sites/email/titan-existing-mailboxes/titan-existing-mailboxes.tsx
+++ b/client/my-sites/email/titan-existing-mailboxes/titan-existing-mailboxes.tsx
@@ -58,9 +58,8 @@ export const TitanExistingMailboxes = ( {
 			screenReaderText={ translate( 'See existing mailboxes' ) }
 			summary={ summary }
 		>
-			{ mailboxes?.map( ( mailbox: Mailbox ) => (
-				<ul> { renderMailbox( mailbox ) } </ul>
-			) ) }
+			<h3 className="titan-existing-mailboxes__existing-mailboxes"> { translate( 'Existing mailboxes' ) }</h3>
+			<ul>{ mailboxes?.map( ( mailbox: Mailbox ) => renderMailbox( mailbox ) ) }</ul>
 		</FoldableCard>
 	);
 };

--- a/client/my-sites/email/titan-existing-mailboxes/titan-existing-mailboxes.tsx
+++ b/client/my-sites/email/titan-existing-mailboxes/titan-existing-mailboxes.tsx
@@ -1,0 +1,66 @@
+import { useTranslate } from 'i18n-calypso';
+import Spinner from 'calypso/components/spinner';
+import { useGetMailboxes } from 'calypso/data/emails/use-get-mailboxes';
+import { FoldableCard } from 'calypso/devdocs/design/playground-scope';
+import { getEmailAddress } from 'calypso/lib/emails';
+import {
+	EMAIL_ACCOUNT_TYPE_TITAN_MAIL,
+	EMAIL_ACCOUNT_TYPE_TITAN_MAIL_EXTERNAL,
+} from 'calypso/lib/emails/email-provider-constants';
+
+import './style.scss';
+
+interface TitanExistingMailboxesProps {
+	selectedDomainName: string;
+	selectedSiteId: number;
+	title: string;
+}
+
+interface Mailbox {
+	account_type: string;
+	domain: string;
+	last_access_time: Date | null;
+	mailbox: string;
+}
+
+export const TitanExistingMailboxes = ( {
+	selectedDomainName,
+	selectedSiteId,
+	title,
+}: TitanExistingMailboxesProps ): JSX.Element | null => {
+	const translate = useTranslate();
+
+	const { data, isLoading } = useGetMailboxes( selectedSiteId, {
+		retry: 2,
+	} );
+
+	const summary = isLoading ? <Spinner /> : translate( 'Existing mailboxes' );
+
+	const mailboxes = data?.mailboxes
+		?.filter(
+			( mailbox: Mailbox ) =>
+				mailbox.domain === selectedDomainName &&
+				[ EMAIL_ACCOUNT_TYPE_TITAN_MAIL, EMAIL_ACCOUNT_TYPE_TITAN_MAIL_EXTERNAL ].some(
+					( accountType ) => accountType === mailbox.account_type
+				)
+		)
+		.sort( ( mailbox: Mailbox ) => mailbox.domain );
+
+	const renderMailbox = ( mailbox: Mailbox ) => {
+		return <li> { getEmailAddress( mailbox ) } </li>;
+	};
+
+	return (
+		<FoldableCard
+			className="titan-existing-mailboxes__header"
+			compact
+			header={ title }
+			screenReaderText={ translate( 'See existing mailboxes' ) }
+			summary={ summary }
+		>
+			{ mailboxes?.map( ( mailbox: Mailbox ) => (
+				<ul> { renderMailbox( mailbox ) } </ul>
+			) ) }
+		</FoldableCard>
+	);
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a proposal to show the existing mailboxes in the Professional Email add mailboxes form.

#### Testing instructions

1. Go to Upgrades -> Emails.
2. Choose a domain with an existing Professional Email subscription (or create a new one).
3. Click on "Add new mailboxes" at the bottom of the form.
4. Click to expand the header "Add new mailboxes" in the right side chevron icon.
5. Check that the shown mailboxes are really existing ones.

Loading state:
![image](https://user-images.githubusercontent.com/5689927/158226949-4457a18c-651b-4078-b557-953b90d4bd4a.png)

Loaded state:
![image](https://user-images.githubusercontent.com/5689927/158227097-64afd86a-cffe-4c6e-b490-bbb1a9dabd71.png)

Expanded state:
![image](https://user-images.githubusercontent.com/5689927/158228953-2de1eb29-5143-4c59-aacf-08863fa38dca.png)


Related to {1200414241759894-as-1201610800776451}
