### PR TITLE
Plan overhaul Phase 1: Fix My Plan redirection after cancelling a Pro plan

### DIFF
--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -1,16 +1,12 @@
-import { isFreePlanProduct, isFlexiblePlanProduct } from '@automattic/calypso-products';
+import { isFreePlanProduct } from '@automattic/calypso-products';
 import page from 'page';
-import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
-import { getSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import CurrentPlan from './';
 
 export function currentPlan( context, next ) {
 	const state = context.store.getState();
 
-	const siteId = getSelectedSiteId( state );
-	const selectedSite = getSite( state, siteId );
-	const eligibleForProPlan = isEligibleForProPlan( state, siteId );
+	const selectedSite = getSelectedSite( state );
 
 	if ( ! selectedSite ) {
 		page.redirect( '/plans/' );
@@ -18,10 +14,7 @@ export function currentPlan( context, next ) {
 		return null;
 	}
 
-	if (
-		isFreePlanProduct( selectedSite.plan ) ||
-		( eligibleForProPlan && isFlexiblePlanProduct( selectedSite.plan ) )
-	) {
+	if ( isFreePlanProduct( selectedSite.plan ) ) {
 		page.redirect( `/plans/${ selectedSite.slug }` );
 
 		return null;

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -14,13 +14,13 @@ import {
 	JETPACK_VIDEOPRESS_PRODUCTS,
 	isFreeJetpackPlan,
 	isFreePlanProduct,
-	isFlexiblePlanProduct,
 	isPro,
 } from '@automattic/calypso-products';
 import { Dialog } from '@automattic/components';
 import { Global } from '@emotion/react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -191,10 +191,17 @@ class CurrentPlan extends Component {
 
 		if (
 			eligibleForProPlan &&
-			! isFlexiblePlanProduct( selectedSite.plan ) &&
+			! isFreePlanProduct( selectedSite.plan ) &&
 			! isPro( selectedSite.plan )
 		) {
 			showLegacyPlanNotice = true;
+		}
+
+		// Ensures the Plan tab is shown in case the plan changes after the controller redirect.
+		if ( eligibleForProPlan && isFreePlanProduct( selectedSite.plan ) ) {
+			page.redirect( `/plans/${ selectedSite.slug }` );
+
+			return null;
 		}
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

More info: point 10. of pdgrnI-tQ#comment-863-p2

This addresses a bug where after canceling the Pro plan, the My Plan tab, for the Free plan is shown, instead of the Plans page. 
This is caused by the fact that the redirect is happening before the `selectedSite.plan` has been change to Free.
The fix adds a similar redirect, inside the My Plan component which should eventually catch the updated state.
<img width="320px" src="https://user-images.githubusercontent.com/2749938/159707994-56a8e111-0752-41b6-a20e-499c6100ab04.jpg" />

#### Testing instructions

* Go to `/start/new?flags=plans/pro-plan` and create a site with a Pro plan. (Or use one you already have).
* Go to `/plans/[site]?flags=plans/pro-plan` and you'll see the My Plan page
* Click Manage and cancel the Pro plan
* Without refreshing, go back to the `/plans/[site]?flags=plans/pro-plan` page
* You should now see the Plans grid
<img width="320" alt="Screenshot on 2022-03-23 at 15-16-27" src="https://user-images.githubusercontent.com/2749938/159708121-656f3207-0788-4308-ae78-dc35cd55933b.png">

* Make sure that the changes are isolated to only using the `?flags=plans/pro-plan` flag.

