### PR TITLE
Masterbar: Refactor `MasterbarItemNew` away from `redux-bridge`

### DIFF
--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import { navigate } from 'calypso/lib/navigate';
-import { reduxGetState } from 'calypso/lib/redux-bridge';
 import { preloadEditor } from 'calypso/sections-preloaders';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserVisibleSiteCount } from 'calypso/state/current-user/selectors';
@@ -58,8 +57,7 @@ class MasterbarItemNew extends Component {
 	}
 
 	onSiteSelect = ( siteId ) => {
-		const redirectUrl = getEditorUrl( reduxGetState(), siteId, null, 'post' );
-		this.props.openEditor( redirectUrl );
+		this.props.openEditorForSite( siteId );
 		return true; // handledByHost = true, don't let the component nav
 	};
 
@@ -110,9 +108,10 @@ class MasterbarItemNew extends Component {
 	}
 }
 
-const openEditor = ( editorUrl ) => ( dispatch ) => {
+const openEditorForSite = ( siteId ) => ( dispatch, getState ) => {
+	const redirectUrl = getEditorUrl( getState(), siteId, null, 'post' );
 	dispatch( recordTracksEvent( 'calypso_masterbar_write_button_clicked' ) );
-	navigate( editorUrl );
+	navigate( redirectUrl );
 };
 
 export default connect(
@@ -134,5 +133,5 @@ export default connect(
 
 		return { shouldOpenSiteSelector, editorUrl, draftCount };
 	},
-	{ openEditor }
+	{ openEditorForSite }
 )( MasterbarItemNew );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes one of the last remaining instances of `redux-bridge` in the masterbar. It was necessary to retrieve the editor URL by site ID when selecting a site to write a post in, but we're moving that logic to the action creator, which has access to state anyway.

#### Testing instructions

* Go to `/home`
* In the masterbar, click "Write".
* Click on a site.
* Verify you're properly redirected to write a new post on that site (usually `/post/:site`)