### PR TITLE
Revert WebPreview changes introduced in #61732

### DIFF
--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -3,8 +3,8 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import AsyncLoad from 'calypso/components/async-load';
 import { hasTouch } from 'calypso/lib/touch-detect';
+import WebPreviewContent from './connectedContent';
 
 import './style.scss';
 
@@ -57,8 +57,6 @@ export class WebPreviewModal extends Component {
 		frontPageMetaDescription: PropTypes.string,
 		// A post object used to override the selected post in the SEO preview
 		overridePost: PropTypes.object,
-		// Whether WebPreviewContent should be connected to the Calypso Redux store.
-		shouldConnectContent: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -75,7 +73,6 @@ export class WebPreviewModal extends Component {
 		onEdit: noop,
 		hasSidebar: false,
 		overridePost: null,
-		shouldConnectContent: true,
 	};
 
 	constructor( props ) {
@@ -145,25 +142,12 @@ export class WebPreviewModal extends Component {
 					<div className="web-preview__backdrop" onClick={ this.props.onClose } />
 					{ /* eslint-enable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */ }
 					<div className="web-preview__content">
-						{ this.props.shouldConnectContent ? (
-							<AsyncLoad
-								{ ...this.props }
-								onDeviceUpdate={ this.setDeviceViewport }
-								isModalWindow={ true }
-								frontPageMetaDescription={ this.props.frontPageMetaDescription || null }
-								require="calypso/components/web-preview/connectedContent"
-								placeholder={ null }
-							></AsyncLoad>
-						) : (
-							<AsyncLoad
-								{ ...this.props }
-								onDeviceUpdate={ this.setDeviceViewport }
-								isModalWindow={ true }
-								frontPageMetaDescription={ this.props.frontPageMetaDescription || null }
-								require="calypso/components/web-preview/content"
-								placeholder={ null }
-							></AsyncLoad>
-						) }
+						<WebPreviewContent
+							{ ...this.props }
+							onDeviceUpdate={ this.setDeviceViewport }
+							isModalWindow={ true }
+							frontPageMetaDescription={ this.props.frontPageMetaDescription || null }
+						/>
 					</div>
 				</div>
 			</RootChild>
@@ -173,22 +157,7 @@ export class WebPreviewModal extends Component {
 
 const LocalizedWebPreviewModal = localize( WebPreviewModal );
 
-const WebPreviewInner = ( { isContentOnly, shouldConnectContent = true, ...restProps } ) => {
-	const WebPreviewContent = ( props ) =>
-		shouldConnectContent ? (
-			<AsyncLoad
-				{ ...props }
-				placeholder={ null }
-				require="calypso/components/web-preview/connectedContent"
-			></AsyncLoad>
-		) : (
-			<AsyncLoad
-				{ ...props }
-				placeholder={ null }
-				require="calypso/components/web-preview/content"
-			></AsyncLoad>
-		);
-
+const WebPreviewInner = ( { isContentOnly, ...restProps } ) => {
 	const WebPreviewComponent = isContentOnly ? WebPreviewContent : LocalizedWebPreviewModal;
 
 	return <WebPreviewComponent { ...restProps } />;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -18,7 +18,7 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
-import WebPreview from 'calypso/components/web-preview';
+import WebPreview from 'calypso/components/web-preview/content';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import AsyncCheckoutModal from 'calypso/my-sites/checkout/modal/async';
 import { useFSEStatus } from '../../../../hooks/use-fse-status';
@@ -229,7 +229,6 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		stepContent = (
 			<WebPreview
 				showPreview
-				isContentOnly
 				showClose={ false }
 				showEdit={ false }
 				externalUrl={ siteSlug }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I'm not surehow https://github.com/Automattic/wp-calypso/pull/61732 breaks web-preview. But I'm reverting the changes introduced there to fix the /view page in Calypso.

#### Testing instructions
1. Go to Calypso Home.
2. Click on the site name on the top left corner.
3. Preview should work.

Related to #61732
