### PR TITLE
Move cta hiding to woo landing page

### DIFF
--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
-import { useEffect, useRef } from '@wordpress/element';
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import Breadcrumb from 'calypso/components/breadcrumb';
 
 const Header = styled.header`
@@ -56,64 +55,20 @@ interface Props {
 	className?: string;
 	children?: ReactNode;
 	navigationItems: { label: string; href?: string }[];
-	contentRef?: React.RefObject< HTMLElement >;
-	componentRef?: React.RefObject< HTMLElement >;
 	compactBreadcrumb?: boolean;
 }
 
-const FixedNavigationHeader: React.FunctionComponent< Props > = ( props ) => {
-	const {
-		id,
-		componentRef,
-		className,
-		children,
-		navigationItems,
-		contentRef,
-		compactBreadcrumb = false,
-	} = props;
-	const actionsRef = useRef< HTMLDivElement >( null );
-	const headerRef = useRef< HTMLElement >( null );
-
-	useEffect( () => {
-		if ( ! contentRef ) {
-			return;
-		}
-
-		const handleScroll = () => {
-			const headerHeight = headerRef?.current?.getBoundingClientRect().height;
-			const offset =
-				contentRef.current && headerHeight ? contentRef.current.offsetTop - headerHeight : 0;
-			const scrollPosition = window.scrollY;
-			const actionElement = actionsRef?.current;
-
-			if ( ! actionElement ) {
-				return;
-			}
-
-			if ( offset > 0 && scrollPosition < offset ) {
-				actionElement.style.visibility = 'hidden';
-			} else {
-				actionElement.style.visibility = 'visible';
-			}
-		};
-
-		handleScroll();
-
-		window.addEventListener( 'scroll', handleScroll );
-		return () => {
-			window.removeEventListener( 'scroll', handleScroll );
-		};
-	}, [ contentRef ] );
-
+const FixedNavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) => {
+	const { id, className, children, navigationItems, compactBreadcrumb = false } = props;
 	return (
-		<Header id={ id } className={ className } ref={ componentRef || headerRef }>
+		<Header id={ id } className={ className } ref={ ref }>
 			<Container>
 				<Breadcrumb items={ navigationItems } compact={ compactBreadcrumb } />
-				<ActionsContainer ref={ actionsRef }>{ children }</ActionsContainer>
+				<ActionsContainer>{ children }</ActionsContainer>
 			</Container>
 		</Header>
 	);
-};
+} );
 
 FixedNavigationHeader.defaultProps = {
 	id: '',

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -275,7 +275,7 @@ const PluginsBrowser = ( {
 					className="plugins-browser__header"
 					navigationItems={ breadcrumbs }
 					compactBreadcrumb={ isMobile }
-					componentRef={ navigationHeaderRef }
+					ref={ navigationHeaderRef }
 				>
 					<div className="plugins-browser__main-buttons">
 						<ManageButton

--- a/client/my-sites/woocommerce/landing-page.tsx
+++ b/client/my-sites/woocommerce/landing-page.tsx
@@ -1,12 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
-import { useRef } from '@wordpress/element';
 import { sprintf, _x } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import page from 'page';
-import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
@@ -14,6 +12,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import WarningCard from 'calypso/components/warning-card';
+import useScrollAboveElement from 'calypso/lib/use-scroll-above-element';
 import useWooCommerceOnPlansEligibility from 'calypso/signup/steps/woocommerce-install/hooks/use-woop-handling';
 import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import WooCommerceColophon from './woocommerce-colophon';
@@ -39,10 +38,6 @@ interface DisplayData {
 const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 	const { __ } = useI18n();
 	const navigationItems = [ { label: 'WooCommerce' } ];
-	const [ showActions, setShowActions ] = useState( false );
-	const headerRef = useRef< HTMLElement >( null );
-	const ctaRef = useRef< HTMLElement >( null );
-
 	const currentIntent = useSelector( ( state ) => getSiteOption( state, siteId, 'site_intent' ) );
 
 	const {
@@ -157,30 +152,12 @@ const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 		};
 	}
 
-	useEffect( () => {
-		const handleScroll = () => {
-			const headerHeight = headerRef?.current?.getBoundingClientRect().height;
-			const offset = ctaRef.current && headerHeight ? ctaRef.current.offsetTop - headerHeight : 0;
-
-			if ( offset > 0 && window.scrollY < offset ) {
-				setShowActions( false );
-			} else {
-				setShowActions( true );
-			}
-		};
-
-		handleScroll();
-
-		window.addEventListener( 'scroll', handleScroll );
-		return () => {
-			window.removeEventListener( 'scroll', handleScroll );
-		};
-	}, [ ctaRef, headerRef ] );
+	const { isAboveElement, targetRef: ctaRef, referenceRef: headerRef } = useScrollAboveElement();
 
 	return (
 		<div className="landing-page">
 			<FixedNavigationHeader navigationItems={ navigationItems } ref={ headerRef }>
-				{ showActions && (
+				{ isAboveElement && (
 					<Button onClick={ onCTAClickHandler } primary disabled={ isTransferringBlocked }>
 						{ displayData.action }
 					</Button>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move ctaAction ref juggling out of the FixedNavigationHeader and into the parent woo landing page component.

#### Testing instructions

* No visible change
* Test scrolling on the woo landing page still adds the CTA to the header when you scroll the content one out of view
* Test domains and plugins navigation header still works as expected (neither made use of this behavior)

https://user-images.githubusercontent.com/811776/161899461-cc71855d-e585-4732-903a-c2907f65f0f8.mp4

Fixes #62166
