### PR TITLE
G Suite: Enable Google Workspace monthly for all users

### DIFF
--- a/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
@@ -25,9 +24,6 @@ const usePlanAvailable = (
 		selectedDomainName: selectedDomainName,
 	} );
 
-	const isMonthlyBillingSupported =
-		isEnabled( 'google-workspace-monthly' ) || intervalLength === IntervalLength.ANNUALLY;
-
 	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
 
 	if ( emailProviderSlug !== GOOGLE_WORKSPACE_PRODUCT_TYPE ) {
@@ -39,14 +35,10 @@ const usePlanAvailable = (
 	}
 
 	if ( isDomainInCart ) {
-		return isMonthlyBillingSupported;
+		return true;
 	}
 
-	if ( ! domain || ! hasGSuiteSupportedDomain( [ domain ] ) ) {
-		return false;
-	}
-
-	return isMonthlyBillingSupported;
+	return domain && hasGSuiteSupportedDomain( [ domain ] );
 };
 
 const SelectButton = ( {

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY,
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
@@ -58,14 +57,6 @@ const GoogleWorkspacePrice = ( {
 		return (
 			<div className="google-workspace-price__unavailable">
 				{ translate( 'Not available for this domain name' ) }
-			</div>
-		);
-	}
-
-	if ( ! isEnabled( 'google-workspace-monthly' ) && intervalLength === IntervalLength.MONTHLY ) {
-		return (
-			<div className="google-workspace-price__unavailable">
-				{ translate( 'Only available with annual billing' ) }
 			</div>
 		);
 	}

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY,
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
@@ -109,9 +108,7 @@ const GoogleWorkspaceCard = ( {
 	const [ addingToCart, setAddingToCart ] = useState( false );
 
 	const isGSuiteSupported =
-		canPurchaseGSuite &&
-		( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) ) &&
-		( isEnabled( 'google-workspace-monthly' ) || intervalLength === IntervalLength.ANNUALLY );
+		canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );
 
 	const googleWorkspace: ProviderCardProps = { ...googleWorkspaceCardInformation };
 	googleWorkspace.detailsExpanded = isGSuiteSupported && detailsExpanded;

--- a/config/development.json
+++ b/config/development.json
@@ -59,7 +59,6 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"google-drive": true,
-		"google-workspace-monthly": false,
 		"gutenboarding/alpha-templates": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,


### PR DESCRIPTION
This pull request removes a feature flag in order to offer monthly billing for Google Workspace on the `Email Comparison` page:

![image](https://user-images.githubusercontent.com/594356/161758682-d079576a-6cba-4f17-8f12-c6b000e243ab.png)

#### Testing instructions

1. Run `git checkout enable/google-workspace-monthly` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/62491#issuecomment-1087664377)
2. Log into a WordPress.com account with a domain but no email yet
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Click the `Add Email` button for that domain
5. Click the `Pay monthly` selector at the top of the page
6. Assert that you can purchase Google Workspace with a monthly subscription
7. Navigate to the `Email Plan` page for that account
8. Assert that you can purchase additional mailboxes