### PR TITLE
Update Storage tooltip copy

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -231,7 +231,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 		get description() {
 			return translate(
-				'The free plan allows a maximum storage of 500MB, which equals to approximately 100 high quality images. With WordPress Pro you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.'
+				'The free plan allows a maximum storage of 0.5GB, which equals to approximately 100 high quality images. With WordPress Pro you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.'
 			);
 		},
 		features: [ FEATURE_500MB_STORAGE, FEATURE_50GB_STORAGE ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There's a new update request for two tooltip copies. New strings below:

**Storage**: The free plan allows a maximum storage of 0.5GB, which equals to approximately 100 high quality images. With WordPress Pro you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.

#### Testing instructions

* Go to `/plans` and `/start/plans`
* The Storage tooltip should have the latest copy

<img width="320" alt="Screenshot on 2022-04-01 at 12-16-58" src="https://user-images.githubusercontent.com/2749938/161234236-fb200c8b-1725-4a5c-b124-51ba1bb0fce4.png">



