### PR TITLE
Domains: Prevent domain actions for domains with `pendingRegistration`

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -4,7 +4,6 @@ import moment from 'moment';
 import { modeType, stepSlug } from 'calypso/components/domains/connect-domain-step/constants';
 import { isSubdomain } from 'calypso/lib/domains';
 import { isExpiringSoon } from 'calypso/lib/domains/utils/is-expiring-soon';
-import { isRecentlyRegistered } from 'calypso/lib/domains/utils/is-recently-registered';
 import { shouldRenderExpiringCreditCard, handleRenewNowClick } from 'calypso/lib/purchases';
 import {
 	SETTING_PRIMARY_DOMAIN,
@@ -461,7 +460,7 @@ export function resolveDomainStatus(
 				};
 			}
 
-			if ( isRecentlyRegistered( domain.registrationDate ) ) {
+			if ( domain.pendingRegistration ) {
 				let noticeText;
 				if ( domain.isPrimary ) {
 					noticeText = translate(
@@ -552,10 +551,7 @@ export function resolveDomainStatus(
 				};
 			}
 
-			if (
-				gdprConsentStatus.PENDING_ASYNC === domain.gdprConsentStatus ||
-				domain.pendingRegistration
-			) {
+			if ( gdprConsentStatus.PENDING_ASYNC === domain.gdprConsentStatus ) {
 				const detailCta = domain.currentUserIsOwner
 					? translate( 'Please check the email sent to you for further details' )
 					: translate( 'Please check the email sent to the domain owner for further details' );

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -18,7 +18,13 @@ const DomainDeleteInfoCard = ( {
 }: DomainDeleteInfoCardProps ): JSX.Element | null => {
 	const translate = useTranslate();
 
-	if ( isLoadingPurchase || ! purchase || ! domain.currentUserIsOwner ) return null;
+	if (
+		isLoadingPurchase ||
+		! purchase ||
+		! domain.currentUserIsOwner ||
+		domain.pendingRegistration
+	)
+		return null;
 
 	const removePurchaseClassName = 'domain-delete-info-card is-compact button';
 

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx
@@ -15,6 +15,7 @@ const DomainTransferInfoCard = ( {
 	if (
 		! domain.currentUserIsOwner ||
 		domain.isRedeemable ||
+		domain.pendingRegistration ||
 		typesUnableToTransfer.includes( domain.type ) ||
 		domain.aftermarketAuction
 	) {

--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -104,6 +104,7 @@ const RegisteredDomainDetails = ( {
 		return (
 			! domain.subscriptionId ||
 			domain.isPendingRenewal ||
+			domain.pendingRegistration ||
 			! domain.currentUserCanManage ||
 			( domain.expired && ! domain.isRenewable && ! domain.isRedeemable ) ||
 			( ! isLoadingPurchase && ! purchase ) ||

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -1,4 +1,4 @@
-import { Card, Button } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -45,6 +45,7 @@ import isPrimaryDomainBySiteId from 'calypso/state/selectors/is-primary-domain-b
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import TransferUnavailableNotice from '../transfer-unavailable-notice';
 import type { TransferPageProps } from './types';
 import type { AppState } from 'calypso/types';
 
@@ -128,6 +129,16 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 					headerText={ __( 'To another user' ) }
 					mainText={ mainText }
 				/>
+			);
+		}
+
+		if ( domain?.pendingRegistration ) {
+			return (
+				<TransferUnavailableNotice
+					message={ __(
+						'We are still setting up your domain. You will not be available to transfer it until the registration setup is done.'
+					) }
+				></TransferUnavailableNotice>
 			);
 		}
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -26,6 +26,7 @@ import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import { requestSites } from 'calypso/state/sites/actions';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import TransferUnavailableNotice from '../transfer-unavailable-notice';
 import TransferConfirmationDialog from './confirmation-dialog';
 import type {
 	TransferDomainToOtherSitePassedProps,
@@ -184,7 +185,13 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 	};
 
 	renderSection(): JSX.Element {
-		const { currentUserCanManage, selectedDomainName, aftermarketAuction, domain } = this.props;
+		const {
+			currentUserCanManage,
+			selectedDomainName,
+			aftermarketAuction,
+			translate,
+			domain,
+		} = this.props;
 		const { children, ...propsWithoutChildren } = this.props;
 		if ( ! currentUserCanManage ) {
 			return <NonOwnerCard { ...propsWithoutChildren } />;
@@ -196,6 +203,18 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 
 		if ( domain && domain.isRedeemable ) {
 			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
+		}
+
+		if ( domain?.pendingRegistration ) {
+			if ( domain?.pendingRegistration ) {
+				return (
+					<TransferUnavailableNotice
+						message={ translate(
+							'We are still setting up your domain. You will not be available to transfer it until the registration setup is done.'
+						) }
+					></TransferUnavailableNotice>
+				);
+			}
 		}
 
 		return (

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -206,15 +206,13 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		}
 
 		if ( domain?.pendingRegistration ) {
-			if ( domain?.pendingRegistration ) {
-				return (
-					<TransferUnavailableNotice
-						message={ translate(
-							'We are still setting up your domain. You will not be available to transfer it until the registration setup is done.'
-						) }
-					></TransferUnavailableNotice>
-				);
-			}
+			return (
+				<TransferUnavailableNotice
+					message={ translate(
+						'We are still setting up your domain. You will not be available to transfer it until the registration setup is done.'
+					) }
+				></TransferUnavailableNotice>
+			);
 		}
 
 		return (

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -30,6 +30,7 @@ import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import TransferUnavailableNotice from '../transfer-unavailable-notice';
 
 import './style.scss';
 
@@ -253,7 +254,8 @@ class TransferDomainToOtherUser extends Component {
 			aftermarketAuction,
 			isRedeemable,
 		} = getSelectedDomain( this.props );
-		const { domains, selectedDomainName } = this.props;
+		const { domains, selectedDomainName, translate } = this.props;
+		const selectedDomain = domains.find( ( domain ) => selectedDomainName === domain.name );
 
 		if ( ! currentUserCanManage ) {
 			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
@@ -267,7 +269,17 @@ class TransferDomainToOtherUser extends Component {
 			return <NonTransferrableDomainNotice domainName={ selectedDomainName } />;
 		}
 
-		const { isMapping, translate, users } = this.props;
+		if ( selectedDomain?.pendingRegistration ) {
+			return (
+				<TransferUnavailableNotice
+					message={ translate(
+						'We are still setting up your domain. You will not be available to transfer it until the registration setup is done.'
+					) }
+				></TransferUnavailableNotice>
+			);
+		}
+
+		const { isMapping, users } = this.props;
 		const availableUsers = this.filterAvailableUsers( users );
 		const saveButtonLabel = isMapping
 			? translate( 'Transfer domain connection' )

--- a/client/my-sites/domains/domain-management/transfer/transfer-unavailable-notice/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-unavailable-notice/index.tsx
@@ -1,0 +1,22 @@
+import { Icon, info } from '@wordpress/icons';
+import type { TransferUnavailableNoticeProps } from './types';
+
+import './style.scss';
+
+const TransferUnavailableNotice = ( { message }: TransferUnavailableNoticeProps ): JSX.Element => {
+	return (
+		<div className="transfer-unavailable-notice__domain-notice">
+			<Icon
+				icon={ info }
+				size={ 18 }
+				className={
+					'transfer-unavailable-notice__domain-notice-icon gridicon gridicon--error transfer-unavailable-notice__domain-notice-icon--rotated'
+				}
+				viewBox="2 2 20 20"
+			/>
+			<div className="transfer-unavailable-notice__domain-notice-message">{ message }</div>
+		</div>
+	);
+};
+
+export default TransferUnavailableNotice;

--- a/client/my-sites/domains/domain-management/transfer/transfer-unavailable-notice/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-unavailable-notice/style.scss
@@ -1,0 +1,53 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/colors';
+
+.transfer-unavailable-notice {
+    &__domain-notice {
+        flex-basis: 100%;
+        background-color: var( --studio-gray-0 );
+        display: flex;
+        align-items: center;
+        padding: 5px;
+        margin: 12px 0 0;
+        gap: 8px;
+        border-radius: 2px;
+
+        @include break-mobile {
+            margin: 8px 0 0;
+        }
+    }
+
+    &__domain-notice-icon.gridicon {
+        align-self: flex-start;
+        min-width: 18px;
+        position: relative;
+        top: 2px;
+        fill: var( --studio-green-50 );
+
+        &--error {
+            fill: var( --studio-orange-40 );
+        }
+    }
+
+    &__domain-notice-icon--rotated {
+        transform: rotate( 180deg );
+    }
+
+    &__domain-notice-message {
+        font-weight: 400;
+        font-size: $font-body-small;
+        color: var( --studio-gray-80 );
+
+        button.button-plain {
+            cursor: pointer;
+            color: var( --color-link );
+
+            &:hover,
+            &:focus,
+            &:active {
+                color: var( --color-link-dark );
+            }
+        }
+    }
+}

--- a/client/my-sites/domains/domain-management/transfer/transfer-unavailable-notice/types.ts
+++ b/client/my-sites/domains/domain-management/transfer/transfer-unavailable-notice/types.ts
@@ -1,0 +1,5 @@
+import type { TranslateResult } from 'i18n-calypso';
+
+export type TransferUnavailableNoticeProps = {
+	message: TranslateResult;
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR depends on D77695-code.
Shows the "Activating" notice/description and prevents the renew, transfer and delete actions for domains that have the `pendingRegistration` flag set as `true`.

#### Preview

##### Transfer to another site
<img width="969" alt="image" src="https://user-images.githubusercontent.com/18705930/160484575-34ab687a-cf8a-47c0-a7c5-61eecf4b334e.png">

##### Transfer to another user
<img width="659" alt="image" src="https://user-images.githubusercontent.com/18705930/160485210-0c82aa04-e55a-4b15-9284-fbbbcfea907b.png">

##### Domain settings
![image](https://user-images.githubusercontent.com/18705930/160485309-b1872312-bca6-4e25-9a0a-aaa3486c1a53.png)

#### Testing instructions
- Apply the back-end patch locally;
- Hack the back-end so the domain you're using for the tests returns `true` for `pendingRegistration`;
- In the domain settings page, make sure that:
  - The notice looks the same as in the screenshot;
  - The renew button is not rendered;
  - The delete block is not rendered;
  - The transfer block is not rendered.
- Confirm that the "Transfer to other site" and "Transfer to other user" pages will not have their content rendered - same as in the screenshot;
- Also check that trying to call the transfer endpoints (`transfer-to-site`, `transfer-to-user`) returns an error with the following message: `This domain is pending registration and cannot yet be transferred to a new site.` - or `(...) to a new user`, depending on the tested endpoint)