### PR TITLE
Disable free plan when user is connecting a domain in signup

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-action.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-action.tsx
@@ -24,6 +24,7 @@ interface Props {
 	isPrimary?: boolean;
 	manageHref?: string;
 	onClick?: () => void;
+	disabled?: boolean;
 }
 
 type TranslateFunc = ReturnType< typeof useTranslate >;
@@ -58,6 +59,7 @@ export const PlansComparisonAction: React.FunctionComponent< Props > = ( {
 	currentSitePlanSlug,
 	manageHref,
 	onClick,
+	disabled,
 	...props
 } ) => {
 	const { plan } = props;
@@ -91,7 +93,12 @@ export const PlansComparisonAction: React.FunctionComponent< Props > = ( {
 	}
 
 	return (
-		<Button className={ className } onClick={ handleClick } href={ manageHref }>
+		<Button
+			className={ className }
+			onClick={ handleClick }
+			href={ manageHref }
+			disabled={ disabled }
+		>
 			{ buttonText }
 		</Button>
 	);

--- a/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
@@ -9,6 +9,7 @@ interface Props {
 	plan: Plan;
 	price?: number;
 	originalPrice?: number;
+	showDomainConnectionExplanation?: boolean;
 	onClick?: ( productSlug: string ) => void;
 	translate: typeof translate;
 }
@@ -76,6 +77,7 @@ export const PlansComparisonColHeader: React.FunctionComponent< Props > = ( {
 	price,
 	originalPrice,
 	children,
+	showDomainConnectionExplanation,
 	translate,
 } ) => {
 	const isDiscounted = typeof originalPrice === 'number';
@@ -84,6 +86,7 @@ export const PlansComparisonColHeader: React.FunctionComponent< Props > = ( {
 		<th scope="col">
 			<PlanTitle>{ plan.getTitle() }</PlanTitle>
 			<PlanDescription>{ plan.getDescription() }</PlanDescription>
+			{ showDomainConnectionExplanation && <p>Connecting your domain requires the Pro plan</p> }
 			<PriceContainer>
 				{ isDiscounted && (
 					<>

--- a/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
@@ -9,7 +9,6 @@ interface Props {
 	plan: Plan;
 	price?: number;
 	originalPrice?: number;
-	showDomainConnectionExplanation?: boolean;
 	onClick?: ( productSlug: string ) => void;
 	translate: typeof translate;
 }
@@ -77,7 +76,6 @@ export const PlansComparisonColHeader: React.FunctionComponent< Props > = ( {
 	price,
 	originalPrice,
 	children,
-	showDomainConnectionExplanation,
 	translate,
 } ) => {
 	const isDiscounted = typeof originalPrice === 'number';
@@ -86,7 +84,6 @@ export const PlansComparisonColHeader: React.FunctionComponent< Props > = ( {
 		<th scope="col">
 			<PlanTitle>{ plan.getTitle() }</PlanTitle>
 			<PlanDescription>{ plan.getDescription() }</PlanDescription>
-			{ showDomainConnectionExplanation && <p>Connecting your domain requires the Pro plan</p> }
 			<PriceContainer>
 				{ isDiscounted && (
 					<>

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -21,6 +21,7 @@ import { PlansComparisonAction } from './plans-comparison-action';
 import { PlansComparisonColHeader } from './plans-comparison-col-header';
 import { planComparisonFeatures } from './plans-comparison-features';
 import { PlansComparisonRow, DesktopContent, MobileContent } from './plans-comparison-row';
+import { PlansDomainConnectionInfo } from './plans-domain-connection-info';
 import { usePlanPrices, PlanPrices } from './use-plan-prices';
 import type { WPComPlan } from '@automattic/calypso-products';
 import type { RequestCartProduct as CartItem } from '@automattic/shopping-cart';
@@ -394,6 +395,7 @@ interface Props {
 	isInSignup?: boolean;
 	selectedSiteId?: number;
 	selectedSiteSlug?: string;
+	selectedDomainConnection?: boolean;
 	hideFreePlan?: boolean;
 	purchaseId?: number | null;
 	onSelectPlan: ( item: Partial< CartItem > | null ) => void;
@@ -414,6 +416,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	isInSignup = false,
 	selectedSiteId,
 	selectedSiteSlug,
+	selectedDomainConnection,
 	purchaseId,
 	hideFreePlan,
 	onSelectPlan,
@@ -467,6 +470,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 								originalPrice={ prices[ index ].originalPrice }
 								translate={ translate }
 							>
+								{ selectedDomainConnection && <PlansDomainConnectionInfo plan={ plan } /> }
 								<PlansComparisonAction
 									currentSitePlanSlug={ sitePlan?.product_slug }
 									plan={ plan }
@@ -474,6 +478,9 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 									isPrimary={ plan.type === TYPE_PRO }
 									isCurrentPlan={ sitePlan?.product_slug === plan.getStoreSlug() }
 									manageHref={ manageHref }
+									disabled={
+										selectedDomainConnection && [ TYPE_FREE, TYPE_FLEXIBLE ].includes( plan.type )
+									}
 									onClick={ () => onSelectPlan( planToCartItem( plan ) ) }
 								/>
 							</PlansComparisonColHeader>

--- a/client/my-sites/plans-comparison/plans-domain-connection-info.tsx
+++ b/client/my-sites/plans-comparison/plans-domain-connection-info.tsx
@@ -1,0 +1,52 @@
+import { TYPE_FREE, TYPE_FLEXIBLE } from '@automattic/calypso-products';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import InfoPopover from 'calypso/components/info-popover';
+import { SCREEN_BREAKPOINT_SIGNUP } from './constant';
+import type { WPComPlan } from '@automattic/calypso-products';
+
+const P = styled.p`
+	display: flex;
+	font-size: 0.9em;
+
+	.info-popover {
+		display: none;
+	}
+
+	@media screen and ( min-width: ${ SCREEN_BREAKPOINT_SIGNUP + 1 }px ) {
+		height: 21px;
+
+		.info-popover {
+			display: initial;
+		}
+	}
+`;
+
+const Span = styled.span`
+	margin-left: 0;
+
+	@media screen and ( min-width: ${ SCREEN_BREAKPOINT_SIGNUP + 1 }px ) {
+		margin-left: 4px;
+	}
+`;
+
+interface Props {
+	plan: WPComPlan;
+}
+
+export const PlansDomainConnectionInfo: React.FunctionComponent< Props > = ( { plan } ) => {
+	const translate = useTranslate();
+
+	if ( [ TYPE_FREE, TYPE_FLEXIBLE ].includes( plan.type ) ) {
+		return <P />;
+	}
+
+	return (
+		<P>
+			<InfoPopover position="top" iconSize={ 18 } showOnHover={ true }>
+				{ translate( 'Only paid annual subscriptions allow you to connect domains.' ) }
+			</InfoPopover>
+			<Span>{ translate( 'Connecting a domain requires a paid plan' ) }</Span>
+		</P>
+	);
+};

--- a/client/my-sites/plans-comparison/plans-domain-connection-info.tsx
+++ b/client/my-sites/plans-comparison/plans-domain-connection-info.tsx
@@ -46,7 +46,7 @@ export const PlansDomainConnectionInfo: React.FunctionComponent< Props > = ( { p
 			<InfoPopover position="top" iconSize={ 18 } showOnHover={ true }>
 				{ translate( 'Only paid annual subscriptions allow you to connect domains.' ) }
 			</InfoPopover>
-			<Span>{ translate( 'Connecting a domain requires a paid plan' ) }</Span>
+			<Span>{ translate( 'Connecting a domain requires a Pro plan' ) }</Span>
 		</P>
 	);
 };

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -155,6 +155,8 @@ export class PlansStep extends Component {
 		}
 
 		if ( eligibleForProPlan ) {
+			const selectedDomainConnection =
+				this.props.progress?.domains?.domainItem?.product_slug === 'domain_map';
 			return (
 				<div>
 					{ errorDisplay }
@@ -162,6 +164,7 @@ export class PlansStep extends Component {
 						isInSignup={ true }
 						onSelectPlan={ this.onSelectPlan }
 						selectedSiteId={ selectedSite?.ID || undefined }
+						selectedDomainConnection={ selectedDomainConnection }
 					/>
 				</div>
 			);


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR disables the free plan selection button in the plan selection step when the user wants to connect a domain during signup. It also adds a message explaining that only paid plans allow users to connect domains.

#### Screenshots:

- Desktop view

![Markup on 2022-04-04 at 17:08:19](https://user-images.githubusercontent.com/5324818/161623571-fac3f11b-c7f9-48cf-a654-e95bd6775a64.png)

- Tooltip text

<img width="448" alt="Screen Shot 2022-04-04 at 17 08 30" src="https://user-images.githubusercontent.com/5324818/161623591-83f8a528-d3e5-4be2-8f34-fc75f6841e1a.png">

- Mobile view

<img width="393" alt="Screen Shot 2022-04-04 at 17 09 43" src="https://user-images.githubusercontent.com/5324818/161623753-6866279e-32a7-489f-8b2e-d796767bcbca.png">

### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to `/start`
- Select the "Use a domain I own" flow
- Input a domain that can be connected
- In the "Transfer or connect" page, select "Connect your domain"
- In the plan selection page, ensure that the free plan button is disabled and there's an explanation text about the domain connection only being available in the Pro plan
- Also please test going through signup when selecting a domain for registration or transfer and ensure the free plan is enabled in these cases