### PR TITLE
Mention Pro plan in Seller Upsell card

### DIFF
--- a/client/my-sites/customer-home/cards/notices/site-launch-seller-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/site-launch-seller-upsell/index.jsx
@@ -3,18 +3,29 @@ import { useSelector } from 'react-redux';
 import sellerIllustration from 'calypso/assets/images/customer-home/illustration--seller.svg';
 import { NOTICE_SITE_LAUNCH_SELLER_UPSELL } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const SiteLaunchSellerUpsell = () => {
-	const { domain } = useSelector( getSelectedSite );
+	const selectedSite = useSelector( getSelectedSite );
+	const { domain } = selectedSite;
 	const translate = useTranslate();
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, selectedSite.ID )
+	);
 
 	return (
 		<Task
 			title={ translate( 'Need more from your store?' ) }
-			description={ translate(
-				'Upgrade to our premium plan to gain access to all the tools you need to run an online ecommerce store, from marketing to shipping.'
-			) }
+			description={
+				eligibleForProPlan
+					? translate(
+							'Upgrade to our Pro plan to gain access to all the tools you need to run an online ecommerce store, from marketing to shipping.'
+					  )
+					: translate(
+							'Upgrade to our premium plan to gain access to all the tools you need to run an online ecommerce store, from marketing to shipping.'
+					  )
+			}
 			actionText={ translate( 'Learn more' ) }
 			actionUrl={ `http://wordpress.com/woocommerce-installation/${ domain }` }
 			actionTarget="_blank"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This changes the Copy of the Seller Upsell card to mention the Pro plan instead of premium plan.
<img width="240" src="https://user-images.githubusercontent.com/2749938/160437398-33d556a3-d043-4b52-b4d7-b1bc19102a78.jpg"/>



#### Testing instructions

* Go to `/home/[site]` for a site with Business plan set up as an Simple online store (WooCommerce not installed yet)
<img width="240" alt="Screenshot on 2022-03-28 at 18-07-14" src="https://user-images.githubusercontent.com/2749938/160435398-7d2d98aa-af29-407d-8ede-44140457ee38.png">
* Go through all the steps and Launch your site
* Go to `/home/[site]?flags=plans/pro-plan`
* You should be able to see the `Need more from your store?` card mentioning the Pro plan.

* Removing the `?flags=plans/pro-plan` parameter should mention the premium plan.

