### PR TITLE
Checkout: Hide tax info on existing-credit-card methods when editing is disabled

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
@@ -335,15 +335,15 @@ function TaxInfoArea( {
 	);
 	const { formStatus } = useFormStatus();
 
+	if ( ! allowEditing ) {
+		return null;
+	}
 	if ( taxInfoDisplay ) {
 		return (
 			<span className="existing-credit-card__tax-info-display">
 				<span className="existing-credit-card__tax-info-postal-country">{ taxInfoDisplay }</span>
 			</span>
 		);
-	}
-	if ( ! allowEditing ) {
-		return null;
 	}
 	return (
 		<span className="existing-credit-card__tax-info-display tax-info-incomplete">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

https://github.com/Automattic/wp-calypso/pull/57807 modified the existing credit card payment method so that it displays the attached tax location information (postal code and country) and possibly a button to edit that information. However, this display was intended for the "change payment method" page and not checkout, which uses the same payment method.

In this PR we remove the displayed tax location information on existing cards in checkout.

Fixes https://github.com/Automattic/wp-calypso/issues/62143

#### Testing instructions

- Use an account with at least one active subscription and at least one saved card that includes tax location information.
- Visit `/me/purchases` and click on an active subscription.
- Click "Change payment method" or "Add payment method".
- Verify that the radio button for the saved card **does** include a country and postal code.
- Add a product to your cart and visit checkout.
- Verify that the radio button for the saved card **does not** include a country or postal code.