### PR TITLE
Check for selected domain to determine wether to hide the Free plan

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -220,8 +220,7 @@ class DomainsStep extends Component {
 	};
 
 	handleDomainExplainerClick = () => {
-		const { eligibleForProPlan } = this.props;
-		const hideFreePlan = eligibleForProPlan ? false : true;
+		const hideFreePlan = true;
 		this.handleSkip( undefined, hideFreePlan );
 	};
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -160,7 +160,7 @@ export class PlansStep extends Component {
 					{ errorDisplay }
 					<PlansComparison
 						isInSignup={ true }
-						hideFreePlan={ hideFreePlan }
+						hideFreePlan={ !! this.getDomainName() }
 						onSelectPlan={ this.onSelectPlan }
 						selectedSiteId={ selectedSite?.ID || undefined }
 					/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The previous fix to #62374 to not hide the Free plan was causing an error when trying to skip the domain step on the `/start/pro` flow.

<img width="320" alt="Screenshot on 2022-03-30 at 16-12-14 (1)" src="https://user-images.githubusercontent.com/2749938/160860479-2cc20017-3f25-4cc4-a651-a08f62f65a1f.png">


This uses a different check which doesn't affect the `/start/pro` and only hides the Free plan if a paid domain was used.

#### Testing instructions

##### /start/pro flow

* Go to `/start/pro?flags=plans/pro-plan`
* Click `Choose my domain later`
* You should be redirected to the Checkout page with a Pro plan in the shopping cart

##### Paid Domain

* Go to `/start?flags=plans/pro-plan`
* Type and select a Paid domain
* The Plans page should not show the Free plan

<img width="320" alt="Screenshot on 2022-03-30 at 17-28-20" src="https://user-images.githubusercontent.com/2749938/160858982-f450193f-d8b6-4104-9339-f29553fdfdf8.png">


##### Free/skipped Domain

* Go to `/start?flags=plans/pro-plan`
* Select a Free domain or click on `Choose my domain later`
* The Plans page should show the Free plan

<img width="320" alt="Screenshot on 2022-03-30 at 17-28-04" src="https://user-images.githubusercontent.com/2749938/160859003-7dc36593-0cf2-4bb3-b18b-994448d1d347.png">


