### PR TITLE
Disable feature flag for signup/site-vertical-step in favor of explicitly via URL

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -136,7 +136,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
 		"signup/redesigned-difm-flow": true,
-		"signup/site-vertical-step": true,
+		"signup/site-vertical-step": false,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,

--- a/config/development.json
+++ b/config/development.json
@@ -136,7 +136,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/hero-flow-non-en": true,
 		"signup/redesigned-difm-flow": true,
-		"signup/site-vertical-step": false,
+		"signup/site-vertical-step": true,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -95,7 +95,7 @@
 		"signup/hero-flow-non-en": true,
 		"signup/redesigned-difm-flow": false,
 		"signup/starting-point-courses": true,
-		"signup/site-vertical-step": true,
+		"signup/site-vertical-step": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": false,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -108,7 +108,7 @@
 		"signup/hero-flow-non-en": true,
 		"signup/redesigned-difm-flow": false,
 		"signup/starting-point-courses": true,
-		"signup/site-vertical-step": true,
+		"signup/site-vertical-step": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": false,
 		"themes/premium": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR sets the feature flag `signup/site-vertical-step` to false for all environments (except development), in favor of explicitly enabling it via URL parameter as per discussion p1649342801384849/1649340425.524309-slack-C02T4NVL4JJ

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing is a bit tricky since it doesn't affect development environment, but we can test if the `flags` URL works as intended.

* Head to `/stepper/vertical` via browser.
* Since the feature flag is enabled in development, you should see the vertical question screen.
* Now try `/stepper/vertical?flags=-signup/site-vertical-step`
* You should be redirected to the intent screen `/stepper/intent`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #61526