### PR TITLE
Fix "open in new tab" keyboard modifiers in wpcom block editor

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -767,7 +767,7 @@ function openCustomizer( calypsoPort ) {
  */
 function openTemplatePartLinks( calypsoPort ) {
 	addEditorListener( '.template__block-container .template-block__overlay a', ( e ) => {
-		e.preventDefault(); // TODO: link?
+		e.preventDefault();
 		e.stopPropagation(); // Otherwise it will port the message twice.
 
 		// Get the template part ID from the current href.

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -36,8 +36,7 @@ const debug = debugFactory( 'wpcom-block-editor:iframe-bridge-server' );
 
 const clickOverrides = {};
 let addedListener = false;
-// Replicates basic '$( el ).on( selector, cb )'. Includes preventDefault to override
-// the default event handlers.
+// Replicates basic '$( el ).on( selector, cb )'.
 function addEditorListener( selector, cb ) {
 	clickOverrides[ selector ] = cb;
 
@@ -62,10 +61,7 @@ function triggerOverrideHandler( e ) {
 
 	// Find the correct callback to use for this clicked element.
 	for ( const [ selector, cb ] of Object.entries( clickOverrides ) ) {
-		if ( matchingElement.matches( selector ) ) {
-			e.preventDefault();
-			cb( e );
-		}
+		matchingElement.matches( selector ) && cb( e );
 	}
 }
 
@@ -128,7 +124,8 @@ function handlePostTrash( calypsoPort ) {
 }
 
 function overrideRevisions( calypsoPort ) {
-	addEditorListener( '[href*="revision.php"]', () => {
+	addEditorListener( '[href*="revision.php"]', ( e ) => {
+		e.preventDefault();
 		calypsoPort.postMessage( { action: 'openRevisions' } );
 
 		calypsoPort.addEventListener( 'message', onLoadRevision, false );
@@ -586,11 +583,11 @@ async function openLinksInParentFrame( calypsoPort ) {
 	].join( ',' );
 
 	addEditorListener( viewPostLinks, ( e ) => {
-		// Ignore if the click has modifier
+		// Allows modifiers to open links outside of the current tab using the default behavior.
 		if ( e.shiftKey || e.ctrlKey || e.metaKey ) {
 			return;
 		}
-
+		e.preventDefault();
 		calypsoPort.postMessage( {
 			action: 'viewPost',
 			payload: { postUrl: e.target.href },
@@ -751,6 +748,7 @@ async function openLinksInParentFrame( calypsoPort ) {
  */
 function openCustomizer( calypsoPort ) {
 	addEditorListener( '[href*="customize.php"]', ( e ) => {
+		e.preventDefault();
 		calypsoPort.postMessage( {
 			action: 'openCustomizer',
 			payload: {
@@ -769,6 +767,7 @@ function openCustomizer( calypsoPort ) {
  */
 function openTemplatePartLinks( calypsoPort ) {
 	addEditorListener( '.template__block-container .template-block__overlay a', ( e ) => {
+		e.preventDefault(); // TODO: link?
 		e.stopPropagation(); // Otherwise it will port the message twice.
 
 		// Get the template part ID from the current href.


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Resolves #61237. A portion of the pre-jquery-removal event handlers checked if events used a modifier like ctrl or shift _before_ preventing the default behavior. After removing Jquery, `preventDefault` happened automatically for all of our overridden events. However, this meant that our keyboard modifier code happens _after_ calling `preventDefault`. Since prevent default stops the default behavior -- opening the link in a new tab when using the ctrl modifier -- we got a bug.

The easiest way to solve this is to move `preventDefault` back into the callbacks instead of running it automatically. Then we can check the keyboard modifiers first in the correct spot.

~I also added a drive-by fix for a console error I noticed -- the selector changed for the more menu, so the reusable blocks link in that menu was no longer opening in Calypso.~ Resolved in #62473

#### Testing instructions
1. Sandbox a test site and widgets.wp.com.
2. Run `install-plugin.sh wbe fix/wpcom-block-editor-new-tab-links` on your sandbox
3. Load a post in gutenberg on the sandboxed site
4. Update the post
5. Using `cmd` (or `ctrl` if not macOS), click on the "view post" link in the snackbar at the bottom which shows after updating.
6. The post should open in a new tab

