### PR TITLE
Plans overhaul Phase 1: Update tooltip messages

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -204,7 +204,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 	{
 		title: translate( 'Storage' ),
 		description: translate(
-			'The free plan allows a maximum storage of 500MB, which equals to approximately 100 high quality images, whilst with WordPress Pro you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.'
+			'The free plan allows a maximum storage of 500MB, which equals to approximately 100 high quality images. With WordPress Pro you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.'
 		),
 		features: [ FEATURE_500MB_STORAGE, FEATURE_50GB_STORAGE ],
 		getCellText: ( feature, isMobile = false ) => {
@@ -254,7 +254,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 	{
 		title: translate( 'Remove ads' ),
 		description: translate(
-			'Free sites include ads whilst the WordPress Pro plan allows you to remove these to keep your website clean of ads.'
+			'Free sites include ads. The WordPress Pro plan allows you to remove these to keep your website clean of ads.'
 		),
 		features: [ FEATURE_NO_ADS ],
 		getCellText: ( feature, isMobile = false ) => {

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -228,9 +228,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 	},
 	{
 		title: translate( 'Visits per month' ),
-		description: translate(
-			'The WordPress Pro plan bundles up to 100,000 visits a month to help you rest assured traffic won’t be a concern.'
-		),
+		description: translate( 'Max visits per month.' ),
 		features: [ FEATURE_10K_VISITS, FEATURE_100K_VISITS ],
 		getCellText: ( feature, isMobile = false ) => {
 			let visitCount = 0;

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -165,7 +165,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 
 			return feature
 				? translate( 'Unlimited WordPress plugins' )
-				: translate( 'WordPress plugins are not incldued' );
+				: translate( 'WordPress plugins are not included' );
 		},
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There's a new update request for two tooltip copies. New strings below:

**Storage**: The free plan allows a maximum storage of 500MB, which equals to approximately 100 high quality images. With WordPress Pro you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.

**Remove ads**: Free sites include ads. The WordPress Pro plan allows you to remove these to keep your website clean of ads.

**Visits per month**:  Max visits per month.

#### Testing instructions

* Go to /plans/[site]/?flags=plans/pro-plan
* The Storage and Remove ads tooltips should have the latest copy
<img width="240" alt="calypso-Screenshot on 2022-03-25 at 12-37-56" src="https://user-images.githubusercontent.com/2749938/160107405-8e277325-ca7a-4848-97f2-83c06dd25bcb.png">
<img width="240" alt="calypso-Screenshot on 2022-03-25 at 12-38-06" src="https://user-images.githubusercontent.com/2749938/160107409-e2f315e9-01ce-4f30-9803-70921cd30ac3.png">
<img width="240" alt="calypso-Screenshot on 2022-03-28 at 14-38-05" src="https://user-images.githubusercontent.com/2749938/160390581-898524bf-8ed1-4cbf-90a8-f60f777a9f9e.png">


