### PR TITLE
Plans overhaul Phase 1: Do not hide Free plans when skipping domain step

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -24,6 +24,7 @@ import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getStepUrl, isPlanSelectionAvailableLaterInFlow } from 'calypso/signup/utils';
 import {
@@ -219,7 +220,8 @@ class DomainsStep extends Component {
 	};
 
 	handleDomainExplainerClick = () => {
-		const hideFreePlan = true;
+		const { eligibleForProPlan } = this.props;
+		const hideFreePlan = eligibleForProPlan ? false : true;
 		this.handleSkip( undefined, hideFreePlan );
 	};
 
@@ -830,6 +832,7 @@ export default connect(
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
 		const isPlanStepSkipped = isPlanStepExistsAndSkipped( state );
+		const selectedSite = getSelectedSite( state );
 
 		return {
 			designType: getDesignType( state ),
@@ -837,11 +840,12 @@ export default connect(
 			productsLoaded,
 			siteType: getSiteType( state ),
 			vertical: getVerticalForDomainSuggestions( state ),
-			selectedSite: getSelectedSite( state ),
+			selectedSite,
 			sites: getSitesItems( state ),
 			isPlanSelectionAvailableLaterInFlow:
 				! isPlanStepSkipped && isPlanSelectionAvailableLaterInFlow( steps ),
 			userLoggedIn: isUserLoggedIn( state ),
+			eligibleForProPlan: isEligibleForProPlan( state, selectedSite?.ID ),
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This allows the Free plan to be shown after skipping the domain step.


#### Testing instructions

* Go to `/start/domains?flags=plans/pro-plan` 
* Click on the `Choose my domain later` 
* The Plans page should show the Free Plan and Pro Plan

<img width="320" alt="Screenshot on 2022-03-30 at 10-39-32" src="https://user-images.githubusercontent.com/2749938/160777813-ee4148bb-6b9f-48df-a6dd-00a06490ef18.png">

* Go to `/start/domains`
* Click on the `Choose my domain later` 
* The Free plan link should continue to not be mentioned in the subtitle
<img width="320" alt="Screenshot on 2022-03-30 at 10-44-16" src="https://user-images.githubusercontent.com/2749938/160778806-0fbdacb4-6c14-4a9d-bfb8-ba7901c030b7.png">



