### PR TITLE
Payment Methods: Pass postal/country to save/update credit card endpoints

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -107,6 +107,8 @@ export async function assignNewCardProcessor(
 				stripeConfiguration,
 				useForAllSubscriptions: Boolean( useForAllSubscriptions ),
 				eventSource,
+				postalCode,
+				countryCode,
 			} );
 
 			return makeSuccessResponse( result );
@@ -117,6 +119,8 @@ export async function assignNewCardProcessor(
 			stripeConfiguration,
 			useForAllSubscriptions: Boolean( useForAllSubscriptions ),
 			eventSource,
+			postalCode,
+			countryCode,
 		} );
 
 		return makeSuccessResponse( result );

--- a/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
@@ -10,17 +10,23 @@ export async function saveCreditCard( {
 	stripeConfiguration,
 	useForAllSubscriptions,
 	eventSource,
+	postalCode,
+	countryCode,
 }: {
 	token: string;
 	stripeConfiguration: StripeConfiguration;
 	useForAllSubscriptions: boolean;
 	eventSource?: string;
+	postalCode?: string;
+	countryCode: string;
 } ): Promise< StoredCardEndpointResponse > {
 	const additionalData = getParamsForApi( {
 		cardToken: token,
 		stripeConfiguration,
 		useForAllSubscriptions,
 		eventSource,
+		postalCode,
+		countryCode,
 	} );
 	const response = await wp.req.post(
 		{
@@ -46,12 +52,16 @@ export async function updateCreditCard( {
 	stripeConfiguration,
 	useForAllSubscriptions,
 	eventSource,
+	postalCode,
+	countryCode,
 }: {
 	purchase: Purchase;
 	token: string;
 	stripeConfiguration: StripeConfiguration;
 	useForAllSubscriptions: boolean;
 	eventSource?: string;
+	postalCode?: string;
+	countryCode: string;
 } ): Promise< StoredCardEndpointResponse > {
 	const {
 		purchaseId,
@@ -59,18 +69,24 @@ export async function updateCreditCard( {
 		paygate_token,
 		use_for_existing,
 		event_source,
+		postal_code,
+		country_code,
 	} = getParamsForApi( {
 		cardToken: token,
 		stripeConfiguration,
 		purchase,
 		useForAllSubscriptions,
 		eventSource,
+		postalCode,
+		countryCode,
 	} );
 	const response = await wp.req.post( '/upgrades/' + purchaseId + '/update-credit-card', {
 		payment_partner,
 		paygate_token,
 		use_for_existing,
 		event_source,
+		postal_code,
+		country_code,
 	} );
 	if ( response.error ) {
 		recordTracksEvent( 'calypso_purchases_save_new_payment_method_error' );
@@ -86,12 +102,16 @@ function getParamsForApi( {
 	purchase,
 	useForAllSubscriptions,
 	eventSource,
+	postalCode,
+	countryCode,
 }: {
 	cardToken: string;
 	stripeConfiguration: StripeConfiguration;
 	purchase?: Purchase | undefined;
 	useForAllSubscriptions?: boolean;
 	eventSource?: string;
+	postalCode: string | undefined;
+	countryCode: string;
 } ) {
 	return {
 		payment_partner: stripeConfiguration ? stripeConfiguration.processor_id : '',
@@ -100,5 +120,7 @@ function getParamsForApi( {
 		...( useForAllSubscriptions === false ? { use_for_existing: false } : {} ), // if undefined, we do not add this property
 		...( purchase ? { purchaseId: purchase.id } : {} ),
 		...( eventSource ? { event_source: eventSource } : {} ),
+		postal_code: postalCode ?? '',
+		country_code: countryCode,
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies the payment processor function which handles adding a new card (outside of checkout) so that it passes the country code and (optionally) postal code to its endpoints. This way the data can be used for tax purposes. The data itself already exists and is being sent to Stripe for card validation during the transaction, so this is a relatively small change.

The endpoints affected by this are:

- `/upgrades/PURCHASEID/update-credit-card` (POST)
- `/me/stored-cards` (POST)

The arguments added are:

- `country_code`
- `postal_code`

We should validate these fields (by our standards, not just by Stripe) before sending them to the endpoints, which will be handled by https://github.com/Automattic/wp-calypso/pull/61862, but that is not a blocker for this change because currently the endpoints do not actually use these properties. That behavior will be added by D76613-code.

#### Testing instructions

To test the add endpoint:

- Visit `/me/purchases/add-payment-method`.
- Open your network devtools panel.
- Fill in the form and submit it.
- Verify that you see a request to `/me/stored-cards` and that it includes `country_code` and `postal_code`.

Next, test the update endpoint.

- Use an account with at least one active subscription.
- Visit `/me/purchases`.
- Click on an active subscription and then click "Change payment method" or "Add payment method".
- Fill in the form and submit it.
- Verify that you see a request to `/upgrades/PURCHASEID/update-credit-card` and that it includes `country_code` and `postal_code`.