### PR TITLE
Editing Toolkit: fix block description links

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.ts
@@ -8,21 +8,11 @@ const addBlockSupportLinks = (
 	},
 	name: string
 ) => {
-	/**
-	 * Adjust the block name to apply link to InnerBlocks. This gets reset at the end
-	 */
-	const applyToChildren = [
-		'core/columns',
-		'core/social-links',
-		'core/buttons',
-		'jetpack/contact-form',
-	].includes( settings[ 'parent' ]?.toString() );
+	// If block has a parent, use the parents name in the switch. This will apply the link to all nested blocks.
+	const isChild = settings[ 'parent' ];
+	const blockName = isChild ? settings[ 'parent' ].toString() : name;
 
-	if ( applyToChildren ) {
-		name = settings[ 'parent' ]?.toString();
-	}
-
-	switch ( name ) {
+	switch ( blockName ) {
 		/**
 		 * Core Blocks
 		 */
@@ -140,10 +130,6 @@ const addBlockSupportLinks = (
 				'https://wordpress.com/support/wordpress-editor/blocks/mailchimp-block/'
 			);
 			break;
-	}
-
-	if ( applyToChildren ) {
-		name = settings[ 'name' ] as string;
 	}
 
 	return settings;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This addresses a [comment in the original PR](https://github.com/Automattic/wp-calypso/pull/62019#pullrequestreview-921303686). *TLDR*... there was an argument being mutated to check if the block had a parent which was not an ideal solution. This PR replaces that mutation with a simpler variable defined logically.

#### Testing instructions
1. Pull branch run `cd apps/editing-toolkit && yarn dev --sync`
2. Go to your sandbox site and open the post/page editor.
3. Add the above-mentioned blocks and verify the description has the link and it is working properly.
4. Make sure the links are not appearing in any other areas such as the block picker preview when you click the [ + ] to add a new block.

Related to #62019
