### PR TITLE
Plan overhaul Phase 1 Pro plan: "Included with your purchase" list in checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
 	isMonthly,
+	isWpComProPlan,
 	isWpComBusinessPlan,
 	isWpComEcommercePlan,
 	isWpComPersonalPlan,
@@ -53,7 +54,7 @@ export default function getPlanFeatures(
 		].filter( isValueTruthy );
 	}
 
-	if ( isWpComBusinessPlan( productSlug ) ) {
+	if ( isWpComBusinessPlan( productSlug ) || isWpComProPlan( productSlug ) ) {
 		return [
 			! isMonthlyPlan && freeOneYearDomain,
 			! isMonthlyPlan && liveChatSupport,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This shows the same included feature list in the Pro plan as the one from Business plan.

#### Testing instructions

* Go to /start/plans?flags=plans/pro-plan
* Select the Pro plan and proceed to the checkout page
* The `Included with your purchase` list should match the one from the Business plan
<img width="374" alt="Screenshot on 2022-03-18 at 12-26-44" src="https://user-images.githubusercontent.com/2749938/158986559-1ddf93e7-9143-4186-99e4-8a6c1ad82374.png">

