### PR TITLE
Payment Methods: Add tax location edit form to payment method list

### DIFF
--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -48,14 +48,20 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 		const text = isDeleting ? translate( 'Deleting…' ) : translate( 'Delete' );
 
 		return (
-			<Button disabled={ isDeleting } onClick={ () => setIsDialogVisible( true ) }>
+			<Button
+				className="payment-method-delete__button"
+				disabled={ isDeleting }
+				onClick={ () => setIsDialogVisible( true ) }
+				scary
+				borderless
+			>
 				{ text }
 			</Button>
 		);
 	};
 
 	return (
-		<>
+		<div className="payment-method-delete">
 			<PaymentMethodDeleteDialog
 				paymentMethodSummary={
 					<PaymentMethodSummary
@@ -69,7 +75,7 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 				onConfirm={ handleDelete }
 			/>
 			{ renderDeleteButton() }
-		</>
+		</div>
 	);
 };
 

--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -45,7 +45,7 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 	}, [ closeDialog, card, translate, reduxDispatch ] );
 
 	const renderDeleteButton = () => {
-		const text = isDeleting ? translate( 'Deleting…' ) : translate( 'Delete' );
+		const text = isDeleting ? translate( 'Deleting…' ) : translate( 'Delete this payment method' );
 
 		return (
 			<Button

--- a/client/me/purchases/payment-methods/payment-method-details.tsx
+++ b/client/me/purchases/payment-methods/payment-method-details.tsx
@@ -40,7 +40,7 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 	const type = cardType?.toLocaleLowerCase() || paymentPartner || '';
 
 	return (
-		<>
+		<div className="payment-method-details">
 			<img
 				src={ getPaymentMethodImageURL( type ) }
 				className="payment-method-details__image"
@@ -72,7 +72,7 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 				) }
 				<span className="payment-method-details__name">{ name }</span>
 			</div>
-		</>
+		</div>
 	);
 };
 

--- a/client/me/purchases/payment-methods/payment-method-list.tsx
+++ b/client/me/purchases/payment-methods/payment-method-list.tsx
@@ -1,4 +1,5 @@
 import { Button, CompactCard } from '@automattic/components';
+import { CheckoutProvider } from '@automattic/composite-checkout';
 import { localize, translate } from 'i18n-calypso';
 import page from 'page';
 import { Component } from 'react';
@@ -6,17 +7,13 @@ import { connect } from 'react-redux';
 import QueryStoredCards from 'calypso/components/data/query-stored-cards';
 import SectionHeader from 'calypso/components/section-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { isCreditCard } from 'calypso/lib/checkout/payment-methods';
 import PaymentMethod from 'calypso/me/purchases/payment-methods/payment-method';
-import PaymentMethodBackupToggle from 'calypso/me/purchases/payment-methods/payment-method-backup-toggle';
-import PaymentMethodDelete from 'calypso/me/purchases/payment-methods/payment-method-delete';
 import {
 	getAllStoredCards,
 	getUniquePaymentAgreements,
 	hasLoadedStoredCardsFromServer,
 	isFetchingStoredCards,
 } from 'calypso/state/stored-cards/selectors';
-import PaymentMethodDetails from './payment-method-details';
 import type { PaymentMethod as PaymentMethodType } from 'calypso/lib/checkout/payment-methods';
 import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
 
@@ -48,23 +45,20 @@ class PaymentMethodList extends Component< PaymentMethodListProps > {
 			);
 		}
 
-		return paymentMethods.map( ( paymentMethod ) => {
-			return (
-				<PaymentMethod key={ paymentMethod.stored_details_id }>
-					<PaymentMethodDetails
-						lastDigits={ paymentMethod.card }
-						email={ paymentMethod.email }
-						cardType={ paymentMethod.card_type || '' }
-						paymentPartner={ paymentMethod.payment_partner }
-						name={ paymentMethod.name }
-						expiry={ paymentMethod.expiry }
-						isExpired={ paymentMethod.is_expired }
-					/>
-					{ isCreditCard( paymentMethod ) && <PaymentMethodBackupToggle card={ paymentMethod } /> }
-					<PaymentMethodDelete card={ paymentMethod } />
-				</PaymentMethod>
-			);
-		} );
+		return (
+			<div className="payment-method-list__payment-methods">
+				<CheckoutProvider paymentMethods={ [] } paymentProcessors={ {} }>
+					{ paymentMethods.map( ( paymentMethod ) => {
+						return (
+							<PaymentMethod
+								paymentMethod={ paymentMethod }
+								key={ paymentMethod.stored_details_id }
+							/>
+						);
+					} ) }
+				</CheckoutProvider>
+			</div>
+		);
 	}
 
 	goToAddPaymentMethod = () => {

--- a/client/me/purchases/payment-methods/payment-method.tsx
+++ b/client/me/purchases/payment-methods/payment-method.tsx
@@ -2,25 +2,17 @@ import { CompactCard } from '@automattic/components';
 import classNames from 'classnames';
 import { FunctionComponent } from 'react';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import PaymentMethodDetails from './payment-method-details';
-import type { PaymentMethod as PaymentMethodType } from 'calypso/lib/checkout/payment-methods';
 
 import 'calypso/me/purchases/payment-methods/style.scss';
 
-interface Props {
-	card?: PaymentMethodType;
-}
-
-const PaymentMethod: FunctionComponent< Props > = ( { card, children } ) => {
+const PaymentMethod: FunctionComponent = ( { children } ) => {
 	return (
 		<CompactCard
 			className={ classNames( 'payment-method__wrapper', {
 				'is-jetpack-cloud': isJetpackCloud(),
 			} ) }
 		>
-			<div className="payment-method">
-				{ card ? <PaymentMethodDetails { ...card } /> : children }
-			</div>
+			<div className="payment-method">{ children }</div>
 		</CompactCard>
 	);
 };

--- a/client/me/purchases/payment-methods/payment-method.tsx
+++ b/client/me/purchases/payment-methods/payment-method.tsx
@@ -1,20 +1,41 @@
 import { CompactCard } from '@automattic/components';
 import classNames from 'classnames';
-import { FunctionComponent } from 'react';
+import { isCreditCard } from 'calypso/lib/checkout/payment-methods';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import PaymentMethodBackupToggle from 'calypso/me/purchases/payment-methods/payment-method-backup-toggle';
+import PaymentMethodDelete from 'calypso/me/purchases/payment-methods/payment-method-delete';
+import { TaxInfoArea } from 'calypso/my-sites/checkout/composite-checkout/components/payment-method-tax-info';
+import PaymentMethodDetails from './payment-method-details';
+import type { PaymentMethod as PaymentMethodType } from 'calypso/lib/checkout/payment-methods';
 
 import 'calypso/me/purchases/payment-methods/style.scss';
 
-const PaymentMethod: FunctionComponent = ( { children } ) => {
+export default function PaymentMethod( { paymentMethod }: { paymentMethod: PaymentMethodType } ) {
 	return (
 		<CompactCard
 			className={ classNames( 'payment-method__wrapper', {
-				'is-jetpack-cloud': isJetpackCloud(),
+				'payment-method__wrapper--jetpack-cloud': isJetpackCloud(),
 			} ) }
 		>
-			<div className="payment-method">{ children }</div>
+			<div className="payment-method">
+				<PaymentMethodDetails
+					lastDigits={ paymentMethod.card }
+					email={ paymentMethod.email }
+					cardType={ paymentMethod.card_type || '' }
+					paymentPartner={ paymentMethod.payment_partner }
+					name={ paymentMethod.name }
+					expiry={ paymentMethod.expiry }
+					isExpired={ paymentMethod.is_expired }
+				/>
+				{ isCreditCard( paymentMethod ) && <PaymentMethodBackupToggle card={ paymentMethod } /> }
+				<TaxInfoArea
+					last4={ paymentMethod.card }
+					brand={ paymentMethod.card_type }
+					storedDetailsId={ paymentMethod.stored_details_id }
+					paymentPartnerProcessorId={ paymentMethod.payment_partner }
+				/>
+				<PaymentMethodDelete card={ paymentMethod } />
+			</div>
 		</CompactCard>
 	);
-};
-
-export default PaymentMethod;
+}

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -22,6 +22,11 @@
 .payment-method {
 	margin-bottom: 0;
 	display: grid;
+	grid-template-areas:
+		'payment-method-details'
+		'payment-method-billing-information'
+		'payment-method-backup'
+		'payment-method-delete';
 	grid-template-columns: 1fr;
 	align-items: center;
 	justify-content: space-between;
@@ -29,14 +34,17 @@
 	width: 100%;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		grid-template-columns: 1fr 1fr;
+		grid-template-areas:
+		'payment-method-details payment-method-backup'
+		'payment-method-billing-information payment-method-delete';
+		grid-template-columns: 2fr 1fr;
 	}
 }
 
 .payment-method-details {
 	display: flex;
 	align-items: center;
-	order: 1;
+	grid-area: payment-method-details;
 }
 
 .payment-method-details__image {
@@ -74,7 +82,7 @@
 	display: block;
 
 	@include breakpoint-deprecated( '>960px' ) {
-		display: inline;
+		display: inline-block;
 	}
 
 	.gridicon {
@@ -94,16 +102,23 @@
 }
 
 .payment-method .payment-method-tax-info {
-	order: 2;
+	font-size: 0.875rem;
+	grid-area: payment-method-billing-information;
+	margin-left: 76px;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		order: 3;
 		width: auto;
 	}
 }
 
 .payment-method-delete {
-	order: 4;
+	grid-area: payment-method-delete;
+	margin-top: 12px;
+	text-align: right;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		margin-top: 0;
+	}
 }
 
 .payment-method-delete__button {
@@ -122,12 +137,15 @@
 }
 
 .payment-method-backup-toggle {
-	order: 3;
+	grid-area: payment-method-backup;
+	margin-left: 76px;
+	margin-top: 6px;
 	width: 100%;
-	padding-top: 8px;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		order: 2;
+		margin-left: 0;
+		margin-top: 0;
+		text-align: right;
 		width: auto;
 	}
 }

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -1,5 +1,9 @@
-.payment-method__wrapper {
-	margin-bottom: 0;
+.payment-method-list__payment-methods {
+	margin-top: 12px;
+}
+
+.payment-method-list__payment-methods > div {
+	width: 100%;
 }
 
 .payment-method-list__loader {
@@ -17,10 +21,22 @@
 
 .payment-method {
 	margin-bottom: 0;
-	display: flex;
+	display: grid;
+	grid-template-columns: 1fr;
 	align-items: center;
 	justify-content: space-between;
 	flex-wrap: wrap;
+	width: 100%;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		grid-template-columns: 1fr 1fr;
+	}
+}
+
+.payment-method-details {
+	display: flex;
+	align-items: center;
+	order: 1;
 }
 
 .payment-method-details__image {
@@ -77,6 +93,24 @@
 	font-size: 0.875rem;
 }
 
+.payment-method .payment-method-tax-info {
+	order: 2;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		order: 3;
+		width: auto;
+	}
+}
+
+.payment-method-delete {
+	order: 4;
+}
+
+.payment-method-delete__button {
+	text-decoration: underline;
+	padding: 0;
+}
+
 .payment-method-delete-dialog {
 	&.dialog {
 		max-width: 440px;
@@ -88,20 +122,23 @@
 }
 
 .payment-method-backup-toggle {
-	margin: 6px 16px 4px 76px;
-	order: 4;
+	order: 3;
 	width: 100%;
+	padding-top: 8px;
 
-	@include breakpoint-deprecated( '>660px' ) {
-		margin: 4px 32px 4px 16px;
-		order: unset;
+	@include breakpoint-deprecated( '>480px' ) {
+		order: 2;
 		width: auto;
 	}
 }
 
+.payment-method__wrapper {
+	margin-bottom: 0;
+}
+
 /* Jetpack cloud overwrites */
 
-.payment-method__wrapper.is-jetpack-cloud {
+.payment-method__wrapper--jetpack-cloud {
 	.components-checkbox-control__input[type='checkbox']:checked {
 		background-color: var( --studio-jetpack-green-50 );
 	}

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/style.scss
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/style.scss
@@ -18,3 +18,9 @@ button.button.payment-method-tax-info__edit-button svg.gridicon {
 .payment-method-tax-info__address {
 	margin-right: 0.5em;
 }
+
+.payment-method-tax-info {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is an attempt to make the payment method tax location edit button (currently available in the change payment method form) available in the list of payment methods.

Before:

<img width="659" alt="Screen Shot 2022-05-03 at 4 06 07 PM" src="https://user-images.githubusercontent.com/2036909/166557279-3a5026d3-65be-42c5-944b-b2eea33c8094.png">

After:

<img width="660" alt="Screen Shot 2022-05-03 at 4 05 32 PM" src="https://user-images.githubusercontent.com/2036909/166557298-87d5e97f-0af7-45c7-b9c6-ecabd54f4226.png">

After, mobile width:

<img width="471" alt="Screen Shot 2022-05-03 at 4 07 04 PM" src="https://user-images.githubusercontent.com/2036909/166557458-0e90abdd-18c1-45ef-88f3-27edf4f1ad6f.png">

Fixes https://github.com/Automattic/wp-calypso/issues/62142

#### Testing instructions

- Use an account with at least one payment method.
- Visit `/me/purchases/payment-methods`.
- Verify that the list looks ok since this PR significantly restyles the list items.
- Verify that you see options for the payment method including a delete button and a button to edit the tax location information.
- Click to edit the tax location information and verify that it works as expected.
- Repeat the above at different widths to be sure that the UI still looks good.
