### PR TITLE
Refactor Variant Item Rendering

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -1,12 +1,27 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 import { RadioButton } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
+import { ItemVariantPrice } from './variant-price';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
 import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
+
+const TermOptions = styled.ul`
+	flex-basis: 100%;
+	margin: 20px 0 0;
+	padding: 0;
+`;
+
+const TermOptionsItem = styled.li`
+	margin: 8px 0 0;
+	padding: 0;
+	list-style: none;
+
+	:first-of-type {
+		margin-top: 0;
+	}
+`;
 
 export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerProps > = ( {
 	selectedItem,
@@ -36,19 +51,21 @@ export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerPr
 	);
 };
 
-function ProductVariant( {
-	productVariant,
-	selectedItem,
-	onChangeItemVariant,
-	isDisabled,
-}: {
+interface ProductVariantProps {
 	productVariant: WPCOMProductVariant;
 	selectedItem: ResponseCartProduct;
 	onChangeItemVariant: OnChangeItemVariant;
 	isDisabled: boolean;
-} ) {
+}
+
+const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
+	productVariant,
+	selectedItem,
+	onChangeItemVariant,
+	isDisabled,
+} ) => {
 	const translate = useTranslate();
-	const { variantLabel, variantDetails, productSlug, productId } = productVariant;
+	const { variantLabel, productSlug, productId } = productVariant;
 	const selectedProductSlug = selectedItem.product_slug;
 	const isChecked = productSlug === selectedProductSlug;
 
@@ -64,35 +81,9 @@ function ProductVariant( {
 					! isDisabled && onChangeItemVariant( selectedItem.uuid, productSlug, productId );
 				} }
 				ariaLabel={ translate( 'Select a different term length' ) as string }
-				label={
-					<>
-						<VariantLabel>{ variantLabel }</VariantLabel>
-						{ variantDetails }
-					</>
-				}
+				label={ <ItemVariantPrice variant={ productVariant } /> }
 				children={ [] }
 			/>
 		</TermOptionsItem>
 	);
-}
-
-const TermOptions = styled.ul`
-	flex-basis: 100%;
-	margin: 20px 0 0;
-	padding: 0;
-`;
-
-const TermOptionsItem = styled.li`
-	margin: 8px 0 0;
-	padding: 0;
-	list-style: none;
-
-	:first-of-type {
-		margin-top: 0;
-	}
-`;
-
-const VariantLabel = styled.span`
-	flex: 1;
-	display: flex;
-`;
+};

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -2,8 +2,8 @@ import { RadioButton } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
-import { ItemVariantPrice } from './variant-price';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
+import { ItemVariantPrice } from './variant-price';
 import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -22,34 +22,6 @@ const TermOptionsItem = styled.li`
 		margin-top: 0;
 	}
 `;
-
-export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerProps > = ( {
-	selectedItem,
-	onChangeItemVariant,
-	isDisabled,
-	siteId,
-	productSlug,
-} ) => {
-	const variants = useGetProductVariants( siteId, productSlug );
-
-	if ( variants.length < 2 ) {
-		return null;
-	}
-
-	return (
-		<TermOptions className="item-variation-picker">
-			{ variants.map( ( productVariant: WPCOMProductVariant ) => (
-				<ProductVariant
-					key={ productVariant.productSlug + productVariant.variantLabel }
-					selectedItem={ selectedItem }
-					onChangeItemVariant={ onChangeItemVariant }
-					isDisabled={ isDisabled }
-					productVariant={ productVariant }
-				/>
-			) ) }
-		</TermOptions>
-	);
-};
 
 interface ProductVariantProps {
 	productVariant: WPCOMProductVariant;
@@ -85,5 +57,33 @@ const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
 				children={ [] }
 			/>
 		</TermOptionsItem>
+	);
+};
+
+export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerProps > = ( {
+	selectedItem,
+	onChangeItemVariant,
+	isDisabled,
+	siteId,
+	productSlug,
+} ) => {
+	const variants = useGetProductVariants( siteId, productSlug );
+
+	if ( variants.length < 2 ) {
+		return null;
+	}
+
+	return (
+		<TermOptions className="item-variation-picker">
+			{ variants.map( ( productVariant: WPCOMProductVariant ) => (
+				<ProductVariant
+					key={ productVariant.productSlug + productVariant.variantLabel }
+					selectedItem={ selectedItem }
+					onChangeItemVariant={ onChangeItemVariant }
+					isDisabled={ isDisabled }
+					productVariant={ productVariant }
+				/>
+			) ) }
+		</TermOptions>
 	);
 };

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
@@ -3,10 +3,12 @@ import type { ResponseCartProduct } from '@automattic/shopping-cart';
 export type WPCOMProductSlug = string;
 
 export type WPCOMProductVariant = {
-	variantLabel: string;
-	variantDetails: React.ReactNode;
-	productSlug: WPCOMProductSlug;
+	discountPercentage: number;
+	formattedCurrentPrice: string | null;
+	formattedPriceBeforeDiscount: string | null;
 	productId: number;
+	productSlug: WPCOMProductSlug;
+	variantLabel: string;
 };
 
 export type ItemVariationPickerProps = {

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -1,0 +1,84 @@
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { styled } from '@automattic/wpcom-checkout';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import type { WPCOMProductVariant } from './types';
+
+const Discount = styled.span`
+	color: ${ ( props ) => props.theme.colors.discount };
+	margin-right: 8px;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
+
+	@media ( max-width: 660px ) {
+		width: 100%;
+	}
+`;
+
+const DoNotPayThis = styled.del`
+	text-decoration: line-through;
+	margin-right: 8px;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
+`;
+
+const Variant = styled.div`
+	display: flex;
+	width: 100%;
+	justify-content: space-between;
+`;
+
+const Label = styled.span`
+	display: flex;
+	// MOBILE_BREAKPOINT is <480px, used in useMobileBreakpoint
+	@media ( max-width: 480px ) {
+		flex-direction: column;
+	}
+`;
+
+interface Props {
+	variant: WPCOMProductVariant;
+}
+
+const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {
+	const translate = useTranslate();
+	return (
+		<Discount>
+			{ translate( 'Save %(percent)s%%', {
+				args: {
+					percent,
+				},
+			} ) }
+		</Discount>
+	);
+};
+
+export const ItemVariantPrice: FunctionComponent< Props > = ( { variant } ) => {
+	const isMobile = useMobileBreakpoint();
+
+	return (
+		<Variant>
+			<Label>
+				{ variant.variantLabel }
+				{ variant.discountPercentage > 0 && isMobile && (
+					<DiscountPercentage percent={ variant.discountPercentage } />
+				) }
+			</Label>
+			<span>
+				{ variant.discountPercentage > 0 && ! isMobile && (
+					<DiscountPercentage percent={ variant.discountPercentage } />
+				) }
+				{ variant.discountPercentage > 0 && (
+					<DoNotPayThis>{ variant.formattedPriceBeforeDiscount }</DoNotPayThis>
+				) }
+				{ variant.formattedCurrentPrice }
+			</span>
+		</Variant>
+	);
+};

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -42,10 +42,6 @@ const Label = styled.span`
 	}
 `;
 
-interface Props {
-	variant: WPCOMProductVariant;
-}
-
 const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {
 	const translate = useTranslate();
 	return (
@@ -59,7 +55,9 @@ const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent
 	);
 };
 
-export const ItemVariantPrice: FunctionComponent< Props > = ( { variant } ) => {
+export const ItemVariantPrice: FunctionComponent< {
+	variant: WPCOMProductVariant;
+} > = ( { variant } ) => {
 	const isMobile = useMobileBreakpoint();
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -13,10 +13,9 @@ import {
 	TERM_MONTHLY,
 } from '@automattic/calypso-products';
 import formatCurrency, { CURRENCIES } from '@automattic/format-currency';
-import { styled } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, useEffect, useState, useMemo, useCallback } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { requestPlans } from 'calypso/state/plans/actions';
 import { requestProductsList } from 'calypso/state/products-list/actions';
@@ -26,6 +25,14 @@ import type { WPCOMProductVariant } from '../components/item-variation-picker';
 import type { Plan, Product } from '@automattic/calypso-products';
 
 const debug = debugFactory( 'calypso:composite-checkout:product-variants' );
+
+function myFormatCurrency( price: number, code: string, options = {} ) {
+	const precision = CURRENCIES[ code ].precision;
+	const EPSILON = Math.pow( 10, -precision ) - 0.000000001;
+
+	const hasCents = Math.abs( price % 1 ) >= EPSILON;
+	return formatCurrency( price, code, hasCents ? options : { ...options, precision: 0 } );
+}
 
 export interface AvailableProductVariant {
 	planSlug: string;
@@ -52,32 +59,6 @@ export interface SitePlanData {
 interface SitesPlansResult {
 	data: SitePlanData[];
 }
-
-const Discount = styled.span`
-	color: ${ ( props ) => props.theme.colors.discount };
-	margin-right: 8px;
-
-	.rtl & {
-		margin-right: 0;
-		margin-left: 8px;
-	}
-	order: unset;
-
-	@media ( max-width: 660px ) {
-		order: 1;
-		width: 100%;
-	}
-`;
-
-const DoNotPayThis = styled.del`
-	text-decoration: line-through;
-	margin-right: 8px;
-
-	.rtl & {
-		margin-right: 0;
-		margin-left: 8px;
-	}
-`;
 
 export function useGetProductVariants(
 	siteId: number | undefined,
@@ -115,11 +96,26 @@ export function useGetProductVariants(
 
 	const getProductVariantFromAvailableVariant = useCallback(
 		( variant: AvailableProductVariantAndCompared ): WPCOMProductVariant => {
+			const currentPrice =
+				variant.introductoryOfferPrice !== null
+					? variant.introductoryOfferPrice
+					: variant.priceFinal || variant.priceFull;
+			// extremely low "discounts" are possible if the price of the longer term has been rounded
+			// if they cannot be rounded to at least a percentage point we should not show them
+			const discountPercentage = Math.floor(
+				100 - ( currentPrice / variant.priceFullBeforeDiscount ) * 100
+			);
+
 			return {
 				variantLabel: getTermText( variant.plan.term, translate ),
-				variantDetails: <VariantPrice variant={ variant } />,
 				productSlug: variant.planSlug,
 				productId: variant.product.product_id,
+				discountPercentage,
+				formattedPriceBeforeDiscount: myFormatCurrency(
+					variant.priceFullBeforeDiscount,
+					variant.product.currency_code
+				),
+				formattedCurrentPrice: myFormatCurrency( currentPrice, variant.product.currency_code ),
 			};
 		},
 		[ translate ]
@@ -202,47 +198,6 @@ function isVariantAllowed(
 	return false;
 }
 
-function VariantPrice( { variant }: { variant: AvailableProductVariantAndCompared } ) {
-	const currentPrice =
-		variant.introductoryOfferPrice !== null
-			? variant.introductoryOfferPrice
-			: variant.priceFinal || variant.priceFull;
-	// extremely low "discounts" are possible if the price of the longer term has been rounded
-	// if they cannot be rounded to at least a percentage point we should not show them
-	const isDiscounted =
-		Math.floor( 100 - ( currentPrice / variant.priceFullBeforeDiscount ) * 100 ) > 0;
-	return (
-		<Fragment>
-			{ isDiscounted && <VariantPriceDiscount variant={ variant } /> }
-			{ isDiscounted && (
-				<DoNotPayThis>
-					{ myFormatCurrency( variant.priceFullBeforeDiscount, variant.product.currency_code ) }
-				</DoNotPayThis>
-			) }
-			{ myFormatCurrency( currentPrice, variant.product.currency_code ) }
-		</Fragment>
-	);
-}
-
-function VariantPriceDiscount( { variant }: { variant: AvailableProductVariantAndCompared } ) {
-	const translate = useTranslate();
-	const maybeFinalPrice =
-		variant.introductoryOfferPrice !== null ? variant.introductoryOfferPrice : variant.priceFinal;
-	const discountPercentage = Math.floor(
-		100 - ( maybeFinalPrice / variant.priceFullBeforeDiscount ) * 100
-	);
-
-	return (
-		<Discount>
-			{ translate( 'Save %(percent)s%%', {
-				args: {
-					percent: discountPercentage,
-				},
-			} ) }
-		</Discount>
-	);
-}
-
 function getVariantPlanProductSlugs( productSlug: string | undefined ): string[] {
 	const chosenPlan = getPlan( productSlug ?? '' )
 		? getPlan( productSlug ?? '' )
@@ -304,12 +259,4 @@ function getTermText( term: string, translate: ReturnType< typeof useTranslate >
 		default:
 			return '';
 	}
-}
-
-function myFormatCurrency( price: number, code: string, options = {} ) {
-	const precision = CURRENCIES[ code ].precision;
-	const EPSILON = Math.pow( 10, -precision ) - 0.000000001;
-
-	const hasCents = Math.abs( price % 1 ) >= EPSILON;
-	return formatCurrency( price, code, hasCents ? options : { ...options, precision: 0 } );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Pull out styled-components from `composite-checkout/hooks/product-variants.tsx`
* Add new `ItemVariantPrice` component to render with the styled-components from above
* This will allow easily adding the Dropdown chevron indicator in #61174

#### Testing instructions

1. Add Items to cart with variants ( monthly, yearly, etc. )
2. Compare cart on branch vs production at wide and mobile widths
3. Verify there are no differences on the branch.
