### PR TITLE
Fix: Pro plan price in the site launch flow is zero

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -422,7 +422,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	const [ showCollapsibleRows, setShowCollapsibleRows ] = useState( false );
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) ?? '';
 	const plans = [ getPlan( PLAN_WPCOM_FLEXIBLE ), getPlan( PLAN_WPCOM_PRO ) ] as WPComPlan[];
-	const prices: PlanPrices[] = [ { price: 0 }, usePlanPrices( plans[ 1 ], selectedSiteId ) ];
+	const prices: PlanPrices[] = [ { price: 0 }, usePlanPrices( plans[ 1 ] ) ];
 
 	if ( hideFreePlan ) {
 		plans.shift();

--- a/client/my-sites/plans-comparison/use-plan-prices.tsx
+++ b/client/my-sites/plans-comparison/use-plan-prices.tsx
@@ -1,10 +1,6 @@
 import { TYPE_FREE, TYPE_FLEXIBLE } from '@automattic/calypso-products';
 import { useSelector } from 'react-redux';
 import { getPlanRawPrice, getDiscountedRawPrice } from 'calypso/state/plans/selectors';
-import {
-	getPlanDiscountedRawPrice,
-	getSitePlanRawPrice,
-} from 'calypso/state/sites/plans/selectors';
 import type { WPComPlan } from '@automattic/calypso-products';
 export interface PlanPrices {
 	price: number;
@@ -15,22 +11,16 @@ function toMonthlyPrice( yearlyPrice: number ) {
 	return yearlyPrice ? yearlyPrice / 12 : 0;
 }
 
-export function usePlanPrices( plan: WPComPlan, siteId?: number ): PlanPrices {
-	const productSlug = plan.getStoreSlug();
+export function usePlanPrices( plan: WPComPlan ): PlanPrices {
 	const productId = plan.getProductId();
 	const [ price, discountPrice ] = useSelector( ( state ) => {
 		if ( plan.type === TYPE_FREE || plan.type === TYPE_FLEXIBLE ) {
 			return [ 0 ];
 		}
 
-		return [
-			siteId
-				? getSitePlanRawPrice( state, siteId, productSlug )
-				: getPlanRawPrice( state, productId ),
-			siteId
-				? getPlanDiscountedRawPrice( state, siteId, productSlug )
-				: getDiscountedRawPrice( state, productId ),
-		].map( toMonthlyPrice );
+		return [ getPlanRawPrice( state, productId ), getDiscountedRawPrice( state, productId ) ].map(
+			toMonthlyPrice
+		);
 	} );
 
 	if ( ! discountPrice ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a bug in the site launch flow that causes the Pro plan's price to be displayed as zero

<img width="974" alt="Screenshot 2022-04-11 at 12 56 00 PM" src="https://user-images.githubusercontent.com/1269602/162711082-f80b6cd2-4ece-447c-9e7a-ecff0cf72d4a.png">

* Reason why the bug is seen: We fetch the price for the free plan and Pro plan [in this line](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/plans-comparison/plans-comparison.tsx#L425). `usePlanPrices()` attempts to [fetch the plan price](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/plans-comparison/use-plan-prices.tsx#L26) based on the current plan active on the site, but this is not correct. The Pro plan price is the same USD 15, irrespective of which plan is active on your site. If the site is on a free plan, then `getSitePlanRawPrice()` will return the price as $0, which is why we're seeing the bug. 

The fix is to fetch the raw price of the Pro plan, and remove the line which fetches the price of the current active plan.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In the launch flow of a site on the free plan, verify that the Pro plan price is correctly displayed in the plans step. To get to the site launch flow, create a new site on the free plan, then in "My Home" page checklist (in `/home`), click on the "Launch site" button ([screenshot](https://d.pr/i/GYrfL0)). 
* In the `onboarding` signup flow, verify that the Pro plan price is correctly displayed in the plans step of the signup flow. To get to the `onboarding` flow, navigate to `/start` and signup for a new account. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

