### PR TITLE
Add a note when preventing primary domain transfer on AT

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -131,30 +131,35 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			);
 		}
 
-		if ( ! ( isPrimaryDomain && isAtomic ) ) {
-			if ( options.length > 0 ) {
-				options.push( <div key="separator" className="transfer-page__item-separator"></div> );
-			}
-			const mainText = isMapping
-				? __( 'Transfer this domain connection to any site you are an administrator on' )
-				: __( 'Transfer this domain to any site you are an administrator on' );
+		const canTransferToAnotherSite = ! ( isPrimaryDomain && isAtomic );
 
-			options.push(
-				<ActionCard
-					key="transfer-to-another-site"
-					buttonHref={ domainManagementTransferToOtherSite(
-						selectedSite.slug,
-						selectedDomainName,
-						currentRoute
-					) }
-					// translators: Continue is a verb
-					buttonText={ __( 'Continue' ) }
-					// translators: Transfer a domain to another WordPress.com site
-					headerText={ __( 'To another WordPress.com site' ) }
-					mainText={ mainText }
-				/>
-			);
+		if ( options.length > 0 ) {
+			options.push( <div key="separator" className="transfer-page__item-separator"></div> );
 		}
+		const mainText = isMapping
+			? __( 'Transfer this domain connection to any site you are an administrator on' )
+			: __( 'Transfer this domain to any site you are an administrator on' );
+
+		const buttonHref = canTransferToAnotherSite
+			? domainManagementTransferToOtherSite( selectedSite.slug, selectedDomainName, currentRoute )
+			: domainManagementList( selectedSite.slug, selectedDomainName );
+		options.push(
+			<ActionCard
+				key="transfer-to-another-site"
+				buttonHref={ buttonHref }
+				// translators: Continue is a verb
+				buttonText={ canTransferToAnotherSite ? __( 'Continue' ) : __( 'Change primary domain' ) }
+				// translators: Transfer a domain to another WordPress.com site
+				headerText={ __( 'To another WordPress.com site' ) }
+				mainText={
+					canTransferToAnotherSite
+						? mainText
+						: __(
+								'This domain is currently set as primary and cannot be transferred. Before transfer it, you need to set another primary domain for this site.'
+						  )
+				}
+			/>
+		);
 
 		return options.length > 0 ? <Card>{ options }</Card> : null;
 	};


### PR DESCRIPTION
## Changes proposed in this Pull Request

Primary domains on atomic sites cannot be transferred to another site. Currently this option is just hidden, with no explanation.

This pr adds a card to handle this case, adding some context to the user and providing a button to change site primary domain.

![transfer-before](https://user-images.githubusercontent.com/2797601/159673055-920b7721-3587-4a22-a067-d9ee5c3afcd5.png)

![transfer-after](https://user-images.githubusercontent.com/2797601/159673150-e4ee3e46-0b70-457e-9bb4-af5b65cffed9.png)

## Testing instructions

- Build this branch locally or open the live Calypso link
- Select a primary domain on an AT and go to transfer page (`/domains/manage/{:domain}/transfer/{:site}`)
- Verify that the new card is rendered and that "Change primary domain" button leads to site domains page