### PR TITLE
Marketplace: allow referrer information in the plugin sections links.

### DIFF
--- a/client/lib/plugins/sanitize-section-content.js
+++ b/client/lib/plugins/sanitize-section-content.js
@@ -1,3 +1,4 @@
+import { addQueryArgs } from '@wordpress/url';
 import { filter } from 'lodash';
 import validUrl from 'valid-url';
 
@@ -193,6 +194,10 @@ export const sanitizeSectionContent = ( content ) => {
 		if ( 'a' === tagName && node.getAttribute( 'href' ) ) {
 			node.setAttribute( 'target', '_blank' );
 			node.setAttribute( 'rel', 'external noopener noreferrer' );
+			node.setAttribute(
+				'href',
+				addQueryArgs( node.getAttribute( 'href' ), { referrer: 'wordpress.com' } )
+			);
 		}
 
 		// prevent mixed-content issues from blocking Youtube embeds

--- a/client/lib/plugins/test/sanitize-section-content.js
+++ b/client/lib/plugins/test/sanitize-section-content.js
@@ -76,7 +76,7 @@ test( 'should add referrer query parameter', () => {
 	const link = cleanNode( '<a href="https://example.com?other-query">' );
 
 	expect( link.getAttribute( 'href' ) ).toBe(
-		'https://example.com?other-query&referrer=wordpress.com'
+		'https://example.com?other-query=&referrer=wordpress.com'
 	);
 } );
 

--- a/client/lib/plugins/test/sanitize-section-content.js
+++ b/client/lib/plugins/test/sanitize-section-content.js
@@ -49,7 +49,9 @@ test( 'should allow http(s) links', () => {
 	expect( img.getAttribute( 'src' ) ).toBe( 'http://example.com/images/1f39.png?v=25' );
 
 	const link = cleanNode( '<a id="test" href="https://github.com/README.md">docs</a>' );
-	expect( link.getAttribute( 'href' ) ).toBe( 'https://github.com/README.md' );
+	expect( link.getAttribute( 'href' ) ).toBe(
+		'https://github.com/README.md?referrer=wordpress.com'
+	);
 } );
 
 test( 'should omit non http(s) links', () => {
@@ -68,6 +70,14 @@ test( 'should set link params', () => {
 	expect( rel ).toContain( 'external' );
 	expect( rel ).toContain( 'noopener' );
 	expect( rel ).toContain( 'noreferrer' );
+} );
+
+test( 'should add referrer query parameter', () => {
+	const link = cleanNode( '<a href="https://example.com?other-query">' );
+
+	expect( link.getAttribute( 'href' ) ).toBe(
+		'https://example.com?other-query&referrer=wordpress.com'
+	);
 } );
 
 test( 'should only set link params if href set', () => {
@@ -160,5 +170,5 @@ test( 'should prevent backspace-based XSS attacks', () => {
 		'<a href="http://example.com">' + '\u0008'.repeat( 71 ) + 'javascript:alert(1)\u0022>xss</a>'
 	);
 
-	expect( link.getAttribute( 'href' ) ).toBe( 'http://example.com' );
+	expect( link.getAttribute( 'href' ) ).toBe( 'http://example.com?referrer=wordpress.com' );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Since we will be hosting premium plugins that also have free plugin versions we want all premium plugin references appearing in the free plugin sections to link back to WordPress.com and not to the 3pd site. 3pds can make this work by redirecting depending on the referrer which in our case will be wordpress.com.

* Adds `referrer` query parameter in all `a` (link) tags in plugin sections

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit a plugin page
* inspect links and make sure that `?referrer=wordpress.com` is added when no query is present or `&referrer=wordpress.com` when there are parameters present

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdh6GB-xD-p2