### PR TITLE
Signup: Reset store if saved step missing in flow

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -130,6 +130,7 @@ export default class SignupFlowController {
 
 		this._resetStoresIfProcessing(); // reset the stores if the cached progress contained a processing step
 		this._resetStoresIfUserHasLoggedIn(); // reset the stores if user has newly authenticated
+		this._resetStoresIfSavedProgressStepRemoved(); // reset the stores if the cached progress contains a step that is missing in the current flow
 		this._resetSiteSlugIfUserEnteredAnotherFlow(); // reset the site slug if user entered another flow
 
 		// If we have access to the siteId, then make sure we've also loaded the siteSlug into
@@ -209,6 +210,20 @@ export default class SignupFlowController {
 			) {
 				this._reduxStore.dispatch( removeSiteSlugDependency() );
 			}
+		}
+	}
+
+	_resetStoresIfSavedProgressStepRemoved() {
+		const signupProgress = getSignupProgress( this._reduxStore.getState() );
+		const flowSteps = this._getFlowSteps();
+		if (
+			Object.values( signupProgress ).some(
+				( savedStep ) =>
+					this._flowName === savedStep.lastKnownFlow && ! flowSteps.includes( savedStep.stepName )
+			)
+		) {
+			debug( `Resetting stores: saved progress step missing in flow: ${ this._flowName }` );
+			this.reset();
 		}
 	}
 

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -47,11 +47,11 @@ describe( 'flow-controller', () => {
 		test( 'should reset stores if there are processing steps in the state upon instantitaion', () => {
 			const store = createSignupStore( {
 				signup: {
-					progress: [
-						{ stepName: 'stepA', status: 'processing' },
-						{ stepName: 'stepB' },
-						{ stepName: 'stepC' },
-					],
+					progress: {
+						stepA: { stepName: 'stepA', status: 'processing' },
+						stepB: { stepName: 'stepB' },
+						stepC: { stepName: 'stepC' },
+					},
 				},
 			} );
 
@@ -67,7 +67,7 @@ describe( 'flow-controller', () => {
 		test( 'should reset stores if user is logged in and there is a user step in the saved progress', () => {
 			const store = createSignupStore( {
 				signup: {
-					progress: [ { stepName: 'user' } ],
+					progress: { user: { stepName: 'user' } },
 				},
 			} );
 

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -79,6 +79,42 @@ describe( 'flow-controller', () => {
 
 			expect( getSignupProgress( store.getState() ) ).toEqual( {} );
 		} );
+
+		test( 'should reset stores if a step in signup progress does not exist in the current flow', () => {
+			const store = createSignupStore( {
+				signup: {
+					progress: { stepNotInfLow: { stepName: 'stepNotInfLow', lastKnownFlow: 'simple_flow' } },
+				},
+			} );
+
+			signupFlowController = new SignupFlowController( {
+				flowName: 'simple_flow',
+				onComplete: () => {},
+				reduxStore: store,
+			} );
+
+			expect( getSignupProgress( store.getState() ) ).toEqual( {} );
+		} );
+
+		test( 'should not reset stores if a step in signup progress does not exist in the current flow', () => {
+			const store = createSignupStore( {
+				signup: {
+					progress: {
+						stepNotInfLow: { stepName: 'stepNotInfLow', lastKnownFlow: 'some_random_flow' },
+					},
+				},
+			} );
+
+			signupFlowController = new SignupFlowController( {
+				flowName: 'simple_flow',
+				onComplete: () => {},
+				reduxStore: store,
+			} );
+
+			expect( getSignupProgress( store.getState() ) ).toEqual( {
+				stepNotInfLow: { stepName: 'stepNotInfLow', lastKnownFlow: 'some_random_flow' },
+			} );
+		} );
 	} );
 
 	describe( 'controlling a simple flow', () => {

--- a/client/state/signup/progress/schema.ts
+++ b/client/state/signup/progress/schema.ts
@@ -24,6 +24,7 @@ export const schema = {
 };
 
 export interface StepState {
+	lastKnownFlow: string;
 	formData: {
 		url: string;
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR resets the signup stores if the cached progress contains a step that is missing in the current flow. This can happen when a step is removed from a flow or the steps are controlled by a feature flag.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
