### PR TITLE
Added payments Pattern to non-eCommerce theme

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -6,6 +6,7 @@ import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/js-utils';
 import debugFactory from 'debug';
+import { translate } from 'i18n-calypso';
 import { defer, difference, get, includes, isEmpty, pick, startsWith } from 'lodash';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -40,7 +41,7 @@ import {
 } from 'calypso/state/signup/steps/site-vertical/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'calypso/state/signup/steps/survey/selectors';
 import { getWebsiteContent } from 'calypso/state/signup/steps/website-content/selectors';
-import { requestSite } from 'calypso/state/sites/actions';
+import { requestSite, updateSiteFrontPage } from 'calypso/state/sites/actions';
 import { getSiteId } from 'calypso/state/sites/selectors';
 
 const Visibility = Site.Visibility;
@@ -417,23 +418,73 @@ export function submitWebsiteContent( callback, { siteSlug }, step, reduxStore )
 		} );
 }
 
-export function setDesignOnSite( callback, { siteSlug, selectedDesign } ) {
+export async function setDesignOnSite(
+	callback,
+	{ siteSlug, selectedDesign, intent },
+	stepProvidedItems,
+	reduxStore
+) {
 	if ( ! selectedDesign ) {
 		defer( callback );
 		return;
 	}
 
 	const { theme } = selectedDesign;
+	//@TODO: Get this list from a query rather than manually
+	const sellThemes = [ 'marl', 'winkel', 'attar', 'dorna', 'hari' ];
+	const choseSellTheme = sellThemes.includes( theme );
 
 	wpcom.req
 		.post( `/sites/${ siteSlug }/themes/mine`, { theme, dont_change_homepage: true } )
-		.then( () =>
-			wpcom.req.post( {
-				path: `/sites/${ siteSlug }/theme-setup`,
-				apiNamespace: 'wpcom/v2',
-				body: { trim_content: true },
-			} )
-		)
+		.then( () => {
+			//If we don't have sell intent or we're using a seller-oriented theme, run theme setup
+			if ( 'sell' !== intent || choseSellTheme ) {
+				wpcom.req.post( {
+					path: `/sites/${ siteSlug }/theme-setup`,
+					apiNamespace: 'wpcom/v2',
+					body: { trim_content: true },
+				} );
+			}
+		} )
+		.then( async () => {
+			if ( 'sell' === intent && ! choseSellTheme ) {
+				try {
+					/*
+					 * Get the block pattern source for use in our new home page.
+					 * Original pattern: https://dotcompatterns.wordpress.com/wp-admin/post.php?post=4348&action=edit
+					 */
+					const patternList = await wpcom.req.get( {
+						path: `/ptk/patterns/${ getLocaleSlug() }?post_id=4348&http_envelope=1`,
+						apiNamespace: 'rest/v1',
+					} );
+
+					//Only item since we filter by id
+					const singleProductPattern = patternList[ 0 ];
+
+					// Create a new Home page
+					const newPage = await wpcom.req.post( {
+						path: `/sites/${ siteSlug }/pages`,
+						apiNamespace: 'wp/v2',
+						body: {
+							content: singleProductPattern.html,
+							title: translate( 'Available now!' ),
+							status: 'publish',
+							template: 'header-footer-only',
+						},
+					} );
+
+					const siteId = getSiteId( reduxStore.getState(), siteSlug );
+
+					//Set the new Home page as the front page.
+					await updateSiteFrontPage( siteId, {
+						show_on_front: 'page',
+						page_on_front: newPage.id,
+					} )( reduxStore.dispatch );
+				} catch ( errors ) {
+					return callback( [ errors ] );
+				}
+			}
+		} )
 		.then( () =>
 			wpcom.req.get( {
 				path: `/sites/${ siteSlug }/block-editor`,
@@ -443,9 +494,16 @@ export function setDesignOnSite( callback, { siteSlug, selectedDesign } ) {
 		.then( ( data ) => {
 			callback( null, { isFSEActive: data?.is_fse_active ?? false } );
 		} )
-		.catch( ( errors ) => {
-			callback( [ errors ] );
-		} );
+		.then( () => {
+			//If we have the sell intent, change the store footer
+			if ( 'sell' === intent ) {
+				wpcom.req.post( {
+					path: `/sites/${ siteSlug }/seller_footer`,
+					apiNamespace: 'wpcom/v2',
+				} );
+			}
+		} )
+		.catch( ( errors ) => callback( [ errors ] ) );
 }
 
 export function setOptionsOnSite( callback, { siteSlug, siteTitle, tagline } ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -665,8 +665,8 @@ export function generateSteps( {
 			apiRequestFunction: setDesignOnSite,
 			delayApiRequestUntilComplete: true,
 			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'isFSEActive', 'selectedDesign', 'selectedSiteCategory' ],
-			optionalDependencies: [ 'isFSEActive', 'selectedDesign', 'selectedSiteCategory' ],
+			providesDependencies: [ 'isFSEActive', 'selectedDesign', 'selectedSiteCategory', 'intent' ],
+			optionalDependencies: [ 'isFSEActive', 'selectedDesign', 'selectedSiteCategory', 'intent' ],
 			props: {
 				showDesignPickerCategories: config.isEnabled( 'signup/design-picker-categories' ),
 				showDesignPickerCategoriesAllFilter: config.isEnabled( 'signup/design-picker-categories' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update setDesignOnSite to account for cases where someone with the sell intent chooses a non-ecommerce theme. Instead of running theme setup in these cases, create a new home page with a Payments block pattern