### PR TITLE
Fix/jetpack scan UI adjustments

### DIFF
--- a/client/components/jetpack/scan-placeholder/style.scss
+++ b/client/components/jetpack/scan-placeholder/style.scss
@@ -13,3 +13,13 @@
 .scan__content .scan-placeholder.scan__content {
 	padding-top: 0;
 }
+
+.scan-placeholder__header.is-placeholder,
+.scan-placeholder__content.is-placeholder {
+	margin-left: auto;
+	margin-right: auto;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-left: 0;
+	}
+}

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -144,10 +144,13 @@
 			// line-height: 24px;
 
 			@include breakpoint-deprecated( '>660px' ) {
-				flex-grow: 1;
-				margin: 0 !important;
 				width: auto;
 				text-align: left;
+			}
+
+			@include breakpoint-deprecated( '>800px' ) {
+				flex-grow: 1;
+				margin: 0 !important;
 			}
 		}
 	}

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -1,5 +1,10 @@
 .scan-threats {
 	display: flex;
+	justify-content: center;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		justify-content: start;
+	}
 
 	&__threats {
 		margin: 0;
@@ -17,6 +22,11 @@
 	&__header-message {
 		display: flex;
 		padding-bottom: 8px;
+		justify-content: center;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			justify-content: start;
+		}
 	}
 
 	&__low-risk {
@@ -129,11 +139,15 @@
 		> p {
 			font-size: $font-body;
 			font-weight: normal;
+			width: 100%;
+			text-align: center;
 			// line-height: 24px;
 
-			@include breakpoint-deprecated( '>800px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				flex-grow: 1;
 				margin: 0 !important;
+				width: auto;
+				text-align: left;
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Center align content of the threats header on mobile screens.
* Center align loading placeholders for the threats header on mobile screens.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch and `yarn start`
* Open http://calypso.localhost:3000/scan/[SITE_URL]
* Verify content is centered on mobile screens (see screenshots).
* Verify there is no regression on desktop screens.

#### Screenshots:

Design:

<img width="477" alt="design" src="https://user-images.githubusercontent.com/10933065/159806902-8f65fec3-dce4-42ef-93e7-ff5debce27c2.png">

Before/After:

![Screen Shot 2022-03-23 at 3 44 03 PM](https://user-images.githubusercontent.com/10933065/159806940-d125945d-51a3-47e3-adf0-11ab8912b0a4.jpg)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1201069996155224-as-1202014712471234/f