### PR TITLE
Temporarily reverting anchor flow selection

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -9,7 +9,6 @@ import { requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { LocaleContext } from '../gutenboarding/components/locale-context';
 import { WindowLocaleEffectManager } from '../gutenboarding/components/window-locale-effect-manager';
 import { setupWpDataDebug } from '../gutenboarding/devtools';
-import { anchorFmFlow } from './declarative-flow/anchor-fm-flow';
 import { FlowRenderer } from './declarative-flow/internals';
 import { siteSetupFlow } from './declarative-flow/site-setup-flow';
 import 'calypso/components/environment-badge/style.scss';
@@ -44,7 +43,7 @@ window.AppBoot = async () => {
 
 	const queryClient = new QueryClient();
 
-	const flow = config.isEnabled( 'signup/anchor-fm' ) ? anchorFmFlow : siteSetupFlow;
+	const flow = siteSetupFlow;
 
 	ReactDom.render(
 		<LocaleContext>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR temporarily reverts logic which caused the Stepper framework to default into the new Anchor onboarding flow if the associated feature flag was enabled.
* Since we don't want to *replace* the site-setup flow, we need to add a more nuanced logic here instead (probably making use of a query string parameter like we were in gutenboarding).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/setup/intent?siteSlug=<slug>` with the `signup/anchor-fm` feature flag enabled.
* Verify that you are directed to the Intent screen, not the Podcast title screen.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1649875983026069-slack-C0Q664T29