### PR TITLE
P2: update pre-approved domains to use the new API endpoints

### DIFF
--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -27,7 +27,7 @@ const P2PreapprovedDomainsForm = ( {
 	updateFields,
 } ) => {
 	const SETTING_KEY_PREAPPROVED_DOMAINS = 'p2_preapproved_domains';
-	const DEFAULT_ROLE = 'author';
+	const DEFAULT_ROLE = 'editor';
 
 	const isWPForTeamsSite = useSelector( ( state ) => isSiteWPForTeams( state, siteId ) );
 	const isP2Hub = useSelector( ( state ) => isSiteP2Hub( state, siteId ) );
@@ -63,7 +63,7 @@ const P2PreapprovedDomainsForm = ( {
 		};
 
 		if ( ! domains?.[ 0 ] ) {
-			updateFields( { [ SETTING_KEY_PREAPPROVED_DOMAINS ]: '' } );
+			updateFields( { [ SETTING_KEY_PREAPPROVED_DOMAINS ]: { domains: [], role: '' } } );
 			return;
 		}
 

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -277,7 +277,6 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 				<div>
 					<QuerySiteSettings siteId={ this.props.siteId } />
 					{ this.props.siteIsJetpack && <QueryJetpackSettings siteId={ this.props.siteId } /> }
-					{ /*this.props.isWPForTeamsSite && <QueryP2SiteSettings siteId={ this.props.siteId } />*/ }
 					<SettingsForm { ...this.props } { ...utils } />
 				</div>
 			);

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -18,8 +18,10 @@ import getRequest from 'calypso/state/selectors/get-request';
 import isJetpackSettingsSaveFailure from 'calypso/state/selectors/is-jetpack-settings-save-failure';
 import isRequestingJetpackSettings from 'calypso/state/selectors/is-requesting-jetpack-settings';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isUpdatingJetpackSettings from 'calypso/state/selectors/is-updating-jetpack-settings';
 import { saveSiteSettings } from 'calypso/state/site-settings/actions';
+import { saveP2SiteSettings } from 'calypso/state/site-settings/p2/actions';
 import {
 	isRequestingSiteSettings,
 	isSavingSiteSettings,
@@ -173,6 +175,10 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 				this.props.saveJetpackSettings( siteId, jetpackFieldsToUpdate );
 			}
 
+			if ( typeof fields?.p2_preapproved_domains !== 'undefined' ) {
+				return this.props.saveP2SiteSettings( siteId, fields );
+			}
+
 			const siteFields = pick( fields, settingsFields.site );
 			this.props.saveSiteSettings( siteId, siteFields );
 		};
@@ -271,6 +277,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 				<div>
 					<QuerySiteSettings siteId={ this.props.siteId } />
 					{ this.props.siteIsJetpack && <QueryJetpackSettings siteId={ this.props.siteId } /> }
+					{ /*this.props.isWPForTeamsSite && <QueryP2SiteSettings siteId={ this.props.siteId } />*/ }
 					<SettingsForm { ...this.props } { ...utils } />
 				</div>
 			);
@@ -330,6 +337,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 				path,
 				siteIsJetpack: isJetpack,
 				siteIsAtomic: isSiteAutomatedTransfer( state, siteId ),
+				siteIsP2Hub: isSiteP2Hub( state, siteId ),
 				siteSettingsSaveError,
 				settings,
 				settingsFields,
@@ -346,6 +354,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 					saveSiteSettings,
 					successNotice,
 					saveJetpackSettings,
+					saveP2SiteSettings,
 					activateModule,
 				},
 				dispatch

--- a/client/state/site-settings/p2/actions.js
+++ b/client/state/site-settings/p2/actions.js
@@ -1,0 +1,67 @@
+import wpcom from 'calypso/lib/wp';
+import {
+	SITE_SETTINGS_SAVE,
+	SITE_SETTINGS_SAVE_FAILURE,
+	SITE_SETTINGS_SAVE_SUCCESS,
+} from 'calypso/state/action-types';
+import { updateSiteSettings } from 'calypso/state/site-settings/actions';
+import { normalizeSettings } from 'calypso/state/site-settings/utils';
+import { requestSite } from 'calypso/state/sites/actions';
+import 'calypso/state/site-settings/init';
+import 'calypso/state/ui/init';
+
+export function saveP2SiteSettings( siteId, settings = {} ) {
+	return ( dispatch ) => {
+		dispatch( {
+			type: SITE_SETTINGS_SAVE,
+			siteId,
+		} );
+
+		if ( typeof settings?.p2_preapproved_domains !== 'undefined' ) {
+			saveP2PreapprovedDomainSettings( siteId, settings, dispatch );
+		}
+	};
+}
+
+function saveP2PreapprovedDomainSettings( siteId, settings = {}, dispatch ) {
+	return wpcom.req
+		.post(
+			'/p2/preapproved-joining/settings',
+			{
+				global: true,
+				apiNamespace: 'wpcom/v2',
+			},
+			{
+				hub_id: siteId,
+				role: settings?.p2_preapproved_domains?.role,
+				domains: settings?.p2_preapproved_domains?.domains,
+			}
+		)
+		.then( ( body ) => {
+			dispatch(
+				updateSiteSettings(
+					siteId,
+					normalizeSettings( {
+						p2_preapproved_domains: {
+							...body.settings,
+						},
+					} )
+				)
+			);
+			dispatch( {
+				type: SITE_SETTINGS_SAVE_SUCCESS,
+				siteId,
+			} );
+			dispatch( requestSite( siteId ) );
+			return body;
+		} )
+		.catch( ( error ) => {
+			dispatch( {
+				type: SITE_SETTINGS_SAVE_FAILURE,
+				siteId,
+				error,
+			} );
+
+			return error;
+		} );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update settings to use the new endpoints
* Drive-by: change default role to `editor` (as there are talks about simplifying roles and removing `author`)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Please also apply changes from `D77830`, and sandbox `public-api.wordpress.com`.

* Visit `calypso.localhost:3000/settings/general/<YOUR-TEST-HUB>.wordpress.com`.
* You should see the *Joining this workspace* section
* Updating the settings should work as expected, i.e. changes are saved and loaded.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
