### PR TITLE
Licensing Portal: Disable the "Set as primary payment method" checkbox when there are no other payment methods

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/index.tsx
@@ -4,8 +4,10 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useState } from 'react';
-import { useDispatch as useReduxDispatch } from 'react-redux';
+import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
+import QueryJetpackPartnerPortalStoredCards from 'calypso/components/data/query-jetpack-partner-portal-stored-cards';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getAllStoredCards } from 'calypso/state/partner-portal/stored-cards/selectors';
 import CreditCardElementField from './credit-card-element-field';
 import CreditCardLoading from './credit-card-loading';
 import SetAsPrimaryPaymentMethod from './set-as-primary-payment-method';
@@ -65,11 +67,15 @@ export default function CreditCardFields() {
 		},
 	};
 
+	const storedCards = useSelector( getAllStoredCards );
+
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 
 	return (
 		<>
+			<QueryJetpackPartnerPortalStoredCards paging={ { startingAfter: '', endingBefore: '' } } />
+
 			{ ! isStripeFullyLoaded && <CreditCardLoading /> }
 
 			<div
@@ -97,8 +103,8 @@ export default function CreditCardFields() {
 				/>
 
 				<SetAsPrimaryPaymentMethod
-					isChecked={ useAsPrimaryPaymentMethod }
-					isDisabled={ isDisabled }
+					isChecked={ useAsPrimaryPaymentMethod || storedCards.length === 0 }
+					isDisabled={ isDisabled || storedCards.length === 0 }
 					onChange={ setUseAsPrimaryPaymentMethod }
 				/>
 			</div>

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/index.tsx
@@ -4,10 +4,9 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useState } from 'react';
-import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
-import QueryJetpackPartnerPortalStoredCards from 'calypso/components/data/query-jetpack-partner-portal-stored-cards';
+import { useDispatch as useReduxDispatch } from 'react-redux';
+import { useRecentPaymentMethodsQuery } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getAllStoredCards } from 'calypso/state/partner-portal/stored-cards/selectors';
 import CreditCardElementField from './credit-card-element-field';
 import CreditCardLoading from './credit-card-loading';
 import SetAsPrimaryPaymentMethod from './set-as-primary-payment-method';
@@ -67,15 +66,16 @@ export default function CreditCardFields() {
 		},
 	};
 
-	const storedCards = useSelector( getAllStoredCards );
+	const {
+		data: { items: paymentMethods } = [],
+		isFetching: isFetchingPaymentMethods,
+	} = useRecentPaymentMethodsQuery();
 
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 
 	return (
 		<>
-			<QueryJetpackPartnerPortalStoredCards paging={ { startingAfter: '', endingBefore: '' } } />
-
 			{ ! isStripeFullyLoaded && <CreditCardLoading /> }
 
 			<div
@@ -103,8 +103,8 @@ export default function CreditCardFields() {
 				/>
 
 				<SetAsPrimaryPaymentMethod
-					isChecked={ useAsPrimaryPaymentMethod || storedCards.length === 0 }
-					isDisabled={ isDisabled || storedCards.length === 0 }
+					isChecked={ useAsPrimaryPaymentMethod || paymentMethods.length === 0 }
+					isDisabled={ isFetchingPaymentMethods || isDisabled || paymentMethods.length === 0 }
 					onChange={ setUseAsPrimaryPaymentMethod }
 				/>
 			</div>

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/style.scss
@@ -29,6 +29,11 @@
 				background: var( --color-accent );
 				border-color: var( --color-accent );
 			}
+
+			&:disabled {
+				opacity: 0.3;
+				cursor: default;
+			}
 		}
 
 		.components-checkbox-control__label {

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-actions/index.tsx
@@ -33,7 +33,7 @@ const PaymentMethodActions: FunctionComponent< Props > = ( { card } ) => {
 
 	const handleDelete = useCallback( () => {
 		closeDialog();
-		reduxDispatch( deleteStoredCard( card, nextPrimaryPaymentMethod.id ) )
+		reduxDispatch( deleteStoredCard( card, nextPrimaryPaymentMethod?.id ) )
 			.then( () => {
 				reduxDispatch( successNotice( translate( 'Payment method deleted successfully' ) ) );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/61001, @kallehauge suggested that we can improve the UX by setting the "Set as primary payment method" checkbox, and also disabling it when the partner doesn't have any other payment methods connected (i.e. when adding the first payment method).

#### Prerequisites

- See pbtFFM-1v8-p2
- If you have any payment methods already connected to the licensing portal, please remove all of them.

#### Testing instructions

- If you do not have a partner key, please get in touch with Avalon for one, or you will be unable to view the UI.
- Checkout PR locally, `run yarn && yarn start-jetpack-cloud`.
- Visit http://jetpack.cloud.localhost:3000/partner-portal/payment-methods and select your partner key if prompted.
- Visit http://jetpack.cloud.localhost:3000/partner-portal/payment-methods/add to add your first payment method.
- Verify that "Set as primary payment method" is checked and disabled.
- Save your first payment method, and visit the same URL to add a second payment method.
- Verify that the "Set as primary payment method" is checked but not disabled.

Related to 1201734780767770-as-1201877161869023