### PR TITLE
Marketplace: Indicate that popular search term has been clicked

### DIFF
--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -29,7 +29,7 @@ const SearchBox = ( { isMobile, doSearch, searchTerm, searchBoxRef } ) => {
 };
 
 const PopularSearches = ( props ) => {
-	const { searchTerms, doSearch } = props;
+	const { searchTerms, doSearch, searchedTerm } = props;
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -50,18 +50,27 @@ const PopularSearches = ( props ) => {
 			</div>
 
 			<div className="search-box-header__recommended-searches-list">
-				{ searchTerms.map( ( searchTerm, n ) => (
-					<span
-						onClick={ () => onClick( searchTerm ) }
-						onKeyPress={ () => onClick( searchTerm ) }
-						role="link"
-						tabIndex={ 0 }
-						className="search-box-header__recommended-searches-list-item"
-						key={ 'recommended-search-item-' + n }
-					>
-						{ searchTerm }
-					</span>
-				) ) }
+				{ searchTerms.map( ( searchTerm, n ) =>
+					searchTerm === searchedTerm ? (
+						<span
+							className="search-box-header__recommended-searches-list-item search-box-header__recommended-searches-list-item-selected"
+							key={ 'recommended-search-item-' + n }
+						>
+							{ searchTerm }
+						</span>
+					) : (
+						<span
+							onClick={ () => onClick( searchTerm ) }
+							onKeyPress={ () => onClick( searchTerm ) }
+							role="link"
+							tabIndex={ 0 }
+							className="search-box-header__recommended-searches-list-item"
+							key={ 'recommended-search-item-' + n }
+						>
+							{ searchTerm }
+						</span>
+					)
+				) }
 			</div>
 		</div>
 	);
@@ -82,7 +91,11 @@ const SearchBoxHeader = ( props ) => {
 			<div className="search-box-header__search">
 				<SearchBox doSearch={ doSearch } searchTerm={ searchTerm } searchBoxRef={ searchBoxRef } />
 			</div>
-			<PopularSearches doSearch={ updateSearchBox } searchTerms={ searchTerms } />
+			<PopularSearches
+				doSearch={ updateSearchBox }
+				searchedTerm={ searchTerm }
+				searchTerms={ searchTerms }
+			/>
 		</div>
 	);
 };

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -68,7 +68,7 @@
 			text-align: center;
 
 			.search-box-header__recommended-searches-list-item {
-				&:hover {
+				&:hover:not( .search-box-header__recommended-searches-list-item-selected ) {
 					color: var( --color-link );
 					cursor: pointer;
 				}
@@ -82,9 +82,16 @@
 					content: '\00a0,\00a0'; // comma and spaces
 				}
 
+				&:not( .search-box-header__recommended-searches-list-item-selected ) {
+					text-decoration: underline;
+				}
+
+				&.search-box-header__recommended-searches-list-item-selected {
+					font-weight: bold;
+				}
+
 				color: var( --studio-gray-100 );
 				font-size: $font-body-small;
-				text-decoration: underline;
 				line-height: 22px;
 				text-align: center;
 			}

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -25,20 +25,20 @@
 				&.is-expanded-to-container {
 					height: 100%;
 				}
-		
+
 				box-shadow: 0 0 0 1px var( --studio-gray-10 );
-		
+
 				.search-component__open-icon,
 				.search-component__close-icon {
 					color: var( --studio-black );
 				}
-		
+
 				&.is-open input.search-component__input[type='search'] {
 					font-size: $font-body-small;
 				}
 			}
 		}
-		
+
 	}
 
 	.search-box-header__header {
@@ -84,10 +84,6 @@
 
 				&:not( .search-box-header__recommended-searches-list-item-selected ) {
 					text-decoration: underline;
-				}
-
-				&.search-box-header__recommended-searches-list-item-selected {
-					font-weight: bold;
 				}
 
 				color: var( --studio-gray-100 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a popular search term is clicked and we land on the results page, that search term word should no longer be a link. It should be unclickable with no underline. From pdh6GB-AJ-p2#comment-1158

<img width="646" alt="Screen Shot 2022-04-04 at 9 35 52 AM" src="https://user-images.githubusercontent.com/1689238/161556086-b03cb4d8-1b42-43ba-a4bc-e826e4b97a2c.png">


Acceptance criteria:
- [x] The search term that results are displayed for is no longer clickable.
- [x] The search term becomes clickable again after any change to the search field, or clicking on another search term.

#### Testing instructions

1. Go to /plugins
2. Click on one of the popular search terms
3. The word you clicked should not have been underlined and should not be clickable

Related to #62490
