### PR TITLE
Playwright: Editor tracking migration -- Add initial library and some easy specs.

### DIFF
--- a/packages/calypso-e2e/jest.config.js
+++ b/packages/calypso-e2e/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
+	testMatch: [ '<rootDir>/test/**/*.test.ts' ],
 };

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -40,7 +40,6 @@
 	},
 	"scripts": {
 		"clean": "yarn build --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json",
-		"test": "yarn jest"
+		"build": "tsc --build ./tsconfig.json"
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-block-list-view-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-block-list-view-component.ts
@@ -8,7 +8,7 @@ const selectors = {
  * Represents an instance of the WordPress.com Editor's sidebar list view.
  * The component is available only in the Desktop viewport.
  */
-export class EditorListViewComponent {
+export class EditorBlockListViewComponent {
 	private page: Page;
 	private editor: Locator;
 

--- a/packages/calypso-e2e/src/lib/components/editor-list-view-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-list-view-component.ts
@@ -1,0 +1,35 @@
+import { Locator, Page } from 'playwright';
+
+const selectors = {
+	blockLink: ( blockName: string ) => `.block-editor-list-view-leaf a:has-text("${ blockName }")`,
+};
+
+/**
+ * Represents an instance of the WordPress.com Editor's sidebar list view.
+ * The component is available only in the Desktop viewport.
+ */
+export class EditorListViewComponent {
+	private page: Page;
+	private editor: Locator;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 * @param {Locator} editor Locator or FrameLocator to the editor.
+	 */
+	constructor( page: Page, editor: Locator ) {
+		this.page = page;
+		this.editor = editor;
+	}
+
+	/**
+	 * Clicks the first block entry in the list view that has the provided block name (e.g. "Heading").
+	 *
+	 * @param {string} blockName Name of the block type (e.g. "Heading").
+	 */
+	async clickFirstBlockOfType( blockName: string ): Promise< void > {
+		const locator = this.editor.locator( selectors.blockLink( blockName ) ).first();
+		await locator.click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -1,4 +1,5 @@
 import { Page, Locator } from 'playwright';
+import envVariables from '../../env-variables';
 
 export type PreviewOptions = 'Desktop' | 'Mobile' | 'Tablet';
 
@@ -25,6 +26,12 @@ const selectors = {
 		const buttonState = state === 'disabled' ? 'true' : 'false';
 		return `${ panel } button.editor-post-publish-button__button[aria-disabled="${ buttonState }"]`;
 	},
+
+	// List view
+	listViewButton: `${ panel } button[aria-label="List View"]`,
+
+	// Details popover
+	detailsButton: `${ panel } button[aria-label="Details"]`,
 
 	// Editor settings
 	settingsButton: `${ panel } .edit-post-header__settings .interface-pinned-items button:first-child`,
@@ -218,6 +225,61 @@ export class EditorToolbarComponent {
 			return;
 		}
 		const locator = this.editor.locator( selectors.settingsButton );
+		await locator.click();
+	}
+
+	/* List view */
+
+	/**
+	 * Opens the list view.
+	 */
+	async openListView(): Promise< void > {
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// List view is not available on mobile!
+			return;
+		}
+
+		if ( await this.targetIsOpen( selectors.listViewButton ) ) {
+			return;
+		}
+
+		const locator = this.editor.locator( selectors.listViewButton );
+		await locator.click();
+	}
+
+	/**
+	 * Closes the list view.
+	 */
+	async closeListView(): Promise< void > {
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// List view is not available on mobile!
+			return;
+		}
+
+		if ( ! ( await this.targetIsOpen( selectors.listViewButton ) ) ) {
+			return;
+		}
+
+		const locator = this.editor.locator( selectors.listViewButton );
+		await locator.click();
+	}
+
+	/* Details popover */
+
+	/**
+	 * Opens the post details popover (i.e. number of character, words, etc.).
+	 */
+	async openDetailsPopover(): Promise< void > {
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// Details are not available on mobile!
+			return;
+		}
+
+		if ( await this.targetIsOpen( selectors.detailsButton ) ) {
+			return;
+		}
+
+		const locator = this.editor.locator( selectors.detailsButton );
 		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -20,5 +20,6 @@ export * from './editor-publish-panel-component';
 export * from './editor-nav-sidebar-component';
 export * from './editor-toolbar-component';
 export * from './editor-gutenberg-component';
+export * from './editor-list-view-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -20,6 +20,6 @@ export * from './editor-publish-panel-component';
 export * from './editor-nav-sidebar-component';
 export * from './editor-toolbar-component';
 export * from './editor-gutenberg-component';
-export * from './editor-list-view-component';
+export * from './editor-block-list-view-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
@@ -16,17 +16,17 @@ const selectors = {
  */
 export class PageTemplateModalComponent {
 	private page: Page;
-	private editorIframe: Frame;
+	private editorFrame: Page | Frame;
 
 	/**
 	 * Creates an instance of the page.
 	 *
-	 * @param {Frame} editorIframe Iframe from the gutenberg editor.
+	 * @param {Page | Frame} editorFrame Frame for the gutenberg editor.
 	 * @param {Page} page Object representing the base page.
 	 */
-	constructor( editorIframe: Frame, page: Page ) {
+	constructor( editorFrame: Page | Frame, page: Page ) {
 		this.page = page;
-		this.editorIframe = editorIframe;
+		this.editorFrame = editorFrame;
 	}
 
 	/**
@@ -36,12 +36,12 @@ export class PageTemplateModalComponent {
 	 */
 	async selectTemplateCatagory( category: TemplateCategory ): Promise< void > {
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			await this.editorIframe.selectOption(
+			await this.editorFrame.selectOption(
 				selectors.mobileTemplateCategorySelectBox,
 				category.toLowerCase()
 			);
 		} else {
-			const locator = this.editorIframe.locator( selectors.templateCategoryButton( category ) );
+			const locator = this.editorFrame.locator( selectors.templateCategoryButton( category ) );
 			await locator.click();
 		}
 	}
@@ -52,7 +52,7 @@ export class PageTemplateModalComponent {
 	 * @param {string} label Label for the template (the string underneath the preview).
 	 */
 	async selectTemplate( label: string ): Promise< void > {
-		const locator = this.editorIframe.locator( selectors.template( label ) );
+		const locator = this.editorFrame.locator( selectors.template( label ) );
 		await locator.click();
 	}
 
@@ -60,7 +60,7 @@ export class PageTemplateModalComponent {
 	 * Select a blank page as your template.
 	 */
 	async selectBlankPage(): Promise< void > {
-		const locator = this.editorIframe.locator( selectors.blankPageButton );
+		const locator = this.editorFrame.locator( selectors.blankPageButton );
 		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -9,6 +9,7 @@ import {
 	EditorSettingsSidebarComponent,
 	EditorGutenbergComponent,
 	NavbarComponent,
+	EditorListViewComponent,
 } from '../components';
 import type { SiteType } from '../../lib/utils';
 import type { PreviewOptions, EditorSidebarTab, PrivacyOptions, Schedule } from '../components';
@@ -42,6 +43,7 @@ export class EditorPage {
 	private editorToolbarComponent: EditorToolbarComponent;
 	private editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
 	private editorGutenbergComponent: EditorGutenbergComponent;
+	private editorListViewComponent: EditorListViewComponent;
 
 	/**
 	 * Constructs an instance of the component.
@@ -70,9 +72,10 @@ export class EditorPage {
 		this.editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( page, this.editor );
 		this.editorPublishPanelComponent = new EditorPublishPanelComponent( page, this.editor );
 		this.editorNavSidebarComponent = new EditorNavSidebarComponent( page, this.editor );
+		this.editorListViewComponent = new EditorListViewComponent( page, this.editor );
 	}
 
-	/* Generic methods */
+	//#region Generic and Shell Methods
 
 	/**
 	 * Opens the "new post/page" page. By default it will open the "new post" page.
@@ -169,7 +172,9 @@ export class EditorPage {
 		] );
 	}
 
-	/* Editor */
+	//#endregion
+
+	//#region Basic Entry
 
 	/**
 	 * Enters the text into the title block and verifies the result.
@@ -211,6 +216,10 @@ export class EditorPage {
 	async getText(): Promise< string > {
 		return await this.editorGutenbergComponent.getText();
 	}
+
+	//#endregion
+
+	//#region Block and Pattern Insertion
 
 	/**
 	 * Adds a Gutenberg block from the block inserter panel.
@@ -288,7 +297,9 @@ export class EditorPage {
 		await this.page.keyboard.press( 'Backspace' );
 	}
 
-	/* Settings Sidebar */
+	//#endregion
+
+	//#region Settings Sidebar
 
 	/**
 	 * Opens the Settings sidebar.
@@ -395,7 +406,36 @@ export class EditorPage {
 		await this.editorSettingsSidebarComponent.enterUrlSlug( slug );
 	}
 
-	/* Publish, Draft & Schedule */
+	//#endregion
+
+	//#region List View
+
+	/**
+	 * Opens the list view.
+	 */
+	async openListView(): Promise< void > {
+		await this.editorToolbarComponent.openListView();
+	}
+
+	/**
+	 * Closes the list view.
+	 */
+	async closeListView(): Promise< void > {
+		await this.editorToolbarComponent.closeListView();
+	}
+
+	/**
+	 * In the list view, click on the first block of a given type (e.g. "Heading").
+	 *
+	 * @param blockName Name of the block type to find and click (e.g. "Heading").
+	 */
+	async clickFirstListViewEntryByType( blockName: string ): Promise< void > {
+		await this.editorListViewComponent.clickFirstBlockOfType( blockName );
+	}
+
+	//#endregion
+
+	//#region Publish, Draft & Schedule
 
 	/**
 	 * Publishes the post or page.
@@ -525,7 +565,9 @@ export class EditorPage {
 		}
 	}
 
-	/* Previews */
+	//#endregion
+
+	//#region Previews
 
 	/**
 	 * Launches the Preview as mobile viewport.
@@ -578,7 +620,9 @@ export class EditorPage {
 		await this.editorToolbarComponent.openDesktopPreview( 'Desktop' );
 	}
 
-	/* Misc */
+	//#endregion
+
+	//#region Misc
 
 	/**
 	 * Leave the editor to return to the Calypso dashboard.
@@ -618,6 +662,13 @@ export class EditorPage {
 	}
 
 	/**
+	 * Opens the post details popover (i.e. number of character, words, etc.).
+	 */
+	async openDetailsPopover(): Promise< void > {
+		await this.editorToolbarComponent.openDetailsPopover();
+	}
+
+	/**
 	 * Checks whether the editor has any block warnings/errors displaying.
 	 *
 	 * @returns {Promise<boolean>} True if there are block warnings/errors.
@@ -626,4 +677,6 @@ export class EditorPage {
 	async editorHasBlockWarnings(): Promise< boolean > {
 		return await this.editorGutenbergComponent.editorHasBlockWarning();
 	}
+
+	//#endregion
 }

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -9,7 +9,7 @@ import {
 	EditorSettingsSidebarComponent,
 	EditorGutenbergComponent,
 	NavbarComponent,
-	EditorListViewComponent,
+	EditorBlockListViewComponent,
 } from '../components';
 import type { SiteType } from '../../lib/utils';
 import type { PreviewOptions, EditorSidebarTab, PrivacyOptions, Schedule } from '../components';
@@ -43,7 +43,7 @@ export class EditorPage {
 	private editorToolbarComponent: EditorToolbarComponent;
 	private editorSettingsSidebarComponent: EditorSettingsSidebarComponent;
 	private editorGutenbergComponent: EditorGutenbergComponent;
-	private editorListViewComponent: EditorListViewComponent;
+	private editorBlockListViewComponent: EditorBlockListViewComponent;
 
 	/**
 	 * Constructs an instance of the component.
@@ -72,7 +72,7 @@ export class EditorPage {
 		this.editorSettingsSidebarComponent = new EditorSettingsSidebarComponent( page, this.editor );
 		this.editorPublishPanelComponent = new EditorPublishPanelComponent( page, this.editor );
 		this.editorNavSidebarComponent = new EditorNavSidebarComponent( page, this.editor );
-		this.editorListViewComponent = new EditorListViewComponent( page, this.editor );
+		this.editorBlockListViewComponent = new EditorBlockListViewComponent( page, this.editor );
 	}
 
 	//#region Generic and Shell Methods
@@ -430,7 +430,7 @@ export class EditorPage {
 	 * @param blockName Name of the block type to find and click (e.g. "Heading").
 	 */
 	async clickFirstListViewEntryByType( blockName: string ): Promise< void > {
-		await this.editorListViewComponent.clickFirstBlockOfType( blockName );
+		await this.editorBlockListViewComponent.clickFirstBlockOfType( blockName );
 	}
 
 	//#endregion

--- a/packages/calypso-e2e/src/lib/utils/editor-tracks-event-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/editor-tracks-event-manager.ts
@@ -1,13 +1,6 @@
 import { Locator, Page } from 'playwright';
 import { TracksEvent, TracksEventProperties } from '../../types';
 
-export interface TracksEventSearchOptions {
-	/**
-	 *
-	 */
-	waitForEventMs?: number;
-}
-
 // Exporting just for unit testing
 export const createEventMatchingPredicate = (
 	expectedName: string,

--- a/packages/calypso-e2e/src/lib/utils/editor-tracks-event-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/editor-tracks-event-manager.ts
@@ -33,7 +33,6 @@ const sleep = async ( ms: number ) => new Promise( ( resolve ) => setTimeout( re
  */
 export class EditorTracksEventManager {
 	private page: Page;
-	private editor: Locator;
 
 	/**
 	 * Construct an instance of the editor Tracks event manager
@@ -42,16 +41,18 @@ export class EditorTracksEventManager {
 	 */
 	constructor( page: Page ) {
 		this.page = page;
+	}
 
+	/**
+	 * A locator within the correct iframe for the editor, to correctly grab values off of window.
+	 */
+	private get editor(): Locator {
 		// The Tracks events are stashed on "window" in whatever iframe is the actual editor (whether post, page, or site).
 		// We need to consolidate down to a single locator that works across all editors, and handles if we have the Gutenframe wrapper.
 		// It just matters that we're in the right iframe, so we use a very generic selector ("body") to get something safe and top-level.
-		if ( this.page.url().includes( '/wp-admin' ) ) {
-			this.editor = this.page.locator( 'body' );
-		} else {
-			// We're in some kind of Gutenframe!
-			this.editor = this.page.frameLocator( '[src*="wp-admin/post"]' ).locator( 'body' );
-		}
+		return this.page.url().includes( '/wp-admin' )
+			? this.page.locator( 'body' ) // No Gutenframe
+			: this.page.frameLocator( '[src*="wp-admin/post"]' ).locator( 'body' ); // Gutenframe
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/utils/editor-tracks-event-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/editor-tracks-event-manager.ts
@@ -1,0 +1,126 @@
+import { Locator, Page } from 'playwright';
+import { TracksEvent, TracksEventProperties } from '../../types';
+
+export interface TracksEventSearchOptions {
+	/**
+	 *
+	 */
+	waitForEventMs?: number;
+}
+
+// Exporting just for unit testing
+export const createEventMatchingPredicate = (
+	expectedName: string,
+	matchingProperties?: TracksEventProperties
+) => {
+	return ( event: TracksEvent ) => {
+		const [ name, properties ] = event;
+		if ( expectedName !== name ) {
+			return false;
+		}
+
+		if ( ! matchingProperties ) {
+			return true; // Nothing more to check, we're done here!
+		}
+
+		for ( const expectedProperty in matchingProperties ) {
+			if ( properties[ expectedProperty ] !== matchingProperties[ expectedProperty ] ) {
+				return false;
+			}
+		}
+
+		return true;
+	};
+};
+
+const sleep = async ( ms: number ) => new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+
+/**
+ * A class wrapping the editor Tracks events monitored in the browser
+ */
+export class EditorTracksEventManager {
+	private page: Page;
+	private editor: Locator;
+
+	/**
+	 * Construct an instance of the editor Tracks event manager
+	 *
+	 * @param page The Playwright page
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+
+		// The Tracks events are stashed on "window" in whatever iframe is the actual editor (whether post, page, or site).
+		// We need to consolidate down to a single locator that works across all editors, and handles if we have the Gutenframe wrapper.
+		// It just matters that we're in the right iframe, so we use a very generic selector ("body") to get something safe and top-level.
+		if ( this.page.url().includes( '/wp-admin' ) ) {
+			this.editor = this.page.locator( 'body' );
+		} else {
+			// We're in some kind of Gutenframe!
+			this.editor = this.page.frameLocator( '[src*="wp-admin/post"]' ).locator( 'body' );
+		}
+	}
+
+	/**
+	 * Get the full stack (reverse chronological) of Tracks events that is tracked for E2E tests.
+	 *
+	 * @throws If we can't find the events. Empty but instantiated event stacks are still valid.
+	 */
+	async getAllEvents(): Promise< TracksEvent[] > {
+		const eventStack = await this.editor.evaluate( () => window._e2eEventsStack );
+
+		if ( ! eventStack ) {
+			throw new Error(
+				'Could not find the Tracks events. Expected "_e2eEventsStack" property on the editor window object.'
+			);
+		}
+
+		return eventStack;
+	}
+
+	/**
+	 * Clears the E2E Tracks events in the browser.
+	 */
+	async clearEvents(): Promise< void > {
+		// We need to make sure that we're accurately finding the event stack first.
+		// Otherwise, resetting it could cause weird artifacts later!
+		await this.getAllEvents();
+		await this.editor.evaluate( () => {
+			window._e2eEventsStack = [];
+		} );
+	}
+
+	/**
+	 * Checks if a given Tracks event fired by matching on event name and optionally event properties
+	 *
+	 * @param {string} name The name of the event we are searching for.
+	 * @param {Object} options Keyed valued parameter of options to modify searching.
+	 * @param {TracksEventProperties} options.matchingProperties Any properties that must be present and matching for the event to match.
+	 * @param {number} options.waitForEventMs The number of milliseconds to wait to see if the Tracks event fires. Useful if the events are debounced.
+	 * @returns True/false based on whether a matching event was found.
+	 */
+	async didEventFire(
+		name: string,
+		options?: { matchingProperties?: TracksEventProperties; waitForEventMs?: number }
+	): Promise< boolean > {
+		const isEventOnStack = async ( name: string, matchingProperties?: TracksEventProperties ) => {
+			const eventStack = await this.getAllEvents();
+			return eventStack.some( createEventMatchingPredicate( name, matchingProperties ) );
+		};
+
+		const WAIT_INTERVAL_MS = 200;
+		const maxMstoWait = options?.waitForEventMs || 0;
+		let totalWaitedMs = 0;
+
+		// By doing an initial check and starting the loop with the wait,
+		// we avoid doing an extra, unnecessary wait at the end.
+		let eventIsOnStack = await isEventOnStack( name, options?.matchingProperties );
+		while ( ! eventIsOnStack && totalWaitedMs < maxMstoWait ) {
+			await sleep( WAIT_INTERVAL_MS );
+			totalWaitedMs += WAIT_INTERVAL_MS;
+			eventIsOnStack = await isEventOnStack( name, options?.matchingProperties );
+		}
+
+		return eventIsOnStack;
+	}
+}

--- a/packages/calypso-e2e/src/lib/utils/index.ts
+++ b/packages/calypso-e2e/src/lib/utils/index.ts
@@ -1,2 +1,4 @@
 export * from './validate-translations';
 export * from './get-test-account-by-feature';
+export { EditorTracksEventManager } from './editor-tracks-event-manager';
+export type { TracksEventSearchOptions } from './editor-tracks-event-manager';

--- a/packages/calypso-e2e/src/lib/utils/index.ts
+++ b/packages/calypso-e2e/src/lib/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './validate-translations';
 export * from './get-test-account-by-feature';
+
+// Other items are exported for unit testing, we only care about the manager class.
 export { EditorTracksEventManager } from './editor-tracks-event-manager';
-export type { TracksEventSearchOptions } from './editor-tracks-event-manager';

--- a/packages/calypso-e2e/src/types.d.ts
+++ b/packages/calypso-e2e/src/types.d.ts
@@ -4,6 +4,12 @@ import { Browser } from 'playwright';
 export type Plans = typeof PlansArray[ number ];
 export const PlansArray = [ 'Free', 'Personal', 'Premium', 'Business', 'eCommerce' ] as const;
 
+// Because these types are ultimately accessed on "window", adding them here.
+interface TracksEventProperties {
+	[ key: string ]: boolean | number | string;
+}
+export type TracksEvent = [ string, TracksEventProperties ];
+
 // Expose global browser initialized in jest-playwright-config/test-environment.ts
 declare global {
 	// Node 16 types removed the NodeJS.Global interface in favor of just using globalThis.
@@ -12,4 +18,8 @@ declare global {
 	// See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#type-checking-for-globalthis
 	// eslint-disable-next-line no-var
 	var browser: Browser;
+
+	interface Window {
+		_e2eEventsStack: TracksEvent[];
+	}
 }

--- a/packages/calypso-e2e/test/lib/utils/editor-tracks-event-manager.test.ts
+++ b/packages/calypso-e2e/test/lib/utils/editor-tracks-event-manager.test.ts
@@ -1,0 +1,50 @@
+import { it, describe, expect } from '@jest/globals';
+import { createEventMatchingPredicate } from '../../../src/lib/utils/editor-tracks-event-manager';
+import { TracksEvent } from '../../../src/types';
+
+describe( 'Test: createEventMatchingPredicate', function () {
+	const fakeTracksEvents: TracksEvent[] = [
+		[ 'wpcom_event_a', { prop_1: 'foo', prop_2: 'bar' } ],
+		[ 'wpcom_event_b', {} ],
+	];
+
+	it( 'Finds a matching event by name', function () {
+		const expectedEventName = 'wpcom_event_b';
+		const foundEvent = fakeTracksEvents.find( createEventMatchingPredicate( expectedEventName ) );
+		expect( foundEvent?.[ 0 ] ).toBe( expectedEventName );
+	} );
+
+	it( 'Does not match on an event that does not match by name', function () {
+		const foundEvent = fakeTracksEvents.find( createEventMatchingPredicate( 'no_event_here' ) );
+		expect( foundEvent ).toBeUndefined();
+	} );
+
+	it( 'Does a partial match of expected event properties', function () {
+		const expectedEventName = 'wpcom_event_a';
+		const foundEvent = fakeTracksEvents.find(
+			createEventMatchingPredicate( expectedEventName, { prop_2: 'bar' } )
+		);
+		expect( foundEvent?.[ 0 ] ).toBe( expectedEventName );
+	} );
+
+	it( 'Does not match on an event if property value is incorrect', function () {
+		const foundEvent = fakeTracksEvents.find(
+			createEventMatchingPredicate( 'wpcom_event_a', { prop_2: 'wrong' } )
+		);
+		expect( foundEvent ).toBeUndefined();
+	} );
+
+	it( 'Does not match on an event if property key itself is incorrect', function () {
+		const foundEvent = fakeTracksEvents.find(
+			createEventMatchingPredicate( 'wpcom_event_a', { wrong_prop: 'foo' } )
+		);
+		expect( foundEvent ).toBeUndefined();
+	} );
+
+	it( 'Requires all provided properties to match', function () {
+		const foundEvent = fakeTracksEvents.find(
+			createEventMatchingPredicate( 'wpcom_event_a', { prop_1: 'foo', prop_2: 'second_is_wrong' } )
+		);
+		expect( foundEvent ).toBeUndefined();
+	} );
+} );

--- a/packages/calypso-e2e/test/lib/utils/get-account-by-feature.test.ts
+++ b/packages/calypso-e2e/test/lib/utils/get-account-by-feature.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import {
 	getTestAccountByFeature,
 	envToFeatureKey,
@@ -64,7 +64,7 @@ describe( 'getTestAccountByFeature', function () {
 		expect( accountName ).toBe( 'multipleFeaturesUndefinedRightAccountName' );
 	} );
 
-	test( 'order of attributes in the criteria should not matter', () => {
+	it( 'order of attributes in the criteria should not matter', () => {
 		// Objects are rebuilt internally so as to have their keys sorted. Two objects
 		// with the same attributes but in different order will be considered to
 		// be the exact same criterion.
@@ -96,6 +96,9 @@ describe( 'getTestAccountByFeature', function () {
 	} );
 
 	it( 'will throw en error if passed feature does not match an account', () => {
+		// Trying to maintain this test over time will be tedious if we stick to allowed values.
+		// We might not support a combination now, but may in the future, which would cause this test to fail.
+		// So, we use a bad value and override the typing to check the error throwing.
 		expect( () =>
 			/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 			getTestAccountByFeature( { coblocks: 'foo', siteType: 'bar' } as any )

--- a/packages/calypso-e2e/test/lib/utils/get-account-by-feature.test.ts
+++ b/packages/calypso-e2e/test/lib/utils/get-account-by-feature.test.ts
@@ -96,9 +96,6 @@ describe( 'getTestAccountByFeature', function () {
 	} );
 
 	it( 'will throw en error if passed feature does not match an account', () => {
-		// Trying to maintain this test over time will be tedious if we stick to allowed values.
-		// We might not support a combination now, but may in the future, which would cause this test to fail.
-		// So, we use a bad value and override the typing to check the error throwing.
 		expect( () =>
 			/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 			getTestAccountByFeature( { coblocks: 'foo', siteType: 'bar' } as any )

--- a/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.ts
@@ -1,0 +1,71 @@
+/**
+ * @group gutenberg
+ */
+
+import {
+	DataHelper,
+	EditorPage,
+	envVariables,
+	getTestAccountByFeature,
+	PageTemplateModalComponent,
+	TestAccount,
+	EditorTracksEventManager,
+} from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Editor tracking: Pattern-related events' ), function () {
+	const siteType = envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple';
+	const accountName = getTestAccountByFeature( {
+		gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
+		siteType: siteType,
+	} );
+
+	const patternName = 'Two columns of text and title'; // This is distinct and returns one result.
+	const patternNameInEventProperty = 'core/two-columns-of-text-and-title';
+
+	describe( 'wpcom_pattern_inserted', function () {
+		let page: Page;
+		let editorPage: EditorPage;
+		let eventManager: EditorTracksEventManager;
+
+		beforeAll( async () => {
+			page = await browser.newPage();
+
+			const testAccount = new TestAccount( accountName );
+			await testAccount.authenticate( page );
+
+			eventManager = new EditorTracksEventManager( page );
+			editorPage = new EditorPage( page, { target: siteType } );
+		} );
+
+		it( 'Start a new page', async function () {
+			await editorPage.visit( 'page' );
+			await editorPage.waitUntilLoaded();
+		} );
+
+		it( 'Select blank template from modal', async function () {
+			const editorFrame = await editorPage.getEditorHandle();
+			const pageTemplateModalComponent = new PageTemplateModalComponent( editorFrame, page );
+			await pageTemplateModalComponent.selectBlankPage();
+		} );
+
+		describe( 'From the sidebar inserter', function () {
+			it( 'Add pattern from sidebar inserter', async function () {
+				await editorPage.addPattern( patternName );
+			} );
+
+			it( '"wpcom_pattern_inserted" event is added with correct "pattern_name" property', async function () {
+				const eventDidFire = await eventManager.didEventFire( 'wpcom_pattern_inserted', {
+					matchingProperties: {
+						pattern_name: patternNameInEventProperty,
+					},
+				} );
+				expect( eventDidFire ).toBe( true );
+			} );
+		} );
+
+		// TODO: Once we have better inline inserter support, add testing for inline inserter here.
+	} );
+} );

--- a/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
@@ -1,0 +1,134 @@
+/**
+ * @group gutenberg
+ */
+
+import {
+	DataHelper,
+	EditorPage,
+	envVariables,
+	getTestAccountByFeature,
+	TestAccount,
+	EditorTracksEventManager,
+	skipDescribeIf,
+} from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+// None of these toolbar actions are available in mobile.
+skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
+	DataHelper.createSuiteTitle( 'Editor tracking: Toolbar-related events' ),
+	function () {
+		const siteType = envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple';
+		const accountName = getTestAccountByFeature( {
+			gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
+			siteType: siteType,
+		} );
+
+		describe( 'wpcom_block_editor_list_view_toggle/select', function () {
+			let page: Page;
+			let editorPage: EditorPage;
+			let eventManager: EditorTracksEventManager;
+			beforeAll( async () => {
+				page = await browser.newPage();
+
+				const testAccount = new TestAccount( accountName );
+				await testAccount.authenticate( page );
+
+				eventManager = new EditorTracksEventManager( page );
+				editorPage = new EditorPage( page, { target: siteType } );
+			} );
+
+			it( 'Start a new post', async function () {
+				await editorPage.visit( 'post' );
+				await editorPage.waitUntilLoaded();
+			} );
+
+			it( 'Enter some text', async function () {
+				await editorPage.enterText( 'The actual text does not matter for this test.' );
+			} );
+
+			it( 'Toggle open the list view', async function () {
+				await editorPage.openListView();
+			} );
+
+			it( '"wpcom_block_editor_list_view_toggle" event fires with "is_open" set to true', async function () {
+				const eventDidFire = await eventManager.didEventFire(
+					'wpcom_block_editor_list_view_toggle',
+					{
+						matchingProperties: {
+							is_open: true,
+						},
+					}
+				);
+				expect( eventDidFire ).toBe( true );
+			} );
+
+			it( 'Select paragphraph block in list view', async function () {
+				await editorPage.clickFirstListViewEntryByType( 'Paragraph' );
+			} );
+
+			it( '"wpcom_block_editor_list_view_select" event fires with correct "block_name" property', async function () {
+				const eventDidFire = await eventManager.didEventFire(
+					'wpcom_block_editor_list_view_select',
+					{
+						matchingProperties: {
+							block_name: 'core/paragraph',
+						},
+					}
+				);
+				expect( eventDidFire ).toBe( true );
+			} );
+
+			it( 'Close the list view', async function () {
+				await editorPage.closeListView();
+			} );
+
+			it( '"wpcom_block_editor_list_view_toggle" event fires again with "is_open" set to false', async function () {
+				const eventDidFire = await eventManager.didEventFire(
+					'wpcom_block_editor_list_view_toggle',
+					{
+						matchingProperties: {
+							is_open: false,
+						},
+					}
+				);
+				expect( eventDidFire ).toBe( true );
+			} );
+		} );
+
+		describe( 'wpcom_block_editor_details_open', function () {
+			let page: Page;
+			let editorPage: EditorPage;
+			let eventManager: EditorTracksEventManager;
+			beforeAll( async () => {
+				page = await browser.newPage();
+
+				const testAccount = new TestAccount( accountName );
+				await testAccount.authenticate( page );
+
+				eventManager = new EditorTracksEventManager( page );
+				editorPage = new EditorPage( page, { target: siteType } );
+			} );
+
+			it( 'Start a new post', async function () {
+				await editorPage.visit( 'post' );
+				await editorPage.waitUntilLoaded();
+			} );
+
+			// Needed to enable the details button.
+			it( 'Enter some text', async function () {
+				await editorPage.enterText( 'The actual text does not matter for this test either.' );
+			} );
+
+			it( 'Click details button', async function () {
+				await editorPage.openDetailsPopover();
+			} );
+
+			it( '"wpcom_block_editor_details_open" event fires', async function () {
+				const eventDidFire = await eventManager.didEventFire( 'wpcom_block_editor_details_open' );
+				expect( eventDidFire ).toBe( true );
+			} );
+		} );
+	}
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Test plan map for context: pciE2j-QC-p2.

This PR makes a few major additions/changes:
- Adds the initial library code for fetching and searching for Tracks editor events.
- Adds some of the initial tests from the test plan map that don't require any big overhauls (e.g. inline inserter refactor) or new large POMs (like the SiteEditor).

#### Testing instructions

- [x] Gutenberg desktop tests pass
- [x] Gutenberg mobile tests pass
- [x] Unit tests pass
