### PR TITLE
Plugins: Fix Renew Now action

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -28,6 +28,7 @@ import {
 	isP2Plus,
 	isMonthlyProduct,
 	isBiennially,
+	isRenewable,
 	getTermDuration,
 	getPlan,
 	isBloggerPlan,
@@ -494,6 +495,15 @@ export function jetpackProductItem( slug: string ): MinimalRequestCartProduct {
 }
 
 /**
+ * Creates a new shopping cart item for a renewable product.
+ */
+export function renewableProductItem( slug: string ): MinimalRequestCartProduct {
+	return {
+		product_slug: slug,
+	};
+}
+
+/**
  * Retrieves all the domain registration items in the specified shopping cart.
  */
 export function getDomainRegistrations( cart: ResponseCart ): ResponseCartProduct[] {
@@ -515,6 +525,7 @@ export function getRenewalItemFromProduct(
 		is_domain_registration?: boolean;
 		isDomainRegistration?: boolean;
 		id: string | number;
+		isRenewable?: boolean;
 	} & Partial< RequestCartProduct > & {
 			domain?: string;
 			users?: GSuiteProductUser[];
@@ -570,6 +581,10 @@ export function getRenewalItemFromProduct(
 
 	if ( isSpaceUpgrade( product ) ) {
 		cartItem = spaceUpgradeItem( slug );
+	}
+
+	if ( isRenewable( product ) ) {
+		cartItem = renewableProductItem( slug );
 	}
 
 	if ( ! cartItem ) {

--- a/packages/calypso-products/src/is-renewable.ts
+++ b/packages/calypso-products/src/is-renewable.ts
@@ -1,0 +1,3 @@
+export function isRenewable( product: { isRenewable?: boolean } ): boolean {
+	return Boolean( product.isRenewable );
+}

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -84,3 +84,4 @@ export * from './is-p2-plus';
 export * from './products-list';
 export * from './translations';
 export { findProductKeys } from './find-product-keys';
+export { isRenewable } from './is-renewable';


### PR DESCRIPTION
It adds an additional condition to the `calypso-products` package to
check if a product is renewable. If that is the case, the Renew Now
action allows the product to be renewed.

#### Changes proposed in this Pull Request

* It adds a new utility method to `calypso-products` package
* It uses the previous condition to renew a product if _is renewable_

> ⚠️ **NOTE:** With this changes all products with the attribute `isRenewable` being `true` will be accepted for Renewal.

#### Testing instructions

* On a site with Premium Plugins installed
* Go to Upgrades -> Purchases
* Select one Plugin
* Click on Renew Now
* Make sure the Renew process works as expected

Fixes #62128
