### PR TITLE
ETK NUX: fix duplicating masterbar from blogger flow

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
@@ -3,8 +3,10 @@ import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import React from 'react';
 import NuxModal from '../nux-modal';
 import postPublishedImage from './images/post-published.svg';
+
 import './style.scss';
 
 /**
@@ -57,6 +59,11 @@ const PostPublishedModal: React.FC = () => {
 		setShouldShowFirstPostPublishedModal,
 	] );
 
+	const handleClick = ( event: React.MouseEvent ) => {
+		event.preventDefault();
+		( window.top as Window ).location.href = link;
+	};
+
 	return (
 		<NuxModal
 			isOpen={ isOpen }
@@ -68,7 +75,7 @@ const PostPublishedModal: React.FC = () => {
 			) }
 			imageSrc={ postPublishedImage }
 			actionButtons={
-				<Button isPrimary href={ link }>
+				<Button isPrimary onClick={ handleClick }>
 					{ __( 'View Post', 'full-site-editing' ) }
 				</Button>
 			}

--- a/apps/editing-toolkit/typings/index.d.ts
+++ b/apps/editing-toolkit/typings/index.d.ts
@@ -4,6 +4,10 @@ import '@automattic/calypso-build';
 // Our build system externalizes and adds it to the script dependencies when it's imported.
 declare module 'a8c-fse-common-data-stores' {}
 
+declare module '*.svg' {
+	const url: string;
+}
+
 declare global {
 	interface Window {
 		wpcomEditorSiteLaunch?: {


### PR DESCRIPTION
## Changes proposed in this Pull Request

Currently there is a bug when creating a new site from the Blogger flow. If you follow the flow and publish a post you are given a modal to view the new post. If you are in `calypsoify` and viewing from mobile orientation the masterbar gets duplicated AFTER clicking the button to `View Post`.

From my testing, this only happens in calypsoified editors ( here ⇢ `https://wordpress.com/post/test633710148.wordpress.com` not here ⇢ `https://test633710148.wordpress.com/wp-admin/post.php`). Because the modal is opened in the calypso iframe, when the button is clicked it only changes the location of the iframe and not the entire window. This results in a duplicated masterbar.

I am not sure if there were changes down the line that caused this to happen or what exactly. It seemed like the best fix was to make the link open the post in the parent window rather than sniffing around for ways to hide the masterbar outside the iframe.

#### Testing instructions

1. Pull branch, login to your sandbox, and run `cd apps/editing-toolkit/ && yarn dev --sync`
2. Go to https://wordpress.com/start choose a domain and make sure you are in a mobile orientation 
3. Sandbox the domain you just chose
4. Follow the flow for Blogger (Write) and then start writing your post.
5. Publish your post and click `View Post`. This should take you to the live version of the post with only one masterbar.

| Before | After |
| - | - |
| <img width="890" alt="Markup 2022-04-14 at 12 58 55" src="https://user-images.githubusercontent.com/33258733/163399834-013ee427-56e2-4aa1-9533-42dc557b3c49.png"> | <img width="942" alt="Markup 2022-04-13 at 22 12 35" src="https://user-images.githubusercontent.com/33258733/163399907-0eb2ec3c-b565-4c7d-b271-3049bfac9864.png"> |