### PR TITLE
Update the calypso_plugin_browser_item_click metric to also send the grid position.

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -73,8 +73,9 @@ const PluginsBrowserListElement = ( props ) => {
 			plugin: plugin.slug,
 			list_name: props.listName,
 			grid_position: props.gridPosition,
+			blog_id: selectedSite?.ID,
 		} );
-	}, [ site, plugin, props.listName ] );
+	}, [ site, plugin, selectedSite, props.listName ] );
 
 	const isWpcomPreinstalled = useMemo( () => {
 		if ( plugin.isPreinstalled ) {

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -72,6 +72,7 @@ const PluginsBrowserListElement = ( props ) => {
 			site: site,
 			plugin: plugin.slug,
 			list_name: props.listName,
+			grid_position: props.gridPosition,
 		} );
 	}, [ site, plugin, props.listName ] );
 

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -38,6 +38,7 @@ const PluginsBrowserList = ( {
 				<PluginBrowserItem
 					site={ site }
 					key={ plugin.slug + n }
+					gridPosition={ n + 1 }
 					plugin={ plugin }
 					currentSites={ currentSites }
 					listName={ listName }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add the `grid_position` data to `calypso_plugin_browser_item_click` event.

#### Testing instructions
- Use the Calypso version of this branch
- Go to `/plugins` page
- in the console enter `localStorage.setItem( 'debug', 'calypso:analytics*' )`
- reload the page
- Click on any plugin on the screen
- Verify the event `calypso_plugin_browser_item_click` is logged with the following info: site, plugin slug, list name (paid, popular, `plugins-browser-list__search-for_*`) and grid position.
- The `grid_position` should be the ordinal position relative to the beginning of each list.
---

Related to #62727
