### PR TITLE
Editing Toolkit: add support link to block descriptions

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -348,3 +348,11 @@ function load_wpcom_documentation_links() {
 	require_once __DIR__ . '/wpcom-documentation-links/class-wpcom-documentation-links.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_documentation_links' );
+
+/**
+ * Add support links to block description
+ */
+function load_block_description_links() {
+	require_once __DIR__ . '/wpcom-block-description-links/class-wpcom-block-description-links.php';
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_description_links' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/README.md
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/README.md
@@ -1,5 +1,20 @@
-# wpcom-block-description-links
+# Block Description Links
 
-## TODO
+## Summary
 
-Add content here.
+This adds a "Learn more" link inline with the Block Description.
+
+## Adding more
+
+To extend this to more blocks you must add the block name to the switch case found in `./src/index.ts`. The case should set the `settings.description` using the `inlineBlockDescriptionLink` and break, it should not be returned. Please notice they are segregated as Core, Jetpack, and A8C.
+
+## Example
+
+```javasctipt
+case 'core/social-links':
+	settings[ 'description' ] = inlineBlockDescriptionLink(
+		settings[ 'description' ],
+		'https://wordpress.com/support/wordpress-editor/blocks/social-links-block/'
+	);
+	break;
+```

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/README.md
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/README.md
@@ -1,0 +1,5 @@
+# wpcom-block-description-links
+
+## TODO
+
+Add content here.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/class-wpcom-block-description-links.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/class-wpcom-block-description-links.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * WPCOM add support link to block descriptions.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+/**
+ * Class WPCOM_Block_Description_Links
+ */
+class WPCOM_Block_Description_Links {
+	/**
+	 * Class instance.
+	 *
+	 * @var WPCOM_Block_Description_Links
+	 */
+	private static $instance = null;
+
+	/**
+	 * WPCOM_Block_Description_Links constructor.
+	 */
+	public function __construct() {
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_script' ), 100 );
+	}
+
+	/**
+	 * Creates instance.
+	 *
+	 * @return \A8C\FSE\WPCOM_Block_Description_Links
+	 */
+	public static function init() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Enqueue block editor assets.
+	 */
+	public function enqueue_script() {
+		$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/wpcom-block-description-links.asset.php';
+		$script_dependencies = $asset_file['dependencies'];
+		$version             = $asset_file['version'];
+
+		wp_enqueue_script(
+			'wpcom-block-description-links-script',
+			plugins_url( 'dist/wpcom-block-description-links.js', __FILE__ ),
+			is_array( $script_dependencies ) ? $script_dependencies : array(),
+			$version,
+			true
+		);
+	}
+}
+add_action( 'init', array( __NAMESPACE__ . '\WPCOM_Block_Description_Links', 'init' ) );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/class-wpcom-block-description-links.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/class-wpcom-block-description-links.php
@@ -52,6 +52,19 @@ class WPCOM_Block_Description_Links {
 			$version,
 			true
 		);
+
+		wp_localize_script(
+			'wpcom-block-description-links-script',
+			'wpcomBlockDescriptionLinksAssetsUrl',
+			plugins_url( 'dist/', __FILE__ )
+		);
+
+		wp_localize_script(
+			'wpcom-block-description-links-script',
+			'wpcomBlockDescriptionLinksLocale',
+			\A8C\FSE\Common\get_iso_639_locale( determine_locale() )
+		);
 	}
+
 }
 add_action( 'init', array( __NAMESPACE__ . '\WPCOM_Block_Description_Links', 'init' ) );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/index.ts
@@ -1,0 +1,1 @@
+import './src';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.ts
@@ -16,10 +16,10 @@ const addBlockSupportLinks = (
 		'core/social-links',
 		'core/buttons',
 		'jetpack/contact-form',
-	].includes( settings[ 'parent' ] as string );
+	].includes( settings[ 'parent' ]?.toString() );
 
 	if ( applyToChildren ) {
-		name = settings[ 'parent' ] as string;
+		name = settings[ 'parent' ]?.toString();
 	}
 
 	switch ( name ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.ts
@@ -118,6 +118,7 @@ const addBlockSupportLinks = (
 				'https://wordpress.com/support/wordpress-editor/blocks/subscription-form-block/'
 			);
 			break;
+
 		case 'jetpack/contact-form':
 			settings[ 'description' ] = inlineBlockDescriptionLink(
 				settings[ 'description' ],

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.ts
@@ -1,0 +1,155 @@
+import { addFilter } from '@wordpress/hooks';
+import { ReactElement } from 'react';
+import { inlineBlockDescriptionLink } from './inline-block-link';
+
+const addBlockSupportLinks = (
+	settings: {
+		[ key: string ]: string | ReactElement;
+	},
+	name: string
+) => {
+	/**
+	 * Adjust the block name to apply link to InnerBlocks. This gets reset at the end
+	 */
+	const applyToChildren = [
+		'core/columns',
+		'core/social-links',
+		'core/buttons',
+		'jetpack/contact-form',
+	].includes( settings[ 'parent' ] as string );
+
+	if ( applyToChildren ) {
+		name = settings[ 'parent' ] as string;
+	}
+
+	switch ( name ) {
+		/**
+		 * Core Blocks
+		 */
+		case 'core/table':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/table-block/'
+			);
+			break;
+
+		case 'core/social-links':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/social-links-block/'
+			);
+			break;
+
+		case 'core/columns':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/columns-block/'
+			);
+			break;
+
+		case 'core/image':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/image-block/'
+			);
+			break;
+
+		case 'core/cover':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/cover-block/'
+			);
+			break;
+
+		case 'core/buttons':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/buttons-block/'
+			);
+			break;
+
+		case 'core/gallery':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/gallery-block/'
+			);
+			break;
+
+		/**
+		 * A8C Blocks
+		 */
+		case 'premium-content/container':
+		case 'premium-content/subscriber-view':
+		case 'premium-content/logged-out-view':
+		case 'premium-content/buttons':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/premium-content-block/'
+			);
+			break;
+
+		case 'a8c/blog-posts':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/blog-posts-block/'
+			);
+			break;
+
+		/**
+		 * Jetpack Blocks
+		 */
+		case 'jetpack/tiled-gallery':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/tiled-gallery-block/'
+			);
+			break;
+
+		case 'jetpack/slideshow':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/slideshow-block/'
+			);
+			break;
+
+		case 'jetpack/subscriptions':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				'Allow readers to receive a newsletter with future posts in their inbox. Subscribers can get notifications through email or the Reader app.',
+				'https://wordpress.com/support/wordpress-editor/blocks/subscription-form-block/'
+			);
+			break;
+		case 'jetpack/contact-form':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/form-block/'
+			);
+			break;
+
+		case 'jetpack/layout-grid':
+		case 'jetpack/layout-grid-column':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/layout-grid-block/'
+			);
+			break;
+
+		case 'jetpack/mailchimp':
+			settings[ 'description' ] = inlineBlockDescriptionLink(
+				settings[ 'description' ],
+				'https://wordpress.com/support/wordpress-editor/blocks/mailchimp-block/'
+			);
+			break;
+	}
+
+	if ( applyToChildren ) {
+		name = settings[ 'name' ] as string;
+	}
+
+	return settings;
+};
+
+addFilter(
+	'blocks.registerBlockType',
+	'full-site-editing/add-block-support-link',
+	addBlockSupportLinks
+);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/inline-block-link.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/inline-block-link.tsx
@@ -20,7 +20,7 @@ const BlockDescriptionLink = ( { url }: Props ) => {
 		<ExternalLink
 			ref={ ( reference ) => ref !== reference && setRef( reference ) }
 			style={ { paddingLeft: 5 } }
-			className="inline-support-link"
+			className="fse-inline-support-link"
 			href={ url }
 		>
 			{ __( 'Learn more', 'full-site-editing' ) }{ ' ' }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/inline-block-link.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/inline-block-link.tsx
@@ -1,0 +1,36 @@
+import { ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import React, { ReactElement } from 'react';
+
+type Props = {
+	url: string;
+};
+
+const BlockDescriptionLink = ( { url }: Props ) => {
+	// This was cooked up to only apply the link in the BlockEditor sidebar.
+	// Since there was no identifier in the environment to differentiate.
+	const [ ref, setRef ] = React.useState< any >();
+
+	if ( ref && ! ref?.closest( '.block-editor-block-inspector' ) ) {
+		return null;
+	}
+
+	return (
+		<ExternalLink
+			ref={ ( reference ) => ref !== reference && setRef( reference ) }
+			style={ { paddingLeft: 5 } }
+			className="inline-support-link"
+			href={ url }
+		>
+			{ __( 'Learn more', 'full-site-editing' ) }{ ' ' }
+		</ExternalLink>
+	);
+};
+
+export const inlineBlockDescriptionLink = ( description: string | ReactElement, url: string ) => {
+	return createInterpolateElement( description + '<BlockDescriptionLink/>', {
+		span: <span />,
+		BlockDescriptionLink: <BlockDescriptionLink url={ url } />,
+	} );
+};

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -28,6 +28,7 @@
 		"build:starter-page-templates": "calypso-build --env source='starter-page-templates'",
 		"build:tags-education": "calypso-build --env source='tags-education'",
 		"build:whats-new": "calypso-build --env source='whats-new'",
+		"build:wpcom-block-description-links": "calypso-build --env source='wpcom-block-description-links'",
 		"build:wpcom-block-editor-nav-sidebar": "calypso-build --env source='wpcom-block-editor-nav-sidebar'",
 		"build:wpcom-block-editor-nux": "calypso-build --env source='wpcom-block-editor-nux'",
 		"build:wpcom-documentation-links": "calypso-build --env source='wpcom-documentation-links'",


### PR DESCRIPTION
## Changes proposed in this Pull Request

![Screen Capture on 2022-03-17 at 17-46-11](https://user-images.githubusercontent.com/33258733/158851745-eb5e5f26-75e7-4091-b3f9-db2310763c99.gif)

In order to add more help in the editor for users, a feature request was made to add a link to relative support documentation in the block description.

I have added this to the `editing-toolkit` This hooks into `blocks.registerBlockType` and filters out the specific block and appends an `ExternalLink` to the description. To allow the links to be added to certain children blocks I added some logic as well to look for listed parents. Not sure if there should be any tracking on this?

This is hopefully a stop-gap until we can incorporate a fix in core.

## Testing instructions

Filtered blocks:
- core/table
- core/social-links
- core/columns
- core/image
- core/cover
- core/buttons
- core/gallery
- premium-content/container
- a8c/blog-posts
- jetpack/tiled-gallery
- jetpack/slideshow
- jetpack/subscriptions
- jetpack/contact-form
- jetpack/layout-grid
- jetpack/mailchimp

1. Pull branch run `cd apps/editing-toolkit && yarn dev --sync`
2. Go to your sandbox site and open the post/page editor.
3. Add the above-mentioned blocks and verify the description has the link and it is working properly.
4. Make sure the links are *not* appearing in any other areas such as the block picker preview when you click the [ + ] to add a new block.

Related to #56091 
Fixes #56091 