### PR TITLE
Upgrades: Rename 'New Plans' tab for free and flexible sites to 'Plans'

### DIFF
--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -39,7 +39,7 @@ class PlansNavigation extends Component {
 	}
 
 	render() {
-		const { site, shouldShowMyPlan, shouldShowPlans, translate, isFreeOrFlexible } = this.props;
+		const { site, shouldShowMyPlan, shouldShowPlans, translate } = this.props;
 		const path = sectionify( this.props.path );
 		const sectionTitle = this.getSectionTitle( path );
 		const hasPinnedItems = Boolean( site ) && isMobile();
@@ -63,7 +63,7 @@ class PlansNavigation extends Component {
 									path === '/plans' || path === '/plans/monthly' || path === '/plans/yearly'
 								}
 							>
-								{ isFreeOrFlexible ? translate( 'New Plans' ) : translate( 'Plans' ) }
+								{ translate( 'Plans' ) }
 							</NavItem>
 						) }
 					</NavTabs>


### PR DESCRIPTION
'New Plans' is a useful term for us, but not so much for users.

#### Changes proposed in this Pull Request

* Rename the "New Plans" tab (shown only to sites on a free or flexible plan) to just "Plans".

#### Testing instructions

1. Visit the plans page for a free site, either by using Upgrades > Plans in the nav menu or by loading /plans/$site_slug directly.
2. Note the title of the tab-

Before:

<img width="1550" alt="Screen Shot 2022-04-12 at 9 56 54 AM" src="https://user-images.githubusercontent.com/9310939/162994601-8133f65a-f5e4-433b-9d86-16fa7293dea0.png">

After:

<img width="1582" alt="Screen Shot 2022-04-12 at 10 02 12 AM" src="https://user-images.githubusercontent.com/9310939/162994676-62e97ce2-6d4b-4e52-b513-4d64596c0940.png">

Sites on a legacy plan or a Pro plan are not affected.

Tracked in c/zUcvBLjR-tr
