### PR TITLE
Search plugin: Redirects to checkout with Annual Jetpack Search on connection

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1,5 +1,8 @@
 import config from '@automattic/calypso-config';
-import { PRODUCT_JETPACK_BACKUP_T1_YEARLY } from '@automattic/calypso-products';
+import {
+	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+	PRODUCT_JETPACK_SEARCH,
+} from '@automattic/calypso-products';
 import { Button, Card, Gridicon } from '@automattic/components';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -41,6 +44,7 @@ import {
 	isFetchingSitePurchases,
 	siteHasJetpackProductPurchase,
 	siteHasBackupProductPurchase,
+	siteHasSearchProductPurchase,
 } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getPartnerIdFromQuery from 'calypso/state/selectors/get-partner-id-from-query';
@@ -217,7 +221,12 @@ export class JetpackAuthorize extends Component {
 	}
 
 	redirect() {
-		const { isMobileAppFlow, mobileAppRedirect, siteHasJetpackBackupProduct } = this.props;
+		const {
+			isMobileAppFlow,
+			mobileAppRedirect,
+			siteHasJetpackBackupProduct,
+			siteHasJetpackSearchProduct,
+		} = this.props;
 		const {
 			from,
 			homeUrl,
@@ -281,6 +290,9 @@ export class JetpackAuthorize extends Component {
 		} else if ( this.isFromJetpackBackupPlugin() && ! siteHasJetpackBackupProduct ) {
 			debug( `Redirecting directly to cart with ${ PRODUCT_JETPACK_BACKUP_T1_YEARLY } in cart.` );
 			navigate( `/checkout/${ urlToSlug( homeUrl ) }/${ PRODUCT_JETPACK_BACKUP_T1_YEARLY }` );
+		} else if ( this.isFromJetpackSearchPlugin() && ! siteHasJetpackSearchProduct ) {
+			debug( `Redirecting directly to cart with ${ PRODUCT_JETPACK_SEARCH } in cart.` );
+			navigate( `/checkout/${ urlToSlug( homeUrl ) }/${ PRODUCT_JETPACK_SEARCH }` );
 		} else {
 			const redirectionTarget = this.getRedirectionTarget();
 			debug( `Redirecting to: ${ redirectionTarget }` );
@@ -359,6 +371,11 @@ export class JetpackAuthorize extends Component {
 	isFromJetpackBackupPlugin( props = this.props ) {
 		const { from } = props.authQuery;
 		return startsWith( from, 'jetpack-backup' );
+	}
+
+	isFromJetpackSearchPlugin( props = this.props ) {
+		const { from } = props.authQuery;
+		return startsWith( from, 'jetpack-search' );
 	}
 
 	isWooRedirect = ( props = this.props ) => {
@@ -920,6 +937,7 @@ const connectComponent = connect(
 			selectedPlanSlug,
 			siteHasJetpackPaidProduct: siteHasJetpackProductPurchase( state, authQuery.clientId ),
 			siteHasJetpackBackupProduct: siteHasBackupProductPurchase( state, authQuery.clientId ),
+			siteHasJetpackSearchProduct: siteHasSearchProductPurchase( state, authQuery.clientId ),
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),
 		};

--- a/client/state/purchases/selectors/index.js
+++ b/client/state/purchases/selectors/index.js
@@ -20,3 +20,4 @@ export { shouldRevertAtomicSiteBeforeDeactivation } from './should-revert-atomic
 export { siteHasBackupProductPurchase } from './site-has-backup-product-purchase';
 export { siteHasJetpackProductPurchase } from './site-has-jetpack-product-purchase';
 export { siteHasScanProductPurchase } from './site-has-scan-product-purchase';
+export { siteHasSearchProductPurchase } from './site-has-search-product-purchase';

--- a/client/state/purchases/selectors/site-has-search-product-purchase.js
+++ b/client/state/purchases/selectors/site-has-search-product-purchase.js
@@ -5,11 +5,11 @@ import { getSitePurchases } from './get-site-purchases';
 import 'calypso/state/purchases/init';
 
 /**
- * Whether a site has an active Jetpack backup purchase.
+ * Whether a site has an active Jetpack Search purchase.
  *
  * @param   {object} state       global state
  * @param   {number} siteId      the site id
- * @returns {boolean} True if the site has an active Jetpack Backup purchase, false otherwise.
+ * @returns {boolean} True if the site has an active Jetpack Search purchase, false otherwise.
  */
 export const siteHasSearchProductPurchase = ( state, siteId ) => {
 	return some(

--- a/client/state/purchases/selectors/site-has-search-product-purchase.js
+++ b/client/state/purchases/selectors/site-has-search-product-purchase.js
@@ -1,0 +1,19 @@
+import { isJetpackSearch } from '@automattic/calypso-products';
+import { some } from 'lodash';
+import { getSitePurchases } from './get-site-purchases';
+
+import 'calypso/state/purchases/init';
+
+/**
+ * Whether a site has an active Jetpack backup purchase.
+ *
+ * @param   {object} state       global state
+ * @param   {number} siteId      the site id
+ * @returns {boolean} True if the site has an active Jetpack Backup purchase, false otherwise.
+ */
+export const siteHasSearchProductPurchase = ( state, siteId ) => {
+	return some(
+		getSitePurchases( state, siteId ),
+		( purchase ) => purchase.active && isJetpackSearch( purchase )
+	);
+};

--- a/client/state/sites/selectors/get-jetpack-checkout-redirect-url.js
+++ b/client/state/sites/selectors/get-jetpack-checkout-redirect-url.js
@@ -17,12 +17,14 @@ export default function getJetpackCheckoutRedirectUrl( state, siteId ) {
 	const redirectMap = {
 		jetpack: 'admin.php?page=jetpack#/recommendations',
 		'jetpack-backup': 'admin.php?page=jetpack-backup',
+		'jetpack-search': 'admin.php?page=jetpack-search',
 	};
 
 	// Higher values are prioritized
 	const priority = {
 		jetpack: 1,
 		'jetpack-backup': 0,
+		'jetpack-search': 0,
 	};
 
 	let bestMatchingPlugin = null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change logic on the authorization of the Jetpack Search Plugin to redirect to cart if the site does not already have a Jetpack Search Product. Mostly stolen from #60468.
* Add redirection URL after purchase to Search Dashboard

#### Testing instructions

1. Boot this branch locally `yarn start`
2. Create a new Jurassic Ninja site
   - Navigate to [Jurassic Ninja with more options](https://jurassic.ninja/specialops/)
   - Uncheck "Include Jetpack"
   - Check "include Jetpack Beta"
   - Launch "Launch single site" 
![image](https://user-images.githubusercontent.com/1425433/160743407-2132d905-1203-4cb2-bda7-d3f7ce1526ca.png)

3. Navigate to `/wp-admin/admin.php?page=jetpack-beta&plugin=jetpack-search`
4. Activate Search plugin the Bleeding Edge version
![image](https://user-images.githubusercontent.com/1425433/160743342-2e4b2163-6e52-4eba-8ce0-504fabd190de.png)

3. Navigate to `/wp-admin/admin.php?page=jetpack-search` on your new temporary site
6. Click "Get Jetpack Search" 
7. On the authorization step, switch the host in the URL from `wordpress.com` to `calypso.localhost:3000` and reload the page 
8. Click "Approve"
9. **_Ensure_** you are redirected to the Checkout page with Annual Jetpack Search
10. **_Ensure_** you could pay
11. **_Ensure_** you are redirected to your new Jurassic Ninja site Search dashboard `/wp-admin/admin.php?page=jetpack-search`
12. **_Ensure_**  Search module and Instant Search are enabled on the site
![image](https://user-images.githubusercontent.com/1425433/160747450-2d949dcb-8b89-4c71-9266-8beff63d6f52.png)


