### PR TITLE
Shopping Cart: Filter out unknown properties in createRequestCartProduct

### DIFF
--- a/packages/shopping-cart/src/create-request-cart-product.ts
+++ b/packages/shopping-cart/src/create-request-cart-product.ts
@@ -6,12 +6,14 @@ export default function createRequestCartProduct(
 	if ( ! properties.product_slug ) {
 		throw new Error( 'product_slug is required for request cart products' );
 	}
+	const { product_slug, product_id, meta, volume, quantity, extra } = properties;
 	return {
-		meta: '',
-		volume: 1,
-		quantity: null,
-		extra: {},
-		...properties,
+		product_slug,
+		product_id,
+		meta: meta ?? '',
+		volume: volume ?? 1,
+		quantity: quantity ?? null,
+		extra: extra ?? {},
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of the motivation for replacing the old `CartStore` with the `@automattic/shopping-cart` package was to better control what data was being passed to the shopping-cart endpoint. Previously all the data returned from the previous call to the endpoint was being passed back to it on any change. This makes it unclear which properties of the request actually had an effect and resulted in a lot of superstitious properties being set just in case they were needed. To this end, the new package defines a TypeScript type, `RequestCartProduct`, that specifies which properties should be sent to the endpoint for each product.

However, when creating a new product for the cart using `createRequestCartProduct()` (sometimes called directly but also used by the `addProductsToCart()` cart manager action), we actually allow _any_ properties to be passed through. This could result in unexpected behavior if there is a property which has an effect but which we want to ignore or which are not documented.

In this PR, we filter out all unexpected properties in `createRequestCartProduct()` so that it only returns the properties known to us:

```
	product_slug: string;
	product_id?: number;
	meta: string;
	volume: number;
	quantity: number | null;
	extra: RequestCartProductExtra;
```

This was inspired by 824-gh-Automattic/payments-shilling although it's not clear if it is actually related.

#### Testing instructions

Unless there's an existing bug which was exploiting the previous behavior, this PR should not have any effect. We can test by performing common cart actions which add products to the cart: using the buttons on the plans page, using the renew button on a subscription page, or adding a product during signup.