### PR TITLE
Seller Experience: Fix action button for contextual Payments doc

### DIFF
--- a/client/blocks/inline-help/constants.js
+++ b/client/blocks/inline-help/constants.js
@@ -10,4 +10,4 @@ export const SUPPORT_TYPE_CONTEXTUAL_HELP = 'contextual_help';
 export const SUPPORT_TYPE_API_HELP = 'api_help';
 export const SUPPORT_TYPE_ADMIN_SECTION = 'admin_section';
 
-export const SELL_INTENT_ARTICLE = 'sell_intent_article';
+export const SELL_INTENT = 'sell_intent';

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -1,6 +1,6 @@
 import { translate } from 'i18n-calypso';
 import { localizeUrl } from 'calypso/lib/i18n-utils';
-import { RESULT_TOUR, RESULT_VIDEO, SELL_INTENT_ARTICLE } from './constants';
+import { RESULT_TOUR, RESULT_VIDEO, SELL_INTENT } from './constants';
 
 /**
  * Module variables
@@ -1310,7 +1310,7 @@ const contextLinksForSection = {
 			},
 		},
 		{
-			type: SELL_INTENT_ARTICLE,
+			intent: SELL_INTENT,
 			get link() {
 				return localizeUrl(
 					'https://wordpress.com/support/video-tutorials-add-payments-features-to-your-site-with-our-guides/'
@@ -2285,7 +2285,7 @@ export function getContextResults( section, siteIntent ) {
 	// Remove sell docs if not on a site with the 'sell' intent.
 	if ( section === 'gutenberg-editor' && siteIntent !== 'sell' ) {
 		links = links.filter( ( link ) => {
-			return link.type !== SELL_INTENT_ARTICLE;
+			return link.intent !== SELL_INTENT;
 		} );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds text to the action button on the contextual help for Payments.

##### Testing
1. Apply this patch or go to calypso.live link.
2. Create or open a site that has the sell intent.
3. Go to the post editor.
4. Click on the question mark & verify you see the payments documentation.
5. Click on the Payments Block link. <img width="312" alt="image" src="https://user-images.githubusercontent.com/375980/158405236-2ff9f940-87ac-4228-897a-8b1a25323e01.png">
6. Verify the action button reads `Read more`.

| Before  | After |
| ------------- | ------------- |
| <img width="338" alt="image" src="https://user-images.githubusercontent.com/375980/158404801-0547c0d9-5328-4f71-8023-57deb2513a16.png">  | <img width="343" alt="image" src="https://user-images.githubusercontent.com/375980/158404712-0023f002-4ac4-4226-8ea9-ae91722de8c3.png"> |

Closes https://github.com/Automattic/wp-calypso/issues/61956
