### PR TITLE
[E2E][GB][getTestAccountByFeature] Add stable and edge AT account criteria for testing the Site Editor

### DIFF
--- a/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
+++ b/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
@@ -37,6 +37,18 @@ const defaultCriteria: FeatureCriteria[] = [
 	{
 		gutenberg: 'stable',
 		siteType: 'atomic',
+		variant: 'siteEditor',
+		accountName: 'gutenbergAtomicSiteUser',
+	},
+	{
+		gutenberg: 'edge',
+		siteType: 'atomic',
+		variant: 'siteEditor',
+		accountName: 'gutenbergAtomicSiteEdgeUser',
+	},
+	{
+		gutenberg: 'stable',
+		siteType: 'atomic',
 		accountName: 'gutenbergAtomicSiteUser',
 	},
 	{


### PR DESCRIPTION
Requires https://github.com/Automattic/wp-calypso/pull/62192.


#### Changes proposed in this Pull Request

* Add stable and edge AT E2E WP account criteria for testing the Site Editor

#### Why

Some tests in the recently-created `calypso_WPComTests_gutenberg_Playwright_atomic_desktop` and `calypso_WPComTests_gutenberg_Playwright_atomic_mobile` builds are failing with a `No account found for this feature' exception. This is because these tests are FSE-specific and pass a `variant: "siteEditor"` attribute to the `FeatureKey` and it wasn't matching any criteria. This PR adds the two needed criteria for the accounts.

#### Testing instructions

* Tests should pass
