### PR TITLE
[E2E][GB] Fix: Use `SiteType` in the `EditorPage` class' constructor param

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -50,7 +50,7 @@ export class EditorPage {
 	 * @param param0 Keyed object parameter.
 	 * @param param0.target Target editor type. Defaults to 'simple'.
 	 */
-	constructor( page: Page, { target = 'simple' }: { target?: 'simple' | 'atomic' } = {} ) {
+	constructor( page: Page, { target = 'simple' }: { target?: SiteType } = {} ) {
 		if ( target === 'atomic' ) {
 			// For Atomic editors, there is no iFrame - the editor is
 			// part of the page DOM and is thus accessible directly.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Just a quick fix for a type that I forgot to replace

#### Testing instructions

* Tests should pass.

Related to #
