### PR TITLE
Updates copy on DIFM options page

### DIFF
--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -37,7 +37,10 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 				return {
 					headerText: translate( "First, let's give your site a name" ),
 					headerImage: siteOptionsImage,
-					siteTitleLabel: translate( 'Site title' ),
+					siteTitleLabel: translate( 'Site name' ),
+					siteTitleExplanation: translate(
+						'Enter the name of your business or project as it should appear on your site.'
+					),
 					taglineExplanation: translate( 'In a few words, explain what your site is about.' ),
 					isSiteTitleRequired: true,
 				};
@@ -57,6 +60,7 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 		headerText,
 		headerImage,
 		siteTitleLabel,
+		siteTitleExplanation,
 		taglineExplanation,
 		isSiteTitleRequired,
 	} = getSiteOptionsProps( stepName );
@@ -87,6 +91,7 @@ export default function SiteOptionsStep( props: Props ): React.ReactNode {
 					defaultSiteTitle={ siteTitle }
 					defaultTagline={ tagline }
 					siteTitleLabel={ siteTitleLabel }
+					siteTitleExplanation={ siteTitleExplanation }
 					taglineExplanation={ taglineExplanation }
 					isSiteTitleRequired={ isSiteTitleRequired }
 					onSubmit={ submitSiteOptions }

--- a/client/signup/steps/site-options/site-options.tsx
+++ b/client/signup/steps/site-options/site-options.tsx
@@ -16,7 +16,8 @@ interface Props {
 	defaultSiteTitle: string;
 	defaultTagline: string;
 	siteTitleLabel: ReactChild;
-	taglineExplanation: ReactChild;
+	siteTitleExplanation?: ReactChild;
+	taglineExplanation?: ReactChild;
 	isSiteTitleRequired?: boolean;
 	isTaglineRequired?: boolean;
 	onSubmit: ( siteOptionsFormValues: SiteOptionsFormValues ) => void;
@@ -27,6 +28,7 @@ const SiteOptions: React.FC< Props > = ( {
 	defaultSiteTitle = '',
 	defaultTagline = '',
 	siteTitleLabel,
+	siteTitleExplanation,
 	taglineExplanation,
 	isSiteTitleRequired,
 	isTaglineRequired,
@@ -77,6 +79,12 @@ const SiteOptions: React.FC< Props > = ( {
 					onChange={ onChange }
 				/>
 				{ siteTitleError && <FormInputValidation isError text={ siteTitleError } /> }
+				{ siteTitleExplanation && (
+					<FormSettingExplanation>
+						<Icon className="site-options__form-icon" icon={ tip } size={ 20 } />
+						{ siteTitleExplanation }
+					</FormSettingExplanation>
+				) }
 			</FormFieldset>
 			<FormFieldset className="site-options__form-fieldset">
 				<FormLabel htmlFor="tagline" optional={ ! isTaglineRequired }>
@@ -90,10 +98,12 @@ const SiteOptions: React.FC< Props > = ( {
 					onChange={ onChange }
 				/>
 				{ taglineError && <FormInputValidation isError text={ taglineError } /> }
-				<FormSettingExplanation>
-					<Icon className="site-options__form-icon" icon={ tip } size={ 20 } />
-					{ taglineExplanation }
-				</FormSettingExplanation>
+				{ taglineExplanation && (
+					<FormSettingExplanation>
+						<Icon className="site-options__form-icon" icon={ tip } size={ 20 } />
+						{ taglineExplanation }
+					</FormSettingExplanation>
+				) }
 			</FormFieldset>
 			<Button className="site-options__submit-button" type="submit" primary>
 				{ translate( 'Continue' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: pdh1Xd-LF-p2#comment-1022

* Updates the copy for the `difm-options` step.
* Adds a `siteTitleExplanation` prop to the `SiteOptionsStep` component.
<img width="1917" alt="image" src="https://user-images.githubusercontent.com/5436027/161549174-e12a9e5e-268c-4b35-a119-de1876c23f1f.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me/?flags=signup/redesigned-difm-flow`.
* Click on "New Site".
* Confirm that the copy has been updated and the site title explanation is visible.

**Testing the intent step:**
* Go to `/start/setup-site/intent?siteSlug=<site slug>`
* Click on "Write".
* Confirm that there are no breakages on this screen.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 0-as-1202070479513039/f