### PR TITLE
[E2E][GB] Pass the `target` (`simple` or `atomic`) to the `Editor` for relevant E2E tests

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -10,6 +10,7 @@ import {
 	EditorGutenbergComponent,
 	NavbarComponent,
 } from '../components';
+import type { SiteType } from '../../lib/utils';
 import type { PreviewOptions, EditorSidebarTab, PrivacyOptions, Schedule } from '../components';
 
 const selectors = {
@@ -35,7 +36,7 @@ const EXTENDED_TIMEOUT = 90 * 1000;
 export class EditorPage {
 	private page: Page;
 	private editor: Locator;
-	private target: 'simple' | 'atomic';
+	private target: SiteType;
 	private editorPublishPanelComponent: EditorPublishPanelComponent;
 	private editorNavSidebarComponent: EditorNavSidebarComponent;
 	private editorToolbarComponent: EditorToolbarComponent;

--- a/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts
+++ b/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts
@@ -8,7 +8,7 @@ export type TestAccountEnvVariables = Pick<
 
 type Env = 'edge' | 'stable';
 
-type SiteType = 'simple' | 'atomic';
+export type SiteType = 'simple' | 'atomic';
 
 type Variant = 'siteEditor';
 

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -20,7 +20,8 @@ import {
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 
-const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+const features = envToFeatureKey( envVariables );
+const accountName = getTestAccountByFeature( features );
 
 declare const browser: Browser;
 
@@ -40,7 +41,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ), () => {
 		page = await browser.newPage();
 		logoImage = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
 		testAccount = new TestAccount( accountName );
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
 		await testAccount.authenticate( page );
 	} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -16,7 +16,8 @@ import {
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 
-const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+const features = envToFeatureKey( envVariables );
+const accountName = getTestAccountByFeature( features );
 
 declare const browser: Browser;
 
@@ -31,7 +32,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), (
 		page = await browser.newPage();
 		imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
 		testAccount = new TestAccount( accountName );
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
 		await testAccount.authenticate( page );
 	} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -13,7 +13,8 @@ import {
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
-const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+const features = envToFeatureKey( envVariables );
+const accountName = getTestAccountByFeature( features );
 
 declare const browser: Browser;
 
@@ -26,7 +27,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ),
 	beforeAll( async () => {
 		page = await browser.newPage();
 		testAccount = new TestAccount( accountName );
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
 		await testAccount.authenticate( page );
 	} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -17,7 +17,8 @@ import {
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 
-const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+const features = envToFeatureKey( envVariables );
+const accountName = getTestAccountByFeature( features );
 
 declare const browser: Browser;
 
@@ -32,7 +33,7 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ), 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -28,8 +28,9 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	let pagesPage: PagesPage;
 	let publishedUrl: URL;
 
+	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature(
-		envToFeatureKey( envVariables ),
+		features,
 		// The default accounts for gutenberg+simple are `gutenbergSimpleSiteEdgeUser` for GB edge
 		// and `gutenbergSimpleSiteUser` for stable. The criteria below conflicts with the default
 		// one that would return the `gutenbergSimpleSiteUser`. We also can't define it as part of
@@ -56,7 +57,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Select page template', async function () {
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 		// @TODO Consider moving this to EditorPage.
 		await editorPage.waitUntilLoaded();
 		const editorIframe = await editorPage.getEditorHandle();

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -19,7 +19,8 @@ import { Browser, Page } from 'playwright';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function () {
-	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( features, [
 		{ gutenberg: 'edge', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 	] );
 
@@ -46,7 +47,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 
 	describe( 'Publish post', function () {
 		it( 'Enter post title', async function () {
-			editorPage = new EditorPage( page );
+			editorPage = new EditorPage( page, { target: features.siteType } );
 			await editorPage.enterTitle( postTitle );
 		} );
 

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -26,13 +26,15 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	let page: Page;
 	let editorPage: EditorPage;
 	let publishedPostPage: PublishedPostPage;
-	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( features, [
 		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 	] );
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -18,9 +18,11 @@ import { Browser, Page } from 'playwright';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
-	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( features, [
 		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 	] );
+
 	let editorPage: EditorPage;
 	let revisionsComponent: RevisionsComponent;
 	let page: Page;
@@ -33,7 +35,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 	} );
 
 	it( 'Go to the new post page', async function () {
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 		await editorPage.visit( 'post' );
 	} );
 

--- a/test/e2e/specs/editor/editor__schedule.ts
+++ b/test/e2e/specs/editor/editor__schedule.ts
@@ -16,7 +16,8 @@ import { Browser, Page } from 'playwright';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
-	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( features, [
 		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 	] );
 	const postTitle = `Scheduled Post: ${ DataHelper.getTimestamp() }`;
@@ -33,7 +34,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 	} );
 
 	it( 'Go to the new post page', async function () {
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 		await editorPage.visit( 'post' );
 	} );
 

--- a/test/e2e/specs/editor/shared/privacy-testing.ts
+++ b/test/e2e/specs/editor/shared/privacy-testing.ts
@@ -26,7 +26,8 @@ const pagePassword = 'cat';
  */
 export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions } ): void {
 	describe( DataHelper.createSuiteTitle( `Editor: Privacy (${ visibility })` ), function () {
-		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+		const features = envToFeatureKey( envVariables );
+		const accountName = getTestAccountByFeature( features, [
 			{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 		] );
 
@@ -43,7 +44,7 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 			} );
 
 			it( 'Start new page', async function () {
-				editorPage = new EditorPage( page );
+				editorPage = new EditorPage( page, { target: features.siteType } );
 				await editorPage.visit( 'page' );
 				await editorPage.waitUntilLoaded();
 				const editorIframe = await editorPage.getEditorHandle();

--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -15,14 +15,15 @@ import { Page, Browser } from 'playwright';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), function () {
-	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( features );
 
 	let page: Page;
 	let editorPage: EditorPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		editorPage = new EditorPage( page );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );


### PR DESCRIPTION
Requires https://github.com/Automattic/wp-calypso/pull/62192.

#### Changes proposed in this Pull Request

* Connect the `target` `Editor` param to the `TEST_ON_ATOMIC` env var via the `FeatureKey` object's `siteType` attribute, allowing these tests to be parameterizable via the aforementioned env var, set via TC builds and to finally run and access the editor on AT sites (i.e no Gutenframe).

#### Testing instructions

* After merging, more tests should (ideally) pass in the `Playwright Gutenberg atomic E2E tests (desktop)` and `Playwright Gutenberg atomic E2E tests (mobile)` builds OR we'll get different errors instead of the timeouts due to the iframe not being found (which is true, it isn't accessible in AT sites!).

#### Outsanding questions / TODO

- [x] Does the Site Editor work from within the Gutenframe in simple sites? I still haven't checked. If it uses, then we should implement a similar logic to what we did in the `Editor` class and pass the `target` there, too. [Relevant test](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/specs/fse/fse__temp-smoke-test.ts).