### PR TITLE
Backup: Make the storage usage bar more visible/readable

### DIFF
--- a/client/components/activity-card-list/visible-days-limit-upsell/index.tsx
+++ b/client/components/activity-card-list/visible-days-limit-upsell/index.tsx
@@ -7,8 +7,10 @@ import ActivityCard from 'calypso/components/activity-card';
 import { preventWidows } from 'calypso/lib/formatting/prevent-widows';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import ActivityLogItem from 'calypso/my-sites/activity/activity-log-item';
+import { getJetpackStorageUpgradeUrl } from 'calypso/state/plans/selectors';
 import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useTrackUpsellView, useTrackUpgradeClick } from './hooks';
 import type { Activity } from 'calypso/components/activity-card/types';
 
@@ -46,7 +48,11 @@ const VisibleDaysLimitUpsell: React.FC< OwnProps > = ( { cardClassName } ) => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const visibleDays = useSelector( ( state ) => getActivityLogVisibleDays( state, siteId ) );
 	const trackUpgradeClick = useTrackUpgradeClick( siteId );
-	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+	const storageUpgradeUrl = useSelector( ( state ) =>
+		getJetpackStorageUpgradeUrl( state, siteSlug )
+	);
 
 	const upsellRef = useTrackUpsellView( siteId );
 
@@ -98,9 +104,7 @@ const VisibleDaysLimitUpsell: React.FC< OwnProps > = ( { cardClassName } ) => {
 					ref={ upsellRef }
 					className="visible-days-limit-upsell__call-to-action-button"
 					onClick={ trackUpgradeClick }
-					href={
-						isJetpackCloud() ? `/pricing/storage/${ siteSlug }` : `/plans/storage/${ siteSlug }`
-					}
+					href={ storageUpgradeUrl }
 				>
 					{ translate( 'Upgrade storage' ) }
 				</Button>

--- a/client/components/backup-storage-space/hooks.tsx
+++ b/client/components/backup-storage-space/hooks.tsx
@@ -2,6 +2,7 @@ import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import getJetpackStorageUpgradeUrl from 'calypso/state/plans/selectors/get-jetpack-storage-upgrade-url';
+import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 
 enum StorageUnits {
 	Gigabyte = 2 ** 30,
@@ -23,7 +24,11 @@ export const useStorageUsageText = (
 	bytesAvailable: number | undefined
 ): TranslateResult | null => {
 	const translate = useTranslate();
-	const storageUpgradeUrl = useSelector( getJetpackStorageUpgradeUrl );
+
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const storageUpgradeUrl = useSelector( ( state ) =>
+		getJetpackStorageUpgradeUrl( state, siteSlug )
+	);
 
 	return useMemo( () => {
 		if ( bytesUsed === undefined ) {

--- a/client/components/backup-storage-space/hooks.tsx
+++ b/client/components/backup-storage-space/hooks.tsx
@@ -1,5 +1,7 @@
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import getJetpackStorageUpgradeUrl from 'calypso/state/plans/selectors/get-jetpack-storage-upgrade-url';
 
 enum StorageUnits {
 	Gigabyte = 2 ** 30,
@@ -21,6 +23,7 @@ export const useStorageUsageText = (
 	bytesAvailable: number | undefined
 ): TranslateResult | null => {
 	const translate = useTranslate();
+	const storageUpgradeUrl = useSelector( getJetpackStorageUpgradeUrl );
 
 	return useMemo( () => {
 		if ( bytesUsed === undefined ) {
@@ -43,20 +46,23 @@ export const useStorageUsageText = (
 
 		if ( availableUnit === StorageUnits.Gigabyte ) {
 			return translate(
-				'%(usedGigabytes).1fGB of %(availableUnitAmount)dGB used',
-				'%(usedGigabytes).1fGB of %(availableUnitAmount)dGB used',
+				'%(usedGigabytes).1fGB used of %(availableUnitAmount)dGB - {{a}}Upgrade{{/a}}',
+				'%(usedGigabytes).1fGB used of %(availableUnitAmount)dGB - {{a}}Upgrade{{/a}}',
 				{
 					count: usedGigabytes,
 					args: { usedGigabytes, availableUnitAmount },
 					comment:
 						'Must use unit abbreviation; describes used vs available storage amounts (e.g., 20.0GB of 30GB used, 0.5GB of 20GB used)',
+					components: {
+						a: <a href={ storageUpgradeUrl } />,
+					},
 				}
 			);
 		}
 
 		return translate(
-			'%(usedGigabytes).1fGB of %(availableUnitAmount)dTB used',
-			'%(usedGigabytes).1fGB of %(availableUnitAmount)dTB used',
+			'%(usedGigabytes).1fGB used of %(availableUnitAmount)dTB',
+			'%(usedGigabytes).1fGB used of %(availableUnitAmount)dTB',
 			{
 				count: usedGigabytes,
 				args: { usedGigabytes, availableUnitAmount },
@@ -64,5 +70,5 @@ export const useStorageUsageText = (
 					'Must use unit abbreviation; describes used vs available storage amounts (e.g., 20.0GB of 1TB used, 0.5GB of 2TB used)',
 			}
 		);
-	}, [ translate, bytesUsed, bytesAvailable ] );
+	}, [ translate, storageUpgradeUrl, bytesUsed, bytesAvailable ] );
 };

--- a/client/components/backup-storage-space/index.tsx
+++ b/client/components/backup-storage-space/index.tsx
@@ -28,7 +28,7 @@ const BackupStorageSpace: React.FC = () => {
 	const bytesAvailable = useSelector( ( state ) => getRewindBytesAvailable( state, siteId ) );
 	const usageLevel = getUsageLevel( bytesUsed, bytesAvailable ) ?? StorageUsageLevels.Normal;
 
-	const showWarning = usageLevel > StorageUsageLevels.Normal;
+	const showWarning = usageLevel !== StorageUsageLevels.Normal;
 
 	const requestingPurchases = useSelector( isFetchingSitePurchases );
 	const requestingPolicies = useSelector( ( state ) =>

--- a/client/components/backup-storage-space/storage-usage-levels.ts
+++ b/client/components/backup-storage-space/storage-usage-levels.ts
@@ -1,25 +1,27 @@
-export enum StorageUsageLevels {
-	Full = 100,
-	Critical = 80,
-	Warning = 65,
-	Normal = 0,
-}
+export type StorageUsageLevelName = 'Full' | 'Critical' | 'Warning' | 'Normal';
+export const StorageUsageLevels: Record< StorageUsageLevelName, StorageUsageLevelName > = {
+	Full: 'Full',
+	Critical: 'Critical',
+	Warning: 'Warning',
+	Normal: 'Normal',
+} as const;
 
-// Transform the enum so we can iterate more easily,
-// sorting levels from highest to lowest.
-//
-// This ordering is important for getUsageLevel,
-// because it looks at the elements *in order*.
-const levelsArray: StorageUsageLevels[] = Object.values( StorageUsageLevels )
-	// Get only numeric values, ignoring the enum keys (which are also stored as values)
-	.filter( Number.isInteger )
-	.sort( ( a, b ) => ( b as number ) - ( a as number ) )
-	.map( ( val ) => val as StorageUsageLevels );
+const THRESHOLDS: Record< number, StorageUsageLevelName > = {
+	100: StorageUsageLevels.Full,
+	80: StorageUsageLevels.Critical,
+	65: StorageUsageLevels.Warning,
+	0: StorageUsageLevels.Normal,
+};
+const THRESHOLD_VALUES = Object.keys( THRESHOLDS )
+	.map( Number )
+	// Sorting from highest to lowest is important for getUsageLevel,
+	// because it looks at the elements *in order*.
+	.sort( ( a, b ) => b - a );
 
 export const getUsageLevel = (
 	used: number | undefined,
 	available: number | undefined
-): StorageUsageLevels | null => {
+): StorageUsageLevelName | null => {
 	if ( available === undefined || used === undefined ) {
 		return null;
 	}
@@ -30,5 +32,6 @@ export const getUsageLevel = (
 	}
 
 	const percentUsed = ( 100 * used ) / available;
-	return levelsArray.find( ( level ) => percentUsed >= level ) ?? StorageUsageLevels.Normal;
+	const thresholdValue = THRESHOLD_VALUES.find( ( value ) => percentUsed >= value ) ?? 0;
+	return THRESHOLDS[ thresholdValue ];
 };

--- a/client/components/backup-storage-space/style.scss
+++ b/client/components/backup-storage-space/style.scss
@@ -86,12 +86,15 @@
 
 .backup-storage-space__progress-heading {
 	margin-block-end: 12px;
+	white-space: nowrap;
+
 	font-weight: 600;
 	font-size: $font-body-small;
 }
 
 .backup-storage-space__progress-usage-text {
 	margin-block-start: 8px;
+	white-space: nowrap;
 
 	font-size: $font-body-extra-small;
 	color: var( --color-text-subtle );

--- a/client/components/backup-storage-space/style.scss
+++ b/client/components/backup-storage-space/style.scss
@@ -85,14 +85,18 @@
 }
 
 .backup-storage-space__progress-heading {
+	margin-block-end: 12px;
 	font-weight: 600;
-	margin-block-end: 8px;
-
-	@include breakpoint-deprecated( '>960px' ) {
-		margin-block-end: initial;
-	}
+	font-size: $font-body-small;
 }
 
 .backup-storage-space__progress-usage-text {
+	margin-block-start: 8px;
+
+	font-size: $font-body-extra-small;
 	color: var( --color-text-subtle );
+
+	a {
+		text-decoration: underline;
+	}
 }

--- a/client/components/backup-storage-space/style.scss
+++ b/client/components/backup-storage-space/style.scss
@@ -14,11 +14,6 @@
 .backup-storage-space__progress-bar-container {
 	display: flex;
 	flex-direction: column;
-	column-gap: 24px;
-
-	@include breakpoint-deprecated( '>960px' ) {
-		flex-direction: row;
-	}
 }
 
 /**

--- a/client/components/backup-storage-space/style.scss
+++ b/client/components/backup-storage-space/style.scss
@@ -21,10 +21,38 @@
 	}
 }
 
+/**
+ * .backup-storage-space__progress-bar: wraps the storage progress bar
+ * .progress-bar: the actual progress bar, both filled and empty portions
+ * .progress-bar__progress: the filled part of the bar
+**/
+
+/* stylelint-disable scales/radii --
+   We need to be able to define a border-radius of 1/2 the parent height
+*/
 .backup-storage-space__progress-bar {
-	flex-grow: 1;
+	height: 24px;
 
 	.progress-bar {
+		height: 100%;
+		border-radius: 12px;
+
+		.progress-bar__progress {
+			// Unless we're 100% full, the left side of the bar
+			// is rounded and the right side is flat
+			border-radius: 12px 0 0 12px;
+
+			// We always expect some amount of used storage,
+			// so keep a border-radius sized buffer so
+			// the left side of the bar looks correctly rounded
+			min-width: 12px;
+
+			// Only allow full width if storage is full;
+			// otherwise, leave a border-radius sized buffer,
+			// so the right side looks okay without a radius
+			max-width: calc( 100% - 12px );
+		}
+
 		&.no-warning {
 			.progress-bar__progress {
 				background-color: var( --studio-gray-80 );
@@ -42,8 +70,19 @@
 				background-color: var( --studio-red-40 );
 			}
 		}
+
+		// When the bar is full, we can show the filled portion
+		// at full width, with a rounded right side
+		&.full-warning {
+			.progress-bar__progress {
+				max-width: initial;
+				background-color: var( --studio-red-40 );
+				border-radius: 12px;
+			}
+		}
 	}
 }
+/* stylelint-enable scales/radii */
 
 .backup-storage-space__divider {
 	margin: 16px -32px;

--- a/client/components/backup-storage-space/style.scss
+++ b/client/components/backup-storage-space/style.scss
@@ -31,6 +31,7 @@
 	.progress-bar {
 		height: 100%;
 		border-radius: 12px;
+		background-color: var( --studio-gray-0 );
 
 		.progress-bar__progress {
 			// Unless we're 100% full, the left side of the bar
@@ -56,7 +57,7 @@
 
 		&.yellow-warning {
 			.progress-bar__progress {
-				background-color: var( --studio-yellow-30 );
+				background-color: var( --studio-yellow-20 );
 			}
 		}
 

--- a/client/components/backup-storage-space/usage-display.tsx
+++ b/client/components/backup-storage-space/usage-display.tsx
@@ -9,7 +9,7 @@ import { useStorageUsageText } from './hooks';
 import { StorageUsageLevels } from './storage-usage-levels';
 
 const PROGRESS_BAR_CLASS_NAMES = {
-	[ StorageUsageLevels.Full ]: 'red-warning',
+	[ StorageUsageLevels.Full ]: 'full-warning',
 	[ StorageUsageLevels.Critical ]: 'red-warning',
 	[ StorageUsageLevels.Warning ]: 'yellow-warning',
 	[ StorageUsageLevels.Normal ]: 'no-warning',

--- a/client/components/backup-storage-space/usage-display.tsx
+++ b/client/components/backup-storage-space/usage-display.tsx
@@ -6,7 +6,7 @@ import { useSelector } from 'react-redux';
 import { getRewindBytesAvailable, getRewindBytesUsed } from 'calypso/state/rewind/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import { useStorageUsageText } from './hooks';
-import { StorageUsageLevels } from './storage-usage-levels';
+import { StorageUsageLevelName, StorageUsageLevels } from './storage-usage-levels';
 
 const PROGRESS_BAR_CLASS_NAMES = {
 	[ StorageUsageLevels.Full ]: 'full-warning',
@@ -17,7 +17,7 @@ const PROGRESS_BAR_CLASS_NAMES = {
 
 type OwnProps = {
 	loading?: boolean;
-	usageLevel: StorageUsageLevels;
+	usageLevel: StorageUsageLevelName;
 };
 
 const UsageDisplay: React.FC< OwnProps > = ( { loading = false, usageLevel } ) => {

--- a/client/components/backup-storage-space/usage-warning/action-button.tsx
+++ b/client/components/backup-storage-space/usage-warning/action-button.tsx
@@ -1,12 +1,12 @@
 import { Button } from '@wordpress/components';
 import classnames from 'classnames';
-import { StorageUsageLevels } from '../storage-usage-levels';
 import useStorageStatusText from './use-storage-status-text';
+import type { StorageUsageLevelName } from '../storage-usage-levels';
 import type { TranslateResult } from 'i18n-calypso';
 
 type OwnProps = {
 	className?: string;
-	usageLevel: StorageUsageLevels;
+	usageLevel: StorageUsageLevelName;
 	actionText: TranslateResult;
 	href?: string;
 	onClick?: React.MouseEventHandler;

--- a/client/components/backup-storage-space/usage-warning/index.tsx
+++ b/client/components/backup-storage-space/usage-warning/index.tsx
@@ -1,14 +1,14 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
-import { StorageUsageLevels } from '../storage-usage-levels';
+import { StorageUsageLevelName, StorageUsageLevels } from '../storage-usage-levels';
 import ManageStorage from './manage-storage';
 import siteCanUpgradeBackupStorage from './site-can-upgrade-backup-storage';
 import Upsell from './upsell';
 
 type OwnProps = {
 	siteId: number;
-	usageLevel: StorageUsageLevels;
+	usageLevel: StorageUsageLevelName;
 	bytesUsed: number;
 };
 

--- a/client/components/backup-storage-space/usage-warning/manage-storage.tsx
+++ b/client/components/backup-storage-space/usage-warning/manage-storage.tsx
@@ -2,11 +2,11 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import { StorageUsageLevels } from '../storage-usage-levels';
 import ActionButton from './action-button';
+import type { StorageUsageLevelName } from '../storage-usage-levels';
 
 type OwnProps = {
-	usageLevel: StorageUsageLevels;
+	usageLevel: StorageUsageLevelName;
 	bytesUsed: number;
 };
 
@@ -17,7 +17,7 @@ const ManageStorage: React.FC< OwnProps > = ( { usageLevel, bytesUsed } ) => {
 	useEffect( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_backup_storage_managestorage_display', {
-				type: StorageUsageLevels[ usageLevel ],
+				type: usageLevel,
 				bytes_used: bytesUsed,
 			} )
 		);

--- a/client/components/backup-storage-space/usage-warning/upsell.tsx
+++ b/client/components/backup-storage-space/usage-warning/upsell.tsx
@@ -5,15 +5,15 @@ import { useDispatch } from 'react-redux';
 import { preventWidows } from 'calypso/lib/formatting';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import { StorageUsageLevels } from '../storage-usage-levels';
 import ActionButton from './action-button';
+import type { StorageUsageLevelName } from '../storage-usage-levels';
 
 import './style.scss';
 
 type OwnProps = {
 	siteSlug: string;
 	bytesUsed: number;
-	usageLevel: StorageUsageLevels;
+	usageLevel: StorageUsageLevelName;
 };
 
 const UsageWarningUpsell: React.FC< OwnProps > = ( { siteSlug, bytesUsed, usageLevel } ) => {
@@ -23,7 +23,7 @@ const UsageWarningUpsell: React.FC< OwnProps > = ( { siteSlug, bytesUsed, usageL
 	useEffect( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_display', {
-				type: StorageUsageLevels[ usageLevel ],
+				type: usageLevel,
 				bytes_used: bytesUsed,
 			} )
 		);
@@ -32,7 +32,7 @@ const UsageWarningUpsell: React.FC< OwnProps > = ( { siteSlug, bytesUsed, usageL
 	const onClick = useCallback( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_backup_storage_upsell_click', {
-				type: StorageUsageLevels[ usageLevel ],
+				type: usageLevel,
 				bytes_used: bytesUsed,
 			} )
 		);

--- a/client/components/backup-storage-space/usage-warning/upsell.tsx
+++ b/client/components/backup-storage-space/usage-warning/upsell.tsx
@@ -1,10 +1,10 @@
 import { useJetpack1TbStorageAmountText } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { preventWidows } from 'calypso/lib/formatting';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import getJetpackStorageUpgradeUrl from 'calypso/state/plans/selectors/get-jetpack-storage-upgrade-url';
 import ActionButton from './action-button';
 import type { StorageUsageLevelName } from '../storage-usage-levels';
 
@@ -46,12 +46,16 @@ const UsageWarningUpsell: React.FC< OwnProps > = ( { siteSlug, bytesUsed, usageL
 		} )
 	);
 
+	const storageUpgradeUrl = useSelector( ( state ) =>
+		getJetpackStorageUpgradeUrl( state, siteSlug )
+	);
+
 	return (
 		<ActionButton
 			className="usage-warning__upsell"
 			usageLevel={ usageLevel }
 			actionText={ actionText }
-			href={ isJetpackCloud() ? `/pricing/storage/${ siteSlug }` : `/plans/storage/${ siteSlug }` }
+			href={ storageUpgradeUrl }
 			onClick={ onClick }
 		/>
 	);

--- a/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
+++ b/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
@@ -1,8 +1,8 @@
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { StorageUsageLevels } from '../storage-usage-levels';
+import { StorageUsageLevelName, StorageUsageLevels } from '../storage-usage-levels';
 
-const useStorageStatusText = ( usageLevel: StorageUsageLevels ): TranslateResult | null => {
+const useStorageStatusText = ( usageLevel: StorageUsageLevelName ): TranslateResult | null => {
 	const translate = useTranslate();
 
 	// TODO: For StorageUsageLevels.Warning, estimate how many days until

--- a/client/components/jetpack/daily-backup-status/status-card/visible-days-limit.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/visible-days-limit.tsx
@@ -4,13 +4,14 @@ import { useCallback, useEffect, useMemo } from 'react';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Button from 'calypso/components/forms/form-button';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import { getJetpackStorageUpgradeUrl } from 'calypso/state/plans/selectors';
 import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import cloudSuccessIcon from './icons/cloud-success.svg';
 import './style.scss';
 
@@ -54,7 +55,10 @@ const VisibleDaysLimit: React.FC< OwnProps > = ( { selectedDate } ) => {
 		);
 	}, [ dispatch, siteId ] );
 
-	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+	const storageUpgradeUrl = useSelector( ( state ) =>
+		getJetpackStorageUpgradeUrl( state, siteSlug )
+	);
 
 	return (
 		<div className="visible-days-limit">
@@ -79,9 +83,7 @@ const VisibleDaysLimit: React.FC< OwnProps > = ( { selectedDate } ) => {
 				</p>
 				<Button
 					className="status-card__button"
-					href={
-						isJetpackCloud() ? `/pricing/storage/${ siteSlug }` : `/plans/storage/${ siteSlug }`
-					}
+					href={ storageUpgradeUrl }
 					onClick={ recordUpsellButtonClick }
 				>
 					{ translate( 'Upgrade storage' ) }

--- a/client/my-sites/plans/current-plan/my-plan-card/style.scss
+++ b/client/my-sites/plans/current-plan/my-plan-card/style.scss
@@ -189,57 +189,12 @@
 	padding: 0;
 	box-shadow: none;
 
-	@include breakpoint-deprecated( '>960px' ) {
-		margin-block-end: 16px;
+	.usage-warning__upsell {
+		margin-block-start: 16px;
 	}
 
 	.backup-storage-space__divider,
 	.usage-warning__storage-full {
 		display: none;
-	}
-
-	.backup-storage-space__progress-bar-container {
-		margin-block-end: 24px;
-
-		display: grid;
-		column-gap: 16px;
-	}
-
-	.backup-storage-space__progress-heading {
-		margin-block-end: 8px;
-
-		font-weight: 600;
-		white-space: nowrap;
-
-		grid-row: 1 / 1;
-		grid-column: 1 / 1;
-
-		@include breakpoint-deprecated( '>1040px' ) {
-			margin-block-end: initial;
-		}
-	}
-
-	.backup-storage-space__progress-usage-text {
-		grid-row: 3;
-		grid-column: 1 / 1;
-
-		color: var( --color-text-subtle );
-		white-space: nowrap;
-
-		@include breakpoint-deprecated( '>1040px' ) {
-			grid-row: 1;
-			grid-column: 2;
-
-			text-align: end;
-		}
-	}
-
-	.backup-storage-space__progress-bar {
-		padding: 0;
-		grid-row: 2;
-
-		@include breakpoint-deprecated( '>1040px' ) {
-			grid-column: 1 / span 2;
-		}
 	}
 }

--- a/client/state/plans/selectors/get-jetpack-storage-upgrade-url.ts
+++ b/client/state/plans/selectors/get-jetpack-storage-upgrade-url.ts
@@ -1,0 +1,20 @@
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import type { AppState } from 'calypso/types';
+
+/**
+ *
+ * @param state The Redux application state
+ * @returns A Calypso Blue- or Green-relative URL that points to the Jetpack storage upgrade page;
+ * 			or, if no site is selected, an empty URL ("#").
+ */
+const getJetpackStorageUpgradeUrl = ( state: AppState ): string => {
+	const siteSlug = getSelectedSiteSlug( state );
+
+	if ( ! siteSlug ) {
+		return '#';
+	}
+
+	return isJetpackCloud() ? `/pricing/storage/${ siteSlug }` : `/plans/storage/${ siteSlug }`;
+};
+
+export default getJetpackStorageUpgradeUrl;

--- a/client/state/plans/selectors/get-jetpack-storage-upgrade-url.ts
+++ b/client/state/plans/selectors/get-jetpack-storage-upgrade-url.ts
@@ -4,12 +4,11 @@ import type { AppState } from 'calypso/types';
 /**
  *
  * @param state The Redux application state
+ * @param siteSlug The site whose storage upgrade URL should be returned
  * @returns A Calypso Blue- or Green-relative URL that points to the Jetpack storage upgrade page;
  * 			or, if no site is selected, an empty URL ("#").
  */
-const getJetpackStorageUpgradeUrl = ( state: AppState ): string => {
-	const siteSlug = getSelectedSiteSlug( state );
-
+const getJetpackStorageUpgradeUrl = ( state: AppState, siteSlug: string | null ): string => {
 	if ( ! siteSlug ) {
 		return '#';
 	}

--- a/client/state/plans/selectors/index.js
+++ b/client/state/plans/selectors/index.js
@@ -1,3 +1,4 @@
 export { getPlan, getPlanBySlug, getPlans, getPlanSlug, isRequestingPlans } from './plan';
 export { getPlanRawPrice } from './get-plan-raw-price';
 export { getDiscountedRawPrice } from './get-discounted-raw-price';
+export { default as getJetpackStorageUpgradeUrl } from './get-jetpack-storage-upgrade-url';


### PR DESCRIPTION
Resolves `1164141197617539-as-1202079046529162`.

I realize this PR could probably be broken up into two (styling in one, refactors in the other), but since the changes are so related, I chose to combine them. If anyone would rather they still be split, let me know and I can try to accommodate.

#### Changes proposed in this Pull Request

##### Visual changes

*For reference/source designs, see `XBBg9tWPg31yJZjaYDjetd-fi-1%3A29`.*

* Render storage usage elements vertically on all screen layouts, not just small screens.
* Increase the height of the storage usage progress bar from 9 to 24px, for visibility.
* Change the border radius behavior on the filled portion of the storage usage progress bar (see screenshots).
* Add a link to **Upgrade** backup storage next to the storage usage display text, if an upgrade is possible.
* Decrease font size for text elements surrounding the storage usage progress bar.
* Slightly change storage usage text copy, from `X of Y used` to `X used of Y`.

##### Refactoring

* Create a new selector to get the storage upgrade URL for Jetpack sites, `getJetpackStorageUpgradeUrl`.
* Use the aforementioned selector in all React components that render a link to upgrade a Jetpack site's storage.
* Convert `StorageUsageLevels` from an `enum` to a `const` object and a string-based union type, pursuant to `p7H4VZ-3sK-p2`.
* Remove styling rules from the My Plan storage usage card that are no longer necessary.

#### Testing instructions

***NOTE:** To test thoroughly, go through the following steps on the **Backup** page in both Calypso Blue and Calypso Green, and the **My Plan** page on Calypso Blue. Try sites with various levels of storage usage and availability (i.e., both 10GB and 1TB).*

#### Reference screenshots

##### Progress bar: mobile/tablet

<img height="250" alt="Screen Shot 2022-04-12 at 08 01 35" src="https://user-images.githubusercontent.com/670067/163203244-c6609f8d-cd66-419e-985e-a86a34919af7.png"> <img height="250" alt="Screen Shot 2022-04-12 at 08 01 17" src="https://user-images.githubusercontent.com/670067/163203242-4ba77626-c728-47d6-bd8f-033743b51f5f.png">

##### Usage levels: desktop

<img height="150" alt="Screen Shot 2022-04-12 at 08 01 46" src="https://user-images.githubusercontent.com/670067/163203246-649781e6-868b-4887-be1e-ec67d37caf2c.png"> <img height="150" alt="Screen Shot 2022-04-13 at 09 25 29" src="https://user-images.githubusercontent.com/670067/163203248-a347fc8b-d722-4481-b4b1-612b15e32806.png">
<img height="150" alt="Screen Shot 2022-04-13 at 09 26 16" src="https://user-images.githubusercontent.com/670067/163203250-b61715f7-4e9f-49e4-b0f8-fa4006e6bbbe.png"> <img height="150" alt="Screen Shot 2022-04-13 at 09 26 42" src="https://user-images.githubusercontent.com/670067/163203253-ad8cc1ee-9f7c-4f17-8831-bac2660a8867.png">

##### No upgrade link for 1TB

<img height="250" alt="Screen Shot 2022-04-13 at 09 27 56" src="https://user-images.githubusercontent.com/670067/163203256-dfe865ce-5536-4ab0-bcd7-68980abb5ad5.png">

##### Usage levels: My Plan

<img height="150" alt="Screen Shot 2022-04-13 at 09 49 18" src="https://user-images.githubusercontent.com/670067/163207908-02b07eb4-1cf0-4ec9-9065-723407c0a9c6.png"> <img height="150" alt="Screen Shot 2022-04-13 at 09 48 11" src="https://user-images.githubusercontent.com/670067/163207911-edaaee6e-c7d9-4ccc-9285-a8e5737a9b98.png">

