### PR TITLE
Emails: Enable billing interval selector through inbox flow

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -10,6 +10,7 @@ import { castIntervalLength } from 'calypso/my-sites/email/email-providers-compa
 import EmailProvidersStackedComparisonPage from 'calypso/my-sites/email/email-providers-stacked-comparison/page';
 import GSuiteAddUsers from 'calypso/my-sites/email/gsuite-add-users';
 import InboxManagement from 'calypso/my-sites/email/inbox';
+import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import TitanAddMailboxes from 'calypso/my-sites/email/titan-add-mailboxes';
 import TitanSetUpMailbox from 'calypso/my-sites/email/titan-set-up-mailbox';
@@ -164,7 +165,12 @@ export default {
 	},
 
 	emailManagementInbox( pageContext, next ) {
-		pageContext.primary = <InboxManagement />;
+		pageContext.primary = (
+			<InboxManagement
+				selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
+				source={ INBOX_SOURCE }
+			/>
+		);
 		next();
 	},
 };

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -10,7 +10,6 @@ import { castIntervalLength } from 'calypso/my-sites/email/email-providers-compa
 import EmailProvidersStackedComparisonPage from 'calypso/my-sites/email/email-providers-stacked-comparison/page';
 import GSuiteAddUsers from 'calypso/my-sites/email/gsuite-add-users';
 import InboxManagement from 'calypso/my-sites/email/inbox';
-import { INBOX_SOURCE } from 'calypso/my-sites/email/inbox/constants';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import TitanAddMailboxes from 'calypso/my-sites/email/titan-add-mailboxes';
 import TitanSetUpMailbox from 'calypso/my-sites/email/titan-set-up-mailbox';
@@ -168,7 +167,6 @@ export default {
 		pageContext.primary = (
 			<InboxManagement
 				selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
-				source={ INBOX_SOURCE }
 			/>
 		);
 		next();

--- a/client/my-sites/email/inbox/index.jsx
+++ b/client/my-sites/email/inbox/index.jsx
@@ -89,7 +89,7 @@ const hasAtLeastOneMailbox = ( domains ) =>
 const showActiveDomainList = ( domains ) =>
 	domains.some( ( domain ) => hasPaidEmailWithUs( domain ) || hasEmailForwards( domain ) );
 
-const InboxManagement = () => {
+const InboxManagement = ( { selectedIntervalLength, source } ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const canManageSite = useSelector( ( state ) =>
 		canCurrentUser( state, selectedSiteId, 'manage_options' )
@@ -127,8 +127,9 @@ const InboxManagement = () => {
 				<EmailManagementHome
 					emailListInactiveHeader={ <MainHeader /> }
 					sectionHeaderLabel={ translate( 'Domains' ) }
+					selectedIntervalLength={ selectedIntervalLength }
 					showActiveDomainList={ showActiveDomainList( nonWPCOMDomains ) }
-					source={ INBOX_SOURCE }
+					source={ source }
 				/>
 			</>
 		</CalypsoShoppingCartProvider>

--- a/client/my-sites/email/inbox/index.jsx
+++ b/client/my-sites/email/inbox/index.jsx
@@ -89,7 +89,7 @@ const hasAtLeastOneMailbox = ( domains ) =>
 const showActiveDomainList = ( domains ) =>
 	domains.some( ( domain ) => hasPaidEmailWithUs( domain ) || hasEmailForwards( domain ) );
 
-const InboxManagement = ( { selectedIntervalLength, source } ) => {
+const InboxManagement = ( { selectedIntervalLength } ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const canManageSite = useSelector( ( state ) =>
 		canCurrentUser( state, selectedSiteId, 'manage_options' )
@@ -129,7 +129,7 @@ const InboxManagement = ( { selectedIntervalLength, source } ) => {
 					sectionHeaderLabel={ translate( 'Domains' ) }
 					selectedIntervalLength={ selectedIntervalLength }
 					showActiveDomainList={ showActiveDomainList( nonWPCOMDomains ) }
-					source={ source }
+					source={ INBOX_SOURCE }
 				/>
 			</>
 		</CalypsoShoppingCartProvider>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Billing interval through the mailbox flow (when no email subscription but domain exists) is not togging the interval.

#### Testing instructions

Have a site without email subscription and a domain

1. Go to inbox
2. Click on the interval toggle at the top
3. Check that the interval is changing in the below cards

Related to {1200182182542585-as-1201999460597743}
