### PR TITLE
Playwright: Editor Tracking -- Add initial block insertion event specs

### DIFF
--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 const VIEWPORT_NAMES = [ 'mobile', 'desktop' ] as const;
-const TEST_LOCALES = [
+export const TEST_LOCALES = [
 	'en',
 	'es',
 	'pt-br',

--- a/packages/calypso-e2e/src/index.ts
+++ b/packages/calypso-e2e/src/index.ts
@@ -3,12 +3,13 @@ export * as DataHelper from './data-helper';
 export * as ElementHelper from './element-helper';
 export * as MediaHelper from './media-helper';
 
-export { default as envVariables } from './env-variables';
+export { default as envVariables, TEST_LOCALES } from './env-variables';
 
 export * from './jest-conditionals';
 export * from './lib';
 export * from './email-client';
 export * from './totp-client';
 
+export type { TracksEvent, TracksEventProperties } from './types';
 export type { TestFile } from './media-helper';
 export type { PaymentDetails } from './data-helper';

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -666,9 +666,7 @@ export class EditorPage {
 		//
 		// Once https://github.com/Automattic/wp-calypso/issues/54421 is resolved,
 		// this listener can be removed.
-		this.page.once( 'dialog', async ( dialog ) => {
-			await dialog.accept();
-		} );
+		this.allowLeavingWithoutSaving();
 
 		await this.page.goto( url, { waitUntil: 'domcontentloaded' } );
 
@@ -785,6 +783,15 @@ export class EditorPage {
 
 		// Perform the actions and resolve promises.
 		await Promise.all( actions );
+	}
+
+	/**
+	 * Sets up a handler to accept the leave without saving warning.
+	 */
+	allowLeavingWithoutSaving(): void {
+		this.page.once( 'dialog', async ( dialog ) => {
+			await dialog.accept();
+		} );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/utils/editor-tracks-event-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/editor-tracks-event-manager.ts
@@ -28,6 +28,18 @@ export const createEventMatchingPredicate = (
 
 const sleep = async ( ms: number ) => new Promise( ( resolve ) => setTimeout( resolve, ms ) );
 
+interface EventSearchOptions {
+	/**
+	 * Any properties that must be present and matching for the event to match.
+	 */
+	matchingProperties?: TracksEventProperties;
+
+	/**
+	 * The number of milliseconds to wait to see if the Tracks event fires. Useful if the events are debounced.
+	 */
+	waitForEventMs?: number;
+}
+
 /**
  * A class wrapping the editor Tracks events monitored in the browser
  */
@@ -88,33 +100,90 @@ export class EditorTracksEventManager {
 	 * Checks if a given Tracks event fired by matching on event name and optionally event properties
 	 *
 	 * @param {string} name The name of the event we are searching for.
-	 * @param {Object} options Keyed valued parameter of options to modify searching.
-	 * @param {TracksEventProperties} options.matchingProperties Any properties that must be present and matching for the event to match.
-	 * @param {number} options.waitForEventMs The number of milliseconds to wait to see if the Tracks event fires. Useful if the events are debounced.
+	 * @param {EventSearchOptions} options Options to control searching for the event.
 	 * @returns True/false based on whether a matching event was found.
 	 */
-	async didEventFire(
-		name: string,
-		options?: { matchingProperties?: TracksEventProperties; waitForEventMs?: number }
-	): Promise< boolean > {
-		const isEventOnStack = async ( name: string, matchingProperties?: TracksEventProperties ) => {
+	async didEventFire( name: string, options?: EventSearchOptions ): Promise< boolean > {
+		const isEventOnStack = async () => {
 			const eventStack = await this.getAllEvents();
-			return eventStack.some( createEventMatchingPredicate( name, matchingProperties ) );
+			return eventStack.some( createEventMatchingPredicate( name, options?.matchingProperties ) );
 		};
-
-		const WAIT_INTERVAL_MS = 200;
+		const stopSearching = ( result: boolean ) => result;
 		const maxMstoWait = options?.waitForEventMs || 0;
+
+		const eventIsOnStack = await this.searchWithRetry( isEventOnStack, stopSearching, maxMstoWait );
+		return eventIsOnStack;
+	}
+
+	/**
+	 * Get the most Tracks event that matches the name and options provided.
+	 *
+	 * @param {string} name The name of the event we are searching for.
+	 * @param {EventSearchOptions} options Options to control searching for the event.
+	 * @returns The most recent matching Tracks event.
+	 * @throws If no matching Tracks event was found.
+	 */
+	async getMostRecentMatchingEvent(
+		name: string,
+		options?: EventSearchOptions
+	): Promise< TracksEvent > {
+		const findMostRecentEventOnStack = async () => {
+			const eventStack = await this.getAllEvents();
+			return eventStack.find( createEventMatchingPredicate( name, options?.matchingProperties ) );
+		};
+		const stopSearching = ( result: TracksEvent | undefined ) => !! result;
+		const maxMstoWait = options?.waitForEventMs || 0;
+
+		const mostRecentEvent = await this.searchWithRetry(
+			findMostRecentEventOnStack,
+			stopSearching,
+			maxMstoWait
+		);
+
+		if ( ! mostRecentEvent ) {
+			throw new Error(
+				`No Tracks event was found with provided name (${ name }) and matching properties.`
+			);
+		}
+
+		return mostRecentEvent;
+	}
+
+	/**
+	 * A shared private helper method for retrying an event search on a loop.
+	 *
+	 * Because Tracks events can be debounced, sometimes we'll need to wait and retry while searching.
+	 *
+	 * This supports generic typing because we could be looking for various things.
+	 * That means our result return type could vary: boolean, a single event, an array of events, etc.
+	 *
+	 * Because our event searching function could return a variety of types,
+	 * we need some way to translate those varied types to a boolean.
+	 * It's safer to be explicit rather than force the type conversion.
+	 * For example, an empty array is technically "truthy"!
+	 *
+	 * @param {Function} searchForEvent Function to do the event searching.
+	 * @param {Function} stopSearching Function to determine when to stop searching, based on the result of the search.
+	 * @param {number} maxMsToWait Max number of milliseconds to keep retrying.
+	 * @returns The result of the searchForEvent function after necessary retries.
+	 */
+	private async searchWithRetry< Result >(
+		searchForEvent: () => Promise< Result >,
+		stopSearching: ( result: Result ) => boolean,
+		maxMsToWait: number
+	): Promise< Result > {
+		const WAIT_INTERVAL_MS = 200;
 		let totalWaitedMs = 0;
 
 		// By doing an initial check and starting the loop with the wait,
 		// we avoid doing an extra, unnecessary wait at the end.
-		let eventIsOnStack = await isEventOnStack( name, options?.matchingProperties );
-		while ( ! eventIsOnStack && totalWaitedMs < maxMstoWait ) {
+		let result = await searchForEvent();
+		while ( ! stopSearching( result ) && totalWaitedMs < maxMsToWait ) {
 			await sleep( WAIT_INTERVAL_MS );
 			totalWaitedMs += WAIT_INTERVAL_MS;
-			eventIsOnStack = await isEventOnStack( name, options?.matchingProperties );
+			result = await searchForEvent();
 		}
 
-		return eventIsOnStack;
+		return result;
 	}
 }

--- a/packages/calypso-e2e/src/lib/utils/editor-tracks-event-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/editor-tracks-event-manager.ts
@@ -167,11 +167,11 @@ export class EditorTracksEventManager {
 	 * @param {number} maxMsToWait Max number of milliseconds to keep retrying.
 	 * @returns The result of the searchForEvent function after necessary retries.
 	 */
-	private async searchWithRetry< Result >(
-		searchForEvent: () => Promise< Result >,
-		stopSearching: ( result: Result ) => boolean,
+	private async searchWithRetry< SearchResult >(
+		searchForEvent: () => Promise< SearchResult >,
+		stopSearching: ( result: SearchResult ) => boolean,
 		maxMsToWait: number
-	): Promise< Result > {
+	): Promise< SearchResult > {
 		const WAIT_INTERVAL_MS = 200;
 		let totalWaitedMs = 0;
 

--- a/packages/calypso-e2e/src/types.d.ts
+++ b/packages/calypso-e2e/src/types.d.ts
@@ -5,7 +5,7 @@ export type Plans = typeof PlansArray[ number ];
 export const PlansArray = [ 'Free', 'Personal', 'Premium', 'Business', 'eCommerce' ] as const;
 
 // Because these types are ultimately accessed on "window", adding them here.
-interface TracksEventProperties {
+export interface TracksEventProperties {
 	[ key: string ]: boolean | number | string;
 }
 export type TracksEvent = [ string, TracksEventProperties ];

--- a/test/e2e/specs/editor-tracking/editor-tracking__block-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__block-events.ts
@@ -1,0 +1,145 @@
+/**
+ * @group gutenberg
+ */
+
+import {
+	DataHelper,
+	EditorPage,
+	envVariables,
+	getTestAccountByFeature,
+	envToFeatureKey,
+	PageTemplateModalComponent,
+	TestAccount,
+	EditorTracksEventManager,
+	TracksEventProperties,
+	SiteType,
+	TEST_LOCALES,
+} from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Editor tracking: Block-related events' ), function () {
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( features );
+
+	describe( 'wpcom_block_inserted', function () {
+		let page: Page;
+		let editorPage: EditorPage;
+		let editorTracksEventManager: EditorTracksEventManager;
+
+		beforeAll( async () => {
+			page = await browser.newPage();
+
+			const testAccount = new TestAccount( accountName );
+			await testAccount.authenticate( page );
+
+			editorTracksEventManager = new EditorTracksEventManager( page );
+			editorPage = new EditorPage( page, { target: features.siteType } );
+		} );
+
+		describe( 'Basic insertion and shared properties', function () {
+			it( 'Start a new post', async function () {
+				await editorPage.visit( 'post' );
+				await editorPage.waitUntilLoaded();
+				// We'll be exiting without saving.
+				editorPage.allowLeavingWithoutSaving();
+			} );
+
+			it( 'Insert a Heading block from the sidebar', async function () {
+				await editorPage.addBlockFromSidebar( 'Heading', '[aria-label="Block: Heading"]' );
+			} );
+
+			it( '"wpcom_block_inserted" event fires with expected block-related properties', async function () {
+				const eventDidFire = await editorTracksEventManager.didEventFire( 'wpcom_block_inserted', {
+					matchingProperties: {
+						block_name: 'core/heading',
+						blocks_replaced: false,
+						insert_method: 'header-inserter',
+						inner_block: false,
+					},
+				} );
+				expect( eventDidFire ).toBe( true );
+			} );
+
+			describe( 'Validating properties shared among events', function () {
+				// We're taking a different approach here and first finding the event, then checking properties one-by-one.
+				// This is done for two reasons:
+				//   1. We are validating a lot of shared, required properties. Granular failing is helpful.
+				//   2. For stability, some of these properties (e.g. blog_id) are best done with "soft" assertions.
+
+				// Our current list doesn't include GB english, which is on some of our test sites.
+				// Adding that here so we don't accidentally expand our i18n tests.
+				const expectedLocales = new Set( [ ...TEST_LOCALES, 'en-gb' ] );
+				const numericRegex = /^\d+$/;
+
+				let tracksEventProperties: TracksEventProperties;
+				beforeAll( async function () {
+					[ , tracksEventProperties ] = await editorTracksEventManager.getMostRecentMatchingEvent(
+						'wpcom_block_inserted'
+					);
+				} );
+
+				it( '"editor_type" is "post"', async function () {
+					expect( tracksEventProperties.editor_type ).toBe( 'post' );
+				} );
+
+				it( '"post_type" is "post"', async function () {
+					expect( tracksEventProperties.post_type ).toBe( 'post' );
+				} );
+
+				it( '"blog_id" is a numeric value', async function () {
+					expect( numericRegex.test( tracksEventProperties.blog_id ) ).toBe( true );
+				} );
+
+				it( '"site_type" matches the current site type', async function () {
+					const expectedSiteType: SiteType = envVariables.TEST_ON_ATOMIC ? 'atomic' : 'simple';
+					expect( tracksEventProperties.site_type ).toBe( expectedSiteType );
+				} );
+
+				it( '"user_locale" is a valid locale', async function () {
+					expect( expectedLocales.has( tracksEventProperties.user_locale ) ).toBe( true );
+				} );
+
+				it( '"blog_tz" is a numeric value', async function () {
+					expect( numericRegex.test( tracksEventProperties.blog_tz ) ).toBe( true );
+				} );
+
+				it( '"user_lang" is a valid locale', async function () {
+					expect( expectedLocales.has( tracksEventProperties.user_lang ) ).toBe( true );
+				} );
+
+				it( '"blog_lang" is a valid locale', async function () {
+					expect( expectedLocales.has( tracksEventProperties.blog_lang ) ).toBe( true );
+				} );
+			} );
+		} );
+
+		describe( 'Added from a page template', function () {
+			it( 'Start a new page', async function () {
+				await editorPage.visit( 'page' );
+				await editorPage.waitUntilLoaded();
+				// We'll be leaving without saving here too.
+				editorPage.allowLeavingWithoutSaving();
+			} );
+
+			it( 'Clear the current Tracks events for a clean slate', async function () {
+				await editorTracksEventManager.clearEvents();
+			} );
+
+			it( 'Add "Two column about me layout" page template', async function () {
+				const editorFrame = await editorPage.getEditorHandle();
+				const pageTemplateModalComponent = new PageTemplateModalComponent( editorFrame, page );
+				await pageTemplateModalComponent.selectTemplateCatagory( 'About' );
+				await pageTemplateModalComponent.selectTemplate( 'Two column about me layout' );
+			} );
+
+			it( '"wpcom_block_inserted" event fires with "from_template_selector" set to true', async function () {
+				const eventDidFire = await editorTracksEventManager.didEventFire( 'wpcom_block_inserted', {
+					matchingProperties: { from_template_selector: true },
+				} );
+				expect( eventDidFire ).toBe( true );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Background test plan map: pciE2j-QC-p2

This adds the `wpcom_block_inserted` event specs that don't rely on the full site editor. 

#### Testing instructions

- [x] Gutenberg desktop passes
- [x] Gutenberg mobile passes

Related to #