### PR TITLE
Add Olark chat widget to the themes showcase page

### DIFF
--- a/client/components/olark-chat/index.jsx
+++ b/client/components/olark-chat/index.jsx
@@ -2,7 +2,7 @@ import { Component } from 'react';
 
 class OlarkChat extends Component {
 	componentDidMount() {
-		const { identity, shouldDisablePreChatSurvey } = this.props;
+		const { identity, shouldDisablePreChatSurvey, systemsGroupId } = this.props;
 		const script = document.createElement( 'script' );
 		script.setAttribute( 'id', 'olark-chat' );
 		script.setAttribute( 'type', 'text/javascript' );
@@ -15,6 +15,12 @@ class OlarkChat extends Component {
 		if ( shouldDisablePreChatSurvey ) {
 			script.innerHTML += `
 				olark.configure("features.prechat_survey", false);
+			`;
+		}
+
+		if ( systemsGroupId ) {
+			script.innerHTML += `
+				olark.configure('system.group', ${ systemsGroupId }); 
 			`;
 		}
 

--- a/client/components/olark-chat/index.jsx
+++ b/client/components/olark-chat/index.jsx
@@ -2,7 +2,7 @@ import { Component } from 'react';
 
 class OlarkChat extends Component {
 	componentDidMount() {
-		const { identity } = this.props;
+		const { identity, shouldDisablePreChatSurvey } = this.props;
 		const script = document.createElement( 'script' );
 		script.setAttribute( 'id', 'olark-chat' );
 		script.setAttribute( 'type', 'text/javascript' );
@@ -11,6 +11,13 @@ class OlarkChat extends Component {
 			;(function(o,l,a,r,k,y){if(o.olark)return; r="script";y=l.createElement(r);r=l.getElementsByTagName(r)[0]; y.async=1;y.src="//"+a;r.parentNode.insertBefore(y,r); y=o.olark=function(){k.s.push(arguments);k.t.push(+new Date)}; y.extend=function(i,j){y("extend",i,j)}; y.identify=function(i){y("identify",k.i=i)}; y.configure=function(i,j){y("configure",i,j);k.c[i]=j}; k=y._={s:[],t:[+new Date],c:{},l:a}; })(window,document,"static.olark.com/jsclient/loader.js");
 			olark.identify('${ identity }');
 		`;
+
+		if ( shouldDisablePreChatSurvey ) {
+			script.innerHTML += `
+				olark.configure("features.prechat_survey", false);
+			`;
+		}
+
 		document.body.appendChild( script );
 	}
 

--- a/client/components/olark-chat/index.jsx
+++ b/client/components/olark-chat/index.jsx
@@ -20,7 +20,7 @@ class OlarkChat extends Component {
 
 		if ( systemsGroupId ) {
 			script.innerHTML += `
-				olark.configure('system.group', ${ systemsGroupId }); 
+				olark.configure('system.group', '${ systemsGroupId }'); 
 			`;
 		}
 

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
@@ -10,6 +11,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
+import OlarkChat from 'calypso/components/olark-chat';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -328,6 +330,8 @@ class ThemeShowcase extends Component {
 				),
 		};
 
+		const olarkIdentity = config( 'olark_chat_identity' );
+
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<div>
@@ -376,6 +380,7 @@ class ThemeShowcase extends Component {
 					<ThanksModal source={ 'list' } />
 					<AutoLoadingHomepageModal source={ 'list' } />
 					<ThemePreview />
+					<OlarkChat identity={ olarkIdentity } />
 				</div>
 			</div>
 		);

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -331,6 +331,7 @@ class ThemeShowcase extends Component {
 		};
 
 		const olarkIdentity = config( 'olark_chat_identity' );
+		const olarkSystemsGroupId = '239c0f99c53692d81539f76e86910d52';
 		const isEligibleForOlarkChat = ! isLoggedIn && 'en' === locale;
 
 		// FIXME: Logged-in title should only be 'Themes'
@@ -381,7 +382,9 @@ class ThemeShowcase extends Component {
 					<ThanksModal source={ 'list' } />
 					<AutoLoadingHomepageModal source={ 'list' } />
 					<ThemePreview />
-					{ isEligibleForOlarkChat && <OlarkChat identity={ olarkIdentity } /> }
+					{ isEligibleForOlarkChat && (
+						<OlarkChat identity={ olarkIdentity } systemsGroupId={ olarkSystemsGroupId } />
+					) }
 				</div>
 			</div>
 		);

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -331,6 +331,7 @@ class ThemeShowcase extends Component {
 		};
 
 		const olarkIdentity = config( 'olark_chat_identity' );
+		const isEligibleForOlarkChat = ! isLoggedIn && 'en' === locale;
 
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
@@ -380,7 +381,7 @@ class ThemeShowcase extends Component {
 					<ThanksModal source={ 'list' } />
 					<AutoLoadingHomepageModal source={ 'list' } />
 					<ThemePreview />
-					<OlarkChat identity={ olarkIdentity } />
+					{ isEligibleForOlarkChat && <OlarkChat identity={ olarkIdentity } /> }
 				</div>
 			</div>
 		);

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -726,6 +726,7 @@ class Signup extends Component {
 
 		const isReskinned = isReskinnedFlow( this.props.flowName );
 		const olarkIdentity = config( 'olark_chat_identity' );
+		const olarkSystemsGroupId = '2dfd76a39ce77758f128b93942ae44b5';
 		const isEligibleForOlarkChat =
 			'onboarding' === this.props.flowName && 'en' === this.props.localeSlug;
 
@@ -758,7 +759,11 @@ class Signup extends Component {
 					) }
 				</div>
 				{ isEligibleForOlarkChat && (
-					<OlarkChat identity={ olarkIdentity } shouldDisablePreChatSurvey={ true } />
+					<OlarkChat
+						identity={ olarkIdentity }
+						shouldDisablePreChatSurvey={ true }
+						systemsGroupId={ olarkSystemsGroupId }
+					/>
 				) }
 			</>
 		);

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -757,7 +757,9 @@ class Signup extends Component {
 						/>
 					) }
 				</div>
-				{ isEligibleForOlarkChat && <OlarkChat identity={ olarkIdentity } /> }
+				{ isEligibleForOlarkChat && (
+					<OlarkChat identity={ olarkIdentity } shouldDisablePreChatSurvey={ true } />
+				) }
 			</>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the Olark chat widget in logged-out `/themes` page
* As per the request in pau2Xa-40L#comment-11800, disable pre-chat survey for the signup pages.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/themes` logged out in `en` locale and verify that the Olark chat widget is visible.
* Visit `/themes` logged in and verify that the chat is not visible.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

