### PR TITLE
Fix domain status bubble counter

### DIFF
--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -344,6 +344,7 @@ class AllDomains extends Component {
 					domains.map( ( domain ) =>
 						resolveDomainStatus( domain, null, {
 							getMappingErrors: true,
+							siteSlug: sites[ domain.blogId ].slug,
 						} )
 					)
 				),

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -133,6 +133,7 @@ export class SiteDomains extends Component {
 					nonWpcomDomains.map( ( domain ) =>
 						resolveDomainStatus( domain, null, {
 							getMappingErrors: true,
+							siteSlug: selectedSite.slug,
 						} )
 					)
 				),


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes a bug that prevent _Status bubble counter_ (in all domains & site domains) to shows the right number of domains that require attention (_error_, _alert_, or _warning_).

This problem probably started to occur after migrating resolveDomainStatus from js to ts (https://github.com/Automattic/wp-calypso/pull/60234).

![bug-before](https://user-images.githubusercontent.com/2797601/158840733-57573a0c-eb79-4fbb-9446-e968426d2c96.png)

![bug-after](https://user-images.githubusercontent.com/2797601/158840745-40683d8d-2627-43bc-b71b-3bab018d837b.png)

## Testing instructions

- Apply this commit or open the calypso link below
- Ensure that in All domains page (`/domains/manage`)  the status bubble report the correct number of domains that require attentions
- Do the same for a site domains page (`/domains/manage({:site}`)