### PR TITLE
Plans: Basic updates for renaming the Managed plan to the Pro plan

### DIFF
--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -31,7 +31,7 @@ export const PLAN_VIP = 'vip';
 export const PLAN_P2_PLUS = 'wp_p2_plus_monthly';
 export const PLAN_P2_FREE = 'p2_free_plan'; // Not a real plan; it's a renamed WP.com Free for the P2 project.
 export const PLAN_WPCOM_FLEXIBLE = 'wpcom-flexible'; // Not a real plan; it's a renamed WP.com Free for the plans overhaul.
-export const PLAN_WPCOM_MANAGED = 'managed-bundle';
+export const PLAN_WPCOM_MANAGED = 'pro-plan';
 
 export const WPCOM_PLANS = <const>[
 	PLAN_BUSINESS_MONTHLY,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1598,10 +1598,10 @@ PLANS_LIST[ PLAN_WPCOM_MANAGED ] = {
 	group: GROUP_WPCOM,
 	type: TYPE_MANAGED,
 	term: TERM_ANNUALLY,
-	getTitle: () => i18n.translate( 'Managed' ),
+	getTitle: () => i18n.translate( 'Pro' ),
 	getProductId: () => 1032,
 	getStoreSlug: () => PLAN_WPCOM_MANAGED,
-	getPathSlug: () => 'managed',
+	getPathSlug: () => 'pro',
 	getDescription: () =>
 		i18n.translate( 'Enjoy the classic WordPress.com experience using plugins and much more.' ),
 	getBillingTimeFrame: WPComGetBillingTimeframe,

--- a/packages/components/src/product-icon/config.ts
+++ b/packages/components/src/product-icon/config.ts
@@ -76,7 +76,7 @@ export type SupportedSlugs =
 	| 'business-bundle'
 	| 'business-bundle-2y'
 	| 'business-bundle-monthly'
-	| 'managed-bundle'
+	| 'pro-plan'
 	| 'jetpack_free'
 	| 'jetpack_personal'
 	| 'jetpack_personal_monthly'
@@ -166,7 +166,7 @@ export const iconToProductSlugMap: Record< keyof typeof paths, readonly Supporte
 		'value_bundle-2y',
 		'value_bundle-monthly',
 		'value_bundle_monthly',
-		'managed-bundle',
+		'pro-plan',
 	],
 	'wpcom-ecommerce': [ 'ecommerce-bundle', 'ecommerce-bundle-2y', 'ecommerce-bundle-monthly' ],
 	'wpcom-business': [ 'business-bundle', 'business-bundle-2y', 'business-bundle-monthly' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We are renaming the not-yet-launched WordPress.com Managed plan to "WordPress.com Pro" and changing some corresponding database slugs.  This diff does a very basic rename in the Calypso codebase (only of code that is associated with those slugs).

#### Testing instructions

This is difficult to test until the database updates in D76695-code have run.  So mostly this just needs a code review.

But you can do a basic test by going to `calypso.localhost:3000/plans/[site]` and making sure the Pro plan shows up there.  Note that it will be $0 and not purchasable, until the database updates in D76695-code have run. But this is OK, since you can't see it or buy it in production yet anyway.