### PR TITLE
Fix product card incorrectly displays multisite incompatible

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -28,6 +28,7 @@ type OwnProps = {
 	buttonPrimary: boolean;
 	onButtonClick?: React.MouseEventHandler;
 	buttonURL?: string;
+	buttonDisabled?: boolean;
 	expiryDate?: Moment;
 	isFeatured?: boolean;
 	isOwned?: boolean;
@@ -67,6 +68,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 	buttonPrimary,
 	onButtonClick,
 	buttonURL,
+	buttonDisabled,
 	expiryDate,
 	isFeatured,
 	isOwned,
@@ -188,8 +190,8 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 						primary={ buttonPrimary }
 						className="jetpack-product-card__button"
 						onClick={ onButtonClick }
-						href={ isDisabled ? '#' : buttonURL }
-						disabled={ isDisabled }
+						href={ isDisabled || buttonDisabled ? '#' : buttonURL }
+						disabled={ isDisabled || buttonDisabled }
 					>
 						{ buttonLabel }
 					</Button>
@@ -198,7 +200,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 						primary={ buttonPrimary }
 						className="jetpack-product-card__button"
 						onClick={ onButtonClick }
-						disabled={ isDisabled }
+						disabled={ isDisabled || buttonDisabled }
 					>
 						{ buttonLabel }
 					</Button>

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -164,6 +164,11 @@
 	em {
 		font-style: normal;
 	}
+	.info-popover.owner-info__pop-over {
+		> .gridicon {
+			color: var( --color-accent );
+		}
+	}
 }
 
 .jetpack-product-card__features {

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -165,12 +165,15 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 	const isDisabled =
 		( ( isMultisite && ! isMultisiteCompatible ) ||
 			isCrmMonthlyProduct ||
-			( ! purchase && item.type === ITEM_TYPE_PLAN && jetpackUpgradesLocked ) ||
-			( purchase && isNotPlanOwner ) ) ??
+			( ! purchase && item.type === ITEM_TYPE_PLAN && jetpackUpgradesLocked ) ) ??
 		false;
 
+	// Disable the button CTA if the overall product card is disabled, or disable
+	//  the "Manage Plan/Subscription" button if the user is not the purchase owner.
+	const buttonDisabled = isOwned || isIncludedInPlan ? isDisabled || isNotPlanOwner : isDisabled;
+
 	let disabledMessage;
-	if ( isDisabled && isNotPlanOwner ) {
+	if ( isDisabled ) {
 		if ( ! isMultisiteCompatible && ! isDeprecated ) {
 			disabledMessage = translate( 'Not available for multisite WordPress installs' );
 		} else if ( isCrmMonthlyProduct ) {
@@ -220,6 +223,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			buttonURL={
 				createButtonURL ? createButtonURL( item, isUpgradeableToYearly, purchase ) : undefined
 			}
+			buttonDisabled={ isDisabled || buttonDisabled }
 			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
 			isFeatured={ isFeatured }
 			isOwned={ isOwned }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Asana ticket: 1164141197617539-as-1202093428789820/f

This PR fixes an issue when logged in as a secondary admin user the plans page incorrectly shows the owned products as disabled with a message saying the products are incompatible with multisite installations, when the site is Not a multisite installation.  (See screenshots)

The desired behavior would be the the owned product cards should **not** be disabled, however the the "Manage Plan/Subscription" _button_ would be disabled, because a secondary admin cannot manage the subscription unless they are the  _purchase **owner**_. The result of this PR is this desired behavior.

**Before:**

![Markup 2022-04-11 at 20 30 56](https://user-images.githubusercontent.com/11078128/162855001-79564c88-65dc-4d8b-bf84-49e6bc0f9452.png)


**After:**

![Markup 2022-04-11 at 20 33 03](https://user-images.githubusercontent.com/11078128/162855017-6eee2f6b-9b01-446c-9820-e73443c4fc1c.png)


#### Testing instructions

- Do not checkout and run this PR yet
- Create a JN site (do not create a multi-site)
- Purchase and activate a Jetpack Security subscription with a user A 
- Add a secondary admin user to the site (let's call it user B)
    - To create a secondary admin user, go to Users --> Invitees --> + Invite --> Add username/email of another wordpress.com user you can access (user B).  Check your email and accept invite.
- Log in to [WordPress.com](https://wordpress.com/) with user B
- Select the site
- Visit the Plans page
- Verify that you see the "Not available for multisite WordPress installs" message over most product cards. This is incorrect.
- Now checkout this PR and start calypso blue (`yarn start`).
- While logged in with user B, Select the site, and visit the plans page. (`calypso.localhost:3000/plans/:site`)
- Verify none of the product cards are disabled.
- Verify the owned/included with plan products CTA _buttons_ are disabled with an info icon tooltip, explaining that the user cannot manage the subscription.
- Now, log in with user A, Select the site, and visit the plans page. (`calypso.localhost:3000/plans/:site`);
- Verify the owned/included with plan product CTA buttons are Not disabled, and the user can click to manage the plan/product.


Related to #