### PR TITLE
[GB][E2E] Add two new GB build types for AT-specific E2E testing

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -220,13 +220,22 @@ fun gutenbergBuildType(screenSize: String, buildUuid: String): BuildType {
 }
 
 fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomic: Boolean = false ): E2EBuildType {
-	var isAtomicDescription = if (atomic) "atomic" else "";
+	var buildId = if (atomic) {
+		"WPComTests_gutenberg_Playwright_atomic_$targetDevice"
+	} else {
+		// buildId should stay the same for non-atomic or TC will not find the entry
+		// and will create a new one. We want to keep all the data/history for it, so
+		// we keep the id as is.
+		"WPComTests_gutenberg_Playwright_$targetDevice"
+	}
+
+	var siteType = if (atomic) "atomic" else "simple";
 
     return E2EBuildType (
-		buildId = "WPComTests_gutenberg_Playwright_${isAtomicDescription}_$targetDevice",
+		buildId = buildId,
 		buildUuid = buildUuid,
-		buildName = "Playwright Gutenberg $isAtomicDescription E2E tests ($targetDevice)",
-		buildDescription = "Runs Gutenberg $isAtomicDescription E2E tests on $targetDevice size",
+		buildName = "Playwright Gutenberg $siteType E2E tests ($targetDevice)",
+		buildDescription = "Runs Gutenberg $siteType E2E tests on $targetDevice size",
 		testGroup = "gutenberg",
 		buildParams = {
 			text(

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -262,7 +262,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 			)
 			param("env.AUTHENTICATE_ACCOUNTS", "gutenbergSimpleSiteEdgeUser,gutenbergSimpleSiteUser,coBlocksSimpleSiteEdgeUser,simpleSitePersonalPlanUser")
 			param("env.VIEWPORT_NAME", "$targetDevice")
-			if (atomic) Parametrized().param("TEST_ON_ATOMIC", "true")
+			if (atomic) Parametrized().param("env.TEST_ON_ATOMIC", "true")
 		},
 		buildFeatures = {
 			notifications {

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -38,8 +38,8 @@ object WPComTests : Project({
 
 	buildType(gutenbergPlaywrightBuildType("desktop", "fab2e82e-d27b-4ba2-bbd7-232df944e75c"));
 	buildType(gutenbergPlaywrightBuildType("mobile", "77a5a0f1-9644-4c04-9d27-0066cd2d4ada"));
-	buildType(gutenbergPlaywrightBuildType("desktop", "?" , true));
-	buildType(gutenbergPlaywrightBuildType("mobile", "?", true));
+	buildType(gutenbergPlaywrightBuildType("desktop", "c341e9b9-1118-48e9-a569-325100f5fd9" , true));
+	buildType(gutenbergPlaywrightBuildType("mobile", "e0f7e412-ae6c-41d3-9eec-c57c94dd8385", true));
 
 	buildType(coblocksPlaywrightBuildType("desktop", "08f88b93-993e-4de8-8d80-4a94981d9af4"));
 	buildType(coblocksPlaywrightBuildType("mobile", "cbcd44d5-4d31-4adc-b1b5-97f1225c6a7c"));

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -220,19 +220,10 @@ fun gutenbergBuildType(screenSize: String, buildUuid: String): BuildType {
 }
 
 fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomic: Boolean = false ): E2EBuildType {
-	var buildId = if (atomic) {
-		"WPComTests_gutenberg_Playwright_atomic_$targetDevice"
-	} else {
-		// buildId should stay the same for non-atomic or TC will not find the entry
-		// and will create a new one. We want to keep all the data/history for it, so
-		// we keep the id as is.
-		"WPComTests_gutenberg_Playwright_$targetDevice"
-	}
-
 	var siteType = if (atomic) "atomic" else "simple";
 
     return E2EBuildType (
-		buildId = buildId,
+		buildId = "WPComTests_gutenberg_Playwright_${siteType}_$targetDevice",
 		buildUuid = buildUuid,
 		buildName = "Playwright Gutenberg $siteType E2E tests ($targetDevice)",
 		buildDescription = "Runs Gutenberg $siteType E2E tests on $targetDevice size",

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -6,7 +6,6 @@ import _self.lib.customBuildType.E2EBuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
-import jetbrains.buildServer.configs.kotlin.v2019_2.Parametrized
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.notifications
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
@@ -262,7 +261,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 			)
 			param("env.AUTHENTICATE_ACCOUNTS", "gutenbergSimpleSiteEdgeUser,gutenbergSimpleSiteUser,coBlocksSimpleSiteEdgeUser,simpleSitePersonalPlanUser")
 			param("env.VIEWPORT_NAME", "$targetDevice")
-			if (atomic) Parametrized().param("env.TEST_ON_ATOMIC", "true")
+			if (atomic) param("env.TEST_ON_ATOMIC", "true")
 		},
 		buildFeatures = {
 			notifications {

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -5,8 +5,8 @@ import _self.bashNodeScript
 import _self.lib.customBuildType.E2EBuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
-import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
+import jetbrains.buildServer.configs.kotlin.v2019_2.Parametrized
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.notifications
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
@@ -35,12 +35,18 @@ object WPComTests : Project({
 	// Keep the previous ID in order to preserve the historical data
 	buildType(gutenbergBuildType("desktop", "aee94c18-ee11-4c80-b6aa-245b967a97db"));
 	buildType(gutenbergBuildType("mobile","2af2eaed-87d5-41f4-ab1d-4ed589d5ae82"));
+
 	buildType(gutenbergPlaywrightBuildType("desktop", "fab2e82e-d27b-4ba2-bbd7-232df944e75c"));
 	buildType(gutenbergPlaywrightBuildType("mobile", "77a5a0f1-9644-4c04-9d27-0066cd2d4ada"));
+	buildType(gutenbergPlaywrightBuildType("desktop", "?" , true));
+	buildType(gutenbergPlaywrightBuildType("mobile", "?", true));
+
 	buildType(coblocksPlaywrightBuildType("desktop", "08f88b93-993e-4de8-8d80-4a94981d9af4"));
 	buildType(coblocksPlaywrightBuildType("mobile", "cbcd44d5-4d31-4adc-b1b5-97f1225c6a7c"));
+
 	buildType(jetpackBuildType("desktop"));
 	buildType(jetpackBuildType("mobile"));
+
 	buildType(VisualRegressionTests);
 	buildType(I18NTests);
 	buildType(P2E2ETests)
@@ -113,7 +119,6 @@ fun gutenbergBuildType(screenSize: String, buildUuid: String): BuildType {
 					export NODE_CONFIG_ENV=test
 					export TEST_VIDEO=true
 					export HIGHLIGHT_ELEMENT=true
-					export TEST_ON_ATOMIC=%TEST_ON_ATOMIC%
 					export GUTENBERG_EDGE=%GUTENBERG_EDGE%
 					export COBLOCKS_EDGE=%COBLOCKS_EDGE%
 					export URL=%URL%
@@ -214,12 +219,14 @@ fun gutenbergBuildType(screenSize: String, buildUuid: String): BuildType {
 	}
 }
 
-fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String ): E2EBuildType {
+fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomic: Boolean = false ): E2EBuildType {
+	var isAtomicDescription = if (atomic) "atomic" else "";
+
     return E2EBuildType (
-		buildId = "WPComTests_gutenberg_Playwright_$targetDevice",
+		buildId = "WPComTests_gutenberg_Playwright_${isAtomicDescription}_$targetDevice",
 		buildUuid = buildUuid,
-		buildName = "Playwright Gutenberg E2E tests ($targetDevice)",
-		buildDescription = "Runs Gutenberg e2e tests on $targetDevice size",
+		buildName = "Playwright Gutenberg $isAtomicDescription E2E tests ($targetDevice)",
+		buildDescription = "Runs Gutenberg $isAtomicDescription E2E tests on $targetDevice size",
 		testGroup = "gutenberg",
 		buildParams = {
 			text(
@@ -255,6 +262,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String ): E2E
 			)
 			param("env.AUTHENTICATE_ACCOUNTS", "gutenbergSimpleSiteEdgeUser,gutenbergSimpleSiteUser,coBlocksSimpleSiteEdgeUser,simpleSitePersonalPlanUser")
 			param("env.VIEWPORT_NAME", "$targetDevice")
+			if (atomic) Parametrized().param("TEST_ON_ATOMIC", "true")
 		},
 		buildFeatures = {
 			notifications {


### PR DESCRIPTION
Project: p9oQ9f-13V-p2.

#### Changes proposed in this Pull Request

* Add two new TC builds: `Playwright Gutenberg atomic E2E tests (desktop)` and `Playwright Gutenberg atomic E2E tests (mobile)`

#### Testing instructions

* Merge and 🤞🏻 

Related to #
