### PR TITLE
Plans Overhaul Phase 1: Hide the Free plan when a custom domain is picked

### DIFF
--- a/client/my-sites/plans-comparison/index.tsx
+++ b/client/my-sites/plans-comparison/index.tsx
@@ -1,2 +1,2 @@
-export { PlansComparison as default, globalOverrides } from './plans-comparison';
+export { PlansComparison as default } from './plans-comparison';
 export { isEligibleForProPlan } from './is-eligible-for-pro-plan';

--- a/client/my-sites/plans-comparison/plans-comparison-row.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-row.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import { intersection } from 'lodash';
-import { SCREEN_BREAKPOINT_SIGNUP, SCREEN_BREAKPOINT_PLANS } from './constant';
 import { PlansComparisonRowHeader } from './plans-comparison-row-header';
 import type { PlanComparisonFeature } from './plans-comparison-features';
 import type { WPComPlan } from '@automattic/calypso-products';
@@ -10,38 +9,14 @@ interface Props {
 	plans: WPComPlan[];
 }
 
-const DesktopContent = styled.div`
+export const DesktopContent = styled.div`
 	display: flex;
 	flex-direction: column;
-
-	@media screen and ( max-width: ${ SCREEN_BREAKPOINT_SIGNUP }px ) {
-		.is-section-signup & {
-			display: none;
-		}
-	}
-
-	@media screen and ( max-width: ${ SCREEN_BREAKPOINT_PLANS }px ) {
-		.is-section-plans & {
-			display: none;
-		}
-	}
 `;
 
-const MobileContent = styled.div`
+export const MobileContent = styled.div`
 	display: none;
 	font-weight: 400;
-
-	@media screen and ( max-width: ${ SCREEN_BREAKPOINT_SIGNUP }px ) {
-		.is-section-signup & {
-			display: block;
-		}
-	}
-
-	@media screen and ( max-width: ${ SCREEN_BREAKPOINT_PLANS }px ) {
-		.is-section-plans & {
-			display: block;
-		}
-	}
 `;
 
 const Title = styled.div`

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -28,6 +28,7 @@ import type { RequestCartProduct as CartItem } from '@automattic/shopping-cart';
 interface TableProps {
 	firstColWidth: number;
 	planCount: number;
+	hideFreePlan?: boolean;
 }
 
 const getRowMobileLayout = ( breakpoint: number, pageClass: string ) => `
@@ -55,169 +56,171 @@ const getRowMobileLayout = ( breakpoint: number, pageClass: string ) => `
 `;
 
 export const globalOverrides = css`
-	#content.layout__content {
-		overflow: unset;
-		min-height: 100vh !important;
-		background: #fdfdfd;
-		padding-left: 0;
-		padding-right: 0;
-		padding-top: 47px;
-	}
-
-	.layout__secondary {
-		box-shadow: 0 1px 0 1px rgba( 0, 0, 0, 0.1 );
-	}
-
-	.is-nav-unification .sidebar .sidebar__heading::after,
-	.is-nav-unification .sidebar .sidebar__menu-link::after {
-		html[dir='ltr'] & {
-			margin-right: -1px;
-			border-right-color: #fdfdfd;
-		}
-		html[dir='rtl'] & {
-			margin-left: -1px;
-			border-left-color: #fdfdfd;
-		}
-	}
-
-	.main.is-wide-layout.is-wide-layout {
-		max-width: 100%;
-	}
-
-	.formatted-header__title.formatted-header__title {
-		font-size: 1rem;
-		font-family: inherit !important;
-		font-weight: 600;
-		margin: 0 auto;
-		max-width: 1040px;
-
-		.gridicon {
-			margin-bottom: -2px;
-			fill: rgba( 140, 143, 148, 1 );
-		}
-	}
-
-	.formatted-header__subtitle {
-		display: none;
-	}
-
-	.formatted-header.formatted-header {
-		border-bottom: 1px solid #dcdcde;
-		padding-bottom: 24px;
-		margin: 0;
-
-		html[dir='ltr'] & {
-			padding: 12px 24px 24px calc( var( --sidebar-width-min ) + 24px + 1px );
-		}
-		html[dir='rtl'] & {
-			padding: 12px calc( var( --sidebar-width-min ) + 24px + 1px ) 24px 24px;
+	.is-section-plans {
+		#content.layout__content {
+			overflow: unset;
+			min-height: 100vh !important;
+			background: #fdfdfd;
+			padding-left: 0;
+			padding-right: 0;
+			padding-top: 47px;
 		}
 
-		@media ( max-width: 782px ) {
-			html[dir='ltr'] &,
-			html[dir='rtl'] & {
-				padding: 24px 16px;
-				margin: 0;
-			}
-		}
-	}
-
-	.plans,
-	.current-plan__content {
-		max-width: 1040px;
-		margin: auto;
-
-		html[dir='ltr'] & {
-			padding: 0 24px 0 calc( var( --sidebar-width-min ) + 24px + 1px );
-		}
-		html[dir='rtl'] & {
-			padding: 0 calc( var( --sidebar-width-min ) + 24px + 1px ) 0 24px;
+		.layout__secondary {
+			box-shadow: 0 1px 0 1px rgba( 0, 0, 0, 0.1 );
 		}
 
-		@media ( max-width: 782px ) {
-			html[dir='ltr'] &,
-			html[dir='rtl'] & {
-				padding: 0;
-			}
-		}
-	}
-
-	.section-nav.section-nav {
-		box-shadow: none;
-		background: none;
-		margin: 16px 0 32px;
-	}
-
-	.section-nav-tab {
-		opacity: 0.7;
-	}
-
-	.section-nav-tab.is-selected,
-	.section-nav-tab:hover {
-		opacity: 1;
-	}
-
-	.section-nav-tab__link {
-		font-size: 16px;
-	}
-
-	.section-nav-tab__link,
-	.section-nav-tab__link:hover,
-	.section-nav-tab__link:focus,
-	.section-nav-tab__link:active {
-		color: inherit !important;
-		background: none !important;
-	}
-
-	.section-nav-tab:hover:not( .is-selected ) {
-		border-bottom-color: transparent;
-	}
-
-	.my-plan-card__icon {
-		display: none;
-	}
-
-	.my-plan-card__title {
-		font-family: Recoleta;
-		font-size: 1.5rem;
-		margin-bottom: 0.5rem;
-	}
-
-	.notice.is-info,
-	.notice.is-success {
-		color: inherit;
-		background: #f6f7f7;
-
-		.notice__content.notice__content {
+		.is-nav-unification .sidebar .sidebar__heading::after,
+		.is-nav-unification .sidebar .sidebar__menu-link::after {
 			html[dir='ltr'] & {
-				padding: 10px 10px 10px 0;
+				margin-right: -1px;
+				border-right-color: #fdfdfd;
 			}
 			html[dir='rtl'] & {
-				padding: 10px 0 10px 10px;
+				margin-left: -1px;
+				border-left-color: #fdfdfd;
 			}
 		}
 
-		.notice__icon-wrapper.notice__icon-wrapper {
+		.main.is-wide-layout.is-wide-layout {
+			max-width: 100%;
+		}
+
+		.formatted-header__title.formatted-header__title {
+			font-size: 1rem;
+			font-family: inherit !important;
+			font-weight: 600;
+			margin: 0 auto;
+			max-width: 1040px;
+
+			.gridicon {
+				margin-bottom: -2px;
+				fill: rgba( 140, 143, 148, 1 );
+			}
+		}
+
+		.formatted-header__subtitle {
+			display: none;
+		}
+
+		.formatted-header.formatted-header {
+			border-bottom: 1px solid #dcdcde;
+			padding-bottom: 24px;
+			margin: 0;
+
+			html[dir='ltr'] & {
+				padding: 12px 24px 24px calc( var( --sidebar-width-min ) + 24px + 1px );
+			}
+			html[dir='rtl'] & {
+				padding: 12px calc( var( --sidebar-width-min ) + 24px + 1px ) 24px 24px;
+			}
+
+			@media ( max-width: 782px ) {
+				html[dir='ltr'] &,
+				html[dir='rtl'] & {
+					padding: 24px 16px;
+					margin: 0;
+				}
+			}
+		}
+
+		.plans,
+		.current-plan__content {
+			max-width: 1040px;
+			margin: auto;
+
+			html[dir='ltr'] & {
+				padding: 0 24px 0 calc( var( --sidebar-width-min ) + 24px + 1px );
+			}
+			html[dir='rtl'] & {
+				padding: 0 calc( var( --sidebar-width-min ) + 24px + 1px ) 0 24px;
+			}
+
+			@media ( max-width: 782px ) {
+				html[dir='ltr'] &,
+				html[dir='rtl'] & {
+					padding: 0;
+				}
+			}
+		}
+
+		.section-nav.section-nav {
+			box-shadow: none;
 			background: none;
-			width: 40px;
+			margin: 16px 0 32px;
 		}
 
-		.gridicons-info-outline {
-			fill: #008a20;
+		.section-nav-tab {
+			opacity: 0.7;
 		}
-	}
 
-	.my-plan-card.my-plan-card.card {
-		flex-direction: column;
-		justify-content: stretch;
-	}
+		.section-nav-tab.is-selected,
+		.section-nav-tab:hover {
+			opacity: 1;
+		}
 
-	.my-plan-card__primary.my-plan-card__primary {
-		min-width: 60%;
-	}
+		.section-nav-tab__link {
+			font-size: 16px;
+		}
 
-	.my-plan-card__details.my-plan-card__details {
-		display: none;
+		.section-nav-tab__link,
+		.section-nav-tab__link:hover,
+		.section-nav-tab__link:focus,
+		.section-nav-tab__link:active {
+			color: inherit !important;
+			background: none !important;
+		}
+
+		.section-nav-tab:hover:not( .is-selected ) {
+			border-bottom-color: transparent;
+		}
+
+		.my-plan-card__icon {
+			display: none;
+		}
+
+		.my-plan-card__title {
+			font-family: Recoleta;
+			font-size: 1.5rem;
+			margin-bottom: 0.5rem;
+		}
+
+		.notice.is-info,
+		.notice.is-success {
+			color: inherit;
+			background: #f6f7f7;
+
+			.notice__content.notice__content {
+				html[dir='ltr'] & {
+					padding: 10px 10px 10px 0;
+				}
+				html[dir='rtl'] & {
+					padding: 10px 0 10px 10px;
+				}
+			}
+
+			.notice__icon-wrapper.notice__icon-wrapper {
+				background: none;
+				width: 40px;
+			}
+
+			.gridicons-info-outline {
+				fill: #008a20;
+			}
+		}
+
+		.my-plan-card.my-plan-card.card {
+			flex-direction: column;
+			justify-content: stretch;
+		}
+
+		.my-plan-card__primary.my-plan-card__primary {
+			min-width: 60%;
+		}
+
+		.my-plan-card__details.my-plan-card__details {
+			display: none;
+		}
 	}
 
 	.popover__arrow {
@@ -235,15 +238,20 @@ export const globalOverrides = css`
 
 const ComparisonTable = styled.table< TableProps >`
 	border-collapse: collapse;
+	max-width: ${ ( { hideFreePlan } ) => ( hideFreePlan ? 728 : 980 ) }px;
 
 	.is-section-plans & {
-		max-width: 980px;
 		html[dir='ltr'] & {
 			margin-left: auto;
 		}
 		html[dir='rtl'] & {
 			margin-right: auto;
 		}
+	}
+
+	.is-section-signup & {
+		margin-left: auto;
+		margin-right: auto;
 	}
 
 	th,
@@ -287,14 +295,14 @@ const ComparisonTable = styled.table< TableProps >`
 		}
 	}
 
-	th:nth-of-type( even ),
-	td:nth-of-type( even ) {
+	th:last-child,
+	td:last-child {
 		background: #f0f7fc;
 	}
 
 	th.is-first,
 	td.is-first {
-		width: ${ ( { firstColWidth } ) => `${ firstColWidth }%` };
+		width: ${ ( { firstColWidth, hideFreePlan } ) => ( hideFreePlan ? 50 : firstColWidth ) }%;
 	}
 
 	th .button {
@@ -320,8 +328,10 @@ const ComparisonTable = styled.table< TableProps >`
 		}
 	}
 
-	${ getRowMobileLayout( SCREEN_BREAKPOINT_SIGNUP, '.is-section-signup' ) }
-	${ getRowMobileLayout( SCREEN_BREAKPOINT_PLANS, '.is-section-plans' ) }
+	${ ( { hideFreePlan } ) =>
+		! hideFreePlan && getRowMobileLayout( SCREEN_BREAKPOINT_SIGNUP, '.is-section-signup' ) }
+	${ ( { hideFreePlan } ) =>
+		! hideFreePlan && getRowMobileLayout( SCREEN_BREAKPOINT_PLANS, '.is-section-plans' ) }
 
 	.plans-comparison__collapsible-rows {
 		display: none;
@@ -350,9 +360,11 @@ const THead = styled.thead< { isInSignup: boolean } >`
 
 const PlanComparisonToggle = styled.tr`
 	th,
-	td {
+	td,
+	td:last-child {
 		padding: 0;
 		border-bottom: none;
+		background: none;
 	}
 
 	${ getRowMobileLayout( SCREEN_BREAKPOINT_SIGNUP, '.is-section-signup' ) }
@@ -382,6 +394,7 @@ interface Props {
 	isInSignup?: boolean;
 	selectedSiteId?: number;
 	selectedSiteSlug?: string;
+	hideFreePlan?: boolean;
 	purchaseId?: number | null;
 	onSelectPlan: ( item: Partial< CartItem > | null ) => void;
 }
@@ -402,6 +415,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	selectedSiteId,
 	selectedSiteSlug,
 	purchaseId,
+	hideFreePlan,
 	onSelectPlan,
 } ) => {
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSiteId || null ) );
@@ -409,6 +423,12 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) ?? '';
 	const plans = [ getPlan( PLAN_WPCOM_FLEXIBLE ), getPlan( PLAN_WPCOM_PRO ) ] as WPComPlan[];
 	const prices: PlanPrices[] = [ { price: 0 }, usePlanPrices( plans[ 1 ], selectedSiteId ) ];
+
+	if ( hideFreePlan ) {
+		plans.shift();
+		prices.shift();
+	}
+
 	const translate = useTranslate();
 
 	const toggleCollapsibleRows = useCallback( () => {
@@ -426,65 +446,72 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	);
 
 	return (
-		<ComparisonTable firstColWidth={ 32 } planCount={ plans.length }>
-			<THead isInSignup={ isInSignup }>
-				<tr>
-					<td className={ `is-first` }>
-						<br />
-					</td>
-					{ plans.map( ( plan, index ) => (
-						<PlansComparisonColHeader
-							key={ plan.getProductId() }
-							plan={ plan }
-							currencyCode={ currencyCode }
-							price={ prices[ index ].price }
-							originalPrice={ prices[ index ].originalPrice }
-							translate={ translate }
-						>
-							<PlansComparisonAction
-								currentSitePlanSlug={ sitePlan?.product_slug }
+		<>
+			<Global styles={ globalOverrides } />
+			<ComparisonTable
+				firstColWidth={ 32 }
+				planCount={ plans.length }
+				hideFreePlan={ hideFreePlan }
+			>
+				<THead isInSignup={ isInSignup }>
+					<tr>
+						<td className={ `is-first` }>
+							<br />
+						</td>
+						{ plans.map( ( plan, index ) => (
+							<PlansComparisonColHeader
+								key={ plan.getProductId() }
 								plan={ plan }
-								isInSignup={ isInSignup }
-								isPrimary={ plan.type === TYPE_PRO }
-								isCurrentPlan={ sitePlan?.product_slug === plan.getStoreSlug() }
-								manageHref={ manageHref }
-								onClick={ () => onSelectPlan( planToCartItem( plan ) ) }
-							/>
-						</PlansComparisonColHeader>
+								currencyCode={ currencyCode }
+								price={ prices[ index ].price }
+								originalPrice={ prices[ index ].originalPrice }
+								translate={ translate }
+							>
+								<PlansComparisonAction
+									currentSitePlanSlug={ sitePlan?.product_slug }
+									plan={ plan }
+									isInSignup={ isInSignup }
+									isPrimary={ plan.type === TYPE_PRO }
+									isCurrentPlan={ sitePlan?.product_slug === plan.getStoreSlug() }
+									manageHref={ manageHref }
+									onClick={ () => onSelectPlan( planToCartItem( plan ) ) }
+								/>
+							</PlansComparisonColHeader>
+						) ) }
+					</tr>
+				</THead>
+				<tbody className="plans-comparison__rows">
+					{ planComparisonFeatures.slice( 0, 7 ).map( ( feature ) => (
+						<PlansComparisonRow feature={ feature } plans={ plans } key={ feature.features[ 0 ] } />
 					) ) }
-				</tr>
-			</THead>
-			<tbody className="plans-comparison__rows">
-				{ planComparisonFeatures.slice( 0, 7 ).map( ( feature ) => (
-					<PlansComparisonRow feature={ feature } plans={ plans } key={ feature.features[ 0 ] } />
-				) ) }
-			</tbody>
-			<tbody className={ collapsibleRowsclassName }>
-				{ planComparisonFeatures.slice( 7 ).map( ( feature ) => (
-					<PlansComparisonRow feature={ feature } plans={ plans } key={ feature.features[ 0 ] } />
-				) ) }
-			</tbody>
-			<tbody>
-				<PlanComparisonToggle>
-					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-					<th className="is-first"></th>
-					<td colSpan={ 2 }>
-						<button onClick={ toggleCollapsibleRows }>
-							{ showCollapsibleRows ? (
-								<>
-									<Gridicon size={ 12 } icon="chevron-up" />
-									{ translate( 'Hide full plan comparison' ) }
-								</>
-							) : (
-								<>
-									<Gridicon size={ 12 } icon="chevron-down" />
-									{ translate( 'Show full plan comparison' ) }
-								</>
-							) }
-						</button>
-					</td>
-				</PlanComparisonToggle>
-			</tbody>
-		</ComparisonTable>
+				</tbody>
+				<tbody className={ collapsibleRowsclassName }>
+					{ planComparisonFeatures.slice( 7 ).map( ( feature ) => (
+						<PlansComparisonRow feature={ feature } plans={ plans } key={ feature.features[ 0 ] } />
+					) ) }
+				</tbody>
+				<tbody>
+					<PlanComparisonToggle>
+						{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+						<th className="is-first"></th>
+						<td colSpan={ 2 }>
+							<button onClick={ toggleCollapsibleRows }>
+								{ showCollapsibleRows ? (
+									<>
+										<Gridicon size={ 12 } icon="chevron-up" />
+										{ translate( 'Hide full plan comparison' ) }
+									</>
+								) : (
+									<>
+										<Gridicon size={ 12 } icon="chevron-down" />
+										{ translate( 'Show full plan comparison' ) }
+									</>
+								) }
+							</button>
+						</td>
+					</PlanComparisonToggle>
+				</tbody>
+			</ComparisonTable>
+		</>
 	);
 };

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -7,7 +7,7 @@ import {
 	TYPE_PRO,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
-import { css } from '@emotion/react';
+import { css, Global } from '@emotion/react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -20,7 +20,7 @@ import { SCREEN_BREAKPOINT_SIGNUP, SCREEN_BREAKPOINT_PLANS } from './constant';
 import { PlansComparisonAction } from './plans-comparison-action';
 import { PlansComparisonColHeader } from './plans-comparison-col-header';
 import { planComparisonFeatures } from './plans-comparison-features';
-import { PlansComparisonRow } from './plans-comparison-row';
+import { PlansComparisonRow, DesktopContent, MobileContent } from './plans-comparison-row';
 import { usePlanPrices, PlanPrices } from './use-plan-prices';
 import type { WPComPlan } from '@automattic/calypso-products';
 import type { RequestCartProduct as CartItem } from '@automattic/shopping-cart';
@@ -36,6 +36,14 @@ const getRowMobileLayout = ( breakpoint: number, pageClass: string ) => `
 			th.is-first,
 			td.is-first {
 				display: none;
+			}
+
+			${ DesktopContent } {
+				display: none;
+			}
+
+			${ MobileContent } {
+				display: block;
 			}
 
 			th,

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -18,7 +18,6 @@ import {
 	isPro,
 } from '@automattic/calypso-products';
 import { Dialog } from '@automattic/components';
-import { Global } from '@emotion/react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -40,7 +39,7 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { isCloseToExpiration } from 'calypso/lib/purchases';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings';
-import { globalOverrides, isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import JetpackChecklist from 'calypso/my-sites/plans/current-plan/jetpack-checklist';
 import PlanRenewalMessage from 'calypso/my-sites/plans/jetpack-plans/plan-renewal-message';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
@@ -199,7 +198,6 @@ class CurrentPlan extends Component {
 
 		return (
 			<Main className="current-plan" wideLayout>
-				{ eligibleForProPlan && <Global styles={ globalOverrides } /> }
 				<DocumentHead title={ translate( 'My Plan' ) } />
 				<FormattedHeader
 					brandFont

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -6,7 +6,6 @@ import {
 	PLAN_WPCOM_PRO,
 	PLAN_WPCOM_FLEXIBLE,
 } from '@automattic/calypso-products';
-import { Global } from '@emotion/react';
 import styled from '@emotion/styled';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -25,10 +24,7 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import { useExperiment } from 'calypso/lib/explat';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
-import PlansComparison, {
-	globalOverrides,
-	isEligibleForProPlan,
-} from 'calypso/my-sites/plans-comparison';
+import PlansComparison, { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import P2PlansMain from 'calypso/my-sites/plans/p2-plans-main';
@@ -206,7 +202,6 @@ class Plans extends Component {
 				{ selectedSite.ID && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<PageViewTracker path="/plans/:site" title="Plans" />
-				{ eligibleForProPlan && <Global styles={ globalOverrides } /> }
 				<QueryContactDetailsCache />
 				<QueryPlans />
 				<TrackComponentView eventName="calypso_plans_view" />

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -160,6 +160,7 @@ export class PlansStep extends Component {
 					{ errorDisplay }
 					<PlansComparison
 						isInSignup={ true }
+						hideFreePlan={ hideFreePlan }
 						onSelectPlan={ this.onSelectPlan }
 						selectedSiteId={ selectedSite?.ID || undefined }
 					/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This hides the Free plan when the user selects a custom domain in the domains step of the signup flow.

#### Testing instructions

##### Signup Plans grid doesn't show Free Plan
* Go to `/start?flags=plans/pro-plan`
* Select a custom domain in the domains step
* Only the Pro plan should be shown in the Plans step
<img width="320" alt="Screenshot on 2022-03-25 at 10-10-39" src="https://user-images.githubusercontent.com/2749938/160082217-68b28fe2-2ddb-4d04-b8d2-7a8bc5cfc21d.png">
* The layout and copy should look the same on mobile views (as opposed to switching to mobile content which)
<img width="240" alt="Screenshot on 2022-03-25 at 10-10-59" src="https://user-images.githubusercontent.com/2749938/160082253-751847d8-f68b-46f9-adae-0b06dd9c2bb0.png">


##### Plans grid on the /plans page is not affected
* Go to `/plans/[site]?flags=plans/pro-plan` on a Free plan
* Double-check the Plans grid haven't been affected by these changes
<img width="320" alt="Screenshot on 2022-03-25 at 10-21-55" src="https://user-images.githubusercontent.com/2749938/160082467-6cf56338-988b-4cf5-bf95-0e885132c708.png">
<img width="240" alt="Screenshot on 2022-03-25 at 10-23-06" src="https://user-images.githubusercontent.com/2749938/160082580-94b83047-e487-449f-b0d6-fa039898f6b0.png">


##### Legacy Plans grid is not affected
* Double check that both pages without the `flags=plans/pro-plan` haven't been affected by the changes

