### PR TITLE
Components: Refactor `PostSchedule` away from `UNSAFE_` methods

### DIFF
--- a/client/components/post-schedule/docs/example.jsx
+++ b/client/components/post-schedule/docs/example.jsx
@@ -54,13 +54,9 @@ const PostScheduleExample = localize(
 					eventsByDay: [],
 					showTooltip: false,
 					tooltipContext: null,
-				};
-			}
 
-			UNSAFE_componentWillMount() {
-				this.setState( {
 					isFuture: true,
-				} );
+				};
 			}
 
 			setDate = ( date ) => {

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -13,6 +13,9 @@ import { convertDateToUserLocation, convertDateToGivenOffset } from './utils';
 import './style.scss';
 
 const noop = () => {};
+const getDateToUserLocation = ( date, timezone, gmtOffset ) => {
+	return convertDateToUserLocation( date || new Date(), timezone, gmtOffset );
+};
 
 export default class PostSchedule extends Component {
 	static propTypes = {
@@ -44,35 +47,19 @@ export default class PostSchedule extends Component {
 		showTooltip: false,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		if ( ! this.props.selectedDay ) {
-			return this.setState( {
+	static getDerivedStateFromProps( { selectedDay, timezone, gmtOffset }, { isFutureDate } ) {
+		if ( ! selectedDay ) {
+			return {
 				localizedDate: null,
 				isFutureDate: false,
-			} );
+			};
 		}
 
-		const localizedDate = this.getDateToUserLocation( this.props.selectedDay );
-		this.setState( {
+		const localizedDate = getDateToUserLocation( selectedDay, timezone, gmtOffset );
+		return {
 			localizedDate,
-			isFutureDate: localizedDate.isAfter(),
-		} );
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.selectedDay === nextProps.selectedDay ) {
-			return;
-		}
-
-		if ( ! nextProps.selectedDay ) {
-			return this.setState( { localizedDate: null } );
-		}
-
-		this.setState( {
-			localizedDate: this.getDateToUserLocation( nextProps.selectedDay ),
-		} );
+			isFutureDate: isFutureDate === undefined ? localizedDate.isAfter() : isFutureDate,
+		};
 	}
 
 	getLocaleUtils() {
@@ -100,11 +87,7 @@ export default class PostSchedule extends Component {
 	}
 
 	getDateToUserLocation( date ) {
-		return convertDateToUserLocation(
-			date || new Date(),
-			this.props.timezone,
-			this.props.gmtOffset
-		);
+		return getDateToUserLocation( date, this.props.timezone, this.props.gmtOffset );
 	}
 
 	setCurrentMonth = ( date ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `PostSchedule` component away from the `UNSAFE_` deprecated React component methods.

We use `getDerivedStateFromProps` because the original component essentially unconditionally derives state from props, so it only makes sense to use API in this scenario.

Part of #58453.

#### Testing instructions
* Go to `/devdocs/blocks/post-schedule`
* Try selecting past dates, future dates, and today, and verify everything works as it does in production.