### PR TITLE
Domains: Fix wrong description for domains with pending registration transfer

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -136,7 +136,7 @@ const TransferPage = ( props: TransferPageProps ): JSX.Element => {
 			return (
 				<TransferUnavailableNotice
 					message={ __(
-						'We are still setting up your domain. You will not be available to transfer it until the registration setup is done.'
+						'We are still setting up your domain. You will not be able to transfer it until the registration setup is done.'
 					) }
 				></TransferUnavailableNotice>
 			);

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -209,7 +209,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 			return (
 				<TransferUnavailableNotice
 					message={ translate(
-						'We are still setting up your domain. You will not be available to transfer it until the registration setup is done.'
+						'We are still setting up your domain. You will not be able to transfer it until the registration setup is done.'
 					) }
 				></TransferUnavailableNotice>
 			);

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -273,7 +273,7 @@ class TransferDomainToOtherUser extends Component {
 			return (
 				<TransferUnavailableNotice
 					message={ translate(
-						'We are still setting up your domain. You will not be available to transfer it until the registration setup is done.'
+						'We are still setting up your domain. You will not be able to transfer it until the registration setup is done.'
 					) }
 				></TransferUnavailableNotice>
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Minor fix for the wrong description for the notice introduced in #62317. Replaces `available` with `able`.

#### Testing instructions
Make sure the new text is correct - `able` instead of `available`.