### PR TITLE
Themes: Don't show My Themes for sites that can't upload themes

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -1,3 +1,4 @@
+import { FEATURE_UPLOAD_THEMES } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
 import page from 'page';
@@ -17,6 +18,8 @@ import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	getActiveTheme,
@@ -72,6 +75,7 @@ class ThemeShowcase extends Component {
 	}
 
 	static propTypes = {
+		canUploadThemes: PropTypes.bool,
 		currentThemeId: PropTypes.string,
 		emptyContent: PropTypes.element,
 		tier: PropTypes.oneOf( [ '', 'free', 'premium' ] ),
@@ -86,6 +90,7 @@ class ThemeShowcase extends Component {
 		upsellBanner: PropTypes.any,
 		trackMoreThemesClick: PropTypes.func,
 		loggedOutComponent: PropTypes.bool,
+		isAtomicSite: PropTypes.bool,
 		isJetpackSite: PropTypes.bool,
 	};
 
@@ -251,7 +256,9 @@ class ThemeShowcase extends Component {
 			case this.tabFilters.ALL.key:
 				return true;
 			case this.tabFilters.MYTHEMES.key:
-				return this.props.isJetpackSite;
+				return (
+					this.props.isJetpackSite || ( this.props.isAtomicSite && this.props.canUploadThemes )
+				);
 		}
 	};
 
@@ -378,9 +385,11 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
 	const currentThemeId = getActiveTheme( state, siteId );
 	const currentTheme = getCanonicalTheme( state, siteId, currentThemeId );
 	return {
+		canUploadThemes: hasActiveSiteFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 		currentThemeId,
 		currentTheme,
 		isLoggedIn: isUserLoggedIn( state ),
+		isAtomicSite: isAtomicSite( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 		description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
 		title: getThemeShowcaseTitle( state, { filter, tier, vertical } ),

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -257,7 +257,8 @@ class ThemeShowcase extends Component {
 				return true;
 			case this.tabFilters.MYTHEMES.key:
 				return (
-					this.props.isJetpackSite || ( this.props.isAtomicSite && this.props.canUploadThemes )
+					( this.props.isJetpackSite && ! this.props.isAtomicSite ) ||
+					( this.props.isAtomicSite && this.props.canUploadThemes )
 				);
 		}
 	};

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -1,4 +1,4 @@
-import { FEATURE_UPLOAD_THEMES } from '@automattic/calypso-products';
+import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
 import page from 'page';
@@ -75,7 +75,6 @@ class ThemeShowcase extends Component {
 	}
 
 	static propTypes = {
-		canUploadThemes: PropTypes.bool,
 		currentThemeId: PropTypes.string,
 		emptyContent: PropTypes.element,
 		tier: PropTypes.oneOf( [ '', 'free', 'premium' ] ),
@@ -86,6 +85,7 @@ class ThemeShowcase extends Component {
 		defaultOption: optionShape,
 		secondaryOption: optionShape,
 		getScreenshotOption: PropTypes.func,
+		siteCanInstallThemes: PropTypes.bool,
 		siteSlug: PropTypes.string,
 		upsellBanner: PropTypes.any,
 		trackMoreThemesClick: PropTypes.func,
@@ -258,7 +258,7 @@ class ThemeShowcase extends Component {
 			case this.tabFilters.MYTHEMES.key:
 				return (
 					( this.props.isJetpackSite && ! this.props.isAtomicSite ) ||
-					( this.props.isAtomicSite && this.props.canUploadThemes )
+					( this.props.isAtomicSite && this.props.siteCanInstallThemes )
 				);
 		}
 	};
@@ -386,11 +386,11 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
 	const currentThemeId = getActiveTheme( state, siteId );
 	const currentTheme = getCanonicalTheme( state, siteId, currentThemeId );
 	return {
-		canUploadThemes: hasActiveSiteFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 		currentThemeId,
 		currentTheme,
 		isLoggedIn: isUserLoggedIn( state ),
 		isAtomicSite: isAtomicSite( state, siteId ),
+		siteCanInstallThemes: hasActiveSiteFeature( state, siteId, FEATURE_INSTALL_THEMES ),
 		siteSlug: getSiteSlug( state, siteId ),
 		description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
 		title: getThemeShowcaseTitle( state, { filter, tier, vertical } ),

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -60,6 +60,7 @@ export const FEATURE_NO_BRANDING = 'no-wp-branding';
 export const FEATURE_ADVANCED_SEO = 'advanced-seo';
 export const FEATURE_UPLOAD_PLUGINS = 'upload-plugins';
 export const FEATURE_INSTALL_PLUGINS = 'install-plugins';
+export const FEATURE_INSTALL_THEMES = 'install-themes';
 export const FEATURE_UPLOAD_THEMES = 'upload-themes';
 export const FEATURE_PERFORMANCE = 'performance';
 export const FEATURE_REPUBLICIZE = 'republicize';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a feature check for WoA sites to determine if My Themes should be shown.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up an Atomic site with a plan below Business.
* Navigate to https://wordpress.com/themes and select a site.
* Verify that My Themes doesn't show up.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #61509
