### PR TITLE
Stepper: Fixed missing style in stepper web preview

### DIFF
--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -6,8 +6,6 @@ import { Component } from 'react';
 import { hasTouch } from 'calypso/lib/touch-detect';
 import WebPreviewContent from './connectedContent';
 
-import './style.scss';
-
 const noop = () => {};
 
 export class WebPreviewModal extends Component {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -11,6 +11,8 @@ import { addQueryArgs } from 'calypso/lib/route';
 import { hasTouch } from 'calypso/lib/touch-detect';
 import Toolbar from './toolbar';
 
+import './style.scss';
+
 const debug = debugModule( 'calypso:web-preview' );
 const noop = () => {};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -232,20 +232,13 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 			}
 
 			.web-preview__inner {
-				height: 100%;
-				display: flex;
-				flex-direction: column;
 				transform: translateY( -48px );
-			}
-			.web-preview__placeholder {
-				flex: 1;
 			}
 
 			.web-preview__frame-wrapper.is-resizable {
 				margin: 0;
 				padding: 0;
 				background-color: transparent;
-				height: 100%;
 			}
 
 			.web-preview__frame {
@@ -254,23 +247,6 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 				/* stylelint-disable-next-line scales/radii */
 				border-radius: 0 0 6px 6px;
 				box-sizing: border-box;
-				height: 100%;
-				width: 100%;
-			}
-
-			.web-preview__loading-message-wrapper {
-				display: flex;
-				justify-content: center;
-				flex-direction: column;
-				position: absolute;
-				height: 100%;
-				width: 100%;
-				text-align: center;
-			}
-
-			.web-preview__loading-message {
-				color: var( --color-text-subtle );
-				font-size: $font-body;
 			}
 
 			.web-preview__inner .spinner-line {
@@ -279,7 +255,8 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 				top: unset;
 				left: unset;
 				transform: unset;
-				margin: 0;
+				margin: 0 auto;
+				position: static;
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the Stepper we are adding the `WebPreview` component from `import WebPreview from 'calypso/components/web-preview/content';`, but the WebPreview scss file was imported only in `calypso/components/web-preview/component`,  used in `start` but not in `stepper`

With this PR we moved the scss import in `calypso/components/web-preview/content`.

| Before  | After |
| ------------- | ------------- |
| ![Screen Capture on 2022-04-06 at 15-12-44](https://user-images.githubusercontent.com/52076348/161982708-d06c4c22-0479-4a90-a533-b299d0941014.gif) | ![Screen Capture on 2022-04-06 at 15-10-14](https://user-images.githubusercontent.com/52076348/161982432-887a61ec-801d-4436-a4b4-de229df380cf.gif) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* `yarn start`
* Go to `http://calypso.localhost:3000/stepper/designSetup?siteSlug=SITE-SLUG`
* Preview a design
* You should be able to see the design in all the devices

