### PR TITLE
Domains: Refactor `RegistrantExtraInfoUkForm` away from `UNSAFE_` methods

### DIFF
--- a/client/components/domains/registrant-extra-info/uk-form.jsx
+++ b/client/components/domains/registrant-extra-info/uk-form.jsx
@@ -56,8 +56,7 @@ export class RegistrantExtraInfoUkForm extends PureComponent {
 		) );
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		// Add defaults to redux state to make accepting default values work.
 		const neededRequiredDetails = difference(
 			[ 'registrantType' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `RegistrantExtraInfoUkForm` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/domains/add/:site` where `:site` is one of your WP.com simple or Atomic sites.
* Input some example `.uk` domain and once domains load, click to buy that .UK domain.
* If you're presented with the screen to add professional email, skip it.
* You'll be redirected to the checkout page.
* Verify that the contact information form still works as it did before (note that it's slightly different for .UK domains).