### PR TITLE
Pro Plan: fix Marketplace eligibility action

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -4,6 +4,8 @@ import {
 	FEATURE_UPLOAD_THEMES,
 	FEATURE_SFTP,
 	FEATURE_INSTALL_PLUGINS,
+	PLAN_BUSINESS,
+	PLAN_WPCOM_PRO,
 } from '@automattic/calypso-products';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
@@ -92,7 +94,7 @@ export const EligibilityWarnings = ( {
 		}
 		if ( siteRequiresUpgrade( listHolds ) ) {
 			recordUpgradeClick( ctaName, feature );
-			const planSlug = eligibleForProPlan ? 'pro' : 'business';
+			const planSlug = eligibleForProPlan ? PLAN_WPCOM_PRO : PLAN_BUSINESS;
 			page.redirect( `/checkout/${ siteSlug }/${ planSlug }` );
 			return;
 		}

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -10,9 +10,10 @@ import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { includes } from 'lodash';
 import page from 'page';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	getEligibility,
@@ -67,6 +68,10 @@ export const EligibilityWarnings = ( {
 	const warnings = eligibilityData.eligibilityWarnings || [];
 	const listHolds = eligibilityData.eligibilityHolds || [];
 
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, siteId || undefined )
+	);
+
 	const showWarnings = warnings.length > 0 && ! hasBlockingHold( listHolds );
 	const classes = classNames(
 		'eligibility-warnings',
@@ -87,7 +92,8 @@ export const EligibilityWarnings = ( {
 		}
 		if ( siteRequiresUpgrade( listHolds ) ) {
 			recordUpgradeClick( ctaName, feature );
-			page.redirect( `/checkout/${ siteSlug }/business` );
+			const planSlug = eligibleForProPlan ? 'pro' : 'business';
+			page.redirect( `/checkout/${ siteSlug }/${ planSlug }` );
 			return;
 		}
 		if ( siteRequiresLaunch( listHolds ) ) {

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -166,7 +166,9 @@ describe( '<EligibilityWarnings>', () => {
 
 		expect( handleProceed ).not.toHaveBeenCalled();
 		expect( page.redirect ).toHaveBeenCalledTimes( 1 );
-		expect( page.redirect ).toHaveBeenCalledWith( '/checkout/example.wordpress.com/business' );
+		expect( page.redirect ).toHaveBeenCalledWith(
+			'/checkout/example.wordpress.com/business-bundle'
+		);
 	} );
 
 	it( `disables the "Continue" button if holds can't be handled automatically`, () => {

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -395,7 +395,7 @@ function onClickInstallPlugin( {
 					eligibleForProPlan
 				) },${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${
 					selectedSite.slug
-				}#step2`
+				}`
 			);
 		}
 

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -385,16 +385,17 @@ function onClickInstallPlugin( {
 		// Plugin install is handled on the backend by activating the subscription.
 		const variationPeriod = getPeriodVariationValue( billingPeriod );
 		const product_slug = plugin?.variations?.[ variationPeriod ]?.product_slug;
+
 		if ( upgradeAndInstall ) {
 			// We also need to add a business plan to the cart.
 			return page(
 				`/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
 					selectedSite?.plan,
-					billingPeriod
+					billingPeriod,
+					eligibleForProPlan
 				) },${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${
 					selectedSite.slug
-				}#step2`,
-				eligibleForProPlan
+				}#step2`
 			);
 		}
 


### PR DESCRIPTION
It looks like a parameter was misplaced in the action for the eligibility warning for Marketplace plugins. This fixes that issue and also addresses the fallback action.

Fixes: #62426

**To test:**
- on a new free site
- visit the /plugins page
- select a Marketplace plugin (at the top)
- click "purchase and activate"
- verify that you're taken to Checkout with a Pro Plan and the correct plugin
- empty your cart and leave checkout
- visit the /plugins page
- click "upload" in the header
- click "upgrade and continue" on the eligibility warning
- verify that you're taken to Checkout with a Pro Plan and the correct plugin