### PR TITLE
Stepper: fix scroll position when changing route

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames';
+import { useEffect } from 'react';
 import { Switch, Route, Redirect, generatePath, useHistory, useLocation } from 'react-router-dom';
 import SignupHeader from 'calypso/signup/signup-header';
 import * as Steps from './steps-repository';
@@ -28,6 +29,10 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	);
 	const pathToClass = ( path: string ) =>
 		path.replace( /([a-z0-9])([A-Z])/g, '$1-$2' ).toLowerCase();
+
+	useEffect( () => {
+		window.scrollTo( 0, 0 );
+	}, [ location ] );
 
 	return (
 		<Switch>


### PR DESCRIPTION
## Changes proposed in this Pull Request
By default when changing route in `react-router-dom` the scroll position does not change. This solves the problem by listening for the `location` to change and resets the scroll position using useEffect.

<img src="https://user-images.githubusercontent.com/33258733/162443400-ea6e03ed-7be2-4e82-bf31-b2d2a3554933.gif" width=200 />

## Testing instructions
1. Pull branch and `yarn start`
2. Go to http://calypso.localhost:3000/stepper/bloggerStartingPoint and use a screen dimension that allows you to scroll down.
3. Scroll down and click `Start Learning`
4. The next page should be at the top.

Fixes #62598 