### PR TITLE
Add an error message to the Use a domain I own flow when the user selects a subdomain

### DIFF
--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -132,6 +132,19 @@ export function getOptionInfo( {
 				),
 			};
 			break;
+		case domainAvailability.MAPPABLE:
+			transferContent = {
+				...optionInfo.transferNotSupported,
+				topText: createInterpolateElement(
+					sprintf(
+						/* translators: %s - the domain the user wanted to transfer */
+						__( "<strong>%s</strong> can't be transferred, but you can connect it instead." ),
+						domain
+					),
+					{ strong: createElement( 'strong' ) }
+				),
+			};
+			break;
 		default: {
 			const availabilityNotice = getAvailabilityNotice( domain, availability.status );
 			transferContent = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the user selects the "Use a domain I own" flow and enters a subdomain, there is no explainer text shown for the "Transfer" option.  We should show a message there explaining that the subdomain isn't transferrable.

<img width="1355" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/161144824-7ab22059-5b3f-4b9c-99ae-34a001fac2a0.png">


<img width="1330" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/161144972-34971a9a-9a97-40a4-9f78-53835b1a3354.png">

#### Testing instructions

Start at `/start/domains`
Enter a subdomain for a registered domain that is not currently mapped to a WPCOM site.
Make sure that you get the explainer text in the "Transfer" option.