### PR TITLE
Calypso: change excerpts and permalink documentation links to wpcom

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -340,3 +340,11 @@ function load_paragraph_block() {
 	require_once __DIR__ . '/paragraph-block/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_paragraph_block' );
+
+/**
+ * Override org documentation links
+ */
+function load_wpcom_documentation_links() {
+	require_once __DIR__ . '/wpcom-documentation-links/class-wpcom-documentation-links.php';
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_documentation_links' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/class-wpcom-documentation-links.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/class-wpcom-documentation-links.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * WPCOM change documentation links
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+/**
+ * Class WPCOM_Documentation
+ */
+class WPCOM_Documentation_Links {
+	/**
+	 * Class instance.
+	 *
+	 * @var WPCOM_Documentation_Links
+	 */
+	private static $instance = null;
+
+	/**
+	 * WPCOM_Documentation_Links constructor.
+	 */
+	public function __construct() {
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_script' ), 100 );
+	}
+
+	/**
+	 * Creates instance.
+	 *
+	 * @return \A8C\FSE\WPCOM_Documentation_Links
+	 */
+	public static function init() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Enqueue block editor assets.
+	 */
+	public function enqueue_script() {
+		$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/wpcom-documentation-links.asset.php';
+		$script_dependencies = $asset_file['dependencies'];
+		$version             = $asset_file['version'];
+
+		wp_enqueue_script(
+			'wpcom-documentation-links-script',
+			plugins_url( 'dist/wpcom-documentation-links.js', __FILE__ ),
+			is_array( $script_dependencies ) ? $script_dependencies : array(),
+			$version,
+			true
+		);
+
+		wp_localize_script(
+			'wpcom-documentation-links-script',
+			'wpcomDocumentationLinksAssetsUrl',
+			plugins_url( 'dist/', __FILE__ )
+		);
+		wp_localize_script(
+			'wpcom-documentation-links-script',
+			'wpcomDocumentationLinksLocale',
+			\A8C\FSE\Common\get_iso_639_locale( determine_locale() )
+		);
+
+		wp_set_script_translations( 'wpcom-documentation-links-script', 'full-site-editing' );
+	}
+}
+add_action( 'init', array( __NAMESPACE__ . '\WPCOM_Documentation_Links', 'init' ) );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/index.ts
@@ -1,0 +1,1 @@
+import './src';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
@@ -1,0 +1,18 @@
+import { addFilter } from '@wordpress/hooks';
+
+function overrideCoreDocumentationLinksToWpcom( translation: string, text: string ) {
+	switch ( text ) {
+		case 'https://wordpress.org/support/article/excerpt/':
+			return 'https://wordpress.com/support/excerpts/';
+		case 'https://wordpress.org/support/article/writing-posts/#post-field-descriptions':
+			return 'https://wordpress.com/support/permalinks-and-slugs/';
+	}
+
+	return translation;
+}
+
+addFilter(
+	'i18n.gettext_default',
+	'full-site-editing/override-core-docs-to-wpcom',
+	overrideCoreDocumentationLinksToWpcom
+);

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -30,6 +30,7 @@
 		"build:whats-new": "calypso-build --env source='whats-new'",
 		"build:wpcom-block-editor-nav-sidebar": "calypso-build --env source='wpcom-block-editor-nav-sidebar'",
 		"build:wpcom-block-editor-nux": "calypso-build --env source='wpcom-block-editor-nux'",
+		"build:wpcom-documentation-links": "calypso-build --env source='wpcom-documentation-links'",
 		"clean": "rm -rf dist editing-toolkit-plugin/*/dist || true",
 		"dev": "yarn run calypso-apps-builder --localPath editing-toolkit-plugin --remotePath /home/wpcom/public_html/wp-content/plugins/editing-toolkit-plugin/dev",
 		"lint:php": "../../vendor/bin/phpcs --standard=../phpcs.xml ./ ",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In wpcom changed documentation link:
- Permalinks: https://wordpress.org/support/article/writing-posts/#post-field-descriptions -> https://wordpress.com/support/permalinks-and-slugs/
- Excerpt: https://wordpress.org/support/article/excerpt/ -> https://wordpress.com/support/excerpts/

### Steps to reproduce the behavior

1. Go to the WordPress editor
2. In the Page/Post settings sidebar on the right, look for 'Permalinks'
3. Click the link "Read about permalinks(opens in a new tab)"
4. In the Page/Post settings sidebar on the right, look for 'Excerpts'
5. Click the link "Learn more about manual excerpts(opens in a new tab)"

#### What I expected to happen

I expected to be taken to a WordPress.com resource.

#### What actually happened

For permalinks, it took me to:

https://wordpress.org/support/article/writing-posts/#post-field-descriptions

For excerpts, it took me to:

https://wordpress.org/support/article/excerpt/

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* `yarn dev --sync` from `apps/editing-toolkit`
* Go to the editor
* Open settings
![image](https://user-images.githubusercontent.com/52076348/158999015-1580be0b-557b-4d36-97dc-fa23a04110c3.png)
* Check that `Read about permalinks` brings you to `https://wordpress.com/support/permalinks-and-slugs/` and `Learn more about manual excerpts` to `https://wordpress.com/support/excerpts/`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #52191, #61513
Fixes #52191 
Fixes #61513
