### PR TITLE
Stepper: Anchor.fm, Added check for anchor_podcast query param

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -51,8 +51,11 @@ window.AppBoot = async () => {
 		new URLSearchParams( search ).get( 'anchor_podcast' )
 	);
 
-	const flow =
-		anchorPodcastId && config.isEnabled( 'signup/anchor-fm' ) ? anchorFmFlow : siteSetupFlow;
+	let flow = siteSetupFlow;
+
+	if ( anchorPodcastId && config.isEnabled( 'signup/anchor-fm' ) ) {
+		flow = anchorFmFlow;
+	}
 
 	ReactDom.render(
 		<LocaleContext>

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -44,7 +44,15 @@ window.AppBoot = async () => {
 
 	const queryClient = new QueryClient();
 
-	const flow = config.isEnabled( 'signup/anchor-fm' ) ? anchorFmFlow : siteSetupFlow;
+	const sanitizePodcastId = ( id: string | null ) => id?.replace( /[^a-zA-Z0-9]/g, '' );
+	const search = location.search;
+
+	const anchorPodcastId = sanitizePodcastId(
+		new URLSearchParams( search ).get( 'anchor_podcast' )
+	);
+
+	const flow =
+		anchorPodcastId && config.isEnabled( 'signup/anchor-fm' ) ? anchorFmFlow : siteSetupFlow;
 
 	ReactDom.render(
 		<LocaleContext>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Checking for the `anchor_podcast` query parameter in order to use the Anchor.fm stepper flow

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try the `/setup/?siteSlug=<slug>` url with and without the `anchor_podcast` parameter. You should get the anchor and the setup flows respectively.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 62669
