### PR TITLE
Add a fragment component to the required key.

### DIFF
--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,6 +1,6 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
-import { useRef } from 'react';
+import { useRef, Fragment } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
@@ -52,7 +52,7 @@ const PopularSearches = ( props ) => {
 
 			<div className="search-box-header__recommended-searches-list">
 				{ searchTerms.map( ( searchTerm, n ) => (
-					<>
+					<Fragment key={ 'search-box-item' + n }>
 						{ searchTerm === searchedTerm ? (
 							<span
 								className="search-box-header__recommended-searches-list-item search-box-header__recommended-searches-list-item-selected"
@@ -73,7 +73,7 @@ const PopularSearches = ( props ) => {
 							</span>
 						) }
 						{ n !== searchTerms.length - 1 && <>,&nbsp;</> }
-					</>
+					</Fragment>
 				) ) }
 			</div>
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a fragment component to add the required key.

#### Testing instructions
**Using the current version on `trunk`**
* Go to the plugins search page `/plugins?s=search`
* You should see an error in the console
```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `PopularSearches`.
```

**Using this version**
* Go to the plugins search page `/plugins?s=search`
* You shouldn't see any error related to the `PopularSearches` component