### PR TITLE
Plugins: Check site type when defining shouldUpgrade const

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -54,9 +54,10 @@ const PluginDetailsCTA = ( {
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
 	const isFreePlan = selectedSite && isFreePlanProduct( selectedSite.plan );
 
-	const shouldUpgrade = useSelector(
-		( state ) => ! hasActiveSiteFeature( state, selectedSite?.ID, FEATURE_INSTALL_PLUGINS )
-	);
+	const shouldUpgrade =
+		useSelector(
+			( state ) => ! hasActiveSiteFeature( state, selectedSite?.ID, FEATURE_INSTALL_PLUGINS )
+		) && ! isJetpackSelfHosted;
 
 	// Eligibilities for Simple Sites.
 	const { eligibilityHolds, eligibilityWarnings } = useSelector( ( state ) =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We are not checking the site type when defining if the site is should be upgraded (`shouldUpgrade` constant). It results out that we are offering an upgrade even for self-hosted sites.
This PR takes in consideration the site type when defining the `shouldUpgrade` constant.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with a self-hosted Jetpack site
* Go to Plugins page
* Search a free plugin, for instance google site kit. (`http://calypso.localhost:3000/plugins/google-site-kit/your-testing-site`)
* Before this change, confirm you see the upgrade site option
* with these changes, it shows as Free

before | after
------|------
<img width="538" alt="image" src="https://user-images.githubusercontent.com/77539/162518050-58c4c1a3-2cf4-48f1-bd92-417c564b12d6.png">| <img width="484" alt="image" src="https://user-images.githubusercontent.com/77539/162518069-b706022b-be0f-4c3a-87e3-eb34b674da26.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
