### PR TITLE
DIFM end-to-end test and page object

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/difm-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/difm-flow.ts
@@ -1,0 +1,89 @@
+import { Page } from 'playwright';
+import { DataHelper } from '../..';
+
+const selectors = {
+	// General
+	button: ( text: string ) => `button:text("${ text }")`,
+
+	// Start page
+	startContainer: '.signup.is-do-it-for-me',
+
+	// Options page
+	siteName: '#siteTitle',
+	tagline: '#tagline',
+
+	// Social page
+	facebook: 'input[name=facebookUrl]',
+};
+
+/**
+ * Class encapsulating the flow when starting a new do-it-for-me site order.
+ */
+export class DIFMFlow {
+	/**
+	 * Constructs an instance of the flow.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( private page: Page ) {}
+
+	/**
+	 * Given text, click on the button's first instance with the text.
+	 *
+	 * @param {string} text User-visible text on the button.
+	 */
+	async clickButton( text: string ): Promise< void > {
+		const selector = selectors.button( text );
+
+		await this.page.waitForSelector( selector );
+		await this.page.click( selector );
+	}
+
+	/**
+	 * Go to first setup page.
+	 */
+	async startSetup(): Promise< void > {
+		await this.page.goto(
+			DataHelper.getCalypsoURL(
+				'/start/do-it-for-me/new-or-existing-site?flags=signup/redesigned-difm-flow'
+			)
+		);
+		await this.validateSetupPage();
+		await this.clickButton( 'Start a new site' );
+	}
+
+	/**
+	 * Validates that we've landed on the setup page.
+	 */
+	async validateSetupPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.startContainer );
+	}
+
+	/**
+	 * Validates that we've landed on the options page.
+	 */
+	async validateOptionsPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.siteName );
+	}
+
+	/**
+	 * Validates that we've landed on the social page.
+	 */
+	async validateSocialPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.facebook );
+	}
+
+	/**
+	 * Enter the values for your site name as well as an optional tagline.
+	 *
+	 * @param {string} name The name for the new site.
+	 * @param {string} [tagline] An optional tagline.
+	 */
+	async enterOptions( name: string, tagline?: string ): Promise< void > {
+		await this.page.fill( selectors.siteName, name );
+		if ( typeof tagline !== 'undefined' ) {
+			await this.page.fill( selectors.tagline, tagline );
+		}
+		await this.clickButton( 'Continue' );
+	}
+}

--- a/packages/calypso-e2e/src/lib/flows/difm-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/difm-flow.ts
@@ -4,25 +4,30 @@ import { DataHelper } from '../..';
 const selectors = {
 	// General
 	button: ( text: string ) => `button:text("${ text }")`,
-
-	// Start page
-	startContainer: '.signup.is-do-it-for-me',
+	header: ( text: string ) => `h1.formatted-header__title:has-text("${ text }")`,
 
 	// Options page
 	siteNameInput: '#siteTitle',
 	taglineInput: '#tagline',
 
 	// Social page
-	facebookInput: 'input[name=facebookUrl]',
+	twitterInput: 'input[name=twitterUrl]',
 
 	// Design page
-	designPickerContainer: '.design-picker',
+	freeDesignButton: 'button[data-e2e-button=freeOption]',
 
 	//Page picker page
-	pagePickerContainer: '.signup__step .is-difm-page-picker',
+	pageOption: ( text: string ) => `div.css-1wedqbn:has-text("${ text }")`,
 
 	// Checkout page
-	checkoutContainer: '.checkout__content',
+	checkoutHeader: '.checkout-step__header:has-text("Your order")',
+
+	// Existing sites
+	searchBar: 'input[type=search]',
+	siteItem: ( text: string ) => `.site__title:has-text("${ text }")`,
+
+	// Confirmation box
+	confirmationInput: 'input#confirmTextChangeInput',
 };
 
 /**
@@ -47,57 +52,79 @@ export class DIFMFlow {
 	}
 
 	/**
+	 * Validates that we've are seeing the correct header.
+	 *
+	 * @param {string} title The title that the page should be showing.
+	 */
+	async validatePageTitle( title: string ): Promise< void > {
+		await this.page.waitForSelector( selectors.header( title ) );
+	}
+
+	/**
 	 * Go to first setup page.
 	 */
-	async startSetup(): Promise< void > {
+	async visitSetup(): Promise< void > {
 		await this.page.goto(
 			DataHelper.getCalypsoURL(
 				'/start/do-it-for-me/new-or-existing-site?flags=signup/redesigned-difm-flow'
 			)
 		);
-		await this.validateSetupPage();
 	}
 
 	/**
-	 * Validates that we've landed on the setup page.
+	 * Validates that we've landed on the starting page.
 	 */
-	async validateSetupPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.startContainer );
+	async validateStartPage(): Promise< void > {
+		await this.validatePageTitle( 'Do It For Me' );
 	}
 
 	/**
 	 * Validates that we've landed on the options page.
 	 */
 	async validateOptionsPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.siteNameInput );
+		await this.validatePageTitle( "First, let's give your site a name" );
 	}
 
 	/**
 	 * Validates that we've landed on the social page.
 	 */
 	async validateSocialPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.facebookInput );
+		await this.validatePageTitle( 'Do you have social media profiles?' );
 	}
 
 	/**
-	 * Validates that we've landed on the design picker page.
+	 * Validates that we've landed on the design page.
 	 */
 	async validateDesignPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.designPickerContainer );
+		await this.validatePageTitle( 'Themes' );
 	}
 
 	/**
 	 * Validates that we've landed on the page picker page.
 	 */
 	async validatePagePickerPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.pagePickerContainer );
+		await this.validatePageTitle( 'Add pages to your' );
+	}
+
+	/**
+	 * Validates that we've landed on the 'choose existing' page.
+	 */
+	async validateUseExistingPage(): Promise< void > {
+		await this.validatePageTitle( 'Choose where you want us to build your site.' );
+	}
+
+	/**
+	 * Validates that the confirmation modal is being shown.
+	 */
+	async validateConfirmationBox(): Promise< void > {
+		await this.validatePageTitle( 'Site Reset Confirmation' );
 	}
 
 	/**
 	 * Validates that we've landed on the checkout page.
 	 */
 	async validateCheckoutPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.checkoutContainer, { timeout: 60000 } );
+		await this.page.waitForSelector( selectors.checkoutHeader, { timeout: 60000 } );
 	}
 
 	/**
@@ -111,5 +138,55 @@ export class DIFMFlow {
 		if ( typeof tagline !== 'undefined' ) {
 			await this.page.fill( selectors.taglineInput, tagline );
 		}
+	}
+
+	/**
+	 * Enter the links to social media profiles.
+	 *
+	 * @param {string} twitter The link to a twitter profile.
+	 */
+	async enterSocial( twitter: string ): Promise< void > {
+		await this.page.fill( selectors.twitterInput, twitter );
+	}
+
+	/**
+	 * Select one of the page designs offered.
+	 *
+	 * @param {string} name The name of the page design
+	 */
+	async selectPage( name: string ): Promise< void > {
+		await this.page.click( selectors.pageOption( name ) );
+	}
+
+	/**
+	 * Choose the first free design offered.
+	 */
+	async chooseFreeDesign(): Promise< void > {
+		await this.page.click( selectors.freeDesignButton );
+	}
+
+	/**
+	 * Search the existing pages available to be replaced.
+	 *
+	 * @param {string} text The search text
+	 */
+	async searchForSite( text: string ): Promise< void > {
+		await this.page.fill( selectors.searchBar, text );
+	}
+
+	/**
+	 * Select one of the pages available to be replaced.
+	 *
+	 * @param {string} title The title of the site to be selected.
+	 */
+	async selectSite( title: string ): Promise< void > {
+		await this.page.click( selectors.siteItem( title ) );
+	}
+
+	/**
+	 * Confirm the deletion by entering DELETE into the text box.
+	 */
+	async confirmDeletion(): Promise< void > {
+		await this.page.fill( selectors.confirmationInput, 'DELETE' );
 	}
 }

--- a/packages/calypso-e2e/src/lib/flows/difm-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/difm-flow.ts
@@ -17,7 +17,7 @@ const selectors = {
 	freeDesignButton: 'button[data-e2e-button=freeOption]',
 
 	//Page picker page
-	pageOption: ( text: string ) => `div.css-1wedqbn:has-text("${ text }")`,
+	pageOption: ( text: string ) => `img:above(div:has-text("${ text }"))`,
 
 	// Checkout page
 	checkoutHeader: '.checkout-step__header:has-text("Your order")',
@@ -29,6 +29,10 @@ const selectors = {
 	// Confirmation box
 	confirmationInput: 'input#confirmTextChangeInput',
 };
+
+export interface SocialProfiles {
+	twitter?: string;
+}
 
 /**
  * Class encapsulating the flow when starting a new do-it-for-me site order.
@@ -143,10 +147,12 @@ export class DIFMFlow {
 	/**
 	 * Enter the links to social media profiles.
 	 *
-	 * @param {string} twitter The link to a twitter profile.
+	 * @param {SocialProfiles} [profiles] The link to a twitter profile.
 	 */
-	async enterSocial( twitter: string ): Promise< void > {
-		await this.page.fill( selectors.twitterInput, twitter );
+	async enterSocial( profiles: SocialProfiles ): Promise< void > {
+		if ( typeof profiles.twitter !== 'undefined' ) {
+			await this.page.fill( selectors.twitterInput, profiles.twitter );
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/difm-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/difm-flow.ts
@@ -9,11 +9,20 @@ const selectors = {
 	startContainer: '.signup.is-do-it-for-me',
 
 	// Options page
-	siteName: '#siteTitle',
-	tagline: '#tagline',
+	siteNameInput: '#siteTitle',
+	taglineInput: '#tagline',
 
 	// Social page
-	facebook: 'input[name=facebookUrl]',
+	facebookInput: 'input[name=facebookUrl]',
+
+	// Design page
+	designPickerContainer: '.design-picker',
+
+	//Page picker page
+	pagePickerContainer: '.signup__step .is-difm-page-picker',
+
+	// Checkout page
+	checkoutContainer: '.checkout__content',
 };
 
 /**
@@ -34,8 +43,6 @@ export class DIFMFlow {
 	 */
 	async clickButton( text: string ): Promise< void > {
 		const selector = selectors.button( text );
-
-		await this.page.waitForSelector( selector );
 		await this.page.click( selector );
 	}
 
@@ -49,7 +56,6 @@ export class DIFMFlow {
 			)
 		);
 		await this.validateSetupPage();
-		await this.clickButton( 'Start a new site' );
 	}
 
 	/**
@@ -63,14 +69,35 @@ export class DIFMFlow {
 	 * Validates that we've landed on the options page.
 	 */
 	async validateOptionsPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.siteName );
+		await this.page.waitForSelector( selectors.siteNameInput );
 	}
 
 	/**
 	 * Validates that we've landed on the social page.
 	 */
 	async validateSocialPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.facebook );
+		await this.page.waitForSelector( selectors.facebookInput );
+	}
+
+	/**
+	 * Validates that we've landed on the design picker page.
+	 */
+	async validateDesignPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.designPickerContainer );
+	}
+
+	/**
+	 * Validates that we've landed on the page picker page.
+	 */
+	async validatePagePickerPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.pagePickerContainer );
+	}
+
+	/**
+	 * Validates that we've landed on the checkout page.
+	 */
+	async validateCheckoutPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.checkoutContainer, { timeout: 60000 } );
 	}
 
 	/**
@@ -80,10 +107,9 @@ export class DIFMFlow {
 	 * @param {string} [tagline] An optional tagline.
 	 */
 	async enterOptions( name: string, tagline?: string ): Promise< void > {
-		await this.page.fill( selectors.siteName, name );
+		await this.page.fill( selectors.siteNameInput, name );
 		if ( typeof tagline !== 'undefined' ) {
-			await this.page.fill( selectors.tagline, tagline );
+			await this.page.fill( selectors.taglineInput, tagline );
 		}
-		await this.clickButton( 'Continue' );
 	}
 }

--- a/packages/calypso-e2e/src/lib/flows/index.ts
+++ b/packages/calypso-e2e/src/lib/flows/index.ts
@@ -4,3 +4,4 @@ export * from './close-account-flow';
 export * from './start-import-flow';
 export * from './start-site-flow';
 export * from './change-ui-language-flow';
+export * from './difm-flow';

--- a/test/e2e/specs/onboarding/signup__difm.ts
+++ b/test/e2e/specs/onboarding/signup__difm.ts
@@ -1,0 +1,40 @@
+/**
+ * @group calypso-pr
+ */
+
+import { DataHelper, DIFMFlow, TestAccount } from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Do it for me' ), () => {
+	let page: Page;
+	let difmFlow: DIFMFlow;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		difmFlow = new DIFMFlow( page );
+
+		const testAccount = new TestAccount( 'defaultUser' );
+		await testAccount.authenticate( page );
+	} );
+
+	/**
+	 * Navigate to initial setup page.
+	 */
+	const navigateToLanding = () => {
+		it( `Navigate to Setup page`, async () => {
+			await difmFlow.startSetup();
+			await difmFlow.validateOptionsPage();
+		} );
+	};
+
+	describe( 'Follow the WordPress import flow', () => {
+		navigateToLanding();
+
+		it( 'Start a WordPress import', async () => {
+			await difmFlow.enterOptions( 'Test Site', 'Just a little test' );
+			await difmFlow.validateSocialPage();
+		} );
+	} );
+} );

--- a/test/e2e/specs/onboarding/signup__difm.ts
+++ b/test/e2e/specs/onboarding/signup__difm.ts
@@ -2,7 +2,7 @@
  * @group calypso-pr
  */
 
-import { DataHelper, DIFMFlow, TestAccount } from '@automattic/calypso-e2e';
+import { DataHelper, DIFMFlow, CartCheckoutPage, TestAccount } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
 declare const browser: Browser;
@@ -10,10 +10,12 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Do it for me' ), () => {
 	let page: Page;
 	let difmFlow: DIFMFlow;
+	let cart: CartCheckoutPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		difmFlow = new DIFMFlow( page );
+		cart = new CartCheckoutPage( page );
 
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
@@ -24,8 +26,8 @@ describe( DataHelper.createSuiteTitle( 'Do it for me' ), () => {
 	 */
 	const navigateToLanding = () => {
 		it( `Navigate to landing page`, async () => {
-			await difmFlow.startSetup();
-			await difmFlow.validateSetupPage();
+			await difmFlow.visitSetup();
+			await difmFlow.validateStartPage();
 		} );
 	};
 
@@ -43,19 +45,44 @@ describe( DataHelper.createSuiteTitle( 'Do it for me' ), () => {
 			await difmFlow.validateSocialPage();
 		} );
 
-		it( 'Skip the social page', async () => {
-			await difmFlow.clickButton( 'Skip' );
+		it( 'Fill out the social page', async () => {
+			await difmFlow.enterSocial( 'https://twitter.com/automattic' );
+			await difmFlow.clickButton( 'Continue' );
 			await difmFlow.validateDesignPage();
 		} );
 
-		it( 'Let the team chose the layout', async () => {
-			await difmFlow.clickButton( 'Let us choose' );
+		it( 'Choose one of the free designs', async () => {
+			await difmFlow.chooseFreeDesign();
 			await difmFlow.validatePagePickerPage();
 		} );
 
 		it( 'Proceed to Checkout', async () => {
+			await difmFlow.selectPage( 'Blog' );
+			await difmFlow.selectPage( 'Services' );
 			await difmFlow.clickButton( 'Go to Checkout' );
 			await difmFlow.validateCheckoutPage();
+			await cart.validateCartItem( 'Do It For Me' );
+		} );
+	} );
+
+	describe( 'Use existing page for DIFM', () => {
+		navigateToLanding();
+
+		it( 'Start a DIFM order for an existing site', async () => {
+			await difmFlow.clickButton( 'Select a site' );
+			await difmFlow.validateUseExistingPage();
+		} );
+
+		it( 'Search and select an existing site', async () => {
+			await difmFlow.searchForSite( 'Test Site' );
+			await difmFlow.selectSite( 'Test Site' );
+			await difmFlow.validateConfirmationBox();
+		} );
+
+		it( 'Confirm and delete existing site', async () => {
+			await difmFlow.confirmDeletion();
+			await difmFlow.clickButton( 'Delete site content' );
+			await difmFlow.validateOptionsPage();
 		} );
 	} );
 } );

--- a/test/e2e/specs/onboarding/signup__difm.ts
+++ b/test/e2e/specs/onboarding/signup__difm.ts
@@ -23,18 +23,39 @@ describe( DataHelper.createSuiteTitle( 'Do it for me' ), () => {
 	 * Navigate to initial setup page.
 	 */
 	const navigateToLanding = () => {
-		it( `Navigate to Setup page`, async () => {
+		it( `Navigate to landing page`, async () => {
 			await difmFlow.startSetup();
-			await difmFlow.validateOptionsPage();
+			await difmFlow.validateSetupPage();
 		} );
 	};
 
-	describe( 'Follow the WordPress import flow', () => {
+	describe( 'Follow the default DIFM order flow', () => {
 		navigateToLanding();
 
-		it( 'Start a WordPress import', async () => {
+		it( 'Start a DIFM order for a new site', async () => {
+			await difmFlow.clickButton( 'start a new site' );
+			await difmFlow.validateOptionsPage();
+		} );
+
+		it( 'Enter relevant information', async () => {
 			await difmFlow.enterOptions( 'Test Site', 'Just a little test' );
+			await difmFlow.clickButton( 'Continue' );
 			await difmFlow.validateSocialPage();
+		} );
+
+		it( 'Skip the social page', async () => {
+			await difmFlow.clickButton( 'Skip' );
+			await difmFlow.validateDesignPage();
+		} );
+
+		it( 'Let the team chose the layout', async () => {
+			await difmFlow.clickButton( 'Let us choose' );
+			await difmFlow.validatePagePickerPage();
+		} );
+
+		it( 'Proceed to Checkout', async () => {
+			await difmFlow.clickButton( 'Go to Checkout' );
+			await difmFlow.validateCheckoutPage();
 		} );
 	} );
 } );

--- a/test/e2e/specs/onboarding/signup__difm.ts
+++ b/test/e2e/specs/onboarding/signup__difm.ts
@@ -46,7 +46,7 @@ describe( DataHelper.createSuiteTitle( 'Do it for me' ), () => {
 		} );
 
 		it( 'Fill out the social page', async () => {
-			await difmFlow.enterSocial( 'https://twitter.com/automattic' );
+			await difmFlow.enterSocial( { twitter: 'https://twitter.com/automattic' } );
 			await difmFlow.clickButton( 'Continue' );
 			await difmFlow.validateDesignPage();
 		} );
@@ -56,9 +56,12 @@ describe( DataHelper.createSuiteTitle( 'Do it for me' ), () => {
 			await difmFlow.validatePagePickerPage();
 		} );
 
-		it( 'Proceed to Checkout', async () => {
+		it( 'Select multiple new pages', async () => {
 			await difmFlow.selectPage( 'Blog' );
 			await difmFlow.selectPage( 'Services' );
+		} );
+
+		it( 'Proceed to Checkout', async () => {
 			await difmFlow.clickButton( 'Go to Checkout' );
 			await difmFlow.validateCheckoutPage();
 			await cart.validateCartItem( 'Do It For Me' );


### PR DESCRIPTION
## Changes proposed in this Pull Request

This is an end-to-end test for the new do-it-for-me feature. It goes through the flow of ordering a new site from WordPress using this option. It is using a flow since it is comprised of multiple pages that all are part of this single DIFM process. It is using the default path with no additional options chosen.

## Steps

1. Go to the DIFM landing page
2. Chose to build a new site
3. Enter all the relevant information
4. Skip the social page
5. Let the team decide on the theme
6. Leave the pages on default and proceed to checkout
7. Verify that you arrived at the checkout