### PR TITLE
[E2E] Allow "unspecified" env vars and bring its interface closer to `getTestAccountByFeature`'s

### DIFF
--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -124,7 +124,7 @@ const currentEnvVariables = { ...defaultEnvVariables };
 supportedEnvVariableNames.forEach( ( name ) => {
 	const originalValue = process.env[ name ];
 	// Some env vars might be set with the `unspecified` "special" value to mean
-	// they're ffectivelly unset. This is useful to avoid creating condition
+	// they're effectivelly unset. This is useful to avoid creating condition
 	// branches in the code that passes the vars to Jest, and one can just
 	// pass `unspecified` and it will have the same effect as not setting it.
 	if ( originalValue && ( originalValue as unspecified ) !== 'unspecified' ) {

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -13,7 +13,7 @@ import {
 	EditorInlineBlockInserterComponent,
 	EditorSidebarBlockInserterComponent,
 } from '../components';
-import type { SiteType } from '../../lib/utils';
+import type { Target } from '../../lib/utils';
 import type { PreviewOptions, EditorSidebarTab, PrivacyOptions, Schedule } from '../components';
 
 const selectors = {
@@ -48,7 +48,7 @@ interface BlockInserter {
 export class EditorPage {
 	private page: Page;
 	private editor: Locator;
-	private target: SiteType;
+	private target: Target;
 	private editorPublishPanelComponent: EditorPublishPanelComponent;
 	private editorNavSidebarComponent: EditorNavSidebarComponent;
 	private editorToolbarComponent: EditorToolbarComponent;
@@ -65,7 +65,7 @@ export class EditorPage {
 	 * @param param0 Keyed object parameter.
 	 * @param param0.target Target editor type. Defaults to 'simple'.
 	 */
-	constructor( page: Page, { target = 'simple' }: { target?: SiteType } = {} ) {
+	constructor( page: Page, { target = 'simple' }: { target?: Target } = {} ) {
 		if ( target === 'atomic' ) {
 			// For Atomic editors, there is no iFrame - the editor is
 			// part of the page DOM and is thus accessible directly.

--- a/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
+++ b/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
@@ -3,68 +3,65 @@ import type { FeatureCriteria } from './get-test-account-by-feature';
 const defaultCriteria: FeatureCriteria[] = [
 	{
 		gutenberg: 'edge',
-		siteType: 'simple',
+		target: 'simple',
 		accountName: 'gutenbergSimpleSiteEdgeUser',
 	},
-	{ gutenberg: 'stable', siteType: 'simple', accountName: 'gutenbergSimpleSiteUser' },
+	{ gutenberg: 'stable', target: 'simple', accountName: 'gutenbergSimpleSiteUser' },
 	// The CoBlocks account name takes precedence if CoBlocks edge
 	// is present. We have two definitions below to effectivelly
 	// ignore gutenberg in this case:
 	{
 		coblocks: 'edge',
 		gutenberg: 'stable',
-		siteType: 'simple',
+		target: 'simple',
 		accountName: 'coBlocksSimpleSiteEdgeUser',
 	},
 	{
 		coblocks: 'edge',
 		gutenberg: 'edge',
-		siteType: 'simple',
+		target: 'simple',
 		accountName: 'coBlocksSimpleSiteEdgeUser',
 	},
 	{
 		gutenberg: 'stable',
-		siteType: 'simple',
+		target: 'simple',
 		variant: 'siteEditor',
 		accountName: 'siteEditorSimpleSiteUser',
 	},
 	{
 		gutenberg: 'edge',
-		siteType: 'simple',
+		target: 'simple',
 		variant: 'siteEditor',
 		accountName: 'siteEditorSimpleSiteEdgeUser',
 	},
 	{
 		gutenberg: 'stable',
-		siteType: 'atomic',
+		target: 'atomic',
 		variant: 'siteEditor',
 		accountName: 'gutenbergAtomicSiteUser',
 	},
 	{
 		gutenberg: 'edge',
-		siteType: 'atomic',
+		target: 'atomic',
 		variant: 'siteEditor',
 		accountName: 'gutenbergAtomicSiteEdgeUser',
 	},
 	{
 		gutenberg: 'stable',
-		siteType: 'atomic',
+		target: 'atomic',
 		accountName: 'gutenbergAtomicSiteUser',
 	},
 	{
 		gutenberg: 'edge',
-		siteType: 'atomic',
+		target: 'atomic',
 		accountName: 'gutenbergAtomicSiteEdgeUser',
 	},
-
-	// @todo consider adding a special '*' wildcard value to ignore certain
-	// features, for example: `gutenberg: '*', siteType: '*'`.
-	{ gutenberg: 'edge', variant: 'i18n', siteType: 'simple', accountName: 'i18nUser' },
-	{ gutenberg: 'stable', variant: 'i18n', siteType: 'simple', accountName: 'i18nUser' },
-	// we're effectivelly ignoring the atomic siteType here, by pointing to the same
+	{ gutenberg: 'edge', variant: 'i18n', target: 'simple', accountName: 'i18nUser' },
+	{ gutenberg: 'stable', variant: 'i18n', target: 'simple', accountName: 'i18nUser' },
+	// we're effectivelly ignoring the atomic target here, by pointing to the same
 	// simple site even if "atomic"
-	{ gutenberg: 'edge', variant: 'i18n', siteType: 'atomic', accountName: 'i18nUser' },
-	{ gutenberg: 'stable', variant: 'i18n', siteType: 'atomic', accountName: 'i18nUser' },
+	{ gutenberg: 'edge', variant: 'i18n', target: 'atomic', accountName: 'i18nUser' },
+	{ gutenberg: 'stable', variant: 'i18n', target: 'atomic', accountName: 'i18nUser' },
 ];
 
 export default defaultCriteria;

--- a/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts
+++ b/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts
@@ -6,7 +6,7 @@ export type TestAccountEnvVariables = Pick<
 	'GUTENBERG' | 'COBLOCKS' | 'TARGET'
 >;
 
-// @todo Would it be better to call this type `ReleasType` or `ReleaseTag`?
+// @todo Would it be better to call this type `ReleaseType` or `ReleaseTag`?
 type Env = 'edge' | 'stable';
 
 export type Target = 'simple' | 'atomic';

--- a/packages/calypso-e2e/test/lib/utils/get-test-account-by-feature.test.ts
+++ b/packages/calypso-e2e/test/lib/utils/get-test-account-by-feature.test.ts
@@ -14,24 +14,24 @@ describe( 'getTestAccountByFeature', function () {
 		{
 			gutenberg: 'edge',
 			coblocks: 'stable',
-			siteType: 'simple',
+			target: 'simple',
 			accountName: 'multipleFeaturesRightAccountName',
 		},
 		{
 			gutenberg: 'edge',
-			siteType: 'simple',
+			target: 'simple',
 			accountName: 'multipleFeaturesUndefinedRightAccountName',
 		},
 		{
 			gutenberg: 'stable',
 			coblocks: 'stable',
-			siteType: 'simple',
+			target: 'simple',
 			accountName: 'wrongAccountName',
 		},
 	];
 
 	it( 'returns the right default account for single feature', () => {
-		const accountName = getTestAccountByFeature( { gutenberg: 'edge', siteType: 'simple' } );
+		const accountName = getTestAccountByFeature( { gutenberg: 'edge', target: 'simple' } );
 
 		expect( accountName ).toBe( 'gutenbergSimpleSiteEdgeUser' );
 	} );
@@ -41,7 +41,7 @@ describe( 'getTestAccountByFeature', function () {
 			{
 				gutenberg: 'edge',
 				coblocks: 'stable',
-				siteType: 'simple',
+				target: 'simple',
 			},
 			customCriteria
 		);
@@ -51,12 +51,14 @@ describe( 'getTestAccountByFeature', function () {
 
 	it( 'returns the right feature if one of the features is undefined', () => {
 		// This simulates a scenario where the presence of a feature depends
-		// on external data (i.e env var) and that data might be not set.
+		// on external data (i.e env var) and that data might be not set. This
+		// indicates that that specific feature is not present (or it might just
+		// fallback to its default in some sites).
 		const accountName = getTestAccountByFeature(
 			{
 				gutenberg: 'edge',
 				coblocks: undefined,
-				siteType: 'simple',
+				target: 'simple',
 			},
 			customCriteria
 		);
@@ -73,20 +75,20 @@ describe( 'getTestAccountByFeature', function () {
 		// last-defined one will prevail.
 		const criteria: FeatureCriteria[] = [
 			{
-				siteType: 'simple',
+				target: 'simple',
 				gutenberg: 'edge',
 				accountName: 'wrongAccount',
 			},
 			{
 				gutenberg: 'edge',
-				siteType: 'simple',
+				target: 'simple',
 				accountName: 'rightAccount',
 			},
 		];
 
 		const accountName = getTestAccountByFeature(
 			{
-				siteType: 'simple',
+				target: 'simple',
 				gutenberg: 'edge',
 			},
 			criteria
@@ -98,7 +100,7 @@ describe( 'getTestAccountByFeature', function () {
 	it( 'will throw en error if passed feature does not match an account', () => {
 		expect( () =>
 			/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-			getTestAccountByFeature( { coblocks: 'foo', siteType: 'bar' } as any )
+			getTestAccountByFeature( { coblocks: 'foo', target: 'bar' } as any )
 		).toThrowError();
 	} );
 
@@ -108,14 +110,14 @@ describe( 'getTestAccountByFeature', function () {
 		const customCriteria: FeatureCriteria[] = [
 			{
 				gutenberg: 'edge',
-				siteType: 'simple',
+				target: 'simple',
 				variant: 'siteEditor',
 				accountName: 'siteEditorEdgeAccount',
 			},
 		];
 		const siteEditorAccountName = getTestAccountByFeature(
 			{
-				siteType: 'simple',
+				target: 'simple',
 				gutenberg: 'edge',
 				variant: 'siteEditor',
 			},
@@ -123,7 +125,7 @@ describe( 'getTestAccountByFeature', function () {
 		);
 
 		const editorAccountName = getTestAccountByFeature( {
-			siteType: 'simple',
+			target: 'simple',
 			gutenberg: 'edge',
 		} );
 
@@ -138,14 +140,14 @@ describe( 'getTestAccountByFeature', function () {
 		const customCriteria: FeatureCriteria[] = [
 			{
 				gutenberg: 'edge',
-				siteType: 'simple',
+				target: 'simple',
 				accountName: 'aNewAccount',
 			},
 		];
 
 		const editorAccountName = getTestAccountByFeature(
 			{
-				siteType: 'simple',
+				target: 'simple',
 				gutenberg: 'edge',
 			},
 			customCriteria
@@ -157,50 +159,16 @@ describe( 'getTestAccountByFeature', function () {
 
 describe( 'envToFeatureKey', () => {
 	const envVariables: TestAccountEnvVariables = {
-		COBLOCKS_EDGE: true,
-		GUTENBERG_EDGE: false,
-		TEST_ON_ATOMIC: false,
+		COBLOCKS: 'edge',
+		GUTENBERG: 'stable',
+		TARGET: 'simple',
 	};
 
-	it( 'will return a proper `FeatureKey` object', () => {
+	it( 'will return a proper `FeatureKey` object based on the `envVariables` object', () => {
 		expect( envToFeatureKey( envVariables ) ).toEqual( {
 			coblocks: 'edge',
 			gutenberg: 'stable',
-			siteType: 'simple',
+			target: 'simple',
 		} as FeatureKey );
-	} );
-
-	it( 'will return a `FeatureKey` object without coblocks (=== `undefined`) if env.COBLOCKS_EDGE is `false`', () => {
-		expect( envToFeatureKey( { ...envVariables, COBLOCKS_EDGE: false } )[ 'coblocks' ] ).toBe(
-			undefined
-		);
-	} );
-
-	it( 'will return a `FeatureKey` object with `coblocks: "edge"` if env.COBLOCKS_EDGE is `true`', () => {
-		expect( envToFeatureKey( envVariables ) ).toMatchObject( {
-			coblocks: 'edge',
-		} );
-	} );
-
-	it( 'will return a `FeatureKey` object with `gutenberg: "stable"` if env.GUTENBERG_EDGE is `false`', () => {
-		expect( envToFeatureKey( envVariables ) ).toMatchObject( { gutenberg: 'stable' } );
-	} );
-
-	it( 'will return a `FeatureKey` object with `gutenberg: "edge"` if env.GUTENBERG_EDGE is `true`', () => {
-		expect( envToFeatureKey( { ...envVariables, GUTENBERG_EDGE: true } ) ).toMatchObject( {
-			gutenberg: 'edge',
-		} );
-	} );
-
-	it( 'will return a `FeatureKey` object with `siteType: "simple"` if env.TEST_ON_ATOMIC is `false`', () => {
-		expect( envToFeatureKey( envVariables ) ).toMatchObject( {
-			siteType: 'simple',
-		} );
-	} );
-
-	it( 'will return a `FeatureKey` object with `siteType: "atomic"` if env.TEST_ON_ATOMIC is `true`', () => {
-		expect( envToFeatureKey( { ...envVariables, TEST_ON_ATOMIC: true } ) ).toMatchObject( {
-			siteType: 'atomic',
-		} );
 	} );
 } );

--- a/test/e2e/docs/environment_variables.md
+++ b/test/e2e/docs/environment_variables.md
@@ -23,10 +23,11 @@ Environment Variables are values that are defined at the system level to serve a
 
 ## CI
 
-| Name           | Description                            | Example | Required |
-| -------------- | -------------------------------------- | ------- | -------- |
-| COBLOCKS_EDGE  | Use the bleeding edge CoBlocks build.  | true    | No       |
-| GUTENBERG_EDGE | Use the bleeding edge Gutenberg build. | true    | No       |
+| Name      | Description                                                                                | - Example | Required                     |
+| --------- | ------------------------------------------------------------------------------------------ | --------- | ---------------------------- |
+| COBLOCKS  | Specifies what release of CoBlocks (stable or edge) to use or none/default if unspecified  | stable    | No (defaults to unspecified) |
+| GUTENBERG | Specifies what release of Gutenberg (stable or edge) to use or none/default if unspecified | edge      | No (defaults to unspecified) |
+| TARGET    | Specifies what WPCOM target environment to use (atomic or simple)                          | simple    | No (defauls to simple)       |
 
 <!-- When adding new rows, run the following command to sort the resulting sub-table in alphabetical order:
 

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -25,7 +25,7 @@ declare const browser: Browser;
 
 const features = envToFeatureKey( envVariables );
 
-skipDescribeIf( features.siteType === 'atomic' )(
+skipDescribeIf( features.target === 'atomic' )(
 	DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ),
 	() => {
 		const accountName = getTestAccountByFeature( features );
@@ -45,7 +45,7 @@ skipDescribeIf( features.siteType === 'atomic' )(
 			page = await browser.newPage();
 			logoImage = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
 			testAccount = new TestAccount( accountName );
-			editorPage = new EditorPage( page, { target: features.siteType } );
+			editorPage = new EditorPage( page, { target: features.target } );
 
 			await testAccount.authenticate( page );
 		} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -21,7 +21,7 @@ declare const browser: Browser;
 
 const features = envToFeatureKey( envVariables );
 
-skipDescribeIf( features.siteType === 'atomic' )(
+skipDescribeIf( features.target === 'atomic' )(
 	DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ),
 	() => {
 		const accountName = getTestAccountByFeature( features );
@@ -36,7 +36,7 @@ skipDescribeIf( features.siteType === 'atomic' )(
 			page = await browser.newPage();
 			imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
 			testAccount = new TestAccount( accountName );
-			editorPage = new EditorPage( page, { target: features.siteType } );
+			editorPage = new EditorPage( page, { target: features.target } );
 
 			await testAccount.authenticate( page );
 		} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -18,7 +18,7 @@ declare const browser: Browser;
 
 const features = envToFeatureKey( envVariables );
 
-skipDescribeIf( features.siteType === 'atomic' )(
+skipDescribeIf( features.target === 'atomic' )(
 	DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ),
 	() => {
 		const accountName = getTestAccountByFeature( features );
@@ -31,7 +31,7 @@ skipDescribeIf( features.siteType === 'atomic' )(
 		beforeAll( async () => {
 			page = await browser.newPage();
 			testAccount = new TestAccount( accountName );
-			editorPage = new EditorPage( page, { target: features.siteType } );
+			editorPage = new EditorPage( page, { target: features.target } );
 
 			await testAccount.authenticate( page );
 		} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -22,7 +22,7 @@ declare const browser: Browser;
 
 const features = envToFeatureKey( envVariables );
 
-skipDescribeIf( features.siteType === 'atomic' )(
+skipDescribeIf( features.target === 'atomic' )(
 	DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ),
 	() => {
 		const accountName = getTestAccountByFeature( features );
@@ -37,7 +37,7 @@ skipDescribeIf( features.siteType === 'atomic' )(
 		beforeAll( async () => {
 			page = await browser.newPage();
 			imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-			editorPage = new EditorPage( page, { target: features.siteType } );
+			editorPage = new EditorPage( page, { target: features.target } );
 
 			const testAccount = new TestAccount( accountName );
 			await testAccount.authenticate( page );

--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -28,7 +28,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 	const accountName = getTestAccountByFeature( features, [
 		{
 			gutenberg: 'stable',
-			siteType: 'simple',
+			target: 'simple',
 			accountName: 'simpleSitePersonalPlanUser',
 		},
 	] );
@@ -54,7 +54,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		editorPage = new EditorPage( page, { target: features.target } );
 	} );
 
 	it( 'Go to new post page', async function () {

--- a/test/e2e/specs/blocks/blocks__shallowly_smoke_test_popular_blocks.ts
+++ b/test/e2e/specs/blocks/blocks__shallowly_smoke_test_popular_blocks.ts
@@ -12,8 +12,8 @@
  * meant to test specific block behavior, but instead to verify if they continue
  * working across GB versions, during the GB upgrade process in WPCOM.
  *
- * To avoid any confusion, the tests here will only run if the GUTENBERG_EDGE env
- * var is set.
+ * To avoid any confusion, the tests here will only run if the test is set to run
+ * against the `edge` version of Gutenberg.
  */
 import {
 	EditorPage,
@@ -30,16 +30,16 @@ declare const browser: Browser;
 const features = envToFeatureKey( envVariables );
 const accountName = getTestAccountByFeature( features );
 
-const { siteType } = features;
+const { target } = features;
 
 // @idea This is a nice example of how `getTestAccountByFeature` could be extended to
 // `getTestDatabagByFeature` or something along those lines. The point is, we
 // could be returning more than just an account name per criteria. It could contain
 // all sorts of additional data. In this case, it could contain a `testPostId` attribute,
 // too.
-const testPostId = siteType === 'atomic' ? 32 : 42805;
+const testPostId = target === 'atomic' ? 32 : 42805;
 
-describe( `Gutenberg Upgrade: Sanity-Check Most Popular Blocks on (${ siteType }) edge`, () => {
+describe( `Gutenberg Upgrade: Sanity-Check Most Popular Blocks on (${ target }) edge`, () => {
 	let page: Page;
 	let editorPage: EditorPage;
 
@@ -58,10 +58,10 @@ describe( `Gutenberg Upgrade: Sanity-Check Most Popular Blocks on (${ siteType }
 
 	// Both block invalidation and crash messages are wrapped by the same `Warning`
 	// component in Gutenberg. If we find at least one warning, then we fail the test.
-	skipItIf( ! envVariables.GUTENBERG_EDGE )(
-		`Block warnings are not obeserved for ${ siteType } editor`,
+	skipItIf( envVariables.GUTENBERG !== 'edge' )(
+		`Block warnings are not obeserved for ${ target } editor`,
 		async () => {
-			editorPage = new EditorPage( page, { target: siteType } );
+			editorPage = new EditorPage( page, { target } );
 			await editorPage.waitUntilLoaded();
 
 			expect( await editorPage.editorHasBlockWarnings() ).toBe( false );

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -27,7 +27,7 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 		const accountName = getTestAccountByFeature( features, [
 			{
 				gutenberg: 'stable',
-				siteType: 'simple',
+				target: 'simple',
 				accountName: 'simpleSitePersonalPlanUser',
 			},
 		] );
@@ -39,7 +39,7 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 
 		beforeAll( async () => {
 			page = await browser.newPage();
-			editorPage = new EditorPage( page, { target: features.siteType } );
+			editorPage = new EditorPage( page, { target: features.target } );
 			const testAccount = new TestAccount( accountName );
 			await testAccount.authenticate( page );
 		} );

--- a/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.ts
@@ -35,7 +35,7 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Pattern-related events'
 			await testAccount.authenticate( page );
 
 			eventManager = new EditorTracksEventManager( page );
-			editorPage = new EditorPage( page, { target: features.siteType } );
+			editorPage = new EditorPage( page, { target: features.target } );
 		} );
 
 		it( 'Start a new page', async function () {

--- a/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
@@ -34,7 +34,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 				await testAccount.authenticate( page );
 
 				eventManager = new EditorTracksEventManager( page );
-				editorPage = new EditorPage( page, { target: features.siteType } );
+				editorPage = new EditorPage( page, { target: features.target } );
 			} );
 
 			it( 'Start a new post', async function () {
@@ -106,7 +106,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 				await testAccount.authenticate( page );
 
 				eventManager = new EditorTracksEventManager( page );
-				editorPage = new EditorPage( page, { target: features.siteType } );
+				editorPage = new EditorPage( page, { target: features.target } );
 			} );
 
 			it( 'Start a new post', async function () {

--- a/test/e2e/specs/editor/editor__navbar.ts
+++ b/test/e2e/specs/editor/editor__navbar.ts
@@ -22,7 +22,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
 	const accountName = getTestAccountByFeature( features, [
 		{
 			gutenberg: 'stable',
-			siteType: 'simple',
+			target: 'simple',
 			accountName: 'simpleSitePersonalPlanUser',
 		},
 	] );
@@ -32,7 +32,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		editorPage = new EditorPage( page, { target: features.target } );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -31,7 +31,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		// the default criteria, and should pass it here, as an override. For this specific function
 		// call, `simpleSitePersonalPlanUser` will be retured when gutenberg is stable, and siteType
 		// is simple.
-		[ { gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' } ]
+		[ { gutenberg: 'stable', target: 'simple', accountName: 'simpleSitePersonalPlanUser' } ]
 	);
 
 	let page: Page;
@@ -57,7 +57,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Select page template', async function () {
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		editorPage = new EditorPage( page, { target: features.target } );
 		// @TODO Consider moving this to EditorPage.
 		await editorPage.waitUntilLoaded();
 		const editorIframe = await editorPage.getEditorHandle();

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -21,7 +21,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function () {
 	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature( features, [
-		{ gutenberg: 'edge', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
+		{ gutenberg: 'edge', target: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 	] );
 
 	const postTitle = `Post Life Cycle: ${ DataHelper.getTimestamp() }`;
@@ -47,7 +47,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 
 	describe( 'Publish post', function () {
 		it( 'Enter post title', async function () {
-			editorPage = new EditorPage( page, { target: features.siteType } );
+			editorPage = new EditorPage( page, { target: features.target } );
 			await editorPage.enterTitle( postTitle );
 		} );
 
@@ -84,7 +84,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 		} );
 
 		it( 'Editor is shown', async function () {
-			editorPage = new EditorPage( page, { target: features.siteType } );
+			editorPage = new EditorPage( page, { target: features.target } );
 			await editorPage.waitUntilLoaded();
 		} );
 

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -25,7 +25,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
 	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature( features, [
-		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
+		{ gutenberg: 'stable', target: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 	] );
 
 	let page: Page;
@@ -34,7 +34,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		editorPage = new EditorPage( page, { target: features.target } );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -20,7 +20,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature( features, [
-		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
+		{ gutenberg: 'stable', target: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 	] );
 
 	let editorPage: EditorPage;
@@ -35,7 +35,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 	} );
 
 	it( 'Go to the new post page', async function () {
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		editorPage = new EditorPage( page, { target: features.target } );
 		await editorPage.visit( 'post' );
 	} );
 

--- a/test/e2e/specs/editor/editor__schedule.ts
+++ b/test/e2e/specs/editor/editor__schedule.ts
@@ -18,7 +18,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature( features, [
-		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
+		{ gutenberg: 'stable', target: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 	] );
 
 	const postTitle = `Scheduled Post: ${ DataHelper.getTimestamp() }`;
@@ -35,12 +35,12 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 	} );
 
 	it( 'Go to the new post page', async function () {
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		editorPage = new EditorPage( page, { target: features.target } );
 		await editorPage.visit( 'post' );
 	} );
 
 	it( 'Enter page title', async function () {
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		editorPage = new EditorPage( page, { target: features.target } );
 		await editorPage.enterTitle( postTitle );
 	} );
 

--- a/test/e2e/specs/editor/shared/privacy-testing.ts
+++ b/test/e2e/specs/editor/shared/privacy-testing.ts
@@ -28,7 +28,7 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 	describe( DataHelper.createSuiteTitle( `Editor: Privacy (${ visibility })` ), function () {
 		const features = envToFeatureKey( envVariables );
 		const accountName = getTestAccountByFeature( features, [
-			{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
+			{ gutenberg: 'stable', target: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 		] );
 
 		let page: Page;
@@ -44,7 +44,7 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 			} );
 
 			it( 'Start new page', async function () {
-				editorPage = new EditorPage( page, { target: features.siteType } );
+				editorPage = new EditorPage( page, { target: features.target } );
 				await editorPage.visit( 'page' );
 				await editorPage.waitUntilLoaded();
 				const editorIframe = await editorPage.getEditorHandle();
@@ -53,7 +53,7 @@ export function createPrivacyTests( { visibility }: { visibility: PrivacyOptions
 			} );
 
 			it( 'Enter page title', async function () {
-				editorPage = new EditorPage( page, { target: features.siteType } );
+				editorPage = new EditorPage( page, { target: features.target } );
 				await editorPage.enterTitle( `Privacy: ${ visibility } - ${ DataHelper.getTimestamp() }` );
 			} );
 

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -234,7 +234,7 @@ describe( 'I18N: Editor', function () {
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		editorPage = new EditorPage( page, { target: features.target } );
 	} );
 
 	describe.each( locales )( `Locale: %s`, function ( locale ) {
@@ -269,7 +269,7 @@ describe( 'I18N: Editor', function () {
 				const blockTimeout = 10 * 1000;
 
 				it( 'Insert test block', async function () {
-					editorPage = new EditorPage( page, { target: features.siteType } );
+					editorPage = new EditorPage( page, { target: features.target } );
 					await editorPage.addBlockFromSidebar( block.blockName, block.blockEditorSelector );
 				} );
 

--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -23,14 +23,14 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		editorPage = new EditorPage( page, { target: features.target } );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 	} );
 
 	it( 'Go to the new post page', async function () {
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		editorPage = new EditorPage( page, { target: features.target } );
 		await editorPage.visit( 'post' );
 	} );
 

--- a/test/e2e/specs/published-content/likes__comment.ts
+++ b/test/e2e/specs/published-content/likes__comment.ts
@@ -38,7 +38,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Comment) ' ), function () {
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		editorPage = new EditorPage( page, { target: features.target } );
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
@@ -49,7 +49,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Comment) ' ), function () {
 	} );
 
 	it( 'Enter post title', async function () {
-		editorPage = new EditorPage( page, { target: features.siteType } );
+		editorPage = new EditorPage( page, { target: features.target } );
 		const title = DataHelper.getRandomPhrase();
 		await editorPage.enterTitle( title );
 	} );

--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -28,7 +28,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 	const accountName = getTestAccountByFeature( features, [
 		{
 			gutenberg: 'stable',
-			siteType: 'simple',
+			target: 'simple',
 			accountName: 'simpleSitePersonalPlanUser',
 		},
 	] );
@@ -44,7 +44,7 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 
 		beforeAll( async () => {
 			page = await browser.newPage();
-			editorPage = new EditorPage( page, { target: features.siteType } );
+			editorPage = new EditorPage( page, { target: features.target } );
 			await postingUser.authenticate( page );
 		} );
 

--- a/test/e2e/specs/wpcom-old/gutenberg__page-editor-tracking.js
+++ b/test/e2e/specs/wpcom-old/gutenberg__page-editor-tracking.js
@@ -17,7 +17,7 @@ const host = dataHelper.getJetpackHost();
 // We need to trigger test runs against Gutenberg Edge (the "next" version of Gutenberg that
 // will be deployed to Dotcom) as well as the current version of Gutenberg.
 const gutenbergUser =
-	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
+	process.env.GUTENBERG === 'edge' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
 
 describe( `[${ host }] Calypso Gutenberg Page Editor Tracking: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );

--- a/test/e2e/specs/wpcom-old/gutenberg__post-editor-tracking.js
+++ b/test/e2e/specs/wpcom-old/gutenberg__post-editor-tracking.js
@@ -13,7 +13,7 @@ const host = dataHelper.getJetpackHost();
 // We need to trigger test runs against Gutenberg Edge (the "next" version of Gutenberg that
 // will be deployed to Dotcom) as well as the current version of Gutenberg.
 const gutenbergUser =
-	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
+	process.env.GUTENBERG === 'edge' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
 
 describe( `[${ host }] Calypso Gutenberg Post Editor Tracking: (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );

--- a/test/e2e/specs/wpcom-old/gutenberg__site-editor-tracking.js
+++ b/test/e2e/specs/wpcom-old/gutenberg__site-editor-tracking.js
@@ -23,9 +23,7 @@ const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 const siteEditorUser =
-	process.env.GUTENBERG_EDGE === 'true'
-		? 'siteEditorSimpleSiteEdgeUser'
-		: 'siteEditorSimpleSiteUser';
+	process.env.GUTENBERG === 'edge' ? 'siteEditorSimpleSiteEdgeUser' : 'siteEditorSimpleSiteUser';
 
 const navigationSidebarBackToRoot = async ( driver ) => {
 	const backButtonLocator = By.css(


### PR DESCRIPTION
## Changes proposed in this Pull Request

As I was writing a P2 about cross-target testing (still a WIP) and to announce the `getTestAccountByFeature` [abstraction](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts), I noticed a couple of things were less than ideal in the current implementation:

### There was no easy way to communicate the absence of a certain artifact when using `envVariables` as an input to `getTestAccountByFeature`:

So far, the absence of an artifact such as the `GUTENBERG_EDGE` env var meant the actual attribute in the [envVariables](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/env-variables.ts) object was set to `false`, implicitly meaning the use of a "stable" release. This is fine to an extent, but there are a couple of problems with it:

1. Its implicit nature can be confusing. It's not 100% clear what version is being used if `GUTENBERG_EDGE` is `false`. You can assume `stable`, but it's not really obvious.
2. It's impossible to write a test against a site that might not have Gutenberg installed. This might be a pretty rare event, but I can see that happening with other plugins or artifacts we might want to test against. A tangible example might be CoBlocks. What if we want to declare a criterion for a site that doesn't have CoBlocks installed (not the case now, but could happen in the future?). Right now (before the changes here), it's not possible to when `getTestAccountByFeature` is connected to the `envVariable` object via the `envToFeatureKeys` ([example](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/specs/blocks/blocks__shallowly_smoke_test_popular_blocks.ts#L30-L31)) because the `envVariables` will forcedly assign `false` to the `COBLOCKS_EDGE` attribute if the env var is not set, which right now means the `stable` plugin is installed and not that it's absent.

### The new `unspecified` state for feature artifacts

If a feature-like artifact - like a plugin - is to be incorporated and configurable via the criteria that are selectable by `getTestAccountByFeature`,  then you should decide what states it should have. In the case of plugins like CoBlocks and Gutenberg - as of this changeset - we have three:

* `stable`
* `edge`
* `unspecified` (=== `undefined`)

The `unspecified` doesn't have strong semantics attached to it. It just means that - that it wasn't explicitly specified. The actual interpretation of what it actually means in practice depends on how the actual site it points to was configured (more on that down below).

Let's say we have TC build focused on testing Gutenberg. We have a couple of approaches on how to set it up. We can setup a simple site with stable and another with `edge` (`gutenberg-edge` sticker applied). We can assume that CoBlocks will be whatever the default is. This is the "I don't care about CoBlocks" approach, and is the approach we currently use for Gutenberg-specific builds. The criteria for these sites would look like this ([the criteria is defined here](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts)):

```js
[
  {gutenberg: 'edge', target: 'simple', accountName: 'gutenbergEdgeOnSimple'},
  {gutenberg: 'edge', target: 'atomic', accountName: 'gutenbergEdgeOnAtomic'},
  {gutenberg: 'stable', target: 'simple', accountName: 'gutenbergEdgeOnSimple'},
  {gutenberg: 'stable', target: 'atomic', accountName: 'gutenbergEdgeOnAtomic'},
]
```

An example of an `envVariable` that would match one of the criteria above:

* `{GUTENBERG: 'edge, TARGET: 'simple'}`

You can see that there's no mention of `COBLOCKS` there. These sites were created specifically for Gutenberg. Since `COBLOCKS` is not specified (`unspecified`), then the version will fallback to the default version these sites have. You're effectively ignoring CoBlocks in that criteria.

One might argue it's best to be explicit and always define the version of `COBLOCKS` being used. We can do that, too:


```js
[
  {coblocks: 'stable', gutenberg: 'edge', target: 'simple', accountName: 'gutenbergEdgeOnSimple'},
  {coblocks: 'stable, gutenberg: 'edge', target: 'atomic', accountName: 'gutenbergEdgeOnAtomic'},
  {coblocks: 'stable', gutenberg: 'stable', target: 'simple', accountName: 'gutenbergEdgeOnSimple'},
  {coblocks: 'stable', gutenberg: 'stable', target: 'atomic', accountName: 'gutenbergEdgeOnAtomic'},
]
```

The following `envVariable` would match one of the criteria above:

* `{COBLOCKS: 'stable', GUTENBERG: 'edge, TARGET: 'simple'}`

Notice that the previous criterion `{GUTENBERG: 'edge, TARGET: 'simple'}` won't match any of these anymore - tthe `FeatureKey` is converted to a string, [so the match is always bit by bit.](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts#L90) and [the order of attributes doesn't matter](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/lib/utils/get-test-account-by-feature.ts#L32).

The problem with always stating all the versions in the criteria for all plugins that might be installed on a site is that there's less room to create more specific rules. This is best illustrated with an example: if we always have to define the version of Gutenberg for the CoBlocks-specific criteria, then we don't have a CoBlocks or Gutenberg-specific criteria anymore. They apply to both. That can be fine as long as we explicitly have a convention for that, for example, notice the names of the accounts below:

```js
[
  {coblocks: 'edge', gutenberg: 'edge', target: 'simple', accountName: 'gutenbergEdgeCoBlocksEdgeSimple'},
  {coblocks: 'stable', gutenberg: 'edge', target: 'simple', accountName: 'gutenbergEdgeCoBlocksStableSimple'},
]
```

The site names don't need to follow that format as it won't scale if we have a lot of features to describe as part of it. The sites* could even be turned into a hash-like name in the future, and we could create one for each possible combination and use the table to find what site is for what:

```js
[
  {coblocks: 'edge', gutenberg: 'edge', target: 'simple', accountName: '1J700n4FokZJQREU2T'}
  {coblocks: 'stable', gutenberg: 'edge', target: 'simple', accountName: 'EK8yxB3l8YtIUZ7t4M'},
  {coblocks: 'stabe', gutenberg: 'stabe', target: 'simple', accountName: 'VUaL6Gt13WZyJunZTs'},
  {coblocks: 'edge', gutenberg: 'edge', target: 'atomic', accountName: 'BZ3qCIK5Mco6tPcqxy'},
  {coblocks: 'stabe', gutenberg: 'edge', target: 'atomic', accountName: 'hg4I6Eb0CR3Q7p4AcH'},
  {coblocks: 'stable', gutenberg: 'stabe', target: 'atomic', accountName: '0Z75EttjpkPe8fAjDm'},
]
```

**This table could even be dynamically created with all possible combinations of features, and then we could either create the sites with the different feature combos manually or plug them into something that could create them for us.** This would create the ultimate testing matrix for all combos of all features that could then be parameterizable via env vars / TC build :)

This table would be the source of truth and the central catalog for all test sites. Do you want to find the test site that has Gutenberg edge and CoBlocks table? Just look at that table (or query it with `getTestAccoutnByFeature`) and you'll find it :) 

**However... this is just food for thought**. The changes in this PR pave the way to that, but I think it's fine to have ad-hoc rules that ignore certain features, like the ones we have for Gutenberg and Coblocks currently (which have their own "ad-hoc" sites). It's also fine to let the absence of a feature mean it'll use the default version on the site, if available. This is virtually the same behavior we've been using so far, just implemented in a different way that paves to way to a more elegant solution in the future (as depicted above). 

**But wait! I ended up digressing a bit here.** The main goal of the `unspecified` env var value is to allow you to communicate the absence of a feature in the site-selection criteria. So for example, you can setup a site *without* CoBlocks and declare the following rule:

```js
{ gutenberg: 'edge', target: 'simple', accountName: 'gutenbergEdgeOnSimpleWithoutCoblocks' }
```

And if the `COBLOCKS` env var is `undefined` or has the `unspecified` value, but the `GUTENBERG` env var is === `ege` and `TARGET` === `simple` then it will match that rule. Whether or not it means a site without CoBlocks depends on the site that's selected. In this case, we're assuming that this is true. Right now, it's not the case, as Gutenberg-specific rules will match sites that have `CoBlocks` `stable` installed. So the `unspecified` value will - for now - have more of an `ignore` semantics rather than `exclude`, but it's up to us to decide how to go from here.

#### Semantics: Explicit or implicit syntax?

It's also important to note that the `unspecified` value from the env var is translated to `undefined` in the `envVariable` object. This supports the syntax of "ignoring" a feature by omitting it in the `FeatureKey` object. This means that the following env variables: `COBLOCKS=unspecified GUTENBERG=edge TARGET=simple` or `GUTENBERG_EDGE=edge TARGET=simple` will both match the following `FeatureKey`: `{ gutenberg: 'edge', target: 'simple' }` (notice how there's no `coblocks` attribute there).

While I find this intuitive (ignoring by omitting), you could argue that it might be simpler and better to let the `unspecified` value be as is in the final `envVariable` object. This means the same env variables would *not* match the aforementioned `FeatureKey`, but would match this one instead: `{ coblocks: 'unspecified', gutenberg: 'edge', target: 'simple' }`.

However, if we're going to be explicit in the rules, it might be better to instead change the value from `unspecified` to `none` to mean that that feature is not present on the site? I'm not entirely sure yet.

Here's my current take: we might gradually refactor the rules to be more explicit but it will probably require more rules and sites (and maybe it would justify some pre-generation of the table alongside sites, as mentioned above). For now, `unspecified` supports the current approach of ad-hoc rules by providing a simpler way to "ignore" other features.


_*I'm using site/account interchangeably here._

### The type of `envVariables` was needlessly different from `FeatureKey`

The `FeatureKey` type defines a key, which is akin to a query for a specific test site in the central table of sites in the `criteria-for-test-account` module. Most of the time, the actual `FeatureKey` will map to an instance of an `envVariable`(ish) object. Not all attributes from the `envVariable` object are suitable for a `FeatureKey` at the moment, and that's why we created the `TestAccountEnvVariables` type. Even so, we had some mismatches that made things more complicated than they should be:

* The `FeatureKey` defines a couple of feature-like artifacts in the `Feature` union type. These are currently the two plugins we test against: `coblocks` and `gutenberg`. It's then used as a the key for each feature in the `FeatureKey` object, and the value is what defines the actual release to use (`edge` or `stable` -- in the (probably misnamed) `Env` type). 

* There was also a `siteType` attribute that defines the actual target (atomic, simple), now renamed to `target`. The `TestAccountEnvVariables` will pick `GUTENBERG_EDGE`, `COBLOCKS_EDGE` and `TEST_ON_ATOMIC`, all `booleans`. They don't map directly to the aforementioned `FeatureKey` attributes. Why not simplify and make them map directly without any data conversion? 

## Positive side-effects

The changes here provide for some positive site-effects that are good for the long-run and better match the original vision I had for the `getTestAccountByFeatuure` abstraction:

1. By keeping a 1:1 type-mapping between the env variables that are consumable by `getTestAccountByFeatureKey` and the attributes in the `FeatureKey`, it's much easier to add new criteria for site-selection. Just add it to the build as a `param`, add it to the `env-variables` module here, provide a default value if needed and add it to the `FeatureKey` type. That's it. After that, you can start adding new criteria to the table. 
2. By looking at the types for `GUTENBERG` and `COBLOCKS`, it's easier to know what releases are available for tests. Before, you had to assume that i.e `GUTENBERG_EDGE` being `false` meant it would be using the `stable` release.
4. We don't have to fight against the type If we want to expand beyond the `edge` and `stable` releases and add more specific ones or other release types. It's just a matter of adding a new `value` to the Kotlin script and a new type to the relevant types in Calypso, and the rest will fall into place.



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
