### PR TITLE
Fixes Pro plan FAQ typo

### DIFF
--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -40,7 +40,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 			<FAQItem
 				question={ translate( 'Do you sell domains?' ) }
 				answer={ translate(
-					'Yes! The Pro plan include a free custom domain for one year. ' +
+					'Yes! The Pro plan includes a free custom domain for one year. ' +
 						'That includes new domains purchased through WordPress.com or your own existing domain that you can map' +
 						' to your WordPress.com site. Does not apply to premium domains. Domain name should be' +
 						' registered within one year of the purchase of the plan to use this promotion. Registered' +


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a typo in the Plans page FAQ

#### Testing instructions
1. Make sure your interface language is set to English.
2. Select a site that already has a plan and visit Upgrades-> Plans
3. Scroll down to the FAQ and under "Do you sell domains?" 
4. Confirm that the type `The Pro plan include` is now fixed.