### PR TITLE
Seller Experience: Hide categories for the sell intent

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -119,14 +119,14 @@ export default function DesignPickerStep( props ) {
 
 	const { designs, featuredPicksDesigns, sellDesigns } = useMemo( () => {
 		/*
-		 * For the sell intent, temporarily filter by theme.slug since we only have a few themes;
-		 * Eventually we'd want to filter by categories.[category].slug === 'store'
+		 * For the sell intent, temporarily return only `store` tagged themes
 		 */
-		const eCommDesigns = [ 'attar', 'dorna', 'hari', 'marl', 'winkel' ];
 		return {
 			designs: shuffle( allThemes.filter( ( theme ) => ! theme.is_featured_picks ) ),
 			featuredPicksDesigns: allThemes.filter( ( theme ) => theme.is_featured_picks ),
-			sellDesigns: allThemes.filter( ( theme ) => eCommDesigns.includes( theme.slug ) ),
+			sellDesigns: allThemes.filter( ( theme ) =>
+				theme.categories.some( ( category ) => category.slug === 'store' )
+			),
 		};
 	}, [ allThemes ] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* An alternative fix to changing what content is used when choosing the simple `sell` intent, this PR disables categories and only shows e-commerce themes.
* Override `showDesignPickerCategories` for users with the `sell` intent with a new constant `shouldShowCategories`
* Filter themes shown by checking the `theme.categories.[category].slug`
* Ideally these changes are temporary until we can offer a broader selection of e-commerce themes.

**Video demo**

https://user-images.githubusercontent.com/2124984/158241320-2424744a-206c-4b61-8c13-0ff9faa43815.mov



#### Testing instructions


* Switch to this PR, navigate to `/start`
* Create a site with the `sell` intent, choosing "Sell" and "Simple"
* You should be brought to the design picker with only five themes showing and no category filters.
* Go back and try other intents; you should be shown the design picker with all themes and the category filters.

Fixes #61921