### PR TITLE
Add Jetpack Boost products to allow for variant selection

### DIFF
--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -172,6 +172,7 @@ export const FEATURE_JETPACK_VIDEOPRESS_STORAGE = 'jetpack-videopress-storage';
 export const FEATURE_JETPACK_VIDEOPRESS_UNBRANDED = 'jetpack-videopress-unbranded';
 export const FEATURE_JETPACK_CRM = PRODUCT_JETPACK_CRM;
 export const FEATURE_JETPACK_CRM_MONTHLY = PRODUCT_JETPACK_CRM_MONTHLY;
+export const FEATURE_CLOUD_CRITICAL_CSS = 'cloud-critical-css';
 
 // Jetpack tiered product features
 export const FEATURE_JETPACK_10GB_BACKUP_STORAGE = 'jetpack-10gb-backup-storage';

--- a/packages/calypso-products/src/constants/jetpack.ts
+++ b/packages/calypso-products/src/constants/jetpack.ts
@@ -3,6 +3,8 @@ import { PRODUCT_WPCOM_SEARCH, PRODUCT_WPCOM_SEARCH_MONTHLY } from './wpcom';
 export const GROUP_JETPACK = 'GROUP_JETPACK';
 
 // Products
+export const PRODUCT_JETPACK_BOOST = 'jetpack_boost_yearly';
+export const PRODUCT_JETPACK_BOOST_MONTHLY = 'jetpack_boost_monthly';
 export const PRODUCT_JETPACK_BACKUP = 'jetpack_backup';
 export const PRODUCT_JETPACK_BACKUP_T1_YEARLY = 'jetpack_backup_t1_yearly';
 export const PRODUCT_JETPACK_BACKUP_T1_MONTHLY = 'jetpack_backup_t1_monthly';
@@ -51,6 +53,12 @@ export const JETPACK_BACKUP_T1_PRODUCTS = <const>[
 	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
 ];
 
+// Boost
+export const JETPACK_BOOST_PRODUCTS = <const>[
+	PRODUCT_JETPACK_BOOST,
+	PRODUCT_JETPACK_BOOST_MONTHLY,
+];
+
 // Scan
 export const JETPACK_SCAN_PRODUCTS = <const>[
 	PRODUCT_JETPACK_SCAN,
@@ -88,6 +96,7 @@ export const JETPACK_VIDEOPRESS_PRODUCTS = <const>[
 
 export const JETPACK_PRODUCTS_LIST = <const>[
 	...JETPACK_BACKUP_PRODUCTS,
+	...JETPACK_BOOST_PRODUCTS,
 	...JETPACK_SCAN_PRODUCTS,
 	...JETPACK_ANTI_SPAM_PRODUCTS,
 	...JETPACK_SEARCH_PRODUCTS,
@@ -138,6 +147,10 @@ export const JETPACK_PRODUCTS_BY_TERM = <const>[
 		yearly: PRODUCT_JETPACK_VIDEOPRESS,
 		monthly: PRODUCT_JETPACK_VIDEOPRESS_MONTHLY,
 	},
+	{
+		yearly: PRODUCT_JETPACK_BOOST,
+		monthly: PRODUCT_JETPACK_BOOST_MONTHLY,
+	},
 ];
 export const JETPACK_PRODUCT_PRICE_MATRIX = <const>{
 	[ PRODUCT_JETPACK_BACKUP_DAILY ]: {
@@ -154,6 +167,10 @@ export const JETPACK_PRODUCT_PRICE_MATRIX = <const>{
 	},
 	[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: {
 		relatedProduct: PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
+		ratio: 12,
+	},
+	[ PRODUCT_JETPACK_BOOST ]: {
+		relatedProduct: PRODUCT_JETPACK_BOOST_MONTHLY,
 		ratio: 12,
 	},
 	[ PRODUCT_JETPACK_SEARCH ]: {

--- a/packages/calypso-products/src/products-list.ts
+++ b/packages/calypso-products/src/products-list.ts
@@ -6,6 +6,7 @@ import {
 	FEATURE_ANTISPAM_V2,
 	FEATURE_BACKUP_DAILY_V2,
 	FEATURE_BACKUP_REALTIME_V2,
+	FEATURE_CLOUD_CRITICAL_CSS,
 	FEATURE_FILTERING_V2,
 	FEATURE_INSTANT_EMAIL_V2,
 	FEATURE_JETPACK_1TB_BACKUP_STORAGE,
@@ -51,6 +52,8 @@ import {
 	TERM_MONTHLY,
 	JETPACK_SECURITY_CATEGORY,
 	JETPACK_PERFORMANCE_CATEGORY,
+	PRODUCT_JETPACK_BOOST,
+	PRODUCT_JETPACK_BOOST_MONTHLY,
 } from './constants';
 import { getJetpackProductsShortNames } from './translations';
 import type { ProductSlug, JetpackProductSlug, WPComProductSlug, Product } from './types';
@@ -295,6 +298,28 @@ export const JETPACK_SITE_PRODUCTS_WITH_FEATURES: Record<
 		],
 		getProductId: () => 2115,
 		getStoreSlug: () => PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
+	},
+	[ PRODUCT_JETPACK_BOOST ]: {
+		product_name: translate( 'Boost' ),
+		product_slug: PRODUCT_JETPACK_BOOST,
+		type: PRODUCT_JETPACK_BOOST,
+		term: TERM_ANNUALLY,
+		bill_period: PLAN_ANNUAL_PERIOD,
+		categories: [],
+		getFeatures: () => [ FEATURE_CLOUD_CRITICAL_CSS ],
+		getProductId: () => 2401,
+		getStoreSlug: () => PRODUCT_JETPACK_BOOST,
+	},
+	[ PRODUCT_JETPACK_BOOST_MONTHLY ]: {
+		product_name: translate( 'Boost' ),
+		product_slug: PRODUCT_JETPACK_BOOST_MONTHLY,
+		type: PRODUCT_JETPACK_BOOST,
+		term: TERM_MONTHLY,
+		bill_period: PLAN_MONTHLY_PERIOD,
+		categories: [],
+		getFeatures: () => [ FEATURE_CLOUD_CRITICAL_CSS ],
+		getProductId: () => 2400,
+		getStoreSlug: () => PRODUCT_JETPACK_BOOST_MONTHLY,
 	},
 	[ PRODUCT_JETPACK_VIDEOPRESS ]: {
 		product_name: translate( 'VideoPress' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add upcoming Jetpack Boost product information to support variant selection in the UI.

#### Testing instructions

* Head to http://calypso.localhost:3000/checkout/jetpack/jetpack_boost_yearly to add Boost to your shopping cart
* Verify that two variants appear (yearly and monthly)
* Verify that you can switch between the variants
* Verify that you can complete the purchase using credits or the store sandbox.

Related to D77544-code