### PR TITLE
Site Editor: Override the help link to point to the correct support document

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
@@ -8,6 +8,8 @@ function overrideCoreDocumentationLinksToWpcom( translation: string, text: strin
 			return 'https://wordpress.com/support/permalinks-and-slugs/';
 		case 'https://wordpress.org/support/article/wordpress-editor/':
 			return 'https://wordpress.com/support/wordpress-editor/';
+		case 'https://wordpress.org/support/article/site-editor/':
+			return 'https://wordpress.com/support/site-editor/';
 	}
 
 	return translation;


### PR DESCRIPTION
… documentation

#### Changes proposed in this Pull Request

* add case to method `overrideCoreDocumentationLinksToWpcom` to override site editors help link to point to the correct support document. ( _This method was recently added and provides the filter mechanism to override wpcom core documentation links_ )

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Sandbox your site
* Navigate to calypso/apps/editing-toolkit in terminal
* Execute yarn dev --sync
* Verify that the help link is now pointing to https://wordpress.com/support/site-editor/

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #61648