### PR TITLE
G Suite: Import Google Workspace functions from Calypso Products package directly

### DIFF
--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -17,13 +17,6 @@ export { getGSuiteSubscriptionId } from './get-gsuite-subscription-id';
 export { getGSuiteSubscriptionStatus } from './get-gsuite-subscription-status';
 export { getLoginUrlWithTOSRedirect } from './get-login-url-with-tos-redirect';
 export { getMonthlyPrice } from './get-monthly-price';
-export {
-	isGoogleWorkspaceProductSlug,
-	isGSuiteExtraLicenseProductSlug,
-	isGSuiteOrExtraLicenseProductSlug,
-	isGSuiteOrGoogleWorkspaceProductSlug,
-	isGSuiteProductSlug,
-} from '@automattic/calypso-products';
 export { getGSuiteSupportedDomains, hasGSuiteSupportedDomain } from './gsuite-supported-domain';
 export { hasGSuiteWithAnotherProvider } from './has-gsuite-with-another-provider';
 export { hasGSuiteWithUs } from './has-gsuite-with-us';

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -1,13 +1,9 @@
+import { isGoogleWorkspaceProductSlug, isGSuiteProductSlug } from '@automattic/calypso-products';
 import emailValidator from 'email-validator';
 import { translate, TranslateResult } from 'i18n-calypso';
 import { v4 as uuidv4 } from 'uuid';
 import { googleApps, googleAppsExtraLicenses } from 'calypso/lib/cart-values/cart-items';
-import {
-	getGSuiteMailboxCount,
-	hasGSuiteWithUs,
-	isGoogleWorkspaceProductSlug,
-	isGSuiteProductSlug,
-} from 'calypso/lib/gsuite';
+import { getGSuiteMailboxCount, hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { SiteDomain } from 'calypso/state/sites/domains/types';
 

--- a/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
@@ -1,11 +1,12 @@
 import {
-	isGSuiteOrExtraLicenseOrGoogleWorkspace,
 	isGoogleWorkspaceExtraLicence,
+	isGSuiteExtraLicenseProductSlug,
+	isGSuiteOrExtraLicenseOrGoogleWorkspace,
 } from '@automattic/calypso-products';
 import i18n from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import PurchaseDetail from 'calypso/components/purchase-detail';
-import { getGoogleMailServiceFamily, isGSuiteExtraLicenseProductSlug } from 'calypso/lib/gsuite';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { CONTACT, GSUITE_LEARNING_CENTER } from 'calypso/lib/url/support';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -4,11 +4,13 @@ import {
 	isDomainMapping,
 	isDomainRegistration,
 	isDomainTransfer,
+	isGoogleWorkspaceExtraLicence,
+	isGSuiteExtraLicenseProductSlug,
 	isGSuiteOrExtraLicenseOrGoogleWorkspace,
+	isGSuiteOrGoogleWorkspaceProductSlug,
 	isPlan,
 	isSiteRedirect,
 	isTitanMail,
-	isGoogleWorkspaceExtraLicence,
 } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
@@ -18,10 +20,6 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { preventWidows } from 'calypso/lib/formatting';
-import {
-	isGSuiteExtraLicenseProductSlug,
-	isGSuiteOrGoogleWorkspaceProductSlug,
-} from 'calypso/lib/gsuite';
 import { getTitanEmailUrl, hasTitanMailWithUs } from 'calypso/lib/titan';
 import { getTitanAppsUrlPrefix } from 'calypso/lib/titan/get-titan-urls';
 import {

--- a/client/my-sites/checkout/composite-checkout/lib/get-contact-details-type.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-contact-details-type.ts
@@ -1,11 +1,14 @@
-import { isGoogleWorkspaceExtraLicence } from '@automattic/calypso-products';
+import {
+	isGoogleWorkspaceExtraLicence,
+	isGoogleWorkspaceProductSlug,
+	isGSuiteProductSlug,
+} from '@automattic/calypso-products';
 import { doesPurchaseHaveFullCredits } from '@automattic/wpcom-checkout';
 import {
 	hasDomainRegistration,
 	hasTransferProduct,
 	hasOnlyRenewalItems,
 } from 'calypso/lib/cart-values/cart-items';
-import { isGoogleWorkspaceProductSlug, isGSuiteProductSlug } from 'calypso/lib/gsuite';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { ContactDetailsType } from '@automattic/wpcom-checkout';
 

--- a/packages/calypso-products/src/constants/google.ts
+++ b/packages/calypso-products/src/constants/google.ts
@@ -1,7 +1,7 @@
-export const GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY =
-	'wp_google_workspace_business_starter_yearly';
 export const GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY =
 	'wp_google_workspace_business_starter_monthly';
+export const GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY =
+	'wp_google_workspace_business_starter_yearly';
 export const GSUITE_BASIC_SLUG = 'gapps';
 export const GSUITE_BUSINESS_SLUG = 'gapps_unlimited';
 export const GSUITE_EXTRA_LICENSE_SLUG = 'gapps_extra_license';


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/62203, and removes imports defined in `client/lib/gsuite/constants.js` that would actually just re-export functions from the `@automattic/calypso-products` package.

#### Testing instructions

1. Run `git checkout update/google-workspace-imports` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/62565#issuecomment-1090395676)
2. Log into a WordPress.com account with a domain but no emails
3. Open the [`Emails` page](http://calypso.localhost:3000/email)
4. Purchase a new Google Workspace account for that domain
5. Assert that this account was provisioned successfully
6. Purchase additional mailboxes for that account
7. Assert that those mailboxes were provisioned successfully