### PR TITLE
Add TUS uploader for video files uploads from media library

### DIFF
--- a/packages/wpcom.js/package.json
+++ b/packages/wpcom.js/package.json
@@ -42,7 +42,8 @@
 	},
 	"dependencies": {
 		"debug": "^4.3.3",
-		"qs": "^6.5.2"
+		"qs": "^6.5.2",
+		"tus-js-client": "2.3.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",

--- a/packages/wpcom.js/src/lib/site.media.js
+++ b/packages/wpcom.js/src/lib/site.media.js
@@ -1,4 +1,5 @@
 import debugFactory from 'debug';
+import TusUploader from './tus-uploader';
 import { createReadStream } from './util/fs';
 
 const debug = debugFactory( 'wpcom:media' );
@@ -150,6 +151,23 @@ Media.prototype.addFiles = function ( query, files, fn ) {
 			files = query;
 			query = {};
 		}
+	}
+
+	const videoFiles = [];
+	const isArray = Array.isArray( files );
+	files = isArray ? files : [ files ];
+
+	files = files.filter( ( file ) => {
+		if ( !! file.type && file.type.startsWith( 'video/' ) ) {
+			videoFiles.push( file );
+			return false;
+		}
+		return true;
+	} );
+
+	if ( videoFiles.length ) {
+		const uploader = new TusUploader( this.wpcom, this._sid );
+		return uploader.startUpload( videoFiles );
 	}
 
 	const params = {

--- a/packages/wpcom.js/src/lib/tus-uploader.js
+++ b/packages/wpcom.js/src/lib/tus-uploader.js
@@ -1,0 +1,160 @@
+import * as tus from 'tus-js-client';
+import Media from './site.media';
+
+/**
+ * This class is an adapted version of wpcom's TUS uploader use-uploader.js.
+ * It enables resumable uploads for videos.
+ */
+export default class TusUploader {
+	constructor( wpcom, sid ) {
+		this.wpcom = wpcom;
+		this._sid = sid;
+	}
+
+	createGetJwtRequest = ( key ) => {
+		const params = {
+			path: '/sites/' + this._sid + '/media/videopress-upload-jwt',
+			apiNamespace: 'wpcom/v2',
+		};
+
+		if ( key ) {
+			params.key = key;
+		}
+
+		return this.wpcom.req.post( params, {}, null, null );
+	};
+
+	startUpload = ( files ) => {
+		const file = files[ 0 ];
+		return new Promise( ( resolve, reject ) => {
+			const uploader = this.resumableUploader( {
+				onError: ( error ) => reject( error ),
+				onSuccess: ( args ) => {
+					const media = new Media( args.mediaId, this._sid, this.wpcom );
+					media
+						.get()
+						.then( ( res ) => resolve( { media: [ res ] } ) )
+						.catch( ( err ) => reject( err ) );
+				},
+				onProgress: (/*bytesUploaded, bytesTotal*/) => {},
+			} );
+
+			return this.createGetJwtRequest().then( ( jwtData ) => uploader( file, jwtData ) );
+		} );
+	};
+
+	resumableUploader = ( { onError, onProgress, onSuccess } ) => {
+		const jwtsForKeys = {};
+		// Keep in sync with wpcom's use-uploader.js
+		return ( file, data ) => {
+			const upload = new tus.Upload( file, {
+				onError: onError,
+				onProgress: onProgress,
+				endpoint: 'https://public-api.wordpress.com/rest/v1.1/video-uploads/' + this._sid + '/',
+				removeFingerprintOnSuccess: true,
+				withCredentials: false,
+				autoRetry: true,
+				overridePatchMethod: false,
+				chunkSize: 500000, // 500 Kb.
+				allowedFileTypes: [ 'video/*' ],
+				metadata: {
+					filename: file.name,
+					filetype: file.type,
+				},
+				retryDelays: [ 0, 1000, 3000, 5000, 10000 ],
+				onAfterResponse: ( req, res ) => {
+					// Why is this not showing the x-headers?
+					if ( res.getStatus() >= 400 ) {
+						return;
+					}
+
+					const GUID_HEADER = 'x-videopress-upload-guid';
+					const MEDIA_ID_HEADER = 'x-videopress-upload-media-id';
+					const SRC_URL_HEADER = 'x-videopress-upload-src-url';
+					const guid = res.getHeader( GUID_HEADER );
+					const mediaId = res.getHeader( MEDIA_ID_HEADER );
+					const src = res.getHeader( SRC_URL_HEADER );
+					if ( guid && mediaId && src ) {
+						onSuccess && onSuccess( { mediaId: Number( mediaId ), guid, src } );
+						return;
+					}
+
+					const headerMap = {
+						'x-videopress-upload-key-token': 'token',
+						'x-videopress-upload-key': 'key',
+					};
+
+					const tokenData = {};
+					Object.keys( headerMap ).forEach( function ( header ) {
+						const value = res.getHeader( header );
+						if ( ! value ) {
+							return;
+						}
+
+						tokenData[ headerMap[ header ] ] = value;
+					} );
+
+					if ( tokenData.key && tokenData.token ) {
+						jwtsForKeys[ tokenData.key ] = tokenData.token;
+					}
+				},
+				onBeforeRequest: ( req ) => {
+					// make ALL requests be either POST or GET to honor the public-api.wordpress.com "contract".
+					const method = req._method;
+					if ( [ 'HEAD', 'OPTIONS' ].indexOf( method ) >= 0 ) {
+						req._method = 'GET';
+						req.setHeader( 'X-HTTP-Method-Override', method );
+					}
+
+					if ( [ 'DELETE', 'PUT', 'PATCH' ].indexOf( method ) >= 0 ) {
+						req._method = 'POST';
+						req.setHeader( 'X-HTTP-Method-Override', method );
+					}
+
+					req._xhr.open( req._method, req._url, true );
+					// Set the headers again, reopening the xhr resets them.
+					Object.keys( req._headers ).map( function ( headerName ) {
+						req.setHeader( headerName, req._headers[ headerName ] );
+					} );
+
+					if ( 'POST' === method ) {
+						const hasJWT = !! data.upload_token;
+						if ( hasJWT ) {
+							req.setHeader( 'x-videopress-upload-token', data.upload_token );
+						} else {
+							throw 'should never happen';
+						}
+					}
+
+					if ( [ 'OPTIONS', 'GET', 'HEAD', 'DELETE', 'PUT', 'PATCH' ].indexOf( method ) >= 0 ) {
+						const url = new URL( req._url );
+						const path = url.pathname;
+						const parts = path.split( '/' );
+						const maybeUploadkey = parts[ parts.length - 1 ];
+						if ( jwtsForKeys[ maybeUploadkey ] ) {
+							req.setHeader( 'x-videopress-upload-token', jwtsForKeys[ maybeUploadkey ] );
+						} else if ( 'HEAD' === method ) {
+							return this.createGetJwtRequest( maybeUploadkey ).then( ( responseData ) => {
+								jwtsForKeys[ maybeUploadkey ] = responseData.token;
+								req.setHeader( 'x-videopress-upload-token', responseData.token );
+								return req;
+							} );
+						}
+					}
+
+					return Promise.resolve( req );
+				},
+			} );
+
+			upload.findPreviousUploads().then( function ( previousUploads ) {
+				if ( previousUploads.length ) {
+					upload.resumeFromPreviousUpload( previousUploads[ 0 ] );
+				}
+
+				upload.start();
+			} );
+
+			return upload;
+		};
+	};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12488,6 +12488,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-from@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "buffer-from@npm:0.1.2"
+  checksum: 5cadb80f26484d547c6ad26372b4f8a34d3784a1a3df15dc11b8414ad2a1670764586aeffdcfc8277f63023b209de7f7300f3fa1bf80c3a526e6f1dd338c613c
+  languageName: node
+  linkType: hard
+
 "buffer-from@npm:^1.0.0":
   version: 1.1.1
   resolution: "buffer-from@npm:1.1.1"
@@ -13997,6 +14004,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"combine-errors@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "combine-errors@npm:3.0.3"
+  dependencies:
+    custom-error-instance: 2.1.1
+    lodash.uniqby: 4.5.0
+  checksum: 6e7c04102596dfc43ddb252c8390e869e358fb6df3b027567b33f5d998fdb2ad84573ce30a3861feb84fdee1fc3da3c465d68e23f7ab39f98bbe846ca9f70c6d
+  languageName: node
+  linkType: hard
+
 "combined-stream@npm:^1.0.6, combined-stream@npm:^1.0.8, combined-stream@npm:~1.0.6":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
@@ -15339,6 +15356,13 @@ __metadata:
   dependencies:
     array-find-index: ^1.0.1
   checksum: 32d197689ec32f035910202c1abb0dc6424dce01d7b51779c685119b380d98535c110ffff67a262fc7e367612a7dfd30d3d3055f9a6634b5a9dd1302de7ef11c
+  languageName: node
+  linkType: hard
+
+"custom-error-instance@npm:2.1.1":
+  version: 2.1.1
+  resolution: "custom-error-instance@npm:2.1.1"
+  checksum: c4f68550ae88426c49810846c62651438f04a10462c4d8667c089fb9264bcf1723c9b188e3f1d7791d727b0e5aa48ed1de0415eef50d43ea078517844296b85e
   languageName: node
   linkType: hard
 
@@ -23688,6 +23712,13 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"js-base64@npm:^2.6.1":
+  version: 2.6.4
+  resolution: "js-base64@npm:2.6.4"
+  checksum: 95d93c4eca0bbe0f2d5ffe8682d9acd23051e5c0ad71873ff5a48dd46a5f19025de9f7b36e63fa3f02f342ae4a8ca4c56e7b590d7300ebb6639ce09675e0fd02
+  languageName: node
+  linkType: hard
+
 "js-sha3@npm:0.8.0":
   version: 0.8.0
   resolution: "js-sha3@npm:0.8.0"
@@ -24643,6 +24674,32 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"lodash._baseiteratee@npm:~4.7.0":
+  version: 4.7.0
+  resolution: "lodash._baseiteratee@npm:4.7.0"
+  dependencies:
+    lodash._stringtopath: ~4.8.0
+  checksum: 67f80e6878444e44e3cc6e779941c78da2bfa02413e305b5bfbe612e6ddedbbb05bda025e673014d734b79d69db911c7cfaf25dbc05abc56356eccc90e1e59e3
+  languageName: node
+  linkType: hard
+
+"lodash._basetostring@npm:~4.12.0":
+  version: 4.12.0
+  resolution: "lodash._basetostring@npm:4.12.0"
+  checksum: 08d4f8affb3cfed7cc50bbe35d35605597bd72c05e6ed0696122b0a4da242de1b5f5396e986645f46a97e976d6f7b4943a001b002a4e2b3b8ea087949dc9eb98
+  languageName: node
+  linkType: hard
+
+"lodash._baseuniq@npm:~4.6.0":
+  version: 4.6.0
+  resolution: "lodash._baseuniq@npm:4.6.0"
+  dependencies:
+    lodash._createset: ~4.0.0
+    lodash._root: ~3.0.0
+  checksum: 07e2ac63efde634685ed12b16664ee04931b258cd2511b703fddd9ddfc624a85542e3f03a6c2fdac369c00559296198daa8efffaf90d71c7a35f5c89f94ebb14
+  languageName: node
+  linkType: hard
+
 "lodash._bindcallback@npm:^3.0.0":
   version: 3.0.1
   resolution: "lodash._bindcallback@npm:3.0.1"
@@ -24650,10 +24707,33 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"lodash._createset@npm:~4.0.0":
+  version: 4.0.3
+  resolution: "lodash._createset@npm:4.0.3"
+  checksum: 6144f59a63cedb8bf2840970579dc7dfdad55970741a80f9a6e5c6b29b629fc204c846e54e29266ec24b41e3f680bcbeb9fe9332fb9f2bab71eb9c70cacd26d8
+  languageName: node
+  linkType: hard
+
 "lodash._getnative@npm:^3.0.0":
   version: 3.9.1
   resolution: "lodash._getnative@npm:3.9.1"
   checksum: 858cff25fc52353a1e39f44ff87fc1e1e8a85da513818f0caebe50c2795cf5cbce9d71a3e91ec0972bee3b174a74d697a38c6bb16d0b416dcc32322ae152a104
+  languageName: node
+  linkType: hard
+
+"lodash._root@npm:~3.0.0":
+  version: 3.0.1
+  resolution: "lodash._root@npm:3.0.1"
+  checksum: 679c8a570381795b6953ec8c680442acb5472c5b399263ed4ea6839630cf4dd5d65aa8c2a0f6934507fc5bc70f2af20bc430cbd847728b8c1672db95555edb51
+  languageName: node
+  linkType: hard
+
+"lodash._stringtopath@npm:~4.8.0":
+  version: 4.8.0
+  resolution: "lodash._stringtopath@npm:4.8.0"
+  dependencies:
+    lodash._basetostring: ~4.12.0
+  checksum: 5e3a58a97b481a9069fc43ca6ddeace83891e3d9cff8d36400064c85977c225621a9c52131224d64632a054a7c19d8ca7b2f0f5bfc983402564bd2a5e49d8672
   languageName: node
   linkType: hard
 
@@ -24920,6 +25000,16 @@ fsevents@~2.1.2:
   version: 4.5.0
   resolution: "lodash.uniq@npm:4.5.0"
   checksum: 262d400bb0952f112162a320cc4a75dea4f66078b9e7e3075ffbc9c6aa30b3e9df3cf20e7da7d566105e1ccf7804e4fbd7d804eee0b53de05d83f16ffbf41c5e
+  languageName: node
+  linkType: hard
+
+"lodash.uniqby@npm:4.5.0":
+  version: 4.5.0
+  resolution: "lodash.uniqby@npm:4.5.0"
+  dependencies:
+    lodash._baseiteratee: ~4.7.0
+    lodash._baseuniq: ~4.6.0
+  checksum: 4f479ec2dd92825c2a308986d3613e32fe02b13dffc5d0998cbb1ef4eeee56835f13a88e093c7a88473fa72cf5ffd37f807f5ae2d9496e738d776c1911fdabc8
   languageName: node
   linkType: hard
 
@@ -29903,6 +29993,16 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"proper-lockfile@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "proper-lockfile@npm:2.0.1"
+  dependencies:
+    graceful-fs: ^4.1.2
+    retry: ^0.10.0
+  checksum: 6db0bbace1e60ff2ddd5ecbecf05807a7fb00b6c96985da755990d1628ac30d7f20ae91912bfb2679733ae501b4bedad48d475b1f156279fd7026276f6234fce
+  languageName: node
+  linkType: hard
+
 "property-information@npm:^5.0.0, property-information@npm:^5.3.0":
   version: 5.6.0
   resolution: "property-information@npm:5.6.0"
@@ -30196,6 +30296,13 @@ fsevents@~2.1.2:
   version: 0.2.0
   resolution: "querystring@npm:0.2.0"
   checksum: 2036c9424beaacd3978bac9e4ba514331cc73163bea7bf3ad7e2c7355e55501938ec195312c607753f9c6e70b1bf9dfcda38db6241bd299c034e27ac639d64ed
+  languageName: node
+  linkType: hard
+
+"querystringify@npm:^2.1.1":
+  version: 2.2.0
+  resolution: "querystringify@npm:2.2.0"
+  checksum: 3258bc3dbdf322ff2663619afe5947c7926a6ef5fb78ad7d384602974c467fadfc8272af44f5eb8cddd0d011aae8fabf3a929a8eee4b86edcc0a21e6bd10f9aa
   languageName: node
   linkType: hard
 
@@ -32886,6 +32993,13 @@ resolve@^2.0.0-next.3:
   version: 0.1.15
   resolution: "ret@npm:0.1.15"
   checksum: 01f77cad0f7ea4f955852c03d66982609893edc1240c0c964b4c9251d0f9fb6705150634060d169939b096d3b77f4c84d6b6098a5b5d340160898c8581f1f63f
+  languageName: node
+  linkType: hard
+
+"retry@npm:^0.10.0":
+  version: 0.10.1
+  resolution: "retry@npm:0.10.1"
+  checksum: d5a7cbc7eca5589a4cf048355150c6746965ace4193080c46b34fe92059506ce39887f5d2bbc58d1d14ecf3b53c5c86d01bd82d158eac9b58aa2f075c2ae7b21
   languageName: node
   linkType: hard
 
@@ -36354,6 +36468,21 @@ testarmada-magellan@11.0.10:
   languageName: node
   linkType: hard
 
+"tus-js-client@npm:2.3.0":
+  version: 2.3.0
+  resolution: "tus-js-client@npm:2.3.0"
+  dependencies:
+    buffer-from: ^0.1.1
+    combine-errors: ^3.0.3
+    is-stream: ^2.0.0
+    js-base64: ^2.6.1
+    lodash.throttle: ^4.1.1
+    proper-lockfile: ^2.0.1
+    url-parse: ^1.4.3
+  checksum: 0ac1c764a066ec2363f3508cd72ab0beaac91af2ad3d3ef5d09155db6d220f73a64a49e8f09f846eef2fd00a3e6d0d10f0900338526a8336846d40a8c051ee3d
+  languageName: node
+  linkType: hard
+
 "tweetnacl@npm:^0.14.3, tweetnacl@npm:~0.14.0":
   version: 0.14.5
   resolution: "tweetnacl@npm:0.14.5"
@@ -37068,6 +37197,16 @@ testarmada-magellan@11.0.10:
   dependencies:
     prepend-http: ^2.0.0
   checksum: 16f918634d41a4fab9e03c5f9702968c9930f7c29aa1a8c19a6dc01f97d02d9b700ab9f47f8da0b9ace6e0c0e99c27848994de1465b494bced6940c653481e55
+  languageName: node
+  linkType: hard
+
+"url-parse@npm:^1.4.3":
+  version: 1.5.10
+  resolution: "url-parse@npm:1.5.10"
+  dependencies:
+    querystringify: ^2.1.1
+    requires-port: ^1.0.0
+  checksum: bd5aa9389f896974beb851c112f63b466505a04b4807cea2e5a3b7092f6fbb75316f0491ea84e44f66fed55f1b440df5195d7e3a8203f64fcefa19d182f5be87
   languageName: node
   linkType: hard
 
@@ -38508,6 +38647,7 @@ testarmada-magellan@11.0.10:
     debug: ^4.3.3
     npm-run-all: ^4.1.5
     qs: ^6.5.2
+    tus-js-client: 2.3.0
     webpack: ^5.68.0
     webpack-cli: ^4.9.2
     wpcom-oauth-cors: ^1.0.2-beta

--- a/yarn.lock
+++ b/yarn.lock
@@ -12488,6 +12488,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-from@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "buffer-from@npm:0.1.2"
+  checksum: 5cadb80f26484d547c6ad26372b4f8a34d3784a1a3df15dc11b8414ad2a1670764586aeffdcfc8277f63023b209de7f7300f3fa1bf80c3a526e6f1dd338c613c
+  languageName: node
+  linkType: hard
+
 "buffer-from@npm:^1.0.0":
   version: 1.1.1
   resolution: "buffer-from@npm:1.1.1"
@@ -23698,14 +23705,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"js-base64@npm:^2.1.9":
-  version: 2.5.2
-  resolution: "js-base64@npm:2.5.2"
-  checksum: 7a2402c60938379545b77550b27c10f299249e4954317913b24bbb640a6f49ce2d5d4d45028101e809c23c0434d582806de09255f34ecdb077ea55babe0e7b25
-  languageName: node
-  linkType: hard
-
-"js-base64@npm:^2.6.1":
+"js-base64@npm:^2.1.9, js-base64@npm:^2.6.1":
   version: 2.6.4
   resolution: "js-base64@npm:2.6.4"
   checksum: 95d93c4eca0bbe0f2d5ffe8682d9acd23051e5c0ad71873ff5a48dd46a5f19025de9f7b36e63fa3f02f342ae4a8ca4c56e7b590d7300ebb6639ce09675e0fd02
@@ -36465,7 +36465,7 @@ testarmada-magellan@11.0.10:
   version: 2.3.0
   resolution: "tus-js-client@npm:2.3.0"
   dependencies:
-    buffer-from: ^1.0.0
+    buffer-from: ^0.1.1
     combine-errors: ^3.0.3
     is-stream: ^2.0.0
     js-base64: ^2.6.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -12488,13 +12488,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-from@npm:^0.1.1":
-  version: 0.1.2
-  resolution: "buffer-from@npm:0.1.2"
-  checksum: 5cadb80f26484d547c6ad26372b4f8a34d3784a1a3df15dc11b8414ad2a1670764586aeffdcfc8277f63023b209de7f7300f3fa1bf80c3a526e6f1dd338c613c
-  languageName: node
-  linkType: hard
-
 "buffer-from@npm:^1.0.0":
   version: 1.1.1
   resolution: "buffer-from@npm:1.1.1"
@@ -36472,7 +36465,7 @@ testarmada-magellan@11.0.10:
   version: 2.3.0
   resolution: "tus-js-client@npm:2.3.0"
   dependencies:
-    buffer-from: ^0.1.1
+    buffer-from: ^1.0.0
     combine-errors: ^3.0.3
     is-stream: ^2.0.0
     js-base64: ^2.6.1


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the TUS uploader to enable resumable uploads for videos in the media library.
It currently replaces the backend upload process with the resumable uploader without modifying the UI.

#### Testing instructions

* On a sandboxed site with VideoPress enabled
* `yarn && yarn start`
* In your sandbox : `tail -f /tmp/php-errors`
* Go to your media library
* Upload a video
* ✅ You should see the TUS upload logs appearing in the error log.
* ✅ The upload should be successful or provide a safe error path.

Fixes Automattic/greenhouse#1111
