### PR TITLE
Checkout: Allow submitting existing cards without tax info

### DIFF
--- a/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
@@ -51,6 +51,7 @@ export default function useCreateAssignablePaymentMethods(
 		storedCards,
 		activePayButtonText: String( translate( 'Use this card' ) ),
 		allowEditingTaxInfo: true,
+		isTaxInfoRequired: true,
 	} );
 
 	const paymentMethods = useMemo(

--- a/client/me/purchases/payment-methods/existing-credit-card.tsx
+++ b/client/me/purchases/payment-methods/existing-credit-card.tsx
@@ -75,6 +75,7 @@ export function createExistingCardMethod( {
 	paymentPartnerProcessorId,
 	activePayButtonText = undefined,
 	allowEditingTaxInfo,
+	isTaxInfoRequired,
 }: {
 	id: string;
 	cardholderName: string;
@@ -86,6 +87,7 @@ export function createExistingCardMethod( {
 	paymentPartnerProcessorId: string;
 	activePayButtonText: string | undefined;
 	allowEditingTaxInfo?: boolean;
+	isTaxInfoRequired?: boolean;
 } ): PaymentMethod {
 	debug( 'creating a new existing credit card payment method', {
 		id,
@@ -115,6 +117,7 @@ export function createExistingCardMethod( {
 				paymentMethodToken={ paymentMethodToken }
 				paymentPartnerProcessorId={ paymentPartnerProcessorId }
 				activeButtonText={ activePayButtonText }
+				isTaxInfoRequired={ isTaxInfoRequired }
 			/>
 		),
 		inactiveContent: (
@@ -374,6 +377,7 @@ function ExistingCardPayButton( {
 	paymentMethodToken,
 	paymentPartnerProcessorId,
 	activeButtonText = undefined,
+	isTaxInfoRequired,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
@@ -382,6 +386,7 @@ function ExistingCardPayButton( {
 	paymentMethodToken: string;
 	paymentPartnerProcessorId: string;
 	activeButtonText: string | undefined;
+	isTaxInfoRequired: boolean;
 } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
@@ -408,7 +413,7 @@ function ExistingCardPayButton( {
 			disabled={ disabled }
 			onClick={ () => {
 				debug( 'submitting existing card payment' );
-				if ( ! taxInfoFromServer?.is_tax_info_set ) {
+				if ( isTaxInfoRequired && ! taxInfoFromServer?.is_tax_info_set ) {
 					dispatch(
 						errorNotice( getMissingTaxLocationInformationMessage( translate, taxInfoFromServer ) )
 					);

--- a/client/me/purchases/payment-methods/existing-credit-card.tsx
+++ b/client/me/purchases/payment-methods/existing-credit-card.tsx
@@ -117,7 +117,7 @@ export function createExistingCardMethod( {
 				paymentMethodToken={ paymentMethodToken }
 				paymentPartnerProcessorId={ paymentPartnerProcessorId }
 				activeButtonText={ activePayButtonText }
-				isTaxInfoRequired={ isTaxInfoRequired }
+				isTaxInfoRequired={ !! isTaxInfoRequired }
 			/>
 		),
 		inactiveContent: (

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/use-create-existing-cards.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/use-create-existing-cards.ts
@@ -11,12 +11,14 @@ export default function useCreateExistingCards( {
 	storedCards,
 	activePayButtonText = undefined,
 	allowEditingTaxInfo,
+	isTaxInfoRequired,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
 	storedCards: StoredCard[];
 	activePayButtonText?: string;
 	allowEditingTaxInfo?: boolean;
+	isTaxInfoRequired?: boolean;
 } ): PaymentMethod[] {
 	// The existing card payment methods do not require stripe, but the existing
 	// card processor does require it (for 3DS cards), so we wait to create the
@@ -46,6 +48,7 @@ export default function useCreateExistingCards( {
 					paymentPartnerProcessorId: storedDetails.payment_partner,
 					activePayButtonText,
 					allowEditingTaxInfo,
+					isTaxInfoRequired,
 				} )
 			) ?? []
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This should fix a regression caused by https://github.com/Automattic/wp-calypso/pull/57807 where you cannot submit an existing card payment method purchase in checkout unless the card already has an assigned tax location.

Recently we made it so that payment methods can have their own tax location information (country code and optionally postal code) attached, and in the above-mentioned PR we made it so you cannot assign a saved card to an existing subscription without first attaching tax info to it. However, tax info is not required to be assigned to a payment method in checkout because checkout includes a contact form which itself collects tax information that will be automatically assigned to the card on the backend.

Before:

<img width="394" alt="Screen Shot 2022-03-19 at 3 42 41 PM" src="https://user-images.githubusercontent.com/2036909/159136045-7268f2b5-0462-49fc-84c1-df150df205ba.png">

#### Testing instructions

- Make sure you have an existing saved card without a postal code and country attached.
- Add a product to your cart and visit checkout.
- Submit the form, selecting the saved card.
- Verify that the purchase is successful without any errors. (Previously you would see `Missing required Country field`.)