### PR TITLE
Marketplace: Updates more generic email search term in popular searches

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -326,7 +326,7 @@ const PluginsBrowser = ( {
 				searchTerm={ search }
 				siteSlug={ siteSlug }
 				title={ translate( 'Plugins you need to get your projects done' ) }
-				searchTerms={ [ 'shipping', 'seo', 'portfolio', 'chat', 'email' ] }
+				searchTerms={ [ 'shipping', 'seo', 'portfolio', 'chat', 'newsletter' ] }
 			/>
 			<PluginBrowserContent
 				pluginsByCategoryPopular={ pluginsByCategoryPopular }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -326,7 +326,7 @@ const PluginsBrowser = ( {
 				searchTerm={ search }
 				siteSlug={ siteSlug }
 				title={ translate( 'Plugins you need to get your projects done' ) }
-				searchTerms={ [ 'shipping', 'seo', 'portfolio', 'chat', 'mailchimp' ] }
+				searchTerms={ [ 'shipping', 'seo', 'portfolio', 'chat', 'email' ] }
 			/>
 			<PluginBrowserContent
 				pluginsByCategoryPopular={ pluginsByCategoryPopular }


### PR DESCRIPTION
#### Screenshots
<img width="1512" alt="Screen Shot 2022-03-29 at 12 53 32 PM" src="https://user-images.githubusercontent.com/1035546/160674777-f29c7143-70c5-42ca-b386-d07d86424a86.png">

#### Changes proposed in this Pull Request

* Adds a more generic search term to the popular searches

#### Testing instructions

* Navigate to `http://calypso.localhost:3000/plugins`.
* Email should appear on popular searches.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62266
