### PR TITLE
Stepper: Fix Design Step theme preview styles

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -310,10 +310,3 @@ a.web-preview__external.button {
 	width: 100%;
 	z-index: z-index( 'root', '.web-preview__inner .spinner-line' );
 }
-
-.web-preview__inner .spinner-line {
-	position: absolute;
-	top: 22px;
-	width: 100%;
-	z-index: z-index( 'root', '.web-preview__inner .spinner-line' );
-}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -195,6 +195,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 	.design-setup__preview {
 		.step-container__header {
 			margin: 12px 0 24px;
+			transform: translateY( -48px );
 
 			.formatted-header {
 				margin-top: 0;
@@ -230,10 +231,21 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 				height: calc( 100vh - 148px );
 			}
 
+			.web-preview__inner {
+				height: 100%;
+				display: flex;
+				flex-direction: column;
+				transform: translateY( -48px );
+			}
+			.web-preview__placeholder {
+				flex: 1;
+			}
+
 			.web-preview__frame-wrapper.is-resizable {
 				margin: 0;
 				padding: 0;
 				background-color: transparent;
+				height: 100%;
 			}
 
 			.web-preview__frame {
@@ -242,6 +254,32 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 				/* stylelint-disable-next-line scales/radii */
 				border-radius: 0 0 6px 6px;
 				box-sizing: border-box;
+				height: 100%;
+				width: 100%;
+			}
+
+			.web-preview__loading-message-wrapper {
+				display: flex;
+				justify-content: center;
+				flex-direction: column;
+				position: absolute;
+				height: 100%;
+				width: 100%;
+				text-align: center;
+			}
+
+			.web-preview__loading-message {
+				color: var( --color-text-subtle );
+				font-size: $font-body;
+			}
+
+			.web-preview__inner .spinner-line {
+				width: 100%;
+				width: calc( 100% - 1px );
+				top: unset;
+				left: unset;
+				transform: unset;
+				margin: 0;
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Recently, in https://github.com/Automattic/wp-calypso/pull/62349, I dropped using `WebPreview` component and used the inner component directly. This makes much more sense since the outer component is completely unused in Stepper and added around 2KB. But by doing that, we lost some styles. This PR adds those styles back.

#### Testing instructions

For easier testing, please take a look at the broken version here:
1. Go to https://wpcalypso.wordpress.com/stepper/designSetup?siteSlug=YOUR_SITE
2. Preview a design.

**Then**

1. Go to http://calypso.localhost:3000/stepper/designSetup?siteSlug=YOUR_SiTE
3. Click preview on a design.
4. Loading state should look good.
5. Preview should look good. 


