### PR TITLE
Update i18n-calypso to v6.0.1

### DIFF
--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.1
+
+- Fix an issue in the published build of i18n-calypso which prevented it from installing correctly.
+
 ## 6.0.0
 
 - Update React peer dependency to v17.

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "i18n-calypso",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"description": "I18n JavaScript library on top of Tannin originally used in Calypso.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When I published i18n-calypso to v6.0.0, I ran `npm publish`. This caused the publish build to be incorrect, as it includes yarn constructs like `workspace:^`. We should be running `yarn npm publish`. This is bumping the version so we can republish a new build. (Thankfully, v6 has 0 downloads, so I deprecated it and changed the latest tag to point back at v5.)
