### PR TITLE
CI: Add Jetpack Playwright builds.

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -43,6 +43,8 @@ object WPComTests : Project({
 	buildType(coblocksPlaywrightBuildType("desktop", "08f88b93-993e-4de8-8d80-4a94981d9af4"));
 	buildType(coblocksPlaywrightBuildType("mobile", "cbcd44d5-4d31-4adc-b1b5-97f1225c6a7c"));
 
+	buildType(jetpackPlaywrightBuildType("desktop", "68fe6336-5869-4244-b236-cca23ba03487"));
+	buildType(jetpackPlaywrightBuildType("mobile", "a80b5c10-1fef-4c7f-9e2c-5c5c30d637c8"));
 	buildType(jetpackBuildType("desktop"));
 	buildType(jetpackBuildType("mobile"));
 
@@ -336,6 +338,27 @@ fun coblocksPlaywrightBuildType( targetDevice: String, buildUuid: String ): E2EB
 				buildFinishedSuccessfully = true
 			}
 		},
+	)
+}
+
+fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String): E2EBuildType {
+	return E2EBuildType (
+		buildId = "WPComTests_jetpack_Playwright_$targetDevice",
+		buildUuid = buildUuid,
+		buildName = "Playwright Jetpack E2E Tests ($targetDevice)",
+		buildDescription = "Runs Jetpack E2E tests as $targetDevice",
+		testGroup = "jetpack",
+		buildParams = {
+			text(
+				name = "env.URL",
+				value = "https://wordpress.com",
+				label = "Test URL",
+				description = "URL to test against",
+				allowEmpty = false
+			)
+			param("env.VIEWPORT_NAME", "$targetDevice")
+		},
+		buildFeatures = {},
 	)
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

To support the [Jetpack e2e spec migration project](pciE2j-NW-p2#comment-892), this PR adds Playwright Jetpack E2E builds.

The UUID field was generated using an online UUID generator.

#### Testing instructions

Ensure the following:
  - [x] TeamCity does not report errors.

Related to #61936.