### PR TITLE
Allow site creation from domain-only domain using a free plan

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -94,7 +94,7 @@ class DomainRow extends PureComponent {
 		if ( site?.options?.is_domain_only ) {
 			return (
 				<div className="domain-row__site-cell">
-					<Button href={ createSiteFromDomainOnly( site?.slug, site?.siteId ) } plain>
+					<Button href={ createSiteFromDomainOnly( site?.slug, site?.ID ) } plain>
 						<MaterialIcon icon="add" /> { translate( 'Create site' ) }
 					</Button>
 				</div>

--- a/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
@@ -20,7 +20,7 @@ const DomainOnlyConnectCard = ( props: DomainOnlyConnectCardProps ): JSX.Element
 				<p>{ translate( 'Your domain is not associated with a WordPress.com site.' ) }</p>
 			</div>
 			<div className="domain-only-connect__card-button-container">
-				<Button href={ createSiteFromDomainOnly( selectedDomainName ) } primary>
+				<Button href={ createSiteFromDomainOnly( selectedDomainName, selectedSite.ID ) } primary>
 					{ translate( 'Create a site' ) }
 				</Button>
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -85,20 +85,20 @@ export class PlansStep extends Component {
 		};
 
 		if ( flowName === 'site-selected' && ! cartItem ) {
-			wp.req
-				.post( {
-					path: `/domains/${ this.props.selectedSite.ID }/${ this.props.selectedSite.name }/convert-domain-only-to-site`,
-					apiVersion: '1.1',
-				} )
-				.catch( ( error ) => {
-					this.props.errorNotice( error.message );
-				} )
-				.finally( () => {
+			wp.req.post(
+				`/domains/${ this.props.selectedSite.ID }/${ this.props.selectedSite.name }/convert-domain-only-to-site`,
+				{},
+				( error ) => {
+					if ( error ) {
+						this.props.errorNotice( error.message );
+						return;
+					}
 					this.props.submitSignupStep( step, {
 						cartItem,
 					} );
 					this.props.goToNextStep();
-				} );
+				}
+			);
 		} else {
 			this.props.submitSignupStep( step, {
 				cartItem,


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes a bug that prevented site creation for domain-only domain when selecting a free plan during the site creation flow.

Calypso code depends on D78208-code (apply this diff if it hasn't been merged yet).

Related to #62462 

## Testing instructions

- Build this branch locally or open the live Calypso link
- Go to the settings page of a domain-only domain and click "Create site"
- In the "Select Plan" step chose "Free plan"
- Verify that the site has been created