### PR TITLE
Redirect: redirect to permalink instead of editor for logged out users

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -305,6 +305,12 @@ export function redirectToPermalinkIfLoggedOut( context, next ) {
 	}
 	const siteFragment = context.params.site || getSiteFragment( context.path );
 	const CONFIGURABLE_TYPES = [ 'jetpack-portfolio', 'jetpack-testimonial' ];
+
+	// The context.path in this case could be one of the following:
+	// - /page/{site}/{id}
+	// - /post/{site}/{id}
+	// - /edit/jetpack-portfolio/{site}/{id}
+	// - /edit/jetpack-testimonial/{site}/{id}
 	const explodedPath = context.path.split( '/' );
 	if (
 		context.path &&

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -1,9 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { makeLayout, render } from 'calypso/controller';
-import { addQueryArgs } from 'calypso/lib/route';
+import { addQueryArgs, getSiteFragment } from 'calypso/lib/route';
 import { EDITOR_START, POST_EDIT } from 'calypso/state/action-types';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { getAdminMenu, getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { stopEditingPost } from 'calypso/state/editor/actions';
 import { requestSelectedEditor } from 'calypso/state/selected-editor/actions';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
@@ -291,3 +292,14 @@ export const redirectSiteEditor = async ( context ) => {
 	// Calling replace to avoid adding an entry to the browser history upon redirect.
 	return location.replace( siteEditorUrl );
 };
+
+export function redirectToPermalinkIfLoggedOut( context, next ) {
+	if ( isUserLoggedIn( context.store.getState() ) ) {
+		return next();
+	}
+	const siteFragment = context.params.site || getSiteFragment( context.path );
+	// Redirect the user to the permalink of the post,page, custom post type if the post is published.
+	// else the endpoint will send the user to the login page.
+	window.location = `https://public-api.wordpress.com/wpcom/v2/redirect?path=${ context.path }&site=${ siteFragment }`;
+	return;
+}

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -292,14 +292,29 @@ export const redirectSiteEditor = async ( context ) => {
 	// Calling replace to avoid adding an entry to the browser history upon redirect.
 	return location.replace( siteEditorUrl );
 };
-
+/**
+ * Redirect the logged user to the permalink of the post, page, custom post type if the post is published.
+ *
+ * @param {Object} context Shared context in the route.
+ * @param {Function} next  Next registered callback for the route.
+ * @returns {*}            Whatever the next callback returns.
+ */
 export function redirectToPermalinkIfLoggedOut( context, next ) {
 	if ( isUserLoggedIn( context.store.getState() ) ) {
 		return next();
 	}
 	const siteFragment = context.params.site || getSiteFragment( context.path );
-	// Redirect the user to the permalink of the post,page, custom post type if the post is published.
-	// else the endpoint will send the user to the login page.
-	window.location = `https://public-api.wordpress.com/wpcom/v2/redirect?path=${ context.path }&site=${ siteFragment }`;
+	const CONFIGURABLE_TYPES = [ 'jetpack-portfolio', 'jetpack-testimonial' ];
+	const explodedPath = context.path.split( '/' );
+	if (
+		context.path &&
+		explodedPath[ 1 ] === 'edit' &&
+		! CONFIGURABLE_TYPES.includes( explodedPath[ 2 ] )
+	) {
+		return next();
+	}
+	// Redirect the logged user to the permalink of the post, page, custom post type if the post is published.
+	// else the endpoint will redirect the user to the login page.
+	window.location = `https://public-api.wordpress.com/wpcom/v2/sites/${ siteFragment }/redirect?path=${ context.path }`;
 	return;
 }

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -321,6 +321,6 @@ export function redirectToPermalinkIfLoggedOut( context, next ) {
 	}
 	// Redirect the logged user to the permalink of the post, page, custom post type if the post is published.
 	// else the endpoint will redirect the user to the login page.
-	window.location = `https://public-api.wordpress.com/wpcom/v2/sites/${ siteFragment }/redirect?path=${ context.path }`;
+	window.location = `https://public-api.wordpress.com/wpcom/v2/sites/${ siteFragment }/editor/redirect?path=${ context.path }`;
 	return;
 }

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -297,7 +297,7 @@ export const redirectSiteEditor = async ( context ) => {
  *
  * @param {Object} context Shared context in the route.
  * @param {Function} next  Next registered callback for the route.
- * @returns {*}            Whatever the next callback returns.
+ * @returns undefined      Whatever the next callback returns.
  */
 export function redirectToPermalinkIfLoggedOut( context, next ) {
 	if ( isUserLoggedIn( context.store.getState() ) ) {

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -1,9 +1,6 @@
 import page from 'page';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/controller';
-import { getSiteFragment } from 'calypso/lib/route';
 import { siteSelection, sites } from 'calypso/my-sites/controller';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { getImmediateLoginLocale } from 'calypso/state/immediate-login/selectors';
 import {
 	authenticate,
 	post,
@@ -11,20 +8,8 @@ import {
 	siteEditor,
 	exitPost,
 	redirectSiteEditor,
+	redirectToPermalinkIfLoggedOut,
 } from './controller';
-
-function redirectToPermalinkIfLoggedOut( context, next ) {
-	if ( isUserLoggedIn( context.store.getState() ) ) {
-		return next();
-	}
-	const state = context.store.getState();
-	const siteFragment = context.params.site || getSiteFragment( context.path );
-	const login_locale = getImmediateLoginLocale( state );
-
-	// force full page reload to avoid SSR hydration issues.
-	window.location = `https://public-api.wordpress.com/wpcom/v2/redirect?path=${ context.path }&site=${ siteFragment }&locale=${ login_locale }&redirect=true`;
-	return;
-}
 
 export default function () {
 	page(

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -5,25 +5,13 @@ import {
 	authenticate,
 	post,
 	redirect,
-	siteEditor,
 	exitPost,
 	redirectSiteEditor,
 	redirectToPermalinkIfLoggedOut,
 } from './controller';
 
 export default function () {
-	page(
-		'/site-editor/:site?',
-		redirectLoggedOut,
-		siteSelection,
-		redirectSiteEditor,
-		redirect,
-		authenticate,
-		siteEditor,
-		makeLayout,
-		clientRender
-	);
-
+	page( '/site-editor/:site?', redirectLoggedOut, siteSelection, redirectSiteEditor );
 	page( '/post', redirectLoggedOut, siteSelection, sites, makeLayout, clientRender );
 	page( '/post/new', '/post' ); // redirect from beep-beep-boop
 	page(

--- a/client/sections.js
+++ b/client/sections.js
@@ -433,6 +433,7 @@ const sections = [
 		module: 'calypso/gutenberg/editor',
 		group: 'gutenberg',
 		trackLoadPerformance: true,
+		enableLoggedOut: true,
 	},
 	{
 		name: 'import',


### PR DESCRIPTION
Alternative to #61925, 
Fixes https://github.com/Automattic/wp-calypso/issues/53017

This PR redirects users of the post editor to a new endpoint defined in D76631-code that then decides to either send the user back to the login screen ( if the post is not published ) or to the permalink.

#### Changes proposed in this Pull Request

Based on the feedback from @tyxla on https://github.com/Automattic/wp-calypso/pull/61925. 
This PR does the following:

1. It make the `editor` section be 'enableLoggedOut` so that we can be really specific as to what should happen if a loggout user visits it. 

2. If you are visit any section other then 
`'/edit/:customPostType/:site/:post?', '/post/:site/:post?' or '/page/:site/:post?' we send the user to loggin if they haven
't already. 

For logged-in users, the experience should stay the same.

Related to D76631-code

#### Testing instructions

    Apply D76631-code to your sandbox and sandbox public-api.wordpress.com to point to your sandbox.
    Copy the url of a published ( page, post, portfolio and testimony ) in the editor.
    In an incognito ( logged out view ) visit the editor page that you published.
    It should take you to the permalink of that post, page, portfolio and testimony instead of the log-in form.
    Note that if you are logged in that you should see the editor.

