### PR TITLE
2FA: Refactor `backupCodes` away from the emitter store

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -200,23 +200,6 @@ TwoStepAuthorization.prototype.sendSMSCode = function ( callback ) {
 };
 
 /*
- * Fetches a new set of backup codes by calling /me/two-step/backup-codes/new
- */
-TwoStepAuthorization.prototype.backupCodes = function ( callback ) {
-	wp.req.post( '/me/two-step/backup-codes/new', ( error, data ) => {
-		if ( error ) {
-			debug( 'Fetching Backup Codes failed: ' + JSON.stringify( error ) );
-		} else {
-			bumpTwoStepAuthMCStat( 'new-backup-codes-success' );
-		}
-
-		if ( callback ) {
-			callback( error, data );
-		}
-	} );
-};
-
-/*
  * Similar to validateCode, but without the change triggers across the
  * TwoStepAuthorization objects, so that the caller can delay state
  * transition until it is ready

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -4,7 +4,8 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
-import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import { bumpTwoStepAuthMCStat } from 'calypso/lib/two-step-authorization';
+import wp from 'calypso/lib/wp';
 import Security2faBackupCodesList from 'calypso/me/security-2fa-backup-codes-list';
 import Security2faBackupCodesPrompt from 'calypso/me/security-2fa-backup-codes-prompt';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -36,17 +37,15 @@ class Security2faBackupCodes extends Component {
 			showPrompt: true,
 		} );
 
-		twoStepAuthorization.backupCodes( this.onRequestComplete );
-	};
+		wp.req.post( '/me/two-step/backup-codes/new', ( error, data ) => {
+			if ( ! error ) {
+				bumpTwoStepAuthMCStat( 'new-backup-codes-success' );
 
-	onRequestComplete = ( error, data ) => {
-		if ( error ) {
-			return;
-		}
-
-		this.setState( {
-			backupCodes: data.codes,
-			generatingCodes: false,
+				this.setState( {
+					backupCodes: data.codes,
+					generatingCodes: false,
+				} );
+			}
 		} );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Our 2FA library is one of the last remaining `EventEmitter` legacy stores. It's time to remove it in favor of a more modern and flexible alternative (either Redux or `react-query`)

This PR migrates the `backupCodes` method away from the emitter and embeds it directly in the consumer components.

~Relies on #61975 and needs to be rebased after it lands.~

Part of #48409 and one of the last items of the gigantic [Flux-to-Redux migration project](https://github.com/Automattic/wp-calypso/projects/45).

#### Testing instructions

* Go to `/me/security/two-step` for a user with 2FA enabled.
* Click on "Generate new backup codes"
* Verify the new backup codes appear correctly.