### PR TITLE
Fix use of calypso-build transpile script

### DIFF
--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -105,14 +105,7 @@ open class WPComPluginBuild(
 
 					# Update composer
 					composer install
-
-					cd $workingDir
-
-					# Focus on the app workspace. This will also install all dependant workspaces
-					yarn workspaces focus
-
-					# Run the script 'prepare' in all dependant workspaces
-					yarn workspaces foreach --recursive --verbose --parallel run prepare
+					yarn
 				"""
 			}
 			bashNodeScript {

--- a/bin/teamcity-task-runner.mjs
+++ b/bin/teamcity-task-runner.mjs
@@ -13,8 +13,8 @@ for ( const stream of [ process.stdout, process.stderr ] ) {
 export default async function runTask( { name = 'yarn', args, env = {}, testId } ) {
 	return new Promise( ( resolve, reject ) => {
 		const startTime = Date.now();
-		console.log( `Spawning task: ${ name } ${ args }` );
-		const task = spawn( name, args.split( ' ' ), {
+		console.log( `Spawning task: ${ name } ${ args ? args : '' }` );
+		const task = spawn( name, args?.split( ' ' ), {
 			shell: true,
 			env: {
 				...process.env,

--- a/bin/test-prepack-transpile.sh
+++ b/bin/test-prepack-transpile.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This script makes sure our prepack and publishing infrastructure works for non-tsc
+# packages. The prepack command relies not only on calypso-build working correctly
+# but also on the transpile binary being linked properly in the workspace.
+set -Eeuo pipefail
+
+# If the package below is ever migrated to Typescript, we'll want to change these
+# variables for another package that does use transpile.
+package_name=i18n-calypso
+package_dir=packages/i18n-calypso
+
+if ! grep -q "run -T transpile" "$package_dir/package.json" ; then
+	echo "This package doesn't use transpile any more -- find another package to use."
+	exit 1
+fi
+
+dist_dir=$package_dir/dist
+rm -rf "$dist_dir"
+
+if [ -d "$dist_dir" ] ; then
+	echo "dist dir shouldn't exist"
+	exit 1
+fi
+
+# We generally can't run this for all packages in parallel, because they often
+# rely on output from other packages. So when "prepack" cleans the output of one
+# package, this can break compilation for others. So we just use one to test the
+# general infrastructure.
+yarn workspace $package_name prepack
+
+if [ ! -f "$dist_dir/esm/index.js" ] ; then
+	echo "prepack failed to compile"
+	exit 1
+fi

--- a/bin/unit-test-suite.mjs
+++ b/bin/unit-test-suite.mjs
@@ -69,6 +69,11 @@ const testWorkspaces = {
 	testId: 'check_storybook',
 };
 
+const testPrepack = {
+	name: './bin/test-prepack-transpile.sh',
+	testId: 'test_prepack',
+};
+
 try {
 	// Since this task is so much larger than the others, we give it a large amount
 	// of CPU and run it by itself. We let other tasks complete in parallel with
@@ -89,6 +94,9 @@ try {
 		// This task is a prerequisite for the other tsc tasks, so it must run separately.
 		await runTask( tscPackages );
 		await completeTasks( tscCommands.map( runTask ) );
+		// This isn't technically a tsc task, but since it cleans the build output
+		// of other packages, it could break compilation.
+		await runTask( testPrepack );
 	} )();
 
 	// Run these smaller tasks in serial to keep a healthy amount of CPU available for the other tasks.

--- a/bin/unit-test-suite.mjs
+++ b/bin/unit-test-suite.mjs
@@ -70,7 +70,7 @@ const testWorkspaces = {
 };
 
 const testPrepack = {
-	name: './bin/test-prepack-transpile.sh',
+	name: 'test-prepack-transpile.sh',
 	testId: 'test_prepack',
 };
 

--- a/bin/unit-test-suite.mjs
+++ b/bin/unit-test-suite.mjs
@@ -70,7 +70,7 @@ const testWorkspaces = {
 };
 
 const testPrepack = {
-	name: 'test-prepack-transpile.sh',
+	name: './test-prepack-transpile.sh',
 	testId: 'test_prepack',
 };
 

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -194,13 +194,16 @@ git push --tags
 
 ### Publishing a package
 
-Once the above steps (checkout `trunk`, get `@automattic` permissions, and package tagging) are done, you are ready to publish the package. Depending on the name of the package (found in the package's `package.json` file), you'll need to log into a different scope:
+**DO NOT USE `npm publish`**. This will cause a package to be published with `workspace:^` as the version for internal dependencies, which does not work outside of the Calypso monorepo. You must run `yarn npm publish` instead, so that those versions are replaced with correct NPM versions.
 
-- If the package name is prefixed with `@automattic` (e.g. `@automattic/components`), run `yarn npm login --scope automattic`.
-- If the package name is not prefixed (e.g. `eslint-plugin-wpcalypso`), run `yarn npm login`.
+Once the above steps (checkout `trunk`, get `@automattic` permissions and package tagging) are done, you are ready to publish the package:
 
-To verify it worked, use `yarn npm whoami --scope automattic` or `yarn npm whoami`.
+First you need to authenticate with the registry: `yarn npm login --scope automattic`. To verify it worked you can use `yarn npm whoami --scope automattic`. You may also need to run `yarn npm login` (without --scope) to publish packages whose names aren't prefixed with `@automattic/`. (Try this if you get an authentication error publishing a non-prefixed package.)
 
-To publish the package, run: `cd packages/<your-package> && yarn npm publish`.
+You can safely test that the pre-publish steps will pass by using `yarn workspace $package_name run prepack`, and then checking the `$package/dist` directory. If you get build errors, you may need to run `yarn build-packages` first.
+
+When you're ready to publish: `yarn workspace $package_name npm publish`. (e.g. `yarn workspace i18n-calypso npm publish` or `yarn workspace @automattic/calypso-build npm publish`).
+
+Note that **yarn does not ask for permission before publishing.** As a result, be sure that you're really ready to publish before running this command!
 
 Done!

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -102,8 +102,8 @@ failing to do so, will make your package work correctly in the dev build but tre
 
 If your package requires compilation, the `package.json` `build` script should compile the package:
 
-- If it contains ES6+ code that needs to be transpiled, use `transpile` (from `@automattic/calypso-build`) which will automatically compile code in `src/` to `dist/cjs` (CommonJS) and `dist/esm` (ECMAScript Modules) by running `babel` over any source files it finds. Also, make sure to add `@automattic/calypso-build` in `devDependencies`.
-- If it contains [assets](https://github.com/Automattic/wp-calypso/blob/d709f0e79ba29f2feb35690d275087179b18f632/packages/calypso-build/bin/copy-assets.js#L17-L25) (eg `.scss`) then after `transpile` append `&& copy-assets` ie `"build": "transpile && copy-assets"`.
+- If it contains ES6+ code that needs to be transpiled, use `run -T transpile` (from `@automattic/calypso-build`) which will automatically compile code in `src/` to `dist/cjs` (CommonJS) and `dist/esm` (ECMAScript Modules) by running `babel` over any source files it finds. Also, make sure to add `@automattic/calypso-build` in `devDependencies`.
+- If it contains [assets](https://github.com/Automattic/wp-calypso/blob/d709f0e79ba29f2feb35690d275087179b18f632/packages/calypso-build/bin/copy-assets.js#L17-L25) (eg `.scss`) then after `transpile` append `&& run -T copy-assets` ie `"build": "transpile && run -T copy-assets"`.
 
 `package.json` is linted using ESLint. Run `yarn eslint packages/*/package.json apps/*/package.json` to validate them.
 

--- a/packages/calypso-build/bin/transpile.js
+++ b/packages/calypso-build/bin/transpile.js
@@ -5,7 +5,6 @@ const { execSync } = require( 'child_process' );
 const path = require( 'path' );
 
 const dir = process.cwd();
-const root = path.dirname( __dirname );
 const babelPresetFile = require.resolve( '@automattic/calypso-babel-config/presets/default.js' );
 
 const inputDir = path.join( dir, 'src' );
@@ -32,18 +31,28 @@ for ( const arg of process.argv.slice( 2 ) ) {
 // root directory (set as cwd) which isn't an ancestor of any of the source files.
 const testIgnorePattern = path.join( dir, '**/test/**' );
 
-console.log( 'Building %s', dir );
-const baseCommand = `npx --no-install babel --presets="${ babelPresetFile }" --ignore "${ testIgnorePattern }" --extensions='.js,.jsx,.ts,.tsx'`;
+// Babel may get hoisted from calypso-build/node_modules to the root-level node_modules.
+// To handle either scenario, use require.resolve to find the path to babel.
+const babelLocation = require.resolve( '@babel/cli' );
+if ( ! babelLocation ) {
+	throw new Error( 'Could not find babel CLI; there may be an issue with dependencies.' );
+}
+// The bin script lives at node_modules/.bin/babel, so this changes node_modules/@babel/cli/...
+// to point to that instead. In theory, this would break if you install wp-calypso
+// under a path which includes babel, like /home/foo/@babel/wp-calypso, but who
+// would do that?
+const babelScript = path.resolve( babelLocation.split( '@babel' )[ 0 ], '.bin', 'babel' );
+
+// NOTE: this depends explicitly on @babel/cli, so @babel/cli must be included
+// in calypso-build's dependencies.
+const baseCommand = `${ babelScript } --presets="${ babelPresetFile }" --ignore "${ testIgnorePattern }" --extensions='.js,.jsx,.ts,.tsx'`;
 
 if ( transpileAll || transpileESM ) {
-	execSync( `${ baseCommand } -d "${ outputDirESM }" "${ inputDir }"`, {
-		cwd: root,
-	} );
+	execSync( `${ baseCommand } -d "${ outputDirESM }" "${ inputDir }"` );
 }
 
 if ( transpileAll || transpileCJS ) {
 	execSync( `${ baseCommand } -d "${ outputDirCJS }" "${ inputDir }"`, {
 		env: Object.assign( {}, process.env, { MODULES: 'commonjs' } ),
-		cwd: root,
 	} );
 }

--- a/packages/calypso-build/bin/transpile.js
+++ b/packages/calypso-build/bin/transpile.js
@@ -47,6 +47,8 @@ const babelScript = path.resolve( babelLocation.split( '@babel' )[ 0 ], '.bin', 
 // in calypso-build's dependencies.
 const baseCommand = `${ babelScript } --presets="${ babelPresetFile }" --ignore "${ testIgnorePattern }" --extensions='.js,.jsx,.ts,.tsx'`;
 
+console.log( 'Building %s', dir );
+
 if ( transpileAll || transpileESM ) {
 	execSync( `${ baseCommand } -d "${ outputDirESM }" "${ inputDir }"` );
 }

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -35,6 +35,7 @@
 	"dependencies": {
 		"@automattic/calypso-babel-config": "workspace:^",
 		"@automattic/webpack-rtl-plugin": "workspace:^",
+		"@babel/cli": "^7.17.6",
 		"@babel/compat-data": "^7.17.0",
 		"@babel/core": "^7.17.5",
 		"@types/webpack-env": "^1.16.3",

--- a/packages/calypso-package-generator/templates/component/package.json.hbs
+++ b/packages/calypso-package-generator/templates/component/package.json.hbs
@@ -24,7 +24,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -69,7 +69,7 @@
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build"
 	}
 }

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -26,7 +26,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -24,7 +24,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -24,7 +24,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -40,7 +40,7 @@
 	},
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "transpile",
+		"build": "run -T transpile",
 		"prepack": "yarn run clean && yarn run build"
 	}
 }

--- a/packages/interpolate-components/package.json
+++ b/packages/interpolate-components/package.json
@@ -33,7 +33,7 @@
 	},
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "transpile",
+		"build": "run -T transpile",
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"types": "types"

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -24,7 +24,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/load-script/package.json
+++ b/packages/load-script/package.json
@@ -27,7 +27,7 @@
 	},
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "transpile",
+		"build": "run -T transpile",
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"devDependencies": {

--- a/packages/mini-cart/package.json
+++ b/packages/mini-cart/package.json
@@ -9,7 +9,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && npx rimraf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -24,7 +24,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets && npx copyfiles ./styles/** dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets && npx copyfiles ./styles/** dist",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -24,7 +24,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets && npx copyfiles ./styles/** dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets && run copyfiles ./styles/** dist",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -55,7 +55,7 @@
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build"
 	}
 }

--- a/packages/plans-grid/package.json
+++ b/packages/plans-grid/package.json
@@ -24,7 +24,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/popup-monitor/package.json
+++ b/packages/popup-monitor/package.json
@@ -28,7 +28,7 @@
 	],
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "transpile",
+		"build": "run -T transpile",
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"dependencies": {

--- a/packages/request-external-access/package.json
+++ b/packages/request-external-access/package.json
@@ -30,7 +30,7 @@
 	],
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "transpile",
+		"build": "run -T transpile",
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"dependencies": {

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -64,7 +64,7 @@
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"storybook": "sb dev"
 	}

--- a/packages/site-picker/package.json
+++ b/packages/site-picker/package.json
@@ -23,6 +23,8 @@
 	},
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"dependencies": {
+		"@automattic/components": "workspace:^",
+		"@automattic/onboarding": "workspace:^",
 		"@automattic/tour-kit": "workspace:^",
 		"@wordpress/dom": "^3.39.0",
 		"@wordpress/i18n": "^4.39.0",

--- a/packages/site-picker/package.json
+++ b/packages/site-picker/package.json
@@ -43,7 +43,7 @@
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build"
 	}
 }

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -34,7 +34,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepare": "yarn run clean && yarn run build",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"

--- a/packages/viewport-react/package.json
+++ b/packages/viewport-react/package.json
@@ -29,7 +29,7 @@
 	},
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "transpile",
+		"build": "run -T transpile",
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"publishConfig": {

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -9,7 +9,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/wpcom-proxy-request/package.json
+++ b/packages/wpcom-proxy-request/package.json
@@ -35,7 +35,7 @@
 	"types": "types",
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "transpile",
+		"build": "run -T transpile",
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"dependencies": {

--- a/packages/wpcom-xhr-request/package.json
+++ b/packages/wpcom-xhr-request/package.json
@@ -33,7 +33,7 @@
 	],
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "transpile",
+		"build": "run -T transpile",
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"dependencies": {

--- a/packages/wpcom.js/package.json
+++ b/packages/wpcom.js/package.json
@@ -13,7 +13,7 @@
 		"clean": "rm -rf dist",
 		"build": "run-s build:modules build:bundle",
 		"prepack": "yarn run clean && yarn run build",
-		"build:modules": "transpile",
+		"build:modules": "run -T transpile",
 		"build:bundle": "webpack --stats-preset errors-only"
 	},
 	"keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,6 +1478,8 @@ __metadata:
   resolution: "@automattic/site-picker@workspace:packages/site-picker"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/components": "workspace:^"
+    "@automattic/onboarding": "workspace:^"
     "@automattic/tour-kit": "workspace:^"
     "@testing-library/jest-dom": ^5.17.0
     "@testing-library/react": ^14.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,6 +276,7 @@ __metadata:
     "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/webpack-rtl-plugin": "workspace:^"
+    "@babel/cli": ^7.17.6
     "@babel/compat-data": ^7.17.0
     "@babel/core": ^7.17.5
     "@types/webpack-env": ^1.16.3


### PR DESCRIPTION
#### Changes proposed in this Pull Request
I first noticed this issue when trying to publish an npm package update from Calypso, and the `transpile` script didn't work. More discussion here: p1638533180499800-slack-C7YPUHBB2. I think some packages (like components and calypso-url) still work fine because they use `tsc`, which doesn't run into the issues.
 
- Fix resolution of "transpile" script using `yarn run -T`
- Fix resolution of "babel" from the transpile script in calypso-build by using `yarn run` instead of `npx`.

Npm package publishing is currently partially broken in some environments because `yarn build` has two issues in some packages:
- It does `yarn run transpile`, but yarn can't find the transpile script. (it's provided by calypso-build)
- The `transpile` script` doesn't work correctly on older `npx` versions. (e.g. `npx babel` can't find babel)

I was able to get the transpile part working by adding `"build":  "run -T transpile"`, which makes yarn look in the root of the monorepo for the script. But now that the transpile script is executing, the `npx --no-install babel` command can fail when using an older `npx` version (e.g. the version of npm you might have active when working on Gutenberg.) But since we don't manage npm/npx versions, we can better solve this by using `yarn run babel` instead, since we do manage `yarn`.

Finally, we probably never caught this because packages are built with the calypso app webpack config for inclusion with calypso itself. So these build scripts aren't triggered as part of our CI. I've added a build step which tests prepack for a single package. 

I did initially try running _every_ prepack script in parallel, but this fails because some package depend on other packages having already been built. When both are getting built at the same time, and when any existing artifacts are deleted as the first step of the build, those dependencies won't always be met. This causes several package builds to fail when building all of them in parallel, but the builds still work individually.

#### Testing instructions
I would **try this on trunk** first, to double check that it is broken for you:

_From the calypso root:_

```sh
yarn distclean
yarn install
yarn workspace @automattic/social-previews build # It should break here on trunk
ls packages/social-previews/dist
```

You should expect the above steps to fail during the workspace build on trunk without this fix. Running those commands on this branch with the fix, the final `ls` should display two directories, one for ESM and one for CJS.