### PR TITLE
Create calypso_plugin_install_activate_click event to track plugin installation events

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -367,6 +367,12 @@ function onClickInstallPlugin( {
 			plugin: plugin.slug,
 		} )
 	);
+	dispatch(
+		recordTracksEvent( 'calypso_plugin_install_activate_click', {
+			plugin: plugin.slug,
+			blog_id: selectedSite?.ID,
+		} )
+	);
 
 	dispatch( productToBeInstalled( plugin.slug, selectedSite.slug ) );
 

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -371,6 +371,8 @@ function onClickInstallPlugin( {
 		recordTracksEvent( 'calypso_plugin_install_activate_click', {
 			plugin: plugin.slug,
 			blog_id: selectedSite?.ID,
+			marketplace_product: isMarketplaceProduct,
+			needs_plan_upgrade: upgradeAndInstall,
 		} )
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a track event triggered when the user clicks on _Install and activate_ button in the Plugin details page.

#### Testing instructions
- Use the Calypso version of this branch
- Go to /plugins page
- in the console enter localStorage.setItem( 'debug', 'calypso:analytics*' )
- make sure the console log displays _Verbose_ log level.
- reload the page
- Click on any plugin on the screen
- Verify the event calypso_plugin_install_activate_click is logged with the following info: blog_id, plugin slug, marketplace_product and needs_plan_upgrade. The meaning of the fields is:
  - blog_id and plugin correspond to the id of the blog and the plugin slug respectively.
  - marketplace_product: boolean that indicates if the plugin is a premium plugin
  - needs_plan_upgrade: boolean that indicates if the user plan is free so it needs to be upgraded. For non-free plans, this boolean should be _false_


Related to #62727
