### PR TITLE
Seller Experience: Open plans links in a new window or tab

### DIFF
--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -101,7 +101,13 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 							? translate( 'Included in your plan' )
 							: translate( 'Requires a {{a}}paid plan{{/a}}', {
 									components: {
-										a: <a href={ `/plans/${ siteSlug }` } />,
+										a: (
+											<a
+												href={ `/plans/${ siteSlug }` }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
 									},
 							  } ) }
 					</span>
@@ -150,7 +156,13 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 							? translate( 'Included in your plan' )
 							: translate( 'Requires a {{a}}Business plan{{/a}}', {
 									components: {
-										a: <a href={ `/plans/${ siteSlug }` } />,
+										a: (
+											<a
+												href={ `/plans/${ siteSlug }` }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
 									},
 							  } ) }
 					</span>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When on the open the plans page links in a new window or tab.
* Fixes #62152

<img width="617" alt="Screen Shot 2022-03-28 at 1 23 33 PM" src="https://user-images.githubusercontent.com/2124984/160453512-84d13bcf-eab3-456a-9ede-286ac4680551.png">


#### Testing instructions

* Switch to this PR & navigate to `/start`
* Create a new site and choose the Sell intent
* On the Store Features step, the red underlined links in the screenshot above should open in a new window or tab