### PR TITLE
Checkout: Do not update cart contact details on auto-refresh

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -7,13 +7,17 @@ import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { requestContactDetailsCache } from 'calypso/state/domains/management/actions';
 import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-cache';
-import type { CountryListItem } from '@automattic/wpcom-checkout';
+import type {
+	PossiblyCompleteDomainContactDetails,
+	CountryListItem,
+} from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-cached-domain-contact-details' );
 
 export default function useCachedDomainContactDetails( countriesList: CountryListItem[] ): void {
 	const reduxDispatch = useReduxDispatch();
 	const haveRequestedCachedDetails = useRef( false );
+	const previousCachedContactDetails = useRef< PossiblyCompleteDomainContactDetails >();
 	const cartKey = useCartKey();
 	const {
 		updateLocation: updateCartLocation,
@@ -52,20 +56,29 @@ export default function useCachedDomainContactDetails( countriesList: CountryLis
 	// When we have fetched or loaded contact details, send them to the
 	// to the shopping cart for calculating taxes.
 	useEffect( () => {
-		if ( isLoadingCart || cartLoadingError ) {
+		if ( isLoadingCart || cartLoadingError || ! cachedContactDetails ) {
 			return;
 		}
 		if (
-			cachedContactDetails?.countryCode ||
-			cachedContactDetails?.postalCode ||
-			cachedContactDetails?.state
+			! cachedContactDetails.countryCode &&
+			! cachedContactDetails.postalCode &&
+			! cachedContactDetails.state
 		) {
-			updateCartLocation( {
-				countryCode: cachedContactDetails.countryCode ?? '',
-				postalCode: arePostalCodesSupported ? cachedContactDetails.postalCode ?? '' : '',
-				subdivisionCode: cachedContactDetails.state ?? '',
-			} );
+			return;
 		}
+		if (
+			cachedContactDetails.countryCode === previousCachedContactDetails.current?.countryCode &&
+			cachedContactDetails.postalCode === previousCachedContactDetails.current?.postalCode &&
+			cachedContactDetails.state === previousCachedContactDetails.current?.state
+		) {
+			return;
+		}
+		updateCartLocation( {
+			countryCode: cachedContactDetails.countryCode ?? '',
+			postalCode: arePostalCodesSupported ? cachedContactDetails.postalCode ?? '' : '',
+			subdivisionCode: cachedContactDetails.state ?? '',
+		} );
+		previousCachedContactDetails.current = cachedContactDetails;
 	}, [
 		cartLoadingError,
 		isLoadingCart,


### PR DESCRIPTION
#### Background and problem

Checkout includes a custom React hook called `useCachedDomainContactDetails` which loads cached contact details from the server and sends them to the shopping-cart endpoint. This allows the contact details fields of checkout to be automatically populated when checkout loads if the user has previously saved them.

However, the way the hook is written, it will send the cached contact details to the shopping-cart endpoint any time that the contact details change _or anytime the cart reloads_. This is just a side effect because we don't want to send data to the shopping cart endpoint until the cart finishes loading for the first time. This becomes a problem when the cart automatically reloads, which it does if the checkout page is refocused after a short amount of time; when this happens, the hook will notice that the cart has finished loading again and will re-send the cached contact details to the cart, even if the user has already changed those details in the form.

#### Changes proposed in this Pull Request

In this PR, we modify the logic of the hook so that it will not send the cached contact details to the server if they have not changed.

#### Testing instructions

- For this test to work you'll need to have cached contact details from a previous purchase.
- Keep your browser's devtools open to the network panel to watch for POST transactions to the `/me/shopping-cart` endpoint.
- Add a product to your cart and visit checkout.
- Verify that the contact details step is pre-filled with your cached contact details.
- Edit the contact details step and change your country and/or postal code.
- Continue to the last step of checkout.
- Leave the checkout tab for about a minute.
- Click back on the checkout tab and you'll see the form go into a loading state briefly while it refreshes the cart (if you don't see this, you may not have waited long enough or the checkout form may not be focused).
- While you will see a GET request to the `/me/shopping-cart` endpoint, verify that you do not see a POST request (previously you would see one with incorrect postal code and country in the `tax` property).