### PR TITLE
Jetpack Cloud: more tweaks for the Search standalone plugin

### DIFF
--- a/client/jetpack-cloud/sections/landing.tsx
+++ b/client/jetpack-cloud/sections/landing.tsx
@@ -8,13 +8,16 @@ import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isBackupPluginActive from 'calypso/state/sites/selectors/is-backup-plugin-active';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
+import isSearchPluginActive from 'calypso/state/sites/selectors/is-search-plugin-active';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import { AppState } from 'calypso/types';
 
 const siteIsEligible = ( state: AppState, siteId: number | null ) =>
 	siteId
-		? ( isJetpackSite( state, siteId ) || isBackupPluginActive( state, siteId ) ) &&
+		? ( isJetpackSite( state, siteId ) ||
+				isBackupPluginActive( state, siteId ) ||
+				isSearchPluginActive( state, siteId ) ) &&
 		  ! isSiteAtomic( state, siteId ) &&
 		  ! isJetpackSiteMultiSite( state, siteId )
 		: null;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -34,6 +34,7 @@ import {
 	isJetpackSite,
 	getJetpackCheckoutRedirectUrl,
 	isBackupPluginActive,
+	isSearchPluginActive,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { recordCompositeCheckoutErrorDuringAnalytics } from '../lib/analytics';
@@ -91,7 +92,9 @@ export default function useCreatePaymentCompleteCallback( {
 		useSelector(
 			( state ) =>
 				siteId &&
-				( isJetpackSite( state, siteId ) || isBackupPluginActive( state, siteId ) ) &&
+				( isJetpackSite( state, siteId ) ||
+					isBackupPluginActive( state, siteId ) ||
+					isSearchPluginActive( state, siteId ) ) &&
 				! isAtomicSite( state, siteId )
 		) || false;
 	const adminPageRedirect = useSelector( ( state ) =>

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -27,11 +27,12 @@ class Sites extends Component {
 	}
 
 	filterSites = ( site ) => {
-		// only show Jetpack sites with the full Plugin or Backup Plugin
+		// only show Jetpack sites with the full Plugin or Backup/Search Plugin
 		if (
 			site?.options?.jetpack_connection_active_plugins &&
 			! site.options.jetpack_connection_active_plugins.includes( 'jetpack' ) &&
-			! site.options.jetpack_connection_active_plugins.includes( 'jetpack-backup' )
+			! site.options.jetpack_connection_active_plugins.includes( 'jetpack-backup' ) &&
+			! site.options.jetpack_connection_active_plugins.includes( 'jetpack-search' )
 		) {
 			return false;
 		}

--- a/client/state/selectors/is-jetpack-section-enabled-for-site.ts
+++ b/client/state/selectors/is-jetpack-section-enabled-for-site.ts
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isBackupPluginActive from 'calypso/state/sites/selectors/is-backup-plugin-active';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
+import isSearchPluginActive from 'calypso/state/sites/selectors/is-search-plugin-active';
 
 const FLAG_JETPACK_SITES = 'jetpack/features-section/jetpack';
 const FLAG_ATOMIC_SITES = 'jetpack/features-section/atomic';
@@ -30,6 +31,10 @@ export default function isJetpackSectionEnabledForSite(
 	}
 
 	if ( isBackupPluginActive( state, siteId ) ) {
+		return isEnabled( FLAG_JETPACK_SITES );
+	}
+
+	if ( isSearchPluginActive( state, siteId ) ) {
 		return isEnabled( FLAG_JETPACK_SITES );
 	}
 

--- a/client/state/sites/selectors/get-site-admin-page.js
+++ b/client/state/sites/selectors/get-site-admin-page.js
@@ -15,12 +15,12 @@ export default function getSiteAdminPage( state, siteId ) {
 	);
 
 	let pluginPage = 'jetpack';
-	if (
-		Array.isArray( activeConnectedPlugins ) &&
-		! activeConnectedPlugins.includes( 'jetpack' ) &&
-		activeConnectedPlugins.includes( 'jetpack-backup' )
-	) {
-		pluginPage = 'jetpack-backup';
+	if ( Array.isArray( activeConnectedPlugins ) && ! activeConnectedPlugins.includes( 'jetpack' ) ) {
+		if ( activeConnectedPlugins.includes( 'jetpack-backup' ) ) {
+			pluginPage = 'jetpack-backup';
+		} else if ( activeConnectedPlugins.includes( 'jetpack-search' ) ) {
+			pluginPage = 'jetpack-search';
+		}
 	}
 	return pluginPage;
 }

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -56,6 +56,7 @@ export { default as isJetpackSiteSecondaryNetworkSite } from './is-jetpack-site-
 export { default as isNewSite } from './is-new-site';
 export { default as isRequestingSite } from './is-requesting-site';
 export { default as isRequestingSites } from './is-requesting-sites';
+export { default as isSearchPluginActive } from './is-search-plugin-active';
 export { default as isSingleUserSite } from './is-single-user-site';
 export { default as isSiteConflicting } from './is-site-conflicting';
 export { default as isSitePreviewable } from './is-site-previewable';

--- a/client/state/sites/selectors/is-search-plugin-active.js
+++ b/client/state/sites/selectors/is-search-plugin-active.js
@@ -1,0 +1,17 @@
+import getSiteOption from './get-site-option';
+
+/**
+ * Returns true if site has the Jetpack Search Plugin active, false if it is not active
+ *
+ * @param  {object}   state  Global state tree
+ * @param  {?number}   siteId Site ID
+ * @returns {?boolean}        Whether site has the Jetpack Search plugin active
+ */
+export default function isSearchPluginActive( state, siteId ) {
+	const activeJetpackPlugins = getSiteOption( state, siteId, 'jetpack_connection_active_plugins' );
+	if ( activeJetpackPlugins && activeJetpackPlugins.includes( 'jetpack-search' ) ) {
+		return true;
+	}
+
+	return false;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A lot is stolen from https://github.com/Automattic/wp-calypso/pull/55250 and https://github.com/Automattic/wp-calypso/pull/56882. We'll likely need a more general solution for other stand-alone plugins when more appear.

- Show sites with only Search plugin for JP cloud.
- Places to test whether site is atomic/jetpack
- Changed WP-Admin in sidebar to redirect to Search dashboard if only Search plugin is activate


#### Testing instructions
1. Run the branch locally with `yarn start-jetpack-cloud` and map `jetpack.cloud.localhost to 127.0.0.1` in your “hosts” file.
2. Create a new Jurassic Ninja site
   - Navigate to [Jurassic Ninja with more options](https://jurassic.ninja/specialops/)
   - Uncheck "Include Jetpack"
   - Check "include Jetpack Beta"
   - Launch "Launch single site" 
![image](https://user-images.githubusercontent.com/1425433/160743407-2132d905-1203-4cb2-bda7-d3f7ce1526ca.png)

3. Navigate to `/wp-admin/admin.php?page=jetpack-beta&plugin=jetpack-search`
4. Activate Search plugin the Bleeding Edge version
![image](https://user-images.githubusercontent.com/1425433/160743342-2e4b2163-6e52-4eba-8ce0-504fabd190de.png)

3. Navigate to `/wp-admin/admin.php?page=jetpack-search` on your new temporary site
6. Click "Get Jetpack Search" 
8. Click "Approve"
9. Purchase the search product ( the return URL might be wrong which is being fixed in #62199 )
11. Ensure the site shows in Calypso Green site list - http://jetpack.cloud.localhost:3000/jetpack-search
![image](https://user-images.githubusercontent.com/1425433/160744434-4f97b168-bc53-4f29-b5e3-3dad620d5fa9.png)
13. Ensure the WP-Admin on sidebar links to Search Dashboard
![image](https://user-images.githubusercontent.com/1425433/160744465-4e62c4ae-f9fd-4aef-b1ee-d16f892ee793.png)


