### PR TITLE
Plugins: Fix Renew Now action, take 2

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -530,7 +530,7 @@ function createRenewalCartItemFromProduct(
 			domain?: string;
 			users?: GSuiteProductUser[];
 		},
-	properties: { domain?: string; isMarketplaceProduct?: boolean }
+	properties: { domain?: string }
 ) {
 	const slug = camelOrSnakeSlug( product );
 
@@ -582,7 +582,7 @@ function createRenewalCartItemFromProduct(
 		return domainItem( slug, properties.domain ?? '' );
 	}
 
-	if ( properties.isMarketplaceProduct && isRenewable( product ) ) {
+	if ( isRenewable( product ) ) {
 		return renewableProductItem( slug );
 	}
 

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -28,6 +28,7 @@ import {
 	isPlan,
 	isPremium,
 	isPro,
+	isRenewable,
 	isSiteRedirect,
 	isSpaceUpgrade,
 	isTitanMail,
@@ -579,6 +580,10 @@ function createRenewalCartItemFromProduct(
 
 	if ( isSpaceUpgrade( product ) ) {
 		return spaceUpgradeItem( slug );
+	}
+
+	if ( isRenewable( product ) ) {
+		return renewableProductItem( slug );
 	}
 
 	return undefined;

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -519,6 +519,71 @@ export function getDomainMappings( cart: ResponseCart ): ResponseCartProduct[] {
 	return getAllCartItems( cart ).filter( ( product ) => product.product_slug === 'domain_map' );
 }
 
+function createRenewalCartItemFromProduct(
+	product: ( WithCamelCaseSlug | WithSnakeCaseSlug ) & {
+		is_domain_registration?: boolean;
+		isDomainRegistration?: boolean;
+		id: string | number;
+		isRenewable?: boolean;
+	} & Partial< RequestCartProduct > & {
+			domain?: string;
+			users?: GSuiteProductUser[];
+		},
+	properties: { domain?: string }
+) {
+	const slug = camelOrSnakeSlug( product );
+
+	if ( isDomainProduct( product ) ) {
+		return domainItem( slug, properties.domain ?? '' );
+	}
+
+	if ( isPlan( product ) ) {
+		return planItem( slug );
+	}
+
+	if ( isGSuiteOrGoogleWorkspace( product ) ) {
+		return googleApps( product );
+	}
+
+	if ( isTitanMail( product ) ) {
+		return titanMailProduct( product, slug );
+	}
+
+	if ( isSiteRedirect( product ) ) {
+		return siteRedirect( properties );
+	}
+
+	if ( isNoAds( product ) ) {
+		return noAdsItem();
+	}
+
+	if ( isCustomDesign( product ) ) {
+		return customDesignItem();
+	}
+
+	if ( isVideoPress( product ) ) {
+		return videoPressItem();
+	}
+
+	if ( isUnlimitedSpace( product ) ) {
+		return unlimitedSpaceItem();
+	}
+
+	if ( isUnlimitedThemes( product ) ) {
+		return unlimitedThemesItem();
+	}
+
+	if ( isJetpackProduct( product ) ) {
+		return jetpackProductItem( slug );
+	}
+
+	if ( isSpaceUpgrade( product ) ) {
+		return spaceUpgradeItem( slug );
+	}
+
+	return undefined;
+}
+
 /**
  * Returns a renewal CartItem object with the given properties and product slug.
  */
@@ -534,61 +599,10 @@ export function getRenewalItemFromProduct(
 		},
 	properties: { domain?: string }
 ): MinimalRequestCartProduct {
-	const slug = camelOrSnakeSlug( product );
-	let cartItem;
-
-	if ( isDomainProduct( product ) ) {
-		cartItem = domainItem( slug, properties.domain ?? '' );
-	}
-
-	if ( isPlan( product ) ) {
-		cartItem = planItem( slug );
-	}
-
-	if ( isGSuiteOrGoogleWorkspace( product ) ) {
-		cartItem = googleApps( product );
-	}
-
-	if ( isTitanMail( product ) ) {
-		cartItem = titanMailProduct( product, slug );
-	}
-
-	if ( isSiteRedirect( product ) ) {
-		cartItem = siteRedirect( properties );
-	}
-
-	if ( isNoAds( product ) ) {
-		cartItem = noAdsItem();
-	}
-
-	if ( isCustomDesign( product ) ) {
-		cartItem = customDesignItem();
-	}
-
-	if ( isVideoPress( product ) ) {
-		cartItem = videoPressItem();
-	}
-
-	if ( isUnlimitedSpace( product ) ) {
-		cartItem = unlimitedSpaceItem();
-	}
-
-	if ( isUnlimitedThemes( product ) ) {
-		cartItem = unlimitedThemesItem();
-	}
-
-	if ( isJetpackProduct( product ) ) {
-		cartItem = jetpackProductItem( slug );
-	}
-
-	if ( isSpaceUpgrade( product ) ) {
-		cartItem = spaceUpgradeItem( slug );
-	}
-
+	const cartItem = createRenewalCartItemFromProduct( product, properties );
 	if ( ! cartItem ) {
 		throw new Error( 'This product cannot be renewed.' );
 	}
-
 	return getRenewalItemFromCartItem( cartItem, product );
 }
 

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -534,52 +534,52 @@ function createRenewalCartItemFromProduct(
 ) {
 	const slug = camelOrSnakeSlug( product );
 
-	if ( isDomainProduct( product ) ) {
-		return domainItem( slug, properties.domain ?? '' );
-	}
-
-	if ( isPlan( product ) ) {
-		return planItem( slug );
-	}
-
-	if ( isGSuiteOrGoogleWorkspace( product ) ) {
-		return googleApps( product );
-	}
-
-	if ( isTitanMail( product ) ) {
-		return titanMailProduct( product, slug );
-	}
-
-	if ( isSiteRedirect( product ) ) {
-		return siteRedirect( properties );
-	}
-
-	if ( isNoAds( product ) ) {
-		return noAdsItem();
-	}
-
-	if ( isCustomDesign( product ) ) {
-		return customDesignItem();
-	}
-
-	if ( isVideoPress( product ) ) {
-		return videoPressItem();
-	}
-
-	if ( isUnlimitedSpace( product ) ) {
-		return unlimitedSpaceItem();
-	}
-
-	if ( isUnlimitedThemes( product ) ) {
-		return unlimitedThemesItem();
+	if ( isSpaceUpgrade( product ) ) {
+		return spaceUpgradeItem( slug );
 	}
 
 	if ( isJetpackProduct( product ) ) {
 		return jetpackProductItem( slug );
 	}
 
-	if ( isSpaceUpgrade( product ) ) {
-		return spaceUpgradeItem( slug );
+	if ( isUnlimitedThemes( product ) ) {
+		return unlimitedThemesItem();
+	}
+
+	if ( isUnlimitedSpace( product ) ) {
+		return unlimitedSpaceItem();
+	}
+
+	if ( isVideoPress( product ) ) {
+		return videoPressItem();
+	}
+
+	if ( isCustomDesign( product ) ) {
+		return customDesignItem();
+	}
+
+	if ( isNoAds( product ) ) {
+		return noAdsItem();
+	}
+
+	if ( isSiteRedirect( product ) ) {
+		return siteRedirect( properties );
+	}
+
+	if ( isTitanMail( product ) ) {
+		return titanMailProduct( product, slug );
+	}
+
+	if ( isGSuiteOrGoogleWorkspace( product ) ) {
+		return googleApps( product );
+	}
+
+	if ( isPlan( product ) ) {
+		return planItem( slug );
+	}
+
+	if ( isDomainProduct( product ) ) {
+		return domainItem( slug, properties.domain ?? '' );
 	}
 
 	if ( properties.isMarketplaceProduct && isRenewable( product ) ) {

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -530,7 +530,7 @@ function createRenewalCartItemFromProduct(
 			domain?: string;
 			users?: GSuiteProductUser[];
 		},
-	properties: { domain?: string }
+	properties: { domain?: string; isMarketplaceProduct?: boolean }
 ) {
 	const slug = camelOrSnakeSlug( product );
 
@@ -582,7 +582,7 @@ function createRenewalCartItemFromProduct(
 		return spaceUpgradeItem( slug );
 	}
 
-	if ( isRenewable( product ) ) {
+	if ( properties.isMarketplaceProduct && isRenewable( product ) ) {
 		return renewableProductItem( slug );
 	}
 
@@ -602,7 +602,7 @@ export function getRenewalItemFromProduct(
 			domain?: string;
 			users?: GSuiteProductUser[];
 		},
-	properties: { domain?: string }
+	properties: { domain?: string; isMarketplaceProduct?: boolean }
 ): MinimalRequestCartProduct {
 	const cartItem = createRenewalCartItemFromProduct( product, properties );
 	if ( ! cartItem ) {

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -635,7 +635,10 @@ describe( 'getRenewalItemFromProduct()', () => {
 	describe( 'isDomainProduct', () => {
 		test( 'should return the corresponding renewal item', () => {
 			expect(
-				getRenewalItemFromProduct( buildPurchase( { product_slug: 'domain_map' } ), properties )
+				getRenewalItemFromProduct(
+					buildPurchase( { product_slug: 'domain_map', isRenewable: true } ),
+					properties
+				)
 			).toEqual( {
 				extra: {
 					purchaseId: 123,
@@ -649,7 +652,10 @@ describe( 'getRenewalItemFromProduct()', () => {
 	describe( 'isPlan', () => {
 		test( 'should return the corresponding renewal item', () => {
 			expect(
-				getRenewalItemFromProduct( buildPurchase( { product_slug: PLAN_PERSONAL } ), properties )
+				getRenewalItemFromProduct(
+					buildPurchase( { product_slug: PLAN_PERSONAL, isRenewable: true } ),
+					properties
+				)
 			).toEqual( {
 				extra: {
 					purchaseId: 123,
@@ -663,7 +669,7 @@ describe( 'getRenewalItemFromProduct()', () => {
 		test( 'should return the corresponding renewal item', () => {
 			expect(
 				getRenewalItemFromProduct(
-					buildPurchase( { product_slug: GSUITE_BASIC_SLUG, users: 123 } ),
+					buildPurchase( { product_slug: GSUITE_BASIC_SLUG, users: 123, isRenewable: true } ),
 					properties
 				)
 			).toEqual( {
@@ -681,7 +687,7 @@ describe( 'getRenewalItemFromProduct()', () => {
 		test( 'should return the corresponding renewal item', () => {
 			expect(
 				getRenewalItemFromProduct(
-					buildPurchase( { product_slug: 'offsite_redirect' } ),
+					buildPurchase( { product_slug: 'offsite_redirect', isRenewable: true } ),
 					properties
 				)
 			).toEqual( {
@@ -698,7 +704,7 @@ describe( 'getRenewalItemFromProduct()', () => {
 		test( 'should return the corresponding renewal item', () => {
 			expect(
 				getRenewalItemFromProduct(
-					buildPurchase( { product_slug: 'no-adverts/no-adverts.php' } ),
+					buildPurchase( { product_slug: 'no-adverts/no-adverts.php', isRenewable: true } ),
 					properties
 				)
 			).toEqual( {
@@ -713,7 +719,10 @@ describe( 'getRenewalItemFromProduct()', () => {
 	describe( 'isCustomDesign', () => {
 		test( 'should return the corresponding renewal item', () => {
 			expect(
-				getRenewalItemFromProduct( buildPurchase( { product_slug: 'custom-design' } ), properties )
+				getRenewalItemFromProduct(
+					buildPurchase( { product_slug: 'custom-design', isRenewable: true } ),
+					properties
+				)
 			).toEqual( {
 				extra: {
 					purchaseId: 123,
@@ -726,7 +735,10 @@ describe( 'getRenewalItemFromProduct()', () => {
 	describe( 'isVideoPress', () => {
 		test( 'should return the corresponding renewal item', () => {
 			expect(
-				getRenewalItemFromProduct( buildPurchase( { product_slug: 'videopress' } ), properties )
+				getRenewalItemFromProduct(
+					buildPurchase( { product_slug: 'videopress', isRenewable: true } ),
+					properties
+				)
 			).toEqual( {
 				extra: {
 					purchaseId: 123,
@@ -740,7 +752,7 @@ describe( 'getRenewalItemFromProduct()', () => {
 		test( 'should return the corresponding renewal item', () => {
 			expect(
 				getRenewalItemFromProduct(
-					buildPurchase( { product_slug: 'unlimited_space' } ),
+					buildPurchase( { product_slug: 'unlimited_space', isRenewable: true } ),
 					properties
 				)
 			).toEqual( {
@@ -756,7 +768,7 @@ describe( 'getRenewalItemFromProduct()', () => {
 		test( 'should return the corresponding renewal item', () => {
 			expect(
 				getRenewalItemFromProduct(
-					buildPurchase( { product_slug: 'unlimited_themes' } ),
+					buildPurchase( { product_slug: 'unlimited_themes', isRenewable: true } ),
 					properties
 				)
 			).toEqual( {
@@ -772,7 +784,7 @@ describe( 'getRenewalItemFromProduct()', () => {
 		test( 'should return the corresponding renewal item', () => {
 			expect(
 				getRenewalItemFromProduct(
-					buildPurchase( { product_slug: PRODUCT_JETPACK_BACKUP_DAILY } ),
+					buildPurchase( { product_slug: PRODUCT_JETPACK_BACKUP_DAILY, isRenewable: true } ),
 					properties
 				)
 			).toEqual( {
@@ -788,7 +800,7 @@ describe( 'getRenewalItemFromProduct()', () => {
 		test( 'should return the corresponding renewal item', () => {
 			expect(
 				getRenewalItemFromProduct(
-					buildPurchase( { product_slug: '1gb_space_upgrade' } ),
+					buildPurchase( { product_slug: '1gb_space_upgrade', isRenewable: true } ),
 					properties
 				)
 			).toEqual( {

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -812,6 +812,22 @@ describe( 'getRenewalItemFromProduct()', () => {
 			} );
 		} );
 	} );
+	describe( 'isRenewable', () => {
+		test( 'should return the corresponding renewal item', () => {
+			expect(
+				getRenewalItemFromProduct(
+					buildPurchase( { product_slug: 'woocommerce_subscriptions_monthly', isRenewable: true } ),
+					properties
+				)
+			).toEqual( {
+				extra: {
+					purchaseId: 123,
+					purchaseType: 'renewal',
+				},
+				product_slug: 'woocommerce_subscriptions_monthly',
+			} );
+		} );
+	} );
 
 	describe( 'renewal not supported', () => {
 		test( 'should return the corresponding renewal item', () => {

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -138,6 +138,7 @@ function getSubscriptionEndDate( purchase ) {
 function handleRenewNowClick( purchase, siteSlug, options = {} ) {
 	const renewItem = getRenewalItemFromProduct( purchase, {
 		domain: purchase.meta,
+		isMarketplaceProduct: options.isMarketplaceProduct,
 	} );
 
 	// Track the renew now submit.

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -138,7 +138,6 @@ function getSubscriptionEndDate( purchase ) {
 function handleRenewNowClick( purchase, siteSlug, options = {} ) {
 	const renewItem = getRenewalItemFromProduct( purchase, {
 		domain: purchase.meta,
-		isMarketplaceProduct: options.isMarketplaceProduct,
 	} );
 
 	// Track the renew now submit.

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -180,8 +180,11 @@ class ManagePurchase extends Component {
 	}
 
 	handleRenew = () => {
-		const { purchase, siteSlug, redirectTo } = this.props;
-		const options = redirectTo ? { redirectTo } : undefined;
+		const { purchase, siteSlug, redirectTo, productsList } = this.props;
+
+		const options = { redirectTo };
+		options.isMarketplaceProduct = hasMarketplaceProduct( productsList, purchase.productSlug );
+
 		handleRenewNowClick( purchase, siteSlug, options );
 	};
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -180,10 +180,8 @@ class ManagePurchase extends Component {
 	}
 
 	handleRenew = () => {
-		const { purchase, siteSlug, redirectTo, productsList } = this.props;
-
-		const options = { redirectTo };
-		options.isMarketplaceProduct = hasMarketplaceProduct( productsList, purchase.productSlug );
+		const { purchase, siteSlug, redirectTo } = this.props;
+		const options = redirectTo ? { redirectTo } : undefined;
 
 		handleRenewNowClick( purchase, siteSlug, options );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is modified reimplementation of https://github.com/Automattic/wp-calypso/pull/62169 which had to be reverted in https://github.com/Automattic/wp-calypso/pull/62438.

In addition, this refactors the `getRenewalItemFromProduct()` function so that it uses early returns instead of a reassigned variable to help prevent such issues in the future. (To do this in a DRY way, this creates a private sub-function to create the initial item.) In order to preserve the behavior of the original version of the function, this also reverses the order of the conditions, since an early return is the opposite of a variable being overwritten.

#### Testing instructions

This adds unit tests to prevent the regression that caused the revert, but tests only test what we expect to find.

See bug report for https://github.com/Automattic/wp-calypso/issues/62128 to see if this fixes that bug.

Verify that clicking to renew a domain product still works.