### PR TITLE
Stepper: Fix overlapping header on mobile

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -194,8 +194,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 	 */
 	.design-setup__preview {
 		.step-container__header {
-			margin: 12px 0 24px;
-			transform: translateY( -48px );
+			margin-top: 40px;
 
 			.formatted-header {
 				margin-top: 0;
@@ -214,13 +213,20 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 					padding: 0;
 				}
 			}
+
+			@include break-mobile {
+				margin: 12px 0 24px;
+				transform: translateY( -48px );
+			}
 		}
 
 		.step-container__content {
 			height: calc( 100vh - 245px );
+			margin-top: 74px;
 
 			@include break-mobile {
 				height: calc( 100vh - 225px );
+				margin-top: 32px;
 			}
 
 			@include break-small {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixed the design name in the preview of the designSetup step.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/52076348/162025552-8038ae7b-ce23-4586-9846-05397a46822f.png) | <img width="381" alt="image" src="https://user-images.githubusercontent.com/52076348/162245662-e02e1e29-b518-4a67-aec0-2179ade2044b.png">
 |


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* `yarn start`
* Go to `http://calypso.localhost:3000/stepper/designSetup?siteSlug=SITE-SLUG`
* Preview a design
* Switch to mobile
* The title should be as in the above image

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62570
Fixes #62570
