### PR TITLE
Hide autorenewal message for expired domains on domain details

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -75,14 +75,15 @@ const RegisteredDomainDetails = ( {
 			formattedPrice = formatCurrency( renewalPrice, currencyCode, { stripZeros: true } )!;
 		}
 
-		const autoRenewAdditionalText = ! isExpiring( purchase )
-			? translate( 'We will attempt to renew on %(renewalDate)s for %(price)s', {
-					args: {
-						renewalDate: moment( domain.autoRenewalDate ).format( 'LL' ),
-						price: formattedPrice,
-					},
-			  } )
-			: null;
+		const autoRenewAdditionalText =
+			! isExpiring( purchase ) && ! domain.expired
+				? translate( 'We will attempt to renew on %(renewalDate)s for %(price)s', {
+						args: {
+							renewalDate: moment( domain.autoRenewalDate ).format( 'LL' ),
+							price: formattedPrice,
+						},
+				  } )
+				: null;
 
 		return (
 			<>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change fixes the bug where the auto-renew message `We will attempt to renew on %(renewalDate)s for %(price)s` appeared for expired domains in the domain details card 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Before**
![image](https://user-images.githubusercontent.com/65082164/160960341-6577b797-c2ad-4e52-b313-e429ab42c42d.png)

**After**

I made sure that the notice is correctly displayed in every scenario: **expired**, **active**, and **active with auto-renew toggled off**

![image](https://user-images.githubusercontent.com/65082164/160960542-a7114d5e-5cef-4414-8b10-d5c8052a8a87.png)

![image](https://user-images.githubusercontent.com/65082164/160960561-94b092d5-d225-443d-94b4-9fa69a805c62.png)

![image](https://user-images.githubusercontent.com/65082164/160960591-930e0ad6-281a-478b-a904-92f2a2c404fd.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


