### PR TITLE
Emails: Remove discount star from Google Workspace section in Email Comparison page

### DIFF
--- a/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
@@ -16,7 +16,6 @@ function EmailProviderCard( {
 	logo,
 	title,
 	badge,
-	starLabel,
 	description,
 	formattedPrice,
 	discount,
@@ -44,12 +43,9 @@ function EmailProviderCard( {
 
 	const labelForExpandButton = expandButtonLabel ? expandButtonLabel : buttonLabel;
 
-	const showStar = detailsExpanded && starLabel;
-
 	return (
 		<PromoCard
 			className={ classnames( 'email-providers-comparison__provider-card', {
-				'has-star': showStar,
 				'is-expanded': detailsExpanded,
 				'is-forwarding': providerKey === 'forwarding',
 			} ) }
@@ -57,16 +53,6 @@ function EmailProviderCard( {
 			title={ title }
 			badge={ badge }
 		>
-			{ showStar && (
-				<div className="email-providers-comparison__provider-card-star">
-					<span>
-						<span>
-							<span>{ starLabel }</span>
-						</span>
-					</span>
-				</div>
-			) }
-
 			<div className="email-providers-comparison__provider-card-main-details">
 				<p>{ description }</p>
 
@@ -120,7 +106,6 @@ EmailProviderCard.propTypes = {
 	logo: PropTypes.object.isRequired,
 	title: PropTypes.string.isRequired,
 	badge: PropTypes.object,
-	starLabel: PropTypes.string,
 	description: PropTypes.string,
 	formattedPrice: PropTypes.node,
 	discount: PropTypes.node,

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -492,15 +492,6 @@ class EmailProvidersComparison extends Component {
 			standardPrice,
 		} );
 
-		const starLabel = productIsDiscounted
-			? translate( '%(discount)d%% off!', {
-					args: {
-						discount: gSuiteProduct.sale_coupon.discount,
-					},
-					comment: "%(discount)d is a numeric discount percentage (e.g. '40')",
-			  } )
-			: null;
-
 		// If we don't have any users, initialize the list to have 1 empty user
 		const googleUsers =
 			( this.state.googleUsers ?? [] ).length === 0
@@ -561,7 +552,6 @@ class EmailProvidersComparison extends Component {
 				providerKey="google"
 				logo={ { path: googleWorkspaceIcon } }
 				title={ getGoogleMailServiceFamily() }
-				starLabel={ starLabel }
 				description={ translate(
 					'Business email with Gmail. Includes other collaboration and productivity tools from Google.'
 				) }

--- a/client/my-sites/email/email-providers-comparison/style.scss
+++ b/client/my-sites/email/email-providers-comparison/style.scss
@@ -105,13 +105,6 @@
 		display: none;
 	}
 
-	&.has-star {
-		.action-panel__title,
-		.email-providers-comparison__provider-card-main-details {
-			margin-right: 70px;
-		}
-	}
-
 	&.is-expanded .promo-card__title-badge {
 		background: none;
 		display: inline-block;
@@ -336,31 +329,5 @@
 			margin-top: 0;
 			margin-left: $child-left-margin;
 		}
-	}
-}
-
-.email-providers-comparison__provider-card-star,
-.email-providers-comparison__provider-card-star span {
-	background-color: var( --color-error-40 );
-	height: 70px;
-	width: 70px;
-}
-
-.email-providers-comparison__provider-card-star {
-	color: #FFFFFF;
-	font-size: $font-body-large;
-	font-weight: bold;
-	position: absolute;
-	right: 8px;
-	text-align: center;
-	top: 8px;
-	transform: rotate( -45deg );
-
-	span {
-		align-items: center;
-		display: flex;
-		justify-content: center;
-		text-shadow: 0 0 30px var( --color-error-10 ), 0 0 5px var( --color-error-90 );
-		transform: rotate( 22.5deg );
 	}
 }


### PR DESCRIPTION
This pull request removes the star with a discount in the Google Workspace section we would show when Google Workspace is on sale. It basically reverts https://github.com/Automattic/wp-calypso/pull/59189, following up on [this discussion](https://github.com/Automattic/wp-calypso/pull/59189#issuecomment-998044432):

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/158361871-747297ca-8ef5-4006-97e0-33e1996b3338.png) | ![image](https://user-images.githubusercontent.com/594356/158363411-b8a9fb6b-2ab0-4548-9726-3ddb776f302a.png)

#### Testing instructions

1. Run `git checkout remove/star-from-email-comparison-page` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/61951#issuecomment-1067838945)
2. Create a sale coupon from Mission Control
3. Point `public-api.wordpress.com` to your sandbox
4. Enable the store sandbox
5. Open the [`Domains` page](http://calypso.localhost:3000/domains/manage)
6. Click the `Add a domain` button
7. Select `Search for a domain`
8. Select any domain to access the `Email Comparison` page
9. Click the `Add Google Workspace` button
10. Assert that no star badge is displayed
11. Assert that you can still add Google Workspace to your shopping cart