### PR TITLE
Remove premium content & newsletter for jp sites

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -292,6 +292,9 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getPremiumContentCard = () => {
+		if ( isNonAtomicJetpack ) {
+			return;
+		}
 		const cta = ! hasPremiumContent
 			? {
 					text: translate( 'Unlock this feature' ),
@@ -356,6 +359,9 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getPaidNewsletterCard = () => {
+		if ( isNonAtomicJetpack ) {
+			return;
+		}
 		const cta = ! hasPremiumContent
 			? {
 					text: translate( 'Unlock this feature' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The premium-content block is limited to WordPress.com customers only, so
remove the two cards related to it from the /earn page for Jetpack
customers.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /earn on a WordPress.com site and notice you see cards related to newsletters and premium content
* Go to /earn on a Jetpack site and notice that now you don't

WordPress.com | Jetpack
-------|------
![image](https://user-images.githubusercontent.com/93301/162789175-0833517c-59b5-4656-8bb4-9189788f1d25.png) | ![image](https://user-images.githubusercontent.com/93301/162789298-959fcf81-d460-4be7-ae7f-b64d13f7026d.png)



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #62619
