### PR TITLE
Playwright: Create site editor POM and start FSE related tracking specs

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
@@ -1,0 +1,34 @@
+import { Page, Locator } from 'playwright';
+
+const popoverParentSelector = '.popover-slot .components-popover';
+
+const selectors = {
+	menuButton: ( name: string ) => `${ popoverParentSelector } button:has-text("${ name }")`,
+};
+
+/**
+ * Represents the popover menu that can be launched from multiple different places.
+ */
+export class EditorPopoverMenuComponent {
+	private page: Page;
+	private editor: Locator;
+
+	/**
+	 * Creates an instance of the component.
+	 *
+	 * @param {Page} page Object representing the base page.
+	 * @param {Locator} editor Frame-safe locator to the editor.
+	 */
+	constructor( page: Page, editor: Locator ) {
+		this.page = page;
+		this.editor = editor;
+	}
+
+	/**
+	 * Click menu button by name.
+	 */
+	async clickMenuButton( name: string ): Promise< void > {
+		const locator = this.editor.locator( selectors.menuButton( name ) );
+		await locator.click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -35,6 +35,10 @@ const selectors = {
 
 	// Editor settings
 	settingsButton: `${ panel } .edit-post-header__settings .interface-pinned-items button:first-child`,
+
+	// Undo/Redo
+	undoButton: 'button[aria-disabled=false][aria-label=Undo]',
+	redoButton: 'button[aria-disabled=false][aria-label=Redo]',
 };
 
 /**
@@ -280,6 +284,26 @@ export class EditorToolbarComponent {
 		}
 
 		const locator = this.editor.locator( selectors.detailsButton );
+		await locator.click();
+	}
+
+	/**
+	 * Click the editor undo button. Throws an error if the button is not enabled.
+	 *
+	 * @throws If the undo button is not enabled.
+	 */
+	async undo(): Promise< void > {
+		const locator = this.page.locator( selectors.undoButton );
+		await locator.click();
+	}
+
+	/**
+	 * Click the editor redo button. Throws an error if the button is not enabled.
+	 *
+	 * @throws If the redo button is not enabled.
+	 */
+	async redo(): Promise< void > {
+		const locator = this.page.locator( selectors.redoButton );
 		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -6,7 +6,8 @@ export type PreviewOptions = 'Desktop' | 'Mobile' | 'Tablet';
 const panel = 'div.interface-interface-skeleton__header';
 const selectors = {
 	// Block Inserter
-	blockInserterButton: `${ panel } button.edit-post-header-toolbar__inserter-toggle`,
+	// Note the partial class match. This is to support site and post editor. We can't use aria-label because of i18n. :(
+	blockInserterButton: `${ panel } button[class*="header-toolbar__inserter-toggle"]`,
 
 	// Draft
 	saveDraftButton: ( state: 'disabled' | 'enabled' ) => {
@@ -37,8 +38,8 @@ const selectors = {
 	settingsButton: `${ panel } .edit-post-header__settings .interface-pinned-items button:first-child`,
 
 	// Undo/Redo
-	undoButton: 'button[aria-disabled=false][aria-label=Undo]',
-	redoButton: 'button[aria-disabled=false][aria-label=Redo]',
+	undoButton: 'button[aria-disabled=false][aria-label="Undo"]',
+	redoButton: 'button[aria-disabled=false][aria-label="Redo"]',
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -294,7 +294,7 @@ export class EditorToolbarComponent {
 	 * @throws If the undo button is not enabled.
 	 */
 	async undo(): Promise< void > {
-		const locator = this.page.locator( selectors.undoButton );
+		const locator = this.editor.locator( selectors.undoButton );
 		await locator.click();
 	}
 
@@ -304,7 +304,7 @@ export class EditorToolbarComponent {
 	 * @throws If the redo button is not enabled.
 	 */
 	async redo(): Promise< void > {
-		const locator = this.page.locator( selectors.redoButton );
+		const locator = this.editor.locator( selectors.redoButton );
 		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-welcome-tour-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-welcome-tour-component.ts
@@ -1,0 +1,51 @@
+import { Page, Locator } from 'playwright';
+
+/**
+ * Represents the welcome tour that shows in a popover when the editor loads.
+ */
+export class EditorWelcomeTourComponent {
+	private page: Page;
+	private editor: Locator;
+
+	/**
+	 * Creates an instance of the component.
+	 *
+	 * @param {Page} page Object representing the base page.
+	 * @param {Locator} editor Frame-safe locator to the editor.
+	 */
+	constructor( page: Page, editor: Locator ) {
+		this.page = page;
+		this.editor = editor;
+	}
+
+	/**
+	 * Force dismisses the welcome tour using Redux state/actions.
+	 *
+	 * @see {@link https://github.com/Automattic/wp-calypso/issues/57660}
+	 */
+	async forceDismissWelcomeTour(): Promise< void > {
+		// Locator API doesn't have waitForFunction yet. We need a Frame for now.
+		const editorElement = await this.editor.elementHandle();
+		const editorFrame = await editorElement?.ownerFrame();
+		if ( ! editorFrame ) {
+			return;
+		}
+
+		await editorFrame.waitForFunction(
+			async () =>
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				await ( window as any ).wp.data
+					.select( 'automattic/wpcom-welcome-guide' )
+					.isWelcomeGuideStatusLoaded()
+		);
+
+		await editorFrame.waitForFunction( async () => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const actionPayload = await ( window as any ).wp.data
+				.dispatch( 'automattic/wpcom-welcome-guide' )
+				.setShowWelcomeGuide( false );
+
+			return actionPayload.show === false;
+		} );
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -22,5 +22,6 @@ export * from './editor-toolbar-component';
 export * from './editor-gutenberg-component';
 export * from './editor-block-list-view-component';
 export * from './editor-sidebar-block-inserter-component';
+export * from './editor-welcome-tour-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -23,5 +23,6 @@ export * from './editor-gutenberg-component';
 export * from './editor-block-list-view-component';
 export * from './editor-sidebar-block-inserter-component';
 export * from './editor-welcome-tour-component';
+export * from './editor-popover-menu-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -71,7 +71,7 @@ export class FullSiteEditorPage {
 	/**
 	 * Visit the site editor by URL directly.
 	 *
-	 * @param siteHostName Host name of the site, without scheme. (e.g. testsite.wordpress.com)
+	 * @param {string} siteHostName Host name of the site, without scheme. (e.g. testsite.wordpress.com)
 	 */
 	async visit( siteHostName: string ): Promise< void > {
 		await this.page.goto( getCalypsoURL( `site-editor/${ siteHostName }` ) );

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -23,7 +23,7 @@ const selectors = {
  * Represents an instance of the FSE site editor.
  * This class is composed of editor components, combining them into larger flows.
  */
-export class SiteEditorPage {
+export class FullSiteEditorPage {
 	private page: Page;
 
 	private editorToolbarComponent: EditorToolbarComponent;

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -26,5 +26,6 @@ export * from './posts-page';
 export * from './pages-page';
 export * from './plugins-page';
 export * from './writing-settings-page';
+export * from './shared-types';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -27,5 +27,6 @@ export * from './pages-page';
 export * from './plugins-page';
 export * from './writing-settings-page';
 export * from './shared-types';
+export * from './site-editor-page';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -27,6 +27,6 @@ export * from './pages-page';
 export * from './plugins-page';
 export * from './writing-settings-page';
 export * from './shared-types';
-export * from './site-editor-page';
+export * from './full-site-editor-page';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/pages/shared-types/editor-types.ts
+++ b/packages/calypso-e2e/src/lib/pages/shared-types/editor-types.ts
@@ -1,0 +1,10 @@
+import { Locator } from 'playwright';
+
+export type OpenInlineInserter = ( editor: Locator ) => Promise< void >;
+export interface BlockInserter {
+	searchBlockInserter( blockName: string ): Promise< void >;
+	selectBlockInserterResult(
+		name: string,
+		options?: { type?: 'block' | 'pattern' }
+	): Promise< void >;
+}

--- a/packages/calypso-e2e/src/lib/pages/shared-types/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/shared-types/index.ts
@@ -1,0 +1,1 @@
+export * from './editor-types';

--- a/packages/calypso-e2e/src/lib/pages/site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-editor-page.ts
@@ -1,0 +1,144 @@
+import { Locator, Page } from 'playwright';
+import {
+	BlockInserter,
+	EditorGutenbergComponent,
+	EditorSidebarBlockInserterComponent,
+	EditorToolbarComponent,
+	EditorWelcomeTourComponent,
+} from '..';
+import envVariables from '../../env-variables';
+
+const wpAdminPath = 'wp-admin/themes.php';
+
+const selectors = {
+	editorIframe: `iframe.is-loaded[src*="${ wpAdminPath }"]`,
+	editorRoot: 'body.block-editor-page',
+	editorCanvasIframe: 'iframe[name="editor-canvas"]',
+	editorCanvasRoot: '.wp-site-blocks',
+	templateLoadingSpinner: '[aria-label=“Block: Template Part”] .components-spinner',
+};
+
+/**
+ * Represents an instance of the FSE site editor.
+ * This class is composed of editor components, combining them into larger flows.
+ */
+export class SiteEditorPage {
+	private page: Page;
+
+	private editorToolbarComponent: EditorToolbarComponent;
+	private editorGutenbergComponent: EditorGutenbergComponent;
+	private editorSidebarBlockInserterComponent: EditorSidebarBlockInserterComponent;
+	private editorWelcomeTourComponent: EditorWelcomeTourComponent;
+
+	/**
+	 * Constructs an instance of the page POM class.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+
+		this.editorToolbarComponent = new EditorToolbarComponent( page, this.editor );
+		this.editorWelcomeTourComponent = new EditorWelcomeTourComponent( page, this.editor );
+		this.editorSidebarBlockInserterComponent = new EditorSidebarBlockInserterComponent(
+			page,
+			this.editor
+		);
+		// Because of the unique extra iframe in the site editor, this component needs the canvas locator.
+		this.editorGutenbergComponent = new EditorGutenbergComponent( page, this.editorCanvas );
+	}
+
+	/**
+	 * A frame-safe locator to the top level element in the editor, for building other editor locators.
+	 */
+	private get editor(): Locator {
+		return this.page.url().includes( wpAdminPath )
+			? this.page.locator( selectors.editorRoot )
+			: this.page.frameLocator( selectors.editorIframe ).locator( selectors.editorRoot );
+	}
+
+	/**
+	 * A frame-safe locator to the top level element in the editor canvas, for building other editor locators.
+	 * The editor canvas is an iframe wrapping the center editor area that is unique to the site-editor.
+	 */
+	private get editorCanvas(): Locator {
+		return this.editor
+			.frameLocator( selectors.editorCanvasIframe )
+			.locator( selectors.editorCanvasRoot );
+	}
+
+	/**
+	 * Waits until the site editor is fully loaded.
+	 */
+	async waitUntilLoaded(): Promise< void > {
+		// There are more stages to the site editor loading than the regular editor.
+		// The most reliable "last" thing to load is the canvas iframe
+		await this.editorCanvas.waitFor( { timeout: 60 * 1000 } );
+		// But then, template parts load async afterwards!
+		const spinnerLocator = this.editorCanvas.locator( selectors.templateLoadingSpinner );
+		// There could be many spinners, so we will keep waiting for the first to be detached.
+		await spinnerLocator.first().waitFor( { state: 'detached' } );
+	}
+
+	/**
+	 * Does all waiting and initial actions to prepare the site editor for interaction.
+	 */
+	async prepareForInteraction(): Promise< void > {
+		await this.waitUntilLoaded();
+		await this.editorWelcomeTourComponent.forceDismissWelcomeTour();
+	}
+
+	/**
+	 * Adds a Gutenberg block from the sidebar block inserter panel.
+	 *
+	 * The name is expected to be formatted in the same manner as it
+	 * appears on the label when visible in the block inserter panel.
+	 *
+	 * Example:
+	 * 		- Click to Tweet
+	 * 		- Pay with Paypal
+	 * 		- SyntaxHighlighter Code
+	 *
+	 * @param {string} blockName Name of the block to be inserted.
+	 */
+	async addBlockFromSidebar( blockName: string ): Promise< void > {
+		await this.editorGutenbergComponent.resetSelectedBlock();
+		await this.editorToolbarComponent.openBlockInserter();
+		await this.addBlockFromInserter( blockName, this.editorSidebarBlockInserterComponent );
+
+		// Dismiss the block inserter if viewport is larger than mobile to
+		// ensure no interference from the block inserter in subsequent actions on the editor.
+		// In mobile, the block inserter will auto-close.
+		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
+			await this.editorToolbarComponent.closeBlockInserter();
+		}
+	}
+
+	/**
+	 * Shared submethod to insert a block from a block inserter.
+	 *
+	 * @param {string} blockName Name of the block.
+	 * @param {BlockInserter} inserter A block inserter component.
+	 */
+	private async addBlockFromInserter(
+		blockName: string,
+		inserter: BlockInserter
+	): Promise< void > {
+		await inserter.searchBlockInserter( blockName );
+		await inserter.selectBlockInserterResult( blockName );
+	}
+
+	/**
+	 * Click the editor undo button.
+	 */
+	async undo(): Promise< void > {
+		await this.editorToolbarComponent.undo();
+	}
+
+	/**
+	 * Click the editor redo button.
+	 */
+	async redo(): Promise< void > {
+		await this.editorToolbarComponent.redo();
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-editor-page.ts
@@ -6,6 +6,7 @@ import {
 	EditorToolbarComponent,
 	EditorWelcomeTourComponent,
 } from '..';
+import { getCalypsoURL } from '../../data-helper';
 import envVariables from '../../env-variables';
 
 const wpAdminPath = 'wp-admin/themes.php';
@@ -15,7 +16,7 @@ const selectors = {
 	editorRoot: 'body.block-editor-page',
 	editorCanvasIframe: 'iframe[name="editor-canvas"]',
 	editorCanvasRoot: '.wp-site-blocks',
-	templateLoadingSpinner: '[aria-label=“Block: Template Part”] .components-spinner',
+	templateLoadingSpinner: '[aria-label="Block: Template Part"] .components-spinner',
 };
 
 /**
@@ -68,6 +69,15 @@ export class SiteEditorPage {
 	}
 
 	/**
+	 * Visit the site editor by URL directly.
+	 *
+	 * @param siteHostName Host name of the site, without scheme. (e.g. testsite.wordpress.com)
+	 */
+	async visit( siteHostName: string ): Promise< void > {
+		await this.page.goto( getCalypsoURL( `site-editor/${ siteHostName }` ) );
+	}
+
+	/**
 	 * Waits until the site editor is fully loaded.
 	 */
 	async waitUntilLoaded(): Promise< void > {
@@ -86,11 +96,13 @@ export class SiteEditorPage {
 	 * @param {object} param0 Keyed object of options.
 	 * @param {boolean} param0.leaveWithoutSaving Set if we should auto-except dialog about unsaved changes when leaving.
 	 */
-	async prepareForInteraction( {
-		leaveWithoutSaving = true,
-	}: {
-		leaveWithoutSaving: boolean;
-	} ): Promise< void > {
+	async prepareForInteraction(
+		{
+			leaveWithoutSaving,
+		}: {
+			leaveWithoutSaving?: boolean;
+		} = { leaveWithoutSaving: true }
+	): Promise< void > {
 		await this.waitUntilLoaded();
 		await this.editorWelcomeTourComponent.forceDismissWelcomeTour();
 
@@ -117,7 +129,6 @@ export class SiteEditorPage {
 	 * @param {string} blockName Name of the block to be inserted.
 	 */
 	async addBlockFromSidebar( blockName: string ): Promise< void > {
-		await this.editorGutenbergComponent.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
 		await this.addBlockFromInserter( blockName, this.editorSidebarBlockInserterComponent );
 

--- a/packages/calypso-e2e/src/lib/pages/site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-editor-page.ts
@@ -82,10 +82,25 @@ export class SiteEditorPage {
 
 	/**
 	 * Does all waiting and initial actions to prepare the site editor for interaction.
+	 *
+	 * @param {object} param0 Keyed object of options.
+	 * @param {boolean} param0.leaveWithoutSaving Set if we should auto-except dialog about unsaved changes when leaving.
 	 */
-	async prepareForInteraction(): Promise< void > {
+	async prepareForInteraction( {
+		leaveWithoutSaving = true,
+	}: {
+		leaveWithoutSaving: boolean;
+	} ): Promise< void > {
 		await this.waitUntilLoaded();
 		await this.editorWelcomeTourComponent.forceDismissWelcomeTour();
+
+		if ( leaveWithoutSaving ) {
+			this.page.on( 'dialog', async ( dialog ) => {
+				if ( dialog.type() === 'beforeunload' ) {
+					await dialog.accept();
+				}
+			} );
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/utils/editor-tracks-event-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/editor-tracks-event-manager.ts
@@ -52,7 +52,9 @@ export class EditorTracksEventManager {
 		// It just matters that we're in the right iframe, so we use a very generic selector ("body") to get something safe and top-level.
 		return this.page.url().includes( '/wp-admin' )
 			? this.page.locator( 'body' ) // No Gutenframe
-			: this.page.frameLocator( '[src*="wp-admin/post"]' ).locator( 'body' ); // Gutenframe
+			: this.page
+					.frameLocator( '[src*="wp-admin/post"],[src*="wp-admin/themes"]' ) // Post, page, and site editor!
+					.locator( 'body' ); // Gutenframe
 	}
 
 	/**

--- a/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
@@ -11,7 +11,7 @@ import {
 	TestAccount,
 	EditorTracksEventManager,
 	skipDescribeIf,
-	SiteEditorPage,
+	FullSiteEditorPage,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
@@ -26,7 +26,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 		describe( 'wpcom_block_editor_list_view_toggle/select', function () {
 			let page: Page;
 			let editorPage: EditorPage;
-			let eventManager: EditorTracksEventManager;
+			let editorTracksEventManager: EditorTracksEventManager;
 			beforeAll( async () => {
 				page = await browser.newPage();
 
@@ -34,7 +34,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 				const testAccount = new TestAccount( accountName );
 				await testAccount.authenticate( page );
 
-				eventManager = new EditorTracksEventManager( page );
+				editorTracksEventManager = new EditorTracksEventManager( page );
 				editorPage = new EditorPage( page, { target: features.siteType } );
 			} );
 
@@ -52,7 +52,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 			} );
 
 			it( '"wpcom_block_editor_list_view_toggle" event fires with "is_open" set to true', async function () {
-				const eventDidFire = await eventManager.didEventFire(
+				const eventDidFire = await editorTracksEventManager.didEventFire(
 					'wpcom_block_editor_list_view_toggle',
 					{
 						matchingProperties: {
@@ -68,7 +68,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 			} );
 
 			it( '"wpcom_block_editor_list_view_select" event fires with correct "block_name" property', async function () {
-				const eventDidFire = await eventManager.didEventFire(
+				const eventDidFire = await editorTracksEventManager.didEventFire(
 					'wpcom_block_editor_list_view_select',
 					{
 						matchingProperties: {
@@ -84,7 +84,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 			} );
 
 			it( '"wpcom_block_editor_list_view_toggle" event fires again with "is_open" set to false', async function () {
-				const eventDidFire = await eventManager.didEventFire(
+				const eventDidFire = await editorTracksEventManager.didEventFire(
 					'wpcom_block_editor_list_view_toggle',
 					{
 						matchingProperties: {
@@ -99,7 +99,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 		describe( 'wpcom_block_editor_details_open', function () {
 			let page: Page;
 			let editorPage: EditorPage;
-			let eventManager: EditorTracksEventManager;
+			let editorTracksEventManager: EditorTracksEventManager;
 			beforeAll( async () => {
 				page = await browser.newPage();
 
@@ -107,7 +107,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 				const testAccount = new TestAccount( accountName );
 				await testAccount.authenticate( page );
 
-				eventManager = new EditorTracksEventManager( page );
+				editorTracksEventManager = new EditorTracksEventManager( page );
 				editorPage = new EditorPage( page, { target: features.siteType } );
 			} );
 
@@ -126,15 +126,17 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 			} );
 
 			it( '"wpcom_block_editor_details_open" event fires', async function () {
-				const eventDidFire = await eventManager.didEventFire( 'wpcom_block_editor_details_open' );
+				const eventDidFire = await editorTracksEventManager.didEventFire(
+					'wpcom_block_editor_details_open'
+				);
 				expect( eventDidFire ).toBe( true );
 			} );
 		} );
 
 		describe( 'wpcom_block_editor_undo/redo_performed', function () {
 			let page: Page;
-			let siteEditorPage: SiteEditorPage;
-			let eventManager: EditorTracksEventManager;
+			let fullSiteEditorPage: FullSiteEditorPage;
+			let editorTracksEventManager: EditorTracksEventManager;
 			let testAccount: TestAccount;
 			beforeAll( async () => {
 				page = await browser.newPage();
@@ -143,34 +145,38 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 				testAccount = new TestAccount( accountName );
 				await testAccount.authenticate( page );
 
-				eventManager = new EditorTracksEventManager( page );
-				siteEditorPage = new SiteEditorPage( page );
+				editorTracksEventManager = new EditorTracksEventManager( page );
+				fullSiteEditorPage = new FullSiteEditorPage( page );
 			} );
 
 			it( 'Go to site editor', async function () {
-				await siteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
-				await siteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 			} );
 
 			it( 'Add a Header block', async function () {
-				await siteEditorPage.addBlockFromSidebar( 'Header' );
+				await fullSiteEditorPage.addBlockFromSidebar( 'Header' );
 			} );
 
 			it( 'Undo action', async function () {
-				await siteEditorPage.undo();
+				await fullSiteEditorPage.undo();
 			} );
 
 			it( '"wpcom_block_editor_undo_performed" event fires', async function () {
-				const eventDidFire = await eventManager.didEventFire( 'wpcom_block_editor_undo_performed' );
+				const eventDidFire = await editorTracksEventManager.didEventFire(
+					'wpcom_block_editor_undo_performed'
+				);
 				expect( eventDidFire ).toBe( true );
 			} );
 
 			it( 'Redo action', async function () {
-				await siteEditorPage.redo();
+				await fullSiteEditorPage.redo();
 			} );
 
 			it( '"wpcom_block_editor_redo_performed" event fires', async function () {
-				const eventDidFire = await eventManager.didEventFire( 'wpcom_block_editor_redo_performed' );
+				const eventDidFire = await editorTracksEventManager.didEventFire(
+					'wpcom_block_editor_redo_performed'
+				);
 				expect( eventDidFire ).toBe( true );
 			} );
 		} );

--- a/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
@@ -146,7 +146,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 				await testAccount.authenticate( page );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
-				fullSiteEditorPage = new FullSiteEditorPage( page );
+				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 			} );
 
 			it( 'Go to site editor', async function () {

--- a/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
@@ -149,7 +149,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 
 			it( 'Go to site editor', async function () {
 				await siteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
-				await siteEditorPage.prepareForInteraction();
+				await siteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 			} );
 
 			it( 'Add a Header block', async function () {
@@ -157,16 +157,21 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 			} );
 
 			it( 'Undo action', async function () {
-				await page.pause();
 				await siteEditorPage.undo();
 			} );
 
-			it( 'redo action', async function () {
+			it( '"wpcom_block_editor_undo_performed" event fires', async function () {
+				const eventDidFire = await eventManager.didEventFire( 'wpcom_block_editor_undo_performed' );
+				expect( eventDidFire ).toBe( true );
+			} );
+
+			it( 'Redo action', async function () {
 				await siteEditorPage.redo();
 			} );
 
-			it( '"wpcom_block_editor_details_open" event fires', async function () {
-				console.log( await eventManager.getAllEvents() );
+			it( '"wpcom_block_editor_redo_performed" event fires', async function () {
+				const eventDidFire = await eventManager.didEventFire( 'wpcom_block_editor_redo_performed' );
+				expect( eventDidFire ).toBe( true );
 			} );
 		} );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Background P2: pciE2j-QC-p2

In continuing with editor tracking, this implements the first spec that uses the site editor -- `wpcom_block_editor_undo/redo_performed`

To do that, we need some site editor POM support!

This...
- Creates a new parent site editor page 
- Pulls welcome tour dismissal out into it's own component
- Adds undo/redo support to the toolbar

And then adds the spec.

Before remembering that the list view isn't present on mobile (🤦 🤦 🤦 ), I made headway into beefing up the list view component and making a popover menu component that could have been used to delete all blocks in the site editor. While not used directly now, the POM structure could be useful in the future, so I'm leaving in there!

#### Testing instructions

- [x] Gutenberg desktop passes


Related to #