### PR TITLE
Theme Showcase: Add close icon to thanks modal

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -1,4 +1,4 @@
-import { Dialog, Gridicon } from '@automattic/components';
+import { Button, Dialog, Gridicon, ScreenReaderText } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -151,6 +151,10 @@ class ThanksModal extends Component {
 
 		return (
 			<div>
+				<Button className="thanks-modal__button-close" onClick={ this.onCloseModal } borderless>
+					<Gridicon icon="cross-small" />
+					<ScreenReaderText>{ this.props.translate( 'Close' ) }</ScreenReaderText>
+				</Button>
 				<h1>
 					{ this.props.translate( 'Thanks for choosing {{br/}} %(themeName)s', {
 						args: { themeName },

--- a/client/my-sites/themes/thanks-modal.scss
+++ b/client/my-sites/themes/thanks-modal.scss
@@ -33,6 +33,12 @@
 		}
 	}
 
+	.thanks-modal__button-close {
+		position: absolute;
+		right: 8px;
+		top: 0;
+	}
+
 	h1 {
 		display: block;
 		font-weight: 400;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add close icon and screen reader text to the thanks modal shown after activating a theme from the Theme Showcase
* Fixes #53174

**Before**
<img width="390" alt="Screen Shot 2022-03-28 at 3 10 15 PM" src="https://user-images.githubusercontent.com/2124984/160469461-0318aa78-58c3-48c1-911c-55c5250cc72f.png">


**After**

<img width="387" alt="Screen Shot 2022-03-28 at 3 03 50 PM" src="https://user-images.githubusercontent.com/2124984/160469246-c408ce7c-c6fb-4478-86b5-f4987f92116e.png">

#### Testing instructions

* Switch to this PR, navigate to `/themes/$site`
* Activate a new theme on your site
* The Thank you modal should show
* Clicking on the X in the corner should hide the modal
* Screen reader text should be present but visually hidden
* The modal should pop back up after activating a new theme
