### PR TITLE
Update the storage space to 1024 in plan-storage

### DIFF
--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -58,7 +58,7 @@ export function PlanStorage( { children, className, siteId } ) {
 			! legacySiteWithHigherLimits &&
 			mediaStorage.max_storage_bytes === 3072 * 1024 * 1024
 		) {
-			mediaStorage.max_storage_bytes = 500 * 1024 * 1024;
+			mediaStorage.max_storage_bytes = 1024 * 1024 * 1024;
 		}
 		if ( sitePlanSlug === PLAN_WPCOM_PRO ) {
 			mediaStorage.max_storage_bytes = 50 * 1024 * 1024 * 1024;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update a hardcoded 500 limit to a hardcoded 1024 limit

<img width="252" alt="Screenshot 2022-04-05 at 18 35 01" src="https://user-images.githubusercontent.com/82778/161791552-d1c99b3f-410c-4983-ad6b-0d8285b15e51.png">


#### Testing instructions

Repeat with a new site (registered after April 1st) and an old site (registered before that):
1. visit /media/YOURSITE.wordpress.com
2. The new site should show 1 GB instead of 500 (without the change)
3. The old site should display 3 GB

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
