### PR TITLE
Fix: move ThreatListHeader below Pagination component

### DIFF
--- a/client/components/jetpack/threat-history-list/index.tsx
+++ b/client/components/jetpack/threat-history-list/index.tsx
@@ -141,47 +141,46 @@ const ThreatHistoryList: React.FC< ThreatHistoryListProps > = ( { filter } ) => 
 			) }
 
 			{ ! isRequestingThreatCounts && filteredThreatCount > 0 && (
-				<>
-					<ThreatListHeader />
-					<div className="threat-history-list__entries">
-						{ isRequestingThreatHistory && (
-							<ListItemsPlaceholder count={ filteredThreatCount } perPage={ THREATS_PER_PAGE } />
-						) }
-						{ ! isRequestingThreatHistory && (
-							<>
-								{ showPagination && (
-									<Pagination
-										compact={ isMobile }
-										className="threat-history-list__pagination--top"
-										total={ threats.length }
-										perPage={ THREATS_PER_PAGE }
-										page={ currentPage }
-										pageClick={ setCurrentPage }
-										nextLabel={ translate( 'Older' ) }
-										prevLabel={ translate( 'Newer' ) }
-									/>
-								) }
+				<div className="threat-history-list__entries">
+					{ isRequestingThreatHistory && (
+						<ListItemsPlaceholder count={ filteredThreatCount } perPage={ THREATS_PER_PAGE } />
+					) }
+					{ ! isRequestingThreatHistory && (
+						<>
+							{ showPagination && (
+								<Pagination
+									compact={ isMobile }
+									className="threat-history-list__pagination--top"
+									total={ threats.length }
+									perPage={ THREATS_PER_PAGE }
+									page={ currentPage }
+									pageClick={ setCurrentPage }
+									nextLabel={ translate( 'Older' ) }
+									prevLabel={ translate( 'Newer' ) }
+								/>
+							) }
 
-								<div className="threat-history-list__threats">
-									<ListItems items={ currentPageThreats } />
-								</div>
+							<ThreatListHeader />
 
-								{ showPagination && (
-									<Pagination
-										compact={ isMobile }
-										className="threat-history-list__pagination--bottom"
-										total={ threats.length }
-										perPage={ THREATS_PER_PAGE }
-										page={ currentPage }
-										pageClick={ setCurrentPage }
-										nextLabel={ translate( 'Older' ) }
-										prevLabel={ translate( 'Newer' ) }
-									/>
-								) }
-							</>
-						) }
-					</div>
-				</>
+							<div className="threat-history-list__threats">
+								<ListItems items={ currentPageThreats } />
+							</div>
+
+							{ showPagination && (
+								<Pagination
+									compact={ isMobile }
+									className="threat-history-list__pagination--bottom"
+									total={ threats.length }
+									perPage={ THREATS_PER_PAGE }
+									page={ currentPage }
+									pageClick={ setCurrentPage }
+									nextLabel={ translate( 'Older' ) }
+									prevLabel={ translate( 'Newer' ) }
+								/>
+							) }
+						</>
+					) }
+				</div>
 			) }
 		</div>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moves `<ThreatListHeader />` down, so that it is displayed below `<Pagination />` and only rendered when there are threats displayed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `git checkout fix/threat-list-header-position` && `yarn start` 
* Open http://calypso.localhost:3000/scan/history/[SITE_URL] with a SITE_URL that has threat history with 11 or more items. This can be achieved by installing `jetpack-threat-library`, adding threats, ignoring them in Jetpack Scan, re-adding threats, ignoring, etc...
* Validate that:
  * The threat list header is not rendered during loading.
  * The threat list header is displayed under the pagination.

#### Screenshots

**Before:**

<img width="754" alt="Screen Shot 2022-03-29 at 9 50 39 AM" src="https://user-images.githubusercontent.com/10933065/160658050-ef9d8510-a5bf-4c60-a549-72d7d09bef48.png">

**After:**

<img width="745" alt="Screen Shot 2022-03-29 at 10 09 45 AM" src="https://user-images.githubusercontent.com/10933065/160658059-c412914e-760c-44b0-9a0e-3a04ca4c634d.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
