### PR TITLE
Design Picker: Remove featured themes list of buttons from onboarding workflow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -2,7 +2,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import { planHasFeature, FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import DesignPicker, {
-	FeaturedPicksButtons,
 	PremiumBadge,
 	useCategorization,
 	isBlankCanvasDesign,
@@ -74,9 +73,6 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	const showGeneratedDesigns =
 		isEnabled( 'signup/design-picker-generated-designs' ) && intent === 'build' && !! siteVertical;
 
-	// In order to show designs with a "featured" term in the theme_picks taxonomy at the below of categories filter
-	const useFeaturedPicksButtons =
-		showDesignPickerCategories && isEnabled( 'signup/design-picker-use-featured-picks-buttons' );
 	const isPremiumThemeAvailable = Boolean(
 		useMemo( () => sitePlanSlug && planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ), [
 			sitePlanSlug,
@@ -107,17 +103,13 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	);
 	const generatedDesigns = useGeneratedDesigns( generatedDesignsCategory );
 
-	const { designs, featuredPicksDesigns } = useMemo( () => {
-		return {
-			designs: [
-				...generatedDesigns,
-				...shuffle( staticDesigns.filter( ( design ) => ! design.is_featured_picks ) ),
-			],
-			featuredPicksDesigns: staticDesigns.filter(
-				( design ) => design.is_featured_picks && ! isBlankCanvasDesign( design )
-			),
-		};
-	}, [ staticDesigns, generatedDesigns ] );
+	const designs = useMemo(
+		() => [
+			...generatedDesigns,
+			...shuffle( staticDesigns.filter( ( design ) => ! isBlankCanvasDesign( design ) ) ),
+		],
+		[ staticDesigns, generatedDesigns ]
+	);
 
 	function headerText() {
 		if ( showDesignPickerCategories ) {
@@ -165,16 +157,6 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		showGeneratedDesigns
 	);
 	const categorization = useCategorization( designs, categorizationOptions );
-
-	function renderCategoriesFooter() {
-		return (
-			<>
-				{ useFeaturedPicksButtons && (
-					<FeaturedPicksButtons designs={ featuredPicksDesigns } onSelect={ pickDesign } />
-				) }
-			</>
-		);
-	}
 
 	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
 		setSelectedDesign( _selectedDesign );
@@ -288,13 +270,6 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		);
 	}
 
-	let featuredDesigns = [ ...featuredPicksDesigns, ...designs ];
-	if ( isAnchorSite ) {
-		featuredDesigns = ANCHOR_FM_THEMES as Design[];
-	} else if ( useFeaturedPicksButtons ) {
-		featuredDesigns = designs;
-	}
-
 	const heading = (
 		<FormattedHeader
 			className={ isAnchorSite ? 'is-anchor-header' : null }
@@ -308,7 +283,7 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	stepContent = (
 		<>
 			<DesignPicker
-				designs={ featuredDesigns }
+				designs={ isAnchorSite ? ( ANCHOR_FM_THEMES as Design[] ) : designs }
 				theme={ isReskinned ? 'light' : 'dark' }
 				locale={ locale }
 				onSelect={ pickDesign }
@@ -325,7 +300,6 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 				recommendedCategorySlug={ categorizationOptions.defaultSelection }
 				categoriesHeading={ heading }
 				anchorHeading={ isAnchorSite && heading }
-				categoriesFooter={ renderCategoriesFooter() }
 				isPremiumThemeAvailable={ isPremiumThemeAvailable }
 			/>
 		</>

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -2,7 +2,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import { planHasFeature, FEATURE_PREMIUM_THEMES, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import DesignPicker, {
-	FeaturedPicksButtons,
 	PremiumBadge,
 	isBlankCanvasDesign,
 	getDesignUrl,
@@ -53,10 +52,6 @@ export default function DesignPickerStep( props ) {
 	);
 
 	const userLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
-
-	// In order to show designs with a "featured" term in the theme_picks taxonomy at the below of categories filter
-	const useFeaturedPicksButtons =
-		showDesignPickerCategories && isEnabled( 'signup/design-picker-use-featured-picks-buttons' );
 
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -116,14 +111,10 @@ export default function DesignPickerStep( props ) {
 		};
 	}, [ props.stepSectionName ] );
 
-	const { designs, featuredPicksDesigns } = useMemo( () => {
-		return {
-			designs: shuffle( apiThemes.filter( ( theme ) => ! theme.is_featured_picks ) ),
-			featuredPicksDesigns: apiThemes.filter(
-				( theme ) => theme.is_featured_picks && ! isBlankCanvasDesign( theme )
-			),
-		};
-	}, [ apiThemes ] );
+	const designs = useMemo(
+		() => shuffle( apiThemes.filter( ( theme ) => ! isBlankCanvasDesign( theme ) ) ),
+		[ apiThemes ]
+	);
 
 	const getEventPropsByDesign = ( design ) => ( {
 		theme: design?.stylesheet ?? `pub/${ design?.theme }`,
@@ -238,7 +229,7 @@ export default function DesignPickerStep( props ) {
 		return (
 			<>
 				<DesignPicker
-					designs={ useFeaturedPicksButtons ? designs : [ ...featuredPicksDesigns, ...designs ] }
+					designs={ designs }
 					theme={ isReskinned ? 'light' : 'dark' }
 					locale={ translate.localeSlug }
 					onSelect={ pickDesign }
@@ -276,9 +267,6 @@ export default function DesignPickerStep( props ) {
 	function renderCategoriesFooter() {
 		return (
 			<>
-				{ useFeaturedPicksButtons && (
-					<FeaturedPicksButtons designs={ featuredPicksDesigns } onSelect={ pickDesign } />
-				) }
 				{ showLetUsChoose && (
 					<LetUsChoose flowName={ props.flowName } designs={ designs } onSelect={ pickDesign } />
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The following changes were done:
* Remove buttons that shows featured themes 
* Keep all featured themes in the list of designs to select from except the blank canvas theme.

#### Testing instructions
* Checkout the branch
* Run yarn start
* Go to http://calypso.localhost:3000/
* Add a new site and step through onboarding 
* Click build to bring up design picker screen
* Verify that no feature pick button is present (_you may need to edit a theme and flag it as featured_)
* Verify the blank canvas theme is not present in the list of themes.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*Before 
![image](https://user-images.githubusercontent.com/47489215/163492276-0f5369d0-4f3d-4dfa-98db-c0f45e6975c5.png)

* After
* 
![image](https://user-images.githubusercontent.com/47489215/163492375-27456e72-2e9c-4729-8f92-32712084b43f.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62566
