### PR TITLE
Update the message displayed when the user is trying to upload a too big plugin.

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -69,6 +69,7 @@ const MarketplacePluginInstall = ( {
 	const pluginUploadError = useSelector( ( state ) => getPluginUploadError( state, siteId ) );
 	const pluginExists = pluginUploadError?.error === 'folder_exists';
 	const pluginMalicious = pluginUploadError?.error === 'plugin_malicious';
+	const pluginTooBig = pluginUploadError?.statusCode === 413;
 	const wporgPlugin = useSelector( ( state ) => getPlugin( state, productSlug ) );
 	const isWporgPluginFetched = useSelector( ( state ) => isFetched( state, productSlug ) );
 	const uploadedPluginSlug = useSelector( ( state ) =>
@@ -350,14 +351,20 @@ const MarketplacePluginInstall = ( {
 				/>
 			);
 		}
-		if ( pluginMalicious ) {
+		if ( pluginMalicious || pluginTooBig ) {
 			return (
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
 					title={ null }
-					line={ translate(
-						'This plugin is identified as malicious. If you still insist to install the plugin, please continue by uploading the plugin again from WP Admin.'
-					) }
+					line={
+						pluginMalicious
+							? translate(
+									'This plugin is identified as malicious. If you still insist to install the plugin, please continue by uploading the plugin again from WP Admin.'
+							  )
+							: translate(
+									'This plugin is too big to be installed via this page. If you still want to install the plugin, please continue by uploading the plugin again from WP Admin.'
+							  )
+					}
 					secondaryAction={ translate( 'Back' ) }
 					secondaryActionURL={ `/plugins/upload/${ selectedSiteSlug }` }
 					action={ translate( 'Continue' ) }

--- a/client/state/selectors/get-plugin-upload-error.js
+++ b/client/state/selectors/get-plugin-upload-error.js
@@ -8,7 +8,7 @@ import 'calypso/state/plugins/init';
  *
  * @param {object} state Global state tree
  * @param {number} siteId the site ID
- * @returns {null|{error?: string}} Error from upload, if any
+ * @returns {null|{error?: string, statusCode: number}} Error from upload, if any
  */
 export default function getPluginUploadError( state, siteId ) {
 	return get( state.plugins.upload.uploadError, siteId, null );


### PR DESCRIPTION

#### Changes proposed in this Pull Request
* Add a check when the server returns 413 (too big)
* Show a message warning the user about the error and how to proceed

#### Testing instructions
* Go to `/plugins/upload/{site}`
* Try to upload a big plugin(you can find one at #61609)
* See if the new message explaining the problem is shown
* Click on continue and get redirected to the WP admin upload page
* Now you should be able to upload the plugin successfully 
<img width="769" alt="Screen Shot 2022-03-17 at 14 47 56" src="https://user-images.githubusercontent.com/5039531/158910483-72e82f5d-cca4-44f2-880d-d94b256e3426.png">

---

Related to #61609
