### PR TITLE
Show all products on Browse All Paid page

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -137,7 +137,7 @@ const PluginsBrowser = ( {
 		sitePlan && ( isBusiness( sitePlan ) || isEnterprise( sitePlan ) || isEcommerce( sitePlan ) );
 
 	const { data: paidPluginsRawList = [], isLoading: isFetchingPaidPlugins } = useWPCOMPlugins(
-		'featured'
+		'all'
 	);
 	const paidPlugins = useMemo( () => paidPluginsRawList.map( updateWpComRating ), [
 		paidPluginsRawList,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the filtering for featured products when browsing all premium products

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the `/plugins/paid/:siteUrl` page
* Verify that all premium plugins are fetched:
  | Before | After | 
  | --- | --- | 
  | ![calypso localhost_3000_plugins_paid_gcsecseyfree wordpress com (1)](https://user-images.githubusercontent.com/11555574/159515278-c834130b-d717-48ba-97a8-d4609889e654.png) | ![calypso localhost_3000_plugins_paid_gcsecseyfree wordpress com (4)](https://user-images.githubusercontent.com/11555574/159515541-2d2fb62c-c6c9-41b4-b886-42aa836c6f3e.png) |

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #61933
