### PR TITLE
Plans overhaul Phase 1: Replace Business upgrade nudge with Pro on the Plugins page

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -3,16 +3,25 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { map } from 'lodash';
+import { useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { isAtomicSiteWithoutBusinessPlan } from './utils';
 
 // Mapping eligibility holds to messages that will be shown to the user
-function getHoldMessages( context: string | null, translate: LocalizeProps[ 'translate' ] ) {
+function getHoldMessages(
+	context: string | null,
+	translate: LocalizeProps[ 'translate' ],
+	eligibleForProPlan: boolean
+) {
 	return {
 		NO_BUSINESS_PLAN: {
-			title: translate( 'Upgrade to a Business plan' ),
+			title: eligibleForProPlan
+				? translate( 'Upgrade to a Pro plan' )
+				: translate( 'Upgrade to a Business plan' ),
 			description: ( function () {
 				if ( context === 'themes' ) {
 					return translate(
@@ -184,7 +193,11 @@ export const HardBlockingNotice = ( {
 };
 
 export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
-	const holdMessages = getHoldMessages( context, translate );
+	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, selectedSite?.ID )
+	);
+	const holdMessages = getHoldMessages( context, translate, eligibleForProPlan );
 	const blockingMessages = getBlockingMessages( translate );
 
 	const blockingHold = holds.find( ( h ) => isHardBlockingHoldType( h, blockingMessages ) );

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -1,4 +1,4 @@
-import { PLAN_BUSINESS_MONTHLY, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { PLAN_BUSINESS_MONTHLY, PLAN_BUSINESS, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -52,14 +52,16 @@ const USPS: React.FC< Props > = ( {
 	const isAnnualPlan = useSelector( isAnnualPlanOrUpgradeableAnnualPeriod );
 
 	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
-	const planDisplayCost = useSelector( ( state ) =>
-		getProductDisplayCost( state, isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY )
-	);
 
 	const selectedSite = useSelector( getSelectedSite );
 	const eligibleForProPlan = useSelector( ( state ) =>
 		isEligibleForProPlan( state, selectedSite?.ID )
 	);
+
+	const planDisplayCost = useSelector( ( state ) => {
+		const productSlug = isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY;
+		return getProductDisplayCost( state, eligibleForProPlan ? PLAN_WPCOM_PRO : productSlug );
+	} );
 
 	const filteredUSPS = [
 		...( isMarketplaceProduct

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -4,8 +4,10 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { isAnnualPlanOrUpgradeableAnnualPeriod } from 'calypso/state/marketplace/selectors';
 import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const StyledUl = styled.ul`
 	margin-top: 20px;
@@ -54,6 +56,11 @@ const USPS: React.FC< Props > = ( {
 		getProductDisplayCost( state, isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY )
 	);
 
+	const selectedSite = useSelector( getSelectedSite );
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, selectedSite?.ID )
+	);
+
 	const filteredUSPS = [
 		...( isMarketplaceProduct
 			? [
@@ -82,9 +89,13 @@ const USPS: React.FC< Props > = ( {
 					{
 						id: 'plan',
 						className: 'title',
-						text: translate( 'Included in the Business plan (%s):', {
-							args: [ planDisplayCost ],
-						} ),
+						text: eligibleForProPlan
+							? translate( 'Included in the Pro plan (%s):', {
+									args: [ planDisplayCost ],
+							  } )
+							: translate( 'Included in the Business plan (%s):', {
+									args: [ planDisplayCost ],
+							  } ),
 						eligibilities: [ 'needs-upgrade' ],
 					},
 			  ]

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -63,6 +63,10 @@ const USPS: React.FC< Props > = ( {
 		return getProductDisplayCost( state, eligibleForProPlan ? PLAN_WPCOM_PRO : productSlug );
 	} );
 
+	const supportText = isAnnualPlan
+		? translate( 'Live chat support 24x7' )
+		: translate( 'Unlimited Email Support' );
+
 	const filteredUSPS = [
 		...( isMarketplaceProduct
 			? [
@@ -127,9 +131,7 @@ const USPS: React.FC< Props > = ( {
 					{
 						id: 'support',
 						image: <Gridicon icon="chat" size={ 16 } />,
-						text: isAnnualPlan
-							? translate( 'Live chat support 24x7' )
-							: translate( 'Unlimited Email Support' ),
+						text: eligibleForProPlan ? translate( 'Premium support' ) : supportText,
 						eligibilities: [ 'needs-upgrade', 'marketplace' ],
 					},
 			  ]

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -3,6 +3,7 @@ import {
 	isBusiness,
 	isEcommerce,
 	isEnterprise,
+	isPro,
 	findFirstSimilarPlanKey,
 	FEATURE_UPLOAD_PLUGINS,
 	TYPE_BUSINESS,
@@ -35,6 +36,7 @@ import { useWPORGPlugins } from 'calypso/data/marketplace/use-wporg-plugin-query
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import UrlSearch from 'calypso/lib/url-search';
 import NoResults from 'calypso/my-sites/no-results';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import EducationFooter from 'calypso/my-sites/plugins/education-footer';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
@@ -128,7 +130,11 @@ const PluginsBrowser = ( {
 	const billingPeriod = useSelector( getBillingInterval );
 
 	const hasBusinessPlan =
-		sitePlan && ( isBusiness( sitePlan ) || isEnterprise( sitePlan ) || isEcommerce( sitePlan ) );
+		sitePlan &&
+		( isBusiness( sitePlan ) ||
+			isEnterprise( sitePlan ) ||
+			isEcommerce( sitePlan ) ||
+			isPro( sitePlan ) );
 
 	const { data: paidPluginsRawList = [], isLoading: isFetchingPaidPlugins } = useWPCOMPlugins(
 		'all'
@@ -614,16 +620,23 @@ const UpgradeNudge = ( {
 	siteSlug,
 } ) => {
 	const translate = useTranslate();
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, selectedSite?.ID )
+	);
 
 	if ( ! selectedSite?.ID || ! sitePlan || isVip || jetpackNonAtomic || hasBusinessPlan ) {
 		return null;
 	}
 
-	const bannerURL = `/checkout/${ siteSlug }/business`;
+	const checkoutPlan = eligibleForProPlan ? 'pro' : 'business';
+	const bannerURL = `/checkout/${ siteSlug }/${ checkoutPlan }`;
 	const plan = findFirstSimilarPlanKey( sitePlan.product_slug, {
 		type: TYPE_BUSINESS,
 	} );
-	const title = translate( 'Upgrade to the Business plan to install plugins.' );
+
+	const title = eligibleForProPlan
+		? translate( 'Upgrade to the Pro plan to install plugins.' )
+		: translate( 'Upgrade to the Business plan to install plugins.' );
 
 	return (
 		<UpsellNudge


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This replaces nudges to upgrade to Business Plan with Pro. It also ensures that the Pro plan is added to the shopping cart when clicking the Upgrade CTA.

#### Testing instructions

* Go to `/plugins/[site]?flags=plans/pro-plan` on a Free plan site
* The top notice should mention the Pro plan

<img width="320" alt="Screenshot on 2022-03-26 at 11-42-28" src="https://user-images.githubusercontent.com/2749938/160234082-4fd21137-9f16-4a60-824b-87ec05b96ca9.png">

* Select the WooCommerce plugin
* The `Included with` section, beneath the Upgrade button should mention the Pro plan. The last feature should be `Premium support`

<img width="320" alt="Screenshot on 2022-03-26 at 12-39-48" src="https://user-images.githubusercontent.com/2749938/160235846-b6df0f88-1f4c-4bfc-b698-ac90f0a50dba.png">


* Click on the Upgrade and activate button
* The pop-up should mention the Pro plan

<img width="320" alt="Screenshot on 2022-03-26 at 11-54-38" src="https://user-images.githubusercontent.com/2749938/160234364-6fdfd97d-98d4-4766-999b-6a1bda09660b.png">

* Click on Upgrade to Continue
* A Pro plan should be added to the Shopping Cart

<img width="320" alt="Screenshot on 2022-03-26 at 11-56-16" src="https://user-images.githubusercontent.com/2749938/160234399-4f81a2a2-c0f2-4aa2-b1f5-fed8a4c21b92.png">



* Make sure that the changes are not visible without the `?flags=plans/pro-plan` flag (ie. Business is shown instead of Pro)
