### PR TITLE
Hide Upgrade option for Pro plan

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -16,6 +16,7 @@ import {
 	isJetpackProduct,
 	isConciergeSession,
 	isTitanMail,
+	isPro,
 	applyTestFiltersToPlansList,
 	isWpComMonthlyPlan,
 	JETPACK_BACKUP_T1_PRODUCTS,
@@ -234,6 +235,7 @@ class ManagePurchase extends Component {
 		const isUpgradeablePlan =
 			isPlan( purchase ) &&
 			! isEcommerce( purchase ) &&
+			! isPro( purchase ) &&
 			! isComplete( purchase ) &&
 			! isP2Plus( purchase );
 		const isUpgradeableProduct =
@@ -344,6 +346,7 @@ class ManagePurchase extends Component {
 			purchase &&
 			isPlan( purchase ) &&
 			! isEcommerce( purchase ) &&
+			! isPro( purchase ) &&
 			! isComplete( purchase ) &&
 			! isP2Plus( purchase );
 


### PR DESCRIPTION
The Pro plan is a top tier plan and has no 2-year option

#### Changes proposed in this Pull Request

Hides 2 buttons from /me/purchases/SITE/PURCHASE

<img width="1335" alt="Screenshot 2022-03-18 at 14 26 03" src="https://user-images.githubusercontent.com/82778/159003098-7cbfea18-0ec7-4b5e-bf9d-8ee9f4f352ea.png">

#### Testing instructions

1. Purchase the Pro plan
2. Go to me/purchases and click on the plan
3. The 2 buttons that offer an upgrade should not be there
4. You can repeat with an existing site on another plan and make sure the buttons still exist.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
