### PR TITLE
E2E: add temporary spec to test the WordPress.com Pro upgrade button.

### DIFF
--- a/client/my-sites/plans-comparison/is-eligible-for-pro-plan.ts
+++ b/client/my-sites/plans-comparison/is-eligible-for-pro-plan.ts
@@ -1,15 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { isE2ETest } from 'calypso/lib/e2e';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import type { AppState } from 'calypso/types';
 
 export function isEligibleForProPlan( state: AppState, siteId?: number ): boolean {
-	if ( isE2ETest() ) {
-		return false;
-	}
-
 	if (
 		siteId &&
 		( ( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -1,10 +1,15 @@
 import { Page } from 'playwright';
+import { toTitleCase } from '../../data-helper';
 import { clickNavTab } from '../../element-helper';
 import envVariables from '../../env-variables';
 
+// Differentiates between the legacy and current (overhauled) plans.
+type PlansGridVersion = 'current' | 'legacy';
+type PlansComparisonAction = 'show' | 'hide';
+
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
-export type Plan = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
-export type PlansPageTab = 'My Plan' | 'Plans';
+export type LegacyPlans = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
+export type PlansPageTab = 'My Plan' | 'Plans' | 'New Plans';
 export type PlanActionButton = 'Manage plan' | 'Upgrade';
 
 const selectors = {
@@ -17,16 +22,24 @@ const selectors = {
 	activeNavigationTab: ( tabName: PlansPageTab ) =>
 		`.is-selected.section-nav-tab:has-text("${ tabName }")`,
 
-	actionButton: ( { plan, buttonText }: { plan: Plan; buttonText: PlanActionButton } ) => {
+	actionButton: ( { plan, buttonText }: { plan: LegacyPlans; buttonText: PlanActionButton } ) => {
 		const viewportSuffix = envVariables.VIEWPORT_NAME === 'mobile' ? 'mobile' : 'table';
 		return `.plan-features__${ viewportSuffix } >> .plan-features__actions-button.is-${ plan.toLowerCase() }-plan:has-text("${ buttonText }")`;
 	},
 
-	// Plans view
-	plansGrid: '.plans-features-main',
+	// Legacy plans view
+	legacyPlansGrid: '.plans-features-main',
+
+	// Overhauled plans view
+	overhauledPlansGrid: 'div.plans > table',
+	upgradeToProButton: 'th button.is-primary',
+	planComparisonActionButton: ( action: PlansComparisonAction ) => {
+		const buttonText = `${ toTitleCase( action ) } full plan comparison`;
+		return `button:text("${ buttonText }")`;
+	},
 
 	// My Plans view
-	myPlanTitle: ( planName: Plan ) => `.my-plan-card__title:has-text("${ planName }")`,
+	myPlanTitle: ( planName: LegacyPlans ) => `.my-plan-card__title:has-text("${ planName }")`,
 };
 
 /**
@@ -34,14 +47,16 @@ const selectors = {
  */
 export class PlansPage {
 	private page: Page;
+	private version: PlansGridVersion;
 
 	/**
 	 * Constructs an instance of the Plans POM.
 	 *
 	 * @param {Page} page Instance of the Playwright page
 	 */
-	constructor( page: Page ) {
+	constructor( page: Page, version: PlansGridVersion ) {
 		this.page = page;
+		this.version = version;
 	}
 
 	/**
@@ -51,14 +66,54 @@ export class PlansPage {
 		await this.page.waitForLoadState( 'load' );
 	}
 
+	/* Current Plans */
+
+	/**
+	 * Clicks on the button to initiate upgrade to WordPress.com Pro plan.
+	 */
+	async upgradeToPro(): Promise< void > {
+		const locator = this.page.locator( selectors.upgradeToProButton );
+		await Promise.all( [
+			this.page.waitForNavigation( { url: /.*checkout.*/ } ),
+			locator.click(),
+		] );
+	}
+
+	/**
+	 * Clicks on the Show/Hide Plan Comparison button at the bottom of the table.
+	 *
+	 * @param {PlansComparisonAction} action Action to perform on the Plans comparison button.
+	 */
+	async clickPlanComparisonActionButton( action: PlansComparisonAction ): Promise< void > {
+		const buttonLocator = this.page.locator( selectors.planComparisonActionButton( action ) );
+		await buttonLocator.click();
+
+		if ( action === 'show' ) {
+			const hideButtonLocator = this.page.locator( selectors.planComparisonActionButton( 'hide' ) );
+			await hideButtonLocator.waitFor();
+		}
+		if ( action === 'hide' ) {
+			const showButtonLocator = this.page.locator( selectors.planComparisonActionButton( 'show' ) );
+			await showButtonLocator.waitFor();
+		}
+	}
+
+	/* Legacy Plans */
+
 	/**
 	 * Clicks on the navigation tab (desktop) or dropdown (mobile).
 	 *
 	 * @param {PlansPageTab} targetTab Name of the tab.
 	 */
 	async clickTab( targetTab: PlansPageTab ): Promise< void > {
-		const currentSelectedLocator = this.page.locator( selectors.activeNavigationTab( targetTab ) );
+		// Plans page against the current WordPress.com Plans do not
+		// require any clicking of navigation tabs.
+		if ( this.version === 'current' ) {
+			return;
+		}
+
 		// If the target tab is already active, short circuit.
+		const currentSelectedLocator = this.page.locator( selectors.activeNavigationTab( targetTab ) );
 		if ( ( await currentSelectedLocator.count() ) > 0 ) {
 			return;
 		}
@@ -66,7 +121,7 @@ export class PlansPage {
 		if ( targetTab === 'My Plan' ) {
 			// User is currently on the Plans tab and going to My Plans.
 			// Wait for the Plans grid to fully render.
-			const plansGridLocator = this.page.locator( selectors.plansGrid );
+			const plansGridLocator = this.page.locator( selectors.legacyPlansGrid );
 			await plansGridLocator.waitFor();
 		}
 		if ( targetTab === 'Plans' ) {
@@ -82,10 +137,10 @@ export class PlansPage {
 	/**
 	 * Validates that the provided plan name is the title of the active plan in the My Plan tab of the Plans page. Throws if it isn't.
 	 *
-	 * @param {Plan} expectedPlan Name of the expected plan.
+	 * @param {LegacyPlans} expectedPlan Name of the expected plan.
 	 * @throws If the expected plan title is not found in the timeout period.
 	 */
-	async validateActivePlanInMyPlanTab( expectedPlan: Plan ): Promise< void > {
+	async validateActivePlanInMyPlanTab( expectedPlan: LegacyPlans ): Promise< void > {
 		const expectedPlanLocator = this.page.locator( selectors.myPlanTitle( expectedPlan ) );
 		await expectedPlanLocator.waitFor();
 	}
@@ -114,14 +169,14 @@ export class PlansPage {
 	 * Click a plan action button (on the plan cards on the "Plans" tab) based on expected plan name and button text.
 	 *
 	 * @param {object} param0 Object containing plan name and button text
-	 * @param {Plan} param0.plan Name of the plan (e.g. "Premium")
+	 * @param {LegacyPlans} param0.plan Name of the plan (e.g. "Premium")
 	 * @param {PlanActionButton} param0.buttonText Expected action button text (e.g. "Upgrade")
 	 */
 	async clickPlanActionButton( {
 		plan,
 		buttonText,
 	}: {
-		plan: Plan;
+		plan: LegacyPlans;
 		buttonText: PlanActionButton;
 	} ): Promise< void > {
 		const selector = selectors.actionButton( {

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -152,16 +152,16 @@ export class PlansPage {
 	 * @throws If the expected tab name is not the active tab.
 	 */
 	async validateActiveNavigationTab( expectedTab: PlansPageTab ): Promise< void > {
-		await this.waitUntilLoaded();
-
-		// For mobile sized viewport, the currently selected tab name will be shown alongside the
-		// dropdown toggle button, so verify the expected tab name is shown there.
+		// For mobile sized viewport, the currently selected tab name
+		// is hidden behind a pseudo-dropdown.
+		// Therefore the valicdation will look for hidden element.
+		const currentSelectedLocator = this.page.locator(
+			selectors.activeNavigationTab( expectedTab )
+		);
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			await this.page.waitForSelector(
-				`${ selectors.mobileNavTabsToggle }:has-text("${ expectedTab }")`
-			);
+			await currentSelectedLocator.waitFor( { state: 'hidden' } );
 		} else {
-			await this.page.waitForSelector( selectors.activeNavigationTab( expectedTab ) );
+			await currentSelectedLocator.waitFor();
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -31,7 +31,6 @@ const selectors = {
 	legacyPlansGrid: '.plans-features-main',
 
 	// Overhauled plans view
-	overhauledPlansGrid: 'div.plans > table',
 	upgradeToProButton: 'th button.is-primary',
 	planComparisonActionButton: ( action: PlansComparisonAction ) => {
 		const buttonText = `${ toTitleCase( action ) } full plan comparison`;
@@ -80,22 +79,29 @@ export class PlansPage {
 	}
 
 	/**
-	 * Clicks on the Show/Hide Plan Comparison button at the bottom of the table.
+	 * Shows the full Plan comparison table.
 	 *
-	 * @param {PlansComparisonAction} action Action to perform on the Plans comparison button.
+	 * This method is applicable only to the overhauled plans.
 	 */
-	async clickPlanComparisonActionButton( action: PlansComparisonAction ): Promise< void > {
-		const buttonLocator = this.page.locator( selectors.planComparisonActionButton( action ) );
+	async showPlanComparison(): Promise< void > {
+		const buttonLocator = this.page.locator( selectors.planComparisonActionButton( 'show' ) );
 		await buttonLocator.click();
 
-		if ( action === 'show' ) {
-			const hideButtonLocator = this.page.locator( selectors.planComparisonActionButton( 'hide' ) );
-			await hideButtonLocator.waitFor();
-		}
-		if ( action === 'hide' ) {
-			const showButtonLocator = this.page.locator( selectors.planComparisonActionButton( 'show' ) );
-			await showButtonLocator.waitFor();
-		}
+		const hideButtonLocator = this.page.locator( selectors.planComparisonActionButton( 'hide' ) );
+		await hideButtonLocator.waitFor();
+	}
+
+	/**
+	 * Hides the full Plan comparison table.
+	 *
+	 * This method is applicable only to the overhauled plans.
+	 */
+	async hidePlanComparison(): Promise< void > {
+		const buttonLocator = this.page.locator( selectors.planComparisonActionButton( 'hide' ) );
+		await buttonLocator.click();
+
+		const showButtonLocator = this.page.locator( selectors.planComparisonActionButton( 'show' ) );
+		await showButtonLocator.waitFor();
 	}
 
 	/* Legacy Plans */

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -9,7 +9,7 @@ type PlansComparisonAction = 'show' | 'hide';
 
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
 export type LegacyPlans = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
-export type PlansPageTab = 'My Plan' | 'Plans' | 'New Plans';
+export type PlansPageTab = 'My Plan' | 'Plans';
 export type PlanActionButton = 'Manage plan' | 'Upgrade';
 
 const selectors = {
@@ -22,13 +22,12 @@ const selectors = {
 	activeNavigationTab: ( tabName: PlansPageTab ) =>
 		`.is-selected.section-nav-tab:has-text("${ tabName }")`,
 
+	// Legacy plans view
+	legacyPlansGrid: '.plans-features-main',
 	actionButton: ( { plan, buttonText }: { plan: LegacyPlans; buttonText: PlanActionButton } ) => {
 		const viewportSuffix = envVariables.VIEWPORT_NAME === 'mobile' ? 'mobile' : 'table';
 		return `.plan-features__${ viewportSuffix } >> .plan-features__actions-button.is-${ plan.toLowerCase() }-plan:has-text("${ buttonText }")`;
 	},
-
-	// Legacy plans view
-	legacyPlansGrid: '.plans-features-main',
 
 	// Overhauled plans view
 	upgradeToProButton: 'th button.is-primary',

--- a/test/e2e/specs/martech/tos-screenshots__checkout.ts
+++ b/test/e2e/specs/martech/tos-screenshots__checkout.ts
@@ -78,7 +78,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		} );
 
 		it( 'Click on the "Plans" navigation tab', async function () {
-			plansPage = new PlansPage( page );
+			plansPage = new PlansPage( page, 'legacy' );
 			await plansPage.clickTab( 'Plans' );
 		} );
 

--- a/test/e2e/specs/onboarding/signup__paid.ts
+++ b/test/e2e/specs/onboarding/signup__paid.ts
@@ -173,7 +173,7 @@ skipDescribeIf( isStagingOrProd )(
 			} );
 
 			it( 'Manage plan', async function () {
-				const plansPage = new PlansPage( page );
+				const plansPage = new PlansPage( page, 'legacy' );
 				await plansPage.clickTab( 'Plans' );
 				await plansPage.clickPlanActionButton( { plan: 'Personal', buttonText: 'Manage plan' } );
 			} );

--- a/test/e2e/specs/plans/plans__add-upgrade-cart.ts
+++ b/test/e2e/specs/plans/plans__add-upgrade-cart.ts
@@ -1,0 +1,58 @@
+/**
+ * @group calypso-pr
+ */
+
+import {
+	DataHelper,
+	SidebarComponent,
+	PlansPage,
+	CartCheckoutPage,
+	TestAccount,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Plans: Add Upgrade to Cart' ), function () {
+	let page: Page;
+	let plansPage: PlansPage;
+	let cartCheckoutPage: CartCheckoutPage;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+
+		const testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
+		await testAccount.authenticate( page );
+	} );
+
+	it( 'Navigate to Upgrades > Plans', async function () {
+		const sidebarComponent = new SidebarComponent( page );
+		await sidebarComponent.navigate( 'Upgrades', 'Plans' );
+	} );
+
+	describe( 'View Plans comparison', function () {
+		it( 'Show full details of the plan', async function () {
+			plansPage = new PlansPage( page, 'current' );
+			await plansPage.clickPlanComparisonActionButton( 'show' );
+		} );
+	} );
+
+	describe( 'Add WordPress.com Pro to cart', function () {
+		it( `Click button to upgrade to WordPress.com Pro`, async function () {
+			await plansPage.upgradeToPro();
+		} );
+
+		it( `WordPress.com Pro is added to cart`, async function () {
+			cartCheckoutPage = new CartCheckoutPage( page );
+			await cartCheckoutPage.validateCartItem( `WordPress.com Pro` );
+		} );
+
+		it( 'Remove plan from cart', async function () {
+			await cartCheckoutPage.removeCartItem( `WordPress.com Pro` );
+		} );
+
+		it( 'Automatically navigated back to Plans page', async function () {
+			await plansPage.validateActiveNavigationTab( 'New Plans' );
+		} );
+	} );
+} );

--- a/test/e2e/specs/plans/plans__add-upgrade-cart.ts
+++ b/test/e2e/specs/plans/plans__add-upgrade-cart.ts
@@ -33,7 +33,7 @@ describe( DataHelper.createSuiteTitle( 'Plans: Add Upgrade to Cart' ), function 
 	describe( 'View Plans comparison', function () {
 		it( 'Show full details of the plan', async function () {
 			plansPage = new PlansPage( page, 'current' );
-			await plansPage.clickPlanComparisonActionButton( 'show' );
+			await plansPage.showPlanComparison();
 		} );
 	} );
 

--- a/test/e2e/specs/plans/plans__add-upgrade-cart.ts
+++ b/test/e2e/specs/plans/plans__add-upgrade-cart.ts
@@ -52,7 +52,7 @@ describe( DataHelper.createSuiteTitle( 'Plans: Add Upgrade to Cart' ), function 
 		} );
 
 		it( 'Automatically navigated back to Plans page', async function () {
-			await plansPage.validateActiveNavigationTab( 'New Plans' );
+			await plansPage.validateActiveNavigationTab( 'Plans' );
 		} );
 	} );
 } );

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -27,7 +27,7 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 
 		const testAccount = new TestAccount( 'simpleSitePersonalPlanUser' );
 		await testAccount.authenticate( page );
-		plansPage = new PlansPage( page );
+		plansPage = new PlansPage( page, 'legacy' );
 	} );
 
 	it( 'Navigate to Upgrades > Plans', async function () {

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -14,7 +14,7 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Plans: Upgrade' ), function () {
+describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () {
 	const planTier = 'Personal';
 	const planName = `WordPress.com ${ planTier }`;
 	let page: Page;

--- a/test/e2e/specs/plans/plans__legacy-upgrade.ts
+++ b/test/e2e/specs/plans/plans__legacy-upgrade.ts
@@ -24,7 +24,7 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 
 		const testAccount = new TestAccount( 'simpleSitePersonalPlanUser' );
 		await testAccount.authenticate( page );
-		plansPage = new PlansPage( page );
+		plansPage = new PlansPage( page, 'legacy' );
 	} );
 
 	it( 'Navigate to Upgrades > Plans', async function () {
@@ -51,7 +51,6 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 		} );
 
 		it( 'Automatically return to Plans page', async function () {
-			plansPage = new PlansPage( page );
 			await plansPage.validateActiveNavigationTab( 'Plans' );
 		} );
 	} );

--- a/test/e2e/specs/plans/plans__legacy-upgrade.ts
+++ b/test/e2e/specs/plans/plans__legacy-upgrade.ts
@@ -13,7 +13,7 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Plans: Upgrade' ), function () {
+describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () {
 	const planName = 'Business';
 	let page: Page;
 	let plansPage: PlansPage;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is the first in the series to lay the groundwork for implementing e2e coverage for the overhauled Plans feature.
This PR also includes a temporary stub spec meant to provide a baseline level of coverage for the Pro plan upgrade button while the fuller spec is being worked on.

Key changes:
1. removal of E2E bypass for the overhauled plans.
2. addition of new methods in the Plans POM to support interaction with the new plans grid.
3. addition of new e2e spec mirroring the addition of Plans Upgrade into the checkout cart.

Details:
1. currently all e2e runs from TeamCity are being redirected to show the legacy plans grid due to the bypass. In order to test the new plans grid, the bypass must be removed.
2. it has been decided to keep the Plans POM in one piece for the time being, therefore requiring new parameters, methods to support interactions with the new Plans grid and restructuring of some types.
3. the new e2e spec is essentially a mirror copy of the existing Plans: Upgrade spec which doesn't actually perform an upgrade; it clicks on a button in the Plans page to upgrade, validates the cart, then exits the checkout page. This spec will serve as a stand-in for now to provide minimal coverage for the time being while I work to spec out the critical code paths.

#### Testing instructions

Ensure the following:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [x] i18n E2E


Related to #62492
