### PR TITLE
Licensing Portal: Add better "missing payment method" explanation

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -9,7 +9,11 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 import useIssueLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-issue-license-mutation';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
-import { APIProductFamily, APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import {
+	APIError,
+	APIProductFamily,
+	APIProductFamilyProduct,
+} from 'calypso/state/partner-portal/types';
 import './style.scss';
 
 function selectProductOptions( families: APIProductFamily[] ): APIProductFamilyProduct[] {
@@ -29,8 +33,29 @@ export default function IssueLicenseForm(): ReactElement {
 				addQueryArgs( { key: license.license_key }, '/partner-portal/assign-license' )
 			);
 		},
-		onError: ( error: Error ) => {
-			dispatch( errorNotice( error.message ) );
+		onError: ( error: APIError ) => {
+			let errorMessage;
+
+			switch ( error.code ) {
+				case 'missing_valid_payment_method':
+					errorMessage = translate(
+						'We could not find a valid payment method.{{br/}} ' +
+							'{{a}}Try adding a new payment method{{/a}} or contact support.',
+						{
+							components: {
+								a: <a href={ '/partner-portal/payment-methods/add' } />,
+								br: <br />,
+							},
+						}
+					);
+					break;
+
+				default:
+					errorMessage = error.message;
+					break;
+			}
+
+			dispatch( errorNotice( errorMessage ) );
 		},
 	} );
 	const [ product, setProduct ] = useState( '' );

--- a/client/state/partner-portal/licenses/hooks/use-issue-license-mutation.ts
+++ b/client/state/partner-portal/licenses/hooks/use-issue-license-mutation.ts
@@ -1,6 +1,6 @@
 import { useMutation, UseMutationOptions, UseMutationResult } from 'react-query';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
-import { APILicense } from 'calypso/state/partner-portal/types';
+import { APIError, APILicense } from 'calypso/state/partner-portal/types';
 
 interface MutationIssueLicenseVariables {
 	product: string;
@@ -15,9 +15,9 @@ function mutationIssueLicense( { product }: MutationIssueLicenseVariables ): Pro
 }
 
 export default function useIssueLicenseMutation< TContext = unknown >(
-	options?: UseMutationOptions< APILicense, Error, MutationIssueLicenseVariables, TContext >
-): UseMutationResult< APILicense, Error, MutationIssueLicenseVariables, TContext > {
-	return useMutation< APILicense, Error, MutationIssueLicenseVariables, TContext >(
+	options?: UseMutationOptions< APILicense, APIError, MutationIssueLicenseVariables, TContext >
+): UseMutationResult< APILicense, APIError, MutationIssueLicenseVariables, TContext > {
+	return useMutation< APILicense, APIError, MutationIssueLicenseVariables, TContext >(
 		mutationIssueLicense,
 		options
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add a context aware explanation for "Missing payment method" when issuing licenses.

The Licensing Portal utilises the [Jetpack Licensing API](https://github.com/Automattic/jetpack-licensing-api) when working with licenses - but the API should not return portal specific error messages (e.g.: a link to where an error can be fixed).
This change should help navigate agencies to payment methods the first time they encounter the error (read: when we start to require valid payment methods to issue licenses). 

#### Context

* PT: pdpAdu-bj-p2
* 1201902532330136-as-1202047741179861

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D77812-code to sandbox
* Enable HTTP traffic and change DNS settings
* Follow the "Easy approach" in the D77812-code testing instructions to trigger the error

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

### Screenshots

**Before**

![Screenshot 2022-03-30 at 13 42 01](https://user-images.githubusercontent.com/3846700/160827713-78c8e18f-ade0-4fd3-b75f-4724e45ddd27.png)

**After**

![Screenshot 2022-03-30 at 13 39 56](https://user-images.githubusercontent.com/3846700/160827734-4fed31b8-833d-47ad-9729-eee6462adc92.png)
