### PR TITLE
Stepper: Added queries to manage site settings

### DIFF
--- a/client/landing/stepper/hooks/use-site-settings-query.ts
+++ b/client/landing/stepper/hooks/use-site-settings-query.ts
@@ -1,0 +1,20 @@
+import { useQuery as useReactQuery } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+export function useSiteSettingsQuery( siteIdOrSlug: number | string | null ) {
+	return useReactQuery(
+		[ 'settings', siteIdOrSlug ],
+		() => {
+			return (
+				siteIdOrSlug &&
+				wpcom.req.get( `/sites/${ siteIdOrSlug }/settings?http_envelope=1`, {
+					apiNamespace: 'rest/v1.2',
+				} )
+			);
+		},
+		{
+			refetchOnReconnect: true,
+			refetchOnWindowFocus: false,
+		}
+	);
+}

--- a/client/landing/stepper/hooks/use-site-settings.ts
+++ b/client/landing/stepper/hooks/use-site-settings.ts
@@ -1,0 +1,6 @@
+import { useSiteSettingsQuery } from './use-site-settings-query';
+
+export function useSiteSettings( siteIdOrSlug: number | string | null ) {
+	const { data } = useSiteSettingsQuery( siteIdOrSlug );
+	return data?.settings;
+}

--- a/client/landing/stepper/hooks/use-update-site-settings-mutation.js
+++ b/client/landing/stepper/hooks/use-update-site-settings-mutation.js
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+function useUpdateSiteSettingsMutation( queryOptions = {} ) {
+	const queryClient = useQueryClient();
+	const mutation = useMutation(
+		( { siteIdOrSlug, newSettings } ) =>
+			wpcom.req.post(
+				`/sites/${ siteIdOrSlug }/settings`,
+				{ apiNamespace: 'rest/v1.4' },
+				newSettings
+			),
+		{
+			...queryOptions,
+			onSuccess( data, variables, context ) {
+				queryClient.invalidateQueries( [ 'settings', variables.siteIdOrSlug ] );
+				queryOptions.onSuccess?.( data, variables, context );
+			},
+		}
+	);
+
+	const { mutate } = mutation;
+
+	const updateSiteSettings = useCallback(
+		( siteIdOrSlug, newSettings ) => mutate( { siteIdOrSlug, newSettings } ),
+		[ mutate ]
+	);
+
+	return { updateSiteSettings, ...mutation };
+}
+
+export default useUpdateSiteSettingsMutation;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Created queries to read/write site settings from stepper (WooCommerce onboarding profile)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* It can be tested from [this PR](https://github.com/Automattic/wp-calypso/pull/62505)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

