### PR TITLE
Playwright: extend Jest timeout if `DEBUG` env var is defined.

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/setup.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/setup.ts
@@ -1,5 +1,9 @@
 import { jest } from '@jest/globals';
 import config from 'config';
 
-// Set the default timeout value
-jest.setTimeout( config.get( 'jestTimeoutMS' ) );
+if ( process.env.PWDEBUG ) {
+	// If the user intends to debug the suite, extend the default timeout.
+	jest.setTimeout( ( config.get( 'jestTimeoutMS' ) as number ) * 1000 );
+} else {
+	jest.setTimeout( config.get( 'jestTimeoutMS' ) );
+}

--- a/packages/calypso-e2e/src/jest-playwright-config/setup.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/setup.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 import config from 'config';
 
-if ( process.env.PWDEBUG ) {
+if ( process.env.PWDEBUG === '1' ) {
 	// If the user intends to debug the suite, extend the default timeout.
 	jest.setTimeout( ( config.get( 'jestTimeoutMS' ) as number ) * 1000 );
 } else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes #62325 with the goal of improving the engineer's debugging experience.

Key changes:
1. if the `DEBUG` environment variable is defined, extend the Jest timeout to the default value * 100.

#### Testing instructions

Not much to check - if desired, place a `console.log` statement to ensure the conditional is being evaluated correctly and check with the following variants:
- PWDEBUG=
- PWDEBUG=1
- PWDEBUG='something'

Related to #62325.