### PR TITLE
Add a new site name independent path to redirect users to a domain's management page.

### DIFF
--- a/client/lib/domains/get-site-slug-domain.ts
+++ b/client/lib/domains/get-site-slug-domain.ts
@@ -1,0 +1,13 @@
+import wpcom from 'calypso/lib/wp';
+import type { DomainsApiError } from './types';
+
+export function getSiteSlugFromDomain(
+	domainName: string,
+	onComplete: ( data: string ) => void,
+	onError: ( error: DomainsApiError ) => void
+) {
+	wpcom.req
+		.get( { path: `/domains/${ domainName }/sitename` } )
+		.then( ( data: string ) => onComplete( data ) )
+		.catch( ( error: DomainsApiError ) => onError( error ) );
+}

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -331,23 +331,6 @@ const jetpackNoDomainsWarning = ( context, next ) => {
 
 const redirectDomainToSite = ( context, next ) => {
 	context.primary = <RedirectComponent domainName={ context.params.domain } />;
-
-	// context.primary = (
-	// 	<Main>
-	// 		{/* <PageViewTracker
-	// 			path={ domainUseYourDomain( ':site' ) }
-	// 			title="Domain Search > Use Your Own Domain"
-	// 		/> */}
-	// 		{/* <DocumentHead title={ translate( 'Use Your Own Domain' ) } /> */}
-	// 		<CalypsoShoppingCartProvider>
-	// 			<UseYourDomainStep
-	// 				basePath={ sectionify( context.path ) }
-	// 				initialQuery={ context.query.initialQuery }
-	// 				goBack={ handleGoBack }
-	// 			/>
-	// 		</CalypsoShoppingCartProvider>
-	// 	</Main>
-	// );
 	next();
 };
 

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -32,6 +32,7 @@ import {
 	getSelectedSite,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import RedirectComponent from './domain-redirect-to-site';
 import DomainSearch from './domain-search';
 import SiteRedirect from './domain-search/site-redirect';
 import EmailProvidersUpsell from './email-providers-upsell';
@@ -328,6 +329,28 @@ const jetpackNoDomainsWarning = ( context, next ) => {
 	}
 };
 
+const redirectDomainToSite = ( context, next ) => {
+	context.primary = <RedirectComponent domainName={ context.params.domain } />;
+
+	// context.primary = (
+	// 	<Main>
+	// 		{/* <PageViewTracker
+	// 			path={ domainUseYourDomain( ':site' ) }
+	// 			title="Domain Search > Use Your Own Domain"
+	// 		/> */}
+	// 		{/* <DocumentHead title={ translate( 'Use Your Own Domain' ) } /> */}
+	// 		<CalypsoShoppingCartProvider>
+	// 			<UseYourDomainStep
+	// 				basePath={ sectionify( context.path ) }
+	// 				initialQuery={ context.query.initialQuery }
+	// 				goBack={ handleGoBack }
+	// 			/>
+	// 		</CalypsoShoppingCartProvider>
+	// 	</Main>
+	// );
+	next();
+};
+
 export default {
 	domainsAddHeader,
 	domainsAddRedirectHeader,
@@ -344,4 +367,5 @@ export default {
 	transferDomainPrecheck,
 	useMyDomain,
 	useYourDomain,
+	redirectDomainToSite,
 };

--- a/client/my-sites/domains/domain-redirect-to-site/index.tsx
+++ b/client/my-sites/domains/domain-redirect-to-site/index.tsx
@@ -1,0 +1,33 @@
+import page from 'page';
+import { useEffect, useState } from 'react';
+import { getSiteSlugFromDomain } from 'calypso/lib/domains/get-site-slug-domain';
+import { domainManagementAllRoot, domainManagementEdit } from '../paths';
+
+const RedirectComponent = ( { domainName }: { domainName: string } ) => {
+	const [ siteSlug, setSiteSlug ] = useState< null | string >( null );
+	const [ isDomainLoaded, setIsDomainLoaded ] = useState( false );
+
+	useEffect( () => {
+		getSiteSlugFromDomain(
+			domainName,
+			( data ) => {
+				setIsDomainLoaded( true );
+				setSiteSlug( data );
+			},
+			() => {
+				// Default: redirect to all domains management
+				page( domainManagementAllRoot() );
+			}
+		);
+	}, [ domainName ] );
+
+	useEffect( () => {
+		if ( isDomainLoaded && siteSlug ) {
+			page( domainManagementEdit( siteSlug, domainName, null ) );
+		}
+	} );
+
+	return null;
+};
+
+export default RedirectComponent;

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -319,7 +319,7 @@ export default function () {
 	);
 
 	page(
-		'/domains/domain/:domain',
+		paths.domainManagementRoot() + '/:domain/edit',
 		domainsController.redirectDomainToSite,
 		makeLayout,
 		clientRender

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -319,6 +319,13 @@ export default function () {
 	);
 
 	page(
+		'/domains/domain/:domain',
+		domainsController.redirectDomainToSite,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/domains/:site',
 		siteSelection,
 		navigation,


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR creates a new path in Calypso to redirect user to domain's management page.

New path doesn't depend on site name: `/domains/manage/{:domain}/edit`

If the provided domain doesn't exist or it's not valid, user is redirect to all domains page.

This PR is part of the new **Attrition Monetization** project.

## Testing instructions

This PR depends on D77721-code.

- Build this branch locally or open the live Calypso link
- Navigate to `/domains/domain/your-valid-domain.com` (provide a valid domain) and verify that you are redirect to domain's management page
- Navigate to `/domains/domain/invalid-domain.com` (provide an invalid domain) and verify that you are redirect to all domains page