### PR TITLE
Onboarding import flow: Fix the WordPress migration process (transition from simple to atomic case)

### DIFF
--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -50,7 +50,9 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	const urlData = useSelector( getUrlData );
 	const searchParams = useSelector( getCurrentQueryArguments );
 	let siteSlug = searchParams?.to as string;
-	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) as number );
+	const _siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) as number );
+	const [ siteId, setSiteId ] = useState( _siteId );
+	! siteId && setSiteId( _siteId );
 	const site = useSelector( ( state ) => getSite( state, siteId ) as SitesItem );
 	const siteImports = useSelector( ( state ) => getImporterStatusForSiteId( state, siteId ) );
 	const canImport = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change patch the case when the entry slug becomes undefined because of the `simple -> atomic` site transition.

#### Testing instructions

* Go to `/start/setup-site/intent?siteSlug={SIMPLE_SLUG}`
* Select `Import your site content`
* Enter a WP URL (could be jurassic.ninja with Jetpack connection established)
* Press `Import your content`
* Select `Everything` option
* Select `See plans`
* Upgrade your account with a free credit
* Run the import process
* Check is there success Hooray screen at the end of the migration process

Related to #57131
