### PR TITLE
Update message shown when selected subdomain is a wordpress.com free URL subdomain

### DIFF
--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -294,7 +294,7 @@ function getAvailabilityNotice( domain, error, errorData ) {
 		case domainAvailability.DOTBLOG_SUBDOMAIN:
 		case domainAvailability.RESTRICTED:
 			message = translate(
-				'You cannot map another WordPress.com subdomain - try creating a new site or one of the custom domains below.'
+				'This is a free WordPress.com subdomain. You can’t map it to another site.'
 			);
 			break;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We use the domain availability messages on both the domain search page and now on the Use a domain I own flow.  The message shown for a free .blog subdomain doesn't make sense for the Use a domain I own flow.

<img width="1346" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/161844645-a3ef9574-0957-4024-8df7-32293085701c.png">

This PR updates this message to something that makes sense in both contexts:

<img width="1411" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/161845290-20669fbc-d91a-4c69-84c7-3a87b5399f17.png">

#### Testing instructions

Visit http://calypso.localhost:3000/start/domains/use-your-domain?step=domain-input&initialQuery=foo.news.blog
Click on the "Next" button.

Make sure that you see the new message shown above.

Also, try searching for the same domain from the domain search page and name sure the notice shows the correct text:

<img width="1072" alt="Domain_Search_‹_A8C_Test_Site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/161850489-2a5e3b62-2a41-46bf-be78-a939bdefe44f.png">

