### PR TITLE
Fix "Manage Reusable blocks" button in components dropdown to the expected page.

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -709,7 +709,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 		const isComponentsPopover = ( node ) => node.classList.contains( 'components-popover' );
 
 		const replaceWithManageReusableBlocksHref = ( anchorElem ) => {
-			anchorElem.ref = manageReusableBlocksUrl;
+			anchorElem.href = manageReusableBlocksUrl;
 			anchorElem.target = '_top';
 		};
 

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -728,31 +728,6 @@ async function openLinksInParentFrame( calypsoPort ) {
 	const popoverSlotElem = document.querySelector( '.interface-interface-skeleton ~ .popover-slot' );
 	popoverSlotObserver.observe( popoverSlotElem, { childList: true } );
 
-	// Manage reusable blocks link in the 3 dots more menu, post and site editors
-	if ( manageReusableBlocksUrl ) {
-		const toggleButton = document.querySelector(
-			'.edit-post-more-menu button, .edit-site-more-menu button'
-		);
-		const moreMenuManageReusableBlocksObserver = new window.MutationObserver( () => {
-			const isExpanded =
-				toggleButton.attributes.getNamedItem( 'aria-expanded' )?.nodeValue === 'true';
-			if ( isExpanded ) {
-				// The menu has not expanded at this point in Safari, so modify the link
-				// after the call stack has cleared and the menu has rendered.
-				setTimeout( () => {
-					const hyperlink = document.querySelector(
-						'a.components-menu-item__button[href*="post_type=wp_block"]'
-					);
-					hyperlink.href = manageReusableBlocksUrl;
-					hyperlink.target = '_top';
-				} );
-			}
-		} );
-		moreMenuManageReusableBlocksObserver.observe( toggleButton, {
-			attributeFilter: [ 'aria-expanded' ],
-		} );
-	}
-
 	// Sidebar might already be open before this script is executed.
 	// post and site editors
 	if ( createNewPostUrl ) {


### PR DESCRIPTION
This commit is fixing an issue where in wpcom block editor when user clicks on "Manage Reusable blocks" button from a reusable block's component settings dropdown, it would open up "grey screen of death".
Now clicking on the button will open up the expected page.

[Issue page here.](https://github.com/Automattic/wp-calypso/issues/59794)

![manageReusableBefore](https://user-images.githubusercontent.com/2019970/161385181-baf5f4cc-6169-40e6-bd11-2c221ae3f5c9.gif)


![manageReusableAfter](https://user-images.githubusercontent.com/2019970/161384987-f422002d-2d9f-494e-a9d1-91fe99d94b0e.gif)


#### Changes proposed in this Pull Request

* observe DOM element of `.interface-interface-skeleton ~ .popover-slot` for `childList` mutations
* when new child is inserted in the DOM element, check whether the child element is `components-popover`
* if it is components popover, then search for any descendant anchor element with href ending with the following string `edit.php?post_type=wp_block`
* if found one, then replace its ref and target properties to contents of `manageReusableBlocksUrl` variable and to `_top` string literal respectively.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test this PR on a wpcom site. See [the automated comment](https://github.com/Automattic/wp-calypso/pull/62473#issuecomment-1086294495) for instructions.
* Go to wpcom block editor. This can be add/edit page or post.
* Open up component dropdown settings on any inserted block, and add it to reusable blocks. Use any name you wish. See below screenshot for reference.
![Screenshot 2022-04-02 at 14 25 31](https://user-images.githubusercontent.com/2019970/161383206-72037cdf-1e8e-4106-b182-614e19f346da.png)
* Once the block is a reusable block, open-up the components dropdown menu again and you should see `Manage Reusable blocks` button this time, click it. 
* You should expect to be redirected to manage reusable blocks and not to see "the grey screen of death".


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/59794
