### PR TITLE
Plan overhaul Phase 1: Do not show timeframe toggle in Plugins page

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -14,6 +14,8 @@ import NoticeAction from 'calypso/components/notice/notice-action';
 import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginDetailsCTA from 'calypso/my-sites/plugins/plugin-details-CTA';
@@ -60,7 +62,6 @@ import {
 	isRequestingSites as checkRequestingSites,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { isEligibleForProPlan } from '../plans-comparison';
 import NoPermissionsError from './no-permissions-error';
 
 function PluginDetails( props ) {
@@ -144,6 +145,12 @@ function PluginDetails( props ) {
 		props.pluginSlug,
 		dispatch,
 	] );
+
+	useEffect( () => {
+		if ( eligibleForProPlan && setBillingInterval ) {
+			dispatch( setBillingInterval( IntervalLength.ANNUALLY ) );
+		}
+	}, [ eligibleForProPlan, dispatch ] );
 
 	// Fetch WPcom plugin data if needed
 	const {

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -60,6 +60,7 @@ import {
 	isRequestingSites as checkRequestingSites,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { isEligibleForProPlan } from '../plans-comparison';
 import NoPermissionsError from './no-permissions-error';
 
 function PluginDetails( props ) {
@@ -78,6 +79,9 @@ function PluginDetails( props ) {
 		isRequestingForSites( state, siteIds )
 	);
 	const analyticsPath = selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, selectedSite?.ID )
+	);
 
 	// Plugin information.
 	const plugin = useSelector( ( state ) => getPluginOnSites( state, siteIds, props.pluginSlug ) );
@@ -249,7 +253,8 @@ function PluginDetails( props ) {
 			<FixedNavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs }>
 				{ ( isMarketplaceProduct || shouldUpgrade ) &&
 					! requestingPluginsForSites &&
-					! isPluginInstalledOnsite && (
+					! isPluginInstalledOnsite &&
+					! eligibleForProPlan && (
 						<BillingIntervalSwitcher
 							billingPeriod={ billingPeriod }
 							onChange={ ( interval ) => dispatch( setBillingInterval( interval ) ) }

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -5,15 +5,10 @@ import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
-import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
-import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
-import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import PluginBrowserItem from 'calypso/my-sites/plugins/plugins-browser-item';
 import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { PluginsBrowserListVariant } from './types';
 
 import './style.scss';
@@ -34,20 +29,10 @@ const PluginsBrowserList = ( {
 	listName,
 	expandedListLink,
 	size,
+	eligibleForProPlan,
 } ) => {
 	const isWide = useBreakpoint( '>1280px' );
 	const { __ } = useI18n();
-	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
-
-	const eligibleForProPlan = useSelector( ( state ) =>
-		isEligibleForProPlan( state, selectedSite?.ID )
-	);
-
-	useEffect( () => {
-		if ( eligibleForProPlan && setBillingPeriod ) {
-			setBillingPeriod( IntervalLength.ANNUALLY );
-		}
-	}, [ eligibleForProPlan, setBillingPeriod ] );
 
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -5,10 +5,15 @@ import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import PluginBrowserItem from 'calypso/my-sites/plugins/plugins-browser-item';
 import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { PluginsBrowserListVariant } from './types';
 
 import './style.scss';
@@ -32,6 +37,17 @@ const PluginsBrowserList = ( {
 } ) => {
 	const isWide = useBreakpoint( '>1280px' );
 	const { __ } = useI18n();
+	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, selectedSite?.ID )
+	);
+
+	useEffect( () => {
+		if ( eligibleForProPlan && setBillingPeriod ) {
+			setBillingPeriod( IntervalLength.ANNUALLY );
+		}
+	}, [ eligibleForProPlan, setBillingPeriod ] );
 
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {
@@ -93,7 +109,7 @@ const PluginsBrowserList = ( {
 					<div className="plugins-browser-list__subtitle">{ subtitle }</div>
 				</div>
 				<div className="plugins-browser-list__actions">
-					{ setBillingPeriod && (
+					{ setBillingPeriod && ! eligibleForProPlan && (
 						<BillingIntervalSwitcher
 							billingPeriod={ billingPeriod }
 							onChange={ setBillingPeriod }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -34,7 +34,9 @@ import {
 import { useWPORGPlugins } from 'calypso/data/marketplace/use-wporg-plugin-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import UrlSearch from 'calypso/lib/url-search';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import NoResults from 'calypso/my-sites/no-results';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import EducationFooter from 'calypso/my-sites/plugins/education-footer';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
@@ -186,6 +188,16 @@ const PluginsBrowser = ( {
 		}
 		return ! selectedSite?.ID && hasJetpack;
 	}, [ isJetpack, selectedSite, hasJetpack ] );
+
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, selectedSite?.ID )
+	);
+
+	useEffect( () => {
+		if ( eligibleForProPlan && setBillingInterval ) {
+			dispatch( setBillingInterval( IntervalLength.ANNUALLY ) );
+		}
+	}, [ eligibleForProPlan, dispatch ] );
 
 	useEffect( () => {
 		const items = [
@@ -345,6 +357,7 @@ const PluginsBrowser = ( {
 				jetpackNonAtomic={ jetpackNonAtomic }
 				billingPeriod={ billingPeriod }
 				setBillingPeriod={ ( interval ) => dispatch( setBillingInterval( interval ) ) }
+				eligibleForProPlan={ eligibleForProPlan }
 			/>
 			<InfiniteScroll nextPageMethod={ fetchNextPagePlugins } />
 			<EducationFooter />
@@ -358,6 +371,7 @@ const SearchListView = ( {
 	siteSlug,
 	sites,
 	billingPeriod,
+	eligibleForProPlan,
 } ) => {
 	const [ page, setPage ] = useState( 1 );
 	const [ pageSize, setPageSize ] = useState( SEARCH_RESULTS_LIST_LENGTH );
@@ -445,6 +459,7 @@ const SearchListView = ( {
 					variant={ PluginsBrowserListVariant.Paginated }
 					extended
 					billingPeriod={ billingPeriod }
+					eligibleForProPlan={ eligibleForProPlan }
 				/>
 				{ pluginsPagination && (
 					<Pagination
@@ -482,6 +497,7 @@ const FullListView = ( {
 	isFetchingPaidPlugins,
 	billingPeriod,
 	setBillingPeriod,
+	eligibleForProPlan,
 } ) => {
 	const translate = useTranslate();
 
@@ -505,6 +521,7 @@ const FullListView = ( {
 				billingPeriod={ billingPeriod }
 				setBillingPeriod={ category === 'paid' && setBillingPeriod }
 				extended
+				eligibleForProPlan={ eligibleForProPlan }
 			/>
 		);
 	}
@@ -531,6 +548,7 @@ const PluginSingleListView = ( {
 	sites,
 	billingPeriod,
 	setBillingPeriod,
+	eligibleForProPlan,
 } ) => {
 	const translate = useTranslate();
 
@@ -577,6 +595,7 @@ const PluginSingleListView = ( {
 			spotlightPlugin={ spotlightPlugin }
 			spotlightPluginFetched={ spotlightPluginFetched }
 			extended
+			eligibleForProPlan={ eligibleForProPlan }
 		/>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This remove the Monthly/Annually toggle from the Plugins page for the overhauled Plans

#### Testing instructions

* Go to /plugins/[site]?flags=plans/pro-plan on a Free site.
* You should not see the timeframe toggle on the top right section.
* The prices should be shown for annual timeframes.

<img width="320" alt="Screenshot on 2022-03-28 at 14-11-00" src="https://user-images.githubusercontent.com/2749938/160386098-7bbd66bc-e9fd-4ee1-8d72-bb5f38f56095.png">


* Go to `/plugins/woocommerce/[site]?flags=plans/pro-plan` on a Free site.
* You should not see the timeframe toggle on the top right section.
* The prices should be shown for annual timeframes.

<img width="320" alt="Screenshot on 2022-03-28 at 14-13-34" src="https://user-images.githubusercontent.com/2749938/160386424-486165da-9c41-4731-ae02-3bb2a2c519c8.png">

##### Legacy plans

* Go to /plugins/[site]?flags=plans/pro-plan on a Free site.
* You should see the timeframe toggle on the top right section.
<img width="320" alt="Screenshot on 2022-03-28 at 14-14-39" src="https://user-images.githubusercontent.com/2749938/160386588-cf511233-1c8f-4a37-b957-6886b6e9e39a.png">


* Go to `/plugins/woocommerce/[site]` on a Free site
* You should see the timeframe toggle on the top right section

<img width="320" alt="Screenshot on 2022-03-28 at 14-12-21" src="https://user-images.githubusercontent.com/2749938/160386242-1a92b2d2-a69a-4300-9e4c-ca22c1132ac4.png">

