### PR TITLE
Restore default branch in Kotlin DSL.

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -404,7 +404,7 @@ object WpCalypso : GitVcsRoot({
 	name = "wp-calypso"
 	url = "git@github.com:Automattic/wp-calypso.git"
 	pushUrl = "git@github.com:Automattic/wp-calypso.git"
-	branch = "trunk"
+	branch = "refs/heads/trunk"
 	branchSpec = "+:refs/heads/*"
 	useTagsAsBranches = true
 	authMethod = uploadedKey {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We are trying to force the Kotlin DSL to update the default branch, which was changed in the UI and the ability to change has now been disabled for unknown reasons.

Context: 
pMz3w-eRL-p2
p1647381775177449-slack-C7YPUHBB2 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
