### PR TITLE
Checkout: Do not update cart contact details on auto-refresh, take 2

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -248,7 +248,7 @@ export default function CompositeCheckout( {
 	useWpcomStore( emptyManagedContactDetails, updateContactDetailsCache );
 
 	useDetectedCountryCode();
-	useCachedDomainContactDetails( countriesList );
+	useCachedDomainContactDetails();
 
 	// Record errors adding products to the cart
 	useActOnceOnStrings( [ cartProductPrepError ].filter( isValueTruthy ), ( messages ) => {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -248,7 +248,7 @@ export default function CompositeCheckout( {
 	useWpcomStore( emptyManagedContactDetails, updateContactDetailsCache );
 
 	useDetectedCountryCode();
-	useCachedDomainContactDetails();
+	useCachedDomainContactDetails( countriesList );
 
 	// Record errors adding products to the cart
 	useActOnceOnStrings( [ cartProductPrepError ].filter( isValueTruthy ), ( messages ) => {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -7,13 +7,17 @@ import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { requestContactDetailsCache } from 'calypso/state/domains/management/actions';
 import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-cache';
-import type { CountryListItem } from '@automattic/wpcom-checkout';
+import type {
+	PossiblyCompleteDomainContactDetails,
+	CountryListItem,
+} from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-cached-domain-contact-details' );
 
 export default function useCachedDomainContactDetails( countriesList: CountryListItem[] ): void {
 	const reduxDispatch = useReduxDispatch();
 	const haveRequestedCachedDetails = useRef( false );
+	const previousCachedContactDetails = useRef< PossiblyCompleteDomainContactDetails >();
 	const cartKey = useCartKey();
 	const {
 		updateLocation: updateCartLocation,
@@ -52,20 +56,29 @@ export default function useCachedDomainContactDetails( countriesList: CountryLis
 	// When we have fetched or loaded contact details, send them to the
 	// to the shopping cart for calculating taxes.
 	useEffect( () => {
-		if ( isLoadingCart || cartLoadingError ) {
+		if ( isLoadingCart || cartLoadingError || ! cachedContactDetails ) {
 			return;
 		}
 		if (
-			cachedContactDetails?.countryCode ||
-			cachedContactDetails?.postalCode ||
-			cachedContactDetails?.state
+			! cachedContactDetails.countryCode &&
+			! cachedContactDetails.postalCode &&
+			! cachedContactDetails.state
 		) {
-			updateCartLocation( {
-				countryCode: cachedContactDetails.countryCode ?? '',
-				postalCode: arePostalCodesSupported ? cachedContactDetails.postalCode ?? '' : '',
-				subdivisionCode: cachedContactDetails.state ?? '',
-			} );
+			return;
 		}
+		if (
+			cachedContactDetails.countryCode === previousCachedContactDetails.current?.countryCode &&
+			cachedContactDetails.postalCode === previousCachedContactDetails.current?.postalCode &&
+			cachedContactDetails.state === previousCachedContactDetails.current?.state
+		) {
+			return;
+		}
+		updateCartLocation( {
+			countryCode: cachedContactDetails.countryCode ?? '',
+			postalCode: arePostalCodesSupported ? cachedContactDetails.postalCode ?? '' : '',
+			subdivisionCode: cachedContactDetails.state ?? '',
+		} );
+		previousCachedContactDetails.current = cachedContactDetails;
 	}, [
 		cartLoadingError,
 		isLoadingCart,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -8,7 +8,10 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { requestContactDetailsCache } from 'calypso/state/domains/management/actions';
 import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-cache';
 import useCountryList from './use-country-list';
-import type { PossiblyCompleteDomainContactDetails } from '@automattic/wpcom-checkout';
+import type {
+	PossiblyCompleteDomainContactDetails,
+	CountryListItem,
+} from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-cached-domain-contact-details' );
 
@@ -26,8 +29,10 @@ function areTaxFieldsDifferent(
 	return true;
 }
 
-function useArePostalCodesSupportedByCountry( country: string | undefined | null ): boolean {
-	const countriesList = useCountryList();
+function arePostalCodesSupportedByCountry(
+	country: string | undefined | null,
+	countriesList: CountryListItem[]
+): boolean {
 	if ( ! country ) {
 		return true;
 	}
@@ -38,9 +43,11 @@ function useArePostalCodesSupportedByCountry( country: string | undefined | null
 	return getCountryPostalCodeSupport( countriesList, country );
 }
 
-export default function useCachedDomainContactDetails(): void {
+export default function useCachedDomainContactDetails(
+	overrideCountryList?: CountryListItem[]
+): void {
 	const reduxDispatch = useReduxDispatch();
-	const countriesList = useCountryList();
+	const countriesList = useCountryList( overrideCountryList );
 	const haveRequestedCachedDetails = useRef( false );
 	const previousCachedContactDetails = useRef< PossiblyCompleteDomainContactDetails >();
 	const cartKey = useCartKey();
@@ -60,8 +67,9 @@ export default function useCachedDomainContactDetails(): void {
 
 	const cachedContactDetails = useSelector( getContactDetailsCache );
 
-	const arePostalCodesSupported = useArePostalCodesSupportedByCountry(
-		cachedContactDetails?.countryCode
+	const arePostalCodesSupported = arePostalCodesSupportedByCountry(
+		cachedContactDetails?.countryCode,
+		countriesList
 	);
 	debug(
 		'are postal codes supported by',

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -49,7 +49,8 @@ export default function useCachedDomainContactDetails(
 	const reduxDispatch = useReduxDispatch();
 	const countriesList = useCountryList( overrideCountryList );
 	const haveRequestedCachedDetails = useRef( false );
-	const previousCachedContactDetails = useRef< PossiblyCompleteDomainContactDetails >();
+	const previousDetailsForCart = useRef< PossiblyCompleteDomainContactDetails >();
+	const previousDetailsForForm = useRef< PossiblyCompleteDomainContactDetails >();
 	const cartKey = useCartKey();
 	const {
 		updateLocation: updateCartLocation,
@@ -86,6 +87,10 @@ export default function useCachedDomainContactDetails(
 		if ( ! cachedContactDetails || ! countriesList ) {
 			return;
 		}
+		if ( ! areTaxFieldsDifferent( previousDetailsForForm.current, cachedContactDetails ) ) {
+			return;
+		}
+		previousDetailsForForm.current = cachedContactDetails;
 		debug( 'using fetched cached domain contact details', cachedContactDetails );
 		loadDomainContactDetailsFromCache( {
 			...cachedContactDetails,
@@ -111,16 +116,16 @@ export default function useCachedDomainContactDetails(
 		) {
 			return;
 		}
-		if ( ! areTaxFieldsDifferent( previousCachedContactDetails.current, cachedContactDetails ) ) {
+		if ( ! areTaxFieldsDifferent( previousDetailsForCart.current, cachedContactDetails ) ) {
 			return;
 		}
+		previousDetailsForCart.current = cachedContactDetails;
 		debug( 'updating cart tax details with cached contact details', cachedContactDetails );
 		updateCartLocation( {
 			countryCode: cachedContactDetails.countryCode ?? '',
 			postalCode: arePostalCodesSupported ? cachedContactDetails.postalCode ?? '' : '',
 			subdivisionCode: cachedContactDetails.state ?? '',
 		} );
-		previousCachedContactDetails.current = cachedContactDetails;
 	}, [
 		cartLoadingError,
 		isLoadingCart,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -69,9 +69,10 @@ export default function useCachedDomainContactDetails(
 
 	const cachedContactDetails = useSelector( getContactDetailsCache );
 
-	const arePostalCodesSupported = cachedContactDetails?.countryCode
-		? getCountryPostalCodeSupport( countriesList, cachedContactDetails.countryCode )
-		: true;
+	const arePostalCodesSupported =
+		countriesList && cachedContactDetails?.countryCode
+			? getCountryPostalCodeSupport( countriesList, cachedContactDetails.countryCode )
+			: true;
 
 	const { loadDomainContactDetailsFromCache } = useDispatch( 'wpcom-checkout' );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -40,20 +40,6 @@ function areAnyContactFieldsDifferent(
 	} );
 }
 
-function arePostalCodesSupportedByCountry(
-	country: string | undefined | null,
-	countriesList: CountryListItem[]
-): boolean {
-	if ( ! country ) {
-		return true;
-	}
-	if ( countriesList.length < 1 ) {
-		debug( 'no country list available, so we are assuming postal codes exist' );
-		return true;
-	}
-	return getCountryPostalCodeSupport( countriesList, country );
-}
-
 /**
  * Load cached contact details from the server and use them to populate the
  * checkout contact form and the shopping cart tax location.
@@ -83,10 +69,9 @@ export default function useCachedDomainContactDetails(
 
 	const cachedContactDetails = useSelector( getContactDetailsCache );
 
-	const arePostalCodesSupported = arePostalCodesSupportedByCountry(
-		cachedContactDetails?.countryCode,
-		countriesList
-	);
+	const arePostalCodesSupported = cachedContactDetails?.countryCode
+		? getCountryPostalCodeSupport( countriesList, cachedContactDetails.countryCode )
+		: true;
 
 	const { loadDomainContactDetailsFromCache } = useDispatch( 'wpcom-checkout' );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -78,9 +78,13 @@ export default function useCachedDomainContactDetails(
 	// When we have fetched or loaded contact details, send them to the
 	// `wpcom-checkout` data store for use by the checkout contact form.
 	useEffect( () => {
+		// Do nothing if the contact details are loading, or the countries are loading.
 		if ( ! cachedContactDetails || ! countriesList ) {
 			return;
 		}
+		// Do nothing if the cached data has not changed since the last time we
+		// sent the data to the form (this typically will only ever need to be
+		// activated once).
 		if ( ! areAnyContactFieldsDifferent( previousDetailsForForm.current, cachedContactDetails ) ) {
 			return;
 		}
@@ -100,6 +104,7 @@ export default function useCachedDomainContactDetails(
 	// When we have fetched or loaded contact details, send them to the
 	// to the shopping cart for calculating taxes.
 	useEffect( () => {
+		// Do nothing if the cart is loading, the contact details are loading, or the countries are loading.
 		if ( isLoadingCart || cartLoadingError || ! cachedContactDetails || ! countriesList ) {
 			return;
 		}
@@ -110,6 +115,9 @@ export default function useCachedDomainContactDetails(
 		) {
 			return;
 		}
+		// Do nothing if the cached data has not changed since the last time we
+		// sent the data to the cart endpoint (this typically will only ever need
+		// to be activated once).
 		if ( ! areTaxFieldsDifferent( previousDetailsForCart.current, cachedContactDetails ) ) {
 			return;
 		}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -59,7 +59,7 @@ export default function useCachedDomainContactDetails(
 	const cachedContactDetails = useSelector( getContactDetailsCache );
 
 	const arePostalCodesSupported =
-		countriesList && cachedContactDetails?.countryCode
+		countriesList.length && cachedContactDetails?.countryCode
 			? getCountryPostalCodeSupport( countriesList, cachedContactDetails.countryCode )
 			: true;
 
@@ -69,7 +69,7 @@ export default function useCachedDomainContactDetails(
 	// `wpcom-checkout` data store for use by the checkout contact form.
 	useEffect( () => {
 		// Do nothing if the contact details are loading, or the countries are loading.
-		if ( ! cachedContactDetails || ! countriesList ) {
+		if ( ! cachedContactDetails || ! countriesList.length ) {
 			return;
 		}
 		// Do nothing if the cached data has not changed since the last time we
@@ -95,7 +95,7 @@ export default function useCachedDomainContactDetails(
 	// to the shopping cart for calculating taxes.
 	useEffect( () => {
 		// Do nothing if the cart is loading, the contact details are loading, or the countries are loading.
-		if ( isLoadingCart || cartLoadingError || ! cachedContactDetails || ! countriesList ) {
+		if ( isLoadingCart || cartLoadingError || ! cachedContactDetails || ! countriesList.length ) {
 			return;
 		}
 		if (

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -29,17 +29,6 @@ function areTaxFieldsDifferent(
 	return true;
 }
 
-function areAnyContactFieldsDifferent(
-	previous: PossiblyCompleteDomainContactDetails | undefined,
-	next: PossiblyCompleteDomainContactDetails | undefined
-): boolean {
-	return Object.keys( next ?? {} ).some( ( key: string ) => {
-		const previousRecord = previous as undefined | Record< string, string | null | undefined >;
-		const nextRecord = next as undefined | Record< string, string | null | undefined >;
-		return previousRecord?.[ key ] !== nextRecord?.[ key ];
-	} );
-}
-
 /**
  * Load cached contact details from the server and use them to populate the
  * checkout contact form and the shopping cart tax location.
@@ -86,7 +75,7 @@ export default function useCachedDomainContactDetails(
 		// Do nothing if the cached data has not changed since the last time we
 		// sent the data to the form (this typically will only ever need to be
 		// activated once).
-		if ( ! areAnyContactFieldsDifferent( previousDetailsForForm.current, cachedContactDetails ) ) {
+		if ( previousDetailsForForm.current === cachedContactDetails ) {
 			return;
 		}
 		previousDetailsForForm.current = cachedContactDetails;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -29,6 +29,17 @@ function areTaxFieldsDifferent(
 	return true;
 }
 
+function areAnyContactFieldsDifferent(
+	previous: PossiblyCompleteDomainContactDetails | undefined,
+	next: PossiblyCompleteDomainContactDetails | undefined
+): boolean {
+	return Object.keys( next ?? {} ).some( ( key: string ) => {
+		const previousRecord = previous as undefined | Record< string, string | null | undefined >;
+		const nextRecord = next as undefined | Record< string, string | null | undefined >;
+		return previousRecord?.[ key ] !== nextRecord?.[ key ];
+	} );
+}
+
 function arePostalCodesSupportedByCountry(
 	country: string | undefined | null,
 	countriesList: CountryListItem[]
@@ -43,6 +54,10 @@ function arePostalCodesSupportedByCountry(
 	return getCountryPostalCodeSupport( countriesList, country );
 }
 
+/**
+ * Load cached contact details from the server and use them to populate the
+ * checkout contact form and the shopping cart tax location.
+ */
 export default function useCachedDomainContactDetails(
 	overrideCountryList?: CountryListItem[]
 ): void {
@@ -72,12 +87,6 @@ export default function useCachedDomainContactDetails(
 		cachedContactDetails?.countryCode,
 		countriesList
 	);
-	debug(
-		'are postal codes supported by',
-		cachedContactDetails?.countryCode,
-		'?',
-		arePostalCodesSupported
-	);
 
 	const { loadDomainContactDetailsFromCache } = useDispatch( 'wpcom-checkout' );
 
@@ -87,7 +96,7 @@ export default function useCachedDomainContactDetails(
 		if ( ! cachedContactDetails || ! countriesList ) {
 			return;
 		}
-		if ( ! areTaxFieldsDifferent( previousDetailsForForm.current, cachedContactDetails ) ) {
+		if ( ! areAnyContactFieldsDifferent( previousDetailsForForm.current, cachedContactDetails ) ) {
 			return;
 		}
 		previousDetailsForForm.current = cachedContactDetails;


### PR DESCRIPTION
#### Background and problem

Checkout includes a custom React hook called `useCachedDomainContactDetails` which loads cached contact details from the server and sends them to the shopping-cart endpoint. This allows the contact details fields of checkout to be automatically populated when checkout loads if the user has previously saved them.

However, the way the hook is written, it will send the cached contact details to the shopping-cart endpoint any time that the contact details change _or anytime the cart reloads_. This is just a side effect because we don't want to send data to the shopping cart endpoint until the cart finishes loading for the first time. This becomes a problem when the cart automatically reloads, which it does if the checkout page is refocused after a short amount of time; when this happens, the hook will notice that the cart has finished loading again and will re-send the cached contact details to the cart, even if the user has already changed those details in the form.

#### Changes proposed in this Pull Request

In this PR, we modify the logic of the hook so that it will not send the cached contact details to the server if they have not changed. This is the second attempt at this bug fix after https://github.com/Automattic/wp-calypso/pull/62572, as the first had to be reverted due to a bug 866-gh-Automattic/payments-shilling.

#### Differences from the first attempt

`useCachedDomainContactDetails()` relies on `getCountryPostalCodeSupport()` to determine if it should send a postal code along with its tax information. However, that function relies on the list of countries returned by the `useCountryList()` hook which fetches it from an API endpoint, and `useCachedDomainContactDetails()` does not wait for that data to be loaded before sending the cached contact details to the cart. This creates a race condition between the cached contact details endpoint and the countries list endpoint.

In this PR we modify `useCachedDomainContactDetails()` so that it will wait for the list of countries to be populated before sending any data anywhere. (See also https://github.com/Automattic/wp-calypso/pull/62808 which will help find bugs like this in the future.)

#### Testing instructions

- For this test to work you'll need to have cached contact details from a previous purchase. You can use https://github.com/Automattic/wp-calypso/pull/62784 to set some without having to make a purchase.
- Keep your browser's devtools open to the network panel to watch for POST transactions to the `/me/shopping-cart` endpoint.
- Add a product to your cart and visit checkout.
- Verify that the contact details step is pre-filled with your cached contact details.
- Edit the contact details step and change your country and/or postal code.
- Continue to the last step of checkout.
- Leave the checkout tab for about a minute.
- Click back on the checkout tab and you'll see the form go into a loading state briefly while it refreshes the cart (if you don't see this, you may not have waited long enough or the checkout form may not be focused).
- While you will see a GET request to the `/me/shopping-cart` endpoint, verify that you do not see a POST request (previously you would see one with incorrect postal code and country in the `tax` property).

To test the previous regression:

- Make sure your saved contact information is a postal code that includes taxes. You can use https://github.com/Automattic/wp-calypso/pull/62784 to set it without having to make a purchase.
- Empty your cart.
- Visit `/plans` for your site.
- Click to upgrade to a new plan.
- Verify that checkout shows taxes included in your total as soon as it loads.