### PR TITLE
Fix tests for remove/a-b-test-for-professional-email-upsell

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -903,7 +903,7 @@ describe( 'getThankYouPageUrl', () => {
 			} );
 
 			expect( url ).toBe(
-				'/checkout/offer/professional-email-offer/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
+				'/checkout/offer-professional-email/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
 			);
 		} );
 
@@ -925,7 +925,7 @@ describe( 'getThankYouPageUrl', () => {
 			} );
 
 			expect( url ).toBe(
-				'/checkout/offer/professional-email-offer/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
+				'/checkout/offer-professional-email/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
 			);
 		} );
 
@@ -947,7 +947,7 @@ describe( 'getThankYouPageUrl', () => {
 			} );
 
 			expect( url ).toBe(
-				'/checkout/offer/professional-email-offer/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
+				'/checkout/offer-professional-email/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
 			);
 		} );
 
@@ -969,7 +969,7 @@ describe( 'getThankYouPageUrl', () => {
 			} );
 
 			expect( url ).toBe(
-				'/checkout/offer/professional-email-offer/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
+				'/checkout/offer-professional-email/domain-eligible-for-free-trial.com/1234abcd/foo.bar'
 			);
 		} );
 
@@ -995,7 +995,7 @@ describe( 'getThankYouPageUrl', () => {
 			} );
 
 			expect( url ).toBe(
-				'/checkout/offer/professional-email-offer/domain-from-cart.com/1234abcd/foo.bar'
+				'/checkout/offer-professional-email/domain-from-cart.com/1234abcd/foo.bar'
 			);
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes the test for the branch: https://github.com/Automattic/wp-calypso/pull/62163

#### Testing instructions

Run tests: `yarn test` 

#### Remarks

The base branch for this pull request is not trunk, its [remove/a-b-test-for-professional-email-upsell](https://github.com/Automattic/wp-calypso/tree/remove/a-b-test-for-professional-email-upsell)
so it won't be changing anything in trunk until that branch is merged.