### PR TITLE
Checkout: Replace processor id in CheckoutSubmitButton with new property on payment methods

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-submit-button.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-submit-button.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
 import { useMemo } from 'react';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
+import type { ProcessPayment } from '@automattic/composite-checkout';
 import type { Stripe } from '@stripe/stripe-js';
 import type { I18n } from '@wordpress/i18n';
 import type { State } from 'calypso/state/partner-portal/credit-card-form/reducer';
@@ -20,7 +21,7 @@ export default function CreditCardSubmitButton( {
 	activeButtonText,
 }: {
 	disabled?: boolean;
-	onClick?: ( element: string, submitData: unknown ) => void;
+	onClick?: ProcessPayment;
 	store: State;
 	stripe: Stripe | null;
 	stripeConfiguration: StripeConfiguration | null;
@@ -61,7 +62,7 @@ export default function CreditCardSubmitButton( {
 						);
 					}
 
-					onClick( 'card', {
+					onClick( {
 						stripe,
 						name: cardholderName?.value,
 						stripeConfiguration,

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/stored-credit-card-method.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/stored-credit-card-method.tsx
@@ -18,6 +18,7 @@ export function createStoredCreditCardMethod( {
 } ): PaymentMethod {
 	return {
 		id: 'card',
+		paymentProcessorId: 'card',
 		label: <></>,
 		activeContent: <CreditCardFields />,
 		submitButton: (

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -36,7 +36,7 @@ export default function CreditCardPayButton( {
 				if ( isCreditCardFormValid( store, paymentPartner, __ ) ) {
 					if ( paymentPartner === 'stripe' ) {
 						debug( 'submitting stripe payment' );
-						onClick( 'card', {
+						onClick( {
 							stripe,
 							name: cardholderName?.value,
 							items,
@@ -53,7 +53,7 @@ export default function CreditCardPayButton( {
 					}
 					if ( paymentPartner === 'ebanx' ) {
 						debug( 'submitting ebanx payment' );
-						onClick( 'card', {
+						onClick( {
 							name: cardholderName?.value || '',
 							countryCode: fields?.countryCode?.value || '',
 							number: fields?.number?.value?.replace( /\s+/g, '' ) || '',

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/index.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/index.js
@@ -201,6 +201,7 @@ export function createCreditCardMethod( {
 } ) {
 	return {
 		id: 'card',
+		paymentProcessorId: 'card',
 		label: <CreditCardLabel />,
 		activeContent: (
 			<CreditCardFields

--- a/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
@@ -121,6 +121,7 @@ export function createEbanxTefPaymentMethodStore() {
 export function createEbanxTefMethod( { store } ) {
 	return {
 		id: 'brazil-tef',
+		paymentProcessorId: 'brazil-tef',
 		label: <EbanxTefLabel />,
 		activeContent: <EbanxTefFields />,
 		submitButton: <EbanxTefPayButton store={ store } />,
@@ -285,7 +286,7 @@ function EbanxTefPayButton( { disabled, onClick, store } ) {
 			onClick={ () => {
 				if ( isFormValid( store, contactCountryCode, __, reduxDispatch ) ) {
 					debug( 'submitting ebanx-tef payment' );
-					onClick( 'ebanx-tef', {
+					onClick( {
 						...massagedFields,
 						name: customerName?.value, // this needs to come after massagedFields to prevent it from being overridden
 						address: massagedFields?.address1,

--- a/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
@@ -121,7 +121,7 @@ export function createEbanxTefPaymentMethodStore() {
 export function createEbanxTefMethod( { store } ) {
 	return {
 		id: 'brazil-tef',
-		paymentProcessorId: 'brazil-tef',
+		paymentProcessorId: 'ebanx-tef',
 		label: <EbanxTefLabel />,
 		activeContent: <EbanxTefFields />,
 		submitButton: <EbanxTefPayButton store={ store } />,

--- a/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
@@ -100,6 +100,7 @@ export function createExistingCardMethod( {
 
 	return {
 		id,
+		paymentProcessorId: 'existing-card',
 		label: (
 			<ExistingCardLabel
 				last4={ last4 }
@@ -424,7 +425,7 @@ function ExistingCardPayButton( {
 						errorNotice( getMissingTaxLocationInformationMessage( translate, taxInfoFromServer ) )
 					);
 				} else {
-					onClick( 'existing-card', {
+					onClick( {
 						items,
 						name: cardholderName,
 						storedDetailsId,

--- a/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.js
@@ -6,6 +6,7 @@ import WordPressLogo from '../components/wordpress-logo';
 export function createFreePaymentMethod() {
 	return {
 		id: 'free-purchase',
+		paymentProcessorId: 'free-purchase',
 		label: <WordPressFreePurchaseLabel />,
 		submitButton: <FreePurchaseSubmitButton />,
 		inactiveContent: <WordPressFreePurchaseSummary />,
@@ -18,7 +19,7 @@ function FreePurchaseSubmitButton( { disabled, onClick } ) {
 	const { formStatus } = useFormStatus();
 
 	const handleButtonPress = () => {
-		onClick( 'free-purchase', {
+		onClick( {
 			items,
 		} );
 	};

--- a/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.js
@@ -9,6 +9,7 @@ import WordPressLogo from '../components/wordpress-logo';
 export function createFullCreditsMethod() {
 	return {
 		id: 'full-credits',
+		paymentProcessorId: 'full-credits',
 		label: <WordPressCreditsLabel />,
 		submitButton: <FullCreditsSubmitButton />,
 		inactiveContent: <WordPressCreditsSummary />,
@@ -23,7 +24,7 @@ function FullCreditsSubmitButton( { disabled, onClick } ) {
 	const { formStatus } = useFormStatus();
 
 	const handleButtonPress = () => {
-		onClick( 'full-credits', {
+		onClick( {
 			items,
 		} );
 	};

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -112,6 +112,7 @@ export function createNetBankingPaymentMethodStore() {
 export function createNetBankingMethod( { store } ) {
 	return {
 		id: 'netbanking',
+		paymentProcessorId: 'netbanking',
 		label: <NetBankingLabel />,
 		activeContent: <NetBankingFields />,
 		submitButton: <NetBankingPayButton store={ store } />,
@@ -215,7 +216,7 @@ function NetBankingPayButton( { disabled, onClick, store } ) {
 			onClick={ () => {
 				if ( isFormValid( store, contactCountryCode, __, reduxDispatch ) ) {
 					debug( 'submitting netbanking payment' );
-					onClick( 'netbanking', {
+					onClick( {
 						...massagedFields,
 						name: customerName?.value,
 						address: massagedFields?.address1,

--- a/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
@@ -101,6 +101,7 @@ export function createPayPalMethod(
 	debug( 'creating new paypal payment method' );
 	return {
 		id: storeKey,
+		paymentProcessorId: storeKey,
 		label: (
 			<PayPalLabel
 				labelText={ args.labelText }
@@ -218,7 +219,7 @@ function PayPalSubmitButton( {
 				'Missing onClick prop; PayPalSubmitButton must be used as a payment button in CheckoutSubmitButton'
 			);
 		}
-		onClick( storeKey, {
+		onClick( {
 			items,
 			postalCode: postalCode?.value,
 			countryCode: countryCode?.value,

--- a/client/my-sites/checkout/composite-checkout/payment-methods/wechat/index.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/wechat/index.js
@@ -61,6 +61,7 @@ export function createWeChatPaymentMethodStore() {
 export function createWeChatMethod( { store, stripe, stripeConfiguration, siteSlug } ) {
 	return {
 		id: 'wechat',
+		paymentProcessorId: 'wechat',
 		label: <WeChatLabel />,
 		activeContent: <WeChatFields stripe={ stripe } stripeConfiguration={ stripeConfiguration } />,
 		submitButton: (
@@ -162,7 +163,7 @@ function WeChatPayButton( { disabled, onClick, store, stripe, stripeConfiguratio
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting wechat payment' );
-					onClick( 'wechat', {
+					onClick( {
 						stripe,
 						name: customerName?.value,
 						items,

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
@@ -27,7 +27,7 @@ export function useSubmitTransaction( {
 	setStep: SetStep;
 	onClose: OnClose;
 } ): SubmitTransactionFunction {
-	const callPaymentProcessor = useProcessPayment();
+	const callPaymentProcessor = useProcessPayment( 'existing-card' );
 	const reduxDispatch = useDispatch();
 
 	return useCallback( () => {
@@ -36,7 +36,7 @@ export function useSubmitTransaction( {
 		}
 		const wpcomCart = translateResponseCartToWPCOMCart( cart );
 		setStep( 'processing' );
-		callPaymentProcessor( 'existing-card', {
+		callPaymentProcessor( {
 			items: wpcomCart.items,
 			name: storedCard.name,
 			storedDetailsId: storedCard.stored_details_id,

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -63,7 +63,8 @@ Each component will be styled using [@emotion/styled](https://emotion.sh/docs/st
 
 Each payment method is an object with the following properties:
 
-- `id: string`. A unique id.
+- `id: string`. A unique id for this instance of this payment method.
+- `paymentProcessorId: string`. The id that will be used to map this payment method to a payment processor function. Unlike the `id`, this does not have to be unique.
 - `label?: React.ReactNode`. A component that displays that payment method selection button which can be as simple as the name and an icon.
 - `activeContent?: React.ReactNode`. A component that displays that payment method (this can return null or something like a credit card form).
 - `inactiveContent?: React.ReactNode`. A component that renders a summary of the selected payment method when the step is inactive.
@@ -72,7 +73,7 @@ Each payment method is an object with the following properties:
 
 Within the components inside [CheckoutProvider](#CheckoutProvider), [usePaymentMethod](#usePaymentMethod) will return the currently selected payment method object if one is selected.
 
-When a payment method is ready to submit its data, it can use an appropriate "payment processor" function. These are functions passed to [CheckoutProvider](#CheckoutProvider) with the `paymentProcessors` prop and each one has a unique key. For convenience, the `submitButton` will be provided with an `onClick` function prop that will begin the transaction. The `onClick` function takes two arguments, a string which is the key of the payment processor function to be used, and an object that contains the data needed by the payment processor function.
+When a payment method is ready to submit its data, it can use an appropriate "payment processor" function. These are functions passed to [CheckoutProvider](#CheckoutProvider) with the `paymentProcessors` prop and each one has a unique key. For convenience, the `submitButton` will be provided with an `onClick` function prop that will begin the transaction. The `onClick` function takes one argument, an object that contains the data needed by the payment processor function.
 
 The payment processor function's response will control what happens next. Each payment processor function must return a Promise that resolves to one of four results: [makeManualResponse](#makeManualResponse), [makeRedirectResponse](#makeRedirectResponse), [makeSuccessResponse](#makeSuccessResponse), or [makeErrorResponse](#makeErrorResponse).
 
@@ -403,7 +404,7 @@ A React Hook that returns all the payment processor functions in a Record.
 
 ### useProcessPayment
 
-A React Hook that will return the function passed to each [payment method's submitButton component](#payment-methods). Call it with a payment method ID and data for the payment processor and it will handle the transaction.
+A React Hook that will return the `onClick` function passed to each [payment method's submitButton component](#payment-methods). The hook requires a payment processor ID. Call the returned function with data for the payment processor and it will begin the transaction.
 
 ### useSetStepComplete
 

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -16,9 +16,9 @@ export default function CheckoutSubmitButton( {
 	const { formStatus } = useFormStatus();
 	const { __ } = useI18n();
 	const isDisabled = disabled || formStatus !== FormStatus.READY;
-	const onClick = useProcessPayment();
-
 	const paymentMethod = usePaymentMethod();
+	const onClick = useProcessPayment( paymentMethod?.paymentProcessorId ?? '' );
+
 	if ( ! paymentMethod ) {
 		return null;
 	}

--- a/packages/composite-checkout/src/components/use-process-payment.ts
+++ b/packages/composite-checkout/src/components/use-process-payment.ts
@@ -17,13 +17,13 @@ import {
 
 const debug = debugFactory( 'composite-checkout:use-create-payment-processor-on-click' );
 
-export default function useProcessPayment(): ProcessPayment {
+export default function useProcessPayment( paymentProcessorId: string ): ProcessPayment {
 	const paymentProcessors = usePaymentProcessors();
 	const { setTransactionPending } = useTransactionStatus();
 	const handlePaymentProcessorPromise = useHandlePaymentProcessorResponse();
 
 	return useCallback(
-		async ( paymentProcessorId, submitData ) => {
+		async ( submitData ) => {
 			debug( 'beginning payment processor onClick handler' );
 			if ( ! paymentProcessors[ paymentProcessorId ] ) {
 				throw new Error( `No payment processor found with key: ${ paymentProcessorId }` );
@@ -33,7 +33,7 @@ export default function useProcessPayment(): ProcessPayment {
 			const response = paymentProcessors[ paymentProcessorId ]( submitData );
 			return handlePaymentProcessorPromise( paymentProcessorId, response );
 		},
-		[ handlePaymentProcessorPromise, paymentProcessors, setTransactionPending ]
+		[ paymentProcessorId, handlePaymentProcessorPromise, paymentProcessors, setTransactionPending ]
 	);
 }
 

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -32,6 +32,7 @@ export interface OrderSummaryData {
 
 export interface PaymentMethod {
 	id: string;
+	paymentProcessorId: string;
 	label?: React.ReactNode;
 	activeContent?: React.ReactNode;
 	inactiveContent?: React.ReactNode;
@@ -251,7 +252,6 @@ export interface TransactionStatusManager extends TransactionStatusState {
 }
 
 export type ProcessPayment = (
-	paymentProcessorId: string,
 	processorData: PaymentProcessorSubmitData
 ) => Promise< PaymentProcessorResponse >;
 

--- a/packages/wpcom-checkout/src/payment-methods/alipay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/alipay.tsx
@@ -66,6 +66,7 @@ export function createAlipayPaymentMethodStore(): AlipayStore {
 export function createAlipayMethod( { store }: { store: AlipayStore } ): PaymentMethod {
 	return {
 		id: 'alipay',
+		paymentProcessorId: 'alipay',
 		label: <AlipayLabel />,
 		activeContent: <AlipayFields />,
 		inactiveContent: <AlipaySummary />,
@@ -156,7 +157,7 @@ function AlipayPayButton( {
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting alipay payment' );
-					onClick( 'alipay', {
+					onClick( {
 						name: customerName?.value,
 						items,
 						total,

--- a/packages/wpcom-checkout/src/payment-methods/apple-pay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/apple-pay.tsx
@@ -17,6 +17,7 @@ export function createApplePayMethod(
 ): PaymentMethod {
 	return {
 		id: 'apple-pay',
+		paymentProcessorId: 'apple-pay',
 		label: <ApplePayLabel />,
 		submitButton: (
 			<ApplePaySubmitButton stripe={ stripe } stripeConfiguration={ stripeConfiguration } />
@@ -59,7 +60,7 @@ export function ApplePaySubmitButton( {
 					'Missing onClick prop; ApplePaySubmitButton must be used as a payment button in CheckoutSubmitButton'
 				);
 			}
-			onClick( 'apple-pay', {
+			onClick( {
 				stripe,
 				paymentMethodToken,
 				name,

--- a/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
@@ -68,6 +68,7 @@ export function createBancontactPaymentMethodStore(): BancontactStore {
 export function createBancontactMethod( { store }: { store: BancontactStore } ): PaymentMethod {
 	return {
 		id: 'bancontact',
+		paymentProcessorId: 'bancontact',
 		label: <BancontactLabel />,
 		activeContent: <BancontactFields />,
 		inactiveContent: <BancontactSummary />,
@@ -154,7 +155,7 @@ function BancontactPayButton( {
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting bancontact payment' );
-					onClick( 'bancontact', {
+					onClick( {
 						name: customerName.value,
 					} );
 				}

--- a/packages/wpcom-checkout/src/payment-methods/eps.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/eps.tsx
@@ -67,6 +67,7 @@ export function createEpsPaymentMethodStore(): EpsStore {
 export function createEpsMethod( { store }: { store: EpsStore } ): PaymentMethod {
 	return {
 		id: 'eps',
+		paymentProcessorId: 'eps',
 		label: <EpsLabel />,
 		activeContent: <EpsFields />,
 		submitButton: <EpsPayButton store={ store } />,
@@ -157,7 +158,7 @@ function EpsPayButton( {
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting eps payment' );
-					onClick( 'eps', {
+					onClick( {
 						name: customerName?.value,
 					} );
 				}

--- a/packages/wpcom-checkout/src/payment-methods/giropay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/giropay.tsx
@@ -69,6 +69,7 @@ export function createGiropayPaymentMethodStore(): GiropayStore {
 export function createGiropayMethod( { store }: { store: GiropayStore } ): PaymentMethod {
 	return {
 		id: 'giropay',
+		paymentProcessorId: 'giropay',
 		label: <GiropayLabel />,
 		activeContent: <GiropayFields />,
 		inactiveContent: <GiropaySummary />,
@@ -159,7 +160,7 @@ function GiropayPayButton( {
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting giropay payment' );
-					onClick( 'giropay', {
+					onClick( {
 						name: customerName.value,
 					} );
 				}

--- a/packages/wpcom-checkout/src/payment-methods/google-pay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/google-pay.tsx
@@ -17,6 +17,7 @@ export function createGooglePayMethod(
 ): PaymentMethod {
 	return {
 		id: 'google-pay',
+		paymentProcessorId: 'google-pay',
 		label: <GooglePayLabel />,
 		submitButton: (
 			<GooglePaySubmitButton stripe={ stripe } stripeConfiguration={ stripeConfiguration } />
@@ -57,7 +58,7 @@ export function GooglePaySubmitButton( {
 					'Missing onClick prop; GooglePaySubmitButton must be used as a payment button in CheckoutSubmitButton'
 				);
 			}
-			onClick( 'google-pay', {
+			onClick( {
 				stripe,
 				paymentMethodToken,
 				name,

--- a/packages/wpcom-checkout/src/payment-methods/ideal.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/ideal.tsx
@@ -77,6 +77,7 @@ export function createIdealPaymentMethodStore(): IdealStore {
 export function createIdealMethod( { store }: { store: IdealStore } ): PaymentMethod {
 	return {
 		id: 'ideal',
+		paymentProcessorId: 'ideal',
 		label: <IdealLabel />,
 		activeContent: <IdealFields />,
 		submitButton: <IdealPayButton store={ store } />,
@@ -288,7 +289,7 @@ function IdealPayButton( {
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting ideal payment' );
-					onClick( 'ideal', {
+					onClick( {
 						name: customerName?.value,
 						idealBank: customerBank?.value,
 						items,

--- a/packages/wpcom-checkout/src/payment-methods/p24.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/p24.tsx
@@ -78,6 +78,7 @@ export function createP24PaymentMethodStore(): P24Store {
 export function createP24Method( { store }: { store: P24Store } ): PaymentMethod {
 	return {
 		id: 'p24',
+		paymentProcessorId: 'p24',
 		label: <P24Label />,
 		activeContent: <P24Fields />,
 		inactiveContent: <P24Summary />,
@@ -181,7 +182,7 @@ function P24PayButton( {
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting p24 payment' );
-					onClick( 'p24', {
+					onClick( {
 						name: customerName.value,
 						email: customerEmail.value,
 					} );

--- a/packages/wpcom-checkout/src/payment-methods/sofort.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/sofort.tsx
@@ -68,6 +68,7 @@ export function createSofortPaymentMethodStore(): SofortStore {
 export function createSofortMethod( { store }: { store: SofortStore } ): PaymentMethod {
 	return {
 		id: 'sofort',
+		paymentProcessorId: 'sofort',
 		label: <SofortLabel />,
 		activeContent: <SofortFields />,
 		submitButton: <SofortPayButton store={ store } />,
@@ -158,7 +159,7 @@ function SofortPayButton( {
 			onClick={ () => {
 				if ( isFormValid( store ) ) {
 					debug( 'submitting sofort payment' );
-					onClick( 'sofort', {
+					onClick( {
 						name: customerName?.value,
 						items,
 						total,


### PR DESCRIPTION
#### Background

The `@automattic/composite-checkout` package defines the concept of "payment method objects" which contain the UI and state elements of a payment method. When the submit button of a payment method object is pressed, it calls an `onClick()` prop which is provided by its wrapper, `CheckoutSubmitButton` (which in turn gets it from the `useProcessPayment()` hook). That function initiates the transaction flow and calls the appropriate payment processor function.

#### The problem

To determine which payment processor function to call, the `onClick()` function requires that its first argument be the ID of that processor. This has always been a leaky abstraction since the whole idea of the `onClick` prop was as a convenience for building a payment method without needing to handle any of the transaction flow itself. It also hides the ID that a payment method will use deep inside its implementation. Finally, the ergonomics of an `onClick()` function suggest that it would only take one argument, like other functions of the same name.

#### Changes proposed in this Pull Request

In this PR we aim to solve all these issues by moving the ID from the `onClick` call up into the payment method object itself, in a new property called `paymentProcessorId`. Usually this is the same as the `id` property, but it can differ in the case that there is more than one instance of a payment method available (eg: saved credit cards) since the `id` has to be unique.

The result is that the `onClick` prop now only has one argument and the ID of the payment processor function used by a payment method object is immediately apparent at its definition.

Requires https://github.com/Automattic/wp-calypso/pull/62114

#### Testing instructions

This is a big breaking change for the API of the `@automattic/composite-checkout` package because it adds a new required property to payment method objects and it changes the function signature of the `onClick` handler. (It also changes the signature of the `useProcessPayment` hook.) Therefore, even though it is conceptually a simple adjustment, we have to make certain that nothing was missed.

1. The most important thing to do is to look for any payment methods that aren't changed by this PR. All payment methods using TypeScript are guaranteed, but there are payment methods that do not use types yet. The best way I can think of to do this is to search for `getAriaLabel`, which is a fairly unique required property name also used by payment method objects.

2. Secondly, make sure there are no uses of `useProcessPayment()` which have not been updated to provide an ID.

3. Third, test a full purchase flow with at least one payment method. Thanks to TypeScript guarantees, it's likely that if any one payment method works, all of them will.