### PR TITLE
Jetpack Cloud: Add search redirect for landing page

### DIFF
--- a/client/jetpack-cloud/sections/landing.tsx
+++ b/client/jetpack-cloud/sections/landing.tsx
@@ -3,6 +3,11 @@ import { useEffect } from 'react';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import QueryRewindCapabilities from 'calypso/components/data/query-rewind-capabilities';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import {
+	isFetchingSitePurchases as isFetchingSitePurchasesSelector,
+	siteHasSearchProductPurchase,
+} from 'calypso/state/purchases/selectors';
 import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isBackupPluginActive from 'calypso/state/sites/selectors/is-backup-plugin-active';
@@ -28,10 +33,14 @@ const Landing: React.FC = () => {
 
 	const isEligible = useSelector( ( state ) => siteIsEligible( state, siteId ) );
 	const capabilities = useSelector( ( state ) => getRewindCapabilities( state, siteId ) );
+	const hasSearch = useSelector( ( state ) => siteHasSearchProductPurchase( state, siteId ) );
+	const isFetchingSitePurchases = useSelector( ( state ) =>
+		isFetchingSitePurchasesSelector( state )
+	);
 
 	useEffect( () => {
 		// early return while we wait to retrieve information
-		if ( isEligible === null || capabilities === undefined ) {
+		if ( isEligible === null || capabilities === undefined || isFetchingSitePurchases === true ) {
 			return;
 		}
 
@@ -45,19 +54,26 @@ const Landing: React.FC = () => {
 
 		const redirectUrl = new URL( window.location.href );
 
-		// For sites with Scan but not Backup, redirect to Scan
-		if ( hasScan && ! hasBackup ) {
+		if ( hasBackup ) {
+			redirectUrl.pathname = `/backup/${ siteSlug ?? '' }`;
+		} else if ( hasScan ) {
 			redirectUrl.pathname = `/scan/${ siteSlug ?? '' }`;
-			return page.redirect( redirectUrl.toString() );
+		} else if ( hasSearch ) {
+			redirectUrl.pathname = `/jetpack-search/${ siteSlug ?? '' }`;
+		} else {
+			// For sites with no eligibile capabilities, show the Backup upsell page.
+			redirectUrl.pathname = `/backup/${ siteSlug ?? '' }`;
 		}
 
-		// For sites with Backup, show the Backup page;
-		// for sites with neither Backup nor Scan, show the Backup upsell page
-		redirectUrl.pathname = `/backup/${ siteSlug ?? '' }`;
-		page.redirect( redirectUrl.toString() );
-	}, [ isEligible, siteSlug, capabilities ] );
+		return page.redirect( redirectUrl.toString() );
+	}, [ capabilities, hasSearch, isEligible, isFetchingSitePurchases, siteSlug ] );
 
-	return <QueryRewindCapabilities siteId={ siteId } />;
+	return (
+		<>
+			<QueryRewindCapabilities siteId={ siteId } />
+			<QuerySitePurchases siteId={ siteId } />
+		</>
+	);
 };
 
 export default Landing;

--- a/client/state/purchases/selectors/site-has-search-product-purchase.js
+++ b/client/state/purchases/selectors/site-has-search-product-purchase.js
@@ -8,7 +8,7 @@ import 'calypso/state/purchases/init';
  * Whether a site has an active Jetpack Search purchase.
  *
  * @param   {object} state       global state
- * @param   {number} siteId      the site id
+ * @param   {number|null} siteId      the site id
  * @returns {boolean} True if the site has an active Jetpack Search purchase, false otherwise.
  */
 export const siteHasSearchProductPurchase = ( state, siteId ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes https://github.com/Automattic/jetpack/issues/23770.

Adds redirect logic to the Search settings page if an active search product is detected for the site. Backup and Scan products retain higher priority for redirections.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up this change locally (`yarn start-jetpack-cloud`) or via a live branch.
2. Navigate to `/`, which should redirect you to `/landing` after authentication.
3. Select a site with only a Jetpack Search purchase. Ensure that you're redirected to `/jetpack-search/<siteSlug>`.
4. Purchase a Jetpack Scan subscription for the site and repeat steps 2 and 3. Ensure that you're redirected to `/scan/<siteSlug>`.
5. Purchase a Jetpack Backup subscription for the site and repeat steps 2 and 3. Ensure that you're redirected to `/backup/<siteSlug>`.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
