### PR TITLE
[E2E][GB] Disable Coblocks E2E tests on atomic

### DIFF
--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -16,104 +16,109 @@ import {
 	TestAccount,
 	getTestAccountByFeature,
 	envToFeatureKey,
+	skipDescribeIf,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ), () => {
-	const features = envToFeatureKey( envVariables );
-	const accountName = getTestAccountByFeature( features );
+const features = envToFeatureKey( envVariables );
 
-	let page: Page;
-	let testAccount: TestAccount;
-	let editorPage: EditorPage;
-	let pricingTableBlock: PricingTableBlock;
-	let logoImage: TestFile;
+skipDescribeIf( features.siteType === 'atomic' )(
+	DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ),
+	() => {
+		const accountName = getTestAccountByFeature( features );
 
-	// Test data
-	const pricingTableBlockPrices = [ 4.99, 9.99 ];
-	const heroBlockHeading = 'Hero heading';
-	const clicktoTweetBlockTweet = 'Tweet text';
+		let page: Page;
+		let testAccount: TestAccount;
+		let editorPage: EditorPage;
+		let pricingTableBlock: PricingTableBlock;
+		let logoImage: TestFile;
 
-	beforeAll( async () => {
-		page = await browser.newPage();
-		logoImage = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-		testAccount = new TestAccount( accountName );
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		// Test data
+		const pricingTableBlockPrices = [ 4.99, 9.99 ];
+		const heroBlockHeading = 'Hero heading';
+		const clicktoTweetBlockTweet = 'Tweet text';
 
-		await testAccount.authenticate( page );
-	} );
+		beforeAll( async () => {
+			page = await browser.newPage();
+			logoImage = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
+			testAccount = new TestAccount( accountName );
+			editorPage = new EditorPage( page, { target: features.siteType } );
 
-	it( 'Go to the new post page', async () => {
-		await editorPage.visit( 'post' );
-	} );
+			await testAccount.authenticate( page );
+		} );
 
-	it( `Insert ${ PricingTableBlock.blockName } block and enter prices`, async function () {
-		const blockHandle = await editorPage.addBlockFromSidebar(
-			PricingTableBlock.blockName,
-			PricingTableBlock.blockEditorSelector
+		it( 'Go to the new post page', async () => {
+			await editorPage.visit( 'post' );
+		} );
+
+		it( `Insert ${ PricingTableBlock.blockName } block and enter prices`, async function () {
+			const blockHandle = await editorPage.addBlockFromSidebar(
+				PricingTableBlock.blockName,
+				PricingTableBlock.blockEditorSelector
+			);
+			pricingTableBlock = new PricingTableBlock( blockHandle );
+			await pricingTableBlock.enterPrice( 1, pricingTableBlockPrices[ 0 ] );
+			await pricingTableBlock.enterPrice( 2, pricingTableBlockPrices[ 1 ] );
+		} );
+
+		it( `Insert ${ DynamicHRBlock.blockName } block`, async function () {
+			await editorPage.addBlockFromSidebar(
+				DynamicHRBlock.blockName,
+				DynamicHRBlock.blockEditorSelector
+			);
+		} );
+
+		it( `Insert ${ HeroBlock.blockName } block and enter heading`, async function () {
+			const blockHandle = await editorPage.addBlockFromSidebar(
+				HeroBlock.blockName,
+				HeroBlock.blockEditorSelector
+			);
+			const heroBlock = new HeroBlock( blockHandle );
+			await heroBlock.enterHeading( heroBlockHeading );
+		} );
+
+		it( `Insert ${ ClicktoTweetBlock.blockName } block and enter tweet content`, async function () {
+			const blockHandle = await editorPage.addBlockFromSidebar(
+				ClicktoTweetBlock.blockName,
+				ClicktoTweetBlock.blockEditorSelector
+			);
+			const clickToTweetBlock = new ClicktoTweetBlock( blockHandle );
+			await clickToTweetBlock.enterTweetContent( clicktoTweetBlockTweet );
+		} );
+
+		it( `Insert ${ LogosBlock.blockName } block and set image`, async function () {
+			const blockHandle = await editorPage.addBlockFromSidebar(
+				LogosBlock.blockName,
+				LogosBlock.blockEditorSelector
+			);
+			const logosBlock = new LogosBlock( blockHandle );
+			await logosBlock.upload( logoImage.fullpath );
+		} );
+
+		it( 'Publish and visit the post', async function () {
+			await editorPage.publish( { visit: true } );
+		} );
+
+		// Pass in a 1D array of values or text strings to validate each block.
+		it.each`
+			block                  | content
+			${ PricingTableBlock } | ${ pricingTableBlockPrices }
+			${ DynamicHRBlock }    | ${ null }
+			${ HeroBlock }         | ${ [ heroBlockHeading ] }
+			${ ClicktoTweetBlock } | ${ [ clicktoTweetBlockTweet ] }
+		`(
+			`Confirm $block.blockName block is visible in published post`,
+			async ( { block, content } ) => {
+				// Pass the Block object class here then call the static method to validate.
+				await block.validatePublishedContent( page, content );
+			}
 		);
-		pricingTableBlock = new PricingTableBlock( blockHandle );
-		await pricingTableBlock.enterPrice( 1, pricingTableBlockPrices[ 0 ] );
-		await pricingTableBlock.enterPrice( 2, pricingTableBlockPrices[ 1 ] );
-	} );
 
-	it( `Insert ${ DynamicHRBlock.blockName } block`, async function () {
-		await editorPage.addBlockFromSidebar(
-			DynamicHRBlock.blockName,
-			DynamicHRBlock.blockEditorSelector
-		);
-	} );
-
-	it( `Insert ${ HeroBlock.blockName } block and enter heading`, async function () {
-		const blockHandle = await editorPage.addBlockFromSidebar(
-			HeroBlock.blockName,
-			HeroBlock.blockEditorSelector
-		);
-		const heroBlock = new HeroBlock( blockHandle );
-		await heroBlock.enterHeading( heroBlockHeading );
-	} );
-
-	it( `Insert ${ ClicktoTweetBlock.blockName } block and enter tweet content`, async function () {
-		const blockHandle = await editorPage.addBlockFromSidebar(
-			ClicktoTweetBlock.blockName,
-			ClicktoTweetBlock.blockEditorSelector
-		);
-		const clickToTweetBlock = new ClicktoTweetBlock( blockHandle );
-		await clickToTweetBlock.enterTweetContent( clicktoTweetBlockTweet );
-	} );
-
-	it( `Insert ${ LogosBlock.blockName } block and set image`, async function () {
-		const blockHandle = await editorPage.addBlockFromSidebar(
-			LogosBlock.blockName,
-			LogosBlock.blockEditorSelector
-		);
-		const logosBlock = new LogosBlock( blockHandle );
-		await logosBlock.upload( logoImage.fullpath );
-	} );
-
-	it( 'Publish and visit the post', async function () {
-		await editorPage.publish( { visit: true } );
-	} );
-
-	// Pass in a 1D array of values or text strings to validate each block.
-	it.each`
-		block                  | content
-		${ PricingTableBlock } | ${ pricingTableBlockPrices }
-		${ DynamicHRBlock }    | ${ null }
-		${ HeroBlock }         | ${ [ heroBlockHeading ] }
-		${ ClicktoTweetBlock } | ${ [ clicktoTweetBlockTweet ] }
-	`(
-		`Confirm $block.blockName block is visible in published post`,
-		async ( { block, content } ) => {
-			// Pass the Block object class here then call the static method to validate.
-			await block.validatePublishedContent( page, content );
-		}
-	);
-
-	it( `Confirm Logos block is visible in published post`, async () => {
-		await LogosBlock.validatePublishedContent( page, [ logoImage.filename ] );
-	} );
-} );
+		it( `Confirm Logos block is visible in published post`, async () => {
+			await LogosBlock.validatePublishedContent( page, [ logoImage.filename ] );
+		} );
+	}
+);

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -12,73 +12,78 @@ import {
 	TestAccount,
 	getTestAccountByFeature,
 	envToFeatureKey,
+	skipDescribeIf,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), () => {
-	const features = envToFeatureKey( envVariables );
-	const accountName = getTestAccountByFeature( features );
+const features = envToFeatureKey( envVariables );
 
-	let page: Page;
-	let testAccount: TestAccount;
-	let editorPage: EditorPage;
-	let imageFile: TestFile;
-	let coverBlock: CoverBlock;
+skipDescribeIf( features.siteType === 'atomic' )(
+	DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ),
+	() => {
+		const accountName = getTestAccountByFeature( features );
 
-	beforeAll( async () => {
-		page = await browser.newPage();
-		imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-		testAccount = new TestAccount( accountName );
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		let page: Page;
+		let testAccount: TestAccount;
+		let editorPage: EditorPage;
+		let imageFile: TestFile;
+		let coverBlock: CoverBlock;
 
-		await testAccount.authenticate( page );
-	} );
+		beforeAll( async () => {
+			page = await browser.newPage();
+			imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
+			testAccount = new TestAccount( accountName );
+			editorPage = new EditorPage( page, { target: features.siteType } );
 
-	it( 'Go to the new post page', async () => {
-		await editorPage.visit( 'post' );
-	} );
+			await testAccount.authenticate( page );
+		} );
 
-	it( 'Insert Cover block', async () => {
-		const blockHandle = await editorPage.addBlockFromSidebar(
-			CoverBlock.blockName,
-			CoverBlock.blockEditorSelector
-		);
-		coverBlock = new CoverBlock( blockHandle );
-	} );
+		it( 'Go to the new post page', async () => {
+			await editorPage.visit( 'post' );
+		} );
 
-	it( 'Upload image', async () => {
-		await coverBlock.upload( imageFile.fullpath );
-		// After uploading the image the focus is switched to the inner
-		// paragraph block (Cover title), so we need to switch it back outside.
-		const editorFrame = await editorPage.getEditorHandle();
-		await editorFrame.click( '.wp-block-cover', { position: { x: 1, y: 1 } } );
-	} );
+		it( 'Insert Cover block', async () => {
+			const blockHandle = await editorPage.addBlockFromSidebar(
+				CoverBlock.blockName,
+				CoverBlock.blockEditorSelector
+			);
+			coverBlock = new CoverBlock( blockHandle );
+		} );
 
-	it( 'Open settings sidebar', async function () {
-		await editorPage.openSettings();
-	} );
+		it( 'Upload image', async () => {
+			await coverBlock.upload( imageFile.fullpath );
+			// After uploading the image the focus is switched to the inner
+			// paragraph block (Cover title), so we need to switch it back outside.
+			const editorFrame = await editorPage.getEditorHandle();
+			await editorFrame.click( '.wp-block-cover', { position: { x: 1, y: 1 } } );
+		} );
 
-	it.each( CoverBlock.coverStyles )( 'Verify "%s" style is available', async ( style ) => {
-		const editorFrame = await editorPage.getEditorHandle();
-		await editorFrame.waitForSelector( `button[aria-label="${ style }"]` );
-	} );
+		it( 'Open settings sidebar', async function () {
+			await editorPage.openSettings();
+		} );
 
-	it( 'Set "Bottom Wave" style', async () => {
-		await coverBlock.setCoverStyle( 'Bottom Wave' );
-	} );
+		it.each( CoverBlock.coverStyles )( 'Verify "%s" style is available', async ( style ) => {
+			const editorFrame = await editorPage.getEditorHandle();
+			await editorFrame.waitForSelector( `button[aria-label="${ style }"]` );
+		} );
 
-	it( 'Close settings sidebar', async () => {
-		await editorPage.closeSettings();
-	} );
+		it( 'Set "Bottom Wave" style', async () => {
+			await coverBlock.setCoverStyle( 'Bottom Wave' );
+		} );
 
-	it( 'Publish and visit the post', async () => {
-		await editorPage.publish( { visit: true } );
-	} );
+		it( 'Close settings sidebar', async () => {
+			await editorPage.closeSettings();
+		} );
 
-	it( 'Verify the class for "Bottom Wave" style is present', async () => {
-		await page.waitForSelector( '.wp-block-cover.is-style-bottom-wave' );
-	} );
-} );
+		it( 'Publish and visit the post', async () => {
+			await editorPage.publish( { visit: true } );
+		} );
+
+		it( 'Verify the class for "Bottom Wave" style is present', async () => {
+			await page.waitForSelector( '.wp-block-cover.is-style-bottom-wave' );
+		} );
+	}
+);

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -10,70 +10,75 @@ import {
 	TestAccount,
 	getTestAccountByFeature,
 	envToFeatureKey,
+	skipDescribeIf,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ), () => {
-	const features = envToFeatureKey( envVariables );
-	const accountName = getTestAccountByFeature( features );
+const features = envToFeatureKey( envVariables );
 
-	let page: Page;
-	let testAccount: TestAccount;
-	let editorPage: EditorPage;
-	let pricingTableBlock: PricingTableBlock;
+skipDescribeIf( features.siteType === 'atomic' )(
+	DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ),
+	() => {
+		const accountName = getTestAccountByFeature( features );
 
-	beforeAll( async () => {
-		page = await browser.newPage();
-		testAccount = new TestAccount( accountName );
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		let page: Page;
+		let testAccount: TestAccount;
+		let editorPage: EditorPage;
+		let pricingTableBlock: PricingTableBlock;
 
-		await testAccount.authenticate( page );
-	} );
+		beforeAll( async () => {
+			page = await browser.newPage();
+			testAccount = new TestAccount( accountName );
+			editorPage = new EditorPage( page, { target: features.siteType } );
 
-	it( 'Go to the new post page', async () => {
-		await editorPage.visit( 'post' );
-	} );
+			await testAccount.authenticate( page );
+		} );
 
-	it( 'Insert Pricing Table block', async () => {
-		const blockHandle = await editorPage.addBlockFromSidebar(
-			PricingTableBlock.blockName,
-			PricingTableBlock.blockEditorSelector
+		it( 'Go to the new post page', async () => {
+			await editorPage.visit( 'post' );
+		} );
+
+		it( 'Insert Pricing Table block', async () => {
+			const blockHandle = await editorPage.addBlockFromSidebar(
+				PricingTableBlock.blockName,
+				PricingTableBlock.blockEditorSelector
+			);
+			pricingTableBlock = new PricingTableBlock( blockHandle );
+		} );
+
+		it( 'Open settings sidebar', async () => {
+			await editorPage.openSettings();
+		} );
+
+		it.each( PricingTableBlock.gutterValues )(
+			'Verify "%s" gutter button is present',
+			async ( value ) => {
+				const editorFrame = await editorPage.getEditorHandle();
+				await editorFrame.waitForSelector( `button[aria-label="${ value }"]` );
+			}
 		);
-		pricingTableBlock = new PricingTableBlock( blockHandle );
-	} );
 
-	it( 'Open settings sidebar', async () => {
-		await editorPage.openSettings();
-	} );
+		it( 'Set gutter to "Huge"', async () => {
+			await pricingTableBlock.setGutter( 'Huge' );
+		} );
 
-	it.each( PricingTableBlock.gutterValues )(
-		'Verify "%s" gutter button is present',
-		async ( value ) => {
-			const editorFrame = await editorPage.getEditorHandle();
-			await editorFrame.waitForSelector( `button[aria-label="${ value }"]` );
-		}
-	);
+		it( 'Close settings sidebar', async () => {
+			await editorPage.closeSettings();
+		} );
 
-	it( 'Set gutter to "Huge"', async () => {
-		await pricingTableBlock.setGutter( 'Huge' );
-	} );
+		it( 'Fill the price fields so the block is visible', async () => {
+			await pricingTableBlock.enterPrice( 1, 4.99 );
+			await pricingTableBlock.enterPrice( 2, 9.99 );
+		} );
 
-	it( 'Close settings sidebar', async () => {
-		await editorPage.closeSettings();
-	} );
+		it( 'Publish and visit the post', async () => {
+			await editorPage.publish( { visit: true } );
+		} );
 
-	it( 'Fill the price fields so the block is visible', async () => {
-		await pricingTableBlock.enterPrice( 1, 4.99 );
-		await pricingTableBlock.enterPrice( 2, 9.99 );
-	} );
-
-	it( 'Publish and visit the post', async () => {
-		await editorPage.publish( { visit: true } );
-	} );
-
-	it( 'Verify the class for "Huge" gutter is present', async () => {
-		await page.waitForSelector( '.wp-block-coblocks-pricing-table .has-huge-gutter' );
-	} );
-} );
+		it( 'Verify the class for "Huge" gutter is present', async () => {
+			await page.waitForSelector( '.wp-block-coblocks-pricing-table .has-huge-gutter' );
+		} );
+	}
+);

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -13,75 +13,80 @@ import {
 	TestAccount,
 	getTestAccountByFeature,
 	envToFeatureKey,
+	skipDescribeIf,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ), () => {
-	const features = envToFeatureKey( envVariables );
-	const accountName = getTestAccountByFeature( features );
+const features = envToFeatureKey( envVariables );
 
-	let page: Page;
-	let editorPage: EditorPage;
-	let imageBlock: ImageBlock;
-	let imageFile: TestFile;
-	let uploadedImageURL: string;
-	let newImageURL: string;
+skipDescribeIf( features.siteType === 'atomic' )(
+	DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ),
+	() => {
+		const accountName = getTestAccountByFeature( features );
 
-	beforeAll( async () => {
-		page = await browser.newPage();
-		imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		let page: Page;
+		let editorPage: EditorPage;
+		let imageBlock: ImageBlock;
+		let imageFile: TestFile;
+		let uploadedImageURL: string;
+		let newImageURL: string;
 
-		const testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
-	} );
+		beforeAll( async () => {
+			page = await browser.newPage();
+			imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
+			editorPage = new EditorPage( page, { target: features.siteType } );
 
-	it( 'Go to the new post page', async () => {
-		await editorPage.visit( 'post' );
-	} );
-
-	it( `Insert ${ ImageBlock.blockName } block and upload image`, async () => {
-		const blockHandle = await editorPage.addBlockFromSidebar(
-			ImageBlock.blockName,
-			ImageBlock.blockEditorSelector
-		);
-		imageBlock = new ImageBlock( blockHandle );
-		const uploadedImage = await imageBlock.upload( imageFile.fullpath );
-		uploadedImageURL = ( await uploadedImage.getAttribute( 'src' ) ) as string;
-		uploadedImageURL = uploadedImageURL.split( '?' )[ 0 ];
-	} );
-
-	it( `Replace uploaded image`, async () => {
-		const editorFrame = await editorPage.getEditorHandle();
-		await editorFrame.click( 'button:text("Replace")' );
-		await editorFrame.setInputFiles(
-			'.components-form-file-upload input[type="file"]',
-			imageFile.fullpath
-		);
-		await imageBlock.waitUntilUploaded();
-
-		const newImage = await imageBlock.getImage();
-		newImageURL = ( await newImage.getAttribute( 'src' ) ) as string;
-		newImageURL = newImageURL.split( '?' )[ 0 ];
-
-		expect( newImageURL ).not.toEqual( uploadedImageURL );
-	} );
-
-	it( 'Publish the post', async () => {
-		await editorPage.publish( { visit: true } );
-	} );
-
-	it( 'Verify the new image was published', async () => {
-		// Image is not always immediately available on a published site, so we need
-		// to refresh and check again.
-		await ElementHelper.reloadAndRetry( page, async function () {
-			const publishedImage = await page.waitForSelector( '.wp-block-image img' );
-			const publishedImageURL = ( await publishedImage.getAttribute( 'src' ) ) as string;
-
-			expect( publishedImageURL.split( '?' )[ 0 ] ).toEqual( newImageURL );
+			const testAccount = new TestAccount( accountName );
+			await testAccount.authenticate( page );
 		} );
-	} );
-} );
+
+		it( 'Go to the new post page', async () => {
+			await editorPage.visit( 'post' );
+		} );
+
+		it( `Insert ${ ImageBlock.blockName } block and upload image`, async () => {
+			const blockHandle = await editorPage.addBlockFromSidebar(
+				ImageBlock.blockName,
+				ImageBlock.blockEditorSelector
+			);
+			imageBlock = new ImageBlock( blockHandle );
+			const uploadedImage = await imageBlock.upload( imageFile.fullpath );
+			uploadedImageURL = ( await uploadedImage.getAttribute( 'src' ) ) as string;
+			uploadedImageURL = uploadedImageURL.split( '?' )[ 0 ];
+		} );
+
+		it( `Replace uploaded image`, async () => {
+			const editorFrame = await editorPage.getEditorHandle();
+			await editorFrame.click( 'button:text("Replace")' );
+			await editorFrame.setInputFiles(
+				'.components-form-file-upload input[type="file"]',
+				imageFile.fullpath
+			);
+			await imageBlock.waitUntilUploaded();
+
+			const newImage = await imageBlock.getImage();
+			newImageURL = ( await newImage.getAttribute( 'src' ) ) as string;
+			newImageURL = newImageURL.split( '?' )[ 0 ];
+
+			expect( newImageURL ).not.toEqual( uploadedImageURL );
+		} );
+
+		it( 'Publish the post', async () => {
+			await editorPage.publish( { visit: true } );
+		} );
+
+		it( 'Verify the new image was published', async () => {
+			// Image is not always immediately available on a published site, so we need
+			// to refresh and check again.
+			await ElementHelper.reloadAndRetry( page, async function () {
+				const publishedImage = await page.waitForSelector( '.wp-block-image img' );
+				const publishedImageURL = ( await publishedImage.getAttribute( 'src' ) ) as string;
+
+				expect( publishedImageURL.split( '?' )[ 0 ] ).toEqual( newImageURL );
+			} );
+		} );
+	}
+);


### PR DESCRIPTION
Project: p9oQ9f-13V-p2

#### Changes proposed in this Pull Request

These E2E tests have been written against the version of CoBlocks on simple sites.

There's currently no established process or plan for keeping the version in simple sites compatible with the version in AT -- the version in AT is managed but is mainly updated on a per-need basis by fellow HEs, and we (@Automattic/team-calypso-platform / @Automattic/quality-squad) currently don't have direct control over what's running there.

Finally, the only AT sites that have a managed version of CoBlocks are sites that were transferred prior to the cutoff date for p4TIVU-9QA-p2. In other words, the actual test E2E site we use doesn't include CoBlocks currently.

We might re-introduce these tests on AT, but if so it'll be part of its own project to test CoBlocks across simple and AT, with its own CoBlocks-specific TC builds, I think.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests should pass.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #