### PR TITLE
DIFM: Update copy to mention the Pro plan

### DIFF
--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -1,4 +1,10 @@
-import { WPCOM_DIFM_LITE } from '@automattic/calypso-products';
+import { isEnabled } from '@automattic/calypso-config';
+import {
+	getPlan,
+	PLAN_PREMIUM,
+	PLAN_WPCOM_PRO,
+	WPCOM_DIFM_LITE,
+} from '@automattic/calypso-products';
 import { IntentScreen } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -40,11 +46,14 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 	const headerText = translate( 'Do It For Me' );
 
 	const subHeaderText = translate(
-		'Get a professionally designed, mobile-optimized website in %(fulfillmentDays)d business days or less for a one-time fee of {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}} plus a one year subscription of the Premium plan.',
+		'Get a professionally designed, mobile-optimized website in %(fulfillmentDays)d business days or less for a one-time fee of {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}} plus a one year subscription of the %(plan)s plan.',
 		{
 			args: {
 				displayCost,
 				fulfillmentDays: 4,
+				plan: isEnabled( 'plans/pro-plan' )
+					? getPlan( PLAN_WPCOM_PRO )?.getTitle()
+					: getPlan( PLAN_PREMIUM )?.getTitle(),
 			},
 			components: {
 				PriceWrapper: isLoading ? <Placeholder /> : <strong />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the copy on the New/Existing site step to mention the "WordPress Pro" plan instead of the "Premium" plan if the `plans/pro-plan` feature flag is enabled.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`.
* Confirm that the copy mentions the "Premium" plan.
<img width="656" alt="image" src="https://user-images.githubusercontent.com/5436027/159629417-2ea13750-71fa-426a-82c8-49b14623377e.png">

* Go to `/start/do-it-for-me?flags=plans/pro-plan`
* Confirm that the copy mentions the "WordPress Pro" plan.
<img width="570" alt="image" src="https://user-images.githubusercontent.com/5436027/159629461-5fa3a241-e7c8-4d2f-9b4e-072bb58c574f.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->