### PR TITLE
Show billing period selector when there is an active plan and trying to purchase a compatible product

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -1,4 +1,5 @@
 import {
+	isPlan,
 	findPlansKeys,
 	findProductKeys,
 	getBillingMonthsForTerm,
@@ -39,6 +40,7 @@ export interface AvailableProductVariant {
 	plan: Plan | Product;
 	product: {
 		product_id: number;
+		product_slug: string;
 		currency_code: string;
 	};
 	priceFull: number;
@@ -177,6 +179,11 @@ function isVariantAllowed(
 	variant: AvailableProductVariant,
 	activePlanRenewalInterval: number | undefined
 ): boolean {
+	// Allow the variant when the item added to the cart is not a plan.
+	if ( ! isPlan( variant.product ) ) {
+		return true;
+	}
+
 	// If this is a plan, does the site currently own a plan? If so, is the term
 	// of the variant lower than the term of the currently owned plan? If so, do
 	// not allow the variant.


### PR DESCRIPTION
#### Context
- p1648123701130479-slack-C0117V2PCAE

#### Changes proposed in this Pull Request

This PR will allow users to choose the billing period (monthly or yearly) when they have an active plan but try to purchase a product upgrade compatible with the plan itself.

Currently, If there's an already purchased plan (e.g., Jetpack Security) with a yearly billing period, purchasing a product (e.g., Jetpack VideoPress) with monthly billing is impossible (the billing period selector won't be shown in the UI). 

#### Testing instructions

- Checkout this PR.
- Start Calypso with `yarn start`
- Create a JN site (or use any self-hosted test website you have).
- Visit https://cloud.jetpack.com/pricing.
- Purchase Jetpack Security (yearly).
- Now, try to purchase VideoPress or Site Search (which are products, and also are not overlapping features for the plan).
- Verify that you can see the billing period selector in the UI (the selector [was not visible before](https://user-images.githubusercontent.com/1749918/160359865-9ba3f0af-937f-4fc3-889e-29bfdb66ffb4.png)).
- Verify that this PR introduces no regression in the existing checkout flow.

Related to 1164141197617539-as-1202006884283612