### PR TITLE
Adds assembler for DIFM cart extras

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -22,6 +22,8 @@ import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client
 import flows from 'calypso/signup/config/flows';
 import steps from 'calypso/signup/config/steps';
 import { getCurrentUserName, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { createDIFMCartExtrasObject } from 'calypso/state/difm/assemblers';
+import { getDIFMState } from 'calypso/state/difm/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
@@ -333,44 +335,17 @@ export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
 		.catch( ( error ) => callback( [ error ] ) );
 }
 
-function getDIFMLiteCartItemFromDependencies( dependencies ) {
-	const {
-		newOrExistingSiteChoice,
-		selectedDesign,
-		selectedSiteCategory,
-		isLetUsChooseSelected,
-		siteTitle,
-		siteDescription,
-		twitterUrl,
-		facebookUrl,
-		linkedinUrl,
-		instagramUrl,
-		displayEmail,
-		displayPhone,
-		displayAddress,
-	} = dependencies;
-	const extra = {
-		selected_design: selectedDesign?.theme,
-		site_category: selectedSiteCategory,
-		new_or_existing_site_choice: newOrExistingSiteChoice,
-		let_us_choose_selected: isLetUsChooseSelected,
-		site_title: siteTitle,
-		site_description: siteDescription,
-		twitter_url: twitterUrl,
-		facebook_url: facebookUrl,
-		linkedin_url: linkedinUrl,
-		instagram_url: instagramUrl,
-		display_email: displayEmail,
-		display_phone: displayPhone,
-		display_address: displayAddress,
-	};
+function getDIFMLiteCartItemFromDependencies( dependencies, reduxStore ) {
+	const state = reduxStore.getState();
+	const difmState = getDIFMState( state );
+	const extra = createDIFMCartExtrasObject( difmState, dependencies );
 	const cartItem = { product_slug: WPCOM_DIFM_LITE, extra };
 	return cartItem;
 }
 
 function addDIFMLiteToCart( callback, dependencies, step, reduxStore ) {
 	const { selectedDesign, selectedSiteCategory, isLetUsChooseSelected, siteSlug } = dependencies;
-	const cartItem = getDIFMLiteCartItemFromDependencies( dependencies );
+	const cartItem = getDIFMLiteCartItemFromDependencies( dependencies, reduxStore );
 	const providedDependencies = {
 		selectedDesign,
 		selectedSiteCategory,

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -22,8 +22,7 @@ import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client
 import flows from 'calypso/signup/config/flows';
 import steps from 'calypso/signup/config/steps';
 import { getCurrentUserName, isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { createDIFMCartExtrasObject } from 'calypso/state/difm/assemblers';
-import { getDIFMState } from 'calypso/state/difm/selectors';
+import { buildDIFMCartExtrasObject } from 'calypso/state/difm/assemblers';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
@@ -335,17 +334,10 @@ export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
 		.catch( ( error ) => callback( [ error ] ) );
 }
 
-function getDIFMLiteCartItemFromDependencies( dependencies, reduxStore ) {
-	const state = reduxStore.getState();
-	const difmState = getDIFMState( state );
-	const extra = createDIFMCartExtrasObject( difmState, dependencies );
-	const cartItem = { product_slug: WPCOM_DIFM_LITE, extra };
-	return cartItem;
-}
-
 function addDIFMLiteToCart( callback, dependencies, step, reduxStore ) {
 	const { selectedDesign, selectedSiteCategory, isLetUsChooseSelected, siteSlug } = dependencies;
-	const cartItem = getDIFMLiteCartItemFromDependencies( dependencies, reduxStore );
+	const extra = buildDIFMCartExtrasObject( dependencies );
+	const cartItem = { product_slug: WPCOM_DIFM_LITE, extra };
 	const providedDependencies = {
 		selectedDesign,
 		selectedSiteCategory,

--- a/client/signup/steps/site-options/site-options.tsx
+++ b/client/signup/steps/site-options/site-options.tsx
@@ -73,7 +73,7 @@ const SiteOptions: React.FC< Props > = ( {
 					name="siteTitle"
 					id="siteTitle"
 					value={ formValues.siteTitle }
-					isError={ siteTitleError }
+					isError={ Boolean( siteTitleError ) }
 					onChange={ onChange }
 				/>
 				{ siteTitleError && <FormInputValidation isError text={ siteTitleError } /> }
@@ -86,7 +86,7 @@ const SiteOptions: React.FC< Props > = ( {
 					name="tagline"
 					id="tagline"
 					value={ formValues.tagline }
-					isError={ taglineError }
+					isError={ Boolean( taglineError ) }
 					onChange={ onChange }
 				/>
 				{ taglineError && <FormInputValidation isError text={ taglineError } /> }

--- a/client/state/difm/assemblers.ts
+++ b/client/state/difm/assemblers.ts
@@ -1,0 +1,57 @@
+import 'calypso/state/difm/init';
+import type { Design } from '@automattic/design-picker';
+
+interface Dependencies {
+	newOrExistingSiteChoice: boolean;
+	siteTitle: string;
+	siteDescription: string;
+	tagline: string;
+	selectedDesign: Design;
+	selectedSiteCategory: string;
+	isLetUsChooseSelected: boolean;
+	twitterUrl: string;
+	facebookUrl: string;
+	linkedinUrl: string;
+	instagramUrl: string;
+	displayEmail: string;
+	displayPhone: string;
+	displayAddress: string;
+}
+
+export function createDIFMCartExtrasObject(
+	difmState: any,
+	dependencies: Partial< Dependencies >
+) {
+	const {
+		newOrExistingSiteChoice,
+		siteTitle,
+		siteDescription,
+		tagline,
+		selectedDesign,
+		selectedSiteCategory,
+		isLetUsChooseSelected,
+		twitterUrl,
+		facebookUrl,
+		linkedinUrl,
+		instagramUrl,
+		displayEmail,
+		displayPhone,
+		displayAddress,
+	} = dependencies;
+
+	return {
+		new_or_existing_site_choice: newOrExistingSiteChoice,
+		site_title: siteTitle,
+		site_description: siteDescription || tagline,
+		selected_design: selectedDesign?.theme,
+		site_category: selectedSiteCategory,
+		let_us_choose_selected: isLetUsChooseSelected,
+		twitter_url: twitterUrl || difmState.socialProfiles.TWITTER,
+		facebook_url: facebookUrl || difmState.socialProfiles.FACEBOOK,
+		linkedin_url: linkedinUrl || difmState.socialProfiles.LINKEDIN,
+		instagram_url: instagramUrl || difmState.socialProfiles.INSTAGRAM,
+		display_email: displayEmail,
+		display_phone: displayPhone,
+		display_address: displayAddress,
+	};
+}

--- a/client/state/difm/assemblers.ts
+++ b/client/state/difm/assemblers.ts
@@ -50,8 +50,8 @@ export function createDIFMCartExtrasObject(
 		facebook_url: facebookUrl || difmState.socialProfiles.FACEBOOK,
 		linkedin_url: linkedinUrl || difmState.socialProfiles.LINKEDIN,
 		instagram_url: instagramUrl || difmState.socialProfiles.INSTAGRAM,
-		display_email: displayEmail,
-		display_phone: displayPhone,
-		display_address: displayAddress,
+		...( displayEmail && { display_email: displayEmail } ),
+		...( displayPhone && { display_phone: displayPhone } ),
+		...( displayAddress && { display_address: displayAddress } ),
 	};
 }

--- a/client/state/difm/assemblers.ts
+++ b/client/state/difm/assemblers.ts
@@ -1,4 +1,3 @@
-import 'calypso/state/difm/init';
 import type { Design } from '@automattic/design-picker';
 
 interface Dependencies {
@@ -18,10 +17,7 @@ interface Dependencies {
 	displayAddress: string;
 }
 
-export function createDIFMCartExtrasObject(
-	difmState: any,
-	dependencies: Partial< Dependencies >
-) {
+export function buildDIFMCartExtrasObject( dependencies: Partial< Dependencies > ) {
 	const {
 		newOrExistingSiteChoice,
 		siteTitle,
@@ -46,10 +42,10 @@ export function createDIFMCartExtrasObject(
 		selected_design: selectedDesign?.theme,
 		site_category: selectedSiteCategory,
 		let_us_choose_selected: isLetUsChooseSelected,
-		twitter_url: twitterUrl || difmState.socialProfiles.TWITTER,
-		facebook_url: facebookUrl || difmState.socialProfiles.FACEBOOK,
-		linkedin_url: linkedinUrl || difmState.socialProfiles.LINKEDIN,
-		instagram_url: instagramUrl || difmState.socialProfiles.INSTAGRAM,
+		twitter_url: twitterUrl,
+		facebook_url: facebookUrl,
+		linkedin_url: linkedinUrl,
+		instagram_url: instagramUrl,
 		display_email: displayEmail,
 		display_phone: displayPhone,
 		display_address: displayAddress,

--- a/client/state/difm/assemblers.ts
+++ b/client/state/difm/assemblers.ts
@@ -50,8 +50,8 @@ export function createDIFMCartExtrasObject(
 		facebook_url: facebookUrl || difmState.socialProfiles.FACEBOOK,
 		linkedin_url: linkedinUrl || difmState.socialProfiles.LINKEDIN,
 		instagram_url: instagramUrl || difmState.socialProfiles.INSTAGRAM,
-		...( displayEmail && { display_email: displayEmail } ),
-		...( displayPhone && { display_phone: displayPhone } ),
-		...( displayAddress && { display_address: displayAddress } ),
+		display_email: displayEmail,
+		display_phone: displayPhone,
+		display_address: displayAddress,
 	};
 }

--- a/client/state/difm/assemblers.ts
+++ b/client/state/difm/assemblers.ts
@@ -15,6 +15,7 @@ interface Dependencies {
 	displayEmail: string;
 	displayPhone: string;
 	displayAddress: string;
+	selectedPageTitles: string[];
 }
 
 export function buildDIFMCartExtrasObject( dependencies: Partial< Dependencies > ) {
@@ -33,6 +34,7 @@ export function buildDIFMCartExtrasObject( dependencies: Partial< Dependencies >
 		displayEmail,
 		displayPhone,
 		displayAddress,
+		selectedPageTitles,
 	} = dependencies;
 
 	return {
@@ -49,5 +51,6 @@ export function buildDIFMCartExtrasObject( dependencies: Partial< Dependencies >
 		display_email: displayEmail,
 		display_phone: displayPhone,
 		display_address: displayAddress,
+		selected_page_titles: selectedPageTitles,
 	};
 }

--- a/client/state/difm/test/assemblers.js
+++ b/client/state/difm/test/assemblers.js
@@ -1,9 +1,8 @@
 import { expect } from 'chai';
-import { createDIFMCartExtrasObject } from '../assemblers';
+import { buildDIFMCartExtrasObject } from '../assemblers';
 
 describe( 'assembler', () => {
 	test( 'should convert dependencies and difm state to the extras object when difm state is empty', () => {
-		const difmState = {};
 		const dependencies = {
 			newOrExistingSiteChoice: false,
 			siteTitle: 'test title',
@@ -19,7 +18,7 @@ describe( 'assembler', () => {
 			displayPhone: 'test displayPhone',
 			displayAddress: 'test displayAddress',
 		};
-		expect( createDIFMCartExtrasObject( difmState, dependencies ) ).to.be.eql( {
+		expect( buildDIFMCartExtrasObject( dependencies ) ).to.be.eql( {
 			twitter_url: 'test twitterUrl',
 			facebook_url: 'test facebookUrl',
 			linkedin_url: 'test linkedinUrl',
@@ -27,37 +26,6 @@ describe( 'assembler', () => {
 			display_email: 'test displayEmail',
 			display_phone: 'test displayPhone',
 			display_address: 'test displayAddress',
-			let_us_choose_selected: false,
-			new_or_existing_site_choice: false,
-			selected_design: 'test theme',
-			site_category: 'test category',
-			site_description: 'test tagline',
-			site_title: 'test title',
-		} );
-	} );
-
-	test( 'should convert dependencies and difm state to the extras object when difm state is not empty', () => {
-		const difmState = {
-			socialProfiles: {
-				TWITTER: 'test twitterUrl',
-				FACEBOOK: 'test facebookUrl',
-				LINKEDIN: 'test linkedinUrl',
-				INSTAGRAM: 'test instagramUrl',
-			},
-		};
-		const dependencies = {
-			newOrExistingSiteChoice: false,
-			siteTitle: 'test title',
-			tagline: 'test tagline',
-			selectedDesign: { theme: 'test theme' },
-			selectedSiteCategory: 'test category',
-			isLetUsChooseSelected: false,
-		};
-		expect( createDIFMCartExtrasObject( difmState, dependencies ) ).to.be.eql( {
-			twitter_url: 'test twitterUrl',
-			facebook_url: 'test facebookUrl',
-			linkedin_url: 'test linkedinUrl',
-			instagram_url: 'test instagramUrl',
 			let_us_choose_selected: false,
 			new_or_existing_site_choice: false,
 			selected_design: 'test theme',

--- a/client/state/difm/test/assemblers.js
+++ b/client/state/difm/test/assemblers.js
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import { createDIFMCartExtrasObject } from '../assemblers';
+
+describe( 'assembler', () => {
+	test( 'should convert dependencies and difm state to the extras object when difm state is empty', () => {
+		const difmState = {};
+		const dependencies = {
+			newOrExistingSiteChoice: false,
+			siteTitle: 'test title',
+			siteDescription: 'test tagline',
+			selectedDesign: { theme: 'test theme' },
+			selectedSiteCategory: 'test category',
+			isLetUsChooseSelected: false,
+			twitterUrl: 'test twitterUrl',
+			facebookUrl: 'test facebookUrl',
+			linkedinUrl: 'test linkedinUrl',
+			instagramUrl: 'test instagramUrl',
+			displayEmail: 'test displayEmail',
+			displayPhone: 'test displayPhone',
+			displayAddress: 'test displayAddress',
+		};
+		expect( createDIFMCartExtrasObject( difmState, dependencies ) ).to.be.eql( {
+			twitter_url: 'test twitterUrl',
+			facebook_url: 'test facebookUrl',
+			linkedin_url: 'test linkedinUrl',
+			instagram_url: 'test instagramUrl',
+			display_email: 'test displayEmail',
+			display_phone: 'test displayPhone',
+			display_address: 'test displayAddress',
+			let_us_choose_selected: false,
+			new_or_existing_site_choice: false,
+			selected_design: 'test theme',
+			site_category: 'test category',
+			site_description: 'test tagline',
+			site_title: 'test title',
+		} );
+	} );
+
+	test( 'should convert dependencies and difm state to the extras object when difm state is not empty', () => {
+		const difmState = {
+			socialProfiles: {
+				TWITTER: 'test twitterUrl',
+				FACEBOOK: 'test facebookUrl',
+				LINKEDIN: 'test linkedinUrl',
+				INSTAGRAM: 'test instagramUrl',
+			},
+		};
+		const dependencies = {
+			newOrExistingSiteChoice: false,
+			siteTitle: 'test title',
+			tagline: 'test tagline',
+			selectedDesign: { theme: 'test theme' },
+			selectedSiteCategory: 'test category',
+			isLetUsChooseSelected: false,
+		};
+		expect( createDIFMCartExtrasObject( difmState, dependencies ) ).to.be.eql( {
+			twitter_url: 'test twitterUrl',
+			facebook_url: 'test facebookUrl',
+			linkedin_url: 'test linkedinUrl',
+			instagram_url: 'test instagramUrl',
+			let_us_choose_selected: false,
+			new_or_existing_site_choice: false,
+			selected_design: 'test theme',
+			site_category: 'test category',
+			site_description: 'test tagline',
+			site_title: 'test title',
+		} );
+	} );
+} );

--- a/client/state/difm/test/assemblers.js
+++ b/client/state/difm/test/assemblers.js
@@ -17,6 +17,7 @@ describe( 'assembler', () => {
 			displayEmail: 'test displayEmail',
 			displayPhone: 'test displayPhone',
 			displayAddress: 'test displayAddress',
+			selectedPageTitles: [ 'test1', 'test2' ],
 		};
 		expect( buildDIFMCartExtrasObject( dependencies ) ).to.be.eql( {
 			twitter_url: 'test twitterUrl',
@@ -32,6 +33,7 @@ describe( 'assembler', () => {
 			site_category: 'test category',
 			site_description: 'test tagline',
 			site_title: 'test title',
+			selected_page_titles: [ 'test1', 'test2' ],
 		} );
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds an assembler to abstract away logic for building the `extras` object for the DIFM cart item. The redesigned flow can be tested by enabling the `signup/redesigned-difm-flow` feature flag. Once this PR is tested and merged, we can completely replace the `site-info-collection` step with the new `difm-options` and `social-profiles` step.
* I also included a small change in `client/signup/steps/site-options/site-options.tsx` to remove a console error.

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Testing for regressions
* Start the flow at `/start/do-it-for-me`. 
* Go through the flow steps and confirm that you are able to complete checkout.
* Confirm that there are no JS errors.

#### Testing the new flow
* Start the flow at `/start/do-it-for-me?flags=signup/redesigned-difm-flow`. 
* Go through the flow steps and confirm that you are able to complete checkout.
* Confirm that there are no JS errors.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
