### PR TITLE
E2E: add step to close the block inserter in mobile in case the auto-dismissal fails.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -1,7 +1,9 @@
 import { Page, Locator } from 'playwright';
+import envVariables from '../../env-variables';
 
 const sidebarParentSelector = '.block-editor-inserter__content';
 const selectors = {
+	closeBlockInserterButton: 'button[aria-label="Close block inserter"]',
 	blockSearchInput: `${ sidebarParentSelector } input[type="search"]`,
 	blockResultItem: ( name: string ) =>
 		`${ sidebarParentSelector } .block-editor-block-types-list__list-item span:text("${ name }")`,
@@ -24,6 +26,23 @@ export class EditorSidebarBlockInserterComponent {
 	constructor( page: Page, editor: Locator ) {
 		this.page = page;
 		this.editor = editor;
+	}
+
+	/**
+	 * Closes the Block Inserter from the panel.
+	 *
+	 * This operation is only available for Mobile viewports where the
+	 * Block Inserter panel is treated as an overlay.
+	 */
+	async closeBlockInserter(): Promise< void > {
+		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
+			return;
+		}
+
+		const blockInserterPanelLocator = this.editor.locator( selectors.closeBlockInserterButton );
+		if ( ( await blockInserterPanelLocator.count() ) > 0 ) {
+			await blockInserterPanelLocator.click();
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -284,9 +284,12 @@ export class EditorPage {
 
 		// Dismiss the block inserter if viewport is larger than mobile to
 		// ensure no interference from the block inserter in subsequent actions on the editor.
-		// In mobile, the block inserter will auto-close.
+		// In mobile, the block inserter will typically auto-close, but sometimes there can
+		// be issues with auto-close.
 		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
 			await this.editorToolbarComponent.closeBlockInserter();
+		} else {
+			await this.editorSidebarBlockInserterComponent.closeBlockInserter();
 		}
 
 		// Return an ElementHandle pointing to the block for compatibility


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a safety handling of the block inserter in mobile viewport.

Normally, when a target block is clicked on (and therefore inserted into the editor) the block inserter panel auto-dismisses. However, in some rare instances this can fail, leading to rest of the test case failing.

Key changes:
- add a method to close the panel in the component class for EditorSidebarBlockInserterComponent, similar to the EditorPostPublishPanel.
- add handling in the `if/else` conditional in the `EditorPage.addBlock` method to call this closure method.


#### Testing instructions

Ensure the following:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [x] i18n E2E


Related to #62366
