### PR TITLE
Playwright: add Atomic editor support to framework.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -1,4 +1,4 @@
-import { Page, FrameLocator, ElementHandle, Locator } from 'playwright';
+import { Page, ElementHandle, Locator } from 'playwright';
 
 const editorPane = 'div.edit-post-visual-editor__content-area';
 const selectors = {
@@ -25,15 +25,15 @@ const selectors = {
  */
 export class EditorGutenbergComponent {
 	private page: Page;
-	private editor: Locator | FrameLocator;
+	private editor: Locator;
 
 	/**
 	 * Constructs an instance of the component.
 	 *
 	 * @param {Page} page The underlying page.
-	 * @param {FrameLocator|Locator} editor Locator or FrameLocator to the editor.
+	 * @param {Locator} editor Locator or FrameLocator to the editor.
 	 */
-	constructor( page: Page, editor: Locator | FrameLocator ) {
+	constructor( page: Page, editor: Locator ) {
 		this.page = page;
 		this.editor = editor;
 	}
@@ -64,7 +64,7 @@ export class EditorGutenbergComponent {
 	async enterTitle( title: string ): Promise< void > {
 		const sanitizedTitle = title.trim();
 		const locator = this.editor.locator( selectors.title );
-		await locator.fill( title );
+		await locator.fill( sanitizedTitle );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
@@ -1,4 +1,4 @@
-import { Page, FrameLocator } from 'playwright';
+import { Page, FrameLocator, Locator } from 'playwright';
 import envVariables from '../../env-variables';
 
 const panel = 'div.wpcom-block-editor-nav-sidebar-nav-sidebar__container';
@@ -13,17 +13,17 @@ const selectors = {
  */
 export class EditorNavSidebarComponent {
 	private page: Page;
-	private frameLocator: FrameLocator;
+	private editor: Locator | FrameLocator;
 
 	/**
 	 * Constructs an instance of the component.
 	 *
 	 * @param {Page} page The underlying page.
-	 * @param {FrameLocator} frameLocator Locator of the editor iframe.
+	 * @param {FrameLocator|Locator} editor Locator or FrameLocator to the editor.
 	 */
-	constructor( page: Page, frameLocator: FrameLocator ) {
+	constructor( page: Page, editor: Locator | FrameLocator ) {
 		this.page = page;
-		this.frameLocator = frameLocator;
+		this.editor = editor;
 	}
 
 	/**
@@ -38,7 +38,7 @@ export class EditorNavSidebarComponent {
 			return;
 		}
 
-		const locator = this.frameLocator.locator( selectors.sidebarButton );
+		const locator = this.editor.locator( selectors.sidebarButton );
 		await locator.click();
 	}
 
@@ -54,7 +54,7 @@ export class EditorNavSidebarComponent {
 			return;
 		}
 
-		const locator = this.frameLocator.locator( selectors.sidebarButton );
+		const locator = this.editor.locator( selectors.sidebarButton );
 		await locator.click();
 	}
 
@@ -69,7 +69,7 @@ export class EditorNavSidebarComponent {
 			return;
 		}
 
-		const exitLinkLocator = this.frameLocator.locator( selectors.exitLink );
+		const exitLinkLocator = this.editor.locator( selectors.exitLink );
 		await exitLinkLocator.click();
 	}
 
@@ -79,7 +79,7 @@ export class EditorNavSidebarComponent {
 	 * @returns {boolean} True if the sidebar is open. False otherwise.
 	 */
 	private async sidebarIsOpen(): Promise< boolean > {
-		const locator = this.frameLocator.locator( selectors.sidebarButton );
+		const locator = this.editor.locator( selectors.sidebarButton );
 		const status = await locator.getAttribute( 'aria-expanded' );
 		return status === 'true';
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-nav-sidebar-component.ts
@@ -1,4 +1,4 @@
-import { Page, FrameLocator, Locator } from 'playwright';
+import { Page, Locator } from 'playwright';
 import envVariables from '../../env-variables';
 
 const panel = 'div.wpcom-block-editor-nav-sidebar-nav-sidebar__container';
@@ -13,15 +13,15 @@ const selectors = {
  */
 export class EditorNavSidebarComponent {
 	private page: Page;
-	private editor: Locator | FrameLocator;
+	private editor: Locator;
 
 	/**
 	 * Constructs an instance of the component.
 	 *
 	 * @param {Page} page The underlying page.
-	 * @param {FrameLocator|Locator} editor Locator or FrameLocator to the editor.
+	 * @param {Locator} editor Locator or FrameLocator to the editor.
 	 */
-	constructor( page: Page, editor: Locator | FrameLocator ) {
+	constructor( page: Page, editor: Locator ) {
 		this.page = page;
 		this.editor = editor;
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
@@ -1,4 +1,4 @@
-import { Page, FrameLocator } from 'playwright';
+import { Page, FrameLocator, Locator } from 'playwright';
 
 const panel = 'div.editor-post-publish-panel';
 const selectors = {
@@ -16,17 +16,17 @@ const selectors = {
  */
 export class EditorPublishPanelComponent {
 	private page: Page;
-	private frameLocator: FrameLocator;
+	private editor: Locator | FrameLocator;
 
 	/**
 	 * Constructs an instance of the component.
 	 *
 	 * @param {Page} page The underlying page.
-	 * @param {FrameLocator} frameLocator Locator of the editor iframe.
+	 * @param {FrameLocator|Locator} editor Locator or FrameLocator to the editor.
 	 */
-	constructor( page: Page, frameLocator: FrameLocator ) {
+	constructor( page: Page, editor: Locator | FrameLocator ) {
 		this.page = page;
-		this.frameLocator = frameLocator;
+		this.editor = editor;
 	}
 
 	/**
@@ -37,7 +37,7 @@ export class EditorPublishPanelComponent {
 	 * @returns {Promise<boolean>} True if panel is visible. False otherwise.
 	 */
 	async panelIsOpen(): Promise< boolean > {
-		const locator = this.frameLocator.locator( `${ panel }:visible` );
+		const locator = this.editor.locator( `${ panel }:visible` );
 		try {
 			await locator.waitFor( { timeout: 5 * 1000 } );
 			return true;
@@ -62,7 +62,7 @@ export class EditorPublishPanelComponent {
 			return;
 		}
 		const selector = `${ selectors.cancelPublishButton }:visible, ${ selectors.postPublishClosePanelButton }:visible`;
-		const locator = this.frameLocator.locator( selector );
+		const locator = this.editor.locator( selector );
 		await locator.click();
 	}
 
@@ -72,7 +72,7 @@ export class EditorPublishPanelComponent {
 	 * Publish or schedule the article.
 	 */
 	async publish(): Promise< void > {
-		const publishButtonLocator = this.frameLocator.locator( selectors.publishButton );
+		const publishButtonLocator = this.editor.locator( selectors.publishButton );
 		await publishButtonLocator.click();
 	}
 
@@ -84,7 +84,7 @@ export class EditorPublishPanelComponent {
 	 * @returns {URL} URL to the published article.
 	 */
 	async getPublishedURL(): Promise< URL > {
-		const locator = this.frameLocator.locator( selectors.publishedArticleURL );
+		const locator = this.editor.locator( selectors.publishedArticleURL );
 		const publishedURL = ( await locator.getAttribute( 'value' ) ) as string;
 		return new URL( publishedURL );
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
@@ -1,4 +1,4 @@
-import { Page, FrameLocator, Locator } from 'playwright';
+import { Page, Locator } from 'playwright';
 
 const panel = 'div.editor-post-publish-panel';
 const selectors = {
@@ -16,15 +16,15 @@ const selectors = {
  */
 export class EditorPublishPanelComponent {
 	private page: Page;
-	private editor: Locator | FrameLocator;
+	private editor: Locator;
 
 	/**
 	 * Constructs an instance of the component.
 	 *
 	 * @param {Page} page The underlying page.
-	 * @param {FrameLocator|Locator} editor Locator or FrameLocator to the editor.
+	 * @param {Locator} editor Locator or FrameLocator to the editor.
 	 */
-	constructor( page: Page, editor: Locator | FrameLocator ) {
+	constructor( page: Page, editor: Locator ) {
 		this.page = page;
 		this.editor = editor;
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -1,4 +1,4 @@
-import { FrameLocator, Page } from 'playwright';
+import { FrameLocator, Page, Locator } from 'playwright';
 import envVariables from '../../env-variables';
 
 export type EditorSidebarTab = 'Post' | 'Block' | 'Page';
@@ -64,21 +64,21 @@ const selectors = {
 };
 
 /**
- * Component representing the settings sidebar in the editor.
+ * Represents an instance of the WordPress.com Editor's Settings sidebar.
  */
 export class EditorSettingsSidebarComponent {
 	private page: Page;
-	private frameLocator: FrameLocator;
+	private editor: Locator | FrameLocator;
 
 	/**
 	 * Constructs an instance of the component.
 	 *
-	 * @param {Page} page The underlying Playwright page.
-	 * @param {FrameLocator} frameLocator Locator of the editor iframe.
+	 * @param {Page} page The underlying page.
+	 * @param {FrameLocator|Locator} editor Locator or FrameLocator to the editor.
 	 */
-	constructor( page: Page, frameLocator: FrameLocator ) {
+	constructor( page: Page, editor: Locator | FrameLocator ) {
 		this.page = page;
-		this.frameLocator = frameLocator;
+		this.editor = editor;
 	}
 
 	/**
@@ -89,7 +89,7 @@ export class EditorSettingsSidebarComponent {
 			return;
 		}
 
-		const locator = this.frameLocator.locator( selectors.mobileCloseSidebarButton );
+		const locator = this.editor.locator( selectors.mobileCloseSidebarButton );
 		await locator.click();
 	}
 
@@ -100,12 +100,10 @@ export class EditorSettingsSidebarComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickTab( tabName: EditorSidebarTab ): Promise< void > {
-		const locator = this.frameLocator.locator( selectors.tabButton( tabName ) );
+		const locator = this.editor.locator( selectors.tabButton( tabName ) );
 		await locator.click();
 
-		const activeTabLocator = this.frameLocator.locator(
-			`${ selectors.tabButton( tabName ) }.is-active`
-		);
+		const activeTabLocator = this.editor.locator( `${ selectors.tabButton( tabName ) }.is-active` );
 		await activeTabLocator.waitFor();
 	}
 
@@ -125,10 +123,10 @@ export class EditorSettingsSidebarComponent {
 		// Avoid the wpcalypso/staging banner.
 		await this.scrollToBottomOfSidebar();
 
-		const sectionLocator = this.frameLocator.locator( selectors.section( name ) );
+		const sectionLocator = this.editor.locator( selectors.section( name ) );
 		await sectionLocator.click();
 
-		const expandedLocator = this.frameLocator.locator(
+		const expandedLocator = this.editor.locator(
 			`${ selectors.section( name ) }[aria-expanded="true"]`
 		);
 		await expandedLocator.waitFor();
@@ -145,7 +143,7 @@ export class EditorSettingsSidebarComponent {
 	 * @returns {Promise<boolean>} True if target is in an expanded state. False otherwise.
 	 */
 	private async targetIsOpen( selector: string ): Promise< boolean > {
-		const locator = this.frameLocator.locator( selector );
+		const locator = this.editor.locator( selector );
 		const state = await locator.getAttribute( 'aria-expanded' );
 
 		return state === 'true';
@@ -165,10 +163,10 @@ export class EditorSettingsSidebarComponent {
 			return;
 		}
 
-		const buttonLocator = this.frameLocator.locator( selectors.visibilityButton );
+		const buttonLocator = this.editor.locator( selectors.visibilityButton );
 		await buttonLocator.click();
 
-		const expandedLocator = this.frameLocator.locator(
+		const expandedLocator = this.editor.locator(
 			`${ selectors.visibilityButton }[aria-expanded="true"]`
 		);
 		await expandedLocator.waitFor();
@@ -186,10 +184,10 @@ export class EditorSettingsSidebarComponent {
 			return;
 		}
 
-		const buttonLocator = this.frameLocator.locator( selectors.visibilityButton );
+		const buttonLocator = this.editor.locator( selectors.visibilityButton );
 		await buttonLocator.click();
 
-		const closedLocator = this.frameLocator.locator(
+		const closedLocator = this.editor.locator(
 			`${ selectors.visibilityButton }[aria-expanded="false"]`
 		);
 		await closedLocator.waitFor();
@@ -207,14 +205,14 @@ export class EditorSettingsSidebarComponent {
 		visibility: PrivacyOptions,
 		{ password }: { password?: string } = {}
 	): Promise< void > {
-		const optionLocator = this.frameLocator.locator( selectors.visibilityOption( visibility ) );
+		const optionLocator = this.editor.locator( selectors.visibilityOption( visibility ) );
 		await optionLocator.click();
 
 		if ( visibility === 'Private' ) {
 			// Private articles are posted immediately and thus we must break the
 			// single responsibility principle for this case.
 			// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
-			const dialogConfirmLocator = this.frameLocator.locator(
+			const dialogConfirmLocator = this.editor.locator(
 				`div[role="dialog"] button:has-text("OK")`
 			);
 			await dialogConfirmLocator.click();
@@ -235,7 +233,7 @@ export class EditorSettingsSidebarComponent {
 	 * @param {string} password Password to be used.
 	 */
 	private async setPostPassword( password: string ): Promise< void > {
-		const inputLocator = this.frameLocator.locator( selectors.postPasswordInput );
+		const inputLocator = this.editor.locator( selectors.postPasswordInput );
 		await inputLocator.fill( password );
 	}
 
@@ -249,7 +247,7 @@ export class EditorSettingsSidebarComponent {
 			return;
 		}
 
-		const buttonLocator = this.frameLocator.locator( selectors.scheduleButton );
+		const buttonLocator = this.editor.locator( selectors.scheduleButton );
 		await buttonLocator.click();
 	}
 
@@ -266,7 +264,7 @@ export class EditorSettingsSidebarComponent {
 			return;
 		}
 
-		const buttonLocator = this.frameLocator.locator( selectors.scheduleButton );
+		const buttonLocator = this.editor.locator( selectors.scheduleButton );
 		await buttonLocator.click();
 	}
 
@@ -281,7 +279,7 @@ export class EditorSettingsSidebarComponent {
 		for ( key in date ) {
 			if ( key === 'meridian' ) {
 				// am/pm is a button.
-				const meridianButtonLocator = this.frameLocator.locator(
+				const meridianButtonLocator = this.editor.locator(
 					selectors.scheduleMeridianButton( date[ key ] )
 				);
 				await meridianButtonLocator.click();
@@ -290,13 +288,13 @@ export class EditorSettingsSidebarComponent {
 			if ( key === 'month' ) {
 				// For month numbers less than 10, pad the digit to be
 				// 2 digits as required by the select.
-				const monthSelectLocator = this.frameLocator.locator( selectors.scheduleMonthSelect );
+				const monthSelectLocator = this.editor.locator( selectors.scheduleMonthSelect );
 				await monthSelectLocator.selectOption( date[ key ].toString().padStart( 2, '0' ) );
 				continue;
 			}
 
 			// Regular input fields.
-			const inputLocator = this.frameLocator.locator( selectors.scheduleInput( key ) );
+			const inputLocator = this.editor.locator( selectors.scheduleInput( key ) );
 			await inputLocator.fill( date[ key ].toString() );
 		}
 	}
@@ -307,7 +305,7 @@ export class EditorSettingsSidebarComponent {
 	 * Clicks on the Revisions section in the sidebar to show a revisions modal.
 	 */
 	async showRevisions(): Promise< void > {
-		const locator = this.frameLocator.locator( selectors.showRevisionButton );
+		const locator = this.editor.locator( selectors.showRevisionButton );
 		await locator.click();
 	}
 
@@ -319,7 +317,7 @@ export class EditorSettingsSidebarComponent {
 	 */
 	async checkCategory( name: string ): Promise< void > {
 		//TODO: Categories can be slow because we never do any cleanup. Remove extended timeout once we start doing cleanup.
-		const locator = this.frameLocator.locator( selectors.categoryCheckbox( name ) );
+		const locator = this.editor.locator( selectors.categoryCheckbox( name ) );
 
 		try {
 			await locator.click( { timeout: 60 * 1000 } );
@@ -338,11 +336,11 @@ export class EditorSettingsSidebarComponent {
 	 * @param {string} name Tag name to enter.
 	 */
 	async enterTag( name: string ): Promise< void > {
-		const inputLocator = this.frameLocator.locator( selectors.tagInput );
+		const inputLocator = this.editor.locator( selectors.tagInput );
 		await inputLocator.fill( name );
 		await this.page.keyboard.press( 'Enter' );
 
-		const addedTagLocator = this.frameLocator.locator( selectors.addedTag( name ) );
+		const addedTagLocator = this.editor.locator( selectors.addedTag( name ) );
 		await addedTagLocator.waitFor();
 	}
 
@@ -352,13 +350,13 @@ export class EditorSettingsSidebarComponent {
 	 * @param {string} slug URL slug to set.
 	 */
 	async enterUrlSlug( slug: string ) {
-		const inputLocator = this.frameLocator.locator( selectors.permalinkInput );
+		const inputLocator = this.editor.locator( selectors.permalinkInput );
 		await inputLocator.fill( slug );
 		// Hit the Tab key to confirm URL slug input and update the Post URL
 		// shown in this section.
 		await this.page.keyboard.press( 'Tab' );
 
-		const generatedURL = this.frameLocator.locator(
+		const generatedURL = this.editor.locator(
 			`${ selectors.permalinkGeneratedURL } > text=/${ slug }`
 		);
 		await generatedURL.waitFor();
@@ -370,7 +368,7 @@ export class EditorSettingsSidebarComponent {
 	 * Useful to work around the wpcalypso/staging banner (for proxied users).
 	 */
 	private async scrollToBottomOfSidebar(): Promise< void > {
-		const locator = this.frameLocator.locator( selectors.section( 'Discussion' ) );
+		const locator = this.editor.locator( selectors.section( 'Discussion' ) );
 		await locator.scrollIntoViewIfNeeded();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -1,4 +1,4 @@
-import { FrameLocator, Page, Locator } from 'playwright';
+import { Page, Locator } from 'playwright';
 import envVariables from '../../env-variables';
 
 export type EditorSidebarTab = 'Post' | 'Block' | 'Page';
@@ -68,15 +68,15 @@ const selectors = {
  */
 export class EditorSettingsSidebarComponent {
 	private page: Page;
-	private editor: Locator | FrameLocator;
+	private editor: Locator;
 
 	/**
 	 * Constructs an instance of the component.
 	 *
 	 * @param {Page} page The underlying page.
-	 * @param {FrameLocator|Locator} editor Locator or FrameLocator to the editor.
+	 * @param {Locator} editor Locator or FrameLocator to the editor.
 	 */
-	constructor( page: Page, editor: Locator | FrameLocator ) {
+	constructor( page: Page, editor: Locator ) {
 		this.page = page;
 		this.editor = editor;
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -1,4 +1,4 @@
-import { Page, FrameLocator, Locator } from 'playwright';
+import { Page, Locator } from 'playwright';
 
 export type PreviewOptions = 'Desktop' | 'Mobile' | 'Tablet';
 
@@ -35,15 +35,15 @@ const selectors = {
  */
 export class EditorToolbarComponent {
 	private page: Page;
-	private editor: Locator | FrameLocator;
+	private editor: Locator;
 
 	/**
 	 * Constructs an instance of the component.
 	 *
 	 * @param {Page} page The underlying page.
-	 * @param {FrameLocator|Locator} editor Locator or FrameLocator to the editor.
+	 * @param {Locator} editor Locator or FrameLocator to the editor.
 	 */
-	constructor( page: Page, editor: Locator | FrameLocator ) {
+	constructor( page: Page, editor: Locator ) {
 		this.page = page;
 		this.editor = editor;
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -1,4 +1,4 @@
-import { Page, FrameLocator } from 'playwright';
+import { Page, FrameLocator, Locator } from 'playwright';
 
 export type PreviewOptions = 'Desktop' | 'Mobile' | 'Tablet';
 
@@ -31,22 +31,21 @@ const selectors = {
 };
 
 /**
- * Represents an instance of the WordPress.com Editor's navigation sidebar.
- * The component is available only in the Desktop viewport.
+ * Represents an instance of the WordPress.com Editor's persistent toolbar.
  */
 export class EditorToolbarComponent {
 	private page: Page;
-	private frameLocator: FrameLocator;
+	private editor: Locator | FrameLocator;
 
 	/**
 	 * Constructs an instance of the component.
 	 *
 	 * @param {Page} page The underlying page.
-	 * @param {FrameLocator} frameLocator Locator of the editor iframe.
+	 * @param {FrameLocator|Locator} editor Locator or FrameLocator to the editor.
 	 */
-	constructor( page: Page, frameLocator: FrameLocator ) {
+	constructor( page: Page, editor: Locator | FrameLocator ) {
 		this.page = page;
-		this.frameLocator = frameLocator;
+		this.editor = editor;
 	}
 
 	/* General helper */
@@ -62,7 +61,7 @@ export class EditorToolbarComponent {
 	 * @returns {Promise<boolean>} True if target is in an expanded state. False otherwise.
 	 */
 	private async targetIsOpen( selector: string ): Promise< boolean > {
-		const locator = this.frameLocator.locator( selector );
+		const locator = this.editor.locator( selector );
 		const pressed = await locator.getAttribute( 'aria-pressed' );
 		const expanded = await locator.getAttribute( 'aria-expanded' );
 		return pressed === 'true' || expanded === 'true';
@@ -75,7 +74,7 @@ export class EditorToolbarComponent {
 	 */
 	async openBlockInserter(): Promise< void > {
 		if ( ! ( await this.targetIsOpen( selectors.blockInserterButton ) ) ) {
-			const locator = this.frameLocator.locator( selectors.blockInserterButton );
+			const locator = this.editor.locator( selectors.blockInserterButton );
 			await locator.click();
 		}
 	}
@@ -85,7 +84,7 @@ export class EditorToolbarComponent {
 	 */
 	async closeBlockInserter(): Promise< void > {
 		if ( await this.targetIsOpen( selectors.blockInserterButton ) ) {
-			const locator = this.frameLocator.locator( selectors.blockInserterButton );
+			const locator = this.editor.locator( selectors.blockInserterButton );
 			await locator.click();
 		}
 	}
@@ -98,7 +97,7 @@ export class EditorToolbarComponent {
 	 * If the button cannot be clicked, the method short-circuits.
 	 */
 	async saveDraft(): Promise< void > {
-		const saveButtonLocator = this.frameLocator.locator( selectors.saveDraftButton( 'enabled' ) );
+		const saveButtonLocator = this.editor.locator( selectors.saveDraftButton( 'enabled' ) );
 
 		try {
 			await saveButtonLocator.waitFor( { timeout: 5 * 1000 } );
@@ -109,7 +108,7 @@ export class EditorToolbarComponent {
 		await saveButtonLocator.click();
 
 		// Ensure the Save Draft button is disabled after successful save.
-		const savedButtonLocator = this.frameLocator.locator( selectors.saveDraftButton( 'disabled' ) );
+		const savedButtonLocator = this.editor.locator( selectors.saveDraftButton( 'disabled' ) );
 		await savedButtonLocator.waitFor();
 	}
 
@@ -121,7 +120,7 @@ export class EditorToolbarComponent {
 	 * @returns {Page} Handler for the new page object.
 	 */
 	async openMobilePreview(): Promise< Page > {
-		const mobilePreviewButtonLocator = this.frameLocator.locator( selectors.previewButton );
+		const mobilePreviewButtonLocator = this.editor.locator( selectors.previewButton );
 
 		const [ popup ] = await Promise.all( [
 			this.page.waitForEvent( 'popup' ),
@@ -139,13 +138,13 @@ export class EditorToolbarComponent {
 		await this.openDesktopPreviewMenu();
 
 		// Locate and click on the intended preview target.
-		const desktopPreviewMenuItemLocator = this.frameLocator.locator(
+		const desktopPreviewMenuItemLocator = this.editor.locator(
 			selectors.desktopPreviewMenuItem( target )
 		);
 		await desktopPreviewMenuItemLocator.click();
 
 		// Verify the editor panel is resized and stable.
-		const desktopPreviewPaneLocator = this.frameLocator.locator( selectors.previewPane( target ) );
+		const desktopPreviewPaneLocator = this.editor.locator( selectors.previewPane( target ) );
 		await desktopPreviewPaneLocator.waitFor();
 		const elementHandle = await desktopPreviewPaneLocator.elementHandle();
 		await elementHandle?.waitForElementState( 'stable' );
@@ -159,7 +158,7 @@ export class EditorToolbarComponent {
 	 */
 	async openDesktopPreviewMenu(): Promise< void > {
 		if ( ! ( await this.targetIsOpen( selectors.previewButton ) ) ) {
-			const desktopPreviewButtonLocator = this.frameLocator.locator( selectors.previewButton );
+			const desktopPreviewButtonLocator = this.editor.locator( selectors.previewButton );
 			await desktopPreviewButtonLocator.click();
 		}
 	}
@@ -169,7 +168,7 @@ export class EditorToolbarComponent {
 	 */
 	async closeDesktopPreviewMenu(): Promise< void > {
 		if ( await this.targetIsOpen( selectors.previewButton ) ) {
-			const desktopPreviewButtonLocator = this.frameLocator.locator( selectors.previewButton );
+			const desktopPreviewButtonLocator = this.editor.locator( selectors.previewButton );
 			await desktopPreviewButtonLocator.click();
 		}
 	}
@@ -185,7 +184,7 @@ export class EditorToolbarComponent {
 	 * 	- schedule a post (Schedule)
 	 */
 	async clickPublish(): Promise< void > {
-		const publishButtonLocator = this.frameLocator.locator( selectors.publishButton( 'enabled' ) );
+		const publishButtonLocator = this.editor.locator( selectors.publishButton( 'enabled' ) );
 		await publishButtonLocator.click();
 	}
 
@@ -194,7 +193,7 @@ export class EditorToolbarComponent {
 	 * the article.
 	 */
 	async switchToDraft(): Promise< void > {
-		const swithcToDraftLocator = this.frameLocator.locator( selectors.switchToDraftButton );
+		const swithcToDraftLocator = this.editor.locator( selectors.switchToDraftButton );
 		await swithcToDraftLocator.click();
 	}
 
@@ -207,7 +206,7 @@ export class EditorToolbarComponent {
 		if ( await this.targetIsOpen( selectors.settingsButton ) ) {
 			return;
 		}
-		const locator = this.frameLocator.locator( selectors.settingsButton );
+		const locator = this.editor.locator( selectors.settingsButton );
 		await locator.click();
 	}
 
@@ -218,7 +217,7 @@ export class EditorToolbarComponent {
 		if ( ! ( await this.targetIsOpen( selectors.settingsButton ) ) ) {
 			return;
 		}
-		const locator = this.frameLocator.locator( selectors.settingsButton );
+		const locator = this.editor.locator( selectors.settingsButton );
 		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -15,7 +15,7 @@ import type { PreviewOptions, EditorSidebarTab, PrivacyOptions, Schedule } from 
 const selectors = {
 	// iframe and editor
 	editorFrame: 'iframe.is-loaded',
-	editor: 'div[id="editor"]',
+	editor: 'body.block-editor-page',
 	editorTitle: '.editor-post-title__input',
 
 	// Within the editor body.

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -91,6 +91,8 @@ export class PublishedPostPage {
 	 * @param {string} text Text to search for in post page
 	 */
 	async validateTextInPost( text: string ): Promise< void > {
-		await this.page.waitForSelector( `text=${ text }` );
+		// Oddly, if the selector is replaced with :text():visible,
+		// it produces a BADSTRING error.
+		await this.page.waitForSelector( `text=${ text } >> visible=true` );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -86,13 +86,52 @@ export class PublishedPostPage {
 	}
 
 	/**
+	 * Validates that the title is as expected.
+	 *
+	 * @param {string} title Title text to check.
+	 */
+	async validateTitle( title: string ): Promise< void > {
+		const dash = /-/g;
+		title = title.replace( dash, '–' );
+		await this.page.waitForSelector( `:text("${ title }")` );
+	}
+
+	/**
 	 * Validates that the provided text can be found in the post page. Throws if it isn't.
 	 *
 	 * @param {string} text Text to search for in post page
 	 */
 	async validateTextInPost( text: string ): Promise< void > {
-		// Oddly, if the selector is replaced with :text():visible,
-		// it produces a BADSTRING error.
-		await this.page.waitForSelector( `text=${ text } >> visible=true` );
+		const splitString = text.split( '\n' );
+		const dash = /-/;
+		for await ( let line of splitString ) {
+			// Sanitize the string and replace U+002d (hyphen/dash)
+			// with U+2013 (em dash) if the paragraph starts with a dash.
+			// Note that dashes found outside of leading position are
+			// not impacted.
+			// https://make.wordpress.org/docs/style-guide/punctuation/dashes/
+			if ( line.search( dash ) === 0 ) {
+				line = line.replace( dash, '–' );
+			}
+			await this.page.waitForSelector( `:text("${ line }"):visible` );
+		}
+	}
+
+	/**
+	 * Validates that the category has been added to the article.
+	 *
+	 * @param {string} category Category to validate on page.
+	 */
+	async validateCategory( category: string ): Promise< void > {
+		await this.page.waitForSelector( `.cat-links :text("${ category }")` );
+	}
+
+	/**
+	 * Validates that the tag has been added to the article.
+	 *
+	 * @param {string} tag Tag to validate on page.
+	 */
+	async validateTags( tag: string ): Promise< void > {
+		await this.page.waitForSelector( `.tags-links :text("${ tag }")` );
 	}
 }

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -57,7 +57,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), (
 		await coverBlock.upload( imageFile.fullpath );
 		// After uploading the image the focus is switched to the inner
 		// paragraph block (Cover title), so we need to switch it back outside.
-		const editorFrame = await editorPage.getEditorFrame();
+		const editorFrame = await editorPage.getEditorHandle();
 		await editorFrame.click( '.wp-block-cover', { position: { x: 1, y: 1 } } );
 	} );
 
@@ -66,7 +66,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), (
 	} );
 
 	it.each( CoverBlock.coverStyles )( 'Verify "%s" style is available', async ( style ) => {
-		const editorFrame = await editorPage.getEditorFrame();
+		const editorFrame = await editorPage.getEditorHandle();
 		await editorFrame.waitForSelector( `button[aria-label="${ style }"]` );
 	} );
 

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -55,7 +55,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ),
 	it.each( PricingTableBlock.gutterValues )(
 		'Verify "%s" gutter button is present',
 		async ( value ) => {
-			const editorFrame = await editorPage.getEditorFrame();
+			const editorFrame = await editorPage.getEditorHandle();
 			await editorFrame.waitForSelector( `button[aria-label="${ value }"]` );
 		}
 	);

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -59,7 +59,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ), 
 	} );
 
 	it( `Replace uploaded image`, async () => {
-		const editorFrame = await editorPage.getEditorFrame();
+		const editorFrame = await editorPage.getEditorHandle();
 		await editorFrame.click( 'button:text("Replace")' );
 		await editorFrame.setInputFiles(
 			'.components-form-file-upload input[type="file"]',

--- a/test/e2e/specs/blocks/blocks__smoke-test-across-gb-edge-versions.ts
+++ b/test/e2e/specs/blocks/blocks__smoke-test-across-gb-edge-versions.ts
@@ -41,15 +41,14 @@ describe.each`
 			} ) }/${ testPostId }`;
 
 			await page.goto( postURL );
-
-			editorPage = new EditorPage( page );
 		} );
 
 		// Both block invalidation and crash messages are wrapped by the same `Warning`
 		// component in Gutenberg. If we find at least one warning, then we fail the test.
 		skipItIf( ! envVariables.GUTENBERG_EDGE )(
-			`Block warnings are not obeserved for ${ siteType }`,
+			`Block warnings are not obeserved for ${ siteType } editor`,
 			async () => {
+				editorPage = new EditorPage( page, { target: siteType.toLowerCase() } );
 				await editorPage.waitUntilLoaded();
 
 				expect( await editorPage.editorHasBlockWarnings() ).toBe( false );

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -43,7 +43,7 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 					);
 					editorContext = {
 						page: page,
-						editorIframe: await editorPage.getEditorFrame(),
+						editorIframe: await editorPage.getEditorHandle(),
 						blockHandle: blockHandle,
 					};
 				} );

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -48,7 +48,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	it( 'Select page template', async function () {
 		editorPage = new EditorPage( page );
 		// @TODO Consider moving this to EditorPage.
-		editorIframe = await editorPage.waitUntilLoaded();
+		await editorPage.waitUntilLoaded();
+		const editorIframe = await editorPage.getEditorFrame();
 		const pageTemplateModalComponent = new PageTemplateModalComponent( editorIframe, page );
 		await pageTemplateModalComponent.selectTemplateCatagory( pageTemplateCategory );
 		await pageTemplateModalComponent.selectTemplate( pageTemplateLable );

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -49,7 +49,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		editorPage = new EditorPage( page );
 		// @TODO Consider moving this to EditorPage.
 		await editorPage.waitUntilLoaded();
-		const editorIframe = await editorPage.getEditorFrame();
+		const editorIframe = await editorPage.getEditorHandle();
 		const pageTemplateModalComponent = new PageTemplateModalComponent( editorIframe, page );
 		await pageTemplateModalComponent.selectTemplateCatagory( pageTemplateCategory );
 		await pageTemplateModalComponent.selectTemplate( pageTemplateLable );

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -112,13 +112,13 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		it( 'Post content is found in published post', async function () {
 			publishedPostPage = new PublishedPostPage( page );
-			await publishedPostPage.validateTextInPost( title );
+			await publishedPostPage.validateTitle( title );
 			await publishedPostPage.validateTextInPost( quote );
 		} );
 
 		it( 'Post metadata is found in published post', async function () {
-			await publishedPostPage.validateTextInPost( category );
-			await publishedPostPage.validateTextInPost( tag );
+			await publishedPostPage.validateCategory( category );
+			await publishedPostPage.validateTags( tag );
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -13,7 +13,7 @@ import {
 import { Page, Browser } from 'playwright';
 
 const quote =
-	'The problem with quotes on the Internet is that it is hard to verify their authenticity. \n— Abraham Lincoln';
+	'The problem with quotes on the Internet is that it is hard to verify their authenticity.\n- Abraham Lincoln';
 const title = DataHelper.getRandomPhrase();
 const category = 'Uncategorized';
 const tag = 'test-tag';

--- a/test/e2e/specs/editor/shared/privacy-testing.ts
+++ b/test/e2e/specs/editor/shared/privacy-testing.ts
@@ -43,7 +43,8 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 			it( 'Start new page', async function () {
 				editorPage = new EditorPage( page );
 				await editorPage.visit( 'page' );
-				const editorIframe = await editorPage.waitUntilLoaded();
+				await editorPage.waitUntilLoaded();
+				const editorIframe = await editorPage.getEditorFrame();
 				const pageTemplateModalComponent = new PageTemplateModalComponent( editorIframe, page );
 				await pageTemplateModalComponent.selectBlankPage();
 			} );

--- a/test/e2e/specs/editor/shared/privacy-testing.ts
+++ b/test/e2e/specs/editor/shared/privacy-testing.ts
@@ -44,7 +44,7 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 				editorPage = new EditorPage( page );
 				await editorPage.visit( 'page' );
 				await editorPage.waitUntilLoaded();
-				const editorIframe = await editorPage.getEditorFrame();
+				const editorIframe = await editorPage.getEditorHandle();
 				const pageTemplateModalComponent = new PageTemplateModalComponent( editorIframe, page );
 				await pageTemplateModalComponent.selectBlankPage();
 			} );

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -269,7 +269,7 @@ describe( 'I18N: Editor', function () {
 				} );
 
 				it( 'Render block content translations', async function () {
-					frame = await editorPage.getEditorFrame();
+					frame = await editorPage.getEditorHandle();
 					// Ensure block contents are translated as expected.
 					await Promise.all(
 						block.blockEditorContent.map( ( content: any ) =>

--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -36,7 +36,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 	] )(
 		'Experimental package %s and feature %s are available',
 		async function ( packageName, feature, featureType ) {
-			const frame = await editorPage.getEditorFrame();
+			const frame = await editorPage.getEditorHandle();
 			const packageAvailable = await frame.evaluate( `typeof window[ "wp" ]["${ packageName }"]` );
 
 			expect( packageAvailable ).not.toStrictEqual( 'undefined' );
@@ -53,7 +53,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 	);
 
 	it( 'Experimental data is available', async function () {
-		const frame = await editorPage.getEditorFrame();
+		const frame = await editorPage.getEditorHandle();
 		const blockPatterns = await frame.evaluate(
 			`Array.isArray( window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns )`
 		);
@@ -73,7 +73,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 		// patterns will be added than removed. This also means if we see a dramatic
 		// change in the number to the lower end, then something is probably wrong.
 		const expectedBlockPatternCount = 50;
-		const frame = await editorPage.getEditorFrame();
+		const frame = await editorPage.getEditorHandle();
 		const actualBlockPatternCount = await frame.evaluate(
 			`window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns.length`
 		);

--- a/test/e2e/specs/onboarding/gutenboarding__happy-path.ts
+++ b/test/e2e/specs/onboarding/gutenboarding__happy-path.ts
@@ -75,7 +75,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 			// {@TODO} This is temporary while the FSE spec is awaiting migration to Playwright.
 			const editorPage = new EditorPage( page );
 			await editorPage.forceDismissWelcomeTour();
-			const outerFrame = await editorPage.getEditorFrame();
+			const outerFrame = await editorPage.getEditorHandle();
 
 			// There's another iframe within the parent iframe.
 			const innerFrame = ( await (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds support for Atomic editor interactions to the framework.

**Key changes:**
- add an optional parameter `target` for `EditorPage` that accepts either `simple` or `atomic` as valid values.
- add switching mechanism inside the `EditorPage` constructor to switch between the appropriate selector depending on the value for `target`.
- make child classes (`EditorToolbarComponent`, `EditorPublishPanelComponent`, `EditorNavSidebarComponent`, `EditorGutenbergComponent`) editor-agonostic.

**Context:**
@fullofcaffeine and I discussed how to add Atomic editor support in [this Slack thread](p1646939651108749-slack-C01QG4Y91RR). 

**Technical Details:**
This PR adds support for Atomic editor in addition to Simple (framed) editor.

For Atomic sites, there are two variations for editors:
- framed (like Simple)
- non-framed

As per Marcelo in [this comment](p1646956452682009/1646939651.108749-slack-C01QG4Y91RR), iframed editor in Atomic is on the path to deprecation due to issues with third-party cookies. This effectively eliminates the Atomic iframed editor as a consideration, which _greatly_ simplifies the logic required.

To add Atomic support without upending the work of previous refactors in https://github.com/Automattic/wp-calypso/issues/60868, it was decided to maintain the `Locator` based architecture for Editor sub-component classes.

Further consideration was given to maintaining a simple user-facing API. As of [refactor stack 4](https://github.com/Automattic/wp-calypso/pull/61784) the API is as follows:

```
const editorPage  = new EditorPage( page );
await editorPage.doSomething();
```

The option of introducing a required action after instantiation of `EditorPage` is undesirable for the following reasons:
- if call is forgotten, resulting `editorPage` object can be in a non-ready state.
- adds to the mental burden of test developers.

Thus the decision was made to accept an optional parameter `target`, which defaults to `simple` but can be set to `atomic` as necessary. This parameter is used in the constructor of `EditorPage` to determine the selector and ultimately the locator to be used to locate the editor.

This parameter value will be supplied by the test spec and the structure to provide this value in a parametrized manner is implemented in https://github.com/Automattic/wp-calypso/pull/61783. 

#### Testing instructions

Ensure the following:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [x] i18n E2E

Related to https://github.com/Automattic/wp-calypso/issues/60868.
Depends on https://github.com/Automattic/wp-calypso/pull/61784.