### PR TITLE
Marketing: Fix official sharing buttons iframe error

### DIFF
--- a/client/my-sites/marketing/buttons/preview-buttons.jsx
+++ b/client/my-sites/marketing/buttons/preview-buttons.jsx
@@ -127,7 +127,7 @@ class SharingButtonsPreviewButtons extends Component {
 		if ( 'official' === this.props.style ) {
 			// To show the more preview when rendering official style buttons,
 			// we request that the frame emit a show message with the offset
-			this.previewIframeRef.current.contentWindow.postMessage( 'more-show', '*' );
+			this.previewIframeRef.current.iframeRef.current.contentWindow.postMessage( 'more-show', '*' );
 		} else {
 			// For custom styles, we can calculate the offset using the
 			// position of the rendered button


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the reference to the official sharing buttons preview iframe that we broke when porting refs to the string syntax in #56719.

Fixes #60354.

#### Testing instructions

* Go to Marketing > Sharing Buttons.
* In the Button style radio group, select "Official Buttons".
* Click on the "Edit "More" buttons" button.
* Verify you can edit (select, deselect, reorder) the buttons and they save correctly.
* Verify the preview also works and there are no errors in the console.