### PR TITLE
Marketplace: Removes marketplace-spotlight flag

### DIFF
--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Card, Gridicon } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useI18n } from '@wordpress/react-i18n';
@@ -109,7 +108,7 @@ const PluginsBrowserList = ( {
 					) }
 				</div>
 			</div>
-			{ listName === 'paid' && isEnabled( 'marketplace-spotlight' ) && (
+			{ listName === 'paid' && (
 				<AsyncLoad
 					require="calypso/blocks/jitm"
 					template="spotlight"

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	isBusiness,
 	isEcommerce,
@@ -28,7 +27,6 @@ import NoticeAction from 'calypso/components/notice/notice-action';
 import Pagination from 'calypso/components/pagination';
 import { PaginationVariant } from 'calypso/components/pagination/constants';
 import {
-	useWPCOMPlugin,
 	useWPCOMPlugins,
 	useWPCOMFeaturedPlugins,
 } from 'calypso/data/marketplace/use-wpcom-plugins-query';
@@ -568,9 +566,6 @@ const PluginSingleListView = ( {
 
 	const siteId = useSelector( getSelectedSiteId );
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
-	const { data: spotlightPlugin, isFetched: spotlightPluginFetched } =
-		useWPCOMPlugin( 'wordpress-seo-premium', { enabled: isEnabled( 'marketplace-spotlight' ) } ) ||
-		{};
 
 	let plugins;
 	let isFetching;
@@ -606,8 +601,6 @@ const PluginSingleListView = ( {
 			variant={ PluginsBrowserListVariant.Fixed }
 			billingPeriod={ billingPeriod }
 			setBillingPeriod={ category === 'paid' && setBillingPeriod }
-			spotlightPlugin={ spotlightPlugin }
-			spotlightPluginFetched={ spotlightPluginFetched }
 			extended
 			eligibleForProPlan={ eligibleForProPlan }
 		/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes `marketplace-spotlight` flag check.
* Removes unused conditional api call to fetch `wordpress-seo-premium` plugin info.

#### Testing instructions

* ~Apply D77801-code.~ this is live
* Navigate into `/plugins/:siteId` with an a11n account on a simple site.
* Yoast spotlight should appear.
* Change account to a non a11n one and repeat step one.
* Yoast spotlight shouldn't appear.

Notice: Wait until D77801-code lands before merging this one.

Fixes #62230