### PR TITLE
Enable feature list for Pro plan and match it with the Business Plan

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -209,7 +209,7 @@ export class ProductPurchaseFeaturesList extends Component {
 	}
 
 	getProFeatuers() {
-		const { isPlaceholder, selectedSite, planHasDomainCredit } = this.props;
+		const { isPlaceholder, selectedSite, plan, planHasDomainCredit } = this.props;
 
 		return (
 			<Fragment>
@@ -219,9 +219,16 @@ export class ProductPurchaseFeaturesList extends Component {
 					liveChatButtonEventName={ 'calypso_livechat_my_plan_pro' }
 				/>
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
+				{ isWordadsInstantActivationEligible( selectedSite ) && (
+					<MonetizeSite selectedSite={ selectedSite } />
+				) }
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
 				<GoogleMyBusiness selectedSite={ selectedSite } />
 				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
+				<CustomizeTheme selectedSite={ selectedSite } />
+				<CustomCSS selectedSite={ selectedSite } />
+				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
+				{ isEnabled( 'themes/premium' ) && <FindNewTheme selectedSite={ selectedSite } /> }
 				<UploadPlugins selectedSite={ selectedSite } />
 				<SiteActivity />
 				<MobileApps onClick={ this.handleMobileAppsClick } />

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -1,4 +1,5 @@
 import {
+	isProPlan,
 	isWpComBusinessPlan,
 	isWpComEcommercePlan,
 	isWpComPremiumPlan,
@@ -13,6 +14,12 @@ function getDescription( plan, translate ) {
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
 				'directly to your site — the Business Plan has 200 GB storage.'
+		);
+	}
+	if ( isProPlan( plan ) ) {
+		return translate(
+			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
+				'directly to your site — the Pro Plan has 50 GB storage.'
 		);
 	}
 	if ( isWpComEcommercePlan( plan ) ) {

--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -5,6 +5,7 @@ import {
 	isSecurityDaily,
 	isSecurityRealTime,
 	isComplete,
+	isPro,
 } from '@automattic/calypso-products';
 import { userCan } from 'calypso/lib/site/utils';
 
@@ -15,7 +16,8 @@ export function hasWordAdsPlan( site ) {
 		isEcommerce( site.plan ) ||
 		isSecurityDaily( site.plan ) ||
 		isSecurityRealTime( site.plan ) ||
-		isComplete( site.plan )
+		isComplete( site.plan ) ||
+		isPro( site.plan )
 	);
 }
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -277,23 +277,20 @@ class CurrentPlan extends Component {
 						</Fragment>
 					) }
 
-					{ ! isPro( selectedSite.plan ) && (
-						<>
-							<div
-								className={ classNames( 'current-plan__header-text current-plan__text', {
-									'is-placeholder': { isLoading },
-								} ) }
-							>
-								<h1 className="current-plan__header-heading">{ planFeaturesHeader }</h1>
-							</div>
-							<AsyncLoad
-								require="calypso/blocks/product-purchase-features-list"
-								placeholder={ null }
-								plan={ currentPlanSlug }
-								isPlaceholder={ isLoading }
-							/>
-						</>
-					) }
+					<div
+						className={ classNames( 'current-plan__header-text current-plan__text', {
+							'is-placeholder': { isLoading },
+						} ) }
+					>
+						<h1 className="current-plan__header-heading">{ planFeaturesHeader }</h1>
+					</div>
+					<AsyncLoad
+						require="calypso/blocks/product-purchase-features-list"
+						placeholder={ null }
+						plan={ currentPlanSlug }
+						isPlaceholder={ isLoading }
+					/>
+
 					<TrackComponentView eventName={ 'calypso_plans_my_plan_view' } />
 				</div>
 			</Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This enables the Features list for the Pro plan on the My Plan page. It also makes sure it matches the Business plan and adjusts the Video and Audio posts copy.

#### Testing instructions

* Go to /plans/[site]/?flags=plans/pro-plan on a site with a Pro plan
* Make sure the Features list is visible and matches the Business plan.
* The `Video and Audio posts` feature should mention the Pro plan and 50GB of storage

##### Pro Plan Features
<img width="320" alt="Screenshot 2022-03-25 at 13 20 58" src="https://user-images.githubusercontent.com/2749938/160112613-7e2e93ba-0d91-4087-a14e-cd62b0a5a303.png">

##### Business Plan Features
<img width="320" alt="Screenshot 2022-03-25 at 13 21 04" src="https://user-images.githubusercontent.com/2749938/160112600-1e43d6d6-5215-4a73-9c77-b24e7038f113.png">

