### PR TITLE
Themes: Refactor `ThemesSelectionWithPage` away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -1,5 +1,5 @@
 import { FEATURE_PREMIUM_THEMES, planHasFeature } from '@automattic/calypso-products';
-import { compact, isEqual, property, snakeCase } from 'lodash';
+import { compact, property, snakeCase } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import * as React from 'react';
@@ -275,24 +275,8 @@ class ThemesSelectionWithPage extends React.Component {
 		page: 1,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if (
-			nextProps.search !== this.props.search ||
-			nextProps.tier !== this.props.tier ||
-			! isEqual( nextProps.filter, this.props.filter ) ||
-			! isEqual( nextProps.vertical, this.props.vertical )
-		) {
-			this.resetPage();
-		}
-	}
-
 	incrementPage = () => {
-		this.setState( { page: this.state.page + 1 } );
-	};
-
-	resetPage = () => {
-		this.setState( { page: 1 } );
+		this.setState( ( prevState ) => ( { page: prevState.page + 1 } ) );
 	};
 
 	render() {
@@ -306,4 +290,21 @@ class ThemesSelectionWithPage extends React.Component {
 	}
 }
 
-export default ThemesSelectionWithPage;
+/**
+ * Key component instances by search, tier, filter and vertical
+ * to ensure that as any of them is changed, pagination is reset.
+ */
+function KeyedThemesSelectionWithPage( { search, tier, filter, vertical, ...restProps } ) {
+	return (
+		<ThemesSelectionWithPage
+			key={ `${ search }-${ tier }-${ filter }-${ vertical }` }
+			search={ search }
+			tier={ tier }
+			filter={ filter }
+			vertical={ vertical }
+			{ ...restProps }
+		/>
+	);
+}
+
+export default KeyedThemesSelectionWithPage;

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -297,7 +297,7 @@ class ThemesSelectionWithPage extends React.Component {
 function KeyedThemesSelectionWithPage( { search, tier, filter, vertical, ...restProps } ) {
 	return (
 		<ThemesSelectionWithPage
-			key={ `${ search }-${ tier }-${ filter }-${ vertical }` }
+			key={ `themes-selection-${ search }-${ tier }-${ filter }-${ vertical }` }
 			search={ search }
 			tier={ tier }
 			filter={ filter }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `ThemesSelectionWithPage` component away from the `UNSAFE_` deprecated React component methods.

We use the `key` approach because it's doing a fine job to reset the pagination when the arguments are changed. We might get an `undefined-undefined-undefined-undefined` key if we have no filters set, but that's totally expected and still doing the job fine.

Part of #58453.

#### Testing instructions
* Go to `/themes/:site` on a site with a paid plan.
* Click on "All Themes".
* Play with various filters and search queries and verify that as you change them, you land on the first page of themes just like you did before.