### PR TITLE
Sending transfer domain choosers straight to the plans page

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { localize } from 'i18n-calypso';
+import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
@@ -14,6 +14,11 @@ class ReskinSideExplainer extends Component {
 		let title;
 		let subtitle;
 		let ctaText;
+
+		const showNewTransferCard =
+			i18n.hasTranslation(
+				'Choose the WordPress Pro plan on the next page to connect the domain you own to your new WordPress.com site.'
+			) || 'en' === getLocaleSlug();
 
 		// The special case latter is for handling the case in the sign-up flow.
 		// By that time, a site is not available yet, so we can only check the feature flag for now
@@ -44,9 +49,16 @@ class ReskinSideExplainer extends Component {
 
 			case 'use-your-domain':
 				title = translate( 'Already own a domain?' );
-				subtitle = translate(
-					'Connect your domain purchased elsewhere to your WordPress.com site through mapping or transfer.'
-				);
+				subtitle = showNewTransferCard
+					? translate(
+							'Choose the {{b}}WordPress Pro{{/b}} plan on the next page to connect the domain you own to your new WordPress.com site.',
+							{
+								components: { b: <strong /> },
+							}
+					  )
+					: translate(
+							'Connect your domain purchased elsewhere to your WordPress.com site through mapping or transfer.'
+					  );
 				ctaText = translate( 'Use a domain I own' );
 				break;
 
@@ -63,11 +75,11 @@ class ReskinSideExplainer extends Component {
 				break;
 		}
 
-		return { title, subtitle, ctaText };
+		return { title, subtitle, ctaText, showNewTransferCard };
 	}
 
 	render() {
-		const { title, subtitle, ctaText } = this.getStrings();
+		const { title, subtitle, ctaText, showNewTransferCard } = this.getStrings();
 
 		return (
 			/* eslint-disable jsx-a11y/click-events-have-key-events */
@@ -79,7 +91,7 @@ class ReskinSideExplainer extends Component {
 						<span
 							className="reskin-side-explainer__cta-text"
 							role="button"
-							onClick={ this.props.onClick }
+							onClick={ showNewTransferCard ? this.props.skipOption : this.props.onClick }
 							tabIndex="0"
 						>
 							{ ctaText }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -442,6 +442,7 @@ class DomainsStep extends Component {
 					<div className="domains__domain-side-content">
 						<ReskinSideExplainer
 							onClick={ this.handleUseYourDomainClick }
+							skipOption={ this.handleDomainExplainerClick }
 							type={ 'use-your-domain' }
 						/>
 					</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the transfer copy on the domain step in signup and also points the link to the plans page instead of the transfer domain flow.
* The reason for this change is because that link gets clicked 5,000+ times per day and the flow is a bit confusing. It would be better for the user to go through the transfer exercise within the product rather than during signup.

Here's a screenshot of the updated page:
![CleanShot 2022-04-08 at 13 42 10@2x](https://user-images.githubusercontent.com/35781181/162494125-5e5b6da2-b4ea-4392-a1c2-c24d31fc9e8c.png)


#### Testing instructions

* Check out this PR and start Calypso.
* Navigate to the domain step in signup.
* Click the "Use a domain I own" link.
* Confirm that you're taken to the Plans step and that clicking the Pro plan takes you to checkout.
* 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
