### PR TITLE
Plugin Details: Upgrade needed site list

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -1,5 +1,22 @@
+import {
+	PLAN_BUSINESS_MONTHLY,
+	PLAN_BUSINESS,
+	PLAN_PREMIUM,
+	PLAN_PERSONAL,
+	PLAN_BLOGGER,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_BLOGGER_2_YEARS,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_WPCOM_PRO,
+	isPro,
+	isBusiness,
+	isEnterprise,
+	isEcommerce,
+} from '@automattic/calypso-products';
 import { filter, map, pick, sortBy } from 'lodash';
 import { decodeEntities, parseHtml } from 'calypso/lib/formatting';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { sanitizeSectionContent } from './sanitize-section-content';
 
 /**
@@ -311,4 +328,43 @@ export function getPluginAuthorProfileKeyword( plugin ) {
 	}
 
 	return plugin.author_profile.replace( WPORG_PROFILE_URL, '' ).replaceAll( '/', '' );
+}
+
+/**
+ * @param site
+ * @returns if a given site can install Marketplace products
+ */
+export function isMarketplaceInstallationEligibleSite( site ) {
+	return (
+		isPro( site?.plan ) ||
+		isBusiness( site?.plan ) ||
+		isEnterprise( site?.plan ) ||
+		isEcommerce( site?.plan )
+	);
+}
+
+/**
+ * @param currentPlan
+ * @param pluginBillingPeriod
+ * @returns the correct business plan slug depending on current plan and pluginBillingPeriod
+ */
+export function businessPlanToAdd( currentPlan, pluginBillingPeriod, eligibleForProPlan ) {
+	if ( eligibleForProPlan ) {
+		return PLAN_WPCOM_PRO;
+	}
+	switch ( currentPlan.product_slug ) {
+		case PLAN_PERSONAL_2_YEARS:
+		case PLAN_PREMIUM_2_YEARS:
+		case PLAN_BLOGGER_2_YEARS:
+			return PLAN_BUSINESS_2_YEARS;
+		case PLAN_PERSONAL:
+		case PLAN_PREMIUM:
+		case PLAN_BLOGGER:
+			return PLAN_BUSINESS;
+		default:
+			// Return annual plan if selected, monthly otherwise.
+			return pluginBillingPeriod === IntervalLength.ANNUALLY
+				? PLAN_BUSINESS
+				: PLAN_BUSINESS_MONTHLY;
+	}
 }

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -9,10 +9,6 @@ import {
 	PLAN_BLOGGER_2_YEARS,
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_WPCOM_PRO,
-	isPro,
-	isBusiness,
-	isEnterprise,
-	isEcommerce,
 } from '@automattic/calypso-products';
 import { filter, map, pick, sortBy } from 'lodash';
 import { decodeEntities, parseHtml } from 'calypso/lib/formatting';
@@ -328,19 +324,6 @@ export function getPluginAuthorProfileKeyword( plugin ) {
 	}
 
 	return plugin.author_profile.replace( WPORG_PROFILE_URL, '' ).replaceAll( '/', '' );
-}
-
-/**
- * @param site
- * @returns if a given site can install Marketplace products
- */
-export function isMarketplaceInstallationEligibleSite( site ) {
-	return (
-		isPro( site?.plan ) ||
-		isBusiness( site?.plan ) ||
-		isEnterprise( site?.plan ) ||
-		isEcommerce( site?.plan )
-	);
 }
 
 /**

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -99,7 +99,7 @@ const PluginDetailsCTA = ( {
 								)
 							}
 						</PluginPrice>
-						{ shouldUpgrade && (
+						{ selectedSite && shouldUpgrade && (
 							<span className="plugin-details-CTA__uprade-required">
 								{ translate( 'Plan upgrade required' ) }
 							</span>

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -1,4 +1,4 @@
-import { isFreePlanProduct } from '@automattic/calypso-products';
+import { isFreePlanProduct, FEATURE_INSTALL_PLUGINS } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -17,12 +17,12 @@ import {
 } from 'calypso/state/automated-transfer/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
-import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import { isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
+import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -54,7 +54,9 @@ const PluginDetailsCTA = ( {
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
 	const isFreePlan = selectedSite && isFreePlanProduct( selectedSite.plan );
 
-	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );
+	const shouldUpgrade = useSelector(
+		( state ) => ! hasActiveSiteFeature( state, selectedSite?.ID, FEATURE_INSTALL_PLUGINS )
+	);
 
 	// Eligibilities for Simple Sites.
 	const { eligibilityHolds, eligibilityWarnings } = useSelector( ( state ) =>

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -1,16 +1,4 @@
-import {
-	PLAN_BUSINESS_MONTHLY,
-	PLAN_BUSINESS,
-	PLAN_PREMIUM,
-	PLAN_WPCOM_PRO,
-	PLAN_PERSONAL,
-	PLAN_BLOGGER,
-	PLAN_PREMIUM_2_YEARS,
-	PLAN_BUSINESS_2_YEARS,
-	PLAN_BLOGGER_2_YEARS,
-	PLAN_PERSONAL_2_YEARS,
-	isFreePlanProduct,
-} from '@automattic/calypso-products';
+import { isFreePlanProduct } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -18,8 +6,8 @@ import page from 'page';
 import { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
+import { businessPlanToAdd } from 'calypso/lib/plugins/utils';
 import { userCan } from 'calypso/lib/site/utils';
-import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -419,28 +407,6 @@ function onClickInstallPlugin( {
 
 	// No need to go through chekout, go to install page directly.
 	return page( installPluginURL );
-}
-
-// Return the correct business plan slug depending on current plan and pluginBillingPeriod
-function businessPlanToAdd( currentPlan, pluginBillingPeriod, eligibleForProPlan ) {
-	if ( eligibleForProPlan ) {
-		return PLAN_WPCOM_PRO;
-	}
-	switch ( currentPlan.product_slug ) {
-		case PLAN_PERSONAL_2_YEARS:
-		case PLAN_PREMIUM_2_YEARS:
-		case PLAN_BLOGGER_2_YEARS:
-			return PLAN_BUSINESS_2_YEARS;
-		case PLAN_PERSONAL:
-		case PLAN_PREMIUM:
-		case PLAN_BLOGGER:
-			return PLAN_BUSINESS;
-		default:
-			// Return annual plan if selected, monthly otherwise.
-			return pluginBillingPeriod === IntervalLength.ANNUALLY
-				? PLAN_BUSINESS
-				: PLAN_BUSINESS_MONTHLY;
-	}
 }
 
 export default PluginDetailsCTA;

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,3 +1,4 @@
+import { isBusiness, isEcommerce, isEnterprise, isPro } from '@automattic/calypso-products';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
@@ -38,7 +39,7 @@ import {
 	getPluginOnSite,
 	getPluginOnSites,
 	getSiteObjectsWithPlugin,
-	getSitesWithoutPlugin,
+	getSiteObjectsWithoutPlugin,
 	isRequestingForSites,
 } from 'calypso/state/plugins/installed/selectors';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
@@ -370,16 +371,15 @@ function SitesListArea( { fullPlugin: plugin, isPluginInstalledOnsite, billingPe
 		getSiteObjectsWithPlugin( state, siteIds, props.pluginSlug )
 	);
 	const sitesWithoutPlugin = useSelector( ( state ) =>
-		getSitesWithoutPlugin( state, siteIds, props.pluginSlug )
+		getSiteObjectsWithoutPlugin( state, siteIds, props.pluginSlug )
 	);
 
 	if ( isFetching || ( props.siteUrl && ! isPluginInstalledOnsite ) ) {
 		return null;
 	}
 
-	const notInstalledSites = sitesWithoutPlugin.map( ( siteId ) =>
-		sitesWithPlugins.find( ( site ) => site.ID === siteId )
-	);
+	const availableOnSites = sitesWithoutPlugin.filter( hasEligiblePlan );
+	// const needsUpgradeSites = sitesWithoutPlugin.filter( ( site ) => ! hasEligiblePlan( site ) );
 
 	return (
 		<div className="plugin-details__sites-list-background">
@@ -403,12 +403,21 @@ function SitesListArea( { fullPlugin: plugin, isPluginInstalledOnsite, billingPe
 						translate,
 						selectedSite,
 					} ) }
-					sites={ notInstalledSites }
+					sites={ availableOnSites }
 					plugin={ plugin }
 					billingPeriod={ billingPeriod }
 				/>
 			</div>
 		</div>
+	);
+}
+
+function hasEligiblePlan( selectedSite ) {
+	return (
+		isPro( selectedSite.plan ) ||
+		isBusiness( selectedSite.plan ) ||
+		isEnterprise( selectedSite.plan ) ||
+		isEcommerce( selectedSite.plan )
 	);
 }
 

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,3 +1,4 @@
+import { FEATURE_INSTALL_PLUGINS } from '@automattic/calypso-products';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
@@ -14,7 +15,6 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { isMarketplaceInstallationEligibleSite } from 'calypso/lib/plugins/utils';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
@@ -57,6 +57,7 @@ import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-use
 import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
+import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import {
 	isJetpackSite,
@@ -375,15 +376,13 @@ function SitesListArea( { fullPlugin: plugin, isPluginInstalledOnsite, billingPe
 	);
 
 	const availableOnSites = useSelector( ( state ) =>
-		sitesWithoutPlugin.filter(
-			( site ) =>
-				isMarketplaceInstallationEligibleSite( site ) && isSiteAutomatedTransfer( state, site.ID )
+		sitesWithoutPlugin.filter( ( site ) =>
+			hasActiveSiteFeature( state, site.ID, FEATURE_INSTALL_PLUGINS )
 		)
 	);
 	const upgradeNeededSites = useSelector( ( state ) =>
 		sitesWithoutPlugin.filter(
-			( site ) =>
-				! isMarketplaceInstallationEligibleSite( site ) && isSiteAutomatedTransfer( state, site.ID )
+			( site ) => ! hasActiveSiteFeature( state, site.ID, FEATURE_INSTALL_PLUGINS )
 		)
 	);
 

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -11,6 +11,10 @@ import { connect } from 'react-redux';
 import QuerySiteConnectionStatus from 'calypso/components/data/query-site-connection-status';
 import ExternalLink from 'calypso/components/external-link';
 import InfoPopover from 'calypso/components/info-popover';
+import {
+	isMarketplaceInstallationEligibleSite,
+	businessPlanToAdd,
+} from 'calypso/lib/plugins/utils';
 import { getSiteFileModDisableReason, isMainNetworkSite } from 'calypso/lib/site/utils';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { installPlugin } from 'calypso/state/plugins/installed/actions';
@@ -152,15 +156,24 @@ export class PluginInstallButton extends Component {
 		const { translate, selectedSite, plugin, billingPeriod } = this.props;
 		const variationPeriod = getPeriodVariationValue( billingPeriod );
 		const product_slug = plugin?.variations?.[ variationPeriod ]?.product_slug;
+		const pluginInstallEligibleSite = isMarketplaceInstallationEligibleSite( selectedSite );
+		const buttonLink = pluginInstallEligibleSite
+			? `/checkout/${ selectedSite.slug }/${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${ selectedSite.slug }#step2`
+			: `/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
+					selectedSite?.plan,
+					billingPeriod
+			  ) },${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${
+					selectedSite.slug
+			  }#step2`;
 
 		return (
 			<span className="plugin-install-button__install embed">
-				<Button
-					href={ `/checkout/${ selectedSite.slug }/${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${ selectedSite.slug }#step2` }
-				>
+				<Button href={ buttonLink }>
 					<Gridicon key="plus-icon" icon="plus-small" size={ 18 } />
 					<Gridicon icon="plugins" size={ 18 } />
-					{ translate( 'Purchase and activate' ) }
+					{ pluginInstallEligibleSite
+						? translate( 'Purchase and activate' )
+						: translate( 'Upgrade and activate' ) }
 				</Button>
 			</span>
 		);

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -14,6 +14,7 @@ import ExternalLink from 'calypso/components/external-link';
 import InfoPopover from 'calypso/components/info-popover';
 import { businessPlanToAdd } from 'calypso/lib/plugins/utils';
 import { getSiteFileModDisableReason, isMainNetworkSite } from 'calypso/lib/site/utils';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { installPlugin } from 'calypso/state/plugins/installed/actions';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
@@ -152,7 +153,14 @@ export class PluginInstallButton extends Component {
 	}
 
 	renderMarketplaceButton() {
-		const { translate, selectedSite, plugin, billingPeriod, canInstallPlugins } = this.props;
+		const {
+			translate,
+			selectedSite,
+			plugin,
+			billingPeriod,
+			canInstallPlugins,
+			eligibleForProPlan,
+		} = this.props;
 		const variationPeriod = getPeriodVariationValue( billingPeriod );
 		const product_slug = plugin?.variations?.[ variationPeriod ]?.product_slug;
 
@@ -160,7 +168,8 @@ export class PluginInstallButton extends Component {
 			? `/checkout/${ selectedSite.slug }/${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${ selectedSite.slug }`
 			: `/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
 					selectedSite?.plan,
-					billingPeriod
+					billingPeriod,
+					eligibleForProPlan
 			  ) },${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${
 					selectedSite.slug
 			  }#step2`;
@@ -330,6 +339,7 @@ export default connect(
 			siteIsConnected: getSiteConnectionStatus( state, siteId ),
 			siteIsWpcomAtomic: isSiteWpcomAtomic( state, siteId ),
 			canInstallPlugins: hasActiveSiteFeature( state, siteId, FEATURE_INSTALL_PLUGINS ),
+			eligibleForProPlan: isEligibleForProPlan( state, siteId ),
 		};
 	},
 	{

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -148,6 +148,11 @@ export function getSitesWithoutPlugin( state, siteIds, pluginSlug ) {
 	} );
 }
 
+export function getSiteObjectsWithoutPlugin( state, siteIds, pluginSlug ) {
+	const siteIdsWithoutPlugin = getSitesWithoutPlugin( state, siteIds, pluginSlug );
+	return siteIdsWithoutPlugin.map( ( siteId ) => getSite( state, siteId ) );
+}
+
 export function getStatusForPlugin( state, siteId, pluginId ) {
 	if ( typeof state.plugins.installed.status[ siteId ] === 'undefined' ) {
 		return false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show on "available on" sites only sites which eligible plans
* Add a new section on Plugin Details for sites that needs an upgrade
* Use feature checks to verify the plugin installation eligibility

Depends on #62472




#### Testing instructions
* Set a site as atomic but without a business or e-commerce plan
* Go to a Markeplace Plugin Details page: Ex: `/plugins/woocommerce-subscriptions`
* See if the plugin appears on the list called *Upgrade needed*
* Click on `Upgrade and activate`
* See if the following items were added to the cart: The selected plugin and a business plan.

#### Demo
| Plugin Details  | Cart |
| ------------- | ------------- |
|<img width="1231" alt="Screen Shot 2022-03-29 at 15 57 12" src="https://user-images.githubusercontent.com/5039531/160701551-1da4db55-0446-4873-be08-8a406aa25679.png">|<img width="558" alt="Screen Shot 2022-03-29 at 16 18 19" src="https://user-images.githubusercontent.com/5039531/160701589-c9e2bb8a-88fa-4aef-9a27-87a615ee3bce.png">|


---
Fixes #61522