### PR TITLE
Add Categories component to plugins browser

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -16,7 +16,7 @@ const baseStaleTime = 1000 * 60 * 60 * 2; // 2h
 
 const getCacheKey = ( key: string ): QueryKey => [ 'wpcom-plugins', key ];
 
-const fetchWPCOMPlugins = ( type: Type, searchTerm?: string ) => {
+const fetchWPCOMPlugins = ( type: Type, searchTerm?: string, tag?: string ) => {
 	const [ search, author ] = extractSearchInformation( searchTerm );
 
 	return wpcom.req.get(
@@ -28,6 +28,7 @@ const fetchWPCOMPlugins = ( type: Type, searchTerm?: string ) => {
 			type: type,
 			...( search && { q: search } ),
 			...( author && { author } ),
+			...( tag && { tag } ),
 		}
 	);
 };
@@ -37,20 +38,26 @@ const fetchWPCOMPlugins = ( type: Type, searchTerm?: string ) => {
  *
  * @param {Type} type Optional The query type
  * @param {string} searchTerm Optional The term to search for
+ * @param {string} tag Optional The tag to search for
  * @param {{enabled: boolean, staleTime: number, refetchOnMount: boolean}} {} Optional options to pass to the underlying query engine
  * @returns {{ data, error, isLoading: boolean ...}} Returns various parameters piped from `useQuery`
  */
 export const useWPCOMPlugins = (
 	type: Type,
 	searchTerm?: string,
+	tag?: string,
 	{ enabled = true, staleTime = baseStaleTime, refetchOnMount = true }: UseQueryOptions = {}
 ): UseQueryResult => {
-	return useQuery( getCacheKey( type + searchTerm ), () => fetchWPCOMPlugins( type, searchTerm ), {
-		select: ( data ) => normalizePluginsList( data.results ),
-		enabled: enabled,
-		staleTime: staleTime,
-		refetchOnMount: refetchOnMount,
-	} );
+	return useQuery(
+		getCacheKey( type + searchTerm + tag ),
+		() => fetchWPCOMPlugins( type, searchTerm, tag ),
+		{
+			select: ( data ) => normalizePluginsList( data.results ),
+			enabled: enabled,
+			staleTime: staleTime,
+			refetchOnMount: refetchOnMount,
+		}
+	);
 };
 
 const fetchWPCOMPlugin = ( slug: string ) => {

--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -28,7 +28,7 @@ const fetchWPCOMPlugins = ( type: Type, searchTerm?: string, tag?: string ) => {
 			type: type,
 			...( search && { q: search } ),
 			...( author && { author } ),
-			...( tag && { tag } ),
+			...( tag && ! search && { tag } ),
 		}
 	);
 };

--- a/client/data/marketplace/use-wporg-plugin-query.ts
+++ b/client/data/marketplace/use-wporg-plugin-query.ts
@@ -20,6 +20,7 @@ type WPORGOptionsType = {
 	page?: number;
 	category?: string;
 	searchTerm?: string;
+	tag?: string;
 	locale: string;
 };
 
@@ -29,7 +30,7 @@ const getPluginsListKey = ( options: WPORGOptionsType, infinite?: boolean ): Que
 	getCacheKey(
 		`${ infinite ? 'infinite' : '' }${ options.category || '' }_${ options.searchTerm || '' }_${
 			options.page || ''
-		}_${ options.pageSize || '' }_${ options.locale || '' }`
+		}${ options.tag || '' }_${ options.pageSize || '' }_${ options.locale || '' }`
 	);
 
 export const useWPORGPlugins = (
@@ -84,6 +85,7 @@ export const useWPORGInfinitePlugins = (
 				category: options.category,
 				locale: options.locale || locale,
 				search,
+				tag: options.tag,
 				author,
 			} ),
 		{

--- a/client/data/marketplace/use-wporg-plugin-query.ts
+++ b/client/data/marketplace/use-wporg-plugin-query.ts
@@ -30,7 +30,9 @@ const getPluginsListKey = ( options: WPORGOptionsType, infinite?: boolean ): Que
 	getCacheKey(
 		`${ infinite ? 'infinite' : '' }${ options.category || '' }_${ options.searchTerm || '' }_${
 			options.page || ''
-		}${ options.tag || '' }_${ options.pageSize || '' }_${ options.locale || '' }`
+		}_${ options.tag && ! options.searchTerm ? options.tag : '' }_${ options.pageSize || '' }_${
+			options.locale || ''
+		}`
 	);
 
 export const useWPORGPlugins = (
@@ -50,6 +52,7 @@ export const useWPORGPlugins = (
 				locale: options.locale || locale,
 				search,
 				author,
+				tag: options.tag && ! search ? options.tag : null,
 			} ),
 		{
 			select: ( { plugins = [], info = {} } ) => ( {
@@ -85,7 +88,7 @@ export const useWPORGInfinitePlugins = (
 				category: options.category,
 				locale: options.locale || locale,
 				search,
-				tag: options.tag,
+				tag: options.tag && ! search ? options.tag : null,
 				author,
 			} ),
 		{

--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -1,4 +1,5 @@
-import url from 'url';
+// eslint-disable-next-line no-restricted-imports
+import url from 'url'; //TODO: fix this restricted import
 import debugFactory from 'debug';
 import { pick } from 'lodash';
 import page from 'page';
@@ -22,7 +23,7 @@ const debug = debugFactory( 'calypso:url-search' );
  *
  * @returns {string} The built search url
  */
-export const buildSearchUrl = ( { uri, search, queryKey = 's' } ) => {
+export const buildSearchUrl = ( { uri, search, queryKey = 's' }, extraParams = {} ) => {
 	const parsedUrl = pick( url.parse( uri, true ), 'pathname', 'hash', 'query' );
 
 	if ( search ) {
@@ -30,6 +31,10 @@ export const buildSearchUrl = ( { uri, search, queryKey = 's' } ) => {
 	} else {
 		delete parsedUrl.query[ queryKey ];
 	}
+
+	Object.keys( extraParams ).forEach( ( extraParamKey ) => {
+		parsedUrl.query[ extraParamKey ] = extraParams[ extraParamKey ];
+	} );
 
 	return url.format( parsedUrl ).replace( /%20/g, '+' );
 };
@@ -50,16 +55,19 @@ const UrlSearch = ( Component ) =>
 			return ! search && this.setState( { searchOpen: false } );
 		}
 
-		doSearch = ( query ) => {
+		doSearch = ( query, extraParams = {} ) => {
 			this.setState( {
 				searchOpen: false !== query,
 			} );
 
-			const searchURL = buildSearchUrl( {
-				uri: window.location.href,
-				search: query,
-				queryKey: this.props.queryKey,
-			} );
+			const searchURL = buildSearchUrl(
+				{
+					uri: window.location.href,
+					search: query,
+					queryKey: this.props.queryKey,
+				},
+				extraParams
+			);
 
 			debug( 'search for: %s', query );
 			if ( this.props.search && query ) {
@@ -79,6 +87,7 @@ const UrlSearch = ( Component ) =>
 			return (
 				<Component
 					{ ...this.props }
+					queryParams={ url.parse( this.props.path, true ).query }
 					doSearch={ this.doSearch }
 					getSearchOpen={ this.getSearchOpen }
 				/>

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -59,13 +59,14 @@ export function fetchPluginsList( options ) {
 	const category = options.category || DEFAULT_CATEGORY;
 	const search = options.search;
 	const author = options.author;
+	const tag = options.tag;
 
 	const query = {
 		action: 'query_plugins',
 		'request[page]': page,
 		'request[per_page]': pageSize,
 		'request[fields]':
-			'icons,last_updated,rating,active_installs,tested,-downloaded,-ratings,-requires,-requires_php,-tags,-contributors,-added,-donate_link,-homepage',
+			'icons,last_updated,rating,active_installs,tested,-downloaded,-ratings,-requires,-requires_php,-contributors,-added,-donate_link,-homepage',
 		'request[locale]': getWporgLocaleCode( options.locale ),
 	};
 
@@ -77,7 +78,11 @@ export function fetchPluginsList( options ) {
 		query[ 'request[author]' ] = author;
 	}
 
-	if ( ! search && ! author ) {
+	if ( tag ) {
+		query[ 'request[tag]' ] = tag;
+	}
+
+	if ( ! search && ! author && ! tag ) {
 		query[ 'request[browse]' ] = category;
 	}
 

--- a/client/my-sites/plugins/categories/README.md
+++ b/client/my-sites/plugins/categories/README.md
@@ -1,0 +1,15 @@
+# Categories
+
+This component is used to render the discover section of the plugin marketplace.
+
+## How to use
+
+```jsx
+import Discover from 'calypso/my-sites/plugins/discover';
+
+<Categories onSelect={ ( category ) => {} } />;
+```
+
+## Props
+
+- `onSelect`: Called when the user selects a new category.

--- a/client/my-sites/plugins/categories/README.md
+++ b/client/my-sites/plugins/categories/README.md
@@ -5,7 +5,7 @@ This component is used to render the discover section of the plugin marketplace.
 ## How to use
 
 ```jsx
-import Discover from 'calypso/my-sites/plugins/discover';
+import Discover from 'calypso/my-sites/plugins/categories';
 
 <Categories onSelect={ ( category ) => {} } />;
 ```

--- a/client/my-sites/plugins/categories/categories-list.tsx
+++ b/client/my-sites/plugins/categories/categories-list.tsx
@@ -1,0 +1,152 @@
+import { translate } from 'i18n-calypso';
+
+export type Category = {
+	name: string;
+	slug: string;
+	tags: string[];
+	description?: string;
+	icon?: string;
+	separator?: boolean;
+};
+
+const ALL_CATEGORIES: Record< string, Category > = {
+	discover: { name: translate( 'Discover', { textOnly: true } ), slug: 'discover', tags: [] },
+	// 'top-free': {
+	// 	name: translate( 'Top free plugins', { textOnly: true } ),
+	// 	slug: 'top-free',
+	// 	tags: [],
+	// },
+	// 'top-paid': {
+	// 	name: translate( 'Top premium plugins', { textOnly: true } ),
+	// 	slug: 'top-paid',
+	// 	tags: [],
+	// },
+	// editors: { name: translate( 'Editor’s pick', { textOnly: true } ), slug: 'editors', tags: [] },
+	// separator: { name: '', separator: true, slug: '', tags: [] },
+	// all: { name: translate( 'All Categories', { textOnly: true } ), slug: 'all', tags: [] },
+	analytics: {
+		name: translate( 'Analytics', { textOnly: true } ),
+		description: translate( 'Analytics', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'analytics',
+		tags: [ 'analytics' ],
+	},
+	business: {
+		name: translate( 'Business', { textOnly: true } ),
+		description: translate( 'Business', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'business',
+		tags: [ 'business' ],
+	},
+	customer: {
+		name: translate( 'Customer Service', { textOnly: true } ),
+		description: translate( 'Customer Service', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'customer',
+		tags: [ 'customer-service' ],
+	},
+	design: {
+		name: translate( 'Design', { textOnly: true } ),
+		description: translate( 'Design', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'design',
+		tags: [ 'design' ],
+	},
+	ecommerce: {
+		name: translate( 'Ecommerce', { textOnly: true } ),
+		description: translate( 'Ecommerce', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'ecommerce',
+		tags: [ 'ecommerce', 'woocommerce' ],
+	},
+	education: {
+		name: translate( 'Education', { textOnly: true } ),
+		description: translate( 'Education', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'education',
+		tags: [ 'education' ],
+	},
+	finance: {
+		name: translate( 'Finance', { textOnly: true } ),
+		description: translate( 'Finance', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'finance',
+		tags: [ 'finance' ],
+	},
+	marketing: {
+		name: translate( 'Marketing', { textOnly: true } ),
+		description: translate( 'Marketing', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'marketing',
+		tags: [ 'marketing' ],
+	},
+	seo: {
+		name: translate( 'Search Optimization', { textOnly: true } ),
+		description: translate( 'Search Optimization', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'seo',
+		tags: [ 'seo' ],
+	},
+	photo: {
+		name: translate( 'Photo & Video', { textOnly: true } ),
+		description: translate( 'Photo & Video', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'photo',
+		tags: [ 'photo', 'video', 'media' ],
+	},
+	social: {
+		name: translate( 'Social', { textOnly: true } ),
+		description: translate( 'Social', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'social',
+		tags: [ 'social', 'facebook', 'twitter', 'instagram', 'tiktok', 'youtube', 'pinterest' ],
+	},
+	widgets: {
+		name: translate( 'Widgets', { textOnly: true } ),
+		description: translate( 'Widgets', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'widgets',
+		tags: [ 'widgets' ],
+	},
+	email: {
+		name: translate( 'Email', { textOnly: true } ),
+		description: translate( 'Email', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'email',
+		tags: [ 'email' ],
+	},
+	security: {
+		name: translate( 'Security', { textOnly: true } ),
+		description: translate( 'Security', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'security',
+		tags: [ 'security' ],
+	},
+	posts: {
+		name: translate( 'Posts & Posting', { textOnly: true } ),
+		description: translate( 'Posts & Posting', { textOnly: true } ),
+		icon: 'grid',
+		slug: 'posts',
+		tags: [ 'posts', 'post', 'page', 'pages' ],
+	},
+};
+
+export function getAllCategoriesRecords() {
+	return ALL_CATEGORIES;
+}
+
+export function getTagsFromCategory( categorySlug: string ) {
+	return ALL_CATEGORIES[ categorySlug ]?.tags;
+}
+
+export function getCategoryUrl( category: Category, siteSlug?: string ) {
+	return category.slug !== 'discover' && category.slug !== 'all'
+		? `/plugins/${ category.slug }/${ siteSlug || '' }`
+		: `/plugins/${ siteSlug || '' }`;
+}
+
+export function getCategoriesWithTags() {
+	return Object.values( ALL_CATEGORIES ).filter( ( category ) => {
+		return category.tags.length > 0;
+	} );
+}

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -1,0 +1,115 @@
+import { Card, Gridicon } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import './style.scss';
+
+export type Category = {
+	slug: string;
+	name: string;
+	separator?: boolean;
+};
+
+const PopularCategories = ( {
+	onSelect,
+	categories,
+}: {
+	onSelect: ( category: Category ) => void;
+	categories: Category[];
+} ) => {
+	return (
+		<div className="categories__card-list">
+			{ categories.slice( 0, 6 ).map(
+				( category, n ) =>
+					! category.separator && (
+						<Card
+							className="categories__card-list-item"
+							onClick={ () => onSelect( category ) }
+							onKeyPress={ () => onSelect( category ) }
+							role="link"
+							tabIndex={ 0 }
+							key={ 'popular-categories-' + n }
+						>
+							{ category.name }
+						</Card>
+					)
+			) }
+		</div>
+	);
+};
+
+const Categories = ( { onSelect }: { onSelect: ( category: Category ) => void } ) => {
+	const dispatch = useDispatch();
+	const { __ } = useI18n();
+
+	const popularCategories: Category[] = [
+		{ slug: 'discover', name: __( 'Discover' ) },
+		{ slug: 'collections', name: __( 'Collections' ) },
+		{ slug: '', name: '', separator: true },
+		{ slug: 'all', name: __( 'All Categories' ) },
+		{ slug: 'ecommerce', name: __( 'Ecommerce' ) },
+		{ slug: 'widget', name: __( 'Widgets' ) },
+		{ slug: 'posts', name: __( 'Posts & Pages' ) },
+		{ slug: 'admin', name: __( 'Administration' ) },
+		{ slug: 'shortcode', name: __( 'Shortcodes' ) },
+		{ slug: 'comments', name: __( 'Comments' ) },
+		{ slug: 'seo', name: __( 'SEO' ) },
+		{ slug: 'images', name: __( 'Images' ) },
+		{ slug: 'social', name: __( 'Social' ) },
+		{ slug: 'sidebar', name: __( 'Sidebar' ) },
+		{ slug: 'email', name: __( 'Email' ) },
+		{ slug: 'security', name: __( 'Security' ) },
+		{ slug: 'video', name: __( 'Video' ) },
+		{ slug: 'links', name: __( 'Links' ) },
+	];
+
+	const onClick = () => {
+		const category = { slug: 'todo', name: 'ToDo' };
+
+		dispatch(
+			recordTracksEvent( 'calypso_plugins_discover_click', {
+				category: category.slug,
+			} )
+		);
+
+		onSelect( category );
+	};
+
+	const [ selecting, setSelecting ] = useState( false );
+	const toggleSelecting = () => setSelecting( ! selecting );
+
+	return (
+		<div className="categories__discover">
+			<button className="categories__header" onClick={ toggleSelecting }>
+				{ /* translators: Page title, referring to discovering categories */ }
+				{ __( 'Discover' ) }
+				&nbsp;
+				{ ! selecting && <Gridicon icon="chevron-right" /> }
+				{ selecting && <Gridicon icon="chevron-down" /> }
+			</button>
+			{ selecting && (
+				<ul className="categories__select-list">
+					{ popularCategories.map( ( category, n ) => (
+						<li key={ 'categories-' + n }>
+							{ category.separator && <hr /> }
+							{ ! category.separator && (
+								<span
+									onClick={ () => onSelect( category ) }
+									onKeyPress={ () => onSelect( category ) }
+									role="link"
+									tabIndex={ 0 }
+								>
+									{ category.name }
+								</span>
+							) }
+						</li>
+					) ) }
+				</ul>
+			) }
+			<PopularCategories onSelect={ onClick } categories={ popularCategories } />
+		</div>
+	);
+};
+
+export default Categories;

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -1,9 +1,8 @@
 import { Gridicon } from '@automattic/components';
-import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import PopularCategories from './popular-categories';
+import { getAllCategoriesRecords } from './categories-list';
 import './style.scss';
 
 export type Category = {
@@ -15,127 +14,20 @@ export type Category = {
 	separator?: boolean;
 };
 
-const Categories = ( { onSelect }: { onSelect: ( category: Category ) => void } ) => {
+const Categories = ( {
+	onSelect,
+	selectedSlug,
+}: {
+	onSelect: ( category: Category ) => void;
+	selectedSlug?: string;
+} ) => {
 	const dispatch = useDispatch();
-	const { __ } = useI18n();
-
-	const popularCategories: Record< string, Category > = {
-		discover: { name: __( 'Discover' ), slug: 'discover', tags: [] },
-		'top-free': { name: __( 'Top free plugins' ), slug: 'top-free', tags: [] },
-		'top-paid': { name: __( 'Top premium plugins' ), slug: 'top-paid', tags: [] },
-		editors: { name: __( 'Editor’s pick' ), slug: 'editors', tags: [] },
-		separator: { name: '', separator: true, slug: '', tags: [] },
-		all: { name: __( 'All Categories' ), slug: 'all', tags: [] },
-		analytics: {
-			name: __( 'Analytics' ),
-			description: __( 'Analytics' ),
-			icon: 'grid',
-			slug: 'analytics',
-			tags: [ 'analytics' ],
-		},
-		business: {
-			name: __( 'Business' ),
-			description: __( 'Business' ),
-			icon: 'grid',
-			slug: 'business',
-			tags: [ 'business' ],
-		},
-		customer: {
-			name: __( 'Customer Service' ),
-			description: __( 'Customer Service' ),
-			icon: 'grid',
-			slug: 'customer',
-			tags: [ 'customer-service' ],
-		},
-		design: {
-			name: __( 'Design' ),
-			description: __( 'Design' ),
-			icon: 'grid',
-			slug: 'design',
-			tags: [ 'design' ],
-		},
-		ecommerce: {
-			name: __( 'Ecommerce' ),
-			description: __( 'Ecommerce' ),
-			icon: 'grid',
-			slug: 'ecommerce',
-			tags: [ 'ecommerce', 'woocommerce' ],
-		},
-		education: {
-			name: __( 'Education' ),
-			description: __( 'Education' ),
-			icon: 'grid',
-			slug: 'education',
-			tags: [ 'education' ],
-		},
-		finance: {
-			name: __( 'Finance' ),
-			description: __( 'Finance' ),
-			icon: 'grid',
-			slug: 'finance',
-			tags: [ 'finance' ],
-		},
-		marketing: {
-			name: __( 'Marketing' ),
-			description: __( 'Marketing' ),
-			icon: 'grid',
-			slug: 'marketing',
-			tags: [ 'marketing' ],
-		},
-		seo: {
-			name: __( 'Search Optimization' ),
-			description: __( 'Search Optimization' ),
-			icon: 'grid',
-			slug: 'seo',
-			tags: [ 'seo' ],
-		},
-		photo: {
-			name: __( 'Photo & Video' ),
-			description: __( 'Photo & Video' ),
-			icon: 'grid',
-			slug: 'photo',
-			tags: [ 'photo', 'video', 'media' ],
-		},
-		social: {
-			name: __( 'Social' ),
-			description: __( 'Social' ),
-			icon: 'grid',
-			slug: 'social',
-			tags: [ 'social', 'facebook', 'twitter', 'instagram', 'tiktok', 'youtube', 'pinterest' ],
-		},
-		widgets: {
-			name: __( 'Widgets' ),
-			description: __( 'Widgets' ),
-			icon: 'grid',
-			slug: 'widgets',
-			tags: [ 'widgets' ],
-		},
-		email: {
-			name: __( 'Email' ),
-			description: __( 'Email' ),
-			icon: 'grid',
-			slug: 'email',
-			tags: [ 'email' ],
-		},
-		security: {
-			name: __( 'Security' ),
-			description: __( 'Security' ),
-			icon: 'grid',
-			slug: 'security',
-			tags: [ 'security' ],
-		},
-		posts: {
-			name: __( 'Posts & Posting' ),
-			description: __( 'Posts & Posting' ),
-			icon: 'grid',
-			slug: 'posts',
-			tags: [ 'posts', 'post', 'page', 'pages' ],
-		},
-	};
 
 	const [ selecting, setSelecting ] = useState( false );
 	const toggleSelecting = () => setSelecting( ! selecting );
-	const [ selected, setSelected ] = useState< Category >( popularCategories.discover );
+	const [ selected, setSelected ] = useState< Category >(
+		getAllCategoriesRecords()[ selectedSlug || 'discover' ]
+	);
 
 	const onClick = ( category: Category ) => {
 		dispatch(
@@ -161,7 +53,7 @@ const Categories = ( { onSelect }: { onSelect: ( category: Category ) => void } 
 			</button>
 			{ selecting && (
 				<ul className="categories__select-list">
-					{ Object.values( popularCategories ).map( ( category, n ) => (
+					{ Object.values( getAllCategoriesRecords() ).map( ( category, n ) => (
 						<li key={ 'categories-' + n }>
 							{ category.separator && <hr /> }
 							{ ! category.separator && (
@@ -178,9 +70,9 @@ const Categories = ( { onSelect }: { onSelect: ( category: Category ) => void } 
 					) ) }
 				</ul>
 			) }
-			{ selected.slug === 'discover' && (
-				<PopularCategories onSelect={ onClick } categories={ Object.values( popularCategories ) } />
-			) }
+			{ /*{ selected.slug === 'discover' && (*/ }
+			{ /*	<PopularCategories onSelect={ onClick } categories={ Object.values( popularCategories ) } />*/ }
+			{ /*) }*/ }
 		</div>
 	);
 };

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -1,102 +1,173 @@
-import { Card, Gridicon } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+// import PopularCategories from './popular-categories';
 import './style.scss';
 
 export type Category = {
-	slug: string;
 	name: string;
+	slug: string;
+	tags: string[];
+	description?: string;
+	icon?: string;
 	separator?: boolean;
-};
-
-const PopularCategories = ( {
-	onSelect,
-	categories,
-}: {
-	onSelect: ( category: Category ) => void;
-	categories: Category[];
-} ) => {
-	return (
-		<div className="categories__card-list">
-			{ categories.slice( 0, 6 ).map(
-				( category, n ) =>
-					! category.separator && (
-						<Card
-							className="categories__card-list-item"
-							onClick={ () => onSelect( category ) }
-							onKeyPress={ () => onSelect( category ) }
-							role="link"
-							tabIndex={ 0 }
-							key={ 'popular-categories-' + n }
-						>
-							{ category.name }
-						</Card>
-					)
-			) }
-		</div>
-	);
 };
 
 const Categories = ( { onSelect }: { onSelect: ( category: Category ) => void } ) => {
 	const dispatch = useDispatch();
 	const { __ } = useI18n();
 
-	const popularCategories: Category[] = [
-		{ slug: 'discover', name: __( 'Discover' ) },
-		{ slug: 'collections', name: __( 'Collections' ) },
-		{ slug: '', name: '', separator: true },
-		{ slug: 'all', name: __( 'All Categories' ) },
-		{ slug: 'ecommerce', name: __( 'Ecommerce' ) },
-		{ slug: 'widget', name: __( 'Widgets' ) },
-		{ slug: 'posts', name: __( 'Posts & Pages' ) },
-		{ slug: 'admin', name: __( 'Administration' ) },
-		{ slug: 'shortcode', name: __( 'Shortcodes' ) },
-		{ slug: 'comments', name: __( 'Comments' ) },
-		{ slug: 'seo', name: __( 'SEO' ) },
-		{ slug: 'images', name: __( 'Images' ) },
-		{ slug: 'social', name: __( 'Social' ) },
-		{ slug: 'sidebar', name: __( 'Sidebar' ) },
-		{ slug: 'email', name: __( 'Email' ) },
-		{ slug: 'security', name: __( 'Security' ) },
-		{ slug: 'video', name: __( 'Video' ) },
-		{ slug: 'links', name: __( 'Links' ) },
-	];
-
-	const onClick = () => {
-		const category = { slug: 'todo', name: 'ToDo' };
-
-		dispatch(
-			recordTracksEvent( 'calypso_plugins_discover_click', {
-				category: category.slug,
-			} )
-		);
-
-		onSelect( category );
+	const popularCategories: Record< string, Category > = {
+		discover: { name: __( 'Discover' ), slug: 'discover', tags: [] },
+		'top-free': { name: __( 'Top free plugins' ), slug: 'top-free', tags: [] },
+		'top-paid': { name: __( 'Top premium plugins' ), slug: 'top-paid', tags: [] },
+		editors: { name: __( 'Editor’s pick' ), slug: 'editors', tags: [] },
+		separator: { name: '', separator: true, slug: '', tags: [] },
+		all: { name: __( 'All Categories' ), slug: 'all', tags: [] },
+		analytics: {
+			name: __( 'Analytics' ),
+			description: __( 'Analytics' ),
+			icon: 'grid',
+			slug: 'analytics',
+			tags: [ 'analytics' ],
+		},
+		business: {
+			name: __( 'Business' ),
+			description: __( 'Business' ),
+			icon: 'grid',
+			slug: 'business',
+			tags: [ 'business' ],
+		},
+		customer: {
+			name: __( 'Customer Service' ),
+			description: __( 'Customer Service' ),
+			icon: 'grid',
+			slug: 'customer',
+			tags: [ 'customer-service' ],
+		},
+		design: {
+			name: __( 'Design' ),
+			description: __( 'Design' ),
+			icon: 'grid',
+			slug: 'design',
+			tags: [ 'design' ],
+		},
+		ecommerce: {
+			name: __( 'Ecommerce' ),
+			description: __( 'Ecommerce' ),
+			icon: 'grid',
+			slug: 'ecommerce',
+			tags: [ 'ecommerce', 'woocommerce' ],
+		},
+		education: {
+			name: __( 'Education' ),
+			description: __( 'Education' ),
+			icon: 'grid',
+			slug: 'education',
+			tags: [ 'education' ],
+		},
+		finance: {
+			name: __( 'Finance' ),
+			description: __( 'Finance' ),
+			icon: 'grid',
+			slug: 'finance',
+			tags: [ 'finance' ],
+		},
+		marketing: {
+			name: __( 'Marketing' ),
+			description: __( 'Marketing' ),
+			icon: 'grid',
+			slug: 'marketing',
+			tags: [ 'marketing' ],
+		},
+		seo: {
+			name: __( 'Search Optimization' ),
+			description: __( 'Search Optimization' ),
+			icon: 'grid',
+			slug: 'seo',
+			tags: [ 'seo' ],
+		},
+		photo: {
+			name: __( 'Photo & Video' ),
+			description: __( 'Photo & Video' ),
+			icon: 'grid',
+			slug: 'photo',
+			tags: [ 'photo', 'video', 'media' ],
+		},
+		social: {
+			name: __( 'Social' ),
+			description: __( 'Social' ),
+			icon: 'grid',
+			slug: 'social',
+			tags: [ 'social', 'facebook', 'twitter', 'instagram', 'tiktok', 'youtube', 'pinterest' ],
+		},
+		widgets: {
+			name: __( 'Widgets' ),
+			description: __( 'Widgets' ),
+			icon: 'grid',
+			slug: 'widgets',
+			tags: [ 'widgets' ],
+		},
+		email: {
+			name: __( 'Email' ),
+			description: __( 'Email' ),
+			icon: 'grid',
+			slug: 'email',
+			tags: [ 'email' ],
+		},
+		security: {
+			name: __( 'Security' ),
+			description: __( 'Security' ),
+			icon: 'grid',
+			slug: 'security',
+			tags: [ 'security' ],
+		},
+		posts: {
+			name: __( 'Posts & Posting' ),
+			description: __( 'Posts & Posting' ),
+			icon: 'grid',
+			slug: 'posts',
+			tags: [ 'posts', 'post', 'page', 'pages' ],
+		},
 	};
 
 	const [ selecting, setSelecting ] = useState( false );
 	const toggleSelecting = () => setSelecting( ! selecting );
+	const [ selected, setSelected ] = useState< Category >( popularCategories.discover );
+
+	const onClick = ( category: Category ) => {
+		dispatch(
+			recordTracksEvent( 'calypso_plugins_discover_click', {
+				tag: category.slug || '',
+			} )
+		);
+
+		setSelected( category );
+		setSelecting( false );
+
+		onSelect( category );
+	};
 
 	return (
 		<div className="categories__discover">
 			<button className="categories__header" onClick={ toggleSelecting }>
 				{ /* translators: Page title, referring to discovering categories */ }
-				{ __( 'Discover' ) }
+				{ selected.name }
 				&nbsp;
 				{ ! selecting && <Gridicon icon="chevron-right" /> }
 				{ selecting && <Gridicon icon="chevron-down" /> }
 			</button>
 			{ selecting && (
 				<ul className="categories__select-list">
-					{ popularCategories.map( ( category, n ) => (
+					{ Object.values( popularCategories ).map( ( category, n ) => (
 						<li key={ 'categories-' + n }>
 							{ category.separator && <hr /> }
 							{ ! category.separator && (
 								<span
-									onClick={ () => onSelect( category ) }
-									onKeyPress={ () => onSelect( category ) }
+									onClick={ () => onClick( category ) }
+									onKeyPress={ () => onClick( category ) }
 									role="link"
 									tabIndex={ 0 }
 								>
@@ -107,7 +178,7 @@ const Categories = ( { onSelect }: { onSelect: ( category: Category ) => void } 
 					) ) }
 				</ul>
 			) }
-			<PopularCategories onSelect={ onClick } categories={ popularCategories } />
+			{ /* <PopularCategories onSelect={ onClick } categories={ popularCategories } /> */ }
 		</div>
 	);
 };

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -3,7 +3,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-// import PopularCategories from './popular-categories';
+import PopularCategories from './popular-categories';
 import './style.scss';
 
 export type Category = {
@@ -178,7 +178,9 @@ const Categories = ( { onSelect }: { onSelect: ( category: Category ) => void } 
 					) ) }
 				</ul>
 			) }
-			{ /* <PopularCategories onSelect={ onClick } categories={ popularCategories } /> */ }
+			{ selected.slug === 'discover' && (
+				<PopularCategories onSelect={ onClick } categories={ Object.values( popularCategories ) } />
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/plugins/categories/popular-categories.tsx
+++ b/client/my-sites/plugins/categories/popular-categories.tsx
@@ -1,0 +1,37 @@
+import { Card, Gridicon } from '@automattic/components';
+import type { Category } from '../categories';
+import './style.scss';
+
+const PopularCategories = ( {
+	onSelect,
+	categories,
+}: {
+	onSelect: ( category: Category ) => void;
+	categories: Category[];
+} ) => {
+	return (
+		<div className="categories__card-list">
+			{ categories.slice( 6, 12 ).map(
+				( category, n ) =>
+					! category.separator && (
+						<Card
+							className="categories__card-list-item"
+							onClick={ () => onSelect( category ) }
+							onKeyPress={ () => onSelect( category ) }
+							role="link"
+							tabIndex={ 0 }
+							key={ 'popular-categories-' + n }
+						>
+							{ category?.icon && <Gridicon icon={ category?.icon } /> }
+							<div>
+								<p>{ category.name }</p>
+								{ category?.description?.length && <p>{ category?.description }</p> }
+							</div>
+						</Card>
+					)
+			) }
+		</div>
+	);
+};
+
+export default PopularCategories;

--- a/client/my-sites/plugins/categories/style.scss
+++ b/client/my-sites/plugins/categories/style.scss
@@ -1,0 +1,8 @@
+.categories__discover {
+	.categories__header {
+		@extend .wp-brand-font;
+		font-size: $font-title-large;
+		display: flex;
+		align-items: center;
+	}
+}

--- a/client/my-sites/plugins/categories/style.scss
+++ b/client/my-sites/plugins/categories/style.scss
@@ -5,4 +5,22 @@
 		display: flex;
 		align-items: center;
 	}
+
+	.categories__select-list {
+		background: #656667;
+		border: 1px solid #000000;
+		box-sizing: border-box;
+		border-radius: 15px; /* stylelint-disable-line */
+		max-width: 210px;
+		margin: 0;
+		list-style: none;
+		padding: 20px;
+		color: var( --studio-white );
+		position: absolute;
+		z-index: 10;
+
+		li span {
+			cursor: pointer;
+		}
+	}
 }

--- a/client/my-sites/plugins/categories/style.scss
+++ b/client/my-sites/plugins/categories/style.scss
@@ -14,13 +14,23 @@
 		max-width: 210px;
 		margin: 0;
 		list-style: none;
-		padding: 20px;
+		padding: 18px 5px;
 		color: var( --studio-white );
 		position: absolute;
 		z-index: 10;
 
-		li span {
+		span {
+			padding: 2px 10px;
+			border-radius: 5px; /* stylelint-disable-line */
+			display: block;
 			cursor: pointer;
+		}
+		span:hover {
+			background-color: #82a7ec;
+		}
+
+		hr {
+			margin: 15px 10px;
 		}
 	}
 }

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -3,6 +3,7 @@ import page from 'page';
 import { createElement } from 'react';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { getSiteFragment, sectionify } from 'calypso/lib/route';
+import { getCategoriesWithTags } from 'calypso/my-sites/plugins/categories/categories-list';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PlanSetup from './jetpack-plugins-setup';
@@ -14,7 +15,10 @@ import PluginBrowser from './plugins-browser';
 /**
  * Module variables
  */
-const allowedCategoryNames = [ 'new', 'popular', 'featured', 'paid' ];
+const pluginsCategories = getCategoriesWithTags().map( ( category ) => {
+	return category.slug;
+} );
+const allowedCategoryNames = [ 'new', 'popular', 'featured', 'paid', ...pluginsCategories ];
 
 let lastPluginsListVisited;
 let lastPluginsQuerystring;

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -77,6 +77,7 @@ function getCategoryForPluginsBrowser( context ) {
 
 function renderPluginsBrowser( context ) {
 	const searchTerm = context.query.s;
+	const tag = context.query.tag;
 	const site = getSelectedSite( context.store.getState() );
 	const category = getCategoryForPluginsBrowser( context );
 
@@ -87,6 +88,7 @@ function renderPluginsBrowser( context ) {
 		path: context.path,
 		category,
 		search: searchTerm,
+		tag: tag,
 	} );
 }
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -328,7 +328,9 @@ const PluginsBrowser = ( {
 				title={ translate( 'Plugins you need to get your projects done' ) }
 				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
 			/>
-			<Categories onSelect={ ( c ) => doSearch( search, { tag: c.tags?.join( ',' ) || '' } ) } />
+			{ ! search && (
+				<Categories onSelect={ ( c ) => doSearch( search, { tag: c.tags?.join( ',' ) || '' } ) } />
+			) }
 			<PluginBrowserContent
 				tag={ tag }
 				pluginsByCategoryPopular={ pluginsByCategoryPopular }
@@ -418,15 +420,16 @@ const SearchListView = ( {
 	) {
 		const searchTitle =
 			searchTitleTerm ||
-			translate( 'Search results for {{b}}%(searchTerm)s{{/b}}', {
-				textOnly: true,
-				args: {
-					searchTerm,
-				},
-				components: {
-					b: <b />,
-				},
-			} );
+			( searchTerm &&
+				translate( 'Search results for {{b}}%(searchTerm)s{{/b}}', {
+					textOnly: true,
+					args: {
+						searchTerm,
+					},
+					components: {
+						b: <b />,
+					},
+				} ) );
 
 		const subtitle =
 			pluginsPagination &&

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -325,7 +325,7 @@ const PluginsBrowser = ( {
 				title={ translate( 'Plugins you need to get your projects done' ) }
 				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
 			/>
-			<Categories />
+			<Categories onSelect={ ( c ) => doSearch( c.tags?.[ 0 ] || '' ) } />
 			<PluginBrowserContent
 				pluginsByCategoryPopular={ pluginsByCategoryPopular }
 				isFetchingPluginsByCategoryPopular={ isFetchingPluginsByCategoryPopular }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -119,12 +119,15 @@ const PluginsBrowser = ( {
 	searchTitle,
 	hideHeader,
 	doSearch,
+	queryParams,
 } ) => {
 	const {
 		isAboveElement,
 		targetRef: searchHeaderRef,
 		referenceRef: navigationHeaderRef,
 	} = useScrollAboveElement();
+
+	const { tag } = queryParams;
 
 	const breadcrumbs = useSelector( getBreadcrumbs );
 
@@ -325,8 +328,9 @@ const PluginsBrowser = ( {
 				title={ translate( 'Plugins you need to get your projects done' ) }
 				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
 			/>
-			<Categories onSelect={ ( c ) => doSearch( c.tags?.[ 0 ] || '' ) } />
+			<Categories onSelect={ ( c ) => doSearch( search, { tag: c.tags?.join( ',' ) || '' } ) } />
 			<PluginBrowserContent
+				tag={ tag }
 				pluginsByCategoryPopular={ pluginsByCategoryPopular }
 				isFetchingPluginsByCategoryPopular={ isFetchingPluginsByCategoryPopular }
 				pluginsByCategoryFeatured={ pluginsByCategoryFeatured }
@@ -350,6 +354,7 @@ const PluginsBrowser = ( {
 
 const SearchListView = ( {
 	search: searchTerm,
+	tag,
 	searchTitle: searchTitleTerm,
 	siteSlug,
 	siteId,
@@ -357,23 +362,25 @@ const SearchListView = ( {
 	billingPeriod,
 } ) => {
 	const dispatch = useDispatch();
+
 	const {
 		data: { plugins: pluginsBySearchTerm = [], pagination: pluginsPagination } = {},
 		isLoading: isFetchingPluginsBySearchTerm,
 		fetchNextPage,
 	} = useWPORGInfinitePlugins(
-		{ searchTerm },
+		{ searchTerm, tag },
 		{
-			enabled: !! searchTerm,
+			enabled: !! searchTerm || !! tag,
 		}
 	);
 
 	const {
 		data: paidPluginsBySearchTermRaw = [],
 		isLoading: isFetchingPaidPluginsBySearchTerm,
-	} = useWPCOMPlugins( 'all', searchTerm, {
-		enabled: !! searchTerm,
+	} = useWPCOMPlugins( 'all', searchTerm, tag, {
+		enabled: !! searchTerm || !! tag,
 	} );
+
 	const paidPluginsBySearchTerm = useMemo(
 		() => paidPluginsBySearchTermRaw.map( updateWpComRating ),
 		[ paidPluginsBySearchTermRaw ]
@@ -567,7 +574,7 @@ const PluginSingleListView = ( {
 };
 
 const PluginBrowserContent = ( props ) => {
-	if ( props.search ) {
+	if ( props.search || props.tag ) {
 		return <SearchListView { ...props } />;
 	}
 	if ( props.category ) {

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -37,6 +37,7 @@ import UrlSearch from 'calypso/lib/url-search';
 import useScrollAboveElement from 'calypso/lib/use-scroll-above-element';
 import NoResults from 'calypso/my-sites/no-results';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import Categories from 'calypso/my-sites/plugins/categories';
 import EducationFooter from 'calypso/my-sites/plugins/education-footer';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
@@ -324,6 +325,7 @@ const PluginsBrowser = ( {
 				title={ translate( 'Plugins you need to get your projects done' ) }
 				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
 			/>
+			<Categories />
 			<PluginBrowserContent
 				pluginsByCategoryPopular={ pluginsByCategoryPopular }
 				isFetchingPluginsByCategoryPopular={ isFetchingPluginsByCategoryPopular }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new discover section (component named `Categories`)

#### Testing instructions

* http://calypso.localhost:3000/plugins
* Should see new discover section
* Should be able to click on discover dropdown
* Should be able to select categories

Related to https://github.com/Automattic/wp-calypso/issues/62264
