### PR TITLE
Remove domain check which can hide the Free plan

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -160,7 +160,6 @@ export class PlansStep extends Component {
 					{ errorDisplay }
 					<PlansComparison
 						isInSignup={ true }
-						hideFreePlan={ !! this.getDomainName() }
 						onSelectPlan={ this.onSelectPlan }
 						selectedSiteId={ selectedSite?.ID || undefined }
 					/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This ensures the Free plan is always shown.


#### Testing instructions


##### Free/skipped Domain

* Go to `/start?flags=plans/pro-plan`
* Select a Free domain or click on `Choose my domain later`
* The Plans page should show the Free plan


<img width="320" alt="Screenshot on 2022-03-30 at 17-28-04" src="https://user-images.githubusercontent.com/2749938/160859003-7dc36593-0cf2-4bb3-b18b-994448d1d347.png">


##### Paid Domain

* Go to `/start?flags=plans/pro-plan`
* Type and select a Paid domain
* The Plans page should continue to show the Free plan




