### PR TITLE
Mini-cart: Fix scrollbar styles

### DIFF
--- a/packages/mini-cart/src/mini-cart-line-items.tsx
+++ b/packages/mini-cart/src/mini-cart-line-items.tsx
@@ -20,6 +20,10 @@ const MiniCartLineItemsWrapper = styled.ul< { theme?: Theme } >`
 	padding: 0;
 	overflow-y: auto;
 	max-height: 50vh;
+	scrollbar-color: var( --color-text, #000 ) var( --color-surface, #fff );
+	&::-webkit-scrollbar {
+		background: var( --color-surface, #fff );
+	}
 `;
 
 const MiniCartLineItemWrapper = styled.li`

--- a/packages/mini-cart/src/mini-cart-line-items.tsx
+++ b/packages/mini-cart/src/mini-cart-line-items.tsx
@@ -21,9 +21,6 @@ const MiniCartLineItemsWrapper = styled.ul< { theme?: Theme } >`
 	overflow-y: auto;
 	max-height: 50vh;
 	scrollbar-color: var( --color-text, #000 ) var( --color-surface, #fff );
-	&::-webkit-scrollbar {
-		background: var( --color-surface, #fff );
-	}
 `;
 
 const MiniCartLineItemWrapper = styled.li`

--- a/packages/mini-cart/src/mini-cart-line-items.tsx
+++ b/packages/mini-cart/src/mini-cart-line-items.tsx
@@ -18,7 +18,7 @@ const MiniCartLineItemsWrapper = styled.ul< { theme?: Theme } >`
 	box-sizing: border-box;
 	margin: 20px 0;
 	padding: 0;
-	overflow-y: scroll;
+	overflow-y: auto;
 	max-height: 50vh;
 `;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The mini-cart used by calypso has an internal scrollable area for use in cases where the number of cart items exceeds the height of the viewport. However, depending on your OS settings, that scrollbar may be displayed even if the content is not very tall, and its basic appearance is often confusing and not very pleasing.

This PR makes two changes to the scrollable area:

1. It hides the scrollbar if the content does not require scrolling.
2. It makes the scrollbar background the same color as the popover background (in Firefox; Chrome/Safari scrollbars already look ok).

Before:

<img width="489" alt="Screen Shot 2022-04-08 at 5 11 14 PM" src="https://user-images.githubusercontent.com/2036909/162532111-bde8542c-ce48-4e83-9c6f-af2b0c3743f7.png">

After, small height, Chrome:

<img width="491" alt="Screen Shot 2022-04-08 at 5 11 01 PM" src="https://user-images.githubusercontent.com/2036909/162532158-7762c7fd-e6a4-4bf0-9fce-7bd2b3d01596.png">

After, small height, Firefox:

<img width="493" alt="Screen Shot 2022-04-08 at 5 34 27 PM" src="https://user-images.githubusercontent.com/2036909/162535210-cf66e87b-1ea3-4010-abae-51cb86b856e0.png">

After, tall height, Chrome:

<img width="494" alt="Screen Shot 2022-04-08 at 5 32 24 PM" src="https://user-images.githubusercontent.com/2036909/162535062-e2a75d8e-ba8c-436e-8069-b829492b261b.png">

After, tall height, Firefox:

<img width="488" alt="Screen Shot 2022-04-08 at 5 32 38 PM" src="https://user-images.githubusercontent.com/2036909/162535083-7dc83220-ee68-4043-9909-cb718a0439af.png">

Fixes https://github.com/Automattic/wp-calypso/issues/60360

#### Testing instructions

First you need to make sure scrollbars are always visible on your OS. If you are using the MacOS and want to reproduce this, visit System Preferences and click "Always" next to "Show scroll bars":

<img width="658" alt="Screen Shot 2022-04-08 at 4 42 52 PM" src="https://user-images.githubusercontent.com/2036909/162527362-80bec21b-bd31-4d46-b1d6-09870eca7554.png">

Next, visit calypso, add a product to your cart, and leave checkout without clearing the cart.

Click on the masterbar cart icon to display the mini-cart.

<img width="633" alt="Screen_Shot_2022-04-08_at_5_11_26_PM" src="https://user-images.githubusercontent.com/2036909/162532335-31536788-3f83-4cb5-987a-194b27bd2312.png">

Verify that the scrollbar looks like the screenshots above.
