### PR TITLE
Fix calypso app build issue where normalizer couldn't access build meta

### DIFF
--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -156,6 +156,11 @@ open class WPComPluginBuild(
 						wget "%teamcity.serverUrl%/repository/download/%system.teamcity.buildType.id%/$releaseTag.tcbuildtag/$pluginSlug.zip?guest=1&branch=trunk" -O ./tmp-release-archive-download.zip
 						unzip -q ./tmp-release-archive-download.zip -d ./release-archive
 
+						# 2. Change anything from the release build which is "unstable", like the version number and build metadata.
+						# These operations restore idempotence between the two builds.
+						$normalizeFiles
+
+						# Finally, remove the build meta files, since those are also a source of difference.
 						if [ -f ./release-archive/build_meta.txt ] ; then
 							build_num=`grep build_number ./release-archive/build_meta.txt | sed s/build_number=//`
 							rm ./release-archive/build_meta.txt
@@ -164,10 +169,6 @@ open class WPComPluginBuild(
 							rm ./release-archive/build_meta.json
 						fi
 						echo "Diffing against current trunk release build (${'$'}build_num).";
-
-						# 2. Change anything from the release build which is "unstable", like the version number and build metadata.
-						# These operations restore idempotence between the two builds.
-						$normalizeFiles
 					fi
 
 					# 3. Check if the current build has changed, and if so, tag it for release.


### PR DESCRIPTION
#### Changes proposed in this Pull Request
In my recent change to update the way cache busters and build meta works in Calypso app builds, I accidentally referred to a file which doesn't exist in the "normalizer" function. The solution is to normalize files _before_ deleting that other file so that the normalizer can access information in that file before it's deleted.

#### Testing instructions
TC builds pass