### PR TITLE
Pass the the `eligibleForProPlan` as a `businessPlanToAdd` parameter.

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -390,11 +390,11 @@ function onClickInstallPlugin( {
 			return page(
 				`/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
 					selectedSite?.plan,
-					billingPeriod
+					billingPeriod,
+					eligibleForProPlan
 				) },${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${
 					selectedSite.slug
-				}#step2`,
-				eligibleForProPlan
+				}#step2`
 			);
 		}
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Pass the `eligibleForProPlan` parameter on the right place, it allows customers eligible for pro plans to add a plugin with the plan to the cart.

#### Testing instructions
* Go to a paid plugin details page. Eg: `/plugins/woocommerce-subscriptions/`
* Select a free site
* Click on the CTA `Purchase and activate`
* This will open a modal, click on `Upgrade and continue`
* You should the see the cart with the pro plan and the selected plugin

---

Fixes #62426
