### PR TITLE
Contact: Add 2022 holiday closure notices for Live Chat and Quick Start

### DIFF
--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -13,21 +13,21 @@ class PrimaryHeader extends Component {
 		return (
 			<Fragment>
 				<ClosureNotice
-					displayAt="2021-03-28 00:00Z"
-					closesAt="2021-04-04 00:00Z"
-					reopensAt="2021-04-05 06:00Z"
+					displayAt="2022-04-10 00:01Z"
+					closesAt="2022-04-17 00:01Z"
+					reopensAt="2022-04-18 07:00Z"
 					holidayName="Easter"
 				/>
 				<ClosureNotice
-					displayAt="2021-12-17 00:00Z"
-					closesAt="2021-12-24 00:00Z"
-					reopensAt="2021-12-26 07:00Z"
+					displayAt="2022-12-17 00:01Z"
+					closesAt="2022-12-24 00:01Z"
+					reopensAt="2022-12-26 07:00Z"
 					holidayName="Christmas"
 				/>
 				<ClosureNotice
-					displayAt="2021-12-26 07:00Z"
-					closesAt="2021-12-31 00:00Z"
-					reopensAt="2022-01-02 07:00Z"
+					displayAt="2022-12-26 07:00Z"
+					closesAt="2022-12-31 00:01Z"
+					reopensAt="2023-01-02 07:00Z"
 					holidayName="New Year's Day"
 				/>
 				<Card>

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -13,20 +13,20 @@ class PrimaryHeader extends Component {
 		return (
 			<Fragment>
 				<ClosureNotice
-					displayAt="2022-04-10 00:01Z"
-					closesAt="2022-04-17 00:01Z"
+					displayAt="2022-04-10 00:00Z"
+					closesAt="2022-04-17 00:00Z"
 					reopensAt="2022-04-18 07:00Z"
 					holidayName="Easter"
 				/>
 				<ClosureNotice
-					displayAt="2022-12-17 00:01Z"
-					closesAt="2022-12-24 00:01Z"
+					displayAt="2022-12-17 00:00Z"
+					closesAt="2022-12-24 00:00Z"
 					reopensAt="2022-12-26 07:00Z"
 					holidayName="Christmas"
 				/>
 				<ClosureNotice
 					displayAt="2022-12-26 07:00Z"
-					closesAt="2022-12-31 00:01Z"
+					closesAt="2022-12-31 00:00Z"
 					reopensAt="2023-01-02 07:00Z"
 					holidayName="New Year's Day"
 				/>

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -659,8 +659,8 @@ class HelpContact extends Component {
 								context: 'Holiday name',
 							} ) }
 							compact={ compact }
-							displayAt="2022-04-10 00:01Z"
-							closesAt="2022-04-17 00:01Z"
+							displayAt="2022-04-10 00:00Z"
+							closesAt="2022-04-17 00:00Z"
 							reopensAt="2022-04-18 07:00Z"
 						/>
 						<ChatHolidayClosureNotice
@@ -668,8 +668,8 @@ class HelpContact extends Component {
 								context: 'Holiday name',
 							} ) }
 							compact={ compact }
-							displayAt="2022-12-17 00:01Z"
-							closesAt="2022-12-24 00:01Z"
+							displayAt="2022-12-17 00:00Z"
+							closesAt="2022-12-24 00:00Z"
 							reopensAt="2022-12-26 07:00Z"
 						/>
 						<ChatHolidayClosureNotice
@@ -678,7 +678,7 @@ class HelpContact extends Component {
 							} ) }
 							compact={ compact }
 							displayAt="2022-12-26 07:00Z"
-							closesAt="2022-12-31 00:01Z"
+							closesAt="2022-12-31 00:00Z"
 							reopensAt="2023-01-02 07:00Z"
 						/>
 					</>

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -659,27 +659,27 @@ class HelpContact extends Component {
 								context: 'Holiday name',
 							} ) }
 							compact={ compact }
-							displayAt="2021-03-28 00:00Z"
-							closesAt="2021-04-04 00:00Z"
-							reopensAt="2021-04-05 06:00Z"
+							displayAt="2022-04-10 00:01Z"
+							closesAt="2022-04-17 00:01Z"
+							reopensAt="2022-04-18 07:00Z"
 						/>
 						<ChatHolidayClosureNotice
 							holidayName={ translate( 'Christmas', {
 								context: 'Holiday name',
 							} ) }
 							compact={ compact }
-							displayAt="2021-12-17 00:00Z"
-							closesAt="2021-12-24 00:00Z"
-							reopensAt="2021-12-26 07:00Z"
+							displayAt="2022-12-17 00:01Z"
+							closesAt="2022-12-24 00:01Z"
+							reopensAt="2022-12-26 07:00Z"
 						/>
 						<ChatHolidayClosureNotice
 							holidayName={ translate( "New Year's Day", {
 								context: 'Holiday name',
 							} ) }
 							compact={ compact }
-							displayAt="2021-12-26 07:00Z"
-							closesAt="2021-12-31 00:00Z"
-							reopensAt="2022-01-02 07:00Z"
+							displayAt="2022-12-26 07:00Z"
+							closesAt="2022-12-31 00:01Z"
+							reopensAt="2023-01-02 07:00Z"
 						/>
 					</>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Updating the Live Chat and Quick Start closure notices for the 2022 holidays.
- Ref: pdm0RZ-2C-p2

#### Testing instructions

1. Open both http://calypso.localhost:3000/help/contact and http://calypso.localhost:3000/me/quickstart
2. Change the system date and time on your computer (no need to reload the browser).
3. Check the message at the top when checking the following dates and times:

	- **Now** — Nothing.
	- **April 10 00:01 UTC** — Pre-closure messages for Easter.
	- **April 17 00:01 UTC** — Closure  messages for Easter.
	- **April 18 07:00 UTC** — Nothing.
	- **December 17 00:01 UTC** — Pre-closure messages for Christmas.
	- **December 24 00:01 UTC** — Closure messages for Christmas.
	- **December 26 07:00 UTC** — Pre-closure messages for New Year's Day.
	- **December 31 00:01 UTC** — Closure messages for New Year's Day.
	- **January 2 07:00 UTC** — Nothing.

Example of the message you should see at the top:

Happy Chat Form:
![Chat pre-closure message](https://user-images.githubusercontent.com/3696121/159019241-de900f85-c1c8-4875-a483-686ba737961b.png)

Quick Start Form:
![Quick Start message](https://user-images.githubusercontent.com/3696121/159020311-e6aeaf82-4d0f-408a-a99b-4396afd1fc0a.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/49785/