### PR TITLE
Add marketplace CTA on /marketing/tools

### DIFF
--- a/client/my-sites/marketing/paths.ts
+++ b/client/my-sites/marketing/paths.ts
@@ -17,3 +17,7 @@ export const marketingSharingButtons = ( siteSlug?: string | null ): string => {
 export const marketingUltimateTrafficGuide = ( siteSlug?: string | null ): string => {
 	return `/marketing/ultimate-traffic-guide/${ siteSlug || '' }`;
 };
+
+export const pluginsPath = ( siteSlug?: string | null ): string => {
+	return `/plugins/${ siteSlug || '' }`;
+};

--- a/client/my-sites/marketing/tools/header.tsx
+++ b/client/my-sites/marketing/tools/header.tsx
@@ -24,7 +24,7 @@ const MarketingToolsHeader: FunctionComponent< Props > = ( { handleButtonClick }
 
 				<h2 className="tools__header-description">
 					{ translate(
-						"We've added premium plugins to boost your site's capabilities. From bookings and subscriptions to email marketing and Shipment tracking, we have you covered."
+						"We've added premium plugins to boost your site's capabilities. From bookings and subscriptions to email marketing and shipment tracking, we have you covered."
 					) }
 				</h2>
 

--- a/client/my-sites/marketing/tools/header.tsx
+++ b/client/my-sites/marketing/tools/header.tsx
@@ -20,19 +20,17 @@ const MarketingToolsHeader: FunctionComponent< Props > = ( { handleButtonClick }
 			</div>
 
 			<div className="tools__header-info">
-				<h1 className="tools__header-title">
-					{ translate( 'Explore our business tools marketplace' ) }
-				</h1>
+				<h1 className="tools__header-title">{ translate( 'Explore our premium plugins' ) }</h1>
 
 				<h2 className="tools__header-description">
 					{ translate(
-						'From finance services to productivity apps and marketing tools, our Business Tool hub includes hand-picked services that we think can help you grow your business.'
+						"We've added premium plugins to boost your site's capabilities. From bookings and subscriptions to email marketing and Shipment tracking, we have you covered."
 					) }
 				</h2>
 
 				<div className="tools__header-button-row">
 					<Button onClick={ handleButtonClick } primary>
-						{ translate( 'Find new tools' ) }
+						{ translate( 'Explore now' ) }
 					</Button>
 				</div>
 			</div>

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -17,8 +17,8 @@ import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import {
 	marketingConnections,
-	marketingBusinessTools,
 	marketingUltimateTrafficGuide,
+	pluginsPath,
 } from 'calypso/my-sites/marketing/paths';
 import { hasTrafficGuidePurchase } from 'calypso/my-sites/marketing/ultimate-traffic-guide';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
@@ -47,7 +47,7 @@ export const MarketingTools: FunctionComponent = () => {
 	const handleBusinessToolsClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_business_tools_button_click' );
 
-		page( marketingBusinessTools( selectedSiteSlug ) );
+		page( pluginsPath( selectedSiteSlug ) );
 	};
 
 	const handleEarnClick = () => {

--- a/client/my-sites/marketing/tools/style.scss
+++ b/client/my-sites/marketing/tools/style.scss
@@ -1,11 +1,12 @@
 .tools__header-body {
 	display: flex;
 	flex-direction: column;
-	padding: 40px;
+	padding: 32px;
 
 	@include breakpoint-deprecated( '>1040px' ) {
 		max-height: 300px;
 		flex-direction: row;
+		padding: 0;
 	}
 }
 
@@ -13,6 +14,10 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
+	padding: 0;
+	@include breakpoint-deprecated( '>1040px' ) {
+		padding: 40px 40px 40px 0;
+	}
 }
 
 .tools__header-title {
@@ -44,7 +49,7 @@
 .tools__header-image-wrapper {
 	@include breakpoint-deprecated( '>1040px' ) {
 		display: flex;
-		margin-right: 40px;
+		margin: 0 40px;
 	}
 
 	.tools__header-image {

--- a/client/my-sites/marketing/tools/style.scss
+++ b/client/my-sites/marketing/tools/style.scss
@@ -1,10 +1,11 @@
 .tools__header-body {
 	display: flex;
-	flex-direction: row;
-	padding: 11px 24px; // standard padding
+	flex-direction: column;
+	padding: 40px;
 
 	@include breakpoint-deprecated( '>1040px' ) {
 		max-height: 300px;
+		flex-direction: row;
 	}
 }
 
@@ -15,10 +16,10 @@
 }
 
 .tools__header-title {
-	font-size: $font-title-small;
-	font-weight: 400;
-	margin-bottom: 10px;
-	margin-top: 10px;
+	display: block;
+	color: var( --color-neutral-50 );
+	font-family: $brand-serif;
+	font-size: $font-title-large;
 }
 
 .tools__header-description {
@@ -41,16 +42,16 @@
 }
 
 .tools__header-image-wrapper {
-	display: none;
-
 	@include breakpoint-deprecated( '>1040px' ) {
 		display: flex;
-		min-width: 400px;
+		margin-right: 40px;
 	}
 
 	.tools__header-image {
 		position: relative;
-		left: -20px;
+		@include breakpoint-deprecated( '>1040px' ) {
+			max-width: 220px;
+		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adjust CTA on /marketing/tools to focus on premium plugins, and link to the Marketplace.

#### Testing instructions

* Go to /marketing/tools and see if matches the design and text

#### Screenshots
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/402286/164263256-d63ad7fd-d786-4955-bb41-2a4818ed03bc.png">


Related to #62308
