### PR TITLE
Checkout: Convert most remaining payment methods to TypeScript

### DIFF
--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -340,9 +340,9 @@ validators.validStreetNumber = {
  * with keys that are the field names of those errors.  The value of each
  * property of that object is an array of error strings.
  *
- * @param {object} paymentDetails object containing fieldname/value keypairs
+ * @param {Object.<string, string>} paymentDetails object containing fieldname/value keypairs
  * @param {string} paymentType credit-card|paypal|p24|brazil-tef|netbanking|token|stripe|ebanx
- * @returns {object} validation errors, if any
+ * @returns {{errors:Object.<string, string[]>}} validation errors, if any
  */
 export function validatePaymentDetails( paymentDetails, paymentType ) {
 	const rules = paymentFieldRules( paymentDetails, paymentType ) || {};

--- a/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
@@ -2,8 +2,9 @@ import { Button, useFormStatus, FormStatus, useLineItems } from '@automattic/com
 import { useI18n } from '@wordpress/react-i18n';
 import { Fragment } from 'react';
 import WordPressLogo from '../components/wordpress-logo';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 
-export function createFreePaymentMethod() {
+export function createFreePaymentMethod(): PaymentMethod {
 	return {
 		id: 'free-purchase',
 		paymentProcessorId: 'free-purchase',
@@ -14,9 +15,24 @@ export function createFreePaymentMethod() {
 	};
 }
 
-function FreePurchaseSubmitButton( { disabled, onClick } ) {
+function FreePurchaseSubmitButton( {
+	disabled,
+	onClick,
+}: {
+	disabled?: boolean;
+	onClick?: ProcessPayment;
+} ) {
 	const [ items ] = useLineItems();
 	const { formStatus } = useFormStatus();
+
+	// This must be typed as optional because it's injected by cloning the
+	// element in CheckoutSubmitButton, but the uncloned element does not have
+	// this prop yet.
+	if ( ! onClick ) {
+		throw new Error(
+			'Missing onClick prop; FreePurchaseSubmitButton must be used as a payment button in CheckoutSubmitButton'
+		);
+	}
 
 	const handleButtonPress = () => {
 		onClick( {
@@ -37,15 +53,15 @@ function FreePurchaseSubmitButton( { disabled, onClick } ) {
 	);
 }
 
-function ButtonContents( { formStatus } ) {
+function ButtonContents( { formStatus }: { formStatus: FormStatus } ) {
 	const { __ } = useI18n();
 	if ( formStatus === FormStatus.SUBMITTING ) {
-		return __( 'Processing…' );
+		return <>{ __( 'Processing…' ) }</>;
 	}
 	if ( formStatus === FormStatus.READY ) {
-		return __( 'Complete Checkout' );
+		return <>{ __( 'Complete Checkout' ) }</>;
 	}
-	return __( 'Please wait…' );
+	return <>{ __( 'Please wait…' ) }</>;
 }
 
 function WordPressFreePurchaseLabel() {

--- a/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.tsx
@@ -5,8 +5,9 @@ import { useI18n } from '@wordpress/react-i18n';
 import { Fragment } from 'react';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import WordPressLogo from '../components/wordpress-logo';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 
-export function createFullCreditsMethod() {
+export function createFullCreditsMethod(): PaymentMethod {
 	return {
 		id: 'full-credits',
 		paymentProcessorId: 'full-credits',
@@ -17,11 +18,26 @@ export function createFullCreditsMethod() {
 	};
 }
 
-function FullCreditsSubmitButton( { disabled, onClick } ) {
+function FullCreditsSubmitButton( {
+	disabled,
+	onClick,
+}: {
+	disabled?: boolean;
+	onClick?: ProcessPayment;
+} ) {
 	const [ items ] = useLineItems();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const { formStatus } = useFormStatus();
+
+	// This must be typed as optional because it's injected by cloning the
+	// element in CheckoutSubmitButton, but the uncloned element does not have
+	// this prop yet.
+	if ( ! onClick ) {
+		throw new Error(
+			'Missing onClick prop; FullCreditsSubmitButton must be used as a payment button in CheckoutSubmitButton'
+		);
+	}
 
 	const handleButtonPress = () => {
 		onClick( {
@@ -45,16 +61,16 @@ function FullCreditsSubmitButton( { disabled, onClick } ) {
 	);
 }
 
-function ButtonContents( { formStatus, total } ) {
+function ButtonContents( { formStatus, total }: { formStatus: FormStatus; total: string } ) {
 	const { __ } = useI18n();
 	if ( formStatus === FormStatus.SUBMITTING ) {
-		return __( 'Processing…' );
+		return <>{ __( 'Processing…' ) }</>;
 	}
 	if ( formStatus === FormStatus.READY ) {
 		/* translators: %s is the total to be paid in localized currency */
-		return sprintf( __( 'Pay %s with credits' ), total );
+		return <>{ sprintf( __( 'Pay %s with credits' ), total ) }</>;
 	}
-	return __( 'Please wait…' );
+	return <>{ __( 'Please wait…' ) }</>;
 }
 
 function WordPressCreditsLabel() {

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.tsx
@@ -244,11 +244,7 @@ function NetBankingPayButton( {
 		( accum, [ key, managedValue ] ) => ( { ...accum, [ camelCase( key ) ]: managedValue.value } ),
 		{}
 	);
-	const contactCountryCode = useSelect(
-		( select ) =>
-			( select( 'wpcom-checkout' )?.getContactInfo() as Record< string, StoreStateValue > )
-				.countryCode?.value
-	);
+	const contactCountryCode = 'IN'; // If this payment method is available and the country is not India, we have other problems
 	const reduxDispatch = useReduxDispatch();
 
 	// This must be typed as optional because it's injected by cloning the

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.tsx
@@ -236,7 +236,7 @@ function NetBankingPayButton( {
 	store: NetBankingStore;
 } ) {
 	const { __ } = useI18n();
-	const [ items, total ] = useLineItems();
+	const [ , total ] = useLineItems();
 	const { formStatus } = useFormStatus();
 	const customerName = useSelect( ( select ) => select( 'netbanking' ).getCustomerName() );
 	const fields = useSelect( ( select ) => select( 'netbanking' ).getFields() );
@@ -266,8 +266,6 @@ function NetBankingPayButton( {
 						...massagedFields,
 						name: customerName?.value,
 						address: massagedFields?.address1,
-						items,
-						total,
 					} );
 				}
 			} }

--- a/client/my-sites/checkout/composite-checkout/test/netbanking.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/netbanking.tsx
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	CheckoutProvider,
+	CheckoutStepGroup,
+	PaymentMethodStep,
+	makeSuccessResponse,
+	CheckoutFormSubmit,
+} from '@automattic/composite-checkout';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider as ReduxProvider } from 'react-redux';
+import {
+	createNetBankingMethod,
+	createNetBankingPaymentMethodStore,
+} from 'calypso/my-sites/checkout/composite-checkout/payment-methods/netbanking';
+import { createReduxStore } from 'calypso/state';
+
+function TestWrapper( { paymentMethods, paymentProcessors = undefined } ) {
+	const store = createReduxStore();
+	const queryClient = new QueryClient();
+	return (
+		<ReduxProvider store={ store }>
+			<QueryClientProvider client={ queryClient }>
+				<CheckoutProvider
+					paymentMethods={ paymentMethods }
+					initiallySelectedPaymentMethodId={ paymentMethods[ 0 ].id }
+					paymentProcessors={ paymentProcessors ?? {} }
+				>
+					<CheckoutStepGroup>
+						<PaymentMethodStep />
+						<CheckoutFormSubmit />
+					</CheckoutStepGroup>
+				</CheckoutProvider>
+			</QueryClientProvider>
+		</ReduxProvider>
+	);
+}
+
+const customerName = 'Human Person';
+const pan = 'ABCDE1234F';
+const gstin = '22AAAAA0000A1Z5';
+const customerPostalCode = '1234';
+const customerAddress = 'Main Street';
+const customerStreet = '1100';
+const customerCity = 'Somewhere';
+const customerState = 'Elsewhere';
+const activePayButtonText = 'Pay 0';
+function getPaymentMethod( additionalArgs = {} ) {
+	const store = createNetBankingPaymentMethodStore();
+	return createNetBankingMethod( {
+		store,
+		...additionalArgs,
+	} );
+}
+
+describe( 'Netbanking payment method', () => {
+	it( 'renders a netbanking option', async () => {
+		const paymentMethod = getPaymentMethod();
+		render( <TestWrapper paymentMethods={ [ paymentMethod ] }></TestWrapper> );
+		await waitFor( () => {
+			expect( screen.queryByText( 'Net Banking' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders submit button when netbanking is selected', async () => {
+		const paymentMethod = getPaymentMethod();
+		render( <TestWrapper paymentMethods={ [ paymentMethod ] }></TestWrapper> );
+		await waitFor( () => {
+			expect( screen.queryByText( activePayButtonText ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'submits the data to the processor when the submit button is pressed', async () => {
+		const paymentMethod = getPaymentMethod();
+		const processorFunction = jest.fn( () => Promise.resolve( makeSuccessResponse( {} ) ) );
+		render(
+			<TestWrapper
+				paymentMethods={ [ paymentMethod ] }
+				paymentProcessors={ { netbanking: processorFunction } }
+			></TestWrapper>
+		);
+		await waitFor( () => expect( screen.getByText( activePayButtonText ) ).not.toBeDisabled() );
+
+		fireEvent.change( screen.getByLabelText( /Your name/i ), {
+			target: { value: customerName },
+		} );
+		fireEvent.change( screen.getByLabelText( /GSTIN/i ), {
+			target: { value: gstin },
+		} );
+		fireEvent.change( screen.getAllByLabelText( /PAN Number/i )[ 1 ], {
+			target: { value: pan },
+		} );
+		fireEvent.change( screen.getByLabelText( /Address/i ), {
+			target: { value: customerAddress },
+		} );
+		fireEvent.change( screen.getByLabelText( /Street Number/i ), {
+			target: { value: customerStreet },
+		} );
+		fireEvent.change( screen.getByLabelText( /City/i ), {
+			target: { value: customerCity },
+		} );
+		fireEvent.change( screen.getByLabelText( /State/i ), {
+			target: { value: customerState },
+		} );
+		fireEvent.change( screen.getByLabelText( /Postal code/i ), {
+			target: { value: customerPostalCode },
+		} );
+
+		fireEvent.click( await screen.findByText( activePayButtonText ) );
+		await waitFor( () => {
+			expect( processorFunction ).toHaveBeenCalledWith( {
+				name: customerName,
+				address: customerAddress,
+				address1: customerAddress,
+				streetNumber: customerStreet,
+				city: customerCity,
+				state: customerState,
+				postalCode: customerPostalCode,
+				pan,
+				gstin,
+			} );
+		} );
+	} );
+
+	it( 'does not submit the data to the processor when the submit button is pressed if fields are missing', async () => {
+		const paymentMethod = getPaymentMethod();
+		const processorFunction = jest.fn( () => Promise.resolve( makeSuccessResponse( {} ) ) );
+		render(
+			<TestWrapper
+				paymentMethods={ [ paymentMethod ] }
+				paymentProcessors={ { netbanking: processorFunction } }
+			></TestWrapper>
+		);
+		await waitFor( () => expect( screen.getByText( activePayButtonText ) ).not.toBeDisabled() );
+		fireEvent.click( await screen.findByText( activePayButtonText ) );
+		await waitFor( () => {
+			expect( processorFunction ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/packages/wpcom-checkout/src/payment-method-store.ts
+++ b/packages/wpcom-checkout/src/payment-method-store.ts
@@ -3,6 +3,7 @@ import { registerStore } from '@wordpress/data';
 export interface StoreStateValue {
 	value: string;
 	isTouched: boolean;
+	errors?: string[];
 }
 
 type AddStateArg< F, S > = F extends ( ...args: infer P ) => infer R


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR converts the following payment methods to TypeScript:

- Free
- Full credits
- Netbanking

#### Testing instructions

All methods are covered by unit tests, but you can test them manually if you like:

To test Netbanking:

- Set your currency to INR.
- Apply D48222-code and sandbox the API; this will make it appear that you are in India.
- Visit checkout with a product in your cart.
- Select "India" as a country in the contact form.
- Select "Netbanking" and verify that you see the form fields for PAN, GSTIN, and other contact data appear.
- Fill in valid PAN (eg: `ABCDE1234F`) and GSTIN (eg: `22AAAAA0000A1Z5`) data.
- Try to submit the form. Verify that you are taken to the dLocal page.

To test the `free-purchase` method:

- Use a site that has a domain credit.
- Add a domain product to your cart and visit checkout.
- Select the "free" payment method (it should be the only one) and submit the purchase.

To test the `full-credits` method:

- Use a user that has enough credits to completely cover a plan purchase.
- Add a plan product to your cart and visit checkout.
- Select the "credits" payment method (it should be the only one) and submit the purchase.

