### PR TITLE
Add external link to threat source to threat item descriptions

### DIFF
--- a/client/components/jetpack/threat-description/index.tsx
+++ b/client/components/jetpack/threat-description/index.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from '@wordpress/components';
 import { translate, TranslateResult } from 'i18n-calypso';
 import { PureComponent, ReactNode } from 'react';
 import DiffViewer from 'calypso/components/diff-viewer';
@@ -10,6 +11,7 @@ export interface Props {
 	children?: ReactNode;
 	status: ThreatStatus;
 	problem: string | ReactNode;
+	source?: string;
 	fix?: string | ReactNode;
 	context?: Record< string, unknown >;
 	diff?: string;
@@ -87,7 +89,7 @@ class ThreatDescription extends PureComponent< Props > {
 	}
 
 	render() {
-		const { children, problem, fix, diff, rows, context, filename } = this.props;
+		const { children, problem, source, fix, diff, rows, context, filename } = this.props;
 
 		return (
 			<div className="threat-description">
@@ -95,6 +97,14 @@ class ThreatDescription extends PureComponent< Props > {
 					<strong>{ translate( 'What did Jetpack find?' ) }</strong>
 				</p>
 				{ this.renderTextOrNode( <p className="threat-description__section-text">{ problem }</p> ) }
+				{ source &&
+					this.renderTextOrNode(
+						<p className="threat-description__section-text">
+							<ExternalLink href={ source } rel="noopener noreferrer" target="_blank">
+								{ translate( 'Learn more about this vulnerability' ) }
+							</ExternalLink>
+						</p>
+					) }
 				{ ( filename || context || diff || rows ) && (
 					<p className="threat-description__section-title">
 						<strong>{ translate( 'The technical details' ) }</strong>

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -168,6 +168,7 @@ const ThreatItem: React.FC< Props > = ( {
 				status={ threat.status }
 				fix={ getFix() }
 				problem={ threat.description }
+				source={ threat.source }
 				context={ threat.context }
 				diff={ threat.diff }
 				rows={ threat.rows }

--- a/client/components/jetpack/threat-item/types.tsx
+++ b/client/components/jetpack/threat-item/types.tsx
@@ -35,6 +35,7 @@ export interface BaseThreat {
 	diff?: string;
 	context?: Record< string, unknown >;
 	severity: number;
+	source?: string;
 }
 
 export interface FixableThreat extends BaseThreat {

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -32,6 +32,7 @@ export const formatScanThreat = ( threat ) => ( {
 	table: threat.table,
 	context: threat.context,
 	severity: threat.severity,
+	source: threat.source,
 } );
 
 /**


### PR DESCRIPTION
This PR integrates the threat `source` attribute introduced in 2201-gh-Automattic/jetpack-backups/files to the Calypso Scan UI. When a source is available, an external "Learn more about this vulnerability" link is displayed in the threat description.

Task: 1132448019695145-as-1159067512440665/f

#### Changes proposed in this Pull Request

* Adds the `source` property to `formatScanThreat()` and the `BaseThreat` type.
* Conditionally renders an external link to the source inside `<ThreatDescription />`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `git checkout add/threat-source-links` && `yarn start` || `yarn start-jetpack-cloud`
* Open http://calypso.localhost:3000/scan/[SITE_URL] with a site that contains a threat with a `source`. One way to accomplish this is to install [this vulnerable plugin](https://downloads.wordpress.org/plugin/popup-builder.3.42.zip) and then run a fresh scan.
* Validate that the source link is displayed, and works correctly.
* Validate that the source link is not displayed for threats without a source. You can use threats from `jetpack-threat-tester` to accomplish this.

#### Screenshots

**Before:**

<img width="737" alt="Screen Shot 2022-03-29 at 2 20 20 PM" src="https://user-images.githubusercontent.com/10933065/160700533-065a6561-de0a-498c-ac31-64f65f4db588.png">

**After:**

<img width="739" alt="Screen Shot 2022-03-29 at 2 19 57 PM" src="https://user-images.githubusercontent.com/10933065/160700550-fab0019b-6e0e-4392-8ccb-c4ada7b704a7.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1132448019695145-as-1159067512440665