### PR TITLE
Domains: Skip plan selection step when connecting a domain

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -929,6 +929,14 @@ export function isDomainFulfilled( stepName, defaultDependencies, nextProps ) {
 	}
 }
 
+export function excludePlansStep( submitSignupStep ) {
+	submitSignupStep(
+		{ stepName: 'plans', cartItem: undefined, wasSkipped: true },
+		{ cartItem: undefined }
+	);
+	flows.excludeStep( 'plans' );
+}
+
 export function maybeExcludeEmailsStep( {
 	domainItem,
 	resetSignupStep,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -21,7 +21,7 @@ import {
 import { getDomainProductSlug, TRUENAME_COUPONS, TRUENAME_TLDS } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
-import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
+import { excludePlansStep, maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
@@ -298,6 +298,8 @@ class DomainsStep extends Component {
 
 		this.props.recordAddDomainButtonClickInMapDomain( domain, this.getAnalyticsSection() );
 
+		excludePlansStep( this.props.submitSignupStep );
+
 		this.props.submitSignupStep(
 			Object.assign(
 				{
@@ -331,6 +333,8 @@ class DomainsStep extends Component {
 			: {};
 
 		this.props.recordAddDomainButtonClickInTransferDomain( domain, this.getAnalyticsSection() );
+
+		excludePlansStep( this.props.submitSignupStep );
 
 		this.props.submitSignupStep(
 			Object.assign(

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -334,8 +334,6 @@ class DomainsStep extends Component {
 
 		this.props.recordAddDomainButtonClickInTransferDomain( domain, this.getAnalyticsSection() );
 
-		excludePlansStep( this.props.submitSignupStep );
-
 		this.props.submitSignupStep(
 			Object.assign(
 				{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the "Use a domain I own" flow to skip the plan selection step when a user is connecting a domain. This change was made because otherwise the user would need to select the Pro plan without having any other choice, as we'll only offer that plan for the near future.

#### Testing instructions

- Build this branch locally or open the live Calypso link
- Access `/start`
- Select "Use a domain I own"
- Input a domain
- Select the "Connect domain" option
- Ensure you go straight to the checkout page, skipping plan selection, with the Pro plan and the domain connection in the shopping cart

Also please test:

- Repeat the test again but select the "Transfer a domain" option instead of "Connect domain"
- Ensure you go through the plan selection step

Also please try searching for a domain when you visit the `/start` flow and ensure you also go through the plan selection step