### PR TITLE
Add a CTA on /earn/payments-plans to upgrade

### DIFF
--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -74,13 +74,18 @@ class MembershipsProductsSection extends Component {
 					{ this.props.translate( 'Payment plans' ) }
 				</HeaderCake>
 
-				{ this.props.hasStripeFeature && (
-					<SectionHeader>
+				<SectionHeader>
+					{ this.props.hasStripeFeature && (
 						<Button primary compact onClick={ () => this.openAddEditDialog( null ) }>
 							{ this.props.translate( 'Add a new payment plan' ) }
 						</Button>
-					</SectionHeader>
-				) }
+					) }
+					{ ! this.props.hasStripeFeature && (
+						<Button primary compact href={ '/plans/' + this.props.siteSlug }>
+							{ this.props.translate( 'Upgrade to add and edit plans' ) }
+						</Button>
+					) }
+				</SectionHeader>
 				{ this.props.products.map( ( product ) => (
 					<CompactCard className="memberships__products-product-card" key={ product.ID }>
 						<div className="memberships__products-product-details">

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -95,13 +95,13 @@ class MembershipsProductsSection extends Component {
 					/>
 				) }
 
-				<SectionHeader>
-					{ this.props.hasStripeFeature && (
+				{ this.props.hasStripeFeature && (
+					<SectionHeader>
 						<Button primary compact onClick={ () => this.openAddEditDialog( null ) }>
 							{ this.props.translate( 'Add a new payment plan' ) }
 						</Button>
-					) }
-				</SectionHeader>
+					</SectionHeader>
+				) }
 				{ this.props.products.map( ( product ) => (
 					<CompactCard className="memberships__products-product-card" key={ product.ID }>
 						<div className="memberships__products-product-details">

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -80,9 +80,7 @@ class MembershipsProductsSection extends Component {
 					// Purposefully isn't a dismissible nudge as without this nudge, the page would appear to be
 					// broken as it only does listing and deleting of plans and it wouldn't be clear how to change that.
 					<UpsellNudge
-						title={ this.props.translate(
-							'Upgrade to change payment plans and add new payment plans'
-						) }
+						title={ this.props.translate( 'Upgrade to modify payment plans or add new plans' ) }
 						href={ '/plans/' + this.props.siteSlug }
 						showIcon={ true }
 						onClick={ () => this.props.trackUpgrade() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

People without a WordPress.com subscription can access
/earn/payments-plans if they have previously connected their site to
Stripe (see #62616). They can only view and delete their plans though,
not add and edit them. In order to add or edit their plans they need to
have a current WordPress.com subscription.

This change adds an UpgradeNudge (with related stats tracking) to make that clear, and to invite them to upgrade.



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Be on a paid plan
2. Go to wordpress.com/earn (or Tools -> Earn) in the menu
3. Follow the prompts to link your stripe account as normal
4. Click on one of the stripe-related features on /earn
5. Click on Payment plans
6. Notice you can add plans and edit them (via the ellipses menu)
7. Cancel your paid plan
8. Click on one of the stripe-related features on /earn
9. Open your browser dev console and enter `localStorage.setItem('debug', 'calypso:analytics*');`
10. Click on Payment plans
11. Notice that there is a nudge to upgrade plans
13. Click the nudge, it should take you to the /plans page to upgrade
14. Check your browser console, you should see three events:
   * Bump stats event for clicking the nudge - `calypso_earn_page:payment-plans-upgrade-button`
   * Tracks event for viewing the nudge - `calypso_earn_page_payment_plans_upgrade_button_view`
   * Tracks event for clicking the nudge - `calypso_earn_page_payment_plans_upgrade_button_click`
   * You should also be able to see the two Tracks events in Tracks Live by searching for your user name.

Before | After
-------|------
![image](https://user-images.githubusercontent.com/93301/162756454-9427f738-bf89-4054-85ca-32a7ed2f0d0b.png)  | ![image](https://user-images.githubusercontent.com/93301/165349058-36b1b7aa-2f72-4ae5-a7f9-0d574554a559.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to suggestion made in #62616
