### PR TITLE
2FA: Remove unused `authExpiresSoon` and related flag

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -95,7 +95,6 @@ TwoStepAuthorization.prototype.refreshDataOnSuccessfulAuth = function () {
 		reduxDispatch( requestUserProfileLinks() );
 	}
 	this.data.two_step_reauthorization_required = false;
-	this.data.two_step_authorization_expires_soon = false;
 	this.invalidCode = false;
 
 	this.emit( 'change' );
@@ -270,10 +269,6 @@ TwoStepAuthorization.prototype.isSMSResendThrottled = function () {
 
 TwoStepAuthorization.prototype.isReauthRequired = function () {
 	return this.data.two_step_reauthorization_required ?? false;
-};
-
-TwoStepAuthorization.prototype.authExpiresSoon = function () {
-	return this.data.two_step_authorization_expires_soon ?? false;
 };
 
 TwoStepAuthorization.prototype.isTwoStepSMSEnabled = function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Our 2FA library is one of the last remaining `EventEmitter` legacy stores. It's time to remove it in favor of a more modern and flexible alternative (either Redux or `react-query`)

This PR removes the `authExpiresSoon` method and its related `two_step_authorization_expires_soon` flag which has been unused since the creation of the module.

Part of #48409 and one of the last items of the gigantic [Flux-to-Redux migration project](https://github.com/Automattic/wp-calypso/projects/45).

#### Testing instructions

* Verify the removed function and flag are not in use.