### PR TITLE
Fix default site suggestion positioning

### DIFF
--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -417,25 +417,27 @@ class P2Site extends Component {
 		const { isFetchingDefaultSuggestion } = this.state;
 
 		return (
-			<span
-				className="p2-site__wordpress-domain-default"
-				title={ site ? `https://${ site }.wordpress.com` : '' }
-			>
-				<span onMouseLeave={ handleMouseLeave } className="p2-site__site-wordpress-domain">
-					{ site }
-				</span>
-				<span className="p2-site__site-wordpress-suffix">
-					{ site ? '.wordpress.com' : '' }&nbsp;
-				</span>
-				<button
-					type="button"
-					disabled={ isFetchingDefaultSuggestion }
-					className="p2-site__site-wordpress-domain-refresh"
-					onClick={ this.suggestDefaultSubdomain }
+			<div class="p2-site__wordpress-domain-default-container">
+				<span
+					className="p2-site__wordpress-domain-default"
+					title={ site ? `https://${ site }.wordpress.com` : '' }
 				>
-					<Icon size={ 24 } icon={ reusableBlock } />
-				</button>
-			</span>
+					<span onMouseLeave={ handleMouseLeave } className="p2-site__site-wordpress-domain">
+						{ site }
+					</span>
+					<span className="p2-site__site-wordpress-suffix">
+						{ site ? '.wordpress.com' : '' }&nbsp;
+					</span>
+					<button
+						type="button"
+						disabled={ isFetchingDefaultSuggestion }
+						className="p2-site__site-wordpress-domain-refresh"
+						onClick={ this.suggestDefaultSubdomain }
+					>
+						<Icon size={ 24 } icon={ reusableBlock } />
+					</button>
+				</span>
+			</div>
 		);
 	};
 
@@ -465,7 +467,7 @@ class P2Site extends Component {
 					name="suggested-site"
 					value={ site ? `https://${ site }.wordpress.com` : '' }
 				/>
-				<div class="p2-site__wordpress-domain-default-container">{ this.renderDefaultSite() }</div>
+				{ this.renderDefaultSite() }
 				<FormSettingExplanation className="p2-site__workspace-form-input-explanation">
 					{ this.props.translate(
 						'We suggest this URL, but you can {{a}}choose manually{{/a}} too',

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -465,6 +465,7 @@ class P2Site extends Component {
 					name="suggested-site"
 					value={ site ? `https://${ site }.wordpress.com` : '' }
 				/>
+				<div class="p2-site__wordpress-domain-default-container">{ this.renderDefaultSite() }</div>
 				<FormSettingExplanation className="p2-site__workspace-form-input-explanation">
 					{ this.props.translate(
 						'We suggest this URL, but you can {{a}}choose manually{{/a}} too',
@@ -475,7 +476,6 @@ class P2Site extends Component {
 						}
 					) }
 				</FormSettingExplanation>
-				{ this.renderDefaultSite() }
 			</>
 		);
 	};

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -40,11 +40,18 @@
 	box-sizing: border-box;
 }
 
+.p2-site__wordpress-domain-default-container {
+	position: relative;
+	height: 0;
+}
+
 .p2-site__wordpress-domain-default {
 	color: var( --p2-color-text );
-	position: relative;
+	position: absolute;
 	font-size: var( --p2-font-size-form );
-	top: -66px;
+	top: -42px;
+	left: 0;
+	right: 0;
 	display: flex;
 	align-items: center;
 	max-width: 400px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix relative positioning of default suggested domain when the helper text spans more than one line.

Before:

<img width="719" alt="image" src="https://user-images.githubusercontent.com/1574407/162741661-f229e9bc-e946-40d7-baa4-b79d1a5b282a.png">


After:

<img width="724" alt="image" src="https://user-images.githubusercontent.com/1574407/162741516-17704b40-ccfc-413b-abfa-46fa5793f7fd.png">


#### Testing instructions

* Build this branch locally or open the live Calypso link
* Go /start/p2/p2-site
* Ensure your WordPress account is in Spanish, or any other language where the translation for the helper text for the suggested domain name spans more than one line.
* Enter any workspace name
* Ensure the suggested domain shows correctly as shown in the screenshots above.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
