### PR TITLE
Happy Chat: fix design and i18n of in-chat unread message indicator

### DIFF
--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -230,6 +230,8 @@ function Timeline( props ) {
 
 	const prevUnreadMessagesCount = useRef( unreadMessagesCount );
 
+	const translate = useTranslate();
+
 	useEffect( () => {
 		if ( prevUnreadMessagesCount.current === 0 && unreadMessagesCount > 0 ) {
 			recordTracksEvent( 'calypso_happychat_unread_messages_button_show' );
@@ -277,7 +279,16 @@ function Timeline( props ) {
 						className="happychat__unread-messages-button"
 						onClick={ handleUnreadMessagesButtonClick }
 					>
-						{ unreadMessagesCount } new message{ unreadMessagesCount ? 's' : '' }
+						{ translate(
+							'%(unreadMessagesCount)d new message',
+							'%(unreadMessagesCount)d new messages',
+							{
+								count: unreadMessagesCount,
+								args: {
+									unreadMessagesCount: unreadMessagesCount,
+								},
+							}
+						) }
 						<Gridicon icon="arrow-down" />
 					</Button>
 				</div>

--- a/client/components/happychat/timeline.scss
+++ b/client/components/happychat/timeline.scss
@@ -135,9 +135,10 @@
 	bottom: 10px;
 	left: 50%;
 	transform: translateX( -50% );
-	border-radius: 8px;
-	padding-left: 2em;
-	padding-right: 2em;
+	border-radius: 4px;
+	padding: 0.5em;
+	max-width: 100%;
+	width: max-content;
 	> .gridicon {
 		margin-left: 0.5em;
 	}

--- a/client/components/happychat/timeline.scss
+++ b/client/components/happychat/timeline.scss
@@ -29,7 +29,7 @@
 	font-size: $font-body-small;
 	flex: 1;
 	padding: 8px 12px;
-	border-radius: 8px 8px 8px 0;
+	border-radius: 8px 8px 8px 0; /* stylelint-disable-line */
 	color: var( --color-neutral-70 );
 	background: var( --color-surface );
 	position: relative;
@@ -68,7 +68,7 @@
 	.is-user-message & {
 		color: var( --color-primary-dark );
 		background: var( --color-primary-5 );
-		border-radius: 8px 8px 0;
+		border-radius: 8px 8px 0;  /* stylelint-disable-line */
 
 		&::after {
 			left: auto;
@@ -86,10 +86,10 @@
 
 .happychat__message-edited-flag {
 	color: var( --color-neutral-40 );
-	font-size: 0.8em;
+	font-size: 0.75rem;
 	vertical-align: text-bottom;
 	white-space: nowrap;
-	&:before {
+	&::before {
 		content: '  ';
 	}
 }

--- a/client/components/happychat/timeline.scss
+++ b/client/components/happychat/timeline.scss
@@ -86,7 +86,7 @@
 
 .happychat__message-edited-flag {
 	color: var( --color-neutral-40 );
-	font-size: 0.75rem;
+	font-size: $font-body-extra-small;
 	vertical-align: text-bottom;
 	white-space: nowrap;
 	&::before {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Add i18n support for the new messages notice
* Fix the design of the new messages notice - reduce padding, and set width to match content
* Fix/prevent some other minor stylelint issues.

#### Screenshots

**Before**: 
<img width="353" alt="Screen Shot 2022-03-29 at 10 06 39" src="https://user-images.githubusercontent.com/844866/160553424-53eb44bd-0f2f-4275-bd04-fb2c59fad2d9.png">

**After**: 
<img width="170" alt="Screen Shot 2022-03-29 at 9 43 59" src="https://user-images.githubusercontent.com/844866/160553509-7cda6d9e-f6af-4116-aaaf-20c68c1e5746.png">
<img width="197" alt="Screen Shot 2022-03-29 at 9 45 23" src="https://user-images.githubusercontent.com/844866/160553501-e73105ee-db74-408f-9634-aeec8c611baa.png">

#### Testing instructions

* Log in to staging on happy-chat so that you can chat with someone
* In an account eligible for chat in calypso, start a chat
* Add one or more messages, and notice how the notice looks like



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1829-gh-Automattic/happychat

