### PR TITLE
Emails: Proposal to change the way the interval toggle is changing the url

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -258,7 +258,7 @@ const emailUpsellForDomainRegistration = ( context, next ) => {
 					args: { domain: context.params.domain },
 				} ) }
 			/>
-			<EmailProvidersUpsell domain={ context.params.domain } />
+			<EmailProvidersUpsell domain={ context.params.domain } interval={ context.query.interval } />
 		</Main>
 	);
 

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -9,7 +9,7 @@ import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-com
 import EmailProvidersStackedComparison from 'calypso/my-sites/email/email-providers-stacked-comparison';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-export default function EmailProvidersUpsell( { domain } ) {
+export default function EmailProvidersUpsell( { domain, interval } ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
 
@@ -47,6 +47,7 @@ export default function EmailProvidersUpsell( { domain } ) {
 					comparisonContext="domain-upsell"
 					isDomainInCart={ true }
 					selectedDomainName={ domain }
+					selectedIntervalLength={ interval }
 					source="domain-upsell"
 				></EmailProvidersStackedComparison>
 			) }

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -155,6 +155,7 @@ export default {
 				<EmailManagementHomePage
 					source={ pageContext.query.source }
 					selectedDomainName={ pageContext.params.domain }
+					selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -69,7 +69,7 @@ interface EmailManagementHomeProps {
 	emailListInactiveHeader?: ReactElement;
 	sectionHeaderLabel?: TranslateResult;
 	selectedDomainName: string;
-	selectedIntervalLength: IntervalLength;
+	selectedIntervalLength?: IntervalLength;
 	showActiveDomainList?: boolean;
 	source: string;
 }

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -15,6 +15,7 @@ import EmailListActive from 'calypso/my-sites/email/email-management/home/email-
 import EmailListInactive from 'calypso/my-sites/email/email-management/home/email-list-inactive';
 import EmailNoDomain from 'calypso/my-sites/email/email-management/home/email-no-domain';
 import EmailPlan from 'calypso/my-sites/email/email-management/home/email-plan';
+import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import EmailProvidersStackedComparisonPage from 'calypso/my-sites/email/email-providers-stacked-comparison';
 import { emailManagementTitanSetUpMailbox } from 'calypso/my-sites/email/paths';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -68,6 +69,7 @@ interface EmailManagementHomeProps {
 	emailListInactiveHeader?: ReactElement;
 	sectionHeaderLabel?: TranslateResult;
 	selectedDomainName: string;
+	selectedIntervalLength: IntervalLength;
 	showActiveDomainList?: boolean;
 	source: string;
 }
@@ -77,6 +79,7 @@ const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
 		emailListInactiveHeader,
 		showActiveDomainList = true,
 		selectedDomainName,
+		selectedIntervalLength,
 		sectionHeaderLabel,
 		source,
 	} = props;
@@ -156,6 +159,7 @@ const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
 				comparisonContext="email-home-single-domain"
 				selectedDomainName={ domainsWithNoEmail[ 0 ].name }
 				source={ source }
+				selectedIntervalLength={ selectedIntervalLength }
 			/>
 		);
 	}

--- a/client/my-sites/email/email-management/home-page.tsx
+++ b/client/my-sites/email/email-management/home-page.tsx
@@ -1,9 +1,11 @@
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import EmailHome from 'calypso/my-sites/email/email-management/email-home';
+import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 
 type EmailManagementHomePageProps = {
 	selectedDomainName: string;
+	selectedIntervalLength: IntervalLength;
 	source: string;
 };
 

--- a/client/my-sites/email/email-management/home-page.tsx
+++ b/client/my-sites/email/email-management/home-page.tsx
@@ -5,7 +5,7 @@ import { emailManagement } from 'calypso/my-sites/email/paths';
 
 type EmailManagementHomePageProps = {
 	selectedDomainName: string;
-	selectedIntervalLength: IntervalLength;
+	selectedIntervalLength?: IntervalLength;
 	source: string;
 };
 

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
+import { stringify } from 'qs';
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
@@ -17,10 +18,7 @@ import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparis
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import GoogleWorkspaceCard from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card';
 import ProfessionalEmailCard from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card';
-import {
-	emailManagementInDepthComparison,
-	emailManagementPurchaseNewEmailAccount,
-} from 'calypso/my-sites/email/paths';
+import { emailManagementInDepthComparison } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwards';
@@ -109,16 +107,8 @@ const EmailProvidersStackedComparison = ( {
 			} )
 		);
 
-		page(
-			emailManagementPurchaseNewEmailAccount(
-				selectedSite.slug,
-				selectedDomainName,
-				currentRoute,
-				null,
-				selectedEmailProviderSlug,
-				newIntervalLength
-			)
-		);
+		const queryString = stringify( { interval: newIntervalLength } );
+		page( `${ currentRoute }?${ queryString }` );
 	};
 
 	const handleCompareClick = () => {

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -102,12 +102,17 @@ const EmailProvidersStackedComparison = ( {
 
 		dispatch(
 			recordTracksEvent( 'calypso_email_providers_billing_interval_toggle_click', {
+				current_route: currentRoute,
 				domain_name: selectedDomainName,
 				new_interval: newIntervalLength,
 			} )
 		);
 
-		const queryString = stringify( { interval: newIntervalLength } );
+		const queryString = stringify( {
+			interval: newIntervalLength,
+			provider: selectedEmailProviderSlug,
+			source,
+		} );
 		page( `${ currentRoute }?${ queryString }` );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I am showing the new comparison component under the feature flag (emails/show-new-comparison-component is enabled) to keep working on retire the old comparison page.
I'm breaking down all the changes and this change only adapt the component to receive a domain name, instead of a domain object plus hiding email forward components for this view.

**Things to tackle in the following Pull Requests:**
- `See how they compare` link is not working.
- Navigation buttons
- Multiple mailboxes support

#### Testing instructions

**Main scenario!**
Ensure that new comparison page keeps working:
1. Have a domain without email subscription on it.
2. Go to Upgrades -> Emails
3. Click on Add Email button
4. Try to add to the cart an email solution of each provider for each interval (just go to the check out and check that everything is working, no need to actually buy it, after you checked everything, remove the subscription for the domain and repeat for another variant subscription/interval)

Test also a site with only one domain and no subscription attached to it, this will bring up the EmailsComparison page in the /email/:domain path, which is a very common case.


**Second scenario**
1. Open the [Domains page](http://calypso.localhost:3000/domains/manage)
3. Click the Add a domain button
6. Select Search for a domain
7. Select any domain to access the Email Comparison page
8. Add the following query to the URL in your browser: ?flags=+emails/show-new-comparison-component
9. Assert that the next screen is displayed.
10. Assert that the billing interval is working as expected (dealing with prices, dealing with the URL parameters)

![image](https://user-images.githubusercontent.com/5689927/158605508-1a66346c-828b-41c7-a594-8cee1fadb827.png)


Related to {1200182182542585-as-1201978089916826}
