### PR TITLE
Framework: Enable React `StrictMode`

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import page from 'page';
+import { StrictMode } from 'react';
 import { QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
@@ -46,19 +47,21 @@ export const ProviderWrappedLayout = ( {
 	);
 
 	return (
-		<CalypsoI18nProvider>
-			<RouteProvider
-				currentSection={ currentSection }
-				currentRoute={ currentRoute }
-				currentQuery={ currentQuery }
-			>
-				<QueryClientProvider client={ queryClient }>
-					<ReduxProvider store={ store }>
-						<MomentProvider>{ layout }</MomentProvider>
-					</ReduxProvider>
-				</QueryClientProvider>
-			</RouteProvider>
-		</CalypsoI18nProvider>
+		<StrictMode>
+			<CalypsoI18nProvider>
+				<RouteProvider
+					currentSection={ currentSection }
+					currentRoute={ currentRoute }
+					currentQuery={ currentQuery }
+				>
+					<QueryClientProvider client={ queryClient }>
+						<ReduxProvider store={ store }>
+							<MomentProvider>{ layout }</MomentProvider>
+						</ReduxProvider>
+					</QueryClientProvider>
+				</RouteProvider>
+			</CalypsoI18nProvider>
+		</StrictMode>
 	);
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR enables React `StrictMode` on Calypso's client. 

As per the [official docs](https://reactjs.org/docs/strict-mode.html):

> StrictMode is a tool for highlighting potential problems in an application. Like Fragment, StrictMode does not render any visible UI. It activates additional checks and warnings for its descendants.

It nicely highlights various errors and obsolete practices we've been meaning to refactor away from:

* [Identifying components with unsafe lifecycles](https://reactjs.org/docs/strict-mode.html#identifying-unsafe-lifecycles)
* [Warning about legacy string ref API usage](https://reactjs.org/docs/strict-mode.html#warning-about-legacy-string-ref-api-usage)
* [Warning about deprecated findDOMNode usage](https://reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)
* [Detecting unexpected side effects](https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects)
* [Detecting legacy context API](https://reactjs.org/docs/strict-mode.html#detecting-legacy-context-api)

I'd like to enable strict mode in order to raise awareness of these issues and ideally, get additional help in refactoring away from them.

#### Testing instructions

* Open `/me`
* Verify you see a warning in the console about the usage of `UNSAFE_` lifecycle methods:

![](https://cldup.com/uGWuRutHjZ.png)