### PR TITLE
Don't show logo teaser on P2s

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -93,6 +93,7 @@ export class SiteSettingsFormGeneral extends Component {
 			eventTracker,
 			onChangeField,
 			uniqueEventTracker,
+			isWPForTeamsSite,
 		} = this.props;
 
 		return (
@@ -131,33 +132,35 @@ export class SiteSettingsFormGeneral extends Component {
 					</div>
 					<SiteIconSetting />
 				</div>
-				<div className="site-settings__fiverr-logo-maker-cta">
-					<div className="site-settings__fiverr-logo-icon">
-						<img
-							className="site-settings__fiverr-logo-cta"
-							src={ fiverrLogo }
-							alt="fiverr small logo"
-						/>
-					</div>
-					<div className="site-settings__fiverr-logo-maker-cta-text">
-						<div className="site-settings__fiverr-logo-maker-cta-text-title">
-							{ translate( 'Make an incredible logo in minutes' ) }
+				{ ! isWPForTeamsSite && (
+					<div className="site-settings__fiverr-logo-maker-cta">
+						<div className="site-settings__fiverr-logo-icon">
+							<img
+								className="site-settings__fiverr-logo-cta"
+								src={ fiverrLogo }
+								alt="fiverr small logo"
+							/>
 						</div>
-						<div className="site-settings__fiverr-logo-maker-cta-text-subhead">
-							{ translate( 'Pre-designed by top talent. Just add your touch.' ) }
+						<div className="site-settings__fiverr-logo-maker-cta-text">
+							<div className="site-settings__fiverr-logo-maker-cta-text-title">
+								{ translate( 'Make an incredible logo in minutes' ) }
+							</div>
+							<div className="site-settings__fiverr-logo-maker-cta-text-subhead">
+								{ translate( 'Pre-designed by top talent. Just add your touch.' ) }
+							</div>
+						</div>
+						<div className="site-settings__fiver-cta-button">
+							<Button
+								target="_blank"
+								href="https://wp.me/logo-maker/?utm_campaign=general_settings"
+								onClick={ this.trackFiverrLogoMakerClick }
+							>
+								<Gridicon icon="external" />
+								{ translate( 'Try Fiverr Logo Maker' ) }
+							</Button>
 						</div>
 					</div>
-					<div className="site-settings__fiver-cta-button">
-						<Button
-							target="_blank"
-							href="https://wp.me/logo-maker/?utm_campaign=general_settings"
-							onClick={ this.trackFiverrLogoMakerClick }
-						>
-							<Gridicon icon="external" />
-							{ translate( 'Try Fiverr Logo Maker' ) }
-						</Button>
-					</div>
-				</div>
+				) }
 			</>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR hides the logomaker CTA added in #57249 on P2s. It does not really make sense in P2 context.

See 4845-gh-Automattic/p2

#### Testing instructions
* Go to `http://calypso.localhost:3000/settings/general/<some-site>` where <some-site> is a P2 and check that the logomaker CTA _is not_ there.
* * Go to `http://calypso.localhost:3000/settings/general/<some-site>` where <some-site> is not a P2 and check that the logomaker CTA _is_ there.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
The CTA looks like this:
<img width="810" alt="Screen Shot 2022-03-16 at 14 09 51" src="https://user-images.githubusercontent.com/193283/158597076-75cf2d44-61ac-4de7-b6e7-ea5417cb0168.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
