### PR TITLE
Allow underscore in service field for SRV records

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -159,6 +159,11 @@ class DnsAddNew extends React.Component {
 			return recordToEdit[ field ].replace( /\.$/, '' );
 		}
 
+		// Make sure we can handle protocols with and without a leading underscore
+		if ( 'SRV' === recordToEdit.type && 'protocol' === field ) {
+			return recordToEdit[ field ].replace( /^_+/, '' );
+		}
+
 		return recordToEdit[ field ];
 	}
 

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -98,7 +98,7 @@ class DnsAddNew extends React.Component {
 					weight: 10,
 					target: '',
 					port: '',
-					protocol: 'tcp',
+					protocol: '_tcp',
 				},
 			},
 		];
@@ -161,7 +161,7 @@ class DnsAddNew extends React.Component {
 
 		// Make sure we can handle protocols with and without a leading underscore
 		if ( 'SRV' === recordToEdit.type && 'protocol' === field ) {
-			return recordToEdit[ field ].replace( /^_+/, '' );
+			return recordToEdit[ field ].replace( /^_*/, '_' );
 		}
 
 		return recordToEdit[ field ];

--- a/client/my-sites/domains/domain-management/dns/srv-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/srv-record.jsx
@@ -20,10 +20,10 @@ class SrvRecord extends Component {
 	render() {
 		const { fieldValues, isValid, onChange, selectedDomainName, show, translate } = this.props;
 		const classes = classnames( { 'is-hidden': ! show } );
-		const options = [ 'tcp', 'udp', 'tls' ].map( ( protocol ) => {
+		const options = [ '_tcp', '_udp', '_tls' ].map( ( protocol ) => {
 			return (
 				<option key={ protocol } value={ protocol }>
-					{ protocol.toUpperCase() }
+					{ protocol }
 				</option>
 			);
 		} );

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -22,7 +22,7 @@ function validateField( { name, value, type, domainName } ) {
 		case 'data':
 			return isValidData( value, type );
 		case 'protocol':
-			return [ 'tcp', 'udp', 'tls' ].includes( value );
+			return [ '_tcp', '_udp', '_tls' ].includes( value );
 		case 'weight':
 		case 'aux':
 		case 'port': {

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -83,11 +83,6 @@ function getNormalizedData( record, selectedDomainName ) {
 	if ( record.target ) {
 		normalizedRecord.target = getFieldWithDot( record.target );
 	}
-	// The leading '_' in SRV's service field is a convention
-	// The record itself should not contain it
-	if ( record.service ) {
-		normalizedRecord.service = record.service.replace( /^_+/, '' );
-	}
 
 	return normalizedRecord;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This fixes #61440 
* The leading underscore was being stripped from the service field even though it is allowed and saved in the record.
* This PR leaves the leading `_` as-is and stops stripping it when sending/retrieving data.
* This PR also shows the leading `_` for protocol, allowing the fields in the dropdown to show as they are saved in the DB.

#### Testing instructions

* checkout this branch locally and start calypso or use the live link below.
* This depends on `D77578-code`
* Navigate to `Upgrades > Domains > [domain-you-own] > DNS Records > Manage`, then click on `+ Add a Record`
* Select `SRV` in `Type` and in the service field, type an example with a leading underscore ( e.g. `_autodiscover` )
* Save the record.
* Find the row of the record you just added and edit it by selecting `Edit` from the menu to the right of each row.
* Validate that the `Service` field has the same name used for testing (including the leading underscore)

#### Related:
* #61440
* 1146722293412575-as-1201878823646755

