### PR TITLE
fix: force happychat socketio websocket connection

### DIFF
--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -21,7 +21,10 @@ const debug = debugFactory( 'calypso:happychat:connection' );
 
 const buildConnection = ( socket ) =>
 	typeof socket === 'string'
-		? new IO( socket ) // If socket is an URL, connect to server.
+		? new IO( socket, {
+				// force websocket connection since we no longer have sticky connections server side.
+				transports: [ 'websocket' ],
+		  } ) // If socket is an URL, connect to server.
 		: socket; // If socket is not an url, use it directly. Useful for testing.
 
 class Connection {
@@ -70,7 +73,10 @@ class Connection {
 						.on( 'message.optimistic', ( message ) =>
 							dispatch( receiveMessageOptimistic( message ) )
 						)
-						.on( 'message.update', ( message ) => dispatch( receiveMessageUpdate( message ) ) );
+						.on( 'message.update', ( message ) => dispatch( receiveMessageUpdate( message ) ) )
+						.on( 'reconnect_attempt', () => {
+							socket.io.opts.transports = [ 'polling', 'websocket' ];
+						} );
 				} )
 				.catch( ( e ) => reject( e ) );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR aims to fix a new issue that resulted after migrating our HappyChat servers.
We no longer have sticky server connections, meaning the first HappyChat polling connection attempt will fail, until a WebSocket connection is established.

More [info](https://socket.io/docs/v2/using-multiple-nodes/#sticky-load-balancing) on the issue

#### Testing instructions

* Open `http://calypso.localhost:3000/help/contact`

Before the changes, you should see errors like these when trying to connect to staging HappyChat:

![Screenshot 2022-03-30 at 19 25 01](https://user-images.githubusercontent.com/8320845/160905195-b0fed6b6-c310-4217-84fa-c990a2eb505a.png)

Please let me know if you find any issues or have any suggestions