### PR TITLE
Themes: Link themes in activity log to theme page

### DIFF
--- a/client/components/notes-formatted-block/blocks.jsx
+++ b/client/components/notes-formatted-block/blocks.jsx
@@ -134,7 +134,7 @@ export const Theme = ( { content, onClick, meta, children } ) => {
 
 	return (
 		<a
-			href={ themeUri }
+			href={ `/theme/${ themeSlug }/${ siteSlug }` }
 			target="_blank"
 			rel="noopener noreferrer"
 			onClick={ onClick }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously, we used the `theme_uri` field for the link which was often a Github repository. Now we link to the actual theme page on WordPress.com.

#### Testing instructions

1. Go to "My Sites" and select a site.
2. Go to "Appearance -> Themes" and change to the **Archeo** theme.
3. Go to "Appearance -> Themes" and change to the **Skatepark** theme.
4. Go to "Jetpack -> Activity Log". You should see something like the following:
<img width="657" alt="image" src="https://user-images.githubusercontent.com/917632/161619303-97490b4f-db8b-42bf-acd3-fa830db8fe60.png">
5. Clicking on the links to the themes should take you to `/theme` and not the Github repo for the theme.

Fixes #55383
