### PR TITLE
Add console errors when calling getCountryPostalCodeSupport with invalid data

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -355,7 +355,9 @@ export class ContactDetailsFormFields extends Component {
 	}
 
 	getCountryPostalCodeSupport = ( countryCode ) =>
-		getCountryPostalCodeSupport( this.props.countriesList, countryCode );
+		this.props.countriesList && countryCode
+			? getCountryPostalCodeSupport( this.props.countriesList, countryCode )
+			: false;
 
 	renderContactDetailsFields() {
 		const { translate, needsFax, hasCountryStates, labelTexts } = this.props;

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -355,7 +355,7 @@ export class ContactDetailsFormFields extends Component {
 	}
 
 	getCountryPostalCodeSupport = ( countryCode ) =>
-		this.props.countriesList && countryCode
+		this.props.countriesList?.length && countryCode
 			? getCountryPostalCodeSupport( this.props.countriesList, countryCode )
 			: false;
 

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -284,7 +284,7 @@ export class ManagedContactDetailsFormFields extends Component {
 	}
 
 	getCountryPostalCodeSupport = ( countryCode ) =>
-		this.props.countriesList && countryCode
+		this.props.countriesList?.length && countryCode
 			? getCountryPostalCodeSupport( this.props.countriesList, countryCode )
 			: false;
 

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -284,7 +284,9 @@ export class ManagedContactDetailsFormFields extends Component {
 	}
 
 	getCountryPostalCodeSupport = ( countryCode ) =>
-		getCountryPostalCodeSupport( this.props.countriesList, countryCode );
+		this.props.countriesList && countryCode
+			? getCountryPostalCodeSupport( this.props.countriesList, countryCode )
+			: false;
 
 	renderContactDetailsFields() {
 		const { translate, hasCountryStates } = this.props;

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -106,6 +106,10 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
               "code": "BR",
               "name": "Brazil",
             },
+            Object {
+              "code": "IT",
+              "name": "Italy",
+            },
           ]
         }
         countryCode="US"
@@ -140,6 +144,10 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
             Object {
               "code": "BR",
               "name": "Brazil",
+            },
+            Object {
+              "code": "IT",
+              "name": "Italy",
             },
           ]
         }

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -40,6 +40,10 @@ describe( 'ContactDetailsFormFields', () => {
 				code: 'BR',
 				name: 'Brazil',
 			},
+			{
+				code: 'IT',
+				name: 'Italy',
+			},
 		],
 		onSubmit: noop,
 		translate: ( string ) => string,

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -49,7 +49,7 @@ export default function TaxFields( {
 	const translate = useTranslate();
 	const { postalCode, countryCode } = taxInfo;
 	const arePostalCodesSupported =
-		countriesList && countryCode?.value
+		countriesList.length && countryCode?.value
 			? getCountryPostalCodeSupport( countriesList, countryCode.value )
 			: false;
 
@@ -108,7 +108,7 @@ function updatePostalCodeForCountry(
 	countriesList: CountryListItem[]
 ): ManagedValue | undefined {
 	const arePostalCodesSupported =
-		countriesList && countryCode?.value
+		countriesList.length && countryCode?.value
 			? getCountryPostalCodeSupport( countriesList, countryCode.value )
 			: false;
 	if ( ! arePostalCodesSupported ) {

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -48,10 +48,10 @@ export default function TaxFields( {
 } ): JSX.Element {
 	const translate = useTranslate();
 	const { postalCode, countryCode } = taxInfo;
-	const arePostalCodesSupported = getCountryPostalCodeSupport(
-		countriesList,
-		countryCode?.value ?? ''
-	);
+	const arePostalCodesSupported =
+		countriesList && countryCode?.value
+			? getCountryPostalCodeSupport( countriesList, countryCode.value )
+			: false;
 
 	return (
 		<FieldRow>
@@ -107,10 +107,10 @@ function updatePostalCodeForCountry(
 	countryCode: ManagedValue | undefined,
 	countriesList: CountryListItem[]
 ): ManagedValue | undefined {
-	const arePostalCodesSupported = getCountryPostalCodeSupport(
-		countriesList,
-		countryCode?.value ?? ''
-	);
+	const arePostalCodesSupported =
+		countriesList && countryCode?.value
+			? getCountryPostalCodeSupport( countriesList, countryCode.value )
+			: false;
 	if ( ! arePostalCodesSupported ) {
 		return { value: '', errors: [], isTouched: true };
 	}

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -226,7 +226,7 @@ export default function WPCheckout( {
 	const { formStatus } = useFormStatus();
 
 	const arePostalCodesSupported =
-		countriesList && contactInfo.countryCode?.value
+		countriesList.length && contactInfo.countryCode?.value
 			? getCountryPostalCodeSupport( countriesList, contactInfo.countryCode.value )
 			: false;
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -225,10 +225,10 @@ export default function WPCheckout( {
 
 	const { formStatus } = useFormStatus();
 
-	const arePostalCodesSupported = getCountryPostalCodeSupport(
-		countriesList,
-		contactInfo.countryCode?.value ?? ''
-	);
+	const arePostalCodesSupported =
+		countriesList && contactInfo.countryCode?.value
+			? getCountryPostalCodeSupport( countriesList, contactInfo.countryCode.value )
+			: false;
 
 	const updateCartContactDetails = useCallback( () => {
 		// Update tax location in cart

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -61,7 +61,7 @@ export default function useCachedDomainContactDetails(
 	const arePostalCodesSupported =
 		countriesList.length && cachedContactDetails?.countryCode
 			? getCountryPostalCodeSupport( countriesList, cachedContactDetails.countryCode )
-			: true;
+			: false;
 
 	const { loadDomainContactDetailsFromCache } = useDispatch( 'wpcom-checkout' );
 

--- a/packages/wpcom-checkout/src/get-country-postal-code-support.ts
+++ b/packages/wpcom-checkout/src/get-country-postal-code-support.ts
@@ -14,7 +14,7 @@ export function getCountryPostalCodeSupport(
 	if ( ! countryCode ) {
 		return false;
 	}
-	if ( ! countries ) {
+	if ( ! countries?.length ) {
 		// eslint-disable-next-line no-console
 		console.error(
 			'Error: getCountryPostalCodeSupport was called without a countries list. This will result in incorrect data!'

--- a/packages/wpcom-checkout/src/get-country-postal-code-support.ts
+++ b/packages/wpcom-checkout/src/get-country-postal-code-support.ts
@@ -1,15 +1,32 @@
 import type { CountryListItem } from './types';
 
 /**
- * Returns true if postal codes are supported on the specified country code,
- * or false otherwise.
+ * Returns true if postal codes are supported on the specified country code.
+ *
+ * NOTE: Will return false if the countries list is empty or if the country
+ * code is not in the list! Always check that the countries list has loaded
+ * before calling this.
  */
 export function getCountryPostalCodeSupport(
 	countries: CountryListItem[],
 	countryCode: string
 ): boolean {
-	return (
-		countries.find( ( country ) => country.code === countryCode.toUpperCase() )?.has_postal_codes ??
-		false
+	if ( ! countries ) {
+		// eslint-disable-next-line no-console
+		console.error(
+			'Error: getCountryPostalCodeSupport was called without a countries list. This will result in incorrect data!'
+		);
+		return false;
+	}
+	const countryListItem = countries.find(
+		( country ) => country.code === countryCode.toUpperCase()
 	);
+	if ( ! countryListItem ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			`Warning: getCountryPostalCodeSupport could not find the country "${ countryCode }"!`
+		);
+		return false;
+	}
+	return countryListItem.has_postal_codes ?? false;
 }

--- a/packages/wpcom-checkout/src/get-country-postal-code-support.ts
+++ b/packages/wpcom-checkout/src/get-country-postal-code-support.ts
@@ -11,6 +11,9 @@ export function getCountryPostalCodeSupport(
 	countries: CountryListItem[],
 	countryCode: string
 ): boolean {
+	if ( ! countryCode ) {
+		return false;
+	}
 	if ( ! countries ) {
 		// eslint-disable-next-line no-console
 		console.error(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`getCountryPostalCodeSupport()` requires two arguments: a list of country data (returned by an API endpoint) and a country code. If called without one of these, it can return misleading data. This is actually a fairly common scenario because the function is easily called before the country data is loaded. The result is that the function returns `false`, which is usually safe since many use-cases are in React components that will re-render once the country data loads, but there are cases (like `useCachedDomainContactDetails` which only fires once) where we must know if the result is correct.

One way to do this would be to throw an error if the function is called with missing data, but that would be a big breaking change and require a lot of error handling to be added. Instead, this PR adds a console error message if the function is called with a missing country list, which should at least help people find bugs more easily. It also adds a warning if a country cannot be found since that should also never happen.

This PR also changes most of the function's callers to avoid calling it with missing data.

Inspired by https://github.com/Automattic/wp-calypso/pull/62808

#### Testing instructions

This should not change any behavior. However, it may be worth visiting some places which use the country and postal code fields to verify that they work as expected. Some examples are: checkout, adding a new credit card, domain management contact information. In all these locations, there should be no console warnings or errors (at least none added by this PR).

For convenience, a country that does not have postal codes is Macau.
