### PR TITLE
Update wording for connected domain details, when autorenew is active

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
@@ -42,9 +42,20 @@ const ConnectedDomainDetails = ( {
 			return translate( 'Domain connection expired on %(expirationDate)s', args );
 		}
 
-		return domain.bundledPlanSubscriptionId
-			? translate( 'Domain connection expires with your plan on %(expirationDate)s', args )
+		const expireWithBundledMessage = domain.isAutoRenewing
+			? translate(
+					'Domain connection will be autorenewed with your plan on %(expirationDate)s',
+					args
+			  )
+			: translate( 'Domain connection expires with your plan on %(expirationDate)s', args );
+
+		const expireWithoutBundledMessage = domain.isAutoRenewing
+			? translate( 'Domain connection will be autorenewed on %(expirationDate)s', args )
 			: translate( 'Domain connection expires on %(expirationDate)s', args );
+
+		return domain.bundledPlanSubscriptionId
+			? expireWithBundledMessage
+			: expireWithoutBundledMessage;
 	};
 
 	return (

--- a/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
@@ -44,13 +44,13 @@ const ConnectedDomainDetails = ( {
 
 		const expireWithBundledMessage = domain.isAutoRenewing
 			? translate(
-					'Domain connection will be autorenewed with your plan on %(expirationDate)s',
+					'Domain connection will be auto-renewed with your plan on %(expirationDate)s',
 					args
 			  )
 			: translate( 'Domain connection expires with your plan on %(expirationDate)s', args );
 
 		const expireWithoutBundledMessage = domain.isAutoRenewing
-			? translate( 'Domain connection will be autorenewed on %(expirationDate)s', args )
+			? translate( 'Domain connection will be auto-renewed on %(expirationDate)s', args )
 			: translate( 'Domain connection expires on %(expirationDate)s', args );
 
 		return domain.bundledPlanSubscriptionId


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR update the message displayed in _Details Card_, under _Domain settings page_, for bundled connected domains.

Before this, we showed "Domain connection expires with your plan on [...]" even if the bundled subscription had autorenew enabled.

Now we show a new message: "Domain connection will be renewed with your plan on [...]"

If the autorenew is off, we continue to display the old one.

Related to [#61999](https://github.com/Automattic/wp-calypso/issues/61999)

![wording-before](https://user-images.githubusercontent.com/2797601/161243316-b167358a-d0b4-4aab-a340-5b1b55762f3e.png)

![wording-after](https://user-images.githubusercontent.com/2797601/161243360-ef5e55c5-f83b-416d-9e3d-4c2153182c45.png)

## Testing instructions
- Build this branch locally or open the live Calypso link
- Select a connected domain that belongs to a bundled plan with active autorenew
- Verify that Details card shows the new message
- Disable autorenew on the subscription
- Verify that Details card shows the old message
