### PR TITLE
Plans overhaul Phase 1: Restore Plans tab for Legacy plans

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -174,30 +174,28 @@ export const globalOverrides = css`
 		margin-bottom: 0.5rem;
 	}
 
-	.notice.notice {
+	.notice.is-info,
+	.notice.is-success {
 		color: inherit;
-	}
-
-	.notice.is-info {
 		background: #f6f7f7;
-	}
 
-	.notice__content.notice__content {
-		html[dir='ltr'] & {
-			padding: 10px 10px 10px 0;
+		.notice__content.notice__content {
+			html[dir='ltr'] & {
+				padding: 10px 10px 10px 0;
+			}
+			html[dir='rtl'] & {
+				padding: 10px 0 10px 10px;
+			}
 		}
-		html[dir='rtl'] & {
-			padding: 10px 0 10px 10px;
+
+		.notice__icon-wrapper.notice__icon-wrapper {
+			background: none;
+			width: 40px;
 		}
-	}
 
-	.notice.is-info .notice__icon-wrapper.notice__icon-wrapper {
-		background: none;
-		width: 40px;
-	}
-
-	.notice .gridicons-info-outline {
-		fill: #008a20;
+		.gridicons-info-outline {
+			fill: #008a20;
+		}
 	}
 
 	.my-plan-card.my-plan-card.card {

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -1,4 +1,4 @@
-import { isFreePlanProduct, isFlexiblePlanProduct } from '@automattic/calypso-products';
+import { isPro } from '@automattic/calypso-products';
 import page from 'page';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
@@ -32,11 +32,7 @@ export function plans( context, next ) {
 	const selectedSite = getSite( state, siteId );
 	const eligibleForProPlan = isEligibleForProPlan( state, siteId );
 
-	if (
-		eligibleForProPlan &&
-		! isFreePlanProduct( selectedSite.plan ) &&
-		! isFlexiblePlanProduct( selectedSite.plan )
-	) {
+	if ( eligibleForProPlan && isPro( selectedSite.plan ) ) {
 		page.redirect( `/plans/my-plan/${ selectedSite.slug }` );
 
 		return null;

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -260,9 +260,9 @@ class CurrentPlan extends Component {
 					{ showLegacyPlanNotice && (
 						<Notice
 							status="is-info"
-							text={
-								'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer ut felis et orci fringilla pretium. Consectura elit et orci fel.'
-							}
+							text={ translate(
+								'You’re currently on a legacy plan. If you’d like to learn about your eligibility to switch to a Pro plan please contact support.'
+							) }
 							icon="info-outline"
 							showDismiss={ false }
 						></Notice>
@@ -277,7 +277,7 @@ class CurrentPlan extends Component {
 						</Fragment>
 					) }
 
-					{ ! eligibleForProPlan && (
+					{ ! isPro( selectedSite.plan ) && (
 						<>
 							<div
 								className={ classNames( 'current-plan__header-text current-plan__text', {

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -1,4 +1,4 @@
-import { isFreePlanProduct, isFlexiblePlanProduct } from '@automattic/calypso-products';
+import { isFreePlanProduct, isFlexiblePlanProduct, isPro } from '@automattic/calypso-products';
 import { isMobile } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -39,7 +39,7 @@ class PlansNavigation extends Component {
 	}
 
 	render() {
-		const { site, shouldShowMyPlan, shouldShowPlans, translate, eligibleForProPlan } = this.props;
+		const { site, shouldShowMyPlan, shouldShowPlans, translate, isFreeOrFlexible } = this.props;
 		const path = sectionify( this.props.path );
 		const sectionTitle = this.getSectionTitle( path );
 		const hasPinnedItems = isMobile() && site;
@@ -63,7 +63,7 @@ class PlansNavigation extends Component {
 									path === '/plans' || path === '/plans/monthly' || path === '/plans/yearly'
 								}
 							>
-								{ eligibleForProPlan ? translate( 'New Plans' ) : translate( 'Plans' ) }
+								{ isFreeOrFlexible ? translate( 'New Plans' ) : translate( 'Plans' ) }
 							</NavItem>
 						) }
 					</NavTabs>
@@ -83,12 +83,12 @@ export default connect( ( state ) => {
 	const currentPlan = getCurrentPlan( state, siteId );
 	let shouldShowMyPlan = ! isOnFreePlan || ( isJetpack && ! isAtomic );
 	let shouldShowPlans = true;
+	let isFreeOrFlexible = false;
 
 	if ( eligibleForProPlan && currentPlan ) {
-		const isFreeOrFlexible =
-			isFreePlanProduct( currentPlan ) || isFlexiblePlanProduct( currentPlan );
+		isFreeOrFlexible = isFreePlanProduct( currentPlan ) || isFlexiblePlanProduct( currentPlan );
 		shouldShowMyPlan = isFreeOrFlexible ? false : true;
-		shouldShowPlans = isFreeOrFlexible ? true : false;
+		shouldShowPlans = isFreeOrFlexible || ! isPro( currentPlan ) ? true : false;
 	}
 	return {
 		isJetpack,
@@ -96,5 +96,6 @@ export default connect( ( state ) => {
 		shouldShowPlans,
 		site,
 		eligibleForProPlan,
+		isFreeOrFlexible,
 	};
 } )( localize( PlansNavigation ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Discussion: p1647430377355079-slack-C031TFM2NKC

This is a follow-up after #61656 in which we restore the Plans tab and Features section for legacy Plan. The idea is to allow users to continue to be able to down/upgrade to legacy plans.

#### Testing instructions

##### Free Plans
* go to the `/plans/[site]?flags=plans/pro-plan` page on a Free plan site
* you should see the New Plans page
<img width="320" alt="Screenshot on 2022-03-16 at 14-18-57" src="https://user-images.githubusercontent.com/2749938/158588339-9d14a4a5-c33e-43eb-929f-52669cdc2df3.png">


##### Legacy Plan
* go to the `/plans/[site]?flags=plans/pro-plan` page on a Legacy plan site (ex.Business)
* you should see the Plans page
<img width="320" alt="Screenshot on 2022-03-16 at 14-19-54" src="https://user-images.githubusercontent.com/2749938/158588566-30e3f72b-c8b1-4499-b375-1c43adea7728.png">

* go to he z/plans/my-plan/[site]?flags=plans/pro-planz page on the same site
* you should see the My Plan page with a notification and the Features section
<img width="320" alt="Screenshot on 2022-03-16 at 14-21-18" src="https://user-images.githubusercontent.com/2749938/158588990-f918a57d-30ae-409e-b46b-0dd9fa27ff0a.png">


##### Pro Plan
* go to the `/plans/[site]?flags=plans/pro-plan` page on a Pro plan site
* you should be redirected and see the My Plan page
<img width="320" alt="Screenshot on 2022-03-16 at 14-23-47" src="https://user-images.githubusercontent.com/2749938/158589254-af6e0f45-70c0-4b76-a405-9f1b918b7618.png">


##### Staging
* going to any of the pages without the `?flags=plans/pro-plan` should not showcase any changes compared to production
