### PR TITLE
Jetpack pricing page test - focus on intro price in product cards

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
@@ -29,6 +29,8 @@ type OwnProps = {
 	originalPrice?: number;
 	productName: TranslateResult;
 	tooltipText?: TranslateResult | ReactNode;
+	isPricingPageTreatment202204?: boolean;
+	isPricingPageTest202204Loading?: boolean;
 };
 
 const DisplayPrice: React.FC< OwnProps > = ( {
@@ -48,6 +50,8 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 	pricesAreFetching,
 	productName,
 	tooltipText,
+	isPricingPageTreatment202204,
+	isPricingPageTest202204Loading,
 } ) => {
 	if ( isDeprecated ) {
 		return <Deprecated productName={ productName } />;
@@ -81,6 +85,8 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 			displayFrom={ displayFrom }
 			tooltipText={ tooltipText }
 			expiryDate={ expiryDate }
+			isPricingPageTreatment202204={ isPricingPageTreatment202204 }
+			isPricingPageTest202204Loading={ isPricingPageTest202204Loading }
 		/>
 	);
 };

--- a/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/index.tsx
@@ -30,7 +30,7 @@ type OwnProps = {
 	productName: TranslateResult;
 	tooltipText?: TranslateResult | ReactNode;
 	isPricingPageTreatment202204?: boolean;
-	isPricingPageTest202204Loading?: boolean;
+	isPricingPageTest202204AssignmentLoading?: boolean;
 };
 
 const DisplayPrice: React.FC< OwnProps > = ( {
@@ -51,7 +51,7 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 	productName,
 	tooltipText,
 	isPricingPageTreatment202204,
-	isPricingPageTest202204Loading,
+	isPricingPageTest202204AssignmentLoading,
 } ) => {
 	if ( isDeprecated ) {
 		return <Deprecated productName={ productName } />;
@@ -86,7 +86,7 @@ const DisplayPrice: React.FC< OwnProps > = ( {
 			tooltipText={ tooltipText }
 			expiryDate={ expiryDate }
 			isPricingPageTreatment202204={ isPricingPageTreatment202204 }
-			isPricingPageTest202204Loading={ isPricingPageTest202204Loading }
+			isPricingPageTest202204AssignmentLoading={ isPricingPageTest202204AssignmentLoading }
 		/>
 	);
 };

--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -1,4 +1,4 @@
-import { TranslateResult } from 'i18n-calypso';
+import { translate, TranslateResult } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import TimeFrame from './time-frame';
@@ -15,6 +15,8 @@ type OwnProps = {
 	displayFrom?: boolean;
 	tooltipText?: TranslateResult | ReactNode;
 	expiryDate?: Moment;
+	isPricingPageTreatment202204?: boolean;
+	isPricingPageTest202204Loading?: boolean;
 };
 
 const Paid: React.FC< OwnProps > = ( {
@@ -26,11 +28,13 @@ const Paid: React.FC< OwnProps > = ( {
 	displayFrom,
 	tooltipText,
 	expiryDate,
+	isPricingPageTreatment202204,
+	isPricingPageTest202204Loading,
 } ) => {
 	const finalPrice = discountedPrice ?? originalPrice;
 
 	// Placeholder (while prices are loading)
-	if ( ! currencyCode || ! originalPrice || pricesAreFetching ) {
+	if ( ! currencyCode || ! originalPrice || pricesAreFetching || isPricingPageTest202204Loading ) {
 		return (
 			<>
 				<PlanPrice
@@ -47,14 +51,42 @@ const Paid: React.FC< OwnProps > = ( {
 	}
 
 	const renderDiscountedPrice = () => {
+		/*
+		 * Price should be displayed from left-to-right, even in right-to-left
+		 * languages. `PlanPrice` seems to keep the ltr direction no matter
+		 * what when seen in the dev docs page, but somehow it doesn't in
+		 * the pricing page.
+		 */
+		if ( isPricingPageTreatment202204 ) {
+			return (
+				<>
+					<span dir="ltr">
+						<PlanPrice
+							discounted
+							className="display-price__discounted-price"
+							rawPrice={ finalPrice as number }
+							currencyCode={ currencyCode }
+							displayShortPerMonthNotation
+						/>
+					</span>
+					<br />
+					<span dir="ltr">
+						<PlanPrice
+							original
+							className="display-price__original-price display-price__original-price-small"
+							rawPrice={ originalPrice as number }
+							currencyCode={ currencyCode }
+							originalPricePrefix={ translate( 'Normally', {
+								comment: 'A way to describe a price before a discount is applied',
+							} ) }
+						/>
+					</span>
+				</>
+			);
+		}
+
 		return (
 			<>
-				{ /*
-				 * Price should be displayed from left-to-right, even in right-to-left
-				 * languages. `PlanPrice` seems to keep the ltr direction no matter
-				 * what when seen in the dev docs page, but somehow it doesn't in
-				 * the pricing page.
-				 */ }
 				<span dir="ltr">
 					<PlanPrice
 						original
@@ -88,7 +120,9 @@ const Paid: React.FC< OwnProps > = ( {
 					{ tooltipText }
 				</InfoPopover>
 			) }
-			<TimeFrame expiryDate={ expiryDate } billingTerm={ billingTerm } />
+			{ ! isPricingPageTreatment202204 && (
+				<TimeFrame expiryDate={ expiryDate } billingTerm={ billingTerm } />
+			) }
 		</>
 	);
 };

--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -81,7 +81,7 @@ const Paid: React.FC< OwnProps > = ( {
 							className="display-price__original-price display-price__original-price-small"
 							rawPrice={ originalPrice as number }
 							currencyCode={ currencyCode }
-							originalPricePrefix={ translate( 'Normally', {
+							originalPricePrefix={ translate( 'normally', {
 								comment: 'A way to describe a price before a discount is applied',
 							} ) }
 						/>

--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -16,7 +16,7 @@ type OwnProps = {
 	tooltipText?: TranslateResult | ReactNode;
 	expiryDate?: Moment;
 	isPricingPageTreatment202204?: boolean;
-	isPricingPageTest202204Loading?: boolean;
+	isPricingPageTest202204AssignmentLoading?: boolean;
 };
 
 const Paid: React.FC< OwnProps > = ( {
@@ -29,12 +29,17 @@ const Paid: React.FC< OwnProps > = ( {
 	tooltipText,
 	expiryDate,
 	isPricingPageTreatment202204,
-	isPricingPageTest202204Loading,
+	isPricingPageTest202204AssignmentLoading,
 } ) => {
 	const finalPrice = discountedPrice ?? originalPrice;
 
 	// Placeholder (while prices are loading)
-	if ( ! currencyCode || ! originalPrice || pricesAreFetching || isPricingPageTest202204Loading ) {
+	if (
+		! currencyCode ||
+		! originalPrice ||
+		pricesAreFetching ||
+		isPricingPageTest202204AssignmentLoading
+	) {
 		return (
 			<>
 				<PlanPrice

--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -42,12 +42,7 @@ const Paid: React.FC< OwnProps > = ( {
 	) {
 		return (
 			<>
-				<PlanPrice
-					original
-					className="display-price__original-price"
-					rawPrice={ 0.01 }
-					currencyCode={ '$' }
-				/>
+				<PlanPrice original className="display-price__original-price" />
 				{ /* Remove this secondary <PlanPrice/> placeholder if we're not showing discounted prices */ }
 				<PlanPrice discounted rawPrice={ 0.01 } currencyCode={ '$' } />
 				<TimeFrame expiryDate={ expiryDate } billingTerm={ billingTerm } />

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -46,7 +46,7 @@ type OwnProps = {
 	scrollCardIntoView?: ScrollCardIntoViewCallback;
 	collapseFeaturesOnMobile?: boolean;
 	isPricingPageTreatment202204?: boolean;
-	isPricingPageTest202204Loading?: boolean;
+	isPricingPageTest202204AssignmentLoading?: boolean;
 	belowButtonText?: string;
 };
 
@@ -89,7 +89,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 	scrollCardIntoView,
 	collapseFeaturesOnMobile,
 	isPricingPageTreatment202204,
-	isPricingPageTest202204Loading,
+	isPricingPageTest202204AssignmentLoading,
 	belowButtonText,
 } ) => {
 	const isFree = item.isFree;
@@ -182,7 +182,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 						productName={ item.displayName }
 						hideSavingLabel={ hideSavingLabel }
 						isPricingPageTreatment202204={ isPricingPageTreatment202204 }
-						isPricingPageTest202204Loading={ isPricingPageTest202204Loading }
+						isPricingPageTest202204AssignmentLoading={ isPricingPageTest202204AssignmentLoading }
 					/>
 				) }
 

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -45,6 +45,9 @@ type OwnProps = {
 	showAbovePriceText?: boolean;
 	scrollCardIntoView?: ScrollCardIntoViewCallback;
 	collapseFeaturesOnMobile?: boolean;
+	isPricingPageTreatment202204?: boolean;
+	isPricingPageTest202204Loading?: boolean;
+	belowButtonText?: string;
 };
 
 type HeaderLevel = 1 | 2 | 3 | 4 | 5 | 6;
@@ -85,6 +88,9 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 	aboveButtonText = null,
 	scrollCardIntoView,
 	collapseFeaturesOnMobile,
+	isPricingPageTreatment202204,
+	isPricingPageTest202204Loading,
+	belowButtonText,
 } ) => {
 	const isFree = item.isFree;
 
@@ -128,6 +134,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 				'is-deprecated': isDeprecated,
 				'is-aligned': isAligned,
 				'is-featured': isFeatured,
+				'jetpack-discount-price-focused': isPricingPageTreatment202204,
 			} ) }
 			data-e2e-product-slug={ item.productSlug }
 		>
@@ -174,6 +181,8 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 						tooltipText={ tooltipText }
 						productName={ item.displayName }
 						hideSavingLabel={ hideSavingLabel }
+						isPricingPageTreatment202204={ isPricingPageTreatment202204 }
+						isPricingPageTest202204Loading={ isPricingPageTest202204Loading }
 					/>
 				) }
 
@@ -204,6 +213,9 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 					>
 						{ buttonLabel }
 					</Button>
+				) }
+				{ belowButtonText && (
+					<p className="jetpack-product-card__below-button">{ belowButtonText }</p>
 				) }
 
 				{ description && <p className="jetpack-product-card__description">{ description }</p> }

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -17,6 +17,8 @@ export class PlanPrice extends Component {
 			className,
 			displayFlatPrice,
 			displayPerMonthNotation,
+			displayShortPerMonthNotation,
+			originalPricePrefix,
 			isOnSale,
 			taxText,
 			translate,
@@ -88,30 +90,42 @@ export class PlanPrice extends Component {
 		const higherPriceHtml = priceRange[ 1 ] && renderPriceHtml( priceRange[ 1 ] );
 
 		return (
-			<h4 className={ classes }>
-				<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
-				{ ! higherPriceHtml && renderPriceHtml( priceRange[ 0 ] ) }
-				{ higherPriceHtml &&
-					translate( '{{smallerPrice/}}-{{higherPrice/}}', {
-						components: { smallerPrice: smallerPriceHtml, higherPrice: higherPriceHtml },
-						comment: 'The price range for a particular product',
-					} ) }
-				{ taxText && (
-					<sup className="plan-price__tax-amount">
-						{ translate( '(+%(taxText)s tax)', { args: { taxText } } ) }
-					</sup>
+			<>
+				{ originalPricePrefix && (
+					<span className="plan-price__original-price-prefix">{ originalPricePrefix }</span>
 				) }
-				{ displayPerMonthNotation && (
-					<span className="plan-price__term">
-						{ translate( 'per{{newline/}}month', {
-							components: { newline: <br /> },
-							comment:
-								'Displays next to the price. You can remove the "{{newline/}}" if it is not proper for your language.',
+				<h4 className={ classes }>
+					<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
+					{ ! higherPriceHtml && renderPriceHtml( priceRange[ 0 ] ) }
+					{ higherPriceHtml &&
+						translate( '{{smallerPrice/}}-{{higherPrice/}}', {
+							components: { smallerPrice: smallerPriceHtml, higherPrice: higherPriceHtml },
+							comment: 'The price range for a particular product',
 						} ) }
-					</span>
-				) }
-				{ isOnSale && <Badge>{ saleBadgeText }</Badge> }
-			</h4>
+					{ taxText && (
+						<sup className="plan-price__tax-amount">
+							{ translate( '(+%(taxText)s tax)', { args: { taxText } } ) }
+						</sup>
+					) }
+					{ displayPerMonthNotation && (
+						<span className="plan-price__term">
+							{ translate( 'per{{newline/}}month', {
+								components: { newline: <br /> },
+								comment:
+									'Displays next to the price. You can remove the "{{newline/}}" if it is not proper for your language.',
+							} ) }
+						</span>
+					) }
+					{ displayShortPerMonthNotation && (
+						<span className="plan-price__term-short">
+							{ translate( '/mo', {
+								comment: 'An abbreviated version of "per month"',
+							} ) }
+						</span>
+					) }
+					{ isOnSale && <Badge>{ saleBadgeText }</Badge> }
+				</h4>
+			</>
 		);
 	}
 }
@@ -128,6 +142,8 @@ PlanPrice.propTypes = {
 	taxText: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 	displayPerMonthNotation: PropTypes.bool,
+	displayShortPerMonthNotation: PropTypes.bool,
+	originalPricePrefix: PropTypes.string,
 	currencyFormatOptions: PropTypes.object,
 };
 
@@ -138,4 +154,6 @@ PlanPrice.defaultProps = {
 	className: '',
 	isOnSale: false,
 	displayPerMonthNotation: false,
+	displayShortPerMonthNotation: false,
+	originalPricePrefix: '',
 };

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -72,3 +72,72 @@
 	line-height: 1rem;
 	margin-left: 5px;
 }
+
+.jetpack-discount-price-focused {
+	.display-price {
+		.plan-price.is-discounted {
+			margin-bottom: -8px;
+
+			.plan-price__fraction {
+				font-size: 1.5rem;
+				margin-top: 0.25rem;
+			}
+		}
+	}
+
+	.display-price {
+		.plan-price.is-original {
+			color: var(--studio-gray-80);
+
+			.plan-price__integer, .plan-price__fraction, .plan-price__currency-symbol {
+				font-size: 0.875rem;
+				line-height: 1.2rem;
+			}
+
+			.plan-price__currency-symbol {
+				margin-top: 0;
+			}
+		}
+
+		.plan-price.is-original::before {
+			border-color: var(--studio-gray-80);
+			border-top-width: 1px;
+		}
+
+
+	}
+
+	.jetpack-product-card__heading {
+		margin: 0.75rem 0 0 0;
+	}
+
+	.jetpack-product-card__button {
+		margin-block-start: 24px;
+	}
+
+	.jetpack-product-card__below-button {
+		display: inline-block;
+		color: var(--studio-gray-60);
+		font-size: 0.875rem;
+		line-height: 1.2rem;
+	}
+
+	.plan-price__term-short {
+		display: inline-block;
+		font-size: 1.5rem;
+		text-align: left;
+		line-height: 3.375rem;
+		margin-left: 0;
+		margin-top: 0.25rem;
+		font-weight: 600;
+	}
+
+	.plan-price__original-price-prefix {
+		font-size: 0.875rem;
+		line-height: 1.2rem;
+		margin: 0 3px 0 6px;
+		color: var(--studio-gray-40);
+	}
+}
+
+

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -87,7 +87,7 @@
 
 	.display-price {
 		.plan-price.is-original {
-			color: var(--studio-gray-80);
+			color: var( --studio-gray-80 );
 
 			.plan-price__integer, .plan-price__fraction, .plan-price__currency-symbol {
 				font-size: 0.875rem;
@@ -100,7 +100,7 @@
 		}
 
 		.plan-price.is-original::before {
-			border-color: var(--studio-gray-80);
+			border-color: var( --studio-gray-80 );
 			border-top-width: 1px;
 		}
 
@@ -108,7 +108,7 @@
 	}
 
 	.jetpack-product-card__heading {
-		margin: 0.75rem 0 0 0;
+		margin: 0.75rem 0 0;
 	}
 
 	.jetpack-product-card__button {
@@ -117,7 +117,7 @@
 
 	.jetpack-product-card__below-button {
 		display: inline-block;
-		color: var(--studio-gray-60);
+		color: var( --studio-gray-60 );
 		font-size: 0.875rem;
 		line-height: 1.2rem;
 	}
@@ -136,8 +136,6 @@
 		font-size: 0.875rem;
 		line-height: 1.2rem;
 		margin: 0 3px 0 6px;
-		color: var(--studio-gray-40);
+		color: var( --studio-gray-40 );
 	}
 }
-
-

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -137,5 +137,6 @@
 		line-height: 1.2rem;
 		margin: 0 3px 0 6px;
 		color: var( --studio-gray-40 );
+		text-transform: capitalize;
 	}
 }

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -247,7 +247,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			isPricingPageTreatment202204={ isPricingPageTreatment202204 }
 			isPricingPageTest202204AssignmentLoading={ isPricingPageTest202204AssignmentLoading }
 			belowButtonText={
-				isPricingPageTreatment202204 ? translate( 'Renews at the normal rate.' ) : ''
+				isPricingPageTreatment202204 ? translate( 'Renews at the normal rate.' ).toString() : ''
 			}
 		/>
 	);

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -22,6 +22,7 @@ import OwnerInfo from 'calypso/me/purchases/purchase-item/owner-info';
 import { ITEM_TYPE_PLAN } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getUserOwnsPurchase } from 'calypso/state/purchases/selectors/get-user-owns-purchase';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import { getSiteAvailableProduct } from 'calypso/state/sites/products/selectors';
 import { isJetpackSiteMultiSite, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -254,15 +255,17 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			collapseFeaturesOnMobile={ collapseFeaturesOnMobile }
 			pricesAreFetching={ pricesAreFetching }
 			isPricingPageTreatment202204={ isPricingPageTreatment202204 }
-			isPricingPageTest202204Loading={ isLoadingExperimentAssignment }
+			isPricingPageTest202204AssignmentLoading={ isLoadingExperimentAssignment }
 			belowButtonText={ isPricingPageTreatment202204 ? 'Renews at the normal rate.' : '' }
 		/>
 	);
 };
 
 export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state ) ?? 0;
-	const currentRoute = getCurrentRouteParameterized( state, siteId );
+	const siteId = getSelectedSiteId( state );
+	const currentRoute = siteId
+		? getCurrentRouteParameterized( state, siteId )
+		: getCurrentRoute( state );
 
 	return {
 		isJetpackPricingPage:

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -10,25 +10,20 @@ import {
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import * as React from 'react';
-import { useSelector, connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import isSupersedingJetpackItem from 'calypso/../packages/calypso-products/src/is-superseding-jetpack-item';
 import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { useExperiment } from 'calypso/lib/explat';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isCloseToExpiration } from 'calypso/lib/purchases';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 import OwnerInfo from 'calypso/me/purchases/purchase-item/owner-info';
 import { ITEM_TYPE_PLAN } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getUserOwnsPurchase } from 'calypso/state/purchases/selectors/get-user-owns-purchase';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import { getSiteAvailableProduct } from 'calypso/state/sites/products/selectors';
-import { isJetpackSiteMultiSite, isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PlanRenewalMessage from '../plan-renewal-message';
 import useItemPrice from '../use-item-price';
 import productAboveButtonText from './product-above-button-text';
@@ -57,7 +52,8 @@ interface ProductCardProps {
 	hideSavingLabel?: boolean;
 	scrollCardIntoView?: ScrollCardIntoViewCallback;
 	collapseFeaturesOnMobile?: boolean;
-	isJetpackPricingPage?: boolean;
+	isPricingPageTreatment202204?: boolean;
+	isPricingPageTest202204AssignmentLoading?: boolean;
 }
 
 const ProductCard: React.FC< ProductCardProps > = ( {
@@ -73,7 +69,8 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 	hideSavingLabel,
 	scrollCardIntoView,
 	collapseFeaturesOnMobile,
-	isJetpackPricingPage,
+	isPricingPageTreatment202204,
+	isPricingPageTest202204AssignmentLoading,
 } ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
@@ -215,13 +212,6 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 		buttonLabel
 	);
 
-	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'calypso_jetpack_pricing_page_focus_on_intro_rate_202204_v1'
-	);
-
-	const isPricingPageTreatment202204 =
-		isJetpackPricingPage && experimentAssignment?.variationName === 'treatment';
-
 	return (
 		<JetpackProductCard
 			item={ item }
@@ -255,7 +245,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			collapseFeaturesOnMobile={ collapseFeaturesOnMobile }
 			pricesAreFetching={ pricesAreFetching }
 			isPricingPageTreatment202204={ isPricingPageTreatment202204 }
-			isPricingPageTest202204AssignmentLoading={ isLoadingExperimentAssignment }
+			isPricingPageTest202204AssignmentLoading={ isPricingPageTest202204AssignmentLoading }
 			belowButtonText={
 				isPricingPageTreatment202204 ? translate( 'Renews at the normal rate.' ) : ''
 			}
@@ -263,16 +253,4 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 	);
 };
 
-export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
-	const currentRoute = siteId
-		? getCurrentRouteParameterized( state, siteId )
-		: getCurrentRoute( state );
-
-	return {
-		isJetpackPricingPage:
-			( isJetpackCloud() && currentRoute === '/pricing' ) ||
-			( isJetpackSite( state, siteId ) && currentRoute === '/plans/:site' ) ||
-			currentRoute === '/jetpack/connect/store',
-	};
-} )( ProductCard );
+export default ProductCard;

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -22,11 +22,12 @@ import OwnerInfo from 'calypso/me/purchases/purchase-item/owner-info';
 import { ITEM_TYPE_PLAN } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getUserOwnsPurchase } from 'calypso/state/purchases/selectors/get-user-owns-purchase';
-import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import { getSiteAvailableProduct } from 'calypso/state/sites/products/selectors';
-import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
+import { isJetpackSiteMultiSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PlanRenewalMessage from '../plan-renewal-message';
 import useItemPrice from '../use-item-price';
 import productAboveButtonText from './product-above-button-text';
@@ -260,7 +261,13 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 };
 
 export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state ) ?? 0;
+	const currentRoute = getCurrentRouteParameterized( state, siteId );
+
 	return {
-		isJetpackPricingPage: isJetpackCloud() && getCurrentRoute( state ) === '/pricing',
+		isJetpackPricingPage:
+			( isJetpackCloud() && currentRoute === '/pricing' ) ||
+			( isJetpackSite( state, siteId ) && currentRoute === '/plans/:site' ) ||
+			currentRoute === '/jetpack/connect/store',
 	};
 } )( ProductCard );

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -256,7 +256,9 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			pricesAreFetching={ pricesAreFetching }
 			isPricingPageTreatment202204={ isPricingPageTreatment202204 }
 			isPricingPageTest202204AssignmentLoading={ isLoadingExperimentAssignment }
-			belowButtonText={ isPricingPageTreatment202204 ? 'Renews at the normal rate.' : '' }
+			belowButtonText={
+				isPricingPageTreatment202204 ? translate( 'Renews at the normal rate.' ) : ''
+			}
 		/>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -100,6 +100,8 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	onDurationChange,
 	scrollCardIntoView,
 	createButtonURL,
+	isPricingPageTreatment202204,
+	isPricingPageTest202204AssignmentLoading,
 } ) => {
 	const translate = useTranslate();
 	const isDesktop = useDesktopBreakpoint();
@@ -199,6 +201,8 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 				scrollCardIntoView={ scrollCardIntoView }
 				createButtonURL={ createButtonURL }
 				collapseFeaturesOnMobile
+				isPricingPageTreatment202204={ isPricingPageTreatment202204 }
+				isPricingPageTest202204AssignmentLoading={ isPricingPageTest202204AssignmentLoading }
 			/>
 		</li>
 	);
@@ -251,6 +255,10 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 									isFeatured={ isFeatured }
 									scrollCardIntoView={ scrollCardIntoView }
 									createButtonURL={ createButtonURL }
+									isPricingPageTreatment202204={ isPricingPageTreatment202204 }
+									isPricingPageTest202204AssignmentLoading={
+										isPricingPageTest202204AssignmentLoading
+									}
 								/>
 							</li>
 						);

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -16,6 +16,7 @@ import LicensingPromptDialog from 'calypso/components/jetpack/licensing-prompt-d
 import Main from 'calypso/components/main';
 import { MAIN_CONTENT_ID } from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useExperiment } from 'calypso/lib/explat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { EXTERNAL_PRODUCTS_LIST } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
@@ -32,7 +33,6 @@ import type {
 	SelectorProduct,
 	PurchaseCallback,
 } from 'calypso/my-sites/plans/jetpack-plans/types';
-
 import './style.scss';
 
 const SelectorPage: React.FC< SelectorPageProps > = ( {
@@ -183,6 +183,12 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 		( variation: Iterations | null ) => `jetpack-plans__iteration--${ variation ?? 'default' }`
 	);
 
+	// Set up pricing display test
+	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
+		'calypso_jetpack_pricing_page_focus_on_intro_rate_202204_v1'
+	);
+	const isPricingPageTreatment202204 = experimentAssignment?.variationName === 'treatment';
+
 	return (
 		<>
 			<QueryJetpackSaleCoupon />
@@ -217,6 +223,8 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 					onDurationChange={ trackDurationChange }
 					scrollCardIntoView={ scrollCardIntoView }
 					createButtonURL={ createProductURL }
+					isPricingPageTreatment202204={ isPricingPageTreatment202204 }
+					isPricingPageTest202204AssignmentLoading={ isLoadingExperimentAssignment }
 				/>
 
 				<QueryProductsList type="jetpack" />

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -51,6 +51,8 @@ export interface ProductsGridProps {
 	onDurationChange?: DurationChangeCallback;
 	scrollCardIntoView: ScrollCardIntoViewCallback;
 	createButtonURL?: PurchaseURLCallback;
+	isPricingPageTreatment202204?: boolean;
+	isPricingPageTest202204AssignmentLoading?: boolean;
 }
 
 export type PlanGridProducts = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This implements an experiment to test making the discounted intro rate pricing more prominent, and the original price smaller.

P2: pbNhbs-2io-p2

#### Testing instructions

**Jetpack Cloud**

1. With this branch checked out, start a local Jetpack cloud environment with: `yarn start-jetpack-cloud`.
2. Assign yourself to the the `treatment` group (details here: pbNhbs-2io-p2#comment-7622).
3. Visit the pricing page: http://jetpack.cloud.localhost:3000/pricing
4. You should see the test/treatment variation (it should closely resemble the design shown here: p1HpG7-fpe-p2#comment-53559). Make sure the discounted price shows on top and the original price is the one below with the strike-through. This should be the case with all product cards with prices on the page (not free).

<img width="1054" alt="Screen Shot 2022-04-08 at 2 58 51 PM" src="https://user-images.githubusercontent.com/690843/162537549-7160f5c7-c9ee-46f4-a287-b0cb5ae6fce3.png">
5. Repeat steps 2-4 again, but this time assign yourself to the `control` group. You should see the original control variation.

<img width="1060" alt="Screen Shot 2022-04-08 at 3 01 01 PM" src="https://user-images.githubusercontent.com/690843/162537747-d7eda0a8-c5c7-4709-b47e-8be7e350d4f1.png">

**Calypso**

1. Stop the local Jetpack Cloud environment with `ctrl c` and start a Calypso environment with `yarn start`.
2. Visit the Jetpack connect store pricing page: http://calypso.localhost:3000/jetpack/connect/store
3. You should see the correct variation for the one you're assigned to.
4. Change your assignment to the other one using the steps mentioned above and refresh. You see the other variation.
5. Visit the Calypso plans page for a Jetpack site: http://calypso.localhost:3000/plans/SITE_SLUG
7. Again, test both variations to make sure they display correctly.
8. Visit the Calypso plans page for a non-Jetpack (WordPress.com) site and make sure it displays like on production with no change.
9. Edit the currency for your user from Store Admin (PCYsg-w4h-p2). Then visit one of the Calyspo pages again with a Jetpack site to make sure it looks OK.
10. Edit your language from the [WordPress.com account setting page](http://calypso.localhost:3000/me/account). Then visit one of the Calyspo pages again with a Jetpack site to make sure it looks OK.
11. Change your currency and language back to the originals.

<img width="507" alt="Screen Shot 2022-04-13 at 12 52 52 PM" src="https://user-images.githubusercontent.com/690843/163259424-335d94af-b6ca-44fe-85b8-1785ee2b37be.png">
<img width="1002" alt="Screen Shot 2022-04-13 at 12 25 15 PM" src="https://user-images.githubusercontent.com/690843/163256978-569e992d-eff7-453b-a35f-e8ea74318e7f.png">
<img width="1060" alt="Screen Shot 2022-04-13 at 12 30 04 PM" src="https://user-images.githubusercontent.com/690843/163256968-550c30b1-de78-43d6-b9cd-11c91944775e.png">

