### PR TITLE
Domains: Refactor `ContactDetailsFormFields` away from `UNSAFE_` methods

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -128,8 +128,7 @@ export class ContactDetailsFormFields extends Component {
 		);
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		this.formStateController = formState.Controller( {
 			debounceWait: 500,
 			fieldNames: CONTACT_DETAILS_FORM_FIELDS,
@@ -524,6 +523,11 @@ export class ContactDetailsFormFields extends Component {
 			labelTexts,
 			contactDetailsErrors,
 		} = this.props;
+
+		if ( ! this.state.form ) {
+			return null;
+		}
+
 		const countryCode = this.getCountryCode();
 
 		const isFooterVisible = !! ( this.props.onSubmit || onCancel );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `ContactDetailsFormFields` component away from the `UNSAFE_` deprecated React component methods.

It introduces minimal changes by moving the form state controller initialization to `componentDidMount`. I'd very much prefer not using form state, but it's work for another PR.

Part of #58453.

#### Testing instructions
* Go to `/domains/manage/:site` where `:site` is a site with a custom domain hosted on WP.com.
* Click on your domain.
* Expand "Contact Information".
* Click the button at the bottom to edit the contact info.
* Verify the form still works as it did before.