### PR TITLE
Marketplace: Show 3pd plugin terms

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -146,6 +146,17 @@ export function hasDomainRenewal( cart: ResponseCart ): boolean {
 	return getAllCartItems( cart ).some( isDomainRenewal );
 }
 
+export function hasMarketplaceProduct( cart: ResponseCart ): boolean {
+	return getAllCartItems( cart ).some( isMarketplaceProduct );
+}
+
+/**
+ * @todo Confirm the condition below
+ */
+function isMarketplaceProduct( cartItem: ResponseCartProduct ): boolean {
+	return cartItem.cost > 0;
+}
+
 /**
  * Determines whether the supplied cart item is a new domain registration (i.e. not a renewal).
  */

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -146,17 +146,6 @@ export function hasDomainRenewal( cart: ResponseCart ): boolean {
 	return getAllCartItems( cart ).some( isDomainRenewal );
 }
 
-export function hasMarketplaceProduct( cart: ResponseCart ): boolean {
-	return getAllCartItems( cart ).some( isMarketplaceProduct );
-}
-
-/**
- * @todo Confirm the condition below
- */
-function isMarketplaceProduct( cartItem: ResponseCartProduct ): boolean {
-	return cartItem.cost > 0;
-}
-
 /**
  * Determines whether the supplied cart item is a new domain registration (i.e. not a renewal).
  */

--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
@@ -8,6 +8,7 @@ import DomainRefundPolicy from './domain-refund-policy';
 import DomainRegistrationAgreement from './domain-registration-agreement';
 import DomainRegistrationHsts from './domain-registration-hsts';
 import TermsOfService from './terms-of-service';
+import ThirdPartyPluginsTermsOfService from './third-party-plugins-terms-of-service';
 import TitanTermsOfService from './titan-terms-of-service';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -32,6 +33,7 @@ class CheckoutTerms extends Component {
 				<ConciergeRefundPolicy cart={ cart } />
 				<BundledDomainNotice cart={ cart } />
 				<TitanTermsOfService cart={ cart } />
+				<ThirdPartyPluginsTermsOfService cart={ cart } />
 				<AdditionalTermsOfServiceInCart />
 			</Fragment>
 		);

--- a/client/my-sites/checkout/composite-checkout/components/third-party-plugins-terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/third-party-plugins-terms-of-service.jsx
@@ -1,12 +1,11 @@
 import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
+import { hasMarketplaceProduct } from 'calypso/lib/cart-values/cart-items';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-const hasThirdPartyToS = () => true;
-
 function ThirdPartyPluginsTermsOfService( { cart, translate } ) {
-	if ( ! hasThirdPartyToS( cart ) ) {
+	if ( ! hasMarketplaceProduct( cart ) ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/components/third-party-plugins-terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/third-party-plugins-terms-of-service.jsx
@@ -20,7 +20,7 @@ function ThirdPartyPluginsTermsOfService( { cart, translate } ) {
 			components: {
 				thirdPartyToS: (
 					<a
-						href="https://wordpress.com/marketplace-third-party-plugins-terms"
+						href="https://wordpress.com/third-party-plugins-terms/"
 						target="_blank"
 						rel="noopener noreferrer"
 					/>

--- a/client/my-sites/checkout/composite-checkout/components/third-party-plugins-terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/third-party-plugins-terms-of-service.jsx
@@ -1,11 +1,16 @@
 import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { hasMarketplaceProduct } from 'calypso/lib/cart-values/cart-items';
+import { useSelector } from 'react-redux';
+import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 function ThirdPartyPluginsTermsOfService( { cart, translate } ) {
-	if ( ! hasMarketplaceProduct( cart ) ) {
+	const hasMarketplaceProduct = useSelector( ( state ) => {
+		return cart?.products?.some( ( p ) => isMarketplaceProduct( state, p.product_slug ) );
+	} );
+
+	if ( ! hasMarketplaceProduct ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/components/third-party-plugins-terms-of-service.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/third-party-plugins-terms-of-service.jsx
@@ -1,0 +1,36 @@
+import { Gridicon } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+const hasThirdPartyToS = () => true;
+
+function ThirdPartyPluginsTermsOfService( { cart, translate } ) {
+	if ( ! hasThirdPartyToS( cart ) ) {
+		return null;
+	}
+
+	const thirdPartyPluginsTerms = translate(
+		'You agree to our {{thirdPartyToS}}Third-Party Plugins Terms of Service{{/thirdPartyToS}}',
+		{
+			components: {
+				thirdPartyToS: (
+					<a
+						href="https://wordpress.com/marketplace-third-party-plugins-terms"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			},
+		}
+	);
+
+	return (
+		<div className="checkout__terms">
+			<Gridicon icon="info-outline" size={ 18 } />
+			<p>{ thirdPartyPluginsTerms }</p>
+		</div>
+	);
+}
+
+export default localize( ThirdPartyPluginsTermsOfService );

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -177,7 +177,7 @@ const PluginDetailsCTA = ( {
 									<a
 										target="_blank"
 										rel="noopener noreferrer"
-										href="https://wordpress.com/marketplace-third-party-plugins-terms/"
+										href="https://wordpress.com/third-party-plugins-terms/"
 									/>
 								),
 							},

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -164,14 +164,21 @@ const PluginDetailsCTA = ( {
 					isSiteConnected={ isSiteConnected }
 				/>
 			</div>
-			{ ( ! isJetpackSelfHosted || ! isMarketplaceProduct ) && (
+			{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
 				<div className="plugin-details-CTA__t-and-c">
 					{ translate(
-						'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the Third-Party plugin Terms.',
+						'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the {{thirdPartyTos}}Third-Party plugin Terms{{/thirdPartyTos}}.',
 						{
 							components: {
 								a: (
 									<a target="_blank" rel="noopener noreferrer" href="https://wordpress.com/tos/" />
+								),
+								thirdPartyTos: (
+									<a
+										target="_blank"
+										rel="noopener noreferrer"
+										href="https://wordpress.com/marketplace-third-party-plugins-terms/"
+									/>
 								),
 							},
 						}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Display the Third Party plugin terms as a link to a newly created page in WordPress.com https://wordpress.com/third-party-plugins-terms/ 
* For **free plugins** it will be displayed in the Plugin Details screen: 

|Free plugins Plugin Details|
|---|
|![CleanShot 2022-03-21 at 17 06 32@2x](https://user-images.githubusercontent.com/3519124/159302386-cd1cacd6-de3d-4a1d-b827-dd8b35c2d017.png)|

* For **marketplace plugins** it will **not** be displayed the Plugin Details but it will be in the Checkout screen: 

|Plugin Details | Checkout|
|-------|------|
|![CleanShot 2022-03-21 at 17 09 27@2x](https://user-images.githubusercontent.com/3519124/159302983-b508c5c7-2fe8-486c-befb-a8aaa8641162.png)|![CleanShot 2022-03-21 at 17 10 18@2x](https://user-images.githubusercontent.com/3519124/159303462-90f5d593-7690-435f-945f-db7be47712c9.png)|




#### Testing instructions

* Select a Business or eCommerce site
* Go to Plugins and select a **Free** plugin
* Make sure you can click on the Third-Party plugin Terms link under the CTA button and navigate to [the following page](https://wordpress.com/third-party-plugins-terms/)
* Go back to the Plugins list page and select a **Premium** plugin
* Check that there are no Terms of Service clauses under the CTA button
* Click on Purchase and activate
* Make sure there are clauses for [WordPress.com Terms of Service](https://wordpress.com/third-party-plugins-terms/) and for [Third-Party Plugins Terms of Service](https://wordpress.com/third-party-plugins-terms/) and you can navigate to the corresponding pages.

Closes #61607
