### PR TITLE
Add tracking and store site preferences on vertical question submission

### DIFF
--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -9,9 +9,10 @@ import type { SiteVerticalsResponse } from 'calypso/data/site-verticals';
 
 interface Props {
 	isSkipSynonyms?: boolean;
+	onSelect?: ( vertical: Vertical ) => void;
 }
 
-const SelectVertical: React.FC< Props > = ( { isSkipSynonyms } ) => {
+const SelectVertical: React.FC< Props > = ( { isSkipSynonyms, onSelect } ) => {
 	const translate = useTranslate();
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 300 );
@@ -36,6 +37,7 @@ const SelectVertical: React.FC< Props > = ( { isSkipSynonyms } ) => {
 				suggestions={ mapSiteVerticalsResponseToVertical( suggestions || [] ) }
 				isLoading={ undefined === suggestions }
 				onInputChange={ setSearchTerm }
+				onSelect={ onSelect }
 			/>
 		</>
 	);

--- a/client/components/select-vertical/style.scss
+++ b/client/components/select-vertical/style.scss
@@ -29,6 +29,7 @@
         height: 44px;
         font-size: $font-body;
         line-height: 20px;
+        padding: 12px 16px;
 
         &::placeholder {
             font-size: $font-body-small;
@@ -46,6 +47,7 @@
 }
 
 .select-vertical__suggestion-search-dropdown {
+    background-color: #fff;
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
     border-color: var( --color-neutral-10 );
@@ -53,9 +55,10 @@
     border-width: 0 1px 1px;
     box-sizing: border-box;
     left: 0;
-    margin-top: -2px;
+    margin-top: -12px;
     max-height: 350px;
     overflow: auto;
+    padding: 10px 0;
     position: absolute;
     right: 0;
     top: 42px;
@@ -67,12 +70,13 @@
         color: #646970;
         font-size: $font-body-extra-small;
         line-height: 20px;
-        padding: 12px 16px;
+        padding: 6px 16px;
     }
 
     .suggestions__item {
         border: 0;
         line-height: normal;
+        padding: 6px 16px;
     }
 
     .suggestions__label {

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -12,6 +12,7 @@ interface Props {
 	suggestions: Vertical[];
 	isLoading?: boolean | undefined;
 	onInputChange?: ( value: string ) => void;
+	onSelect?: ( vertical: Vertical ) => void;
 }
 
 const SelectVerticalSuggestionSearch: FC< Props > = ( {
@@ -20,6 +21,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 	suggestions,
 	isLoading,
 	onInputChange,
+	onSelect,
 } ) => {
 	const [ isShowSuggestions, setIsShowSuggestions ] = useState( false );
 	const [ isFocused, setIsFocused ] = useState( false );
@@ -49,7 +51,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 
 	const handleTextInputKeyDown = useCallback(
 		( event: KeyboardEvent ) => {
-			if ( event.key === 'Enter' ) {
+			if ( event.key === 'Enter' && isShowSuggestions ) {
 				event.preventDefault();
 			}
 
@@ -61,13 +63,14 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 				( suggestionsRef.current as Suggestions ).handleKeyEvent( event );
 			}
 		},
-		[ setIsShowSuggestions, suggestionsRef ]
+		[ setIsShowSuggestions, isShowSuggestions, suggestionsRef ]
 	);
 
 	const handleSuggestionsSelect = useCallback(
-		( { label }: { label: string } ) => {
+		( { label, value }: { label: string; value?: string } ) => {
 			setIsShowSuggestions( false );
 			onInputChange?.( label );
+			onSelect?.( { label, value } as Vertical );
 		},
 		[ setIsShowSuggestions, onInputChange ]
 	);

--- a/client/data/site-verticals/types.ts
+++ b/client/data/site-verticals/types.ts
@@ -1,5 +1,6 @@
 export interface SiteVerticalsResponse {
 	id: string;
+	name: string;
 	title: string;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-starting-point/index.tsx
@@ -32,7 +32,7 @@ const StartingPointStep: Step = function StartingPointStep( { navigation } ) {
 			stepName={ 'blogger-starting-point' }
 			headerImageUrl={ startingPointImageUrl }
 			goBack={ goBack }
-			skipLabelText={ translate( 'Skip to My Home' ) }
+			skipLabelText={ translate( 'Skip to dashboard' ) }
 			goNext={ () => submitIntent( 'skip-to-my-home' ) }
 			skipButtonAlign={ 'top' }
 			isHorizontalLayout={ true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
@@ -18,7 +18,7 @@ import './style.scss';
  * The intent capture step
  */
 const IntentStep: Step = function IntentStep( { navigation } ) {
-	const { goBack, submit } = navigation;
+	const { goBack, goNext, submit } = navigation;
 	const translate = useTranslate();
 	const headerText = translate( 'Where will you start?' );
 	const subHeaderText = translate( 'You can change your mind at any time.' );
@@ -48,7 +48,9 @@ const IntentStep: Step = function IntentStep( { navigation } ) {
 			stepName={ 'intent-step' }
 			headerImageUrl={ intentImageUrl }
 			goBack={ goBack }
-			hideSkip
+			goNext={ goNext }
+			skipLabelText={ translate( 'Skip to dashboard' ) }
+			skipButtonAlign={ 'top' }
 			hideBack={ ! isEnabled( 'signup/site-vertical-step' ) }
 			isHorizontalLayout={ true }
 			formattedHeader={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
@@ -6,20 +6,22 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import SelectVertical from 'calypso/components/select-vertical';
 import { tip } from 'calypso/signup/icons';
+import type { Vertical } from 'calypso/components/select-vertical/types';
 import './form.scss';
 
 interface Props {
 	isSkipSynonyms?: boolean;
+	onSelect?: ( vertical: Vertical ) => void;
 	onSubmit?: ( event: React.FormEvent ) => void;
 }
 
-const SiteVerticalForm: React.FC< Props > = ( { isSkipSynonyms, onSubmit } ) => {
+const SiteVerticalForm: React.FC< Props > = ( { isSkipSynonyms, onSelect, onSubmit } ) => {
 	const translate = useTranslate();
 
 	return (
 		<form className="site-vertical__form" onSubmit={ onSubmit }>
 			<FormFieldset className="site-vertical__form-fieldset">
-				<SelectVertical isSkipSynonyms={ isSkipSynonyms } />
+				<SelectVertical isSkipSynonyms={ isSkipSynonyms } onSelect={ onSelect } />
 				<FormSettingExplanation>
 					<Icon className="site-vertical__form-icon" icon={ tip } size={ 20 } />
 					{ translate( 'We will use this information to guide you towards next steps.' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -1,23 +1,44 @@
 import { StepContainer } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import siteVerticalImage from 'calypso/assets/images/onboarding/site-vertical.svg';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useQuery } from '../../../../hooks/use-query';
+import { useSite } from '../../../../hooks/use-site';
+import { SITE_STORE } from '../../../../stores';
 import SiteVerticalForm from './form';
 import type { Step } from '../../types';
+import type { Vertical } from 'calypso/components/select-vertical/types';
 
 const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const { goNext, submit } = navigation;
+	const [ vertical, setVertical ] = React.useState< Vertical | null >();
+	const { saveSiteSettings } = useDispatch( SITE_STORE );
+	const site = useSite();
 	const translate = useTranslate();
 	const headerText = translate( 'What’s your website about?' );
 	const subHeaderText = translate( 'Choose a category that defines your website the best.' );
 	const isSkipSynonyms = useQuery().get( 'isSkipSynonyms' );
 
-	const handleSubmit = ( event: React.FormEvent ) => {
+	const handleSiteVerticalSelect = ( vertical: Vertical ) => {
+		setVertical( vertical );
+	};
+
+	const handleSubmit = async ( event: React.FormEvent ) => {
 		event.preventDefault();
-		submit?.();
+		if ( site && vertical ) {
+			const vertical_id = vertical.value;
+
+			await saveSiteSettings( site.ID, { site_vertical: vertical_id } );
+			recordTracksEvent( 'calypso_signup_site_vertical_submit', {
+				vertical_id,
+				vertical_title: vertical.label,
+			} );
+
+			submit?.();
+		}
 	};
 
 	return (
@@ -25,7 +46,7 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 			stepName={ 'site-vertical' }
 			goNext={ goNext }
 			headerImageUrl={ siteVerticalImage }
-			skipLabelText={ translate( 'Skip this step' ) }
+			skipLabelText={ translate( 'Skip to dashboard' ) }
 			skipButtonAlign={ 'top' }
 			isHorizontalLayout={ true }
 			hideBack={ true }
@@ -38,7 +59,11 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 				/>
 			}
 			stepContent={
-				<SiteVerticalForm isSkipSynonyms={ Boolean( isSkipSynonyms ) } onSubmit={ handleSubmit } />
+				<SiteVerticalForm
+					isSkipSynonyms={ Boolean( isSkipSynonyms ) }
+					onSelect={ handleSiteVerticalSelect }
+					onSubmit={ handleSubmit }
+				/>
 			}
 			recordTracksEvent={ recordTracksEvent }
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-features/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-features/index.tsx
@@ -51,7 +51,7 @@ const StoreFeatures: Step = function StartingPointStep( { navigation } ) {
 		<StepContainer
 			stepName={ 'store-features' }
 			goBack={ goBack }
-			skipLabelText={ translate( 'Skip to My Home' ) }
+			skipLabelText={ translate( 'Skip to dashboard' ) }
 			isHorizontalLayout={ true }
 			formattedHeader={
 				<FormattedHeader

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -177,6 +177,12 @@ export const siteSetupFlow: Flow = {
 					}
 					return navigate( 'bloggerStartingPoint' );
 
+				case 'intent':
+					return redirect( `/home/${ siteSlug }` );
+
+				case 'vertical':
+					return redirect( `/home/${ siteSlug }` );
+
 				default:
 					return navigate( 'intent' );
 			}

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -88,6 +88,12 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		tagline,
 	} );
 
+	const receiveSiteVertical = ( siteId: number, vertical: string | undefined ) => ( {
+		type: 'RECEIVE_SITE_VERTICAL' as const,
+		siteId,
+		vertical,
+	} );
+
 	const receiveSiteFailed = ( siteId: number, response: SiteError | undefined ) => ( {
 		type: 'RECEIVE_SITE_FAILED' as const,
 		siteId,
@@ -169,6 +175,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		settings: {
 			blogname?: string;
 			blogdescription?: string;
+			site_vertical?: string;
 			woocommerce_onboarding_profile?: { [ key: string ]: any };
 		}
 	) {
@@ -185,6 +192,9 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			}
 			if ( 'blogdescription' in settings ) {
 				yield receiveSiteTagline( siteId, settings.blogdescription );
+			}
+			if ( 'site_vertical' in settings ) {
+				yield receiveSiteVertical( siteId, settings.site_vertical );
 			}
 		} catch ( e ) {}
 	}
@@ -237,6 +247,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveSite,
 		receiveSiteFailed,
 		receiveSiteTagline,
+		receiveSiteVertical,
 		saveSiteTagline,
 		reset,
 		launchSite,
@@ -260,6 +271,7 @@ export type Action =
 			| ActionCreators[ 'receiveSiteTitle' ]
 			| ActionCreators[ 'receiveNewSiteFailed' ]
 			| ActionCreators[ 'receiveSiteTagline' ]
+			| ActionCreators[ 'receiveSiteVertical' ]
 			| ActionCreators[ 'receiveSite' ]
 			| ActionCreators[ 'receiveSiteFailed' ]
 			| ActionCreators[ 'reset' ]

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -99,6 +99,14 @@ export const sites: Reducer< { [ key: number | string ]: SiteDetails | undefined
 				description: action.tagline ?? '',
 			},
 		};
+	} else if ( action.type === 'RECEIVE_SITE_VERTICAL' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				...( state[ action.siteId ] as SiteDetails ),
+				site_vertical: action.vertical ?? '',
+			},
+		};
 	}
 	return state;
 };

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -149,6 +149,7 @@ export interface SiteDetails {
 		show_on_front?: string;
 		site_intent?: string;
 		site_segment?: string;
+		site_vertical?: string;
 		software_version?: string;
 		selected_features?: FeatureId[];
 		theme_slug?: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the vertical question screen (`/stepper/vertical`) by adding tracking and store site preferences when user submits the vertical form. The PR also updates some UX behavior based on the feedback provided #62582 and https://github.com/Automattic/wp-calypso/pull/62365#issuecomment-1092169700 that concerns the screen flow:

tracks event: `calypso_signup_site_vertical_submit`

- [x] Allow users to click "Continue" without selecting a vertical
- [x] Replacing "Skip to My Home" to "Skip to Dashboard"
- [x] Update suggestion dropdown UI as follows
<img width="1529" alt="Screen Shot 2022-04-07 at 4 18 52 PM" src="https://user-images.githubusercontent.com/78876323/162289086-359caaae-aac1-45e1-896f-71850bba180d.png">

#### Task dependencies
- [x] ✅ D78462-code

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the vertical question screen `/stepper/vertical`.
* Type in the input field and select a vertical.
* Click on "Continue".
* Expect to land on the intent screen, with the selected vertical tracked and stored. 
* (Optional) Head back to the vertical question screen
* (Optional) Type in the input field and select "Something Else"
* (Optional) Click on "Continue"
* (Optional) Expect to land on the intent screen, with the vertical tracked and stored as empty string. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #61526