### PR TITLE
Use branch steps for the DIFM flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -404,6 +404,7 @@ export function generateFlows( {
 			description: 'A flow for DIFM Lite leads',
 			excludeFromManageSiteFlows: true,
 			lastModified: '2022-03-10',
+			enableBranchSteps: true,
 		},
 
 		{

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_DIFM_LITE } from '@automattic/calypso-products';
 import { IntentScreen } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
@@ -7,6 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import difmImage from 'calypso/assets/images/difm/difm.svg';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { preventWidows } from 'calypso/lib/formatting';
+import useBranchSteps from 'calypso/signup/hooks/use-branch-steps';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import {
 	getProductDisplayCost,
@@ -87,7 +87,14 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 		dispatch( saveSignupStep( { stepName: props.stepName } ) );
 	}, [ dispatch, props.stepName ] );
 
+	const branchSteps = useBranchSteps( props.stepName, () => [ 'difm-site-picker' ] );
+
 	const newOrExistingSiteSelected = ( value: ChoiceType ) => {
+		// If 'new-site' is selected, skip the `difm-site-picker` step.
+		if ( 'new-site' === value ) {
+			branchSteps( {} );
+			dispatch( removeSiteSlugDependency() );
+		}
 		dispatch(
 			submitSignupStep(
 				{ stepName: props.stepName },
@@ -97,15 +104,7 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 				}
 			)
 		);
-		if ( 'existing-site' === value ) {
-			props.goToNextStep();
-		} else {
-			dispatch( removeSiteSlugDependency() );
-			dispatch( submitSignupStep( { stepName: 'difm-site-picker', wasSkipped: true } ) );
-			props.goToStep(
-				isEnabled( 'signup/redesigned-difm-flow' ) ? 'difm-options' : 'site-info-collection'
-			);
-		}
+		props.goToNextStep();
 	};
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds the `useBranchSteps` hook to skip the `difm-site-picker` step if the user chooses DIFM for a new site. This change was necessary to remove the hardcoded `goToStep` call to the `site-info-collection` step in client/signup/steps/new-or-existing-site/index.tsx. 
* This also fixes the behaviour of the `Step x of y` label in the top-right of the screen.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`. Choose "Existing Site" and complete the flow. After choosing "Existing Site", the step number shown in the top-right should be Step n of 4.
* Go to `/start/do-it-for-me`. Choose "New Site" and complete the flow. After choosing "New Site", the step number shown in the top-right should be Step n of 3.
* Repeat the steps while also clicking on the Back button and confirm that the flow shows the correct steps.
