### PR TITLE
Misc: Remove some unused component state

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -50,7 +50,6 @@ export class SiteAddressChanger extends Component {
 
 	state = {
 		step: 0,
-		showDialog: false,
 		domainFieldValue: '',
 		newDomainSuffix: this.props.currentDomainSuffix,
 	};

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -98,7 +98,6 @@ class P2Site extends Component {
 			form: this.formStateController.getInitialState(),
 			submitting: false,
 			lastSuggestionSuffixIndex: 0,
-			lastInvalidSite: '',
 			isFetchingDefaultSuggestion: false,
 			showCustomSiteAddressInput: false,
 		};
@@ -222,8 +221,6 @@ class P2Site extends Component {
 				},
 				( error, response ) => {
 					debug( error, response );
-
-					this.setState( { lastInvalidSite: fields.site } );
 
 					if ( error && error.message ) {
 						if ( fields.site && ! includes( siteUrlsSearched, fields.site ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since #61602, the `lastInvalidSite` component state of `<P2Site />` is not necessary. This PR removes it. It also removes another unused component state I stumbled upon today in `<SiteAddressChanger />`.

#### Testing instructions

Verify the removed component state is not in use.