### PR TITLE
Media Library: Fix the storage bar to show the correct limit for legacy sites

### DIFF
--- a/client/state/selectors/is-legacy-site-with-higher-limits.ts
+++ b/client/state/selectors/is-legacy-site-with-higher-limits.ts
@@ -23,7 +23,7 @@ export default function isLegacySiteWithHigherLimits( state: AppState, siteId: n
 		return false;
 	}
 
-	const siteOptions = getSiteOptions( state, siteId );
+	const siteOptions = getSiteOptions( state, siteId ) as undefined | { created_at: string };
 	const createdAt = siteOptions?.created_at ?? '';
 
 	if ( ! createdAt ) {

--- a/client/state/selectors/is-legacy-site-with-higher-limits.ts
+++ b/client/state/selectors/is-legacy-site-with-higher-limits.ts
@@ -1,0 +1,36 @@
+import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
+import { getSiteOptions } from 'calypso/state/sites/selectors';
+import { AppState } from 'calypso/types';
+
+/**
+ * Determines if the site is old enough that it should have higher free site limits.
+ *
+ * When the Pro plan was launched on 2022-03-31, we also reduced some of the
+ * features of the free plan (for example, 3 GB storage limit down to 0.5 GB).
+ * Legacy sites created before that launch should still get the original limits
+ * they were created with, though.
+ *
+ * Note that this does not check if the site is actually a free site *currently*
+ * (it might have a paid plan and have even higher limits as a result of that).
+ *
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @returns {boolean} True if the site is considered a legacy site
+ */
+export default function isLegacySiteWithHigherLimits( state: AppState, siteId: number ): boolean {
+	// Note this checks for both simple and Atomic sites.
+	if ( ! isSiteWpcom( state, siteId ) ) {
+		return false;
+	}
+
+	const siteOptions = getSiteOptions( state, siteId );
+	const createdAt = siteOptions?.created_at ?? '';
+
+	if ( ! createdAt ) {
+		return false;
+	}
+
+	// This matches the date checked in is_legacy_site_with_higher_limits() on
+	// the server.
+	return createdAt < '2022-04-01 00:00:00';
+}

--- a/client/state/selectors/test/is-legacy-site-with-higher-limits.js
+++ b/client/state/selectors/test/is-legacy-site-with-higher-limits.js
@@ -1,0 +1,113 @@
+import isLegacySiteWithHigherLimits from 'calypso/state/selectors/is-legacy-site-with-higher-limits';
+
+describe( 'isLegacySiteWithHigherLimits()', () => {
+	test( 'should return false for simple sites without a created_at option', () => {
+		const state = { sites: { items: { 99: { options: {} } } } };
+
+		expect( isLegacySiteWithHigherLimits( state, 99 ) ).toBe( false );
+	} );
+
+	test( 'should return false for unresolved sites', () => {
+		expect( isLegacySiteWithHigherLimits( { sites: [] }, 99 ) ).toBe( false );
+	} );
+
+	test( 'should return true for a site created before 2022-04-01', () => {
+		const state = {
+			sites: {
+				items: {
+					99: {
+						options: {
+							created_at: '2022-03-31 23:59:59',
+						},
+					},
+				},
+			},
+		};
+
+		expect( isLegacySiteWithHigherLimits( state, 99 ) ).toBe( true );
+	} );
+
+	test( 'should return false for a site created on 2022-04-01', () => {
+		const state = {
+			sites: {
+				items: {
+					99: {
+						options: {
+							created_at: '2022-04-01 00:00:00',
+						},
+					},
+				},
+			},
+		};
+
+		expect( isLegacySiteWithHigherLimits( state, 99 ) ).toBe( false );
+	} );
+
+	test( 'should return false for a site created later on 2022-04-01', () => {
+		const state = {
+			sites: {
+				items: {
+					99: {
+						options: {
+							created_at: '2022-04-01 00:00:01',
+						},
+					},
+				},
+			},
+		};
+
+		expect( isLegacySiteWithHigherLimits( state, 99 ) ).toBe( false );
+	} );
+
+	test( 'should return true for an Atomic site created before 2022-04-01', () => {
+		const state = {
+			sites: {
+				items: {
+					99: {
+						options: {
+							is_automated_transfer: '1',
+							created_at: '2022-03-31 23:59:59',
+						},
+					},
+				},
+			},
+		};
+
+		expect( isLegacySiteWithHigherLimits( state, 99 ) ).toBe( true );
+	} );
+
+	test( 'should return true for an Atomic Jetpack site created before 2022-04-01', () => {
+		const state = {
+			sites: {
+				items: {
+					99: {
+						jetpack: true,
+						options: {
+							is_automated_transfer: '1',
+							created_at: '2022-03-31 23:59:59',
+						},
+					},
+				},
+			},
+		};
+
+		expect( isLegacySiteWithHigherLimits( state, 99 ) ).toBe( true );
+	} );
+
+	test( 'should return false for a non-Atomic Jetpack site even if it was created before 2022-04-01', () => {
+		const state = {
+			sites: {
+				items: {
+					99: {
+						jetpack: true,
+						options: {
+							created_at: '2022-03-31 23:59:59',
+						},
+					},
+				},
+			},
+		};
+
+		expect( isLegacySiteWithHigherLimits( state, 99 ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since the new Pro plan was launched, free sites are limited to 500 MB rather than 3 GB.  However, this limit should only apply to new free sites created after the changes went live.

This fixes an issue that caused legacy free sites (as well as sites that had purchased a standalone space upgrade product) to incorrectly see 500 MB.

#### Testing instructions

Use an old site (created before 2022-04-01) and a new site.  Go to the `/media` page in Calypso for each.  Make sure the storage bar shows a 3 GB limit for the old site and a 500 MB limit for the new one.

If you have access to the server, you can also add a space upgrade product (e.g. an extra 3 GB) to each site and make sure the 500 MB override goes away for the new site, and is replaced by the actual total available storage for each site.

See also: c/uGZ6vgCx-tr, and the corresponding server-side change at D78070-code