### PR TITLE
Marketplace: removes spaces between commas from popular searches

### DIFF
--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -50,27 +50,30 @@ const PopularSearches = ( props ) => {
 			</div>
 
 			<div className="search-box-header__recommended-searches-list">
-				{ searchTerms.map( ( searchTerm, n ) =>
-					searchTerm === searchedTerm ? (
-						<span
-							className="search-box-header__recommended-searches-list-item search-box-header__recommended-searches-list-item-selected"
-							key={ 'recommended-search-item-' + n }
-						>
-							{ searchTerm }
-						</span>
-					) : (
-						<span
-							onClick={ () => onClick( searchTerm ) }
-							onKeyPress={ () => onClick( searchTerm ) }
-							role="link"
-							tabIndex={ 0 }
-							className="search-box-header__recommended-searches-list-item"
-							key={ 'recommended-search-item-' + n }
-						>
-							{ searchTerm }
-						</span>
-					)
-				) }
+				{ searchTerms.map( ( searchTerm, n ) => (
+					<>
+						{ searchTerm === searchedTerm ? (
+							<span
+								className="search-box-header__recommended-searches-list-item search-box-header__recommended-searches-list-item-selected"
+								key={ 'recommended-search-item-' + n }
+							>
+								{ searchTerm }
+							</span>
+						) : (
+							<span
+								onClick={ () => onClick( searchTerm ) }
+								onKeyPress={ () => onClick( searchTerm ) }
+								role="link"
+								tabIndex={ 0 }
+								className="search-box-header__recommended-searches-list-item"
+								key={ 'recommended-search-item-' + n }
+							>
+								{ searchTerm }
+							</span>
+						) }
+						{ n !== searchTerms.length - 1 && <>,&nbsp;</> }
+					</>
+				) ) }
 			</div>
 		</div>
 	);

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -81,11 +81,6 @@
 					outline: none;
 				}
 
-				&:not( :last-child )::after {
-					display: inline-block;
-					content: ', '; // comma
-				}
-
 				&:not( .search-box-header__recommended-searches-list-item-selected ) {
 					text-decoration: underline;
 				}

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -83,7 +83,7 @@
 
 				&:not( :last-child )::after {
 					display: inline-block;
-					content: '\00a0,\00a0'; // comma and spaces
+					content: ','; // comma
 				}
 
 				&:not( .search-box-header__recommended-searches-list-item-selected ) {

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -83,7 +83,7 @@
 
 				&:not( :last-child )::after {
 					display: inline-block;
-					content: ','; // comma
+					content: ', '; // comma
 				}
 
 				&:not( .search-box-header__recommended-searches-list-item-selected ) {


### PR DESCRIPTION
#### Screenshots
![Screenshot 2022-04-07 at 12-00-20 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/162105286-09efe06b-b63a-47e8-8c1e-38c00403c94f.png)

#### Changes proposed in this Pull Request

* Removes spaces between commas from popular searches.

#### Testing instructions

* Navigate into `/plugins/`.
* Commas on popular searches shouldn't have spaces around them.

Related to #62539
