### PR TITLE
Remove the new .org plugins section from plugins browser

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -81,10 +81,6 @@ const SEARCH_RESULTS_LIST_LENGTH = 12;
 
 const translateCategory = ( { category, translate } ) => {
 	switch ( category ) {
-		case 'new':
-			return translate( 'New', {
-				context: 'Category description for the plugin browser.',
-			} );
 		case 'popular':
 			return translate( 'Popular', {
 				context: 'Category description for the plugin browser.',
@@ -104,8 +100,6 @@ const translateCategory = ( { category, translate } ) => {
 
 const translateCategoryTitle = ( { category, translate } ) => {
 	switch ( category ) {
-		case 'new':
-			return translate( 'All New Plugins' );
 		case 'popular':
 			return translate( 'All Popular Plugins' );
 		case 'featured':
@@ -165,10 +159,6 @@ const PluginsBrowser = ( {
 		data: { plugins: pluginsByCategory = [] } = {},
 		isLoading: isFetchingPluginsByCategory,
 	} = useWPORGPlugins( { category } );
-	const {
-		data: { plugins: pluginsByCategoryNew = [] } = {},
-		isLoading: isFetchingPluginsByCategoryNew,
-	} = useWPORGPlugins( { category: 'new' } );
 	const {
 		data: pluginsByCategoryFeatured = [],
 		isLoading: isFetchingPluginsByCategoryFeatured,
@@ -339,8 +329,6 @@ const PluginsBrowser = ( {
 				searchTerms={ [ 'shipping', 'seo', 'portfolio', 'chat', 'mailchimp' ] }
 			/>
 			<PluginBrowserContent
-				pluginsByCategoryNew={ pluginsByCategoryNew }
-				isFetchingPluginsByCategoryNew={ isFetchingPluginsByCategoryNew }
 				pluginsByCategoryPopular={ pluginsByCategoryPopular }
 				isFetchingPluginsByCategoryPopular={ isFetchingPluginsByCategoryPopular }
 				pluginsByCategoryFeatured={ pluginsByCategoryFeatured }
@@ -533,8 +521,6 @@ const FullListView = ( {
 
 const PluginSingleListView = ( {
 	category,
-	pluginsByCategoryNew,
-	isFetchingPluginsByCategoryNew,
 	pluginsByCategoryPopular,
 	isFetchingPluginsByCategoryPopular,
 	pluginsByCategoryFeatured,
@@ -556,10 +542,7 @@ const PluginSingleListView = ( {
 
 	let plugins;
 	let isFetching;
-	if ( category === 'new' ) {
-		plugins = pluginsByCategoryNew;
-		isFetching = isFetchingPluginsByCategoryNew;
-	} else if ( category === 'popular' ) {
+	if ( category === 'popular' ) {
 		plugins = pluginsByCategoryPopular;
 		isFetching = isFetchingPluginsByCategoryPopular;
 	} else if ( category === 'featured' ) {
@@ -618,7 +601,6 @@ const PluginBrowserContent = ( props ) => {
 			) }
 
 			<PluginSingleListView { ...props } category="popular" />
-			<PluginSingleListView { ...props } category="new" />
 		</>
 	);
 };

--- a/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
+++ b/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
@@ -25,7 +25,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			await pluginsPage.visit();
 		} );
 
-		it.each( [ 'Premium', 'Featured', 'Popular', 'New' ] )(
+		it.each( [ 'Premium', 'Featured', 'Popular' ] )(
 			'Plugins page loads %s section',
 			async function ( section: string ) {
 				await pluginsPage.validateHasSection( section );
@@ -64,7 +64,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			await pluginsPage.visit( siteUrl );
 		} );
 
-		it.each( [ 'Premium', 'Featured', 'Popular', 'New' ] )(
+		it.each( [ 'Premium', 'Featured', 'Popular' ] )(
 			'Plugins page loads %s section',
 			async function ( section: string ) {
 				await pluginsPage.validateHasSection( section );

--- a/test/e2e/specs/plugins/plugins__browser-jetpack-user.ts
+++ b/test/e2e/specs/plugins/plugins__browser-jetpack-user.ts
@@ -30,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:jetpack-site' ), 
 		await pluginsPage.visit( siteUrl );
 	} );
 
-	it.each( [ 'Featured', 'Popular', 'New' ] )(
+	it.each( [ 'Premium', 'Featured', 'Popular' ] )(
 		'Plugins page loads %s section',
 		async function ( section: string ) {
 			await pluginsPage.validateHasSection( section );

--- a/test/e2e/specs/plugins/plugins__browser-jetpack-user.ts
+++ b/test/e2e/specs/plugins/plugins__browser-jetpack-user.ts
@@ -30,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:jetpack-site' ), 
 		await pluginsPage.visit( siteUrl );
 	} );
 
-	it.each( [ 'Premium', 'Featured', 'Popular' ] )(
+	it.each( [ 'Featured', 'Popular' ] )(
 		'Plugins page loads %s section',
 		async function ( section: string ) {
 			await pluginsPage.validateHasSection( section );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `New` section from the plugins browser

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the `/plugins` page
* Verify that the `New` section is not shown
* Verify that there are no regressions

**The bottom-most section:**
| Before | After |
| ------ | ----- |
| <img width="977" alt="image" src="https://user-images.githubusercontent.com/11555574/159971097-d04a51fb-21e2-43ff-bdf4-07d758c951ab.png"> | <img width="977" alt="image" src="https://user-images.githubusercontent.com/11555574/159970766-2544b3cf-611c-443a-a559-ae493b063f2d.png"> |

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #62202