### PR TITLE
Ensure account recovery email is validated as changes are made

### DIFF
--- a/client/me/security-account-recovery/edit-email.jsx
+++ b/client/me/security-account-recovery/edit-email.jsx
@@ -113,23 +113,11 @@ class SecurityAccountRecoveryRecoveryEmailEdit extends Component {
 			return;
 		}
 
-		if ( this.props.primaryEmail && email === this.props.primaryEmail ) {
-			this.setState( {
-				validation: this.props.translate(
-					'You have entered your primary email address. Please enter a different email address.'
-				),
-			} );
+		const isEmailValid = this.validateEmail( email );
+		if ( ! isEmailValid ) {
 			return;
 		}
 
-		if ( ! emailValidator.validate( email ) ) {
-			this.setState( {
-				validation: this.props.translate( 'Please enter a valid email address.' ),
-			} );
-			return;
-		}
-
-		this.setState( { validation: null } );
 		this.props.onSave( email );
 	};
 
@@ -141,8 +129,37 @@ class SecurityAccountRecoveryRecoveryEmailEdit extends Component {
 		this.props.onDelete();
 	};
 
+	validateEmail = ( newEmail ) => {
+		const { primaryEmail, translate } = this.props;
+
+		if ( primaryEmail && newEmail === primaryEmail ) {
+			this.setState( {
+				validation: translate(
+					'You have entered your primary email address. Please enter a different email address.'
+				),
+			} );
+			return false;
+		}
+
+		if ( ! emailValidator.validate( newEmail ) ) {
+			this.setState( {
+				validation: translate( 'Please enter a valid email address.' ),
+			} );
+			return false;
+		}
+
+		this.setState( { validation: null } );
+
+		return true;
+	};
+
 	handleChange = ( e ) => {
 		const { name, value } = e.currentTarget;
+
+		if ( 'email' === name ) {
+			this.validateEmail( value );
+		}
+
 		this.setState( { [ name ]: value } );
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR ensures that we validate account recovery email addresses as users are typing, rather than only on submit

#### Testing instructions

* Run this branch locally or via the calypso.live branch
* Navigate to `/me/security`
* If the UI is showing the new checklist-style menu, click on the "Recovery Email" menu item.
  - If the UI is showing the tab navigation, click on the "Account Recovery" tab
* Click on the "Edit" button on the "Recovery email address" row
* Modify the email address so it is invalid, and verify that you see an error message below the input field
  - You should see validation errors for an empty email address, entering the same email address as your primary email address, and an otherwise invalid email address (note that the validation doesn't check for whether the TLD exists, merely that it matches expected patterns)
* Verify that you can't save the email address with an invalid value
* Verify that if you update the email address to be valid that the validation error is removed