### PR TITLE
Licensing Portal: Update billing UI to display usage for daily usage pricing

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -17,8 +17,8 @@ export default function BillingDetails(): ReactElement {
 			<Card compact className="billing-details__header">
 				<div className="billing-details__row">
 					<div>{ translate( 'Products' ) }</div>
-					<div>{ translate( 'Assigned' ) }</div>
-					<div>{ translate( 'Unassigned' ) }</div>
+					<div>{ translate( 'Assigned licenses' ) }</div>
+					<div>{ translate( 'Unassigned licenses' ) }</div>
 					<div></div>
 				</div>
 			</Card>
@@ -30,9 +30,15 @@ export default function BillingDetails(): ReactElement {
 							<div className="billing-details__product">
 								{ product.productName }
 								<span className="billing-details__line-item-meta">
-									{ translate( 'Price per license per month: %(price)s', {
-										args: { price: formatCurrency( product.productCost, 'USD' ) },
-									} ) }
+									{ billing.data.costInterval === 'day' &&
+										translate( 'Price per license per day: %(price)s', {
+											args: { price: formatCurrency( product.productCost, 'USD' ) },
+										} ) }
+
+									{ billing.data.costInterval === 'month' &&
+										translate( 'Price per license per month: %(price)s', {
+											args: { price: formatCurrency( product.productCost, 'USD' ) },
+										} ) }
 								</span>
 							</div>
 
@@ -51,10 +57,18 @@ export default function BillingDetails(): ReactElement {
 							</div>
 
 							<div className="billing-details__subtotal">
-								{ translate( '%(count)d License', '%(count)d Licenses', {
-									count: product.counts.total,
-									args: { count: product.counts.total },
-								} ) }
+								{ billing.data.costInterval === 'day' &&
+									translate( '%(count)d Day Usage', '%(count)d Days Usage', {
+										count: product.productQuantity,
+										args: { count: product.productQuantity },
+									} ) }
+
+								{ billing.data.costInterval === 'month' &&
+									translate( '%(count)d License', '%(count)d Licenses', {
+										count: product.counts.total,
+										args: { count: product.counts.total },
+									} ) }
+
 								<span className="billing-details__line-item-meta">
 									{ translate( 'Subtotal: %(subtotal)s', {
 										args: { subtotal: formatCurrency( product.productTotalCost, 'USD' ) },
@@ -114,27 +128,27 @@ export default function BillingDetails(): ReactElement {
 						{ billing.isError && <Gridicon icon="minus" /> }
 					</strong>
 
-					<span className="billing-details__total-label billing-details__line-item-meta">
-						{ translate( 'Assigned licenses:' ) }
-					</span>
-					<span className="billing-details__line-item-meta">
-						{ billing.isSuccess && formatCurrency( billing.data.costs.assigned, 'USD' ) }
+					{ billing.isSuccess && billing.data.costInterval === 'month' && (
+						<>
+							<span className="billing-details__total-label billing-details__line-item-meta">
+								{ translate( 'Assigned licenses:' ) }
+							</span>
+							<span className="billing-details__line-item-meta">
+								{ formatCurrency( billing.data.costs.assigned, 'USD' ) }
+							</span>
+						</>
+					) }
 
-						{ billing.isLoading && <TextPlaceholder /> }
-
-						{ billing.isError && <Gridicon icon="minus" /> }
-					</span>
-
-					<span className="billing-details__total-label billing-details__line-item-meta">
-						{ translate( 'Unassigned licenses:' ) }
-					</span>
-					<span className="billing-details__line-item-meta">
-						{ billing.isSuccess && formatCurrency( billing.data.costs.unassigned, 'USD' ) }
-
-						{ billing.isLoading && <TextPlaceholder /> }
-
-						{ billing.isError && <Gridicon icon="minus" /> }
-					</span>
+					{ billing.isSuccess && billing.data.costInterval === 'month' && (
+						<>
+							<span className="billing-details__total-label billing-details__line-item-meta">
+								{ translate( 'Unassigned licenses:' ) }
+							</span>
+							<span className="billing-details__line-item-meta">
+								{ formatCurrency( billing.data.costs.unassigned, 'USD' ) }
+							</span>
+						</>
+					) }
 				</div>
 			</Card>
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -62,7 +62,8 @@ export default function BillingDetails(): ReactElement {
 
 							<div className="billing-details__subtotal">
 								{ billing.data.priceInterval === 'day' &&
-									translate( '%(count)d Day', '%(count)d Days', {
+									// Translators: * designates a footnote explaining how we calculate the number of days.
+									translate( '%(count)d Day*', '%(count)d Days*', {
 										count: product.productQuantity,
 										args: { count: product.productQuantity },
 									} ) }
@@ -155,6 +156,15 @@ export default function BillingDetails(): ReactElement {
 					) }
 				</div>
 			</Card>
+
+			{ billing.isSuccess && billing.data.priceInterval === 'day' && (
+				<Card compact className="billing-details__footer">
+					<small>
+						* Estimate of the combined number of full days each license will be active for by the
+						end of the current month, accounting for licenses that were newly issued or revoked.
+					</small>
+				</Card>
+			) }
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -19,7 +19,11 @@ export default function BillingDetails(): ReactElement {
 					<div>{ translate( 'Products' ) }</div>
 					<div>{ translate( 'Assigned licenses' ) }</div>
 					<div>{ translate( 'Unassigned licenses' ) }</div>
-					<div></div>
+					<div>
+						{ billing.isSuccess &&
+							billing.data.priceInterval === 'day' &&
+							translate( 'Days in Total' ) }
+					</div>
 				</div>
 			</Card>
 
@@ -58,7 +62,7 @@ export default function BillingDetails(): ReactElement {
 
 							<div className="billing-details__subtotal">
 								{ billing.data.priceInterval === 'day' &&
-									translate( '%(count)d Total Day', '%(count)d Total Days', {
+									translate( '%(count)d Day', '%(count)d Days', {
 										count: product.productQuantity,
 										args: { count: product.productQuantity },
 									} ) }

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -30,12 +30,12 @@ export default function BillingDetails(): ReactElement {
 							<div className="billing-details__product">
 								{ product.productName }
 								<span className="billing-details__line-item-meta">
-									{ billing.data.costInterval === 'day' &&
+									{ billing.data.priceInterval === 'day' &&
 										translate( 'Price per license per day: %(price)s', {
 											args: { price: formatCurrency( product.productCost, 'USD' ) },
 										} ) }
 
-									{ billing.data.costInterval === 'month' &&
+									{ billing.data.priceInterval === 'month' &&
 										translate( 'Price per license per month: %(price)s', {
 											args: { price: formatCurrency( product.productCost, 'USD' ) },
 										} ) }
@@ -57,13 +57,13 @@ export default function BillingDetails(): ReactElement {
 							</div>
 
 							<div className="billing-details__subtotal">
-								{ billing.data.costInterval === 'day' &&
-									translate( '%(count)d Day Usage', '%(count)d Days Usage', {
+								{ billing.data.priceInterval === 'day' &&
+									translate( '%(count)d Total Day', '%(count)d Total Days', {
 										count: product.productQuantity,
 										args: { count: product.productQuantity },
 									} ) }
 
-								{ billing.data.costInterval === 'month' &&
+								{ billing.data.priceInterval === 'month' &&
 									translate( '%(count)d License', '%(count)d Licenses', {
 										count: product.counts.total,
 										args: { count: product.counts.total },
@@ -128,7 +128,7 @@ export default function BillingDetails(): ReactElement {
 						{ billing.isError && <Gridicon icon="minus" /> }
 					</strong>
 
-					{ billing.isSuccess && billing.data.costInterval === 'month' && (
+					{ billing.isSuccess && billing.data.priceInterval === 'month' && (
 						<>
 							<span className="billing-details__total-label billing-details__line-item-meta">
 								{ translate( 'Assigned licenses:' ) }
@@ -139,7 +139,7 @@ export default function BillingDetails(): ReactElement {
 						</>
 					) }
 
-					{ billing.isSuccess && billing.data.costInterval === 'month' && (
+					{ billing.isSuccess && billing.data.priceInterval === 'month' && (
 						<>
 							<span className="billing-details__total-label billing-details__line-item-meta">
 								{ translate( 'Unassigned licenses:' ) }

--- a/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-details/index.tsx
@@ -11,6 +11,7 @@ export default function BillingDetails(): ReactElement {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const billing = useBillingDashboardQuery();
+	const useDailyPrices = billing.isSuccess && billing.data.priceInterval === 'day';
 
 	return (
 		<div className="billing-details">
@@ -19,11 +20,7 @@ export default function BillingDetails(): ReactElement {
 					<div>{ translate( 'Products' ) }</div>
 					<div>{ translate( 'Assigned licenses' ) }</div>
 					<div>{ translate( 'Unassigned licenses' ) }</div>
-					<div>
-						{ billing.isSuccess &&
-							billing.data.priceInterval === 'day' &&
-							translate( 'Days in Total' ) }
-					</div>
+					<div>{ billing.isSuccess && useDailyPrices && translate( 'Days in Total' ) }</div>
 				</div>
 			</Card>
 
@@ -34,12 +31,12 @@ export default function BillingDetails(): ReactElement {
 							<div className="billing-details__product">
 								{ product.productName }
 								<span className="billing-details__line-item-meta">
-									{ billing.data.priceInterval === 'day' &&
+									{ useDailyPrices &&
 										translate( 'Price per license per day: %(price)s', {
 											args: { price: formatCurrency( product.productCost, 'USD' ) },
 										} ) }
 
-									{ billing.data.priceInterval === 'month' &&
+									{ ! useDailyPrices &&
 										translate( 'Price per license per month: %(price)s', {
 											args: { price: formatCurrency( product.productCost, 'USD' ) },
 										} ) }
@@ -61,14 +58,14 @@ export default function BillingDetails(): ReactElement {
 							</div>
 
 							<div className="billing-details__subtotal">
-								{ billing.data.priceInterval === 'day' &&
+								{ useDailyPrices &&
 									// Translators: * designates a footnote explaining how we calculate the number of days.
 									translate( '%(count)d Day*', '%(count)d Days*', {
 										count: product.productQuantity,
 										args: { count: product.productQuantity },
 									} ) }
 
-								{ billing.data.priceInterval === 'month' &&
+								{ ! useDailyPrices &&
 									translate( '%(count)d License', '%(count)d Licenses', {
 										count: product.counts.total,
 										args: { count: product.counts.total },
@@ -133,7 +130,7 @@ export default function BillingDetails(): ReactElement {
 						{ billing.isError && <Gridicon icon="minus" /> }
 					</strong>
 
-					{ billing.isSuccess && billing.data.priceInterval === 'month' && (
+					{ billing.isSuccess && ! useDailyPrices && (
 						<>
 							<span className="billing-details__total-label billing-details__line-item-meta">
 								{ translate( 'Assigned licenses:' ) }
@@ -144,7 +141,7 @@ export default function BillingDetails(): ReactElement {
 						</>
 					) }
 
-					{ billing.isSuccess && billing.data.priceInterval === 'month' && (
+					{ billing.isSuccess && ! useDailyPrices && (
 						<>
 							<span className="billing-details__total-label billing-details__line-item-meta">
 								{ translate( 'Unassigned licenses:' ) }
@@ -157,7 +154,7 @@ export default function BillingDetails(): ReactElement {
 				</div>
 			</Card>
 
-			{ billing.isSuccess && billing.data.priceInterval === 'day' && (
+			{ billing.isSuccess && useDailyPrices && (
 				<Card compact className="billing-details__footer">
 					<small>
 						* Estimate of the combined number of full days each license will be active for by the

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -55,7 +55,8 @@ export default function LicenseProductCard( props: Props ): ReactElement {
 							{ formatCurrency( product.amount, product.currency ) }
 						</div>
 						<div className="license-product-card__price-interval">
-							{ translate( '/per site per month' ) }
+							{ product.price_interval === 'day' && translate( '/per license per day' ) }
+							{ product.price_interval === 'month' && translate( '/per license per month' ) }
 						</div>
 					</div>
 				</div>

--- a/client/state/partner-portal/licenses/hooks/use-billing-dashboard-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-billing-dashboard-query.ts
@@ -32,7 +32,7 @@ interface APIBilling {
 	products: APIBillingProduct[];
 	licenses: APIBillingCounts;
 	costs: APIBillingCosts;
-	cost_interval: string;
+	price_interval: string;
 }
 
 // Calypso interfaces.
@@ -62,7 +62,7 @@ interface Billing {
 	products: BillingProduct[];
 	licenses: BillingCounts;
 	costs: BillingCosts;
-	costInterval: string;
+	priceInterval: string;
 }
 
 interface BillingDashboardQueryError {
@@ -91,7 +91,7 @@ function selectBillingDashboard( api: APIBilling ): Billing {
 		),
 		licenses: api.licenses,
 		costs: api.costs,
-		costInterval: api.cost_interval,
+		priceInterval: api.price_interval,
 	};
 }
 

--- a/client/state/partner-portal/licenses/hooks/use-billing-dashboard-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-billing-dashboard-query.ts
@@ -21,6 +21,7 @@ interface APIBillingCosts {
 interface APIBillingProduct {
 	product_slug: string;
 	product_name: string;
+	product_quantity: number;
 	product_cost: number;
 	product_total_cost: number;
 	counts: APIBillingCounts;
@@ -31,6 +32,7 @@ interface APIBilling {
 	products: APIBillingProduct[];
 	licenses: APIBillingCounts;
 	costs: APIBillingCosts;
+	cost_interval: string;
 }
 
 // Calypso interfaces.
@@ -49,6 +51,7 @@ interface BillingCosts {
 interface BillingProduct {
 	productSlug: string;
 	productName: string;
+	productQuantity: number;
 	productCost: number;
 	productTotalCost: number;
 	counts: BillingCounts;
@@ -59,6 +62,7 @@ interface Billing {
 	products: BillingProduct[];
 	licenses: BillingCounts;
 	costs: BillingCosts;
+	costInterval: string;
 }
 
 interface BillingDashboardQueryError {
@@ -79,6 +83,7 @@ function selectBillingDashboard( api: APIBilling ): Billing {
 			( product ): BillingProduct => ( {
 				productSlug: product.product_slug,
 				productName: product.product_name,
+				productQuantity: product.product_quantity,
 				productCost: product.product_cost,
 				productTotalCost: product.product_total_cost,
 				counts: product.counts,
@@ -86,6 +91,7 @@ function selectBillingDashboard( api: APIBilling ): Billing {
 		),
 		licenses: api.licenses,
 		costs: api.costs,
+		costInterval: api.cost_interval,
 	};
 }
 

--- a/client/state/partner-portal/licenses/test/hooks.js
+++ b/client/state/partner-portal/licenses/test/hooks.js
@@ -311,7 +311,7 @@ describe( 'useBillingDashboardQuery', () => {
 				assigned: 200,
 				unassigned: 100,
 			},
-			cost_interval: 'month',
+			price_interval: 'month',
 		};
 
 		const formattedStub = {
@@ -340,7 +340,7 @@ describe( 'useBillingDashboardQuery', () => {
 				assigned: 200,
 				unassigned: 100,
 			},
-			costInterval: 'month',
+			priceInterval: 'month',
 		};
 
 		nock( 'https://public-api.wordpress.com' )

--- a/client/state/partner-portal/licenses/test/hooks.js
+++ b/client/state/partner-portal/licenses/test/hooks.js
@@ -291,6 +291,7 @@ describe( 'useBillingDashboardQuery', () => {
 				{
 					product_slug: 'foo',
 					product_name: 'Foo',
+					product_quantity: 6,
 					product_cost: 3,
 					product_total_cost: 18,
 					counts: {
@@ -310,6 +311,7 @@ describe( 'useBillingDashboardQuery', () => {
 				assigned: 200,
 				unassigned: 100,
 			},
+			cost_interval: 'month',
 		};
 
 		const formattedStub = {
@@ -318,6 +320,7 @@ describe( 'useBillingDashboardQuery', () => {
 				{
 					productSlug: 'foo',
 					productName: 'Foo',
+					productQuantity: 6,
 					productCost: 3,
 					productTotalCost: 18,
 					counts: {
@@ -337,6 +340,7 @@ describe( 'useBillingDashboardQuery', () => {
 				assigned: 200,
 				unassigned: 100,
 			},
+			costInterval: 'month',
 		};
 
 		nock( 'https://public-api.wordpress.com' )

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -78,6 +78,7 @@ export interface APIProductFamilyProduct {
 	product_id: number;
 	currency: string;
 	amount: number;
+	price_interval: string;
 }
 
 export interface APIProductFamily {


### PR DESCRIPTION
PT: pdpAdu-bj-p2
Card: 1201902532330136-as-1201935935452157
Requires D77767-code.

#### Changes proposed in this Pull Request

* Change the Licensing Portal Billing UI based on whether the user is being billed for daily usage of licenses.
* Change the Licensing Portal Issue License UI based on whether the user is being billed for daily usage of licenses.

#### Testing instructions

* Follow the test instructions in D77767-code.
* Visit http://jetpack.cloud.localhost:3000/partner-portal/issue-license and confirm the price interval label matches your partner type.
* Visit http://jetpack.cloud.localhost:3000/partner-portal/billing and confirm the displayed quantities and prices match your partner type price interval (day vs month).
* Adjust the logic in D77767-code so your partner account is considered to have daily pricing and repeat the previous two steps.

Billing UI:
| Monthly | Daily |
| - | - |
| ![monthly](https://user-images.githubusercontent.com/22746396/161291298-973b8ce8-dc49-4514-a01d-2f260ecd92d2.png) | ![daily](https://user-images.githubusercontent.com/22746396/161986002-4eb6131b-67f3-4bbb-b035-7190e94b011d.png) |

Note: the price values are not real and are for testing purposes only. The "Days Total" numbers represent the number of days each license for a given product has been active or will be by the end of the current month.

Issue License UI:
| Monthly | Daily |
| - | - |
| ![Screen Shot 2022-03-31 at 18 53 15](https://user-images.githubusercontent.com/22746396/161097609-9a1b35e7-7cf0-4683-b3a0-587664d5bfef.png) | ![Screen Shot 2022-03-31 at 18 52 37](https://user-images.githubusercontent.com/22746396/161097483-bcae962d-9c77-414d-a19d-37e2d7791131.png) |

Note: the price values are not real and are for testing purposes only - the interval below the amount is what changes.