### PR TITLE
Domains: Show an error message when trying to connect an already connected subdomain

### DIFF
--- a/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
@@ -35,13 +35,18 @@ export function getAvailabilityErrorMessage( { availabilityData, domainName, sel
 		return null;
 	}
 
-	const availabilityStatus = [
+	let availabilityStatus = [
 		domainAvailability.MAPPABLE,
 		domainAvailability.MAPPED,
 		domainAvailability.TRANSFER_PENDING,
 	].includes( mappable )
 		? status
 		: mappable;
+
+	if ( domainAvailability.MAPPED === mappable && domainAvailability.MAPPABLE === status ) {
+		availabilityStatus = mappable;
+	}
+
 	const maintenanceEndTime = maintenance_end_time ?? null;
 	const site = other_site_domain ?? selectedSite?.slug;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

When you tried to connect an already connected subdomain to a WPCOM site, you would reach the "Transfer or connect" page but wouldn't be able to do anything.

<img width="1323" alt="Screen Shot 2022-04-05 at 18 37 01" src="https://user-images.githubusercontent.com/5324818/161854248-2111803c-44fb-4671-9291-eba48b7a9f77.png">

This PR fixes this problem by showing the correct error message in the previous step, when you input the domain name you want to use:

<img width="1340" alt="Screen Shot 2022-04-05 at 18 38 21" src="https://user-images.githubusercontent.com/5324818/161854285-f8ae4a10-c1a3-47cb-a91b-b894093b579c.png">

#### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to `/start` or go to the domains section of a site you own
- Select "Use a domain I own"
- Provide a subdomain that's already connect to a WPCOM site
- Ensure an "This domain is already mapped to a WordPress.com site" error appears