### PR TITLE
Olark: In themes page, hide chat widget for logged out existing users

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -334,7 +334,8 @@ class ThemeShowcase extends Component {
 		const olarkIdentity = config( 'olark_chat_identity' );
 		const olarkSystemsGroupId = '239c0f99c53692d81539f76e86910d52';
 		const cookies = cookie.parse( document.cookie );
-		const isEligibleForOlarkChat = ! isLoggedIn && 'en' === locale && ! cookies?.recognized_logins;
+		const isEligibleForOlarkChat =
+			! isLoggedIn && 'en' === locale && ! cookies.hasOwnProperty( 'recognized_logins' );
 
 		// FIXME: Logged-in title should only be 'Themes'
 		return (

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
+import cookie from 'cookie';
 import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
 import page from 'page';
@@ -332,7 +333,8 @@ class ThemeShowcase extends Component {
 
 		const olarkIdentity = config( 'olark_chat_identity' );
 		const olarkSystemsGroupId = '239c0f99c53692d81539f76e86910d52';
-		const isEligibleForOlarkChat = ! isLoggedIn && 'en' === locale;
+		const cookies = cookie.parse( document.cookie );
+		const isEligibleForOlarkChat = ! isLoggedIn && 'en' === locale && ! cookies?.recognized_logins;
 
 		// FIXME: Logged-in title should only be 'Themes'
 		return (

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -333,9 +333,9 @@ class ThemeShowcase extends Component {
 
 		const olarkIdentity = config( 'olark_chat_identity' );
 		const olarkSystemsGroupId = '239c0f99c53692d81539f76e86910d52';
-		const cookies = cookie.parse( document.cookie );
+		const cookies = typeof window !== 'undefined' && cookie.parse( document.cookie );
 		const isEligibleForOlarkChat =
-			! isLoggedIn && 'en' === locale && ! cookies.hasOwnProperty( 'recognized_logins' );
+			! isLoggedIn && 'en' === locale && ! cookies?.hasOwnProperty( 'recognized_logins' );
 
 		// FIXME: Logged-in title should only be 'Themes'
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As per the request in pau2Xa-40L#comment-11857, we will hide the chat widget for existing users (who are identified with the `recognized_logins` cookie) on the themes page. This is an accompaniment to the patch D78360-code.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/themes` on a fresh incognito window and verify that you can see the chat widget.
* Now, set the recognized_logins cookie on your browser and reload the /themes page, you should not see the widget. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
