### PR TITLE
i18n: Use getters for Signup flows definition attributes with translate calls

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -22,7 +22,9 @@ export function generateFlows( {
 			destination: getRedirectDestination,
 			description: 'Create an account without a blog.',
 			lastModified: '2020-08-12',
-			pageTitle: translate( 'Create an account' ),
+			get pageTitle() {
+				return translate( 'Create an account' );
+			},
 			showRecaptcha: true,
 		},
 		{
@@ -270,13 +272,17 @@ export function generateFlows( {
 			description: 'A flow to launch a private site.',
 			providesDependenciesInQuery: [ 'siteSlug' ],
 			lastModified: '2019-11-22',
-			pageTitle: translate( 'Launch your site' ),
+			get pageTitle() {
+				return translate( 'Launch your site' );
+			},
 		},
 		{
 			name: 'importer',
 			steps: isEnabled( 'onboarding/import' ) ? [ 'capture', 'list', 'ready' ] : [],
 			destination: '/',
-			pageTitle: translate( 'Import your site content' ),
+			get pageTitle() {
+				return translate( 'Import your site content' );
+			},
 			description: 'A new import flow that can be used from the onboarding flow',
 			lastModified: '2021-10-18',
 			disallowResume: true,
@@ -286,7 +292,9 @@ export function generateFlows( {
 			name: 'from',
 			steps: [ 'importing' ],
 			destination: '/',
-			pageTitle: translate( 'Import your site content' ),
+			get pageTitle() {
+				return translate( 'Import your site content' );
+			},
 			description: 'Onboarding - start from importer',
 			lastModified: '2021-11-15',
 			enableBranchSteps: true,
@@ -295,7 +303,9 @@ export function generateFlows( {
 			name: 'import-light',
 			steps: isEnabled( 'onboarding/import-light' ) ? [ 'static' ] : [],
 			destination: '/',
-			pageTitle: translate( 'Import light' ),
+			get pageTitle() {
+				return translate( 'Import light' );
+			},
 			description: 'Import light',
 			lastModified: '2022-02-25',
 			enableBranchSteps: true,
@@ -332,7 +342,9 @@ export function generateFlows( {
 			description:
 				'Launch flow without domain or plan selected, used for sites that already have a paid plan and domain (e.g. via the launch banner in the site preview)',
 			lastModified: '2020-11-30',
-			pageTitle: translate( 'Launch your site' ),
+			get pageTitle() {
+				return translate( 'Launch your site' );
+			},
 			providesDependenciesInQuery: [ 'siteSlug' ],
 		},
 		{
@@ -379,7 +391,9 @@ export function generateFlows( {
 			lastModified: '2021-10-14',
 			providesDependenciesInQuery: [ 'siteId', 'siteSlug' ],
 			optionalDependenciesInQuery: [ 'siteId' ],
-			pageTitle: translate( 'Set up your site' ),
+			get pageTitle() {
+				return translate( 'Set up your site' );
+			},
 			enableBranchSteps: true,
 		},
 		{
@@ -418,7 +432,9 @@ export function generateFlows( {
 		},
 		{
 			name: 'woocommerce-install',
-			pageTitle: translate( 'Add WooCommerce to your site' ),
+			get pageTitle() {
+				return translate( 'Add WooCommerce to your site' );
+			},
 			steps: [ 'store-address', 'business-info', 'confirm', 'transfer' ],
 			destination: '/',
 			description: 'Onboarding and installation flow for woocommerce on all plans.',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use getters for the Signup flows attributes that use translate calls, so that translate call is executed whenever the property is accessed and returns results according to the current translation data state (i.e. with async translations loaded).

**Before:**
![CleanShot 2022-03-21 at 13 35 14](https://user-images.githubusercontent.com/2722412/159255093-a403f2e3-63d6-46e2-b5a9-aa1e935134c8.png)

**After:**
![CleanShot 2022-03-21 at 13 34 41](https://user-images.githubusercontent.com/2722412/159255116-dced3f37-0d12-4ef8-b42c-7919de479e37.png)

#### Testing instructions

* Use calypso.live build or checkout branch locally.
* While not logged in, go to `/start/user/de`. Do a few page refreshes (with cache disabled) and confirm the page title is always translated.
* While logged in, change your UI language to any of the Mag-16 locales.
* Go to `/start` and create a new website.
* When you reach the `/start/setup-site/intent` step, confirm the page title is translated into the selected language.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 412-gh-Automattic/i18n-issues
