### PR TITLE
My-sites Backups: add sub-header with support link

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -11,9 +11,6 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/restore/',
 		post_id: 159843,
 	},
-	'backups-jetpack': {
-		link: 'https://jetpack.com/support/backup/',
-	},
 	backup_payment_methods: {
 		link: 'https://wordpress.com/support/payment/#backup-payment-methods',
 		post_id: 76237,

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -7,6 +7,13 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/manage-purchases/#automatic-renewal',
 		post_id: 111349,
 	},
+	backups: {
+		link: 'https://wordpress.com/support/restore/',
+		post_id: 159843,
+	},
+	'backups-jetpack': {
+		link: 'https://jetpack.com/support/backup/',
+	},
 	backup_payment_methods: {
 		link: 'https://wordpress.com/support/payment/#backup-payment-methods',
 		post_id: 76237,

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -11,6 +11,7 @@ import QueryRewindCapabilities from 'calypso/components/data/query-rewind-capabi
 import QueryRewindPolicies from 'calypso/components/data/query-rewind-policies';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
@@ -23,6 +24,7 @@ import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filte
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
 import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import BackupDatePicker from './backup-date-picker';
 import EnableRestoresBanner from './enable-restores-banner';
@@ -37,8 +39,10 @@ import {
 import './style.scss';
 
 const BackupPage = ( { queryDate } ) => {
+	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSettingsUrl = useSelector( ( state ) => getSettingsUrl( state, siteId, 'general' ) );
+	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 
 	const moment = useLocalizedMoment();
 	const parsedQueryDate = queryDate ? moment( queryDate, INDEX_FORMAT ) : moment();
@@ -68,7 +72,24 @@ const BackupPage = ( { queryDate } ) => {
 				{ isJetpackCloud() && <SidebarNavigation /> }
 				<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
 				{ ! isJetpackCloud() && (
-					<FormattedHeader headerText="Jetpack Backup" align="left" brandFont />
+					<FormattedHeader
+						headerText="Jetpack Backup"
+						subHeaderText={ translate(
+							'Restore or download a backup of your site from a specific moment in time. {{learnMoreLink/}}',
+							{
+								components: {
+									learnMoreLink: (
+										<InlineSupportLink
+											supportContext={ isAtomic ? 'backups' : 'backups-jetpack' }
+											showIcon={ false }
+										/>
+									),
+								},
+							}
+						) }
+						align="left"
+						brandFont
+					/>
 				) }
 
 				<AdminContent selectedDate={ selectedDate } />

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { ExternalLink } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -58,6 +59,12 @@ const BackupPage = ( { queryDate } ) => {
 		keepLocalTime: !! queryDate,
 	} );
 
+	const supportLink = isAtomic ? (
+		<InlineSupportLink supportContext={ 'backups' } showIcon={ false } />
+	) : (
+		<ExternalLink href={ 'https://jetpack.com/support/backup/' }>{ 'Learn more' }</ExternalLink>
+	);
+
 	return (
 		<div
 			className={ classNames( 'backup__page', {
@@ -78,12 +85,7 @@ const BackupPage = ( { queryDate } ) => {
 							'Restore or download a backup of your site from a specific moment in time. {{learnMoreLink/}}',
 							{
 								components: {
-									learnMoreLink: (
-										<InlineSupportLink
-											supportContext={ isAtomic ? 'backups' : 'backups-jetpack' }
-											showIcon={ false }
-										/>
-									),
+									learnMoreLink: supportLink,
 								},
 							}
 						) }


### PR DESCRIPTION
## Changes proposed in this Pull Request

To offer more context and help to users, this change adds a sub-header with a support link. The link should differ depending on if the user is an Atomic or Jetpack site. Jetpack sites will get an external link to the Jetpack steps and Atomic sites will get the WPCOM support guide for this.

| Jetpack | Atomic |
| - | - |
| <img width="758" alt="Markup 2022-03-25 at 16 02 03" src="https://user-images.githubusercontent.com/33258733/160146891-a24320ff-7963-4c52-98e2-9d6c1608dbdd.png"> | <img width="760" alt="Markup 2022-03-25 at 15 46 09" src="https://user-images.githubusercontent.com/33258733/160146923-db2b0159-45cf-4543-b9fb-c556e98a398a.png"> |



## Testing instructions

1. Pull and `yarn start`
2. Go to Jetpack ⇢ Backups
3. Verify the subheader is shown and the link is correctly working for Jetpack and Atomic sites.
4. Simple sites should see nothing.

Related to #60876 
