### PR TITLE
Begin adding Anchor.fm as a separate flow

### DIFF
--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -25,7 +25,7 @@ export const anchorFmFlow: Flow = {
 			recordSubmitStep( providedDependencies, 'anchor-fm', currentStep );
 
 			switch ( currentStep ) {
-				case 'options':
+				case 'podcastTitle':
 					return navigate( 'designSetup' );
 				case 'designSetup':
 					return navigate( 'fontPairing' );
@@ -37,17 +37,17 @@ export const anchorFmFlow: Flow = {
 		const goBack = () => {
 			switch ( currentStep ) {
 				case 'designSetup':
-					return navigate( 'options' );
+					return navigate( 'podcastTitle' );
 				case 'fontPairing':
 					return navigate( 'designSetup' );
 				default:
-					return navigate( 'options' );
+					return navigate( 'podcastTitle' );
 			}
 		};
 
 		const goNext = () => {
 			switch ( currentStep ) {
-				case 'options':
+				case 'podcastTitle':
 					return navigate( 'designSetup' );
 				case 'designSetup':
 					return navigate( 'fontPairing' );
@@ -55,7 +55,7 @@ export const anchorFmFlow: Flow = {
 					return redirect( `/page/home/${ siteSlug }` );
 
 				default:
-					return navigate( 'options' );
+					return navigate( 'podcastTitle' );
 			}
 		};
 

--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -11,11 +11,7 @@ export const anchorFmFlow: Flow = {
 	name: 'anchor-fm',
 
 	useSteps() {
-		return [
-			'podcastTitle', //This step doesn't exist yet
-			'designSetup', //This is the design picker with only three "podcast" themes loaded, no sidebar
-			'fontPairing', //This step doesn't exist yet
-		] as StepPath[];
+		return [ 'podcastTitle', 'designSetup', 'fontPairing' ] as StepPath[];
 	},
 
 	useStepNavigation( currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -1,0 +1,68 @@
+import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import type { StepPath } from './internals/steps-repository';
+import type { Flow, ProvidedDependencies } from './internals/types';
+
+function redirect( to: string ) {
+	window.location.href = to;
+}
+
+export const anchorFmFlow: Flow = {
+	name: 'anchor-fm',
+
+	useSteps() {
+		return [
+			'podcastTitle', //This step doesn't exist yet
+			'designSetup', //This is the design picker with only three "podcast" themes loaded, no sidebar
+			'fontPairing', //This step doesn't exist yet
+		] as StepPath[];
+	},
+
+	useStepNavigation( currentStep, navigate ) {
+		const siteSlug = useSiteSlugParam();
+
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, 'anchor-fm', currentStep );
+
+			switch ( currentStep ) {
+				case 'options':
+					return navigate( 'designSetup' );
+				case 'designSetup':
+					return navigate( 'fontPairing' );
+				case 'fontPairing':
+					return redirect( `/page/home/${ siteSlug }` );
+			}
+		}
+
+		const goBack = () => {
+			switch ( currentStep ) {
+				case 'designSetup':
+					return navigate( 'options' );
+				case 'fontPairing':
+					return navigate( 'designSetup' );
+				default:
+					return navigate( 'options' );
+			}
+		};
+
+		const goNext = () => {
+			switch ( currentStep ) {
+				case 'options':
+					return navigate( 'designSetup' );
+				case 'designSetup':
+					return navigate( 'fontPairing' );
+				case 'fontPairing':
+					return redirect( `/page/home/${ siteSlug }` );
+
+				default:
+					return navigate( 'options' );
+			}
+		};
+
+		const goToStep = ( step: StepPath ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/font-pairing/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/font-pairing/index.tsx
@@ -7,19 +7,12 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
 const FontPairingStep: Step = function FontPairingStep( { navigation } ) {
-	const { goBack, submit } = navigation;
+	const { goBack, goNext } = navigation;
 	const translate = useTranslate();
 	const headerText = translate( 'Pick a font pairing' );
 	const subHeaderText = translate(
 		'Customize your design with typography that best suits your podcast. You can always fine-tune it later.'
 	);
-
-	const submitFontPairing = ( fontPairing: string ) => {
-		const providedDependencies = { fontPairing };
-		recordTracksEvent( 'calypso_signup_font_pairing_select', providedDependencies );
-		//setFontPairing( fontPairing );
-		submit?.( providedDependencies, fontPairing );
-	};
 
 	return (
 		<StepContainer
@@ -35,11 +28,7 @@ const FontPairingStep: Step = function FontPairingStep( { navigation } ) {
 					align={ 'left' }
 				/>
 			}
-			stepContent={
-				<Button type="submit" primary onClick={ submitFontPairing }>
-					{ translate( 'Continue' ) }
-				</Button>
-			}
+			stepContent={ <Button onClick={ goNext }>Go to next step</Button> }
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/font-pairing/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/font-pairing/index.tsx
@@ -1,0 +1,48 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { Button } from '@automattic/components';
+import { StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+const FontPairingStep: Step = function FontPairingStep( { navigation } ) {
+	const { goBack, submit } = navigation;
+	const translate = useTranslate();
+	const headerText = translate( 'Pick a font pairing' );
+	const subHeaderText = translate(
+		'Customize your design with typography that best suits your podcast. You can always fine-tune it later.'
+	);
+
+	const submitFontPairing = ( fontPairing: string ) => {
+		const providedDependencies = { fontPairing };
+		recordTracksEvent( 'calypso_signup_font_pairing_select', providedDependencies );
+		//setFontPairing( fontPairing );
+		submit?.( providedDependencies, fontPairing );
+	};
+
+	return (
+		<StepContainer
+			stepName={ 'font-pairing-step' }
+			goBack={ goBack }
+			hideSkip
+			isHorizontalLayout={ true }
+			formattedHeader={
+				<FormattedHeader
+					id={ 'font-pairing-header' }
+					headerText={ headerText }
+					subHeaderText={ subHeaderText }
+					align={ 'left' }
+				/>
+			}
+			stepContent={
+				<Button type="submit" primary onClick={ submitFontPairing }>
+					{ translate( 'Continue' ) }
+				</Button>
+			}
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default FontPairingStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/font-pairing/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/font-pairing/index.tsx
@@ -7,12 +7,16 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
 const FontPairingStep: Step = function FontPairingStep( { navigation } ) {
-	const { goBack, goNext } = navigation;
+	const { goBack, submit } = navigation;
 	const translate = useTranslate();
 	const headerText = translate( 'Pick a font pairing' );
 	const subHeaderText = translate(
 		'Customize your design with typography that best suits your podcast. You can always fine-tune it later.'
 	);
+
+	const handleClick = () => {
+		submit?.();
+	};
 
 	return (
 		<StepContainer
@@ -28,7 +32,7 @@ const FontPairingStep: Step = function FontPairingStep( { navigation } ) {
 					align={ 'left' }
 				/>
 			}
-			stepContent={ <Button onClick={ goNext }>Go to next step</Button> }
+			stepContent={ <Button onClick={ handleClick }>Go to next step</Button> }
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -1,10 +1,12 @@
 export { default as courses } from './courses';
 export { default as intent } from './intent-step';
+export { default as podcastTitle } from './podcast-title';
 export { default as options } from './site-options';
 export { default as bloggerStartingPoint } from './blogger-starting-point';
 export { default as storeFeatures } from './store-features';
 export { default as designSetup } from './design-setup';
 export { default as businessInfo } from './business-info';
+export { default as fontPairing } from './font-pairing';
 export { default as storeAddress } from './store-address';
 export { default as vertical } from './site-vertical';
 export { default as processing } from './processing-step';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -17,6 +17,7 @@ export type StepPath =
 	| 'storeFeatures'
 	| 'designSetup'
 	| 'businessInfo'
+	| 'fontPairing'
 	| 'storeAddress'
 	| 'processing'
 	| 'vertical';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -12,6 +12,7 @@ export { default as processing } from './processing-step';
 export type StepPath =
 	| 'courses'
 	| 'intent'
+	| 'podcastTitle'
 	| 'options'
 	| 'bloggerStartingPoint'
 	| 'storeFeatures'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
@@ -7,17 +7,10 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
 const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
-	const { goBack, submit } = navigation;
+	const { goBack, goNext } = navigation;
 	const translate = useTranslate();
 	const headerText = translate( 'My podcast is called' );
 	const subHeaderText = translate( "Don't worry, you can change it later." );
-
-	const submitPodcastTitle = ( podcastTitle: string ) => {
-		const providedDependencies = { podcastTitle };
-		recordTracksEvent( 'calypso_signup_podcast_title_select', providedDependencies );
-		//setPodcastTitle( podcastTitle );
-		submit?.( providedDependencies, podcastTitle );
-	};
 
 	return (
 		<StepContainer
@@ -34,11 +27,7 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 					align={ 'left' }
 				/>
 			}
-			stepContent={
-				<Button type="submit" primary onClick={ submitPodcastTitle }>
-					{ translate( 'Continue' ) }
-				</Button>
-			}
+			stepContent={ <Button onClick={ goNext }>Go to next step</Button> }
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
@@ -1,0 +1,47 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { Button } from '@automattic/components';
+import { StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
+	const { goBack, submit } = navigation;
+	const translate = useTranslate();
+	const headerText = translate( 'My podcast is called' );
+	const subHeaderText = translate( "Don't worry, you can change it later." );
+
+	const submitPodcastTitle = ( podcastTitle: string ) => {
+		const providedDependencies = { podcastTitle };
+		recordTracksEvent( 'calypso_signup_podcast_title_select', providedDependencies );
+		//setPodcastTitle( podcastTitle );
+		submit?.( providedDependencies, podcastTitle );
+	};
+
+	return (
+		<StepContainer
+			stepName={ 'podcast-title-step' }
+			goBack={ goBack }
+			hideSkip
+			hideBack
+			isHorizontalLayout={ true }
+			formattedHeader={
+				<FormattedHeader
+					id={ 'podcast-title-header' }
+					headerText={ headerText }
+					subHeaderText={ subHeaderText }
+					align={ 'left' }
+				/>
+			}
+			stepContent={
+				<Button type="submit" primary onClick={ submitPodcastTitle }>
+					{ translate( 'Continue' ) }
+				</Button>
+			}
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default PodcastTitleStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
@@ -7,10 +7,14 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
 const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
-	const { goBack, goNext } = navigation;
+	const { goBack, submit } = navigation;
 	const translate = useTranslate();
 	const headerText = translate( 'My podcast is called' );
 	const subHeaderText = translate( "Don't worry, you can change it later." );
+
+	const handleClick = () => {
+		submit?.();
+	};
 
 	return (
 		<StepContainer
@@ -27,7 +31,7 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 					align={ 'left' }
 				/>
 			}
-			stepContent={ <Button onClick={ goNext }>Go to next step</Button> }
+			stepContent={ <Button onClick={ handleClick }>Go to next step</Button> }
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -9,6 +9,7 @@ import { requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { LocaleContext } from '../gutenboarding/components/locale-context';
 import { WindowLocaleEffectManager } from '../gutenboarding/components/window-locale-effect-manager';
 import { setupWpDataDebug } from '../gutenboarding/devtools';
+import { anchorFmFlow } from './declarative-flow/anchor-fm-flow';
 import { FlowRenderer } from './declarative-flow/internals';
 import { siteSetupFlow } from './declarative-flow/site-setup-flow';
 import 'calypso/components/environment-badge/style.scss';
@@ -43,12 +44,19 @@ window.AppBoot = async () => {
 
 	const queryClient = new QueryClient();
 
+	const flow = config.isEnabled( 'signup/anchor-fm' ) ? anchorFmFlow : siteSetupFlow;
+
 	ReactDom.render(
 		<LocaleContext>
 			<QueryClientProvider client={ queryClient }>
 				<WindowLocaleEffectManager />
+<<<<<<< HEAD
 				<BrowserRouter basename="setup">
 					<FlowRenderer flow={ siteSetupFlow } />
+=======
+				<BrowserRouter basename="stepper">
+					<FlowRenderer flow={ flow } />
+>>>>>>> 1e39f48536 (Begin adding Anchor.fm as a separate flow)
 				</BrowserRouter>
 			</QueryClientProvider>
 		</LocaleContext>,

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -50,13 +50,8 @@ window.AppBoot = async () => {
 		<LocaleContext>
 			<QueryClientProvider client={ queryClient }>
 				<WindowLocaleEffectManager />
-<<<<<<< HEAD
 				<BrowserRouter basename="setup">
-					<FlowRenderer flow={ siteSetupFlow } />
-=======
-				<BrowserRouter basename="stepper">
 					<FlowRenderer flow={ flow } />
->>>>>>> 1e39f48536 (Begin adding Anchor.fm as a separate flow)
 				</BrowserRouter>
 			</QueryClientProvider>
 		</LocaleContext>,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new flow for Anchor.fm users that will replace the flow in `/new` (behind a feature flag, of course!)
* Access the flow by going to `/setup?flags=signup/anchor-fm&siteSlug=[yoursite.wordpress.com]`

I'm unsure on the architecture for adding a new flow. I've broken it out into its own file, but kept it within the `declarative-flow` directory alongside site setup. I've done so because I suspect there will be lots of overlap in the steps (eg. we could use `designSetup` rather than recreating it for Anchor), hooks, and stores...but I'm not fixed to this route if it makes more sense to isolate the flow elsewhere. 

**(Unstyled very ugly barely functional) Visual**

<img width="1194" alt="Screen Shot 2022-04-11 at 3 48 37 PM" src="https://user-images.githubusercontent.com/2124984/162818079-db7e9aa6-ce00-421f-9334-297baf818d3a.png">


#### Testing instructions

* Switch to this PR locally and go to `/setup?flags=signup/anchor-fm&siteSlug=[yoursite.wordpress.com]` -- there's a temporary check here to show the Anchor flow when the flag is enabled instead of the site setup flow.
* You should be shown the `podcastTitle` step
* You should be able to click "Go to next step", select a theme, and "Go to next step" to land on `/page/[yoursite.wordpress.com]` (eventually we'll create a Home page and land them there)
* You should be able to go back and forward within the flow and land on the correct steps

Related to #62669
