### PR TITLE
Browser Plugins: Add an event to track the plugins search pages being retrieved.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -163,6 +163,7 @@ const PluginsBrowser = ( {
 			!! selectedSite?.ID && ! canCurrentUser( state, selectedSite?.ID, 'manage_options' )
 	);
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteId = useSelector( getSelectedSiteId );
 	const sites = useSelector( getSelectedOrAllSitesJetpackCanManage );
 	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
 	const {
@@ -335,6 +336,7 @@ const PluginsBrowser = ( {
 				sites={ sites }
 				searchTitle={ searchTitle }
 				siteSlug={ siteSlug }
+				siteId={ siteId }
 				jetpackNonAtomic={ jetpackNonAtomic }
 				billingPeriod={ billingPeriod }
 				setBillingPeriod={ ( interval ) => dispatch( setBillingInterval( interval ) ) }
@@ -348,6 +350,7 @@ const SearchListView = ( {
 	search: searchTerm,
 	searchTitle: searchTitleTerm,
 	siteSlug,
+	siteId,
 	sites,
 	billingPeriod,
 } ) => {
@@ -381,6 +384,18 @@ const SearchListView = ( {
 				recordTracksEvent( 'calypso_plugins_search_results_show', {
 					search_term: searchTerm,
 					results_count: pluginsPagination?.results,
+					blog_id: siteId,
+				} )
+			);
+		}
+
+		if ( searchTerm && pluginsPagination ) {
+			dispatch(
+				recordTracksEvent( 'calypso_plugins_search_results_page', {
+					search_term: searchTerm,
+					page: pluginsPagination.page,
+					results_count: pluginsPagination.results,
+					blog_id: siteId,
 				} )
 			);
 		}


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Create the `calypso_plugins_search_results_page` to track the search pages retrieved

#### Testing instructions
- Use the Calypso version of this branch
- Go to `/plugins` page
- in the console enter `localStorage.setItem( 'debug', 'calypso:analytics*' )`
- reload the page
- Search for plugins. Eg: `WooCommerce`
- Check if the event `calypso_plugins_search_results_page` is being logged on the console
- Confirm all the properties are being sent: search_term, page, results_count and blog_id.


---


Related to #62727
