### PR TITLE
Payment Methods: Change TaxFields to have a single onChange prop

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -60,6 +60,10 @@ export default function ContactDetailsContainer( {
 	} = useDispatch( 'wpcom-checkout' );
 	const contactDetails = prepareDomainContactDetails( contactInfo );
 	const contactDetailsErrors = prepareDomainContactDetailsErrors( contactInfo );
+	const onChangeContactInfo = ( newInfo: ManagedContactDetails ) => {
+		updateCountryCode( newInfo.countryCode?.value ?? '' );
+		updatePostalCode( newInfo.postalCode?.value ?? '' );
+	};
 	const { email } = useSelect( ( select ) => select( 'wpcom-checkout' ).getContactInfo() );
 
 	const updateDomainContactRelatedData = ( details: DomainContactDetailsData ) => {
@@ -129,8 +133,7 @@ export default function ContactDetailsContainer( {
 					<TaxFields
 						section="contact"
 						taxInfo={ contactInfo }
-						updateCountryCode={ updateCountryCode }
-						updatePostalCode={ updatePostalCode }
+						onChange={ onChangeContactInfo }
 						countriesList={ countriesList }
 						isDisabled={ isDisabled }
 					/>

--- a/client/my-sites/checkout/composite-checkout/hooks/use-country-list.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-country-list.ts
@@ -10,12 +10,12 @@ const debug = debugFactory( 'calypso:composite-checkout:use-country-list' );
 const emptyList: CountryListItem[] = [];
 
 export default function useCountryList(
-	overrideCountryList: CountryListItem[]
+	overrideCountryList?: CountryListItem[]
 ): CountryListItem[] {
 	// Should we fetch the country list from global state?
-	const shouldFetchList = overrideCountryList?.length <= 0;
+	const shouldFetchList = ( overrideCountryList?.length ?? 0 ) <= 0;
 
-	const [ countriesList, setCountriesList ] = useState( overrideCountryList );
+	const [ countriesList, setCountriesList ] = useState( overrideCountryList ?? [] );
 
 	const reduxDispatch = useDispatch();
 	const globalCountryList =

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
@@ -13,7 +13,7 @@ export default function ContactFields( {
 } ) {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
-	const countriesList = useCountryList( [] );
+	const countriesList = useCountryList();
 	const fields = useSelect( ( select ) => select( 'credit-card' ).getFields() );
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
@@ -15,6 +15,10 @@ export default function ContactFields( {
 	const isDisabled = formStatus !== FormStatus.READY;
 	const countriesList = useCountryList();
 	const fields = useSelect( ( select ) => select( 'credit-card' ).getFields() );
+	const onChangeContactInfo = ( newInfo ) => {
+		setFieldValue( 'countryCode', newInfo.countryCode?.value ?? '' );
+		setFieldValue( 'postalCode', newInfo.postalCode?.value ?? '' );
+	};
 
 	return (
 		<div className="contact-fields">
@@ -32,10 +36,9 @@ export default function ContactFields( {
 				<TaxFields
 					section="update-to-new-card"
 					taxInfo={ fields }
+					onChange={ onChangeContactInfo }
 					countriesList={ countriesList }
 					isDisabled={ isDisabled }
-					updateCountryCode={ ( value ) => setFieldValue( 'countryCode', value ) }
-					updatePostalCode={ ( value ) => setFieldValue( 'postalCode', value ) }
 				/>
 			) }
 		</div>

--- a/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
@@ -146,7 +146,7 @@ function EbanxTefFields() {
 	const { changeCustomerName, changeCustomerBank } = useDispatch( 'ebanx-tef' );
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
-	const countriesList = useCountryList( [] );
+	const countriesList = useCountryList();
 
 	return (
 		<EbanxTefFormWrapper>

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -136,7 +136,7 @@ function NetBankingFields() {
 	const { changeCustomerName } = useDispatch( 'netbanking' );
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
-	const countriesList = useCountryList( [] );
+	const countriesList = useCountryList();
 
 	return (
 		<NetBankingFormWrapper>

--- a/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
@@ -139,7 +139,7 @@ const PayPalFieldsWrapper = styled.div`
 function PayPalTaxFields(): JSX.Element {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
-	const countriesList = useCountryList( [] );
+	const countriesList = useCountryList();
 	const postalCode = useSelect( ( select ) => select( storeKey ).getPostalCode() );
 	const countryCode = useSelect( ( select ) => select( storeKey ).getCountryCode() );
 	const fields = useMemo(

--- a/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
@@ -22,6 +22,7 @@ import type {
 	StoreActions,
 	StoreSelectorsWithState,
 	StoreState,
+	ManagedContactDetails,
 } from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:paypal-payment-method' );
@@ -150,15 +151,18 @@ function PayPalTaxFields(): JSX.Element {
 		[ postalCode, countryCode ]
 	);
 	const { changePostalCode, changeCountryCode } = useDispatch( storeKey );
+	const onChangeContactInfo = ( newInfo: ManagedContactDetails ) => {
+		changeCountryCode( newInfo.countryCode?.value ?? '' );
+		changePostalCode( newInfo.postalCode?.value ?? '' );
+	};
 	return (
 		<PayPalFieldsWrapper>
 			<TaxFields
 				section="paypal-payment-method"
 				taxInfo={ fields }
+				onChange={ onChangeContactInfo }
 				countriesList={ countriesList }
 				isDisabled={ isDisabled }
-				updatePostalCode={ changePostalCode }
-				updateCountryCode={ changeCountryCode }
 			/>
 		</PayPalFieldsWrapper>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `TaxFields` component is a managed React form element. It has one prop for its input values, but two props for its change handlers. This can cause race conditions if they both update in one event (which happens if the postal code gets reformatted).

<img width="691" alt="Screen Shot 2022-03-21 at 12 12 33 PM" src="https://user-images.githubusercontent.com/2036909/159303527-98923db2-db7a-4bc1-a3f8-39083605b0cf.png">

This PR modifies the component to have a single change handler (with a value that matches the input value) like most controlled components.

By fixing the race condition, this will allow using the component for existing payment methods in https://github.com/Automattic/wp-calypso/pull/62089

#### Testing instructions

This modifies the following forms. We should test each one to be sure that they still register changes as expected. For each form, try setting the country and the postal code to different values. If the values change, then it is working. 

If you select a country that does not support postal codes (eg: Macau), the postal code field should vanish, and if you then change it back to a country that does support postal codes (eg: US), the postal code field should reappear empty even if it previously had a value.

You can also test the postal code formatting; choose UK as the country and enter the postal code `sw1a1aa` and verify that it becomes `SW1A 1AA`.

- Checkout contact form (without G Suite or a domain in the cart).
- New credit card form at `/me/purchases/add-payment-method`.
- Assign new PayPal payment method form (visit `/me/purchases`, click a subscription, click "Add payment method"/"Change payment method", then select PayPal).