### PR TITLE
Stepper: add loading spinner when configuring the site

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -12,6 +12,7 @@ import DesignPicker, {
 import { useLocale, englishLocales } from '@automattic/i18n-utils';
 import { shuffle } from '@automattic/js-utils';
 import { StepContainer } from '@automattic/onboarding';
+import { Spinner } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
@@ -34,6 +35,7 @@ import type { Design, Category } from '@automattic/design-picker';
  */
 const designSetup: Step = function DesignSetup( { navigation } ) {
 	const [ isPreviewingDesign, setIsPreviewingDesign ] = useState( false );
+	const [ loading, setIsLoading ] = useState( false );
 	// CSS breakpoints are set at 600px for mobile
 	const isMobile = ! useViewportMatch( 'small' );
 	const { goBack, submit } = navigation;
@@ -165,6 +167,7 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	}
 
 	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
+		setIsLoading( true );
 		setSelectedDesign( _selectedDesign );
 		if ( siteSlug && _selectedDesign ) {
 			setDesignOnSite( siteSlug, _selectedDesign ).then( () => {
@@ -265,12 +268,16 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 						align={ isMobile ? 'left' : 'center' }
 					/>
 				}
+				shouldHideNavButtons={ loading }
 				customizedActionButtons={
-					shouldUpgrade ? (
-						<Button primary borderless={ false } onClick={ upgradePlan }>
-							{ translate( 'Upgrade Plan' ) }
-						</Button>
-					) : undefined
+					<>
+						{ shouldUpgrade ? (
+							<Button primary borderless={ false } onClick={ upgradePlan }>
+								{ translate( 'Upgrade Plan' ) }
+							</Button>
+						) : undefined }
+						{ loading ? <Spinner /> : '' }
+					</>
 				}
 				recordTracksEvent={ recordTracksEvent }
 			/>

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -153,7 +153,11 @@ const StepContainer: React.FC< Props > = ( {
 
 	return (
 		<div className={ classes }>
-			<ActionButtons className="step-container__navigation">
+			<ActionButtons
+				className={ classNames( 'step-container__navigation', {
+					'should-hide-nav-buttons': shouldHideNavButtons,
+				} ) }
+			>
 				{ ! hideBack && <BackButton /> }
 				{ ! hideSkip && skipButtonAlign === 'top' && <SkipButton /> }
 				{ ! hideNext && <NextButton /> }

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -159,6 +159,10 @@
 			display: none;
 		}
 
+		&.should-hide-nav-buttons {
+			justify-content: flex-end;
+		}
+
 		.step-container__navigation-link {
 			font-size: 0.875rem;
 			font-weight: 500;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a loading spinner next to "Start with..." button to indicate to the user something is going on.

#### Testing instructions

1. Go to http://calypso.localhost:3000/stepper/designSetup?siteSlug=YOUR_SITE
2. Click "Preview X", where X is a design.
3. Click "Start with X". A loading spinner should appear and nav buttons should disappear.

