### PR TITLE
Emails: Add a new option to allow the user to change his alternative email

### DIFF
--- a/client/my-sites/email/titan-new-mailbox/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox/index.jsx
@@ -149,11 +149,8 @@ const TitanNewMailbox = ( {
 										strong: <strong />,
 									},
 								} ) }
-								<a
-									className="titan-new-mailbox__show-alternate-email"
-									href
-									onClick={ showAlternateEmailField }
-								>
+								{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+								<a href="#" onClick={ showAlternateEmailField }>
 									{ ' ' }
 									{ translate( 'Change it', {
 										context: 'Button to show an input field to change an email',

--- a/client/my-sites/email/titan-new-mailbox/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox/index.jsx
@@ -138,26 +138,24 @@ const TitanNewMailbox = ( {
 						/>
 					</FormLabel>
 					{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
-					{ ( showAlternateEmail || hiddenFieldNames.includes( TITAN_PASSWORD_RESET_FIELD ) ) &&
-						! showAlternateEmail && (
-							<FormSettingExplanation>
-								{ translate( 'Your password reset email is {{strong}}%(userEmail)s{{/strong}}.', {
-									args: {
-										userEmail,
-									},
-									components: {
-										strong: <strong />,
-									},
+					{ hiddenFieldNames.includes( TITAN_PASSWORD_RESET_FIELD ) && ! showAlternateEmail && (
+						<FormSettingExplanation>
+							{ translate( 'Your password reset email is {{strong}}%(userEmail)s{{/strong}}.', {
+								args: {
+									userEmail,
+								},
+								components: {
+									strong: <strong />,
+								},
+							} ) }{ ' ' }
+							{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+							<a href="#" onClick={ showAlternateEmailField }>
+								{ translate( 'Change it', {
+									context: "'It' refers to an email address that can be used to reset a password.",
 								} ) }
-								{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-								<a href="#" onClick={ showAlternateEmailField }>
-									{ ' ' }
-									{ translate( 'Change it', {
-										context: 'Button to show an input field to change an email',
-									} ) }
-								</a>
-							</FormSettingExplanation>
-						) }
+							</a>
+						</FormSettingExplanation>
+					) }
 				</FormFieldset>
 				{ showIsAdminToggle && (
 					<FormFieldset>

--- a/client/my-sites/email/titan-new-mailbox/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox/index.jsx
@@ -140,20 +140,19 @@ const TitanNewMailbox = ( {
 					{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
 					{ hiddenFieldNames.includes( TITAN_PASSWORD_RESET_FIELD ) && ! showAlternateEmail && (
 						<FormSettingExplanation>
-							{ translate( 'Your password reset email is {{strong}}%(userEmail)s{{/strong}}.', {
-								args: {
-									userEmail,
-								},
-								components: {
-									strong: <strong />,
-								},
-							} ) }{ ' ' }
-							{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-							<a href="#" onClick={ showAlternateEmailField }>
-								{ translate( 'Change it', {
-									context: "'It' refers to an email address that can be used to reset a password.",
-								} ) }
-							</a>
+							{ translate(
+								'Your password reset email is {{strong}}%(userEmail)s{{/strong}}. {{a}}Change it{{/a}}.',
+								{
+									args: {
+										userEmail,
+									},
+									components: {
+										strong: <strong />,
+										// eslint-disable-next-line jsx-a11y/anchor-is-valid
+										a: <a href="#" onClick={ showAlternateEmailField } />,
+									},
+								}
+							) }
 						</FormSettingExplanation>
 					) }
 				</FormFieldset>

--- a/client/my-sites/email/titan-new-mailbox/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox/index.jsx
@@ -55,7 +55,7 @@ const TitanNewMailbox = ( {
 	const [ nameFieldTouched, setNameFieldTouched ] = useState( false );
 	const [ passwordFieldTouched, setPasswordFieldTouched ] = useState( false );
 	const [ showAlternateEmail, setShowAlternateEmail ] = useState( false );
-	const primaryEmail = useSelector( getCurrentUserEmail );
+	const userEmail = useSelector( getCurrentUserEmail );
 
 	const hasAlternativeEmailError =
 		( alternativeEmailFieldTouched || showAllErrors ) &&
@@ -70,10 +70,9 @@ const TitanNewMailbox = ( {
 
 	const showIsAdminToggle = false;
 
-	const showAlternativeEmailField = () => {
-		hiddenFieldNames = hiddenFieldNames.filter( ( field ) => field === TITAN_PASSWORD_RESET_FIELD );
+	const showAlternateEmailField = () => {
 		setShowAlternateEmail( true );
-		onMailboxValueChange( 'alternativeEmail', primaryEmail );
+		onMailboxValueChange( 'alternativeEmail', userEmail );
 		setAlternativeEmailFieldTouched( true );
 	};
 
@@ -140,26 +139,29 @@ const TitanNewMailbox = ( {
 						/>
 					</FormLabel>
 					{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
-					{ hiddenFieldNames.includes( TITAN_PASSWORD_RESET_FIELD ) && ! showAlternateEmail && (
-						<FormSettingExplanation>
-							{ translate( 'Your password reset email is {{strong}}%(primaryEmail)s{{/strong}}.', {
-								args: {
-									primaryEmail,
-								},
-								components: {
-									strong: <strong />,
-								},
-							} ) }
-							<Button
-								primary
-								className="titan-new-mailbox__show-alternate-email"
-								borderless
-								onClick={ showAlternativeEmailField }
-							>
-								{ translate( 'Change it' ) }
-							</Button>
-						</FormSettingExplanation>
-					) }
+					{ ( showAlternateEmail || hiddenFieldNames.includes( TITAN_PASSWORD_RESET_FIELD ) ) &&
+						! showAlternateEmail && (
+							<FormSettingExplanation>
+								{ translate( 'Your password reset email is {{strong}}%(userEmail)s{{/strong}}.', {
+									args: {
+										userEmail,
+									},
+									components: {
+										strong: <strong />,
+									},
+								} ) }
+								<a
+									className="titan-new-mailbox__show-alternate-email"
+									href
+									onClick={ showAlternateEmailField }
+								>
+									{ ' ' }
+									{ translate( 'Change it', {
+										context: 'Button to show an input field to change an email',
+									} ) }
+								</a>
+							</FormSettingExplanation>
+						) }
 				</FormFieldset>
 				{ showIsAdminToggle && (
 					<FormFieldset>

--- a/client/my-sites/email/titan-new-mailbox/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox/index.jsx
@@ -1,4 +1,3 @@
-import { Button } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate, useRtl } from 'i18n-calypso';
 import PropTypes from 'prop-types';

--- a/client/my-sites/email/titan-new-mailbox/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox/index.jsx
@@ -8,6 +8,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { getMailboxPropTypeShape } from 'calypso/lib/titan/new-mailbox';
@@ -139,6 +140,26 @@ const TitanNewMailbox = ( {
 						/>
 					</FormLabel>
 					{ hasPasswordError && <FormInputValidation text={ passwordError } isError /> }
+					{ hiddenFieldNames.includes( TITAN_PASSWORD_RESET_FIELD ) && ! showAlternateEmail && (
+						<FormSettingExplanation>
+							{ translate( 'Your password reset email is {{strong}}%(primaryEmail)s{{/strong}}.', {
+								args: {
+									primaryEmail,
+								},
+								components: {
+									strong: <strong />,
+								},
+							} ) }
+							<Button
+								primary
+								className="titan-new-mailbox__show-alternate-email"
+								borderless
+								onClick={ showAlternativeEmailField }
+							>
+								{ translate( 'Change it' ) }
+							</Button>
+						</FormSettingExplanation>
+					) }
 				</FormFieldset>
 				{ showIsAdminToggle && (
 					<FormFieldset>
@@ -174,26 +195,6 @@ const TitanNewMailbox = ( {
 							<FormInputValidation text={ alternativeEmailError } isError />
 						) }
 					</FormFieldset>
-				) }
-				{ hiddenFieldNames.includes( TITAN_PASSWORD_RESET_FIELD ) && ! showAlternateEmail && (
-					<>
-						{ translate( '*Your password reset email is {{strong}}%(primaryEmail)s{{/strong}}.', {
-							args: {
-								primaryEmail,
-							},
-							components: {
-								strong: <strong />,
-							},
-						} ) }
-						<Button
-							primary
-							className="titan-new-mailbox__show-alternate-email"
-							borderless
-							onClick={ showAlternativeEmailField }
-						>
-							{ translate( 'Change it' ) }
-						</Button>
-					</>
 				) }
 			</div>
 		</>

--- a/client/my-sites/email/titan-new-mailbox/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox/index.jsx
@@ -1,7 +1,9 @@
+import { Button } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate, useRtl } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -9,6 +11,7 @@ import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { getMailboxPropTypeShape } from 'calypso/lib/titan/new-mailbox';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 
 import './style.scss';
 
@@ -50,6 +53,8 @@ const TitanNewMailbox = ( {
 	const [ mailboxFieldTouched, setMailboxFieldTouched ] = useState( false );
 	const [ nameFieldTouched, setNameFieldTouched ] = useState( false );
 	const [ passwordFieldTouched, setPasswordFieldTouched ] = useState( false );
+	const [ showAlternateEmail, setShowAlternateEmail ] = useState( false );
+	const primaryEmail = useSelector( getCurrentUserEmail );
 
 	const hasAlternativeEmailError =
 		( alternativeEmailFieldTouched || showAllErrors ) &&
@@ -63,6 +68,13 @@ const TitanNewMailbox = ( {
 	const hasPasswordError = ( passwordFieldTouched || showAllErrors ) && null !== passwordError;
 
 	const showIsAdminToggle = false;
+
+	const showAlternativeEmailField = () => {
+		hiddenFieldNames = hiddenFieldNames.filter( ( field ) => field === TITAN_PASSWORD_RESET_FIELD );
+		setShowAlternateEmail( true );
+		onMailboxValueChange( 'alternativeEmail', primaryEmail );
+		setAlternativeEmailFieldTouched( true );
+	};
 
 	return (
 		<>
@@ -140,7 +152,7 @@ const TitanNewMailbox = ( {
 						/>
 					</FormFieldset>
 				) }
-				{ ! hiddenFieldNames.includes( TITAN_PASSWORD_RESET_FIELD ) && (
+				{ ( ! hiddenFieldNames.includes( TITAN_PASSWORD_RESET_FIELD ) || showAlternateEmail ) && (
 					<FormFieldset>
 						<FormLabel>
 							{ translate( 'Password reset email address', {
@@ -162,6 +174,26 @@ const TitanNewMailbox = ( {
 							<FormInputValidation text={ alternativeEmailError } isError />
 						) }
 					</FormFieldset>
+				) }
+				{ hiddenFieldNames.includes( TITAN_PASSWORD_RESET_FIELD ) && ! showAlternateEmail && (
+					<>
+						{ translate( '*Your password reset email is {{strong}}%(primaryEmail)s{{/strong}}.', {
+							args: {
+								primaryEmail,
+							},
+							components: {
+								strong: <strong />,
+							},
+						} ) }
+						<Button
+							primary
+							className="titan-new-mailbox__show-alternate-email"
+							borderless
+							onClick={ showAlternativeEmailField }
+						>
+							{ translate( 'Change it' ) }
+						</Button>
+					</>
 				) }
 			</div>
 		</>

--- a/client/my-sites/email/titan-new-mailbox/style.scss
+++ b/client/my-sites/email/titan-new-mailbox/style.scss
@@ -49,3 +49,8 @@
 		}
 	}
 }
+
+.titan-new-mailbox__show-alternate-email {
+	padding: 0;
+	margin-left: 0.5em;
+}

--- a/client/my-sites/email/titan-new-mailbox/style.scss
+++ b/client/my-sites/email/titan-new-mailbox/style.scss
@@ -49,7 +49,3 @@
 		}
 	}
 }
-
-.titan-new-mailbox__show-alternate-email {
-	cursor: pointer;
-}

--- a/client/my-sites/email/titan-new-mailbox/style.scss
+++ b/client/my-sites/email/titan-new-mailbox/style.scss
@@ -51,6 +51,5 @@
 }
 
 .titan-new-mailbox__show-alternate-email {
-	padding: 0;
-	margin-left: 0.5em;
+	cursor: pointer;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull requests tries to improve the upsell email for Professional Email. This is just a draft and has not been discussed yet, but it will allow to test this feature live, agree on the wording and decide what to do.

#### Testing instructions

1. Have a domain without any email subscription attached to it.
2. Go to Upgrade -> Emails
3. Click in the "Add email" button for the chosen domain in the step 1
4. Check that we are displaying new information regarding the email that is going to be used for the alternative email.
5. Click on the button "Change it"
6. Assert that the Alternative Email input field appears profiled with the user's main WordPress registration email

| BEFORE  | AFTER |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/5689927/159225381-57a56479-d752-4a85-ad42-aa253c4902b0.png) | ![image](https://user-images.githubusercontent.com/5689927/159246402-5adfe7b8-7fde-42a5-938c-2383030f480e.png)|

Related to [Github Issue](https://github.com/Automattic/email-documentation/issues/47)
