### PR TITLE
Plans comparison: this-is-your-plan button 

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-action.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-action.tsx
@@ -87,6 +87,10 @@ export const PlansComparisonAction: React.FunctionComponent< Props > = ( {
 	}
 
 	if ( ! isInSignup && [ TYPE_FLEXIBLE, TYPE_FREE ].includes( plan.type ) ) {
+		if ( isCurrentPlan ) {
+			return <Button disabled>{ translate( 'This is your plan' ) }</Button>;
+		}
+
 		return null;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Partially addresses c/4PHxCS4J-tr 

Adds a disabled "This is your plan" button to emphasize the user is on the Free plan.

### Media

<img width="1095" alt="Screenshot 2022-04-14 at 2 30 09 PM" src="https://user-images.githubusercontent.com/1705499/163382657-d44069c6-7712-4a8a-8730-a5145c40a5e4.png">


### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/[SITE_ON_FREE_PLAN_URL]`
* Ensure the disabled button shows as above

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
