### PR TITLE
Re-enable Olark in signup flow

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -27,6 +27,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
+import OlarkChat from 'calypso/components/olark-chat';
 import {
 	recordSignupStart,
 	recordSignupComplete,
@@ -724,6 +725,10 @@ class Signup extends Component {
 		}
 
 		const isReskinned = isReskinnedFlow( this.props.flowName );
+		const olarkIdentity = config( 'olark_chat_identity' );
+		const olarkSystemsGroupId = '2dfd76a39ce77758f128b93942ae44b5';
+		const isEligibleForOlarkChat =
+			'onboarding' === this.props.flowName && 'en' === this.props.localeSlug;
 
 		return (
 			<>
@@ -753,6 +758,13 @@ class Signup extends Component {
 						/>
 					) }
 				</div>
+				{ isEligibleForOlarkChat && (
+					<OlarkChat
+						identity={ olarkIdentity }
+						shouldDisablePreChatSurvey={ true }
+						systemsGroupId={ olarkSystemsGroupId }
+					/>
+				) }
 			</>
 		);
 	}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -728,7 +728,9 @@ class Signup extends Component {
 		const olarkIdentity = config( 'olark_chat_identity' );
 		const olarkSystemsGroupId = '2dfd76a39ce77758f128b93942ae44b5';
 		const isEligibleForOlarkChat =
-			'onboarding' === this.props.flowName && 'en' === this.props.localeSlug;
+			'onboarding' === this.props.flowName &&
+			[ 'en', 'en-gb' ].includes( this.props.localeSlug ) &&
+			this.props.existingSiteCount < 1;
 
 		return (
 			<>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Olark chat in the signup flow was originally introduced in #61760 and then reverted in #62413 because Olark had a bug that caused signup to break, issue reported in p1648726094257739-slack-C031TFM2NKC.
* Since Olark team have reported in p1648750924723629-slack-C034SHB5WQH that they've fixed the issue, this PR will now re-enable the chat. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Same as in #61760.
* Also verify that you are able to signup on /start, search and select a custom domain, and create a site without issues.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
