### PR TITLE
Retrieve the featured list of plugins from WPCOM '/plugins/featured' namespace.

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -9,7 +9,10 @@ import wpcom from 'calypso/lib/wp';
 type Type = 'all' | 'featured';
 
 const plugisApiBase = '/marketplace/products';
+const featuredPluginsApiBase = '/plugins/featured';
 const pluginsApiNamespace = 'wpcom/v2';
+
+const baseStaleTime = 1000 * 60 * 60 * 2; // 2h
 
 const getCacheKey = ( key: string ): QueryKey => [ 'wpcom-plugins', key ];
 
@@ -40,7 +43,7 @@ const fetchWPCOMPlugins = ( type: Type, searchTerm?: string ) => {
 export const useWPCOMPlugins = (
 	type: Type,
 	searchTerm?: string,
-	{ enabled = true, staleTime = 1000 * 60 * 60 * 2, refetchOnMount = true }: UseQueryOptions = {}
+	{ enabled = true, staleTime = baseStaleTime, refetchOnMount = true }: UseQueryOptions = {}
 ): UseQueryResult => {
 	return useQuery( getCacheKey( type + searchTerm ), () => fetchWPCOMPlugins( type, searchTerm ), {
 		select: ( data ) => normalizePluginsList( data.results ),
@@ -66,7 +69,7 @@ const fetchWPCOMPlugin = ( slug: string ) => {
  */
 export const useWPCOMPlugin = (
 	slug: string,
-	{ enabled = true, staleTime = 1000 * 60 * 60 * 2, refetchOnMount = true }: UseQueryOptions = {}
+	{ enabled = true, staleTime = baseStaleTime, refetchOnMount = true }: UseQueryOptions = {}
 ): UseQueryResult< any > => {
 	return useQuery( getCacheKey( slug ), () => fetchWPCOMPlugin( slug ), {
 		select: ( data ) => normalizePluginData( { detailsFetched: Date.now() }, data ),
@@ -74,4 +77,31 @@ export const useWPCOMPlugin = (
 		staleTime: staleTime,
 		refetchOnMount: refetchOnMount,
 	} );
+};
+
+/**
+ * Returns the featured list of plugins from WPCOM
+ *
+ * @param {{enabled: boolean, staleTime: number, refetchOnMount: boolean}} {} Optional options to pass to the underlying query engine
+ * @returns {{ data, error, isLoading: boolean ...}} Returns various parameters piped from `useQuery`
+ */
+export const useWPCOMFeaturedPlugins = ( {
+	enabled = true,
+	staleTime = baseStaleTime,
+	refetchOnMount = true,
+}: UseQueryOptions = {} ): UseQueryResult => {
+	return useQuery(
+		'plugins-featured-list',
+		() =>
+			wpcom.req.get( {
+				path: featuredPluginsApiBase,
+				apiNamespace: pluginsApiNamespace,
+			} ),
+		{
+			select: ( data ) => normalizePluginsList( data ),
+			enabled,
+			staleTime,
+			refetchOnMount,
+		}
+	);
 };

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -27,7 +27,11 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import Pagination from 'calypso/components/pagination';
 import { PaginationVariant } from 'calypso/components/pagination/constants';
-import { useWPCOMPlugin, useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import {
+	useWPCOMPlugin,
+	useWPCOMPlugins,
+	useWPCOMFeaturedPlugins,
+} from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import { useWPORGPlugins } from 'calypso/data/marketplace/use-wporg-plugin-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import UrlSearch from 'calypso/lib/url-search';
@@ -168,7 +172,7 @@ const PluginsBrowser = ( {
 	const {
 		data: pluginsByCategoryFeatured = [],
 		isLoading: isFetchingPluginsByCategoryFeatured,
-	} = useWPCOMPlugins( 'featured' );
+	} = useWPCOMFeaturedPlugins();
 
 	const {
 		data: { plugins: popularPlugins = [] } = {},

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -4,6 +4,8 @@ import { getCalypsoURL } from '../../data-helper';
 
 const selectors = {
 	sectionTitle: ( section: string ) => `.plugins-browser-list__title:text("${ section }")`,
+	pluginTitleOnSection: ( section: string, plugin: string ) =>
+		`.plugins-browser-list:has(.plugins-browser-list__title.${ section }) :text-is("${ plugin }")`,
 	sectionTitles: '.plugins-browser-list__title',
 	browseAllPopular: 'a[href^="/plugins/popular"]',
 	breadcrumb: ( section: string ) => `.plugins-browser__header li a:text("${ section }") `,
@@ -64,6 +66,13 @@ export class PluginsPage {
 			const title = await titles.nth( i ).innerText();
 			assert.notEqual( title, section );
 		}
+	}
+
+	/**
+	 * Validate page has the section
+	 */
+	async validateHasPluginOnSection( section: string, plugin: string ): Promise< void > {
+		await this.page.waitForSelector( selectors.pluginTitleOnSection( section, plugin ) );
 	}
 
 	/**

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -42,6 +42,17 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins' ), function () {
 		}
 		await pluginsPage.validateHasSection( 'Premium' );
 	} );
+
+	it.each( [
+		'WooCommerce',
+		'Yoast SEO',
+		'MailPoet – emails and newsletters in WordPress',
+		'Jetpack CRM – Clients, Invoices, Leads, & Billing for WordPress',
+		'Contact Form 7',
+		'Site Kit by Google – Analytics, Search Console, AdSense, Speed',
+	] )( 'Featured Plugins section should show the %s plugin', async function ( plugin: string ) {
+		await pluginsPage.validateHasPluginOnSection( 'featured', plugin );
+	} );
 } );
 
 describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:wpcom-site' ), function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Create a new hook called `useWPCOMFeaturedPlugins` and use it on the Plugins Browser screen to populate the **Featured** section
* The `useWPCOMFeaturedPlugins` request points to `'wpcom/v2/plugins/featured'`

#### Testing instructions
* Go to https://wordpress.com/plugins, see the **Featured** section will show paid plugins
* Go to `/plugins` page on this branch version, the **Featured** section will show the following plugins: WooCommerce, Yoast SEO, Mailpoet, Jetpack CRM, Contact Form 7, and Site Kit By Google.

 
<img width="972" alt="Screen Shot 2022-03-14 at 16 28 43" src="https://user-images.githubusercontent.com/5039531/158247377-dc3209fd-7f5c-46d9-ae11-f20faca87cd8.png">

---

Fixes #61900
