### PR TITLE
Emails: Create a page handler for the billing selector

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -23,6 +23,7 @@ import {
 	domainUseYourDomain,
 } from 'calypso/my-sites/domains/paths';
 import TransferDomain from 'calypso/my-sites/domains/transfer-domain';
+import { castIntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -258,7 +259,10 @@ const emailUpsellForDomainRegistration = ( context, next ) => {
 					args: { domain: context.params.domain },
 				} ) }
 			/>
-			<EmailProvidersUpsell domain={ context.params.domain } />
+			<EmailProvidersUpsell
+				domain={ context.params.domain }
+				selectedIntervalLength={ castIntervalLength( context.query.interval ) }
+			/>
 		</Main>
 	);
 

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -4,7 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useSelector } from 'react-redux';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
-import { domainAddNew } from 'calypso/my-sites/domains/paths';
+import { domainAddEmailUpsell, domainAddNew } from 'calypso/my-sites/domains/paths';
 import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-comparison';
 import EmailProvidersStackedComparison from 'calypso/my-sites/email/email-providers-stacked-comparison';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -14,6 +14,10 @@ export default function EmailProvidersUpsell( { domain, selectedIntervalLength }
 	const translate = useTranslate();
 
 	const comment = '%(domainName)s is the domain name, e.g example.com';
+
+	const changeIntervalLength = ( props, intervalLength ) => {
+		page( domainAddEmailUpsell( selectedSiteSlug, props.selectedDomainName, intervalLength ) );
+	};
 
 	return (
 		<CalypsoShoppingCartProvider>
@@ -46,6 +50,7 @@ export default function EmailProvidersUpsell( { domain, selectedIntervalLength }
 				<EmailProvidersStackedComparison
 					comparisonContext="domain-upsell"
 					isDomainInCart={ true }
+					onIntervalLengthChange={ changeIntervalLength }
 					selectedDomainName={ domain }
 					selectedIntervalLength={ selectedIntervalLength }
 					source="domain-upsell"

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -9,7 +9,7 @@ import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-com
 import EmailProvidersStackedComparison from 'calypso/my-sites/email/email-providers-stacked-comparison';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-export default function EmailProvidersUpsell( { domain } ) {
+export default function EmailProvidersUpsell( { domain, selectedIntervalLength } ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
 
@@ -47,6 +47,7 @@ export default function EmailProvidersUpsell( { domain } ) {
 					comparisonContext="domain-upsell"
 					isDomainInCart={ true }
 					selectedDomainName={ domain }
+					selectedIntervalLength={ selectedIntervalLength }
 					source="domain-upsell"
 				></EmailProvidersStackedComparison>
 			) }

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -15,8 +15,8 @@ export default function EmailProvidersUpsell( { domain, selectedIntervalLength }
 
 	const comment = '%(domainName)s is the domain name, e.g example.com';
 
-	const changeIntervalLength = ( props, intervalLength ) => {
-		page( domainAddEmailUpsell( selectedSiteSlug, props.selectedDomainName, intervalLength ) );
+	const changeIntervalLength = ( newIntervalLength ) => {
+		page( domainAddEmailUpsell( selectedSiteSlug, domain, newIntervalLength ) );
 	};
 
 	return (
@@ -49,12 +49,12 @@ export default function EmailProvidersUpsell( { domain, selectedIntervalLength }
 			) : (
 				<EmailProvidersStackedComparison
 					comparisonContext="domain-upsell"
-					isDomainInCart={ true }
+					isDomainInCart
 					onIntervalLengthChange={ changeIntervalLength }
 					selectedDomainName={ domain }
 					selectedIntervalLength={ selectedIntervalLength }
 					source="domain-upsell"
-				></EmailProvidersStackedComparison>
+				/>
 			) }
 		</CalypsoShoppingCartProvider>
 	);

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -2,6 +2,15 @@ import { filter } from 'lodash';
 import { stringify } from 'qs';
 import { isUnderEmailManagementAll } from 'calypso/my-sites/email/paths';
 
+/**
+ * Builds a URL query string with the specified parameters.
+ *
+ * @param {Object} parameters - set of parameters, any null one will be skipped
+ * @returns {string} the corresponding query string prepended with a question mark
+ */
+const buildQueryString = ( parameters = {} ) =>
+	parameters ? stringify( parameters, { addQueryPrefix: true, skipNulls: true } ) : '';
+
 function resolveRootPath( relativeTo = null ) {
 	if ( relativeTo ) {
 		if ( relativeTo === domainManagementRoot() ) {
@@ -60,15 +69,6 @@ export function domainAddNew( siteName, searchTerm ) {
 
 	return path;
 }
-
-/**
- * Builds a URL query string from an object. Handles null values.
- *
- * @param {Object} parameters - optional path prefix
- * @returns {string} the corresponding query string
- */
-const buildQueryString = ( parameters = {} ) =>
-	parameters ? stringify( parameters, { addQueryPrefix: true, skipNulls: true } ) : '';
 
 export function domainAddEmailUpsell( siteName, domainName, interval ) {
 	return `/domains/add/${ domainName }/email/${ siteName }${ buildQueryString( {

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -61,8 +61,19 @@ export function domainAddNew( siteName, searchTerm ) {
 	return path;
 }
 
-export function domainAddEmailUpsell( siteName, domainName ) {
-	return `/domains/add/${ domainName }/email/${ siteName }`;
+/**
+ * Builds a URL query string from an object. Handles null values.
+ *
+ * @param {Object} parameters - optional path prefix
+ * @returns {string} the corresponding query string
+ */
+const buildQueryString = ( parameters = {} ) =>
+	parameters ? stringify( parameters, { addQueryPrefix: true, skipNulls: true } ) : '';
+
+export function domainAddEmailUpsell( siteName, domainName, interval ) {
+	return `/domains/add/${ domainName }/email/${ siteName }${ buildQueryString( {
+		interval,
+	} ) }`;
 }
 
 export function domainManagementAllRoot() {

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -155,6 +155,7 @@ export default {
 				<EmailManagementHomePage
 					source={ pageContext.query.source }
 					selectedDomainName={ pageContext.params.domain }
+					selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -15,8 +15,9 @@ import EmailListActive from 'calypso/my-sites/email/email-management/home/email-
 import EmailListInactive from 'calypso/my-sites/email/email-management/home/email-list-inactive';
 import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no-domain';
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
-import EmailProvidersStackedComparisonPage from 'calypso/my-sites/email/email-providers-stacked-comparison';
-import { emailManagementTitanSetUpMailbox } from 'calypso/my-sites/email/paths';
+import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
+import EmailProvidersStackedComparison from 'calypso/my-sites/email/email-providers-stacked-comparison';
+import { emailManagement, emailManagementTitanSetUpMailbox } from 'calypso/my-sites/email/paths';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
@@ -68,6 +69,7 @@ interface EmailManagementHomeProps {
 	emailListInactiveHeader?: ReactElement;
 	sectionHeaderLabel?: TranslateResult;
 	selectedDomainName: string;
+	selectedIntervalLength?: IntervalLength;
 	showActiveDomainList?: boolean;
 	source: string;
 }
@@ -77,6 +79,7 @@ const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
 		emailListInactiveHeader,
 		showActiveDomainList = true,
 		selectedDomainName,
+		selectedIntervalLength,
 		sectionHeaderLabel,
 		source,
 	} = props;
@@ -109,6 +112,14 @@ const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
 		return <NoAccess />;
 	}
 
+	const changeIntervalLength = ( newIntervalLength: IntervalLength ) => {
+		page(
+			emailManagement( selectedSite.slug ?? '', selectedDomainName, null, {
+				interval: newIntervalLength,
+			} )
+		);
+	};
+
 	const domainHasEmail = ( domain: ResponseDomain ) =>
 		hasTitanMailWithUs( domain ) || hasGSuiteWithUs( domain ) || hasEmailForwards( domain );
 
@@ -120,9 +131,11 @@ const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
 
 		if ( ! domainHasEmail( selectedDomain ) ) {
 			return (
-				<EmailProvidersStackedComparisonPage
+				<EmailProvidersStackedComparison
 					comparisonContext="email-home-selected-domain"
+					onIntervalLengthChange={ changeIntervalLength }
 					selectedDomainName={ selectedDomainName }
+					selectedIntervalLength={ selectedIntervalLength }
 					source={ source }
 				/>
 			);
@@ -152,9 +165,11 @@ const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
 
 	if ( domainsWithEmail.length < 1 && domainsWithNoEmail.length === 1 ) {
 		return (
-			<EmailProvidersStackedComparisonPage
+			<EmailProvidersStackedComparison
 				comparisonContext="email-home-single-domain"
+				onIntervalLengthChange={ changeIntervalLength }
 				selectedDomainName={ domainsWithNoEmail[ 0 ].name }
+				selectedIntervalLength={ selectedIntervalLength }
 				source={ source }
 			/>
 		);

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
@@ -10,7 +9,6 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
-import { domainAddEmailUpsell } from 'calypso/my-sites/domains/paths';
 import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-forwards-notice';
 import EmailExistingPaidServiceNotice from 'calypso/my-sites/email/email-existing-paid-service-notice';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
@@ -18,10 +16,7 @@ import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparis
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import GoogleWorkspaceCard from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card';
 import ProfessionalEmailCard from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card';
-import {
-	emailManagementInDepthComparison,
-	emailManagementPurchaseNewEmailAccount,
-} from 'calypso/my-sites/email/paths';
+import { emailManagementInDepthComparison } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwards';

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -54,6 +54,7 @@ const EmailProvidersStackedComparison = (
 		selectedIntervalLength = IntervalLength.ANNUALLY,
 		source,
 	} = props;
+
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -10,6 +10,7 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
+import { domainAddEmailUpsell } from 'calypso/my-sites/domains/paths';
 import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-forwards-notice';
 import EmailExistingPaidServiceNotice from 'calypso/my-sites/email/email-existing-paid-service-notice';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
@@ -97,6 +98,29 @@ const EmailProvidersStackedComparison = ( {
 		setDetailsExpanded( Object.fromEntries( expandedEntries ) );
 	};
 
+	const onIntervalLengthPathHandlerResolver = ( newIntervalLength: IntervalLength ) => {
+		const selectedSiteSlug = selectedSite?.slug ?? '';
+
+		if (
+			[ 'email-purchase', 'email-home-single-domain', 'email-home-selected-domain' ].some(
+				( context ) => context === comparisonContext
+			)
+		) {
+			page(
+				emailManagementPurchaseNewEmailAccount(
+					selectedSiteSlug,
+					selectedDomainName,
+					currentRoute,
+					null,
+					selectedEmailProviderSlug,
+					newIntervalLength
+				)
+			);
+		} else if ( comparisonContext === 'domain-upsell' ) {
+			page( domainAddEmailUpsell( selectedSiteSlug, selectedDomainName, newIntervalLength ) );
+		}
+	};
+
 	const changeIntervalLength = ( newIntervalLength: IntervalLength ) => {
 		if ( ! selectedSite?.slug ) {
 			return;
@@ -109,16 +133,7 @@ const EmailProvidersStackedComparison = ( {
 			} )
 		);
 
-		page(
-			emailManagementPurchaseNewEmailAccount(
-				selectedSite.slug,
-				selectedDomainName,
-				currentRoute,
-				null,
-				selectedEmailProviderSlug,
-				newIntervalLength
-			)
-		);
+		onIntervalLengthPathHandlerResolver( newIntervalLength );
 	};
 
 	const handleCompareClick = () => {

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -22,39 +22,25 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwards';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { EmailProvidersStackedComparisonPageProps } from 'calypso/my-sites/email/email-providers-stacked-comparison/page';
 
 import './style.scss';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
-
-export type EmailProvidersStackedComparisonProps = {
+type EmailProvidersStackedComparisonProps = {
 	cartDomainName?: string;
-	comparisonContext: string;
 	isDomainInCart?: boolean;
-	onIntervalLengthChange?: (
-		props: EmailProvidersStackedComparisonProps,
-		newIntervalLength: IntervalLength
-	) => void;
-	selectedDomainName: string;
-	selectedEmailProviderSlug?: string;
-	selectedIntervalLength?: IntervalLength;
-	source: string;
-};
+	onIntervalLengthChange: ( newIntervalLength: IntervalLength ) => void;
+} & EmailProvidersStackedComparisonPageProps;
 
-const EmailProvidersStackedComparison = (
-	props: EmailProvidersStackedComparisonProps
-): JSX.Element | null => {
-	const {
-		comparisonContext,
-		isDomainInCart = false,
-		onIntervalLengthChange = noop,
-		selectedDomainName,
-		selectedEmailProviderSlug,
-		selectedIntervalLength = IntervalLength.ANNUALLY,
-		source,
-	} = props;
-
+const EmailProvidersStackedComparison = ( {
+	comparisonContext,
+	isDomainInCart = false,
+	onIntervalLengthChange,
+	selectedDomainName,
+	selectedEmailProviderSlug,
+	selectedIntervalLength = IntervalLength.ANNUALLY,
+	source,
+}: EmailProvidersStackedComparisonProps ): JSX.Element | null => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -117,7 +103,7 @@ const EmailProvidersStackedComparison = (
 			} )
 		);
 
-		onIntervalLengthChange( props, newIntervalLength );
+		onIntervalLengthChange( newIntervalLength );
 	};
 
 	const handleCompareClick = () => {

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -30,24 +30,35 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
 export type EmailProvidersStackedComparisonProps = {
 	cartDomainName?: string;
 	comparisonContext: string;
 	isDomainInCart?: boolean;
+	onIntervalLengthChange?: (
+		props: EmailProvidersStackedComparisonProps,
+		newIntervalLength: IntervalLength
+	) => void;
 	selectedDomainName: string;
 	selectedEmailProviderSlug?: string;
 	selectedIntervalLength?: IntervalLength;
 	source: string;
 };
 
-const EmailProvidersStackedComparison = ( {
-	comparisonContext,
-	isDomainInCart = false,
-	selectedDomainName,
-	selectedEmailProviderSlug,
-	selectedIntervalLength = IntervalLength.ANNUALLY,
-	source,
-}: EmailProvidersStackedComparisonProps ): JSX.Element | null => {
+const EmailProvidersStackedComparison = (
+	props: EmailProvidersStackedComparisonProps
+): JSX.Element | null => {
+	const {
+		comparisonContext,
+		isDomainInCart = false,
+		onIntervalLengthChange = noop,
+		selectedDomainName,
+		selectedEmailProviderSlug,
+		selectedIntervalLength = IntervalLength.ANNUALLY,
+		source,
+	} = props;
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -98,29 +109,6 @@ const EmailProvidersStackedComparison = ( {
 		setDetailsExpanded( Object.fromEntries( expandedEntries ) );
 	};
 
-	const onIntervalLengthPathHandlerResolver = ( newIntervalLength: IntervalLength ) => {
-		const selectedSiteSlug = selectedSite?.slug ?? '';
-
-		if (
-			[ 'email-purchase', 'email-home-single-domain', 'email-home-selected-domain' ].some(
-				( context ) => context === comparisonContext
-			)
-		) {
-			page(
-				emailManagementPurchaseNewEmailAccount(
-					selectedSiteSlug,
-					selectedDomainName,
-					currentRoute,
-					null,
-					selectedEmailProviderSlug,
-					newIntervalLength
-				)
-			);
-		} else if ( comparisonContext === 'domain-upsell' ) {
-			page( domainAddEmailUpsell( selectedSiteSlug, selectedDomainName, newIntervalLength ) );
-		}
-	};
-
 	const changeIntervalLength = ( newIntervalLength: IntervalLength ) => {
 		if ( ! selectedSite?.slug ) {
 			return;
@@ -133,7 +121,7 @@ const EmailProvidersStackedComparison = ( {
 			} )
 		);
 
-		onIntervalLengthPathHandlerResolver( newIntervalLength );
+		onIntervalLengthChange( props, newIntervalLength );
 	};
 
 	const handleCompareClick = () => {

--- a/client/my-sites/email/email-providers-stacked-comparison/page.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/page.tsx
@@ -6,19 +6,24 @@ import EmailProvidersStackedComparison from 'calypso/my-sites/email/email-provid
 import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { EmailProvidersStackedComparisonProps } from 'calypso/my-sites/email/email-providers-stacked-comparison';
+
+export type EmailProvidersStackedComparisonPageProps = {
+	comparisonContext: string;
+	selectedDomainName: string;
+	selectedEmailProviderSlug?: string;
+	selectedIntervalLength?: IntervalLength;
+	source: string;
+};
 
 const EmailProvidersStackedComparisonPage = (
-	props: EmailProvidersStackedComparisonProps
+	props: EmailProvidersStackedComparisonPageProps
 ): JSX.Element => {
+	const { comparisonContext, selectedDomainName, selectedEmailProviderSlug, source } = props;
+
 	const currentRoute = useSelector( getCurrentRoute );
 	const selectedSite = useSelector( getSelectedSite );
 
-	const changeIntervalLength = (
-		props: EmailProvidersStackedComparisonProps,
-		newIntervalLength: IntervalLength
-	) => {
-		const { selectedDomainName, selectedEmailProviderSlug } = props;
+	const changeIntervalLength = ( newIntervalLength: IntervalLength ) => {
 		page(
 			emailManagementPurchaseNewEmailAccount(
 				selectedSite?.slug ?? '',
@@ -37,11 +42,12 @@ const EmailProvidersStackedComparisonPage = (
 				path={ emailManagementPurchaseNewEmailAccount( ':site', ':domain' ) }
 				title="Email Comparison"
 				properties={ {
-					source: props.source,
-					context: props.comparisonContext,
-					provider: props.selectedEmailProviderSlug,
+					source: source,
+					context: comparisonContext,
+					provider: selectedEmailProviderSlug,
 				} }
 			/>
+
 			<EmailProvidersStackedComparison
 				{ ...props }
 				onIntervalLengthChange={ changeIntervalLength }

--- a/client/my-sites/email/email-providers-stacked-comparison/page.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/page.tsx
@@ -1,11 +1,36 @@
+import page from 'page';
+import { useSelector } from 'react-redux';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import EmailProvidersStackedComparison from 'calypso/my-sites/email/email-providers-stacked-comparison';
 import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersStackedComparisonProps } from 'calypso/my-sites/email/email-providers-stacked-comparison';
 
 const EmailProvidersStackedComparisonPage = (
 	props: EmailProvidersStackedComparisonProps
 ): JSX.Element => {
+	const currentRoute = useSelector( getCurrentRoute );
+	const selectedSite = useSelector( getSelectedSite );
+
+	const changeIntervalLength = (
+		props: EmailProvidersStackedComparisonProps,
+		newIntervalLength: IntervalLength
+	) => {
+		const { selectedDomainName, selectedEmailProviderSlug } = props;
+		page(
+			emailManagementPurchaseNewEmailAccount(
+				selectedSite?.slug ?? '',
+				selectedDomainName,
+				currentRoute,
+				null,
+				selectedEmailProviderSlug,
+				newIntervalLength
+			)
+		);
+	};
+
 	return (
 		<>
 			<PageViewTracker
@@ -17,7 +42,10 @@ const EmailProvidersStackedComparisonPage = (
 					provider: props.selectedEmailProviderSlug,
 				} }
 			/>
-			<EmailProvidersStackedComparison { ...props } />
+			<EmailProvidersStackedComparison
+				{ ...props }
+				onIntervalLengthChange={ changeIntervalLength }
+			/>
 		</>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I am showing the new comparison component under the feature flag (emails/show-new-comparison-component is enabled) to keep working on retire the old comparison page.
I'm breaking down all the changes and this change only adapt the component to receive a domain name, instead of a domain object plus hiding email forward components for this view.

**Things to tackle in the following Pull Requests:**
- `See how they compare` link is not working.
- Navigation buttons
- Multiple mailboxes support

#### Testing instructions

**Main scenario!**
Ensure that new comparison page keeps working:
1. Have a domain without email subscription on it.
2. Go to Upgrades -> Emails
3. Click on Add Email button
4. Try to add to the cart an email solution of each provider for each interval (just go to the check out and check that everything is working, no need to actually buy it, after you checked everything, remove the subscription for the domain and repeat for another variant subscription/interval)

**Second scenario**
1. Open the [Domains page](http://calypso.localhost:3000/domains/manage)
3. Click the Add a domain button
5. Select Search for a domain
6. Select any domain to access the Email Comparison page
7. Add the following query to the URL in your browser: ?flags=+emails/show-new-comparison-component
8. Assert that the next screen is displayed.
9. Assert that the billing interval is working as expected (dealing with prices, dealing with the URL parameters)

![image](https://user-images.githubusercontent.com/5689927/158605508-1a66346c-828b-41c7-a594-8cee1fadb827.png)


Related to {1200182182542585-as-1201978089916826}
