### PR TITLE
Seller Experience-Stepper: Error step.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -1,0 +1,64 @@
+import { StepContainer } from '@automattic/onboarding';
+import styled from '@emotion/styled';
+import { useI18n } from '@wordpress/react-i18n';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSiteDomains } from '../../../../hooks/use-site-domains';
+import { useSiteSetupError } from '../../../../hooks/use-site-setup-error';
+import SupportCard from '../store-address/support-card';
+import type { Step } from '../../types';
+import './style.scss';
+
+const WarningsOrHoldsSection = styled.div`
+	margin-top: 40px;
+`;
+
+const ErrorStep: Step = function ErrorStep( { navigation } ) {
+	const { goBack, goNext } = navigation;
+	const { __ } = useI18n();
+	const siteDomains = useSiteDomains();
+	const siteSetupError = useSiteSetupError();
+
+	let domain = '';
+
+	if ( siteDomains && siteDomains.length > 0 ) {
+		domain = siteDomains[ 0 ].domain;
+	}
+
+	const headerText = siteSetupError ? siteSetupError.error : __( "We've hit a snag" );
+	const bodyText = siteSetupError
+		? siteSetupError.message
+		: __(
+				'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
+		  );
+
+	const getContent = () => {
+		return (
+			<WarningsOrHoldsSection>
+				<SupportCard domain={ domain } />
+			</WarningsOrHoldsSection>
+		);
+	};
+
+	return (
+		<StepContainer
+			stepName={ 'error-step' }
+			goBack={ goBack }
+			goNext={ goNext }
+			isHorizontalLayout={ false }
+			formattedHeader={
+				<>
+					<FormattedHeader id={ 'step-error-header' } headerText={ headerText } align={ 'left' } />
+					<p>{ bodyText }</p>
+				</>
+			}
+			stepContent={ getContent() }
+			recordTracksEvent={ recordTracksEvent }
+			hideBack
+			hideSkip
+			hideNext
+		/>
+	);
+};
+
+export default ErrorStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/style.scss
@@ -1,0 +1,11 @@
+@import '@automattic/onboarding/styles/mixins';
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+
+.step-container.error-step {
+	padding: 1rem;
+
+	.formatted-header .formatted-header__title {
+		margin: 40px 0;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -10,6 +10,7 @@ export { default as fontPairing } from './font-pairing';
 export { default as storeAddress } from './store-address';
 export { default as vertical } from './site-vertical';
 export { default as processing } from './processing-step';
+export { default as error } from './error-step';
 
 export type StepPath =
 	| 'courses'
@@ -23,4 +24,5 @@ export type StepPath =
 	| 'fontPairing'
 	| 'storeAddress'
 	| 'processing'
-	| 'vertical';
+	| 'vertical'
+	| 'error';

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -27,6 +27,7 @@ export const siteSetupFlow: Flow = {
 			'businessInfo',
 			'storeAddress',
 			'processing',
+			'error',
 		] as StepPath[];
 	},
 

--- a/client/landing/stepper/hooks/use-site-domains.ts
+++ b/client/landing/stepper/hooks/use-site-domains.ts
@@ -1,0 +1,19 @@
+import { useSelect } from '@wordpress/data';
+import { SITE_STORE } from '../stores';
+import { useQuery } from './use-query';
+
+export function useSiteDomains() {
+	const siteSlug = useQuery().get( 'siteSlug' );
+	const siteId = useSelect(
+		( select ) => siteSlug && select( SITE_STORE ).getSiteIdBySlug( siteSlug )
+	);
+	const siteDomains = useSelect(
+		( select ) => siteId && select( SITE_STORE ).getSiteDomains( siteId )
+	);
+
+	if ( siteSlug && siteId && siteDomains ) {
+		return siteDomains;
+	}
+
+	return null;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This provides a simple error display along with a support link. The step will display any error content for the site from the site data-store or it will fall back to a default message if there is no custom error content.

**Default error message**
This provides a simple error display along with a support link. The step
will display any error content for the site from the site data-store or
it will fall back to a default message if there is no custom error
content.

![image](https://user-images.githubusercontent.com/917632/163445406-3fb2ddfb-7a89-440e-a5a5-6a22e6bb1c8a.png)

**Custom error message**
![image](https://user-images.githubusercontent.com/917632/163445521-50953653-ed14-44ed-8557-5b48bd6de4b0.png)


#### Testing instructions

Go to `http://calypso.localhost:3000/setup/error?siteSlug=<your-site-name>`. You should see the error dialog pictured above.

Related to #62712
