### PR TITLE
Seller Experience: Add tracking to support links in seller xp flow

### DIFF
--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -63,6 +63,12 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 		goToNextStep();
 	};
 
+	const trackSupportLinkClick = ( storeType: StoreFeatureSet ) => {
+		recordTracksEvent( 'calypso_signup_store_feature_support_link_click', {
+			store_feature: storeType,
+		} );
+	};
+
 	const sitePlanSlug = useSelector( ( state ) => getSite( state, siteSlug )?.plan?.product_slug );
 
 	const isPaidPlan = sitePlanSlug !== 'free_plan';
@@ -122,6 +128,7 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 										) }
 										target="_blank"
 										rel="noopener noreferrer"
+										onClick={ () => trackSupportLinkClick( 'simple' ) }
 									/>
 								),
 							},
@@ -170,6 +177,7 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 										) }
 										target="_blank"
 										rel="noopener noreferrer"
+										onClick={ () => trackSupportLinkClick( 'power' ) }
 									/>
 								),
 							},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I noticed as I was creating funnels that we don't track clicks on the support links to docs for Payment Blocks or WooCommerce. This adds Tracks events for those clicks so we can see what percentage of the drop-off they account for at this step.

<img width="600" alt="Screen Shot 2022-03-22 at 10 33 36 AM" src="https://user-images.githubusercontent.com/2124984/159506373-a3bc35c3-d787-45b5-aabb-d64040f58d6f.png">

<img width="960" alt="Screen Shot 2022-03-22 at 10 32 56 AM" src="https://user-images.githubusercontent.com/2124984/159506176-b7c50065-474e-4a38-b0fc-acf33f5f8fdc.png">


#### Testing instructions

* Spin up this diff, navigate to `/start` and create a new site
* Make sure you're logging Tracks events to localStorage; open your console and add the following line, hit Enter, and reload the page: `localStorage.debug( 'calypso:analytics*' )`
* Choose the Sell intent and add a site title/tagline
* At the Simple/Power step, click on either of the support links (Payment Blocks or WooCommerce) and check the console 
* You should see the click event fire `calypso_signup_store_feature_support_link_click` with the `store_feature` property for the type of link you clicked on (`simple` or `power`)