### PR TITLE
Fix Site Editor close button link - update fill to use state and hook

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -464,7 +464,23 @@ function handleCloseEditor( calypsoPort ) {
 	// Add back to dashboard fill for Site Editor when edit-site package is available.
 	if ( editSitePackage ) {
 		registerPlugin( 'a8c-wpcom-block-editor-site-editor-back-to-dashboard-override', {
-			render: () => {
+			render: function SiteEditorCloseFill() {
+				const [ closeUrl, setCloseUrl ] = useState( calypsoifyGutenberg.closeUrl );
+
+				useEffect( () => {
+					addAction(
+						'updateCloseButtonOverrides',
+						'a8c/wpcom-block-editor/SiteEditorCloseFill',
+						( data ) => {
+							setCloseUrl( data.closeUrl );
+						}
+					);
+					return () =>
+						removeAction(
+							'updateCloseButtonOverrides',
+							'a8c/wpcom-block-editor/SiteEditorCloseFill'
+						);
+				} );
 				const SiteEditorDashboardFill = editSitePackage?.__experimentalMainDashboardButton;
 				if ( ! SiteEditorDashboardFill || ! NavigationBackButton ) {
 					return null;
@@ -476,7 +492,7 @@ function handleCloseEditor( calypsoPort ) {
 							backButtonLabel={ __( 'Dashboard' ) }
 							// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 							className="edit-site-navigation-panel__back-to-dashboard"
-							href={ calypsoifyGutenberg.closeUrl }
+							href={ closeUrl }
 							onClick={ dispatchAction }
 						/>
 					</SiteEditorDashboardFill>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

resolves https://github.com/Automattic/wp-calypso/issues/62173

For whatever reason the site editor close URL is no longer being updated properly with the url sent from calypso (most likely things have been optimized and this slot/fill no longer re-renders after the calypsoify closeUrl is updated). This updates the fill to use state and an action hook to update the URL as expected, as is done in previous post editor implementations.

#### Testing instructions
Sync this wpcom-block-editor build to your sandbox
sandbox widgets
open the site editor, verify the closeURL points the user to my home instead of .../types//SITE_URL
