### PR TITLE
New plans page copy update for traffic limit description

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -259,7 +259,9 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			return translate( 'Visits per month' );
 		},
 		get description() {
-			return translate( 'Max visits per month.' );
+			return translate(
+				'WordPress Pro includes a generous 100,000 visits per month, which is 4x the limit for similarly priced plans at other popular managed WordPress hosts. Additional traffic can be purchased in 100,000 increments.'
+			);
 		},
 		features: [ FEATURE_10K_VISITS, FEATURE_100K_VISITS ],
 		getCellText: ( feature, isMobile = false ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR updates the description copy for the "Visits per month" tooltip in the the new plans page in signup an on the Calypso /plans page.

The updated copy is:
> WordPress Pro includes a generous 100,000 visits per month, which is 4x the limit for similarly priced plans at other popular managed WordPress hosts. Additional traffic can be purchased in 100,000 increments.

And it looks like:
<img width="809" alt="CleanShot 2022-04-03 at 16 35 45@2x" src="https://user-images.githubusercontent.com/35781181/161447467-e87c04be-9648-4898-a28c-eddb30e67b35.png">



#### Testing instructions

* Checkout this PR and start your local Calypso.
* Navigate to the signup flow in an incognito browser (/start) and complete the signup flow up to the plans page.
* Confirm that the updated tooltip copy for the visits feature matches the copy above.
* This PR does not affect the copy on the marketing site.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
