### PR TITLE
Plans overhaul Phase 1: Show updated Pro plan storage limits without enforcing them

### DIFF
--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -3,9 +3,7 @@ import {
 	planHasFeature,
 	isBusinessPlan,
 	isEcommercePlan,
-	PLAN_FREE,
 	PLAN_WPCOM_PRO,
-	PLAN_WPCOM_FLEXIBLE,
 	isProPlan,
 } from '@automattic/calypso-products';
 import classNames from 'classnames';
@@ -44,9 +42,6 @@ export function PlanStorage( { children, className, siteId } ) {
 	}
 
 	if ( eligibleForProPlan && mediaStorage ) {
-		if ( sitePlanSlug === PLAN_FREE || sitePlanSlug === PLAN_WPCOM_FLEXIBLE ) {
-			mediaStorage.max_storage_bytes = 500 * 1024 * 1024;
-		}
 		if ( sitePlanSlug === PLAN_WPCOM_PRO ) {
 			mediaStorage.max_storage_bytes = 50 * 1024 * 1024 * 1024;
 		}

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -3,7 +3,9 @@ import {
 	planHasFeature,
 	isBusinessPlan,
 	isEcommercePlan,
+	PLAN_FREE,
 	PLAN_WPCOM_PRO,
+	PLAN_WPCOM_FLEXIBLE,
 	isProPlan,
 } from '@automattic/calypso-products';
 import classNames from 'classnames';
@@ -42,6 +44,9 @@ export function PlanStorage( { children, className, siteId } ) {
 	}
 
 	if ( eligibleForProPlan && mediaStorage ) {
+		if ( sitePlanSlug === PLAN_FREE || sitePlanSlug === PLAN_WPCOM_FLEXIBLE ) {
+			mediaStorage.max_storage_bytes = 500 * 1024 * 1024;
+		}
 		if ( sitePlanSlug === PLAN_WPCOM_PRO ) {
 			mediaStorage.max_storage_bytes = 50 * 1024 * 1024 * 1024;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This ensures that the updated storage limits are shown for the overhauled Free and Pro plans, without imposing them.
- Free Plan: show 500MB - enforce 3GB
- Pro Plan: show 50GB - enforce 200GB

#### Testing instructions

##### Overhauled Plans

* Go to `/media/[site]?flags=plans/pro-plan` on a Free plan site
* The limit should be 500MB
<img width="320" alt="Screenshot on 2022-03-28 at 12-49-54" src="https://user-images.githubusercontent.com/2749938/160372968-7ee08c6f-1889-41ee-a478-2f44dbb51c6e.png">

* Uploading more than 500MB, but less than 3GB should be allowed

* Go to `/media/[site]?flags=plans/pro-plan` on a Pro plan site
* The limit should be 50GB
<img width="320" alt="Screenshot on 2022-03-24 at 14-30-54" src="https://user-images.githubusercontent.com/2749938/159917258-749cdbdf-3781-44ca-b4a2-f56737835dff.png">

* The Upgrade button should not be visible


##### Legacy Plans

* Go to `/media/[site]` on a Free plan site
* The limit should be 3GB
<img width="320" alt="Screenshot on 2022-03-28 at 12-51-47" src="https://user-images.githubusercontent.com/2749938/160373239-bd324ff6-ffbd-421f-a14d-5cb20e5fca0e.png">


* Go to `/media/[site]` on a Pro plan site (or Business)
* The limit should be 200GB
<img width="320" alt="Screenshot 2022-03-24 at 14 35 35" src="https://user-images.githubusercontent.com/2749938/159917447-e391e5b9-797c-4153-a9cc-f1d8682a2aac.png">

