### PR TITLE
WIP: Save the site editor iframe so it's not recreated each time the user navs to the editor

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -26,15 +26,37 @@ import { render, hydrate } from './web-util.js';
 export { setSectionMiddleware, setLocaleMiddleware } from './shared.js';
 export { render, hydrate } from './web-util.js';
 
-export const ProviderWrappedLayout = ( {
+export const ClientProviders = ( {
 	store,
 	queryClient,
 	currentSection,
 	currentRoute,
 	currentQuery,
+	children,
+} ) => {
+	return (
+		<CalypsoI18nProvider>
+			<RouteProvider
+				currentSection={ currentSection }
+				currentRoute={ currentRoute }
+				currentQuery={ currentQuery }
+			>
+				<QueryClientProvider client={ queryClient }>
+					<ReduxProvider store={ store }>
+						<MomentProvider>{ children }</MomentProvider>
+					</ReduxProvider>
+				</QueryClientProvider>
+			</RouteProvider>
+		</CalypsoI18nProvider>
+	);
+};
+
+export const ProviderWrappedLayout = ( {
+	store,
 	primary,
 	secondary,
 	redirectUri,
+	...otherProviderProps
 } ) => {
 	const state = store.getState();
 	const userLoggedIn = isUserLoggedIn( state );
@@ -46,19 +68,9 @@ export const ProviderWrappedLayout = ( {
 	);
 
 	return (
-		<CalypsoI18nProvider>
-			<RouteProvider
-				currentSection={ currentSection }
-				currentRoute={ currentRoute }
-				currentQuery={ currentQuery }
-			>
-				<QueryClientProvider client={ queryClient }>
-					<ReduxProvider store={ store }>
-						<MomentProvider>{ layout }</MomentProvider>
-					</ReduxProvider>
-				</QueryClientProvider>
-			</RouteProvider>
-		</CalypsoI18nProvider>
+		<ClientProviders store={ store } { ...otherProviderProps }>
+			{ layout }
+		</ClientProviders>
 	);
 };
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -1,5 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { SaveElements } from '@automattic/components';
 import { makeLayout, render } from 'calypso/controller';
+import { ClientProviders } from 'calypso/controller/index.web';
 import { addQueryArgs } from 'calypso/lib/route';
 import { EDITOR_START, POST_EDIT } from 'calypso/state/action-types';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
@@ -266,12 +268,22 @@ export const siteEditor = ( context, next ) => {
 	const siteId = getSelectedSiteId( state );
 
 	context.primary = (
-		<CalypsoifyIframe
-			// This key is added as a precaution due to it's oberserved necessity in the above post editor.
-			// It will force the component to remount completely when the Id changes.
-			key={ siteId }
-			editorType={ 'site' }
-		/>
+		<SaveElements storageKey={ `saved-iframe-${ siteId }` }>
+			<ClientProviders
+				store={ context.store }
+				queryClient={ context.queryClient }
+				currentSection={ context.section }
+				currentRoute={ context.pathname }
+				currentQuery={ context.query }
+			>
+				<CalypsoifyIframe
+					// This key is added as a precaution due to it's oberserved necessity in the above post editor.
+					// It will force the component to remount completely when the Id changes.
+					key={ siteId }
+					editorType={ 'site' }
+				/>
+			</ClientProviders>
+		</SaveElements>
 	);
 
 	return next();

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -11,3 +11,4 @@ export { default as RootChild } from './root-child';
 export { default as ScreenReaderText } from './screen-reader-text';
 export { default as Suggestions } from './suggestions';
 export { default as PaginationControl } from './pagination-control';
+export { default as SaveElements } from './save-elements';

--- a/packages/components/src/save-elements/index.tsx
+++ b/packages/components/src/save-elements/index.tsx
@@ -1,0 +1,53 @@
+import { useLayoutEffect, useRef, ReactElement } from 'react';
+import { render, hydrate } from 'react-dom';
+
+const storageDiv = document.createElement( 'div' );
+storageDiv.id = 'storage';
+storageDiv.style.display = 'none';
+document.body.appendChild( storageDiv );
+
+const storageMap = new Map< string, HTMLElement >();
+( window as any ).debugStorageMap = storageMap;
+
+export default function SaveElements( {
+	storageKey,
+	children,
+}: {
+	storageKey: string;
+	children: ReactElement;
+} ) {
+	const divEl = useRef< HTMLDivElement >( null );
+
+	useLayoutEffect( () => {
+		const el = divEl.current;
+		if ( ! el ) {
+			return;
+		}
+
+		// const storedDiv = document.getElementById( storageKey );
+		const storedDiv = storageMap.get( storageKey );
+
+		let elementToStore: HTMLElement | null = null;
+
+		if ( storedDiv ) {
+			el.appendChild( storedDiv );
+			hydrate( children, storedDiv );
+			elementToStore = storedDiv;
+		} else {
+			const newDiv = document.createElement( 'div' );
+			newDiv.id = storageKey;
+			storageMap.set( storageKey, newDiv );
+			el.appendChild( newDiv );
+			render( children, newDiv );
+			elementToStore = newDiv;
+		}
+
+		return () => {
+			if ( elementToStore ) {
+				// document.getElementById( 'storage' )?.appendChild( elementToStore );
+			}
+		};
+	} );
+
+	return <div ref={ divEl } />;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Still a WIP

* `<SaveElements>` component that can stash expensive DOM elements for later
* Save the site editor iframe so it's not recreated each time it's used

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
