### PR TITLE
Update theme search to account for twentytwenty-two theme

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -325,6 +325,7 @@ class ThemesMagicSearchCard extends Component {
 						terms={ this.props.filters }
 						input={ this.state.editedSearchElement }
 						suggest={ this.suggest }
+						exclusions={ [ /twenty.*?two/ ] }
 					/>
 				) }
 				{ this.state.searchInput !== '' && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Normally entering the word "two" anywhere in the theme search pops up the "Two Column" suggestions.

This change makes it so any search that matches `twenty.*?two` will only display the search results and not the suggestion.

We do this by adding an `exclusions` prop to the `KeyedSuggestions` component. This prop is an array of regexes. If the current search term matches any of those regexes, then we only search for matches by the full term rather than splitting the term up and searching by similarity.

https://user-images.githubusercontent.com/917632/158873797-53781805-6df0-4841-b134-6fbe724d5e71.mp4

#### Testing instructions

1. Prior to applying the update, go to `/themes` and enter `twenty-two` in the search box.
2. You should see the following suggestions:
<img width="895" alt="image" src="https://user-images.githubusercontent.com/917632/158874958-7d49a1f8-dc7e-4a45-87cf-badebbdb5a77.png">
3. Apply this update and enter the same search term.
4. You should only see search results, no suggestions.

Related to #61544
