### PR TITLE
Support: Fix wordpress importers context link

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -94,7 +94,7 @@ const contextLinks = {
 	},
 	'importers-wordpress': {
 		link: 'https://wordpress.com/support/export/',
-		post_id: 102755,
+		post_id: 2087,
 	},
 	'introduction-to-woocommerce': {
 		link: 'https://wordpress.com/support/introduction-to-woocommerce/',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the ID of the support article that we missed updating in #62484.

Fixes #62452.

#### Testing instructions

* Go to `/import/:site` where `:site` is a WP.com simple site.
* Click on "WordPress".
* Click on "upload it to import content".
* Click on "Need help exporting your content"
* Verify that https://wordpress.com/support/export/ is opened in the dialog.