### PR TITLE
2FA: Refactor `getAppAuthCodes` away from the emitter store

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -244,22 +244,6 @@ TwoStepAuthorization.prototype.validateBackupCode = function ( code, callback ) 
 	} );
 };
 
-/*
- * Requests the authentication app QR code URL and time code
- * from me/two-step/app-auth-setup
- */
-TwoStepAuthorization.prototype.getAppAuthCodes = function ( callback ) {
-	wp.req.get( '/me/two-step/app-auth-setup/', function ( error, data ) {
-		if ( error ) {
-			debug( 'Getting App Auth Codes failed: ' + JSON.stringify( error ) );
-		}
-
-		if ( callback ) {
-			callback( error, data );
-		}
-	} );
-};
-
 TwoStepAuthorization.prototype.codeValidationFailed = function () {
 	return this.invalidCode;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Our 2FA library is one of the last remaining `EventEmitter` legacy stores. It's time to remove it in favor of a more modern and flexible alternative (either Redux or `react-query`)

This PR migrates the `getAppAuthCodes` method away from the emitter and embeds it directly in the consumer components.

~Relies on #61975 and needs to be rebased after it lands.~

Part of #48409 and one of the last items of the gigantic [Flux-to-Redux migration project](https://github.com/Automattic/wp-calypso/projects/45).

#### Testing instructions

* Go to `/me/security/two-step` for a user without 2FA setup.
* Make sure "Set up using an app" is selected.
* Click "Get Started"
* Verify you're redirected to the next step, and you can properly see the QR code.