### PR TITLE
Marketplace: Add tracking to popular searches

### DIFF
--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -33,9 +33,9 @@ const PopularSearches = ( props ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const trackImpresion = ( searchTerm ) => {
+	const trackImpression = ( searchTerm ) => {
 		dispatch(
-			recordTracksEvent( 'calypso_plugins_popular_searches_impresion', {
+			recordTracksEvent( 'calypso_plugins_popular_searches_impression', {
 				search_term: searchTerm,
 			} )
 		);
@@ -51,7 +51,7 @@ const PopularSearches = ( props ) => {
 		page( `/plugins/${ siteSlug || '' }?s=${ searchTerm }` );
 	};
 
-	searchTerms.forEach( trackImpresion );
+	searchTerms.forEach( trackImpression );
 
 	return (
 		<div className="search-box-header__recommended-searches">

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,7 +1,8 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useDispatch } from 'react-redux';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
 
@@ -29,7 +30,28 @@ const SearchBox = ( { isMobile, doSearch, searchTerm } ) => {
 
 const PopularSearches = ( props ) => {
 	const { searchTerms, siteSlug } = props;
+	const dispatch = useDispatch();
 	const translate = useTranslate();
+
+	const trackImpresion = ( searchTerm ) => {
+		dispatch(
+			recordTracksEvent( 'calypso_plugins_popular_searches_impresion', {
+				search_term: searchTerm,
+			} )
+		);
+	};
+
+	const onClick = ( searchTerm ) => {
+		dispatch(
+			recordTracksEvent( 'calypso_plugins_popular_searches_click', {
+				search_term: searchTerm,
+			} )
+		);
+
+		page( `/plugins/${ siteSlug || '' }?s=${ searchTerm }` );
+	};
+
+	searchTerms.forEach( trackImpresion );
 
 	return (
 		<div className="search-box-header__recommended-searches">
@@ -39,13 +61,16 @@ const PopularSearches = ( props ) => {
 
 			<div className="search-box-header__recommended-searches-list">
 				{ searchTerms.map( ( searchTerm, n ) => (
-					<a
-						href={ `/plugins/${ siteSlug || '' }?s=${ searchTerm }` }
+					<span
+						onClick={ () => onClick( searchTerm ) }
+						onKeyPress={ () => onClick( searchTerm ) }
+						role="link"
+						tabIndex={ 0 }
 						className="search-box-header__recommended-searches-list-item"
 						key={ 'recommended-search-item-' + n }
 					>
 						{ searchTerm }
-					</a>
+					</span>
 				) ) }
 			</div>
 		</div>

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,7 +1,6 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
@@ -32,16 +31,6 @@ const PopularSearches = ( props ) => {
 	const { searchTerms, siteSlug } = props;
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-
-	useEffect( () => {
-		searchTerms.forEach( ( searchTerm ) =>
-			dispatch(
-				recordTracksEvent( 'calypso_plugins_popular_searches_impression', {
-					search_term: searchTerm,
-				} )
-			)
-		);
-	}, [ JSON.stringify( searchTerms ) ] );
 
 	const onClick = ( searchTerm ) => {
 		dispatch(

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,9 +1,9 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
-
 import './style.scss';
 
 const SearchBox = ( { isMobile, doSearch, searchTerm } ) => {
@@ -33,13 +33,15 @@ const PopularSearches = ( props ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const trackImpression = ( searchTerm ) => {
-		dispatch(
-			recordTracksEvent( 'calypso_plugins_popular_searches_impression', {
-				search_term: searchTerm,
-			} )
+	useEffect( () => {
+		searchTerms.forEach( ( searchTerm ) =>
+			dispatch(
+				recordTracksEvent( 'calypso_plugins_popular_searches_impression', {
+					search_term: searchTerm,
+				} )
+			)
 		);
-	};
+	}, searchTerms );
 
 	const onClick = ( searchTerm ) => {
 		dispatch(
@@ -50,8 +52,6 @@ const PopularSearches = ( props ) => {
 
 		page( `/plugins/${ siteSlug || '' }?s=${ searchTerm }` );
 	};
-
-	searchTerms.forEach( trackImpression );
 
 	return (
 		<div className="search-box-header__recommended-searches">

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -41,7 +41,7 @@ const PopularSearches = ( props ) => {
 				} )
 			)
 		);
-	}, searchTerms );
+	}, [ JSON.stringify( searchTerms ) ] );
 
 	const onClick = ( searchTerm ) => {
 		dispatch(

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -70,6 +70,7 @@
 			.search-box-header__recommended-searches-list-item {
 				&:hover {
 					color: var( --color-link );
+					cursor: pointer;
 				}
 
 				&:focus {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds impression and click tracking to the Popular Searches list.
* Changes anchor tag for a span tag so I could use the `onClick` event.

#### Testing instructions
* Enable tracks debugging PCYsg-cae-p2
* Navigate into `/plugins`.
* Check that is sending a `calypso_plugins_popular_searches_impression` event with each search term of the list.
* Click on any search term from the list
* Check that is sending `calypso_plugins_popular_searches_click` with the correct search term

Related to #62391