### PR TITLE
Fallback untranslated title, subtitle and plan CTA copy

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-action.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-action.tsx
@@ -8,7 +8,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import type { WPComPlan } from '@automattic/calypso-products';
 import type { TranslateResult } from 'i18n-calypso';
@@ -35,7 +35,9 @@ function getButtonText( props: Partial< Props >, translate: TranslateFunc ): Tra
 	const planSlug = plan?.getStoreSlug();
 
 	if ( planSlug === PLAN_WPCOM_PRO ) {
-		return translate( 'Start with Pro' );
+		return 'en' === i18n.getLocaleSlug() || i18n.hasTranslation( 'Start with Pro' )
+			? translate( 'Start with Pro' )
+			: translate( 'Try Pro risk-free' );
 	} else if ( planSlug === PLAN_FREE || planSlug === PLAN_WPCOM_FLEXIBLE ) {
 		return translate( 'Start with Free' );
 	}

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -8,7 +8,7 @@ import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
 import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { parse as parseQs } from 'qs';
 import { Component } from 'react';
@@ -276,10 +276,12 @@ export class PlansStep extends Component {
 	}
 
 	getHeaderText() {
-		const { headerText, translate, eligibleForProPlan } = this.props;
+		const { headerText, translate, eligibleForProPlan, locale } = this.props;
 
 		if ( eligibleForProPlan ) {
-			return translate( 'Choose your hosting plan' );
+			return 'en' === locale || i18n.hasTranslation( 'Choose your hosting plan' )
+				? translate( 'Choose your hosting plan' )
+				: translate( 'Choose the plan that’s right for you' );
 		}
 
 		if ( this.state.isDesktop ) {
@@ -290,10 +292,13 @@ export class PlansStep extends Component {
 	}
 
 	getSubHeaderText() {
-		const { hideFreePlan, subHeaderText, translate, eligibleForProPlan } = this.props;
+		const { hideFreePlan, subHeaderText, translate, eligibleForProPlan, locale } = this.props;
 
 		if ( eligibleForProPlan ) {
-			return translate( 'The WordPress Pro plan comes with a 14-day money back guarantee' );
+			return 'en' === locale ||
+				i18n.hasTranslation( 'he WordPress Pro plan comes with a 14-day money back guarantee' )
+				? translate( 'The WordPress Pro plan comes with a 14-day money back guarantee' )
+				: translate( 'The WordPress Pro plan comes with a 14-day full money back guarantee' );
 		}
 
 		if ( ! hideFreePlan ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This ensures that the copy changes from #62331 fall back to the previous version until they're translated.

#### Testing instructions

* On an english locale account
* Go to `/start/plans?flags=plans/pro-plan` and to `plans/my-plan/[free_site]?flags=plans/pro-plan`
* The title, subtitle and Pro plan CTA copy should match the summary from #62331:

<img width="320" alt="Markup 2022-03-29 at 12 53 58" src="https://user-images.githubusercontent.com/2749938/160585914-adaffca5-b0fe-4c6f-aa0f-f53518978484.png">


* Change the account to a non-english locale
* Go to `/start/plans?flags=plans/pro-plan` and to `plans/my-plan/[free_site]?flags=plans/pro-plan`
* The title, subtitle and Pro plan CTA copy should be translated from the previous copy:

<img width="320" alt="Screenshot on 2022-03-31 at 12-38-53" src="https://user-images.githubusercontent.com/2749938/161026866-d7309868-2a0b-4ef5-8044-4ee6d2bee279.png">

