### PR TITLE
Show verticalized designs in the Design Picker

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -8,7 +8,7 @@ const CATEGORY_GENERATED = 'generated';
  * Ensures the category appears at the top of the design category list
  * (directly below the Show All filter).
  */
-function sortCategoryToTop( slug: string ) {
+function makeSortCategoryToTop( slug: string ) {
 	return ( a: Category, b: Category ) => {
 		if ( a.slug === b.slug ) {
 			return 0;
@@ -21,9 +21,9 @@ function sortCategoryToTop( slug: string ) {
 	};
 }
 
-const sortBlogToTop = sortCategoryToTop( CATEGORY_BLOG );
-const sortStoreToTop = sortCategoryToTop( CATEGORY_STORE );
-const sortGeneratedToTop = sortCategoryToTop( CATEGORY_GENERATED );
+const sortBlogToTop = makeSortCategoryToTop( CATEGORY_BLOG );
+const sortStoreToTop = makeSortCategoryToTop( CATEGORY_STORE );
+const sortGeneratedToTop = makeSortCategoryToTop( CATEGORY_GENERATED );
 
 export function getGeneratedDesignsCategory( name: string ): Category {
 	return { slug: CATEGORY_GENERATED, name };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -1,0 +1,73 @@
+import { Category } from '@automattic/design-picker';
+
+const CATEGORY_BLOG = 'blog';
+const CATEGORY_STORE = 'store';
+const CATEGORY_GENERATED = 'generated';
+
+/**
+ * Ensures the category appears at the top of the design category list
+ * (directly below the Show All filter).
+ */
+function sortCategoryToTop( slug: string ) {
+	return ( a: Category, b: Category ) => {
+		if ( a.slug === b.slug ) {
+			return 0;
+		} else if ( a.slug === slug ) {
+			return -1;
+		} else if ( b.slug === slug ) {
+			return 1;
+		}
+		return 0;
+	};
+}
+
+const sortBlogToTop = sortCategoryToTop( CATEGORY_BLOG );
+const sortStoreToTop = sortCategoryToTop( CATEGORY_STORE );
+const sortGeneratedToTop = sortCategoryToTop( CATEGORY_GENERATED );
+
+export function getGeneratedDesignsCategory( name: string ): Category {
+	return { slug: CATEGORY_GENERATED, name };
+}
+
+export function getCategorizationOptions(
+	intent: string,
+	showAllFilter: boolean,
+	showGeneratedDesigns: boolean
+) {
+	const result = {
+		showAllFilter,
+		defaultSelection: null,
+	} as {
+		showAllFilter: boolean;
+		defaultSelection: string | null;
+		sort: ( a: Category, b: Category ) => 0 | 1 | -1;
+	};
+
+	if ( showGeneratedDesigns ) {
+		return {
+			...result,
+			defaultSelection: CATEGORY_GENERATED,
+			sort: sortGeneratedToTop,
+		};
+	}
+
+	switch ( intent ) {
+		case 'write':
+			return {
+				...result,
+				defaultSelection: CATEGORY_BLOG,
+				sort: sortBlogToTop,
+			};
+		case 'sell':
+			return {
+				...result,
+				defaultSelection: CATEGORY_STORE,
+				sort: sortStoreToTop,
+			};
+		default:
+			return {
+				...result,
+				sort: sortBlogToTop,
+			};
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -7,6 +7,7 @@ import DesignPicker, {
 	useCategorization,
 	isBlankCanvasDesign,
 	getDesignPreviewUrl,
+	useGeneratedDesigns,
 	useThemeDesignsQuery,
 } from '@automattic/design-picker';
 import { useLocale, englishLocales } from '@automattic/i18n-utils';
@@ -25,10 +26,11 @@ import { useFSEStatus } from '../../../../hooks/use-fse-status';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
+import { getCategorizationOptions, getGeneratedDesignsCategory } from './categories';
 import PreviewToolbar from './preview-toolbar';
 import type { Step } from '../../types';
 import './style.scss';
-import type { Design, Category } from '@automattic/design-picker';
+import type { Design } from '@automattic/design-picker';
 /**
  * The design picker step
  */
@@ -51,12 +53,22 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	const siteTitle = site?.name;
 	const isReskinned = true;
 	const sitePlanSlug = site?.plan?.product_slug;
+	const siteVertical = useMemo(
+		() => ( {
+			// TODO: fetch from store/site settings
+			id: '439',
+			name: 'Photographic & Digital Arts',
+		} ),
+		[]
+	);
 	const isPrivateAtomic = Boolean(
 		site?.launch_status === 'unlaunched' && site?.options?.is_automated_transfer
 	);
 
 	const showDesignPickerCategories = isEnabled( 'signup/design-picker-categories' );
 	const showDesignPickerCategoriesAllFilter = isEnabled( 'signup/design-picker-categories' );
+	const showGeneratedDesigns =
+		isEnabled( 'signup/design-picker-generated-designs' ) && intent === 'build' && !! siteVertical;
 
 	// In order to show designs with a "featured" term in the theme_picks taxonomy at the below of categories filter
 	const useFeaturedPicksButtons =
@@ -77,22 +89,31 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		? 'auto-loading-homepage,full-site-editing'
 		: 'auto-loading-homepage';
 
-	const { data: apiThemes = [] } = useThemeDesignsQuery(
+	const { data: themeDesigns = [] } = useThemeDesignsQuery(
 		{ filter: themeFilters, tier },
 		// Wait until block editor settings have loaded to load themes
 		{ enabled: ! isLoading }
 	);
 
-	const allThemes = apiThemes;
+	const staticDesigns = themeDesigns;
+
+	const generatedDesignsCategory = useMemo(
+		() => ( showGeneratedDesigns ? getGeneratedDesignsCategory( siteVertical.name ) : undefined ),
+		[ showGeneratedDesigns, siteVertical ]
+	);
+	const generatedDesigns = useGeneratedDesigns( generatedDesignsCategory );
 
 	const { designs, featuredPicksDesigns } = useMemo( () => {
 		return {
-			designs: shuffle( allThemes.filter( ( theme ) => ! theme.is_featured_picks ) ),
-			featuredPicksDesigns: allThemes.filter(
-				( theme ) => theme.is_featured_picks && ! isBlankCanvasDesign( theme )
+			designs: [
+				...generatedDesigns,
+				...shuffle( staticDesigns.filter( ( design ) => ! design.is_featured_picks ) ),
+			],
+			featuredPicksDesigns: staticDesigns.filter(
+				( design ) => design.is_featured_picks && ! isBlankCanvasDesign( design )
 			),
 		};
-	}, [ allThemes ] );
+	}, [ staticDesigns, generatedDesigns ] );
 
 	function headerText() {
 		if ( showDesignPickerCategories ) {
@@ -129,34 +150,12 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		intent: intent,
 	} );
 
-	const getCategorizationOptionsForStep = () => {
-		const result: {
-			showAllFilter: boolean;
-			defaultSelection: string | null;
-			sort: ( a: Category, b: Category ) => 0 | 1 | -1;
-		} = {
-			showAllFilter: showDesignPickerCategoriesAllFilter,
-			defaultSelection: '',
-			sort: sortBlogToTop,
-		};
-		switch ( intent ) {
-			case 'write':
-				result.defaultSelection = 'blog';
-				result.sort = sortBlogToTop;
-				break;
-			case 'sell':
-				result.defaultSelection = 'store';
-				result.sort = sortStoreToTop;
-				break;
-			default:
-				result.defaultSelection = null;
-				result.sort = sortBlogToTop;
-				break;
-		}
-
-		return result;
-	};
-	const categorization = useCategorization( designs, getCategorizationOptionsForStep() );
+	const categorizationOptions = getCategorizationOptions(
+		intent,
+		showDesignPickerCategoriesAllFilter,
+		showGeneratedDesigns
+	);
+	const categorization = useCategorization( designs, categorizationOptions );
 
 	function renderCategoriesFooter() {
 		return (
@@ -301,7 +300,7 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 				highResThumbnails
 				premiumBadge={ <PremiumBadge isPremiumThemeAvailable={ !! isPremiumThemeAvailable } /> }
 				categorization={ showDesignPickerCategories ? categorization : undefined }
-				recommendedCategorySlug={ getCategorizationOptionsForStep().defaultSelection }
+				recommendedCategorySlug={ categorizationOptions.defaultSelection }
 				categoriesHeading={
 					<FormattedHeader
 						id={ 'step-header' }
@@ -334,30 +333,5 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		/>
 	);
 };
-
-// Ensures Blog category appears at the top of the design category list
-// (directly below the All Themes category).
-function sortBlogToTop( a: Category, b: Category ) {
-	if ( a.slug === b.slug ) {
-		return 0;
-	} else if ( a.slug === 'blog' ) {
-		return -1;
-	} else if ( b.slug === 'blog' ) {
-		return 1;
-	}
-	return 0;
-}
-// Ensures store category appears at the top of the design category list
-// (directly below the All Themes category).
-function sortStoreToTop( a: Category, b: Category ) {
-	if ( a.slug === b.slug ) {
-		return 0;
-	} else if ( a.slug === 'store' ) {
-		return -1;
-	} else if ( b.slug === 'store' ) {
-		return 1;
-	}
-	return 0;
-}
 
 export default designSetup;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -6,7 +6,7 @@ import DesignPicker, {
 	PremiumBadge,
 	useCategorization,
 	isBlankCanvasDesign,
-	getDesignUrl,
+	getDesignPreviewUrl,
 	useThemeDesignsQuery,
 } from '@automattic/design-picker';
 import { useLocale, englishLocales } from '@automattic/i18n-utils';
@@ -227,11 +227,10 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
 		const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
 		const shouldUpgrade = selectedDesign.is_premium && ! isPremiumThemeAvailable;
-		const previewUrl = getDesignUrl( selectedDesign, locale, {
-			iframe: true,
+		const previewUrl = getDesignPreviewUrl( selectedDesign, {
+			language: locale,
 			// If the user fills out the site title with write intent, we show it on the design preview
-			// Otherwise, use the title of selected design directly
-			site_title: intent === 'write' && siteTitle ? siteTitle : selectedDesign?.title,
+			siteTitle: intent === 'write' ? siteTitle : undefined,
 		} );
 
 		stepContent = (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -122,7 +122,7 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	}
 
 	const getEventPropsByDesign = ( design: Design ) => ( {
-		theme: design?.stylesheet ?? `pub/${ design.theme }`,
+		theme: design.recipe?.theme,
 		template: design.template,
 		is_premium: design?.is_premium,
 		flow: flowName,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -143,7 +143,7 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	}
 
 	const getEventPropsByDesign = ( design: Design ) => ( {
-		theme: design.recipe?.theme,
+		theme: design.recipe?.stylesheet,
 		template: design.template,
 		is_premium: design?.is_premium,
 		flow: flowName,

--- a/client/signup/steps/difm-design-picker/themes.tsx
+++ b/client/signup/steps/difm-design-picker/themes.tsx
@@ -15,7 +15,7 @@ const difmThemes: Design[] = [
 		theme: 'russell',
 		title: 'Russell',
 		recipe: {
-			theme: 'pub/russell',
+			stylesheet: 'pub/russell',
 		},
 	},
 	{
@@ -32,7 +32,7 @@ const difmThemes: Design[] = [
 		theme: 'zoologist',
 		title: 'Zoologist',
 		recipe: {
-			theme: 'pub/zoologist',
+			stylesheet: 'pub/zoologist',
 		},
 	},
 	{
@@ -44,7 +44,7 @@ const difmThemes: Design[] = [
 		theme: 'quadrat',
 		title: 'Quadrat',
 		recipe: {
-			theme: 'pub/quadrat',
+			stylesheet: 'pub/quadrat',
 		},
 	},
 	{
@@ -56,7 +56,7 @@ const difmThemes: Design[] = [
 		theme: 'geologist',
 		title: 'Geologist',
 		recipe: {
-			theme: 'pub/geologist',
+			stylesheet: 'pub/geologist',
 		},
 	},
 	{
@@ -68,7 +68,7 @@ const difmThemes: Design[] = [
 		theme: 'bradford',
 		title: 'Bradford',
 		recipe: {
-			theme: 'pub/bradford',
+			stylesheet: 'pub/bradford',
 		},
 	},
 	{
@@ -86,7 +86,7 @@ const difmThemes: Design[] = [
 		theme: 'twentytwentyone',
 		title: 'Twenty Twenty-One',
 		recipe: {
-			theme: 'pub/twentytwentyone',
+			stylesheet: 'pub/twentytwentyone',
 		},
 	},
 	{
@@ -103,7 +103,7 @@ const difmThemes: Design[] = [
 		theme: 'spearhead',
 		title: 'Spearhead',
 		recipe: {
-			theme: 'pub/spearhead',
+			stylesheet: 'pub/spearhead',
 		},
 	},
 	{
@@ -120,7 +120,7 @@ const difmThemes: Design[] = [
 		theme: 'seedlet',
 		title: 'Seedlet',
 		recipe: {
-			theme: 'pub/seedlet',
+			stylesheet: 'pub/seedlet',
 		},
 	},
 	{
@@ -137,7 +137,7 @@ const difmThemes: Design[] = [
 		theme: 'twentytwenty',
 		title: 'Twenty Twenty',
 		recipe: {
-			theme: 'pub/twentytwenty',
+			stylesheet: 'pub/twentytwenty',
 		},
 	},
 	{
@@ -154,7 +154,7 @@ const difmThemes: Design[] = [
 		theme: 'barnsbury',
 		title: 'Barnsbury',
 		recipe: {
-			theme: 'pub/barnsbury',
+			stylesheet: 'pub/barnsbury',
 		},
 	},
 	{
@@ -171,7 +171,7 @@ const difmThemes: Design[] = [
 		theme: 'rivington',
 		title: 'Rivington',
 		recipe: {
-			theme: 'pub/rivington',
+			stylesheet: 'pub/rivington',
 		},
 	},
 	{
@@ -183,7 +183,7 @@ const difmThemes: Design[] = [
 		theme: 'maywood',
 		title: 'Maywood',
 		recipe: {
-			theme: 'pub/maywood',
+			stylesheet: 'pub/maywood',
 		},
 	},
 	{
@@ -200,7 +200,7 @@ const difmThemes: Design[] = [
 		theme: 'shawburn',
 		title: 'Shawburn',
 		recipe: {
-			theme: 'pub/shawburn',
+			stylesheet: 'pub/shawburn',
 		},
 	},
 	{
@@ -212,7 +212,7 @@ const difmThemes: Design[] = [
 		theme: 'alves',
 		title: 'Alves',
 		recipe: {
-			theme: 'pub/alves',
+			stylesheet: 'pub/alves',
 		},
 	},
 	{
@@ -229,7 +229,7 @@ const difmThemes: Design[] = [
 		theme: 'exford',
 		title: 'Exford',
 		recipe: {
-			theme: 'pub/exford',
+			stylesheet: 'pub/exford',
 		},
 	},
 	{
@@ -241,7 +241,7 @@ const difmThemes: Design[] = [
 		theme: 'rockfield',
 		title: 'Rockfield',
 		recipe: {
-			theme: 'pub/rockfield',
+			stylesheet: 'pub/rockfield',
 		},
 	},
 	{
@@ -258,7 +258,7 @@ const difmThemes: Design[] = [
 		theme: 'coutoire',
 		title: 'Coutoire',
 		recipe: {
-			theme: 'pub/coutoire',
+			stylesheet: 'pub/coutoire',
 		},
 	},
 	{
@@ -275,7 +275,7 @@ const difmThemes: Design[] = [
 		theme: 'morden',
 		title: 'Morden',
 		recipe: {
-			theme: 'pub/morden',
+			stylesheet: 'pub/morden',
 		},
 	},
 	{
@@ -292,7 +292,7 @@ const difmThemes: Design[] = [
 		theme: 'stow',
 		title: 'Stow',
 		recipe: {
-			theme: 'pub/stow',
+			stylesheet: 'pub/stow',
 		},
 	},
 	{
@@ -309,7 +309,7 @@ const difmThemes: Design[] = [
 		theme: 'hever',
 		title: 'Hever',
 		recipe: {
-			theme: 'pub/hever',
+			stylesheet: 'pub/hever',
 		},
 	},
 	{
@@ -326,7 +326,7 @@ const difmThemes: Design[] = [
 		theme: 'independent-publisher-2',
 		title: 'Independent Publisher 2',
 		recipe: {
-			theme: 'pub/independent-publisher-2',
+			stylesheet: 'pub/independent-publisher-2',
 		},
 	},
 	{
@@ -343,7 +343,7 @@ const difmThemes: Design[] = [
 		theme: 'twentysixteen',
 		title: 'Twenty Sixteen',
 		recipe: {
-			theme: 'pub/twentysixteen',
+			stylesheet: 'pub/twentysixteen',
 		},
 	},
 	{
@@ -360,7 +360,7 @@ const difmThemes: Design[] = [
 		theme: 'twentyfifteen',
 		title: 'Twenty Fifteen',
 		recipe: {
-			theme: 'pub/twentyfifteen',
+			stylesheet: 'pub/twentyfifteen',
 		},
 	},
 	{
@@ -377,7 +377,7 @@ const difmThemes: Design[] = [
 		theme: 'hemingway-rewritten',
 		title: 'Hemingway Rewritten',
 		recipe: {
-			theme: 'pub/hemingway-rewritten',
+			stylesheet: 'pub/hemingway-rewritten',
 		},
 	},
 ];

--- a/client/signup/steps/difm-design-picker/themes.tsx
+++ b/client/signup/steps/difm-design-picker/themes.tsx
@@ -14,6 +14,9 @@ const difmThemes: Design[] = [
 		template: 'russell',
 		theme: 'russell',
 		title: 'Russell',
+		recipe: {
+			theme: 'pub/russell',
+		},
 	},
 	{
 		categories: [
@@ -28,6 +31,9 @@ const difmThemes: Design[] = [
 		template: 'zoologist',
 		theme: 'zoologist',
 		title: 'Zoologist',
+		recipe: {
+			theme: 'pub/zoologist',
+		},
 	},
 	{
 		categories: [ { name: 'Professional Services', slug: 'professional-services' } ],
@@ -37,6 +43,9 @@ const difmThemes: Design[] = [
 		template: 'quadrat',
 		theme: 'quadrat',
 		title: 'Quadrat',
+		recipe: {
+			theme: 'pub/quadrat',
+		},
 	},
 	{
 		categories: [ { name: 'Creative Arts', slug: 'creative-arts' } ],
@@ -46,6 +55,9 @@ const difmThemes: Design[] = [
 		template: 'geologist',
 		theme: 'geologist',
 		title: 'Geologist',
+		recipe: {
+			theme: 'pub/geologist',
+		},
 	},
 	{
 		categories: [ { name: 'Creative Arts', slug: 'creative-arts' } ],
@@ -55,6 +67,9 @@ const difmThemes: Design[] = [
 		template: 'bradford',
 		theme: 'bradford',
 		title: 'Bradford',
+		recipe: {
+			theme: 'pub/bradford',
+		},
 	},
 	{
 		categories: [
@@ -70,6 +85,9 @@ const difmThemes: Design[] = [
 		template: 'twentytwentyone',
 		theme: 'twentytwentyone',
 		title: 'Twenty Twenty-One',
+		recipe: {
+			theme: 'pub/twentytwentyone',
+		},
 	},
 	{
 		categories: [
@@ -84,6 +102,9 @@ const difmThemes: Design[] = [
 		template: 'spearhead',
 		theme: 'spearhead',
 		title: 'Spearhead',
+		recipe: {
+			theme: 'pub/spearhead',
+		},
 	},
 	{
 		categories: [
@@ -98,6 +119,9 @@ const difmThemes: Design[] = [
 		template: 'seedlet',
 		theme: 'seedlet',
 		title: 'Seedlet',
+		recipe: {
+			theme: 'pub/seedlet',
+		},
 	},
 	{
 		categories: [
@@ -112,6 +136,9 @@ const difmThemes: Design[] = [
 		template: 'twentytwenty',
 		theme: 'twentytwenty',
 		title: 'Twenty Twenty',
+		recipe: {
+			theme: 'pub/twentytwenty',
+		},
 	},
 	{
 		categories: [
@@ -126,6 +153,9 @@ const difmThemes: Design[] = [
 		template: 'barnsbury',
 		theme: 'barnsbury',
 		title: 'Barnsbury',
+		recipe: {
+			theme: 'pub/barnsbury',
+		},
 	},
 	{
 		categories: [
@@ -140,6 +170,9 @@ const difmThemes: Design[] = [
 		template: 'rivington',
 		theme: 'rivington',
 		title: 'Rivington',
+		recipe: {
+			theme: 'pub/rivington',
+		},
 	},
 	{
 		categories: [ { name: 'Restaurant', slug: 'restaurant' } ],
@@ -149,6 +182,9 @@ const difmThemes: Design[] = [
 		template: 'maywood',
 		theme: 'maywood',
 		title: 'Maywood',
+		recipe: {
+			theme: 'pub/maywood',
+		},
 	},
 	{
 		categories: [
@@ -163,6 +199,9 @@ const difmThemes: Design[] = [
 		template: 'shawburn',
 		theme: 'shawburn',
 		title: 'Shawburn',
+		recipe: {
+			theme: 'pub/shawburn',
+		},
 	},
 	{
 		categories: [ { name: 'Local Services', slug: 'local-services' } ],
@@ -172,6 +211,9 @@ const difmThemes: Design[] = [
 		template: 'alves',
 		theme: 'alves',
 		title: 'Alves',
+		recipe: {
+			theme: 'pub/alves',
+		},
 	},
 	{
 		categories: [
@@ -186,6 +228,9 @@ const difmThemes: Design[] = [
 		template: 'exford',
 		theme: 'exford',
 		title: 'Exford',
+		recipe: {
+			theme: 'pub/exford',
+		},
 	},
 	{
 		categories: [ { name: 'Restaurant', slug: 'restaurant' } ],
@@ -195,6 +240,9 @@ const difmThemes: Design[] = [
 		template: 'rockfield',
 		theme: 'rockfield',
 		title: 'Rockfield',
+		recipe: {
+			theme: 'pub/rockfield',
+		},
 	},
 	{
 		categories: [
@@ -209,6 +257,9 @@ const difmThemes: Design[] = [
 		template: 'coutoire',
 		theme: 'coutoire',
 		title: 'Coutoire',
+		recipe: {
+			theme: 'pub/coutoire',
+		},
 	},
 	{
 		categories: [
@@ -223,6 +274,9 @@ const difmThemes: Design[] = [
 		template: 'morden',
 		theme: 'morden',
 		title: 'Morden',
+		recipe: {
+			theme: 'pub/morden',
+		},
 	},
 	{
 		categories: [
@@ -237,6 +291,9 @@ const difmThemes: Design[] = [
 		template: 'stow',
 		theme: 'stow',
 		title: 'Stow',
+		recipe: {
+			theme: 'pub/stow',
+		},
 	},
 	{
 		categories: [
@@ -251,6 +308,9 @@ const difmThemes: Design[] = [
 		template: 'hever',
 		theme: 'hever',
 		title: 'Hever',
+		recipe: {
+			theme: 'pub/hever',
+		},
 	},
 	{
 		categories: [
@@ -265,6 +325,9 @@ const difmThemes: Design[] = [
 		template: 'independent-publisher-2',
 		theme: 'independent-publisher-2',
 		title: 'Independent Publisher 2',
+		recipe: {
+			theme: 'pub/independent-publisher-2',
+		},
 	},
 	{
 		categories: [
@@ -279,6 +342,9 @@ const difmThemes: Design[] = [
 		template: 'twentysixteen',
 		theme: 'twentysixteen',
 		title: 'Twenty Sixteen',
+		recipe: {
+			theme: 'pub/twentysixteen',
+		},
 	},
 	{
 		categories: [
@@ -293,6 +359,9 @@ const difmThemes: Design[] = [
 		template: 'twentyfifteen',
 		theme: 'twentyfifteen',
 		title: 'Twenty Fifteen',
+		recipe: {
+			theme: 'pub/twentyfifteen',
+		},
 	},
 	{
 		categories: [
@@ -307,6 +376,9 @@ const difmThemes: Design[] = [
 		template: 'hemingway-rewritten',
 		theme: 'hemingway-rewritten',
 		title: 'Hemingway Rewritten',
+		recipe: {
+			theme: 'pub/hemingway-rewritten',
+		},
 	},
 ];
 

--- a/config/development.json
+++ b/config/development.json
@@ -134,6 +134,7 @@
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
+		"signup/design-picker-generated-designs": true,
 		"signup/hero-flow-non-en": true,
 		"signup/redesigned-difm-flow": true,
 		"signup/site-vertical-step": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -85,6 +85,7 @@
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
+		"signup/design-picker-generated-designs": false,
 		"signup/hero-flow-non-en": true,
 		"signup/redesigned-difm-flow": false,
 		"signup/starting-point-courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -92,6 +92,7 @@
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
+		"signup/design-picker-generated-designs": false,
 		"signup/hero-flow-non-en": true,
 		"signup/redesigned-difm-flow": false,
 		"signup/starting-point-courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -92,6 +92,7 @@
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
+		"signup/design-picker-generated-designs": false,
 		"signup/hero-flow-non-en": true,
 		"signup/redesigned-difm-flow": false,
 		"signup/starting-point-courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -105,6 +105,7 @@
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
+		"signup/design-picker-generated-designs": true,
 		"signup/hero-flow-non-en": true,
 		"signup/redesigned-difm-flow": false,
 		"signup/starting-point-courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -105,7 +105,7 @@
 		"signup/design-picker-categories": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
-		"signup/design-picker-generated-designs": true,
+		"signup/design-picker-generated-designs": false,
 		"signup/hero-flow-non-en": true,
 		"signup/redesigned-difm-flow": false,
 		"signup/starting-point-courses": true,

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { useMemo } from 'react';
 import {
 	getAvailableDesigns,
-	getDesignUrl,
+	getDesignPreviewUrl,
 	mShotOptions,
 	isBlankCanvasDesign,
 	filterDesignsByCategory,
@@ -31,7 +31,7 @@ interface DesignPreviewImageProps {
 
 const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( { design, locale, highRes } ) => (
 	<MShotsImage
-		url={ getDesignUrl( design, locale ) }
+		url={ getDesignPreviewUrl( design, { language: locale } ) }
 		aria-labelledby={ makeOptionId( design ) }
 		alt=""
 		options={ mShotOptions( design, highRes ) }

--- a/packages/design-picker/src/generated-designs-config.json
+++ b/packages/design-picker/src/generated-designs-config.json
@@ -1,0 +1,43 @@
+[
+	{
+		"slug": "business",
+		"title": "Business",
+		"recipe": {
+			"theme": "pub/winkel",
+			"patternIds": [ 1603, 162, 157 ]
+		},
+		"is_premium": false,
+		"categories": [],
+		"features": [],
+
+		"theme": "",
+		"template": ""
+	},
+	{
+		"slug": "portfolio",
+		"title": "Portfolio",
+		"recipe": {
+			"theme": "pub/quadrat-white",
+			"patternIds": [ 1349 ]
+		},
+		"is_premium": false,
+		"categories": [],
+		"features": [],
+
+		"theme": "",
+		"template": ""
+	},
+	{
+		"slug": "blog",
+		"title": "Blog",
+		"recipe": {
+			"theme": "pub/zoologist"
+		},
+		"is_premium": false,
+		"categories": [],
+		"features": [],
+
+		"theme": "",
+		"template": ""
+	}
+]

--- a/packages/design-picker/src/generated-designs-config.json
+++ b/packages/design-picker/src/generated-designs-config.json
@@ -3,7 +3,7 @@
 		"slug": "business",
 		"title": "Business",
 		"recipe": {
-			"theme": "pub/winkel",
+			"stylesheet": "pub/winkel",
 			"patternIds": [ 1603, 162, 157 ]
 		},
 		"is_premium": false,
@@ -17,7 +17,7 @@
 		"slug": "portfolio",
 		"title": "Portfolio",
 		"recipe": {
-			"theme": "pub/quadrat-white",
+			"stylesheet": "pub/quadrat-white",
 			"patternIds": [ 1349 ]
 		},
 		"is_premium": false,
@@ -31,7 +31,7 @@
 		"slug": "blog",
 		"title": "Blog",
 		"recipe": {
-			"theme": "pub/zoologist"
+			"stylesheet": "pub/zoologist"
 		},
 		"is_premium": false,
 		"categories": [],

--- a/packages/design-picker/src/hooks/use-generated-designs.ts
+++ b/packages/design-picker/src/hooks/use-generated-designs.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import rawGeneratedDesignsConfig from '../generated-designs-config.json';
+import { Category, Design } from '../types';
+
+export function useGeneratedDesigns( category?: Category ): Design[] {
+	// TODO: fetch designs from backend
+	return useMemo( () => {
+		if ( ! category ) {
+			return [];
+		}
+		return ( rawGeneratedDesignsConfig as Design[] ).map( ( design ) => ( {
+			...design,
+			categories: [ ...design.categories, category ],
+		} ) );
+	}, [ category ] );
+}

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -59,17 +59,21 @@ function apiThemeToDesign( { id, name, taxonomies, stylesheet }: any ): Design {
 	);
 
 	return {
-		categories: taxonomies?.theme_subject ?? [],
-		// Design appears prominently in theme galleries.
-		showFirst: isFeaturedPicks,
-		features: [],
-		is_premium: stylesheet && stylesheet.startsWith( 'premium/' ),
-		is_featured_picks: isFeaturedPicks,
-		stylesheet,
 		slug: id,
+		title: name,
+		recipe: {
+			theme: stylesheet,
+		},
+		is_premium: stylesheet && stylesheet.startsWith( 'premium/' ),
+		categories: taxonomies?.theme_subject ?? [],
+		features: [],
+		is_featured_picks: isFeaturedPicks,
+		showFirst: isFeaturedPicks,
+		...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
+
+		// Deprecated; used for /start flow
+		stylesheet,
 		template: id,
 		theme: id,
-		title: name,
-		...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
 	};
 }

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -62,7 +62,7 @@ function apiThemeToDesign( { id, name, taxonomies, stylesheet }: any ): Design {
 		slug: id,
 		title: name,
 		recipe: {
-			theme: stylesheet,
+			stylesheet,
 		},
 		is_premium: stylesheet && stylesheet.startsWith( 'premium/' ),
 		categories: taxonomies?.theme_subject ?? [],

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -7,6 +7,7 @@ export {
 	getAvailableDesigns,
 	getFontTitle,
 	getDesignUrl,
+	getDesignPreviewUrl,
 	isBlankCanvasDesign,
 } from './utils';
 export { FONT_PAIRINGS, ANCHORFM_FONT_PAIRINGS } from './constants';

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -13,4 +13,5 @@ export {
 export { FONT_PAIRINGS, ANCHORFM_FONT_PAIRINGS } from './constants';
 export type { FontPair, Design, Category } from './types';
 export { useCategorization } from './hooks/use-categorization';
+export { useGeneratedDesigns } from './hooks/use-generated-designs';
 export { useThemeDesignsQuery } from './hooks/use-theme-designs-query';

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -3,6 +3,7 @@ import type { ValuesType } from 'utility-types';
 
 export type Font = ValuesType< ValuesType< typeof FONT_PAIRINGS > >;
 
+/** @deprecated used for Gutenboarding (/new flow) */
 export interface FontPair {
 	headings: Font;
 	base: Font;
@@ -13,34 +14,38 @@ export interface Category {
 	name: string;
 }
 
+export interface DesignRecipe {
+	theme?: string;
+	patternIds?: number[];
+}
+
 export type DesignFeatures = 'anchorfm' | 'difm-lite-default'; // For additional features, = 'anchorfm' | 'feature2' | 'feature3'
 
 export interface Design {
-	categories: Array< Category >;
-	fonts?: FontPair;
-	is_alpha?: boolean;
-	is_fse?: boolean;
-	is_premium: boolean;
-	stylesheet?: string;
 	slug: string;
-	template: string;
-	theme: string;
-	preview?: 'static';
 	title: string;
-	features: Array< DesignFeatures >;
+	recipe?: DesignRecipe;
+	is_premium: boolean;
+	categories: Category[];
+	features: DesignFeatures[];
+	is_featured_picks?: boolean; // Whether this design will be featured in the sidebar. Example: Blank Canvas
+	showFirst?: boolean; // Whether this design will appear at the top, regardless of category
+	preview?: 'static';
 
-	// This design will appear at the top, regardless of category
-	showFirst?: boolean;
-
-	/**
-	 * Quickly hide a design from the picker without having to remove
-	 * it from the list of available design configs (stored in the
-	 * `@automattic/design-picker` package)
-	 */
+	/** @deprecated used for Gutenboarding (/new flow) */
+	stylesheet?: string;
+	/** @deprecated used for Gutenboarding (/new flow) */
+	template: string;
+	/** @deprecated used for Gutenboarding (/new flow) */
+	theme: string;
+	/** @deprecated used for Gutenboarding (/new flow) */
+	fonts?: FontPair;
+	/** @deprecated used for Gutenboarding (/new flow) */
+	is_alpha?: boolean;
+	/** @deprecated used for Gutenboarding (/new flow) */
+	is_fse?: boolean;
+	/** @deprecated used for Gutenboarding (/new flow) */
 	hide?: boolean;
-
-	// designs with a "featured" term in the theme_picks taxonomy
-	is_featured_picks?: boolean;
 }
 
 export interface DesignUrlOptions {

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -15,7 +15,7 @@ export interface Category {
 }
 
 export interface DesignRecipe {
-	theme?: string;
+	stylesheet?: string;
 	patternIds?: number[];
 }
 

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -48,6 +48,12 @@ export interface Design {
 	hide?: boolean;
 }
 
+export interface DesignPreviewOptions {
+	language?: string;
+	siteTitle?: string;
+}
+
+/** @deprecated used for Gutenboarding (/new flow) */
 export interface DesignUrlOptions {
 	iframe?: boolean;
 	site_title?: string;

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -6,14 +6,14 @@ describe( 'Design Picker designs utils', () => {
 		const design = {
 			title: 'Zoologist',
 			recipe: {
-				theme: 'pub/zoologist',
+				stylesheet: 'pub/zoologist',
 				patternIds: [ 12, 34 ],
 			},
 		} as Design;
 
 		it( 'should return the block-previews/site endpoint with the correct query params', () => {
 			expect( getDesignPreviewUrl( design, {} ) ).toEqual(
-				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?theme=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=700&site_title=Zoologist'
+				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=700&site_title=Zoologist'
 			);
 		} );
 
@@ -24,7 +24,7 @@ describe( 'Design Picker designs utils', () => {
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?theme=pub%2Fzoologist&pattern_ids=12%2C34&language=id&viewport_height=700&site_title=Design%20Title'
+				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&language=id&viewport_height=700&site_title=Design%20Title'
 			);
 		} );
 
@@ -36,7 +36,7 @@ describe( 'Design Picker designs utils', () => {
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?theme=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=700&site_title=Mock%28Design%29%28Title%29'
+				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=700&site_title=Mock%28Design%29%28Title%29'
 			);
 		} );
 	} );

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -1,0 +1,43 @@
+import { Design, DesignPreviewOptions } from '../../types';
+import { getDesignPreviewUrl } from '../designs';
+
+describe( 'Design Picker designs utils', () => {
+	describe( 'getDesignPreviewUrl', () => {
+		const design = {
+			title: 'Zoologist',
+			recipe: {
+				theme: 'pub/zoologist',
+				patternIds: [ 12, 34 ],
+			},
+		} as Design;
+
+		it( 'should return the block-previews/site endpoint with the correct query params', () => {
+			expect( getDesignPreviewUrl( design, {} ) ).toEqual(
+				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?theme=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=700&site_title=Zoologist'
+			);
+		} );
+
+		it( 'should append the preview options to the query params', () => {
+			const options: DesignPreviewOptions = {
+				language: 'id',
+				siteTitle: 'Design Title',
+			};
+
+			expect( getDesignPreviewUrl( design, options ) ).toEqual(
+				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?theme=pub%2Fzoologist&pattern_ids=12%2C34&language=id&viewport_height=700&site_title=Design%20Title'
+			);
+		} );
+
+		// Parentheses in uri components don't usually need to be escaped, but because the design url sometimes appears
+		// in a `background-url: url( ... )` CSS rule the parentheses will break it.
+		it( 'should escape parentheses within the site title', () => {
+			const options: DesignPreviewOptions = {
+				siteTitle: 'Mock(Design)(Title)',
+			};
+
+			expect( getDesignPreviewUrl( design, options ) ).toEqual(
+				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?theme=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=700&site_title=Mock%28Design%29%28Title%29'
+			);
+		} );
+	} );
+} );

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -6,6 +6,7 @@ import type { Design, DesignUrlOptions } from '../types';
 import type { AvailableDesigns } from './available-designs-config';
 import type { MShotsOptions } from '@automattic/onboarding';
 
+/** @deprecated used for Gutenboarding (/new flow) */
 export const getDesignUrl = (
 	design: Design,
 	locale: string,

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -8,7 +8,7 @@ export const getDesignPreviewUrl = (
 	const { recipe } = design;
 
 	let url = addQueryArgs( 'https://public-api.wordpress.com/wpcom/v2/block-previews/site', {
-		theme: recipe?.theme,
+		stylesheet: recipe?.stylesheet,
 		pattern_ids: recipe?.patternIds?.join( ',' ),
 		language: options.language,
 		viewport_height: 700,

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -1,0 +1,28 @@
+import { addQueryArgs } from '@wordpress/url';
+import type { Design, DesignPreviewOptions } from '../types';
+
+export const getDesignPreviewUrl = (
+	design: Design,
+	options: DesignPreviewOptions = {}
+): string => {
+	const { recipe } = design;
+
+	let url = addQueryArgs( 'https://public-api.wordpress.com/wpcom/v2/block-previews/site', {
+		theme: recipe?.theme,
+		pattern_ids: recipe?.patternIds?.join( ',' ),
+		language: options.language,
+		viewport_height: 700,
+	} );
+
+	const siteTitle = options.siteTitle || design.title;
+	if ( siteTitle ) {
+		// The preview url is sometimes used in a `background-image: url()` CSS rule and unescaped
+		// parentheses in the URL break it. `addQueryArgs` and `encodeURIComponent` don't escape
+		// parentheses so we've got to do it ourselves.
+		url +=
+			'&site_title=' +
+			encodeURIComponent( siteTitle ).replace( /\(/g, '%28' ).replace( /\)/g, '%29' );
+	}
+
+	return url;
+};

--- a/packages/design-picker/src/utils/index.ts
+++ b/packages/design-picker/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './available-designs-config';
 export * from './available-designs';
+export * from './designs';
 export * from './fonts';
 import { SHOW_ALL_SLUG } from '../constants';
 import type { Category, Design } from '../types';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the verticalization project, we want to start showing generated designs in the Design Picker. For the MVP, in this PR, we will show the name of selected vertical (selected via #62365) as a new category, which consists of 3 hardcoded designs (currently hardcoded as JSON in `packages/design-picker/src/generated-designs-config.json`).

For now, this logic is for the Build intent only.

As part of this PR, I also:

- Extract `theme` in the `Design` type into `DesignRecipe` (which also contains `patternIds`), and deprecate the old fields.
- Use the new `/wpcom/v2/block-previews/site` endpoint to preview a design, instead of the old `/template/demo`.
- Extract logic around categorization in the `design-setup-site` into a separate file so that it can be shared by both `/start` and `/stepper` flows.

#### Testing instructions

1. Apply this PR or use the Calypso Live link.
2. Go to `/stepper/intent?siteSlug=<your site>`.
3. Select Build intent.
4. Verify that there is a new category called `Photographic & Digital Arts` (from the hardcoded vertical):

      <img width="1114" alt="image" src="https://user-images.githubusercontent.com/1525580/161521950-ccc9dca2-f82b-4566-82f3-e28edae7a31e.png">

5. Verify that the generated designs can be previewed.
6. Click another category, and verify that the designs from that category can still work as usual.
7. Click back and select another intent (Write & Store), and verify that the generated category does not appear.
8. Apply this PR and change `signup/design-picker-generated-designs` to `false` in `config/development.json`.
9. Repeat the above process and verify that the generated category does not appear even in the Build flow.
10. Please test also the designs shown in the DIFM flow (`/start/do-it-for-me/`) because the Design Picker is also used in that flow, to verify that we are not breaking anything.

#### Out of scope

1. Actually selecting the design and applying it to the new site.
2. Actually choosing and selecting the vertical.

#### Related to
- #62237 