### PR TITLE
Domains: Refactor `RegistrantExtraInfoFrForm` away from `UNSAFE_` methods

### DIFF
--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -71,8 +71,7 @@ class RegistrantExtraInfoFrForm extends PureComponent {
 		registrantVatId: sanitizeVat,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		// We're pushing props out into the global state here because:
 		// 1) We want to use these values if the user navigates unexpectedly then returns
 		// 2) We want to use the tld specific forms to manage the tld specific


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `RegistrantExtraInfoFrForm` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/domains/add/:site` where `:site` is one of your WP.com simple or Atomic sites.
* Input some example `.fr` domain and once domains load, click to buy that .fr domain.
* If you're presented with the screen to add professional email, skip it.
* You'll be redirected to the checkout page.
* Verify that the contact information form still works as it did before (note that it's slightly different for .fr domains).