### PR TITLE
Checkout: Ignore analytics errors when adding products

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -403,7 +403,13 @@ export default function CompositeCheckout( {
 
 	const addItemAndLog = useCallback(
 		( cartItem ) => {
-			recordAddEvent( cartItem );
+			try {
+				recordAddEvent( cartItem );
+			} catch ( error ) {
+				logStashEvent( 'checkout_add_product_analytics_error', {
+					error: String( error ),
+				} );
+			}
 			addProductsToCart( [ cartItem ] );
 		},
 		[ addProductsToCart ]

--- a/client/my-sites/checkout/composite-checkout/hooks/use-record-cart-loaded.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-record-cart-loaded.ts
@@ -2,6 +2,7 @@ import { useRef, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordAddEvent } from 'calypso/lib/analytics/cart';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { logStashEvent } from '../lib/analytics';
 import type { ResponseCart, RequestCartProduct } from '@automattic/shopping-cart';
 
 export default function useRecordCartLoaded( {
@@ -28,7 +29,13 @@ export default function useRecordCartLoaded( {
 				} )
 			);
 			productsForCart.forEach( ( productToAdd ) => {
-				recordAddEvent( productToAdd );
+				try {
+					recordAddEvent( productToAdd );
+				} catch ( error ) {
+					logStashEvent( 'checkout_add_product_analytics_error', {
+						error: String( error ),
+					} );
+				}
 			} );
 		}
 	}, [ isInitialCartLoading, productsForCart, responseCart, reduxDispatch ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `window.gtags()` analytics method can sometimes throw fatal errors, but we don't want those errors to break checkout.

This PR wraps the analytics code called by checkout when adding products to the cart in `try`/`catch` so that the errors are ignored (but logged in logstash).

#### Testing instructions

To test this you'll need to manually throw an error in the `recordAddEvent()` function:

```diff
--- a/client/lib/analytics/cart.js
+++ b/client/lib/analytics/cart.js
@@ -7,6 +7,7 @@ function removeNestedProperties( cartItem ) {
 }

 export function recordAddEvent( cartItem ) {
+       throw new Error( 'testing error' );
        recordTracksEvent( 'calypso_cart_product_add', removeNestedProperties( cartItem ) );
        recordAddToCart( { cartItem } );
 }
```

Then add a product to your cart and visit checkout. Verify that checkout loads successfully. Before this PR, this would be the result:
<img width="737" alt="Screen Shot 2022-04-05 at 3 54 20 PM" src="https://user-images.githubusercontent.com/2036909/161838342-65991a13-e716-47bc-af07-b7926e68ab0b.png">

