### PR TITLE
Enable the redesigned DIFM flow

### DIFF
--- a/client/signup/steps/social-profiles/social-profiles.tsx
+++ b/client/signup/steps/social-profiles/social-profiles.tsx
@@ -28,7 +28,7 @@ const TextInputWrapper = styled.div`
 		opacity: 0.18;
 		margin: 11px 0 11px 10px;
 	}
-	input.form-text-input {
+	input[type='text'].form-text-input {
 		border: none;
 		padding-inline-start: 0px;
 		&:focus,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -86,7 +86,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
-		"signup/redesigned-difm-flow": false,
+		"signup/redesigned-difm-flow": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,
 		"site-indicator": true,

--- a/config/production.json
+++ b/config/production.json
@@ -93,7 +93,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
-		"signup/redesigned-difm-flow": false,
+		"signup/redesigned-difm-flow": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,
 		"site-indicator": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -93,7 +93,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
-		"signup/redesigned-difm-flow": false,
+		"signup/redesigned-difm-flow": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": true,
 		"site-indicator": true,

--- a/config/test.json
+++ b/config/test.json
@@ -72,7 +72,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"signup/social": true,
-		"signup/redesigned-difm-flow": false,
+		"signup/redesigned-difm-flow": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": false,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -106,7 +106,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
-		"signup/redesigned-difm-flow": false,
+		"signup/redesigned-difm-flow": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": true,
 		"site-indicator": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables the `signup/redesigned-difm-flow` feature flag in all environments. More context: pdh1Xd-N7-p2
* Also includes a small change in the styling for the inputs in the social profiles step. This change adds more specificity to the selector.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`.
* Confirm that you can go through the flow steps and complete checkout.
* After checkout, on the Website Content step, confirm that the page sections match with the pages you selected in the pre-checkout page selector step.