### PR TITLE
FixedNavigationHeader: pass element as contentEl, not ref

### DIFF
--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useEffect, useRef } from '@wordpress/element';
-import { ReactNode } from 'react';
 import Breadcrumb from 'calypso/components/breadcrumb';
+import type { ReactNode } from 'react';
 
 const Header = styled.header`
 	position: fixed;
@@ -56,26 +56,32 @@ interface Props {
 	className?: string;
 	children?: ReactNode;
 	navigationItems: { label: string; href?: string }[];
-	contentRef?: React.RefObject< HTMLElement >;
+	contentEl?: HTMLElement;
 	compactBreadcrumb?: boolean;
 }
 
 const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
-	const { id, className, children, navigationItems, contentRef, compactBreadcrumb = false } = props;
+	const {
+		id,
+		className,
+		children,
+		navigationItems = [],
+		contentEl,
+		compactBreadcrumb = false,
+	} = props;
 	const actionsRef = useRef< HTMLDivElement >( null );
 	const headerRef = useRef< HTMLElement >( null );
 
 	useEffect( () => {
-		if ( ! contentRef ) {
+		if ( ! contentEl ) {
 			return;
 		}
 
 		const handleScroll = () => {
-			const headerHeight = headerRef?.current?.getBoundingClientRect().height;
-			const offset =
-				contentRef.current && headerHeight ? contentRef.current.offsetTop - headerHeight : 0;
+			const headerHeight = headerRef.current?.getBoundingClientRect().height;
+			const offset = headerHeight ? contentEl.offsetTop - headerHeight : 0;
 			const scrollPosition = window.scrollY;
-			const actionElement = actionsRef?.current;
+			const actionElement = actionsRef.current;
 
 			if ( ! actionElement ) {
 				return;
@@ -94,7 +100,7 @@ const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
 		return () => {
 			window.removeEventListener( 'scroll', handleScroll );
 		};
-	}, [ contentRef ] );
+	}, [ contentEl ] );
 
 	return (
 		<Header id={ id } className={ className } ref={ headerRef }>
@@ -104,12 +110,6 @@ const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
 			</Container>
 		</Header>
 	);
-};
-
-FixedNavigationHeader.defaultProps = {
-	id: '',
-	className: '',
-	navigationItems: [],
 };
 
 export default FixedNavigationHeader;

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -66,7 +66,7 @@ export class PlanFeaturesComparison extends Component {
 			<div className={ planWrapperClasses }>
 				<QueryActivePromotions />
 				<div className={ planClasses }>
-					<div ref={ this.contentRef } className="plan-features-comparison__content">
+					<div className="plan-features-comparison__content">
 						<div>
 							<table className={ tableClasses }>
 								<caption className="plan-features-comparison__screen-reader-text screen-reader-text">

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -125,7 +125,7 @@ export class PlanFeatures extends Component {
 				<QueryActivePromotions />
 				<div className={ planClasses }>
 					{ this.renderNotice() }
-					<div ref={ this.contentRef } className="plan-features__content">
+					<div className="plan-features__content">
 						{ mobileView }
 						<PlanFeaturesScroller
 							withScroll={ withScroll }

--- a/client/my-sites/woocommerce/landing-page.tsx
+++ b/client/my-sites/woocommerce/landing-page.tsx
@@ -37,7 +37,7 @@ interface DisplayData {
 const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 	const { __ } = useI18n();
 	const navigationItems = [ { label: 'WooCommerce' } ];
-	const ctaRef = useRef( null );
+	const ctaRef = useRef();
 	const simpleSeller = useIsSimpleSeller();
 
 	const {
@@ -154,7 +154,7 @@ const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 
 	return (
 		<div className="landing-page">
-			<FixedNavigationHeader navigationItems={ navigationItems } contentRef={ ctaRef }>
+			<FixedNavigationHeader navigationItems={ navigationItems } contentEl={ ctaRef.current }>
 				<Button onClick={ onCTAClickHandler } primary disabled={ isTransferringBlocked }>
 					{ displayData.action }
 				</Button>


### PR DESCRIPTION
Fixes a little bug/inefficiency in the `FixedNavigationHeader`. It takes a `contentRef` prop whose `contentRef.current` property is a DOM element whose scroll position the header component watches. And when that element scrolls _under_ the header, a container in the header (`actionsRef`) is shown.

For example, see this screenshot where the main "Start a new store" CTA button has just scrolled under, and therefore the header displayed an alternative one:

<img width="926" alt="Screenshot 2022-03-23 at 9 47 24" src="https://user-images.githubusercontent.com/664258/159663075-961fda90-271c-4454-bee1-dc1e744199f4.png">

Instead of `contentRef` ref, the prop should really be an element, `contentEl`. Because the component never assigns to the ref: it just wants an element to work with.

Also, `contentRef` doesn't work as a dependency of the `useEffect`: the `contentRef` object never changes, only its `.current` field does.

That's why I'm converting the prop to `contentEl: HTMLElement`.

As a drive-by, I'm removing unwanted default prop values (leaving only `navigationItems = []`), and also removing two unrelated `this.contentRef` refs in other components which are not used.

**How to test:**
Go to `/woocommerce-installation/example.wordpress.com` for any site that doesn't have WooCommerce. Any Simple site will do. You should see the page shown on the above screenshot. Scroll down until the CTA button is hidden and verify that the alternative CTA in the header is displayed.

This Woo landing page is the only place where `FixedNavigationHeader` is used with this feature.

