### PR TITLE
`EditorMediaModalGallery`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -34,8 +34,7 @@ class EditorMediaModalGallery extends Component {
 		invalidItemDropped: false,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		if ( this.props.settings ) {
 			this.maybeUpdateColumnsSetting();
 			this.reconcileSettingsItems( this.props.settings, this.props.items );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `EditorMediaModalGallery`: refactor away from `UNSAFE_*`

#### Testing instructions

* Create a new post and add a _Classic_ block
* Hit _Add media_ and choose >1 item
* Verify the next screen is still presented as expected

Related to #58453 
