### PR TITLE
Change labels in Memebership Subscription Page for one-time payment

### DIFF
--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -29,11 +29,12 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 	const dispatch = useDispatch();
 
 	const stopSubscription = () => dispatch( requestSubscriptionStop( subscription.ID ) );
+	const isProduct = subscription && ! subscription.renew_interval;
 
 	useEffect( () => {
 		if ( stoppingStatus === 'fail' ) {
 			// run is-error notice to contact support
-			subscription && ! subscription.renew_interval
+			isProduct
 				? dispatch(
 						errorNotice(
 							translate(
@@ -72,25 +73,19 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 	return (
 		<Main wideLayout className="memberships__subscription">
 			<DocumentHead
-				title={
-					subscription && ! subscription.renew_interval
-						? translate( 'Product Details' )
-						: translate( 'Subscription Details' )
-				}
+				title={ isProduct ? translate( 'Product Details' ) : translate( 'Subscription Details' ) }
 			/>
 			<QueryMembershipsSubscriptions />
 			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
 			<HeaderCake backHref={ purchasesRoot }>
-				{ subscription && ! subscription.renew_interval
-					? translate( 'Product Details' )
-					: translate( 'Subscription Details' ) }
+				{ isProduct ? translate( 'Product Details' ) : translate( 'Subscription Details' ) }
 			</HeaderCake>
 			{ stoppingStatus === 'start' && (
 				<Notice
 					status="is-info"
 					isLoading={ true }
 					text={
-						subscription && ! subscription.renew_interval
+						isProduct
 							? translate( 'Removing this product' )
 							: translate( 'Stopping this subscription' )
 					}
@@ -143,7 +138,7 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 						className="memberships__subscription-remove"
 						onClick={ stopSubscription }
 					>
-						{ subscription && ! subscription.renew_interval
+						{ isProduct
 							? translate( 'Remove %s product.', { args: subscription.title } )
 							: translate( 'Stop %s subscription.', { args: subscription.title } ) }
 						<Gridicon className="card__link-indicator" icon="trash" />

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -33,26 +33,37 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 	useEffect( () => {
 		if ( stoppingStatus === 'fail' ) {
 			// run is-error notice to contact support
-			dispatch(
-				errorNotice(
-					translate(
-						'There was a problem while stopping your subscription, please {{a}}{{strong}}contact support{{/strong}}{{/a}}.',
-						{
-							components: {
-								a: <a href={ CALYPSO_CONTACT } />,
-								strong: <strong />,
-							},
-						}
-					)
-				)
-			);
+			subscription && ! subscription.renew_interval
+				? dispatch(
+						errorNotice(
+							translate(
+								'There was a problem while removing your product, please {{a}}{{strong}}contact support{{/strong}}{{/a}}.',
+								{
+									components: {
+										a: <a href={ CALYPSO_CONTACT } />,
+										strong: <strong />,
+									},
+								}
+							)
+						)
+				  )
+				: dispatch(
+						errorNotice(
+							translate(
+								'There was a problem while stopping your subscription, please {{a}}{{strong}}contact support{{/strong}}{{/a}}.',
+								{
+									components: {
+										a: <a href={ CALYPSO_CONTACT } />,
+										strong: <strong />,
+									},
+								}
+							)
+						)
+				  );
 		} else if ( stoppingStatus === 'success' ) {
 			// redirect back to Purchases list
 			dispatch(
-				successNotice(
-					translate( 'This subscription has been canceled. You will no longer be charged.' ),
-					{ displayOnNextPage: true }
-				)
+				successNotice( translate( 'This item has been removed.' ), { displayOnNextPage: true } )
 			);
 			page( purchasesRoot );
 		}
@@ -60,15 +71,29 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 
 	return (
 		<Main wideLayout className="memberships__subscription">
-			<DocumentHead title={ translate( 'Subscription Details' ) } />
+			<DocumentHead
+				title={
+					subscription && ! subscription.renew_interval
+						? translate( 'Product Details' )
+						: translate( 'Subscription Details' )
+				}
+			/>
 			<QueryMembershipsSubscriptions />
 			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
-			<HeaderCake backHref={ purchasesRoot }>{ translate( 'Subscription Details' ) }</HeaderCake>
+			<HeaderCake backHref={ purchasesRoot }>
+				{ subscription && ! subscription.renew_interval
+					? translate( 'Product Details' )
+					: translate( 'Subscription Details' ) }
+			</HeaderCake>
 			{ stoppingStatus === 'start' && (
 				<Notice
 					status="is-info"
 					isLoading={ true }
-					text={ translate( 'Stopping this subscription' ) }
+					text={
+						subscription && ! subscription.renew_interval
+							? translate( 'Removing this product' )
+							: translate( 'Stopping this subscription' )
+					}
 				/>
 			) }
 			{ subscription && (
@@ -118,7 +143,9 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 						className="memberships__subscription-remove"
 						onClick={ stopSubscription }
 					>
-						{ translate( 'Stop %s subscription.', { args: subscription.title } ) }
+						{ subscription && ! subscription.renew_interval
+							? translate( 'Remove %s product.', { args: subscription.title } )
+							: translate( 'Stop %s subscription.', { args: subscription.title } ) }
 						<Gridicon className="card__link-indicator" icon="trash" />
 					</CompactCard>
 				</>

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -68,7 +68,7 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 			);
 			page( purchasesRoot );
 		}
-	}, [ stoppingStatus, dispatch, translate ] );
+	}, [ stoppingStatus, dispatch, translate, isProduct ] );
 
 	return (
 		<Main wideLayout className="memberships__subscription">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Premium Content block has new type "One-time Payment". In case using it showed to user messages are not relevant any more. This PR change label for this types to not confuse user.

#### Testing instructions

- Setup a wp.com simple or atomic site
- Go to wordpress.com/earn, connect to stripe etc, 
- Add a premium content block
- Add a one-off payment plan called "Foo"
- Add another premium content block
- Add second monthly subscription plan called "Bar"
- Publish the post
- Open the site in a different browser, where you're not logged in
- Press subscribe and fill out the form for "Foo"
- I get a message about making a one-off payment
- I can see the content
- Press subscribe and fill out the form for "Bar"
- I get a message about making a one-off payment
- I can see the content
- As the subscriber, I can see both payments "Foo" and "Bar" in https://wordpress.com/me/purchases/
- Go to details of "Foo" payment
- I can see "Product Details" instead "Subscription Details"
- I can see "Remove Foo product" instead "Stop Foobar subscription"
- I can click "Remove Foo product" and remove prodcut
- As the subscriber, I can see notification "This item has been removed."
- Go back to https://wordpress.com/me/purchases/
- Go to details of "Bar" payment
- I can see "Subscription Details"
- I can see "Stop Bar subscription"
- I can click "Stop Bar subscription" and remove subscription
- As the subscriber, I can see notification "This item has been removed."

<img width="1060" alt="62329" src="https://user-images.githubusercontent.com/82798599/162257871-b52baa7e-2d65-463b-b3c9-7b6ee5b4d1d3.png">

Related to #62329 
