### PR TITLE
Remove box shadow from search icon when focused

### DIFF
--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -28,6 +28,10 @@
 
 				box-shadow: 0 0 0 1px var( --studio-gray-10 );
 
+				.search-component__icon-navigation:focus {
+					box-shadow: none;
+				}
+
 				.search-component__open-icon,
 				.search-component__close-icon {
 					color: var( --studio-black );
@@ -38,7 +42,6 @@
 				}
 			}
 		}
-
 	}
 
 	.search-box-header__header {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the box shadow on focus from the search button in the plugins browser

#### Before
![Screenshot 2022-04-06 at 13-42-00 Plugins ‹ Site Title — WordPress com](https://user-images.githubusercontent.com/811776/161891731-2e54c56b-4f9d-48a1-8948-5201955091c0.png)

#### After
![Screenshot 2022-04-06 at 13-42-20 Plugins ‹ Site Title — WordPress com](https://user-images.githubusercontent.com/811776/161891724-248ae490-78d8-4cab-a917-ce54ec8062d4.png)


#### Testing instructions

- https://wordpress.com/plugins
- Click the search icon, it should not get a focus based box shadow

Fixes #62540