### PR TITLE
Plugins: Remove unused methods and props

### DIFF
--- a/client/my-sites/plugins/plugin-activate-toggle/README.md
+++ b/client/my-sites/plugins/plugin-activate-toggle/README.md
@@ -21,5 +21,4 @@ function render() {
 - `plugin`: a plugin object.
 - `site`: a site object.
 - `notices`: a notices object.
-- `isMock`: a boolean indicating if the toggle should not launch any real action when interacted
 - `disabled`: a boolean indicating whether the toggle is disabled (grayed out and non interactive) or not

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -17,14 +17,13 @@ const activationActions = [ ACTIVATE_PLUGIN, DEACTIVATE_PLUGIN ];
 export class PluginActivateToggle extends Component {
 	toggleActivation = () => {
 		const {
-			isMock,
 			disabled,
 			site,
 			plugin,
 			recordGoogleEvent: recordGAEvent,
 			recordTracksEvent: recordEvent,
 		} = this.props;
-		if ( isMock || disabled ) {
+		if ( disabled ) {
 			return;
 		}
 
@@ -125,12 +124,10 @@ export class PluginActivateToggle extends Component {
 PluginActivateToggle.propTypes = {
 	site: PropTypes.object.isRequired,
 	plugin: PropTypes.object.isRequired,
-	isMock: PropTypes.bool,
 	disabled: PropTypes.bool,
 };
 
 PluginActivateToggle.defaultProps = {
-	isMock: false,
 	disabled: false,
 };
 

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/README.md
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/README.md
@@ -22,5 +22,4 @@ function render() {
 - `site`: a site object.
 - `notices`: a notices object.
 - `wporg`: whether the plugin is from .org or not
-- `isMock`: a boolean indicating if the toggle should not launch any real action when interacted
 - `disabled`: a boolean indicating whether the toggle is disabled (grayed out and non interactive) or not

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -16,7 +16,6 @@ const autoUpdateActions = [ ENABLE_AUTOUPDATE_PLUGIN, DISABLE_AUTOUPDATE_PLUGIN 
 export class PluginAutoUpdateToggle extends Component {
 	toggleAutoUpdates = () => {
 		const {
-			isMock,
 			disabled,
 			site,
 			plugin,
@@ -24,7 +23,7 @@ export class PluginAutoUpdateToggle extends Component {
 			recordTracksEvent: recordEvent,
 		} = this.props;
 
-		if ( isMock || disabled ) {
+		if ( disabled ) {
 			return;
 		}
 
@@ -177,7 +176,6 @@ export class PluginAutoUpdateToggle extends Component {
 }
 
 PluginAutoUpdateToggle.propTypes = {
-	isMock: PropTypes.bool,
 	site: PropTypes.object.isRequired,
 	plugin: PropTypes.object.isRequired,
 	wporg: PropTypes.bool,
@@ -186,7 +184,6 @@ PluginAutoUpdateToggle.propTypes = {
 };
 
 PluginAutoUpdateToggle.defaultProps = {
-	isMock: false,
 	disabled: false,
 	isMarketplaceProduct: false,
 };

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -59,21 +59,6 @@ export class PluginInstallButton extends Component {
 		}
 	};
 
-	updateJetpackAction = () => {
-		const {
-			plugin,
-			siteId,
-			recordGoogleEvent: recordGAEvent,
-			recordTracksEvent: recordEvent,
-		} = this.props;
-
-		recordGAEvent( 'Plugins', 'Update jetpack', 'Plugin Name', plugin.slug );
-		recordEvent( 'calypso_plugin_update_jetpack', {
-			site: siteId,
-			plugin: plugin.slug,
-		} );
-	};
-
 	clickSupportLink = () => {
 		this.props.recordGoogleEvent(
 			'Plugins',

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -305,7 +305,6 @@ PluginInstallButton.propTypes = {
 	plugin: PropTypes.object.isRequired,
 	isEmbed: PropTypes.bool,
 	isInstalling: PropTypes.bool,
-	isMock: PropTypes.bool,
 	disabled: PropTypes.bool,
 };
 

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -217,7 +217,6 @@ class PluginItem extends Component {
 			<div className="plugin-item__actions">
 				{ canToggleActivation && (
 					<PluginActivateToggle
-						isMock={ this.props.isMock }
 						plugin={ this.props.plugin }
 						disabled={ this.props.isSelectable }
 						site={ this.props.selectedSite }
@@ -225,7 +224,6 @@ class PluginItem extends Component {
 				) }
 				{ canToggleAutoupdate && (
 					<PluginAutoupdateToggle
-						isMock={ this.props.isMock }
 						plugin={ this.props.plugin }
 						disabled={ this.props.isSelectable }
 						site={ this.props.selectedSite }

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -25,7 +25,6 @@ export class PluginsListHeader extends PureComponent {
 	};
 
 	static defaultProps = {
-		isMock: false,
 		disabled: false,
 	};
 

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -45,8 +45,6 @@ export class PluginsListHeader extends PureComponent {
 		removePluginNotice: PropTypes.func.isRequired,
 		haveActiveSelected: PropTypes.bool,
 		haveInactiveSelected: PropTypes.bool,
-		bulkManagement: PropTypes.bool,
-		selectedSiteSlug: PropTypes.string,
 		plugins: PropTypes.array.isRequired,
 		selected: PropTypes.array.isRequired,
 	};

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -1,4 +1,4 @@
-import { Card, ProgressBar } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { isEmpty, flowRight } from 'lodash';
 import page from 'page';
@@ -21,7 +21,6 @@ import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/ac
 import { successNotice } from 'calypso/state/notices/actions';
 import { uploadPlugin, clearPluginUpload } from 'calypso/state/plugins/upload/actions';
 import getPluginUploadError from 'calypso/state/selectors/get-plugin-upload-error';
-import getPluginUploadProgress from 'calypso/state/selectors/get-plugin-upload-progress';
 import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id';
 import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-complete';
 import isPluginUploadInProgress from 'calypso/state/selectors/is-plugin-upload-in-progress';
@@ -80,26 +79,6 @@ class PluginUpload extends Component {
 		);
 	}
 
-	renderProgressBar() {
-		const { translate, progress, installing } = this.props;
-
-		const uploadingMessage = translate( 'Uploading your plugin' );
-		const installingMessage = translate( 'Installing your plugin' );
-
-		return (
-			<div>
-				<span className="plugin-upload__title">
-					{ installing ? installingMessage : uploadingMessage }
-				</span>
-				<ProgressBar
-					value={ progress }
-					title={ translate( 'Uploading progress' ) }
-					isPulsing={ installing }
-				/>
-			</div>
-		);
-	}
-
 	renderNotAvailableForMultisite() {
 		const { translate, siteAdminUrl } = this.props;
 
@@ -138,7 +117,6 @@ class PluginUpload extends Component {
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const error = getPluginUploadError( state, siteId );
-	const progress = getPluginUploadProgress( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
 	const isJetpackMultisite = isJetpackSiteMultiSite( state, siteId );
 	const { eligibilityHolds, eligibilityWarnings } = getEligibility( state, siteId );
@@ -158,8 +136,6 @@ const mapStateToProps = ( state ) => {
 		failed: !! error,
 		pluginId: getUploadedPluginId( state, siteId ),
 		error,
-		progress,
-		installing: progress === 100,
 		isJetpackMultisite,
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -1,7 +1,7 @@
 import { Card } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { find, get, includes, isEmpty, isEqual, range, reduce, sortBy } from 'lodash';
+import { get, includes, isEmpty, isEqual, range, reduce, sortBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -140,11 +140,6 @@ export class PluginsList extends Component {
 			selectedPlugins: Object.assign( {}, this.state.selectedPlugins, slugsToBeUpdated ),
 		} );
 	};
-
-	getPluginBySlug( slug ) {
-		const { plugins } = this.props;
-		return find( plugins, ( plugin ) => plugin.slug === slug );
-	}
 
 	filterSelection = {
 		active( plugin ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR cleans up a few unused methods and props across the plugins code. The only unused method that I know of is being addressed in #61599.

#### Testing instructions

* Verify Calypso builds well.
* Smoke test plugins.
* Verify the removed code is not in use.
* Verify all tests pass.