### PR TITLE
Enable Professional Email upsell in all cases, including for new Pro plan

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -27,6 +27,7 @@ import {
 	isPersonal,
 	isPlan,
 	isPremium,
+	isPro,
 	isRenewable,
 	isSiteRedirect,
 	isSpaceUpgrade,
@@ -106,6 +107,10 @@ export function hasPersonalPlan( cart: ResponseCart ): boolean {
 
 export function hasPremiumPlan( cart: ResponseCart ): boolean {
 	return getAllCartItems( cart ).some( isPremium );
+}
+
+export function hasProPlan( cart: ResponseCart ): boolean {
+	return getAllCartItems( cart ).some( isPro );
 }
 
 export function hasBusinessPlan( cart: ResponseCart ): boolean {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -31,6 +31,7 @@ import {
 	hasTrafficGuide,
 	hasDIFMProduct,
 	hasMonthlyCartItem,
+	hasProPlan,
 } from 'calypso/lib/cart-values/cart-items';
 import { dangerouslyGetExperimentAssignment } from 'calypso/lib/explat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -38,7 +39,6 @@ import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import { getEligibleTitanDomain } from 'calypso/lib/titan';
 import { addQueryArgs, isExternal, resemblesUrl, urlToSlug } from 'calypso/lib/url';
 import { managePurchase } from 'calypso/me/purchases/paths';
-import { PROFESSIONAL_EMAIL_OFFER } from 'calypso/my-sites/checkout/post-checkout-upsell-experiment-redirector';
 import {
 	clearSignupCompleteFlowName,
 	getSignupCompleteFlowName,
@@ -578,7 +578,8 @@ function getProfessionalEmailUpsellUrl( {
 		! hasBloggerPlan( cart ) &&
 		! hasPersonalPlan( cart ) &&
 		! hasBusinessPlan( cart ) &&
-		! hasEcommercePlan( cart )
+		! hasEcommercePlan( cart ) &&
+		! hasProPlan( cart )
 	) {
 		return;
 	}
@@ -602,7 +603,7 @@ function getProfessionalEmailUpsellUrl( {
 		return;
 	}
 
-	return `/checkout/offer/${ PROFESSIONAL_EMAIL_OFFER }/${ domainName }/${ pendingOrReceiptId }/${ siteSlug }`;
+	return `/checkout/offer-professional-email/${ domainName }/${ pendingOrReceiptId }/${ siteSlug }`;
 }
 
 function getDisplayModeParamFromCart( cart: ResponseCart | undefined ): Record< string, string > {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -903,7 +903,7 @@ describe( 'getThankYouPageUrl', () => {
 			} );
 
 			expect( url ).toBe(
-				'/checkout/offer/professional-email-offer/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
+				'/checkout/offer-professional-email/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
 			);
 		} );
 
@@ -925,7 +925,7 @@ describe( 'getThankYouPageUrl', () => {
 			} );
 
 			expect( url ).toBe(
-				'/checkout/offer/professional-email-offer/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
+				'/checkout/offer-professional-email/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
 			);
 		} );
 
@@ -947,7 +947,7 @@ describe( 'getThankYouPageUrl', () => {
 			} );
 
 			expect( url ).toBe(
-				'/checkout/offer/professional-email-offer/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
+				'/checkout/offer-professional-email/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
 			);
 		} );
 
@@ -969,7 +969,7 @@ describe( 'getThankYouPageUrl', () => {
 			} );
 
 			expect( url ).toBe(
-				'/checkout/offer/professional-email-offer/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
+				'/checkout/offer-professional-email/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
 			);
 		} );
 
@@ -995,7 +995,7 @@ describe( 'getThankYouPageUrl', () => {
 			} );
 
 			expect( url ).toBe(
-				'/checkout/offer/professional-email-offer/domain-from-cart.com/1234abcd/foo.bar'
+				'/checkout/offer-professional-email/domain-from-cart.com/1234abcd/foo.bar'
 			);
 		} );
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -294,8 +294,16 @@ export function upsellRedirect( context, next ) {
 	let upsellExperimentAssignmentName;
 	let upsellUrl;
 
-	// When next we need a redirect based on A/B test, add any logic based on upsellType here
-	// While this code block is empty, this function is effectively a no-op.
+	/*
+	 * When next we need a redirect based on A/B test, add any logic based on upsellType here
+	 * While this code block is empty, this function is effectively a no-op.
+
+	if ( PROFESSIONAL_EMAIL_OFFER === upsellType ) {
+		upsellExperimentName = 'calypso_promote_professional_email_post_checkout_2022_02';
+		upsellExperimentAssignmentName = 'treatment';
+		upsellUrl = `/checkout/offer-professional-email/${ upsellMeta }/${ receiptId }/${ site }`;
+	}
+	*/
 
 	if ( upsellExperimentName && upsellExperimentAssignmentName && upsellUrl ) {
 		context.primary = (

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -13,9 +13,7 @@ import LicensingThankYouAutoActivationCompleted from 'calypso/my-sites/checkout/
 import LicensingThankYouManualActivation from 'calypso/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation';
 import LicensingThankYouManualActivationInstructions from 'calypso/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions';
 import LicensingThankYouManualActivationLicenseKey from 'calypso/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key';
-import PostCheckoutUpsellExperimentRedirector, {
-	PROFESSIONAL_EMAIL_OFFER,
-} from 'calypso/my-sites/checkout/post-checkout-upsell-experiment-redirector';
+import PostCheckoutUpsellExperimentRedirector from 'calypso/my-sites/checkout/post-checkout-upsell-experiment-redirector';
 import { sites } from 'calypso/my-sites/controller';
 import {
 	retrieveSignupDestination,
@@ -288,7 +286,7 @@ export function upsellNudge( context, next ) {
 }
 
 export function upsellRedirect( context, next ) {
-	const { receiptId, site, upsellMeta, upsellType } = context.params;
+	const { receiptId, site /*, upsellMeta, upsellType */ } = context.params;
 
 	setSectionMiddleware( { name: 'checkout-offer-redirect' } )( context );
 
@@ -296,11 +294,8 @@ export function upsellRedirect( context, next ) {
 	let upsellExperimentAssignmentName;
 	let upsellUrl;
 
-	if ( PROFESSIONAL_EMAIL_OFFER === upsellType ) {
-		upsellExperimentName = 'calypso_promote_professional_email_post_checkout_2022_02';
-		upsellExperimentAssignmentName = 'treatment';
-		upsellUrl = `/checkout/offer-professional-email/${ upsellMeta }/${ receiptId }/${ site }`;
-	}
+	// When next we need a redirect based on A/B test, add any logic based on upsellType here
+	// While this code block is empty, this function is effectively a no-op.
 
 	if ( upsellExperimentName && upsellExperimentAssignmentName && upsellUrl ) {
 		context.primary = (

--- a/client/my-sites/checkout/post-checkout-upsell-experiment-redirector/index.tsx
+++ b/client/my-sites/checkout/post-checkout-upsell-experiment-redirector/index.tsx
@@ -4,8 +4,13 @@ import { useExperiment } from 'calypso/lib/explat';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url';
 import isEligibleForSignupDestination from 'calypso/state/selectors/is-eligible-for-signup-destination';
 
+/* When adding future upsells, you can use the following approach:
+
 export const PROFESSIONAL_EMAIL_OFFER = 'professional-email-offer';
 export type SupportedUpsellType = typeof PROFESSIONAL_EMAIL_OFFER;
+
+*/
+
 export interface PostCheckoutUpsellRedirectorProps {
 	receiptId: string | undefined;
 	siteSlug: string | undefined;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the A/B test infrastructure used to show a Professional Email upsell after plan purchases, which it achieves by redirecting directly to the offer page instead of the upsell redirector component
* The PR also enables the upsell for purchases of the new WordPress.com Pro plan

#### Testing instructions

* Run this branch locally or via [the calypso.live branch](https://github.com/Automattic/wp-calypso/pull/62163#issuecomment-1076183760)
* Ensure you have a site that doesn't have a paid plan, and has an existing domain that is eligible for a Professional Email trial. (You can optionally enable Store Sandbox if you wish to purchase a new domain in that environment.)
* For that site, navigate to **Upgrades** -> **Plans**
* First, we need to test the flow for the current set of plans, so add `?flags=-plans/pro-plan` to the URL to ensure we're testing with the current plans (i.e. Personal, Premium, Business, and eCommerce)
* Select any monthly or annual plan _except for the Premium plan_. (i.e. Personal, Business, or eCommerce, though the first two are likely to be better as they don't require the site be made Atomic)
* Complete the purchase in checkout
* Verify that you see the Professional Email upsell, where you can skip the offer
* For your test site, navigate to **Upgrades** -> **Plans**, and then select the "Plans" tab
* For your current plan, click on the "Manage plan" button
* From this management page, ensure you cancel your plan - the exact button/CTA will depend on how you made the plan purchase
* Once the plan has been cancelled, navigate to **Upgrades** -> **Plans**
* This time we need to test the flow for the new Pro plan, so add `?flags=plans/pro-plan` to the URL
* Select the Pro plan, which should drop you into checkout
* Complete the purchase
* Verify that you see the Professional Email upsell, where you can skip the offer
* To clean up, feel free to cancel your plan