### PR TITLE
Reinstate Google sale banner

### DIFF
--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -9,6 +9,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import DomainToPlanNudge from 'calypso/blocks/domain-to-plan-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import EmptyContent from 'calypso/components/empty-content';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -21,6 +22,7 @@ import EmptyDomainsListCard from 'calypso/my-sites/domains/domain-management/lis
 import FreeDomainItem from 'calypso/my-sites/domains/domain-management/list/free-domain-item';
 import OptionsDomainButton from 'calypso/my-sites/domains/domain-management/list/options-domain-button';
 import { domainManagementList, domainManagementRoot } from 'calypso/my-sites/domains/paths';
+import GoogleSaleBanner from 'calypso/my-sites/email/google-sale-banner';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
@@ -33,6 +35,7 @@ import {
 	showUpdatePrimaryDomainErrorNotice,
 } from 'calypso/state/domains/management/actions';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { getProductsList } from 'calypso/state/products-list/selectors';
 import { getPurchases, isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
@@ -84,6 +87,7 @@ export class SiteDomains extends Component {
 		const {
 			currentRoute,
 			domains,
+			hasProductsList,
 			isAtomicSite,
 			isFetchingPurchases,
 			selectedSite,
@@ -152,6 +156,10 @@ export class SiteDomains extends Component {
 
 		return (
 			<>
+				{ ! hasProductsList && <QueryProductsList /> }
+
+				{ ! this.isLoading() && <GoogleSaleBanner domains={ domains } /> }
+
 				<div className="domain-management-list__items">
 					<div className="domain-management-list__filter">
 						{ this.renderDomainTableFilterButton() }
@@ -492,6 +500,7 @@ export default connect(
 		return {
 			currentRoute: getCurrentRoute( state ),
 			hasDomainCredit: !! ownProps.selectedSite && hasDomainCredit( state, siteId ),
+			hasProductsList: 0 < ( getProductsList( state )?.length ?? 0 ),
 			isDomainOnly: isDomainOnlySite( state, siteId ),
 			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
 			hasNonPrimaryDomainsFlag: getCurrentUser( state )

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -156,9 +156,9 @@ export class SiteDomains extends Component {
 
 		return (
 			<>
-				{ ! hasProductsList && <QueryProductsList /> }
+				{ hasProductsList || <QueryProductsList /> }
 
-				{ ! this.isLoading() && <GoogleSaleBanner domains={ domains } /> }
+				{ this.isLoading() || <GoogleSaleBanner domains={ domains } /> }
 
 				<div className="domain-management-list__items">
 					<div className="domain-management-list__filter">
@@ -496,11 +496,12 @@ export default connect(
 		const selectedSite = ownProps?.selectedSite || null;
 		const isOnFreePlan = selectedSite?.plan?.is_free || false;
 		const purchases = getPurchases( state );
+		const productsList = getProductsList( state );
 
 		return {
 			currentRoute: getCurrentRoute( state ),
 			hasDomainCredit: !! ownProps.selectedSite && hasDomainCredit( state, siteId ),
-			hasProductsList: 0 < ( getProductsList( state )?.length ?? 0 ),
+			hasProductsList: 0 < ( Object.getOwnPropertyNames( productsList )?.length ?? 0 ),
 			isDomainOnly: isDomainOnlySite( state, siteId ),
 			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
 			hasNonPrimaryDomainsFlag: getCurrentUser( state )

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -156,9 +156,9 @@ export class SiteDomains extends Component {
 
 		return (
 			<>
-				{ hasProductsList || <QueryProductsList /> }
+				{ ! hasProductsList && <QueryProductsList /> }
 
-				{ this.isLoading() || <GoogleSaleBanner domains={ domains } /> }
+				{ ! this.isLoading() && <GoogleSaleBanner domains={ domains } /> }
 
 				<div className="domain-management-list__items">
 					<div className="domain-management-list__filter">

--- a/client/my-sites/domains/domain-management/list/test/index.js
+++ b/client/my-sites/domains/domain-management/list/test/index.js
@@ -95,6 +95,7 @@ describe( 'index', () => {
 				currentUser: {
 					capabilities: {},
 				},
+				productsList: {},
 			},
 			( state ) => {
 				return state;

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -131,16 +131,12 @@ class EmailProvidersComparison extends Component {
 	constructor( props ) {
 		super( props );
 
-		const { selectedDomainName } = props;
+		const { selectedDomainName, shouldPromoteGoogleWorkspace } = props;
 
 		this.state = {
 			googleUsers: newUsers( selectedDomainName ),
 			titanMailboxes: [ buildNewTitanMailbox( selectedDomainName, false ) ],
-			expanded: {
-				forwarding: false,
-				google: false,
-				titan: true,
-			},
+			expanded: this.getDefaultExpandedState( shouldPromoteGoogleWorkspace ),
 			addingToCart: false,
 			emailForwardAdded: false,
 			validatedTitanMailboxUuids: [],
@@ -153,6 +149,22 @@ class EmailProvidersComparison extends Component {
 
 	componentWillUnmount() {
 		this.isMounted = false;
+	}
+
+	getDefaultExpandedState( shouldPromoteGoogleWorkspace ) {
+		if ( shouldPromoteGoogleWorkspace ) {
+			return {
+				forwarding: false,
+				google: true,
+				titan: false,
+			};
+		}
+
+		return {
+			forwarding: false,
+			google: false,
+			titan: true,
+		};
 	}
 
 	onExpandedStateChange = ( providerKey, isExpanded ) => {
@@ -362,12 +374,11 @@ class EmailProvidersComparison extends Component {
 		currencyCode,
 		isEligibleForFreeTrial,
 		gSuiteProduct,
-		productIsDiscounted,
 		standardPrice,
 	} ) {
-		const { translate } = this.props;
+		const { hasDiscountForGSuite, translate } = this.props;
 
-		if ( productIsDiscounted ) {
+		if ( hasDiscountForGSuite ) {
 			return (
 				<span className="email-providers-comparison__discount-with-renewal">
 					{ translate(
@@ -440,6 +451,7 @@ class EmailProvidersComparison extends Component {
 			gSuiteIntroductoryOffer,
 			gSuiteProduct,
 			hasCartDomain,
+			hasDiscountForGSuite,
 			isGSuiteSupported,
 			onSkipClick,
 			selectedDomainName,
@@ -457,9 +469,8 @@ class EmailProvidersComparison extends Component {
 
 		const isEligibleForFreeTrial = gSuiteIntroductoryOffer && hasCartDomain;
 
-		const productIsDiscounted = hasDiscount( gSuiteProduct );
 		const monthlyPrice = getMonthlyPrice( gSuiteProduct?.cost ?? null, currencyCode );
-		const formattedPrice = productIsDiscounted
+		const formattedPrice = hasDiscountForGSuite
 			? translate( '{{fullPrice/}} {{discountedPrice/}} /mailbox /month (billed annually)', {
 					components: {
 						fullPrice: <span>{ monthlyPrice }</span>,
@@ -480,7 +491,7 @@ class EmailProvidersComparison extends Component {
 			  } );
 
 		const standardPrice =
-			! productIsDiscounted && isEligibleForFreeTrial
+			! hasDiscountForGSuite && isEligibleForFreeTrial
 				? formatCurrency( gSuiteProduct?.cost ?? null, currencyCode )
 				: getAnnualPrice( gSuiteProduct?.cost ?? null, currencyCode );
 
@@ -488,7 +499,6 @@ class EmailProvidersComparison extends Component {
 			currencyCode,
 			isEligibleForFreeTrial,
 			gSuiteProduct,
-			productIsDiscounted,
 			standardPrice,
 		} );
 
@@ -853,6 +863,7 @@ class EmailProvidersComparison extends Component {
 			isSubmittingEmailForward,
 			selectedDomainName,
 			selectedSite,
+			shouldPromoteGoogleWorkspace,
 			source,
 		} = this.props;
 
@@ -884,7 +895,7 @@ class EmailProvidersComparison extends Component {
 
 				{ this.renderTitanCard() }
 
-				{ this.renderGoogleCard() }
+				{ ! shouldPromoteGoogleWorkspace && this.renderGoogleCard() }
 
 				{ ! hideEmailForwardingCard && this.renderEmailForwardingCard() }
 
@@ -920,6 +931,8 @@ export default connect(
 			( hasCartDomain || ( domain && hasGSuiteSupportedDomain( [ domain ] ) ) );
 		const gSuiteProduct = getProductBySlug( state, GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY );
 
+		const hasDiscountForGSuite = hasDiscount( gSuiteProduct );
+
 		const titanProductSlug = ownProps.titanProductSlug ?? TITAN_MAIL_MONTHLY_SLUG;
 
 		return {
@@ -933,10 +946,13 @@ export default connect(
 			),
 			gSuiteProduct,
 			hasCartDomain,
+			hasDiscountForGSuite,
 			isSubmittingEmailForward: isAddingEmailForward( state, ownProps.selectedDomainName ),
 			isGSuiteSupported,
 			requestingSiteDomains: isRequestingSiteDomains( state, domainName ),
 			selectedSite,
+			shouldPromoteGoogleWorkspace:
+				isGSuiteSupported && ( ownProps.source === 'google-sale' || hasDiscountForGSuite ),
 			titanMailProduct: getProductBySlug( state, titanProductSlug ),
 		};
 	},

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -131,12 +131,12 @@ class EmailProvidersComparison extends Component {
 	constructor( props ) {
 		super( props );
 
-		const { selectedDomainName, shouldPromoteGoogleWorkspace } = props;
+		const { selectedDomainName } = props;
 
 		this.state = {
 			googleUsers: newUsers( selectedDomainName ),
 			titanMailboxes: [ buildNewTitanMailbox( selectedDomainName, false ) ],
-			expanded: this.getDefaultExpandedState( shouldPromoteGoogleWorkspace ),
+			expanded: this.getDefaultExpandedState(),
 			addingToCart: false,
 			emailForwardAdded: false,
 			validatedTitanMailboxUuids: [],
@@ -151,7 +151,9 @@ class EmailProvidersComparison extends Component {
 		this.isMounted = false;
 	}
 
-	getDefaultExpandedState( shouldPromoteGoogleWorkspace ) {
+	getDefaultExpandedState() {
+		const { shouldPromoteGoogleWorkspace } = this.props;
+
 		if ( shouldPromoteGoogleWorkspace ) {
 			return {
 				forwarding: false,
@@ -863,7 +865,6 @@ class EmailProvidersComparison extends Component {
 			isSubmittingEmailForward,
 			selectedDomainName,
 			selectedSite,
-			shouldPromoteGoogleWorkspace,
 			source,
 		} = this.props;
 
@@ -895,7 +896,7 @@ class EmailProvidersComparison extends Component {
 
 				{ this.renderTitanCard() }
 
-				{ ! shouldPromoteGoogleWorkspace && this.renderGoogleCard() }
+				{ this.renderGoogleCard() }
 
 				{ ! hideEmailForwardingCard && this.renderEmailForwardingCard() }
 

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -865,7 +865,6 @@ class EmailProvidersComparison extends Component {
 			isSubmittingEmailForward,
 			selectedDomainName,
 			selectedSite,
-			shouldPromoteGoogleWorkspace,
 			source,
 		} = this.props;
 
@@ -895,11 +894,9 @@ class EmailProvidersComparison extends Component {
 					/>
 				) }
 
-				{ shouldPromoteGoogleWorkspace && this.renderGoogleCard() }
-
 				{ this.renderTitanCard() }
 
-				{ ! shouldPromoteGoogleWorkspace && this.renderGoogleCard() }
+				{ this.renderGoogleCard() }
 
 				{ ! hideEmailForwardingCard && this.renderEmailForwardingCard() }
 

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -865,6 +865,7 @@ class EmailProvidersComparison extends Component {
 			isSubmittingEmailForward,
 			selectedDomainName,
 			selectedSite,
+			shouldPromoteGoogleWorkspace,
 			source,
 		} = this.props;
 
@@ -894,9 +895,11 @@ class EmailProvidersComparison extends Component {
 					/>
 				) }
 
+				{ shouldPromoteGoogleWorkspace && this.renderGoogleCard() }
+
 				{ this.renderTitanCard() }
 
-				{ this.renderGoogleCard() }
+				{ ! shouldPromoteGoogleWorkspace && this.renderGoogleCard() }
 
 				{ ! hideEmailForwardingCard && this.renderEmailForwardingCard() }
 

--- a/client/my-sites/email/google-sale-banner/index.tsx
+++ b/client/my-sites/email/google-sale-banner/index.tsx
@@ -1,0 +1,115 @@
+import { GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY } from '@automattic/calypso-products';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
+import { Banner } from 'calypso/components/banner';
+import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
+import { canCurrentUserAddEmail } from 'calypso/lib/domains';
+import { hasPaidEmailWithUs } from 'calypso/lib/emails';
+import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
+import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
+import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import { getSite } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { ReactElement } from 'react';
+
+import './style.scss';
+
+type GoogleSaleBannerProps = {
+	domains: Array< ResponseDomain >;
+};
+
+const GoogleSaleBanner = ( { domains }: GoogleSaleBannerProps ): ReactElement | null => {
+	const googleWorkspaceProduct = useSelector( ( state ) =>
+		getProductBySlug( state, GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY )
+	);
+
+	const domainsEligibleForGoogleWorkspaceSale = domains
+		.filter( ( domain ) => {
+			if ( domain.expired || domain.isWpcomStagingDomain ) {
+				return false;
+			}
+			if ( ! canCurrentUserAddEmail( domain ) ) {
+				return false;
+			}
+			if ( hasPaidEmailWithUs( domain ) ) {
+				return false;
+			}
+			return hasGSuiteSupportedDomain( [ domain ] );
+		} )
+		// Push the primary domain to be listed first
+		.sort( ( a, b ) => Number( b.isPrimary ?? false ) - Number( a.isPrimary ?? false ) );
+
+	const domainForSale = domainsEligibleForGoogleWorkspaceSale[ 0 ] ?? null;
+
+	const siteForSale = useSelector( ( state ) =>
+		domainForSale?.blogId ? getSite( state, domainForSale.blogId ) : getSelectedSite( state )
+	);
+
+	const canCurrentUserPurchaseGSuite = useSelector( canUserPurchaseGSuite );
+	const currentRoute = useSelector( getCurrentRoute );
+	const isMobile = useMobileBreakpoint();
+	const translate = useTranslate();
+
+	if ( isMobile ) {
+		return null;
+	}
+
+	if ( ! canCurrentUserPurchaseGSuite ) {
+		return null;
+	}
+
+	if ( 0 === domainsEligibleForGoogleWorkspaceSale.length ) {
+		return null;
+	}
+
+	// Verify that we have a percentage discount
+	if (
+		! hasDiscount( googleWorkspaceProduct ) ||
+		( ! googleWorkspaceProduct?.sale_coupon?.discount ?? null )
+	) {
+		return null;
+	}
+
+	return (
+		<Banner
+			callToAction={ translate( 'Claim Now' ) }
+			className="google-sale-banner"
+			description={ translate(
+				'Set up your custom mailbox @%(domainName)s and enable all the productivity tools Google Workspace offers.',
+				{
+					args: {
+						domainName: domainForSale.name,
+					},
+					comment: '%(domainName)s is a domain name, e.g. example.com',
+					components: {
+						em: <em />,
+					},
+				}
+			) }
+			disableCircle
+			event="claim-now"
+			iconPath={ googleWorkspaceIcon }
+			href={ emailManagementPurchaseNewEmailAccount(
+				siteForSale?.slug ?? '',
+				domainForSale.name,
+				currentRoute,
+				'google-sale'
+			) }
+			title={ translate( 'Get %(discount)d%% off Google Workspace for a limited time!', {
+				args: {
+					discount: googleWorkspaceProduct.sale_coupon.discount,
+				},
+				comment: "%(discount)d is a numeric percentage discount (e.g. '50')",
+			} ) }
+			tracksClickName="calypso_email_google_workspace_sale_banner_cta_click"
+			tracksImpressionName="calypso_email_google_workspace_sale_banner_impression"
+		/>
+	);
+};
+
+export default GoogleSaleBanner;

--- a/client/my-sites/email/google-sale-banner/style.scss
+++ b/client/my-sites/email/google-sale-banner/style.scss
@@ -1,0 +1,28 @@
+.google-sale-banner {
+
+	@include breakpoint-deprecated( '>480px' ) {
+		&.banner.card {
+			padding-right: 24px;
+		}
+	}
+
+	.banner__icons {
+		.banner__icon {
+			display: none;
+		}
+
+		.banner__icon-no-circle {
+			align-self: center;
+			height: 36px;
+			width: 36px;
+		}
+	}
+
+	.banner__action {
+		margin-right: 0;
+
+		.button.is-compact {
+			line-height: 1.25;
+		}
+	}
+}


### PR DESCRIPTION
This mostly reverses the changes from #60403 which removes logic that was initially introduced in #57530

#### Changes proposed in this Pull Request

* Reinstates the Google sale banner
* Updates some props/variables

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You require access to a back end sandbox:
  - You need to create a sales coupon for Google workspace in the test Store environment - see D77139-code for instructions
  - Enable the test Store environment
  - Modify the back end APIs to mock test domains having WordPress.com nameservers - I have a sample in D69406-code
* Once you have all of those set up, load the UI via a local branch or the live branch
* Go to Upgrades -> Domains for a site that has at least one eligible domain - verify that you see the banner displayed with an eligible domain.
* Try the steps above for a site that doesn't have any domains eligible for the purchase - verify that you don't see the banner.
* Switch your back end APIs to the production API and ensure that you've disabled the Store sandbox/test mode.
* Work through the flow again and verify that you don't see the banner for the sites with and without eligible domains.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #57530
