### PR TITLE
Playwright: Ensure screenshots for failures by removing extra page.close() calls

### DIFF
--- a/test/e2e/specs/i18n/i18n__logged-out-redirect.ts
+++ b/test/e2e/specs/i18n/i18n__logged-out-redirect.ts
@@ -19,9 +19,6 @@ describe( 'I18N: Homepage Redirect', function () {
 			// Locale slug for English is not included in the path name.
 			const localePath = locale === 'en' ? '' : `${ locale }/`;
 			await page.waitForURL( DataHelper.getCalypsoURL( localePath ) );
-
-			// Close the page/context.
-			await page.close();
 		}
 	);
 } );

--- a/test/e2e/specs/media/media__edit.ts
+++ b/test/e2e/specs/media/media__edit.ts
@@ -39,10 +39,6 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 			await testAccount.authenticate( page );
 		} );
 
-		afterAll( async () => {
-			await page.close();
-		} );
-
 		it( 'Navigate to Media', async function () {
 			const sidebarComponent = new SidebarComponent( page );
 			await sidebarComponent.navigate( 'Media' );

--- a/test/e2e/specs/media/media__upload.ts
+++ b/test/e2e/specs/media/media__upload.ts
@@ -46,10 +46,6 @@ describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 			await testAccount.authenticate( page );
 		} );
 
-		afterAll( async () => {
-			await page.close();
-		} );
-
 		it( 'Navigate to Media', async function () {
 			const sidebarComponent = new SidebarComponent( page );
 			await sidebarComponent.navigate( 'Media' );

--- a/test/e2e/specs/stats/stats__insights.ts
+++ b/test/e2e/specs/stats/stats__insights.ts
@@ -21,10 +21,6 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 			await testAccount.authenticate( page );
 		} );
 
-		afterAll( async () => {
-			await page.close();
-		} );
-
 		it( 'Navigate to Stats', async function () {
 			const sidebarComponent = new SidebarComponent( page );
 			await sidebarComponent.navigate( 'Stats' );

--- a/test/e2e/specs/support/support__home.ts
+++ b/test/e2e/specs/support/support__home.ts
@@ -23,10 +23,6 @@ describe( DataHelper.createSuiteTitle( 'Support: My Home' ), function () {
 			await testAccount.authenticate( page );
 		} );
 
-		afterAll( async () => {
-			await page.close();
-		} );
-
 		it( 'Displays default entries', async function () {
 			supportComponent = new SupportComponent( page );
 			await supportComponent.showSupportCard();

--- a/test/e2e/specs/support/support__popover-invalid.ts
+++ b/test/e2e/specs/support/support__popover-invalid.ts
@@ -28,10 +28,6 @@ describe( DataHelper.createSuiteTitle( 'Support: Popover/Invalid Keywords' ), fu
 			await testAccount.authenticate( page );
 		} );
 
-		afterAll( async () => {
-			await page.close();
-		} );
-
 		it( 'Open Settings page', async function () {
 			const sidebarComponent = new SidebarComponent( page );
 			await sidebarComponent.navigate( 'Settings', 'General' );

--- a/test/e2e/specs/support/support__popover-valid.ts
+++ b/test/e2e/specs/support/support__popover-valid.ts
@@ -28,10 +28,6 @@ describe( DataHelper.createSuiteTitle( 'Support: Popover' ), function () {
 			await testAccount.authenticate( page );
 		} );
 
-		afterAll( async () => {
-			await page.close();
-		} );
-
 		it( 'Navigate to Tools > Marketing', async function () {
 			const sidebarComponent = new SidebarComponent( page );
 			await sidebarComponent.navigate( 'Tools', 'Marketing' );

--- a/test/e2e/specs/support/support__showme-where.ts
+++ b/test/e2e/specs/support/support__showme-where.ts
@@ -23,10 +23,6 @@ describe( DataHelper.createSuiteTitle( 'Support: Show me where' ), function () {
 			await testAccount.authenticate( page );
 		} );
 
-		afterAll( async () => {
-			await page.close();
-		} );
-
 		it( 'Search for help: Create a site', async function () {
 			supportComponent = new SupportComponent( page );
 			await supportComponent.showSupportCard();

--- a/test/e2e/specs/users/invite__revoke.ts
+++ b/test/e2e/specs/users/invite__revoke.ts
@@ -75,10 +75,6 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 		await peoplePage.revokeInvite();
 	} );
 
-	it( 'Close current page', async () => {
-		await page.close();
-	} );
-
 	it( `Ensure invite link is no longer valid`, async function () {
 		page = await browser.newPage();
 		await page.goto( adjustedInviteLink );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Ever noticed how when most E2E tests fail we get screenshots, but for a few we don't?

Turns out this is because we had orphaned a few old `page.close()` calls in some older specs. Before we had our more robust global environment setup, we would often close pages more directly. However, that doesn't work in our new global jest environment!

We determine which screenshots to take by which pages are left open on the global `browser` instance. [See this for loop](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/jest-playwright-config/environment.ts#L167).

So, if we close the page in the spec, we won't get screenshots!

#### Testing instructions
Just regression testing
- [x] PR tests pass
- [x] Jetpack tests pass
- [x] i18n tests pass

Related to #
