### PR TITLE
Visits tooltip: Add fallback string if string is not translated

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -21,7 +21,7 @@ import {
 	FEATURE_JETPACK_ESSENTIAL,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
-import { translate, numberFormat } from 'i18n-calypso';
+import i18n, { translate, numberFormat, getLocaleSlug } from 'i18n-calypso';
 import type { TranslateResult, TranslateOptionsPlural } from 'i18n-calypso';
 
 export interface PlanComparisonFeature {
@@ -259,9 +259,17 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			return translate( 'Visits per month' );
 		},
 		get description() {
-			return translate(
+			const isStringTranslated = i18n.hasTranslation(
 				'WordPress Pro includes a generous 100,000 visits per month, which is 4x the limit for similarly priced plans at other popular managed WordPress hosts. Additional traffic can be purchased in 100,000 increments.'
 			);
+
+			if ( 'en' === getLocaleSlug() || isStringTranslated ) {
+				return translate(
+					'WordPress Pro includes a generous 100,000 visits per month, which is 4x the limit for similarly priced plans at other popular managed WordPress hosts. Additional traffic can be purchased in 100,000 increments.'
+				);
+			}
+
+			return translate( 'Max visits per month.' );
 		},
 		features: [ FEATURE_10K_VISITS, FEATURE_100K_VISITS ],
 		getCellText: ( feature, isMobile = false ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A new copy was introduced in #62480 for the visits feature tooltip. This PR adds the old string to be a fallback string till the new translations come in.

**BEFORE**
<img width="659" alt="Screenshot 2022-04-04 at 8 44 44 AM" src="https://user-images.githubusercontent.com/1269602/161478897-8d152cb4-01f8-48c9-9f8f-c05a2260a037.png">

**AFTER**



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In any non-en locale, check the tooltip for the visits feature in the signup flow /plans step and confirm that the copy is translated.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
