### PR TITLE
Pro plan: Full importer: fix showing proper plan type details

### DIFF
--- a/client/signup/steps/import-from/wordpress/import-everything/confirm.tsx
+++ b/client/signup/steps/import-from/wordpress/import-everything/confirm.tsx
@@ -131,7 +131,7 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 
 				{ showUpgradePlanScreen && (
 					<>
-						<ConfirmUpgradePlan sourceSite={ sourceSite } />
+						<ConfirmUpgradePlan sourceSite={ sourceSite } targetSite={ targetSite } />
 						<NextButton onClick={ () => setIsModalDetailsOpen( true ) }>
 							{ __( 'Upgrade and import' ) }
 						</NextButton>

--- a/client/signup/steps/import-from/wordpress/import-everything/index.tsx
+++ b/client/signup/steps/import-from/wordpress/import-everything/index.tsx
@@ -11,6 +11,7 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { EVERY_TEN_SECONDS, Interval } from 'calypso/lib/interval';
 import { addQueryArgs } from 'calypso/lib/route';
 import { SectionMigrate } from 'calypso/my-sites/migrate/section-migrate';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { SitesItem } from 'calypso/state/selectors/get-sites-items';
@@ -29,6 +30,7 @@ interface Props {
 	targetSite: SitesItem;
 	targetSiteId: number | null;
 	targetSiteSlug: string;
+	targetSiteEligibleForProPlan: boolean;
 }
 export class ImportEverything extends SectionMigrate {
 	getMigrationUrlPath = () => {
@@ -47,8 +49,9 @@ export class ImportEverything extends SectionMigrate {
 	};
 
 	getCheckoutUrlPath = ( redirectTo: string ) => {
-		const { targetSiteSlug } = this.props;
-		const path = `/checkout/${ targetSiteSlug }/business`;
+		const { targetSiteSlug, targetSiteEligibleForProPlan } = this.props;
+		const plan = targetSiteEligibleForProPlan ? 'pro' : 'business';
+		const path = `/checkout/${ targetSiteSlug }/${ plan }`;
 		const queryParams = { redirect_to: redirectTo };
 
 		return addQueryArgs( queryParams, path );
@@ -238,6 +241,7 @@ export const connector = connect(
 				ownProps.targetSiteId as number,
 				'import.php'
 			),
+			targetSiteEligibleForProPlan: isEligibleForProPlan( state, ownProps.targetSiteId as number ),
 		};
 	},
 	{

--- a/client/signup/steps/import-from/wordpress/import-everything/style.scss
+++ b/client/signup/steps/import-from/wordpress/import-everything/style.scss
@@ -144,7 +144,8 @@
 			margin: 0;
 		}
 
-		.import__upgrade-plan-feature {
+		.import__upgrade-plan-feature,
+		.import__upgrade-plan-feature-more {
 			padding-left: 25px;
 			color: var( --studio-gray-40 );
 			flex-basis: 100%;
@@ -153,12 +154,24 @@
 				flex-basis: 50%;
 			}
 
+			button {
+				color: var( --studio-gray-40 );
+				line-height: 1.5em;
+				cursor: pointer;
+			}
+
 			span {
 				margin: 0;
 			}
 
 			svg {
 				fill: var( --color-success );
+			}
+		}
+
+		.import__upgrade-plan-feature-more {
+			svg {
+				fill: var( --studio-gray-60 );
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Replaced the hardcoded plan for the checkout screen redirection from `business` to dynamically plan type pick
- Updated `Upgrade plan` screen details by showing the plan details dynamically
- Added `See more` button for presenting more than six features in the list

#### Testing instructions

- Go to `/start/importer?siteSlug={SLUG}` (your site should be under the Free plan)
- Enter the self-hosted WP site URL (Jetpack connection should be established)
- Select the `Everything` option
- Click on `See plans`
- Check if there are Pro plan details with option to `See more` features in the list

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Screenshot
![Screen Capture on 2022-04-06 at 15-01-30](https://user-images.githubusercontent.com/1241413/161985422-8416f3aa-d9a5-4b5d-a135-fcbcfb710ce9.gif)

Closes #62554
