### PR TITLE
Disable bilmur on the desktop app

### DIFF
--- a/packages/calypso-config/src/desktop.ts
+++ b/packages/calypso-config/src/desktop.ts
@@ -10,7 +10,6 @@ const config = {
 	readerFollowingSource: 'desktop',
 	boom_analytics_key: 'desktop',
 	google_recaptcha_site_key: '6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn',
-	bilmur_url: '',
 };
 
 const features = {

--- a/packages/calypso-config/src/desktop.ts
+++ b/packages/calypso-config/src/desktop.ts
@@ -10,6 +10,7 @@ const config = {
 	readerFollowingSource: 'desktop',
 	boom_analytics_key: 'desktop',
 	google_recaptcha_site_key: '6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn',
+	bilmur_url: '',
 };
 
 const features = {
@@ -20,6 +21,7 @@ const features = {
 	// that may/may not be relevant to override for the Desktop app.
 	'signup/social': false,
 	'login/magic-login': false,
+	'bilmur-script': false,
 };
 
 export default ( data: ConfigData ): ConfigData => {


### PR DESCRIPTION
This PR disables bilmur on the desktop app, as it's only intended to run in browsers.

#### Changes proposed in this Pull Request

* Disable bilmur on the desktop app

#### Testing instructions

* Build the desktop app for production
* Open any Calypso page on the built app
* Analyse network requests and ensure that no requests were made to load `bilmur.min.js`


CC @josephscott 
