### PR TITLE
Require org field for all non-person CA legal entities

### DIFF
--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -294,7 +294,9 @@ export class ManagedContactDetailsFormFields extends Component {
 		);
 		const countryCode = form.countryCode?.value ?? '';
 		const arePostalCodesSupported = this.getCountryPostalCodeSupport( countryCode );
-		const isOrganizationFieldRequired = form.extra?.value?.ca?.legalType === 'CCO';
+		const isOrganizationFieldRequired = ! [ 'ABO', 'CCT', 'LGR', 'RES' ].includes(
+			form.extra?.value?.ca?.legalType
+		);
 
 		return (
 			<div className="contact-details-form-fields__contact-details">

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -294,9 +294,22 @@ export class ManagedContactDetailsFormFields extends Component {
 		);
 		const countryCode = form.countryCode?.value ?? '';
 		const arePostalCodesSupported = this.getCountryPostalCodeSupport( countryCode );
-		const isOrganizationFieldRequired = ! [ 'ABO', 'CCT', 'LGR', 'RES' ].includes(
-			form.extra?.value?.ca?.legalType
-		);
+		const isOrganizationFieldRequired = [
+			'CCO',
+			'GOV',
+			'EDU',
+			'ASS',
+			'HOP',
+			'PRT',
+			'TDM',
+			'TRD',
+			'PLT',
+			'LAM',
+			'TRS',
+			'INB',
+			'OMK',
+			'MAJ',
+		].includes( form.extra?.value?.ca?.legalType );
 
 		return (
 			<div className="contact-details-form-fields__contact-details">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Because of a change at CIRA, starting April 1, we'll need to ensure that all .ca domains with a non-person legal entity type have a valid organization field.


#### Testing instructions
- Apply the related backend patch: D77409-code
- Add a .ca domain to the shopping cart.
-  Make sure that the Organization field is shown for the following legal types: "CCO", "GOV", "EDU", "ASS", "HOP", "PRT", "TDM", "TRD", "PLT", "LAM", "TRS", "INB", "OMK", "MAJ".
- Make sure that an empty org field when entering contact info on the checkout page shows a validation error for all of those types.