### PR TITLE
Allow the Domain step to be skippable on Pro plan

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -828,11 +828,12 @@ const submitDomainStepSelection = ( suggestion, section ) => {
 };
 
 export default connect(
-	( state, { steps } ) => {
+	( state, { steps, flowName } ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
 		const isPlanStepSkipped = isPlanStepExistsAndSkipped( state );
 		const selectedSite = getSelectedSite( state );
+		const eligibleForProPlan = isEligibleForProPlan( state, selectedSite?.ID );
 
 		return {
 			designType: getDesignType( state ),
@@ -843,9 +844,10 @@ export default connect(
 			selectedSite,
 			sites: getSitesItems( state ),
 			isPlanSelectionAvailableLaterInFlow:
-				! isPlanStepSkipped && isPlanSelectionAvailableLaterInFlow( steps ),
+				( ! isPlanStepSkipped && isPlanSelectionAvailableLaterInFlow( steps ) ) ||
+				( eligibleForProPlan && 'pro' === flowName ),
 			userLoggedIn: isUserLoggedIn( state ),
-			eligibleForProPlan: isEligibleForProPlan( state, selectedSite?.ID ),
+			eligibleForProPlan,
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This allows the Domain step plan upsell section to be shown on Pro plans. This will allow users to skip the step on the `start/pro` flow and continue directly to checkout.

#### Testing instructions

* Go to `/start/pro?flags=plans/pro-plan`
* You should be able to see the Plan Upsell section
![Annotation on 2022-03-28 at 12-10-00](https://user-images.githubusercontent.com/2749938/160365696-05a2546b-1edd-47d0-8774-d8d9ba4d7f7f.png)

* Go to `/start/pro`
* The Plan Upsell section should not be visible (ie. changes should not be visible without the flag)
