### PR TITLE
Increased the Top Margin

### DIFF
--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -10,7 +10,7 @@
 	left: 0;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		top: calc( var( --masterbar-height ) + 16px );
+		top: calc( var( --masterbar-height ) + 64px );
 		right: 16px;
 		bottom: auto;
 		left: auto;
@@ -18,7 +18,7 @@
 	}
 
 	@include breakpoint-deprecated( '>960px' ) {
-		top: calc( var( --masterbar-height ) + 24px );
+		top: calc( var( --masterbar-height ) + 64px );
 		right: 24px;
 		max-width: calc( 100% - 48px );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR increases the top margin of the .global-notices class on screens wider than 660px from 16px and 24px to 64px, respectively. This is done to improve the user interface and the user experience.