### PR TITLE
Add description item to filter array and set to the subHeader

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -84,7 +84,6 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/import/import-from-squarespace/',
 		post_id: 87696,
 	},
-	// @TODO: This isn't a real page and the post_id is Squarespace
 	'importers-substack': {
 		link: 'https://wordpress.com/support/import/import-from-substack/',
 		post_id: 87696,
@@ -97,17 +96,21 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/moving-from-self-hosted-wordpress-to-wordpress-com/',
 		post_id: 102755,
 	},
+	'introduction-to-woocommerce': {
+		link: 'https://wordpress.com/support/introduction-to-woocommerce/',
+		post_id: 176336,
+	},
 	invites: {
 		link: 'https://wordpress.com/support/user-roles/#adding-users-to-your-site',
 		post_id: 1221,
 	},
-	media: {
-		link: 'https://wordpress.com/support/media/',
-		post_id: 853,
-	},
 	'manage-profile': {
 		link: 'https://wordpress.com/support/manage-my-profile/',
 		post_id: 19775,
+	},
+	media: {
+		link: 'https://wordpress.com/support/media/',
+		post_id: 853,
 	},
 	menus: {
 		link: 'https://wordpress.com/support/menus/',
@@ -121,16 +124,16 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/paid-newsletters/',
 		post_id: 168381,
 	},
+	payment_method_all_subscriptions: {
+		link: 'https://wordpress.com/support/payment/#using-a-payment-method-for-all-subscriptions',
+		post_id: 76237,
+	},
 	payment_methods: {
 		link: 'https://wordpress.com/support/payment/',
 		post_id: 76237,
 	},
 	payment_methods_manage: {
 		link: 'https://wordpress.com/support/payment/#manage-payment-methods',
-		post_id: 76237,
-	},
-	payment_method_all_subscriptions: {
-		link: 'https://wordpress.com/support/payment/#using-a-payment-method-for-all-subscriptions',
 		post_id: 76237,
 	},
 	performance: {
@@ -169,6 +172,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/reusable-block/',
 		post_id: 157539,
 	},
+	sharing: {
+		link: 'https://wordpress.com/support/sharing/',
+		post_id: 7499,
+	},
 	'site-speed': {
 		link: 'https://wordpress.com/support/site-speed/',
 		post_id: 150474,
@@ -205,21 +212,21 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/changing-themes/',
 		post_id: 184023,
 	},
-	'themes-upload': {
-		link: 'https://wordpress.com/support/themes/uploading-setting-up-custom-themes/',
-		post_id: 134784,
-	},
 	'themes-unsupported': {
 		link: 'https://wordpress.com/support/plugins/third-party-plugins-and-themes-support/',
 		post_id: 174865,
 	},
+	'themes-upload': {
+		link: 'https://wordpress.com/support/themes/uploading-setting-up-custom-themes/',
+		post_id: 134784,
+	},
+	traffic: {
+		link: 'https://wordpress.com/support/traffic/',
+		post_id: 155209,
+	},
 	'webmaster-tools': {
 		link: 'https://wordpress.com/support/webmaster-tools/',
 		post_id: 5022,
-	},
-	'introduction-to-woocommerce': {
-		link: 'https://wordpress.com/support/introduction-to-woocommerce/',
-		post_id: 176336,
 	},
 };
 

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -52,7 +52,7 @@ export const Sharing = ( {
 			route: '/marketing/traffic' + pathSuffix,
 			title: translate( 'Traffic' ),
 			description: translate(
-				'Manage settings and tools related to the traffic your website receives. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',
+				'Manage settings and tools related to the traffic your website receives. {{learnMoreLink/}}',
 				{
 					components: {
 						learnMoreLink: (
@@ -71,7 +71,7 @@ export const Sharing = ( {
 		route: '/marketing/connections' + pathSuffix,
 		title: translate( 'Connections' ),
 		description: translate(
-			'Connect your site to social networks and other services. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',
+			'Connect your site to social networks and other services. {{learnMoreLink/}}',
 			{
 				components: {
 					learnMoreLink: (
@@ -96,7 +96,9 @@ export const Sharing = ( {
 				'Make it easy for your readers to share your content online. {{learnMoreLink/}}',
 				{
 					components: {
-						learnMoreLink: <InlineSupportLink key="sharing" supportContext="sharing" />,
+						learnMoreLink: (
+							<InlineSupportLink key="sharing" supportContext="sharing" showIcon={ false } />
+						),
 					},
 				}
 			),

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -1,6 +1,6 @@
 import { FEATURE_NO_ADS } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
-import { find, get } from 'lodash';
+import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -133,17 +133,16 @@ export const Sharing = ( {
 				brandFont
 				className="marketing__page-heading"
 				headerText={ titleHeader }
-				subHeaderText={ get(
-					selected,
-					'description',
+				subHeaderText={
+					selected?.description ??
 					translate(
 						'Explore tools to build your audience, market your site, and engage your visitors.'
 					)
-				) }
+				}
 				align="left"
 			/>
 			{ filters.length > 0 && (
-				<SectionNav selectedText={ get( selected, 'title', '' ) }>
+				<SectionNav selectedText={ selected?.title ?? '' }>
 					<NavTabs>
 						{ filters.map( ( { id, route, title } ) => (
 							<NavItem key={ id } path={ route } selected={ pathname === route }>

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -7,6 +7,7 @@ import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
@@ -50,6 +51,16 @@ export const Sharing = ( {
 			id: 'traffic',
 			route: '/marketing/traffic' + pathSuffix,
 			title: translate( 'Traffic' ),
+			description: translate(
+				'Manage settings and tools related to the traffic your website receives. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',
+				{
+					components: {
+						learnMoreLink: (
+							<InlineSupportLink key="traffic" supportContext="traffic" showIcon={ false } />
+						),
+					},
+				}
+			),
 		} );
 	}
 
@@ -59,6 +70,16 @@ export const Sharing = ( {
 		id: 'sharing-connections',
 		route: '/marketing/connections' + pathSuffix,
 		title: translate( 'Connections' ),
+		description: translate(
+			'Connect your site to social networks and other services. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',
+			{
+				components: {
+					learnMoreLink: (
+						<InlineSupportLink key="publicize" supportContext="publicize" showIcon={ false } />
+					),
+				},
+			}
+		),
 	};
 	if ( showConnections ) {
 		filters.push( connectionsFilter );
@@ -71,6 +92,14 @@ export const Sharing = ( {
 			id: 'sharing-buttons',
 			route: '/marketing/sharing-buttons' + pathSuffix,
 			title: translate( 'Sharing Buttons' ),
+			description: translate(
+				'Make it easy for your readers to share your content online. {{learnMoreLink/}}',
+				{
+					components: {
+						learnMoreLink: <InlineSupportLink key="sharing" supportContext="sharing" />,
+					},
+				}
+			),
 		} );
 	}
 
@@ -86,13 +115,10 @@ export const Sharing = ( {
 
 	// For p2 hub sites show only connections tab
 	let titleHeader = translate( 'Marketing and Integrations' );
-	let description = translate(
-		'Explore tools to build your audience, market your site, and engage your visitors.'
-	);
+
 	if ( isP2Hub ) {
 		filters = [ connectionsFilter ];
 		titleHeader = translate( 'Integrations' );
-		description = translate( 'Explore tools to connect to your P2.' );
 	}
 
 	const selected = find( filters, { route: pathname } );
@@ -105,7 +131,13 @@ export const Sharing = ( {
 				brandFont
 				className="marketing__page-heading"
 				headerText={ titleHeader }
-				subHeaderText={ description }
+				subHeaderText={ get(
+					selected,
+					'description',
+					translate(
+						'Explore tools to build your audience, market your site, and engage your visitors.'
+					)
+				) }
 				align="left"
 			/>
 			{ filters.length > 0 && (


### PR DESCRIPTION
## Changes proposed in this Pull Request

To offer more context and help to users, this change adds a relevant sub-header with a support link to each tab of the Marketing and Integrations page. The sub-header was already there for the page, I only needed to include a `description` item to each filter then plug that into the `subHeader` prop. In the absence of a description, it should return the default description that is shown for the Marketing Tools tab.

I also alphabetized the `context-links.js` for clarity.

<img width="852" alt="Markup 2022-03-24 at 13 18 29" src="https://user-images.githubusercontent.com/33258733/159914704-6afd74eb-c982-4c02-bf4b-6842c84dd529.png">

![Screen Capture on 2022-03-24 at 13-17-43](https://user-images.githubusercontent.com/33258733/159914798-b62ca9dc-df6a-4e51-b186-64ec611b9643.gif)

## Testing instructions

1. Pull and `yarn start`
2. Navigate to Tools ⇢ [Marketing](http://calypso.localhost:3000/marketing/tools)
3. Cycle through each of the subpages Traffic, Connections, Sharing buttons, etc and make sure the subheading text changes and the Learn More link is working.

Related to #60876 
