### PR TITLE
DIFM: Use new page IDs in the Website Content step

### DIFF
--- a/client/signup/difm/constants.tsx
+++ b/client/signup/difm/constants.tsx
@@ -11,6 +11,8 @@ export const PORTFOLIO_PAGE = 'PORTFOLIO_PAGE';
 export const FAQ_PAGE = 'FAQ_PAGE';
 export const SITEMAP_PAGE = 'SITEMAP_PAGE';
 export const PROFILE_PAGE = 'PROFILE_PAGE';
+export const MENU_PAGE = 'MENU_PAGE';
+export const SERVICES_PAGE = 'SERVICES_PAGE';
 
 //The maximum number of pages allowed
 export const PAGE_LIMIT = 5;

--- a/client/signup/difm/translation-hooks.tsx
+++ b/client/signup/difm/translation-hooks.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import {
 	HOME_PAGE,
 	BLOG_PAGE,
@@ -12,30 +13,36 @@ import {
 	FAQ_PAGE,
 	SITEMAP_PAGE,
 	PROFILE_PAGE,
+	MENU_PAGE,
+	SERVICES_PAGE,
 } from 'calypso/signup/difm/constants';
 import type { TranslateResult } from 'i18n-calypso';
 
 /**
  * Provides the universal translated set of page titles available for DIFM
  *
- * @param pageId
  * @returns
  */
-export function useTranslatedPageTitles( pageId: string ) {
+export function useTranslatedPageTitles() {
 	const translate = useTranslate();
-	const pages: Record< string, TranslateResult > = {
-		[ HOME_PAGE ]: translate( 'Home' ),
-		[ BLOG_PAGE ]: translate( 'Blog' ),
-		[ CONTACT_PAGE ]: translate( 'Contact' ),
-		[ ABOUT_PAGE ]: translate( 'About' ),
-		[ PHOTO_GALLERY_PAGE ]: translate( 'Photo Gallery' ),
-		[ SERVICE_SHOWCASE_PAGE ]: translate( 'Showcase A Service' ),
-		[ VIDEO_GALLERY_PAGE ]: translate( 'Video Gallery' ),
-		[ PODCAST_PAGE ]: translate( 'Podcast' ),
-		[ PORTFOLIO_PAGE ]: translate( 'Portfolio' ),
-		[ FAQ_PAGE ]: translate( 'FAQ' ),
-		[ SITEMAP_PAGE ]: translate( 'Sitemap' ),
-		[ PROFILE_PAGE ]: translate( 'Profile' ),
-	};
-	return pages[ pageId ];
+	const pages: Record< string, TranslateResult > = useMemo(
+		() => ( {
+			[ HOME_PAGE ]: translate( 'Home' ),
+			[ BLOG_PAGE ]: translate( 'Blog' ),
+			[ CONTACT_PAGE ]: translate( 'Contact' ),
+			[ ABOUT_PAGE ]: translate( 'About' ),
+			[ PHOTO_GALLERY_PAGE ]: translate( 'Photo Gallery' ),
+			[ SERVICE_SHOWCASE_PAGE ]: translate( 'Showcase A Service' ),
+			[ VIDEO_GALLERY_PAGE ]: translate( 'Video Gallery' ),
+			[ PODCAST_PAGE ]: translate( 'Podcast' ),
+			[ PORTFOLIO_PAGE ]: translate( 'Portfolio' ),
+			[ FAQ_PAGE ]: translate( 'FAQ' ),
+			[ SITEMAP_PAGE ]: translate( 'Sitemap' ),
+			[ PROFILE_PAGE ]: translate( 'Profile' ),
+			[ MENU_PAGE ]: translate( 'Menu' ),
+			[ SERVICES_PAGE ]: translate( 'Services' ),
+		} ),
+		[ translate ]
+	);
+	return pages;
 }

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -98,7 +98,7 @@ function PageCell( { pageId, popular, selectedPages, onClick }: PageCellType ) {
 	const totalSelections = selectedPages.length;
 	const isSelected = Boolean( selectedIndex > -1 );
 	const isDisabled = selectedIndex === -1 && totalSelections >= PAGE_LIMIT;
-	const title = useTranslatedPageTitles( pageId );
+	const title = useTranslatedPageTitles()[ pageId ];
 
 	return (
 		<GridCellContainer

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -7,6 +7,15 @@ import { useEffect, useState, ChangeEvent, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import AccordionForm from 'calypso/signup/accordion-form/accordion-form';
 import { ValidationErrors } from 'calypso/signup/accordion-form/types';
+import {
+	PORTFOLIO_PAGE,
+	HOME_PAGE,
+	ABOUT_PAGE,
+	CONTACT_PAGE,
+	MENU_PAGE,
+	SERVICES_PAGE,
+} from 'calypso/signup/difm/constants';
+import { useTranslatedPageTitles } from 'calypso/signup/difm/translation-hooks';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import getDIFMLiteSiteCategory from 'calypso/state/selectors/get-difm-lite-site-category';
 import isDIFMLiteInProgress from 'calypso/state/selectors/is-difm-lite-in-progress';
@@ -80,30 +89,31 @@ function WebsiteContentStep( {
 	);
 
 	const [ isConfirmDialogOpen, setIsConfirmDialogOpen ] = useState( false );
+	const translatedPageTitles = useTranslatedPageTitles();
 
 	useEffect( () => {
 		function getPageFromCategory( category: string | null ) {
 			switch ( category ) {
 				case 'creative-arts':
-					return { id: 'Portfolio', name: translate( 'Portfolio' ) };
+					return { id: PORTFOLIO_PAGE, name: translatedPageTitles[ PORTFOLIO_PAGE ] };
 				case 'restaurant':
-					return { id: 'Menu', name: translate( 'Menu' ) };
+					return { id: MENU_PAGE, name: translatedPageTitles[ MENU_PAGE ] };
 				default:
-					return { id: 'Services', name: translate( 'Services' ) };
+					return { id: SERVICES_PAGE, name: translatedPageTitles[ SERVICES_PAGE ] };
 			}
 		}
 
 		if ( siteCategory ) {
 			dispatch(
 				initializePages( [
-					{ id: 'Home', name: translate( 'Home' ) },
-					{ id: 'About', name: translate( 'About' ) },
-					{ id: 'Contact', name: translate( 'Contact' ) },
+					{ id: HOME_PAGE, name: translatedPageTitles[ HOME_PAGE ] },
+					{ id: ABOUT_PAGE, name: translatedPageTitles[ ABOUT_PAGE ] },
+					{ id: CONTACT_PAGE, name: translatedPageTitles[ CONTACT_PAGE ] },
 					getPageFromCategory( siteCategory ),
 				] )
 			);
 		}
-	}, [ dispatch, siteCategory, translate ] );
+	}, [ dispatch, siteCategory, translate, translatedPageTitles ] );
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );

--- a/client/signup/steps/website-content/section-generator.tsx
+++ b/client/signup/steps/website-content/section-generator.tsx
@@ -1,3 +1,4 @@
+import { CONTACT_PAGE } from 'calypso/signup/difm/constants';
 import { WebsiteContent } from 'calypso/state/signup/steps/website-content/schema';
 import { LogoUploadSection } from './logo-upload-section';
 import { CONTENT_SUFFIX, PageDetails } from './page-details';
@@ -13,9 +14,9 @@ const generateWebsiteContentSections = (
 ) => {
 	const { translate, formValues, formErrors, onChangeField } = params;
 
-	const OPTIONAL_PAGES: Record< string, boolean > = { Contact: true };
+	const OPTIONAL_PAGES: Record< string, boolean > = { [ CONTACT_PAGE ]: true };
 	const PAGE_LABELS: Record< string, TranslateResult > = {
-		Contact: translate(
+		[ CONTACT_PAGE ]: translate(
 			"We'll add a standard contact form on this page, plus a comment box. " +
 				'If you would like text to appear above this form, please enter it below.'
 		),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There are a few related changes in this PR for the Website Content step of the DIFM flow. This PR adds some groundwork to make future changes easier. The next change is to add more text fields to the Contact page section of this step.

* Use the new page IDs introduced in #61790.
* Add MENU_PAGE and SERVICE_PAGE as constants. These don't need to be added to the `page-picker` component, however.
* Modify `useTranslatedPageTitles` to return all translated page titles instead for a particular page id. This makes the hook easier to use and we avoid calling the hook multiple times in `client/signup/steps/website-content/index.tsx`.
* Also added `useMemo` to `useTranslatedPageTitles` so that the `translate` function is not executed every time this hook is executed. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`.
* After checkout, on the Website Content step, confirm that all the page titles are displayed correctly.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

