### PR TITLE
Marketplace: Round install numbers to 0 decimal points.

### DIFF
--- a/client/lib/format-number-compact/index.js
+++ b/client/lib/format-number-compact/index.js
@@ -42,21 +42,21 @@ const ONE_G = ONE_M * 1000;
 
 /*
  * Format a number larger than 1000 by appending a metric unit (K, M, G) and rounding to
- * one decimal point.
+ * the received decimal point, defaults to 0.
  * TODO: merge with formatNumberCompact by adding support for metric units other than 'K'
  */
-export function formatNumberMetric( number ) {
+export function formatNumberMetric( number, decimalPoints = 1 ) {
 	if ( number < ONE_K ) {
 		return String( number );
 	}
 
 	if ( number < ONE_M ) {
-		return ( number / ONE_K ).toFixed( 1 ) + 'K';
+		return ( number / ONE_K ).toFixed( decimalPoints ) + 'K';
 	}
 
 	if ( number < ONE_G ) {
-		return ( number / ONE_M ).toFixed( 1 ) + 'M';
+		return ( number / ONE_M ).toFixed( decimalPoints ) + 'M';
 	}
 
-	return ( number / ONE_G ).toFixed( 1 ) + 'G';
+	return ( number / ONE_G ).toFixed( decimalPoints ) + 'G';
 }

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -34,7 +34,7 @@ const PluginDetailsSidebar = ( {
 								{ translate( 'Active installations' ) }
 							</div>
 							<div className="plugin-details-sidebar__active-installs-value value">
-								{ formatNumberMetric( active_installs ) }
+								{ formatNumberMetric( active_installs, 0 ) }
 							</div>
 						</div>
 					) }

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -34,7 +34,7 @@ const PluginDetailsSidebar = ( {
 								{ translate( 'Active installations' ) }
 							</div>
 							<div className="plugin-details-sidebar__active-installs-value value">
-								{ formatNumberMetric( active_installs, 'en' ) }
+								{ formatNumberMetric( active_installs ) }
 							</div>
 						</div>
 					) }

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -169,7 +169,8 @@ const PluginsBrowserListElement = ( props ) => {
 						{ !! plugin.active_installs && (
 							<div className="plugins-browser-item__active-installs">
 								<span className="plugins-browser-item__active-installs-value">{ `${ formatNumberMetric(
-									plugin.active_installs
+									plugin.active_installs,
+									0
 								) }${ plugin.active_installs > 1000 ? '+' : '' }` }</span>
 								{ translate( ' Active Installs' ) }
 							</div>


### PR DESCRIPTION
#### Screenshot
<img width="1486" alt="Screen Shot 2022-03-30 at 11 41 12 AM" src="https://user-images.githubusercontent.com/1035546/160887451-5bc943b0-d805-478d-92ae-26c2d10616d6.png">
<img width="1486" alt="Screen Shot 2022-03-30 at 11 39 44 AM" src="https://user-images.githubusercontent.com/1035546/160887226-ffb91aa4-5135-4f9b-ac6b-363aa8efce02.png">


#### Changes proposed in this Pull Request

* Rounding the install count to 0 decimal points.
* Extending `formatNumberMetric` to accept a parameter with the amount of decimal points to be rounded.

#### Testing instructions

* Navigate into `/plugins/:siteId`.
* Scroll down to popular plugins.
* The install count should be rounded to 0 decimal points.
* Navigate into `/plugins/contact-form-7/:siteId`.
* On the sidebar the number of installations should also be rounded to 0 decimal points.

Related to #62232
