### PR TITLE
Enable security/security-checkup feature flag

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -79,6 +79,7 @@
 		"reader/list-management": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
+		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -79,7 +79,7 @@
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
-		"security/security-checkup": false,
+		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/test.json
+++ b/config/test.json
@@ -68,6 +68,7 @@
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"rum-tracking/logstash": false,
+		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR enables the `security/security-checkup` feature flag in the stage, test, and production environments.

#### Testing instructions

* This needs to be tested in the stage and production environments by navigating to `/me/security` and confirming that the new menu structure is enabled by default