### PR TITLE
Breadcrumb: Update styles based on the Domains breadcrumb

### DIFF
--- a/client/components/breadcrumb/README.md
+++ b/client/components/breadcrumb/README.md
@@ -6,19 +6,29 @@ Each item should have at least a label.
 ## How to use
 
 ```js
-import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import Breadcrumb from 'calypso/components/breadcrumb';
 
-const navigationItems = [
-	{ label: 'Plugins', href: `/plugins` },
-	{ label: 'Search', href: `/plugins?s=woo` },
-];
+const BreadcrumbExamples = () => {
+	const navigationItems = [
+		{ label: 'Plugins', href: `/plugins` },
+		{ label: 'Search', href: `/plugins?s=woo` },
+		{ label: 'Woocommerce' },
+	];
 
-function render() {
-	return <Breadcrumb items={ navigationItems } />;
-}
+	return (
+		<>
+			<Breadcrumb items={ [ { label: 'Plugins' } ] } />
+			<br />
+			<Breadcrumb items={ navigationItems } />
+			<br />
+			<Breadcrumb items={ navigationItems } mobileItem="Go Back" compact={ true } />
+		</>
+	);
+};
 ```
 
 ## Props
 
 - `items` (`{ label: string; href?: string }[]`) - The Navigations items to be shown
-- `compact` (`boolean`) - Displays only the previous item URL reading "Back" (optional)
+- `compact` (`boolean`) - Displays only the previous item URL (optional)
+- `mobileItem` (`string`) - In compact version, displays this value. If not passed defaults to "Back" (optional)

--- a/client/components/breadcrumb/docs/example.jsx
+++ b/client/components/breadcrumb/docs/example.jsx
@@ -6,7 +6,16 @@ const BreadcrumbExample = () => {
 		{ label: 'Search', href: `/plugins?s=woo` },
 		{ label: 'Woocommerce' },
 	];
-	return <Breadcrumb items={ navigationItems } />;
+
+	return (
+		<>
+			<Breadcrumb items={ [ { label: 'Plugins' } ] } />
+			<br />
+			<Breadcrumb items={ navigationItems } />
+			<br />
+			<Breadcrumb items={ navigationItems } mobileItem="Go Back" compact={ true } />
+		</>
+	);
 };
 
 BreadcrumbExample.displayName = 'Breadcrumb';

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -2,6 +2,7 @@ import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { Key } from 'react';
+import InfoPopover from 'calypso/components/info-popover';
 
 const flexAligned = {
 	display: 'flex',
@@ -28,6 +29,7 @@ const StyledLi = styled.li`
 
 const StyledBackLink = styled.a`
 	${ flexAligned };
+	font-size: 13px;
 	color: var( --studio-gray-80 ) !important; // It uses --studio-gray-50 if not using important
 	> svg {
 		margin-right: 5px;
@@ -41,18 +43,58 @@ const StyledRootLabel = styled.span`
 	color: var( --studio-gray-80 );
 `;
 
+const StyledItem = styled.div`
+	display: flex;
+`;
+
 const StyledGridicon = styled( Gridicon )`
 	margin: 0 12px;
 	color: var( --color-neutral-10 );
 `;
 
+const HelpBuble = styled( InfoPopover )`
+	margin-left: 7px;
+	& .gridicon {
+		color: var( --studio-gray-30 );
+	}
+`;
+
+type Item = { label: string; href?: string; helpBubble?: React.ReactElement };
+
 interface Props {
-	items: { label: string; href?: string }[];
+	items: Item[];
 	compact?: boolean;
 }
 
 const Breadcrumb: React.FunctionComponent< Props > = ( { items, compact = false } ) => {
 	const translate = useTranslate();
+
+	const renderHelpBubble = ( item: Item ) => {
+		if ( ! item.helpBubble ) {
+			return null;
+		}
+
+		return (
+			<HelpBuble
+				id={ 'dude' }
+				icon="help-outline"
+				position={ 'right' }
+				screenReaderText={ 'Learn more' }
+			>
+				{ item.helpBubble }
+			</HelpBuble>
+		);
+	};
+
+	if ( items.length === 1 ) {
+		const [ item ] = items;
+		return (
+			<StyledItem>
+				<StyledRootLabel>{ item.label }</StyledRootLabel>
+				{ renderHelpBubble( item ) }
+			</StyledItem>
+		);
+	}
 
 	if ( compact && items.length > 1 ) {
 		return (
@@ -75,16 +117,13 @@ const Breadcrumb: React.FunctionComponent< Props > = ( { items, compact = false 
 						) : (
 							<span>{ item.label }</span>
 						) }
+						{ renderHelpBubble( item ) }
 					</StyledLi>
 				) ) }
 			</StyledUl>
 		);
 	}
-
-	if ( items.length === 1 ) {
-		return <StyledRootLabel>{ items[ 0 ].label }</StyledRootLabel>;
-	}
-
+	// Default case items: []
 	return null;
 };
 

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -30,7 +30,13 @@ const StyledLi = styled.li`
 const StyledBackLink = styled.a`
 	${ flexAligned };
 	font-size: 13px;
-	color: var( --studio-gray-80 ) !important; // It uses --studio-gray-50 if not using important
+	&,
+	&:link,
+	&:visited,
+	&:hover,
+	&:active {
+		color: var( --studio-gray-80 );
+	}
 	> svg {
 		margin-right: 5px;
 	}

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -72,19 +72,15 @@ const renderHelpBubble = ( item: Item ) => {
 };
 
 type Item = { label: string; href?: string; helpBubble?: React.ReactElement };
-
 interface Props {
 	items: Item[];
 	mobileItem?: string;
 	compact?: boolean;
 }
 
-const Breadcrumb: React.FunctionComponent< Props > = ( { items, mobileItem, compact = false } ) => {
+const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 	const translate = useTranslate();
-
-	if ( items.length === 0 ) {
-		return null;
-	}
+	const { items, mobileItem, compact = false } = props;
 
 	if ( items.length === 1 ) {
 		const [ item ] = items;
@@ -123,6 +119,8 @@ const Breadcrumb: React.FunctionComponent< Props > = ( { items, mobileItem, comp
 			</StyledUl>
 		);
 	}
+	// Default case -> items: []
+	return null;
 };
 
 Breadcrumb.defaultProps = {

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -59,32 +59,32 @@ const HelpBuble = styled( InfoPopover )`
 	}
 `;
 
+const renderHelpBubble = ( item: Item ) => {
+	if ( ! item.helpBubble ) {
+		return null;
+	}
+
+	return (
+		<HelpBuble icon="help-outline" position={ 'right' }>
+			{ item.helpBubble }
+		</HelpBuble>
+	);
+};
+
 type Item = { label: string; href?: string; helpBubble?: React.ReactElement };
 
 interface Props {
 	items: Item[];
+	mobileItem?: string;
 	compact?: boolean;
 }
 
-const Breadcrumb: React.FunctionComponent< Props > = ( { items, compact = false } ) => {
+const Breadcrumb: React.FunctionComponent< Props > = ( { items, mobileItem, compact = false } ) => {
 	const translate = useTranslate();
 
-	const renderHelpBubble = ( item: Item ) => {
-		if ( ! item.helpBubble ) {
-			return null;
-		}
-
-		return (
-			<HelpBuble
-				id={ 'dude' }
-				icon="help-outline"
-				position={ 'right' }
-				screenReaderText={ 'Learn more' }
-			>
-				{ item.helpBubble }
-			</HelpBuble>
-		);
-	};
+	if ( items.length === 0 ) {
+		return null;
+	}
 
 	if ( items.length === 1 ) {
 		const [ item ] = items;
@@ -101,7 +101,7 @@ const Breadcrumb: React.FunctionComponent< Props > = ( { items, compact = false 
 			<StyledBackLink href={ items[ items.length - 2 ].href }>
 				<Gridicon icon="chevron-left" size={ 18 } />
 				{ /*  Show the exactly previous page with items[ items.length - 2 ] */ }
-				{ translate( 'Back' ) }
+				{ mobileItem ? mobileItem : translate( 'Back' ) }
 			</StyledBackLink>
 		);
 	}
@@ -123,8 +123,6 @@ const Breadcrumb: React.FunctionComponent< Props > = ( { items, compact = false 
 			</StyledUl>
 		);
 	}
-	// Default case items: []
-	return null;
 };
 
 Breadcrumb.defaultProps = {

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -3,34 +3,46 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { Key } from 'react';
 
+const flexAligned = {
+	display: 'flex',
+	alignItems: 'center',
+};
+
 const StyledUl = styled.ul`
-	display: flex;
-	align-items: center;
+	${ flexAligned };
 	list-style-type: none;
 	margin: 0;
 `;
 
 const StyledLi = styled.li`
-	display: flex;
-	align-items: center;
+	${ flexAligned };
 	font-size: 13px;
-	font-weight: 500;
-	--color-link: var( --studio-gray-100 );
-
-	:first-of-type {
-		font-size: 16px;
-		font-weight: 600;
-		--color-link: var( --studio-gray-80 );
-	}
+	font-weight: 400;
+	--color-link: var( --studio-gray-50 );
 
 	:last-of-type:not( :first-of-type ) {
-		--color-link: var( --studio-gray-50 );
+		--color-link: var( --studio-gray-80 );
+		font-weight: 500;
 	}
 `;
 
+const StyledBackLink = styled.a`
+	${ flexAligned };
+	color: var( --studio-gray-80 ) !important; // It uses --studio-gray-50 if not using important
+	> svg {
+		margin-right: 5px;
+	}
+`;
+
+const StyledRootLabel = styled.span`
+	${ flexAligned };
+	font-size: 1rem;
+	font-weight: 600;
+	color: var( --cstudio-gray-80 );
+`;
+
 const StyledGridicon = styled( Gridicon )`
-	margin: 0 7px;
-	fill: var( --studio-gray-50 );
+	margin: 0 12px;
 `;
 
 interface Props {
@@ -41,33 +53,38 @@ interface Props {
 const Breadcrumb: React.FunctionComponent< Props > = ( { items, compact = false } ) => {
 	const translate = useTranslate();
 
-	return (
-		<StyledUl>
-			{ compact && items.length > 1 ? (
-				<StyledLi>
-					<StyledGridicon icon="chevron-left" size={ 18 } />
-					{ /*  Show the exactly previous page with items[ items.length - 2 ] */ }
-					<a href={ items[ items.length - 2 ].href }>{ translate( 'Back' ) }</a>
-				</StyledLi>
-			) : (
-				<>
-					{ items.map( ( item: { href?: string; label: string }, index: Key ) => {
-						return (
-							<StyledLi key={ index }>
-								{ compact && <StyledGridicon icon="chevron-left" size={ 18 } /> }
-								{ index !== 0 && <StyledGridicon icon="chevron-right" size={ 18 } /> }
-								{ item.href ? (
-									<a href={ item.href }>{ item.label }</a>
-								) : (
-									<span>{ item.label }</span>
-								) }
-							</StyledLi>
-						);
-					} ) }
-				</>
-			) }
-		</StyledUl>
-	);
+	if ( compact && items.length > 1 ) {
+		return (
+			<StyledBackLink href={ items[ items.length - 2 ].href }>
+				<Gridicon icon="chevron-left" size={ 18 } />
+				{ /*  Show the exactly previous page with items[ items.length - 2 ] */ }
+				{ translate( 'Back' ) }
+			</StyledBackLink>
+		);
+	}
+
+	if ( items.length > 1 ) {
+		return (
+			<StyledUl>
+				{ items.map( ( item: { href?: string; label: string }, index: Key ) => (
+					<StyledLi key={ index }>
+						{ index !== 0 && <StyledGridicon icon="chevron-right" size={ 14 } /> }
+						{ item.href && index !== items.length - 1 ? (
+							<a href={ item.href }>{ item.label }</a>
+						) : (
+							<span>{ item.label }</span>
+						) }
+					</StyledLi>
+				) ) }
+			</StyledUl>
+		);
+	}
+
+	if ( items.length === 1 ) {
+		return <StyledRootLabel>{ items[ 0 ].label }</StyledRootLabel>;
+	}
+
+	return null;
 };
 
 Breadcrumb.defaultProps = {

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -38,11 +38,12 @@ const StyledRootLabel = styled.span`
 	${ flexAligned };
 	font-size: 1rem;
 	font-weight: 600;
-	color: var( --cstudio-gray-80 );
+	color: var( --studio-gray-80 );
 `;
 
 const StyledGridicon = styled( Gridicon )`
 	margin: 0 12px;
+	color: var( --color-neutral-10 );
 `;
 
 interface Props {

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -393,7 +393,13 @@ export class PluginsMain extends Component {
 	getNavigationItems() {
 		const { search, selectedSiteSlug } = this.props;
 		const navigationItems = [
-			{ label: this.props.translate( 'Plugins' ), href: `/plugins/${ selectedSiteSlug || '' }` },
+			{
+				label: this.props.translate( 'Plugins' ),
+				href: `/plugins/${ selectedSiteSlug || '' }`,
+				helpBubble: this.props.translate(
+					'Add new functionality and integrations to your site with plugins.'
+				),
+			},
 			{
 				label: this.props.translate( 'Installed Plugins' ),
 				href: `/plugins/manage/${ selectedSiteSlug || '' }`,

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -203,6 +203,9 @@ function PluginDetails( props ) {
 					label: translate( 'Plugins' ),
 					href: `/plugins/${ selectedSite?.slug || '' }`,
 					id: 'plugins',
+					helpBubble: translate(
+						'Add new functionality and integrations to your site with plugins.'
+					),
 				} )
 			);
 		}

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -199,7 +199,14 @@ const PluginsBrowser = ( {
 
 	useEffect( () => {
 		const items = [
-			{ label: translate( 'Plugins' ), href: `/plugins/${ siteSlug || '' }`, id: 'plugins' },
+			{
+				label: translate( 'Plugins' ),
+				href: `/plugins/${ siteSlug || '' }`,
+				id: 'plugins',
+				helpBubble: translate(
+					'Add new functionality and integrations to your site with plugins.'
+				),
+			},
 		];
 		if ( search ) {
 			items.push( {

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -8,7 +8,7 @@ const selectors = {
 		`.plugins-browser-list:has(.plugins-browser-list__title.${ section }) :text-is("${ plugin }")`,
 	sectionTitles: '.plugins-browser-list__title',
 	browseAllPopular: 'a[href^="/plugins/popular"]',
-	breadcrumb: ( section: string ) => `.plugins-browser__header li a:text("${ section }") `,
+	breadcrumb: ( section: string ) => `.plugins-browser__header a:text("${ section }") `,
 	pricingToggle: ':text("Monthly Price"), :text("Annual Price")',
 	monthlyPricingSelect: 'a[data-bold-text^="Monthly price"]',
 	annualPricingSelect: 'a[data-bold-text^="Annual price"]',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Domain breadcrumb styles have been migrated to the generic breadcrumb component used in Plugins page.

**Note:** The behaviour of the existing Breadcrumb component has **not** been
modified. The only difference is that the back icon will not be displayed
when the page is in the root component so there is only one item

Additionally, the component has been refactored to cope with three
different conditions:
1. When it is in the compact view and there are multiple items:
  - Only show Back navigation
2. When it is not in the compact view and there are multiple items:
  - Standard breadcrumb behaviour with navigation for the parents
3. When there is only one item:
  - No back button is displayed

Additionally, the following task has been created to use this generic component in the Domains pages:
- https://github.com/Automattic/wp-calypso/issues/61952

|Before | After|
|-------|------|
|<img width="470" alt="CleanShot 2022-03-15 at 12 20 53@2x" src="https://user-images.githubusercontent.com/3519124/158367193-813ac16b-d277-4c80-b6ac-b62400bd64dc.png">|<img width="526" alt="image" src="https://user-images.githubusercontent.com/3519124/158792390-3611b16b-505a-4a84-8c70-d5b97d6b647c.png">|
|**Domains**|<img width="490" alt="image" src="https://user-images.githubusercontent.com/3519124/158367401-22aeff94-03ae-4dd6-8a21-b465ff96a705.png">|

##### Responsive behaviour
|Before | After|
|-------|------|
|![CleanShot 2022-03-15 at 12 26 38](https://user-images.githubusercontent.com/3519124/158368323-80200c98-efb7-4035-92e8-eaadea8cfd3c.gif)|![CleanShot 2022-03-17 at 11 35 16](https://user-images.githubusercontent.com/3519124/158792497-7da7a750-8e7f-4a8b-9ab3-96d8d2019518.gif)|
|**Domains**|![CleanShot 2022-03-15 at 12 24 31](https://user-images.githubusercontent.com/3519124/158368296-93e4fce5-ef5e-41f2-b045-89aa3643ea4e.gif)|

#### Testing instructions

* Open plugins and select one plugin
* Check the styles and compare them against the breadcrumb in the Domains page. The Domains page can be accessed by navigating to Upgrades -> Domains and selecting one domain.
* Check that the responsive behaviour works as expected resizing the window.

Fixes 
- #61143
- #61917

This PR has been created as a consequence of the comments in the related PR:
- #61851

