### PR TITLE
Playwright: Editor Tracking -- Add inline pattern insertion editor tracking test

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-inline-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-inline-block-inserter-component.ts
@@ -6,7 +6,7 @@ const selectors = {
 	blockResultItem: ( blockName: string ) =>
 		`${ popoverParentSelector } [aria-label=Blocks] button:has-text("${ blockName }")`,
 	patternResultItem: ( patternName: string ) =>
-		`${ popoverParentSelector } [aria-label="Block Patterns] [aria-label=${ patternName }]`,
+		`${ popoverParentSelector } [aria-label="Block Patterns"] [aria-label="${ patternName }"]`,
 };
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This finishes out the `editor-tracking__pattern-events.ts` script by adding pattern insertion from the inline inserter.

#### Testing instructions

- [x] Gutenberg desktop passes
- [x] Gutenberg mobile passes

Related to #
