### PR TITLE
Redirect: redirect to permalink instead of editor for logged out users.

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -107,7 +107,7 @@ function isEditorPath( path ) {
 		case 'edit':
 			if (
 				splitPath[ 1 ] &&
-				[ 'jetpack-testimonial', 'jetpack-portfolio' ].indexOf( splitPath[ 1 ] )
+				[ 'jetpack-testimonial', 'jetpack-portfolio' ].indexOf( splitPath[ 1 ] ) !== -1
 			) {
 				return true;
 			}

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -107,7 +107,7 @@ function isEditorPath( path ) {
 		case 'edit':
 			if (
 				splitPath[ 1 ] &&
-				[ 'jetpack-testimonial', 'jetpack-portfolio' ].indexOf( splitPath[ 1 ] ) !== -1
+				[ 'jetpack-testimonial', 'jetpack-portfolio' ].includes( splitPath[ 1 ] )
 			) {
 				return true;
 			}

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -98,6 +98,18 @@ export function clientRouter( route, ...middlewares ) {
 	page( route, ...middlewares, smartHydrate );
 }
 
+function isEditorPath( path ) {
+	const splitPath = path.split( '/' ).filter( ( n ) => n );
+	switch ( splitPath[ 0 ] ) {
+		case 'page':
+		case 'post':
+		case 'type':
+			return true;
+	}
+
+	return false;
+}
+
 export function redirectLoggedOut( context, next ) {
 	const state = context.store.getState();
 	const userLoggedOut = ! isUserLoggedIn( state );
@@ -121,6 +133,11 @@ export function redirectLoggedOut( context, next ) {
 		const login_locale = getImmediateLoginLocale( state );
 		if ( login_locale ) {
 			loginParameters.locale = login_locale;
+		}
+
+		if ( isEditorPath( context.path ) && siteFragment ) {
+			window.location = `https://public-api.wordpress.com/wpcom/v2/redirect?path=${ context.path }&site=${ siteFragment }&redirect=true`;
+			return;
 		}
 
 		// force full page reload to avoid SSR hydration issues.

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -103,8 +103,15 @@ function isEditorPath( path ) {
 	switch ( splitPath[ 0 ] ) {
 		case 'page':
 		case 'post':
-		case 'type':
 			return true;
+		case 'edit':
+			if (
+				splitPath[ 1 ] &&
+				[ 'jetpack-testimonial', 'jetpack-portfolio' ].indexOf( splitPath[ 1 ] )
+			) {
+				return true;
+			}
+			return false;
 	}
 
 	return false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixes https://github.com/Automattic/wp-calypso/issues/53017 

Currently, some users are confused when they send an editor link to folks to take a look at but when users visit it they end up on the log in screen. 

This PR redirects users of the post editor to a new endpoint defined in D76631-code that then decides to either send the user back to the login screen ( if the post is not published ) or to the permalink. 

For logged-in users, the experience should stay the same. 

Related to D76631-code

#### Testing instructions
* Apply D76631-code to your sandbox and sandbox public-api.wordpress.com to point to your sandbox. 
* Copy the url of a published ( page, post, portfolio and testimony )  in the editor. 
* In an incognito ( logged out view ) vist the editor page that you published. 
* It should take you to the permalink of that post, page, portfolio and testimony instead of the log-in form. 
* Note that if you are logged in that you should see the editor. 



