### PR TITLE
WPcom: Replace Editor Help Link with WP.com resource

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
@@ -6,6 +6,8 @@ function overrideCoreDocumentationLinksToWpcom( translation: string, text: strin
 			return 'https://wordpress.com/support/excerpts/';
 		case 'https://wordpress.org/support/article/writing-posts/#post-field-descriptions':
 			return 'https://wordpress.com/support/permalinks-and-slugs/';
+		case 'https://wordpress.org/support/article/wordpress-editor/':
+			return 'https://wordpress.com/support/wordpress-editor/';
 	}
 
 	return translation;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Modified Editor Help Link with `https://wordpress.com/support/wordpress-editor`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout the branch
2. Be sure to be sandboxed
3. `cd apps/editing-toolkit && yarn dev --sync`
4. Go to the WordPress editor
5. Click on the three vertical dots in the top-right corner
6. Scroll down to Help and click it
7. Check that it brings you to `https://wordpress.com/support/wordpress-editor/`

![image](https://user-images.githubusercontent.com/30727666/115678981-70a13600-a395-11eb-8c50-e6f419b22704.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #52190
Fixes #52190
