### PR TITLE
Components: Count ref error fix

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 import { Dialog, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -140,7 +141,7 @@ class TaxonomyManagerListItem extends Component {
 
 		return (
 			<div className={ className }>
-				<span className="taxonomy-manager__icon" onClick={ onClick }>
+				<span role="img" className="taxonomy-manager__icon" onClick={ onClick }>
 					<Gridicon icon={ isDefault ? 'checkmark-circle' : 'folder' } />
 				</span>
 				{ /* FIXME: jsx-a11y issues */ }
@@ -159,7 +160,7 @@ class TaxonomyManagerListItem extends Component {
 				{ typeof term.post_count !== 'undefined' && (
 					<div className="taxonomy-manager__count">
 						<Count
-							ref={ this.countRef }
+							forwardRef={ this.countRef }
 							count={ term.post_count }
 							onMouseEnter={ this.showTooltip }
 							onMouseLeave={ this.hideTooltip }

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import { Dialog, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -140,9 +138,21 @@ class TaxonomyManagerListItem extends Component {
 			{ action: 'delete', label: translate( 'OK' ), isPrimary: true },
 		];
 
+		const onKeyUp = ( event ) => {
+			if ( event.key === 'Enter' ) {
+				onClick();
+			}
+		};
+
 		return (
 			<div className={ className }>
-				<span role="img" className="taxonomy-manager__icon" onClick={ onClick }>
+				<span
+					className="taxonomy-manager__icon"
+					role="button"
+					tabIndex={ 0 }
+					onKeyUp={ onKeyUp }
+					onClick={ onClick }
+				>
 					<Gridicon icon={ isDefault ? 'checkmark-circle' : 'folder' } />
 				</span>
 				{ /* FIXME: jsx-a11y issues */ }

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import { Dialog, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';

--- a/client/components/count/index.jsx
+++ b/client/components/count/index.jsx
@@ -24,10 +24,7 @@ Count.propTypes = {
 	numberFormat: PropTypes.func,
 	primary: PropTypes.bool,
 	compact: PropTypes.bool,
-	refProp: PropTypes.oneOfType( [
-		PropTypes.func,
-		PropTypes.shape( { current: PropTypes.instanceOf( Element ) } ),
-	] ),
+	refProp: PropTypes.oneOfType( [ PropTypes.func, PropTypes.shape( { current: PropTypes.any } ) ] ),
 };
 
 Count.defaultProps = {

--- a/client/components/count/index.jsx
+++ b/client/components/count/index.jsx
@@ -6,10 +6,11 @@ import formatNumberCompact from 'calypso/lib/format-number-compact';
 
 import './style.scss';
 
-export const Count = ( { count, compact, numberFormat, primary, ...inheritProps } ) => {
+export const Count = ( { count, compact, numberFormat, forwardRef, primary, ...inheritProps } ) => {
 	return (
 		// Omit props passed from the `localize` higher-order component that we don't need.
 		<span
+			ref={ forwardRef }
 			className={ classnames( 'count', { 'is-primary': primary } ) }
 			{ ...omit( inheritProps, [ 'translate', 'moment' ] ) }
 		>
@@ -23,6 +24,10 @@ Count.propTypes = {
 	numberFormat: PropTypes.func,
 	primary: PropTypes.bool,
 	compact: PropTypes.bool,
+	refProp: PropTypes.oneOfType( [
+		PropTypes.func,
+		PropTypes.shape( { current: PropTypes.instanceOf( Element ) } ),
+	] ),
 };
 
 Count.defaultProps = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While working on updating the `<Taxonomies />` I kept getting an error for ref elements being passed to function components. I traced this back to `<Count />` and decided to add the ref to the component and pass this in as a Prop instead.

The ref is now passed in as `forwardRef`. I searched to make sure there were no other instances where `ref` was attempting to be passed in.

AND.... apparently this fixes the hover card that is supposed to appear

<img width="366" alt="Markup 2022-03-24 at 17 20 51" src="https://user-images.githubusercontent.com/33258733/159962920-f9defce6-9f8d-44b9-a14a-6e068b34c6e1.png">

#### Testing instructions

1. Pull and `yarn start`
2. Go to Posts ⇢ Categories
3. Check that there are no errors in the console and the count is showing properly.
4. Check the Tags section as well.

<img width="1587" alt="Markup 2022-03-24 at 16 45 29" src="https://user-images.githubusercontent.com/33258733/159957161-08b60bf3-273d-4ddc-916a-36e588a36be3.png">

