### PR TITLE
Plans overhaul Phase 1:  Update the Domain notice Upsell copy and Upgrade button 

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell.jsx
+++ b/client/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell.jsx
@@ -2,6 +2,7 @@ import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import isSiteOnPaidPlan from 'calypso/state/selectors/is-site-on-paid-plan';
@@ -21,6 +22,7 @@ class NewDomainsRedirectionNoticeUpsell extends Component {
 			selectedSite,
 			selectedSiteId,
 			translate,
+			eligibleForProPlan,
 		} = this.props;
 
 		if (
@@ -33,23 +35,38 @@ class NewDomainsRedirectionNoticeUpsell extends Component {
 			return null;
 		}
 
+		const checkoutPlan = eligibleForProPlan ? 'pro' : 'personal';
+
 		return (
 			<UpsellNudge
 				className="new-domains-redirection-notice-upsell__banner"
 				showIcon={ true }
 				icon="info"
-				href={ `/checkout/${ selectedSiteId }/personal` }
+				href={ `/checkout/${ selectedSiteId }/${ checkoutPlan }` }
 				title={ '' }
-				description={ translate(
-					'Domains purchased on a free site will get redirected to %(primaryDomain)s. If you upgrade to ' +
-						'the Personal plan, you can use your own domain name instead of having WordPress.com ' +
-						'in your URL.',
-					{
-						args: {
-							primaryDomain: selectedSite.slug,
-						},
-					}
-				) }
+				description={
+					eligibleForProPlan
+						? translate(
+								'Domains purchased on a free site will get redirected to %(primaryDomain)s. If you upgrade to ' +
+									'the Pro plan, you can use your own domain name instead of having WordPress.com ' +
+									'in your URL.',
+								{
+									args: {
+										primaryDomain: selectedSite.slug,
+									},
+								}
+						  )
+						: translate(
+								'Domains purchased on a free site will get redirected to %(primaryDomain)s. If you upgrade to ' +
+									'the Personal plan, you can use your own domain name instead of having WordPress.com ' +
+									'in your URL.',
+								{
+									args: {
+										primaryDomain: selectedSite.slug,
+									},
+								}
+						  )
+				}
 				callToAction={ translate( 'Upgrade' ) }
 				primaryButton={ false }
 				tracksImpressionName="calypso_new_domain_will_redirect_notice_upsell_impression"
@@ -64,6 +81,7 @@ const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const selectedSite = getSelectedSite( state );
 	const sitePlans = selectedSite && getPlansBySite( state, selectedSite );
+	const eligibleForProPlan = isEligibleForProPlan( state, selectedSiteId );
 
 	return {
 		isOnPaidPlan: isSiteOnPaidPlan( state, selectedSiteId ),
@@ -74,6 +92,7 @@ const mapStateToProps = ( state ) => {
 		hasCustomPrimaryDomain: hasCustomDomain( selectedSite ),
 		selectedSite,
 		selectedSiteId,
+		eligibleForProPlan,
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

More info point 27: pdgrnI-tQ#comment-888-p2

This changes the copy for Domain notice Upsell to mention the Pro plan and changes the Upgrade button to go to the Pro plan checkout

#### Testing instructions

* Go to `/domains/add/[site]?flags=plans/pro-plan` on a Free plan site
* You should see a notice on the top with the updated copy
* The Upgrade button should also add a Pro plan to the shopping cart
<img width="1110" alt="Screenshot on 2022-03-25 at 14-48-31" src="https://user-images.githubusercontent.com/2749938/160124571-76c32fad-d1b6-44f5-a1e7-d664b0ccf454.png">

* Go to `/domains/add/[site]` on a Free plan site
* These changes should not apply without the `flags=plans/pro-plan` flag
