### PR TITLE
Reduce duration of success notice on DNS Management

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -204,7 +204,7 @@ class DnsAddNew extends React.Component {
 		const { selectedSite, selectedDomainName } = this.props;
 
 		page( domainManagementDns( selectedSite.slug, selectedDomainName ) );
-		this.props.successNotice( message, { duration: 5000 } );
+		this.props.successNotice( message, { duration: 3000 } );
 	};
 
 	handleError = ( error, message ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As recommended [here](https://github.com/Automattic/wp-calypso/pull/62315#issuecomment-1082102013), it was advised that decreasing the duration of the success message displayed would be better than changing the position of the `.global-notices` class or the "Add a Record" button. In this commit, I've changed the duration from `5000` to `3000`. This seems to be a better compromise than moving the notice or button.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Upgrades > Domains > DomainName > DNS Records > Manage, then Add a record. The success notice now has a duration of 3 seconds. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62313 & PR #62315