### PR TITLE
Color Schemes: update default background color

### DIFF
--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -2,10 +2,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-body.is-section-home.theme-default.color-scheme {
-	--color-surface-backdrop: var( --studio-white );
-}
-
 .customer-home__heading {
 	display: block;
 
@@ -85,7 +81,7 @@ body.is-section-home.theme-default.color-scheme {
 	@include break-medium {
 		display: flex;
 		flex: 0 0 auto;
-	
+
 		.customer-home__site-content {
 			display: none;
 		}
@@ -95,7 +91,7 @@ body.is-section-home.theme-default.color-scheme {
 			display: block;
 		}
 	}
-	
+
 }
 
 .customer-home__heading + .customer-home__layout {

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -21,10 +21,6 @@
 	}
 }
 
-body.edit__body-white.theme-default.color-scheme {
-	--color-surface-backdrop: var( --studio-white );
-}
-
 .domain-details-card {
 	.flag {
 		font-size: $font-body-extra-small;

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/style.scss
@@ -20,10 +20,6 @@
 	}
 }
 
-body.transfer-to-other-user.theme-default.color-scheme {
-	--color-surface-backdrop: var( --studio-white );
-}
-
 body.transfer-to-other-user {
 	.formatted-header {
 		&.is-left-align,

--- a/client/my-sites/email/inbox/mailbox-selection-list/style.scss
+++ b/client/my-sites/email/inbox/mailbox-selection-list/style.scss
@@ -1,10 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-body.is-section-inbox.theme-default.color-scheme {
-	--color-surface-backdrop: var( --studio-white );
-}
-
 body.is-section-inbox .layout.is-section-inbox > .layout__content {
 	padding-top: 120px;
 }

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/style.scss
@@ -1,7 +1,3 @@
-body.is-section-marketplace.theme-default.color-scheme {
-	--color-surface-backdrop: var( --studio-white );
-}
-
 .is-section-marketplace {
 	&.has-no-sidebar {
 		.layout__content {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -12,10 +12,6 @@
 	}
 }
 
-body.is-section-plugins.theme-default.color-scheme {
-	--color-surface-backdrop: var( --studio-white );
-}
-
 .plugin__installed-on,
 .plugin-details__installed-on {
 	margin-bottom: 16px;

--- a/client/my-sites/woocommerce/style.scss
+++ b/client/my-sites/woocommerce/style.scss
@@ -5,10 +5,6 @@
 	padding-bottom: 0; //removes whitespace in the end
 }
 
-body.is-section-woocommerce-installation.theme-default.color-scheme {
-	--color-surface-backdrop: var( --studio-white );
-}
-
 .woocommerce {
 	.main {
 		padding-top: 72px;

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -189,8 +189,8 @@
 
 	--color-surface: var( --studio-white );
 	--color-surface-rgb: var( --studio-white-rgb );
-	--color-surface-backdrop: var( --studio-gray-0 );
-	--color-surface-backdrop-rgb: var( --studio-gray-0-rgb );
+	--color-surface-backdrop: var( --studio-white );
+	--color-surface-backdrop-rgb: var( --studio-white-rgb );
 
 	--color-text: var( --studio-gray-80 );
 	--color-text-rgb: var( --studio-gray-80-rgb );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -188,8 +188,8 @@
 
 	--color-surface: var( --studio-white );
 	--color-surface-rgb: var( --studio-white-rgb );
-	--color-surface-backdrop: var( --studio-gray-0 );
-	--color-surface-backdrop-rgb: var( --studio-gray-0-rgb );
+	--color-surface-backdrop: var( --studio-white );
+	--color-surface-backdrop-rgb: var( --studio-white-rgb );
 
 	--color-text: var( --studio-gray-80 );
 	--color-text-rgb: var( --studio-gray-80-rgb );


### PR DESCRIPTION
At some point, every new design in Calypso started to use a white background, but this creates a disjointed visual feel when switching between screens (e.g. My Home > Stats > Inbox > Upgrades > Posts). 

This PR aims to lessen that effect by updating the default background to `--studio-white` and removing the overrides introduced by the new screens. It doesn't go as far as making any of the other new design changes, but the background was the most visually impactful.

Unfortunately, this doesn't address the visual difference between Calypso and wp-admin screens, but this can be addressed in a future iteration and at least this unifies the Calypso views.

**Before:**

https://user-images.githubusercontent.com/942359/161128011-38aa445a-6452-444c-bff8-e7881159e260.mov

**After:**

https://user-images.githubusercontent.com/942359/161128159-7f78cf68-6498-44a2-91ba-112a2be107e2.mov

#### Testing instructions
- Click around Calypso to verify that the background is white and there are no obvious visual or usability issues
- Change your color scheme in Me > Account Settings to verify that other color schemes work as expected
- Change your color scheme back to "default" (which is technically "classic dark" in the code) and click around Calypso to verify that the background is white and there are no obvious visual or usability issues
