### PR TITLE
`SiteRedirect`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -1,10 +1,11 @@
 import { CompactCard as Card } from '@automattic/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -48,15 +49,6 @@ class SiteRedirect extends Component {
 
 	componentDidMount() {
 		this.props.fetchSiteRedirect( this.props.selectedSite.domain );
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.location.value !== nextProps.location.value ) {
-			this.setState( {
-				redirectUrl: nextProps.location.value,
-			} );
-		}
 	}
 
 	componentWillUnmount() {
@@ -234,6 +226,15 @@ const recordUpdateSiteRedirectClick = ( domainName, location, success ) =>
 		} )
 	);
 
+const withLocationAsKey = createHigherOrderComponent( ( Wrapped ) => ( props ) => {
+	const selectedSite = useSelector( getSelectedSite );
+	const location = useSelector( ( state ) =>
+		getSiteRedirectLocation( state, selectedSite?.domain )
+	);
+
+	return <Wrapped { ...props } key={ `redirect-${ location.value }` } />;
+} );
+
 export default connect(
 	( state ) => {
 		const selectedSite = getSelectedSite( state );
@@ -249,4 +250,4 @@ export default connect(
 		recordLocationFocus,
 		recordUpdateSiteRedirectClick,
 	}
-)( localize( SiteRedirect ) );
+)( localize( withLocationAsKey( SiteRedirect ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This legacy component is different from the component updated in https://github.com/Automattic/wp-calypso/pull/62493 and since the redesign of domain management it doesn't seem to be in use anymore.

It may be a better option to remove it but since domain management code is quite complex and I'm not an expert in that area of Calypso I'm calling for advice from @rafaelgalani or @Automattic/nomado.

* `SiteRedirect`: refactor away from `UNSAFE_*`

#### Testing instructions

I couldn't find a link from within Calypso but you can test this component by manually manipulating the URL in Step 2 of the instructions described in https://github.com/Automattic/wp-calypso/pull/62493 to `/domains/manage/:domain/redirect-settings/:site` (please note the `-settings` part of the URL).

Related to #58453 
