### PR TITLE
Domains: Update/use my domain trim spaces from input

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -190,7 +190,7 @@ function UseMyDomain( props ) {
 	}, [ domainName, selectedSite, setDomainTransferData, validateDomainName, onNextStep ] );
 
 	const onDomainNameChange = ( event ) => {
-		setDomainName( event.target.value );
+		setDomainName( event.target.value.trim() );
 		domainNameValidationError && setDomainNameValidationError();
 	};
 

--- a/client/components/domains/use-my-domain/utilities/get-domain-name-validation-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-domain-name-validation-error-message.js
@@ -8,7 +8,7 @@ export function getDomainNameValidationErrorMessage( domainName ) {
 
 	if (
 		! /^(([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)\.)+([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)$/.test(
-			domainName
+			domainName.trim()
 		)
 	) {
 		return createInterpolateElement(

--- a/client/components/domains/use-my-domain/utilities/get-domain-name-validation-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-domain-name-validation-error-message.js
@@ -8,7 +8,7 @@ export function getDomainNameValidationErrorMessage( domainName ) {
 
 	if (
 		! /^(([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)\.)+([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)$/.test(
-			domainName.trim()
+			domainName
 		)
 	) {
 		return createInterpolateElement(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When searching for a domain in the "Use My Domain" page ( `/domains/add/use-my-domain/{site}` ), the extra spaces would be automatically trimmed for the user.
* Typing spaces in the input field won't be allowed as well.

#### Testing instructions

* checkout this branch locally or use the live link below.
* Navigate to `/domains/add/use-my-domain/` and select any site.
* Try typing or pasting a domain name with a space at the end or beginning of it.
* The spaces should be trimmed from the input and should not affect the results.

Related to PR [#56366](https://github.com/Automattic/wp-calypso/pull/56366#:~:text=We%20could%20trim%20spaces%20when%20checking%20for%20a%20valid%20domain.%20For%20example%2C%20in%20the%20following%20screenshot%2C%20searching%20for%20%22matt.com%20%22%20shows%20an%20error.)

<img width="1192" alt="image" src="https://user-images.githubusercontent.com/1080253/158680458-346c8b70-50e6-4ad3-803d-8bd049e2935c.png">
