### PR TITLE
Stats: Refactor `StatsModule` away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -51,13 +51,14 @@ class StatsModule extends Component {
 		loaded: false,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( ! nextProps.requesting && this.props.requesting ) {
+	componentDidUpdate( prevProps ) {
+		if ( ! this.props.requesting && prevProps.requesting ) {
+			// eslint-disable-next-line react/no-did-update-set-state
 			this.setState( { loaded: true } );
 		}
 
-		if ( nextProps.query !== this.props.query && this.state.loaded ) {
+		if ( this.props.query !== prevProps.query && this.state.loaded ) {
+			// eslint-disable-next-line react/no-did-update-set-state
 			this.setState( { loaded: false } );
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `StatsModule` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/stats/day/:site` for a site that has a lot of traffic.
* Navigate between different periods (weeks, months, years)
* Verify that as you navigate, the stats modules still display loading state while loading, and after loading they still display stats properly.