### PR TITLE
[E2E][GB][getTestAccountByFeature] Add `envToFeatureKey` helper 

### DIFF
--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -31,7 +31,7 @@ type EnvVariables = {
 export type ViewportName = typeof VIEWPORT_NAMES[ number ];
 export type TestLocales = string[] & typeof TEST_LOCALES;
 
-interface SupportedEnvVariables extends EnvVariables {
+export interface SupportedEnvVariables extends EnvVariables {
 	VIEWPORT_NAME: ViewportName;
 	GUTENBERG_EDGE: boolean;
 	COBLOCKS_EDGE: boolean;
@@ -56,6 +56,11 @@ const defaultEnvVariables: SupportedEnvVariables = {
 	ARTIFACTS_PATH: path.join( process.cwd(), 'results' ),
 	TEST_ON_ATOMIC: false,
 };
+
+type TestAccountEnvVariables = Pick<
+	SupportedEnvVariables,
+	'GUTENBERG_EDGE' | 'COBLOCKS_EDGE' | 'TEST_ON_ATOMIC'
+>;
 
 const castKnownEnvVariable = ( name: string, value: string ): EnvVariableValue => {
 	let output: EnvVariableValue = value;

--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -57,11 +57,6 @@ const defaultEnvVariables: SupportedEnvVariables = {
 	TEST_ON_ATOMIC: false,
 };
 
-type TestAccountEnvVariables = Pick<
-	SupportedEnvVariables,
-	'GUTENBERG_EDGE' | 'COBLOCKS_EDGE' | 'TEST_ON_ATOMIC'
->;
-
 const castKnownEnvVariable = ( name: string, value: string ): EnvVariableValue => {
 	let output: EnvVariableValue = value;
 

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -10,6 +10,7 @@ import {
 	EditorGutenbergComponent,
 	NavbarComponent,
 } from '../components';
+import type { SiteType } from '../../lib/utils';
 import type { PreviewOptions, EditorSidebarTab, PrivacyOptions, Schedule } from '../components';
 
 const selectors = {
@@ -35,7 +36,7 @@ const EXTENDED_TIMEOUT = 90 * 1000;
 export class EditorPage {
 	private page: Page;
 	private editor: Locator;
-	private target: 'simple' | 'atomic';
+	private target: SiteType;
 	private editorPublishPanelComponent: EditorPublishPanelComponent;
 	private editorNavSidebarComponent: EditorNavSidebarComponent;
 	private editorToolbarComponent: EditorToolbarComponent;

--- a/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
+++ b/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
@@ -37,6 +37,18 @@ const defaultCriteria: FeatureCriteria[] = [
 	{
 		gutenberg: 'stable',
 		siteType: 'atomic',
+		variant: 'siteEditor',
+		accountName: 'gutenbergAtomicSiteUser',
+	},
+	{
+		gutenberg: 'edge',
+		siteType: 'atomic',
+		variant: 'siteEditor',
+		accountName: 'gutenbergAtomicSiteEdgeUser',
+	},
+	{
+		gutenberg: 'stable',
+		siteType: 'atomic',
 		accountName: 'gutenbergAtomicSiteUser',
 	},
 	{

--- a/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
+++ b/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
@@ -1,0 +1,49 @@
+import type { FeatureCriteria } from './get-test-account-by-feature';
+
+const defaultCriteria: FeatureCriteria[] = [
+	{
+		gutenberg: 'edge',
+		siteType: 'simple',
+		accountName: 'gutenbergSimpleSiteEdgeUser',
+	},
+	{ gutenberg: 'stable', siteType: 'simple', accountName: 'gutenbergSimpleSiteUser' },
+	// The CoBlocks account name takes precedence if CoBlocks edge
+	// is present. We have two definitions below to effectivelly
+	// ignore gutenberg in this case:
+	{
+		coblocks: 'edge',
+		gutenberg: 'stable',
+		siteType: 'simple',
+		accountName: 'coBlocksSimpleSiteEdgeUser',
+	},
+	{
+		coblocks: 'edge',
+		gutenberg: 'edge',
+		siteType: 'simple',
+		accountName: 'coBlocksSimpleSiteEdgeUser',
+	},
+	{
+		gutenberg: 'stable',
+		siteType: 'simple',
+		variant: 'siteEditor',
+		accountName: 'siteEditorSimpleSiteUser',
+	},
+	{
+		gutenberg: 'edge',
+		siteType: 'simple',
+		variant: 'siteEditor',
+		accountName: 'siteEditorSimpleSiteEdgeUser',
+	},
+	{
+		gutenberg: 'stable',
+		siteType: 'atomic',
+		accountName: 'gutenbergAtomicSiteUser',
+	},
+	{
+		gutenberg: 'edge',
+		siteType: 'atomic',
+		accountName: 'gutenbergAtomicSiteEdgeUser',
+	},
+];
+
+export default defaultCriteria;

--- a/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts
+++ b/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts
@@ -1,5 +1,5 @@
-import type { SupportedEnvVariables } from '../../env-variables';
 import defaultCriteria from './criteria-for-test-accounts';
+import type { SupportedEnvVariables } from '../../env-variables';
 
 export type TestAccountEnvVariables = Pick<
 	SupportedEnvVariables,
@@ -105,8 +105,8 @@ export function getTestAccountByFeature(
  * often, changes to the former might require the logic here to be updated, so
  * beware :)
  *
- * @param {SupportedEnvVariables} envVars
- * @returns {FeaureKey}
+ * @param {SupportedEnvVariables} envVariables
+ * @returns {FeatureKey}
  */
 export function envToFeatureKey( envVariables: TestAccountEnvVariables ): FeatureKey {
 	return {

--- a/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts
+++ b/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts
@@ -8,7 +8,7 @@ export type TestAccountEnvVariables = Pick<
 
 type Env = 'edge' | 'stable';
 
-type SiteType = 'simple' | 'atomic';
+export type SiteType = 'simple' | 'atomic';
 
 type Variant = 'siteEditor';
 

--- a/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts
+++ b/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts
@@ -105,7 +105,7 @@ export function getTestAccountByFeature(
  * often, changes to the former might require the logic here to be updated, so
  * beware :)
  *
- * @param {SupportedEnvVariables} envVariables
+ * @param {TestAccountEnvVariables} envVariables
  * @returns {FeatureKey}
  */
 export function envToFeatureKey( envVariables: TestAccountEnvVariables ): FeatureKey {

--- a/packages/calypso-e2e/test/lib/utils/get-account-by-feature.test.ts
+++ b/packages/calypso-e2e/test/lib/utils/get-account-by-feature.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it, test } from '@jest/globals';
-import { getTestAccountByFeature } from '../../../src/lib/utils/get-test-account-by-feature';
-import type { FeatureCriteria } from '../../../src/lib/utils/get-test-account-by-feature';
+import {
+	getTestAccountByFeature,
+	envToFeatureKey,
+} from '../../../src/lib/utils/get-test-account-by-feature';
+import type {
+	FeatureCriteria,
+	TestAccountEnvVariables,
+	FeatureKey,
+} from '../../../src/lib/utils/get-test-account-by-feature';
 
 describe( 'getTestAccountByFeature', function () {
 	const customCriteria: FeatureCriteria[] = [
@@ -90,7 +97,7 @@ describe( 'getTestAccountByFeature', function () {
 
 	it( 'will throw en error if passed feature does not match an account', () => {
 		expect( () =>
-			getTestAccountByFeature( { gutenberg: 'edge', siteType: 'atomic' } )
+			getTestAccountByFeature( { coblocks: 'foo', siteType: 'bar' } as any )
 		).toThrowError();
 	} );
 
@@ -123,7 +130,7 @@ describe( 'getTestAccountByFeature', function () {
 		expect( editorAccountName ).toBe( 'gutenbergSimpleSiteEdgeUser' );
 	} );
 
-	it( 'will replce any existing criteria if a identical one is passed as the 2nd argument', () => {
+	it( 'will replace any existing criteria if a identical one is passed as the 2nd argument', () => {
 		// There's already a default account that would match the criterion below. The default
 		// has an `accoutnName` of `gutenbergSimpleSiteEdgeUser`. By passing this one, the default
 		// one should be replaced.
@@ -144,5 +151,55 @@ describe( 'getTestAccountByFeature', function () {
 		);
 
 		expect( editorAccountName ).toBe( 'aNewAccount' );
+	} );
+} );
+
+describe( 'envToFeatureKey', () => {
+	const envVariables: TestAccountEnvVariables = {
+		COBLOCKS_EDGE: true,
+		GUTENBERG_EDGE: false,
+		TEST_ON_ATOMIC: false,
+	};
+
+	it( 'will return a proper `FeatureKey` object', () => {
+		expect( envToFeatureKey( envVariables ) ).toEqual( {
+			coblocks: 'edge',
+			gutenberg: 'stable',
+			siteType: 'simple',
+		} as FeatureKey );
+	} );
+
+	it( 'will return a `FeatureKey` object without coblocks (=== `undefined`) if env.COBLOCKS_EDGE is `false`', () => {
+		expect( envToFeatureKey( { ...envVariables, COBLOCKS_EDGE: false } )[ 'coblocks' ] ).toBe(
+			undefined
+		);
+	} );
+
+	it( 'will return a `FeatureKey` object with `coblocks: "edge"` if env.COBLOCKS_EDGE is `true`', () => {
+		expect( envToFeatureKey( envVariables ) ).toMatchObject( {
+			coblocks: 'edge',
+		} );
+	} );
+
+	it( 'will return a `FeatureKey` object with `gutenberg: "stable"` if env.GUTENBERG_EDGE is `false`', () => {
+		expect( envToFeatureKey( envVariables ) ).toMatchObject( { gutenberg: 'stable' } );
+	} );
+
+	it( 'will return a `FeatureKey` object with `gutenberg: "edge"` if env.GUTENBERG_EDGE is `true`', () => {
+		expect( envToFeatureKey( { ...envVariables, GUTENBERG_EDGE: true } ) ).toMatchObject( {
+			gutenberg: 'edge',
+		} );
+	} );
+
+	it( 'will return a `FeatureKey` object with `siteType: "simple"` if env.TEST_ON_ATOMIC is `false`', () => {
+		expect( envToFeatureKey( envVariables ) ).toMatchObject( {
+			siteType: 'simple',
+		} );
+	} );
+
+	it( 'will return a `FeatureKey` object with `siteType: "atomic"` if env.TEST_ON_ATOMIC is `true`', () => {
+		expect( envToFeatureKey( { ...envVariables, TEST_ON_ATOMIC: true } ) ).toMatchObject( {
+			siteType: 'atomic',
+		} );
 	} );
 } );

--- a/packages/calypso-e2e/test/lib/utils/get-account-by-feature.test.ts
+++ b/packages/calypso-e2e/test/lib/utils/get-account-by-feature.test.ts
@@ -97,6 +97,7 @@ describe( 'getTestAccountByFeature', function () {
 
 	it( 'will throw en error if passed feature does not match an account', () => {
 		expect( () =>
+			/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 			getTestAccountByFeature( { coblocks: 'foo', siteType: 'bar' } as any )
 		).toThrowError();
 	} );

--- a/test/e2e/specs/appearance/widgets__legacy-visibility.ts
+++ b/test/e2e/specs/appearance/widgets__legacy-visibility.ts
@@ -10,13 +10,11 @@ import {
 	BlockWidgetEditorComponent,
 	skipDescribeIf,
 	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
-const accountName = getTestAccountByFeature( {
-	gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
-	siteType: envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple',
-} );
+const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 
 declare const browser: Browser;
 

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -20,7 +20,8 @@ import {
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 
-const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+const features = envToFeatureKey( envVariables );
+const accountName = getTestAccountByFeature( features );
 
 declare const browser: Browser;
 
@@ -40,7 +41,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ), () => {
 		page = await browser.newPage();
 		logoImage = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
 		testAccount = new TestAccount( accountName );
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
 		await testAccount.authenticate( page );
 	} );

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -15,15 +15,12 @@ import {
 	PricingTableBlock,
 	TestAccount,
 	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 
-const accountName = getTestAccountByFeature( {
-	coblocks: envVariables.COBLOCKS_EDGE ? 'edge' : undefined,
-	gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
-	siteType: envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple',
-} );
+const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 
 declare const browser: Browser;
 

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -16,7 +16,8 @@ import {
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 
-const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+const features = envToFeatureKey( envVariables );
+const accountName = getTestAccountByFeature( features );
 
 declare const browser: Browser;
 
@@ -31,7 +32,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), (
 		page = await browser.newPage();
 		imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
 		testAccount = new TestAccount( accountName );
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
 		await testAccount.authenticate( page );
 	} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -11,15 +11,12 @@ import {
 	CoverBlock,
 	TestAccount,
 	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 
-const accountName = getTestAccountByFeature( {
-	coblocks: envVariables.COBLOCKS_EDGE ? 'edge' : undefined,
-	gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
-	siteType: envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple',
-} );
+const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 
 declare const browser: Browser;
 

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -9,14 +9,11 @@ import {
 	PricingTableBlock,
 	TestAccount,
 	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
-const accountName = getTestAccountByFeature( {
-	coblocks: envVariables.COBLOCKS_EDGE ? 'edge' : undefined,
-	gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
-	siteType: envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple',
-} );
+const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 
 declare const browser: Browser;
 

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -13,7 +13,8 @@ import {
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
-const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+const features = envToFeatureKey( envVariables );
+const accountName = getTestAccountByFeature( features );
 
 declare const browser: Browser;
 
@@ -26,7 +27,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ),
 	beforeAll( async () => {
 		page = await browser.newPage();
 		testAccount = new TestAccount( accountName );
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
 		await testAccount.authenticate( page );
 	} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -12,15 +12,12 @@ import {
 	ImageBlock,
 	TestAccount,
 	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 
-const accountName = getTestAccountByFeature( {
-	coblocks: envVariables.COBLOCKS_EDGE ? 'edge' : undefined,
-	gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
-	siteType: envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple',
-} );
+const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 
 declare const browser: Browser;
 

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -17,7 +17,8 @@ import {
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 
-const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+const features = envToFeatureKey( envVariables );
+const accountName = getTestAccountByFeature( features );
 
 declare const browser: Browser;
 
@@ -32,7 +33,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ), 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -28,8 +28,9 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	let pagesPage: PagesPage;
 	let publishedUrl: URL;
 
+	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature(
-		envToFeatureKey( envVariables ),
+		features,
 		// The default accounts for gutenberg+simple are `gutenbergSimpleSiteEdgeUser` for GB edge
 		// and `gutenbergSimpleSiteUser` for stable. The criteria below conflicts with the default
 		// one that would return the `gutenbergSimpleSiteUser`. We also can't define it as part of
@@ -56,7 +57,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Select page template', async function () {
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 		// @TODO Consider moving this to EditorPage.
 		await editorPage.waitUntilLoaded();
 		const editorIframe = await editorPage.getEditorHandle();

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -7,6 +7,7 @@ import {
 	PagesPage,
 	PageTemplateModalComponent,
 	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Browser, Page, Frame } from 'playwright';
 
@@ -28,10 +29,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	let publishedUrl: URL;
 
 	const accountName = getTestAccountByFeature(
-		{
-			gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
-			siteType: envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple',
-		},
+		envToFeatureKey( envVariables ),
 		// The default accounts for gutenberg+simple are `gutenbergSimpleSiteEdgeUser` for GB edge
 		// and `gutenbergSimpleSiteUser` for stable. The criteria below conflicts with the default
 		// one that would return the `gutenbergSimpleSiteUser`. We also can't define it as part of

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -19,7 +19,8 @@ import { Browser, Page } from 'playwright';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function () {
-	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( features, [
 		{ gutenberg: 'edge', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 	] );
 
@@ -46,7 +47,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 
 	describe( 'Publish post', function () {
 		it( 'Enter post title', async function () {
-			editorPage = new EditorPage( page );
+			editorPage = new EditorPage( page, { target: features.siteType } );
 			await editorPage.enterTitle( postTitle );
 		} );
 

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -12,19 +12,16 @@ import {
 	ParagraphBlock,
 	SnackbarNotificationComponent,
 	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function () {
-	const accountName = getTestAccountByFeature(
-		{
-			gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
-			siteType: envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple',
-		},
-		[ { gutenberg: 'edge', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' } ]
-	);
+	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+		{ gutenberg: 'edge', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
+	] );
 
 	const postTitle = `Post Life Cycle: ${ DataHelper.getTimestamp() }`;
 	const originalContent = DataHelper.getRandomPhrase();

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -26,13 +26,15 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	let page: Page;
 	let editorPage: EditorPage;
 	let publishedPostPage: PublishedPostPage;
-	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( features, [
 		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 	] );
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -10,6 +10,7 @@ import {
 	TestAccount,
 	envVariables,
 	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
@@ -25,13 +26,9 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	let page: Page;
 	let editorPage: EditorPage;
 	let publishedPostPage: PublishedPostPage;
-	const accountName = getTestAccountByFeature(
-		{
-			gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
-			siteType: envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple',
-		},
-		[ { gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' } ]
-	);
+	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
+	] );
 
 	beforeAll( async () => {
 		page = await browser.newPage();

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -11,19 +11,16 @@ import {
 	RevisionsComponent,
 	ParagraphBlock,
 	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
-	const accountName = getTestAccountByFeature(
-		{
-			gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
-			siteType: envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple',
-		},
-		[ { gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' } ]
-	);
+	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
+	] );
 	let editorPage: EditorPage;
 	let revisionsComponent: RevisionsComponent;
 	let page: Page;

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -18,9 +18,11 @@ import { Browser, Page } from 'playwright';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
-	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( features, [
 		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 	] );
+
 	let editorPage: EditorPage;
 	let revisionsComponent: RevisionsComponent;
 	let page: Page;
@@ -33,7 +35,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 	} );
 
 	it( 'Go to the new post page', async function () {
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 		await editorPage.visit( 'post' );
 	} );
 

--- a/test/e2e/specs/editor/editor__schedule.ts
+++ b/test/e2e/specs/editor/editor__schedule.ts
@@ -9,19 +9,16 @@ import {
 	EditorPage,
 	PublishedPostPage,
 	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
-	const accountName = getTestAccountByFeature(
-		{
-			gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
-			siteType: envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple',
-		},
-		[ { gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' } ]
-	);
+	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
+	] );
 	const postTitle = `Scheduled Post: ${ DataHelper.getTimestamp() }`;
 	const postContent = DataHelper.getRandomPhrase();
 	let postURL: URL;

--- a/test/e2e/specs/editor/editor__schedule.ts
+++ b/test/e2e/specs/editor/editor__schedule.ts
@@ -16,7 +16,8 @@ import { Browser, Page } from 'playwright';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
-	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( features, [
 		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 	] );
 	const postTitle = `Scheduled Post: ${ DataHelper.getTimestamp() }`;
@@ -33,7 +34,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 	} );
 
 	it( 'Go to the new post page', async function () {
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 		await editorPage.visit( 'post' );
 	} );
 

--- a/test/e2e/specs/editor/shared/privacy-testing.ts
+++ b/test/e2e/specs/editor/shared/privacy-testing.ts
@@ -26,7 +26,8 @@ const pagePassword = 'cat';
  */
 export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions } ): void {
 	describe( DataHelper.createSuiteTitle( `Editor: Privacy (${ visibility })` ), function () {
-		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+		const features = envToFeatureKey( envVariables );
+		const accountName = getTestAccountByFeature( features, [
 			{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 		] );
 
@@ -43,7 +44,7 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 			} );
 
 			it( 'Start new page', async function () {
-				editorPage = new EditorPage( page );
+				editorPage = new EditorPage( page, { target: features.siteType } );
 				await editorPage.visit( 'page' );
 				await editorPage.waitUntilLoaded();
 				const editorIframe = await editorPage.getEditorHandle();

--- a/test/e2e/specs/editor/shared/privacy-testing.ts
+++ b/test/e2e/specs/editor/shared/privacy-testing.ts
@@ -7,6 +7,7 @@ import {
 	PublishedPostPage,
 	PageTemplateModalComponent,
 	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
@@ -25,13 +26,9 @@ const pagePassword = 'cat';
  */
 export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions } ): void {
 	describe( DataHelper.createSuiteTitle( `Editor: Privacy (${ visibility })` ), function () {
-		const accountName = getTestAccountByFeature(
-			{
-				gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
-				siteType: envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple',
-			},
-			[ { gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' } ]
-		);
+		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+			{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
+		] );
 
 		let page: Page;
 		let url: URL;

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -9,6 +9,7 @@ import {
 	SidebarComponent,
 	TestAccount,
 	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
@@ -24,8 +25,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
 	let page: Page;
 	const accountName = getTestAccountByFeature( {
-		gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
-		siteType: envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple',
+		...envToFeatureKey( envVariables ),
 		variant: 'siteEditor',
 	} );
 

--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -15,14 +15,15 @@ import { Page, Browser } from 'playwright';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), function () {
-	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( features );
 
 	let page: Page;
 	let editorPage: EditorPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );

--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -8,16 +8,14 @@ import {
 	DataHelper,
 	EditorPage,
 	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), function () {
-	const accountName = getTestAccountByFeature( {
-		gutenberg: envVariables.GUTENBERG_EDGE ? 'edge' : 'stable',
-		siteType: envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple',
-	} );
+	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 
 	let page: Page;
 	let editorPage: EditorPage;


### PR DESCRIPTION
Follow up to: https://github.com/Automattic/wp-calypso/pull/61783.
Project: p9oQ9f-13V-p2.

#### Changes proposed in this Pull Request

* Add `envToFeatureKey` (ad-hoc) helper to turn a `SupportedEnvVariables`ish object into a `FeatureKey`. 

##### Additional changes

* Move the `defaultCriteria` definition to its own module;
* Fixed a [test](https://github.com/Automattic/wp-calypso/pull/62192/files#diff-299c981fa7af6648cb08a17e29e87c51177f8ab7944d4aa8f05abe801b66b556R100).


#### Other observations

I initially pondered if we could just change the `getTestAccountByFeature` signature to accept a single `SupportedEnvVariable`-like object (like @dpasque suggested [here](https://github.com/Automattic/wp-calypso/pull/61783#discussion_r827378857)), or create a public wrapper that would accept an env var object instead of a `FeatureKey` object. If _all_ input data indeed came from env variables, it'd make sense to do it, while making the latter part of the encapsulate private implementation detail. 

However, there will be cases when we'd like to pass a test-specific feature criterion that's not dependent on an external env var. A clear example of that is the optional `variant` criterion that can be passed as part of a `FeatureKey`. It's very test-specific and can't be set through an env var (an env var is by definition build-specific) and defines if the test is for the `siteEditor` instead of the regular editor.[ Example here](https://github.com/Automattic/wp-calypso/pull/62192/files#diff-f0bf6913db82b58ce87f903fa5116e2b7c71306b8bc321cfe93dc1092c07dcbaR29). Hence, it looks like it's best to keep `envToFeatureKey' as a public helper function that can be used inline whenever needed and its return value can be extended inline, if needed, too. 

#### Testing instructions

* Tests should pass.

