### PR TITLE
Add padding to stepper container

### DIFF
--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -28,13 +28,13 @@
 		max-width: 1024px;
 		padding: 0 20px;
 
+		&.has-navigation {
+			padding-bottom: 60px;
+		}
+
 		@include break-small {
 			margin-top: 25vh;
 			display: flex;
-
-			&.has-navigation {
-				padding-bottom: 60px;
-			}
 
 			.step-container__header {
 				margin-top: 0;


### PR DESCRIPTION
##  Changes proposed in this Pull Request

Adds padding to the stepper container on mobile orientation. This accounts for the bottom nav bar in the flow.

<img width="430" alt="Markup 2022-04-08 at 17 32 29" src="https://user-images.githubusercontent.com/33258733/162475038-8543ac94-7b79-4028-b814-55e513ab8670.png">

## Testing instructions

1. Pull branch and `yarn start`
2. Go to `http://calypso.localhost:3000/stepper/storeFeatures?siteSlug=[ SITE-SLUG ]`
3. View from mobile orientation and check to make sure the bottom of the page is not cut off.

Fixes #62597 