### PR TITLE
My-sites: add sub-header to Reusable Blocks type page

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -157,6 +157,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/manage-purchases/',
 		post_id: 111349,
 	},
+	'reusable-blocks': {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/reusable-block/',
+		post_id: 157539,
+	},
 	'site-speed': {
 		link: 'https://wordpress.com/support/site-speed/',
 		post_id: 150474,

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -28,24 +28,41 @@ function Types( {
 	translate,
 } ) {
 	let subHeaderText = '';
-	if ( 'Testimonials' === get( postType, 'label', '' ) ) {
-		subHeaderText = translate(
-			'Create and manage all the testimonials on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-			{
-				components: {
-					learnMoreLink: <InlineSupportLink supportContext="testimonials" showIcon={ false } />,
-				},
-			}
-		);
-	} else if ( 'Projects' === get( postType, 'label', '' ) ) {
-		subHeaderText = translate(
-			'Create, edit, and manage the portfolio projects on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-			{
-				components: {
-					learnMoreLink: <InlineSupportLink supportContext="portfolios" showIcon={ false } />,
-				},
-			}
-		);
+	switch ( get( postType, 'label', '' ) ) {
+		case 'Testimonials':
+			subHeaderText = translate(
+				'Create and manage all the testimonials on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+				{
+					components: {
+						learnMoreLink: <InlineSupportLink supportContext="testimonials" showIcon={ false } />,
+					},
+				}
+			);
+			break;
+
+		case 'Projects':
+			subHeaderText = translate(
+				'Create, edit, and manage the portfolio projects on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+				{
+					components: {
+						learnMoreLink: <InlineSupportLink supportContext="portfolios" showIcon={ false } />,
+					},
+				}
+			);
+			break;
+
+		case 'Reusable blocks':
+			subHeaderText = translate(
+				'Create, edit, and manage the reusable blocks on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+				{
+					components: {
+						learnMoreLink: (
+							<InlineSupportLink supportContext="reusable-blocks" showIcon={ false } />
+						),
+					},
+				}
+			);
+			break;
 	}
 
 	return (


### PR DESCRIPTION
## Changes proposed in this Pull Request

To offer more context and help to users, this change adds a sub-header with a support link. This was already accounted for with Portfolio and Testimony types we just needed to extend it to apply to Reusable Blocks.

## Testing instructions

1. Pull and `yarn start`
2. Go to http://calypso.localhost:3000/types/wp_block/
3. Make sure the subheader is showing and the link is correct.

<img width="726" alt="Markup 2022-03-24 at 11 51 10" src="https://user-images.githubusercontent.com/33258733/159900802-ac533ff5-3f63-45d7-b537-acb090de1eb5.png">

Related to #60876 
Fixes #60876 