### PR TITLE
Add notice to show legacy plan notice for users on legacy plans on /plans page

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -14,7 +14,6 @@ import {
 	JETPACK_VIDEOPRESS_PRODUCTS,
 	isFreeJetpackPlan,
 	isFreePlanProduct,
-	isPro,
 } from '@automattic/calypso-products';
 import { Dialog } from '@automattic/components';
 import classNames from 'classnames';
@@ -42,6 +41,7 @@ import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings'
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import JetpackChecklist from 'calypso/my-sites/plans/current-plan/jetpack-checklist';
 import PlanRenewalMessage from 'calypso/my-sites/plans/jetpack-plans/plan-renewal-message';
+import legacyPlanNotice from 'calypso/my-sites/plans/legacy-plan-notice';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
@@ -181,19 +181,10 @@ class CurrentPlan extends Component {
 
 		let showExpiryNotice = false;
 		let purchase = null;
-		let showLegacyPlanNotice = false;
 
 		if ( JETPACK_LEGACY_PLANS.includes( currentPlanSlug ) ) {
 			purchase = getPurchaseByProductSlug( purchases, currentPlanSlug );
 			showExpiryNotice = purchase && isCloseToExpiration( purchase );
-		}
-
-		if (
-			eligibleForProPlan &&
-			! isFreePlanProduct( selectedSite.plan ) &&
-			! isPro( selectedSite.plan )
-		) {
-			showLegacyPlanNotice = true;
 		}
 
 		// Ensures the Plan tab is shown in case the plan changes after the controller redirect.
@@ -262,16 +253,7 @@ class CurrentPlan extends Component {
 						</Notice>
 					) }
 
-					{ showLegacyPlanNotice && (
-						<Notice
-							status="is-info"
-							text={ translate(
-								'You’re currently on a legacy plan. If you’d like to learn about your eligibility to switch to a Pro plan please contact support.'
-							) }
-							icon="info-outline"
-							showDismiss={ false }
-						></Notice>
-					) }
+					{ legacyPlanNotice( eligibleForProPlan, selectedSite ) }
 
 					<PurchasesListing />
 

--- a/client/my-sites/plans/legacy-plan-notice.jsx
+++ b/client/my-sites/plans/legacy-plan-notice.jsx
@@ -1,0 +1,32 @@
+import { isFreePlanProduct, isPro } from '@automattic/calypso-products';
+import { translate } from 'i18n-calypso';
+import Notice from 'calypso/components/notice';
+
+/**
+ * Renders a "You're on a legacy plan" for users on legacy plans (excluding legacy free plan users).
+ *
+ * @param {boolean} eligibleForProPlan - Is the user eligible for pro plan?
+ * @param {number} selectedSite - Site ID.
+ * @returns - Legacy plan Notice component.
+ */
+const maybeRenderLegacyPlanNotice = ( eligibleForProPlan, selectedSite ) => {
+	// Renders the legacy plan notice for users on legacy plans (not including legacy Free plan).
+	if (
+		eligibleForProPlan &&
+		! isFreePlanProduct( selectedSite.plan ) &&
+		! isPro( selectedSite.plan )
+	) {
+		return (
+			<Notice
+				status="is-info"
+				text={ translate(
+					'You’re currently on a legacy plan. If you’d like to learn about your eligibility to switch to a Pro plan please contact support.'
+				) }
+				icon="info-outline"
+				showDismiss={ false }
+			></Notice>
+		);
+	}
+};
+
+export default maybeRenderLegacyPlanNotice;

--- a/client/my-sites/plans/legacy-plan-notice.jsx
+++ b/client/my-sites/plans/legacy-plan-notice.jsx
@@ -6,7 +6,7 @@ import Notice from 'calypso/components/notice';
  * Renders a "You're on a legacy plan" for users on legacy plans (excluding legacy free plan users).
  *
  * @param {boolean} eligibleForProPlan - Is the user eligible for pro plan?
- * @param {number} selectedSite - Site ID.
+ * @param {object} selectedSite - Site object from store.
  * @returns - Legacy plan Notice component.
  */
 const maybeRenderLegacyPlanNotice = ( eligibleForProPlan, selectedSite ) => {

--- a/client/my-sites/plans/legacy-plan-notice.jsx
+++ b/client/my-sites/plans/legacy-plan-notice.jsx
@@ -10,7 +10,6 @@ import Notice from 'calypso/components/notice';
  * @returns - Legacy plan Notice component.
  */
 const maybeRenderLegacyPlanNotice = ( eligibleForProPlan, selectedSite ) => {
-	// Renders the legacy plan notice for users on legacy plans (not including legacy Free plan).
 	if (
 		eligibleForProPlan &&
 		! isFreePlanProduct( selectedSite.plan ) &&

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -5,6 +5,8 @@ import {
 	PLAN_FREE,
 	PLAN_WPCOM_PRO,
 	PLAN_WPCOM_FLEXIBLE,
+	isFreePlanProduct,
+	isPro,
 } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { localize } from 'i18n-calypso';
@@ -19,6 +21,7 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
@@ -191,6 +194,26 @@ class Plans extends Component {
 	render() {
 		const { selectedSite, translate, canAccessPlans, currentPlan, eligibleForProPlan } = this.props;
 
+		const maybeRenderLegacyPlanNotice = () => {
+			// Renders the legacy plan notice for users on legacy plans (not including legacy Free plan).
+			if (
+				eligibleForProPlan &&
+				! isFreePlanProduct( selectedSite.plan ) &&
+				! isPro( selectedSite.plan )
+			) {
+				return (
+					<Notice
+						status="is-info"
+						text={
+							'You’re currently on a legacy plan. If you’d like to learn about your eligibility to switch to a Pro plan please contact support.'
+						}
+						icon="info-outline"
+						showDismiss={ false }
+					></Notice>
+				);
+			}
+		};
+
 		if ( ! selectedSite || this.isInvalidPlanInterval() || ! currentPlan ) {
 			return this.renderPlaceholder();
 		}
@@ -223,6 +246,7 @@ class Plans extends Component {
 							/>
 							<div id="plans" className="plans plans__has-sidebar">
 								<PlansNavigation path={ this.props.context.path } />
+								{ maybeRenderLegacyPlanNotice() }
 								{ this.renderPlansMain() }
 								<PerformanceTrackerStop />
 							</div>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -5,8 +5,6 @@ import {
 	PLAN_FREE,
 	PLAN_WPCOM_PRO,
 	PLAN_WPCOM_FLEXIBLE,
-	isFreePlanProduct,
-	isPro,
 } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { localize } from 'i18n-calypso';
@@ -21,7 +19,6 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
-import Notice from 'calypso/components/notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
@@ -29,6 +26,7 @@ import { useExperiment } from 'calypso/lib/explat';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import PlansComparison, { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
+import legacyPlanNotice from 'calypso/my-sites/plans/legacy-plan-notice';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import P2PlansMain from 'calypso/my-sites/plans/p2-plans-main';
 import { isTreatmentPlansReorderTest } from 'calypso/state/marketing/selectors';
@@ -194,26 +192,6 @@ class Plans extends Component {
 	render() {
 		const { selectedSite, translate, canAccessPlans, currentPlan, eligibleForProPlan } = this.props;
 
-		const maybeRenderLegacyPlanNotice = () => {
-			// Renders the legacy plan notice for users on legacy plans (not including legacy Free plan).
-			if (
-				eligibleForProPlan &&
-				! isFreePlanProduct( selectedSite.plan ) &&
-				! isPro( selectedSite.plan )
-			) {
-				return (
-					<Notice
-						status="is-info"
-						text={
-							'You’re currently on a legacy plan. If you’d like to learn about your eligibility to switch to a Pro plan please contact support.'
-						}
-						icon="info-outline"
-						showDismiss={ false }
-					></Notice>
-				);
-			}
-		};
-
 		if ( ! selectedSite || this.isInvalidPlanInterval() || ! currentPlan ) {
 			return this.renderPlaceholder();
 		}
@@ -246,7 +224,7 @@ class Plans extends Component {
 							/>
 							<div id="plans" className="plans plans__has-sidebar">
 								<PlansNavigation path={ this.props.context.path } />
-								{ maybeRenderLegacyPlanNotice() }
+								{ legacyPlanNotice( eligibleForProPlan, selectedSite ) }
 								{ this.renderPlansMain() }
 								<PerformanceTrackerStop />
 							</div>

--- a/client/my-sites/plans/test/legacy-plan-notice.js
+++ b/client/my-sites/plans/test/legacy-plan-notice.js
@@ -1,0 +1,92 @@
+import legacyPlanNotice from 'calypso/my-sites/plans/legacy-plan-notice';
+
+describe( 'Shows legacy plan notice for ex-plans', () => {
+	let fakeLegacySiteSlice;
+
+	beforeAll( () => {
+		// Sites from store.
+		fakeLegacySiteSlice = {
+			sites: {
+				items: {
+					// Free plan site.
+					1: {
+						ID: 1,
+						name: 'Free Inc.',
+						jetpack: false,
+						is_wpcom_atomic: false,
+						options: {},
+						plan: {
+							product_id: 1,
+							product_slug: 'FREE_PLAN',
+							product_name_short: 'free',
+							expired: false,
+							user_is_owner: false,
+							is_free: true,
+						},
+					},
+					// Legacy Business plan site.
+					2: {
+						ID: 2,
+						name: 'Business Inc.',
+						jetpack: false,
+						is_wpcom_atomic: true,
+						options: {},
+						plan: {
+							product_id: 1008,
+							product_slug: 'value_bundle',
+							product_name_short: 'Business',
+							expired: false,
+							user_is_owner: false,
+							is_free: false,
+						},
+					},
+					// Site with pro plan.
+					3: {
+						ID: 3,
+						name: 'Pro Inc.',
+						jetpack: false,
+						is_wpcom_atomic: true,
+						options: {},
+						plan: {
+							product_id: 1032,
+							product_slug: 'pro-plan',
+							product_name_short: 'Pro',
+							expired: false,
+							user_is_owner: true,
+							is_free: false,
+						},
+					},
+				},
+			},
+		};
+	} );
+
+	test( 'Do not show legacy plan notice for users on Free plan', () => {
+		const freePlanSite = fakeLegacySiteSlice.sites.items[ '1' ];
+		const siteIsEligibleForProPlan = true;
+		const legacyPlanNoticeComponent = legacyPlanNotice( siteIsEligibleForProPlan, freePlanSite );
+
+		expect( legacyPlanNoticeComponent ).toBeUndefined;
+	} );
+
+	test( 'Show legacy plan notice to users on Business plan', () => {
+		const legacyBusinessPlanSite = fakeLegacySiteSlice.sites.items[ '2' ];
+		const siteIsEligibleForProPlan = true;
+		const legacyPlanNoticeComponent = legacyPlanNotice(
+			siteIsEligibleForProPlan,
+			legacyBusinessPlanSite
+		);
+
+		expect( legacyPlanNoticeComponent.props.text ).toContain( 'You’re currently on a legacy plan' );
+	} );
+
+	test( 'Do not show legacy plan notice to users on Pro plan', () => {
+		const proPlanSite = fakeLegacySiteSlice.sites.items[ '3' ];
+
+		// Even with this set to true, the notice should not show as the plan is checked for whether it's "pro-plan" or not.
+		const siteIsEligibleForProPlan = true;
+		const legacyPlanNoticeComponent = legacyPlanNotice( siteIsEligibleForProPlan, proPlanSite );
+
+		expect( legacyPlanNoticeComponent ).toBeUndefined;
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adding a notice to users on legacy plans (not including legacy free plans). 
* WIP, might be better to add it here `/client/my-sites/plan-features/index.jsx` where other notifications live.

#### Testing instructions

* Use a site with a legacy plan, i.e. Business. Go to upgrade > plans. You should see a notice that you're on a legacy plan. Similar to what's showing on "My Plan".
* Do the same with a legacy free site. You should see the new plans grid and no related notice.
* You can also check a pro plan site, and make sure that the notice does not show.
* Checking in a non-EN language/locale, should show the translated description.

![Screenshot 2022-04-14 at 13 24 07](https://user-images.githubusercontent.com/52675688/163381725-77b19025-d2b9-425f-b737-e1a270570f23.png)

