### PR TITLE
Increased top margin for .global-notices class

### DIFF
--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -10,7 +10,7 @@
 	left: 0;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		top: calc( var( --masterbar-height ) + 16px );
+		top: calc( var( --masterbar-height ) + 64px );
 		right: 16px;
 		bottom: auto;
 		left: auto;
@@ -18,7 +18,7 @@
 	}
 
 	@include breakpoint-deprecated( '>960px' ) {
-		top: calc( var( --masterbar-height ) + 24px );
+		top: calc( var( --masterbar-height ) + 64px );
 		right: 24px;
 		max-width: calc( 100% - 48px );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR increases the top margin of the `.global-notices` class on screens wider than 660px from 16px and 24px to 64px, respectively. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In my testing, this had no noticeable adverse effects on screens widths 660px and up on any other screens. The increased top margin did not appear to conflict with buttons on any other screens, i.e., Settings, etc. On screen width smaller than 660px, the success message appears at the bottom of the screen and is not affected by this change.

Before:
![image](https://user-images.githubusercontent.com/65082164/160470733-e7f3a4e7-568d-40a4-97a6-7335c6e21967.png)


After:
![image](https://user-images.githubusercontent.com/65082164/160471381-64cc4344-9e47-41ad-94ab-dcad1070e9e9.png)



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62313