### PR TITLE
Stepper: support for siteId and added useAssertConditions

### DIFF
--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -77,6 +77,27 @@ export const exampleFlow: Flow = {
 };
 ```
 
+### Assert Conditions
+
+Optionally, you could also define a `useAssertConditions` function in the flow. This function can be used to add some conditions to check, and maybe return an error if those are not met.
+
+```ts
+import type { StepPath } from './internals/steps-repository';
+import type { Flow } from './internals/types';
+
+export const exampleFlow: Flow = {
+	useSteps()...
+	useStepNavigation( currentStep, navigate )...
+	useAssertConditions() {
+		const siteSlug = useSiteSlugParam();
+
+		if ( ! siteSlug ) {
+			throw new Error( 'site-setup did not provide the site slug it is configured to.' );
+		}
+	}
+};
+```
+
 ## Reusability
 
 Stepper aims to create a big `steps-repository` that contains the steps and allows them to be recycled and reused. Every step you create is inherently reusable by any future flow. Because steps are like components, they're not parts of the flows, flows just happen to use them.

--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -98,7 +98,7 @@ export const exampleFlow: Flow = {
 		if ( ! siteSlug ) {
 			throw new Error( 'site-setup did not provide the site slug it is configured to.' );
 		}
-	}
+	},
 };
 ```
 

--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -86,8 +86,12 @@ import type { StepPath } from './internals/steps-repository';
 import type { Flow } from './internals/types';
 
 export const exampleFlow: Flow = {
-	useSteps()...
-	useStepNavigation( currentStep, navigate )...
+	useSteps(): Array< StepPath > {
+		return [];
+	},
+	useStepNavigation( currentStep, navigate ) {
+		return { goNext, goBack };
+	},
 	useAssertConditions() {
 		const siteSlug = useSiteSlugParam();
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -34,6 +34,8 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		window.scrollTo( 0, 0 );
 	}, [ location ] );
 
+	flow.useAssertConditions?.();
+
 	return (
 		<Switch>
 			{ stepPaths.map( ( path ) => {

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -33,11 +33,14 @@ export type UseStepNavigationHook = (
 	steps?: StepPath[]
 ) => NavigationControls;
 
+export type UseAssertConditionsHook = () => void;
+
 export type Flow = {
 	name: string;
 	classnames?: string | [ string ];
 	useSteps: UseStepHook;
 	useStepNavigation: UseStepNavigationHook;
+	useAssertConditions?: UseAssertConditionsHook;
 };
 
 export type StepProps = {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -198,4 +198,12 @@ export const siteSetupFlow: Flow = {
 
 		return { goNext, goBack, goToStep, submit };
 	},
+
+	useAssertConditions() {
+		const siteSlug = useSiteSlugParam();
+
+		if ( ! siteSlug ) {
+			throw new Error( 'site-setup did not provide the site slug it is configured to.' );
+		}
+	},
 };

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useSelect } from '@wordpress/data';
 import { useFSEStatus } from '../hooks/use-fse-status';
+import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
@@ -201,9 +202,10 @@ export const siteSetupFlow: Flow = {
 
 	useAssertConditions() {
 		const siteSlug = useSiteSlugParam();
+		const siteId = useSiteIdParam();
 
-		if ( ! siteSlug ) {
-			throw new Error( 'site-setup did not provide the site slug it is configured to.' );
+		if ( ! siteSlug && ! siteId ) {
+			throw new Error( 'site-setup did not provide the site slug or site id it is configured to.' );
 		}
 	},
 };

--- a/client/landing/stepper/hooks/test/use-site-id-param.ts
+++ b/client/landing/stepper/hooks/test/use-site-id-param.ts
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { renderHook } from '@testing-library/react-hooks';
+import { useSiteIdParam } from '../use-site-id-param';
+
+jest.mock( 'react-router-dom', () => ( {
+	useLocation: jest.fn().mockImplementation( () => ( {
+		pathname: '/setup',
+		search: '?siteId=2053432885',
+		hash: '',
+		state: undefined,
+	} ) ),
+} ) );
+
+describe( 'use-site-id-param hook', () => {
+	test( 'returns site id if provided', async () => {
+		const { result } = renderHook( () => useSiteIdParam() );
+		expect( result.current ).toEqual( '2053432885' );
+	} );
+} );

--- a/client/landing/stepper/hooks/use-site-id-param.ts
+++ b/client/landing/stepper/hooks/use-site-id-param.ts
@@ -1,0 +1,5 @@
+import { useQuery } from './use-query';
+
+export function useSiteIdParam(): string | null {
+	return useQuery().get( 'siteId' );
+}

--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -1,15 +1,21 @@
 import { useSelect } from '@wordpress/data';
 import { SITE_STORE } from '../stores';
-import { useQuery } from './use-query';
+import { useSiteIdParam } from './use-site-id-param';
+import { useSiteSlugParam } from './use-site-slug-param';
 
 export function useSite() {
-	const siteSlug = useQuery().get( 'siteSlug' );
+	const siteSlug = useSiteSlugParam();
+	const siteIdParam = useSiteIdParam();
 	const siteId = useSelect(
 		( select ) => siteSlug && select( SITE_STORE ).getSiteIdBySlug( siteSlug )
 	);
-	const site = useSelect( ( select ) => siteId && select( SITE_STORE ).getSite( siteId ) );
+	const site = useSelect(
+		( select ) =>
+			( siteId || siteIdParam ) &&
+			select( SITE_STORE ).getSite( ( siteId ?? siteIdParam ) as string | number )
+	);
 
-	if ( siteSlug && siteId && site ) {
+	if ( ( siteSlug || siteIdParam ) && site ) {
 		return site;
 	}
 	return null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Now the stepper works not only with `?siteSlug=site-slug`, but also with `?siteId=site-is`.

Added a new optional property in the Flow, `useAssertConditions`, where we can define some checks to do and throw Error if those are not met. 
It's quite open to customization, one could not throw errors but simply log something, for example.
In our case, it checks for the presence of either `siteSlug` or `siteId`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* checkout the branch
* yarn start
* visit `http://calypso.localhost:3000/stepper/designSetup` and make sure that an error is thrown in the browser console.
* visit other steps (like `intent' or `storeFeatures` and check that the error is there)
* visit the steps with the appropriate query parameter `?siteSlug=YOUR-SITE.wordpress.com` and everything should work as usual
* verify that the design setup step works
* visit the steps with site id as a query parameter `?siteid=4142...` and everything should work as usual.
* if you need an id try with `205343885`, so `http://calypso.localhost:3000/stepper/intent?siteId=205343885`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62688
Fixes #62688
