### PR TITLE
Updated WordPress export link

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -93,7 +93,7 @@ const contextLinks = {
 		post_id: 147777,
 	},
 	'importers-wordpress': {
-		link: 'https://wordpress.com/support/moving-from-self-hosted-wordpress-to-wordpress-com/',
+		link: 'https://wordpress.com/support/export/',
 		post_id: 102755,
 	},
 	'introduction-to-woocommerce': {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updated WordPress export guide link

#### Testing instructions

1. Go to Tools → Import
2. Click the WordPress link
3. Click the "upload it to import content" link
4. Click the "Need help exporting your content?" link
5. It should lead to [https://wordpress.com/support/export/](Export WordPress Page)

#### Screenshot
![Screenshot 2022-04-04 at 3 23 37 PM](https://user-images.githubusercontent.com/20247338/161520267-a74787d8-99bb-4e1d-81bd-f6ff1eea884a.png)


Fixes #62452
