### PR TITLE
Plans: Handle case where there is no highestPlan and planProperties is empty

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -209,7 +209,7 @@ export class PlanFeatures extends Component {
 	higherPlanAvailable() {
 		const currentPlan = get( this.props, 'sitePlan.product_slug', '' );
 		const highestPlan = last( this.props.planProperties );
-		return currentPlan !== highestPlan.planName && highestPlan.availableForPurchase;
+		return currentPlan !== highestPlan?.planName && highestPlan?.availableForPurchase;
 	}
 
 	renderCreditNotice() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a quick fix for a fatal error that will be thrown by the plans page theme upsell if there is no highest plan (the `planProperties` prop is empty) when rendering credits. You can find this page by clicking the upsell link on the Themes page:

<img width="983" alt="Screen Shot 2022-04-08 at 2 42 18 PM" src="https://user-images.githubusercontent.com/2036909/162502346-51e2c619-f76e-48e4-8933-68d0b077b9d7.png">

It's possible that this is unexpected behavior that `planProperties` is empty, but I'm not really sure the context of that prop and it seems wise to support a fallback that will not crash.

I think that the actual issue is that [this array](https://github.com/Automattic/wp-calypso/blob/0e83a621a1bf8640240e763afe4417566a89cbf4/client/my-sites/plans-features-main/index.jsx#L265-L274) does not include the Pro plan, but I don't know enough about all that logic to fix it (just adding the Pro plan there causes other errors).

Props to @cuemarie for finding this!

Before:

<img width="672" alt="Screen Shot 2022-04-08 at 2 33 21 PM" src="https://user-images.githubusercontent.com/2036909/162501049-1c85f961-7bbc-4fe5-a4c5-ecfb64b59123.png">


After:

<img width="673" alt="Screen Shot 2022-04-08 at 2 32 50 PM" src="https://user-images.githubusercontent.com/2036909/162500980-5eb50c80-dd5f-4458-80b8-027563ca27df.png">


#### Testing instructions

- Use a site which has a Premium plan.
- Visit `/plans/example.com?feature=upload-themes&plan=pro-plan`, replacing `example.com` with your site.
- Verify that the page loads without crashing.