### PR TITLE
Make DocumentHead work in SSR

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -38,7 +38,7 @@ import { initConnection as initHappychatConnection } from 'calypso/state/happych
 import wasHappychatRecentlyActive from 'calypso/state/happychat/selectors/was-happychat-recently-active';
 import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
 import { getHappychatAuth } from 'calypso/state/happychat/utils';
-import { getInitialState, persistOnChange } from 'calypso/state/initial-state';
+import { getInitialState, getStateFromCache, persistOnChange } from 'calypso/state/initial-state';
 import { loadPersistedState } from 'calypso/state/persisted-state';
 import { init as pushNotificationsInit } from 'calypso/state/push-notifications/actions';
 import { createQueryClient } from 'calypso/state/query-client';
@@ -395,7 +395,7 @@ const boot = async ( currentUser, registerRoutes ) => {
 	const queryClient = await createQueryClient( currentUser?.ID );
 	const initialState = getInitialState( initialReducer, currentUser?.ID );
 	const reduxStore = createReduxStore( initialState, initialReducer );
-	setStore( reduxStore, currentUser?.ID );
+	setStore( reduxStore, getStateFromCache( currentUser?.ID ) );
 	onDisablePersistence( persistOnChange( reduxStore, currentUser?.ID ) );
 	setupLocale( currentUser, reduxStore );
 	configureReduxStore( currentUser, reduxStore );

--- a/client/landing/login/index.js
+++ b/client/landing/login/index.js
@@ -8,6 +8,7 @@ import { setupLocale } from 'calypso/boot/locale';
 import { render } from 'calypso/controller/web-util';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
 import initLoginSection from 'calypso/login';
+import { getStateFromCache } from 'calypso/state/initial-state';
 import { setStore } from 'calypso/state/redux-store';
 import { setupMiddlewares, configureReduxStore } from './common';
 import createStore from './store';
@@ -18,7 +19,7 @@ import 'calypso/components/environment-badge/style.scss';
 
 const boot = ( currentUser ) => {
 	const store = createStore();
-	setStore( store, currentUser?.ID );
+	setStore( store, getStateFromCache( currentUser?.ID ) );
 	configureReduxStore( currentUser, store );
 	setupMiddlewares( currentUser, store );
 	setupLocale( currentUser, store );

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -66,7 +66,7 @@ jest.mock( 'calypso/server/render', () => ( {
 	attachI18n: jest.fn(),
 } ) );
 
-jest.mock( 'calypso/server/state-cache', () => jest.fn() );
+jest.mock( 'calypso/server/state-cache', () => new Map() );
 
 jest.mock( 'calypso/server/user-bootstrap', () => jest.fn() );
 

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -21,7 +21,6 @@ import {
 	getDocumentHeadMeta,
 	getDocumentHeadLink,
 } from 'calypso/state/document-head/selectors';
-import initialReducer from 'calypso/state/reducer';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentLocaleVariant from 'calypso/state/selectors/get-current-locale-variant';
 import { serialize } from 'calypso/state/utils';
@@ -243,9 +242,9 @@ export function serverRender( req, res ) {
 
 		// And cache on the server, too.
 		if ( cacheKey ) {
-			const cacheableInitialState = pick( context.store.getState(), cacheableReduxSubtrees );
-			const serverState = serialize( initialReducer, cacheableInitialState );
-			stateCache.set( cacheKey, serverState );
+			const cacheableServerState = pick( context.store.getState(), cacheableReduxSubtrees );
+			const serverState = serialize( context.store.getCurrentReducer(), cacheableServerState );
+			stateCache.set( cacheKey, serverState.get() );
 		}
 	}
 	context.clientData = config.clientData;

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -216,7 +216,7 @@ function getStateFromPersistence( reducer, subkey, currentUserId ) {
 // between server and local persisted data.
 // This function handles both legacy and modularized Redux state.
 // `loadPersistedState` must have completed first.
-export function getStateFromCache( reducer, subkey, currentUserId ) {
+export const getStateFromCache = ( currentUserId ) => ( reducer, subkey ) => {
 	let serverState = null;
 
 	if ( subkey && typeof window !== 'undefined' ) {
@@ -251,7 +251,7 @@ export function getStateFromCache( reducer, subkey, currentUserId ) {
 		reducer,
 		useServerState
 	);
-}
+};
 
 // Deserialize a portion of state.
 // This function handles both legacy and modularized Redux state.

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -352,7 +352,7 @@ describe( 'initial-state', () => {
 					.spyOn( browserStorage, 'getAllStoredItems' )
 					.mockResolvedValue( savedState );
 				await loadPersistedState();
-				state = getStateFromCache( reader, 'reader', 123456789 );
+				state = getStateFromCache( 123456789 )( reader, 'reader' );
 			} );
 
 			afterAll( () => {
@@ -394,7 +394,7 @@ describe( 'initial-state', () => {
 					.spyOn( browserStorage, 'getAllStoredItems' )
 					.mockResolvedValue( savedState );
 				await loadPersistedState();
-				state = getStateFromCache( reader, 'reader' );
+				state = getStateFromCache()( reader, 'reader' );
 			} );
 
 			afterAll( () => {
@@ -444,7 +444,7 @@ describe( 'initial-state', () => {
 					.spyOn( browserStorage, 'getAllStoredItems' )
 					.mockResolvedValue( savedState );
 				await loadPersistedState();
-				state = getStateFromCache( reader, 'reader', 123456789 );
+				state = getStateFromCache( 123456789 )( reader, 'reader' );
 			} );
 
 			afterAll( () => {
@@ -494,7 +494,7 @@ describe( 'initial-state', () => {
 					.spyOn( browserStorage, 'getAllStoredItems' )
 					.mockResolvedValue( savedState );
 				await loadPersistedState();
-				state = getStateFromCache( reader, 'reader', 123456789 );
+				state = getStateFromCache( 123456789 )( reader, 'reader' );
 			} );
 
 			afterAll( () => {
@@ -547,7 +547,7 @@ describe( 'initial-state', () => {
 					.mockResolvedValue( storedState );
 
 				await loadPersistedState();
-				state = getStateFromCache( signupReducer, 'signup' );
+				state = getStateFromCache()( signupReducer, 'signup' );
 			} );
 
 			afterAll( () => {
@@ -616,7 +616,7 @@ describe( 'initial-state', () => {
 					.mockResolvedValue( storedState );
 
 				await loadPersistedState();
-				state = getStateFromCache( signupReducer, 'signup', 123456789 );
+				state = getStateFromCache( 123456789 )( signupReducer, 'signup' );
 			} );
 
 			afterAll( () => {
@@ -899,7 +899,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load a reducer dynamically
 		const aReducer = withStorageKey( 'A', withKeyPrefix( 'A' ) );
-		addReducerToStore( store, userId )( [ 'a' ], aReducer );
+		addReducerToStore( store, getStateFromCache( userId ) )( [ 'a' ], aReducer );
 
 		// verify that the Redux store contains the stored state for `A` now
 		expect( store.getState() ).toEqual( {
@@ -934,7 +934,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load a reducer dynamically
 		const cdReducer = withStorageKey( 'CD', withKeyPrefix( 'CD' ) );
-		addReducerToStore( store, userId )( [ 'c', 'd' ], cdReducer );
+		addReducerToStore( store, getStateFromCache( userId ) )( [ 'c', 'd' ], cdReducer );
 
 		// verify that the Redux store contains the stored state for `A` now
 		expect( store.getState() ).toEqual( {
@@ -971,8 +971,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load a reducer dynamically
 		const eReducer = withStorageKey( 'E', withKeyPrefix( 'E' ) );
-		addReducerToStore( store, userId )( [ 'e' ], eReducer );
-		addReducerToStore( store, userId )( [ 'e' ], eReducer );
+		addReducerToStore( store, getStateFromCache( userId ) )( [ 'e' ], eReducer );
+		addReducerToStore( store, getStateFromCache( userId ) )( [ 'e' ], eReducer );
 
 		// verify that the Redux store contains the stored state for `E` now
 		expect( store.getState() ).toEqual( {
@@ -1010,8 +1010,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 		const cReducer = withStorageKey( 'C', withKeyPrefix( 'C' ) );
 
 		expect( () => {
-			addReducerToStore( store, userId )( [ 'b' ], bReducer );
-			addReducerToStore( store, userId )( [ 'b' ], cReducer );
+			addReducerToStore( store, getStateFromCache( userId ) )( [ 'b' ], bReducer );
+			addReducerToStore( store, getStateFromCache( userId ) )( [ 'b' ], cReducer );
 		} ).toThrow();
 	} );
 } );


### PR DESCRIPTION
In a discussion in https://github.com/Automattic/wp-calypso/pull/60949#discussion_r840617761 we discovered that the `DocumentHead` component doesn't work in SSR. This PR fixed that. This is the mechanism how it's supposed to work:

1. There is a `<DocumentHead>` component that's rendered as part of the React UI tree. When rendered with certain props, it should sync these prop values to Redux state (`state.documentHead`). In browser that happens in an effect (namely `cDM` and `cDU` lifecycle methods), but on server the only available place is in constructor. That's what my first commit does: add a constructor to `DocumentHead` that dispatches Redux actions when in server mode. My inspiration was the [`next/head` component from Next.js](https://github.com/vercel/next.js/blob/canary/packages/next/shared/lib/head.tsx) which works the same way: only they sync to a `headManager` object exposed through context, while we use Redux for that purpose.
2. Now rendering a React tree on server produces a markup string, and as a side-effect it also updates the server-side Redux store. The there's the [`attachHead` Express.js handler](https://github.com/Automattic/wp-calypso/blob/trunk/client/server/render/index.js#L195-L204) that reads the `state.documentHead` info from Redux, and writes it to the Express.js `context` object, to be later read by the code that composes the response HTML. This part works and doesn't need fixing, but only as long as you do actual React tree render on every response. But what if these renders are cached? Then the Redux write side-effect is not performed.

Actually, in addition to caching the rendered React trees for each path, we cache the Redux states, too. The state is read (`stateCache.get()`) when creating a server-side Redux store, and written (`stateCache.set()`) after React tree rendering is done. But that caching is completely broken and requires several fixes to make it work.

First, in #59848, @sgomes added a `:gdpr=<bool>` suffix to the cache key, but the new cache key is used only for writing the Redux state. Reading the Redux state is done with the old cache key, so there's never a cache hit. There's a fix in 7a75152.

Second, the code that serializes the server state was never correctly updated when Redux state was modularized. It serializes the state using the _initial_ reducer, which is almost empty and doesn't contain subreducers for modular parts of the state like `state.documentHead`. I needed to update that to `store.getCurrentReducer()` in 6310c24 in order to serialize `documentHead`, too. Also, we were storing the return value of `serialize()` into the cache. But that was OK when the reducer was monolithic, but for a long time now, `serialize()` returns a `SerializationResult` with state keyed by `storageKey`. I needed to add a `.get()` call to get the storable data from `SerializationResult`.

Finally, when constructing a new store from a cached state, it's not enough pass the cached data as initial state to `createReduxStore`. The cached data are not initial state, they are keyed by `storageKey`. The data structures don't match at all. Here I need to rework the `setStore` function in `client/state/redux-store` that loops through the registered reducers (registered statically in `init.js` modules) and initializes them with persisted data. The `addReducerToStore` function called there used to have a hardcoded call to `getStateFromCache` that reads from the IndexedDB-backed cache. But that's not usable on server. I needed to replace that with a `getStoredCache` callback, where browser code will pass `getStateFromCache`, but server code will pass its own function.

After all these parts are put together, it all works!
1. First SSR creates an empty Redux store, does React rendering, `state.documentHead` is written to, both render result and the Redux store are cached (including the `documentHead` state), `attachHead` populates the head data.
2. Second SSR inits Redux store from cache, reads render result from cache, too, and `attachHead` populates correctly the cached head data. The (unchanged) Redux store is written to cache again.

**How to test:**
Start Calypso in logged-out mode and disable JavaScript in your browser. Go to `/log-in`. Verify the server-rendered `head > title` is `Log In — WordPress.com`, that there is a `<meta name="decription">` tag saying "login" and that there are `<link rel="canonical">` and `<link rel="alternate">` tags linking to various version of the login page.

Verify that these `<head>` data are there both on first (uncached) and on further (cached) requests.

