### PR TITLE
Plugins Browser: Use infinite scroll when searching plugins.

### DIFF
--- a/client/data/marketplace/use-wporg-plugin-query.ts
+++ b/client/data/marketplace/use-wporg-plugin-query.ts
@@ -65,6 +65,9 @@ export const useWPORGPlugins = (
 const extractPages = ( pages: Array< { plugins: object; info: object } > = [] ) =>
 	pages.flatMap( ( page ) => page.plugins ).map( normalizePluginData );
 
+const extractPagination = ( pages: Array< { plugins: object; info: object } > = [] ) =>
+	pages[ pages.length - 1 ].info;
+
 export const useWPORGInfinitePlugins = (
 	options: WPORGOptionsType,
 	{ enabled = true, staleTime = 1000 * 60 * 60 * 2, refetchOnMount = true }: UseQueryOptions = {}
@@ -88,6 +91,7 @@ export const useWPORGInfinitePlugins = (
 				return {
 					...data,
 					plugins: extractPages( data.pages ),
+					pagination: extractPagination( data.pages ),
 				};
 			},
 			getNextPageParam: ( lastPage ) => {

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -17,6 +17,10 @@ jest.mock( 'calypso/blocks/upsell-nudge', () => 'upsell-nudge' );
 let mockPlugins = [];
 jest.mock( 'calypso/data/marketplace/use-wporg-plugin-query', () => ( {
 	useWPORGPlugins: jest.fn( () => ( { data: { plugins: mockPlugins } } ) ),
+	useWPORGInfinitePlugins: jest.fn( () => ( {
+		data: { plugins: mockPlugins },
+		fetchNextPage: jest.fn(),
+	} ) ),
 } ) );
 
 jest.mock( '@automattic/languages', () => [


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Use infinite scroll when searching plugins on the Plugins Browser page.

#### Testing instructions
* Open the developer tools
* Delete the indexed DB for Calypso (to remove the cache)
* Go to the network tab to see the new requests being made
* Go to `/plugins` and search by a term. Ex: `seo`
* Scroll down to see the new results and check the new results and requests

![Kapture 2022-04-05 at 14 58 46](https://user-images.githubusercontent.com/5039531/161821186-61919801-7362-46d4-9a11-dd7b8692d3ad.gif)

---

Fixes #61748
