### PR TITLE
Send an analytics event every time a plugin search is made.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -359,6 +359,7 @@ const SearchListView = ( {
 	sites,
 	billingPeriod,
 } ) => {
+	const dispatch = useDispatch();
 	const [ page, setPage ] = useState( 1 );
 	const [ pageSize, setPageSize ] = useState( SEARCH_RESULTS_LIST_LENGTH );
 
@@ -399,12 +400,14 @@ const SearchListView = ( {
 
 	useEffect( () => {
 		if ( searchTerm && pluginsPagination?.page === 1 ) {
-			recordTracksEvent( 'calypso_plugins_search_results_show', {
-				search_term: searchTerm,
-				results_count: pluginsPagination?.results,
-			} );
+			dispatch(
+				recordTracksEvent( 'calypso_plugins_search_results_show', {
+					search_term: searchTerm,
+					results_count: pluginsPagination?.results,
+				} )
+			);
 		}
-	}, [ searchTerm ] );
+	}, [ searchTerm, pluginsPagination?.page ] );
 
 	if (
 		pluginsBySearchTerm.length > 0 ||

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -397,6 +397,15 @@ const SearchListView = ( {
 		setPageSize( pluginItemsFetch( page ) );
 	}, [ paidPluginsBySearchTerm ] );
 
+	useEffect( () => {
+		if ( searchTerm && pluginsPagination?.page === 1 ) {
+			recordTracksEvent( 'calypso_plugins_search_results_show', {
+				search_term: searchTerm,
+				results_count: pluginsPagination?.results,
+			} );
+		}
+	}, [ searchTerm ] );
+
 	if (
 		pluginsBySearchTerm.length > 0 ||
 		paidPluginsBySearchTerm.length > 0 ||


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Send an analytics event every time a plugin search is made.

#### Testing instructions
- Use the Calypso version of this branch
- Go to `/plugins` page
- in the console enter `localStorage.setItem( 'debug', 'calypso:analytics*' )`
- reload the page
- Search for a plugin
- make sure that the `calypso_plugins_search` event is logged and `search_term`, `results_count` are correct
- go to any other results page and make sure that the event isn't logged again
- change the term, make sure that the `calypso_plugins_search` event is logged and `search_term`, `results_count` are correct


---

Fixes #62304
