### PR TITLE
[WIP] Stepper: Add woo confirm step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -10,6 +10,7 @@ export { default as fontPairing } from './font-pairing';
 export { default as storeAddress } from './store-address';
 export { default as vertical } from './site-vertical';
 export { default as processing } from './processing-step';
+export { default as wooCommerceConfirmStep } from './woocommerce-confirm-step';
 
 export type StepPath =
 	| 'courses'
@@ -23,4 +24,5 @@ export type StepPath =
 	| 'fontPairing'
 	| 'storeAddress'
 	| 'processing'
-	| 'vertical';
+	| 'vertical'
+	| 'wooCommerceConfirmStep';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woocommerce-confirm-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woocommerce-confirm-step/index.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { useTranslate } from 'i18n-calypso';
-import type { Step } from '../../types';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
 
 const WooCommerceConfirmStep: Step = function WooCommerceConfirmStep( { navigation } ) {
 	const { goBack, submit } = navigation;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woocommerce-confirm-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woocommerce-confirm-step/index.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@automattic/components';
+import { StepContainer } from '@automattic/onboarding';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { useTranslate } from 'i18n-calypso';
+import type { Step } from '../../types';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+
+const WooCommerceConfirmStep: Step = function WooCommerceConfirmStep( { navigation } ) {
+	const { goBack, submit } = navigation;
+
+	const translate = useTranslate();
+	const headerText = translate( 'One final step' );
+	const subHeaderText = translate(
+		'We’ve highlighted a few important details you should review before we create your store.'
+	);
+	return (
+		<StepContainer
+			stepName={ 'woocommerce-confirm-step' }
+			goBack={ goBack }
+			hideSkip
+			isHorizontalLayout={ true }
+			formattedHeader={
+				<FormattedHeader
+					id={ 'woocommerce-confirm-step-title-header' }
+					headerText={ headerText }
+					subHeaderText={ subHeaderText }
+					align={ 'left' }
+				/>
+			}
+			stepContent={ <Button onClick={ () => submit?.() }>Confirm</Button> }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default WooCommerceConfirmStep;

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -26,6 +26,7 @@ export const siteSetupFlow: Flow = {
 			'businessInfo',
 			'storeAddress',
 			'processing',
+			'wooCommerceConfirmStep',
 		] as StepPath[];
 	},
 


### PR DESCRIPTION
This is still a WIP

The biggest pending issue here is bringing https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts over to the Stepper store.

Closes https://github.com/Automattic/wp-calypso/issues/62714
