### PR TITLE
Force PluginsBrowser rendering when a search term is present

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -127,11 +127,11 @@ function plugin( context, next ) {
 // render the plugin browser for that site. Otherwise render plugin.
 export function browsePluginsOrPlugin( context, next ) {
 	const siteUrl = getSiteFragment( context.path );
-
 	if (
-		context.params.plugin &&
-		( ( siteUrl && context.params.plugin === siteUrl.toString() ) ||
-			includes( allowedCategoryNames, context.params.plugin ) )
+		( context.params.plugin &&
+			( ( siteUrl && context.params.plugin === siteUrl.toString() ) ||
+				includes( allowedCategoryNames, context.params.plugin ) ) ) ||
+		context.query?.s
 	) {
 		browsePlugins( context, next );
 		return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Force `PluginsBrowser` rendering when a search term is present.

#### Testing instructions

* Open http://calypso.localhost:3000/plugins/:some-site
* Search for a plugin
* Click on a plugin card
* Click the "Search" breadcrumb to go back to search results
* Search results should load without having to click twice

Note, this secondary click requirement is only an issue when on the /plugins/:site version, the plain /plugins (without site) version didn't have this issue. 

I couldn't quite narrow down exactly why this was the case but I suspect it's something to do with how we `getSiteFragment`. There's something weird happening with the breadcrumb link, when you click it it first adds `?s=search term` to the current url and only then rewrites to remove the plugin name from the url. I think this is the root cause (which then fails at the `getSiteFragment` step). 

What causes that weird thing? Not sure yet, suspect the `UrlSearch` component we're wrapping PluginBrowser in, it does some `page.replace()` that might not work as we expect it should.

For the time being if this fix isn't causing any regression we should probably move ahead with it and investigate updating `UrlSearch` (it's using old react lifecycle methods).

Fixes https://github.com/Automattic/wp-calypso/issues/62541
