### PR TITLE
Add stored vertical from site settings to the vertical question screen (if site has already set a vertical)

### DIFF
--- a/client/components/select-vertical/style.scss
+++ b/client/components/select-vertical/style.scss
@@ -29,7 +29,7 @@
         height: 44px;
         font-size: $font-body;
         line-height: 20px;
-        padding: 12px 16px;
+        padding: 12px 48px 12px 16px;
 
         &::placeholder {
             font-size: $font-body-small;
@@ -39,6 +39,12 @@
             border-color: #646970;
             box-shadow: none;
         }
+    }
+
+    .spinner {
+        position: absolute;
+        right: 16px;
+        top: 12px;
     }
 
     @include break-small() {

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC, ChangeEvent, useCallback, useMemo, useRef, useState } from 'react';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import Spinner from 'calypso/components/spinner';
 import type { Vertical } from './types';
 import './style.scss';
 
@@ -10,6 +11,7 @@ interface Props {
 	placeholder?: string;
 	searchTerm: string;
 	suggestions: Vertical[];
+	isDisableInput?: boolean | undefined;
 	isLoading?: boolean | undefined;
 	onInputChange?: ( value: string ) => void;
 	onSelect?: ( vertical: Vertical ) => void;
@@ -19,6 +21,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 	placeholder,
 	searchTerm,
 	suggestions,
+	isDisableInput,
 	isLoading,
 	onInputChange,
 	onSelect,
@@ -34,7 +37,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 	}, [ setIsShowSuggestions, setIsFocused ] );
 
 	const handleTextInputFocus = useCallback( () => {
-		if ( 0 < suggestions.length ) {
+		if ( suggestions.length > 0 ) {
 			setIsShowSuggestions( true );
 		}
 
@@ -43,7 +46,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 
 	const handleTextInputChange = useCallback(
 		( event: ChangeEvent< HTMLInputElement > ) => {
-			setIsShowSuggestions( 0 < event.target.value.trim().length );
+			setIsShowSuggestions( event.target.value.trim().length > 0 );
 			onInputChange?.( event.target.value );
 		},
 		[ setIsShowSuggestions, onInputChange ]
@@ -96,9 +99,11 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 				'is-show-suggestions': isShowSuggestions,
 			} ) }
 		>
+			{ isLoading && isShowSuggestions && <Spinner /> }
 			<FormTextInput
 				value={ searchTerm }
 				placeholder={ placeholder }
+				disabled={ isDisableInput }
 				onBlur={ handleTextInputBlur }
 				onFocus={ handleTextInputFocus }
 				onChange={ handleTextInputChange }

--- a/client/data/site-verticals/index.ts
+++ b/client/data/site-verticals/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export { default as useSiteVerticalsQuery } from './use-site-verticals-query';
+export { default as useSiteVerticalQueryById } from './use-site-vertical-query-by-id';

--- a/client/data/site-verticals/types.ts
+++ b/client/data/site-verticals/types.ts
@@ -4,6 +4,10 @@ export interface SiteVerticalsResponse {
 	title: string;
 }
 
+export interface SiteVerticalQueryByIdParams {
+	id?: string;
+}
+
 export interface SiteVerticalsQueryParams {
 	term?: string;
 	limit?: number;

--- a/client/data/site-verticals/use-site-vertical-query-by-id.ts
+++ b/client/data/site-verticals/use-site-vertical-query-by-id.ts
@@ -1,0 +1,27 @@
+import { useQuery, UseQueryResult, QueryKey } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+import type { SiteVerticalsResponse, SiteVerticalQueryByIdParams } from './types';
+
+const useSiteVerticalQueryById = ( id: string ): UseQueryResult< SiteVerticalsResponse > => {
+	return useQuery( getCacheKey( id ), () => fetchSiteVertical( { id } ), {
+		enabled: typeof id === 'string' && id !== '',
+		staleTime: Infinity,
+		refetchInterval: false,
+		refetchOnMount: 'always',
+	} );
+};
+
+export function fetchSiteVertical(
+	params: SiteVerticalQueryByIdParams
+): Promise< SiteVerticalsResponse > {
+	return wpcom.req.get( {
+		apiNamespace: 'wpcom/v2',
+		path: `/site-verticals/${ params.id }`,
+	} );
+}
+
+export function getCacheKey( id: string ): QueryKey {
+	return [ 'site-vertical', 'by-id', id ];
+}
+
+export default useSiteVerticalQueryById;

--- a/client/data/site-verticals/use-site-verticals-query.ts
+++ b/client/data/site-verticals/use-site-verticals-query.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryOptions, UseQueryResult, QueryKey } from 'react-query';
+import { useQuery, UseQueryResult, QueryKey } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 import type { SiteVerticalsResponse, SiteVerticalsQueryParams } from './types';
 
@@ -9,14 +9,15 @@ const defaults = {
 };
 
 const useSiteVerticalsQuery = (
-	fetchOptions: SiteVerticalsQueryParams = {},
-	{ enabled = false }: UseQueryOptions = {}
+	fetchOptions: SiteVerticalsQueryParams = {}
 ): UseQueryResult< SiteVerticalsResponse[] > => {
+	const { term } = fetchOptions;
+
 	return useQuery(
-		getCacheKey( fetchOptions.term || '' ),
+		getCacheKey( term || '' ),
 		() => fetchSiteVerticals( { ...defaults, ...fetchOptions } ),
 		{
-			enabled,
+			enabled: typeof term === 'string' && term !== '',
 			staleTime: Infinity,
 			refetchInterval: false,
 			refetchOnMount: 'always',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
@@ -10,24 +10,42 @@ import type { Vertical } from 'calypso/components/select-vertical/types';
 import './form.scss';
 
 interface Props {
+	defaultVertical?: string;
 	isSkipSynonyms?: boolean;
+	isBusy?: boolean;
 	onSelect?: ( vertical: Vertical ) => void;
 	onSubmit?: ( event: React.FormEvent ) => void;
 }
 
-const SiteVerticalForm: React.FC< Props > = ( { isSkipSynonyms, onSelect, onSubmit } ) => {
+const SiteVerticalForm: React.FC< Props > = ( {
+	defaultVertical,
+	isSkipSynonyms,
+	isBusy,
+	onSelect,
+	onSubmit,
+} ) => {
 	const translate = useTranslate();
 
 	return (
 		<form className="site-vertical__form" onSubmit={ onSubmit }>
 			<FormFieldset className="site-vertical__form-fieldset">
-				<SelectVertical isSkipSynonyms={ isSkipSynonyms } onSelect={ onSelect } />
+				<SelectVertical
+					defaultVertical={ defaultVertical }
+					isSkipSynonyms={ isSkipSynonyms }
+					onSelect={ onSelect }
+				/>
 				<FormSettingExplanation>
 					<Icon className="site-vertical__form-icon" icon={ tip } size={ 20 } />
 					{ translate( 'We will use this information to guide you towards next steps.' ) }
 				</FormSettingExplanation>
 			</FormFieldset>
-			<Button className="site-vertical__submit-button" type="submit" primary>
+			<Button
+				className="site-vertical__submit-button"
+				type="submit"
+				disabled={ isBusy }
+				busy={ isBusy }
+				primary
+			>
 				{ translate( 'Continue' ) }
 			</Button>
 		</form>

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -88,10 +88,10 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		tagline,
 	} );
 
-	const receiveSiteVertical = ( siteId: number, vertical: string | undefined ) => ( {
-		type: 'RECEIVE_SITE_VERTICAL' as const,
+	const receiveSiteVerticalId = ( siteId: number, verticalId: string | undefined ) => ( {
+		type: 'RECEIVE_SITE_VERTICAL_ID' as const,
 		siteId,
-		vertical,
+		verticalId,
 	} );
 
 	const receiveSiteFailed = ( siteId: number, response: SiteError | undefined ) => ( {
@@ -175,7 +175,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		settings: {
 			blogname?: string;
 			blogdescription?: string;
-			site_vertical?: string;
+			site_vertical_id?: string;
 			woocommerce_onboarding_profile?: { [ key: string ]: any };
 		}
 	) {
@@ -193,8 +193,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			if ( 'blogdescription' in settings ) {
 				yield receiveSiteTagline( siteId, settings.blogdescription );
 			}
-			if ( 'site_vertical' in settings ) {
-				yield receiveSiteVertical( siteId, settings.site_vertical );
+			if ( 'site_vertical_id' in settings ) {
+				yield receiveSiteVerticalId( siteId, settings.site_vertical_id );
 			}
 		} catch ( e ) {}
 	}
@@ -247,7 +247,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveSite,
 		receiveSiteFailed,
 		receiveSiteTagline,
-		receiveSiteVertical,
+		receiveSiteVerticalId,
 		saveSiteTagline,
 		reset,
 		launchSite,
@@ -271,7 +271,7 @@ export type Action =
 			| ActionCreators[ 'receiveSiteTitle' ]
 			| ActionCreators[ 'receiveNewSiteFailed' ]
 			| ActionCreators[ 'receiveSiteTagline' ]
-			| ActionCreators[ 'receiveSiteVertical' ]
+			| ActionCreators[ 'receiveSiteVerticalId' ]
 			| ActionCreators[ 'receiveSite' ]
 			| ActionCreators[ 'receiveSiteFailed' ]
 			| ActionCreators[ 'reset' ]

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -99,12 +99,15 @@ export const sites: Reducer< { [ key: number | string ]: SiteDetails | undefined
 				description: action.tagline ?? '',
 			},
 		};
-	} else if ( action.type === 'RECEIVE_SITE_VERTICAL' ) {
+	} else if ( action.type === 'RECEIVE_SITE_VERTICAL_ID' ) {
 		return {
 			...state,
 			[ action.siteId ]: {
 				...( state[ action.siteId ] as SiteDetails ),
-				site_vertical: action.vertical ?? '',
+				options: {
+					...state[ action.siteId ]?.options,
+					site_vertical_id: action.verticalId,
+				},
 			},
 		};
 	}

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -32,6 +32,9 @@ export const getSiteIdBySlug = ( _: State, slug: string ) => {
 export const getSiteTitle = ( _: State, siteId: number ) =>
 	select( STORE_KEY ).getSite( siteId )?.name;
 
+export const getSiteVerticalId = ( _: State, siteId: number ) =>
+	select( STORE_KEY ).getSite( siteId )?.options?.site_vertical_id;
+
 // @TODO: Return LaunchStatus instead of a boolean
 export const isSiteLaunched = ( state: State, siteId: number ) => {
 	return state.launchStatus[ siteId ]?.status === SiteLaunchStatus.SUCCESS;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -102,7 +102,7 @@ export interface SiteDetails {
 		anchor_podcast?: boolean;
 		background_color?: boolean;
 		blog_public?: number;
-		created_at: Date;
+		created_at?: Date;
 		default_category?: number;
 		default_comment_status?: boolean;
 		default_likes_enabled?: boolean;
@@ -149,7 +149,7 @@ export interface SiteDetails {
 		show_on_front?: string;
 		site_intent?: string;
 		site_segment?: string;
-		site_vertical?: string;
+		site_vertical_id?: string;
 		software_version?: string;
 		selected_features?: FeatureId[];
 		theme_slug?: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR will fetch the site vertical from the user's site preferences and set it as the default value for the vertical question input. Most of the time, the site vertical will be empty, since the user has yet to set a vertical. However, if a user goes to the next onboarding step and comes back, it would be good to show their previous selected vertical.

#### Acceptance Criteria
In case site vertical is set in site preferences, heading to the vertical question screen should have the site vertical pre-populated in the vertical question input.

#### Dev tasks
- [x] ✅ D78761-code

#### Testing instructions
1. Head to `/setup/vertical?flags=signup/site-vertical-step&siteSlug={domain}`
2. Select a vertical.
3. You'll land to the next onboarding step - intent screen.
4. Click on the "Go Back" button.
5. You'll land again on the site vertical step.
6. Expect to see the site vertical you just selected, pre-populated in the vertical question input.

#### Related
#61526