### PR TITLE
Fix UI issues in Jetpack Scan threat items

### DIFF
--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -217,7 +217,7 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 	let securityIcon = 'error';
 
 	if ( maxSeverity < 3 ) {
-		headerMessage = translate( 'Your site it not at risk' );
+		headerMessage = translate( 'Your site is not at risk' );
 		securityIcon = 'okay';
 	}
 

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -33,7 +33,7 @@
 		}
 
 		.foldable-card.is-expanded .foldable-card__content {
-				padding: 0;
+			padding: 0;
 		}
 	}
 

--- a/client/components/jetpack/threat-history-list/index.tsx
+++ b/client/components/jetpack/threat-history-list/index.tsx
@@ -159,7 +159,9 @@ const ThreatHistoryList: React.FC< ThreatHistoryListProps > = ( { filter } ) => 
 								/>
 							) }
 
-							<ListItems items={ currentPageThreats } />
+							<div className="threat-history-list__threats">
+								<ListItems items={ currentPageThreats } />
+							</div>
 
 							{ showPagination && (
 								<Pagination

--- a/client/components/jetpack/threat-history-list/index.tsx
+++ b/client/components/jetpack/threat-history-list/index.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryJetpackScanHistory from 'calypso/components/data/query-jetpack-scan-history';
 import QueryJetpackScanThreatCounts from 'calypso/components/data/query-jetpack-scan-threat-counts';
+import ThreatListHeader from 'calypso/components/jetpack/threat-list-header';
 import Pagination from 'calypso/components/pagination';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSiteScanHistory from 'calypso/state/selectors/get-site-scan-history';
@@ -140,44 +141,47 @@ const ThreatHistoryList: React.FC< ThreatHistoryListProps > = ( { filter } ) => 
 			) }
 
 			{ ! isRequestingThreatCounts && filteredThreatCount > 0 && (
-				<div className="threat-history-list__entries">
-					{ isRequestingThreatHistory && (
-						<ListItemsPlaceholder count={ filteredThreatCount } perPage={ THREATS_PER_PAGE } />
-					) }
-					{ ! isRequestingThreatHistory && (
-						<>
-							{ showPagination && (
-								<Pagination
-									compact={ isMobile }
-									className="threat-history-list__pagination--top"
-									total={ threats.length }
-									perPage={ THREATS_PER_PAGE }
-									page={ currentPage }
-									pageClick={ setCurrentPage }
-									nextLabel={ translate( 'Older' ) }
-									prevLabel={ translate( 'Newer' ) }
-								/>
-							) }
+				<>
+					<ThreatListHeader />
+					<div className="threat-history-list__entries">
+						{ isRequestingThreatHistory && (
+							<ListItemsPlaceholder count={ filteredThreatCount } perPage={ THREATS_PER_PAGE } />
+						) }
+						{ ! isRequestingThreatHistory && (
+							<>
+								{ showPagination && (
+									<Pagination
+										compact={ isMobile }
+										className="threat-history-list__pagination--top"
+										total={ threats.length }
+										perPage={ THREATS_PER_PAGE }
+										page={ currentPage }
+										pageClick={ setCurrentPage }
+										nextLabel={ translate( 'Older' ) }
+										prevLabel={ translate( 'Newer' ) }
+									/>
+								) }
 
-							<div className="threat-history-list__threats">
-								<ListItems items={ currentPageThreats } />
-							</div>
+								<div className="threat-history-list__threats">
+									<ListItems items={ currentPageThreats } />
+								</div>
 
-							{ showPagination && (
-								<Pagination
-									compact={ isMobile }
-									className="threat-history-list__pagination--bottom"
-									total={ threats.length }
-									perPage={ THREATS_PER_PAGE }
-									page={ currentPage }
-									pageClick={ setCurrentPage }
-									nextLabel={ translate( 'Older' ) }
-									prevLabel={ translate( 'Newer' ) }
-								/>
-							) }
-						</>
-					) }
-				</div>
+								{ showPagination && (
+									<Pagination
+										compact={ isMobile }
+										className="threat-history-list__pagination--bottom"
+										total={ threats.length }
+										perPage={ THREATS_PER_PAGE }
+										page={ currentPage }
+										pageClick={ setCurrentPage }
+										nextLabel={ translate( 'Older' ) }
+										prevLabel={ translate( 'Newer' ) }
+									/>
+								) }
+							</>
+						) }
+					</div>
+				</>
 			) }
 		</div>
 	);

--- a/client/components/jetpack/threat-history-list/style.scss
+++ b/client/components/jetpack/threat-history-list/style.scss
@@ -42,4 +42,18 @@
 		max-width: 230px;
 		margin: 0 auto;
 	}
+
+	&__threats {
+		.foldable-card {
+			margin-bottom: 0;
+		}
+
+		.foldable-card.card.is-expanded {
+			margin: 0;
+		}
+
+		.foldable-card.is-expanded .foldable-card__content {
+			padding: 0;
+		}
+	}
 }

--- a/client/components/jetpack/threat-item-header/index.tsx
+++ b/client/components/jetpack/threat-item-header/index.tsx
@@ -84,14 +84,14 @@ const ThreatItemHeader: React.FC< Props > = ( { threat } ) => {
 			<ThreatSeverityBadge severity={ threat.severity } />
 			<div className="threat-item-header__card-container">
 				<div className="threat-item-header__card-top">{ getThreatMessage( threat ) }</div>
-				<span
+				<div
 					className={ classnames(
 						'threat-item-header__card-bottom',
 						severityClassNames( threat.severity )
 					) }
 				>
 					<ThreatItemSubheader threat={ threat } />
-				</span>
+				</div>
 			</div>
 			{ threat.fixable && (
 				/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/components/jetpack/threat-item-header/index.tsx
+++ b/client/components/jetpack/threat-item-header/index.tsx
@@ -81,22 +81,26 @@ const getThreatMessage = ( threat: Threat ) => {
 const ThreatItemHeader: React.FC< Props > = ( { threat } ) => {
 	return (
 		<>
-			<ThreatSeverityBadge severity={ threat.severity } />
 			<div className="threat-item-header__card-container">
-				<div className="threat-item-header__card-top">{ getThreatMessage( threat ) }</div>
-				<div
-					className={ classnames(
-						'threat-item-header__card-bottom',
-						severityClassNames( threat.severity )
-					) }
-				>
-					<ThreatItemSubheader threat={ threat } />
+				<ThreatSeverityBadge severity={ threat.severity } />
+				<div className="threat-item-header__titles">
+					<div className="threat-item-header__card-top">{ getThreatMessage( threat ) }</div>
+					<div
+						className={ classnames(
+							'threat-item-header__card-bottom',
+							severityClassNames( threat.severity )
+						) }
+					>
+						<ThreatItemSubheader threat={ threat } />
+					</div>
 				</div>
 			</div>
-			{ threat.fixable && (
-				/* eslint-disable wpcalypso/jsx-classname-namespace */
-				<Gridicon className="threat-item-header__autofix_badge" icon="checkmark" size={ 18 } />
-			) }
+			<div className="threat-item-header__autofix-container">
+				{ threat.fixable && (
+					/* eslint-disable wpcalypso/jsx-classname-namespace */
+					<Gridicon className="threat-item-header__autofix_badge" icon="checkmark" size={ 18 } />
+				) }
+			</div>
 		</>
 	);
 };

--- a/client/components/jetpack/threat-item-header/style.scss
+++ b/client/components/jetpack/threat-item-header/style.scss
@@ -1,18 +1,32 @@
 .threat-item-header {
   &__card-container {
-    flex-direction: column;
+    display: flex;
+    flex-wrap: wrap;
     margin-bottom: auto;
     margin-top: auto;
     margin-right: auto;
+    padding-right: 24px;
     width: 100%;
+    overflow: hidden;
+
+    @include breakpoint-deprecated( '>960px' ) {
+      flex-wrap: nowrap;
+    }
+  }
+
+  &__titles {
     overflow: hidden;
   }
 
-  &__autofix_badge {
+  &__autofix-container {
+    min-width: 18px;
     margin-top: auto;
     margin-bottom: auto;
-    margin-right: 72px;
+    margin-right: 36px;
     margin-left: auto;
+  }
+
+  &__autofix_badge {
     fill: #008710;
   }
 

--- a/client/components/jetpack/threat-item-header/style.scss
+++ b/client/components/jetpack/threat-item-header/style.scss
@@ -4,10 +4,8 @@
     margin-bottom: auto;
     margin-top: auto;
     margin-right: auto;
-		max-width: 435px;
-    @include breakpoint-deprecated( '<960px' ) {
-			max-width: 263px;
-		}
+    width: 100%;
+    overflow: hidden;
   }
 
   &__autofix_badge {
@@ -23,7 +21,6 @@
     font-weight: 600;
     font-size: $font-body-large;
     line-height: 24px;
-    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/client/components/jetpack/threat-item-subheader/style.scss
+++ b/client/components/jetpack/threat-item-subheader/style.scss
@@ -6,7 +6,6 @@
 		flex-direction: column;
 		align-items: flex-start;
 		margin-top: 4px;
-		margin-left: 52px;
 
 		@include breakpoint-deprecated( '>1040px' ) {
 			flex-direction: row;

--- a/client/components/jetpack/threat-item-subheader/style.scss
+++ b/client/components/jetpack/threat-item-subheader/style.scss
@@ -13,12 +13,8 @@
 		}
 	}
 
-	&__status {
-		white-space: nowrap;
-
-		&.is-fixed {
-			color: var( --color-success-50 );
-		}
+	&__status.is-fixed {
+		color: var( --color-success-50 );
 	}
 
 	&__status-separator {

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -12,6 +12,7 @@
 
 	.log-item__header-wrapper {
 		flex-grow: 1;
+		width: 100%;
 	}
 
 	.card-heading {
@@ -22,6 +23,7 @@
 		padding-bottom: 8px;
 		flex-grow: 1;
 		line-height: 16px;
+		max-width: calc( 100% - 32px );
 
 		@include breakpoint-deprecated( '>960px' ) {
 			flex-wrap: nowrap;

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -18,14 +18,14 @@
 		display: flex;
 		flex-wrap: wrap;
 		flex-direction: column;
-		min-height: 121px;
+		padding-top: 8px;
+		padding-bottom: 8px;
 		flex-grow: 1;
 		line-height: 16px;
 
 		@include breakpoint-deprecated( '>960px' ) {
 			flex-wrap: nowrap;
 			flex-direction: row;
-			min-height: 65px;
 		}
 	}
 

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -17,8 +17,6 @@
 
 	.card-heading {
 		display: flex;
-		flex-wrap: wrap;
-		flex-direction: column;
 		padding-top: 8px;
 		padding-bottom: 8px;
 		flex-grow: 1;

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -18,14 +18,14 @@
 		display: flex;
 		flex-wrap: wrap;
 		flex-direction: column;
-		height: 121px;
+		min-height: 121px;
 		flex-grow: 1;
 		line-height: 16px;
 
 		@include breakpoint-deprecated( '>960px' ) {
 			flex-wrap: nowrap;
 			flex-direction: row;
-			height: 65px;
+			min-height: 65px;
 		}
 	}
 

--- a/client/components/jetpack/threat-list-header/style.scss
+++ b/client/components/jetpack/threat-list-header/style.scss
@@ -21,6 +21,10 @@
 
 	&.title__autofix {
 		margin-left: auto;
-		margin-right: 52px;
+		margin-right: 56px;
+
+		@include breakpoint-deprecated( '>480px') {
+			margin-right: 48px;
+		}
 	}
 }

--- a/client/components/jetpack/threat-severity-badge/style.scss
+++ b/client/components/jetpack/threat-severity-badge/style.scss
@@ -21,6 +21,7 @@
     font-size: $font-body-extra-small;
 
     @include breakpoint-deprecated( '<960px' ) {
+      margin-bottom: 16px;
   		margin-left: 0;
   	}
   }


### PR DESCRIPTION
This PR addresses a few layout issues specific to `<ThreatItem>`s.

#### Changes proposed in this Pull Request

* Apply style updates from the recent changes to the "Scanner" tab threat items to the "History" tab:
  * Add `<ThreatListHeader />` to the top of the list.
  * Fix text alignments. 
  * Remove margin between individual threat items.
* Layout fixes for mobile on both "Scanner" and "History" tabs:
  * Align "Auto Fix" checkmark.
  * Allow text to wrap multiple lines.
* Enhancements for string interpolation: allow text to fill the full width of the parent container before being cut off with "..." ellipsis. 
* Typo fix.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `git checkout fix/threat-item-subheader-alignment` && `yarn start` && `yarn start-jetpack-cloud-p`
* Open up or create a site with Jetpack Scan and several vulnerabilities.
* Open up http://calypso.localhost:3000/scan/[site_url] and http://calypso.localhost:3000/scan/history/[site_url]
* Open up http://jetpack.cloud.localhost:3001/scan/[site_url] and http://jetpack.cloud.localhost:3001/scan/history/[site_url]
* Validate the screens match the fixes displayed on the right side of the screenshot below.
* Review the "Scanner" and "History" tab content for regression.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Screenshots

![before-after](https://user-images.githubusercontent.com/10933065/159365253-638a766b-f88c-4801-ad03-5b0e477909e5.jpg)

Related to 7323-gh-Automattic/jpop-issues