### PR TITLE
Restrict setAsPrimary domain action to users that can manage domain

### DIFF
--- a/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
@@ -61,7 +61,8 @@ const SetAsPrimary = ( props: SetAsPrimaryProps ): JSX.Element | null => {
 			domain.canSetAsPrimary &&
 			! domain.isPrimary &&
 			! shouldUpgradeToMakeDomainPrimary() &&
-			! domain.aftermarketAuction
+			! domain.aftermarketAuction &&
+			domain.currentUserCanManage
 		);
 	};
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR restrict the set as primary domain action to users that have permission to manage that domain (domain admins).

## Testing instructions

In order 

- Build this branch locally or open the live Calypso link

Related to #
