### PR TITLE
@automattic/tour-kit: Fix missing text domain from translate calls

### DIFF
--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -39,6 +39,7 @@
 		"@wordpress/i18n": "^4.3.0",
 		"@wordpress/icons": "^6.2.0",
 		"@wordpress/primitives": "^3.0.4",
+		"@wordpress/react-i18n": "^3.0.4",
 		"classnames": "^2.3.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/packages/tour-kit/src/type-declarations.d.ts
+++ b/packages/tour-kit/src/type-declarations.d.ts
@@ -1,0 +1,1 @@
+declare const __i18n_text_domain__: string;

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-minimized.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-minimized.tsx
@@ -1,7 +1,8 @@
 import { Button, Flex } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
 import { Icon, close } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import maximize from '../icons/maximize';
 import type { MinimizedTourRendererProps } from '../../../types';
 
@@ -11,19 +12,20 @@ const WpcomTourKitMinimized: React.FunctionComponent< MinimizedTourRendererProps
 	onDismiss,
 	currentStepIndex,
 } ) => {
+	const { __ } = useI18n();
 	const lastStepIndex = steps.length - 1;
 	const page = currentStepIndex + 1;
 	const numberOfPages = lastStepIndex + 1;
 
 	return (
 		<Flex gap={ 0 } className="wpcom-tour-kit-minimized">
-			<Button onClick={ onMaximize } aria-label={ __( 'Resume Tour' ) }>
+			<Button onClick={ onMaximize } aria-label={ __( 'Resume Tour', __i18n_text_domain__ ) }>
 				<Flex gap={ 13 }>
 					<p>
 						{ createInterpolateElement(
 							sprintf(
 								/* translators: 1: current page number, 2: total number of pages */
-								__( 'Resume tour <span>(%1$d/%2$d)</span>' ),
+								__( 'Resume tour <span>(%1$d/%2$d)</span>', __i18n_text_domain__ ),
 								page,
 								numberOfPages
 							),
@@ -35,7 +37,10 @@ const WpcomTourKitMinimized: React.FunctionComponent< MinimizedTourRendererProps
 					<Icon icon={ maximize } size={ 24 } />
 				</Flex>
 			</Button>
-			<Button onClick={ onDismiss( 'close-btn-minimized' ) } aria-label={ __( 'Close Tour' ) }>
+			<Button
+				onClick={ onDismiss( 'close-btn-minimized' ) }
+				aria-label={ __( 'Close Tour', __i18n_text_domain__ ) }
+			>
 				<Icon icon={ close } size={ 24 } />
 			</Button>
 		</Flex>

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-rating.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-rating.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { useTourKitContext } from '../../../index';
 import thumbsDown from '../icons/thumbs_down';
@@ -12,6 +12,7 @@ const WpcomTourKitRating: React.FunctionComponent = () => {
 	const context = useTourKitContext();
 	const config = ( context.config as unknown ) as WpcomConfig;
 	const tourRating = config.options?.tourRating?.useTourRating?.() ?? tempRating;
+	const { __ } = useI18n();
 
 	let isDisabled = false;
 
@@ -41,11 +42,11 @@ const WpcomTourKitRating: React.FunctionComponent = () => {
 	return (
 		<>
 			<p className="wpcom-tour-kit-rating__end-text">
-				{ __( 'Did you find this guide helpful?' ) }
+				{ __( 'Did you find this guide helpful?', __i18n_text_domain__ ) }
 			</p>
 			<div>
 				<Button
-					aria-label={ __( 'Rate thumbs up' ) }
+					aria-label={ __( 'Rate thumbs up', __i18n_text_domain__ ) }
 					className={ classNames( 'wpcom-tour-kit-rating__end-icon', {
 						active: tourRating === 'thumbs-up',
 					} ) }
@@ -55,7 +56,7 @@ const WpcomTourKitRating: React.FunctionComponent = () => {
 					iconSize={ 24 }
 				/>
 				<Button
-					aria-label={ __( 'Rate thumbs down' ) }
+					aria-label={ __( 'Rate thumbs down', __i18n_text_domain__ ) }
 					className={ classNames( 'wpcom-tour-kit-rating__end-icon', {
 						active: tourRating === 'thumbs-down',
 					} ) }

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-navigation.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-navigation.tsx
@@ -1,6 +1,6 @@
 import { PaginationControl } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import type { WpcomTourStepRendererProps } from '../../../types';
 
 type Props = Omit< WpcomTourStepRendererProps, 'onMinimize' >;
@@ -14,6 +14,7 @@ const WpcomTourKitStepCardNavigation: React.FunctionComponent< Props > = ( {
 	setInitialFocusedElement,
 	steps,
 } ) => {
+	const { __ } = useI18n();
 	const isFirstStep = currentStepIndex === 0;
 	const lastStepIndex = steps.length - 1;
 
@@ -27,7 +28,7 @@ const WpcomTourKitStepCardNavigation: React.FunctionComponent< Props > = ( {
 				{ isFirstStep ? (
 					<div>
 						<Button isTertiary onClick={ onDismiss( 'no-thanks-btn' ) }>
-							{ __( 'Skip' ) }
+							{ __( 'Skip', __i18n_text_domain__ ) }
 						</Button>
 						<Button
 							className="wpcom-tour-kit-step-card-navigation__next-btn"
@@ -35,13 +36,13 @@ const WpcomTourKitStepCardNavigation: React.FunctionComponent< Props > = ( {
 							onClick={ onNextStep }
 							ref={ setInitialFocusedElement }
 						>
-							{ __( 'Try it out!' ) }
+							{ __( 'Try it out!', __i18n_text_domain__ ) }
 						</Button>
 					</div>
 				) : (
 					<div>
 						<Button isTertiary onClick={ onPreviousStep }>
-							{ __( 'Back' ) }
+							{ __( 'Back', __i18n_text_domain__ ) }
 						</Button>
 						<Button
 							className="wpcom-tour-kit-step-card-navigation__next-btn"
@@ -49,7 +50,7 @@ const WpcomTourKitStepCardNavigation: React.FunctionComponent< Props > = ( {
 							onClick={ onNextStep }
 							ref={ setInitialFocusedElement }
 						>
-							{ __( 'Next' ) }
+							{ __( 'Next', __i18n_text_domain__ ) }
 						</Button>
 					</div>
 				) }

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-overlay-controls.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-overlay-controls.tsx
@@ -1,6 +1,6 @@
 import { Button, Flex } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import minimize from '../icons/minimize';
 import type { TourStepRendererProps } from '../../../types';
 
@@ -13,11 +13,13 @@ const WpcomTourKitStepCardOverlayControls: React.FunctionComponent< Props > = ( 
 	onMinimize,
 	onDismiss,
 } ) => {
+	const { __ } = useI18n();
+
 	return (
 		<div className="wpcom-tour-kit-step-card-overlay-controls">
 			<Flex>
 				<Button
-					label={ __( 'Minimize Tour' ) }
+					label={ __( 'Minimize Tour', __i18n_text_domain__ ) }
 					isPrimary
 					className="wpcom-tour-kit-step-card-overlay-controls__minimize-icon"
 					icon={ minimize }
@@ -25,7 +27,7 @@ const WpcomTourKitStepCardOverlayControls: React.FunctionComponent< Props > = ( 
 					onClick={ onMinimize }
 				></Button>
 				<Button
-					label={ __( 'Close Tour' ) }
+					label={ __( 'Close Tour', __i18n_text_domain__ ) }
 					isPrimary
 					icon={ close }
 					iconSize={ 24 }

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
@@ -1,6 +1,6 @@
 import { getMediaQueryList, isMobile, MOBILE_BREAKPOINT } from '@automattic/viewport';
 import { Button, Card, CardBody, CardFooter, CardMedia } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import WpcomTourKitRating from './wpcom-tour-kit-rating';
 import WpcomTourKitStepCardNavigation from './wpcom-tour-kit-step-card-navigation';
 import WpcomTourKitStepCardOverlayControls from './wpcom-tour-kit-step-card-overlay-controls';
@@ -16,6 +16,7 @@ const WpcomTourKitStepCard: React.FunctionComponent< WpcomTourStepRendererProps 
 	onPreviousStep,
 	setInitialFocusedElement,
 } ) => {
+	const { __ } = useI18n();
 	const lastStepIndex = steps.length - 1;
 	const { descriptions, heading, imgSrc } = steps[ currentStepIndex ].meta;
 	const isLastStep = currentStepIndex === lastStepIndex;
@@ -38,7 +39,7 @@ const WpcomTourKitStepCard: React.FunctionComponent< WpcomTourStepRendererProps 
 								media={ mediaQueryList?.media }
 							/>
 						) }
-						<img alt={ __( 'Tour Media' ) } src={ imgSrc.desktop?.src } />
+						<img alt={ __( 'Tour Media', __i18n_text_domain__ ) } src={ imgSrc.desktop?.src } />
 					</picture>
 				</CardMedia>
 			) }
@@ -53,7 +54,7 @@ const WpcomTourKitStepCard: React.FunctionComponent< WpcomTourStepRendererProps 
 							onClick={ () => onGoToStep( 0 ) }
 							ref={ setInitialFocusedElement }
 						>
-							{ __( 'Restart tour' ) }
+							{ __( 'Restart tour', __i18n_text_domain__ ) }
 						</Button>
 					) : null }
 				</p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,6 +1299,7 @@ __metadata:
     "@wordpress/i18n": ^4.3.0
     "@wordpress/icons": ^6.2.0
     "@wordpress/primitives": ^3.0.4
+    "@wordpress/react-i18n": ^3.0.4
     classnames: ^2.3.1
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the `__i18n_text_domain__` variable to translate calls, to ensure the correct text domain is being used for translations.
* Switch to using `@wordpress/react-i18n` instead of `@wordpress/i18n`, as it's recommended to in React components.

**Before:**
![CleanShot 2022-04-11 at 13 49 11](https://user-images.githubusercontent.com/2722412/162725939-a0fd29bf-3469-407e-a404-161c1503bfb4.png)

**After:**
![CleanShot 2022-04-11 at 13 47 24](https://user-images.githubusercontent.com/2722412/162725996-c3c5b0e3-da34-4555-8843-1e21ed11437f.png)

#### Testing instructions

* Checkout diff locally
* Run `cd apps/editing-toolkit` && `yarn dev --sync`
* Change WordPress.com UI to Mag-16 language
* Sandbox a simple site
* Open the Block editor (i.e. add/edit page)
* If hidden, open the Welcome Guide from the Options Menu (the three dots in the top bar)
* Confirm all strings are rendered translated (e.g. 'Minimize', 'Close', 'Try it out!', etc.)

Related to 423-gh-Automattic/i18n-issues
