### PR TITLE
Marketplace: Update search bar to match URL query's value

### DIFF
--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -7,6 +7,9 @@ jest.mock( 'calypso/lib/wporg', () => ( {
 	getWporgLocaleCode: () => 'it_US',
 	fetchPluginsList: () => Promise.resolve( [] ),
 } ) );
+jest.mock( 'calypso/lib/url-search', () => ( Component ) => ( props ) => (
+	<Component { ...props } doSearch={ jest.fn() } />
+) );
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/blocks/upsell-nudge', () => 'upsell-nudge' );

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -18,7 +18,7 @@ const SearchBox = ( { isMobile, doSearch, searchTerm } ) => {
 				pinned={ isMobile }
 				fitsContainer={ isMobile }
 				onSearch={ doSearch }
-				initialValue={ searchTerm }
+				defaultValue={ searchTerm }
 				placeholder={ translate( 'Try searching "ecommerce"' ) }
 				delaySearch={ true }
 				recordEvent={ recordSearchEvent }
@@ -38,10 +38,11 @@ const PopularSearches = ( props ) => {
 			</div>
 
 			<div className="search-box-header__recommended-searches-list">
-				{ searchTerms.map( ( searchTerm ) => (
+				{ searchTerms.map( ( searchTerm, n ) => (
 					<a
 						href={ `/plugins/${ siteSlug || '' }?s=${ searchTerm }` }
 						className="search-box-header__recommended-searches-list-item"
+						key={ 'recommended-search-item-' + n }
 					>
 						{ searchTerm }
 					</a>
@@ -52,13 +53,13 @@ const PopularSearches = ( props ) => {
 };
 
 const SearchHeader = ( props ) => {
-	const { doSearch, search, siteSlug, title, searchTerms } = props;
+	const { doSearch, searchTerm, siteSlug, title, searchTerms } = props;
 
 	return (
 		<div className="search-box-header">
 			<div className="search-box-header__header">{ title }</div>
 			<div className="search-box-header__search">
-				<SearchBox doSearch={ doSearch } search={ search } />
+				<SearchBox doSearch={ doSearch } searchTerm={ searchTerm } />
 			</div>
 			<PopularSearches siteSlug={ siteSlug } searchTerms={ searchTerms } />
 		</div>


### PR DESCRIPTION
#### Quick summary
On the plugins view when doing a search, selecting a plugin, and coming back the search query is not reflected in the search bar.

#### Changes proposed in this Pull Request

- Update search bar to match URL query's value

#### Testing instructions

1. Navigate into the plugin marketplace/plugins/:siteId.
2. Search for a query, for example, "bookings".
3. Click on a plugin.
4. Click "Search Results" on the breadcrumb at the header to go back to the results.

Related to #62119 
