### PR TITLE
DIFM: Fixes prop for signup submit event

### DIFF
--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -55,6 +55,10 @@ function recordSubmitStep( stepName, providedDependencies, optionalProps ) {
 				propValue = otherProps;
 			}
 
+			if ( propName === 'selected_page_titles' && propValue?.length ) {
+				propValue = propValue.join( ',' );
+			}
+
 			if ( [ 'cart_item', 'domain_item' ].includes( propName ) && typeof propValue !== 'string' ) {
 				propValue = Object.entries( propValue || {} )
 					.map( ( pair ) => pair.join( ':' ) )

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -55,7 +55,7 @@ function recordSubmitStep( stepName, providedDependencies, optionalProps ) {
 				propValue = otherProps;
 			}
 
-			if ( propName === 'selected_page_titles' && propValue?.length ) {
+			if ( propName === 'selected_page_titles' && Array.isArray( propValue ) ) {
 				propValue = propValue.join( ',' );
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The page picker step in the DIFM flow provides a dependency `selected_page_titles` which is an array. When the step is submitted, this fires off a Tracks event `calypso_signup_actions_submit_step` which fails with the error:
```
Tracks: Unable to record event "calypso_signup_actions_submit_step" because nested properties are not supported by Tracks. Check 'selected_page_titles'
```
<img width="1128" alt="image" src="https://user-images.githubusercontent.com/5436027/162184133-4d79dab3-cf9d-4629-8e1e-fbb714045197.png">

This change converts the `selected_page_titles` array into a string that is a valid prop for the event.
#### Testing instructions

* This bug is reproducible only when the `signup/redesigned-difm-flow` feature flag is turned on.
* Go to `/start/do-it-for-me/?flags=signup/redesigned-difm-flow`.
* Keep the network tab open to capture network requests and ensure that the "Preserve Log" option is enabled.
* Go through the flow. After submitting the page picker step, search for `calypso_signup_actions_submit_step` in the network request log.
* Confirm that the `selected_page_titles` is a string.
<img width="609" alt="image" src="https://user-images.githubusercontent.com/5436027/162185336-5454b01a-567f-4d79-ac80-33634d260577.png">


* Confirm that there are no console errors.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


