### PR TITLE
[E2E][GB] Add account criteria for Gutenberg on edge on AT and Gutenberg stable on AT

### DIFF
--- a/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts
+++ b/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts
@@ -82,6 +82,16 @@ const defaultCriteria: FeatureCriteria[] = [
 		variant: 'siteEditor',
 		accountName: 'siteEditorSimpleSiteEdgeUser',
 	},
+	{
+		gutenberg: 'stable',
+		siteType: 'atomic',
+		accountName: 'gutenbergAtomicSiteUser',
+	},
+	{
+		gutenberg: 'edge',
+		siteType: 'atomic',
+		accountName: 'gutenbergAtomicSiteEdgeUser',
+	},
 ];
 
 const defaultAccountsTable = criteriaToMap( defaultCriteria, new Map() );


### PR DESCRIPTION
Project: p9oQ9f-13V-p2

Follow up to: https://github.com/Automattic/wp-calypso/pull/62023 and https://github.com/Automattic/wp-calypso/pull/61783.

https://github.com/Automattic/wp-calypso/pull/62023 should be merged first!

#### Changes proposed in this Pull Request

* Add two new declarative criteria to define the account for GB edge on AT and GB stable on AT.

#### Testing instructions

* Make sure the account names are correct and that they exist in your `local-decrypted.json`
* Tests should pass