### PR TITLE
[WordAds]: Fix PayPal mismatch notice always showing

### DIFF
--- a/client/my-sites/earn/ads/payments.jsx
+++ b/client/my-sites/earn/ads/payments.jsx
@@ -116,7 +116,7 @@ class WordAdsPayments extends Component {
 		let hasMismatch = false;
 
 		payments.forEach( ( payment ) => {
-			if ( payment.status === 'pending' && payment.paypal_email !== wordAdsSettings.paypal ) {
+			if ( payment.status === 'pending' && payment.paypalEmail !== wordAdsSettings.paypal ) {
 				hasMismatch = true;
 			}
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The PayPal mismatch notice was always showing even if the PayPal address correctly matched the pending payment.

#### Testing instructions

* Load WordAds site. Verify the PayPal notice does not appear if the pending payment PayPal matches the users current PayPal
