### PR TITLE
Marketing Connections: Ensure Google Photos works with site ID and slug

### DIFF
--- a/client/my-sites/marketing/connections/service-action.jsx
+++ b/client/my-sites/marketing/connections/service-action.jsx
@@ -75,7 +75,7 @@ const SharingServiceAction = ( {
 	}
 
 	// See: https://developers.google.com/photos/library/guides/ux-guidelines
-	if ( 'google_photos' === service.ID && '/marketing/connections/:site' !== path ) {
+	if ( 'google_photos' === service.ID && ! path.startsWith( '/marketing/connections/' ) ) {
 		return (
 			<Button primary onClick={ onClick } disabled={ isPending }>
 				{ translate( 'Connect to Google Photos' ) }


### PR DESCRIPTION


#### Changes proposed in this Pull Request

During some testing we saw that if we went to the
`/marketing/connections` screen with the site ID rather than the site
slug/URL, we would see a connection button for Google Photos regardless
of the connection status. The button was also not in a consistent
format.

This was becaus a check in the code only looked for the path being
`:site` and didn't account for the path having `:siteid`. This changes
fixes that.

#### Testing instructions

* Go to /marketing/connections/<a test site>.wordpress.com
* Click the button to connect Google Photos and connect it to to an account
* Go to /marketing/connections/<site ID> for the same site
* Notice that Google Photos has a 'Connect to Google Photos' button displayed, despite being connected.
* Clicking the button will give a message about the connection being disconnected.
* Repeat this process with this code change and the connection button and UI should remain consistent.

#### Before

<img width="1044" alt="image" src="https://user-images.githubusercontent.com/96462/158574805-5a44d459-22b3-43ab-9fdd-3797ca182ca5.png">

#### After

<img width="1044" alt="image" src="https://user-images.githubusercontent.com/96462/158574876-2fc849f5-51fe-4624-bbad-5a01a381de21.png">

