### PR TITLE
Fix nav from the individual domain view back to the all domains view

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -67,7 +67,6 @@ const Settings = ( {
 }: SettingsPageProps ): JSX.Element => {
 	const translate = useTranslate();
 	const contactInformation = findRegistrantWhois( whoisData );
-	const isDomainOnly = selectedSite.options?.is_domain_only;
 
 	useEffect( () => {
 		if ( ! contactInformation ) {
@@ -120,7 +119,7 @@ const Settings = ( {
 	};
 
 	const renderStatusSection = () => {
-		if ( ! ( domain && isDomainOnly ) ) {
+		if ( ! ( domain && selectedSite.options?.is_domain_only ) ) {
 			return null;
 		}
 
@@ -145,7 +144,7 @@ const Settings = ( {
 					title={ translate( 'Details', { textOnly: true } ) }
 					subtitle={ translate( 'Registration and auto-renew', { textOnly: true } ) }
 					key="main"
-					expanded={ ! isDomainOnly }
+					expanded={ ! selectedSite.options?.is_domain_only }
 				>
 					<RegisteredDomainDetails
 						domain={ domain }


### PR DESCRIPTION
The all-site domain management UI "crashes" when the user navigates from the individual domain settings screen back to the all domains screen.


1. Make sure you're testing with a user who owns some domains
2. Head to `/domains/manage/all` to see the all-site domain management UI
3. Click one of the domains to navigate to that domain's settings UI
4. Either click the browser back button or click "All Domains" in the breadcrumb:
   <img width="1619" alt="Screenshot 2022-04-05 at 2 42 47 PM" src="https://user-images.githubusercontent.com/1500769/161669247-f0ccee4f-4851-4dbd-979b-6c6ea92399e7.png">
5. Crash 😮 
   <img width="1619" alt="Screenshot 2022-04-05 at 2 43 06 PM" src="https://user-images.githubusercontent.com/1500769/161668922-ae79828c-2d71-4058-95ce-df208ec9500c.png">

#### Changes proposed in this Pull Request

The issue appears to be that the `<Settings>` component is still momentarily rendered even as the user navigates back to the all domains view. When this happens `selectedSite` is undefined, but we attempt to access the site options anyway.

Delaying access to `selectedSite` till later in the render, by which time we know there will be a selected site, fixes the issue.

Another fix would be to add a simple undefined check before trying to access the site options a la `selectedSite?.options?.is_domain_only`. IMO it's better to just not even try to access properties that we know might not be defined, but I could be convinced otherwise.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test by checking out this branch and building Calypso locally, or testing with [the calypso.live links](https://github.com/Automattic/wp-calypso/pull/62507#issuecomment-1088222309).
* Follow the steps above to reproduce.
* The Calypso error screen shouldn't appear anymore.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
