### PR TITLE
Domains: Remove the second explain from control on mobile devices

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -482,7 +482,7 @@ class DomainsStep extends Component {
 						<div className="domains__domain-side-content-container">
 							{ ! this.shouldHideDomainExplainer() &&
 								this.props.isPlanSelectionAvailableLaterInFlow && (
-									<div className="domains__domain-side-content">
+									<div className="domains__domain-side-content domains__free-domain">
 										<ReskinSideExplainer
 											onClick={ this.handleDomainExplainerClick }
 											type={ 'free-domain-explainer' }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -139,9 +139,13 @@ body.is-section-signup.is-white-signup {
 					display: none;
 				}
 			}
+		}
 
-			.domains__free-domain .reskin-side-explainer__subtitle-2 {
-				display: none;
+		.domains__free-domain .reskin-side-explainer__subtitle-2 {
+			display: none;
+			
+			@include break-small {
+				display: block;
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR is a follow up to https://github.com/Automattic/wp-calypso/pull/61665

* It updated the control to remove the "We will pay ..." wording from the control on mobile. 

Before:
<img width="300" src="https://user-images.githubusercontent.com/115071/163494880-d8aa431b-32f8-4960-a9fb-ed9287525833.png" />

After:
<img width="300" src="https://user-images.githubusercontent.com/115071/163494860-6cf9d725-6c92-4f14-b302-c6a9cade91c5.png" />

This is done so that the control and the treatment look more alike as per pbxNRc-1t7-p2#comment-3234

#### Testing instructions

Visit /start/domain notice that you don't see the "We will pay ..." screenshot. 

Related to https://github.com/Automattic/wp-calypso/pull/61665.
