### PR TITLE
Remove blocked plugin from the list as it was already removed from WP.org

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -440,13 +440,10 @@ const SearchListView = ( {
 		return (
 			<>
 				<PluginsBrowserList
-					plugins={
-						pluginsPagination?.page === 1
-							? [ ...paidPluginsBySearchTerm, ...pluginsBySearchTerm ].filter(
-									filterOutPluginsFromBlockList
-							  )
-							: pluginsBySearchTerm.filter( filterOutPluginsFromBlockList )
-					}
+					plugins={ ( pluginsPagination?.page === 1
+						? [ ...paidPluginsBySearchTerm, ...pluginsBySearchTerm ]
+						: pluginsBySearchTerm
+					).filter( isNotBlocked ) }
 					listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
 					title={ searchTitle }
 					subtitle={ subtitle }
@@ -567,7 +564,7 @@ const PluginSingleListView = ( {
 		return null;
 	}
 
-	plugins = plugins.filter( filterOutPluginsFromBlockList );
+	plugins = plugins.filter( isNotBlocked );
 
 	let listLink = '/plugins/' + category;
 	if ( domain ) {
@@ -751,7 +748,7 @@ function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
 
 const PLUGIN_SLUGS_BLOCKLIST = [];
 
-function filterOutPluginsFromBlockList( plugin ) {
+function isNotBlocked( plugin ) {
 	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;
 }
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -749,7 +749,7 @@ function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
 	);
 }
 
-const PLUGIN_SLUGS_BLOCKLIST = [ 'zamir' ];
+const PLUGIN_SLUGS_BLOCKLIST = [];
 
 function filterOutPluginsFromBlockList( plugin ) {
 	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the blocked plugin from the list as it was already removed from WP.org.
* Rename the filter function.

#### Testing instructions

* Go to `/plugins` page
* Search for the removed plugin (`zamir`)
* The plugin shouldn't be shown as it was removed from WP.org


#### Left out
The removal logic was kept in place.  If a plugin removal is needed again in the future, it should be as simple as add the slug to the `PLUGIN_SLUGS_BLOCKLIST` array.