### PR TITLE
Stepper: add all missing data pieces and activate going to checkout on upgrading

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -21,7 +21,6 @@ import { useMemo, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview/content';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import AsyncCheckoutModal from 'calypso/my-sites/checkout/modal/async';
 import { useFSEStatus } from '../../../../hooks/use-fse-status';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
@@ -45,9 +44,6 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
 
-	// // const signupDependencies = useSelector( ( state ) => getSignupDependencyStore( state ) );
-
-	// // TODO EMN: These values should come from state
 	const flowName = 'setup-site';
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
@@ -55,16 +51,20 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	const siteTitle = site?.name;
 	const isReskinned = true;
 	const sitePlanSlug = site?.plan?.product_slug;
+	const isPrivateAtomic = Boolean(
+		site?.launch_status === 'unlaunched' && site?.options?.is_automated_transfer
+	);
 
 	const showDesignPickerCategories = isEnabled( 'signup/design-picker-categories' );
 	const showDesignPickerCategoriesAllFilter = isEnabled( 'signup/design-picker-categories' );
 
-	// // In order to show designs with a "featured" term in the theme_picks taxonomy at the below of categories filter
+	// In order to show designs with a "featured" term in the theme_picks taxonomy at the below of categories filter
 	const useFeaturedPicksButtons =
 		showDesignPickerCategories && isEnabled( 'signup/design-picker-use-featured-picks-buttons' );
-	const isPremiumThemeAvailable = useMemo(
-		() => sitePlanSlug && planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ),
-		[ sitePlanSlug ]
+	const isPremiumThemeAvailable = Boolean(
+		useMemo( () => sitePlanSlug && planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ), [
+			sitePlanSlug,
+		] )
 	);
 
 	const tier =
@@ -167,6 +167,8 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	}
 
 	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
+		// scroll up to reveal the spinner
+		window.scrollTo( 0, 0 );
 		setIsLoading( true );
 		setSelectedDesign( _selectedDesign );
 		if ( siteSlug && _selectedDesign ) {
@@ -191,20 +193,21 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	}
 
 	function upgradePlan() {
-		// disable for now
-		/*
-		const params = new URLSearchParams( window.location.search );
-		params.append( 'products', PLAN_PREMIUM );
-		history.replace( { search: params.toString() } );
-		*/
+		goToCheckout();
 	}
 
-	function renderCheckoutModal() {
+	function goToCheckout() {
 		if ( ! isEnabled( 'signup/design-picker-premium-themes-checkout' ) ) {
 			return null;
 		}
+		if ( siteSlug ) {
+			const params = new URLSearchParams();
+			params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
 
-		return <AsyncCheckoutModal />;
+			window.location.href = `/checkout/${ encodeURIComponent(
+				siteSlug
+			) }/premium?${ params.toString() }`;
+		}
 	}
 
 	const handleBackClick = () => {
@@ -242,10 +245,8 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 				} ) }
 				toolbarComponent={ PreviewToolbar }
 				siteId={ site?.ID }
-				// TODO: figure out how to get this info
-				isPrivateAtomic={ false }
+				isPrivateAtomic={ isPrivateAtomic }
 				url={ site?.URL }
-				shouldConnectContent={ false }
 				translate={ translate }
 				recordTracksEvent={ recordTracksEvent }
 			/>
@@ -309,10 +310,8 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 					/>
 				}
 				categoriesFooter={ renderCategoriesFooter() }
-				// disable premium themes for now, because we can't access checkout
-				isPremiumThemeAvailable={ false }
+				isPremiumThemeAvailable={ isPremiumThemeAvailable }
 			/>
-			{ renderCheckoutModal() }
 		</>
 	);
 
@@ -329,6 +328,8 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 			recordTracksEvent={ recordTracksEvent }
 			goNext={ () => submit?.() }
 			goBack={ handleBackClick }
+			shouldHideNavButtons={ loading }
+			customizedActionButtons={ loading ? <Spinner /> : undefined }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
@@ -6,9 +6,11 @@ import intentImageUrl from 'calypso/assets/images/onboarding/intent.svg';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
+import { useSite } from '../../../../hooks/use-site';
 import { ONBOARD_STORE } from '../../../../stores';
 import { useIntents, useIntentsAlt } from './intents';
 import type { Step } from '../../types';
+
 import './style.scss';
 
 /**
@@ -22,8 +24,9 @@ const IntentStep: Step = function IntentStep( { navigation } ) {
 
 	const { setIntent } = useDispatch( ONBOARD_STORE );
 	const intents = useIntents();
-	// TODO: I need to get the site slug to get the siteId to get the canImport
-	const intentsAlt = useIntentsAlt( true );
+	const site = useSite();
+	const canImport = Boolean( site?.capabilities.manage_options );
+	const intentsAlt = useIntentsAlt( canImport );
 
 	const submitIntent = ( intent: string ) => {
 		const providedDependencies = { intent };

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -77,6 +77,12 @@ export interface SiteDetailsPlan {
 	is_free: boolean;
 }
 
+export interface DifmLiteSiteOptions {
+	site_category?: string;
+	is_website_content_submitted?: boolean;
+	selected_page_titles: string[];
+}
+
 export interface SiteDetails {
 	ID: number;
 	name: string | undefined;
@@ -84,10 +90,98 @@ export interface SiteDetails {
 	URL: string;
 	launch_status: string;
 	options: {
-		created_at: string;
-		selected_features?: FeatureId[];
+		admin_url?: string;
+		advanced_seo_front_page_description?: string;
+		advanced_seo_title_formats?: string[];
+		ak_vp_bundle_enabled?: boolean;
+		allowed_file_types?: string[];
+		anchor_podcast?: boolean;
+		background_color?: boolean;
+		blog_public?: number;
+		created_at: Date;
+		default_category?: number;
+		default_comment_status?: boolean;
+		default_likes_enabled?: boolean;
+		default_ping_status?: boolean;
+		default_post_format?: string;
+		default_sharing_status?: boolean;
+		design_type?: string;
+		difm_lite_site_options?: DifmLiteSiteOptions;
+		editing_toolkit_is_active?: boolean;
+		featured_images_enabled?: boolean;
+		frame_nonce?: string;
+		gmt_offset?: number;
+		header_image?: boolean;
+		headstart_is_fresh?: boolean;
+		headstart?: boolean;
+		image_default_link_type?: string;
+		image_large_height?: number;
+		image_large_width?: number;
+		image_medium_height?: number;
+		image_medium_width?: number;
+		image_thumbnail_crop?: number;
+		image_thumbnail_height?: number;
+		image_thumbnail_width?: number;
+		import_engine?: string;
+		is_automated_transfer?: boolean;
+		is_cloud_eligible?: boolean;
+		is_difm_lite_in_progress?: boolean;
+		is_domain_only?: boolean;
+		is_mapped_domain?: boolean;
+		is_pending_plan?: boolean;
+		is_redirect?: boolean;
+		is_wpcom_atomic?: boolean;
+		is_wpcom_store?: boolean;
+		is_wpforteams_site?: boolean;
+		jetpack_frame_nonce?: string;
+		login_url?: string;
+		p2_hub_blog_id?: number;
+		page_for_posts?: number;
+		page_on_front?: number;
+		permalink_structure?: string;
+		podcasting_archive?: boolean;
+		post_formats?: string[];
+		publicize_permanently_disabled?: boolean;
+		show_on_front?: string;
+		site_intent?: string;
+		site_segment?: string;
+		software_version?: string;
+		theme_slug?: string;
+		timezone?: string;
+		unmapped_url?: string;
+		upgraded_filetypes_enabled?: boolean;
+		verification_services_codes?: string;
+		videopress_enabled?: boolean;
+		videopress_storage_used?: number;
+		was_created_with_blank_canvas_design?: boolean;
+		woocommerce_is_active?: boolean;
+		wordads?: boolean;
 	};
 	plan?: SiteDetailsPlan;
+	capabilities: {
+		edit_pages: boolean;
+		edit_posts: boolean;
+		edit_others_posts: boolean;
+		edit_others_pages: boolean;
+		delete_posts: boolean;
+		delete_others_posts: boolean;
+		edit_theme_options: boolean;
+		edit_users: boolean;
+		list_users: boolean;
+		manage_categories: boolean;
+		manage_options: boolean;
+		moderate_comments: boolean;
+		activate_wordads: boolean;
+		promote_users: boolean;
+		publish_posts: boolean;
+		upload_files: boolean;
+		delete_users: boolean;
+		remove_users: boolean;
+		own_site: boolean;
+		view_hosting: boolean;
+		view_stats: boolean;
+		activate_plugins: boolean;
+	};
 }
 
 export interface SiteError {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -146,6 +146,7 @@ export interface SiteDetails {
 		site_intent?: string;
 		site_segment?: string;
 		software_version?: string;
+		selected_features?: FeatureId[];
 		theme_slug?: string;
 		timezone?: string;
 		unmapped_url?: string;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR enables checkout when you pick a premium theme. It achieves this by a pretty clean and straightforward way. 

It also seems we overlooked some configuration info in Blogger and Builder flows. This PR fixes all of them:

1. **`canImport`**: Flag needed to determine whether the current user can configure the current site. This is needed to enable/disable the import intent.
2. **`isPrivateAtomic`**: The web preview needs this piece of info to decide how to fetch the site preview from the API. We already had this info, I just wired things together.
3. **`isPremiumThemeAvailable`**: Just passed this one to the design picker.

### Testing instructions

Go to http://calypso.localhost:3000/stepper/intent?siteSlug=YOUR_SITE

#### Checkout and `isPremiumThemeAvailable`
1. Please pick a premium theme, you should be redirected to checkout, buy the plan.
2. You should be redirected back to design picker after checkout.
3. You should be able to pick a premium theme now. This means `isPremiumThemeAvailable` works now.

### `canImport`
1. Go to the first step (intent) by visiting Go to http://calypso.localhost:3000/stepper/intent?siteSlug=YOUR_SITE
2. Refresh the page while paying attention to `Import your site content`. It should activate after loading. This means it's only activating after fetching site data.

### `isPrivateAtomic`
1. If you have a private atomic site, Go to http://calypso.localhost:3000/stepper/intent?siteSlug=YOUR_ATOMIC_SITE
2. If not, either make one, or we can test in call together.
3. Go to Design step then preview a theme, all should work.
