### PR TITLE
Experiment: Update Masterbar Upgrade experiment name

### DIFF
--- a/client/layout/masterbar/plan-upsell.jsx
+++ b/client/layout/masterbar/plan-upsell.jsx
@@ -61,7 +61,7 @@ class MasterbarItemPlanUpsell extends Component {
 
 		return (
 			<ProvideExperimentData
-				name="masterbar_plan_upsell_202202_v1"
+				name="masterbar_plan_upsell_202202_v2"
 				options={ {
 					isEligible: showPlanUpsell,
 				} }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

More info: pbxNRc-1qR-p2#comment-3229

This updates the name for the Masterbar Upgrade experiment (added in #61361) to `masterbar_plan_upsell_202202_v2`.

#### Testing instructions

##### Treatment 

* Assign yourself to `treatment` variation using the bookmarklet for the experiment `masterbar_plan_upsell_202202_v2`
* Go to a Free site
* Verify that the `Upgrade` button is visible in the Masterbar, next to the `Write` button
<img width="978" alt="Screenshot on 2022-04-13 at 17-43-56" src="https://user-images.githubusercontent.com/2749938/163207130-b9b6f953-096d-43d3-848d-00fdf8d66158.png">

##### Control

* Assign yourself to `control` variation using the bookmarklet for the experiment `masterbar_plan_upsell_202202_v2`.
* Go to a Free site
* Verify that the `Upgrade` button is not visible any longer in the Masterbar.
