### PR TITLE
Jetpack Agency Dashboard: Add feature flag and route

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -1,4 +1,12 @@
+import config from '@automattic/calypso-config';
+import page from 'page';
+
 export function agencyDashboardContext( context: PageJS.Context, next: () => void ): void {
+	if ( ! config.isEnabled( 'jetpack/agency-dashboard' ) ) {
+		page.redirect( '/' );
+		next();
+	}
+
 	context.primary = <div>Agency dashboard placeholder</div>;
 	next();
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -1,0 +1,4 @@
+export function agencyDashboardContext( context: PageJS.Context, next: () => void ): void {
+	context.primary = <div>Agency dashboard placeholder</div>;
+	next();
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/index.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/index.ts
@@ -1,0 +1,7 @@
+import page from 'page';
+import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
+import { agencyDashboardContext } from './controller';
+
+export default function (): void {
+	page( '/dashboard', agencyDashboardContext, makeLayout, clientRender );
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -455,6 +455,12 @@ const sections = [
 		enableLoggedOut: true,
 	},
 	{
+		name: 'jetpack-cloud-agency-dashboard',
+		paths: [ '/dashboard' ],
+		module: 'calypso/jetpack-cloud/sections/agency-dashboard',
+		group: 'jetpack-cloud',
+	},
+	{
 		name: 'jetpack-cloud-settings',
 		paths: [ '/settings' ],
 		module: 'calypso/jetpack-cloud/sections/settings',

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -157,10 +157,11 @@
 	"enable_all_sections": true,
 	"sections": {
 		"jetpack-cloud": false,
-		"jetpack-cloud-settings": false,
+		"jetpack-cloud-agency-dashboard": false,
 		"jetpack-cloud-auth": false,
+		"jetpack-cloud-partner-portal": false,
 		"jetpack-cloud-pricing": false,
-		"jetpack-cloud-partner-portal": false
+		"jetpack-cloud-settings": false
 	},
 	"site_filter": [],
 	"theme": "default",

--- a/config/development.json
+++ b/config/development.json
@@ -76,6 +76,7 @@
 		"i18n/empathy-mode": true,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,
+		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -62,11 +62,12 @@
 	"sections": {
 		"activity": true,
 		"backup": true,
+		"jetpack-cloud": true,
+		"jetpack-cloud-agency-dashboard": true,
 		"jetpack-cloud-auth": true,
+		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud-pricing": true,
 		"jetpack-cloud-settings": true,
-		"jetpack-cloud-partner-portal": true,
-		"jetpack-cloud": true,
 		"jetpack-search": true,
 		"scan": true,
 		"site-purchases": true

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -38,6 +38,7 @@
 		"fullstory": true,
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
+		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -32,6 +32,7 @@
 		"checkout/google-pay": true,
 		"fullstory": true,
 		"jetpack-cloud": true,
+		"jetpack/agency-dashboard": false,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -55,11 +55,12 @@
 	"sections": {
 		"activity": true,
 		"backup": true,
+		"jetpack-cloud": true,
+		"jetpack-cloud-agency-dashboard": true,
 		"jetpack-cloud-auth": false,
+		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud-pricing": true,
 		"jetpack-cloud-settings": true,
-		"jetpack-cloud-partner-portal": true,
-		"jetpack-cloud": true,
 		"jetpack-search": true,
 		"scan": true,
 		"site-purchases": true

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -58,11 +58,12 @@
 	"sections": {
 		"activity": true,
 		"backup": true,
+		"jetpack-cloud": true,
+		"jetpack-cloud-agency-dashboard": true,
 		"jetpack-cloud-auth": true,
+		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud-pricing": true,
 		"jetpack-cloud-settings": true,
-		"jetpack-cloud-partner-portal": true,
-		"jetpack-cloud": true,
 		"jetpack-search": true,
 		"scan": true,
 		"site-purchases": true

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -37,6 +37,7 @@
 		"jetpack/backup-messaging-i3": true,
 		"jetpack-cloud": true,
 		"jetpack/partner-portal-payment": true,
+		"jetpack/agency-dashboard": false,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -35,6 +35,7 @@
 		"fullstory": true,
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
+		"jetpack/agency-dashboard": false,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -59,11 +59,12 @@
 	"sections": {
 		"activity": true,
 		"backup": true,
+		"jetpack-cloud": true,
+		"jetpack-cloud-agency-dashboard": true,
 		"jetpack-cloud-auth": true,
+		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud-pricing": true,
 		"jetpack-cloud-settings": true,
-		"jetpack-cloud-partner-portal": true,
-		"jetpack-cloud": true,
 		"jetpack-search": true,
 		"scan": true,
 		"site-purchases": true

--- a/config/production.json
+++ b/config/production.json
@@ -43,6 +43,7 @@
 		"inline-help": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
+		"jetpack/agency-dashboard": false,
 		"jetpack/api-cache": false,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/concierge-sessions": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,6 +41,7 @@
 		"help": true,
 		"inline-help": true,
 		"i18n/empathy-mode": true,
+		"jetpack/agency-dashboard": false,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/concierge-sessions": false,

--- a/config/test.json
+++ b/config/test.json
@@ -40,6 +40,7 @@
 		"help": true,
 		"importers/substack": true,
 		"inline-help": true,
+		"jetpack/agency-dashboard": false,
 		"jetpack/concierge-sessions": false,
 		"jetpack/features-section/simple": true,
 		"jetpack/features-section/atomic": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -56,6 +56,7 @@
 		"importers/substack": true,
 		"inline-help": true,
 		"i18n/translation-scanner": true,
+		"jetpack/agency-dashboard": false,
 		"jetpack/api-cache": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a feature flag and route/controller for the upcoming Jetpack Agency Dashboard.

The designs are currently in flux, so this PR only displays a text saying "Agency dashboard placeholder" to confirm that the controller is set up correctly, and all nav menus and sidebars are left out pending further design.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit http://jetpack.cloud.localhost:3001/dashboard and confirm that "Agency dashboard placeholder" is displayed.
2. Check that the feature flag is correctly set up in the config files.
3. In `config/jetpack-cloud-development.json` set the `jetpack/agency-dashboard` flag to `false`, rebuild and reload the dashboard page, and verify that you are redirected to http://jetpack.cloud.localhost:3001/ (which will further redirect to `http://jetpack.cloud.localhost:3001/landing` in most cases).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202076982646589-as-1202117620005349