### PR TITLE
Marketplace: "search on hit enter" search component

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -96,9 +96,9 @@ const useSticky = () => {
 			const scrollPosition = window.scrollY;
 
 			if ( offset > 0 && scrollPosition < offset ) {
-				setIsSticky( true );
-			} else {
 				setIsSticky( false );
+			} else {
+				setIsSticky( true );
 			}
 		};
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -79,44 +79,6 @@ import './style.scss';
  */
 const SHORT_LIST_LENGTH = 6;
 
-const useSticky = () => {
-	const contentRef = useRef( null );
-	const headerRef = useRef( null );
-	const [ isSticky, setIsSticky ] = useState( false );
-
-	useEffect( () => {
-		if ( ! contentRef || ! headerRef ) {
-			return;
-		}
-
-		const handleScroll = () => {
-			const headerHeight = headerRef?.current?.getBoundingClientRect().height;
-			const offset =
-				contentRef.current && headerHeight ? contentRef.current.offsetTop - headerHeight : 0;
-			const scrollPosition = window.scrollY;
-
-			if ( offset > 0 && scrollPosition < offset ) {
-				setIsSticky( false );
-			} else {
-				setIsSticky( true );
-			}
-		};
-
-		handleScroll();
-
-		window.addEventListener( 'scroll', handleScroll );
-		return () => {
-			window.removeEventListener( 'scroll', handleScroll );
-		};
-	}, [ contentRef ] );
-
-	return {
-		contentRef,
-		headerRef,
-		isSticky,
-	};
-};
-
 const translateCategory = ( { category, translate } ) => {
 	switch ( category ) {
 		case 'popular':

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -79,6 +79,44 @@ import './style.scss';
  */
 const SHORT_LIST_LENGTH = 6;
 
+const useSticky = () => {
+	const contentRef = useRef( null );
+	const headerRef = useRef( null );
+	const [ isSticky, setIsSticky ] = useState( false );
+
+	useEffect( () => {
+		if ( ! contentRef || ! headerRef ) {
+			return;
+		}
+
+		const handleScroll = () => {
+			const headerHeight = headerRef?.current?.getBoundingClientRect().height;
+			const offset =
+				contentRef.current && headerHeight ? contentRef.current.offsetTop - headerHeight : 0;
+			const scrollPosition = window.scrollY;
+
+			if ( offset > 0 && scrollPosition < offset ) {
+				setIsSticky( true );
+			} else {
+				setIsSticky( false );
+			}
+		};
+
+		handleScroll();
+
+		window.addEventListener( 'scroll', handleScroll );
+		return () => {
+			window.removeEventListener( 'scroll', handleScroll );
+		};
+	}, [ contentRef ] );
+
+	return {
+		contentRef,
+		headerRef,
+		isSticky,
+	};
+};
+
 const translateCategory = ( { category, translate } ) => {
 	switch ( category ) {
 		case 'popular':

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -22,7 +22,7 @@ const SearchBox = ( { isMobile, doSearch, searchTerm, searchBoxRef } ) => {
 				defaultValue={ searchTerm }
 				searchMode="on-enter"
 				placeholder={ translate( 'Try searching "ecommerce"' ) }
-				delaySearch={ true }
+				delaySearch={ false }
 				recordEvent={ recordSearchEvent }
 			/>
 		</div>
@@ -87,7 +87,6 @@ const SearchBoxHeader = ( props ) => {
 	// since the search input is an uncontrolled component we need to tap in into the component api and trigger an update
 	const updateSearchBox = ( keyword ) => {
 		searchBoxRef.current.setKeyword( keyword );
-
 		doSearch( keyword );
 	};
 

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,5 +1,6 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
+import { useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
@@ -12,7 +13,7 @@ const SearchBox = ( { isMobile, doSearch, searchTerm, searchBoxRef } ) => {
 		dispatch( recordGoogleEvent( 'PluginsBrowser', eventName ) );
 
 	return (
-		<div className="search-box-header__searchbox" ref={ searchBoxRef }>
+		<div className="search-box-header__searchbox">
 			<Search
 				ref={ searchBoxRef }
 				pinned={ isMobile }

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,6 +1,5 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
-import { useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
@@ -13,7 +12,7 @@ const SearchBox = ( { isMobile, doSearch, searchTerm, searchBoxRef } ) => {
 		dispatch( recordGoogleEvent( 'PluginsBrowser', eventName ) );
 
 	return (
-		<div className="search-box-header__searchbox">
+		<div className="search-box-header__searchbox" ref={ searchBoxRef }>
 			<Search
 				ref={ searchBoxRef }
 				pinned={ isMobile }

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -20,6 +20,7 @@ const SearchBox = ( { isMobile, doSearch, searchTerm, searchBoxRef } ) => {
 				fitsContainer={ isMobile }
 				onSearch={ doSearch }
 				defaultValue={ searchTerm }
+				searchMode="on-enter"
 				placeholder={ translate( 'Try searching "ecommerce"' ) }
 				delaySearch={ true }
 				recordEvent={ recordSearchEvent }
@@ -86,18 +87,15 @@ const SearchBoxHeader = ( props ) => {
 	// since the search input is an uncontrolled component we need to tap in into the component api and trigger an update
 	const updateSearchBox = ( keyword ) => {
 		searchBoxRef.current.setKeyword( keyword );
+
+		doSearch( keyword );
 	};
 
 	return (
 		<div className={ isSticky ? 'search-box-header fixed-top' : 'search-box-header' }>
 			<div className="search-box-header__header">{ title }</div>
 			<div className="search-box-header__search">
-				<SearchBox
-					doSearch={ doSearch }
-					searchTerm={ searchTerm }
-					delayTimeout={ 1000 }
-					searchBoxRef={ searchBoxRef }
-				/>
+				<SearchBox doSearch={ doSearch } searchTerm={ searchTerm } searchBoxRef={ searchBoxRef } />
 			</div>
 			<PopularSearches
 				doSearch={ updateSearchBox }

--- a/packages/search/CHANGELOG.md
+++ b/packages/search/CHANGELOG.md
@@ -5,5 +5,4 @@
 ## 1.0.1
 
 - Add search modes
-- Add "when-typing" search mode
-- Add "on-enter" searchmode.
+- Add "when-typing" and "on-enter" search modes, defaulting to "when-typing".

--- a/packages/search/CHANGELOG.md
+++ b/packages/search/CHANGELOG.md
@@ -1,3 +1,9 @@
 ## 1.0.0
 
 - Add Search component based on `calypso/components/search`
+
+## 1.0.1
+
+- Add search modes
+- Add "when-typing" search mode
+- Add "on-enter" searchmode.

--- a/packages/search/CHANGELOG.md
+++ b/packages/search/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 1.0.0
-
-- Add Search component based on `calypso/components/search`
-
 ## 1.0.1
 
 - Add search modes
-- Add "when-typing" and "on-enter" search modes, defaulting to "when-typing".
+- Add "when-typing" and "on-enter" search mode
+
+## 1.0.0
+
+- Add Search component based on `calypso/components/search`

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -22,3 +22,10 @@ in the root of the repository to get the required `devDependencies`.
 ### Using [Storybook](https://storybook.js.org/)
 
 `yarn run components:storybook:start`
+
+### Search Modes
+
+There are 2 search modes that can be used through the `searchMode` prop:
+
+- `when-typing` (default): The search component calls the `onSearch` prop while the user is typing.
+- `on-enter`: The search component only triggers the `onSearch` prop when the user hits the `Enter` key.

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/search",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Automattic Search.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/search",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "Automattic Search.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -47,6 +47,7 @@
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
+		"@storybook/addon-actions": "^6.4.21",
 		"@storybook/react": "^6.4.18",
 		"@testing-library/dom": "^8.11.3",
 		"@testing-library/react": "^12.1.3",

--- a/packages/search/src/search.stories.jsx
+++ b/packages/search/src/search.stories.jsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { action } from '@storybook/addon-actions';
 import Search from './search';
 

--- a/packages/search/src/search.stories.jsx
+++ b/packages/search/src/search.stories.jsx
@@ -1,3 +1,5 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { action } from '@storybook/addon-actions';
 import Search from './search';
 
 export default { title: 'Search', component: Search };
@@ -16,6 +18,14 @@ const BoxedSearch = ( props ) => (
 
 export const _default = () => {
 	return <BoxedSearch />;
+};
+
+export const WhenTypingSearchMode = () => {
+	return <BoxedSearch searchMode="when-typing" onSearch={ action( 'onSearch' ) } />;
+};
+
+export const OnEnterSearchMode = () => {
+	return <BoxedSearch searchMode="on-enter" onSearch={ action( 'onSearch' ) } />;
 };
 
 export const Simple = () => {

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -214,6 +214,7 @@ const InnerSearch = (
 		if ( keyword ) {
 			if ( searchMode === 'when-typing' ) {
 				doSearch( keyword );
+				onSearchChange?.( keyword );
 			}
 		} else {
 			if ( searchMode === 'on-enter' ) {
@@ -221,9 +222,8 @@ const InnerSearch = (
 			}
 
 			bypassOnSearchDebounce( keyword );
+			onSearchChange?.( keyword );
 		}
-
-		onSearchChange?.( keyword );
 	}, [ keyword ] );
 
 	const openSearch = ( event: KeyboardOrMouseEvent ) => {
@@ -243,7 +243,11 @@ const InnerSearch = (
 		}
 
 		setKeyword( '' );
-		if ( 'on-enter' === searchMode ) bypassOnSearchDebounce( '' );
+		if ( 'on-enter' === searchMode ) {
+			bypassOnSearchDebounce( '' );
+			onSearchChange?.( '' );
+		}
+
 		setIsOpen( false );
 
 		if ( searchInput.current ) {
@@ -309,6 +313,7 @@ const InnerSearch = (
 
 		if ( event.key === 'Enter' && searchMode === 'on-enter' ) {
 			bypassOnSearchDebounce( keyword );
+			onSearchChange?.( keyword );
 		}
 
 		if ( ! pinned ) {

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -157,6 +157,25 @@ const InnerSearch = (
 	const overlay = React.useRef< HTMLDivElement >( null );
 	const firstRender = React.useRef< boolean >( true );
 
+	React.useImperativeHandle(
+		forwardedRef,
+		() => ( {
+			focus() {
+				searchInput.current?.focus();
+			},
+			blur() {
+				searchInput.current?.blur();
+			},
+			setKeyword( value: string ) {
+				setKeyword( value );
+			},
+			clear() {
+				setKeyword( '' );
+			},
+		} ),
+		[]
+	);
+
 	const doSearch: ( ( search: string ) => void ) & { cancel?: () => void } = React.useMemo( () => {
 		if ( ! onSearch ) {
 			return () => {}; // eslint-disable-line @typescript-eslint/no-empty-function
@@ -181,25 +200,6 @@ const InnerSearch = (
 			onSearch?.( value );
 		},
 		[ delaySearch, doSearch, onSearch ]
-	);
-
-	React.useImperativeHandle(
-		forwardedRef,
-		() => ( {
-			focus() {
-				searchInput.current?.focus();
-			},
-			blur() {
-				searchInput.current?.blur();
-			},
-			setKeyword( value: string ) {
-				setKeyword( value );
-			},
-			clear() {
-				setKeyword( '' );
-			},
-		} ),
-		[]
 	);
 
 	useEffect( () => {

--- a/packages/search/src/test/index.js
+++ b/packages/search/src/test/index.js
@@ -51,6 +51,36 @@ describe( 'search', () => {
 		} );
 	} );
 
+	describe( '"on-enter" search mode', () => {
+		it( "shouldn't call onSearch and onSearchChange when search changes", () => {
+			const searchString = '12345';
+			const onSearch = jest.fn();
+			const onSearchChange = jest.fn();
+			render(
+				<Search onSearch={ onSearch } searchMode="on-enter" onSearchChange={ onSearchChange } />
+			);
+			const searchbox = screen.getByRole( 'searchbox' );
+			userEvent.type( searchbox, searchString );
+			expect( onSearch ).toHaveBeenCalledTimes( 0 ); // once per character
+			expect( onSearchChange ).toHaveBeenCalledTimes( 0 );
+		} );
+
+		it( 'should call onSearch and onSearchChange when user hits enter', () => {
+			const searchString = '12345{enter}';
+			const onSearch = jest.fn();
+			const onSearchChange = jest.fn();
+			render(
+				<Search onSearch={ onSearch } searchMode="on-enter" onSearchChange={ onSearchChange } />
+			);
+			const searchbox = screen.getByRole( 'searchbox' );
+			userEvent.type( searchbox, searchString );
+			expect( onSearch ).toHaveBeenCalledTimes( 1 ); // once per character
+			expect( onSearch ).toHaveBeenCalledWith( '12345' );
+			expect( onSearchChange ).toHaveBeenCalledTimes( 1 );
+			expect( onSearchChange ).toHaveBeenCalledWith( '12345' );
+		} );
+	} );
+
 	it( 'should call onSearch and onSearchChange when search changes', () => {
 		const searchString = '12345';
 		const onSearch = jest.fn();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5253,41 +5253,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-actions@npm:^6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/addon-actions@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/api": 6.4.19
-    "@storybook/components": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.19
-    core-js: ^3.8.2
-    fast-deep-equal: ^3.1.3
-    global: ^4.4.0
-    lodash: ^4.17.21
-    polished: ^4.0.5
-    prop-types: ^15.7.2
-    react-inspector: ^5.1.0
-    regenerator-runtime: ^0.13.7
-    telejson: ^5.3.2
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-    uuid-browser: ^3.1.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: f381df5a1b811ab02108f512cde532714662ad1e6d04580b43b1a55a4077b2dc562434185d3f5a55552d6995d43d6d31ee6167c982fa3c2883fa5e7aa344b7ed
-  languageName: node
-  linkType: hard
-
-"@storybook/addon-actions@npm:^6.4.21":
+"@storybook/addon-actions@npm:^6.4.19, @storybook/addon-actions@npm:^6.4.21":
   version: 6.4.21
   resolution: "@storybook/addon-actions@npm:6.4.21"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,6 +1188,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@babel/runtime": ^7.17.2
+    "@storybook/addon-actions": ^6.4.21
     "@storybook/react": ^6.4.18
     "@testing-library/dom": ^8.11.3
     "@testing-library/react": ^12.1.3
@@ -5286,6 +5287,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/addon-actions@npm:^6.4.21":
+  version: 6.4.21
+  resolution: "@storybook/addon-actions@npm:6.4.21"
+  dependencies:
+    "@storybook/addons": 6.4.21
+    "@storybook/api": 6.4.21
+    "@storybook/components": 6.4.21
+    "@storybook/core-events": 6.4.21
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/theming": 6.4.21
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    polished: ^4.0.5
+    prop-types: ^15.7.2
+    react-inspector: ^5.1.0
+    regenerator-runtime: ^0.13.7
+    telejson: ^5.3.2
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+    uuid-browser: ^3.1.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 18c305e2325c78ef6ba0c31b2afefa73e4ec9004059c66a1f82f011539df5f7e89396545ada2f7561ce7c355f5faedbd0cc99238fe5a3345456da0b4a3f6dad9
+  languageName: node
+  linkType: hard
+
 "@storybook/addon-backgrounds@npm:^6.4.19":
   version: 6.4.19
   resolution: "@storybook/addon-backgrounds@npm:6.4.19"
@@ -5337,6 +5372,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/addons@npm:6.4.21":
+  version: 6.4.21
+  resolution: "@storybook/addons@npm:6.4.21"
+  dependencies:
+    "@storybook/api": 6.4.21
+    "@storybook/channels": 6.4.21
+    "@storybook/client-logger": 6.4.21
+    "@storybook/core-events": 6.4.21
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/router": 6.4.21
+    "@storybook/theming": 6.4.21
+    "@types/webpack-env": ^1.16.0
+    core-js: ^3.8.2
+    global: ^4.4.0
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 2c0b64c9db10e9e8f3a335e57db1021ccb8893fff16aae6c89725d1915127c8af90429ce7a431f0c60a953d1111966ef0d4037028b64b53992936dfd84c2260a
+  languageName: node
+  linkType: hard
+
 "@storybook/api@npm:6.4.19":
   version: 6.4.19
   resolution: "@storybook/api@npm:6.4.19"
@@ -5362,6 +5419,34 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: 77fae2be5269d45d3d30d8364ca35b7b95ffaebe5ae1780275f97c2ebb1b6d9e3fa2a260e82587bbe141feeebac5054e44add36fec19cefe6d058e01ce4810ee
+  languageName: node
+  linkType: hard
+
+"@storybook/api@npm:6.4.21":
+  version: 6.4.21
+  resolution: "@storybook/api@npm:6.4.21"
+  dependencies:
+    "@storybook/channels": 6.4.21
+    "@storybook/client-logger": 6.4.21
+    "@storybook/core-events": 6.4.21
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/router": 6.4.21
+    "@storybook/semver": ^7.3.2
+    "@storybook/theming": 6.4.21
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    regenerator-runtime: ^0.13.7
+    store2: ^2.12.0
+    telejson: ^5.3.2
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: bcd422756e8e1dfc8af176946f54f89546f8255c4284395a76cd3a3f7218dd8ceb4deb3c3c8b377f156ccd9a103f30853e224cefb356d2631312e6ace5245fc6
   languageName: node
   linkType: hard
 
@@ -5558,6 +5643,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/channels@npm:6.4.21":
+  version: 6.4.21
+  resolution: "@storybook/channels@npm:6.4.21"
+  dependencies:
+    core-js: ^3.8.2
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  checksum: a24d02cdef1d74398f9dbce560650207342e446c81d2c9039f8917151bb5bcb7c416f34e85eb7c17addc96950ccfcab144bb79c49d2995f279b0eba82127b26b
+  languageName: node
+  linkType: hard
+
 "@storybook/client-api@npm:6.4.19":
   version: 6.4.19
   resolution: "@storybook/client-api@npm:6.4.19"
@@ -5599,6 +5695,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/client-logger@npm:6.4.21":
+  version: 6.4.21
+  resolution: "@storybook/client-logger@npm:6.4.21"
+  dependencies:
+    core-js: ^3.8.2
+    global: ^4.4.0
+  checksum: e47568172b4c624c8b6066d5e5b884acdc2607ca494e5f336155b680a802dfd69be1bee5edb0a3dfba7716f9c357d6430fdbe8f396af54c24e472cb669dc7364
+  languageName: node
+  linkType: hard
+
 "@storybook/components@npm:6.4.19":
   version: 6.4.19
   resolution: "@storybook/components@npm:6.4.19"
@@ -5631,6 +5737,41 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: bdefb4a689225fcb4f427d7faa58a216620e8fe1eadd7f8020e0fd2596e40f56fa849567fed3c25dce6d6de42df706ed324af7a19995447f8bdff63ae7a25d20
+  languageName: node
+  linkType: hard
+
+"@storybook/components@npm:6.4.21":
+  version: 6.4.21
+  resolution: "@storybook/components@npm:6.4.21"
+  dependencies:
+    "@popperjs/core": ^2.6.0
+    "@storybook/client-logger": 6.4.21
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/theming": 6.4.21
+    "@types/color-convert": ^2.0.0
+    "@types/overlayscrollbars": ^1.12.0
+    "@types/react-syntax-highlighter": 11.0.5
+    color-convert: ^2.0.1
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    markdown-to-jsx: ^7.1.3
+    memoizerific: ^1.11.3
+    overlayscrollbars: ^1.13.1
+    polished: ^4.0.5
+    prop-types: ^15.7.2
+    react-colorful: ^5.1.2
+    react-popper-tooltip: ^3.1.1
+    react-syntax-highlighter: ^13.5.3
+    react-textarea-autosize: ^8.3.0
+    regenerator-runtime: ^0.13.7
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: efa5e6e948a5c6cde2f0ba73e029c7e1e374477453a24c27e12693afd038553e9e296ba1f6591cd314ccbd213b66c96f8f4792949f5f7ff9181104350bbd1446
   languageName: node
   linkType: hard
 
@@ -5738,6 +5879,15 @@ __metadata:
   dependencies:
     core-js: ^3.8.2
   checksum: 574d1fc3adc23ec2a12246898e5f27eaad0592db664f9691dc855dd4ceddcb248d180a389e5c98d69324de2675c818d9cbae67a58d5ed5b6ff4d0e2be0346711
+  languageName: node
+  linkType: hard
+
+"@storybook/core-events@npm:6.4.21":
+  version: 6.4.21
+  resolution: "@storybook/core-events@npm:6.4.21"
+  dependencies:
+    core-js: ^3.8.2
+  checksum: f4c6dfa8afaa44d93bc967286ba205501f392fce53f1c7953fd2781471b236418b63eca20690e19ded77716a8b38156bbe51f435ffcc45e9d2f51c06c5d8874e
   languageName: node
   linkType: hard
 
@@ -6090,6 +6240,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/router@npm:6.4.21":
+  version: 6.4.21
+  resolution: "@storybook/router@npm:6.4.21"
+  dependencies:
+    "@storybook/client-logger": 6.4.21
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    history: 5.0.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    qs: ^6.10.0
+    react-router: ^6.0.0
+    react-router-dom: ^6.0.0
+    ts-dedent: ^2.0.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 774659b6162f0f1672cedcfb7ded3271c5b84b99be88146d9d36af7d955847d1fc6b0d2966fb6a462462efb21eb7c0914026d41c36409cfcb20e39015258cd7d
+  languageName: node
+  linkType: hard
+
 "@storybook/semver@npm:^7.3.2":
   version: 7.3.2
   resolution: "@storybook/semver@npm:7.3.2"
@@ -6148,6 +6320,29 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: b28ba28536f3c958a29b07ff451310eb2d03c2d7c0edf98b6033c1de227aea15391d585b82d4cb9b6f670a47872b03b3beb870eee1aec93c7bd27e01e70cc087
+  languageName: node
+  linkType: hard
+
+"@storybook/theming@npm:6.4.21":
+  version: 6.4.21
+  resolution: "@storybook/theming@npm:6.4.21"
+  dependencies:
+    "@emotion/core": ^10.1.1
+    "@emotion/is-prop-valid": ^0.8.6
+    "@emotion/styled": ^10.0.27
+    "@storybook/client-logger": 6.4.21
+    core-js: ^3.8.2
+    deep-object-diff: ^1.1.0
+    emotion-theming: ^10.0.27
+    global: ^4.4.0
+    memoizerific: ^1.11.3
+    polished: ^4.0.5
+    resolve-from: ^5.0.0
+    ts-dedent: ^2.0.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: c2aa4c0206345d1e249df8fa16c231f5d168628c1db22ca930c6d3b477763255db5a49eaa201a0c2751de7525c44b553d808e9ed4f6a745e11daff73c834ab51
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Adds search modes to the `Search` component.
* Adds the `when-typing` and `on-enter` modes.
* Changes marketplace search bar mode to `on-enter`.

#### Testing instructions

* Go to `/plugins/:siteId`
* Write any search input into the search bar, it should not search when typing.
* Press enter and it should correctly search.
* Click the close button (the one with the X in the search bar), it should clean the search box and go back to the initial state.
* Test that the search bars at `/start/domains` and `/new/language-modal` still work as intended (search as you type).

Related to #62229
Rebase when #62532 is merged