### PR TITLE
Update title, subtitle and plab CTA copy

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-action.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-action.tsx
@@ -35,7 +35,7 @@ function getButtonText( props: Partial< Props >, translate: TranslateFunc ): Tra
 	const planSlug = plan?.getStoreSlug();
 
 	if ( planSlug === PLAN_WPCOM_PRO ) {
-		return translate( 'Try Pro risk-free' );
+		return translate( 'Start with Pro' );
 	} else if ( planSlug === PLAN_FREE || planSlug === PLAN_WPCOM_FLEXIBLE ) {
 		return translate( 'Start with Free' );
 	}

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -279,7 +279,7 @@ export class PlansStep extends Component {
 		const { headerText, translate, eligibleForProPlan } = this.props;
 
 		if ( eligibleForProPlan ) {
-			return translate( 'Choose the plan that’s right for you' );
+			return translate( 'Choose your hosting plan' );
 		}
 
 		if ( this.state.isDesktop ) {
@@ -293,7 +293,7 @@ export class PlansStep extends Component {
 		const { hideFreePlan, subHeaderText, translate, eligibleForProPlan } = this.props;
 
 		if ( eligibleForProPlan ) {
-			return translate( 'The WordPress Pro plan comes with a 14-day full money back guarantee' );
+			return translate( 'The WordPress Pro plan comes with a 14-day money back guarantee' );
 		}
 
 		if ( ! hideFreePlan ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes the following copy changes:

**Title**: Choose your hosting plan.

**Subtitle**: The WordPress Pro plan comes with a 14-day money back guarantee

**CTA for Pro plan**: Start with Pro

#### Testing instructions

* Go to `/start/plans?flags=plans/pro-plan` and to `plans/my-plan/[free_site]?flags=plans/pro-plan`
* The title, subtitle and Pro plan CTA copy should match the summary:

<img width="320" alt="Markup 2022-03-29 at 12 53 58" src="https://user-images.githubusercontent.com/2749938/160585914-adaffca5-b0fe-4c6f-aa0f-f53518978484.png">
