### PR TITLE
Added Tracks events to design picker upgrade buttons

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -122,8 +122,8 @@ export default function DesignPickerStep( props ) {
 	}, [ allThemes ] );
 
 	const getEventPropsByDesign = ( design ) => ( {
-		theme: design?.stylesheet ?? `pub/${ design.theme }`,
-		template: design.template,
+		theme: design?.stylesheet ?? `pub/${ design?.theme }`,
+		template: design?.template,
 		is_premium: design?.is_premium,
 		flow: flowName,
 		intent: dependencies.intent,
@@ -202,18 +202,18 @@ export default function DesignPickerStep( props ) {
 	}
 
 	function upgradePlanFromDesignPicker( design ) {
-		recordTracksEvent( 'calypso_design_picker_grid_upgrade_button', {
-			theme: design?.theme,
-		} );
-
+		recordTracksEvent(
+			'calypso_signup_design_upgrade_button_click',
+			getEventPropsByDesign( design )
+		);
 		upgradePlan();
 	}
 
 	function upgradePlanFromPreview( design ) {
-		recordTracksEvent( 'calypso_design_picker_preview_upgrade_button', {
-			theme: design?.theme,
-		} );
-
+		recordTracksEvent(
+			'calypso_signup_design_preview_upgrade_button_click',
+			getEventPropsByDesign( design )
+		);
 		upgradePlan();
 	}
 

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -201,6 +201,22 @@ export default function DesignPickerStep( props ) {
 		openCheckoutModal( [ PLAN_PREMIUM ] );
 	}
 
+	function upgradePlanFromDesignPicker( design ) {
+		recordTracksEvent( 'calypso_design_picker_grid_upgrade_button', {
+			theme: design?.theme,
+		} );
+
+		upgradePlan();
+	}
+
+	function upgradePlanFromPreview( design ) {
+		recordTracksEvent( 'calypso_design_picker_preview_upgrade_button', {
+			theme: design?.theme,
+		} );
+
+		upgradePlan();
+	}
+
 	function submitDesign( _selectedDesign = selectedDesign ) {
 		recordTracksEvent( 'calypso_signup_select_design', getEventPropsByDesign( _selectedDesign ) );
 		props.goToNextStep();
@@ -223,7 +239,7 @@ export default function DesignPickerStep( props ) {
 					locale={ translate.localeSlug }
 					onSelect={ pickDesign }
 					onPreview={ previewDesign }
-					onUpgrade={ upgradePlan }
+					onUpgrade={ upgradePlanFromDesignPicker }
 					className={ classnames( {
 						'design-picker-step__has-categories': showDesignPickerCategories,
 					} ) }
@@ -365,7 +381,11 @@ export default function DesignPickerStep( props ) {
 				stepSectionName={ designTitle }
 				customizedActionButtons={
 					shouldUpgrade && (
-						<Button primary borderless={ false } onClick={ upgradePlan }>
+						<Button
+							primary
+							borderless={ false }
+							onClick={ () => upgradePlanFromPreview( selectedDesign ) }
+						>
 							{ translate( 'Upgrade Plan' ) }
 						</Button>
 					)

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -118,7 +118,7 @@ interface DesignButtonCoverProps {
 	isPremiumThemeAvailable?: boolean;
 	onSelect: ( design: Design ) => void;
 	onPreview: ( design: Design ) => void;
-	onUpgrade?: () => void;
+	onUpgrade?: ( design: Design ) => void;
 }
 
 const DesignButtonCover: React.FC< DesignButtonCoverProps > = ( {
@@ -143,7 +143,7 @@ const DesignButtonCover: React.FC< DesignButtonCoverProps > = ( {
 				<Button
 					className="design-button-cover__button"
 					isPrimary
-					onClick={ () => ( shouldUpgrade ? onUpgrade?.() : onSelect( design ) ) }
+					onClick={ () => ( shouldUpgrade ? onUpgrade?.( design ) : onSelect( design ) ) }
 				>
 					{ shouldUpgrade
 						? __( 'Upgrade Plan', __i18n_text_domain__ )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Added Tracks events to design picker upgrade buttons:
- `calypso_signup_design_upgrade_button_click` for the grid button
- `calypso_signup_design_preview_upgrade_button_click` for the preview page button

#### Testing instructions

- Enable Tracks logging on the browser console by running `localStorage.debug="calypso:analytics*";` and enabling the `Verbose` level 
![image](https://user-images.githubusercontent.com/3801502/159695827-adf136d0-1847-4626-83aa-7df5378670dc.png)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

After going through the flow you should see the events on your browser console.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #62074
