### PR TITLE
Use the default 'Not found' image when a theme is not found

### DIFF
--- a/client/my-sites/theme/theme-not-found-error.jsx
+++ b/client/my-sites/theme/theme-not-found-error.jsx
@@ -13,7 +13,6 @@ function ThemeNotFoundError( { translate } ) {
 	return (
 		<Main>
 			<EmptyContentComponent
-				illustration="/calypso/images/illustrations/no-themes-drake.svg"
 				title={ emptyContentTitle }
 				line={ emptyContentMessage }
 				action={ translate( 'View the showcase' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the Nessie image to the default one, when a theme is not found.

#### Before
<img width="1508" alt="Not Found page with a image of the mytological monster, Nessie." src="https://user-images.githubusercontent.com/1234758/163020513-c75cda53-874f-46b1-a120-e7830a214a85.png">

#### After
<img width="1508" alt="Not Found page with the default image; One woman holding a magnifying glass and boy" src="https://user-images.githubusercontent.com/1234758/163019901-a888c1fe-32c3-4744-a93c-3902bc26f418.png">

#### Testing instructions

1. Go to `http://wordpress.com/theme/mononoke/[site]`.
2. You'll no longer see Nessie on the Not Found page. 

Closes #54902
