### PR TITLE
Checkout: Fix overflowing registrant info translations

### DIFF
--- a/client/components/domains/registrant-extra-info/style.scss
+++ b/client/components/domains/registrant-extra-info/style.scss
@@ -11,7 +11,7 @@
 
 // Turn off number spinners
 .registrant-extra-info__form {
-	input[type=number].form-text-input {
+	input[type='number'].form-text-input {
 		-moz-appearance: textfield;
 
 		&::-webkit-inner-spin-button,
@@ -21,8 +21,16 @@
 		}
 	}
 
+	.form-fieldset {
+		min-width: 0;
+	}
+
+	.form-select {
+		max-width: 100%;
+	}
+
 	.form-label .form-label__optional {
-		font-size: 100%;
+		font-size: 100%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		margin-left: 5px;
 	}
 
@@ -50,7 +58,6 @@
 		width: 28px;
 	}
 }
-
 
 .registrant-extra-info__dob-column {
 	display: flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix registrant extra info layout overflowing when translations are longer than the container element.

**Before:**
![CleanShot 2022-03-21 at 15 55 20](https://user-images.githubusercontent.com/2722412/159278513-926d7cbb-7c35-43fb-ae30-45cc56f936e4.png)

**After:**
![CleanShot 2022-03-21 at 15 54 48](https://user-images.githubusercontent.com/2722412/159278525-fc148097-2167-48e9-ac75-cfdc69a38799.png)


#### Testing instructions

* Use calypso.live build or checkout branch locally.
* Change UI language to Russian.
* Go to `/domains/add/` and select a `.uk` domain.
* Proceed to checkout.
* Confirm the extra registrant info field doesn't overflow.

Related to 407-gh-Automattic/i18n-issues
