### PR TITLE
Plans page: Show correct free site feature limits for older sites

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -54,7 +54,7 @@ export interface PlanComparisonFeature {
 	getCellText: (
 		feature: string | undefined,
 		isMobile: boolean,
-		isLegacySiteWithHigherLimits: boolean,
+		isLegacySiteWithHigherLimits?: boolean,
 		extraArgs?: unknown
 	) => TranslateResult | [ TranslateResult, TranslateResult ];
 }

--- a/client/my-sites/plans-comparison/plans-comparison-row.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-row.tsx
@@ -61,7 +61,11 @@ function renderContent( content: ReturnType< PlanComparisonFeature[ 'getCellText
 	);
 }
 
-export const PlansComparisonRow: React.FunctionComponent< Props > = ( { feature, plans } ) => {
+export const PlansComparisonRow: React.FunctionComponent< Props > = ( {
+	feature,
+	plans,
+	isLegacySiteWithHigherLimits,
+} ) => {
 	return (
 		<tr>
 			<PlansComparisonRowHeader
@@ -79,10 +83,14 @@ export const PlansComparisonRow: React.FunctionComponent< Props > = ( { feature,
 				return (
 					<td key={ plan.getProductId() }>
 						<DesktopContent>
-							{ renderContent( feature.getCellText( includedFeature, false ) ) }
+							{ renderContent(
+								feature.getCellText( includedFeature, false, isLegacySiteWithHigherLimits )
+							) }
 						</DesktopContent>
 						<MobileContent>
-							{ renderContent( feature.getCellText( includedFeature, true ) ) }
+							{ renderContent(
+								feature.getCellText( includedFeature, true, isLegacySiteWithHigherLimits )
+							) }
 						</MobileContent>
 					</td>
 				);

--- a/client/my-sites/plans-comparison/plans-comparison-row.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-row.tsx
@@ -7,6 +7,7 @@ import type { WPComPlan } from '@automattic/calypso-products';
 interface Props {
 	feature: PlanComparisonFeature;
 	plans: WPComPlan[];
+	isLegacySiteWithHigherLimits: boolean;
 }
 
 export const DesktopContent = styled.div`

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -15,6 +15,7 @@ import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import isLegacySiteWithHigherLimits from 'calypso/state/selectors/is-legacy-site-with-higher-limits';
 import { getSitePlan } from 'calypso/state/sites/selectors';
 import { SCREEN_BREAKPOINT_SIGNUP, SCREEN_BREAKPOINT_PLANS } from './constant';
 import { PlansComparisonAction } from './plans-comparison-action';
@@ -421,6 +422,9 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	hideFreePlan,
 	onSelectPlan,
 } ) => {
+	const legacySiteWithHigherLimits = useSelector( ( state ) =>
+		isLegacySiteWithHigherLimits( state, selectedSiteId || null )
+	);
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSiteId || null ) );
 	const [ showCollapsibleRows, setShowCollapsibleRows ] = useState( false );
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) ?? '';
@@ -489,12 +493,22 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 				</THead>
 				<tbody className="plans-comparison__rows">
 					{ planComparisonFeatures.slice( 0, 7 ).map( ( feature ) => (
-						<PlansComparisonRow feature={ feature } plans={ plans } key={ feature.features[ 0 ] } />
+						<PlansComparisonRow
+							feature={ feature }
+							plans={ plans }
+							isLegacySiteWithHigherLimits={ legacySiteWithHigherLimits }
+							key={ feature.features[ 0 ] }
+						/>
 					) ) }
 				</tbody>
 				<tbody className={ collapsibleRowsclassName }>
 					{ planComparisonFeatures.slice( 7 ).map( ( feature ) => (
-						<PlansComparisonRow feature={ feature } plans={ plans } key={ feature.features[ 0 ] } />
+						<PlansComparisonRow
+							feature={ feature }
+							plans={ plans }
+							isLegacySiteWithHigherLimits={ legacySiteWithHigherLimits }
+							key={ feature.features[ 0 ] }
+						/>
 					) ) }
 				</tbody>
 				<tbody>

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -423,7 +423,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	onSelectPlan,
 } ) => {
 	const legacySiteWithHigherLimits = useSelector( ( state ) =>
-		isLegacySiteWithHigherLimits( state, selectedSiteId || null )
+		isLegacySiteWithHigherLimits( state, selectedSiteId || 0 )
 	);
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSiteId || null ) );
 	const [ showCollapsibleRows, setShowCollapsibleRows ] = useState( false );

--- a/client/state/selectors/is-legacy-site-with-higher-limits.ts
+++ b/client/state/selectors/is-legacy-site-with-higher-limits.ts
@@ -18,6 +18,10 @@ import { AppState } from 'calypso/types';
  * @returns {boolean} True if the site is considered a legacy site
  */
 export default function isLegacySiteWithHigherLimits( state: AppState, siteId: number ): boolean {
+	if ( ! siteId ) {
+		return false;
+	}
+
 	// Note this checks for both simple and Atomic sites.
 	if ( ! isSiteWpcom( state, siteId ) ) {
 		return false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Free WordPress.com sites created prior to April 1 2022 are entitled to some benefits that newer sites don't have (for example, 3 GB of storage space rather than 1 GB).  This pull request makes the Plans page show that information correctly, by displaying the limits that don't apply to those sites as crossed-out text, with the actual limits shown next to it.

On desktop:

![desktop](https://user-images.githubusercontent.com/235183/163507702-cdfde956-8686-408e-8869-4de33c9641e8.png)

On mobile:

![mobile](https://user-images.githubusercontent.com/235183/163507712-3353dd8c-8efd-483f-8f84-370bf0e9563e.png)

See: pdgrnI-xr-p2#comment-1164
Also tracked here internally: c/kQeGy9H2-tr

#### Testing instructions

Visit the `/plans` page for a site that was created prior to April 1 2022.  It should look like the above screenshots, with crossed-out text for the Storage and Website Administrator features on the Free plan showing the higher limits that this site is entitled to.

Visiting the `/plans` page for a site created on April 1 2022 or later, or going through signup for a new site, should not show the above cross-outs, and should instead appear exactly as it does before the changes in this pull request.