### PR TITLE
Fix infinite loop in website content step

### DIFF
--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -124,10 +124,7 @@ function WebsiteContentStep( {
 				] )
 			);
 		}
-		/**
-		 * Adding pageTitles results in an infinite loop most probably due the empty array created each time in the selector
-		 */
-	}, [ dispatch, siteCategory /* pageTitles*/, translatedPageTitles ] );
+	}, [ dispatch, siteCategory, pageTitles, translatedPageTitles ] );
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -124,7 +124,10 @@ function WebsiteContentStep( {
 				] )
 			);
 		}
-	}, [ dispatch, siteCategory, pageTitles, translatedPageTitles ] );
+		/**
+		 * Adding pageTitles results in an infinite loop most probably due the empty array created each time in the selector
+		 */
+	}, [ dispatch, siteCategory /* pageTitles*/, translatedPageTitles ] );
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );

--- a/client/state/selectors/get-difm-lite-site-page-titles.ts
+++ b/client/state/selectors/get-difm-lite-site-page-titles.ts
@@ -23,5 +23,5 @@ export default function getDIFMLiteSitePageTitles(
 		return null;
 	}
 
-	return site.options?.difm_lite_site_options?.selected_page_titles ?? [];
+	return site.options?.difm_lite_site_options?.selected_page_titles ?? null;
 }

--- a/config/development.json
+++ b/config/development.json
@@ -136,7 +136,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
-		"signup/redesigned-difm-flow": true,
+		"signup/redesigned-difm-flow": false,
 		"site-indicator": true,
 		"themes/premium": true,
 		"titan/iframe-control-panel": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Showstopper Bug raised by @mikeicode p1648735414277679-slack-C02KVCAL7GX

https://user-images.githubusercontent.com/3422709/161080395-99335f9a-3e05-4bf8-bda2-01a6aee61e9d.mp4

Reason for bug and the remedy

* The hidden feature implementation of generating new pages was causing a show stopper
* The selector which returned a new array element was fed into a useEffect which caused an infinite loop
* The selector was fixed to return null instead of an empty array
* The feature flag was switched off in dev to make sure we catch these kind of bugs earlier.

#### Testing instructions

- Go through the difm flow `/start/do-it-for-me`
- Complete the flow, checkout and complete purchase
- When redirected to the website content page , the page should work properly and typing should not be disabled.
Related to #62370