### PR TITLE
Emails: Adding mailboxes fails when provisioning is happening on server-side

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -243,16 +243,8 @@ const EmailPlan = ( props ) => {
 	}
 
 	function renderAddNewMailboxesOrRenewNavItem() {
-		const {
-			canAddGoogleWorkspaceMailboxes,
-			canAddProfessionalEmailMailboxes,
-			domain,
-			hasSubscription,
-			purchase,
-			translate,
-		} = props;
+		const { canAddMailboxes, domain, hasSubscription, purchase, translate } = props;
 
-		const canAddMailboxes = canAddGoogleWorkspaceMailboxes || canAddProfessionalEmailMailboxes;
 		if ( hasTitanMailWithUs( domain ) && ! hasSubscription && canAddMailboxes ) {
 			return (
 				<VerticalNavItem { ...getAddMailboxProps() }>
@@ -371,8 +363,9 @@ EmailPlan.propType = {
 
 export default connect( ( state, ownProps ) => {
 	return {
-		canAddGoogleWorkspaceMailboxes: Boolean( getGSuiteProductSlug( ownProps.domain ) ),
-		canAddProfessionalEmailMailboxes: Boolean( getTitanProductSlug( ownProps.domain ) ),
+		canAddMailboxes:
+			Boolean( getGSuiteProductSlug( ownProps.domain ) ) ||
+			Boolean( getTitanProductSlug( ownProps.domain ) ),
 		currentRoute: getCurrentRoute( state ),
 		emailForwards: getEmailForwards( state, ownProps.domain.name ),
 		isLoadingEmailForwards: isRequestingEmailForwards( state, ownProps.domain.name ),

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -351,8 +351,7 @@ EmailPlan.propType = {
 	source: PropTypes.string,
 
 	// Connected props
-	canAddGoogleWorkspaceMailboxes: PropTypes.bool,
-	canAddProfessionalEmailMailboxes: PropTypes.bool,
+	canAddMailboxes: PropTypes.bool,
 	currentRoute: PropTypes.string,
 	emailForwards: PropTypes.array,
 	hasSubscription: PropTypes.bool,

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -19,7 +19,12 @@ import {
 	hasGSuiteWithUs,
 } from 'calypso/lib/gsuite';
 import { handleRenewNowClick, isExpired } from 'calypso/lib/purchases';
-import { getTitanProductName, getTitanSubscriptionId, hasTitanMailWithUs } from 'calypso/lib/titan';
+import {
+	getTitanProductName,
+	getTitanProductSlug,
+	getTitanSubscriptionId,
+	hasTitanMailWithUs,
+} from 'calypso/lib/titan';
 import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/constants';
 import EmailPlanHeader from 'calypso/my-sites/email/email-management/home/email-plan-header';
 import EmailPlanMailboxesList from 'calypso/my-sites/email/email-management/home/email-plan-mailboxes-list';
@@ -238,9 +243,17 @@ const EmailPlan = ( props ) => {
 	}
 
 	function renderAddNewMailboxesOrRenewNavItem() {
-		const { domain, hasSubscription, purchase, translate } = props;
+		const {
+			canAddGoogleWorkspaceMailboxes,
+			canAddProfessionalEmailMailboxes,
+			domain,
+			hasSubscription,
+			purchase,
+			translate,
+		} = props;
 
-		if ( hasTitanMailWithUs( domain ) && ! hasSubscription ) {
+		const canAddMailboxes = canAddGoogleWorkspaceMailboxes || canAddProfessionalEmailMailboxes;
+		if ( hasTitanMailWithUs( domain ) && ! hasSubscription && canAddMailboxes ) {
 			return (
 				<VerticalNavItem { ...getAddMailboxProps() }>
 					{ translate( 'Add new mailboxes' ) }
@@ -261,11 +274,14 @@ const EmailPlan = ( props ) => {
 				);
 			}
 
-			return (
-				<VerticalNavItem { ...getAddMailboxProps() }>
-					{ translate( 'Add new mailboxes' ) }
-				</VerticalNavItem>
-			);
+			if ( canAddMailboxes ) {
+				return (
+					<VerticalNavItem { ...getAddMailboxProps() }>
+						{ translate( 'Add new mailboxes' ) }
+					</VerticalNavItem>
+				);
+			}
+			return null;
 		}
 
 		return (
@@ -343,6 +359,8 @@ EmailPlan.propType = {
 	source: PropTypes.string,
 
 	// Connected props
+	canAddGoogleWorkspaceMailboxes: PropTypes.bool,
+	canAddProfessionalEmailMailboxes: PropTypes.bool,
 	currentRoute: PropTypes.string,
 	emailForwards: PropTypes.array,
 	hasSubscription: PropTypes.bool,
@@ -353,6 +371,8 @@ EmailPlan.propType = {
 
 export default connect( ( state, ownProps ) => {
 	return {
+		canAddGoogleWorkspaceMailboxes: Boolean( getGSuiteProductSlug( ownProps.domain ) ),
+		canAddProfessionalEmailMailboxes: Boolean( getTitanProductSlug( ownProps.domain ) ),
 		currentRoute: getCurrentRoute( state ),
 		emailForwards: getEmailForwards( state, ownProps.domain.name ),
 		isLoadingEmailForwards: isRequestingEmailForwards( state, ownProps.domain.name ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While testing changes not this pull request, I've noticed that if we are adding mailboxes to a domain that is being provisioned and is also adding a new Google Workspace subscription, adding mailboxes fails without no error. Only a null pointer in the console when the user clicks on the confirm mailboxes button.

I've tried to disable the button but I didn't like at all the aesthetic aspects.

#### Testing instructions

**New domain**

1. Buy a domain (I'm mostly always using .blog domains, it is 100% reproducible with it)
2. In the upsell add the Google Workspace monthly (or annual if available)
3. Checkout
4. Go to Upgrades -> Emails
5. Click on your new domain
6. Check that you can't add mailboxes yet
7. Wait around 20-30 minutes
8. Check that you can add mailboxes now

**Regression test**

1. Have a previously bought Professional Email subscription & Google Workspace
2. Go to Upgrades -> Emails
3. Click on a domain with one of those providers
5. Check that you can add mailboxes

| BEFORE  | AFTER |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/5689927/161974862-ef587819-3169-43d2-9b14-002c48ee3ebb.png) | ![image](https://user-images.githubusercontent.com/5689927/161972412-ca1ae08c-c19b-4fe7-a889-5b888184cffa.png) |


Related to {1200182182542585-as-1202071184930420}
