### PR TITLE
Query all sites features when there is no selected site

### DIFF
--- a/client/components/data/query-site-features/index.jsx
+++ b/client/components/data/query-site-features/index.jsx
@@ -10,14 +10,18 @@ const request = ( siteId ) => ( dispatch, getState ) => {
 	}
 };
 
-export default function QuerySiteFeatures( { siteId } ) {
+const siteIdsHash = ( siteIds ) => {
+	siteIds.sort();
+	return siteIds.join( '_' );
+};
+export default function QuerySiteFeatures( { siteIds } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( request( siteId ) );
-	}, [ dispatch, siteId ] );
+		siteIds.forEach( ( siteId ) => dispatch( request( siteId ) ) );
+	}, [ dispatch, siteIdsHash( siteIds ) ] );
 
 	return null;
 }
 
-QuerySiteFeatures.propTypes = { siteId: PropTypes.number };
+QuerySiteFeatures.propTypes = { siteIds: PropTypes.arrayOf( PropTypes.number ) };

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -29,7 +29,6 @@ import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-act
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
@@ -262,7 +261,7 @@ class Layout extends Component {
 				<QuerySites primaryAndRecent={ ! config.isEnabled( 'jetpack-cloud' ) } />
 				{ this.props.shouldQueryAllSites && <QuerySites allSites /> }
 				<QueryPreferences />
-				<QuerySiteFeatures siteIds={ this.props.selectedOrAllSites.map( ( site ) => site.ID ) } />
+				<QuerySiteFeatures siteIds={ [ this.props.siteId ] } />
 				{ config.isEnabled( 'layout/query-selected-editor' ) && (
 					<QuerySiteSelectedEditor siteId={ this.props.siteId } />
 				) }
@@ -394,7 +393,6 @@ export default withCurrentRoute(
 			hasActiveHappyChat: hasActiveHappychatSession( state ),
 			colorSchemePreference: getPreference( state, 'colorScheme' ),
 			siteId,
-			selectedOrAllSites: getSelectedOrAllSites( state ),
 			// We avoid requesting sites in the Jetpack Connect authorization step, because this would
 			// request all sites before authorization has finished. That would cause the "all sites"
 			// request to lack the newly authorized site, and when the request finishes after

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -29,6 +29,7 @@ import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-act
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
+import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
@@ -261,7 +262,7 @@ class Layout extends Component {
 				<QuerySites primaryAndRecent={ ! config.isEnabled( 'jetpack-cloud' ) } />
 				{ this.props.shouldQueryAllSites && <QuerySites allSites /> }
 				<QueryPreferences />
-				<QuerySiteFeatures siteId={ this.props.siteId } />
+				<QuerySiteFeatures siteIds={ this.props.selectedOrAllSites.map( ( site ) => site.ID ) } />
 				{ config.isEnabled( 'layout/query-selected-editor' ) && (
 					<QuerySiteSelectedEditor siteId={ this.props.siteId } />
 				) }
@@ -393,6 +394,7 @@ export default withCurrentRoute(
 			hasActiveHappyChat: hasActiveHappychatSession( state ),
 			colorSchemePreference: getPreference( state, 'colorScheme' ),
 			siteId,
+			selectedOrAllSites: getSelectedOrAllSites( state ),
 			// We avoid requesting sites in the Jetpack Connect authorization step, because this would
 			// request all sites before authorization has finished. That would cause the "all sites"
 			// request to lack the newly authorized site, and when the request finishes after

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -6,6 +6,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import MainComponent from 'calypso/components/main';
@@ -52,6 +53,7 @@ import {
 } from 'calypso/state/products-list/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
+import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -73,6 +75,7 @@ function PluginDetails( props ) {
 	const sitesWithPlugins = useSelector( getSelectedOrAllSitesWithPlugins );
 	const sites = useSelector( getSelectedOrAllSitesWithPlugins );
 	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
+	const selectedOrAllSites = useSelector( getSelectedOrAllSites );
 	const isRequestingSites = useSelector( checkRequestingSites );
 	const requestingPluginsForSites = useSelector( ( state ) =>
 		isRequestingForSites( state, siteIds )
@@ -245,6 +248,7 @@ function PluginDetails( props ) {
 			<PageViewTracker path={ analyticsPath } title="Plugins > Plugin Details" />
 			<QueryJetpackPlugins siteIds={ siteIds } />
 			<QueryEligibility siteId={ selectedSite?.ID } />
+			<QuerySiteFeatures siteIds={ selectedOrAllSites.map( ( site ) => site.ID ) } />
 			<QueryProductsList persist />
 			<FixedNavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs }>
 				{ ( isMarketplaceProduct || shouldUpgrade ) &&

--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -90,7 +90,7 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 			headerImageUrl={ null }
 			stepContent={
 				<>
-					<QuerySiteFeatures siteId={ props.siteId } />
+					<QuerySiteFeatures siteIds={ [ props.siteId ] } />
 					<SelectItems
 						items={ intents }
 						onSelect={ submitStoreFeatures }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Query all sites features when there is no selected site.

This is needed for pages like Plugin Details which need to know the abilities of all sites when none is selected. Eg:
<img width="1220" alt="Screen Shot 2022-04-01 at 16 53 02" src="https://user-images.githubusercontent.com/5039531/161332461-0009330b-404d-4b29-ab9e-c7b258c76d75.png">

The pointed buttons will depend on the abilities of the site.

#### Testing instructions
* Switch Calypso to the all sites view (no selected site).
* Check the redux state at `state.sites.features` and see if there are feature info for all sites.


