### PR TITLE
Emails: Add support for in-depth comparison in Emails Stacked comparison upsell/add

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -258,7 +258,11 @@ const emailUpsellForDomainRegistration = ( context, next ) => {
 					args: { domain: context.params.domain },
 				} ) }
 			/>
-			<EmailProvidersUpsell domain={ context.params.domain } interval={ context.query.interval } />
+			<EmailProvidersUpsell
+				domain={ context.params.domain }
+				interval={ context.query.interval }
+				provider={ context.query.provider }
+			/>
 		</Main>
 	);
 

--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -9,7 +9,7 @@ import EmailProvidersComparison from 'calypso/my-sites/email/email-providers-com
 import EmailProvidersStackedComparison from 'calypso/my-sites/email/email-providers-stacked-comparison';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-export default function EmailProvidersUpsell( { domain, interval } ) {
+export default function EmailProvidersUpsell( { domain, interval, provider } ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
 
@@ -47,6 +47,7 @@ export default function EmailProvidersUpsell( { domain, interval } ) {
 					comparisonContext="domain-upsell"
 					isDomainInCart={ true }
 					selectedDomainName={ domain }
+					selectedEmailProviderSlug={ provider }
 					selectedIntervalLength={ interval }
 					source="domain-upsell"
 				/>

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -112,6 +112,7 @@ export default {
 		pageContext.primary = (
 			<CalypsoShoppingCartProvider>
 				<EmailProvidersInDepthComparison
+					referrer={ pageContext.query.referrer }
 					selectedDomainName={ pageContext.params.domain }
 					selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
 				/>

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -112,7 +112,6 @@ export default {
 		pageContext.primary = (
 			<CalypsoShoppingCartProvider>
 				<EmailProvidersInDepthComparison
-					callbackPath={ pageContext.query.callbackPath }
 					selectedDomainName={ pageContext.params.domain }
 					selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
 				/>

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -112,6 +112,7 @@ export default {
 		pageContext.primary = (
 			<CalypsoShoppingCartProvider>
 				<EmailProvidersInDepthComparison
+					callbackPath={ pageContext.query.callbackPath }
 					selectedDomainName={ pageContext.params.domain }
 					selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
 				/>

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -155,6 +155,7 @@ export default {
 				<EmailManagementHomePage
 					source={ pageContext.query.source }
 					selectedDomainName={ pageContext.params.domain }
+					selectedEmailProviderSlug={ pageContext.query.provider }
 					selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
 				/>
 			</CalypsoShoppingCartProvider>

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -69,6 +69,7 @@ interface EmailManagementHomeProps {
 	emailListInactiveHeader?: ReactElement;
 	sectionHeaderLabel?: TranslateResult;
 	selectedDomainName: string;
+	selectedEmailProviderSlug: string;
 	selectedIntervalLength?: IntervalLength;
 	showActiveDomainList?: boolean;
 	source: string;
@@ -77,6 +78,7 @@ interface EmailManagementHomeProps {
 const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
 	const {
 		emailListInactiveHeader,
+		selectedEmailProviderSlug,
 		showActiveDomainList = true,
 		selectedDomainName,
 		selectedIntervalLength,
@@ -126,6 +128,8 @@ const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
 				<EmailProvidersStackedComparisonPage
 					comparisonContext="email-home-selected-domain"
 					selectedDomainName={ selectedDomainName }
+					selectedEmailProviderSlug={ selectedEmailProviderSlug }
+					selectedIntervalLength={ selectedIntervalLength }
 					source={ source }
 				/>
 			);
@@ -158,8 +162,9 @@ const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
 			<EmailProvidersStackedComparisonPage
 				comparisonContext="email-home-single-domain"
 				selectedDomainName={ domainsWithNoEmail[ 0 ].name }
-				source={ source }
+				selectedEmailProviderSlug={ selectedEmailProviderSlug }
 				selectedIntervalLength={ selectedIntervalLength }
+				source={ source }
 			/>
 		);
 	}

--- a/client/my-sites/email/email-management/home-page.tsx
+++ b/client/my-sites/email/email-management/home-page.tsx
@@ -5,6 +5,7 @@ import { emailManagement } from 'calypso/my-sites/email/paths';
 
 type EmailManagementHomePageProps = {
 	selectedDomainName: string;
+	selectedEmailProviderSlug: string;
 	selectedIntervalLength?: IntervalLength;
 	source: string;
 };

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
@@ -13,6 +13,7 @@ import './style.scss';
 const ComparisonList = ( {
 	emailProviders,
 	intervalLength,
+	isDomainInCart,
 	onSelectEmailProvider,
 	selectedDomainName,
 }: ComparisonListOrTableProps ): ReactElement => {
@@ -61,6 +62,7 @@ const ComparisonList = ( {
 							className="email-providers-in-depth-comparison-list__button"
 							emailProviderSlug={ emailProviderFeatures.slug }
 							intervalLength={ intervalLength }
+							isDomainInCart={ isDomainInCart }
 							onSelectEmailProvider={ onSelectEmailProvider }
 							selectedDomainName={ selectedDomainName }
 						/>

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
@@ -12,6 +12,7 @@ import './style.scss';
 const ComparisonTable = ( {
 	emailProviders,
 	intervalLength,
+	isDomainInCart,
 	onSelectEmailProvider,
 	selectedDomainName,
 }: ComparisonListOrTableProps ): ReactElement => {
@@ -136,6 +137,7 @@ const ComparisonTable = ( {
 									className="email-providers-in-depth-comparison-table__button"
 									emailProviderSlug={ emailProviderFeatures.slug }
 									intervalLength={ intervalLength }
+									isDomainInCart={ isDomainInCart }
 									onSelectEmailProvider={ onSelectEmailProvider }
 									selectedDomainName={ selectedDomainName }
 								/>

--- a/client/my-sites/email/email-providers-comparison/in-depth/email-provider-price.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/email-provider-price.tsx
@@ -1,6 +1,9 @@
+import { useShoppingCart } from '@automattic/shopping-cart';
 import { useSelector } from 'react-redux';
+import { hasDomainInCart } from 'calypso/lib/cart-values/cart-items';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import GoogleWorkspacePrice from 'calypso/my-sites/email/email-providers-comparison/price/google-workspace';
 import ProfessionalEmailPrice from 'calypso/my-sites/email/email-providers-comparison/price/professional-email';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
@@ -14,6 +17,9 @@ const EmailProviderPrice = ( {
 	selectedDomainName,
 }: EmailProviderPriceProps ): ReactElement => {
 	const selectedSite = useSelector( getSelectedSite );
+	const cartKey = useCartKey();
+	const shoppingCartManager = useShoppingCart( cartKey );
+	const isDomainAdded = hasDomainInCart( shoppingCartManager.responseCart, selectedDomainName );
 
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 	const domain = getSelectedDomain( {
@@ -22,10 +28,22 @@ const EmailProviderPrice = ( {
 	} );
 
 	if ( emailProviderSlug === GOOGLE_WORKSPACE_PRODUCT_TYPE ) {
-		return <GoogleWorkspacePrice domain={ domain } intervalLength={ intervalLength } />;
+		return (
+			<GoogleWorkspacePrice
+				domain={ domain }
+				isDomainInCart={ isDomainAdded }
+				intervalLength={ intervalLength }
+			/>
+		);
 	}
 
-	return <ProfessionalEmailPrice domain={ domain } intervalLength={ intervalLength } />;
+	return (
+		<ProfessionalEmailPrice
+			domain={ domain }
+			isDomainInCart={ isDomainAdded }
+			intervalLength={ intervalLength }
+		/>
+	);
 };
 
 export default EmailProviderPrice;

--- a/client/my-sites/email/email-providers-comparison/in-depth/email-provider-price.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/email-provider-price.tsx
@@ -19,7 +19,7 @@ const EmailProviderPrice = ( {
 	const selectedSite = useSelector( getSelectedSite );
 	const cartKey = useCartKey();
 	const shoppingCartManager = useShoppingCart( cartKey );
-	const isDomainAdded = hasDomainInCart( shoppingCartManager.responseCart, selectedDomainName );
+	const isDomainInCart = hasDomainInCart( shoppingCartManager.responseCart, selectedDomainName );
 
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 	const domain = getSelectedDomain( {
@@ -31,7 +31,7 @@ const EmailProviderPrice = ( {
 		return (
 			<GoogleWorkspacePrice
 				domain={ domain }
-				isDomainInCart={ isDomainAdded }
+				isDomainInCart={ isDomainInCart }
 				intervalLength={ intervalLength }
 			/>
 		);
@@ -40,7 +40,7 @@ const EmailProviderPrice = ( {
 	return (
 		<ProfessionalEmailPrice
 			domain={ domain }
-			isDomainInCart={ isDomainAdded }
+			isDomainInCart={ isDomainInCart }
 			intervalLength={ intervalLength }
 		/>
 	);

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -22,13 +22,13 @@ import {
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import { emailManagementInDepthComparison } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersInDepthComparisonProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
 
 import './style.scss';
 
 const EmailProvidersInDepthComparison = ( {
+	referrer,
 	selectedDomainName,
 	selectedIntervalLength = IntervalLength.ANNUALLY,
 }: EmailProvidersInDepthComparisonProps ): JSX.Element => {
@@ -41,8 +41,6 @@ const EmailProvidersInDepthComparison = ( {
 	const cartKey = useCartKey();
 	const shoppingCartManager = useShoppingCart( cartKey );
 	const isDomainInCart = hasDomainInCart( shoppingCartManager.responseCart, selectedDomainName );
-
-	const previousRoute = useSelector( getPreviousRoute );
 
 	const changeIntervalLength = ( newIntervalLength: IntervalLength ) => {
 		if ( selectedSite === null ) {
@@ -60,7 +58,7 @@ const EmailProvidersInDepthComparison = ( {
 			emailManagementInDepthComparison(
 				selectedSite.slug,
 				selectedDomainName,
-				previousRoute,
+				referrer,
 				null,
 				newIntervalLength
 			)
@@ -78,12 +76,12 @@ const EmailProvidersInDepthComparison = ( {
 				provider: emailProviderSlug,
 			} )
 		);
-		const callbackWithQueryParams = `${ previousRoute }?${ stringify( {
+		const path = `${ referrer }?${ stringify( {
 			interval: selectedIntervalLength,
 			provider: emailProviderSlug,
 		} ) }`;
 
-		page( callbackWithQueryParams );
+		page( path );
 	};
 
 	const ComparisonComponent = isMobile ? ComparisonList : ComparisonTable;

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
+import { useShoppingCart } from '@automattic/shopping-cart';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -8,6 +9,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { hasDomainInCart } from 'calypso/lib/cart-values/cart-items';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
 import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparison/email-forwarding-link';
 import ComparisonList from 'calypso/my-sites/email/email-providers-comparison/in-depth/comparison-list';
@@ -19,13 +22,13 @@ import {
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import { emailManagementInDepthComparison } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersInDepthComparisonProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
 
 import './style.scss';
 
 const EmailProvidersInDepthComparison = ( {
-	callbackPath,
 	selectedDomainName,
 	selectedIntervalLength = IntervalLength.ANNUALLY,
 }: EmailProvidersInDepthComparisonProps ): JSX.Element => {
@@ -35,6 +38,11 @@ const EmailProvidersInDepthComparison = ( {
 	const isMobile = useMobileBreakpoint();
 
 	const selectedSite = useSelector( getSelectedSite );
+	const cartKey = useCartKey();
+	const shoppingCartManager = useShoppingCart( cartKey );
+	const isDomainInCart = hasDomainInCart( shoppingCartManager.responseCart, selectedDomainName );
+
+	const previousRoute = useSelector( getPreviousRoute );
 
 	const changeIntervalLength = ( newIntervalLength: IntervalLength ) => {
 		if ( selectedSite === null ) {
@@ -52,7 +60,7 @@ const EmailProvidersInDepthComparison = ( {
 			emailManagementInDepthComparison(
 				selectedSite.slug,
 				selectedDomainName,
-				callbackPath,
+				previousRoute,
 				null,
 				newIntervalLength
 			)
@@ -70,7 +78,7 @@ const EmailProvidersInDepthComparison = ( {
 				provider: emailProviderSlug,
 			} )
 		);
-		const callbackWithQueryParams = `${ callbackPath }?${ stringify( {
+		const callbackWithQueryParams = `${ previousRoute }?${ stringify( {
 			interval: selectedIntervalLength,
 			provider: emailProviderSlug,
 		} ) }`;
@@ -107,6 +115,7 @@ const EmailProvidersInDepthComparison = ( {
 				intervalLength={ selectedIntervalLength }
 				onSelectEmailProvider={ selectEmailProvider }
 				selectedDomainName={ selectedDomainName }
+				isDomainInCart={ isDomainInCart }
 			/>
 
 			<EmailForwardingLink selectedDomainName={ selectedDomainName } />

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -3,6 +3,7 @@
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
+import { stringify } from 'qs';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import Main from 'calypso/components/main';
@@ -16,29 +17,24 @@ import {
 	googleWorkspaceFeatures,
 } from 'calypso/my-sites/email/email-providers-comparison/in-depth/data';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
-import {
-	emailManagementInDepthComparison,
-	emailManagementPurchaseNewEmailAccount,
-} from 'calypso/my-sites/email/paths';
+import { emailManagementInDepthComparison } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersInDepthComparisonProps } from 'calypso/my-sites/email/email-providers-comparison/in-depth/types';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
 const EmailProvidersInDepthComparison = ( {
+	callbackPath,
 	selectedDomainName,
 	selectedIntervalLength = IntervalLength.ANNUALLY,
-}: EmailProvidersInDepthComparisonProps ): ReactElement => {
+}: EmailProvidersInDepthComparisonProps ): JSX.Element => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	const isMobile = useMobileBreakpoint();
 
 	const selectedSite = useSelector( getSelectedSite );
-	const currentRoute = useSelector( getCurrentRoute );
 
 	const changeIntervalLength = ( newIntervalLength: IntervalLength ) => {
 		if ( selectedSite === null ) {
@@ -56,7 +52,7 @@ const EmailProvidersInDepthComparison = ( {
 			emailManagementInDepthComparison(
 				selectedSite.slug,
 				selectedDomainName,
-				currentRoute,
+				callbackPath,
 				null,
 				newIntervalLength
 			)
@@ -74,17 +70,12 @@ const EmailProvidersInDepthComparison = ( {
 				provider: emailProviderSlug,
 			} )
 		);
+		const callbackWithQueryParams = `${ callbackPath }?${ stringify( {
+			interval: selectedIntervalLength,
+			provider: emailProviderSlug,
+		} ) }`;
 
-		page(
-			emailManagementPurchaseNewEmailAccount(
-				selectedSite.slug,
-				selectedDomainName,
-				currentRoute,
-				null,
-				emailProviderSlug,
-				selectedIntervalLength
-			)
-		);
+		page( callbackWithQueryParams );
 	};
 
 	const ComparisonComponent = isMobile ? ComparisonList : ComparisonTable;

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -111,9 +111,9 @@ const EmailProvidersInDepthComparison = ( {
 			<ComparisonComponent
 				emailProviders={ [ professionalEmailFeatures, googleWorkspaceFeatures ] }
 				intervalLength={ selectedIntervalLength }
+				isDomainInCart={ isDomainInCart }
 				onSelectEmailProvider={ selectEmailProvider }
 				selectedDomainName={ selectedDomainName }
-				isDomainInCart={ isDomainInCart }
 			/>
 
 			<EmailForwardingLink selectedDomainName={ selectedDomainName } />

--- a/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
@@ -15,6 +15,7 @@ import type { ReactElement } from 'react';
 const usePlanAvailable = (
 	emailProviderSlug: string,
 	intervalLength: IntervalLength,
+	isDomainInCart: boolean,
 	selectedDomainName: string
 ) => {
 	const selectedSite = useSelector( getSelectedSite );
@@ -34,7 +35,7 @@ const usePlanAvailable = (
 		return false;
 	}
 
-	if ( ! domain || ! hasGSuiteSupportedDomain( [ domain ] ) ) {
+	if ( isDomainInCart || ( domain && hasGSuiteSupportedDomain( [ domain ] ) ) ) {
 		return false;
 	}
 
@@ -45,12 +46,18 @@ const SelectButton = ( {
 	className,
 	emailProviderSlug,
 	intervalLength,
+	isDomainInCart,
 	onSelectEmailProvider,
 	selectedDomainName,
 }: SelectButtonProps ): ReactElement => {
 	const translate = useTranslate();
 
-	const isPlanAvailable = usePlanAvailable( emailProviderSlug, intervalLength, selectedDomainName );
+	const isPlanAvailable = usePlanAvailable(
+		emailProviderSlug,
+		intervalLength,
+		isDomainInCart,
+		selectedDomainName
+	);
 
 	return (
 		<Button

--- a/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
@@ -35,7 +35,7 @@ const usePlanAvailable = (
 		return false;
 	}
 
-	if ( isDomainInCart || ( domain && hasGSuiteSupportedDomain( [ domain ] ) ) ) {
+	if ( ! isDomainInCart && ( ! domain || ! hasGSuiteSupportedDomain( [ domain ] ) ) ) {
 		return false;
 	}
 

--- a/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
@@ -25,6 +25,9 @@ const usePlanAvailable = (
 		selectedDomainName: selectedDomainName,
 	} );
 
+	const isMonthlyBillingSupported =
+		isEnabled( 'google-workspace-monthly' ) || intervalLength === IntervalLength.ANNUALLY;
+
 	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
 
 	if ( emailProviderSlug !== GOOGLE_WORKSPACE_PRODUCT_TYPE ) {
@@ -35,11 +38,15 @@ const usePlanAvailable = (
 		return false;
 	}
 
-	if ( ! isDomainInCart && ( ! domain || ! hasGSuiteSupportedDomain( [ domain ] ) ) ) {
+	if ( isDomainInCart ) {
+		return true && isMonthlyBillingSupported;
+	}
+
+	if ( ! domain || ! hasGSuiteSupportedDomain( [ domain ] ) ) {
 		return false;
 	}
 
-	return isEnabled( 'google-workspace-monthly' ) || intervalLength === IntervalLength.ANNUALLY;
+	return isMonthlyBillingSupported;
 };
 
 const SelectButton = ( {

--- a/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
@@ -39,7 +39,7 @@ const usePlanAvailable = (
 	}
 
 	if ( isDomainInCart ) {
-		return true && isMonthlyBillingSupported;
+		return isMonthlyBillingSupported;
 	}
 
 	if ( ! domain || ! hasGSuiteSupportedDomain( [ domain ] ) ) {

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -37,6 +37,7 @@ export type EmailProviderFeatures = {
 };
 
 export type EmailProvidersInDepthComparisonProps = {
+	callbackPath: string;
 	selectedDomainName: string;
 	selectedIntervalLength?: IntervalLength;
 };

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react';
 export type ComparisonListOrTableProps = {
 	emailProviders: EmailProviderFeatures[];
 	intervalLength: IntervalLength;
+	isDomainInCart: boolean;
 	onSelectEmailProvider: ( emailProviderSlug: string ) => void;
 	selectedDomainName: string;
 };
@@ -37,7 +38,6 @@ export type EmailProviderFeatures = {
 };
 
 export type EmailProvidersInDepthComparisonProps = {
-	callbackPath: string;
 	selectedDomainName: string;
 	selectedIntervalLength?: IntervalLength;
 };
@@ -50,6 +50,7 @@ export type SelectButtonProps = {
 	className: string;
 	emailProviderSlug: string;
 	intervalLength: IntervalLength;
+	isDomainInCart: boolean;
 	onSelectEmailProvider: ( emailProviderSlug: string ) => void;
 	selectedDomainName: string;
 };

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -38,6 +38,7 @@ export type EmailProviderFeatures = {
 };
 
 export type EmailProvidersInDepthComparisonProps = {
+	referrer: string;
 	selectedDomainName: string;
 	selectedIntervalLength?: IntervalLength;
 };

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -31,8 +31,8 @@ const getGoogleWorkspaceProductSlug = ( intervalLength: IntervalLength ): string
 
 type GoogleWorkspacePriceProps = {
 	domain?: SiteDomain;
-	isDomainInCart: boolean;
 	intervalLength: IntervalLength;
+	isDomainInCart: boolean;
 };
 
 const GoogleWorkspacePrice = ( {

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -31,14 +31,14 @@ const getGoogleWorkspaceProductSlug = ( intervalLength: IntervalLength ): string
 
 type GoogleWorkspacePriceProps = {
 	domain?: SiteDomain;
-	isDomainInCart?: boolean;
+	isDomainInCart: boolean;
 	intervalLength: IntervalLength;
 };
 
 const GoogleWorkspacePrice = ( {
 	domain,
 	intervalLength,
-	isDomainInCart = false,
+	isDomainInCart,
 }: GoogleWorkspacePriceProps ): JSX.Element | null => {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -23,13 +23,13 @@ const getTitanProductSlug = ( intervalLength: IntervalLength ): string => {
 type ProfessionalEmailPriceProps = {
 	domain?: SiteDomain;
 	intervalLength: IntervalLength;
-	isDomainInCart?: boolean;
+	isDomainInCart: boolean;
 };
 
 const ProfessionalEmailPrice = ( {
 	domain,
 	intervalLength,
-	isDomainInCart = false,
+	isDomainInCart,
 }: ProfessionalEmailPriceProps ): JSX.Element | null => {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -23,22 +23,24 @@ const getTitanProductSlug = ( intervalLength: IntervalLength ): string => {
 type ProfessionalEmailPriceProps = {
 	domain?: SiteDomain;
 	intervalLength: IntervalLength;
+	isDomainInCart?: boolean;
 };
 
 const ProfessionalEmailPrice = ( {
 	domain,
 	intervalLength,
+	isDomainInCart = false,
 }: ProfessionalEmailPriceProps ): JSX.Element | null => {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 
 	const productSlug = getTitanProductSlug( intervalLength );
 	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
 
-	if ( ! domain ) {
+	if ( ! domain && ! isDomainInCart ) {
 		return null;
 	}
 
-	const isEligibleForFreeTrial = isDomainEligibleForTitanFreeTrial( domain );
+	const isEligibleForFreeTrial = isDomainInCart || isDomainEligibleForTitanFreeTrial( domain );
 
 	const priceWithInterval = (
 		<PriceWithInterval

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -156,11 +156,7 @@ const ProfessionalEmailCard = ( {
 
 	professionalEmail.onExpandedChange = onExpandedChange;
 	professionalEmail.priceBadge = (
-		<ProfessionalEmailPrice
-			domain={ domain }
-			intervalLength={ intervalLength }
-			isDomainInCart={ isDomainInCart }
-		/>
+		<ProfessionalEmailPrice { ...{ domain, intervalLength, isDomainInCart } } />
 	);
 
 	professionalEmail.formFields = (

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -156,7 +156,11 @@ const ProfessionalEmailCard = ( {
 
 	professionalEmail.onExpandedChange = onExpandedChange;
 	professionalEmail.priceBadge = (
-		<ProfessionalEmailPrice domain={ domain } intervalLength={ intervalLength } />
+		<ProfessionalEmailPrice
+			domain={ domain }
+			intervalLength={ intervalLength }
+			isDomainInCart={ isDomainInCart }
+		/>
 	);
 
 	professionalEmail.formFields = (

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -228,6 +228,7 @@ export function emailManagementInDepthComparison(
 	intervalLength = null
 ) {
 	return emailManagementEdit( siteName, domainName, 'compare', relativeTo, {
+		callbackPath: relativeTo,
 		interval: intervalLength,
 		source,
 	} );

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -228,7 +228,6 @@ export function emailManagementInDepthComparison(
 	intervalLength = null
 ) {
 	return emailManagementEdit( siteName, domainName, 'compare', relativeTo, {
-		callbackPath: relativeTo,
 		interval: intervalLength,
 		source,
 	} );

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -229,6 +229,7 @@ export function emailManagementInDepthComparison(
 ) {
 	return emailManagementEdit( siteName, domainName, 'compare', relativeTo, {
 		interval: intervalLength,
+		referrer: relativeTo,
 		source,
 	} );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I am showing the new comparison component under the feature flag (emails/show-new-comparison-component is enabled) to keep working on retire the old comparison page.
I'm breaking down all the changes and this change only adapt the component to receive a domain name, instead of a domain object plus hiding email forward components for this view.

**Things to tackle in the following Pull Requests:**
- Navigation buttons
- Multiple mailboxes support

#### Testing instructions

**Main scenario! (and regression test)**
Ensure that new comparison page keeps working:
1. Have a domain without email subscription on it.
2. Go to Upgrades -> Emails
3. Click on Add Email button
4. Play around with in-depth comparison and check that it works (EG, going back to the regular comparison selects the new interval/provider)
5. Try to add to the cart an email solution of each provider for each interval (just go to the check out and check that everything is working, no need to actually buy it, after you checked everything, remove the subscription for the domain and repeat for another variant subscription/interval)


Test also a site with only one domain and no subscription attached to it, this will bring up the EmailsComparison page in the /email/:domain path, which is a very common case.


**Second scenario**
1. Open the [Domains page](http://calypso.localhost:3000/domains/manage)
2. Click the Add a domain button
3. Select Search for a domain
4. Select any domain to access the Email Comparison page
5. Add the following query to the URL in your browser: ?flags=+emails/show-new-comparison-component
6. Assert that the next screen is displayed.
7. Assert that the billing interval is working as expected (dealing with prices, dealing with the URL parameters)
8. Play around with in-depth comparison and check that it works (EG, going back to the regular comparison selects the new interval/provider)

![image](https://user-images.githubusercontent.com/5689927/158605508-1a66346c-828b-41c7-a594-8cee1fadb827.png)


Related to {1200182182542585-as-1201978089916827}
