### PR TITLE
Woo on Plans: Remove business plan check from requiresUpgrade.

### DIFF
--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -125,17 +125,6 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	const isTransferringBlocked = ! transferringDataIsAvailable || transferringBlockers?.length > 0;
 
 	/*
-	 * Plan site and `woop` site feature.
-	 * If the eligibility holds contains `NO_BUSINESS_PLAN`,
-	 * if the site doesn't have the `woop` feature,
-	 * and if the site has the `woop` feature upgradaable,
-	 * then the site needs to be upgraded.
-	 */
-	const eligibilityNoProperPlan = eligibilityHolds?.includes(
-		eligibilityHoldsConstants.NO_BUSINESS_PLAN
-	);
-
-	/*
 	 * Check whether the `woop` feature is actve.`
 	 * It's defined by wpcom in the store product list.
 	 */
@@ -152,9 +141,7 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	);
 
 	// The site requires upgrading when the feature is not active and available.
-	const requiresUpgrade = Boolean(
-		eligibilityNoProperPlan && ! isWoopFeatureActive && hasWoopFeatureAvailable.length
-	);
+	const requiresUpgrade = Boolean( ! isWoopFeatureActive && hasWoopFeatureAvailable.length );
 
 	/*
 	 * We pick the first plan from the available plans list.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove business plan check from `requiresUpgrade` to prepare for upcoming plan changes on WordPress.com. 

In response to p1647536414767629-slack-C029UPVMGTW

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the flow at /woocommerce-installation with a site that has a free, personal, or premium plan.
* Confirm that you need to upgrade to transfer the site and install WooCommerce.
* Start the flow with a non-Atomic site on a business plan.
* Confirm that you are not asked to upgrade to complete the flow.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/62079