### PR TITLE
Env Badge: Hide tab's contents until the tab is hovered

### DIFF
--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -7,6 +7,16 @@
 
 	&:hover .environment {
 		display: inline-block;
+
+		// hide everything inside each tab
+		& > * {
+			display: none;
+		}
+
+		// only show the tab's title (first child)
+		& > *:first-child {
+			display: block;
+		}
 	}
 
 	.bug-report {
@@ -56,8 +66,8 @@
 		}
 
 		@mixin env-bug-style( $color-name ) {
-			background-color: var( --studio-#{ $color-name }-20 );
-			color: var( --studio-#{ $color-name }-90 );
+			background-color: var( --studio-#{$color-name}-20 );
+			color: var( --studio-#{$color-name}-90 );
 		}
 
 		&.is-staging {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The env badge is broken when you hover it (when it has features tab only - i.e in local env only). This fixes it.

**Before:**

https://user-images.githubusercontent.com/17054134/162434221-632f4914-fbfc-4c10-b8ae-6dd9c9d180f5.mov


**After:** 

https://user-images.githubusercontent.com/17054134/162434423-9538ec7f-44ce-4b68-b350-c64e99ac87ce.mov

