### PR TITLE
Fixed the White Screen to view Website

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -1,6 +1,7 @@
 import { isWithinBreakpoint } from '@automattic/viewport';
 import classNames from 'classnames';
 import debugModule from 'debug';
+import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -16,7 +17,7 @@ import './style.scss';
 const debug = debugModule( 'calypso:web-preview' );
 const noop = () => {};
 
-export default class WebPreviewContent extends Component {
+class WebPreviewContent extends Component {
 	previewId = uuid();
 
 	state = {
@@ -321,6 +322,7 @@ export default class WebPreviewContent extends Component {
 		);
 	}
 }
+export default localize( WebPreviewContent );
 
 WebPreviewContent.propTypes = {
 	// Additional elements to display below the toolbar


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes White Screen from wordpress.com/view link to view website by adding localize() to a component.