### PR TITLE
Hide Renew Monthly option from Pro plans

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -16,6 +16,7 @@ import {
 	isWpComPlan,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
+	TYPE_PRO,
 } from '@automattic/calypso-products';
 import { encodeProductForUrl } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
@@ -724,6 +725,10 @@ function shouldRenderMonthlyRenewalOption( purchase ) {
 	const plan = getPlan( purchase.productSlug );
 
 	if ( ! [ TERM_ANNUALLY, TERM_BIENNIALLY ].includes( plan.term ) ) {
+		return false;
+	}
+
+	if ( TYPE_PRO === plan.type ) {
 		return false;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the `Renew Monthly` option from the expired Pro plans on the `/me/purchases` page. 
This is needed because the Pro plan doesn't support monthly terms.

<img width="320" alt="Screenshot on 2022-04-11 at 17-59-59" src="https://user-images.githubusercontent.com/2749938/162768251-0f534441-5170-4a79-b6f2-cc1669619719.png">

#### Testing instructions

* Change the expiration date for the Pro plan of a site
* Go to the `/me/purchases` page for that site
* You should only see the `Renew Now` instead of the two renewal options

<img width="320" alt="Screenshot on 2022-04-11 at 17-52-56" src="https://user-images.githubusercontent.com/2749938/162768293-7683f258-2b8c-4ba3-b824-1d192a2aba37.png">

