### PR TITLE
Site Design Picker : Remove button to use blank canvas

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -86,7 +86,9 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	const { designs, featuredPicksDesigns } = useMemo( () => {
 		return {
 			designs: shuffle( allThemes.filter( ( theme ) => ! theme.is_featured_picks ) ),
-			featuredPicksDesigns: allThemes.filter( ( theme ) => theme.is_featured_picks ),
+			featuredPicksDesigns: allThemes.filter(
+				( theme ) => theme.is_featured_picks && ! isBlankCanvasDesign( theme )
+			),
 		};
 	}, [ allThemes ] );
 

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -117,7 +117,9 @@ export default function DesignPickerStep( props ) {
 	const { designs, featuredPicksDesigns } = useMemo( () => {
 		return {
 			designs: shuffle( allThemes.filter( ( theme ) => ! theme.is_featured_picks ) ),
-			featuredPicksDesigns: allThemes.filter( ( theme ) => theme.is_featured_picks ),
+			featuredPicksDesigns: allThemes.filter(
+				( theme ) => theme.is_featured_picks && ! isBlankCanvasDesign( theme )
+			),
 		};
 	}, [ allThemes ] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the button to use a blank theme from the site design picker

#### Testing instructions
* Checkout the branch
* Run yarn start
* Go to http://calypso.localhost:3000/
* Add a new site and step through onboarding 
* Click build to bring up design picker screen
* Check that the `Use a blank theme` button is not present
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Before
![image](https://user-images.githubusercontent.com/47489215/161097968-52e33ee4-41b5-4506-807a-4c107e972cf1.png)

* After
![image](https://user-images.githubusercontent.com/47489215/161098125-9529a9bf-5ccd-4df3-96b9-3228a494aa4d.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62384

See conversation on this old [PR](https://github.com/Automattic/wp-calypso/pull/62398)
PR was closed because of a hard reset on trunk to remove previous changes and wasn't updated properly