### PR TITLE
Block Editor tracking: call tracked actions asynchronously

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -764,7 +764,7 @@ if (
 } else {
 	debug( 'registering tracking handlers.' );
 	// Intercept dispatch function and add tracking for actions that need it.
-	use( async ( registry ) => ( {
+	use( ( registry ) => ( {
 		dispatch: ( namespace ) => {
 			const namespaceName = typeof namespace === 'object' ? namespace.name : namespace;
 			const actions = { ...registry.dispatch( namespaceName ) };

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -764,7 +764,7 @@ if (
 } else {
 	debug( 'registering tracking handlers.' );
 	// Intercept dispatch function and add tracking for actions that need it.
-	use( ( registry ) => ( {
+	use( async ( registry ) => ( {
 		dispatch: ( namespace ) => {
 			const namespaceName = typeof namespace === 'object' ? namespace.name : namespace;
 			const actions = { ...registry.dispatch( namespaceName ) };
@@ -774,7 +774,7 @@ if (
 				Object.keys( trackers ).forEach( ( actionName ) => {
 					const originalAction = actions[ actionName ];
 					const tracker = trackers[ actionName ];
-					actions[ actionName ] = ( ...args ) => {
+					actions[ actionName ] = async ( ...args ) => {
 						debug( 'action "%s" called with %o arguments', actionName, [ ...args ] );
 						// We use a try-catch here to make sure the `originalAction`
 						// is always called. We don't want to break the original
@@ -791,7 +791,7 @@ if (
 							// eslint-disable-next-line no-console
 							console.error( err );
 						}
-						return originalAction( ...args );
+						return await originalAction( ...args );
 					};
 				} );
 			}


### PR DESCRIPTION
Fixes #57449

#### Changes proposed in this Pull Request

* Call tracked actions asynchronously

Related discussion: p1649145116774249-slack-CDLH4C1UZ

#### Testing instructions

- To test, you'll need a WordPress.com sandbox as well as a WoA dev site (reference: p9o2xV-1r2-p2 )
- On that WoA dev site, you'll want to `define( 'SCRIPT_DEBUG', true );` to load the unminified version of the script.
- SSH into your WordPress.com sandbox
- Point `widgets.wp.com` to your sandbox in your hosts file.
- Locally, in `~/.ssh/config`, you'll want to have an alias for your WordPress.com sandbox using the `wpcom-sandbox` alias.
- Locally, check out a copy of Calypso.
- `cd apps/wpcom-block-editor`
- `yarn dev --sync`
- You should see the wpcom block editor getting built, and then successfully synced with your sandbox.
- On your WordPress.com sandbox, `git status` will show the changes.
- On your WoA site, the file loading from `https://widgets.wp.com/wpcom-block-editor/wpcom.editor.js?minify=false&ver=20220405` now loads the content from your sandbox.
- On that WoA site, install both the WooCommerce plugin and the WooCommerce blocks plugin
- Go to Posts > Add New, and add a Cart block to your post
- It should be inserted with no issues.
- Repeat on a page.
- Repeat in Appearance > Widgets

*********

Once you've done that, you'll want to test tracking as well:

- Follow steps to enable tracking debugging at PCYsg-nrf-p2
- Make sure you test tracking when in the wp-admin editor (not the iFramed block editor).
- Test in the post / page / widget editor.
- Test by adding blocks.

********

- Also check that the tests pass in CI.