### PR TITLE
Domains: Update pricing and description text in "Use a domain I own" flow

### DIFF
--- a/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
@@ -21,7 +21,7 @@ export function getMappingFreeText( {
 	) {
 		mappingFreeText = __( 'No additional charge with your plan' );
 	} else if ( primaryWithPlansOnly || isSignupStep ) {
-		mappingFreeText = __( 'Included in annual plans' );
+		mappingFreeText = __( 'Included in Pro plan' );
 	}
 
 	return mappingFreeText;

--- a/client/components/domains/use-my-domain/utilities/get-mapping-price-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-mapping-price-text.js
@@ -6,14 +6,7 @@ import {
 	isNextDomainFree,
 } from 'calypso/lib/cart-values/cart-items';
 
-export function getMappingPriceText( {
-	cart,
-	currencyCode,
-	domain,
-	productsList,
-	selectedSite,
-	primaryWithPlansOnly,
-} ) {
+export function getMappingPriceText( { cart, currencyCode, domain, productsList, selectedSite } ) {
 	let mappingProductPrice;
 
 	if (
@@ -25,7 +18,7 @@ export function getMappingPriceText( {
 	}
 
 	const price = productsList?.domain_map?.cost;
-	if ( price && ! primaryWithPlansOnly ) {
+	if ( price ) {
 		mappingProductPrice = formatCurrency( price, currencyCode );
 		/* translators: %s - the cost of the domain mapping formatted in the user's currency */
 		mappingProductPrice = sprintf( __( '%s/year' ), mappingProductPrice );

--- a/client/components/domains/use-my-domain/utilities/get-mapping-price-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-mapping-price-text.js
@@ -6,7 +6,14 @@ import {
 	isNextDomainFree,
 } from 'calypso/lib/cart-values/cart-items';
 
-export function getMappingPriceText( { cart, currencyCode, domain, productsList, selectedSite } ) {
+export function getMappingPriceText( {
+	cart,
+	currencyCode,
+	domain,
+	productsList,
+	selectedSite,
+	primaryWithPlansOnly,
+} ) {
 	let mappingProductPrice;
 
 	if (
@@ -18,7 +25,7 @@ export function getMappingPriceText( { cart, currencyCode, domain, productsList,
 	}
 
 	const price = productsList?.domain_map?.cost;
-	if ( price ) {
+	if ( price && ! primaryWithPlansOnly ) {
 		mappingProductPrice = formatCurrency( price, currencyCode );
 		/* translators: %s - the cost of the domain mapping formatted in the user's currency */
 		mappingProductPrice = sprintf( __( '%s/year' ), mappingProductPrice );

--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -71,6 +71,7 @@ export function getOptionInfo( {
 		domain,
 		productsList,
 		selectedSite,
+		primaryWithPlansOnly,
 	} );
 
 	const transferFreeText = getTransferFreeText( {

--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -5,7 +5,6 @@ import { domainAvailability } from 'calypso/lib/domains/constants';
 import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availability-messages';
 import {
 	getMappingFreeText,
-	getMappingPriceText,
 	getTransferFreeText,
 	getTransferPriceText,
 	getTransferRestrictionMessage,
@@ -65,15 +64,6 @@ export function getOptionInfo( {
 		isSignupStep,
 	} );
 
-	const mappingPriceText = getMappingPriceText( {
-		cart,
-		currencyCode,
-		domain,
-		productsList,
-		selectedSite,
-		primaryWithPlansOnly,
-	} );
-
 	const transferFreeText = getTransferFreeText( {
 		cart,
 		domain,
@@ -103,7 +93,6 @@ export function getOptionInfo( {
 	};
 
 	const mappingPricing = {
-		cost: mappingPriceText,
 		text: mappingFreeText,
 	};
 

--- a/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
@@ -9,7 +9,7 @@ export function getTransferFreeText( { cart, domain, isSignupStep, siteIsOnPaidP
 	if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, domain ) ) {
 		domainProductFreeText = __( 'Free transfer with your plan' );
 	} else if ( siteHasNoPaidPlan ) {
-		domainProductFreeText = __( 'Included in annual plans' );
+		domainProductFreeText = __( 'Included in Pro plan' );
 	}
 
 	return domainProductFreeText;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When users select the "Use a domain I own" flow and input a domain they want to use, they are presented with some inaccurate information regarding the plans which include each upgrade:

![Markup on 2022-03-31 at 18:17:50](https://user-images.githubusercontent.com/5324818/161152733-870fcef9-98b8-4bd8-8734-54c411397261.png)

Notice the text says "Included with annual plans", which should be replaced with the new Pro plan. Also, the standalone pricing for the domain connection is shown but it shouldn't, as it can only be added if the user has a plan.

This is how this page looks with this PR:

![Markup on 2022-03-31 at 18:15:55](https://user-images.githubusercontent.com/5324818/161153033-d6c64f8c-a79c-4a8e-9487-32dd78859094.png)

#### Testing instructions

- Build this branch locally or open the live Calypso link
- Access `/start/domains`
- Select the "Use a domain I own" flow
- Input a domain
- Ensure the transfer or connection page looks like the screenshot above
