### PR TITLE
Pick the right plan in the checkout route

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -13,6 +13,7 @@ import Spinner from 'calypso/components/spinner';
 import { Interval, EVERY_TEN_SECONDS } from 'calypso/lib/interval';
 import { urlToSlug } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -265,11 +266,12 @@ export class SectionMigrate extends Component {
 	};
 
 	goToCart = () => {
-		const { sourceSite, targetSiteSlug } = this.props;
+		const { sourceSite, targetSiteSlug, targetSiteEligibleForProPlan } = this.props;
 		const sourceSiteSlug = get( sourceSite, 'slug' );
+		const plan = targetSiteEligibleForProPlan ? 'pro' : 'business';
 
 		page(
-			`/checkout/${ targetSiteSlug }/business?redirect_to=/migrate/from/${ sourceSiteSlug }/to/${ targetSiteSlug }%3Fstart%3Dtrue`
+			`/checkout/${ targetSiteSlug }/${ plan }?redirect_to=/migrate/from/${ sourceSiteSlug }/to/${ targetSiteSlug }%3Fstart%3Dtrue`
 		);
 	};
 
@@ -710,6 +712,7 @@ export const connector = connect(
 			targetSiteId,
 			targetSiteImportAdminUrl: getSiteAdminUrl( state, targetSiteId, 'import.php' ),
 			targetSiteSlug: getSelectedSiteSlug( state ),
+			targetSiteEligibleForProPlan: isEligibleForProPlan( state, targetSiteId ),
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change brings the fix of choosing the right plan during the migration process. We have recently introduced the new plan, and the plan inside of the checkout URL was hardcoded.

#### Testing instructions

- Go to `/migrate/{SLUG}
- Enter the source site (Jetpack connection should be established)
- Select `Everything` options
- Follow the steps and pick the `Upgrade and import` action
- Check if the checkout screen is available with the whole details of the plan

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
