### PR TITLE
Seller Experience: Change subtitle on Start simple

### DIFF
--- a/client/signup/steps/store-features/intents.tsx
+++ b/client/signup/steps/store-features/intents.tsx
@@ -26,7 +26,7 @@ export function useIntents(
 					<span className="store-features__requirements">
 						{ hasPaymentsFeature
 							? translate( 'Included in your plan' )
-							: translate( 'Requires a {{a}}paid plan{{/a}}', {
+							: translate( 'Requires a {{a}}Pro plan{{/a}}', {
 									components: {
 										a: (
 											<a


### PR DESCRIPTION
Change Start simple subtitle to `Requires a Pro plan`.

| Before  | After |
| ------------- | ------------- |
| <img width="605" alt="image" src="https://user-images.githubusercontent.com/375980/162780833-7c1ca2d8-387c-41ae-a03f-795440ca1b72.png">  | <img width="605" alt="image" src="https://user-images.githubusercontent.com/375980/162780984-3c3a2319-444b-425c-a810-b57efe2c0746.png"> |

#### Testing instructions
1. Apply this diff or go to the calypso.live link in comments.
2. Go through the seller experience flow with a free plan.
3. Verify that the subtitles for "More power" and "Start simple" matches and read: `Requires a Pro plan`.
4. Verify links work correctly.

Closes https://github.com/Automattic/wp-calypso/issues/62674