### PR TITLE
G Suite: Simplify code from cancelation survey

### DIFF
--- a/client/components/gsuite/gsuite-features/index.jsx
+++ b/client/components/gsuite/gsuite-features/index.jsx
@@ -1,8 +1,4 @@
-import {
-	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
-	GSUITE_BASIC_SLUG,
-	GSUITE_BUSINESS_SLUG,
-} from '@automattic/calypso-products';
+import { GSUITE_BUSINESS_SLUG } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import googleDocsIcon from 'calypso/assets/images/email-providers/google-workspace/services/docs.svg';
@@ -19,29 +15,25 @@ const GSuiteFeatures = ( { compact, domainName, productSlug, type } ) => {
 	const getStorageText = () => {
 		if ( compact ) {
 			return undefined;
-		} else if (
-			[ GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY, GSUITE_BASIC_SLUG ].includes( productSlug )
-		) {
-			return translate( 'Get 30GB of storage for all your files synced across devices.' );
-		} else if ( GSUITE_BUSINESS_SLUG === productSlug ) {
+		}
+
+		if ( GSUITE_BUSINESS_SLUG === productSlug ) {
 			return translate( 'Get unlimited storage for all your files synced across devices.' );
 		}
 
-		return translate( 'Get 30GB or unlimited storage for all your files synced across devices.' );
+		return translate( 'Get 30GB of storage for all your files synced across devices.' );
 	};
 
 	const getStorageTitle = () => {
 		if ( ! compact ) {
 			return translate( 'Keep all your files secure' );
-		} else if (
-			[ GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY, GSUITE_BASIC_SLUG ].includes( productSlug )
-		) {
-			return translate( '30GB of cloud storage' );
-		} else if ( GSUITE_BUSINESS_SLUG === productSlug ) {
+		}
+
+		if ( GSUITE_BUSINESS_SLUG === productSlug ) {
 			return translate( 'Unlimited cloud storage (or 1TB per user if fewer than 5 users)' );
 		}
 
-		return translate( '30GB or unlimited cloud storage' );
+		return translate( '30GB of cloud storage' );
 	};
 
 	return (
@@ -61,6 +53,7 @@ const GSuiteFeatures = ( { compact, domainName, productSlug, type } ) => {
 				imageAlt={ 'Gmail Logo' }
 				compact={ compact }
 			/>
+
 			<GSuiteSingleFeature
 				title={ translate( 'Docs, spreadsheets and more' ) }
 				description={
@@ -72,6 +65,7 @@ const GSuiteFeatures = ( { compact, domainName, productSlug, type } ) => {
 				imageAlt={ 'Google Docs Logo' }
 				compact={ compact }
 			/>
+
 			<GSuiteSingleFeature
 				title={ getStorageTitle() }
 				description={ getStorageText() }
@@ -79,6 +73,7 @@ const GSuiteFeatures = ( { compact, domainName, productSlug, type } ) => {
 				imageAlt={ 'Google Drive Logo' }
 				compact={ compact }
 			/>
+
 			<GSuiteSingleFeature
 				title={ compact ? translate( 'Video calls' ) : translate( 'Connect with your team' ) }
 				description={

--- a/client/components/gsuite/gsuite-features/index.jsx
+++ b/client/components/gsuite/gsuite-features/index.jsx
@@ -5,7 +5,7 @@ import googleDocsIcon from 'calypso/assets/images/email-providers/google-workspa
 import googleDriveIcon from 'calypso/assets/images/email-providers/google-workspace/services/drive.svg';
 import gmailIcon from 'calypso/assets/images/email-providers/google-workspace/services/gmail.svg';
 import googleMeetIcon from 'calypso/assets/images/email-providers/google-workspace/services/meet.svg';
-import GSuiteSingleFeature from './single-feature';
+import GSuiteSingleFeature from 'calypso/components/gsuite/gsuite-features/single-feature';
 
 import './style.scss';
 

--- a/client/components/gsuite/gsuite-features/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-features/test/__snapshots__/index.js.snap
@@ -381,7 +381,7 @@ exports[`GSuiteFeatures it renders GSuiteFeatures without a productSlug 1`] = `
         Keep all your files secure
       </h5>
       <p>
-        Get 30GB or unlimited storage for all your files synced across devices.
+        Get 30GB of storage for all your files synced across devices.
       </p>
     </div>
   </div>


### PR DESCRIPTION
This pull request simplifies the code that drives the survey shown to users when they cancel a G Suite or Google Workspace subscription. Those changes were extracted from https://github.com/Automattic/wp-calypso/pull/62215.

![image](https://user-images.githubusercontent.com/594356/160616703-2376ce72-2138-49af-bb77-7a231b69ed90.png)

#### Testing instructions

1. Run `git checkout update/gsuite-cancelation-survey` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/62334#issuecomment-1081838945)
2. Log into a WordPress.com account that has a site with a Google email account
3. Open the [`Purchases` page](http://calypso.localhost:3000/purchases/subscriptions/)
4. Click the subscription for that account
5. Click the `Remove Google Workspace Business Starter` option at the bottom of the page
6. Assert that the survey still shows the right information