### PR TITLE
Added billing term label to purchase items.

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -6,6 +6,7 @@ function createPurchaseObject( purchase ) {
 		active: Boolean( purchase.active ),
 		amount: Number( purchase.amount ),
 		attachedToPurchaseId: Number( purchase.attached_to_purchase_id ),
+		billPeriodDays: Number( purchase.bill_period_days ),
 		mostRecentRenewDate: purchase.most_recent_renew_date,
 		canDisableAutoRenew: Boolean( purchase.can_disable_auto_renew ),
 		canExplicitRenew: Boolean( purchase.can_explicit_renew ),

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -16,9 +16,6 @@ import {
 	isWpComPlan,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
-	PLAN_MONTHLY_PERIOD,
-	PLAN_ANNUAL_PERIOD,
-	PLAN_BIENNIAL_PERIOD,
 } from '@automattic/calypso-products';
 import { encodeProductForUrl } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
@@ -127,23 +124,6 @@ function getPartnerName( purchase ) {
 function getSubscriptionEndDate( purchase ) {
 	const localeSlug = i18n.getLocaleSlug();
 	return moment( purchase.expiryDate ).locale( localeSlug ).format( 'LL' );
-}
-
-/**
- * Returns a purchase term label (i.e. "every month", "every year", "every two years").
- *
- * @param {object} purchase The purchase
- * @returns {string|undefined} The purchase's term label
- */
-function getPurchaseBillingTermLabel( purchase ) {
-	switch ( purchase.billPeriodDays ) {
-		case PLAN_MONTHLY_PERIOD:
-			return String( i18n.translate( 'monthly' ) );
-		case PLAN_ANNUAL_PERIOD:
-			return String( i18n.translate( 'yearly' ) );
-		case PLAN_BIENNIAL_PERIOD:
-			return String( i18n.translate( 'every two years' ) );
-	}
 }
 
 /**
@@ -768,7 +748,6 @@ export {
 	canExplicitRenew,
 	creditCardExpiresBeforeSubscription,
 	creditCardHasAlreadyExpired,
-	getPurchaseBillingTermLabel,
 	getDomainRegistrationAgreementUrl,
 	getIncludedDomain,
 	getName,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -16,6 +16,9 @@ import {
 	isWpComPlan,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
+	PLAN_MONTHLY_PERIOD,
+	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
 } from '@automattic/calypso-products';
 import { encodeProductForUrl } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
@@ -124,6 +127,23 @@ function getPartnerName( purchase ) {
 function getSubscriptionEndDate( purchase ) {
 	const localeSlug = i18n.getLocaleSlug();
 	return moment( purchase.expiryDate ).locale( localeSlug ).format( 'LL' );
+}
+
+/**
+ * Returns a purchase term label (i.e. "every month", "every year", "every two years").
+ *
+ * @param {object} purchase The purchase
+ * @returns {string|undefined} The purchase's term label
+ */
+function getPurchaseBillingTermLabel( purchase ) {
+	switch ( purchase.billPeriodDays ) {
+		case PLAN_MONTHLY_PERIOD:
+			return String( i18n.translate( 'monthly' ) );
+		case PLAN_ANNUAL_PERIOD:
+			return String( i18n.translate( 'yearly' ) );
+		case PLAN_BIENNIAL_PERIOD:
+			return String( i18n.translate( 'every two years' ) );
+	}
 }
 
 /**
@@ -748,6 +768,7 @@ export {
 	canExplicitRenew,
 	creditCardExpiresBeforeSubscription,
 	creditCardHasAlreadyExpired,
+	getPurchaseBillingTermLabel,
 	getDomainRegistrationAgreementUrl,
 	getIncludedDomain,
 	getName,

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -1,4 +1,10 @@
-import { isDomainTransfer, isConciergeSession } from '@automattic/calypso-products';
+import {
+	isDomainTransfer,
+	isConciergeSession,
+	PLAN_MONTHLY_PERIOD,
+	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
+} from '@automattic/calypso-products';
 import { CompactCard, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import i18n, { localize, useTranslate } from 'i18n-calypso';
@@ -13,7 +19,6 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getPaymentMethodImageURL } from 'calypso/lib/checkout/payment-methods';
 import {
 	getDisplayName,
-	getPurchaseBillingTermLabel,
 	isExpired,
 	isExpiring,
 	isIncludedWithPlan,
@@ -197,17 +202,50 @@ class PurchaseItem extends Component {
 				);
 			}
 
-			if ( getPurchaseBillingTermLabel( purchase ) ) {
-				return translate( 'Renews %(interval)s at %(amount)s on {{span}}%(date)s{{/span}}', {
+			if ( purchase.billPeriodDays ) {
+				const translateOptions = {
 					args: {
-						interval: getPurchaseBillingTermLabel( purchase ),
 						amount: purchase.priceText,
 						date: renewDate.format( 'LL' ),
 					},
 					components: {
 						span: <span className="purchase-item__date" />,
 					},
-				} );
+				};
+				switch ( purchase.billPeriodDays ) {
+					case PLAN_MONTHLY_PERIOD:
+						if (
+							locale === 'en' ||
+							i18n.hasTranslation( 'Renews monthly at %(amount)s on {{span}}%(date)s{{/span}}' )
+						) {
+							return translate(
+								'Renews monthly at %(amount)s on {{span}}%(date)s{{/span}}',
+								translateOptions
+							);
+						}
+					case PLAN_ANNUAL_PERIOD:
+						if (
+							locale === 'en' ||
+							i18n.hasTranslation( 'Renews yearly at %(amount)s on {{span}}%(date)s{{/span}}' )
+						) {
+							return translate(
+								'Renews yearly at %(amount)s on {{span}}%(date)s{{/span}}',
+								translateOptions
+							);
+						}
+					case PLAN_BIENNIAL_PERIOD:
+						if (
+							locale === 'en' ||
+							i18n.hasTranslation(
+								'Renews every two years at %(amount)s on {{span}}%(date)s{{/span}}'
+							)
+						) {
+							return translate(
+								'Renews every two years at %(amount)s on {{span}}%(date)s{{/span}}',
+								translateOptions
+							);
+						}
+				}
 			}
 
 			return translate( 'Renews at %(amount)s on {{span}}%(date)s{{/span}}', {

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -13,6 +13,7 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getPaymentMethodImageURL } from 'calypso/lib/checkout/payment-methods';
 import {
 	getDisplayName,
+	getPurchaseBillingTermLabel,
 	isExpired,
 	isExpiring,
 	isIncludedWithPlan,
@@ -194,6 +195,19 @@ class PurchaseItem extends Component {
 						{ this.trackImpression( 'credit-card-expiring' ) }
 					</span>
 				);
+			}
+
+			if ( getPurchaseBillingTermLabel( purchase ) ) {
+				return translate( 'Renews %(interval)s at %(amount)s on {{span}}%(date)s{{/span}}', {
+					args: {
+						interval: getPurchaseBillingTermLabel( purchase ),
+						amount: purchase.priceText,
+						date: renewDate.format( 'LL' ),
+					},
+					components: {
+						span: <span className="purchase-item__date" />,
+					},
+				} );
 			}
 
 			return translate( 'Renews at %(amount)s on {{span}}%(date)s{{/span}}', {

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -70,6 +70,7 @@ describe( 'selectors', () => {
 				active: false,
 				amount: NaN,
 				attachedToPurchaseId: NaN,
+				billPeriodDays: NaN,
 				blogCreatedDate: undefined,
 				canExplicitRenew: false,
 				canDisableAutoRenew: false,


### PR DESCRIPTION
As a follow-up to #51099, this adds the billing interval to "Renews on…" statuses in the purchases list.
This uses a new property on the purchase item called `billPeriodDays` to get the appropriate label.

This is an alternative approach to #51198, that had some limitations regarding Domain purchases as mentioned [here](https://github.com/Automattic/wp-calypso/pull/51198#issuecomment-1078091760)

Depends on D77601-code

Fixes: #47877

**Before** | **After**
------------ | -------------
<img width="1058" alt="Screen Shot 2021-03-18 at 2 29 22 PM" src="https://user-images.githubusercontent.com/11573483/160194094-4105408b-f027-4adb-a3e5-0c8d068704ea.png"> | <img width="1065" alt="Screen Shot 2021-03-18 at 2 26 44 PM" src="https://user-images.githubusercontent.com/11573483/160194075-5f141efd-24e2-4308-a7b4-d8ce52497eaf.png">



**To test:**
- On an account with purchases (with payment methods assigned and auto-renew on)
- Visit Me > Purchases
- Verify that the purchase status includes a billing interval
- Visit My Site > Upgrades > Purchases
- Verify that the purchase status includes a billing interval
