### PR TITLE
Plans overhaul Phase 1: Rename Managed plan to Pro on Plan grid

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -8,7 +8,6 @@ import {
 	TYPE_PREMIUM,
 	TYPE_PERSONAL,
 	TYPE_BLOGGER,
-	TYPE_MANAGED,
 	TYPE_FREE,
 	PLAN_BUSINESS_2_YEARS,
 	PLAN_BUSINESS_ONBOARDING_EXPIRE,
@@ -18,6 +17,7 @@ import {
 	TYPE_ALL,
 	TERM_MONTHLY,
 	getPlans,
+	TYPE_PRO,
 } from '@automattic/calypso-products';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
@@ -208,7 +208,7 @@ export class ProductPurchaseFeaturesList extends Component {
 		);
 	}
 
-	getManagedFeatuers() {
+	getProFeatuers() {
 		const { isPlaceholder, selectedSite, planHasDomainCredit } = this.props;
 
 		return (
@@ -216,7 +216,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<HappinessSupportCard
 					isPlaceholder={ isPlaceholder }
 					showLiveChatButton
-					liveChatButtonEventName={ 'calypso_livechat_my_plan_managed' }
+					liveChatButtonEventName={ 'calypso_livechat_my_plan_pro' }
 				/>
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
@@ -366,7 +366,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				[ TYPE_PREMIUM ]: () => this.getPremiumFeatures(),
 				[ TYPE_PERSONAL ]: () => this.getPersonalFeatures(),
 				[ TYPE_BLOGGER ]: () => this.getBloggerFeatures(),
-				[ TYPE_MANAGED ]: () => this.getManagedFeatuers(),
+				[ TYPE_PRO ]: () => this.getProFeatuers(),
 			},
 			[ GROUP_JETPACK ]: {
 				[ TYPE_BUSINESS ]: () => this.getJetpackBusinessFeatures(),

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1440,7 +1440,7 @@ export const FEATURES_LIST = {
 	},
 	/* END - Jetpack tiered product-specific features */
 
-	/* START - New features Flexible and Managed plans introduced. */
+	/* START - New features Flexible and Pro plans introduced. */
 	[ FEATURE_UNLIMITED_USERS ]: {
 		getSlug: () => FEATURE_UNLIMITED_USERS,
 		getTitle: () => i18n.translate( 'Unlimited users' ),
@@ -1477,7 +1477,7 @@ export const FEATURES_LIST = {
 		getSlug: () => FEATURE_WOOCOMMERCE,
 		getTitle: () => i18n.translate( 'WooCommerce' ),
 	},
-	/* END - New features Flexible and Managed plans introduced. */
+	/* END - New features Flexible and Pro plans introduced. */
 };
 
 export const getPlanFeaturesObject = ( planFeaturesList ) => {

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -1,4 +1,4 @@
-import { isBusiness, isEcommerce, isEnterprise, isManaged } from '@automattic/calypso-products';
+import { isBusiness, isEcommerce, isEnterprise, isPro } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { ThemeProvider } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
@@ -126,7 +126,7 @@ const MarketplacePluginInstall = ( {
 	useEffect( () => {
 		supportsAtomicUpgrade.current =
 			selectedSite?.plan &&
-			( isManaged( selectedSite.plan ) ||
+			( isPro( selectedSite.plan ) ||
 				isBusiness( selectedSite.plan ) ||
 				isEnterprise( selectedSite.plan ) ||
 				isEcommerce( selectedSite.plan ) );

--- a/client/my-sites/plans-comparison/index.tsx
+++ b/client/my-sites/plans-comparison/index.tsx
@@ -1,2 +1,2 @@
 export { PlansComparison as default, globalOverrides } from './plans-comparison';
-export { isEligibleForManagedPlan } from './is-eligible-for-managed-plan';
+export { isEligibleForProPlan } from './is-eligible-for-pro-plan';

--- a/client/my-sites/plans-comparison/is-eligible-for-pro-plan.ts
+++ b/client/my-sites/plans-comparison/is-eligible-for-pro-plan.ts
@@ -4,7 +4,7 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import type { AppState } from 'calypso/types';
 
-export function isEligibleForManagedPlan( state: AppState, siteId?: number ): boolean {
+export function isEligibleForProPlan( state: AppState, siteId?: number ): boolean {
 	if ( isE2ETest() ) {
 		return false;
 	}
@@ -13,5 +13,5 @@ export function isEligibleForManagedPlan( state: AppState, siteId?: number ): bo
 		return false;
 	}
 
-	return isEnabled( 'plans/managed-plan' );
+	return isEnabled( 'plans/pro-plan' );
 }

--- a/client/my-sites/plans-comparison/plans-comparison-action.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-action.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { TYPE_FREE, TYPE_FLEXIBLE } from '@automattic/calypso-products';
+import { TYPE_FREE, TYPE_FLEXIBLE, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -23,12 +23,15 @@ interface Props {
 type TranslateFunc = ReturnType< typeof useTranslate >;
 
 function getButtonText( props: Partial< Props >, translate: TranslateFunc ): TranslateResult {
-	const { isCurrentPlan, isInSignup, plan } = props;
+	const { isCurrentPlan, plan } = props;
 
-	if ( isInSignup ) {
-		return translate( 'Start with %(plan)s', {
+	const planTitle = plan?.getTitle();
+	const planSlug = plan?.getStoreSlug();
+
+	if ( planSlug === PLAN_WPCOM_PRO ) {
+		return translate( 'Try %(plan)s risk-free', {
 			args: {
-				plan: plan?.getTitle(),
+				plan: planTitle,
 			},
 		} );
 	}
@@ -37,11 +40,10 @@ function getButtonText( props: Partial< Props >, translate: TranslateFunc ): Tra
 		return props.canPurchase ? translate( 'Manage plan' ) : translate( 'View plan' );
 	}
 
-	return translate( 'Select %(plan)s', {
+	return translate( 'Start with %(plan)s', {
 		args: {
-			plan: plan?.getTitle(),
+			plan: planTitle,
 		},
-		comment: 'Button to select a paid plan by plan name, e.g., "Select Managed"',
 	} );
 }
 

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -156,9 +156,9 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Storage space' ),
+		title: translate( 'Storage' ),
 		description: translate(
-			'The free plan allows a maximum storage of 500MB, which equals to approximately 100 high quality images, whilst with Managed WordPress you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.'
+			'The free plan allows a maximum storage of 500MB, which equals to approximately 100 high quality images, whilst with Pro you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.'
 		),
 		features: [ FEATURE_500MB_STORAGE, FEATURE_50GB_STORAGE ],
 		getCellText: ( feature, isMobile = false ) => {
@@ -191,7 +191,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 	{
 		title: translate( 'Visits per month' ),
 		description: translate(
-			"WordPress Managed bundles up to 100,000 visits a month to help you rest assured traffic won't be a concern."
+			"WordPress Pro bundles up to 100,000 visits a month to help you rest assured traffic won't be a concern."
 		),
 		features: [ FEATURE_10K_VISITS, FEATURE_100K_VISITS ],
 		getCellText: ( feature, isMobile = false ) => {

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -158,7 +158,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 	{
 		title: translate( 'Storage' ),
 		description: translate(
-			'The free plan allows a maximum storage of 500MB, which equals to approximately 100 high quality images, whilst with Pro you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.'
+			'The free plan allows a maximum storage of 500MB, which equals to approximately 100 high quality images, while with Pro you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.'
 		),
 		features: [ FEATURE_500MB_STORAGE, FEATURE_50GB_STORAGE ],
 		getCellText: ( feature, isMobile = false ) => {

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -1,10 +1,10 @@
 import {
 	getPlan,
 	PLAN_WPCOM_FLEXIBLE,
-	PLAN_WPCOM_MANAGED,
+	PLAN_WPCOM_PRO,
 	TYPE_FREE,
 	TYPE_FLEXIBLE,
-	TYPE_MANAGED,
+	TYPE_PRO,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { css } from '@emotion/react';
@@ -429,7 +429,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSiteId || null ) );
 	const [ showCollapsibleRows, setShowCollapsibleRows ] = useState( false );
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) ?? '';
-	const plans = [ getPlan( PLAN_WPCOM_FLEXIBLE ), getPlan( PLAN_WPCOM_MANAGED ) ] as WPComPlan[];
+	const plans = [ getPlan( PLAN_WPCOM_FLEXIBLE ), getPlan( PLAN_WPCOM_PRO ) ] as WPComPlan[];
 	const prices: PlanPrices[] = [ { price: 0 }, usePlanPrices( plans[ 1 ], selectedSiteId ) ];
 	const translate = useTranslate();
 
@@ -467,7 +467,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 								currentSitePlanSlug={ sitePlan?.product_slug }
 								plan={ plan }
 								isInSignup={ isInSignup }
-								isPrimary={ plan.type === TYPE_MANAGED }
+								isPrimary={ plan.type === TYPE_PRO }
 								isCurrentPlan={ sitePlan?.product_slug === plan.getStoreSlug() }
 								manageHref={ manageHref }
 								onClick={ () => onSelectPlan( planToCartItem( plan ) ) }

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -1,7 +1,7 @@
 import { isFreePlanProduct, isFlexiblePlanProduct } from '@automattic/calypso-products';
 import page from 'page';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
-import { isEligibleForManagedPlan } from 'calypso/my-sites/plans-comparison';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { productSelect } from 'calypso/my-sites/plans/jetpack-plans/controller';
 import setJetpackPlansHeader from 'calypso/my-sites/plans/jetpack-plans/plans-header';
 import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
@@ -30,10 +30,10 @@ export function plans( context, next ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	const selectedSite = getSite( state, siteId );
-	const eligibleForManagedPlan = isEligibleForManagedPlan( state, siteId );
+	const eligibleForProPlan = isEligibleForProPlan( state, siteId );
 
 	if (
-		eligibleForManagedPlan &&
+		eligibleForProPlan &&
 		! isFreePlanProduct( selectedSite.plan ) &&
 		! isFlexiblePlanProduct( selectedSite.plan )
 	) {

--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -1,6 +1,6 @@
 import { isFreePlanProduct, isFlexiblePlanProduct } from '@automattic/calypso-products';
 import page from 'page';
-import { isEligibleForManagedPlan } from 'calypso/my-sites/plans-comparison';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CurrentPlan from './';
@@ -10,7 +10,7 @@ export function currentPlan( context, next ) {
 
 	const siteId = getSelectedSiteId( state );
 	const selectedSite = getSite( state, siteId );
-	const eligibleForManagedPlan = isEligibleForManagedPlan( state, siteId );
+	const eligibleForProPlan = isEligibleForProPlan( state, siteId );
 
 	if ( ! selectedSite ) {
 		page.redirect( '/plans/' );
@@ -20,7 +20,7 @@ export function currentPlan( context, next ) {
 
 	if (
 		isFreePlanProduct( selectedSite.plan ) ||
-		( eligibleForManagedPlan && isFlexiblePlanProduct( selectedSite.plan ) )
+		( eligibleForProPlan && isFlexiblePlanProduct( selectedSite.plan ) )
 	) {
 		page.redirect( `/plans/${ selectedSite.slug }` );
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -15,7 +15,7 @@ import {
 	isFreeJetpackPlan,
 	isFreePlanProduct,
 	isFlexiblePlanProduct,
-	isManaged,
+	isPro,
 } from '@automattic/calypso-products';
 import { Dialog } from '@automattic/components';
 import { Global } from '@emotion/react';
@@ -40,7 +40,7 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { isCloseToExpiration } from 'calypso/lib/purchases';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings';
-import { globalOverrides, isEligibleForManagedPlan } from 'calypso/my-sites/plans-comparison';
+import { globalOverrides, isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import JetpackChecklist from 'calypso/my-sites/plans/current-plan/jetpack-checklist';
 import PlanRenewalMessage from 'calypso/my-sites/plans/jetpack-plans/plan-renewal-message';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
@@ -166,7 +166,7 @@ class CurrentPlan extends Component {
 			showJetpackChecklist,
 			showThankYou,
 			translate,
-			eligibleForManagedPlan,
+			eligibleForProPlan,
 		} = this.props;
 
 		const currentPlanSlug = selectedSite.plan.product_slug;
@@ -190,16 +190,16 @@ class CurrentPlan extends Component {
 		}
 
 		if (
-			eligibleForManagedPlan &&
+			eligibleForProPlan &&
 			! isFlexiblePlanProduct( selectedSite.plan ) &&
-			! isManaged( selectedSite.plan )
+			! isPro( selectedSite.plan )
 		) {
 			showLegacyPlanNotice = true;
 		}
 
 		return (
 			<Main className="current-plan" wideLayout>
-				{ eligibleForManagedPlan && <Global styles={ globalOverrides } /> }
+				{ eligibleForProPlan && <Global styles={ globalOverrides } /> }
 				<DocumentHead title={ translate( 'My Plan' ) } />
 				<FormattedHeader
 					brandFont
@@ -277,7 +277,7 @@ class CurrentPlan extends Component {
 						</Fragment>
 					) }
 
-					{ ! eligibleForManagedPlan && (
+					{ ! eligibleForProPlan && (
 						<>
 							<div
 								className={ classNames( 'current-plan__header-text current-plan__text', {
@@ -313,7 +313,7 @@ export default connect( ( state, { requestThankYou } ) => {
 	const isJetpackNotAtomic = false === isAutomatedTransfer && isJetpack;
 
 	const currentPlan = getCurrentPlan( state, selectedSiteId );
-	const eligibleForManagedPlan = isEligibleForManagedPlan( state, selectedSiteId );
+	const eligibleForProPlan = isEligibleForProPlan( state, selectedSiteId );
 
 	return {
 		currentPlan,
@@ -328,6 +328,6 @@ export default connect( ( state, { requestThankYou } ) => {
 		showJetpackChecklist: isJetpackNotAtomic,
 		showThankYou: requestThankYou && isJetpackNotAtomic,
 		scheduleId: getConciergeScheduleId( state ),
-		eligibleForManagedPlan,
+		eligibleForProPlan,
 	};
 } )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -34,7 +34,7 @@ import {
 } from 'calypso/lib/purchases';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import OwnerInfo from 'calypso/me/purchases/purchase-item/owner-info';
-import { isEligibleForManagedPlan } from 'calypso/my-sites/plans-comparison';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
@@ -174,7 +174,7 @@ class PurchasesListing extends Component {
 	}
 
 	getActionButton( purchase ) {
-		const { selectedSiteSlug, translate, currentUserId, eligibleForManagedPlan } = this.props;
+		const { selectedSiteSlug, translate, currentUserId, eligibleForProPlan } = this.props;
 
 		// No action button if there's no site selected.
 		if ( ! selectedSiteSlug || ! purchase ) {
@@ -228,7 +228,7 @@ class PurchasesListing extends Component {
 						: '#'
 				}
 				disabled={ ! userIsPurchaseOwner }
-				compact={ ! eligibleForManagedPlan }
+				compact={ ! eligibleForProPlan }
 			>
 				{ label }
 				&nbsp;
@@ -334,11 +334,11 @@ class PurchasesListing extends Component {
 	}
 
 	renderPlan() {
-		const { currentPlan, isPlanExpiring, translate, eligibleForManagedPlan } = this.props;
+		const { currentPlan, isPlanExpiring, translate, eligibleForProPlan } = this.props;
 
 		return (
 			<Fragment>
-				{ ! eligibleForManagedPlan && (
+				{ ! eligibleForProPlan && (
 					<Card compact>
 						<strong>{ translate( 'My Plan' ) }</strong>
 					</Card>
@@ -426,6 +426,6 @@ export default connect( ( state ) => {
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 		isCloudEligible: isJetpackCloudEligible( state, selectedSiteId ),
 		currentUserId: getCurrentUserId( state ),
-		eligibleForManagedPlan: isEligibleForManagedPlan( state, selectedSiteId ),
+		eligibleForProPlan: isEligibleForProPlan( state, selectedSiteId ),
 	};
 } )( localize( withLocalizedMoment( PurchasesListing ) ) );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -3,7 +3,7 @@ import {
 	getPlan,
 	getIntervalTypeForTerm,
 	PLAN_FREE,
-	PLAN_WPCOM_MANAGED,
+	PLAN_WPCOM_PRO,
 	PLAN_WPCOM_FLEXIBLE,
 } from '@automattic/calypso-products';
 import { Global } from '@emotion/react';
@@ -27,7 +27,7 @@ import { useExperiment } from 'calypso/lib/explat';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import PlansComparison, {
 	globalOverrides,
-	isEligibleForManagedPlan,
+	isEligibleForProPlan,
 } from 'calypso/my-sites/plans-comparison';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
@@ -140,7 +140,7 @@ class Plans extends Component {
 	};
 
 	renderPlansMain() {
-		const { currentPlan, selectedSite, isWPForTeamsSite, eligibleForManagedPlan } = this.props;
+		const { currentPlan, selectedSite, isWPForTeamsSite, eligibleForProPlan } = this.props;
 
 		if ( ! this.props.plansLoaded || ! currentPlan ) {
 			// Maybe we should show a loading indicator here?
@@ -160,8 +160,8 @@ class Plans extends Component {
 		}
 
 		if (
-			eligibleForManagedPlan &&
-			[ PLAN_FREE, PLAN_WPCOM_FLEXIBLE, PLAN_WPCOM_MANAGED ].includes( currentPlan?.productSlug )
+			eligibleForProPlan &&
+			[ PLAN_FREE, PLAN_WPCOM_FLEXIBLE, PLAN_WPCOM_PRO ].includes( currentPlan?.productSlug )
 		) {
 			return (
 				<PlansComparison
@@ -193,13 +193,7 @@ class Plans extends Component {
 	}
 
 	render() {
-		const {
-			selectedSite,
-			translate,
-			canAccessPlans,
-			currentPlan,
-			eligibleForManagedPlan,
-		} = this.props;
+		const { selectedSite, translate, canAccessPlans, currentPlan, eligibleForProPlan } = this.props;
 
 		if ( ! selectedSite || this.isInvalidPlanInterval() || ! currentPlan ) {
 			return this.renderPlaceholder();
@@ -212,7 +206,7 @@ class Plans extends Component {
 				{ selectedSite.ID && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<PageViewTracker path="/plans/:site" title="Plans" />
-				{ eligibleForManagedPlan && <Global styles={ globalOverrides } /> }
+				{ eligibleForProPlan && <Global styles={ globalOverrides } /> }
 				<QueryContactDetailsCache />
 				<QueryPlans />
 				<TrackComponentView eventName="calypso_plans_view" />
@@ -228,8 +222,8 @@ class Plans extends Component {
 							<FormattedHeader
 								brandFont
 								headerText={ translate( 'Plans' ) }
-								subHeaderText={ ! eligibleForManagedPlan && description }
-								tooltipText={ eligibleForManagedPlan && description }
+								subHeaderText={ ! eligibleForProPlan && description }
+								tooltipText={ eligibleForProPlan && description }
 								align="left"
 							/>
 							<div id="plans" className="plans plans__has-sidebar">
@@ -263,6 +257,6 @@ export default connect( ( state ) => {
 		isSiteEligibleForMonthlyPlan: isEligibleForWpComMonthlyPlan( state, selectedSiteId ),
 		showTreatmentPlansReorderTest: isTreatmentPlansReorderTest( state ),
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
-		eligibleForManagedPlan: isEligibleForManagedPlan( state, selectedSiteId ),
+		eligibleForProPlan: isEligibleForProPlan( state, selectedSiteId ),
 	};
 } )( localize( withTrackingTool( 'HotJar' )( Plans ) ) );

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -8,7 +8,7 @@ import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { sectionify } from 'calypso/lib/route';
-import { isEligibleForManagedPlan } from 'calypso/my-sites/plans-comparison';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -39,13 +39,7 @@ class PlansNavigation extends Component {
 	}
 
 	render() {
-		const {
-			site,
-			shouldShowMyPlan,
-			shouldShowPlans,
-			translate,
-			eligibleForManagedPlan,
-		} = this.props;
+		const { site, shouldShowMyPlan, shouldShowPlans, translate, eligibleForProPlan } = this.props;
 		const path = sectionify( this.props.path );
 		const sectionTitle = this.getSectionTitle( path );
 		const hasPinnedItems = isMobile() && site;
@@ -69,7 +63,7 @@ class PlansNavigation extends Component {
 									path === '/plans' || path === '/plans/monthly' || path === '/plans/yearly'
 								}
 							>
-								{ eligibleForManagedPlan ? translate( 'New Plans' ) : translate( 'Plans' ) }
+								{ eligibleForProPlan ? translate( 'New Plans' ) : translate( 'Plans' ) }
 							</NavItem>
 						) }
 					</NavTabs>
@@ -85,12 +79,12 @@ export default connect( ( state ) => {
 	const isJetpack = isJetpackSite( state, siteId );
 	const isOnFreePlan = isSiteOnFreePlan( state, siteId );
 	const isAtomic = isAtomicSite( state, siteId );
-	const eligibleForManagedPlan = isEligibleForManagedPlan( state, siteId );
+	const eligibleForProPlan = isEligibleForProPlan( state, siteId );
 	const currentPlan = getCurrentPlan( state, siteId );
 	let shouldShowMyPlan = ! isOnFreePlan || ( isJetpack && ! isAtomic );
 	let shouldShowPlans = true;
 
-	if ( eligibleForManagedPlan && currentPlan ) {
+	if ( eligibleForProPlan && currentPlan ) {
 		const isFreeOrFlexible =
 			isFreePlanProduct( currentPlan ) || isFlexiblePlanProduct( currentPlan );
 		shouldShowMyPlan = isFreeOrFlexible ? false : true;
@@ -101,6 +95,6 @@ export default connect( ( state ) => {
 		shouldShowMyPlan,
 		shouldShowPlans,
 		site,
-		eligibleForManagedPlan,
+		eligibleForProPlan,
 	};
 } )( localize( PlansNavigation ) );

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -50,10 +50,10 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
-			name: 'managed',
-			steps: [ 'user', 'domains', 'plans-managed' ],
+			name: 'pro',
+			steps: [ 'user', 'domains', 'plans-pro' ],
 			destination: getSignupDestination,
-			description: 'Create an account and a blog and then add the managed plan to the users cart.',
+			description: 'Create an account and a blog and then add the pro plan to the users cart.',
 			lastModified: '2022-03-08',
 			showRecaptcha: true,
 		},

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -25,7 +25,7 @@ const stepNameToModuleName = {
 	'plans-new': 'plans',
 	'plans-business': 'plans',
 	'plans-ecommerce': 'plans',
-	'plans-managed': 'plans',
+	'plans-pro': 'plans',
 	'plans-import': 'plans',
 	'plans-launch': 'plans',
 	'plans-personal': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -8,7 +8,7 @@ import {
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_ECOMMERCE_MONTHLY,
-	PLAN_WPCOM_MANAGED,
+	PLAN_WPCOM_PRO,
 	TYPE_FREE,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
@@ -280,14 +280,14 @@ export function generateSteps( {
 			},
 		},
 
-		'plans-managed': {
-			stepName: 'plans-managed',
+		'plans-pro': {
+			stepName: 'plans-pro',
 			apiRequestFunction: addPlanToCart,
 			fulfilledStepCallback: isPlanFulfilled,
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'cartItem' ],
 			defaultDependencies: {
-				cartItem: PLAN_WPCOM_MANAGED,
+				cartItem: PLAN_WPCOM_PRO,
 			},
 		},
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -20,7 +20,7 @@ import Notice from 'calypso/components/notice';
 import { getTld, isSubdomain } from 'calypso/lib/domains';
 import { ProvideExperimentData } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
-import PlansComparison, { isEligibleForManagedPlan } from 'calypso/my-sites/plans-comparison';
+import PlansComparison, { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -136,7 +136,7 @@ export class PlansStep extends Component {
 			showTreatmentPlansReorderTest,
 			isInVerticalScrollingPlansExperiment,
 			isReskinned,
-			eligibleForManagedPlan,
+			eligibleForProPlan,
 		} = this.props;
 
 		let errorDisplay;
@@ -154,7 +154,7 @@ export class PlansStep extends Component {
 			return this.renderLoading();
 		}
 
-		if ( eligibleForManagedPlan ) {
+		if ( eligibleForProPlan ) {
 			return (
 				<div>
 					{ errorDisplay }
@@ -275,9 +275,9 @@ export class PlansStep extends Component {
 	}
 
 	getHeaderText() {
-		const { headerText, translate, eligibleForManagedPlan } = this.props;
+		const { headerText, translate, eligibleForProPlan } = this.props;
 
-		if ( eligibleForManagedPlan ) {
+		if ( eligibleForProPlan ) {
 			return translate( 'Managed WordPress made just for you' );
 		}
 
@@ -289,9 +289,9 @@ export class PlansStep extends Component {
 	}
 
 	getSubHeaderText() {
-		const { hideFreePlan, subHeaderText, translate, eligibleForManagedPlan } = this.props;
+		const { hideFreePlan, subHeaderText, translate, eligibleForProPlan } = this.props;
 
-		if ( eligibleForManagedPlan ) {
+		if ( eligibleForProPlan ) {
 			return translate( 'Try risk-free with a 14-day money back guarantee' );
 		}
 
@@ -452,7 +452,7 @@ export default connect(
 		// treatment for the `vertical_plan_listing_v2` experiment is implemented.
 		isInVerticalScrollingPlansExperiment: true,
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
-		eligibleForManagedPlan: isEligibleForManagedPlan( state, getSiteBySlug( state, siteSlug )?.ID ),
+		eligibleForProPlan: isEligibleForProPlan( state, getSiteBySlug( state, siteSlug )?.ID ),
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep }
 )( localize( PlansStep ) );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -278,7 +278,7 @@ export class PlansStep extends Component {
 		const { headerText, translate, eligibleForProPlan } = this.props;
 
 		if ( eligibleForProPlan ) {
-			return translate( 'Managed WordPress made just for you' );
+			return translate( 'WordPress Pro made just for you' );
 		}
 
 		if ( this.state.isDesktop ) {

--- a/client/state/marketplace/selectors.ts
+++ b/client/state/marketplace/selectors.ts
@@ -2,7 +2,7 @@ import {
 	isBusiness,
 	isEcommerce,
 	isEnterprise,
-	isManaged,
+	isPro,
 	isMonthly,
 } from '@automattic/calypso-products';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
@@ -20,7 +20,7 @@ const shouldUpgradeCheck = (
 ) => {
 	return selectedSite
 		? ! (
-				isManaged( selectedSite?.plan ) ||
+				isPro( selectedSite?.plan ) ||
 				isBusiness( selectedSite?.plan ) ||
 				isEnterprise( selectedSite?.plan ) ||
 				isEcommerce( selectedSite?.plan ) ||

--- a/client/state/purchases/selectors/should-revert-atomic-site-before-deactivation.js
+++ b/client/state/purchases/selectors/should-revert-atomic-site-before-deactivation.js
@@ -1,7 +1,7 @@
 import {
 	isWpComBusinessPlan,
 	isWpComEcommercePlan,
-	isWpComManagedPlan,
+	isWpComProPlan,
 } from '@automattic/calypso-products';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -25,7 +25,7 @@ export const shouldRevertAtomicSiteBeforeDeactivation = ( state, purchaseId ) =>
 	const purchase = getByPurchaseId( state, purchaseId );
 
 	const isAtomicSupportedProduct = ( productSlug ) =>
-		isWpComManagedPlan( productSlug ) ||
+		isWpComProPlan( productSlug ) ||
 		isWpComBusinessPlan( productSlug ) ||
 		isWpComEcommercePlan( productSlug ) ||
 		isMarketplaceProduct( state, productSlug );

--- a/client/state/selectors/is-site-on-atomic-plan.js
+++ b/client/state/selectors/is-site-on-atomic-plan.js
@@ -1,4 +1,4 @@
-import { isEcommercePlan, isBusinessPlan, isManagedPlan } from '@automattic/calypso-products';
+import { isEcommercePlan, isBusinessPlan, isProPlan } from '@automattic/calypso-products';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 
 /**
@@ -19,7 +19,7 @@ const isSiteOnAtomicPlan = ( state, siteId ) => {
 	return (
 		isEcommercePlan( currentPlan.productSlug ) ||
 		isBusinessPlan( currentPlan.productSlug ) ||
-		isManagedPlan( currentPlan.productSlug )
+		isProPlan( currentPlan.productSlug )
 	);
 };
 

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -200,7 +200,7 @@
 		"business-monthly",
 		"ecommerce",
 		"ecommerce-monthly",
-		"managed",
+		"pro",
 		"domain"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js"

--- a/config/development.json
+++ b/config/development.json
@@ -105,7 +105,7 @@
 		"p2/preapproved-domains": true,
 		"page/export": true,
 		"plans/personal-plan": true,
-		"plans/managed-plan": true,
+		"plans/pro-plan": true,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,
 		"publicize-preview": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -66,7 +66,7 @@
 		"p2/p2-plus": true,
 		"p2/preapproved-domains": false,
 		"plans/personal-plan": true,
-		"plans/managed-plan": false,
+		"plans/pro-plan": false,
 		"post-editor/checkout-overlay": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,

--- a/config/production.json
+++ b/config/production.json
@@ -68,7 +68,7 @@
 		"p2/p2-plus": true,
 		"p2/preapproved-domains": false,
 		"plans/personal-plan": true,
-		"plans/managed-plan": false,
+		"plans/pro-plan": false,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,
 		"publicize-preview": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -67,7 +67,7 @@
 		"p2/preapproved-domains": true,
 		"page/export": true,
 		"plans/personal-plan": true,
-		"plans/managed-plan": false,
+		"plans/pro-plan": false,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,
 		"publicize-preview": true,

--- a/config/test.json
+++ b/config/test.json
@@ -60,7 +60,7 @@
 		"network-connection": true,
 		"p2/preapproved-domains": true,
 		"plans/personal-plan": true,
-		"plans/managed-plan": false,
+		"plans/pro-plan": false,
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -81,7 +81,7 @@
 		"p2/p2-plus": true,
 		"p2/preapproved-domains": true,
 		"plans/personal-plan": true,
-		"plans/managed-plan": false,
+		"plans/pro-plan": false,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,
 		"publicize-preview": true,

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -196,7 +196,7 @@ export const FEATURE_P2_MORE_FILE_TYPES = 'p2-more-file-types';
 export const FEATURE_P2_PRIORITY_CHAT_EMAIL_SUPPORT = 'p2-priority-chat-email-support';
 export const FEATURE_P2_ACTIVITY_OVERVIEW = 'p2-activity-overview';
 
-// New features Flexible and Managed plans introduced.
+// New features Flexible and Pro plans introduced.
 export const FEATURE_UNLIMITED_USERS = 'unlimited-users';
 export const FEATURE_UNLIMITED_POSTS_PAGES = 'unlimited-posts-pages';
 export const FEATURE_PAYMENT_BLOCKS = 'payment-blocks';

--- a/packages/calypso-products/src/constants/types.ts
+++ b/packages/calypso-products/src/constants/types.ts
@@ -11,7 +11,7 @@ export const TYPE_SECURITY_T2 = 'TYPE_SECURITY_T2';
 export const TYPE_ALL = 'TYPE_ALL';
 export const TYPE_P2_PLUS = 'TYPE_P2_PLUS';
 export const TYPE_FLEXIBLE = 'TYPE_FLEXIBLE';
-export const TYPE_MANAGED = 'TYPE_MANAGED';
+export const TYPE_PRO = 'TYPE_PRO';
 
 export const TYPES_LIST = <const>[
 	TYPE_FREE,
@@ -25,5 +25,5 @@ export const TYPES_LIST = <const>[
 	TYPE_ALL,
 	TYPE_P2_PLUS,
 	TYPE_FLEXIBLE,
-	TYPE_MANAGED,
+	TYPE_PRO,
 ];

--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -31,7 +31,7 @@ export const PLAN_VIP = 'vip';
 export const PLAN_P2_PLUS = 'wp_p2_plus_monthly';
 export const PLAN_P2_FREE = 'p2_free_plan'; // Not a real plan; it's a renamed WP.com Free for the P2 project.
 export const PLAN_WPCOM_FLEXIBLE = 'wpcom-flexible'; // Not a real plan; it's a renamed WP.com Free for the plans overhaul.
-export const PLAN_WPCOM_MANAGED = 'pro-plan';
+export const PLAN_WPCOM_PRO = 'pro-plan';
 
 export const WPCOM_PLANS = <const>[
 	PLAN_BUSINESS_MONTHLY,

--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -56,7 +56,7 @@ export const WPCOM_PLANS = <const>[
 	PLAN_P2_PLUS,
 	PLAN_P2_FREE,
 	PLAN_WPCOM_FLEXIBLE,
-	PLAN_WPCOM_MANAGED,
+	PLAN_WPCOM_PRO,
 ];
 
 export const WPCOM_MONTHLY_PLANS = <const>[

--- a/packages/calypso-products/src/is-managed.ts
+++ b/packages/calypso-products/src/is-managed.ts
@@ -1,7 +1,0 @@
-import { camelOrSnakeSlug } from './camel-or-snake-slug';
-import { isManagedPlan } from './main';
-import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
-
-export function isManaged( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	return isManagedPlan( camelOrSnakeSlug( product ) );
-}

--- a/packages/calypso-products/src/is-pro.ts
+++ b/packages/calypso-products/src/is-pro.ts
@@ -1,0 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
+import { isProPlan } from './main';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isPro( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	return isProPlan( camelOrSnakeSlug( product ) );
+}

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -4,7 +4,7 @@ import {
 	TERM_BIENNIALLY,
 	TYPE_BUSINESS,
 	TYPE_ECOMMERCE,
-	TYPE_MANAGED,
+	TYPE_PRO,
 	TYPE_FREE,
 	TYPE_FLEXIBLE,
 	TYPE_BLOGGER,
@@ -26,7 +26,7 @@ import {
 	isBusiness,
 	isEnterprise,
 	isEcommerce,
-	isManaged,
+	isPro,
 	isVipPlan,
 	getProductFromSlug,
 } from '.';
@@ -101,8 +101,8 @@ export function getPlanClass( planKey: string ): string {
 		return 'is-ecommerce-plan';
 	}
 
-	if ( isManagedPlan( planKey ) ) {
-		return 'is-managed-plan';
+	if ( isProPlan( planKey ) ) {
+		return 'is-pro-plan';
 	}
 
 	if ( isSecurityDailyPlan( planKey ) ) {
@@ -241,8 +241,8 @@ export function isEcommercePlan( planSlug: string ): boolean {
 	return planMatches( planSlug, { type: TYPE_ECOMMERCE } );
 }
 
-export function isManagedPlan( planSlug: string ): boolean {
-	return planMatches( planSlug, { type: TYPE_MANAGED } );
+export function isProPlan( planSlug: string ): boolean {
+	return planMatches( planSlug, { type: TYPE_PRO } );
 }
 
 export function isBusinessPlan( planSlug: string ): boolean {
@@ -293,8 +293,8 @@ export function isWpComEcommercePlan( planSlug: string ): boolean {
 	return planMatches( planSlug, { type: TYPE_ECOMMERCE, group: GROUP_WPCOM } );
 }
 
-export function isWpComManagedPlan( planSlug: string ): boolean {
-	return planMatches( planSlug, { type: TYPE_MANAGED, group: GROUP_WPCOM } );
+export function isWpComProPlan( planSlug: string ): boolean {
+	return planMatches( planSlug, { type: TYPE_PRO, group: GROUP_WPCOM } );
 }
 
 export function isWpComPremiumPlan( planSlug: string ): boolean {
@@ -640,8 +640,8 @@ export const chooseDefaultCustomerType = ( {
 		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_BUSINESS } )[ 0 ],
 		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_ECOMMERCE } )[ 0 ],
 		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_ECOMMERCE } )[ 0 ],
-		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_MANAGED } )[ 0 ],
-		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_MANAGED } )[ 0 ],
+		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_PRO } )[ 0 ],
+		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_PRO } )[ 0 ],
 	]
 		.map( ( planKey ) => getPlan( planKey ) )
 		.filter( isValueTruthy )
@@ -677,7 +677,7 @@ export function planHasJetpackClassicSearch(
 			isBusiness( plan ) ||
 			isEnterprise( plan ) ||
 			isEcommerce( plan ) ||
-			isManaged( plan ) ||
+			isPro( plan ) ||
 			isVipPlan( plan ) )
 	);
 }

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1581,10 +1581,10 @@ PLANS_LIST[ PLAN_WPCOM_FLEXIBLE ] = {
 	...PLANS_LIST[ PLAN_FREE ],
 	group: GROUP_WPCOM,
 	type: TYPE_FLEXIBLE,
-	getBillingTimeFrame: WPComGetBillingTimeframe,
+	getBillingTimeFrame: () => i18n.translate( 'upgrade when you need' ),
 	getDescription: () =>
 		i18n.translate(
-			'Start your free WordPress.com website. Limited functionalities, storage and visits.'
+			'Start your free WordPress.com website. Limited functionality, storage and visits.'
 		),
 	getPlanCompareFeatures: () => [
 		FEATURE_10K_VISITS,
@@ -1604,7 +1604,7 @@ PLANS_LIST[ PLAN_WPCOM_PRO ] = {
 	getPathSlug: () => 'pro',
 	getDescription: () =>
 		i18n.translate( 'Enjoy the classic WordPress.com experience using plugins and much more.' ),
-	getBillingTimeFrame: WPComGetBillingTimeframe,
+	getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
 	getPlanCompareFeatures: () => [
 		FEATURE_ADDITIONAL_SITES,
 		FEATURE_100K_VISITS,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -180,7 +180,7 @@ import {
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_WPCOM_FLEXIBLE,
-	PLAN_WPCOM_MANAGED,
+	PLAN_WPCOM_PRO,
 	PREMIUM_DESIGN_FOR_STORES,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
@@ -198,7 +198,7 @@ import {
 	TYPE_SECURITY_T1,
 	TYPE_SECURITY_T2,
 	TYPE_FLEXIBLE,
-	TYPE_MANAGED,
+	TYPE_PRO,
 } from './constants';
 import type {
 	BillingTerm,
@@ -1594,13 +1594,13 @@ PLANS_LIST[ PLAN_WPCOM_FLEXIBLE ] = {
 	],
 };
 
-PLANS_LIST[ PLAN_WPCOM_MANAGED ] = {
+PLANS_LIST[ PLAN_WPCOM_PRO ] = {
 	group: GROUP_WPCOM,
-	type: TYPE_MANAGED,
+	type: TYPE_PRO,
 	term: TERM_ANNUALLY,
 	getTitle: () => i18n.translate( 'Pro' ),
 	getProductId: () => 1032,
-	getStoreSlug: () => PLAN_WPCOM_MANAGED,
+	getStoreSlug: () => PLAN_WPCOM_PRO,
 	getPathSlug: () => 'pro',
 	getDescription: () =>
 		i18n.translate( 'Enjoy the classic WordPress.com experience using plugins and much more.' ),

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -14,7 +14,7 @@ export { isBiennially } from './is-biennially';
 export { isBlogger } from './is-blogger';
 export { isBundled } from './is-bundled';
 export { isBusiness } from './is-business';
-export { isManaged } from './is-managed';
+export { isPro } from './is-pro';
 export { isChargeback } from './is-chargeback';
 export { isConciergeSession } from './is-concierge-session';
 export { isCredits } from './is-credits';

--- a/packages/calypso-products/test/choose-default-customer-type.js
+++ b/packages/calypso-products/test/choose-default-customer-type.js
@@ -5,7 +5,7 @@ import {
 	PLAN_FREE,
 	PLAN_WPCOM_FLEXIBLE,
 	PLAN_PERSONAL,
-	PLAN_WPCOM_MANAGED,
+	PLAN_WPCOM_PRO,
 } from '../src/constants';
 
 describe( 'chooseDefaultCustomerType', () => {
@@ -43,9 +43,9 @@ describe( 'chooseDefaultCustomerType', () => {
 		expect( chooseDefaultCustomerType( { currentPlan } ) ).toBe( 'business' );
 	} );
 
-	test( 'chooses "business" if the site is on the Managed plan', () => {
+	test( 'chooses "business" if the site is on the Pro plan', () => {
 		const currentPlan = {
-			product_slug: PLAN_WPCOM_MANAGED,
+			product_slug: PLAN_WPCOM_PRO,
 		};
 		expect( chooseDefaultCustomerType( { currentPlan } ) ).toBe( 'business' );
 	} );

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -43,7 +43,7 @@ import {
 	PLAN_PREMIUM,
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_WPCOM_FLEXIBLE,
-	PLAN_WPCOM_MANAGED,
+	PLAN_WPCOM_PRO,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
 	TERM_MONTHLY,
@@ -59,7 +59,7 @@ import {
 	getPlan,
 	getPlans,
 	getPlanClass,
-	isManagedPlan,
+	isProPlan,
 	isBusinessPlan,
 	isPersonalPlan,
 	isPremiumPlan,
@@ -70,7 +70,7 @@ import {
 	isJetpackPersonalPlan,
 	isJetpackPremiumPlan,
 	isJetpackFreePlan,
-	isWpComManagedPlan,
+	isWpComProPlan,
 	isWpComEcommercePlan,
 	isWpComBusinessPlan,
 	isWpComPersonalPlan,
@@ -121,7 +121,7 @@ describe( 'isFlexiblePlan', () => {
 		expect( isFlexiblePlan( PLAN_PREMIUM ) ).to.equal( false );
 		expect( isFlexiblePlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
 		expect( isFlexiblePlan( PLAN_BUSINESS ) ).to.equal( false );
-		expect( isFlexiblePlan( PLAN_WPCOM_MANAGED ) ).to.equal( false );
+		expect( isFlexiblePlan( PLAN_WPCOM_PRO ) ).to.equal( false );
 		expect( isFlexiblePlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
 		expect( isFlexiblePlan( PLAN_ECOMMERCE ) ).to.equal( false );
 		expect( isFlexiblePlan( 'non-existing plan' ) ).to.equal( false );
@@ -202,19 +202,19 @@ describe( 'isBusinessPlan', () => {
 	} );
 } );
 
-describe( 'isManagedPlan', () => {
-	test( 'should return true for the Managed plan', () => {
-		expect( isManagedPlan( PLAN_WPCOM_MANAGED ) ).to.equal( true );
+describe( 'isProPlan', () => {
+	test( 'should return true for the Pro plan', () => {
+		expect( isProPlan( PLAN_WPCOM_PRO ) ).to.equal( true );
 	} );
-	test( 'should return false for non-managed plans', () => {
-		expect( isManagedPlan( PLAN_PERSONAL ) ).to.equal( false );
-		expect( isManagedPlan( PLAN_PERSONAL_2_YEARS ) ).to.equal( false );
-		expect( isManagedPlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
-		expect( isManagedPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
-		expect( isManagedPlan( PLAN_PREMIUM ) ).to.equal( false );
-		expect( isManagedPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
-		expect( isManagedPlan( PLAN_ECOMMERCE ) ).to.equal( false );
-		expect( isManagedPlan( 'non-existing plan' ) ).to.equal( false );
+	test( 'should return false for non-pro plans', () => {
+		expect( isProPlan( PLAN_PERSONAL ) ).to.equal( false );
+		expect( isProPlan( PLAN_PERSONAL_2_YEARS ) ).to.equal( false );
+		expect( isProPlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
+		expect( isProPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
+		expect( isProPlan( PLAN_PREMIUM ) ).to.equal( false );
+		expect( isProPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
+		expect( isProPlan( PLAN_ECOMMERCE ) ).to.equal( false );
+		expect( isProPlan( 'non-existing plan' ) ).to.equal( false );
 	} );
 } );
 
@@ -329,28 +329,28 @@ describe( 'isWpComEcommercePlan', () => {
 	} );
 } );
 
-describe( 'isWpComManagedPlan', () => {
-	test( 'should return true for the Managed plan', () => {
-		expect( isWpComManagedPlan( PLAN_WPCOM_MANAGED ) ).to.equal( true );
+describe( 'isWpComProPlan', () => {
+	test( 'should return true for the Pro plan', () => {
+		expect( isWpComProPlan( PLAN_WPCOM_PRO ) ).to.equal( true );
 	} );
 	test( 'should return false for non-business plans', () => {
-		expect( isWpComManagedPlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
-		expect( isWpComManagedPlan( PLAN_JETPACK_BUSINESS_MONTHLY ) ).to.equal( false );
-		expect( isWpComManagedPlan( PLAN_PERSONAL ) ).to.equal( false );
-		expect( isWpComManagedPlan( PLAN_PERSONAL_2_YEARS ) ).to.equal( false );
-		expect( isWpComManagedPlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
-		expect( isWpComManagedPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
-		expect( isWpComManagedPlan( PLAN_PREMIUM ) ).to.equal( false );
-		expect( isWpComManagedPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
-		expect( isWpComManagedPlan( PLAN_BUSINESS ) ).to.equal( false );
-		expect( isWpComManagedPlan( PLAN_BUSINESS_2_YEARS ) ).to.equal( false );
-		expect( isWpComManagedPlan( 'non-exisWpComting plan' ) ).to.equal( false );
+		expect( isWpComProPlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
+		expect( isWpComProPlan( PLAN_JETPACK_BUSINESS_MONTHLY ) ).to.equal( false );
+		expect( isWpComProPlan( PLAN_PERSONAL ) ).to.equal( false );
+		expect( isWpComProPlan( PLAN_PERSONAL_2_YEARS ) ).to.equal( false );
+		expect( isWpComProPlan( PLAN_JETPACK_PERSONAL ) ).to.equal( false );
+		expect( isWpComProPlan( PLAN_JETPACK_PERSONAL_MONTHLY ) ).to.equal( false );
+		expect( isWpComProPlan( PLAN_PREMIUM ) ).to.equal( false );
+		expect( isWpComProPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
+		expect( isWpComProPlan( PLAN_BUSINESS ) ).to.equal( false );
+		expect( isWpComProPlan( PLAN_BUSINESS_2_YEARS ) ).to.equal( false );
+		expect( isWpComProPlan( 'non-exisWpComting plan' ) ).to.equal( false );
 	} );
 } );
 
 describe( 'isWpComAnnualPlan', () => {
 	test( 'should return true for annual plans', () => {
-		expect( isWpComAnnualPlan( PLAN_WPCOM_MANAGED ) ).to.equal( true );
+		expect( isWpComAnnualPlan( PLAN_WPCOM_PRO ) ).to.equal( true );
 		expect( isWpComAnnualPlan( PLAN_PERSONAL ) ).to.equal( true );
 		expect( isWpComAnnualPlan( PLAN_PREMIUM ) ).to.equal( true );
 		expect( isWpComAnnualPlan( PLAN_BUSINESS ) ).to.equal( true );
@@ -385,7 +385,7 @@ describe( 'isWpComBiennialPlan', () => {
 	} );
 
 	test( 'should return false for non-biennial plans', () => {
-		expect( isWpComBiennialPlan( PLAN_WPCOM_MANAGED ) ).to.equal( false );
+		expect( isWpComBiennialPlan( PLAN_WPCOM_PRO ) ).to.equal( false );
 		expect( isWpComBiennialPlan( PLAN_PERSONAL ) ).to.equal( false );
 		expect( isWpComBiennialPlan( PLAN_PREMIUM ) ).to.equal( false );
 		expect( isWpComBiennialPlan( PLAN_BUSINESS ) ).to.equal( false );
@@ -411,7 +411,7 @@ describe( 'isWpComMonthlyPlan', () => {
 	} );
 
 	test( 'should return false for non-monthly plans', () => {
-		expect( isWpComMonthlyPlan( PLAN_WPCOM_MANAGED ) ).to.equal( false );
+		expect( isWpComMonthlyPlan( PLAN_WPCOM_PRO ) ).to.equal( false );
 		expect( isWpComMonthlyPlan( PLAN_PERSONAL ) ).to.equal( false );
 		expect( isWpComMonthlyPlan( PLAN_PREMIUM ) ).to.equal( false );
 		expect( isWpComMonthlyPlan( PLAN_BUSINESS ) ).to.equal( false );
@@ -830,7 +830,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_JETPACK_SECURITY_T2_YEARLY,
 			PLAN_P2_FREE,
 			PLAN_WPCOM_FLEXIBLE,
-			PLAN_WPCOM_MANAGED,
+			PLAN_WPCOM_PRO,
 		] );
 		expect( findPlansKeys( { term: TERM_MONTHLY } ) ).to.deep.equal( [
 			PLAN_PERSONAL_MONTHLY,
@@ -902,7 +902,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_P2_PLUS,
 			PLAN_P2_FREE,
 			PLAN_WPCOM_FLEXIBLE,
-			PLAN_WPCOM_MANAGED,
+			PLAN_WPCOM_PRO,
 		] );
 		expect( findPlansKeys( { group: GROUP_JETPACK } ) ).to.deep.equal( [
 			PLAN_JETPACK_FREE,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
More context: **pdgrnI-tm-p2**

This renames any Managed plan-related items to match the WordPress Pro naming.

#### Testing instructions

* Go to /star/plans?flags=plans/pro-plan
* You should see the overhauled Plans with the Free and Pro plans
<img width="480" alt="Screenshot on 2022-03-15 at 16-14-15" src="https://user-images.githubusercontent.com/2749938/158398016-3147faef-d941-4959-990f-a24e31d7ca95.png">


* While on a Free Plan site, go to /plans/[site]?flags=plans/pro-plan
* You should see the overhauled Plans with the Free and Pro plans.
NOTE: The Pro plan may have a price of 0. This should show the proper once the DB has been updated with the new product slug for the Pro Plan.
<img width="480" alt="Screenshot on 2022-03-15 at 16-14-58" src="https://user-images.githubusercontent.com/2749938/158398073-3ff25c3a-e357-484d-ac35-f1a9418c069a.png">

* Double-check that the legacy Plans on /star/plans and  /plans/[site] (without the flag param) are unaffected.

