### PR TITLE
[E2E][GB][getTestAccountByFeature] Wildcard syntax + multi-account support for other editor tests

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/pay-with-paypal.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/pay-with-paypal.ts
@@ -34,6 +34,7 @@ export class PayWithPaypalBlockFlow implements BlockFlow {
 	blockSidebarName = 'Pay with Paypal';
 	blockEditorSelector = blockParentSelector;
 
+	// @todo the `configure` below should also support a target: SiteType option as it wraps the `EditorPage`
 	/**
 	 * Configure the block in the editor with the configuration data from the constructor
 	 *

--- a/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/new-post-flow.ts
@@ -19,6 +19,7 @@ export class NewPostFlow {
 		this.isLoggedIn = false;
 	}
 
+	// @todo there should be a way to pass a target: SiteType option as it wraps the `EditorPage` below
 	/**
 	 * Starts a new post from the navbar/masterbar button.
 	 *

--- a/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
+++ b/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
@@ -56,6 +56,14 @@ const defaultCriteria: FeatureCriteria[] = [
 		siteType: 'atomic',
 		accountName: 'gutenbergAtomicSiteEdgeUser',
 	},
+	// @todo consider adding a special '*' wildcard value to ignore certain
+	// features, for example: `gutenberg: '*', siteType: '*'`.
+	{ gutenberg: 'edge', variant: 'i18n', siteType: 'simple', accountName: 'i18nUser' },
+	{ gutenberg: 'stable', variant: 'i18n', siteType: 'simple', accountName: 'i18nUser' },
+	// we're effectivelly ignoring the atomic siteType here, by pointing to the same
+	// simple site even if "atomic"
+	{ gutenberg: 'edge', variant: 'i18n', siteType: 'atomic', accountName: 'i18nUser' },
+	{ gutenberg: 'stable', variant: 'i18n', siteType: 'atomic', accountName: 'i18nUser' },
 ];
 
 export default defaultCriteria;

--- a/packages/calypso-e2e/test/lib/utils/get-account-by-feature.test.ts
+++ b/packages/calypso-e2e/test/lib/utils/get-account-by-feature.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, test } from '@jest/globals';
 import {
 	getTestAccountByFeature,
 	envToFeatureKey,
+	expandIfWildcard,
 } from '../../../src/lib/utils/get-test-account-by-feature';
 import type {
 	FeatureCriteria,
@@ -152,6 +153,38 @@ describe( 'getTestAccountByFeature', function () {
 		);
 
 		expect( editorAccountName ).toBe( 'aNewAccount' );
+	} );
+
+	test.only( 'w', () => {
+		const foo = expandIfWildcard( {
+			gutenberg: '*',
+			coblocks: '*',
+			siteType: 'simple',
+			variant: '*',
+		} );
+
+		debugger;
+		/*const customCriteria: FeatureCriteria[] = [
+			{
+				gutenberg: '*',
+				coblocks: '*',
+				siteType: '*',
+				variant: '*',
+				accountName: 'accountFromWildCardCriteria',
+			},
+		];
+
+		expect(
+			getTestAccountByFeature(
+				{
+					gutenberg: 'edge',
+					coblocks: 'edge',
+					siteType: 'simple',
+				},
+				customCriteria
+			)
+		).toBe( 'accountFromWildCardCriteria' );
+		*/
 	} );
 } );
 

--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -12,9 +12,15 @@ import {
 	FileBlock,
 	TestFile,
 	TestAccount,
+	getTestAccountByFeature,
+	envToFeatureKey,
+	envVariables,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH, TEST_AUDIO_PATH } from '../constants';
+
+//const features = envToFeatureKey( envVariables );
+//const accountName = getTestAccountByFeature( features, [{gutenberg: '*', }] );
 
 declare const browser: Browser;
 

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -8,6 +8,8 @@ import {
 	EditorPage,
 	TestAccount,
 	envVariables,
+	getTestAccountByFeature,
+	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Page, Frame, Browser } from 'playwright';
 import type { LanguageSlug } from '@automattic/languages';
@@ -210,6 +212,9 @@ const translations: Translations = {
 declare const browser: Browser;
 
 describe( 'I18N: Editor', function () {
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( { ...features, variant: 'i18n' } );
+
 	// Filter out the locales that do not have valid translation content defined above.
 	const locales = Object.keys( translations ).filter( ( locale ) =>
 		( envVariables.TEST_LOCALES as ReadonlyArray< string > ).includes( locale )
@@ -226,7 +231,7 @@ describe( 'I18N: Editor', function () {
 			}
 		} );
 
-		const testAccount = new TestAccount( 'i18nUser' );
+		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 
 		editorPage = new EditorPage( page );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is an experiment at adding a wildcard syntax/engine to the declarative DSL used to configure test accounts. This is still a WIP. I might split this PR into two later (for the multi-account part, which was what led me to explore adding the wildcard syntax in order to simplify the accounts configuration table). 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
