### PR TITLE
[WordAds]: Add tests for payments history tab

### DIFF
--- a/client/my-sites/earn/ads/payments.jsx
+++ b/client/my-sites/earn/ads/payments.jsx
@@ -25,7 +25,7 @@ class WordAdsPayments extends Component {
 				paypalEmail: PropTypes.string.isRequired,
 				description: PropTypes.string,
 			} )
-		).isRequired,
+		),
 	};
 
 	checkSize( obj ) {

--- a/client/my-sites/earn/ads/test/fixtures/payments-table.jsx
+++ b/client/my-sites/earn/ads/test/fixtures/payments-table.jsx
@@ -1,0 +1,51 @@
+export const wordAdsPaymentsWithValidPayments = `
+<div>
+    <div class="card payments_history">
+        <div class="ads__module-header module-header">
+            <h1 class="ads__module-header-title module-header-title">Payments history</h1>
+        </div>
+        <div class="ads__module-content module-content">
+            <table>
+                <thead>
+                    <tr>
+                        <th class="ads__payments-history-header">Payment Date</th>
+                        <th class="ads__payments-history-header">Amount</th>
+                        <th class="ads__payments-history-header">Status</th>
+                        <th class="ads__payments-history-header">PayPal</th>
+                        <th class="ads__payments-history-header">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="ads__payments-history-value">2022-01-15</td>
+                        <td class="ads__payments-history-value">$100.00</td>
+                        <td class="ads__payments-history-value">
+                            <div class="badge badge--success ads__payments-history-badge">paid</div>
+                        </td>
+                        <td class="ads__payments-history-value">example@automattic.com</td>
+                        <td class="ads__payments-history-value"></td>
+                    </tr>
+                    <tr>
+                        <td class="ads__payments-history-value">2022-02-15</td>
+                        <td class="ads__payments-history-value">$1.50</td>
+                        <td class="ads__payments-history-value">
+                            <div class="badge badge--error ads__payments-history-badge">failed</div>
+                        </td>
+                        <td class="ads__payments-history-value">example@automattic.com</td>
+                        <td class="ads__payments-history-value">Failed for some reason</td>
+                    </tr>
+                    <tr>
+                        <td class="ads__payments-history-value"><small>Estimated: 2022-03-15</small></td>
+                        <td class="ads__payments-history-value">$100.00</td>
+                        <td class="ads__payments-history-value">
+                            <div class="badge badge--info ads__payments-history-badge">pending</div>
+                        </td>
+                        <td class="ads__payments-history-value">example@automattic.com</td>
+                        <td class="ads__payments-history-value">Pending for some reason</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+`;

--- a/client/my-sites/earn/ads/test/payments.js
+++ b/client/my-sites/earn/ads/test/payments.js
@@ -124,6 +124,6 @@ test( 'Payments table should show as expected', () => {
 	);
 } );
 
-function normalizeOutput( input ) {
-	return input.replace( /\s/g, '' );
+function normalizeOutput( output ) {
+	return output.replace( /\s/g, '' );
 }

--- a/client/my-sites/earn/ads/test/payments.js
+++ b/client/my-sites/earn/ads/test/payments.js
@@ -1,0 +1,129 @@
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import { settings as SETTINGS_FIXTURE } from '../../../../state/selectors/test/fixtures/jetpack-settings';
+import paymentsReducer from '../../../../state/wordads/payments/reducer';
+import WordAdsPayments from '../payments';
+import { wordAdsPaymentsWithValidPayments } from './fixtures/payments-table';
+
+const stateWithoutPayments = {
+	ui: {
+		selectedSiteId: 999,
+	},
+	wordads: {
+		settings: {
+			items: {
+				999: {
+					paypal: 'example@automattic.com',
+				},
+			},
+		},
+	},
+	sites: {
+		items: {},
+	},
+	jetpack: {
+		settings: SETTINGS_FIXTURE,
+	},
+};
+
+const stateWithPendingPaymentAndMismatchEmail = {
+	...stateWithoutPayments,
+	wordads: {
+		payments: {
+			999: [
+				{
+					id: 24846,
+					paymentDate: '2022-01-15',
+					amount: '30',
+					status: 'pending',
+					paypalEmail: 'example@automattic.com',
+					description: 'Pending for some reason',
+				},
+			],
+		},
+		settings: {
+			items: {
+				999: {
+					paypal: 'mismatch_example@automattic.com',
+				},
+			},
+		},
+	},
+};
+
+const stateWithValidPayments = {
+	...stateWithoutPayments,
+	wordads: {
+		...stateWithoutPayments.wordads,
+		payments: {
+			999: [
+				{
+					id: 1,
+					paymentDate: '2022-01-15',
+					amount: '100',
+					status: 'paid',
+					paypalEmail: 'example@automattic.com',
+					description: '',
+				},
+				{
+					id: 2,
+					paymentDate: '2022-02-15',
+					amount: '1.50',
+					status: 'failed',
+					paypalEmail: 'example@automattic.com',
+					description: 'Failed for some reason',
+				},
+				{
+					id: 3,
+					paymentDate: '2022-03-15',
+					amount: '100',
+					status: 'pending',
+					paypalEmail: 'example@automattic.com',
+					description: 'Pending for some reason',
+				},
+			],
+		},
+	},
+};
+
+test( 'Empty payments list should show a notice', () => {
+	const store = createStore( paymentsReducer, stateWithoutPayments );
+	const wordAdsPayments = shallow(
+		<Provider store={ store }>
+			<WordAdsPayments />
+		</Provider>
+	);
+	expect( wordAdsPayments.html() ).to.contain(
+		'You have no payments history. Payment will be made as soon as the total outstanding amount has reached $100.'
+	);
+} );
+
+test( 'Pending payment with email not equals Paypal email configured on settings should show a notice', () => {
+	const store = createStore( paymentsReducer, stateWithPendingPaymentAndMismatchEmail );
+	const wordAdsPayments = shallow(
+		<Provider store={ store }>
+			<WordAdsPayments />
+		</Provider>
+	);
+	expect( wordAdsPayments.html() ).to.contain(
+		'Your pending payment will be sent to a PayPal address different from your current address.'
+	);
+} );
+
+test( 'Payments table should show as expected', () => {
+	const store = createStore( paymentsReducer, stateWithValidPayments );
+	const wordAdsPayments = shallow(
+		<Provider store={ store }>
+			<WordAdsPayments />
+		</Provider>
+	);
+	expect( normalizeOutput( wordAdsPayments.html() ) ).equals(
+		normalizeOutput( wordAdsPaymentsWithValidPayments )
+	);
+} );
+
+function normalizeOutput( input ) {
+	return input.replace( /\s/g, '' );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add tests for payment history tabs covering the scenarios:
* Empty payments list should show a notice
* Pending payment with email not equals Paypal email configured on settings should show a notice
* Expected payments list

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn test-client`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/62145
