### PR TITLE
Plans comparison: some visual tweaks

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -9,7 +9,6 @@ import {
 import { Gridicon } from '@automattic/components';
 import { css, Global } from '@emotion/react';
 import styled from '@emotion/styled';
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -50,6 +49,7 @@ const getRowMobileLayout = ( breakpoint: number, pageClass: string ) => `
 			th,
 			td {
 				width: ${ ( { planCount }: { planCount: number } ) => `${ 100 / planCount }%` };
+				height: unset;
 			}
 		}
 	}
@@ -278,6 +278,16 @@ const ComparisonTable = styled.table< TableProps >`
 		}
 	}
 
+	tbody th,
+	tbody td {
+		padding: 0.78rem 1.25rem;
+		height: 4rem;
+	}
+
+	tbody th {
+		padding-left: 0;
+	}
+
 	thead th,
 	thead td {
 		vertical-align: top;
@@ -321,27 +331,10 @@ const ComparisonTable = styled.table< TableProps >`
 		border-color: #055d9c;
 	}
 
-	.plans-comparison__rows tr:last-child {
-		th,
-		td {
-			border-bottom: none;
-		}
-	}
-
 	${ ( { hideFreePlan } ) =>
 		! hideFreePlan && getRowMobileLayout( SCREEN_BREAKPOINT_SIGNUP, '.is-section-signup' ) }
 	${ ( { hideFreePlan } ) =>
 		! hideFreePlan && getRowMobileLayout( SCREEN_BREAKPOINT_PLANS, '.is-section-plans' ) }
-
-	.plans-comparison__collapsible-rows {
-		display: none;
-		border-top: 1px solid rgba( 220, 220, 222, 0.2 );
-	}
-
-	.plans-comparison__collapsible-rows.is-active {
-		display: table-row-group;
-		animation: fade-in-rows 0.3s ease;
-	}
 
 	@keyframes fade-in-rows {
 		0% {
@@ -358,34 +351,53 @@ const THead = styled.thead< { isInSignup: boolean } >`
 	top: ${ ( { isInSignup } ) => ( isInSignup ? '0' : `var( --masterbar-height )` ) };
 `;
 
-const PlanComparisonToggle = styled.tr`
-	th,
-	td,
-	td:last-child {
-		padding: 0;
-		border-bottom: none;
-		background: none;
+const PlansComparisonRows = styled.tbody`
+	tr:last-child {
+		th,
+		td {
+			border-bottom: none;
+		}
 	}
+`;
 
-	${ getRowMobileLayout( SCREEN_BREAKPOINT_SIGNUP, '.is-section-signup' ) }
-	${ getRowMobileLayout( SCREEN_BREAKPOINT_PLANS, '.is-section-plans' ) }
+const PlansComparisonCollapsibleRows = styled( PlansComparisonRows )< {
+	collapsed: boolean;
+} >`
+	display: ${ ( props ) => ( props.collapsed ? 'table-row-group' : 'none' ) };
+	border-top: 1px solid rgba( 220, 220, 222, 0.2 );
+	animation: fade-in-rows 0.3s ease;
+`;
 
-	button {
-		background: rgba( 246, 247, 247, 0.5 );
-		display: block;
-		text-align: center;
-		border-radius: 2px;
-		padding: 15px;
-		width: 100%;
-		margin: 25px 0;
-		cursor: pointer;
+const PlansComparisonToggle = styled.tbody`
+	tr {
+		th,
+		td,
+		td:last-child {
+			padding: 0;
+			border-bottom: none;
+			background: none;
+		}
 
-		.gridicon.gridicon {
-			html[dir='ltr'] & {
-				margin-right: 4px;
-			}
-			html[dir='rtl'] & {
-				margin-left: 4px;
+		${ getRowMobileLayout( SCREEN_BREAKPOINT_SIGNUP, '.is-section-signup' ) }
+		${ getRowMobileLayout( SCREEN_BREAKPOINT_PLANS, '.is-section-plans' ) }
+
+		button {
+			background: rgba( 246, 247, 247, 0.5 );
+			display: block;
+			text-align: center;
+			border-radius: 2px;
+			padding: 15px;
+			width: 100%;
+			margin: 0;
+			cursor: pointer;
+
+			.gridicon.gridicon {
+				html[dir='ltr'] & {
+					margin-right: 4px;
+				}
+				html[dir='rtl'] & {
+					margin-left: 4px;
+				}
 			}
 		}
 	}
@@ -439,11 +451,6 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 		selectedSiteSlug && purchaseId
 			? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
 			: `/plans/${ selectedSiteSlug || '' }`;
-	const collapsibleRowsclassName = classNames(
-		'plans-comparison__rows',
-		'plans-comparison__collapsible-rows',
-		{ 'is-active': showCollapsibleRows }
-	);
 
 	return (
 		<>
@@ -480,18 +487,18 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 						) ) }
 					</tr>
 				</THead>
-				<tbody className="plans-comparison__rows">
+				<PlansComparisonRows>
 					{ planComparisonFeatures.slice( 0, 7 ).map( ( feature ) => (
 						<PlansComparisonRow feature={ feature } plans={ plans } key={ feature.features[ 0 ] } />
 					) ) }
-				</tbody>
-				<tbody className={ collapsibleRowsclassName }>
+				</PlansComparisonRows>
+				<PlansComparisonCollapsibleRows collapsed={ showCollapsibleRows }>
 					{ planComparisonFeatures.slice( 7 ).map( ( feature ) => (
 						<PlansComparisonRow feature={ feature } plans={ plans } key={ feature.features[ 0 ] } />
 					) ) }
-				</tbody>
-				<tbody>
-					<PlanComparisonToggle>
+				</PlansComparisonCollapsibleRows>
+				<PlansComparisonToggle>
+					<tr>
 						{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 						<th className="is-first"></th>
 						<td colSpan={ 2 }>
@@ -509,8 +516,8 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 								) }
 							</button>
 						</td>
-					</PlanComparisonToggle>
-				</tbody>
+					</tr>
+				</PlansComparisonToggle>
 			</ComparisonTable>
 		</>
 	);

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -285,7 +285,12 @@ const ComparisonTable = styled.table< TableProps >`
 	}
 
 	tbody th {
-		padding-left: 0;
+		html[dir='ltr'] & {
+			padding-left: 0;
+		}
+		html[dir='rtl'] & {
+			padding-right: 0;
+		}
 	}
 
 	thead th,


### PR DESCRIPTION
### Changes proposed in this Pull Request

Partially addresses c/4PHxCS4J-tr 

Visual tweaks and some refactoring.

### Media

**_Vertically align the horizontal line and the "i" icons._**

<img width="670" alt="Screenshot 2022-04-06 at 4 09 53 PM" src="https://user-images.githubusercontent.com/1705499/161984082-cda36e69-e962-4f2e-9dca-2f611bc3589f.png">

**_Reduce the line-height by +-10% (64px, from ~72px)_**

<img width="539" alt="Screenshot 2022-04-06 at 4 08 56 PM" src="https://user-images.githubusercontent.com/1705499/161983542-612d0795-6fd6-4e59-a8b3-23c9ae4f01ff.png">

**_Remove the space between the "show full comparison" button and the table._**

Looks like this is to be different across mobile & desktop, judging from the P2 comment pdgrnI-tQ-p2#comment-936

Mobile:

<img width="699" alt="Screenshot 2022-04-06 at 4 09 25 PM" src="https://user-images.githubusercontent.com/1705499/161986823-cfab68f8-ae3b-47f1-b7d1-1ed8a426e9ba.png">

Desktop (no change):

<img width="1017" alt="Screenshot 2022-04-06 at 4 10 09 PM" src="https://user-images.githubusercontent.com/1705499/161986859-d22eaf01-d456-4c0e-825c-8d8a74f69b90.png">


### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/start/plans`
2. Confirm the visual changes in the media above.
3. Go to `/plans/[SITE_URL]` with a personal site and ensure the same for 2 above.

#### TODO

- [x] Create respective Landpack PR. 1024-gh-Automattic/landpack
- [ ] Create respective WPCOM diff for Landpack changes. [PHAB] (generated via `yarn deploy`)
- [ ] Create respective WPCOM diff for landing pages. [PHAB]
- [ ] Create respective LOHP diff (regeneration). [PHAB]

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #