### PR TITLE
Updating free domain copy on the domain step.

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -16,7 +16,7 @@ class ReskinSideExplainer extends Component {
 		let ctaText;
 
 		const showNewTitle =
-			i18n.hasTranslation( 'Your domain is {{b}}free{{/b}} with WordPress Pro' ) ||
+			i18n.hasTranslation( 'Get your domain {{b}}free{{/b}} with WordPress Pro' ) ||
 			'en' === getLocaleSlug();
 
 		const showNewSubtitle =

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -15,14 +15,14 @@ class ReskinSideExplainer extends Component {
 		let subtitle2;
 		let ctaText;
 
+		const isEnLocale = [ 'en', 'en-gb' ].includes( getLocaleSlug() );
 		const showNewTitle =
-			i18n.hasTranslation( 'Get your domain {{b}}free{{/b}} with WordPress Pro' ) ||
-			'en' === getLocaleSlug();
+			i18n.hasTranslation( 'Get your domain {{b}}free{{/b}} with WordPress Pro' ) || isEnLocale;
 
 		const showNewSubtitle =
 			i18n.hasTranslation(
 				'Use the search tool on this page to find a domain you love, then select the {{b}}WordPress Pro{{/b}} plan.'
-			) || 'en' === getLocaleSlug();
+			) || isEnLocale;
 
 		switch ( type ) {
 			case 'free-domain-explainer':

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -51,6 +51,7 @@ class ReskinSideExplainer extends Component {
 					translate(
 						'We’ll pay the first year’s domain registration fees for you, simple as that!'
 					);
+				ctaText = ! showNewSubtitle && translate( 'Choose my domain later' );
 				break;
 
 			case 'use-your-domain':

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -1,5 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { localize } from 'i18n-calypso';
+import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
@@ -9,37 +8,44 @@ import './style.scss';
 
 class ReskinSideExplainer extends Component {
 	getStrings() {
-		const { type, eligibleForProPlan, selectedSiteId, translate } = this.props;
+		const { type, translate } = this.props;
 
 		let title;
 		let subtitle;
 		let ctaText;
 
-		// The special case latter is for handling the case in the sign-up flow.
-		// By that time, a site is not available yet, so we can only check the feature flag for now
-		const shouldShowProPlanTitle =
-			eligibleForProPlan || ( selectedSiteId == null && isEnabled( 'plans/pro-plan' ) );
+		const showNewTitle =
+			i18n.hasTranslation( 'Your domain is {{b}}free{{/b}} with WordPress Pro' ) ||
+			'en' === getLocaleSlug();
+
+		const showNewSubtitle =
+			i18n.hasTranslation(
+				'Use the search tool on this page to find a domain you love, then select the {{b}}WordPress Pro{{/b}} plan.{{br}}{{br}}We’ll pay the first year’s domain registration fees for you, simple as that!'
+			) || 'en' === getLocaleSlug();
 
 		switch ( type ) {
 			case 'free-domain-explainer':
-				title = shouldShowProPlanTitle
-					? translate(
+				showNewTitle
+					? ( title = translate( 'Get your domain {{b}}free{{/b}} with WordPress Pro', {
+							components: { b: <strong /> },
+					  } ) )
+					: ( title = translate(
 							'Get a {{b}}free{{/b}} one-year domain registration with your WordPress Pro annual plan.',
 							{
 								components: { b: <strong /> },
 							}
-					  )
-					: translate(
-							'Get a {{b}}free{{/b}} one-year domain registration with any paid annual plan.',
-							{
-								components: { b: <strong /> },
-							}
-					  );
+					  ) );
 
-				subtitle = translate(
-					"You can claim your free custom domain later if you aren't ready yet."
-				);
-				ctaText = translate( 'Choose my domain later' );
+				showNewSubtitle
+					? ( subtitle = translate(
+							'Use the search tool on this page to find a domain you love, then select the {{b}}WordPress Pro{{/b}} plan.{{br /}}{{br /}}We’ll pay the first year’s domain registration fees for you, simple as that!',
+							{
+								components: { b: <strong />, br: <br /> },
+							}
+					  ) )
+					: ( subtitle = translate(
+							"You can claim your free custom domain later if you aren't ready yet."
+					  ) );
 				break;
 
 			case 'use-your-domain':

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -12,6 +12,7 @@ class ReskinSideExplainer extends Component {
 
 		let title;
 		let subtitle;
+		let subtitle2;
 		let ctaText;
 
 		const showNewTitle =
@@ -20,32 +21,34 @@ class ReskinSideExplainer extends Component {
 
 		const showNewSubtitle =
 			i18n.hasTranslation(
-				'Use the search tool on this page to find a domain you love, then select the {{b}}WordPress Pro{{/b}} plan.{{br}}{{br}}We’ll pay the first year’s domain registration fees for you, simple as that!'
+				'Use the search tool on this page to find a domain you love, then select the {{b}}WordPress Pro{{/b}} plan.'
 			) || 'en' === getLocaleSlug();
 
 		switch ( type ) {
 			case 'free-domain-explainer':
-				showNewTitle
-					? ( title = translate( 'Get your domain {{b}}free{{/b}} with WordPress Pro', {
+				title = showNewTitle
+					? translate( 'Get your domain {{b}}free{{/b}} with WordPress Pro', {
 							components: { b: <strong /> },
-					  } ) )
-					: ( title = translate(
+					  } )
+					: translate(
 							'Get a {{b}}free{{/b}} one-year domain registration with your WordPress Pro annual plan.',
 							{
 								components: { b: <strong /> },
 							}
-					  ) );
+					  );
 
-				showNewSubtitle
-					? ( subtitle = translate(
-							'Use the search tool on this page to find a domain you love, then select the {{b}}WordPress Pro{{/b}} plan.{{br /}}{{br /}}We’ll pay the first year’s domain registration fees for you, simple as that!',
+				subtitle = showNewSubtitle
+					? translate(
+							'Use the search tool on this page to find a domain you love, then select the {{b}}WordPress Pro{{/b}} plan.',
 							{
-								components: { b: <strong />, br: <br /> },
+								components: { b: <strong /> },
 							}
-					  ) )
-					: ( subtitle = translate(
-							"You can claim your free custom domain later if you aren't ready yet."
-					  ) );
+					  )
+					: translate( "You can claim your free custom domain later if you aren't ready yet." );
+
+				subtitle2 = translate(
+					'We’ll pay the first year’s domain registration fees for you, simple as that!'
+				);
 				break;
 
 			case 'use-your-domain':
@@ -69,17 +72,20 @@ class ReskinSideExplainer extends Component {
 				break;
 		}
 
-		return { title, subtitle, ctaText };
+		return { title, subtitle, subtitle2, ctaText };
 	}
 
 	render() {
-		const { title, subtitle, ctaText } = this.getStrings();
+		const { title, subtitle, subtitle2, ctaText } = this.getStrings();
 
 		return (
 			/* eslint-disable jsx-a11y/click-events-have-key-events */
 			<div className="reskin-side-explainer">
 				<div className="reskin-side-explainer__title">{ title }</div>
-				<div className="reskin-side-explainer__subtitle">{ subtitle }</div>
+				<div className="reskin-side-explainer__subtitle">
+					<p>{ subtitle }</p>
+					{ subtitle2 && <p>{ subtitle2 }</p> }
+				</div>
 				{ ctaText && (
 					<div className="reskin-side-explainer__cta">
 						<span

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -86,8 +86,8 @@ class ReskinSideExplainer extends Component {
 			<div className="reskin-side-explainer">
 				<div className="reskin-side-explainer__title">{ title }</div>
 				<div className="reskin-side-explainer__subtitle">
-					<p>{ subtitle }</p>
-					{ subtitle2 && <p>{ subtitle2 }</p> }
+					<div>{ subtitle }</div>
+					{ subtitle2 && <div className="reskin-side-explainer__subtitle-2">{ subtitle2 }</div> }
 				</div>
 				{ ctaText && (
 					<div className="reskin-side-explainer__cta">

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -46,9 +46,11 @@ class ReskinSideExplainer extends Component {
 					  )
 					: translate( "You can claim your free custom domain later if you aren't ready yet." );
 
-				subtitle2 = translate(
-					'We’ll pay the first year’s domain registration fees for you, simple as that!'
-				);
+				subtitle2 =
+					showNewSubtitle &&
+					translate(
+						'We’ll pay the first year’s domain registration fees for you, simple as that!'
+					);
 				break;
 
 			case 'use-your-domain':

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -24,6 +24,16 @@ class ReskinSideExplainer extends Component {
 				'Use the search tool on this page to find a domain you love, then select the {{b}}WordPress Pro{{/b}} plan.'
 			) || isEnLocale;
 
+		const newSubtitleCopy =
+			'pro' === this.props.flowName
+				? translate( 'Use the search tool on this page to find a domain you love.' )
+				: translate(
+						'Use the search tool on this page to find a domain you love, then select the {{b}}WordPress Pro{{/b}} plan.',
+						{
+							components: { b: <strong /> },
+						}
+				  );
+
 		switch ( type ) {
 			case 'free-domain-explainer':
 				title = showNewTitle
@@ -38,12 +48,7 @@ class ReskinSideExplainer extends Component {
 					  );
 
 				subtitle = showNewSubtitle
-					? translate(
-							'Use the search tool on this page to find a domain you love, then select the {{b}}WordPress Pro{{/b}} plan.',
-							{
-								components: { b: <strong /> },
-							}
-					  )
+					? newSubtitleCopy
 					: translate( "You can claim your free custom domain later if you aren't ready yet." );
 
 				subtitle2 =

--- a/client/components/domains/reskin-side-explainer/style.scss
+++ b/client/components/domains/reskin-side-explainer/style.scss
@@ -19,6 +19,10 @@
         font-size: 0.875rem;
     }
 
+    .reskin-side-explainer__subtitle-2 {
+        margin-top: 1.5em;
+    }
+
     .reskin-side-explainer__cta {
         font-size: 0.875rem;
         line-height: 20px;

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -435,6 +435,7 @@ class DomainsStep extends Component {
 						<ReskinSideExplainer
 							onClick={ this.handleDomainExplainerClick }
 							type={ 'free-domain-explainer' }
+							flowName={ this.props.flowName }
 						/>
 					</div>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the copy on the domain step to highlight that the user should use this page to find their domain, and to explain that the free domain is available to people who choose the Pro plan on the next step. The link is removed to encourage people to find a domain name that they want to use.

Here's a screenshot of the copy on the screen
![CleanShot 2022-04-08 at 11 22 02@2x](https://user-images.githubusercontent.com/35781181/162473460-47e254a2-ba20-41b5-a31a-9ef39b58bec0.png)



#### Testing instructions
* Checkout this branch and start Calypso.
* Navigate to the domains step in signup.
* Confirm that the new copy is displayed properly.
* Confirm that the link is no longer present.
* Check the display in both mobile and desktop viewports.
* Check the page in non-EN mode and confirm that the prior (translated) copy is displayed.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
