### PR TITLE
Fix validation of checkoutBackURL for localised jetpack url

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
@@ -1,7 +1,18 @@
+import { getLanguageSlugs } from '@automattic/i18n-utils';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { resemblesUrl } from 'calypso/lib/url';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+
+const getAllowedHosts = ( siteSlug: string ) => {
+	const basicHosts = [ 'jetpack.com', 'jetpack.cloud.localhost', 'cloud.jetpack.com', siteSlug ];
+
+	const languageSpecificJetpackHosts = getLanguageSlugs().map(
+		( lang: string ) => `${ lang }.jetpack.com`
+	);
+
+	return basicHosts.concat( languageSpecificJetpackHosts );
+};
 
 const useValidCheckoutBackUrl = ( siteSlug: string | undefined ): string | undefined => {
 	const { checkoutBackUrl } = useSelector( getInitialQueryArguments ) ?? {};
@@ -11,12 +22,7 @@ const useValidCheckoutBackUrl = ( siteSlug: string | undefined ): string | undef
 			return undefined;
 		}
 
-		const allowedHosts = [
-			'jetpack.com',
-			'jetpack.cloud.localhost',
-			'cloud.jetpack.com',
-			siteSlug,
-		];
+		const allowedHosts = getAllowedHosts( siteSlug );
 
 		let parsedUrl;
 		try {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
During the development of language-specific checkout forwarded from Jetpack.com I noticed that checkout back URL doesn't work with locale specific jetpack sites. Eg fr.jetpack.com when directed to the checkout, if hit close and empty cart you won't be redirected back. 
In order to fix this we are adding all locale-specific URLs to allowed hosts inside the appropriate hook.


#### Testing instructions

- Check out the branch locally.
- `yarn install`
- `yarn start-jetpack-cloud`
- `PORT=443 PROTOCOL=https yarn start`
- Add next line to hosts file (or using gasmask) `127.0.0.1 wordpress.com `and 'flush dns'
- Navigate to a localised jetpack website eg `fr.jetpack.com/features/security/` and proceed to checkout
- Hit the cross button at the top-left corner of the screen. 
- After answering in the popup window you should be redirected back to `fr.jetpack.com/features/security/`

Related to # 1164141197617539-as-1202023929771408