### PR TITLE
MediaModal: refactor video editing related cmps away from `UNSAFE_*`

### DIFF
--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -1,7 +1,6 @@
 import { ProgressBar } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -42,19 +41,9 @@ class VideoEditor extends Component {
 		pauseVideo: false,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.shouldShowError && ! this.props.shouldShowError ) {
-			this.setState( {
-				error: true,
-				pauseVideo: false,
-			} );
-
-			return;
-		}
-
-		if ( this.props.posterUrl !== nextProps.posterUrl ) {
-			this.props.onUpdatePoster( this.getVideoEditorProps( nextProps.posterUrl ) );
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.posterUrl !== this.props.posterUrl ) {
+			this.props.onUpdatePoster( this.getVideoEditorProps() );
 		}
 	}
 
@@ -85,7 +74,7 @@ class VideoEditor extends Component {
 		}
 
 		const { media } = this.props;
-		const guid = get( media, 'videopress_guid', null );
+		const guid = media?.videopress_guid;
 
 		if ( guid ) {
 			this.props.updatePoster(
@@ -126,15 +115,15 @@ class VideoEditor extends Component {
 		}
 
 		const { media } = this.props;
-		const guid = get( media, 'videopress_guid', null );
+		const guid = media?.videopress_guid;
 
 		if ( guid ) {
 			this.props.updatePoster( guid, { file }, { mediaId: media.ID } );
 		}
 	};
 
-	getVideoEditorProps( posterUrl ) {
-		const { media } = this.props;
+	getVideoEditorProps() {
+		const { media, posterUrl } = this.props;
 		const videoProperties = { posterUrl };
 
 		if ( media && media.ID ) {
@@ -160,7 +149,7 @@ class VideoEditor extends Component {
 	}
 
 	render() {
-		const { className, media, onCancel, uploadProgress, translate } = this.props;
+		const { className, media, onCancel, uploadProgress, translate, shouldShowError } = this.props;
 		const { error, isLoading, isSelectingFrame, pauseVideo } = this.state;
 
 		const classes = classNames( 'video-editor', className );
@@ -201,7 +190,7 @@ class VideoEditor extends Component {
 					</div>
 				</figure>
 
-				{ error && this.renderError() }
+				{ ( error || shouldShowError ) && this.renderError() }
 			</div>
 		);
 	}

--- a/client/post-editor/media-modal/detail/detail-preview-video.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-video.jsx
@@ -15,8 +15,14 @@ export default class extends Component {
 	};
 
 	render() {
-		if ( isVideoPressItem( this.props.item ) ) {
-			return <EditorMediaModalDetailItemVideoPress { ...this.props } />;
+		const { item } = this.props;
+		if ( isVideoPressItem( item ) ) {
+			return (
+				<EditorMediaModalDetailItemVideoPress
+					key={ `videopress-${ item.videopress_guid }` }
+					{ ...this.props }
+				/>
+			);
 		}
 
 		const { className, ...props } = this.props;

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -30,10 +30,13 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.autoplay = props.isPlaying;
+		// We use an instance property because we only want to set this once
+		// before the component got rendered for the first time. `isPlaying`
+		// could change over time but it doesn't make sense to re-set the
+		// `autoPlay` attribute for the videopress iframe (which would also
+		// cause the iframe to flicker).
+		this.enableAutoplay = props.isPlaying;
 	}
-
-	autoplay = false;
 
 	componentDidMount() {
 		window.addEventListener( 'message', this.receiveMessage, false );
@@ -168,7 +171,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		const { height = 480, videopress_guid, width = 854 } = item;
 
 		const params = {
-			autoPlay: this.autoplay,
+			autoPlay: this.enableAutoplay,
 			height,
 			width,
 			fill: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor `VideoEditor` away from `UNSAFE_*`
* Refactor `EditorMediaModalDetailPreviewVideoPress` away from `UNSAFE_*`
* Remove lodash usages from both mentioned components

#### Testing instructions

1. Open the media library and select a video, hit _Edit_, then _Edit thumbnail_
2. Make sure controls are still working as expected (cancel, upload image, select frame)¹

¹ Please note, there's a pre-existing bug I'm not exactly sure how to solve (asking @jgcaruso and @thedebian for advise): After clicking _Edit thumbnail_ start the video (autoplay isn't working for me), then hit _Upload image_ (the video pauses), hit _Cancel_ and then hit _Select frame_, the UI doesn't respond. At this point there's a mismatch between the video actually playing if you hit play again and the state stored in `VideoEditor.pauseVideo` which causes the UI to misbehave. Similarly you can observe that the second time you hit _Upload image_ the video doesn't pause anymore, because there's currently no implemented way to set `VideoEditor.pauseVideo` back to `false`.

Related to #58453 
