### PR TITLE
i18n: Map Norwegian `no` to `nb` in i18n-utils `getLanguage`

### DIFF
--- a/packages/i18n-utils/src/test/utils.js
+++ b/packages/i18n-utils/src/test/utils.js
@@ -1,0 +1,15 @@
+import { getMappedLanguageSlug } from '../';
+
+jest.mock( '@automattic/calypso-config', () => ( {} ) );
+
+describe( '#getMappedLanguageSlug', () => {
+	test( 'should Norwegian `no` locale slug to `nb`.', () => {
+		expect( getMappedLanguageSlug( 'no' ) ).toBe( 'nb' );
+	} );
+
+	test( 'should preserve the same locale slug when mapping is not applicable', () => {
+		expect( getMappedLanguageSlug( 'en' ) ).toBe( 'en' );
+		expect( getMappedLanguageSlug( 'de' ) ).toBe( 'de' );
+		expect( getMappedLanguageSlug( 'he' ) ).toBe( 'he' );
+	} );
+} );

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -91,6 +91,21 @@ export function getLanguageSlugs() {
 }
 
 /**
+ * Map provided language slug to supported slug if applicable.
+ *
+ * @param {string} langSlug Locale slug for the language
+ * @returns {string} Mapped language slug
+ */
+export function getMappedLanguageSlug( langSlug: string ) {
+	// See pxLjZ-6UQ-p2 for details.
+	if ( langSlug === 'no' ) {
+		return 'nb';
+	}
+
+	return langSlug;
+}
+
+/**
  * Return a specifier for page.js/Express route param that enumerates all supported languages.
  *
  * @param {string} name of the parameter. By default it's `lang`, some routes use `locale`.
@@ -108,6 +123,7 @@ export function getLanguageRouteParam( name = 'lang', optional = true ) {
  * @returns {object|undefined} An object containing the locale data or undefined.
  */
 export function getLanguage( langSlug: string | undefined ): Language | undefined {
+	langSlug = getMappedLanguageSlug( langSlug );
 	if ( langSlug && localeRegex.test( langSlug ) ) {
 		// Find for the langSlug first. If we can't find it, split it and find its parent slug.
 		// Please see the comment above `localeRegex` to see why we can split by - or _ and find the parent slug.

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -96,7 +96,7 @@ export function getLanguageSlugs() {
  * @param {string} langSlug Locale slug for the language
  * @returns {string} Mapped language slug
  */
-export function getMappedLanguageSlug( langSlug: string ) {
+export function getMappedLanguageSlug( langSlug: string | undefined ) {
 	// See pxLjZ-6UQ-p2 for details.
 	if ( langSlug === 'no' ) {
 		return 'nb';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Norwegian `no` to `nb` locale slug mapping for the `getLanguage` lookup function to provide backwards compatibility for [the recent changes to Norwegian language definition](https://github.com/Automattic/wp-calypso/pull/61850).

#### Testing instructions

* Use calypso.live build or checkout branch locally.
* Change your browser accepted language settings to use Norwegian as first language.
* Go to `/start/user` (not logged in) and confirm Norwegian (nb) translations are being loaded and rendered.
* Unit tests pass `yarn test-packages i18n-utils`.
