### PR TITLE
[ETK][error-reporting] Point the Sentry SDK configuration to a test release in Sentry

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -18,6 +18,7 @@ function activateSentry() {
 		// Set tracesSampleRate to 1.0 to capture 100%
 		// of transactions for performance monitoring.
 		// We recommend adjusting this value in production
+		release: 'wpcom-test-01',
 		tracesSampleRate: 1.0,
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request



This configures Sentry to refer to the `wpcom-test-01` release created in Sentry's WPCOM project. This is needed as source maps are attached to a certain release, and as we test uploading source maps to various source files in Sentry, the Sentry SDK used by WPCOM should be pointing to a release these source maps were uploaded to. This provides a testing ground for source maps on Sentry on production WPCOM.

For now, the release was created manually (how releases in Sentry will work with WPCOM is something that still needs to be discussed and is not the goal of this PR, see: p1649374188913579/1649293480.612229-slack-C7YPUHBB2) and is meant for testing purposes only. When uploading source maps, be sure to pass `wpcom-test-01` as the release, sot these source maps are correctly associated with it. After that, any new issues that pop-up including source-mapped files should use any available source-maps.

Note that since the source-maps are manually uploaded, if there are any significant changes in the code, we should upload them again. Since Sentry is in a testing phase atm, that should be fine. As a follow-up, we should think of a way to automate uploading source-maps for all relevant projects. 

More info in: p1649293480612229-slack-C7YPUHBB2


#### Testing instructions

* Sync this to your sandbox
* Sandbox widgets.wp.com
* Throw a dummy error somewhere in `wpcom-block-editor`'s `iframe-bridge-server.js` (i.e `throw new Error('foo');`)
* Sync the code to your sandbox
* Open the editor and wait for the error to be thrown
* You should see a new issue in Sentry that uses the source-maps (they have been uploaded already)

Related to #