### PR TITLE
Framework: Remove async store promise from `redux-bridge`

### DIFF
--- a/client/lib/redux-bridge/index.js
+++ b/client/lib/redux-bridge/index.js
@@ -1,23 +1,7 @@
 let reduxStore = null;
 
-let resolveReduxStorePromise;
-const reduxStorePromise = new Promise( ( resolve ) => {
-	resolveReduxStorePromise = resolve;
-} );
-
 export function setReduxStore( store ) {
 	reduxStore = store;
-	resolveReduxStorePromise( store );
-}
-
-/**
- * Asynchronously get the current Redux store. Returns a Promise that gets resolved only
- * after the store is set by `setReduxStore`.
- *
- * @returns {Promise<object>} Promise of the Redux store object.
- */
-export function getReduxStore() {
-	return reduxStorePromise;
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I've noticed that the async Redux store promise that's part of `redux-bridge` is no longer in use since #49614. Since that library is discouraged and we've actively been refactoring away from it, this PR suggests removing that async store promise in order to avoid potential future usages.

#### Testing instructions

* Verify the removed code is not in use.
* Verify the test instructions of #62011 still work.