### PR TITLE
Seller experience: Replace plan checks by features

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-features/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-features/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+import { FEATURE_SIMPLE_PAYMENTS, FEATURE_WOOP } from '@automattic/calypso-products';
 import { IntentScreen, StepContainer } from '@automattic/onboarding';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -8,7 +9,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { useIntents } from 'calypso/signup/steps/store-features/intents';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
-import { ONBOARD_STORE } from '../../../../stores';
+import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import type { Step } from '../../types';
 import './style.scss';
 
@@ -30,7 +31,14 @@ const StoreFeatures: Step = function StartingPointStep( { navigation } ) {
 	const subHeaderText = translate( 'Let’s create a website that suits your needs.' );
 	const siteSlug = useSiteSlugParam();
 	const site = useSite();
-	const intents = useIntents( siteSlug, site?.plan?.product_slug, trackSupportLinkClick );
+	const hasPaymentsFeature = useSelect(
+		( select ) =>
+			site && select( SITE_STORE ).hasActiveSiteFeature( site?.ID, FEATURE_SIMPLE_PAYMENTS )
+	);
+	const hasWooFeature = useSelect(
+		( select ) => site && select( SITE_STORE ).hasActiveSiteFeature( site?.ID, FEATURE_WOOP )
+	);
+	const intents = useIntents( siteSlug, hasPaymentsFeature, hasWooFeature, trackSupportLinkClick );
 	const { setStoreType } = useDispatch( ONBOARD_STORE );
 
 	const submitIntent = ( storeType: string ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-features/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-features/index.tsx
@@ -31,12 +31,11 @@ const StoreFeatures: Step = function StartingPointStep( { navigation } ) {
 	const subHeaderText = translate( 'Let’s create a website that suits your needs.' );
 	const siteSlug = useSiteSlugParam();
 	const site = useSite();
-	const hasPaymentsFeature = useSelect(
-		( select ) =>
-			site && select( SITE_STORE ).hasActiveSiteFeature( site?.ID, FEATURE_SIMPLE_PAYMENTS )
+	const hasPaymentsFeature = useSelect( ( select ) =>
+		select( SITE_STORE ).hasActiveSiteFeature( site?.ID, FEATURE_SIMPLE_PAYMENTS )
 	);
-	const hasWooFeature = useSelect(
-		( select ) => site && select( SITE_STORE ).hasActiveSiteFeature( site?.ID, FEATURE_WOOP )
+	const hasWooFeature = useSelect( ( select ) =>
+		select( SITE_STORE ).hasActiveSiteFeature( site?.ID, FEATURE_WOOP )
 	);
 	const intents = useIntents( siteSlug, hasPaymentsFeature, hasWooFeature, trackSupportLinkClick );
 	const { setStoreType } = useDispatch( ONBOARD_STORE );

--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -1,4 +1,4 @@
-import { FEATURE_SIMPLE_PAYMENTS, FEATURE_WOOCOMMERCE } from '@automattic/calypso-products';
+import { FEATURE_SIMPLE_PAYMENTS, FEATURE_WOOP } from '@automattic/calypso-products';
 import { SelectItems } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
@@ -76,7 +76,7 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 		hasActiveSiteFeature( state, props.siteId, FEATURE_SIMPLE_PAYMENTS )
 	);
 	const hasWooFeature = useSelector( ( state ) =>
-		hasActiveSiteFeature( state, props.siteId, FEATURE_WOOCOMMERCE )
+		hasActiveSiteFeature( state, props.siteId, FEATURE_WOOP )
 	);
 	const intents = useIntents( siteSlug, hasPaymentsFeature, hasWooFeature, trackSupportLinkClick );
 

--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -3,6 +3,7 @@ import { SelectItems } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
 import useBranchSteps from 'calypso/signup/hooks/use-branch-steps';
@@ -88,11 +89,14 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 			fallbackSubHeaderText={ subHeaderText }
 			headerImageUrl={ null }
 			stepContent={
-				<SelectItems
-					items={ intents }
-					onSelect={ submitStoreFeatures }
-					preventWidows={ preventWidows }
-				/>
+				<>
+					<QuerySiteFeatures siteId={ props.siteId } />
+					<SelectItems
+						items={ intents }
+						onSelect={ submitStoreFeatures }
+						preventWidows={ preventWidows }
+					/>
+				</>
 			}
 			align={ 'left' }
 			hideSkip={ true }

--- a/client/signup/steps/store-features/index.tsx
+++ b/client/signup/steps/store-features/index.tsx
@@ -1,3 +1,4 @@
+import { FEATURE_SIMPLE_PAYMENTS, FEATURE_WOOCOMMERCE } from '@automattic/calypso-products';
 import { SelectItems } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
@@ -6,8 +7,8 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
 import useBranchSteps from 'calypso/signup/hooks/use-branch-steps';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { getSite } from 'calypso/state/sites/selectors';
 import { EXCLUDED_STEPS } from '../intent/index';
 import { useIntents } from './intents';
 import { StoreFeatureSet } from './types';
@@ -66,14 +67,18 @@ export default function StoreFeaturesStep( props: Props ): React.ReactNode {
 		} );
 	};
 
-	const sitePlanSlug = useSelector( ( state ) => getSite( state, siteSlug )?.plan?.product_slug );
-
 	// Only do following things when mounted
 	React.useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
 	}, [] );
 
-	const intents = useIntents( siteSlug, sitePlanSlug, trackSupportLinkClick );
+	const hasPaymentsFeature = useSelector( ( state ) =>
+		hasActiveSiteFeature( state, props.siteId, FEATURE_SIMPLE_PAYMENTS )
+	);
+	const hasWooFeature = useSelector( ( state ) =>
+		hasActiveSiteFeature( state, props.siteId, FEATURE_WOOCOMMERCE )
+	);
+	const intents = useIntents( siteSlug, hasPaymentsFeature, hasWooFeature, trackSupportLinkClick );
 
 	return (
 		<StepWrapper

--- a/client/signup/steps/store-features/intents.tsx
+++ b/client/signup/steps/store-features/intents.tsx
@@ -8,8 +8,8 @@ import { StoreFeatureSet } from './types';
 
 export function useIntents(
 	siteSlug: string | null,
-	hasPaymentsFeature: bool | false,
-	hasWooFeature: bool | false,
+	hasPaymentsFeature: boolean | false,
+	hasWooFeature: boolean | false,
 	trackSupportLinkClick: ( url: StoreFeatureSet ) => void
 ): SelectItem< StoreFeatureSet >[] {
 	const translate = useTranslate();

--- a/client/signup/steps/store-features/intents.tsx
+++ b/client/signup/steps/store-features/intents.tsx
@@ -1,4 +1,3 @@
-import { isWpComProPlan } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { SelectItem } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
@@ -9,18 +8,14 @@ import { StoreFeatureSet } from './types';
 
 export function useIntents(
 	siteSlug: string | null,
-	sitePlanSlug: string | undefined,
+	hasPaymentsFeature: bool | false,
+	hasWooFeature: bool | false,
 	trackSupportLinkClick: ( url: StoreFeatureSet ) => void
 ): SelectItem< StoreFeatureSet >[] {
 	const translate = useTranslate();
 	if ( ! siteSlug ) {
 		return [];
 	}
-	const isPaidPlan = sitePlanSlug !== 'free_plan';
-	const isBusinessOrEcommercePlan = [ 'business-bundle', 'ecommerce-bundle' ].includes(
-		sitePlanSlug ?? ''
-	);
-	const isProPlan = sitePlanSlug ? isWpComProPlan( sitePlanSlug ) : false;
 
 	return [
 		{
@@ -29,7 +24,7 @@ export function useIntents(
 			description: (
 				<>
 					<span className="store-features__requirements">
-						{ isPaidPlan
+						{ hasPaymentsFeature
 							? translate( 'Included in your plan' )
 							: translate( 'Requires a {{a}}paid plan{{/a}}', {
 									components: {
@@ -84,7 +79,7 @@ export function useIntents(
 			description: (
 				<>
 					<span className="store-features__requirements">
-						{ isBusinessOrEcommercePlan || isProPlan
+						{ hasWooFeature
 							? translate( 'Included in your plan' )
 							: translate( 'Requires a {{a}}Pro plan{{/a}}', {
 									components: {
@@ -131,7 +126,7 @@ export function useIntents(
 			),
 			icon: truck,
 			value: 'power',
-			actionText: translate( 'Upgrade' ),
+			actionText: hasWooFeature ? translate( 'Continue' ) : translate( 'Upgrade' ),
 		},
 	] as SelectItem< StoreFeatureSet >[];
 }

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -56,6 +56,12 @@ export const getSiteSubdomain = ( _: State, siteId: number ) =>
 		.getSiteDomains( siteId )
 		?.find( ( domain ) => domain.is_subdomain );
 
-export const hasActiveSiteFeature = ( _: State, siteId: number, featureKey: string ) => {
-	return select( STORE_KEY ).getSite( siteId )?.plan?.features.active.includes( featureKey );
+export const hasActiveSiteFeature = (
+	_: State,
+	siteId: number | undefined,
+	featureKey: string
+): boolean => {
+	return Boolean(
+		siteId && select( STORE_KEY ).getSite( siteId )?.plan?.features.active.includes( featureKey )
+	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This changes the seller step to use feature checks instead of plan checks. It also changes the action button to read 'Continue' instead of 'Upgrade' if the user has Woo enabled (checking for FEATURE_WOOP).

| Before  | After |
| ------------- | ------------- |
| <img width="598" alt="image" src="https://user-images.githubusercontent.com/375980/162780662-429c93d6-0ad2-4713-aaa7-9c2faa564efb.png">  | <img width="598" alt="image" src="https://user-images.githubusercontent.com/375980/162780555-b93f6743-7660-4d95-b770-6d200b5d460f.png"> |


#### Testing
1. Apply this patch or go to the calypso.live link in this PR.
2. Go through the seller experience flow with a free plan and verify nothing is changed (subtitle and button text).
3. Go through the seller experience flow with a Pro Plan.
4. Verify under both options it reads: "Included in your Plan"
5. Verify the "More power" option action button reads "Continue" instead of "Upgrade"

**We should also test the sell step on the stepper flow. In order to do this go to this URL with a free and a Pro plan site
http://calypso.localhost:3000/stepper/storeFeatures?siteSlug=[YOUR_SITE] and verify the subtitles and button text.**

Closes https://github.com/Automattic/wp-calypso/issues/62468
