### PR TITLE
Wpcom: Block widget help to wpcom

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
@@ -8,6 +8,8 @@ function overrideCoreDocumentationLinksToWpcom( translation: string, text: strin
 			return 'https://wordpress.com/support/permalinks-and-slugs/';
 		case 'https://wordpress.org/support/article/wordpress-editor/':
 			return 'https://wordpress.com/support/wordpress-editor/';
+		case 'https://wordpress.org/support/article/block-based-widgets-editor/':
+			return 'https://wordpress.com/support/widgets/';
 	}
 
 	return translation;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The block widgets interface links to .org docs in two places. They have been changed to .com.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On a WordPress.com site:

1. Go to Appearance → Customize →  Widgets
2. View the welcome modal:

![image](https://user-images.githubusercontent.com/30727666/132818199-106cb8c0-1752-4f1b-a153-86bd2d956ab7.png)


3. Click the link "Here's a detailed guide.", should bring you to `https://wordpress.com/support/widgets/`
4. Click 'Got it'
5. Click the ... (ellipses) menu
6. Click 'Help', should bring you to `https://wordpress.com/support/widgets/`

![image](https://user-images.githubusercontent.com/30727666/132818335-55f0c13b-5c17-47db-9b9a-4acd5bb58c5d.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56161
Fixes #56161 
