### PR TITLE
Seller Experience - Stepper: Setup error data store

### DIFF
--- a/client/landing/stepper/hooks/use-site-setup-error.ts
+++ b/client/landing/stepper/hooks/use-site-setup-error.ts
@@ -1,0 +1,12 @@
+import { useSelect } from '@wordpress/data';
+import { SITE_STORE } from '../stores';
+import { useQuery } from './use-query';
+
+export function useSiteSetupError() {
+	const siteSlug = useQuery().get( 'siteSlug' );
+	const siteId = useSelect(
+		( select ) => siteSlug && select( SITE_STORE ).getSiteIdBySlug( siteSlug )
+	);
+
+	return useSelect( ( select ) => siteId && select( SITE_STORE ).getSiteSetupError( siteId ) );
+}

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -231,6 +231,18 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		return data?.is_fse_active ?? false;
 	}
 
+	const setSiteSetupError = ( siteId: number, error: string, message: string ) => ( {
+		type: 'SET_SITE_SETUP_ERROR',
+		siteId,
+		error,
+		message,
+	} );
+
+	const clearSiteSetupError = ( siteId: number ) => ( {
+		type: 'CLEAR_SITE_SETUP_ERROR',
+		siteId,
+	} );
+
 	return {
 		receiveSiteDomains,
 		receiveSiteSettings,
@@ -256,6 +268,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		launchSiteFailure,
 		getCart,
 		setCart,
+		setSiteSetupError,
+		clearSiteSetupError,
 	};
 }
 

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -159,6 +159,38 @@ export const launchStatus: Reducer< { [ key: number ]: SiteLaunchState }, Action
 	return state;
 };
 
+export const siteSetupErrors: Reducer<
+	{ [ key: number ]: any | undefined },
+	{
+		type: string;
+		siteId: number;
+		error?: string;
+		message?: string;
+	}
+> = ( state = {}, action ) => {
+	if ( action.type === 'SET_SITE_SETUP_ERROR' ) {
+		const { siteId, error, message } = action;
+
+		return {
+			...state,
+			[ siteId ]: {
+				error,
+				message,
+			},
+		};
+	}
+
+	if ( action.type === 'CLEAR_SITE_SETUP_ERROR' ) {
+		const newState = {
+			...state,
+		};
+
+		delete newState[ action.siteId ];
+	}
+
+	return state;
+};
+
 const newSite = combineReducers( {
 	data: newSiteData,
 	error: newSiteError,
@@ -172,6 +204,7 @@ const reducer = combineReducers( {
 	launchStatus,
 	sitesDomains,
 	sitesSettings,
+	siteSetupErrors,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -54,6 +54,10 @@ export const getSiteSettings = ( state: State, siteId: number ) => {
 	return state.sitesSettings[ siteId ];
 };
 
+export const getSiteSetupError = ( state: State, siteId: number ) => {
+	return state.siteSetupErrors[ siteId ] || null;
+};
+
 export const getPrimarySiteDomain = ( _: State, siteId: number ) =>
 	select( STORE_KEY )
 		.getSiteDomains( siteId )

--- a/packages/data-stores/src/site/test/reducer.ts
+++ b/packages/data-stores/src/site/test/reducer.ts
@@ -7,7 +7,7 @@
  */
 
 import { createActions } from '../actions';
-import { sites, launchStatus } from '../reducer';
+import { sites, launchStatus, siteSetupErrors } from '../reducer';
 import {
 	SiteLaunchError,
 	SiteLaunchState,
@@ -123,6 +123,55 @@ describe( 'Site', () => {
 			};
 
 			expect( launchStatus( originalState, action ) ).toEqual( expected );
+		} );
+	} );
+
+	describe( 'Site Setup Errors', () => {
+		type ClientCredentials = { client_id: string; client_secret: string };
+
+		let siteId: number;
+		let client_id: string;
+		let client_secret: string;
+		let mockedClientCredentials: ClientCredentials;
+		let originalState: { [ key: number ]: SiteLaunchState };
+
+		beforeEach( () => {
+			siteId = 12345;
+			client_id = 'magic_client_id';
+			client_secret = 'magic_client_secret';
+			mockedClientCredentials = { client_id, client_secret };
+			originalState = {};
+		} );
+
+		it( 'should default to the initial state when an unknown action is dispatched', () => {
+			const state = siteSetupErrors( undefined, { type: 'TEST_ACTION', siteId } );
+			expect( state ).toStrictEqual( {} );
+		} );
+
+		it( 'should set a site setup error when a SET_SITE_SETUP_ERROR action is dispatched', () => {
+			const { setSiteSetupError } = createActions( mockedClientCredentials );
+
+			const error = 'test_error';
+			const message = 'This is a test error';
+
+			const action = setSiteSetupError( siteId, error, message );
+			const expected = {
+				[ siteId ]: {
+					error,
+					message,
+				},
+			};
+
+			expect( siteSetupErrors( originalState, action ) ).toEqual( expected );
+		} );
+
+		it( 'should clear a site setup error when a CLEAR_SITE_SETUP_ERROR action is dispatched', () => {
+			const { clearSiteSetupError } = createActions( mockedClientCredentials );
+
+			const action = clearSiteSetupError( siteId );
+			const expected = {};
+
+			expect( siteSetupErrors( originalState, action ) ).toEqual( expected );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a new `siteSetupErrors` prop to the `site` data-store.

The structure of the new prop is:
```
{
  siteSetupErrors: {
    123: {
      error: 'An error occurred',
      message: 'We're very sorry but something went wrong. Please contact support for assistance.'
    }
  }
}
```

#### Testing instructions

`yarn run test-packages ./packages/data-stores/src/site/test`

Related to #62712
