### PR TITLE
Payment Methods: Change saveCreditCard/updateCreditCard to use 1.1 endpoints

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
@@ -31,6 +31,7 @@ export async function saveCreditCard( {
 	const response = await wp.req.post(
 		{
 			path: '/me/stored-cards',
+			apiVersion: '1.1',
 		},
 		{
 			payment_key: token,
@@ -80,14 +81,20 @@ export async function updateCreditCard( {
 		postalCode,
 		countryCode,
 	} );
-	const response = await wp.req.post( '/upgrades/' + purchaseId + '/update-credit-card', {
-		payment_partner,
-		paygate_token,
-		use_for_existing,
-		event_source,
-		postal_code,
-		country_code,
-	} );
+	const response = await wp.req.post(
+		{
+			path: '/upgrades/' + purchaseId + '/update-credit-card',
+			apiVersion: '1.1',
+		},
+		{
+			payment_partner,
+			paygate_token,
+			use_for_existing,
+			event_source,
+			postal_code,
+			country_code,
+		}
+	);
 	if ( response.error ) {
 		recordTracksEvent( 'calypso_purchases_save_new_payment_method_error' );
 		throw new Error( response );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In D76613-code we created 1.1 versions of the (POST) `/me/stored-cards` and (POST) `/upgrades/ID/update-credit-card` endpoints that require tax contact information to be provided. This PR changes calypso's payment method management to use these new endpoints.

Note that this PR should not actually change any part of the user experience because we already validate the contact information since https://github.com/Automattic/wp-calypso/pull/61862 was merged. The only difference here is that we make sure the endpoints themselves won't accept missing details.

#### Testing instructions

To test the add endpoint:

- Visit `/me/purchases/add-payment-method`.
- Fill in the form and submit it, but leave country code and postal code empty.
- Verify that you get an error message about missing info.
- Fill in the form and submit it, with postal code and country included.
- Verify that the card is added.

Next, test the update endpoint.

- Use an account with at least one active subscription.
- Visit `/me/purchases`.
- Click on an active subscription and then click "Change payment method" or "Add payment method".
- Select "Credit or debit card" to add a new card.
- Fill in the form and submit it, but leave country code and postal code empty.
- Verify that you get an error message about missing info.
- Fill in the form and submit it, with postal code and country included.
- Verify that the card is added.