### PR TITLE
Revert "WooCommerce installer: Fix upgrade warning"

### DIFF
--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -136,20 +136,19 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	 * Feature available means although the site doesn't have the feature active,
 	 * it's available to be activated via buying a plan.
 	 */
-	const hasWoopFeatureAvailable: Record< number, string > | false = useSelector( ( state ) =>
-		hasAvailableSiteFeature( state, siteId, FEATURE_WOOP )
+	const hasWoopFeatureAvailable = useSelector(
+		( state ) => hasAvailableSiteFeature( state, siteId, FEATURE_WOOP ) || []
 	);
 
 	// The site requires upgrading when the feature is not active and available.
-	const requiresUpgrade = Boolean( ! isWoopFeatureActive && hasWoopFeatureAvailable );
+	const requiresUpgrade = Boolean( ! isWoopFeatureActive && hasWoopFeatureAvailable.length );
 
 	/*
 	 * We pick the first plan from the available plans list.
 	 * The priority is defined by the store products list.
 	 */
-	const firstAvailablePlan = hasWoopFeatureAvailable ? hasWoopFeatureAvailable[ 0 ] : undefined;
 	const upgradingPlan = useSelector( ( state ) =>
-		firstAvailablePlan ? getProductBySlug( state, firstAvailablePlan ) : undefined
+		getProductBySlug( state, hasWoopFeatureAvailable[ 0 ] )
 	);
 
 	const productName = upgradingPlan?.product_name ?? '';

--- a/client/state/selectors/has-available-site-feature.js
+++ b/client/state/selectors/has-available-site-feature.js
@@ -6,7 +6,7 @@ import getSiteFeatures from 'calypso/state/selectors/get-site-features';
  * @param  {object}  state      Global state tree
  * @param  {number}  siteId     The ID of the site we're querying
  * @param  {string}  featureId  The dotcom feature to check.
- * @returns {false|Object.<number, string>}    Plasns array if the feature is available. Otherwise, False.
+ * @returns {false|string[]}    Plasns array if the feature is available. Otherwise, False.
  */
 export default function hasAvailableSiteFeature( state, siteId, featureId ) {
 	const siteFeatures = getSiteFeatures( state, siteId );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#62518 because the back-end bug that this was compensating for should be fixed by D78211-code