### PR TITLE
Fix/showing onboarding importer

### DIFF
--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -50,7 +50,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	const urlData = useSelector( getUrlData );
 	const searchParams = useSelector( getCurrentQueryArguments );
 	let siteSlug = searchParams?.to as string;
-	const [ siteId ] = useState( useSelector( ( state ) => getSiteId( state, siteSlug ) as number ) );
+	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) as number );
 	const site = useSelector( ( state ) => getSite( state, siteId ) as SitesItem );
 	const siteImports = useSelector( ( state ) => getImporterStatusForSiteId( state, siteId ) );
 	const canImport = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );

--- a/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
+++ b/client/signup/steps/import-from/wordpress/content-chooser/index.tsx
@@ -1,13 +1,15 @@
 import { NextButton, SelectItems } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import ActionCard from 'calypso/components/action-card';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { preventWidows } from 'calypso/lib/formatting';
 import wpcom from 'calypso/lib/wp';
 import { jetpack } from 'calypso/signup/icons';
 import { SitesItem } from 'calypso/state/selectors/get-sites-items';
+import { requestSite } from 'calypso/state/sites/actions';
 
 import './style.scss';
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -23,6 +25,7 @@ interface Props {
 
 export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
+	const dispatch = useDispatch();
 	const {
 		fromSite,
 		onJetpackSelection,
@@ -36,6 +39,7 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 	const showJetpackConnectionBlock = !! fromSite;
 	const [ hasOriginSiteJetpackConnected, setHasOriginSiteJetpackConnected ] = useState( false );
 	const [ initialFetching, setInitialFetching ] = useState( true );
+	const firstRun = useRef( true );
 
 	/**
 	 ↓ Effects
@@ -46,6 +50,15 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 
 		return () => clearInterval( interval );
 	}, [] );
+
+	useEffect( () => {
+		if ( firstRun.current ) {
+			firstRun.current = false;
+			return;
+		}
+
+		dispatch( requestSite( fromSite ) );
+	}, [ hasOriginSiteJetpackConnected ] );
 
 	/**
 	 ↓ Methods


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixed edge cases, some of them were randomly appearing.
(the change is simple enough, just a request site item after the Jetpack connection is established)

#### Testing instructions

* Go to `/start/importer/capture?siteSlug={SLUG}`
* Enter a WP URL (could be jurassic.ninja but without Jetpack established connection)
* Press `Import your content`
* Select `Install Jetpack`, and connect your account (it will be opened in the new tab)
* Go back to the calypso tab and select the `Everything` option
* Check if there is regular details page about the migration process (before this change, there were Unauthorised access warnings)

Related to #57131
