### PR TITLE
Stepper: Add state management for Anchor.fm - Podcast name step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
@@ -1,8 +1,11 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
+import { TextControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
@@ -11,6 +14,8 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 	const translate = useTranslate();
 	const headerText = translate( 'My podcast is called' );
 	const subHeaderText = translate( "Don't worry, you can change it later." );
+	const { siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+	const { setSiteTitle } = useDispatch( ONBOARD_STORE );
 
 	const handleClick = () => {
 		submit?.();
@@ -31,7 +36,12 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 					align={ 'left' }
 				/>
 			}
-			stepContent={ <Button onClick={ handleClick }>Go to next step</Button> }
+			stepContent={
+				<>
+					<TextControl onChange={ setSiteTitle } value={ siteTitle } />
+					<Button onClick={ handleClick }>Continue</Button>
+				</>
+			}
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
@@ -9,6 +10,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
 import getTextWidth from 'calypso/landing/gutenboarding/onboarding-block/acquire-intent/get-text-width';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { tip } from 'calypso/signup/icons';
 import type { Step } from '../../types';
@@ -20,19 +22,20 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 	const { __ } = useI18n();
 
 	const PodcastTitleForm: React.FC = () => {
-		const [ podcastTitle, setPodcastTitle ] = useState( '' );
 		const [ formTouched, setFormTouched ] = useState( false );
+		const { siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+		const { setSiteTitle } = useDispatch( ONBOARD_STORE );
 		const inputRef = useRef< HTMLInputElement >();
 
 		const handleSubmit = () => {
 			submit?.();
 		};
 
-		const underlineWidth = getTextWidth( ( podcastTitle as string ) || '', inputRef.current );
+		const underlineWidth = getTextWidth( ( siteTitle as string ) || '', inputRef.current );
 
 		const handleChange = ( event: React.FormEvent< HTMLInputElement > ) => {
 			setFormTouched( true );
-			return setPodcastTitle( event.currentTarget.value );
+			setSiteTitle( event.currentTarget.value );
 		};
 		return (
 			<form className="podcast-title__form" onSubmit={ handleSubmit }>
@@ -44,13 +47,13 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 						<FormInput
 							id="podcast-title"
 							inputRef={ inputRef }
-							value={ podcastTitle }
+							value={ siteTitle }
 							onChange={ handleChange }
 							placeholder={ __( 'Good Fun' ) }
 						/>
 						<div
 							className={ classNames( 'podcast-title__underline', {
-								'is-empty': ! ( podcastTitle as string )?.length,
+								'is-empty': ! ( siteTitle as string )?.length,
 							} ) }
 							style={ { width: underlineWidth || '100%' } }
 						/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Persist podcast title on ONBOARD_STORE

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to /setup/?flags=signup/anchor-fm&anchor_podcast=[some-id]&siteSlug=[yoursite.wordpress.com]
* You should see the input in synced to the ONBOARD_STORE data.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Relates to #62668
