### PR TITLE
Browser Plugins: Remove blocked plugins from all sections and search.

### DIFF
--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -35,10 +35,6 @@ const PluginsBrowserList = ( {
 
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {
-			if ( 'zamir' === plugin.slug && 'new' === listName ) {
-				return null;
-			}
-
 			return (
 				<PluginBrowserItem
 					site={ site }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -441,8 +441,10 @@ const SearchListView = ( {
 				<PluginsBrowserList
 					plugins={
 						pluginsPagination?.page === 1
-							? [ ...paidPluginsBySearchTerm, ...pluginsBySearchTerm ]
-							: pluginsBySearchTerm
+							? [ ...paidPluginsBySearchTerm, ...pluginsBySearchTerm ].filter(
+									filterOutPluginsFromBlockList
+							  )
+							: pluginsBySearchTerm.filter( filterOutPluginsFromBlockList )
 					}
 					listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
 					title={ searchTitle }
@@ -568,6 +570,8 @@ const PluginSingleListView = ( {
 	} else {
 		return null;
 	}
+
+	plugins = plugins.filter( filterOutPluginsFromBlockList );
 
 	let listLink = '/plugins/' + category;
 	if ( domain ) {
@@ -768,6 +772,12 @@ function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
 		( plugin ) =>
 			! displayedFeaturedSlugsMap.has( plugin.slug ) && isCompatiblePlugin( plugin.slug )
 	);
+}
+
+const PLUGIN_SLUGS_BLOCKLIST = [ 'zamir' ];
+
+function filterOutPluginsFromBlockList( plugin ) {
+	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;
 }
 
 export default UrlSearch( PluginsBrowser );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Create a list of blocked plugins
* Remove those plugins from all sections and search view

#### Testing instructions
* Using this branch
* Go to `/plugins` page and check the plugins on the blocked list is not shown on any section. Ex: `zamir` on new section
* Verify if all sections still showing 6 plugins
* Search for a blocked plugin (`zamir`) and see if it is not shown.

#### Demo

| New Section | Search view |
| ------------- | ------------- |
| <img width="1162" alt="Screen Shot 2022-03-23 at 14 51 58" src="https://user-images.githubusercontent.com/5039531/159764327-774dc54e-f3eb-4f18-af7f-b1e55b48638f.png">  |<img width="1162" alt="Screen Shot 2022-03-23 at 14 52 05" src="https://user-images.githubusercontent.com/5039531/159764334-5d1a6a5e-c088-41ba-88b9-53670b81684d.png">  |






---

Related to #62182
