### PR TITLE
Emails: Add a new feature flag to start breaking down the bigger task to retire old comparison component

### DIFF
--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { TITAN_MAIL_YEARLY_SLUG } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -15,30 +16,32 @@ export default function EmailProvidersUpsell( { domain } ) {
 
 	return (
 		<CalypsoShoppingCartProvider>
-			<EmailProvidersComparison
-				backPath={ domainAddNew( selectedSiteSlug ) }
-				cartDomainName={ domain }
-				comparisonContext="domain-upsell"
-				headerTitle={ translate( 'Register %(domainName)s', {
-					args: { domainName: domain },
-					comment,
-				} ) }
-				hideEmailHeader
-				hideEmailForwardingCard
-				showSkipButton
-				onSkipClick={ () => {
-					page( `/checkout/${ selectedSiteSlug }` );
-				} }
-				promoHeaderTitle={ translate( 'Add a professional email address to %(domainName)s', {
-					args: {
-						domainName: domain,
-					},
-					comment,
-				} ) }
-				selectedDomainName={ domain }
-				skipButtonLabel={ translate( 'Skip' ) }
-				titanProductSlug={ TITAN_MAIL_YEARLY_SLUG }
-			/>
+			{ ! isEnabled( 'emails/show-new-comparison-component' ) ? (
+				<EmailProvidersComparison
+					backPath={ domainAddNew( selectedSiteSlug ) }
+					cartDomainName={ domain }
+					comparisonContext="domain-upsell"
+					headerTitle={ translate( 'Register %(domainName)s', {
+						args: { domainName: domain },
+						comment,
+					} ) }
+					hideEmailHeader
+					hideEmailForwardingCard
+					showSkipButton
+					onSkipClick={ () => {
+						page( `/checkout/${ selectedSiteSlug }` );
+					} }
+					promoHeaderTitle={ translate( 'Add a professional email address to %(domainName)s', {
+						args: {
+							domainName: domain,
+						},
+						comment,
+					} ) }
+					selectedDomainName={ domain }
+					skipButtonLabel={ translate( 'Skip' ) }
+					titanProductSlug={ TITAN_MAIL_YEARLY_SLUG }
+				/>
+			) : null }
 		</CalypsoShoppingCartProvider>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I am adding a new feature flag to start working on retire the old comparison page.

#### Testing instructions

1. Open the [Domains page](http://calypso.localhost:3000/domains/manage)
2. Click the Add a domain button
3. Select Search for a domain
4. Select any domain to access the Email Comparison page
5. Add the following query to the URL in your browser: ?flags=+emails/show-new-comparison-component
6. Assert that an empty screen is displayed.

Related to {1200182182542585-as-1201962630043136}
