### PR TITLE
Fix Site Editor closeUrl

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -836,7 +836,12 @@ const mapStateToProps = (
 	// Prevents the iframe from loading using a cached frame nonce.
 	const shouldLoadIframe = ! isRequestingSite( state, siteId ?? 0 );
 
-	const { url: closeUrl, label: closeLabel } = getEditorCloseConfig( state, siteId, postType );
+	const { url: closeUrl, label: closeLabel } = getEditorCloseConfig(
+		state,
+		siteId,
+		postType,
+		editorType
+	);
 
 	// 'shouldDisplayAppBanner' does not check if we're in Blogger Flow, because it is a selector reading from the Redux state, and
 	// the Blogger Flow information is not in the Redux state, but in the session storage value wpcom_signup_complete_show_draft_post_modal.

--- a/client/state/selectors/get-editor-close-config.js
+++ b/client/state/selectors/get-editor-close-config.js
@@ -9,12 +9,13 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
  * @param {object} state  Global state tree
  * @param {number|string|undefined|null} siteId Site ID
  * @param {string} postType The type of the current post being edited
+ * @param {string|undefined} editorType The type of editor (ex 'site' used to denote the site editor)
  * @returns {{url: string; label: string}} The URL that should be used when the block editor close button is clicked
  * @property {string} url The URL that should be used when the block editor close button is clicked
  * @property {string} label The label that should be used for the block editor back button
  */
 
-export default function getEditorCloseConfig( state, siteId, postType ) {
+export default function getEditorCloseConfig( state, siteId, postType, editorType ) {
 	// @TODO: See if more generic back navigation would work.
 
 	const lastNonEditorRoute = getLastNonEditorRoute( state );
@@ -29,10 +30,15 @@ export default function getEditorCloseConfig( state, siteId, postType ) {
 		};
 	}
 
-	// If a user comes from Home or from a fresh page load (i.e. Signup),
+	// If a user comes from Home, from a fresh page load (i.e. Signup), or is using the site editor,
 	// redirect to Customer Home.
 	// If no postType, assume site editor and land on home.
-	if ( ! lastNonEditorRoute || ! postType || doesRouteMatch( /^\/home\/?/ ) ) {
+	if (
+		! lastNonEditorRoute ||
+		doesRouteMatch( /^\/home\/?/ ) ||
+		editorType === 'site' ||
+		! postType
+	) {
 		return {
 			url: `/home/${ getSiteSlug( state, siteId ) }`,
 			label: translate( 'Dashboard' ),

--- a/client/state/selectors/test/get-editor-close-config.js
+++ b/client/state/selectors/test/get-editor-close-config.js
@@ -5,7 +5,8 @@ import getEditorCloseConfig from 'calypso/state/selectors/get-editor-close-confi
 import getPostTypeAllPostsUrl from 'calypso/state/selectors/get-post-type-all-posts-url';
 
 const postType = 'post';
-const siteEditorPostType = undefined;
+const undefinedPostType = undefined; // An undefined post type is a Site Editor edge case.
+const siteEditorEditorType = 'site';
 const siteId = 1;
 const siteSlug = 'fake.url.wordpress.com';
 const siteUrl = `https://${ siteSlug }`;
@@ -86,7 +87,7 @@ describe( 'getEditorCloseConfig()', () => {
 		expect( getEditorCloseConfig( state, siteId, postType, '' ).url ).toEqual( customerHomeUrl );
 	} );
 
-	test( 'should return URL to home if postType is undefined (site editor) and previous route has no match', () => {
+	test( 'should return URL to home if postType is undefined (site editor edge case) and previous route has no match', () => {
 		const state = {
 			sites: {
 				items: {
@@ -102,12 +103,12 @@ describe( 'getEditorCloseConfig()', () => {
 			userSettings: { settings: {} },
 		};
 
-		expect( getEditorCloseConfig( state, siteId, siteEditorPostType ).url ).toEqual(
+		expect( getEditorCloseConfig( state, siteId, undefinedPostType ).url ).toEqual(
 			customerHomeUrl
 		);
 	} );
 
-	test( 'should still return to matching route w/ undefined (site editor) postType', () => {
+	test( 'should still return to matching route w/ undefined postType (site editor edge case)', () => {
 		const state = {
 			sites: {
 				items: {
@@ -123,8 +124,48 @@ describe( 'getEditorCloseConfig()', () => {
 			userSettings: { settings: {} },
 		};
 
-		expect( getEditorCloseConfig( state, siteId, siteEditorPostType, '' ).url ).toEqual(
+		expect( getEditorCloseConfig( state, siteId, undefinedPostType, '' ).url ).toEqual( themesUrl );
+	} );
+
+	test( 'should return to themes if last route when editorType is of value "site"', () => {
+		const state = {
+			sites: {
+				items: {
+					[ siteId ]: { URL: siteUrl },
+				},
+			},
+			route: {
+				lastNonEditorRoute: themesUrl,
+			},
+			ui: {
+				selectedSiteId: siteId,
+			},
+			userSettings: { settings: {} },
+		};
+
+		expect( getEditorCloseConfig( state, siteId, postType, siteEditorEditorType ).url ).toEqual(
 			themesUrl
+		);
+	} );
+
+	test( 'should return to home if editorType is "site" and last route is not themes', () => {
+		const state = {
+			sites: {
+				items: {
+					[ siteId ]: { URL: siteUrl },
+				},
+			},
+			route: {
+				lastNonEditorRoute: '/route-with-no-match',
+			},
+			ui: {
+				selectedSiteId: siteId,
+			},
+			userSettings: { settings: {} },
+		};
+
+		expect( getEditorCloseConfig( state, siteId, postType, siteEditorEditorType ).url ).toEqual(
+			customerHomeUrl
 		);
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

attempts to resolve https://github.com/Automattic/wp-calypso/issues/62173

The `getEditorCloseConfig` used to determine the site editor by absence (undefined) value of `postType`. With recent changes, these queryArgs are required to load the site editor or else a redirect happens on the back end. We fixed the redirect issue previously in https://github.com/Automattic/wp-calypso/pull/61817, but missed the change this caused to the closeUrl.

Now `getEditorCloseConfig` will accept an additional param `editorType` (conveniently already used where we are already calling this selector), and use that value to determine if we are using the site editor. This should be much less fragile than making assumptions about postType.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR.
* Open the site editor, hover over the `< Dashboard` button, and verify this no longer links to `wordpress.com/types//SITE_URL`. (Both themes and myHome are valid URLs depending on the circumstance).
* Verify unit tests pass.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
