### PR TITLE
VideoPress: Allow player events to set the isPlaying state in the video editor controls

### DIFF
--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -165,6 +165,7 @@ class VideoEditor extends Component {
 								className="video-editor__preview"
 								isPlaying={ ! pauseVideo }
 								setIsPlaying={ this.setIsPlaying }
+								isSelectingFrame={ isSelectingFrame }
 								item={ media }
 								onPause={ this.updatePoster }
 								onScriptLoadError={ this.setError }

--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -96,6 +96,8 @@ class VideoEditor extends Component {
 		this.setState( { isLoading: false } );
 	};
 
+	setIsPlaying = ( isPlaying ) => this.setState( { pauseVideo: ! isPlaying } );
+
 	pauseVideo = () => {
 		this.setState( {
 			error: false,
@@ -162,6 +164,7 @@ class VideoEditor extends Component {
 							<DetailPreviewVideo
 								className="video-editor__preview"
 								isPlaying={ ! pauseVideo }
+								setIsPlaying={ this.setIsPlaying }
 								item={ media }
 								onPause={ this.updatePoster }
 								onScriptLoadError={ this.setError }

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -86,6 +86,8 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 
 		if ( 'playing' === data.event ) {
 			this.props.setIsPlaying( true );
+		} else if ( 'pause' === data.event ) {
+			this.props.setIsPlaying( false );
 		}
 
 		if (

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -16,6 +16,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	static propTypes = {
 		className: PropTypes.string,
 		isPlaying: PropTypes.bool,
+		setIsPlaying: PropTypes.func,
 		isSelectingFrame: PropTypes.bool,
 		item: PropTypes.object.isRequired,
 		onPause: PropTypes.func,
@@ -24,6 +25,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 
 	static defaultProps = {
 		isPlaying: false,
+		setIsPlaying: noop,
 		isSelectingFrame: false,
 		onPause: noop,
 		onVideoLoaded: noop,

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -79,6 +79,10 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 			return;
 		}
 
+		if ( 'playing' === data.event ) {
+			this.props.setIsPlaying( true );
+		}
+
 		if (
 			'videopress_loading_state' === data.event &&
 			'loaded' === data.state &&

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -16,6 +16,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	static propTypes = {
 		className: PropTypes.string,
 		isPlaying: PropTypes.bool,
+		isSelectingFrame: PropTypes.bool,
 		item: PropTypes.object.isRequired,
 		onPause: PropTypes.func,
 		onVideoLoaded: PropTypes.func,
@@ -23,6 +24,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 
 	static defaultProps = {
 		isPlaying: false,
+		isSelectingFrame: false,
 		onPause: noop,
 		onVideoLoaded: noop,
 	};
@@ -47,7 +49,10 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( prevProps.isPlaying && ! this.props.isPlaying ) {
+		if (
+			( prevProps.isPlaying && ! this.props.isPlaying ) ||
+			( ! prevProps.isSelectingFrame && this.props.isSelectingFrame )
+		) {
 			this.pause();
 		} else if ( ! prevProps.isPlaying && this.props.isPlaying ) {
 			this.play();


### PR DESCRIPTION
This PR fixes an issue when the "Upload" button is pressed, then cancelled and "Select Frame" is then attempted when editing a thumbnail for a VideoPress video in the Media Library.

It also keeps the `pauseVideo` variable in sync with the actual playing state of the video player by updating it based on video player postMessages.

Note: The existing interactions between the parent component and video are awkward because the child component is housing an iframe which communicates via postMessage, so communication is VERY indirect via props.

#### Changes proposed in this Pull Request

* Add the ability for the VideoPress player to update the `pauseVideo` state in the parent "video editor controls" component based on the current video player state
* Allow `pause` function to be executed in video player if already paused but `isSelectingFrame` is set to `true`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select a VideoPress video in the Media Library
* Click 'Edit Thumbnail'
* Click 'Upload'
* Click 'Cancel'
* Click the "Play" button in the player to restart the video
* Click 'Select Frame'
* The progress bar should appear and frame selection should be performed
* Repeat test but without pressing 'Play' after clicking 'Cancel' for the upload image, frame selection should still work as expected
* Repeat the above test on `trunk`, the frame selection will never occur

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

CC @flootr as discussed, I'm following up on the bug you found during your refactor
