### PR TITLE
Seller Experience: Site data-store selector for checking if a site is atomic

### DIFF
--- a/client/landing/stepper/hooks/use-is-site-atomic.ts
+++ b/client/landing/stepper/hooks/use-is-site-atomic.ts
@@ -1,0 +1,6 @@
+import { useSelect } from '@wordpress/data';
+import { SITE_STORE } from '../stores';
+
+export function useIsSiteAtomic( siteId: number | string ): boolean | null {
+	return useSelect( ( select ) => select( SITE_STORE ).isSiteAtomic( siteId ) );
+}

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -42,6 +42,10 @@ export const isSiteLaunching = ( state: State, siteId: number ) => {
 	return state.launchStatus[ siteId ]?.status === SiteLaunchStatus.IN_PROGRESS;
 };
 
+export const isSiteAtomic = ( state: State, siteId: number | string ) => {
+	return select( STORE_KEY ).getSite( siteId )?.options.is_wpcom_atomic === true;
+};
+
 export const getSiteDomains = ( state: State, siteId: number ) => {
 	return state.sitesDomains[ siteId ];
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

New site data-store selector to check the `is_wpcom_atomic` option for the site. 

It leverages the existing `getSite` selector so the site data will be loaded as-needed. This means we can easily call the selector or corresponding hook in situations where we don't necessarily need to call `getSite` or `useSite` first.


Fixes #62715
