### PR TITLE
Add back the features list to checkout for Pro Plan

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
@@ -5,6 +5,7 @@ import {
 	isWpComEcommercePlan,
 	isWpComPersonalPlan,
 	isWpComPremiumPlan,
+	isWpComProPlan,
 } from '@automattic/calypso-products';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
@@ -73,6 +74,17 @@ export default function getPlanFeatures(
 			String( translate( 'Integrations with top shipping carriers' ) ),
 			String( translate( 'Unlimited products or services for your online store' ) ),
 			String( translate( 'eCommerce marketing tools for emails and social networks' ) ),
+		].filter( isValueTruthy );
+	}
+
+	if ( isWpComProPlan( productSlug ) ) {
+		return [
+			freeOneYearDomain,
+			liveChatSupport,
+			String( translate( 'Install custom plugins and themes' ) ),
+			String( translate( 'Drive traffic to your site with our advanced SEO tools' ) ),
+			String( translate( 'Track your stats with Google Analytics' ) ),
+			String( translate( 'Real-time backups and activity logs' ) ),
 		].filter( isValueTruthy );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The original task was to replace the email support with Premium support. I'm proposing to bring back the plans features list instead of replacing a hardcoded email support that applies to all plans.

<img width="951" alt="Screenshot 2022-03-18 at 18 49 18" src="https://user-images.githubusercontent.com/82778/159046900-6be2eb63-019b-482f-90f2-9cb9e44b141b.png">

#### Testing instructions

1. Add Pro to cart
2. Verify that there's a meaningful features list

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
