### PR TITLE
Use Pro plan in the domain upsell wording and CTA

### DIFF
--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
@@ -60,18 +60,16 @@ class CartFreeUserPlanUpsell extends Component {
 	getUpgradeText() {
 		const { cart, planPrice, translate, eligibleForProPlan } = this.props;
 		const firstDomain = find( getAllCartItems( cart ), this.isRegistrationOrTransfer );
-		const planName = eligibleForProPlan ? 'Pro' : 'Personal';
 
 		if ( planPrice > firstDomain.cost ) {
 			const extraToPay = planPrice - firstDomain.cost;
 			return eligibleForProPlan
 				? translate(
-						'Pay an {{strong}}extra %(extraToPay)s{{/strong}} for our %(planName)s plan, and get access to all its ' +
+						'Pay an {{strong}}extra %(extraToPay)s{{/strong}} for our Pro plan, and get access to all its ' +
 							'features, plus the first year of your domain for free.',
 						{
 							args: {
 								extraToPay: formatCurrency( extraToPay, firstDomain.currency ),
-								planName,
 							},
 							components: {
 								strong: <strong />,
@@ -94,12 +92,11 @@ class CartFreeUserPlanUpsell extends Component {
 			const savings = firstDomain.cost - planPrice;
 			return eligibleForProPlan
 				? translate(
-						'{{strong}}Save %(savings)s{{/strong}} when you purchase a WordPress.com %(planName)s plan ' +
+						'{{strong}}Save %(savings)s{{/strong}} when you purchase a WordPress.com Pro plan ' +
 							'instead — your domain comes free for a year.',
 						{
 							args: {
 								savings: formatCurrency( savings, firstDomain.currency ),
-								planName,
 							},
 							components: {
 								strong: <strong />,
@@ -122,12 +119,9 @@ class CartFreeUserPlanUpsell extends Component {
 
 		return eligibleForProPlan
 			? translate(
-					'Purchase our %(planName)s plan at {{strong}}no extra cost{{/strong}}, and get access to all its ' +
+					'Purchase our Pro plan at {{strong}}no extra cost{{/strong}}, and get access to all its ' +
 						'features, plus the first year of your domain for free.',
 					{
-						args: {
-							planName,
-						},
 						components: {
 							strong: <strong />,
 						},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This replaces the Personal plan with Pro for the Domain checkout page.

#### Testing instructions

* Go to `/domains/add/[site]` on a Free site
* Search and proceeded to Checkout with a paid domain
* Add `?flags=plans/pro-plan` to your checkout page URL (before any #) and refresh
* You should see the update copy on the `Upgrade and save` section
<img width="320" alt="Screenshot on 2022-03-28 at 17-24-15" src="https://user-images.githubusercontent.com/2749938/160419759-cc17f43c-2995-4413-af16-a6749d4f16b0.png">

* Clicking on `Add to Cart` from this section should add a Pro plan to the Shopping Cart
