### PR TITLE
Seller Experience/Stepper: Hook to load WooCommerce countries from the API

### DIFF
--- a/client/landing/stepper/hooks/test/use-countries.jsx
+++ b/client/landing/stepper/hooks/test/use-countries.jsx
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { renderHook } from '@testing-library/react-hooks';
+import nock from 'nock';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { useCountries } from '../use-countries';
+
+describe( 'use-countries hook', () => {
+	test( 'returns list of countries from the api', async () => {
+		const queryClient = new QueryClient();
+		const wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+
+		const expected = {
+			'AL:AL-01': 'Albania — Berat',
+			'AL:AL-09': 'Albania — Dibër',
+			'AL:AL-02': 'Albania — Durrës',
+			'AL:AL-03': 'Albania — Elbasan',
+		};
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/woocommerce/countries/regions/' )
+			.reply( 200, expected );
+
+		const { result, waitFor } = renderHook( () => useCountries(), {
+			wrapper,
+		} );
+
+		await waitFor( () => result.current.isSuccess );
+
+		expect( result.current.data ).toEqual( expected );
+	} );
+} );

--- a/client/landing/stepper/hooks/use-countries.ts
+++ b/client/landing/stepper/hooks/use-countries.ts
@@ -1,0 +1,22 @@
+import { useQuery, UseQueryResult, UseQueryOptions } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+type WooCountries = Record< string, string >;
+
+export function useCountries(
+	queryOptions: UseQueryOptions< any, unknown, WooCountries > = {}
+): UseQueryResult< WooCountries > {
+	return useQuery< any, unknown, WooCountries >(
+		'countries',
+		() => wpcom.req.get( '/woocommerce/countries/regions/', { apiNamespace: 'wpcom/v2' } ),
+		{
+			staleTime: Infinity,
+			refetchOnWindowFocus: false,
+			refetchOnReconnect: false,
+			...queryOptions,
+			meta: {
+				...queryOptions.meta,
+			},
+		}
+	);
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Added a `useCountries` hook which calls the `/woocommerce/countries/regions/` endpoint to get the list of WooCommerce countries. This list can be used to populate a combo box control.

#### Testing instructions

To test, run the following from the main `calypso` directory:

`yarn test-client client/landing/stepper/hooks/test`

Related to #62305
