### PR TITLE
Fix webpreview component broken in #61732

### DIFF
--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -173,9 +173,9 @@ export class WebPreviewModal extends Component {
 
 const LocalizedWebPreviewModal = localize( WebPreviewModal );
 
-const WebPreviewInner = ( { isContentOnly, ...restProps } ) => {
+const WebPreviewInner = ( { isContentOnly, shouldConnectContent = true, ...restProps } ) => {
 	const WebPreviewContent = ( props ) =>
-		restProps.shouldConnectContent ? (
+		shouldConnectContent ? (
 			<AsyncLoad
 				{ ...props }
 				placeholder={ null }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The web-preview component uses an inside component called Content. This internal component is hooked to the Calypso redux store, which makes it only usable within Calypso. To fix that, we created a thin HoC wrapper that wraps `Content` and connects it to the store, and called it `ConnectedContent`.

This made the `Content` component reusable anywhere, and we used it in Stepper framework. But the issue is that we needed to decide which component should web-preview use (`Content` or `ConnectedContent`) in runtime, so we switched to loading the component asynchronously to be able to decide in runtime, we had to made this decision twice, once in the web-preview component itself, and once inside `Content` component. One of these checks defaulted to the wrong value `undefined` and hence we loaded the unconnected component in a context that expects it to be connected to the redux store. And this naturally broke things.

#### Testing instructions

1. Start in Calypso ([wordpress.com/home/mygroovysite.com](https://wordpress.com/home/mygroovysite.com))
2. Click on the site title in the upper left corner to open the page in the same tab.
3. Site should work.


Related to  [#62341](https://github.com/Automattic/wp-calypso/issues/62341) & https://github.com/Automattic/wp-calypso/pull/61732
