### PR TITLE
Generate pages from selected pages

### DIFF
--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -1,3 +1,4 @@
+import calypsoConfig from '@automattic/calypso-config';
 import { Button, Dialog } from '@automattic/components';
 import styled from '@emotion/styled';
 import debugFactory from 'debug';
@@ -18,6 +19,7 @@ import {
 import { useTranslatedPageTitles } from 'calypso/signup/difm/translation-hooks';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import getDIFMLiteSiteCategory from 'calypso/state/selectors/get-difm-lite-site-category';
+import getDIFMLiteSitePageTitles from 'calypso/state/selectors/get-difm-lite-site-page-titles';
 import isDIFMLiteInProgress from 'calypso/state/selectors/is-difm-lite-in-progress';
 import isDIFMLiteWebsiteContentSubmitted from 'calypso/state/selectors/is-difm-lite-website-content-submitted';
 import { saveSignupStep } from 'calypso/state/signup/progress/actions';
@@ -84,6 +86,7 @@ function WebsiteContentStep( {
 	const websiteContent = useSelector( getWebsiteContent );
 	const currentIndex = useSelector( getWebsiteContentDataCollectionIndex );
 	const siteCategory = useSelector( ( state ) => getDIFMLiteSiteCategory( state, siteId ) );
+	const pageTitles = useSelector( ( state ) => getDIFMLiteSitePageTitles( state, siteId ) );
 	const isImageUploading = useSelector( ( state ) =>
 		isImageUploadInProgress( state as WebsiteContentStateModel )
 	);
@@ -103,7 +106,15 @@ function WebsiteContentStep( {
 			}
 		}
 
-		if ( siteCategory ) {
+		if ( calypsoConfig.isEnabled( 'signup/redesigned-difm-flow' ) ) {
+			if ( pageTitles && pageTitles.length > 0 ) {
+				const pages = pageTitles.map( ( pT ) => ( {
+					id: pT,
+					name: translatedPageTitles[ pT ],
+				} ) );
+				dispatch( initializePages( pages ) );
+			}
+		} else if ( siteCategory ) {
 			dispatch(
 				initializePages( [
 					{ id: HOME_PAGE, name: translatedPageTitles[ HOME_PAGE ] },
@@ -113,7 +124,7 @@ function WebsiteContentStep( {
 				] )
 			);
 		}
-	}, [ dispatch, siteCategory, translate, translatedPageTitles ] );
+	}, [ dispatch, siteCategory, pageTitles, translatedPageTitles ] );
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -108,9 +108,9 @@ function WebsiteContentStep( {
 
 		if ( calypsoConfig.isEnabled( 'signup/redesigned-difm-flow' ) ) {
 			if ( pageTitles && pageTitles.length > 0 ) {
-				const pages = pageTitles.map( ( pT ) => ( {
-					id: pT,
-					name: translatedPageTitles[ pT ],
+				const pages = pageTitles.map( ( pageTitle ) => ( {
+					id: pageTitle,
+					name: translatedPageTitles[ pageTitle ],
 				} ) );
 				dispatch( initializePages( pages ) );
 			}

--- a/client/state/selectors/get-difm-lite-site-page-titles.ts
+++ b/client/state/selectors/get-difm-lite-site-page-titles.ts
@@ -12,7 +12,7 @@ import type { AppState, SiteId } from 'calypso/types';
  */
 export default function getDIFMLiteSitePageTitles(
 	state: AppState,
-	siteId?: SiteId
+	siteId: SiteId | null
 ): string[] | null {
 	if ( ! siteId ) {
 		return null;

--- a/client/state/selectors/get-difm-lite-site-page-titles.ts
+++ b/client/state/selectors/get-difm-lite-site-page-titles.ts
@@ -1,0 +1,27 @@
+import getRawSite from 'calypso/state/selectors/get-raw-site';
+import { SiteData } from '../ui/selectors/site-data';
+import type { AppState, SiteId } from 'calypso/types';
+
+/**
+ * Returns the pages selected by the user in the DIFM Lite
+ * signup flow.  Returns null if the the data is no available
+ *
+ * @param  {object}   state  Global state tree
+ * @param  {number}   siteId Site ID
+ * @returns {Array}   The selected site category
+ */
+export default function getDIFMLiteSitePageTitles(
+	state: AppState,
+	siteId?: SiteId
+): string[] | null {
+	if ( ! siteId ) {
+		return null;
+	}
+	const site = getRawSite( state, siteId ) as SiteData;
+
+	if ( ! site ) {
+		return null;
+	}
+
+	return site.options?.difm_lite_site_options?.selected_page_titles ?? [];
+}

--- a/client/state/ui/selectors/site-data.ts
+++ b/client/state/ui/selectors/site-data.ts
@@ -30,6 +30,7 @@ export interface SiteDataPlan {
 export interface DIFMLiteSiteOptions {
 	site_category?: string;
 	is_website_content_submitted?: boolean;
+	selected_page_titles: string[];
 }
 
 export interface SiteDataOptions {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Generates the website-content step sections from the pages selected


#### Testing instructions

- Go to `/start/do-it-for-me?flags=signup/redesigned-difm-flow`
- Go through the flow
- At checkout make sure to add the above feature flag `flags=signup/redesigned-difm-flow`
- Complete purchase
- Make sure the new pages are visible post checkout on the website-content collection flow

![image](https://user-images.githubusercontent.com/3422709/160825714-dfcced59-1b9b-41fa-8dcf-5996a9242dc1.png)



Related to #
