### PR TITLE
People: fix incorrect isMultisite flag passed to DeleteUser component

### DIFF
--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -12,7 +12,11 @@ import PeopleProfile from 'calypso/my-sites/people/people-profile';
 import { recordGoogleEvent as recordGoogleEventAction } from 'calypso/state/analytics/actions';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import { isJetpackSiteMultiSite, isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'calypso/state/ui/selectors';
 import EditUserForm from './edit-user-form';
 
 import './style.scss';
@@ -79,12 +83,18 @@ export const EditTeamMemberForm = ( {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
+		const site = getSelectedSite( state );
+
+		const isJetpack = isJetpackSite( state, siteId );
+		const isMultisite = isJetpack
+			? isJetpackSiteMultiSite( state, siteId )
+			: site && site.is_multisite;
 
 		return {
 			siteId,
 			siteSlug: getSelectedSiteSlug( state ),
-			isJetpack: isJetpackSite( state, siteId ),
-			isMultisite: isJetpackSiteMultiSite( state, siteId ),
+			isJetpack: isJetpack,
+			isMultisite,
 			previousRoute: getPreviousRoute( state ),
 		};
 	},

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -93,7 +93,7 @@ export default connect(
 		return {
 			siteId,
 			siteSlug: getSelectedSiteSlug( state ),
-			isJetpack: isJetpack,
+			isJetpack,
 			isMultisite,
 			previousRoute: getPreviousRoute( state ),
 		};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When deleting a blog member, the interface displayed depends on the `isMultisite` flag. This PR fixes a bug causing that flag to always be false for non-Jetpack sites.

**BEFORE: User is presented with incorrect options.** These options actually do not do as they describe, as they do not apply to WPCOM simple sites.

<img width="742" alt="Screen Shot 2022-03-25 at 5 28 21 PM" src="https://user-images.githubusercontent.com/730823/160097870-89581138-eadd-4363-bab0-dc16f1c04063.png">



**AFTER: User is presented with a simplified option.**
<img width="740" alt="Screen Shot 2022-03-25 at 5 28 54 PM" src="https://user-images.githubusercontent.com/730823/160094848-dc07a4ac-7752-418e-b95f-22b987c9dbb2.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `http://calypso.localhost:3000/people/edit/<YOUR-TEST-SITE>.wordpress.com/<USERNAME>`, where `<USERNAME>` is for a user that is neither the current user nor the owner of the test site.
* Verify that you get the simple interface for a non-Jetpack site.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2221-gh-Automattic/p2
Related to https://github.com/Automattic/wp-calypso/issues/32079 