### PR TITLE
Components: Refactor `Image` away from `UNSAFE_` methods

### DIFF
--- a/client/components/image/index.js
+++ b/client/components/image/index.js
@@ -1,37 +1,24 @@
 import classnames from 'classnames';
-import { Component } from 'react';
+import PropTypes from 'prop-types';
 
-import './style.scss';
+const hideImageOnError = ( event ) => {
+	event.target.style.display = 'none';
+};
 
-export default class Image extends Component {
-	static defaultProps = {
-		className: '',
-	};
-	// by default, we give the image a shot at loading
-	state = {
-		isError: false,
-	};
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		// reset the error state if we switch images
-		// TODO: support srcsets?
-		if ( nextProps.src !== this.props.src ) {
-			this.setState( { isError: false } );
-		}
-	}
-
-	handleError = () => {
-		this.setState( { isError: true } );
-	};
-
-	render() {
-		const { className, ...others } = this.props;
-		const allClasses = classnames( className, {
-			image: true,
-			'is-error': this.state.isError,
-		} );
-		// eslint-disable-next-line jsx-a11y/alt-text
-		return <img onError={ this.handleError } className={ allClasses } { ...others } />;
-	}
+export default function Image( { alt, className, src, ...restProps } ) {
+	return (
+		<img
+			src={ src }
+			onError={ hideImageOnError }
+			className={ classnames( className, 'image' ) }
+			alt={ alt }
+			{ ...restProps }
+		/>
+	);
 }
+
+Image.propTypes = {
+	alt: PropTypes.string,
+	className: PropTypes.string,
+	src: PropTypes.string,
+};

--- a/client/components/image/style.scss
+++ b/client/components/image/style.scss
@@ -1,3 +1,0 @@
-.image.is-error {
-  display: none;
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `Image` component away from the `UNSAFE_` deprecated React component methods.

We're refactoring the component to a functional one, and using the opportunity to fix an a11y warning. In the meantime, the end result is a much simpler component that achieves the same goal - hiding the image on error, but without the extra complexity.

Part of #58453.

#### Testing instructions
* Go to `/settings/general/:site` where `:site` is one of your sites that has a site icon uploaded.
* Verify the site icon is loading.
* In your dev tools, block the request to load the site icon image.
* Verify the site icon is not loading but the image has a `display: none` and appears like an empty placeholder as it did before.