### PR TITLE
Remove call to isRenewable in getRenewalItemFromProduct

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -28,7 +28,6 @@ import {
 	isPlan,
 	isPremium,
 	isPro,
-	isRenewable,
 	isSiteRedirect,
 	isSpaceUpgrade,
 	isTitanMail,
@@ -584,10 +583,6 @@ export function getRenewalItemFromProduct(
 
 	if ( isSpaceUpgrade( product ) ) {
 		cartItem = spaceUpgradeItem( slug );
-	}
-
-	if ( isRenewable( product ) ) {
-		cartItem = renewableProductItem( slug );
 	}
 
 	if ( ! cartItem ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This reverts part of https://github.com/Automattic/wp-calypso/pull/62169 because it breaks domain renewals.

All the conditions in `getRenewalItemFromProduct()` work consecutively because they are all unique: `isSpaceUpgrade`, `isUnlimitedThemes`, etc. The `isRenewable` call is not unique and would apply to any renewable product, so it would overwrite the products created by all the others.

We might want to refactor the function with some sort of early returns so that earlier conditions overwrite later conditions, but that's a separate matter. Another solution might be to change the condition to `if ( ! cartItem && isRenewable( product ) )`.

cc @epeicher and @cpapazoglou 

Props to @ramynasr who spotted this!

#### Testing instructions

Try to renew a domain registration and be sure it works.