### PR TITLE
Theme Showcase: Don't display support contact card for non-wpcom themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -487,6 +487,7 @@ class ThemeSheet extends Component {
 
 	renderSupportTab = () => {
 		const {
+			author,
 			isCurrentUserPaid,
 			isStandaloneJetpack,
 			forumUrl,
@@ -501,6 +502,7 @@ class ThemeSheet extends Component {
 			renderedTab = (
 				<div>
 					{ isCurrentUserPaid &&
+						( isWpcomTheme || author === 'Automattic' ) &&
 						! isStandaloneJetpack &&
 						this.renderSupportContactUsCard( buttonCount++ ) }
 					{ forumUrl && this.renderSupportThemeForumCard( buttonCount++ ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a user is viewing the 'Support' tab for a non-WordPress.com theme, hide the 'Need extra help' card (since wpcom doesn't support third-party themes

#### Testing instructions

1. View the support tab for a non-WordPress.com theme (eg `/theme/extendednews/support/`).
2. You shouldn't see the "Need extra help"? card.
<img width="710" alt="image" src="https://user-images.githubusercontent.com/917632/158242767-6224f733-e8cf-4141-a369-1a7f6f121cb2.png">


3. View the support for a WordPress.com theme (eg `/theme/skatepark/support/`).
4. You _should_ see the "Need extra help?" card.
<img width="705" alt="image" src="https://user-images.githubusercontent.com/917632/158242800-156d0eed-07d7-433a-9f4b-4bbdd689f675.png">

Fixes #61805
