### PR TITLE
Breadcrumb: Align help bubble to center

### DIFF
--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -20,6 +20,9 @@ const StyledLi = styled.li`
 	font-size: 13px;
 	font-weight: 400;
 	--color-link: var( --studio-gray-50 );
+	& .info-popover {
+		align-self: flex-start;
+	}
 
 	:last-of-type:not( :first-of-type ) {
 		--color-link: var( --studio-gray-80 );
@@ -60,6 +63,8 @@ const StyledGridicon = styled( Gridicon )`
 
 const HelpBuble = styled( InfoPopover )`
 	margin-left: 7px;
+	display: flex;
+	align-items: center;
 	& .gridicon {
 		color: var( --studio-gray-30 );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* It aligns the help bubble in the Breadrumb component to the center of the line

#### Testing instructions

* Go to Plugins
* Make sure the help bubble ❓ is aligned to the middle.
* Navigate to a plugin detail to expand the Breadcrumb
* Make sure the help bubble ❓ is aligned to the middle.

|Before | After|
|-------|------|
|<img width="158" alt="CleanShot 2022-04-01 at 11 59 10@2x" src="https://user-images.githubusercontent.com/3519124/161241717-c61de0da-eb6c-40d6-b9be-2e8fd60ef134.png">|<img width="184" alt="CleanShot 2022-04-01 at 11 57 50@2x" src="https://user-images.githubusercontent.com/3519124/161241773-4274f5d2-9d0c-41b4-90a1-f6fb5f2a51b9.png">|
|<img width="324" alt="CleanShot 2022-04-01 at 11 59 20@2x" src="https://user-images.githubusercontent.com/3519124/161241747-2426f52f-b873-48ec-b860-9bae378829b0.png">|<img width="339" alt="CleanShot 2022-04-01 at 11 58 43@2x" src="https://user-images.githubusercontent.com/3519124/161241793-0699ca9e-4588-485a-9a57-7da9005f40f9.png">|

Fixes #62193 