### PR TITLE
Add categories strings for preemptive translation

### DIFF
--- a/client/my-sites/plugins/categories/categories-translation-strings.js
+++ b/client/my-sites/plugins/categories/categories-translation-strings.js
@@ -1,0 +1,22 @@
+import { translate } from 'i18n-calypso';
+
+translate( 'Discover' );
+translate( 'Top free plugins' );
+translate( 'Top paid plugins' );
+translate( 'Editor’s pick' );
+translate( 'All Categories' );
+translate( 'Analytics' );
+translate( 'Business' );
+translate( 'Customer Service' );
+translate( 'Design' );
+translate( 'Ecommerce' );
+translate( 'Education' );
+translate( 'Email' );
+translate( 'Financial' );
+translate( 'Marketing' );
+translate( 'Search Optimization' );
+translate( 'Security' );
+translate( 'Photo & Video' );
+translate( 'Posts & Posting' );
+translate( 'Social' );
+translate( 'Widgets' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Here we're adding preemptive translation strings, for the new marketplace categories. When the project is in production and fully translated to the mag16, this file and its containing folder can be removed.

More info about preemptive translations: pxLjZ-6Mo-p2

Related task: https://github.com/Automattic/wp-calypso/issues/62796

#### Testing instructions

Since this code is never executed, there is no real testing. Reviewers can spot check that strings match with views in the following P2: pdh6GB-Cq-p2

#### Screenshot 
![Screenshot 2022-04-13 at 08-32-18 Marketplace Plugin Categories](https://user-images.githubusercontent.com/811776/163891871-22bc5c53-a144-49c2-a6d7-a208400e9318.png)
