### PR TITLE
Seller Experience - Stepper: Implement the store-address step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -4,6 +4,7 @@ export { default as options } from './site-options';
 export { default as bloggerStartingPoint } from './blogger-starting-point';
 export { default as storeFeatures } from './store-features';
 export { default as designSetup } from './design-setup';
+export { default as storeAddress } from './store-address';
 
 export type StepPath =
 	| 'courses'
@@ -11,4 +12,5 @@ export type StepPath =
 	| 'options'
 	| 'bloggerStartingPoint'
 	| 'storeFeatures'
-	| 'designSetup';
+	| 'designSetup'
+	| 'storeAddress';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
@@ -1,0 +1,250 @@
+import { StepContainer } from '@automattic/onboarding';
+import styled from '@emotion/styled';
+import { ComboboxControl } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import { FormEvent, ReactElement, useState } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormInput from 'calypso/components/forms/form-text-input';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { ActionSection, StyledNextButton } from 'calypso/signup/steps/woocommerce-install';
+import { useCountries } from '../../../../hooks/use-countries';
+import SupportCard from './support-card';
+import type { Step } from '../../types';
+import './style.scss';
+
+type FormFields =
+	| 'store_address_1'
+	| 'store_address_2'
+	| 'store_city'
+	| 'store_postcode'
+	| 'store_country';
+
+const CityZipRow = styled.div`
+	display: -ms-grid;
+	display: grid;
+	width: 100%;
+	-ms-grid-columns: 48% 4% 48%;
+	grid-template-columns: 48% 48%;
+	grid-column-gap: 4%;
+	justify-items: stretch;
+`;
+
+const StoreAddress: Step = function StoreAddress( { navigation } ) {
+	const { goBack, goNext, submit } = navigation;
+	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
+	const storeAddress = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreAddress() );
+	const site = useSite();
+	const { data: countries } = useCountries();
+	const { __ } = useI18n();
+	const [ errors, setErrors ] = useState( {} as Record< FormFields, string > );
+	const [ storeAddress1, setStoreAddress1 ] = useState( storeAddress.store_address_1 );
+	const [ storeAddress2, setStoreAddress2 ] = useState( storeAddress.store_address_2 );
+	const [ storeCity, setStoreCity ] = useState( storeAddress.store_city );
+	const [ storePostcode, setStorePostcode ] = useState( storeAddress.store_postcode );
+	const [ storeCountry, setStoreCountry ] = useState( storeAddress.store_country );
+	const { setStoreAddressValue } = useDispatch( ONBOARD_STORE );
+
+	if ( ! countries ) {
+		return null;
+	}
+
+	const headerText = __( 'Add an address to accept payments' );
+	const countriesAsOptions = Object.entries( countries ).map( ( [ key, value ] ) => {
+		return { value: key, label: value };
+	} );
+
+	const onChange = ( event: React.FormEvent< HTMLInputElement > ) => {
+		if ( site ) {
+			const errors = {} as Record< FormFields, string >;
+
+			switch ( event.currentTarget.name ) {
+				case 'store_address_1':
+					setStoreAddress1( event.currentTarget.value );
+					errors[ 'store_address_1' ] = '';
+					break;
+				case 'store_address_2':
+					setStoreAddress2( event.currentTarget.value );
+					break;
+				case 'store_city':
+					setStoreCity( event.currentTarget.value );
+					errors[ 'store_city' ] = '';
+					break;
+				case 'store_postcode':
+					setStorePostcode( event.currentTarget.value );
+					errors[ 'store_postcode' ] = '';
+					break;
+			}
+
+			setErrors( errors );
+		}
+	};
+
+	const validate = (): boolean => {
+		const errors = {} as Record< FormFields, string >;
+
+		errors[ 'store_address_1' ] = ! storeAddress1 ? __( 'Please add an address' ) : '';
+		errors[ 'store_city' ] = ! storeCity ? __( 'Please add a city' ) : '';
+		errors[ 'store_country' ] = ! storeCountry ? __( 'Please select a country / region' ) : '';
+
+		setErrors( errors );
+
+		return Object.values( errors ).filter( Boolean ).length === 0;
+	};
+
+	const onSubmit = async ( event: FormEvent ) => {
+		event.preventDefault();
+
+		if ( site ) {
+			if ( ! validate() ) {
+				return;
+			}
+
+			await setStoreAddressValue( 'store_address_1', storeAddress1 );
+			await setStoreAddressValue( 'store_address_2', storeAddress2 || '' );
+			await setStoreAddressValue( 'store_city', storeCity );
+			await setStoreAddressValue( 'store_postcode', storePostcode );
+			await setStoreAddressValue( 'store_country', storeCountry );
+
+			submit?.( {
+				storeAddress1,
+				storeAddress2,
+				storeCity,
+				storePostcode,
+				storeCountry,
+			} );
+		}
+	};
+
+	const getContent = () => {
+		return (
+			<>
+				<form onSubmit={ onSubmit }>
+					<FormFieldset>
+						<FormLabel htmlFor="store_address_1">{ __( 'Address line 1' ) }</FormLabel>
+						<FormInput
+							value={ storeAddress1 }
+							name="store_address_1"
+							id="store_address_1"
+							onChange={ onChange }
+							className={ errors[ 'store_address_1' ] ? 'is-error' : '' }
+						/>
+						<ControlError error={ errors[ 'store_address_1' ] || '' } />
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="store_address_2">{ __( 'Address line 2 (optional)' ) }</FormLabel>
+						<FormInput
+							value={ storeAddress2 }
+							name="store_address_2"
+							id="store_address_2"
+							onChange={ onChange }
+							className={ errors[ 'store_address_2' ] ? 'is-error' : '' }
+						/>
+						<ControlError error={ errors[ 'store_address_2' ] || '' } />
+					</FormFieldset>
+
+					<CityZipRow>
+						<div>
+							<FormFieldset>
+								<FormLabel htmlFor="store_city">{ __( 'City' ) }</FormLabel>
+								<FormInput
+									value={ storeCity }
+									name="store_city"
+									id="store_city"
+									onChange={ onChange }
+									className={ errors[ 'store_city' ] ? 'is-error' : '' }
+								/>
+								<ControlError error={ errors[ 'store_city' ] || '' } />
+							</FormFieldset>
+						</div>
+
+						<div>
+							<FormFieldset>
+								<FormLabel htmlFor="store_postcode">{ __( 'Postcode' ) }</FormLabel>
+								<FormInput
+									value={ storePostcode }
+									name="store_postcode"
+									id="store_postcode"
+									onChange={ onChange }
+									className={ errors[ 'store_postcode' ] ? 'is-error' : '' }
+								/>
+								<ControlError error={ errors[ 'store_postcode' ] || '' } />
+							</FormFieldset>
+						</div>
+					</CityZipRow>
+
+					<FormFieldset>
+						<ComboboxControl
+							label={ __( 'Country / State' ) }
+							value={ storeCountry }
+							onChange={ ( value: string | null ) => {
+								if ( value ) {
+									setStoreCountry( value );
+									setErrors( {
+										...errors,
+										store_country: '',
+									} );
+								}
+							} }
+							options={ countriesAsOptions }
+							className={ errors[ 'store_country' ] ? 'is-error' : '' }
+						/>
+						<ControlError error={ errors[ 'store_country' ] || '' } />
+					</FormFieldset>
+
+					<ActionSection>
+						<SupportCard domain={ site?.URL || '' } />
+						<StyledNextButton
+							type="submit"
+							disabled={ Object.values( errors ).filter( Boolean ).length > 0 }
+						>
+							{ __( 'Continue' ) }
+						</StyledNextButton>
+					</ActionSection>
+				</form>
+			</>
+		);
+	};
+
+	return (
+		<div className="store-address__signup is-woocommerce-install">
+			<div className="store-address__is-store-address">
+				<StepContainer
+					stepName={ 'store-address' }
+					className={ `is-step-${ intent }` }
+					skipButtonAlign={ 'top' }
+					goBack={ goBack }
+					goNext={ goNext }
+					isHorizontalLayout={ true }
+					formattedHeader={
+						<FormattedHeader
+							id={ 'site-options-header' }
+							headerText={ headerText }
+							subHeaderText={ __(
+								'This will be used as your default business address. You can change it later if you need to.'
+							) }
+							align={ 'left' }
+						/>
+					}
+					stepContent={ getContent() }
+					recordTracksEvent={ recordTracksEvent }
+				/>
+			</div>
+		</div>
+	);
+};
+
+function ControlError( { error }: { error: string } ): ReactElement | null {
+	if ( error ) {
+		return <FormInputValidation isError={ true } isValid={ false } text={ error } />;
+	}
+	return null;
+}
+
+export default StoreAddress;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
@@ -1,0 +1,12 @@
+@import '../style';
+
+body.is-group-stepper.is-section-stepper {
+	.store-address__is-store-address {
+		.components-base-control__label {
+			display: block;
+			font-size: 0.875rem;
+			font-weight: 600;
+			margin-bottom: 5px;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/support-card.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/support-card.tsx
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { ReactElement } from 'react';
+
+const SupportLinkContainer = styled.p`
+	@media ( max-width: 320px ) {
+		margin-top: 0px;
+		width: 100%;
+	}
+
+	margin-bottom: 1rem;
+`;
+
+const SupportLinkStyle = styled.a`
+	color: var( --studio-gray-100 ) !important;
+	text-decoration: underline;
+	font-weight: bold;
+`;
+
+export default function SupportCard( {
+	domain,
+	backUrl,
+}: {
+	domain: string;
+	backUrl?: string;
+} ): ReactElement {
+	domain = domain?.replace( /http[s]*:\/\//, '' );
+
+	return (
+		<SupportLinkContainer>
+			{ createInterpolateElement( __( 'Need help? <a>Contact support</a>' ), {
+				a: (
+					<SupportLinkStyle
+						href={ addQueryArgs( '/help/contact', {
+							redirect_to: backUrl || `${ window.location.pathname }?siteSlug=${ domain }`,
+						} ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			} ) }
+		</SupportLinkContainer>
+	);
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/style.scss
@@ -1,0 +1,132 @@
+@import '@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+
+@mixin woocommerce-install-two-column-layout {
+	min-height: 95vh;
+	display: flex;
+	align-items: center;
+
+	@media ( max-width: 660px ) {
+		min-height: 0;
+	}
+
+	// Two column layout.
+	.step-wrapper {
+		display: flex;
+
+		.step-wrapper__header {
+			@media ( min-width: 660px ) {
+				margin-top: 0 !important;
+			}
+
+			.formatted-header {
+				text-align: inherit;
+
+				@media ( min-width: 1024px ) {
+					margin-left: 24px;
+				}
+
+				.formatted-header__title {
+					text-align: inherit;
+
+					@media ( max-width: 660px ) {
+						padding: 0 10px 0 0;
+					}
+				}
+
+				.formatted-header__subtitle {
+					@media ( max-width: 660px ) {
+						margin-top: 8px;
+						padding: 0 10px 0 0;
+					}
+
+					margin-top: 20px;
+					text-align: inherit;
+					max-width: 448px;
+				}
+			}
+		}
+	}
+
+	.is-wide-layout {
+		max-width: 1024px;
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		align-items: flex-start;
+		justify-content: center;
+		column-gap: 2%;
+
+		@media ( max-width: 660px ) {
+			max-width: 90vw;
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.step-wrapper__content {
+		display: flex;
+		margin: 0 24px;
+
+		.step-business-info__instructions-container,
+		.step-store-address__instructions-container,
+		.confirm__instructions-container {
+			font-size: 0.875rem;
+			letter-spacing: -0.16px;
+			color: var( --studio-gray-60 );
+			flex-direction: column;
+			max-width: 520px;
+			min-width: 380px;
+
+			@media ( max-width: 660px ) {
+				max-width: 90vw;
+			}
+
+			p {
+				margin-top: 16px;
+			}
+
+			.components-base-control {
+				font-size: $default-font-size;
+				line-height: $default-line-height;
+				margin-bottom: $grid-unit-30;
+
+				.components-base-control__label,
+				.components-input-control__label {
+					font-size: $editor-font-size;
+					margin-bottom: $grid-unit;
+					padding: 0;
+				}
+
+				.components-checkbox-control__label,
+				.components-select-control__input,
+				.components-text-control__input,
+				.components-combobox-control__input {
+					color: var( --color-neutral-70 );
+				}
+
+				.components-combobox-control__suggestions-container,
+				.components-select-control__input,
+				.components-text-control__input {
+					line-height: 18px;
+					padding: $grid-unit-15 $grid-unit-20;
+				}
+
+				.components-select-control__input {
+					box-sizing: initial;
+					height: auto;
+					line-height: 20px;
+					min-height: auto;
+				}
+
+				.components-combobox-control__input {
+					padding: 0;
+				}
+			}
+
+			.components-text-control__input {
+				box-sizing: border-box;
+			}
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useSelect } from '@wordpress/data';
 import { useFSEStatus } from '../hooks/use-fse-status';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
@@ -21,6 +22,7 @@ export const siteSetupFlow: Flow = {
 			'bloggerStartingPoint',
 			'courses',
 			'storeFeatures',
+			'storeAddress',
 		];
 	},
 
@@ -103,6 +105,10 @@ export const siteSetupFlow: Flow = {
 				case 'storeFeatures': {
 					const storeType = params[ 0 ];
 					if ( storeType === 'power' ) {
+						if ( isEnabled( 'stepper-woocommerce-poc' ) ) {
+							return navigate( 'storeAddress' );
+						}
+
 						const args = new URLSearchParams();
 						args.append( 'back_to', `/start/setup-site/store-features?siteSlug=${ siteSlug }` );
 						args.append( 'siteSlug', siteSlug as string );
@@ -126,6 +132,9 @@ export const siteSetupFlow: Flow = {
 
 				case 'storeFeatures':
 					return navigate( 'options' );
+
+				case 'storeAddress':
+					return navigate( 'storeFeatures' );
 
 				case 'courses':
 					return navigate( 'bloggerStartingPoint' );

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -211,6 +211,15 @@ export const setStoreType = ( storeType: string ) => ( {
 	storeType,
 } );
 
+export const setStoreAddressValue = (
+	store_address_field: string,
+	store_address_value: string
+) => ( {
+	type: 'SET_STORE_ADDRESS_VALUE' as const,
+	store_address_field,
+	store_address_value,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -234,4 +243,5 @@ export type OnboardAction = ReturnType<
 	| typeof startOnboarding
 	| typeof setIntent
 	| typeof setStartingPoint
+	| typeof setStoreAddressValue
 >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -1,4 +1,5 @@
 import { combineReducers } from '@wordpress/data';
+import { StoreAddress } from '../shared-types';
 import type { DomainSuggestion } from '../domain-suggestions/types';
 import type { FeatureId } from '../wpcom-features/types';
 import type { OnboardAction } from './actions';
@@ -221,6 +222,27 @@ const storeType: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	return state;
 };
 
+const storeAddress: Reducer< StoreAddress, OnboardAction > = (
+	state = {
+		store_address_1: '',
+		store_address_2: '',
+		store_city: '',
+		store_postcode: '',
+		store_country: '',
+	},
+	action
+) => {
+	if ( action.type === 'SET_STORE_ADDRESS_VALUE' ) {
+		const { store_address_field, store_address_value } = action;
+
+		return {
+			...state,
+			[ store_address_field ]: store_address_value,
+		};
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	domainSearch,
@@ -241,6 +263,7 @@ const reducer = combineReducers( {
 	lastLocation,
 	intent,
 	startingPoint,
+	storeAddress,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -13,6 +13,7 @@ export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
 export const getIntent = ( state: State ) => state.intent;
 export const getStartingPoint = ( state: State ) => state.startingPoint;
 export const getStoreType = ( state: State ) => state.storeType;
+export const getStoreAddress = ( state: State ) => state.storeAddress;
 export const getState = ( state: State ) => state;
 export const hasPaidDesign = ( state: State ): boolean => {
 	if ( ! state.selectedDesign ) {

--- a/packages/data-stores/src/shared-types.ts
+++ b/packages/data-stores/src/shared-types.ts
@@ -2,3 +2,11 @@ export interface WpcomClientCredentials {
 	client_id: string;
 	client_secret: string;
 }
+
+export interface StoreAddress {
+	store_address_1: string;
+	store_address_2?: string;
+	store_city: string;
+	store_postcode: string;
+	store_country: string;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This implements the "Store Address" step using the new stepper framework. Values entered into the form are added to the `onboarding` Redux store.

<img width="1229" alt="image" src="https://user-images.githubusercontent.com/917632/161628755-dc7f186d-15ee-43b1-9245-da98596fcabb.png">

![image](https://user-images.githubusercontent.com/917632/161628877-7c241bde-7675-4b62-9822-f77832479476.png)

#### Testing instructions

1. Go to `/stepper/?siteSlug=<some test site>` (Note, nothing will function correctly without the `siteSlug` query param.
2. Click through the "Sell" intent.
3. Choose the "More power" sell option.
<img width="624" alt="image" src="https://user-images.githubusercontent.com/917632/161628861-0c3fea3e-9a0e-4087-83df-6a486b828041.png">
4. You should see the form pictured above.

"Address line 1", "City", "Postcode" and "Country/State" are all required fields.

Related to #62305
