### PR TITLE
Fix: Overhauled Plans feature titles, subtitles and tooltips are not translated

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -28,17 +28,17 @@ export interface PlanComparisonFeature {
 	/**
 	 * Row header
 	 */
-	title: TranslateResult;
+	readonly title: TranslateResult;
 
 	/**
 	 * Additional text displayed below the row header
 	 */
-	subtitle?: TranslateResult;
+	readonly subtitle?: TranslateResult;
 
 	/**
 	 * Popup text describing what the feature is.
 	 */
-	description?: TranslateResult;
+	readonly description?: TranslateResult;
 
 	/**
 	 * Features that belong to this row.
@@ -92,10 +92,14 @@ function defaultGetCellText(
 
 export const planComparisonFeatures: PlanComparisonFeature[] = [
 	{
-		title: translate( 'Custom domain name' ),
-		description: translate(
-			'Get a personalized online address that’s easy to remember and easy to share. First year comes for free with your paid annual subscription.'
-		),
+		get title() {
+			return translate( 'Custom domain name' );
+		},
+		get description() {
+			return translate(
+				'Get a personalized online address that’s easy to remember and easy to share. First year comes for free with your paid annual subscription.'
+			);
+		},
 		features: [ FEATURE_CUSTOM_DOMAIN ],
 		getCellText: ( feature, isMobile = false ) => {
 			if ( ! isMobile ) {
@@ -122,10 +126,14 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Premium themes' ),
-		description: translate(
-			'Gain access to advanced, professional & beautiful premium design templates including themes specifically tailored for businesses.'
-		),
+		get title() {
+			return translate( 'Premium themes' );
+		},
+		get description() {
+			return translate(
+				'Gain access to advanced, professional & beautiful premium design templates including themes specifically tailored for businesses.'
+			);
+		},
 		features: [ FEATURE_PREMIUM_THEMES ],
 		getCellText: ( feature, isMobile = false ) => {
 			let cellText = defaultGetCellText( translate( 'Premium themes' ) )( feature, isMobile );
@@ -138,11 +146,17 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'WordPress plugins' ),
-		subtitle: translate( 'Be able to add forms, calendar, and more.' ),
-		description: translate(
-			'Install WordPress plugins and extend functionality for your site with access to more than 50,000 WordPress plugins.'
-		),
+		get title() {
+			return translate( 'WordPress plugins' );
+		},
+		get subtitle() {
+			return translate( 'Be able to add forms, calendar, and more.' );
+		},
+		get description() {
+			return translate(
+				'Install WordPress plugins and extend functionality for your site with access to more than 50,000 WordPress plugins.'
+			);
+		},
 		features: [ FEATURE_INSTALL_PLUGINS ],
 		getCellText: ( feature, isMobile = false ) => {
 			if ( ! isMobile ) {
@@ -169,11 +183,17 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Premium support' ),
-		subtitle: translate( 'Get expert help to build your site.' ),
-		description: translate(
-			'Customer service isn’t just something we offer. It’s who we are. Over 30% of WordPress.com is dedicated to service. We call it Happiness—real support delivered by real human beings who specialize in launching and fine-tuning WordPress sites.'
-		),
+		get title() {
+			return translate( 'Premium support' );
+		},
+		get subtitle() {
+			return translate( 'Get expert help to build your site.' );
+		},
+		get description() {
+			return translate(
+				'Customer service isn’t just something we offer. It’s who we are. Over 30% of WordPress.com is dedicated to service. We call it Happiness—real support delivered by real human beings who specialize in launching and fine-tuning WordPress sites.'
+			);
+		},
 		features: [ FEATURE_PREMIUM_SUPPORT ],
 		getCellText: ( feature, isMobile = false ) => {
 			let cellText = defaultGetCellText( translate( 'Premium support' ) )( feature, isMobile );
@@ -186,10 +206,14 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Sell products with WooCommerce' ),
-		description: translate(
-			'Includes one-click payments, premium store designs and personalized expert support.'
-		),
+		get title() {
+			return translate( 'Sell products with WooCommerce' );
+		},
+		get description() {
+			return translate(
+				'Includes one-click payments, premium store designs and personalized expert support.'
+			);
+		},
 		features: [ FEATURE_WOOCOMMERCE ],
 		getCellText: ( feature, isMobile = false ) => {
 			let cellText = defaultGetCellText( translate( 'WooCommerce' ) )( feature, isMobile );
@@ -202,10 +226,14 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Storage' ),
-		description: translate(
-			'The free plan allows a maximum storage of 500MB, which equals to approximately 100 high quality images. With WordPress Pro you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.'
-		),
+		get title() {
+			return translate( 'Storage' );
+		},
+		get description() {
+			return translate(
+				'The free plan allows a maximum storage of 500MB, which equals to approximately 100 high quality images. With WordPress Pro you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.'
+			);
+		},
 		features: [ FEATURE_500MB_STORAGE, FEATURE_50GB_STORAGE ],
 		getCellText: ( feature, isMobile = false ) => {
 			let storageSize = '0.5';
@@ -227,8 +255,12 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Visits per month' ),
-		description: translate( 'Max visits per month.' ),
+		get title() {
+			return translate( 'Visits per month' );
+		},
+		get description() {
+			return translate( 'Max visits per month.' );
+		},
 		features: [ FEATURE_10K_VISITS, FEATURE_100K_VISITS ],
 		getCellText: ( feature, isMobile = false ) => {
 			let visitCount = 0;
@@ -250,10 +282,14 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Remove ads' ),
-		description: translate(
-			'Free sites include ads. The WordPress Pro plan allows you to remove these to keep your website clean of ads.'
-		),
+		get title() {
+			return translate( 'Remove ads' );
+		},
+		get description() {
+			return translate(
+				'Free sites include ads. The WordPress Pro plan allows you to remove these to keep your website clean of ads.'
+			);
+		},
 		features: [ FEATURE_NO_ADS ],
 		getCellText: ( feature, isMobile = false ) => {
 			let cellText = defaultGetCellText( translate( 'Remove ads' ) )( feature, isMobile );
@@ -266,9 +302,15 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Advanced SEO tools' ),
-		subtitle: translate( 'Get found on search engines.' ),
-		description: translate( 'Get found faster with built-in SEO tools.' ),
+		get title() {
+			return translate( 'Advanced SEO tools' );
+		},
+		get subtitle() {
+			return translate( 'Get found on search engines.' );
+		},
+		get description() {
+			return translate( 'Get found faster with built-in SEO tools.' );
+		},
 		features: [ FEATURE_ADVANCED_SEO ],
 		getCellText: ( feature, isMobile = false ) => {
 			let cellText = defaultGetCellText( translate( 'Advanced SEO tools' ) )( feature, isMobile );
@@ -281,10 +323,14 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Website Administrator' ),
-		description: translate(
-			'Pro WordPress lets you have unlimited users editing your site. This is ideal for having multiple collaborators help you have your website built and maintained.'
-		),
+		get title() {
+			return translate( 'Website Administrator' );
+		},
+		get description() {
+			return translate(
+				'Pro WordPress lets you have unlimited users editing your site. This is ideal for having multiple collaborators help you have your website built and maintained.'
+			);
+		},
 		features: [ FEATURE_UNLIMITED_ADMINS ],
 		getCellText: ( feature, isMobile ) => {
 			const adminCount = 1;
@@ -306,10 +352,14 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Upload videos' ),
-		description: translate(
-			'Upload videos to your website and display them using a fast player on the WordPress Pro plan.'
-		),
+		get title() {
+			return translate( 'Upload videos' );
+		},
+		get description() {
+			return translate(
+				'Upload videos to your website and display them using a fast player on the WordPress Pro plan.'
+			);
+		},
 		features: [ FEATURE_VIDEO_UPLOADS ],
 		getCellText: ( feature, isMobile = false ) => {
 			let cellText = defaultGetCellText( translate( 'Upload videos' ) )( feature, isMobile );
@@ -322,11 +372,17 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Collect payments' ),
-		subtitle: translate( 'Accept donations, subscriptions and more.' ),
-		description: translate(
-			'One simple, flexible way to collect any type of payment. Accept payments for just about anything from goods and services to memberships and donations.'
-		),
+		get title() {
+			return translate( 'Collect payments' );
+		},
+		get subtitle() {
+			return translate( 'Accept donations, subscriptions and more.' );
+		},
+		get description() {
+			return translate(
+				'One simple, flexible way to collect any type of payment. Accept payments for just about anything from goods and services to memberships and donations.'
+			);
+		},
 		features: [ FEATURE_PAYMENT_BLOCKS ],
 		getCellText: ( feature, isMobile = false ) => {
 			let cellText = defaultGetCellText( translate( 'Collect payments' ) )( feature, isMobile );
@@ -339,8 +395,12 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Built in social media tools' ),
-		description: translate( 'Amplify your voice with our built-in social tools.' ),
+		get title() {
+			return translate( 'Built in social media tools' );
+		},
+		get description() {
+			return translate( 'Amplify your voice with our built-in social tools.' );
+		},
 		features: [ FEATURE_SOCIAL_MEDIA_TOOLS ],
 		getCellText: ( feature, isMobile = false ) => {
 			let cellText = defaultGetCellText( translate( 'Built in social media tools' ) )(
@@ -356,11 +416,17 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Professional Email' ),
-		subtitle: translate( 'Custom email address with your own domain.' ),
-		description: translate(
-			'Custom email address with mailbox, calendar, templates and more. Register free for 3 months with your custom domain. After 3 months, you have the option to renew or cancel your email subscription.'
-		),
+		get title() {
+			return translate( 'Professional Email' );
+		},
+		get subtitle() {
+			return translate( 'Custom email address with your own domain.' );
+		},
+		get description() {
+			return translate(
+				'Custom email address with mailbox, calendar, templates and more. Register free for 3 months with your custom domain. After 3 months, you have the option to renew or cancel your email subscription.'
+			);
+		},
 		features: [ FEATURE_TITAN_EMAIL ],
 		getCellText: ( feature, isMobile = false ) => {
 			if ( ! isMobile ) {
@@ -387,11 +453,17 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Earn money from ads' ),
-		subtitle: translate( 'Monetize your website with ads.' ),
-		description: translate(
-			'WordAds connects your site with some of the biggest ad publishers, including Google AdSense, Facebook Audience Network, Amazon A9, and others!'
-		),
+		get title() {
+			return translate( 'Earn money from ads' );
+		},
+		get subtitle() {
+			return translate( 'Monetize your website with ads.' );
+		},
+		get description() {
+			return translate(
+				'WordAds connects your site with some of the biggest ad publishers, including Google AdSense, Facebook Audience Network, Amazon A9, and others!'
+			);
+		},
 		features: [ FEATURE_MONETISE ],
 		getCellText: ( feature, isMobile = false ) => {
 			let cellText = defaultGetCellText( translate( 'Earn money from ads' ) )( feature, isMobile );
@@ -404,10 +476,14 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'SFTP, Database access' ),
-		description: translate(
-			'Upload and remove files to your website using secure FTP data transfer with your WordPress Pro plan.'
-		),
+		get title() {
+			return translate( 'SFTP, Database access' );
+		},
+		get description() {
+			return translate(
+				'Upload and remove files to your website using secure FTP data transfer with your WordPress Pro plan.'
+			);
+		},
 		features: [ FEATURE_SFTP_DATABASE ],
 		getCellText: ( feature, isMobile = false ) => {
 			let cellText = defaultGetCellText( translate( 'SFTP, Database access' ) )(
@@ -423,10 +499,14 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Automated website backups' ),
-		description: translate(
-			'Daily backups give you granular control over your site, with the ability to restore it to any previous state in a snap, and export it at any time.'
-		),
+		get title() {
+			return translate( 'Automated website backups' );
+		},
+		get description() {
+			return translate(
+				'Daily backups give you granular control over your site, with the ability to restore it to any previous state in a snap, and export it at any time.'
+			);
+		},
 		features: [ FEATURE_SITE_BACKUPS_AND_RESTORE ],
 		getCellText: ( feature, isMobile = false ) => {
 			let cellText = defaultGetCellText( translate( 'Automated website backups' ) )(
@@ -442,10 +522,14 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 	},
 	{
-		title: translate( 'Jetpack essentials' ),
-		description: translate(
-			'Optimize your site for better SEO, faster-loading pages, and protection from spam with essential Jetpack features.'
-		),
+		get title() {
+			return translate( 'Jetpack essentials' );
+		},
+		get description() {
+			return translate(
+				'Optimize your site for better SEO, faster-loading pages, and protection from spam with essential Jetpack features.'
+			);
+		},
 		features: [ FEATURE_JETPACK_ESSENTIAL ],
 		getCellText: ( feature, isMobile = false ) => {
 			let cellText = defaultGetCellText( translate( 'Jetpack essentials' ) )( feature, isMobile );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This addresses the untranslated features on the Plans page by using getters for the title, subtitle, and tooltip properties. 

<img width="240" alt="Markup 2022-03-31 at 13 25 45" src="https://user-images.githubusercontent.com/2749938/161034549-40a003fc-eca0-4251-910d-7a22dee69214.png">


#### Testing instructions
* On a non-english locale account go to `/plans/[site]?flags=plans/pro-plan` on a Free site
* All the features should be translated
<img width="320" alt="Screenshot on 2022-03-31 at 13-17-46" src="https://user-images.githubusercontent.com/2749938/161033982-278b084f-097f-4c4f-bc4f-4474d9127fbc.png">

* Double-check features are also translated on `/start/plans?flags=plans/pro-plan`

