### PR TITLE
Marketplace: Popular Search click now correctly updates the Search component keyword

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -328,7 +328,6 @@ const PluginsBrowser = ( {
 			<SearchBoxHeader
 				doSearch={ doSearch }
 				searchTerm={ search }
-				siteSlug={ siteSlug }
 				title={ translate( 'Plugins you need to get your projects done' ) }
 				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
 			/>

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -73,7 +73,7 @@ const SearchBoxHeader = ( props ) => {
 
 	// since the search input is an uncontrolled component we need to tap in into the component api and trigger an update
 	const updateSearchBox = ( keyword ) => {
-		searchBoxRef.current.updateKeyword( keyword );
+		searchBoxRef.current.setKeyword( keyword );
 	};
 
 	return (

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,6 +1,5 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import { useDispatch } from 'react-redux';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
@@ -28,7 +27,7 @@ const SearchBox = ( { isMobile, doSearch, searchTerm } ) => {
 };
 
 const PopularSearches = ( props ) => {
-	const { searchTerms, siteSlug } = props;
+	const { searchTerms, doSearch } = props;
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -39,7 +38,7 @@ const PopularSearches = ( props ) => {
 			} )
 		);
 
-		page( `/plugins/${ siteSlug || '' }?s=${ searchTerm }` );
+		doSearch( searchTerm );
 	};
 
 	return (
@@ -66,8 +65,8 @@ const PopularSearches = ( props ) => {
 	);
 };
 
-const SearchHeader = ( props ) => {
-	const { doSearch, searchTerm, siteSlug, title, searchTerms } = props;
+const SearchBoxHeader = ( props ) => {
+	const { doSearch, searchTerm, title, searchTerms } = props;
 
 	return (
 		<div className="search-box-header">
@@ -75,9 +74,9 @@ const SearchHeader = ( props ) => {
 			<div className="search-box-header__search">
 				<SearchBox doSearch={ doSearch } searchTerm={ searchTerm } />
 			</div>
-			<PopularSearches siteSlug={ siteSlug } searchTerms={ searchTerms } />
+			<PopularSearches doSearch={ doSearch } searchTerms={ searchTerms } />
 		</div>
 	);
 };
 
-export default SearchHeader;
+export default SearchBoxHeader;

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,10 +1,11 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
+import { useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
 
-const SearchBox = ( { isMobile, doSearch, searchTerm } ) => {
+const SearchBox = ( { isMobile, doSearch, searchTerm, searchBoxRef } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -21,6 +22,7 @@ const SearchBox = ( { isMobile, doSearch, searchTerm } ) => {
 				placeholder={ translate( 'Try searching "ecommerce"' ) }
 				delaySearch={ true }
 				recordEvent={ recordSearchEvent }
+				ref={ searchBoxRef }
 			/>
 		</div>
 	);
@@ -67,14 +69,20 @@ const PopularSearches = ( props ) => {
 
 const SearchBoxHeader = ( props ) => {
 	const { doSearch, searchTerm, title, searchTerms } = props;
+	const searchBoxRef = useRef( null );
+
+	// since the search input is an uncontrolled component we need to tap in into the component api and trigger an update
+	const updateSearchBox = ( keyword ) => {
+		searchBoxRef.current.updateKeyword( keyword );
+	};
 
 	return (
 		<div className="search-box-header">
 			<div className="search-box-header__header">{ title }</div>
 			<div className="search-box-header__search">
-				<SearchBox doSearch={ doSearch } searchTerm={ searchTerm } />
+				<SearchBox doSearch={ doSearch } searchTerm={ searchTerm } searchBoxRef={ searchBoxRef } />
 			</div>
-			<PopularSearches doSearch={ doSearch } searchTerms={ searchTerms } />
+			<PopularSearches doSearch={ updateSearchBox } searchTerms={ searchTerms } />
 		</div>
 	);
 };

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -104,6 +104,7 @@ type ImperativeHandle = {
 	focus: () => void;
 	blur: () => void;
 	clear: () => void;
+	updateKeyword?: ( value: string ) => void;
 };
 
 const InnerSearch = (
@@ -140,11 +141,12 @@ const InnerSearch = (
 		maxLength,
 		hideClose = false,
 		isReskinned = false,
+		value,
 	}: Props,
 	forwardedRef: Ref< ImperativeHandle >
 ) => {
 	const { __ } = useI18n();
-	const [ keyword, setKeyword ] = React.useState( defaultValue );
+	const [ keyword, setKeyword ] = React.useState( value || defaultValue );
 	const [ isOpen, setIsOpen ] = React.useState( defaultIsOpen );
 	const [ hasFocus, setHasFocus ] = React.useState( autoFocus );
 
@@ -162,6 +164,9 @@ const InnerSearch = (
 			},
 			blur() {
 				searchInput.current?.blur();
+			},
+			updateKeyword( value: string ) {
+				setKeyword( value );
 			},
 			clear() {
 				setKeyword( '' );

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -141,12 +141,11 @@ const InnerSearch = (
 		maxLength,
 		hideClose = false,
 		isReskinned = false,
-		value,
 	}: Props,
 	forwardedRef: Ref< ImperativeHandle >
 ) => {
 	const { __ } = useI18n();
-	const [ keyword, setKeyword ] = React.useState( value || defaultValue );
+	const [ keyword, setKeyword ] = React.useState( defaultValue );
 	const [ isOpen, setIsOpen ] = React.useState( defaultIsOpen );
 	const [ hasFocus, setHasFocus ] = React.useState( autoFocus );
 

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -104,7 +104,7 @@ type ImperativeHandle = {
 	focus: () => void;
 	blur: () => void;
 	clear: () => void;
-	updateKeyword?: ( value: string ) => void;
+	setKeyword: ( value: string ) => void;
 };
 
 const InnerSearch = (
@@ -164,7 +164,7 @@ const InnerSearch = (
 			blur() {
 				searchInput.current?.blur();
 			},
-			updateKeyword( value: string ) {
+			setKeyword( value: string ) {
 				setKeyword( value );
 			},
 			clear() {


### PR DESCRIPTION
#### Screencast
https://user-images.githubusercontent.com/1035546/161117509-f97427f5-e6c2-408e-9e33-fd9d87aa108a.mp4

#### Changes proposed in this Pull Request

*  Uncontrolled `Search` component now exposes an `updateKeyword` to let outside components update the input value.
*  Popular Searches now updates the input value instead of the url.

#### Testing instructions

* Navigate into `/plugins/:siteId`.
* Click on any search term from popular searches
* It should return the correct results and also update the search bar.

Related to #62265
