### PR TITLE
Marketplace: Fix notice message clipped by adding a global style to override the masterbar height

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -1,4 +1,4 @@
-import { ThemeProvider } from '@emotion/react';
+import { ThemeProvider, Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -44,7 +44,6 @@ const ThankYouContainer = styled.div`
 const MasterbarStyled = styled( Masterbar )`
 	--color-masterbar-background: var( --studio-white );
 	--color-masterbar-text: var( --studio-gray-60 );
-	--masterbar-height: 72px;
 	border-bottom: 0;
 `;
 
@@ -213,6 +212,14 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 
 	return (
 		<ThemeProvider theme={ theme }>
+			{ /* Using Global to override Global masterbar height */ }
+			<Global
+				styles={ css`
+					body.is-section-marketplace.is-nav-unification {
+						--masterbar-height: 72px;
+					}
+				` }
+			/>
 			<MasterbarStyled>
 				<WordPressLogoStyled />
 				<ItemStyled


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The _notice_ message displayed when renewing a plugin was clipped by the Plugins top bar so this PR adds a global style that overrides the `--masterbar-height` CSS variable to the desired height

#### Testing instructions

* Renew a Premium plugin but please note that there is an [existing bug raised here](https://github.com/Automattic/wp-calypso/issues/62128) so the same scenario can be reproduced navigating to the following URL:
  ```
  http://calypso.localhost:3000/checkout/{business-or-eComm site}/wordpress_seo_premium_monthly?redirect_to=/marketplace/thank-you/wordpress-seo-premium/{business-or-eComm site}#step2
  ```
  Replacing `{business-or-eComm site}` by a valid Business or eCommerce site
* Confirm the purchase clicking on Pay
* Make sure the notice Success bar that appears is correctly displayed without being clipped

|Before | After|
|-------|------|
|<img width="1034" alt="image" src="https://user-images.githubusercontent.com/3519124/159542595-2d4ea88e-337b-448c-b27f-b2203501bd26.png">|<img width="1022" alt="image" src="https://user-images.githubusercontent.com/3519124/159542498-4c9e2d8d-f33c-4f96-8cd3-6d72cf977bef.png">|


Fixes #61643
