### PR TITLE
2FA: Refactor `validateBackupCode` away from the emitter store

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -199,34 +199,6 @@ TwoStepAuthorization.prototype.sendSMSCode = function ( callback ) {
 	} );
 };
 
-/*
- * Similar to validateCode, but without the change triggers across the
- * TwoStepAuthorization objects, so that the caller can delay state
- * transition until it is ready
- */
-TwoStepAuthorization.prototype.validateBackupCode = function ( code, callback ) {
-	const args = {
-		code: code.replace( /\s/g, '' ),
-		action: 'create-backup-receipt',
-	};
-
-	wp.req.post( '/me/two-step/validate', args, ( error, data ) => {
-		if ( error ) {
-			debug( 'Validating Two Step Code failed: ' + JSON.stringify( error ) );
-		}
-
-		if ( data ) {
-			bumpTwoStepAuthMCStat(
-				data.success ? 'backup-code-validate-success' : 'backup-code-validate-failure'
-			);
-		}
-
-		if ( callback ) {
-			callback( error, data );
-		}
-	} );
-};
-
 TwoStepAuthorization.prototype.codeValidationFailed = function () {
 	return this.invalidCode;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Our 2FA library is one of the last remaining `EventEmitter` legacy stores. It's time to remove it in favor of a more modern and flexible alternative (either Redux or `react-query`)

This PR migrates the `validateBackupCode` method away from the emitter and embeds it directly in the consumer components.

~Relies on #61975 and needs to be rebased after it lands.~

Part of #48409 and one of the last items of the gigantic [Flux-to-Redux migration project](https://github.com/Automattic/wp-calypso/projects/45).

#### Testing instructions

* Go to `/me/security/two-step` for a user with 2FA enabled.
* Click on "Generate new backup codes"
* Copy one of the backup codes.
* Tick "I have printed or saved these codes" and click "All Finished"
* Input the copied backup code in the newly appeared field.
* Click "Verify".
* Verify everything well, and you're seeing the "Backup codes have been verified."
* Go back and try the same with an incorrect code.
* Verify you get a "You entered an invalid code. Please try again." message.