### PR TITLE
Emails: Show comparison page when the flag emails/show-new-comparison-component is enabled

### DIFF
--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -44,8 +44,8 @@ export default function EmailProvidersUpsell( { domain } ) {
 				/>
 			) : (
 				<EmailProvidersStackedComparison
-					cartDomainName={ domain }
 					comparisonContext="domain-upsell"
+					isDomainInCart="true"
 					selectedDomainName={ domain }
 					source="domain-upsell"
 				></EmailProvidersStackedComparison>

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -6,6 +6,7 @@ import { useSelector } from 'react-redux';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { domainAddNew } from 'calypso/my-sites/domains/paths';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
+import EmailProvidersStackedComparison from 'calypso/my-sites/email/email-providers-stacked-comparison';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 export default function EmailProvidersUpsell( { domain } ) {
@@ -41,7 +42,14 @@ export default function EmailProvidersUpsell( { domain } ) {
 					skipButtonLabel={ translate( 'Skip' ) }
 					titanProductSlug={ TITAN_MAIL_YEARLY_SLUG }
 				/>
-			) : null }
+			) : (
+				<EmailProvidersStackedComparison
+					cartDomainName={ domain }
+					comparisonContext="domain-upsell"
+					selectedDomainName={ domain }
+					source="domain-upsell"
+				></EmailProvidersStackedComparison>
+			) }
 		</CalypsoShoppingCartProvider>
 	);
 }

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -45,7 +45,7 @@ export default function EmailProvidersUpsell( { domain } ) {
 			) : (
 				<EmailProvidersStackedComparison
 					comparisonContext="domain-upsell"
-					isDomainInCart="true"
+					isDomainInCart={ true }
 					selectedDomainName={ domain }
 					source="domain-upsell"
 				></EmailProvidersStackedComparison>

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -83,11 +83,13 @@ const AdditionalPriceInformation = ( {
 
 type GoogleWorkspacePriceProps = {
 	domain: SiteDomain | undefined;
+	hasCartDomain?: boolean;
 	intervalLength: IntervalLength;
 };
 
 const GoogleWorkspacePrice = ( {
 	domain,
+	hasCartDomain = false,
 	intervalLength,
 }: GoogleWorkspacePriceProps ): ReactElement => {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
@@ -97,11 +99,8 @@ const GoogleWorkspacePrice = ( {
 
 	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
 
-	if ( ! domain ) {
-		return <></>;
-	}
-
-	const isGSuiteSupported = canPurchaseGSuite && hasGSuiteSupportedDomain( [ domain ] );
+	const isGSuiteSupported =
+		hasCartDomain || ( canPurchaseGSuite && hasGSuiteSupportedDomain( [ domain ] ) );
 
 	if ( ! isGSuiteSupported ) {
 		return (

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -22,6 +22,7 @@ import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import type { SiteDomain } from 'calypso/state/sites/domains/types';
+import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -37,7 +38,7 @@ const AdditionalPriceInformation = ( {
 }: {
 	currencyCode: string | null;
 	product: ProductListItem | null;
-} ): JSX.Element | null => {
+} ): ReactElement | null => {
 	if ( ! hasDiscount( product ) ) {
 		return null;
 	}
@@ -82,14 +83,14 @@ const AdditionalPriceInformation = ( {
 
 type GoogleWorkspacePriceProps = {
 	domain: SiteDomain | undefined;
-	hasCartDomain?: boolean;
+	isDomainInCart?: boolean;
 	intervalLength: IntervalLength;
 };
 
 const GoogleWorkspacePrice = ( {
 	domain,
-	hasCartDomain = false,
 	intervalLength,
+	isDomainInCart = false,
 }: GoogleWorkspacePriceProps ): JSX.Element | null => {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 
@@ -98,12 +99,12 @@ const GoogleWorkspacePrice = ( {
 
 	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
 
-	if ( ! domain && ! hasCartDomain ) {
+	if ( ! domain && ! isDomainInCart ) {
 		return null;
 	}
 
 	const isGSuiteSupported =
-		canPurchaseGSuite && ( hasCartDomain || hasGSuiteSupportedDomain( [ domain ] ) );
+		canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );
 
 	if ( ! isGSuiteSupported ) {
 		return (

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -22,7 +22,6 @@ import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import type { SiteDomain } from 'calypso/state/sites/domains/types';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -38,7 +37,7 @@ const AdditionalPriceInformation = ( {
 }: {
 	currencyCode: string | null;
 	product: ProductListItem | null;
-} ): ReactElement | null => {
+} ): JSX.Element | null => {
 	if ( ! hasDiscount( product ) ) {
 		return null;
 	}
@@ -91,13 +90,17 @@ const GoogleWorkspacePrice = ( {
 	domain,
 	hasCartDomain = false,
 	intervalLength,
-}: GoogleWorkspacePriceProps ): ReactElement => {
+}: GoogleWorkspacePriceProps ): JSX.Element | null => {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 
 	const productSlug = getGoogleWorkspaceProductSlug( intervalLength );
 	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
 
 	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
+
+	if ( ! domain && ! hasCartDomain ) {
+		return null;
+	}
 
 	const isGSuiteSupported =
 		canPurchaseGSuite && ( hasCartDomain || hasGSuiteSupportedDomain( [ domain ] ) );

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -100,7 +100,7 @@ const GoogleWorkspacePrice = ( {
 	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
 
 	const isGSuiteSupported =
-		hasCartDomain || ( canPurchaseGSuite && hasGSuiteSupportedDomain( [ domain ] ) );
+		canPurchaseGSuite && ( hasCartDomain || hasGSuiteSupportedDomain( [ domain ] ) );
 
 	if ( ! isGSuiteSupported ) {
 		return (

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -32,6 +32,7 @@ import './style.scss';
 export type EmailProvidersStackedComparisonProps = {
 	cartDomainName?: string;
 	comparisonContext: string;
+	isDomainInCart?: boolean;
 	selectedDomainName: string;
 	selectedEmailProviderSlug?: string;
 	selectedIntervalLength?: IntervalLength | undefined;
@@ -39,8 +40,8 @@ export type EmailProvidersStackedComparisonProps = {
 };
 
 const EmailProvidersStackedComparison = ( {
-	cartDomainName,
 	comparisonContext,
+	isDomainInCart = false,
 	selectedDomainName,
 	selectedEmailProviderSlug,
 	selectedIntervalLength = IntervalLength.ANNUALLY,
@@ -129,21 +130,19 @@ const EmailProvidersStackedComparison = ( {
 		);
 	};
 
-	const hasCartDomain = Boolean( cartDomainName );
-
-	if ( ! domain && ! hasCartDomain ) {
+	if ( ! domain && ! isDomainInCart ) {
 		return null;
 	}
 
-	const hasExistingEmailForwards = ! hasCartDomain && hasEmailForwards( domain );
+	const hasExistingEmailForwards = ! isDomainInCart && hasEmailForwards( domain );
 
 	return (
 		<Main wideLayout>
 			<QueryProductsList />
 
-			{ ! hasCartDomain && <QueryEmailForwards domainName={ selectedDomainName } /> }
+			{ ! isDomainInCart && <QueryEmailForwards domainName={ selectedDomainName } /> }
 
-			{ ! hasCartDomain && selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
+			{ ! isDomainInCart && selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
 			<h1 className="email-providers-stacked-comparison__header">
 				{ translate( 'Pick an email solution' ) }
@@ -175,36 +174,36 @@ const EmailProvidersStackedComparison = ( {
 				onIntervalChange={ changeIntervalLength }
 			/>
 
-			{ ! hasCartDomain && hasExistingEmailForwards && domainsWithForwards !== undefined && (
+			{ hasExistingEmailForwards && domainsWithForwards !== undefined && (
 				<EmailExistingForwardsNotice
 					domainsWithForwards={ domainsWithForwards }
 					selectedDomainName={ selectedDomainName }
 				/>
 			) }
 
-			{ ! hasCartDomain && domain && <EmailExistingPaidServiceNotice domain={ domain } /> }
+			{ ! isDomainInCart && domain && <EmailExistingPaidServiceNotice domain={ domain } /> }
 
 			<ProfessionalEmailCard
-				cartDomainName={ cartDomainName }
 				comparisonContext={ comparisonContext }
 				detailsExpanded={ detailsExpanded.titan }
 				intervalLength={ selectedIntervalLength }
+				isDomainInCart={ isDomainInCart }
 				onExpandedChange={ changeExpandedState }
 				selectedDomainName={ selectedDomainName }
 				source={ source }
 			/>
 
 			<GoogleWorkspaceCard
-				cartDomainName={ cartDomainName }
 				comparisonContext={ comparisonContext }
 				detailsExpanded={ detailsExpanded.google }
 				intervalLength={ selectedIntervalLength }
+				isDomainInCart={ isDomainInCart }
 				onExpandedChange={ changeExpandedState }
 				selectedDomainName={ selectedDomainName }
 				source={ source }
 			/>
 
-			{ ! hasCartDomain && <EmailForwardingLink selectedDomainName={ selectedDomainName } /> }
+			{ ! isDomainInCart && <EmailForwardingLink selectedDomainName={ selectedDomainName } /> }
 
 			<TrackComponentView
 				eventName="calypso_email_providers_comparison_page_view"

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -130,6 +130,11 @@ const EmailProvidersStackedComparison = ( {
 	};
 
 	const hasCartDomain = Boolean( cartDomainName );
+
+	if ( ! domain && ! hasCartDomain ) {
+		return null;
+	}
+
 	const hasExistingEmailForwards = ! hasCartDomain && hasEmailForwards( domain );
 
 	return (

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -30,6 +30,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 export type EmailProvidersStackedComparisonProps = {
+	cartDomainName?: string;
 	comparisonContext: string;
 	selectedDomainName: string;
 	selectedEmailProviderSlug?: string;
@@ -38,6 +39,7 @@ export type EmailProvidersStackedComparisonProps = {
 };
 
 const EmailProvidersStackedComparison = ( {
+	cartDomainName,
 	comparisonContext,
 	selectedDomainName,
 	selectedEmailProviderSlug,
@@ -71,10 +73,6 @@ const EmailProvidersStackedComparison = ( {
 		selectedDomainName: selectedDomainName,
 	} );
 	const domainsWithForwards = useSelector( ( state ) => getDomainsWithForwards( state, domains ) );
-
-	if ( ! domain ) {
-		return null;
-	}
 
 	const changeExpandedState = ( providerKey: string, isCurrentlyExpanded: boolean ) => {
 		const expandedEntries = Object.entries( detailsExpanded ).map( ( entry ) => {
@@ -131,15 +129,16 @@ const EmailProvidersStackedComparison = ( {
 		);
 	};
 
-	const hasExistingEmailForwards = hasEmailForwards( domain );
+	const hasCartDomain = Boolean( cartDomainName );
+	const hasExistingEmailForwards = ! hasCartDomain && hasEmailForwards( domain );
 
 	return (
 		<Main wideLayout>
 			<QueryProductsList />
 
-			<QueryEmailForwards domainName={ selectedDomainName } />
+			{ ! hasCartDomain && <QueryEmailForwards domainName={ selectedDomainName } /> }
 
-			{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
+			{ ! hasCartDomain && selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
 			<h1 className="email-providers-stacked-comparison__header">
 				{ translate( 'Pick an email solution' ) }
@@ -171,16 +170,17 @@ const EmailProvidersStackedComparison = ( {
 				onIntervalChange={ changeIntervalLength }
 			/>
 
-			{ hasExistingEmailForwards && domainsWithForwards !== undefined && (
+			{ ! hasCartDomain && hasExistingEmailForwards && domainsWithForwards !== undefined && (
 				<EmailExistingForwardsNotice
 					domainsWithForwards={ domainsWithForwards }
 					selectedDomainName={ selectedDomainName }
 				/>
 			) }
 
-			<EmailExistingPaidServiceNotice domain={ domain } />
+			{ ! hasCartDomain && domain && <EmailExistingPaidServiceNotice domain={ domain } /> }
 
 			<ProfessionalEmailCard
+				cartDomainName={ cartDomainName }
 				comparisonContext={ comparisonContext }
 				detailsExpanded={ detailsExpanded.titan }
 				intervalLength={ selectedIntervalLength }
@@ -190,6 +190,7 @@ const EmailProvidersStackedComparison = ( {
 			/>
 
 			<GoogleWorkspaceCard
+				cartDomainName={ cartDomainName }
 				comparisonContext={ comparisonContext }
 				detailsExpanded={ detailsExpanded.google }
 				intervalLength={ selectedIntervalLength }
@@ -198,7 +199,7 @@ const EmailProvidersStackedComparison = ( {
 				source={ source }
 			/>
 
-			<EmailForwardingLink selectedDomainName={ selectedDomainName } />
+			{ ! hasCartDomain && <EmailForwardingLink selectedDomainName={ selectedDomainName } /> }
 
 			<TrackComponentView
 				eventName="calypso_email_providers_comparison_page_view"

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -107,17 +107,22 @@ const GoogleWorkspaceCard = ( {
 	const [ googleUsers, setGoogleUsers ] = useState( newUsers( selectedDomainName ) );
 	const [ addingToCart, setAddingToCart ] = useState( false );
 
-	const isGSuiteSupported = canPurchaseGSuite && hasGSuiteSupportedDomain( [ domain ] );
+	const hasCartDomain = Boolean( cartDomainName );
+
+	const isGSuiteSupported =
+		hasCartDomain || ( canPurchaseGSuite && hasGSuiteSupportedDomain( [ domain ] ) );
 	const isGSuiteAvailable = intervalLength === IntervalLength.ANNUALLY && isGSuiteSupported;
 
 	const googleWorkspace: ProviderCardProps = { ...googleWorkspaceCardInformation };
 	googleWorkspace.detailsExpanded = isGSuiteAvailable && detailsExpanded;
 	googleWorkspace.showExpandButton = isGSuiteAvailable;
 	googleWorkspace.priceBadge = (
-		<GoogleWorkspacePrice domain={ domain } intervalLength={ intervalLength } />
+		<GoogleWorkspacePrice
+			domain={ domain }
+			hasCartDomain={ hasCartDomain }
+			intervalLength={ intervalLength }
+		/>
 	);
-
-	const hasCartDomain = Boolean( cartDomainName );
 
 	const onGoogleConfirmNewMailboxes = () => {
 		const usersAreValid = areAllUsersValid( googleUsers );

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -75,10 +75,10 @@ const googleWorkspaceCardInformation: ProviderCardProps = {
 };
 
 const GoogleWorkspaceCard = ( {
-	cartDomainName,
 	comparisonContext,
 	detailsExpanded,
 	intervalLength,
+	isDomainInCart = false,
 	onExpandedChange,
 	selectedDomainName,
 	source,
@@ -107,10 +107,8 @@ const GoogleWorkspaceCard = ( {
 	const [ googleUsers, setGoogleUsers ] = useState( newUsers( selectedDomainName ) );
 	const [ addingToCart, setAddingToCart ] = useState( false );
 
-	const hasCartDomain = Boolean( cartDomainName );
-
 	const isGSuiteSupported =
-		canPurchaseGSuite && ( hasCartDomain || hasGSuiteSupportedDomain( [ domain ] ) );
+		canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );
 
 	const isGSuiteAvailable = intervalLength === IntervalLength.ANNUALLY && isGSuiteSupported;
 
@@ -120,14 +118,14 @@ const GoogleWorkspaceCard = ( {
 	googleWorkspace.priceBadge = (
 		<GoogleWorkspacePrice
 			domain={ domain }
-			hasCartDomain={ hasCartDomain }
+			isDomainInCart={ isDomainInCart }
 			intervalLength={ intervalLength }
 		/>
 	);
 
 	const onGoogleConfirmNewMailboxes = () => {
 		const usersAreValid = areAllUsersValid( googleUsers );
-		const userCanAddEmail = hasCartDomain || canCurrentUserAddEmail( domain );
+		const userCanAddEmail = isDomainInCart || canCurrentUserAddEmail( domain );
 
 		recordTracksEventAddToCartClick(
 			comparisonContext,

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -110,7 +110,8 @@ const GoogleWorkspaceCard = ( {
 	const hasCartDomain = Boolean( cartDomainName );
 
 	const isGSuiteSupported =
-		hasCartDomain || ( canPurchaseGSuite && hasGSuiteSupportedDomain( [ domain ] ) );
+		canPurchaseGSuite && ( hasCartDomain || hasGSuiteSupportedDomain( [ domain ] ) );
+
 	const isGSuiteAvailable = intervalLength === IntervalLength.ANNUALLY && isGSuiteSupported;
 
 	const googleWorkspace: ProviderCardProps = { ...googleWorkspaceCardInformation };

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -75,10 +75,10 @@ const professionalEmailCardInformation: ProviderCardProps = {
 };
 
 const ProfessionalEmailCard = ( {
-	cartDomainName,
 	comparisonContext,
 	detailsExpanded,
 	intervalLength,
+	isDomainInCart = false,
 	onExpandedChange,
 	selectedDomainName,
 	source,
@@ -103,13 +103,11 @@ const ProfessionalEmailCard = ( {
 	const professionalEmail: ProviderCardProps = { ...professionalEmailCardInformation };
 	professionalEmail.detailsExpanded = detailsExpanded;
 
-	const hasCartDomain = Boolean( cartDomainName );
-
 	const onTitanConfirmNewMailboxes = () => {
 		const validatedTitanMailboxes = validateTitanMailboxes( titanMailbox, optionalFields );
 
 		const mailboxesAreValid = areAllMailboxesValid( validatedTitanMailboxes, optionalFields );
-		const userCanAddEmail = hasCartDomain || canCurrentUserAddEmail( domain );
+		const userCanAddEmail = isDomainInCart || canCurrentUserAddEmail( domain );
 		const userCannotAddEmailReason = userCanAddEmail
 			? null
 			: getCurrentUserCannotAddEmailReason( domain );

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -21,7 +21,7 @@ export interface ProviderCardProps {
 }
 
 export type EmailProvidersStackedCardProps = {
-	cartDomainName?: string;
+	isDomainInCart?: boolean;
 	comparisonContext: string;
 	detailsExpanded: boolean;
 	intervalLength: IntervalLength;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I am showing the new comparison component under the feature flag (emails/show-new-comparison-component is enabled) to keep working on retire the old comparison page.
I'm breaking down all the changes and this change only adapt the component to receive a domain name, instead of a domain object plus hiding email forward components for this view.

**Things to tackle in the following Pull Requests:**
- Interval toggle not working, it's adding a different URL path when clicking on it.
- `See how they compare` link is not working.
- Navigation buttons
- Multiple mailboxes support

#### Testing instructions

**Main scenario!**
Ensure that new comparison page keeps working:
1. Have a domain without email subscription on it.
2. Go to Upgrades -> Emails
3. Click on Add Email button
4. Try to add to the cart an email solution of each provider for each interval (just go to the check out and check that everything is working, no need to actually buy it, after you checked everything, remove the subscription for the domain and repeat for another variant subscription/interval)

**Second scenario**
1. Open the [Domains page](http://calypso.localhost:3000/domains/manage)
3. Click the Add a domain button
5. Select Search for a domain
6. Select any domain to access the Email Comparison page
7. Add the following query to the URL in your browser: ?flags=+emails/show-new-comparison-component
8. Assert that the next screen is displayed.

![image](https://user-images.githubusercontent.com/5689927/158605508-1a66346c-828b-41c7-a594-8cee1fadb827.png)


Related to {1200182182542585-as-1201971096657078}
