### PR TITLE
Show the new domain step plan upsell copy when condition is met.

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -1,28 +1,45 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
+import { connect } from 'react-redux';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
 class ReskinSideExplainer extends Component {
 	getStrings() {
-		const { type, translate } = this.props;
+		const { type, eligibleForProPlan, selectedSiteId, translate } = this.props;
 
 		let title;
 		let subtitle;
 		let ctaText;
 
+		// The special case latter is for handling the case in the sign-up flow.
+		// By that time, a site is not available yet, so we can only check the feature flag for now
+		const shouldShowProPlanTitle =
+			eligibleForProPlan || ( selectedSiteId == null && isEnabled( 'plans/pro-plan' ) );
+
 		switch ( type ) {
 			case 'free-domain-explainer':
-				title = translate(
-					'Get a {{b}}free{{/b}} one-year domain registration with any paid annual plan.',
-					{
-						components: { b: <strong /> },
-					}
-				);
+				title = shouldShowProPlanTitle
+					? translate(
+							'Get a {{b}}free{{/b}} one-year domain registration with your WordPress Pro annual plan.',
+							{
+								components: { b: <strong /> },
+							}
+					  )
+					: translate(
+							'Get a {{b}}free{{/b}} one-year domain registration with any paid annual plan.',
+							{
+								components: { b: <strong /> },
+							}
+					  );
+
 				subtitle = translate(
 					"You can claim your free custom domain later if you aren't ready yet."
 				);
-				ctaText = translate( 'View plans' );
+				ctaText = translate( 'Choose my domain later' );
 				break;
 
 			case 'use-your-domain':
@@ -75,4 +92,11 @@ class ReskinSideExplainer extends Component {
 	}
 }
 
-export default localize( ReskinSideExplainer );
+export default connect( ( state ) => {
+	const selectedSiteId = getSelectedSiteId( state );
+
+	return {
+		selectedSiteId,
+		eligibleForProPlan: isEligibleForProPlan( state, selectedSiteId ),
+	};
+} )( localize( ReskinSideExplainer ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements the new plan upsell copy for the Pro plan, and updates "View Plan" as a more straightforward "Choose my domain later"

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/1842898/160067470-4aa96ab3-c0da-40f6-abe6-dc8b40a6d262.png">


#### Testing instructions

1. Create a new account with `plans/pro-plan` enabled.
2. Confirm that the new copies are shown in the domain step.
3. Create a new account with `plans/pro-plan` disabled.
4. Confirm that the original copies are shown in the domain step.