### PR TITLE
Playwright: deal with flakiness in the `Plans` page when using mobile viewport.

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -51,6 +51,7 @@ export async function waitForElementEnabled(
 export async function clickNavTab( page: Page, name: string ): Promise< void > {
 	// Mobile view - navtabs become a dropdown.
 	if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+		await page.waitForLoadState( 'networkidle' );
 		const navTabsButtonLocator = page.locator( selectors.mobileNavTabsToggle );
 		await navTabsButtonLocator.click();
 		const navPanelLocator = page.locator( '.section-nav__panel' );

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -81,7 +81,9 @@ export class PlansPage {
 	 * @param {PlansPageTab} targetTab Name of the navigation tab to click on
 	 */
 	async clickTab( targetTab: PlansPageTab ): Promise< void > {
-		await this.page.waitForLoadState( 'networkidle' );
+		if ( targetTab === 'Plans' ) {
+			await this.page.waitForResponse( /.*plans\?/ );
+		}
 		await clickNavTab( this.page, targetTab );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR addresses some flakiness in the `Plans` page on Calypso that is observed when using the mobile viewport, which is a fallout from #62158.

Key changes:
1. at the `ElementHelper` level, include a wait for the `networkidle` event to fire.
2. additional handling in the `PlansPage.clickTab` level to wait for asynchronous loading to complete.

Details:

Change 1 is meant to guard against any potential future regressions by adding a common baseline case when the viewport size is `mobile`. In this size, the NavTabs are hidden behind a pseudo-select dropdown, and this dropdown can be a) dismissed automatically by the page loading if clicked too soon, and b) clicks against the dropdown can be swallowed by the page if the page is not fully loaded.

Change 2 is meant to place additional waiting mechanism specific to the `PlansPage`, as various contents of the page are loaded asynchronously. Waiting for a `networkidle` event to fire is not sufficient here as the event fires despite there continuing to be placeholder elements on page.

#### Testing instructions

Ensure the following:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [x] i18n E2E


Related to #62158