### PR TITLE
Add more branch names to lint test in TeamCity

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -247,6 +247,8 @@ object CheckCodeStyle : BuildType({
 		vcs {
 			branchFilter = """
 				+:renovate/eslint-packages
+				+:renovate/major-linters
+				+:renovate/linters
 			""".trimIndent()
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Renovate creates PRs for linters under a couple branch names. This PR adds two more of those branch names to the test. That way, PRs with those updates automatically trigger this test run.

#### Testing instructions
TeamCity passes