### PR TITLE
WooCommerce installer: Fix upgrade warning

### DIFF
--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -136,21 +136,20 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	 * Feature available means although the site doesn't have the feature active,
 	 * it's available to be activated via buying a plan.
 	 */
-	const hasWoopFeatureAvailable = useSelector(
-		( state ) => hasAvailableSiteFeature( state, siteId, FEATURE_WOOP ) || []
+	const hasWoopFeatureAvailable: Record< number, string > | false = useSelector( ( state ) =>
+		hasAvailableSiteFeature( state, siteId, FEATURE_WOOP )
 	);
 
 	// The site requires upgrading when the feature is not active and available.
-	const requiresUpgrade = Boolean(
-		! isWoopFeatureActive && Object.keys( hasWoopFeatureAvailable ).length > 0
-	);
+	const requiresUpgrade = Boolean( ! isWoopFeatureActive && hasWoopFeatureAvailable );
 
 	/*
 	 * We pick the first plan from the available plans list.
 	 * The priority is defined by the store products list.
 	 */
+	const firstAvailablePlan = hasWoopFeatureAvailable ? hasWoopFeatureAvailable[ 0 ] : undefined;
 	const upgradingPlan = useSelector( ( state ) =>
-		getProductBySlug( state, hasWoopFeatureAvailable[ 0 ] )
+		firstAvailablePlan ? getProductBySlug( state, firstAvailablePlan ) : undefined
 	);
 
 	const productName = upgradingPlan?.product_name ?? '';

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -141,7 +141,9 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	);
 
 	// The site requires upgrading when the feature is not active and available.
-	const requiresUpgrade = Boolean( ! isWoopFeatureActive && hasWoopFeatureAvailable.length );
+	const requiresUpgrade = Boolean(
+		! isWoopFeatureActive && Object.keys( hasWoopFeatureAvailable ).length > 0
+	);
 
 	/*
 	 * We pick the first plan from the available plans list.

--- a/client/state/selectors/has-available-site-feature.js
+++ b/client/state/selectors/has-available-site-feature.js
@@ -6,7 +6,7 @@ import getSiteFeatures from 'calypso/state/selectors/get-site-features';
  * @param  {object}  state      Global state tree
  * @param  {number}  siteId     The ID of the site we're querying
  * @param  {string}  featureId  The dotcom feature to check.
- * @returns {false|string[]}    Plasns array if the feature is available. Otherwise, False.
+ * @returns {false|Object.<number, string>}    Plasns array if the feature is available. Otherwise, False.
  */
 export default function hasAvailableSiteFeature( state, siteId, featureId ) {
 	const siteFeatures = getSiteFeatures( state, siteId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Checks `hasWoopFeatureAvailable` object length instead of array length
* In response to error report here: p1649156762419429-slack-C031TFM2NKC

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With a free plan, start the flow at /woocommerce-installation
* You should be prompted to upgrade before transfer
* With a pro plan, start the flow at /woocommerce-installation
* You should not be prompted to upgrade before transfer

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #