### PR TITLE
VideoPress: increase chunk size to speed up uploads

### DIFF
--- a/packages/wpcom.js/src/lib/tus-uploader.js
+++ b/packages/wpcom.js/src/lib/tus-uploader.js
@@ -55,7 +55,7 @@ export default class TusUploader {
 				withCredentials: false,
 				autoRetry: true,
 				overridePatchMethod: false,
-				chunkSize: 500000, // 500 Kb.
+				chunkSize: 10000000, // 10mb.
 				allowedFileTypes: [ 'video/*' ],
 				metadata: {
 					filename: file.name,

--- a/packages/wpcom.js/src/lib/tus-uploader.js
+++ b/packages/wpcom.js/src/lib/tus-uploader.js
@@ -55,7 +55,7 @@ export default class TusUploader {
 				withCredentials: false,
 				autoRetry: true,
 				overridePatchMethod: false,
-				chunkSize: 10000000, // 10mb.
+				chunkSize: 10000000, // 10Mb.
 				allowedFileTypes: [ 'video/*' ],
 				metadata: {
 					filename: file.name,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Chunk size for VideoPress uploads increased from 500Kb to 10Mb to increase upload speed (reduces overhead)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. DON'T APPLY pryet
2. uploads don't need to be sandboxed (and probably better that they aren't so it doesn't affect the test)
3. time an upload (a 50mb+ file size)
4. apply PR
5. time another upload, you should notice a significant decrease in upload time


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1153-gh-Automattic/greenhouse