### PR TITLE
Exclude build meta files from diff logic

### DIFF
--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -173,7 +173,7 @@ open class WPComPluginBuild(
 
 					# 3. Check if the current build has changed, and if so, tag it for release.
 					# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
-					if [ "%skip_release_diff%" = "true" ] || ! diff -rq --exclude="*.asset.php" --exclude="cache-buster.txt" --exclude="README.md" $archiveDir ./release-archive/ ; then
+					if [ "%skip_release_diff%" = "true" ] || ! diff -rq --exclude="*.asset.php" --exclude="build_meta.json" --exclude="README.md" $archiveDir ./release-archive/ ; then
 						echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
 						tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
 						echo -e "Build tagging status: ${'$'}tag_response\n"


### PR DESCRIPTION
#### Changes proposed in this Pull Request
In #61723, we changed the build meta file to be generated in webpack rather than in TeamCity. As a result, the build meta files exists when the build starts, instead of being created at the end. The existing logic didn't take this into account when checking for differences between two builds. I did update it to ignore the build meta file in the "previous release" it diffs against, but didn't update it to ignore the build meta file in the new release.

The solution is to ignore the file when running the `diff` command.

#### Testing instructions
- TeamCity should pass and no comments should be posted to this PR.
