### PR TITLE
Full importer improvements

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -292,8 +292,8 @@ export class SectionMigrate extends Component {
 					is_atomic: isBackendAtomic,
 				} = response;
 
-				if ( sourceSiteId && sourceSiteId.toString() !== this.props.sourceSiteId.toString() ) {
-					this.setSourceSiteId( sourceSiteId );
+				if ( String( sourceSiteId ) !== String( this.props.sourceSiteId ) ) {
+					sourceSiteId && this.setSourceSiteId( sourceSiteId );
 				}
 
 				if ( migrationStatus ) {

--- a/client/signup/steps/import-from/wordpress/import-everything/confirm-upgrade-plan.tsx
+++ b/client/signup/steps/import-from/wordpress/import-everything/confirm-upgrade-plan.tsx
@@ -78,7 +78,7 @@ export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
 			<div className={ classnames( 'import__upgrade-plan-container' ) }>
 				<div className={ classnames( 'import__upgrade-plan-price' ) }>
 					<h3 className={ classnames( 'plan-title' ) }>{ plan?.getTitle() }</h3>
-					<PlanPrice rawPrice={ rawPrice } currency={ currencyCode } />
+					<PlanPrice rawPrice={ rawPrice } currencyCode={ currencyCode } />
 					<span className={ classnames( 'plan-time-frame' ) }>{ plan?.getBillingTimeFrame() }</span>
 				</div>
 				<div className={ classnames( 'import__upgrade-plan-details' ) }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixed issue with showing wrong price currency on the upgrade plan screen. Before the change, it was USD by default.
* Fixed issue of accessing method of undefined value.

#### Testing instructions

**CURRENCY**
* Go to `/start/importer/capture?siteSlug={SLUG}.wordpress.com`
* Select `Import your content`
* Choose `Everything` option
* Select `See plans`
* Check if the price currency correct

**MIGRATION**
* Go to `/start/importer/capture?siteSlug={SITE_SLUG}`
* Select `Import your content`
* Choose `Everything` option
* Press `Start import`
* In another tab open `/migrate/{SITE_SLUG}`
* Check if the progress screen works correctly (before the change, the screen was showing an error screen with try again button)

Closes #62603
Closes #62608