### PR TITLE
Emails: Refine display of prices in Email Comparison pages

### DIFF
--- a/client/components/promo-section/promo-card/price.tsx
+++ b/client/components/promo-section/promo-card/price.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
-import { useTranslate, TranslateResult } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
+import type { TranslateResult } from 'i18n-calypso';
 import type { ReactElement } from 'react';
 
 export interface Props {

--- a/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
@@ -29,7 +29,11 @@ const usePlanAvailable = (
 		return true;
 	}
 
-	if ( ! canPurchaseGSuite || ! hasGSuiteSupportedDomain( [ domain ] ) ) {
+	if ( ! canPurchaseGSuite ) {
+		return false;
+	}
+
+	if ( ! domain || ! hasGSuiteSupportedDomain( [ domain ] ) ) {
 		return false;
 	}
 

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -38,7 +38,7 @@ export type EmailProviderFeatures = {
 
 export type EmailProvidersInDepthComparisonProps = {
 	selectedDomainName: string;
-	selectedIntervalLength: IntervalLength | undefined;
+	selectedIntervalLength?: IntervalLength;
 };
 
 export type LearnMoreLinkProps = {

--- a/client/my-sites/email/email-providers-comparison/price-badge/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/price-badge/index.tsx
@@ -4,18 +4,15 @@ import type { ReactElement } from 'react';
 import './style.scss';
 
 type PriceBadgeProps = {
-	additionalPriceInformationComponent?: ReactElement | null;
-	priceComponent: ReactElement;
+	additionalPriceInformation?: ReactElement | null;
+	price: ReactElement;
 };
 
-const PriceBadge = ( {
-	additionalPriceInformationComponent,
-	priceComponent,
-}: PriceBadgeProps ): ReactElement => (
+const PriceBadge = ( { additionalPriceInformation, price }: PriceBadgeProps ): ReactElement => (
 	<div className="price-badge">
 		<PromoCardPrice
-			formattedPrice={ priceComponent }
-			additionalPriceInformation={ <span>{ additionalPriceInformationComponent }</span> }
+			formattedPrice={ price }
+			additionalPriceInformation={ <span>{ additionalPriceInformation }</span> }
 		/>
 	</div>
 );

--- a/client/my-sites/email/email-providers-comparison/price-badge/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/price-badge/index.tsx
@@ -4,16 +4,13 @@ import type { ReactElement } from 'react';
 import './style.scss';
 
 type PriceBadgeProps = {
-	additionalPriceInformation?: ReactElement | null;
 	price: ReactElement;
+	priceInformation?: ReactElement;
 };
 
-const PriceBadge = ( { additionalPriceInformation, price }: PriceBadgeProps ): ReactElement => (
+const PriceBadge = ( { price, priceInformation }: PriceBadgeProps ): ReactElement => (
 	<div className="price-badge">
-		<PromoCardPrice
-			formattedPrice={ price }
-			additionalPriceInformation={ <span>{ additionalPriceInformation }</span> }
-		/>
+		<PromoCardPrice formattedPrice={ price } additionalPriceInformation={ priceInformation } />
 	</div>
 );
 

--- a/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/price-with-interval/index.tsx
@@ -2,7 +2,6 @@ import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
-import type { TranslateResult } from 'i18n-calypso';
 import type { ReactElement } from 'react';
 
 import './style.scss';
@@ -31,59 +30,72 @@ const PriceWithInterval = ( {
 	const priceSpan = <span className={ priceClassName } />;
 	const standardPrice = formatCurrency( cost ?? 0, currencyCode );
 
-	const getSalePriceContents = (): TranslateResult => {
+	if ( showSale ) {
 		const saleTranslateArguments = {
 			salePrice: formatCurrency( sale ?? 0, currencyCode ),
 			standardPrice,
 		};
+
 		const saleTranslateComponents = {
 			priceSpan,
 			saleSpan: <span className="price-with-interval__sale-price" />,
 		};
 
 		if ( intervalLength === IntervalLength.ANNUALLY ) {
-			return translate(
-				'{{priceSpan}}%(standardPrice)s{{/priceSpan}} {{saleSpan}}%(salePrice)s{{/saleSpan}} /year /mailbox',
-				{
-					args: saleTranslateArguments,
-					comment:
-						'%(standardPrice)s is a formatted standard price, e.g. $3.50; %(salePrice)s is a formatted sale price, e.g. $2.75',
-					components: saleTranslateComponents,
-				}
+			return (
+				<>
+					{ translate(
+						'{{priceSpan}}%(standardPrice)s{{/priceSpan}} {{saleSpan}}%(salePrice)s{{/saleSpan}} /year /mailbox',
+						{
+							args: saleTranslateArguments,
+							comment:
+								'%(standardPrice)s is a formatted standard price, e.g. $3.50; %(salePrice)s is a formatted sale price, e.g. $2.75',
+							components: saleTranslateComponents,
+						}
+					) }
+				</>
 			);
 		}
 
-		return translate(
-			'{{priceSpan}}%(standardPrice)s{{/priceSpan}} {{saleSpan}}%(salePrice)s{{/saleSpan}} /month /mailbox',
-			{
-				args: saleTranslateArguments,
-				comment:
-					'%(standardPrice)s is a formatted standard price, e.g. $3.50; %(salePrice)s is a formatted sale price, e.g. $2.75',
-				components: saleTranslateComponents,
-			}
+		return (
+			<>
+				{ translate(
+					'{{priceSpan}}%(standardPrice)s{{/priceSpan}} {{saleSpan}}%(salePrice)s{{/saleSpan}} /month /mailbox',
+					{
+						args: saleTranslateArguments,
+						comment:
+							'%(standardPrice)s is a formatted standard price, e.g. $3.50; %(salePrice)s is a formatted sale price, e.g. $2.75',
+						components: saleTranslateComponents,
+					}
+				) }
+			</>
 		);
-	};
+	}
 
-	const getStandardPriceContents = (): TranslateResult => {
-		const standardTranslateArguments = { standardPrice };
-		const standardTranslateComponents = { priceSpan };
+	const standardTranslateArguments = { standardPrice };
+	const standardTranslateComponents = { priceSpan };
 
-		if ( intervalLength === IntervalLength.ANNUALLY ) {
-			return translate( '{{priceSpan}}%(standardPrice)s{{/priceSpan}} /year /mailbox', {
+	if ( intervalLength === IntervalLength.ANNUALLY ) {
+		return (
+			<>
+				{ translate( '{{priceSpan}}%(standardPrice)s{{/priceSpan}} /year /mailbox', {
+					args: standardTranslateArguments,
+					comment: '%(standardPrice)s is a formatted standard price, e.g. $3.50',
+					components: standardTranslateComponents,
+				} ) }
+			</>
+		);
+	}
+
+	return (
+		<>
+			{ translate( '{{priceSpan}}%(standardPrice)s{{/priceSpan}} /month /mailbox', {
 				args: standardTranslateArguments,
 				comment: '%(standardPrice)s is a formatted standard price, e.g. $3.50',
 				components: standardTranslateComponents,
-			} );
-		}
-
-		return translate( '{{priceSpan}}%(standardPrice)s{{/priceSpan}} /month /mailbox', {
-			args: standardTranslateArguments,
-			comment: '%(standardPrice)s is a formatted standard price, e.g. $3.50',
-			components: standardTranslateComponents,
-		} );
-	};
-
-	return <>{ showSale ? getSalePriceContents() : getStandardPriceContents() }</>;
+			} ) }
+		</>
+	);
 };
 
 export default PriceWithInterval;

--- a/client/my-sites/email/email-providers-comparison/price-with-interval/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price-with-interval/style.scss
@@ -3,5 +3,5 @@
 }
 
 .price-with-interval__sale-price {
-	color: var( --studio-green-50 );
+	color: var( --studio-green-50 ) !important;
 }

--- a/client/my-sites/email/email-providers-comparison/price-with-interval/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price-with-interval/style.scss
@@ -2,6 +2,12 @@
 	text-decoration: line-through;
 }
 
-.price-with-interval__sale-price {
-	color: var( --studio-green-50 ) !important;
+.promo-card {
+	.promo-card__price {
+		.price__cost {
+			span.price-with-interval__sale-price {
+				color: var( --studio-green-50 );
+			}
+		}
+	}
 }

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -19,7 +19,6 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selector
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import type { SiteDomain } from 'calypso/state/sites/domains/types';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -30,7 +29,7 @@ const getGoogleWorkspaceProductSlug = ( intervalLength: IntervalLength ): string
 };
 
 type GoogleWorkspacePriceProps = {
-	domain: SiteDomain | undefined;
+	domain?: SiteDomain;
 	isDomainInCart?: boolean;
 	intervalLength: IntervalLength;
 };

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -7,20 +7,17 @@ import {
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
-import InfoPopover from 'calypso/components/info-popover';
 import {
-	getGoogleMailServiceFamily,
 	hasGSuiteSupportedDomain,
 	isDomainEligibleForGoogleWorkspaceFreeTrial,
 } from 'calypso/lib/gsuite';
-import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import PriceBadge from 'calypso/my-sites/email/email-providers-comparison/price-badge';
 import PriceWithInterval from 'calypso/my-sites/email/email-providers-comparison/price-with-interval';
+import PriceInformation from 'calypso/my-sites/email/email-providers-comparison/price/price-information';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
-import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import type { SiteDomain } from 'calypso/state/sites/domains/types';
 import type { ReactElement } from 'react';
 
@@ -30,55 +27,6 @@ const getGoogleWorkspaceProductSlug = ( intervalLength: IntervalLength ): string
 	return intervalLength === IntervalLength.MONTHLY
 		? GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY
 		: GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY;
-};
-
-const AdditionalPriceInformation = ( {
-	currencyCode,
-	product,
-}: {
-	currencyCode: string | null;
-	product: ProductListItem | null;
-} ): ReactElement | null => {
-	if ( ! hasDiscount( product ) ) {
-		return null;
-	}
-
-	const standardPrice = formatPrice( product?.cost ?? 0, currencyCode ?? '' );
-	const discountedPrice = formatPrice( product?.sale_cost ?? 0, currencyCode ?? '' );
-
-	return (
-		<div className="google-workspace-price__discount">
-			{ translate(
-				'%(discount)d%% off{{span}}, %(discountedPrice)s billed today, renews at %(standardPrice)s{{/span}}',
-				{
-					args: {
-						discount: product?.sale_coupon?.discount,
-						discountedPrice,
-						standardPrice,
-					},
-					comment:
-						"%(discount)d is a numeric percentage discount (e.g. '50'), " +
-						"%(discountedPrice)s is a formatted, discounted price that the user will pay today (e.g. '$3'), " +
-						"%(standardPrice)s is a formatted price (e.g. '$5')",
-					components: {
-						span: <span />,
-					},
-				}
-			) }
-
-			<InfoPopover position="right" showOnHover>
-				{ translate(
-					'This discount is only available the first time you purchase a %(googleMailService)s account, any additional mailboxes purchased after that will be at the regular price.',
-					{
-						args: {
-							googleMailService: getGoogleMailServiceFamily( product?.product_slug ),
-						},
-						comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
-					}
-				) }
-			</InfoPopover>
-		</div>
-	);
 };
 
 type GoogleWorkspacePriceProps = {
@@ -123,42 +71,39 @@ const GoogleWorkspacePrice = ( {
 	}
 
 	const isDiscounted = hasDiscount( product );
+	const isEligibleForFreeTrial = isDomainEligibleForGoogleWorkspaceFreeTrial( domain );
 
 	const priceWithInterval = (
 		<PriceWithInterval
-			cost={ product?.cost ?? 0 }
 			currencyCode={ currencyCode ?? '' }
-			hasDiscount={ isDiscounted }
 			intervalLength={ intervalLength }
-			sale={ product?.sale_cost ?? null }
+			isDiscounted={ isDiscounted }
+			isEligibleForFreeTrial={ isEligibleForFreeTrial }
+			product={ product }
 		/>
-	);
-
-	const additionalPriceInformation = (
-		<AdditionalPriceInformation currencyCode={ currencyCode } product={ product } />
 	);
 
 	return (
 		<>
-			{ isDomainEligibleForGoogleWorkspaceFreeTrial( domain ) && (
-				<div className="google-workspace-price__trial-badge badge badge--info-green">
-					{ translate( '1 month free' ) }
-				</div>
-			) }
-
 			{ isDiscounted && (
 				<div className="google-workspace-price__discount-badge badge badge--info-green">
 					{ translate( 'Limited time: %(discount)d%% off', {
 						args: {
-							discount: product.sale_coupon.discount,
+							discount: product?.sale_coupon?.discount,
 						},
 						comment: "%(discount)d is a numeric discount percentage (e.g. '40')",
 					} ) }
 				</div>
 			) }
 
+			{ isEligibleForFreeTrial && (
+				<div className="google-workspace-price__trial-badge badge badge--info-green">
+					{ translate( '1 month free' ) }
+				</div>
+			) }
+
 			<PriceBadge
-				additionalPriceInformation={ additionalPriceInformation }
+				priceInformation={ <PriceInformation domain={ domain } product={ product } /> }
 				price={ priceWithInterval }
 			/>
 		</>

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -140,9 +140,20 @@ const GoogleWorkspacePrice = ( {
 
 	return (
 		<>
-			{ isDomainEligibleForGoogleWorkspaceFreeTrial( domain ) && ! isDiscounted && (
-				<div className="google-workspace-price__trial badge badge--info-green">
+			{ isDomainEligibleForGoogleWorkspaceFreeTrial( domain ) && (
+				<div className="google-workspace-price__trial-badge badge badge--info-green">
 					{ translate( '1 month free' ) }
+				</div>
+			) }
+
+			{ isDiscounted && (
+				<div className="google-workspace-price__discount-badge badge badge--info-green">
+					{ translate( 'Limited time: %(discount)d%% off', {
+						args: {
+							discount: product.sale_coupon.discount,
+						},
+						comment: "%(discount)d is a numeric discount percentage (e.g. '40')",
+					} ) }
 				</div>
 			) }
 

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -122,13 +122,13 @@ const GoogleWorkspacePrice = ( {
 		);
 	}
 
-	const isEligibleForFreeTrial = isDomainEligibleForGoogleWorkspaceFreeTrial( domain );
+	const isDiscounted = hasDiscount( product );
 
 	const priceWithInterval = (
 		<PriceWithInterval
 			cost={ product?.cost ?? 0 }
 			currencyCode={ currencyCode ?? '' }
-			hasDiscount={ isEligibleForFreeTrial || hasDiscount( product ) }
+			hasDiscount={ isDiscounted }
 			intervalLength={ intervalLength }
 			sale={ product?.sale_cost ?? null }
 		/>
@@ -140,15 +140,15 @@ const GoogleWorkspacePrice = ( {
 
 	return (
 		<>
-			{ isEligibleForFreeTrial && (
-				<div className="google-workspace-price__discount badge badge--info-green">
+			{ isDomainEligibleForGoogleWorkspaceFreeTrial( domain ) && ! isDiscounted && (
+				<div className="google-workspace-price__trial badge badge--info-green">
 					{ translate( '1 month free' ) }
 				</div>
 			) }
 
 			<PriceBadge
-				additionalPriceInformationComponent={ additionalPriceInformation }
-				priceComponent={ priceWithInterval }
+				additionalPriceInformation={ additionalPriceInformation }
+				price={ priceWithInterval }
 			/>
 		</>
 	);

--- a/client/my-sites/email/email-providers-comparison/price/price-information.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/price-information.tsx
@@ -82,33 +82,22 @@ const FreeTrialPriceInformation = ( {
 			"%(firstRenewalPrice)s and %(standardPrice)s are formatted prices with the currency (e.g. '$5')",
 	};
 
-	if ( isGoogleWorkspace( product ) ) {
+	if ( isGoogleWorkspace( product ) || ! isTitanMonthlyProduct( product ) ) {
 		return (
 			<div className="price-information__free-trial">
 				{ translate(
-					'Try it for free today - renews at %(firstRenewalPrice)s in one month, and then at %(standardPrice)s every year',
+					'Try free today - first renewal at %(firstRenewalPrice)s after trial, regular price %(standardPrice)s per year',
 					translateArguments
 				) }
 			</div>
 		);
 	}
 
-	if ( isTitanMail( product ) ) {
-		if ( isTitanMonthlyProduct( product ) ) {
-			return (
-				<div className="price-information__free-trial">
-					{ translate(
-						'Try it for free today - renews at %(standardPrice)s in three months',
-						translateArguments
-					) }
-				</div>
-			);
-		}
-
+	if ( isTitanMonthlyProduct( product ) ) {
 		return (
 			<div className="price-information__free-trial">
 				{ translate(
-					'Try it for free today - renews at %(firstRenewalPrice)s in three months, and then at %(standardPrice)s every year',
+					'Try free today - renews at %(standardPrice)s after trial',
 					translateArguments
 				) }
 			</div>
@@ -122,7 +111,7 @@ const PriceInformation = ( {
 	domain,
 	product,
 }: {
-	domain: SiteDomain;
+	domain?: SiteDomain;
 	product: ProductListItem | null;
 } ): ReactElement | null => {
 	if ( ! product ) {

--- a/client/my-sites/email/email-providers-comparison/price/price-information.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/price-information.tsx
@@ -1,0 +1,146 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+import { isGoogleWorkspace, isTitanMail } from '@automattic/calypso-products';
+import formatCurrency from '@automattic/format-currency';
+import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
+import InfoPopover from 'calypso/components/info-popover';
+import {
+	getGoogleMailServiceFamily,
+	isDomainEligibleForGoogleWorkspaceFreeTrial,
+} from 'calypso/lib/gsuite';
+import { formatPrice } from 'calypso/lib/gsuite/utils/format-price';
+import { isDomainEligibleForTitanFreeTrial, isTitanMonthlyProduct } from 'calypso/lib/titan';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+import type { SiteDomain } from 'calypso/state/sites/domains/types';
+import type { ReactElement } from 'react';
+
+import './style.scss';
+
+const getFirstRenewalPrice = ( product: ProductListItem, currencyCode: string ): string | null => {
+	if ( isGoogleWorkspace( product ) ) {
+		return formatCurrency( ( ( product.cost ?? 0 ) * 11 ) / 12, currencyCode, {
+			stripZeros: true,
+		} );
+	}
+
+	if ( isTitanMail( product ) ) {
+		return formatCurrency( ( ( product.cost ?? 0 ) * 9 ) / 12, currencyCode, { stripZeros: true } );
+	}
+
+	return null;
+};
+
+const DiscountPriceInformation = ( { product }: { product: ProductListItem } ): ReactElement => {
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+
+	return (
+		<div className="price-information__discount">
+			{ translate( 'Pay only %(discountedPrice)s today - renews at %(standardPrice)s', {
+				args: {
+					discount: product.sale_coupon?.discount,
+					discountedPrice: formatPrice( product.sale_cost ?? 0, currencyCode ?? '' ),
+					standardPrice: formatPrice( product.cost ?? 0, currencyCode ?? '' ),
+				},
+				comment:
+					"%(discount)d is a numeric percentage discount (e.g. '50'), " +
+					"%(discountedPrice)s and %(standardPrice)s are formatted prices with the currency (e.g. '$5')",
+			} ) }
+
+			{ isGoogleWorkspace( product ) && (
+				<InfoPopover position="right" showOnHover>
+					{ translate(
+						'This discount is only available the first time you purchase a %(googleMailService)s account, any additional mailboxes purchased after that will be at the regular price.',
+						{
+							args: {
+								googleMailService: getGoogleMailServiceFamily( product.product_slug ),
+							},
+							comment: '%(googleMailService)s can be either "G Suite" or "Google Workspace"',
+						}
+					) }
+				</InfoPopover>
+			) }
+		</div>
+	);
+};
+
+const FreeTrialPriceInformation = ( {
+	product,
+}: {
+	product: ProductListItem;
+} ): ReactElement | null => {
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+
+	const translateArguments = {
+		args: {
+			firstRenewalPrice: getFirstRenewalPrice( product, currencyCode ?? '' ),
+			standardPrice: formatCurrency( product.cost ?? 0, currencyCode ?? '', { stripZeros: true } ),
+		},
+		comment:
+			"%(firstRenewalPrice)s and %(standardPrice)s are formatted prices with the currency (e.g. '$5')",
+	};
+
+	if ( isGoogleWorkspace( product ) ) {
+		return (
+			<div className="price-information__free-trial">
+				{ translate(
+					'Try it for free today - renews at %(firstRenewalPrice)s in one month, and then at %(standardPrice)s every year',
+					translateArguments
+				) }
+			</div>
+		);
+	}
+
+	if ( isTitanMail( product ) ) {
+		if ( isTitanMonthlyProduct( product ) ) {
+			return (
+				<div className="price-information__free-trial">
+					{ translate(
+						'Try it for free today - renews at %(standardPrice)s in three months',
+						translateArguments
+					) }
+				</div>
+			);
+		}
+
+		return (
+			<div className="price-information__free-trial">
+				{ translate(
+					'Try it for free today - renews at %(firstRenewalPrice)s in three months, and then at %(standardPrice)s every year',
+					translateArguments
+				) }
+			</div>
+		);
+	}
+
+	return null;
+};
+
+const PriceInformation = ( {
+	domain,
+	product,
+}: {
+	domain: SiteDomain;
+	product: ProductListItem | null;
+} ): ReactElement | null => {
+	if ( ! product ) {
+		return null;
+	}
+
+	if ( isGoogleWorkspace( product ) && hasDiscount( product ) ) {
+		return <DiscountPriceInformation product={ product } />;
+	}
+
+	if (
+		( isGoogleWorkspace( product ) && isDomainEligibleForGoogleWorkspaceFreeTrial( domain ) ) ||
+		( isTitanMail( product ) && isDomainEligibleForTitanFreeTrial( domain ) )
+	) {
+		return <FreeTrialPriceInformation product={ product } />;
+	}
+
+	return null;
+};
+
+export default PriceInformation;

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -46,7 +46,7 @@ const ProfessionalEmailPrice = ( {
 	return (
 		<>
 			{ isDomainEligibleForTitanFreeTrial( domain ) && (
-				<div className="professional-email-price__trial badge badge--info-green">
+				<div className="professional-email-price__trial-badge badge badge--info-green">
 					{ translate( '3 months free' ) }
 				</div>
 			) }

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -7,6 +7,7 @@ import { isDomainEligibleForTitanFreeTrial } from 'calypso/lib/titan';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import PriceBadge from 'calypso/my-sites/email/email-providers-comparison/price-badge';
 import PriceWithInterval from 'calypso/my-sites/email/email-providers-comparison/price-with-interval';
+import PriceInformation from 'calypso/my-sites/email/email-providers-comparison/price/price-information';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import type { SiteDomain } from 'calypso/state/sites/domains/types';
@@ -34,24 +35,33 @@ const ProfessionalEmailPrice = ( {
 	const productSlug = getTitanProductSlug( intervalLength );
 	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
 
+	if ( ! domain ) {
+		return <></>;
+	}
+
+	const isEligibleForFreeTrial = isDomainEligibleForTitanFreeTrial( domain );
+
 	const priceWithInterval = (
 		<PriceWithInterval
-			cost={ product?.cost ?? 0 }
 			currencyCode={ currencyCode ?? '' }
-			hasDiscount={ false }
 			intervalLength={ intervalLength }
+			isEligibleForFreeTrial={ isEligibleForFreeTrial }
+			product={ product }
 		/>
 	);
 
 	return (
 		<>
-			{ isDomainEligibleForTitanFreeTrial( domain ) && (
+			{ isEligibleForFreeTrial && (
 				<div className="professional-email-price__trial-badge badge badge--info-green">
 					{ translate( '3 months free' ) }
 				</div>
 			) }
 
-			<PriceBadge price={ priceWithInterval } />
+			<PriceBadge
+				priceInformation={ <PriceInformation domain={ domain } product={ product } /> }
+				price={ priceWithInterval }
+			/>
 		</>
 	);
 };

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -34,26 +34,24 @@ const ProfessionalEmailPrice = ( {
 	const productSlug = getTitanProductSlug( intervalLength );
 	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
 
-	const isEligibleForFreeTrial = isDomainEligibleForTitanFreeTrial( domain );
-
 	const priceWithInterval = (
 		<PriceWithInterval
 			cost={ product?.cost ?? 0 }
 			currencyCode={ currencyCode ?? '' }
-			hasDiscount={ isEligibleForFreeTrial }
+			hasDiscount={ false }
 			intervalLength={ intervalLength }
 		/>
 	);
 
 	return (
 		<>
-			{ isEligibleForFreeTrial && (
-				<div className="professional-email-price__discount badge badge--info-green">
+			{ isDomainEligibleForTitanFreeTrial( domain ) && (
+				<div className="professional-email-price__trial badge badge--info-green">
 					{ translate( '3 months free' ) }
 				</div>
 			) }
 
-			<PriceBadge priceComponent={ priceWithInterval } />
+			<PriceBadge price={ priceWithInterval } />
 		</>
 	);
 };

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -11,7 +11,6 @@ import PriceInformation from 'calypso/my-sites/email/email-providers-comparison/
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import type { SiteDomain } from 'calypso/state/sites/domains/types';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -22,21 +21,21 @@ const getTitanProductSlug = ( intervalLength: IntervalLength ): string => {
 };
 
 type ProfessionalEmailPriceProps = {
-	domain: SiteDomain | undefined;
+	domain?: SiteDomain;
 	intervalLength: IntervalLength;
 };
 
 const ProfessionalEmailPrice = ( {
 	domain,
 	intervalLength,
-}: ProfessionalEmailPriceProps ): ReactElement => {
+}: ProfessionalEmailPriceProps ): JSX.Element | null => {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 
 	const productSlug = getTitanProductSlug( intervalLength );
 	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
 
 	if ( ! domain ) {
-		return <></>;
+		return null;
 	}
 
 	const isEligibleForFreeTrial = isDomainEligibleForTitanFreeTrial( domain );

--- a/client/my-sites/email/email-providers-comparison/price/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price/style.scss
@@ -1,12 +1,24 @@
-.google-workspace-price__discount {
+.google-workspace-price__trial,
+.professional-email-price__trial {
 	margin-bottom: 12px;
+}
+
+.google-workspace-price__discount {
+	display: none;
+	margin-bottom: 12px;
+	margin-top: 3px;
+
+	.is-expanded & {
+		display: block;
+	}
+
+	button {
+		margin-left: 3px;
+		vertical-align: top;
+	}
 }
 
 .google-workspace-price__unavailable {
 	font-weight: 600;
 	line-height: 24px;
-}
-
-.professional-email-price__discount {
-	margin-bottom: 12px;
 }

--- a/client/my-sites/email/email-providers-comparison/price/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price/style.scss
@@ -4,7 +4,9 @@
 	margin-bottom: 12px;
 }
 
-.google-workspace-price__discount {
+.price-information__discount,
+.price-information__free-trial {
+	color: var( --color-text-subtle );
 	display: none;
 	margin-bottom: 12px;
 	margin-top: 3px;

--- a/client/my-sites/email/email-providers-comparison/price/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price/style.scss
@@ -9,7 +9,7 @@
 	color: var( --color-text-subtle );
 	display: none;
 	margin-bottom: 12px;
-	margin-top: 3px;
+	margin-top: 8px;
 
 	.is-expanded & {
 		display: block;

--- a/client/my-sites/email/email-providers-comparison/price/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price/style.scss
@@ -1,5 +1,6 @@
-.google-workspace-price__trial,
-.professional-email-price__trial {
+.google-workspace-price__discount-badge,
+.google-workspace-price__trial-badge,
+.professional-email-price__trial-badge {
 	margin-bottom: 12px;
 }
 

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -211,7 +211,7 @@ $width-left-panel-card: 55%;
 			display: flex;
 			flex-direction: column;
 			justify-content: start;
-			margin-top: 2em;
+			margin-top: 1em;
 			line-height: 1.5;
 
 			@include break-xlarge {

--- a/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card/style.scss
@@ -211,7 +211,7 @@ $width-left-panel-card: 55%;
 			display: flex;
 			flex-direction: column;
 			justify-content: start;
-			margin-top: 1em;
+			margin-top: 2em;
 			line-height: 1.5;
 
 			@include break-xlarge {
@@ -256,6 +256,8 @@ $width-left-panel-card: 55%;
 }
 
 .email-provider-stacked-card__title-container {
+	align-self: flex-start;
+
 	@include break-xlarge {
 		margin-right: 10px;
 		min-width: $width-left-panel-card;

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -35,7 +35,7 @@ export type EmailProvidersStackedComparisonProps = {
 	isDomainInCart?: boolean;
 	selectedDomainName: string;
 	selectedEmailProviderSlug?: string;
-	selectedIntervalLength?: IntervalLength | undefined;
+	selectedIntervalLength?: IntervalLength;
 	source: string;
 };
 

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.scss
@@ -4,6 +4,7 @@
 .professional-email-card__logo {
 	color: var( --color-wordpress-com );
 	height: 48px;
+	margin-top: -2px;
 	min-width: 48px;
 	width: 48px;
 


### PR DESCRIPTION
This pull request updates the pricing information displayed in the new `Email Comparison` pages. The goal here is to make sure that we are showing prices in a consistent way, and to support free trials and sales correctly. More specifically, this pull request:

* Shows `$0` in green next to the price crossed out
* Shows additional pricing information for free trials below the price
* Shows this pricing information only when the section is expanded to save space
* Shows a green badge with the amount of the discount for sales
* Shows the discount in green in the price for sales
* Strips out zeros from decimals in prices
* Fixes some small alignment issues and an error

This pull request doesn't touch the old `Email Comparison` page shown in the domain purchase flow as we're in the process of retiring that page.


##### `Email Comparison` page (Professional Email, monthly)

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/158846813-540e1cf5-51c5-498b-afc4-09328ab2e9d5.png) | ![image](https://user-images.githubusercontent.com/594356/159492522-3c34ec4f-f617-4f22-a1b1-163454275eb7.png)


##### `Email Comparison` page (Professional Email, annually)

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/158845827-2f8ce484-d371-47c3-96f7-643440d04b92.png) | ![image](https://user-images.githubusercontent.com/594356/159492702-0a6c39d0-eadf-450c-a237-e660a90340a8.png)


##### `Email Comparison` page (Google Workspace, annually)

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/158846344-24625c5e-5686-49e1-9496-b5ca90ae692f.png) | ![image](https://user-images.githubusercontent.com/594356/158846511-6ce6e65e-45c2-4a47-827d-c17989db1029.png)

##### `In-Depth Comparison` page

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/594356/158847332-a0147cfc-eded-443b-80fd-4521a6c900b2.png) | ![image](https://user-images.githubusercontent.com/594356/158847449-f0007970-b281-4c3c-aed6-0b20667ad4d6.png)

#### Testing instructions

1. Run `git checkout update/prices-from-email-comparison-pages` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/61959#issuecomment-1068064319)
2. Create a sale coupon in Mission Control
3. Point `public-api.wordpress.com` to your sandbox
4. Enable the store sandbox
5. Apply patch `2bf1c-pb` to your sandbox as otherwise Google Workspace won't be available for purchase
6. Log into a WordPress.com account with a domain but no emails
7. Open the [`Emails` page](http://calypso.localhost:3000/emails)
8. Click the `Add Email` button to access the new `Email Comparison` page
9. Assert that the page looks like in the screenshots above
10. Click the `See how they compare` link at the top of the page
11. Assert that the page looks like in the screenshot above