### PR TITLE
Taxonomy Pages: update styling and incorporate sub-header

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -19,6 +19,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/manage-purchases/#cancel-a-purchase',
 		post_id: 111349,
 	},
+	categories: {
+		link: 'https://wordpress.com/support/posts/categories/',
+		post_id: 8480,
+	},
 	comments: {
 		link: 'https://wordpress.com/support/comments/',
 		post_id: 113,
@@ -172,6 +176,10 @@ const contextLinks = {
 	stats: {
 		link: 'https://wordpress.com/support/stats/',
 		post_id: 4454,
+	},
+	tags: {
+		link: 'https://wordpress.com/support/posts/tags/',
+		post_id: 8586,
 	},
 	team: {
 		link: 'https://wordpress.com/support/user-roles/',

--- a/client/my-sites/site-settings/taxonomies/index.jsx
+++ b/client/my-sites/site-settings/taxonomies/index.jsx
@@ -1,33 +1,42 @@
+import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
-import page from 'page';
 import { connect } from 'react-redux';
 import TaxonomyManager from 'calypso/blocks/taxonomy-manager';
 import DocumentHead from 'calypso/components/data/document-head';
-import HeaderCake from 'calypso/components/header-cake';
+import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { getPostTypeTaxonomy } from 'calypso/state/post-types/taxonomies/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
-const Taxonomies = ( { translate, labels, postType, site, taxonomy } ) => {
-	const goBack = () => {
-		page( '/settings/writing/' + site.slug );
-	};
-
+const Taxonomies = ( { translate, labels, postType, taxonomy } ) => {
 	return (
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		<div className="main main-column" role="main">
+		<Main wideLayout className={ classnames( 'taxonomies', taxonomy ) }>
 			<ScreenOptionsTab wpAdminPath={ `edit-tags.php?taxonomy=${ taxonomy }` } />
 			<DocumentHead
 				title={ translate( 'Manage %(taxonomy)s', { args: { taxonomy: labels.name } } ) }
 			/>
-			<HeaderCake onClick={ goBack } className="header-cake--has-screen-options">
-				<h1>{ labels.name }</h1>
-			</HeaderCake>
+			<FormattedHeader
+				brandFont
+				headerText={ labels.name }
+				subHeaderText={ translate(
+					'Create, edit, and manage the %(taxonomy)s on your site. {{learnMoreLink/}}',
+					{
+						args: { taxonomy: taxonomy },
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="publicize" showIcon={ false } />,
+						},
+					}
+				) }
+				align="left"
+				hasScreenOptions
+			/>
 			<TaxonomyManager taxonomy={ taxonomy } postType={ postType } />
-		</div>
+		</Main>
 	);
 };
 

--- a/client/my-sites/site-settings/taxonomies/index.jsx
+++ b/client/my-sites/site-settings/taxonomies/index.jsx
@@ -14,6 +14,8 @@ import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 const Taxonomies = ( { translate, labels, postType, taxonomy } ) => {
+	const taxonomyName = labels.name?.toLowerCase();
+
 	return (
 		<Main wideLayout className={ classnames( 'taxonomies', taxonomy ) }>
 			<ScreenOptionsTab wpAdminPath={ `edit-tags.php?taxonomy=${ taxonomy }` } />
@@ -26,9 +28,15 @@ const Taxonomies = ( { translate, labels, postType, taxonomy } ) => {
 				subHeaderText={ translate(
 					'Create, edit, and manage the %(taxonomy)s on your site. {{learnMoreLink/}}',
 					{
-						args: { taxonomy: taxonomy },
+						args: { taxonomy: taxonomyName },
 						components: {
-							learnMoreLink: <InlineSupportLink supportContext="publicize" showIcon={ false } />,
+							learnMoreLink: (
+								<InlineSupportLink
+									key={ taxonomyName }
+									supportContext={ taxonomyName }
+									showIcon={ false }
+								/>
+							),
 						},
 					}
 				) }

--- a/client/my-sites/site-settings/taxonomies/style.scss
+++ b/client/my-sites/site-settings/taxonomies/style.scss
@@ -1,32 +1,3 @@
-.taxonomies__card-title {
-	font-size: $font-body;
-	line-height: 24px;
-	color: var( --color-neutral-70 );
-	padding-bottom: 10px;
-
-	&.is-loading {
-		@include placeholder();
-		width: 80px;
-		display: inline-block;
-	}
-}
-
-.taxonomies__card-content {
-	color: var( --color-text-subtle );
-	font-size: $font-body-small;
-	white-space: nowrap;
-	overflow: hidden;
-
-	&::after {
-		@include long-content-fade( $size: 40% );
-	}
-
-	.gridicon {
-		padding-right: 5px;
-		vertical-align: top;
-	}
-}
-
-.site-settings__taxonomies .card__link-indicator {
-	z-index: z-index( '.site-settings__taxonomies', '.card__link-indicator' );
+.taxonomy-manager__label {
+	font-weight: 500;
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

To offer more context and help to users, this change adds a sub-header with a support link to the taxonomy pages (Categories and Tags). Becasue there was no FormattedHeader in this component already I had to add one and mimicked the styling of the Posts and Pages page. All of the functions and components are the exact same.

The only thing that is missing is a `⇠ Back` button that oddly went to the Settings ⇢ Writing section. I also added some font-weight to closer match the Post and Page page.

I am not seeing this component utilized anywhere else in the codebase other that the sidebar. Please let me know if I missed something.

![Screen Capture on 2022-03-24 at 18-37-01](https://user-images.githubusercontent.com/33258733/159977291-6e7cb551-f444-4a3d-a08c-c6fe63423599.gif)

## Testing instructions

1. Pull and `yarn start`
2. Go to Post ⇢ Categories or Tags
3. Test to make sure all components work including the subheader link

| Before | After |
| - | - |
| <img width="765" alt="Markup 2022-03-24 at 18 38 45" src="https://user-images.githubusercontent.com/33258733/159977157-5403262d-c448-4745-9f93-a0b30cbf82af.png"> | <img width="1122" alt="Markup 2022-03-24 at 18 39 00" src="https://user-images.githubusercontent.com/33258733/159977214-a8ff4f4c-5dde-4b57-a4f3-7f9faf129cba.png"> |

Related to #60876 
