### PR TITLE
Stripe connected accounts can access earn regardless of plan

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -58,6 +58,7 @@ interface ConnectedProps {
 	isPremiumOrBetterPlan?: boolean;
 	isUserAdmin?: boolean;
 	eligibleForProPlan?: boolean;
+	stripeAvailable: boolean;
 }
 
 type BoolFunction = ( arg: string ) => boolean;
@@ -80,6 +81,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	hasConnectedAccount,
 	hasSetupAds,
 	eligibleForProPlan,
+	stripeAvailable,
 	trackUpgrade,
 	trackLearnLink,
 	trackCtaButton,
@@ -179,7 +181,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getRecurringPaymentsCard = () => {
-		const cta = isFreePlan
+		const cta = ! stripeAvailable
 			? {
 					text: translate( 'Unlock this feature' ),
 					action: () => {
@@ -234,7 +236,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getDonationsCard = () => {
-		const cta = isFreePlan
+		const cta = ! stripeAvailable
 			? {
 					text: translate( 'Unlock this feature' ),
 					action: () => {
@@ -282,7 +284,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getPremiumContentCard = () => {
-		const cta = isFreePlan
+		const cta = ! stripeAvailable
 			? {
 					text: translate( 'Unlock this feature' ),
 					action: () => {
@@ -542,7 +544,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	return (
 		<Fragment>
 			{ ! hasWordAds && <QueryWordadsStatus siteId={ siteId } /> }
-			{ ! isFreePlan && <QueryMembershipsSettings siteId={ siteId } /> }
+			{ <QueryMembershipsSettings siteId={ siteId } /> }
 			{ isLoading && (
 				<div className="earn__placeholder-promo-card">
 					<PromoSection
@@ -599,6 +601,7 @@ export default connect(
 			hasSetupAds: Boolean(
 				site?.options?.wordads || isRequestingWordAdsApprovalForSite( state, site )
 			),
+			stripeAvailable: hasConnectedAccount || ! isFreePlan,
 		};
 	},
 	( dispatch ) => ( {

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -356,7 +356,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getPaidNewsletterCard = () => {
-		const cta = isFreePlan
+		const cta = ! hasPremiumContent
 			? {
 					text: translate( 'Unlock this feature' ),
 					action: () => {

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -1,4 +1,7 @@
 import {
+	FEATURE_PREMIUM_CONTENT_CONTAINER,
+	FEATURE_DONATIONS,
+	FEATURE_RECURRING_PAYMENTS,
 	FEATURE_MEMBERSHIPS,
 	PLAN_PERSONAL,
 	PLAN_JETPACK_PERSONAL,
@@ -42,7 +45,7 @@ import {
 	getTotalSubscribersForSiteId,
 	getOwnershipsForSiteId,
 } from 'calypso/state/memberships/subscribers/selectors';
-import isSiteOnPaidPlan from 'calypso/state/selectors/is-site-on-paid-plan';
+import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
@@ -604,7 +607,7 @@ class MembershipsSection extends Component {
 	}
 
 	render() {
-		if ( ! this.props.connectedAccountId && ! this.props.paidPlan ) {
+		if ( ! this.props.connectedAccountId && ! this.props.hasStripeFeature ) {
 			return this.renderOnboarding(
 				<UpsellNudge
 					plan={ this.props.isJetpack ? PLAN_JETPACK_PERSONAL : PLAN_PERSONAL }
@@ -658,7 +661,10 @@ const mapStateToProps = ( state ) => {
 		subscribers: getOwnershipsForSiteId( state, siteId ),
 		connectedAccountId: getConnectedAccountIdForSiteId( state, siteId ),
 		connectUrl: getConnectUrlForSiteId( state, siteId ),
-		paidPlan: isSiteOnPaidPlan( state, siteId ),
+		hasStripeFeature:
+			hasActiveSiteFeature( state, siteId, FEATURE_PREMIUM_CONTENT_CONTAINER ) ||
+			hasActiveSiteFeature( state, siteId, FEATURE_DONATIONS ) ||
+			hasActiveSiteFeature( state, siteId, FEATURE_RECURRING_PAYMENTS ),
 		isJetpack: isJetpackSite( state, siteId ),
 	};
 };

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -604,7 +604,7 @@ class MembershipsSection extends Component {
 	}
 
 	render() {
-		if ( ! this.props.paidPlan ) {
+		if ( ! this.props.connectedAccountId && ! this.props.paidPlan ) {
 			return this.renderOnboarding(
 				<UpsellNudge
 					plan={ this.props.isJetpack ? PLAN_JETPACK_PERSONAL : PLAN_PERSONAL }

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -1,3 +1,8 @@
+import {
+	FEATURE_DONATIONS,
+	FEATURE_PREMIUM_CONTENT_CONTAINER,
+	FEATURE_RECURRING_PAYMENTS,
+} from '@automattic/calypso-products';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localize } from 'i18n-calypso';
@@ -9,6 +14,7 @@ import HeaderCake from 'calypso/components/header-cake';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SectionHeader from 'calypso/components/section-header';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
+import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -28,10 +34,12 @@ class MembershipsProductsSection extends Component {
 	renderEllipsisMenu( productId ) {
 		return (
 			<EllipsisMenu position="bottom left">
-				<PopoverMenuItem onClick={ () => this.openAddEditDialog( productId ) }>
-					<Gridicon size={ 18 } icon={ 'pencil' } />
-					{ this.props.translate( 'Edit' ) }
-				</PopoverMenuItem>
+				{ this.props.hasStripeFeature && (
+					<PopoverMenuItem onClick={ () => this.openAddEditDialog( productId ) }>
+						<Gridicon size={ 18 } icon={ 'pencil' } />
+						{ this.props.translate( 'Edit' ) }
+					</PopoverMenuItem>
+				) }
 				<PopoverMenuItem onClick={ () => this.openDeleteDialog( productId ) }>
 					<Gridicon size={ 18 } icon={ 'trash' } />
 					{ this.props.translate( 'Delete' ) }
@@ -66,11 +74,13 @@ class MembershipsProductsSection extends Component {
 					{ this.props.translate( 'Payment plans' ) }
 				</HeaderCake>
 
-				<SectionHeader>
-					<Button primary compact onClick={ () => this.openAddEditDialog( null ) }>
-						{ this.props.translate( 'Add a new payment plan' ) }
-					</Button>
-				</SectionHeader>
+				{ this.props.hasStripeFeature && (
+					<SectionHeader>
+						<Button primary compact onClick={ () => this.openAddEditDialog( null ) }>
+							{ this.props.translate( 'Add a new payment plan' ) }
+						</Button>
+					</SectionHeader>
+				) }
 				{ this.props.products.map( ( product ) => (
 					<CompactCard className="memberships__products-product-card" key={ product.ID }>
 						<div className="memberships__products-product-details">
@@ -108,5 +118,9 @@ export default connect( ( state ) => {
 		siteId,
 		siteSlug: getSelectedSiteSlug( state ),
 		products: getProductsForSiteId( state, siteId ),
+		hasStripeFeature:
+			hasActiveSiteFeature( state, siteId, FEATURE_PREMIUM_CONTENT_CONTAINER ) ||
+			hasActiveSiteFeature( state, siteId, FEATURE_DONATIONS ) ||
+			hasActiveSiteFeature( state, siteId, FEATURE_RECURRING_PAYMENTS ),
 	};
 } )( localize( MembershipsProductsSection ) );

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -83,7 +83,11 @@ export const FEATURE_ADVANCED_SEO_TOOLS = 'advanced-seo-tools';
 export const FEATURE_ADVANCED_SEO_EXPANDED_ABBR = 'advanced-seo-expanded-abbreviation';
 export const FEATURE_FREE_THEMES_SIGNUP = 'free-themes-signup';
 export const FEATURE_MEMBERSHIPS = 'memberships';
+export const FEATURE_DONATIONS = 'donations';
+export const FEATURE_RECURRING_PAYMENTS = 'recurring-payments';
+// This is a legacy alias, FEATURE_PREMIUM_CONTENT_CONTAINER should be used instead.
 export const FEATURE_PREMIUM_CONTENT_BLOCK = 'premium-content-block';
+export const FEATURE_PREMIUM_CONTENT_CONTAINER = 'premium-content/container';
 export const FEATURE_HOSTING = 'hosting';
 export const PREMIUM_DESIGN_FOR_STORES = 'premium-design-for-stores';
 export const FEATURE_SFTP_DATABASE = 'sftp-and-database-access';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The pages on earn to manage various earn settings are only available to
sites with a paid plan, even though payments will continue to be
processed and the stripe connection will still be in place.

This change allows free sites to use the Manage payments, Donations and
Premium Content so long as they have an existing stripe connection.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure your sandbox is up to date
2. Use the generated calypso link below
3. Be on a paid plan
4. Go to wordpress.com/earn
5. Follow the prompts to link your stripe account as normal, if necessary
6. Go to wordpress.com/earn again, note that **Manage** Payments, Accept Donations and Tips and Manage your premium content all have CTAs  like Collect / Manage / Add respectively
7. Follow each of the three links, you should see the management screens
8. On the management screen press 'Payment plans' to modify the plans, you should be able to edit sites and add new ones. 
9. Remove your paid plan, e.g. using store admin
10. Reload wordpress.com/earn, you should see everything the same as in steps 5-7
11. Step 8 will be different - you should not see the add new button or the link to edit existing plans
12. Disconnect your stripe account
13. Go to wordpress.com/earn
14. You should see that the titles of the three cards have changed slightly, and that the wording on the CTAs has changed to 'unlock' 


** This is blocked from release until D78455-code ✅ and  897-gh-Automattic/wpcomsh are deployed **

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #59937