### PR TITLE
Plans Overhaul: Update Sell screen to mention Pro plan

### DIFF
--- a/client/signup/steps/store-features/intents.tsx
+++ b/client/signup/steps/store-features/intents.tsx
@@ -86,7 +86,7 @@ export function useIntents(
 					<span className="store-features__requirements">
 						{ isBusinessOrEcommercePlan || isProPlan
 							? translate( 'Included in your plan' )
-							: translate( 'Requires {{a}}Pro plan{{/a}}', {
+							: translate( 'Requires a {{a}}Pro plan{{/a}}', {
 									components: {
 										a: (
 											<a

--- a/client/signup/steps/store-features/intents.tsx
+++ b/client/signup/steps/store-features/intents.tsx
@@ -1,3 +1,4 @@
+import { isWpComProPlan } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { SelectItem } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
@@ -19,7 +20,7 @@ export function useIntents(
 	const isBusinessOrEcommercePlan = [ 'business-bundle', 'ecommerce-bundle' ].includes(
 		sitePlanSlug ?? ''
 	);
-	const isProPlan = 'pro-plan' === sitePlanSlug;
+	const isProPlan = sitePlanSlug ? isWpComProPlan( sitePlanSlug ) : false;
 
 	return [
 		{

--- a/client/signup/steps/store-features/intents.tsx
+++ b/client/signup/steps/store-features/intents.tsx
@@ -19,6 +19,7 @@ export function useIntents(
 	const isBusinessOrEcommercePlan = [ 'business-bundle', 'ecommerce-bundle' ].includes(
 		sitePlanSlug ?? ''
 	);
+	const isProPlan = 'pro-plan' === sitePlanSlug;
 
 	return [
 		{
@@ -82,9 +83,9 @@ export function useIntents(
 			description: (
 				<>
 					<span className="store-features__requirements">
-						{ isBusinessOrEcommercePlan
+						{ isBusinessOrEcommercePlan || isProPlan
 							? translate( 'Included in your plan' )
-							: translate( 'Requires a {{a}}Business plan{{/a}}', {
+							: translate( 'Requires {{a}}Pro plan{{/a}}', {
 									components: {
 										a: (
 											<a


### PR DESCRIPTION
### Changes proposed in this Pull Request

Addresses c/HJSowwiZ-tr/84-remove-requires-a-business-plan-from-sell-screen-appearing-after-checkout

Right now, going to the Sell screen with either a free or Pro plan will show `Requires a Business plan`. The changes will show "Pro plan" when on a free plan, and `Included in your plan` when on a Pro plan (or Business).

### Media

#### Before, with Pro plan

<img width="1119" alt="Screenshot 2022-03-31 at 1 59 33 PM" src="https://user-images.githubusercontent.com/1705499/161074205-3d3f3052-91db-466c-b2c4-da7e4e727ffb.png">

#### After, with Pro plan

<img width="1084" alt="Screenshot 2022-03-31 at 5 03 23 PM" src="https://user-images.githubusercontent.com/1705499/161074270-6a84a682-b7da-493e-9312-418b03613e79.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `start/setup-site/store-features?siteSlug=[SITE SLUG]` with a site on Pro or Business plan. Navigate to the Sell screen if not there already. 
2. Ensure it says "Included in your plan" under "More Power".
3. Go to `start/setup-site/store-features?siteSlug=[SITE SLUG]` with a free site. Navigate to the Sell screen if not there already. 
4. Ensure it says "Requires Pro plan" under "More Power".

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
