### PR TITLE
Playwright: separate editor-related methods into `EditorGutenbergComponent`.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/pay-with-paypal.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/pay-with-paypal.ts
@@ -1,5 +1,5 @@
 import { BlockFlow, EditorContext, PublishedPostContext } from '..';
-import { GutenbergEditorPage } from '../..';
+import { EditorPage } from '../..';
 
 interface ConfigurationData {
 	name: string;
@@ -45,8 +45,8 @@ export class PayWithPaypalBlockFlow implements BlockFlow {
 		await context.editorIframe.fill( selectors.email, this.configurationData.email );
 
 		// If the post is not saved as draft, the Pay with Paypal block is not rendered in the published post.
-		const gutenbergEditorPage = new GutenbergEditorPage( context.page );
-		await gutenbergEditorPage.saveDraft();
+		const editorPage = new EditorPage( context.page );
+		await editorPage.saveDraft();
 		// Leave site? popup cannot be prevented when publishing.
 		// See https://github.com/Automattic/wp-calypso/issues/60014.
 	}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
@@ -1,13 +1,11 @@
 import { BlockFlow, EditorContext, PublishedPostContext } from '..';
+import envVariables from '../../../env-variables';
 
 interface ConfigurationData {
 	phoneNumber: number | string;
 	buttonText?: string;
 }
 
-// The parent selector for the block changes between mobile and desktop viewport.
-const blockParentSelector =
-	'div[aria-label="Block: Send A Message"], div[aria-label="Block: WhatsApp Button"]';
 const selectors = {
 	// Editor
 	settings: 'button[aria-label="WhatsApp Button Settings"]',
@@ -23,6 +21,7 @@ const selectors = {
  */
 export class WhatsAppButtonFlow implements BlockFlow {
 	private configurationData: ConfigurationData;
+	blockEditorSelector: string;
 
 	/**
 	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
@@ -31,10 +30,14 @@ export class WhatsAppButtonFlow implements BlockFlow {
 	 */
 	constructor( configurationData: ConfigurationData ) {
 		this.configurationData = configurationData;
+		// The parent selector for the block changes between mobile and desktop viewport.
+		this.blockEditorSelector =
+			envVariables.VIEWPORT_NAME === 'desktop'
+				? 'div[aria-label="Block: WhatsApp Button"]'
+				: 'div[aria-label="Block: Send A Message"]';
 	}
 
 	blockSidebarName = 'WhatsApp Button';
-	blockEditorSelector = blockParentSelector;
 
 	/**
 	 * Configure the block in the editor with the configuration data from the constructor

--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -6,7 +6,7 @@ const selectors = {
 	title: '.editor-post-title__input',
 
 	// Editor body
-	initialBlockAppender: '.block-editor-default-block-appender', // When editor is initially loaded in blank state
+	emptyBlock: 'div.block-editor-default-block-appender', // When editor is in a 'resting' state, without a selected block.
 	paragraphBlock: ( empty: boolean ) => `p[data-title="Paragraph"][data-empty="${ empty }"]`,
 	blockWarning: '.block-editor-warning',
 
@@ -36,6 +36,22 @@ export class EditorGutenbergComponent {
 		this.frameLocator = frameLocator;
 	}
 
+	/**
+	 * Resets the selected block.
+	 *
+	 * The Gutenberg block-based editor 'remembers' what block was last
+	 * selected. This behavior impacts the block options that are shown
+	 * in the block inserter.
+	 *
+	 * For instance, if a Contact Form block is currently selected, the
+	 * block inserter will display a filtered set of blocks that are
+	 * permitted to be inserted within the parent Contact Form block.
+	 */
+	async resetSelectedBlock(): Promise< void > {
+		const locator = this.frameLocator.locator( selectors.title );
+		await locator.click();
+	}
+
 	/* Title block */
 
 	/**
@@ -61,14 +77,6 @@ export class EditorGutenbergComponent {
 	/* Paragraph block shortcuts */
 
 	/**
-	 *
-	 */
-	async resetSelectedBlock(): Promise< void > {
-		const locator = this.frameLocator.locator( selectors.title );
-		await locator.click();
-	}
-
-	/**
 	 * Enters text into the paragraph block(s) and verifies the result.
 	 *
 	 * Note that this method of text entry does not explicitly use the
@@ -79,12 +87,12 @@ export class EditorGutenbergComponent {
 	 * treated as individual Paragraph blocks.
 	 */
 	async enterText( textArray: string[] ): Promise< void > {
-		const initialBlockAppenderLocator = this.frameLocator.locator( selectors.initialBlockAppender );
+		const emptyBlockLocator = this.frameLocator.locator( selectors.emptyBlock );
 		const emptyParagraphLocator = this.frameLocator.locator( selectors.paragraphBlock( true ) );
 		if ( await emptyParagraphLocator.count() ) {
 			await emptyParagraphLocator.click();
 		} else {
-			initialBlockAppenderLocator.click();
+			emptyBlockLocator.click();
 		}
 
 		for await ( const line of textArray ) {
@@ -96,6 +104,8 @@ export class EditorGutenbergComponent {
 
 	/**
 	 * Returns the text as entered in the paragraph blocks.
+	 *
+	 * @returns {Promise<string[]>} Array of strings for all paragraph blocks.
 	 */
 	async getText(): Promise< string[] > {
 		const locator = this.frameLocator.locator( selectors.paragraphBlock( false ) );
@@ -155,9 +165,11 @@ export class EditorGutenbergComponent {
 	}
 
 	/**
+	 * Returns the currently selected block's ElementHandle.
 	 *
+	 * @returns {Promise<ElementHandle>} ElementHandle of the selected block.
 	 */
-	async getBlockElementHandle( blockEditorSelector: string ): Promise< ElementHandle > {
+	async getSelectedBlockElementHandle( blockEditorSelector: string ): Promise< ElementHandle > {
 		const locator = this.frameLocator.locator(
 			`${ editorPane } ${ blockEditorSelector }.is-selected`
 		);

--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -1,6 +1,6 @@
 import { Page, FrameLocator, ElementHandle } from 'playwright';
 
-const editorPane = 'div.block-editor-block-list__layout';
+const editorPane = 'div.edit-post-visual-editor__content-area';
 const selectors = {
 	// Title
 	title: '.editor-post-title__input',

--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -1,0 +1,189 @@
+import { Page, FrameLocator, ElementHandle } from 'playwright';
+
+const editorPane = 'div.block-editor-block-list__layout';
+const selectors = {
+	// Title
+	title: '.editor-post-title__input',
+
+	// Editor body
+	initialBlockAppender: '.block-editor-default-block-appender', // When editor is initially loaded in blank state
+	paragraphBlock: ( empty: boolean ) => `p[data-title="Paragraph"][data-empty="${ empty }"]`,
+	blockWarning: '.block-editor-warning',
+
+	// Block Search
+	blockSearchInput: '.block-editor-inserter__search input[type="search"]',
+	blockResultItem: ( name: string ) =>
+		`.block-editor-block-types-list__list-item span:text("${ name }")`,
+	patternResultItem: ( name: string ) => `div[aria-label="${ name }"]`,
+};
+
+/**
+ * Represents an instance of the Gutenberg Block Editor as loaded on
+ * WordPress.com.
+ */
+export class EditorGutenbergComponent {
+	private page: Page;
+	private frameLocator: FrameLocator;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 * @param {FrameLocator} frameLocator Locator of the editor iframe.
+	 */
+	constructor( page: Page, frameLocator: FrameLocator ) {
+		this.page = page;
+		this.frameLocator = frameLocator;
+	}
+
+	/* Title block */
+
+	/**
+	 * Enters the text into the title block and verifies the result.
+	 *
+	 * @param {string} title Text to be used as the title.
+	 */
+	async enterTitle( title: string ): Promise< void > {
+		const locator = this.frameLocator.locator( selectors.title );
+		await locator.fill( title );
+	}
+
+	/**
+	 * Returns the content of the Page/Post title.
+	 *
+	 * @returns {Promise<string>} String containing contents of the title.
+	 */
+	async getTitle(): Promise< string > {
+		const locator = this.frameLocator.locator( selectors.title );
+		return await locator.innerText();
+	}
+
+	/* Paragraph block shortcuts */
+
+	/**
+	 *
+	 */
+	async resetSelectedBlock(): Promise< void > {
+		const locator = this.frameLocator.locator( selectors.title );
+		await locator.click();
+	}
+
+	/**
+	 * Enters text into the paragraph block(s) and verifies the result.
+	 *
+	 * Note that this method of text entry does not explicitly use the
+	 * ParagraphBlock construct. This is due to text entry being a high
+	 * frequency use case.
+	 *
+	 * @param {string} textArray Array of text to be entered. Each entry is
+	 * treated as individual Paragraph blocks.
+	 */
+	async enterText( textArray: string[] ): Promise< void > {
+		const initialBlockAppenderLocator = this.frameLocator.locator( selectors.initialBlockAppender );
+		const emptyParagraphLocator = this.frameLocator.locator( selectors.paragraphBlock( true ) );
+		if ( await emptyParagraphLocator.count() ) {
+			await emptyParagraphLocator.click();
+		} else {
+			initialBlockAppenderLocator.click();
+		}
+
+		for await ( const line of textArray ) {
+			const locator = this.frameLocator.locator( selectors.paragraphBlock( true ) ).last();
+			await locator.fill( line );
+			await this.page.keyboard.press( 'Enter' );
+		}
+	}
+
+	/**
+	 * Returns the text as entered in the paragraph blocks.
+	 */
+	async getText(): Promise< string[] > {
+		const locator = this.frameLocator.locator( selectors.paragraphBlock( false ) );
+		const enteredText = await locator.allInnerTexts();
+
+		// Extract the textContent of each paragraph block into a list.
+		// Note the special condition for an empty paragraph block, noted below.
+		const sanitizedText = enteredText.filter( async function ( line ) {
+			// Strip out U+FEFF character that can be present even if
+			// a paragraph block is empty.
+			const sanitized = line.replace( /\ufeff/g, '' );
+
+			if ( ! sanitized ) {
+				return;
+			}
+
+			return sanitized;
+		} );
+
+		return sanitizedText;
+	}
+
+	/* Block actions */
+
+	/**
+	 * Searches the Block Inserter for the provided string.
+	 *
+	 * @param {string} text Text to enter into the search input.
+	 */
+	async searchBlockInserter( text: string ): Promise< void > {
+		const locator = this.frameLocator.locator( selectors.blockSearchInput );
+		await locator.fill( text );
+	}
+
+	/**
+	 * Selects the maching result from the block inserter.
+	 *
+	 * By default, this method considers only the Block-type results
+	 * (including Resuable blocks).
+	 * In order to select from Pattern-type results, set the `type`
+	 * optional flag in the parameter to `'pattern'`.
+	 *
+	 * Where mulltiple matches exist (eg. due to partial matching), the first result will be chosen.
+	 */
+	async selectBlockInserterResult(
+		name: string,
+		{ type = 'block' }: { type?: 'block' | 'pattern' } = {}
+	): Promise< void > {
+		let locator;
+
+		if ( type === 'pattern' ) {
+			locator = this.frameLocator.locator( selectors.patternResultItem( name ) );
+		} else {
+			locator = this.frameLocator.locator( selectors.blockResultItem( name ) );
+		}
+		await locator.first().click();
+	}
+
+	/**
+	 *
+	 */
+	async getBlockElementHandle( blockEditorSelector: string ): Promise< ElementHandle > {
+		const locator = this.frameLocator.locator(
+			`${ editorPane } ${ blockEditorSelector }.is-selected`
+		);
+		await locator.waitFor();
+		return ( await locator.elementHandle() ) as ElementHandle;
+	}
+
+	/**
+	 * Remove the block from the editor.
+	 *
+	 * This method requires the handle to the block in question to be passed in as parameter.
+	 *
+	 * @param {ElementHandle} blockHandle ElementHandle of the block to be removed.
+	 */
+	async removeBlock( blockHandle: ElementHandle ): Promise< void > {
+		await blockHandle.press( 'Backspace' );
+	}
+
+	/**
+	 * Checks whether the editor has any block warnings/errors displaying.
+	 *
+	 * @returns {Promise<boolean>} True if there are block warnings/errors.
+	 * False otherwise.
+	 */
+	async editorHasBlockWarning(): Promise< boolean > {
+		const locator = this.frameLocator.locator( selectors.blockWarning );
+		return !! ( await locator.count() );
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
@@ -7,7 +7,7 @@ const selectors = {
 	cancelPublishButton: `${ panel } .editor-post-publish-panel__header-cancel-button > button`,
 
 	// After publishing
-	postPublishClosePanelButton: `${ panel } button[type="button"]:has(svg[aria-hidden="true"])`, // aria-label changes depending on the UI language used.
+	postPublishClosePanelButton: `${ panel } div.editor-post-publish-panel__header > button`, // aria-label changes depending on the UI language used.
 	publishedArticleURL: `${ panel } input[readonly]`,
 };
 
@@ -61,7 +61,7 @@ export class EditorPublishPanelComponent {
 		if ( ! ( await this.panelIsOpen() ) ) {
 			return;
 		}
-		const selector = `${ selectors.cancelPublishButton }, ${ selectors.postPublishClosePanelButton }`;
+		const selector = `${ selectors.cancelPublishButton }:visible, ${ selectors.postPublishClosePanelButton }:visible`;
 		const locator = this.frameLocator.locator( selector );
 		await locator.click();
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -74,6 +74,9 @@ export class EditorToolbarComponent {
 	 * Opens the block inserter.
 	 */
 	async openBlockInserter(): Promise< void > {
+		// const toolbarLocator = this.frameLocator.locator( panel );
+		// await toolbarLocator.click( { position: { x: 100, y: 0 } } );
+
 		if ( ! ( await this.targetIsOpen( selectors.blockInserterButton ) ) ) {
 			const locator = this.frameLocator.locator( selectors.blockInserterButton );
 			await locator.click();

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -74,9 +74,6 @@ export class EditorToolbarComponent {
 	 * Opens the block inserter.
 	 */
 	async openBlockInserter(): Promise< void > {
-		// const toolbarLocator = this.frameLocator.locator( panel );
-		// await toolbarLocator.click( { position: { x: 100, y: 0 } } );
-
 		if ( ! ( await this.targetIsOpen( selectors.blockInserterButton ) ) ) {
 			const locator = this.frameLocator.locator( selectors.blockInserterButton );
 			await locator.click();

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -19,5 +19,6 @@ export * from './popover-block-inserter-component';
 export * from './editor-publish-panel-component';
 export * from './editor-nav-sidebar-component';
 export * from './editor-toolbar-component';
+export * from './editor-gutenberg-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
@@ -26,7 +26,7 @@ export class IsolatedBlockEditorComponent {
 	/**
 	 * Given a block name, insert a matching block to the editor.
 	 *
-	 * This method is nearly identical to the method also named `addBlock` in `GutenbergEditorPage`.
+	 * This method is nearly identical to the method also named `addBlock` in `EditorPage`.
 	 * However, the major distinction is the use of `Page` vs `Frame`.
 	 *
 	 * This is because a P2 frontend (or inline) editor is not a part of an embedded iframe.

--- a/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
@@ -1,6 +1,6 @@
 import { Page } from 'playwright';
 import { NavbarComponent, SidebarComponent } from '../components';
-import { GutenbergEditorPage } from '../pages';
+import { EditorPage } from '../pages';
 
 /**
  * Handles all sorts of flows related to starting a new post.
@@ -30,7 +30,7 @@ export class NewPostFlow {
 		await new SidebarComponent( this.page ).waitForSidebarInitialization();
 		const navbarComponent = new NavbarComponent( this.page );
 		await navbarComponent.clickNewPost();
-		const gutenbergEditorPage = new GutenbergEditorPage( this.page );
-		await gutenbergEditorPage.waitUntilLoaded();
+		const editorPage = new EditorPage( this.page );
+		await editorPage.waitUntilLoaded();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -179,7 +179,7 @@ export class EditorPage {
 				// the Gutenframe, so we return the `mainFrame` to allow the test to access
 				// the editor in the WPAdmin page.
 				console.info( 'Could not locate editor iframe. Returning the top-level frame instead' );
-				return await this.page.mainFrame();
+				return this.page.mainFrame();
 			}
 		}
 	}

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -209,10 +209,10 @@ export class EditorPage {
 	 * @throws {Error} If entered title does not match.
 	 */
 	async enterTitle( title: string ): Promise< void > {
-		const sanitizedTitle = title.trim();
-
 		await this.editorGutenbergComponent.enterTitle( title );
 		const enteredTitle = await this.editorGutenbergComponent.getTitle();
+
+		const sanitizedTitle = title.trim();
 		if ( enteredTitle !== sanitizedTitle ) {
 			throw new Error(
 				`Failed to verify title: got ${ enteredTitle }, expected ${ sanitizedTitle }`
@@ -226,21 +226,20 @@ export class EditorPage {
 	 * @param {string} text Text to be entered into the paragraph blocks, separated by newline characters.
 	 */
 	async enterText( text: string ): Promise< void > {
-		const splitText = text.split( '\n' );
-		await this.editorGutenbergComponent.enterText( splitText );
+		await this.editorGutenbergComponent.enterText( text );
 		const enteredText = await this.editorGutenbergComponent.getText();
 
-		if ( splitText !== enteredText ) {
-			`Failed to verify entered text: got ${ enteredText }, expected ${ splitText }`;
+		if ( text !== enteredText ) {
+			`Failed to verify entered text: got ${ enteredText }, expected ${ text }`;
 		}
 	}
 
 	/**
 	 * Returns the text found in the editor.
 	 *
-	 * @returns {Promise<string[]>} Array of strings representing text entered in each paragraph block.
+	 * @returns {Promise<string>} String representing text entered in each paragraph block.
 	 */
-	async getText(): Promise< string[] > {
+	async getText(): Promise< string > {
 		return await this.editorGutenbergComponent.getText();
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -267,7 +267,7 @@ export class EditorPage {
 		await this.editorGutenbergComponent.searchBlockInserter( blockName );
 		await this.editorGutenbergComponent.selectBlockInserterResult( blockName );
 
-		const blockHandle = await this.editorGutenbergComponent.getBlockElementHandle(
+		const blockHandle = await this.editorGutenbergComponent.getSelectedBlockElementHandle(
 			blockEditorSelector
 		);
 

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -30,7 +30,7 @@ const selectors = {
 /**
  * Represents an instance of the WPCOM's Gutenberg editor page.
  */
-export class GutenbergEditorPage {
+export class EditorPage {
 	private page: Page;
 	private requiresGutenframe: boolean;
 	private frameLocator: FrameLocator;

--- a/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/gutenberg-editor-page.ts
@@ -1,5 +1,4 @@
-import assert from 'assert';
-import { Page, Frame, ElementHandle, Response } from 'playwright';
+import { Page, Frame, ElementHandle, Response, FrameLocator } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 import { reloadAndRetry } from '../../element-helper';
 import envVariables from '../../env-variables';
@@ -8,6 +7,7 @@ import {
 	EditorNavSidebarComponent,
 	EditorToolbarComponent,
 	EditorSettingsSidebarComponent,
+	EditorGutenbergComponent,
 	NavbarComponent,
 } from '../components';
 import type { PreviewOptions, EditorSidebarTab, PrivacyOptions, Schedule } from '../components';
@@ -17,15 +17,7 @@ const selectors = {
 	editorFrame: '.calypsoify.is-iframe iframe.is-loaded',
 	editorTitle: '.editor-post-title__input',
 
-	// Block inserter
-	blockInserterToggle: 'button.edit-post-header-toolbar__inserter-toggle',
-	blockInserterPanel: '.block-editor-inserter__content',
-	blockSearch: '.block-editor-inserter__search input[type="search"]',
-	blockInserterResultItem: '.block-editor-block-types-list__list-item',
-
 	// Within the editor body.
-	blockAppender: '.block-editor-default-block-appender',
-	paragraphBlocks: 'p.block-editor-rich-text__editable',
 	blockWarning: '.block-editor-warning',
 
 	// Toast
@@ -41,10 +33,12 @@ const selectors = {
 export class GutenbergEditorPage {
 	private page: Page;
 	private requiresGutenframe: boolean;
+	private frameLocator: FrameLocator;
 	private editorPublishPanelComponent: EditorPublishPanelComponent;
 	private editorNavSidebarComponent: EditorNavSidebarComponent;
 	private editorToolbarComponent: EditorToolbarComponent;
 	private editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
+	private editorGutenbergComponent: EditorGutenbergComponent;
 
 	/**
 	 * Constructs an instance of the component.
@@ -70,6 +64,7 @@ export class GutenbergEditorPage {
 
 		this.page = page;
 		this.requiresGutenframe = requiresGutenframe;
+		this.frameLocator = page.frameLocator( selectors.editorFrame );
 		this.editorPublishPanelComponent = new EditorPublishPanelComponent(
 			page,
 			page.frameLocator( selectors.editorFrame )
@@ -86,7 +81,13 @@ export class GutenbergEditorPage {
 			page,
 			page.frameLocator( selectors.editorFrame )
 		);
+		this.editorGutenbergComponent = new EditorGutenbergComponent(
+			page,
+			page.frameLocator( selectors.editorFrame )
+		);
 	}
+
+	/* Generic methods */
 
 	/**
 	 * Opens the "new post/page" page. By default it will open the "new post" page.
@@ -112,7 +113,8 @@ export class GutenbergEditorPage {
 		// However, we need a stable way to identify loading being done. NetworkIdle
 		// takes too long here, so the most reliable alternative is the title being
 		// visible.
-		await frame.waitForSelector( selectors.editorTitle );
+		const titleLocator = this.frameLocator.locator( selectors.editorTitle );
+		await titleLocator.waitFor();
 		// Once https://github.com/Automattic/wp-calypso/issues/57660 is resolved,
 		// the next line should be removed.
 		await this.forceDismissWelcomeTour();
@@ -183,114 +185,6 @@ export class GutenbergEditorPage {
 	}
 
 	/**
-	 * Enters the text into the title block and verifies the result.
-	 *
-	 * @param {string} title Text to be used as the title.
-	 * @returns {Promise<void>} No return value.
-	 * @throws {assert.AssertionError} If text entered and text read back do not match.
-	 */
-	async enterTitle( title: string ): Promise< void > {
-		const sanitizedTitle = title.trim();
-		await this.setTitle( sanitizedTitle );
-		const readBack = await this.getTitle();
-		assert.strictEqual( readBack, sanitizedTitle );
-	}
-
-	/**
-	 * Fills the title block with text.
-	 *
-	 * @param {string} title Text to be used as the title.
-	 * @returns {Promise<void>} No return value.
-	 */
-	async setTitle( title: string ): Promise< void > {
-		const frame = await this.getEditorFrame();
-		await frame.click( selectors.editorTitle );
-		await frame.fill( selectors.editorTitle, title );
-	}
-
-	/**
-	 * Returns the text as entered in the title block, or an empty string if
-	 * not found.
-	 *
-	 * @returns {Promise<string>} Text value of the title block.
-	 */
-	async getTitle(): Promise< string > {
-		const frame = await this.getEditorFrame();
-		await frame.waitForSelector( selectors.editorTitle );
-		return ( await frame.$eval( selectors.editorTitle, ( el ) => el.textContent ) ) || '';
-	}
-
-	/**
-	 * Enters text into the paragraph block(s) and verifies the result.
-	 *
-	 * @param {string} text Text to be entered into the paragraph blocks, separated by newline characters.
-	 * @returns {Promise<void>} No return value.
-	 * @throws {assert.AssertionError} If text entered and text read back do not match.
-	 */
-	async enterText( text: string ): Promise< void > {
-		await this.setText( text );
-		const readBack = await this.getText();
-		assert.strictEqual( readBack, text );
-	}
-
-	/**
-	 * Enters text into the body, splitting newlines into new pragraph blocks as necessary.
-	 *
-	 * @param {string} text Text to be entered into the body.
-	 * @returns {Promise<void>} No return value.
-	 */
-	async setText( text: string ): Promise< void > {
-		const frame = await this.getEditorFrame();
-
-		const lines = text.split( '\n' );
-		await frame.click( selectors.blockAppender );
-
-		// Playwright does not break up newlines in Gutenberg. This causes issues when we expect
-		// text to be broken into new lines/blocks. This presents an unexpected issue when entering
-		// text such as 'First sentence\nSecond sentence', as it is all put in one line.
-		// frame.type() will respect newlines like a human would, but it is slow.
-		// This approach will run faster than using frame.type() while respecting the newline chars.
-		await Promise.all(
-			lines.map( async ( line, index ) => {
-				await frame.fill( `${ selectors.paragraphBlocks }:nth-of-type(${ index + 1 })`, line );
-				await this.page.keyboard.press( 'Enter' );
-			} )
-		);
-	}
-
-	/**
-	 * Returns the text as entered in the paragraph blocks.
-	 *
-	 * @returns {string} Visible text in the paragraph blocks, concatenated into one string.
-	 */
-	async getText(): Promise< string > {
-		const frame = await this.getEditorFrame();
-
-		// Each blocks have the same overall selector. This will obtain a list of
-		// blocks that are paragraph type and return an array of ElementHandles.
-		const paragraphBlocks = await frame.$$( selectors.paragraphBlocks );
-
-		// Extract the textContent of each paragraph block into a list.
-		// Note the special condition for an empty paragraph block, noted below.
-		const lines = await Promise.all(
-			paragraphBlocks.map( async function ( block ) {
-				// This U+FEFF character is present in the textContent of an otherwise
-				// empty paragraph block and will evaluate to truthy.
-				const text = String( await block.textContent() ).replace( /\ufeff/g, '' );
-
-				if ( ! text ) {
-					return;
-				}
-
-				return text;
-			} )
-		);
-
-		// Strip out falsey values.
-		return lines.filter( Boolean ).join( '\n' );
-	}
-
-	/**
 	 * Closes all panels that can be opened in the editor.
 	 *
 	 * This method will attempt to close the following panels:
@@ -304,6 +198,50 @@ export class GutenbergEditorPage {
 			this.editorNavSidebarComponent.closeSidebar(),
 			this.editorToolbarComponent.closeSettings(),
 		] );
+	}
+
+	/* Editor */
+
+	/**
+	 * Enters the text into the title block and verifies the result.
+	 *
+	 * @param {string} title Text to be used as the title.
+	 * @throws {Error} If entered title does not match.
+	 */
+	async enterTitle( title: string ): Promise< void > {
+		const sanitizedTitle = title.trim();
+
+		await this.editorGutenbergComponent.enterTitle( title );
+		const enteredTitle = await this.editorGutenbergComponent.getTitle();
+		if ( enteredTitle !== sanitizedTitle ) {
+			throw new Error(
+				`Failed to verify title: got ${ enteredTitle }, expected ${ sanitizedTitle }`
+			);
+		}
+	}
+
+	/**
+	 * Enters text into the body, splitting newlines into new pragraph blocks as necessary. The entered text is then read back and checked.
+	 *
+	 * @param {string} text Text to be entered into the paragraph blocks, separated by newline characters.
+	 */
+	async enterText( text: string ): Promise< void > {
+		const splitText = text.split( '\n' );
+		await this.editorGutenbergComponent.enterText( splitText );
+		const enteredText = await this.editorGutenbergComponent.getText();
+
+		if ( splitText !== enteredText ) {
+			`Failed to verify entered text: got ${ enteredText }, expected ${ splitText }`;
+		}
+	}
+
+	/**
+	 * Returns the text found in the editor.
+	 *
+	 * @returns {Promise<string[]>} Array of strings representing text entered in each paragraph block.
+	 */
+	async getText(): Promise< string[] > {
+		return await this.editorGutenbergComponent.getText();
 	}
 
 	/**
@@ -322,40 +260,27 @@ export class GutenbergEditorPage {
 	 * We recommend using the aria-label for the selector, e.g. '[aria-label="Block: Quote"]'.
 	 *
 	 * @param {string} blockName Name of the block to be inserted.
-	 * @param {string} blockEditorSelector Selector to find the parent block element in the editor.
 	 */
 	async addBlock( blockName: string, blockEditorSelector: string ): Promise< ElementHandle > {
-		const frame = await this.getEditorFrame();
-		// Click on the editor title to work around the following issue:
-		// https://github.com/Automattic/wp-calypso/issues/61508
-		await frame.click( selectors.editorTitle );
-
+		await this.editorGutenbergComponent.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
-		await this.searchBlockInserter( blockName );
-		await frame.click( `${ selectors.blockInserterResultItem } span:text("${ blockName }")` );
-		// Confirm the block has been added to the editor body.
-		const elementHandle = await frame.waitForSelector( `${ blockEditorSelector }.is-selected` );
+		await this.editorGutenbergComponent.searchBlockInserter( blockName );
+		await this.editorGutenbergComponent.selectBlockInserterResult( blockName );
 
-		// Dismiss the block inserter if viewport is larger than mobile to ensure
-		// no interference from the block inserter in subsequent actions on the editor.
+		const blockHandle = await this.editorGutenbergComponent.getBlockElementHandle(
+			blockEditorSelector
+		);
+
+		// Dismiss the block inserter if viewport is larger than mobile to
+		// ensure no interference from the block inserter in subsequent actions on the editor.
 		// In mobile, the block inserter will auto-close.
 		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
 			await this.editorToolbarComponent.closeBlockInserter();
 		}
 
-		return elementHandle;
-	}
-
-	/**
-	 * Remove the block from the editor.
-	 *
-	 * This method requires the handle to the block in question to be passed in as parameter.
-	 *
-	 * @param {ElementHandle} blockHandle ElementHandle of the block to be removed.
-	 */
-	async removeBlock( blockHandle: ElementHandle ): Promise< void > {
-		await blockHandle.click();
-		await this.page.keyboard.press( 'Backspace' );
+		// Return an ElementHandle pointing to the block for compatibility
+		// with existing specs.
+		return blockHandle;
 	}
 
 	/**
@@ -369,22 +294,30 @@ export class GutenbergEditorPage {
 	 *
 	 * @param {string} patternName Name of the pattern to insert.
 	 */
-	async addPattern( patternName: string ): Promise< ElementHandle > {
-		const frame = await this.getEditorFrame();
+	async addPattern( patternName: string ): Promise< void > {
+		await this.editorGutenbergComponent.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
-		await this.searchBlockInserter( patternName );
-		await frame.click( `div[aria-label="${ patternName }"]` );
-		return await frame.waitForSelector( `:text('Block pattern "${ patternName }" inserted.')` );
+		await this.editorGutenbergComponent.searchBlockInserter( patternName );
+		await this.editorGutenbergComponent.selectBlockInserterResult( patternName, {
+			type: 'pattern',
+		} );
+
+		const insertConfirmationToastLocator = this.frameLocator.locator(
+			`.components-snackbar__content:text('Block pattern "${ patternName }" inserted.')`
+		);
+		await insertConfirmationToastLocator.waitFor();
 	}
 
 	/**
-	 * Given a string, enters the said string to the block inserter search bar.
+	 * Remove the block from the editor.
 	 *
-	 * @param {string} text Text to search.
+	 * This method requires the handle to the block in question to be passed in as parameter.
+	 *
+	 * @param {ElementHandle} blockHandle ElementHandle of the block to be removed.
 	 */
-	async searchBlockInserter( text: string ): Promise< void > {
-		const frame = await this.getEditorFrame();
-		await frame.fill( selectors.blockSearch, text );
+	async removeBlock( blockHandle: ElementHandle ): Promise< void > {
+		await blockHandle.click();
+		await this.page.keyboard.press( 'Backspace' );
 	}
 
 	/* Settings Sidebar */
@@ -719,10 +652,10 @@ export class GutenbergEditorPage {
 	/**
 	 * Checks whether the editor has any block warnings/errors displaying.
 	 *
-	 * @returns True if there are block warnings/errors, false otherwise.
+	 * @returns {Promise<boolean>} True if there are block warnings/errors.
+	 * False otherwise.
 	 */
 	async editorHasBlockWarnings(): Promise< boolean > {
-		const frame = await this.getEditorFrame();
-		return await frame.isVisible( selectors.blockWarning );
+		return await this.editorGutenbergComponent.editorHasBlockWarning();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -1,6 +1,6 @@
 export * from './published';
 export * from './login-page';
-export * from './gutenberg-editor-page';
+export * from './editor-page';
 export * from './my-home-page';
 export * from './marketing-page';
 export * from './general-settings-page';

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -32,7 +32,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ), () => {
 	let page: Page;
 	let testAccount: TestAccount;
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: GutenbergEditorPage;
 	let pricingTableBlock: PricingTableBlock;
 	let logoImage: TestFile;
 
@@ -45,17 +45,17 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ), () => {
 		page = await browser.newPage();
 		logoImage = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
 		testAccount = new TestAccount( accountName );
-		gutenbergEditorPage = new GutenbergEditorPage( page );
+		editorPage = new GutenbergEditorPage( page );
 
 		await testAccount.authenticate( page );
 	} );
 
 	it( 'Go to the new post page', async () => {
-		await gutenbergEditorPage.visit( 'post' );
+		await editorPage.visit( 'post' );
 	} );
 
 	it( `Insert ${ PricingTableBlock.blockName } block and enter prices`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock(
+		const blockHandle = await editorPage.addBlock(
 			PricingTableBlock.blockName,
 			PricingTableBlock.blockEditorSelector
 		);
@@ -65,14 +65,11 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ), () => {
 	} );
 
 	it( `Insert ${ DynamicHRBlock.blockName } block`, async function () {
-		await gutenbergEditorPage.addBlock(
-			DynamicHRBlock.blockName,
-			DynamicHRBlock.blockEditorSelector
-		);
+		await editorPage.addBlock( DynamicHRBlock.blockName, DynamicHRBlock.blockEditorSelector );
 	} );
 
 	it( `Insert ${ HeroBlock.blockName } block and enter heading`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock(
+		const blockHandle = await editorPage.addBlock(
 			HeroBlock.blockName,
 			HeroBlock.blockEditorSelector
 		);
@@ -81,7 +78,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ), () => {
 	} );
 
 	it( `Insert ${ ClicktoTweetBlock.blockName } block and enter tweet content`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock(
+		const blockHandle = await editorPage.addBlock(
 			ClicktoTweetBlock.blockName,
 			ClicktoTweetBlock.blockEditorSelector
 		);
@@ -90,7 +87,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ), () => {
 	} );
 
 	it( `Insert ${ LogosBlock.blockName } block and set image`, async function () {
-		const blockHandle = await gutenbergEditorPage.addBlock(
+		const blockHandle = await editorPage.addBlock(
 			LogosBlock.blockName,
 			LogosBlock.blockEditorSelector
 		);
@@ -99,7 +96,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ), () => {
 	} );
 
 	it( 'Publish and visit the post', async function () {
-		await gutenbergEditorPage.publish( { visit: true } );
+		await editorPage.publish( { visit: true } );
 	} );
 
 	// Pass in a 1D array of values or text strings to validate each block.

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -6,7 +6,7 @@ import {
 	envVariables,
 	DataHelper,
 	MediaHelper,
-	GutenbergEditorPage,
+	EditorPage,
 	TestFile,
 	ClicktoTweetBlock,
 	DynamicHRBlock,
@@ -32,7 +32,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ), () => {
 	let page: Page;
 	let testAccount: TestAccount;
-	let editorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 	let pricingTableBlock: PricingTableBlock;
 	let logoImage: TestFile;
 
@@ -45,7 +45,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ), () => {
 		page = await browser.newPage();
 		logoImage = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
 		testAccount = new TestAccount( accountName );
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 
 		await testAccount.authenticate( page );
 	} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -28,7 +28,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), () => {
 	let page: Page;
 	let testAccount: TestAccount;
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: GutenbergEditorPage;
 	let imageFile: TestFile;
 	let coverBlock: CoverBlock;
 
@@ -36,17 +36,17 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), (
 		page = await browser.newPage();
 		imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
 		testAccount = new TestAccount( accountName );
-		gutenbergEditorPage = new GutenbergEditorPage( page );
+		editorPage = new GutenbergEditorPage( page );
 
 		await testAccount.authenticate( page );
 	} );
 
 	it( 'Go to the new post page', async () => {
-		await gutenbergEditorPage.visit( 'post' );
+		await editorPage.visit( 'post' );
 	} );
 
 	it( 'Insert Cover block', async () => {
-		const blockHandle = await gutenbergEditorPage.addBlock(
+		const blockHandle = await editorPage.addBlock(
 			CoverBlock.blockName,
 			CoverBlock.blockEditorSelector
 		);
@@ -57,16 +57,16 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), (
 		await coverBlock.upload( imageFile.fullpath );
 		// After uploading the image the focus is switched to the inner
 		// paragraph block (Cover title), so we need to switch it back outside.
-		const editorFrame = await gutenbergEditorPage.getEditorFrame();
+		const editorFrame = await editorPage.getEditorFrame();
 		await editorFrame.click( '.wp-block-cover', { position: { x: 1, y: 1 } } );
 	} );
 
 	it( 'Open settings sidebar', async function () {
-		await gutenbergEditorPage.openSettings();
+		await editorPage.openSettings();
 	} );
 
 	it.each( CoverBlock.coverStyles )( 'Verify "%s" style is available', async ( style ) => {
-		const editorFrame = await gutenbergEditorPage.getEditorFrame();
+		const editorFrame = await editorPage.getEditorFrame();
 		await editorFrame.waitForSelector( `button[aria-label="${ style }"]` );
 	} );
 
@@ -75,11 +75,11 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), (
 	} );
 
 	it( 'Close settings sidebar', async () => {
-		await gutenbergEditorPage.closeSettings();
+		await editorPage.closeSettings();
 	} );
 
 	it( 'Publish and visit the post', async () => {
-		await gutenbergEditorPage.publish( { visit: true } );
+		await editorPage.publish( { visit: true } );
 	} );
 
 	it( 'Verify the class for "Bottom Wave" style is present', async () => {

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -6,7 +6,7 @@ import {
 	envVariables,
 	DataHelper,
 	MediaHelper,
-	GutenbergEditorPage,
+	EditorPage,
 	TestFile,
 	CoverBlock,
 	TestAccount,
@@ -28,7 +28,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), () => {
 	let page: Page;
 	let testAccount: TestAccount;
-	let editorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 	let imageFile: TestFile;
 	let coverBlock: CoverBlock;
 
@@ -36,7 +36,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), (
 		page = await browser.newPage();
 		imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
 		testAccount = new TestAccount( accountName );
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 
 		await testAccount.authenticate( page );
 	} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -25,23 +25,23 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ), () => {
 	let page: Page;
 	let testAccount: TestAccount;
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: GutenbergEditorPage;
 	let pricingTableBlock: PricingTableBlock;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		testAccount = new TestAccount( accountName );
-		gutenbergEditorPage = new GutenbergEditorPage( page );
+		editorPage = new GutenbergEditorPage( page );
 
 		await testAccount.authenticate( page );
 	} );
 
 	it( 'Go to the new post page', async () => {
-		await gutenbergEditorPage.visit( 'post' );
+		await editorPage.visit( 'post' );
 	} );
 
 	it( 'Insert Pricing Table block', async () => {
-		const blockHandle = await gutenbergEditorPage.addBlock(
+		const blockHandle = await editorPage.addBlock(
 			PricingTableBlock.blockName,
 			PricingTableBlock.blockEditorSelector
 		);
@@ -49,13 +49,13 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ),
 	} );
 
 	it( 'Open settings sidebar', async () => {
-		await gutenbergEditorPage.openSettings();
+		await editorPage.openSettings();
 	} );
 
 	it.each( PricingTableBlock.gutterValues )(
 		'Verify "%s" gutter button is present',
 		async ( value ) => {
-			const editorFrame = await gutenbergEditorPage.getEditorFrame();
+			const editorFrame = await editorPage.getEditorFrame();
 			await editorFrame.waitForSelector( `button[aria-label="${ value }"]` );
 		}
 	);
@@ -65,7 +65,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ),
 	} );
 
 	it( 'Close settings sidebar', async () => {
-		await gutenbergEditorPage.closeSettings();
+		await editorPage.closeSettings();
 	} );
 
 	it( 'Fill the price fields so the block is visible', async () => {
@@ -74,7 +74,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ),
 	} );
 
 	it( 'Publish and visit the post', async () => {
-		await gutenbergEditorPage.publish( { visit: true } );
+		await editorPage.publish( { visit: true } );
 	} );
 
 	it( 'Verify the class for "Huge" gutter is present', async () => {

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -5,7 +5,7 @@
 import {
 	envVariables,
 	DataHelper,
-	GutenbergEditorPage,
+	EditorPage,
 	PricingTableBlock,
 	TestAccount,
 } from '@automattic/calypso-e2e';
@@ -25,13 +25,13 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ), () => {
 	let page: Page;
 	let testAccount: TestAccount;
-	let editorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 	let pricingTableBlock: PricingTableBlock;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		testAccount = new TestAccount( accountName );
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 
 		await testAccount.authenticate( page );
 	} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -28,7 +28,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ), () => {
 	let page: Page;
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: GutenbergEditorPage;
 	let imageBlock: ImageBlock;
 	let imageFile: TestFile;
 	let uploadedImageURL: string;
@@ -37,18 +37,18 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ), 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-		gutenbergEditorPage = new GutenbergEditorPage( page );
+		editorPage = new GutenbergEditorPage( page );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 	} );
 
 	it( 'Go to the new post page', async () => {
-		await gutenbergEditorPage.visit( 'post' );
+		await editorPage.visit( 'post' );
 	} );
 
 	it( `Insert ${ ImageBlock.blockName } block and upload image`, async () => {
-		const blockHandle = await gutenbergEditorPage.addBlock(
+		const blockHandle = await editorPage.addBlock(
 			ImageBlock.blockName,
 			ImageBlock.blockEditorSelector
 		);
@@ -59,7 +59,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ), 
 	} );
 
 	it( `Replace uploaded image`, async () => {
-		const editorFrame = await gutenbergEditorPage.getEditorFrame();
+		const editorFrame = await editorPage.getEditorFrame();
 		await editorFrame.click( 'button:text("Replace")' );
 		await editorFrame.setInputFiles(
 			'.components-form-file-upload input[type="file"]',
@@ -75,7 +75,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ), 
 	} );
 
 	it( 'Publish the post', async () => {
-		await gutenbergEditorPage.publish( { visit: true } );
+		await editorPage.publish( { visit: true } );
 	} );
 
 	it( 'Verify the new image was published', async () => {

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -7,7 +7,7 @@ import {
 	DataHelper,
 	MediaHelper,
 	ElementHelper,
-	GutenbergEditorPage,
+	EditorPage,
 	TestFile,
 	ImageBlock,
 	TestAccount,
@@ -28,7 +28,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ), () => {
 	let page: Page;
-	let editorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 	let imageBlock: ImageBlock;
 	let imageFile: TestFile;
 	let uploadedImageURL: string;
@@ -37,7 +37,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ), 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );

--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -6,7 +6,7 @@
 import {
 	DataHelper,
 	MediaHelper,
-	GutenbergEditorPage,
+	EditorPage,
 	ImageBlock,
 	AudioBlock,
 	FileBlock,
@@ -19,7 +19,7 @@ import { TEST_IMAGE_PATH, TEST_AUDIO_PATH } from '../constants';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
-	let editorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 	let page: Page;
 	let testFiles: {
 		image_modal: TestFile;
@@ -40,7 +40,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		const testAccount = new TestAccount( 'simpleSitePersonalPlanUser' );
 		await testAccount.authenticate( page );
 
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 	} );
 
 	it( 'Go to new post page', async function () {

--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -19,7 +19,7 @@ import { TEST_IMAGE_PATH, TEST_AUDIO_PATH } from '../constants';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: GutenbergEditorPage;
 	let page: Page;
 	let testFiles: {
 		image_modal: TestFile;
@@ -40,20 +40,20 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		const testAccount = new TestAccount( 'simpleSitePersonalPlanUser' );
 		await testAccount.authenticate( page );
 
-		gutenbergEditorPage = new GutenbergEditorPage( page );
+		editorPage = new GutenbergEditorPage( page );
 	} );
 
 	it( 'Go to new post page', async function () {
-		await gutenbergEditorPage.visit( 'post' );
+		await editorPage.visit( 'post' );
 	} );
 
 	it( 'Enter post title', async function () {
-		await gutenbergEditorPage.enterTitle( DataHelper.getRandomPhrase() );
+		await editorPage.enterTitle( DataHelper.getRandomPhrase() );
 	} );
 
 	describe( 'Populate post with media blocks', function () {
 		it( `${ ImageBlock.blockName } block: upload image file with reserved URL characters`, async function () {
-			const blockHandle = await gutenbergEditorPage.addBlock(
+			const blockHandle = await editorPage.addBlock(
 				ImageBlock.blockName,
 				ImageBlock.blockEditorSelector
 			);
@@ -62,7 +62,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		} );
 
 		it( `${ ImageBlock.blockName } block: upload image file using Calypso media modal `, async function () {
-			const blockHandle = await gutenbergEditorPage.addBlock(
+			const blockHandle = await editorPage.addBlock(
 				ImageBlock.blockName,
 				ImageBlock.blockEditorSelector
 			);
@@ -73,7 +73,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		} );
 
 		it( `${ AudioBlock.blockName } block: upload audio file`, async function () {
-			const blockHandle = await gutenbergEditorPage.addBlock(
+			const blockHandle = await editorPage.addBlock(
 				AudioBlock.blockName,
 				AudioBlock.blockEditorSelector
 			);
@@ -82,7 +82,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		} );
 
 		it( `${ FileBlock.blockName } block: upload audio file`, async function () {
-			const blockHandle = await gutenbergEditorPage.addBlock(
+			const blockHandle = await editorPage.addBlock(
 				FileBlock.blockName,
 				FileBlock.blockEditorSelector
 			);
@@ -91,8 +91,8 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		} );
 
 		it( 'Publish and visit post', async function () {
-			await gutenbergEditorPage.saveDraft();
-			await gutenbergEditorPage.publish( { visit: true } );
+			await editorPage.saveDraft();
+			await editorPage.publish( { visit: true } );
 		} );
 	} );
 

--- a/test/e2e/specs/blocks/blocks__smoke-test-across-gb-edge-versions.ts
+++ b/test/e2e/specs/blocks/blocks__smoke-test-across-gb-edge-versions.ts
@@ -15,7 +15,7 @@
  * To avoid any confusion, the tests here will only run if the GUTENBERG_EDGE env
  * var is set.
  */
-import { GutenbergEditorPage, TestAccount, envVariables, skipItIf } from '@automattic/calypso-e2e';
+import { EditorPage, TestAccount, envVariables, skipItIf } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
@@ -26,9 +26,9 @@ describe.each`
 	${ 'Atomic' } | ${ 'gutenbergAtomicSiteEdgeUser' } | ${ 32 }
 `(
 	'Gutenberg Upgrade: Sanity-Check Most Popular Blocks on ($siteType) edge',
-	function ( { accountName, testPostId } ) {
+	function ( { siteType, accountName, testPostId } ) {
 		let page: Page;
-		let gutenbergEditorPage: GutenbergEditorPage;
+		let editorPage: EditorPage;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
@@ -42,15 +42,18 @@ describe.each`
 
 			await page.goto( postURL );
 
-			gutenbergEditorPage = new GutenbergEditorPage( page );
+			editorPage = new EditorPage( page );
 		} );
 
 		// Both block invalidation and crash messages are wrapped by the same `Warning`
 		// component in Gutenberg. If we find at least one warning, then we fail the test.
-		skipItIf( ! envVariables.GUTENBERG_EDGE )( 'will not have any block warnings', async () => {
-			await gutenbergEditorPage.waitUntilLoaded();
+		skipItIf( ! envVariables.GUTENBERG_EDGE )(
+			`Block warnings are not obeserved for ${ siteType }`,
+			async () => {
+				await editorPage.waitUntilLoaded();
 
-			expect( await gutenbergEditorPage.editorHasBlockWarnings() ).toBe( false );
-		} );
+				expect( await editorPage.editorHasBlockWarnings() ).toBe( false );
+			}
+		);
 	}
 );

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -1,7 +1,7 @@
 import {
 	DataHelper,
 	BlockFlow,
-	GutenbergEditorPage,
+	EditorPage,
 	EditorContext,
 	PublishedPostContext,
 	TestAccount,
@@ -19,31 +19,31 @@ declare const browser: Browser;
 export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): void {
 	describe( DataHelper.createSuiteTitle( specName ), function () {
 		let page: Page;
-		let gutenbergEditorPage: GutenbergEditorPage;
+		let editorPage: EditorPage;
 		let editorContext: EditorContext;
 		let publishedPostContext: PublishedPostContext;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
-			gutenbergEditorPage = new GutenbergEditorPage( page );
+			editorPage = new EditorPage( page );
 			const testAccount = new TestAccount( 'gutenbergSimpleSiteUser' );
 			await testAccount.authenticate( page );
 		} );
 
 		it( 'Go to the new post page', async () => {
-			await gutenbergEditorPage.visit( 'post' );
+			await editorPage.visit( 'post' );
 		} );
 
 		describe( 'Add and configure blocks in the editor', function () {
 			for ( const blockFlow of blockFlows ) {
 				it( `${ blockFlow.blockSidebarName }: Add the block from the sidebar`, async function () {
-					const blockHandle = await gutenbergEditorPage.addBlock(
+					const blockHandle = await editorPage.addBlock(
 						blockFlow.blockSidebarName,
 						blockFlow.blockEditorSelector
 					);
 					editorContext = {
 						page: page,
-						editorIframe: await gutenbergEditorPage.getEditorFrame(),
+						editorIframe: await editorPage.getEditorFrame(),
 						blockHandle: blockHandle,
 					};
 				} );
@@ -55,14 +55,14 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 				} );
 
 				it( `${ blockFlow.blockSidebarName }: There are no block warnings or errors in the editor`, async function () {
-					expect( await gutenbergEditorPage.editorHasBlockWarnings() ).toBe( false );
+					expect( await editorPage.editorHasBlockWarnings() ).toBe( false );
 				} );
 			}
 		} );
 
 		describe( 'Publishing the post', function () {
 			it( 'Publish and visit post', async function () {
-				await gutenbergEditorPage.publish( { visit: true } );
+				await editorPage.publish( { visit: true } );
 				publishedPostContext = {
 					page: page,
 				};

--- a/test/e2e/specs/editor/editor__navbar.ts
+++ b/test/e2e/specs/editor/editor__navbar.ts
@@ -10,21 +10,21 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
 	let page: Page;
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: GutenbergEditorPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		gutenbergEditorPage = new GutenbergEditorPage( page );
+		editorPage = new GutenbergEditorPage( page );
 
 		const testAccount = new TestAccount( 'simpleSitePersonalPlanUser' );
 		await testAccount.authenticate( page );
 	} );
 
 	it( 'Go to the new post page', async function () {
-		await gutenbergEditorPage.visit( 'post' );
+		await editorPage.visit( 'post' );
 	} );
 
 	it( 'Return to Calypso dashboard', async function () {
-		await gutenbergEditorPage.exitEditor();
+		await editorPage.exitEditor();
 	} );
 } );

--- a/test/e2e/specs/editor/editor__navbar.ts
+++ b/test/e2e/specs/editor/editor__navbar.ts
@@ -3,18 +3,18 @@
  * @group calypso-pr
  */
 
-import { DataHelper, GutenbergEditorPage, TestAccount } from '@automattic/calypso-e2e';
+import { DataHelper, EditorPage, TestAccount } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
 	let page: Page;
-	let editorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 
 		const testAccount = new TestAccount( 'simpleSitePersonalPlanUser' );
 		await testAccount.authenticate( page );

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -21,7 +21,7 @@ const customUrlSlug = `about-${ DataHelper.getTimestamp() }-${ DataHelper.getRan
 
 describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
 	let page: Page;
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: GutenbergEditorPage;
 	let editorIframe: Frame;
 	let pagesPage: PagesPage;
 	let publishedUrl: URL;
@@ -46,9 +46,9 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Select page template', async function () {
-		gutenbergEditorPage = new GutenbergEditorPage( page );
+		editorPage = new GutenbergEditorPage( page );
 		// @TODO Consider moving this to GutenbergEditorPage.
-		editorIframe = await gutenbergEditorPage.waitUntilLoaded();
+		editorIframe = await editorPage.waitUntilLoaded();
 		const pageTemplateModalComponent = new PageTemplateModalComponent( editorIframe, page );
 		await pageTemplateModalComponent.selectTemplateCatagory( pageTemplateCategory );
 		await pageTemplateModalComponent.selectTemplate( pageTemplateLable );
@@ -60,20 +60,20 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Open setting sidebar', async function () {
-		await gutenbergEditorPage.openSettings();
+		await editorPage.openSettings();
 	} );
 
 	it( 'Set custom URL slug', async function () {
-		await gutenbergEditorPage.setURLSlug( customUrlSlug );
+		await editorPage.setURLSlug( customUrlSlug );
 	} );
 
 	// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional.
 	it( 'Close settings sidebar', async function () {
-		await gutenbergEditorPage.closeSettings();
+		await editorPage.closeSettings();
 	} );
 
 	it( 'Publish page', async function () {
-		publishedUrl = await gutenbergEditorPage.publish( { visit: true } );
+		publishedUrl = await editorPage.publish( { visit: true } );
 	} );
 
 	it( 'Published URL contains the custom URL slug', async function () {

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -1,7 +1,7 @@
 import {
 	DataHelper,
 	envVariables,
-	GutenbergEditorPage,
+	EditorPage,
 	PublishedPostPage,
 	TestAccount,
 	PagesPage,
@@ -21,7 +21,7 @@ const customUrlSlug = `about-${ DataHelper.getTimestamp() }-${ DataHelper.getRan
 
 describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
 	let page: Page;
-	let editorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 	let editorIframe: Frame;
 	let pagesPage: PagesPage;
 	let publishedUrl: URL;
@@ -46,8 +46,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Select page template', async function () {
-		editorPage = new GutenbergEditorPage( page );
-		// @TODO Consider moving this to GutenbergEditorPage.
+		editorPage = new EditorPage( page );
+		// @TODO Consider moving this to EditorPage.
 		editorIframe = await editorPage.waitUntilLoaded();
 		const pageTemplateModalComponent = new PageTemplateModalComponent( editorIframe, page );
 		await pageTemplateModalComponent.selectTemplateCatagory( pageTemplateCategory );
@@ -55,7 +55,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Template content loads into editor', async function () {
-		// @TODO Consider moving this to GutenbergEditorPage.
+		// @TODO Consider moving this to EditorPage.
 		await editorIframe.waitForSelector( `text=${ expectedTemplateText }` );
 	} );
 

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -5,7 +5,7 @@
 
 import {
 	DataHelper,
-	GutenbergEditorPage,
+	EditorPage,
 	envVariables,
 	TestAccount,
 	PostsPage,
@@ -25,7 +25,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 	const additionalContent = 'Updated post content';
 
 	let page: Page;
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 	let postsPage: PostsPage;
 	let paragraphBlock: ParagraphBlock;
 	let postURL: URL;
@@ -43,12 +43,12 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 
 	describe( 'Publish post', function () {
 		it( 'Enter post title', async function () {
-			gutenbergEditorPage = new GutenbergEditorPage( page );
-			await gutenbergEditorPage.enterTitle( postTitle );
+			editorPage = new EditorPage( page );
+			await editorPage.enterTitle( postTitle );
 		} );
 
 		it( 'Enter post content', async function () {
-			const blockHandle = await gutenbergEditorPage.addBlock(
+			const blockHandle = await editorPage.addBlock(
 				ParagraphBlock.blockName,
 				ParagraphBlock.blockEditorSelector
 			);
@@ -57,7 +57,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 		} );
 
 		it( 'Publish post', async function () {
-			postURL = await gutenbergEditorPage.publish();
+			postURL = await editorPage.publish();
 			expect( postURL.href ).toBeDefined();
 		} );
 
@@ -80,12 +80,12 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 		} );
 
 		it( 'Editor is shown', async function () {
-			gutenbergEditorPage = new GutenbergEditorPage( page );
-			await gutenbergEditorPage.waitUntilLoaded();
+			editorPage = new EditorPage( page );
+			await editorPage.waitUntilLoaded();
 		} );
 
 		it( 'Append additional content', async function () {
-			const blockHandle = await gutenbergEditorPage.addBlock(
+			const blockHandle = await editorPage.addBlock(
 				ParagraphBlock.blockName,
 				ParagraphBlock.blockEditorSelector
 			);
@@ -94,7 +94,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 		} );
 
 		it( 'Publish post', async function () {
-			postURL = await gutenbergEditorPage.publish();
+			postURL = await editorPage.publish();
 		} );
 
 		it( 'Published post contains additional post content', async function () {
@@ -111,7 +111,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 
 	describe( 'Revert post to draft', function () {
 		it( 'Switch to draft', async function () {
-			await gutenbergEditorPage.unpublish();
+			await editorPage.unpublish();
 		} );
 
 		it( 'Post is no longer visible', async function () {

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -22,7 +22,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
 	let page: Page;
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: GutenbergEditorPage;
 	let publishedPostPage: PublishedPostPage;
 	const accountName = envVariables.GUTENBERG_EDGE
 		? 'gutenbergSimpleSiteEdgeUser'
@@ -30,23 +30,23 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		gutenbergEditorPage = new GutenbergEditorPage( page );
+		editorPage = new GutenbergEditorPage( page );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 	} );
 
 	it( 'Go to the new post page', async function () {
-		await gutenbergEditorPage.visit( 'post' );
+		await editorPage.visit( 'post' );
 	} );
 
 	describe( 'Blocks', function () {
 		it( 'Enter post title', async function () {
-			await gutenbergEditorPage.enterTitle( title );
+			await editorPage.enterTitle( title );
 		} );
 
 		it( 'Enter post text', async function () {
-			await gutenbergEditorPage.enterText( quote );
+			await editorPage.enterText( quote );
 		} );
 	} );
 
@@ -54,21 +54,21 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		const patternName = 'About Me';
 
 		it( `Add ${ patternName } pattern`, async function () {
-			await gutenbergEditorPage.addPattern( patternName );
+			await editorPage.addPattern( patternName );
 		} );
 	} );
 
 	describe( 'Categories and Tags', function () {
 		it( 'Open settings', async function () {
-			await gutenbergEditorPage.openSettings();
+			await editorPage.openSettings();
 		} );
 
 		it( 'Add post category', async function () {
-			await gutenbergEditorPage.selectCategory( category );
+			await editorPage.selectCategory( category );
 		} );
 
 		it( 'Add post tag', async function () {
-			await gutenbergEditorPage.addTag( tag );
+			await editorPage.addTag( tag );
 		} );
 	} );
 
@@ -77,14 +77,14 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional.
 		it( 'Close settings sidebar', async function () {
-			await gutenbergEditorPage.closeSettings();
+			await editorPage.closeSettings();
 		} );
 
 		it( 'Launch preview', async function () {
 			if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-				previewPage = await gutenbergEditorPage.previewAsMobile();
+				previewPage = await editorPage.previewAsMobile();
 			} else {
-				await gutenbergEditorPage.previewAsDesktop( 'Mobile' );
+				await editorPage.previewAsDesktop( 'Mobile' );
 			}
 		} );
 
@@ -94,19 +94,19 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 				await previewPage.close();
 			} else {
 				// Desktop path - restore the Desktop view.
-				await gutenbergEditorPage.closePreview();
+				await editorPage.closePreview();
 			}
 		} );
 
 		// Step skipped for mobile, since previewing naturally saves the post, rendering this step unnecessary.
 		skipItIf( envVariables.VIEWPORT_NAME === 'mobile' )( 'Save draft', async function () {
-			await gutenbergEditorPage.saveDraft();
+			await editorPage.saveDraft();
 		} );
 	} );
 
 	describe( 'Publish', function () {
 		it( 'Publish and visit post', async function () {
-			const publishedURL: URL = await gutenbergEditorPage.publish( { visit: true } );
+			const publishedURL: URL = await editorPage.publish( { visit: true } );
 			expect( publishedURL.href ).toStrictEqual( page.url() );
 		} );
 

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -4,7 +4,7 @@
 
 import {
 	DataHelper,
-	GutenbergEditorPage,
+	EditorPage,
 	PublishedPostPage,
 	skipItIf,
 	TestAccount,
@@ -22,7 +22,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
 	let page: Page;
-	let editorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 	let publishedPostPage: PublishedPostPage;
 	const accountName = envVariables.GUTENBERG_EDGE
 		? 'gutenbergSimpleSiteEdgeUser'
@@ -30,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -64,6 +64,6 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 		await revisionsComponent.clickButton( 'Load' );
 
 		const text = await gutenbergEditorPage.getText();
-		expect( text ).toEqual( 'Revision 1' );
+		expect( text.join( '\n' ) ).toEqual( 'Revision 1' );
 	} );
 } );

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -19,7 +19,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 	const accountName = envVariables.GUTENBERG_EDGE
 		? 'gutenbergSimpleSiteEdgeUser'
 		: 'simpleSitePersonalPlanUser';
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: GutenbergEditorPage;
 	let revisionsComponent: RevisionsComponent;
 	let page: Page;
 
@@ -31,26 +31,26 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 	} );
 
 	it( 'Go to the new post page', async function () {
-		gutenbergEditorPage = new GutenbergEditorPage( page );
-		await gutenbergEditorPage.visit( 'post' );
+		editorPage = new GutenbergEditorPage( page );
+		await editorPage.visit( 'post' );
 	} );
 
 	it.each( [ { revision: 1 }, { revision: 2 }, { revision: 3 } ] )(
 		'Create revision $revision',
 		async function ( { revision } ) {
-			const blockHandle = await gutenbergEditorPage.addBlock(
+			const blockHandle = await editorPage.addBlock(
 				ParagraphBlock.blockName,
 				ParagraphBlock.blockEditorSelector
 			);
 			const paragraphBlock = new ParagraphBlock( blockHandle );
 			await paragraphBlock.enterParagraph( `Revision ${ revision }` );
-			await gutenbergEditorPage.saveDraft();
+			await editorPage.saveDraft();
 		}
 	);
 
 	it( 'View revisions', async function () {
-		await gutenbergEditorPage.openSettings();
-		await gutenbergEditorPage.viewRevisions();
+		await editorPage.openSettings();
+		await editorPage.viewRevisions();
 	} );
 
 	it( 'Revision 1 displays expected diff', async function () {
@@ -63,7 +63,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 		revisionsComponent = new RevisionsComponent( page );
 		await revisionsComponent.clickButton( 'Load' );
 
-		const text = await gutenbergEditorPage.getText();
+		const text = await editorPage.getText();
 		expect( text.join( '\n' ) ).toEqual( 'Revision 1' );
 	} );
 } );

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -7,7 +7,7 @@ import {
 	DataHelper,
 	TestAccount,
 	envVariables,
-	GutenbergEditorPage,
+	EditorPage,
 	RevisionsComponent,
 	ParagraphBlock,
 } from '@automattic/calypso-e2e';
@@ -19,7 +19,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 	const accountName = envVariables.GUTENBERG_EDGE
 		? 'gutenbergSimpleSiteEdgeUser'
 		: 'simpleSitePersonalPlanUser';
-	let editorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 	let revisionsComponent: RevisionsComponent;
 	let page: Page;
 
@@ -31,7 +31,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 	} );
 
 	it( 'Go to the new post page', async function () {
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 		await editorPage.visit( 'post' );
 	} );
 

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -64,6 +64,6 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 		await revisionsComponent.clickButton( 'Load' );
 
 		const text = await editorPage.getText();
-		expect( text.join( '\n' ) ).toEqual( 'Revision 1' );
+		expect( text ).toEqual( 'Revision 1' );
 	} );
 } );

--- a/test/e2e/specs/editor/editor__schedule.ts
+++ b/test/e2e/specs/editor/editor__schedule.ts
@@ -20,7 +20,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 	const postTitle = `Scheduled Post: ${ DataHelper.getTimestamp() }`;
 	const postContent = DataHelper.getRandomPhrase();
 	let postURL: URL;
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: GutenbergEditorPage;
 	let page: Page;
 
 	beforeAll( async function () {
@@ -31,29 +31,29 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 	} );
 
 	it( 'Go to the new post page', async function () {
-		gutenbergEditorPage = new GutenbergEditorPage( page );
-		await gutenbergEditorPage.visit( 'post' );
+		editorPage = new GutenbergEditorPage( page );
+		await editorPage.visit( 'post' );
 	} );
 
 	it( 'Enter page title', async function () {
-		gutenbergEditorPage = new GutenbergEditorPage( page );
-		await gutenbergEditorPage.enterTitle( postTitle );
+		editorPage = new GutenbergEditorPage( page );
+		await editorPage.enterTitle( postTitle );
 	} );
 
 	it( 'Enter page content', async function () {
-		await gutenbergEditorPage.enterText( postContent );
+		await editorPage.enterText( postContent );
 	} );
 
 	describe( 'Schedule: future', function () {
 		it( 'Open settings', async function () {
-			await gutenbergEditorPage.openSettings();
+			await editorPage.openSettings();
 		} );
 
 		it( 'Schedule the post for next year', async function () {
 			const date = new Date();
 			date.setUTCFullYear( date.getFullYear() + 1 );
 
-			await gutenbergEditorPage.schedule( {
+			await editorPage.schedule( {
 				year: date.getUTCFullYear(),
 				month: date.getUTCMonth(),
 				date: date.getUTCDate(),
@@ -63,12 +63,12 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 			} );
 			// On mobile, the sidebar covers all of the screen.
 			// Dismiss it so publish buttons are available.
-			await gutenbergEditorPage.closeSettings();
+			await editorPage.closeSettings();
 		} );
 
 		it( 'Publish post', async function () {
-			postURL = await gutenbergEditorPage.publish();
-			await gutenbergEditorPage.closeAllPanels();
+			postURL = await editorPage.publish();
+			await editorPage.closeAllPanels();
 		} );
 
 		it( `View post as ${ accountName }`, async function () {
@@ -97,14 +97,14 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 
 	describe( 'Schedule: past', function () {
 		it( 'Open settings', async function () {
-			await gutenbergEditorPage.openSettings();
+			await editorPage.openSettings();
 		} );
 
 		it( 'Schedule post to fist of the current month of last year', async function () {
 			const date = new Date();
 			date.setUTCFullYear( date.getUTCFullYear() - 1 );
 
-			await gutenbergEditorPage.schedule( {
+			await editorPage.schedule( {
 				year: date.getUTCFullYear(),
 				date: 1,
 				month: date.getUTCMonth(),
@@ -114,11 +114,11 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 			} );
 			// On mobile, the sidebar covers all of the screen.
 			// Dismiss it so publish buttons are available.
-			await gutenbergEditorPage.closeSettings();
+			await editorPage.closeSettings();
 		} );
 
 		it( 'Publish post', async function () {
-			postURL = await gutenbergEditorPage.publish();
+			postURL = await editorPage.publish();
 		} );
 
 		it.each( [ 'public', accountName, 'defaultUser' ] )(

--- a/test/e2e/specs/editor/editor__schedule.ts
+++ b/test/e2e/specs/editor/editor__schedule.ts
@@ -6,7 +6,7 @@ import {
 	DataHelper,
 	TestAccount,
 	envVariables,
-	GutenbergEditorPage,
+	EditorPage,
 	PublishedPostPage,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
@@ -20,7 +20,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 	const postTitle = `Scheduled Post: ${ DataHelper.getTimestamp() }`;
 	const postContent = DataHelper.getRandomPhrase();
 	let postURL: URL;
-	let editorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 	let page: Page;
 
 	beforeAll( async function () {
@@ -31,12 +31,12 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 	} );
 
 	it( 'Go to the new post page', async function () {
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 		await editorPage.visit( 'post' );
 	} );
 
 	it( 'Enter page title', async function () {
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 		await editorPage.enterTitle( postTitle );
 	} );
 

--- a/test/e2e/specs/editor/shared/privacy-testing.ts
+++ b/test/e2e/specs/editor/shared/privacy-testing.ts
@@ -1,6 +1,6 @@
 import {
 	DataHelper,
-	GutenbergEditorPage,
+	EditorPage,
 	TestAccount,
 	envVariables,
 	PrivacyOptions,
@@ -30,7 +30,7 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 
 		let page: Page;
 		let url: URL;
-		let gutenbergEditorPage: GutenbergEditorPage;
+		let editorPage: EditorPage;
 
 		describe( `Create a ${ visibility } page`, function () {
 			beforeAll( async function () {
@@ -41,39 +41,37 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 			} );
 
 			it( 'Start new page', async function () {
-				gutenbergEditorPage = new GutenbergEditorPage( page );
-				await gutenbergEditorPage.visit( 'page' );
-				const editorIframe = await gutenbergEditorPage.waitUntilLoaded();
+				editorPage = new EditorPage( page );
+				await editorPage.visit( 'page' );
+				const editorIframe = await editorPage.waitUntilLoaded();
 				const pageTemplateModalComponent = new PageTemplateModalComponent( editorIframe, page );
 				await pageTemplateModalComponent.selectBlankPage();
 			} );
 
 			it( 'Enter page title', async function () {
-				gutenbergEditorPage = new GutenbergEditorPage( page );
-				await gutenbergEditorPage.enterTitle(
-					`Privacy: ${ visibility } - ${ DataHelper.getTimestamp() }`
-				);
+				editorPage = new EditorPage( page );
+				await editorPage.enterTitle( `Privacy: ${ visibility } - ${ DataHelper.getTimestamp() }` );
 			} );
 
 			it( 'Enter page content', async function () {
-				await gutenbergEditorPage.enterText( pageContent );
+				await editorPage.enterText( pageContent );
 			} );
 
 			it( `Set page visibility to ${ visibility }`, async function () {
-				await gutenbergEditorPage.openSettings();
-				await gutenbergEditorPage.setArticleVisibility( visibility as PrivacyOptions, {
+				await editorPage.openSettings();
+				await editorPage.setArticleVisibility( visibility as PrivacyOptions, {
 					password: pagePassword,
 				} );
-				await gutenbergEditorPage.closeSettings();
+				await editorPage.closeSettings();
 			} );
 
 			it( 'Publish page', async function () {
 				// Private articles are published immediately as the option is selected.
 				// In other words, for Private articles the publish action happened in previous step.
 				if ( visibility === 'Private' ) {
-					url = await gutenbergEditorPage.getPublishedURLFromToast();
+					url = await editorPage.getPublishedURLFromToast();
 				} else {
-					url = await gutenbergEditorPage.publish();
+					url = await editorPage.publish();
 				}
 			} );
 		} );

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -215,7 +215,7 @@ describe( 'I18N: Editor', function () {
 		( envVariables.TEST_LOCALES as ReadonlyArray< string > ).includes( locale )
 	);
 	let page: Page;
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: GutenbergEditorPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
@@ -229,7 +229,7 @@ describe( 'I18N: Editor', function () {
 		const testAccount = new TestAccount( 'i18nUser' );
 		await testAccount.authenticate( page );
 
-		gutenbergEditorPage = new GutenbergEditorPage( page );
+		editorPage = new GutenbergEditorPage( page );
 	} );
 
 	describe.each( locales )( `Locale: %s`, function ( locale ) {
@@ -250,7 +250,7 @@ describe( 'I18N: Editor', function () {
 			} );
 
 			it( 'Go to the new post page', async function () {
-				await gutenbergEditorPage.visit( 'post' );
+				await editorPage.visit( 'post' );
 			} );
 		} );
 
@@ -259,17 +259,17 @@ describe( 'I18N: Editor', function () {
 			( ...args ) => {
 				const block = args[ 0 ]; // Makes TS stop complaining about incompatible args type
 				let frame: Frame;
-				let gutenbergEditorPage: GutenbergEditorPage;
+				let editorPage: GutenbergEditorPage;
 
 				const blockTimeout = 10 * 1000;
 
 				it( 'Insert test block', async function () {
-					gutenbergEditorPage = new GutenbergEditorPage( page );
-					await gutenbergEditorPage.addBlock( block.blockName, block.blockEditorSelector );
+					editorPage = new GutenbergEditorPage( page );
+					await editorPage.addBlock( block.blockName, block.blockEditorSelector );
 				} );
 
 				it( 'Render block content translations', async function () {
-					frame = await gutenbergEditorPage.getEditorFrame();
+					frame = await editorPage.getEditorFrame();
 					// Ensure block contents are translated as expected.
 					await Promise.all(
 						block.blockEditorContent.map( ( content: any ) =>
@@ -281,7 +281,7 @@ describe( 'I18N: Editor', function () {
 				} );
 
 				it( 'Render block title translations', async function () {
-					await gutenbergEditorPage.openSettings();
+					await editorPage.openSettings();
 					await frame.click( block.blockEditorSelector );
 
 					// Ensure the block is highlighted.

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -5,7 +5,7 @@
 import {
 	ChangeUILanguageFlow,
 	DataHelper,
-	GutenbergEditorPage,
+	EditorPage,
 	TestAccount,
 	envVariables,
 } from '@automattic/calypso-e2e';
@@ -215,7 +215,7 @@ describe( 'I18N: Editor', function () {
 		( envVariables.TEST_LOCALES as ReadonlyArray< string > ).includes( locale )
 	);
 	let page: Page;
-	let editorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
@@ -229,7 +229,7 @@ describe( 'I18N: Editor', function () {
 		const testAccount = new TestAccount( 'i18nUser' );
 		await testAccount.authenticate( page );
 
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 	} );
 
 	describe.each( locales )( `Locale: %s`, function ( locale ) {
@@ -259,12 +259,12 @@ describe( 'I18N: Editor', function () {
 			( ...args ) => {
 				const block = args[ 0 ]; // Makes TS stop complaining about incompatible args type
 				let frame: Frame;
-				let editorPage: GutenbergEditorPage;
+				let editorPage: EditorPage;
 
 				const blockTimeout = 10 * 1000;
 
 				it( 'Insert test block', async function () {
-					editorPage = new GutenbergEditorPage( page );
+					editorPage = new EditorPage( page );
 					await editorPage.addBlock( block.blockName, block.blockEditorSelector );
 				} );
 

--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -18,19 +18,19 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 		: 'gutenbergSimpleSiteUser';
 
 	let page: Page;
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: GutenbergEditorPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		gutenbergEditorPage = new GutenbergEditorPage( page );
+		editorPage = new GutenbergEditorPage( page );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 	} );
 
 	it( 'Go to the new post page', async function () {
-		gutenbergEditorPage = new GutenbergEditorPage( page );
-		await gutenbergEditorPage.visit( 'post' );
+		editorPage = new GutenbergEditorPage( page );
+		await editorPage.visit( 'post' );
 	} );
 
 	it.each( [
@@ -41,7 +41,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 	] )(
 		'Experimental package %s and feature %s are available',
 		async function ( packageName, feature, featureType ) {
-			const frame = await gutenbergEditorPage.getEditorFrame();
+			const frame = await editorPage.getEditorFrame();
 			const packageAvailable = await frame.evaluate( `typeof window[ "wp" ]["${ packageName }"]` );
 
 			expect( packageAvailable ).not.toStrictEqual( 'undefined' );
@@ -58,7 +58,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 	);
 
 	it( 'Experimental data is available', async function () {
-		const frame = await gutenbergEditorPage.getEditorFrame();
+		const frame = await editorPage.getEditorFrame();
 		const blockPatterns = await frame.evaluate(
 			`Array.isArray( window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns )`
 		);
@@ -78,7 +78,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 		// patterns will be added than removed. This also means if we see a dramatic
 		// change in the number to the lower end, then something is probably wrong.
 		const expectedBlockPatternCount = 50;
-		const frame = await gutenbergEditorPage.getEditorFrame();
+		const frame = await editorPage.getEditorFrame();
 		const actualBlockPatternCount = await frame.evaluate(
 			`window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns.length`
 		);

--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -2,12 +2,7 @@
  * @group gutenberg
  */
 
-import {
-	envVariables,
-	TestAccount,
-	DataHelper,
-	GutenbergEditorPage,
-} from '@automattic/calypso-e2e';
+import { envVariables, TestAccount, DataHelper, EditorPage } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
@@ -18,18 +13,18 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 		: 'gutenbergSimpleSiteUser';
 
 	let page: Page;
-	let editorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 	} );
 
 	it( 'Go to the new post page', async function () {
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 		await editorPage.visit( 'post' );
 	} );
 

--- a/test/e2e/specs/onboarding/gutenboarding__happy-path.ts
+++ b/test/e2e/specs/onboarding/gutenboarding__happy-path.ts
@@ -6,7 +6,7 @@ import {
 	DataHelper,
 	CloseAccountFlow,
 	GutenboardingFlow,
-	GutenbergEditorPage,
+	EditorPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser, Frame } from 'playwright';
 
@@ -73,7 +73,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 			await page.waitForURL( /.*\/site-editor\/.*/, { waitUntil: 'networkidle' } );
 
 			// {@TODO} This is temporary while the FSE spec is awaiting migration to Playwright.
-			const editorPage = new GutenbergEditorPage( page );
+			const editorPage = new EditorPage( page );
 			await editorPage.forceDismissWelcomeTour();
 			const outerFrame = await editorPage.getEditorFrame();
 

--- a/test/e2e/specs/onboarding/gutenboarding__happy-path.ts
+++ b/test/e2e/specs/onboarding/gutenboarding__happy-path.ts
@@ -73,9 +73,9 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 			await page.waitForURL( /.*\/site-editor\/.*/, { waitUntil: 'networkidle' } );
 
 			// {@TODO} This is temporary while the FSE spec is awaiting migration to Playwright.
-			const gutenbergEditorPage = new GutenbergEditorPage( page );
-			await gutenbergEditorPage.forceDismissWelcomeTour();
-			const outerFrame = await gutenbergEditorPage.getEditorFrame();
+			const editorPage = new GutenbergEditorPage( page );
+			await editorPage.forceDismissWelcomeTour();
+			const outerFrame = await editorPage.getEditorFrame();
 
 			// There's another iframe within the parent iframe.
 			const innerFrame = ( await (

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -5,7 +5,7 @@
 import {
 	DataHelper,
 	DomainSearchComponent,
-	GutenbergEditorPage,
+	EditorPage,
 	LoginPage,
 	UserSignupPage,
 	SignupPickPlanPage,
@@ -41,7 +41,7 @@ skipDescribeIf( isStagingOrProd )(
 
 		let page: Page;
 		let domainSearchComponent: DomainSearchComponent;
-		let editorPage: GutenbergEditorPage;
+		let editorPage: EditorPage;
 		let startSiteFlow: StartSiteFlow;
 		let generalSettingsPage: GeneralSettingsPage;
 
@@ -120,7 +120,7 @@ skipDescribeIf( isStagingOrProd )(
 
 		describe( 'Validate site metadata', function () {
 			it( 'Return to Calypso dashboard', async function () {
-				editorPage = new GutenbergEditorPage( page );
+				editorPage = new EditorPage( page );
 				await editorPage.exitEditor();
 			} );
 

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -41,7 +41,7 @@ skipDescribeIf( isStagingOrProd )(
 
 		let page: Page;
 		let domainSearchComponent: DomainSearchComponent;
-		let gutenbergEditorPage: GutenbergEditorPage;
+		let editorPage: GutenbergEditorPage;
 		let startSiteFlow: StartSiteFlow;
 		let generalSettingsPage: GeneralSettingsPage;
 
@@ -120,8 +120,8 @@ skipDescribeIf( isStagingOrProd )(
 
 		describe( 'Validate site metadata', function () {
 			it( 'Return to Calypso dashboard', async function () {
-				gutenbergEditorPage = new GutenbergEditorPage( page );
-				await gutenbergEditorPage.exitEditor();
+				editorPage = new GutenbergEditorPage( page );
+				await editorPage.exitEditor();
 			} );
 
 			it( 'Navigate to settings', async function () {

--- a/test/e2e/specs/published-content/likes__comment.ts
+++ b/test/e2e/specs/published-content/likes__comment.ts
@@ -2,12 +2,7 @@
  * @group gutenberg
  */
 
-import {
-	DataHelper,
-	CommentsComponent,
-	GutenbergEditorPage,
-	TestAccount,
-} from '@automattic/calypso-e2e';
+import { DataHelper, CommentsComponent, EditorPage, TestAccount } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
 const quote =
@@ -20,11 +15,11 @@ describe( DataHelper.createSuiteTitle( 'Likes (Comment) ' ), function () {
 	let page: Page;
 	let publishedURL: URL;
 	let commentsComponent: CommentsComponent;
-	let editorPage: GutenbergEditorPage;
+	let editorPage: EditorPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 
 		const testAccount = new TestAccount( 'simpleSitePersonalPlanUser' );
 		await testAccount.authenticate( page );
@@ -35,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Comment) ' ), function () {
 	} );
 
 	it( 'Enter post title', async function () {
-		editorPage = new GutenbergEditorPage( page );
+		editorPage = new EditorPage( page );
 		const title = DataHelper.getRandomPhrase();
 		await editorPage.enterTitle( title );
 	} );

--- a/test/e2e/specs/published-content/likes__comment.ts
+++ b/test/e2e/specs/published-content/likes__comment.ts
@@ -20,32 +20,32 @@ describe( DataHelper.createSuiteTitle( 'Likes (Comment) ' ), function () {
 	let page: Page;
 	let publishedURL: URL;
 	let commentsComponent: CommentsComponent;
-	let gutenbergEditorPage: GutenbergEditorPage;
+	let editorPage: GutenbergEditorPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		gutenbergEditorPage = new GutenbergEditorPage( page );
+		editorPage = new GutenbergEditorPage( page );
 
 		const testAccount = new TestAccount( 'simpleSitePersonalPlanUser' );
 		await testAccount.authenticate( page );
 	} );
 
 	it( 'Go to the new post page', async function () {
-		await gutenbergEditorPage.visit( 'post' );
+		await editorPage.visit( 'post' );
 	} );
 
 	it( 'Enter post title', async function () {
-		gutenbergEditorPage = new GutenbergEditorPage( page );
+		editorPage = new GutenbergEditorPage( page );
 		const title = DataHelper.getRandomPhrase();
-		await gutenbergEditorPage.enterTitle( title );
+		await editorPage.enterTitle( title );
 	} );
 
 	it( 'Enter post text', async function () {
-		await gutenbergEditorPage.enterText( quote );
+		await editorPage.enterText( quote );
 	} );
 
 	it( 'Publish and visit post', async function () {
-		publishedURL = await gutenbergEditorPage.publish( { visit: true } );
+		publishedURL = await editorPage.publish( { visit: true } );
 		expect( publishedURL.href ).toStrictEqual( page.url() );
 	} );
 

--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -2,12 +2,7 @@
  * @group gutenberg
  */
 
-import {
-	DataHelper,
-	GutenbergEditorPage,
-	PublishedPostPage,
-	TestAccount,
-} from '@automattic/calypso-e2e';
+import { DataHelper, EditorPage, PublishedPostPage, TestAccount } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
@@ -26,11 +21,11 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 	let publishedPostPage: PublishedPostPage;
 
 	describe( 'As the posting user', function () {
-		let editorPage: GutenbergEditorPage;
+		let editorPage: EditorPage;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
-			editorPage = new GutenbergEditorPage( page );
+			editorPage = new EditorPage( page );
 			await postingUser.authenticate( page );
 		} );
 

--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -26,29 +26,29 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 	let publishedPostPage: PublishedPostPage;
 
 	describe( 'As the posting user', function () {
-		let gutenbergEditorPage: GutenbergEditorPage;
+		let editorPage: GutenbergEditorPage;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
-			gutenbergEditorPage = new GutenbergEditorPage( page );
+			editorPage = new GutenbergEditorPage( page );
 			await postingUser.authenticate( page );
 		} );
 
 		it( 'Go to the new post page', async function () {
-			await gutenbergEditorPage.visit( 'post' );
+			await editorPage.visit( 'post' );
 		} );
 
 		it( 'Enter post title', async function () {
 			const title = DataHelper.getRandomPhrase();
-			await gutenbergEditorPage.enterTitle( title );
+			await editorPage.enterTitle( title );
 		} );
 
 		it( 'Enter post text', async function () {
-			await gutenbergEditorPage.enterText( quote );
+			await editorPage.enterText( quote );
 		} );
 
 		it( 'Publish and visit post', async function () {
-			publishedURL = await gutenbergEditorPage.publish( { visit: true } );
+			publishedURL = await editorPage.publish( { visit: true } );
 		} );
 
 		it( 'Like post', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

(Copied over from original PR #61784).

This PR removes editor-related methods from `GutenbergEditorPage`, allowing the rename of said file into `EditorPage`.

Key changes:
- extraction of editor and block-related methods into new child class `EditorGutenbergComponent`.
- removal of dead selectors.
- rename `GutenbergEditorPage` to `EditorPage` in order to decouple the page object from its implementation.

#### Testing instructions

Ensure the following:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [x] i18n E2E

Related to #60868
Depends on https://github.com/Automattic/wp-calypso/pull/61669.
