### PR TITLE
`ConfirmCancelDomain`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -66,22 +66,21 @@ class ConfirmCancelDomain extends Component {
 	};
 
 	componentDidMount() {
-		this.redirectIfDataIsInvalid( this.props );
+		this.redirectIfDataIsInvalid();
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		this.redirectIfDataIsInvalid( nextProps );
+	componentDidUpdate() {
+		this.redirectIfDataIsInvalid();
 	}
 
-	redirectIfDataIsInvalid = ( props ) => {
-		if ( isDataLoading( props ) || this.state.submitting ) {
+	redirectIfDataIsInvalid = () => {
+		if ( isDataLoading( this.props ) || this.state.submitting ) {
 			return null;
 		}
 
-		const { purchase } = props;
+		const { purchase, selectedSite } = this.props;
 
-		if ( ! purchase || ! isDomainRegistration( purchase ) || ! props.selectedSite ) {
+		if ( ! purchase || ! isDomainRegistration( purchase ) || ! selectedSite ) {
 			page.redirect( this.props.purchaseListUrl );
 		}
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `ConfirmCancelDomain`: refactor away from `UNSAFE_*`

#### Testing instructions

I'm unsure about whether this code is still reachable for user. Following previous testing instructions for this component shows me a different flow for removing a domain.

You can still reach this by manually going to `/purchases/subscriptions/:site/:purchaseId/confirm-cancel-domain`.

* Go to `/me/purchases` and click on a domain purchase
* Manually add `/confirm-cancel-domain` to the URL in the address bar of your browser
* Make sure the form behaves as expected
* To test the `cDU` refactor I had to manually switch the boolean flag for `props.purchase.isDomainRegistration`; that should then redirect you to `purchases/subscriptions/:site`

Related to #58453 
