### PR TITLE
Anchor: Apply styles from site-setup flow to Anchor signup flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -50,7 +50,8 @@ button {
 /**
  * Site Setup
  */
-.site-setup {
+.site-setup,
+.anchor-fm {
 	position: relative;
 	padding: 48px 0 0;
 	box-sizing: border-box;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
@@ -46,7 +46,7 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 							inputRef={ inputRef }
 							value={ podcastTitle }
 							onChange={ handleChange }
-							placeholder={ __( 'Good Fun' ) }
+							placeholder="Good Fun"
 						/>
 						<div
 							className={ classNames( 'podcast-title__underline', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/style.scss
@@ -18,9 +18,8 @@ $input-max-width: 448px;
     }
 
     @include break-medium {
-        padding: 0 20px 20px;
-        position: absolute;
-        top: 24%;
+        padding: 20px;
+        top: 24vh;
         left: 50%;
         width: 100%;
         max-width: 1024px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensure both flows use the same styles; this fixes the missing WordPress logo.

**Before**

<img width="1954" alt="Screen Shot 2022-04-14 at 1 06 51 PM" src="https://user-images.githubusercontent.com/2124984/163438793-a2097fc8-cbce-4998-b6ca-b1da144c7c1a.png">

**After**

<img width="1958" alt="Screen Shot 2022-04-14 at 1 15 52 PM" src="https://user-images.githubusercontent.com/2124984/163440210-a485cdac-8b6f-4039-8037-c49b320ecb1a.png">


#### Testing instructions

* Switch to this PR
* Make sure the Anchor flow has a visible WP logo in the upper left
* Make sure this doesn't break anything visually in the site-setup flow (it shouldn't, since it's additive)

Related to #62680
