### PR TITLE
Upsell nudges: Send Free, Blogger, Personal and Premium plan users to the Pro checkout page

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -19,7 +19,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { hasFeature } from 'calypso/state/sites/plans/selectors';
+import { getCurrentPlan, hasFeature } from 'calypso/state/sites/plans/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -33,6 +33,7 @@ export const UpsellNudge = ( {
 	canUserUpgrade,
 	className,
 	compact,
+	currentPlan,
 	customerType,
 	description,
 	disableHref,
@@ -90,9 +91,16 @@ export const UpsellNudge = ( {
 	}
 
 	if ( ! href && siteSlug && canUserUpgrade ) {
-		href = addQueryArgs( { feature, plan }, `/plans/${ siteSlug }` );
-		if ( customerType ) {
-			href = `/plans/${ siteSlug }?customerType=${ customerType }`;
+		const currentPlanSlug = currentPlan?.productSlug;
+
+		// Redirect to the checkout page if the user is on a Premium or Personal plan since the can't view the overhauled Plans page.
+		if ( isPremiumPlan( currentPlanSlug ) || isPersonalPlan( currentPlanSlug ) ) {
+			href = `/checkout/${ siteSlug }/pro`;
+		} else {
+			href = addQueryArgs( { feature, plan }, `/plans/${ siteSlug }` );
+			if ( customerType ) {
+				href = `/plans/${ siteSlug }?customerType=${ customerType }`;
+			}
 		}
 	}
 
@@ -164,6 +172,7 @@ export default connect( ( state, ownProps ) => {
 		isJetpack: isJetpackSite( state, siteId ),
 		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isVip: isVipSite( state, siteId ),
+		currentPlan: getCurrentPlan( state, siteId ),
 		siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
 		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 		siteIsWPForTeams: isSiteWPForTeams( state, getSelectedSiteId( state ) ),

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -3,6 +3,7 @@ import {
 	isBloggerPlan,
 	isPersonalPlan,
 	isPremiumPlan,
+	isFreePlan,
 	isBusinessPlan,
 	isEcommercePlan,
 	GROUP_JETPACK,
@@ -93,8 +94,13 @@ export const UpsellNudge = ( {
 	if ( ! href && siteSlug && canUserUpgrade ) {
 		const currentPlanSlug = currentPlan?.productSlug;
 
-		// Redirect to the checkout page if the user is on a Premium or Personal plan since the can't view the overhauled Plans page.
-		if ( isPremiumPlan( currentPlanSlug ) || isPersonalPlan( currentPlanSlug ) ) {
+		// Redirect to the checkout page in case the Plans page can't be accessed by the plan.
+		if (
+			isFreePlan( currentPlanSlug ) ||
+			isBloggerPlan( currentPlanSlug ) ||
+			isPremiumPlan( currentPlanSlug ) ||
+			isPersonalPlan( currentPlanSlug )
+		) {
 			href = `/checkout/${ siteSlug }/pro`;
 		} else {
 			href = addQueryArgs( { feature, plan }, `/plans/${ siteSlug }` );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This overrides the default Upsell banner nudges for Personal and Premium plans to the Pro checkout because these users can't access the Plans.

#### Testing instructions

##### Free and Personal Plan site
* Go to the `/themes/[site]` page
* Clicking the `Unlock ALL premium themes with our Pro plan!` banner  should take you to the Pro plan checkout page
<img width="320" alt="Screenshot on 2022-04-19 at 16-30-36" src="https://user-images.githubusercontent.com/2749938/164040572-8760fef0-2b83-4d16-8a3a-784062c215f3.png">


##### Premium Plan site
* Go to the `/themes/[site]` page
* Clicking the `Upload your own themes with our Pro plan!` banner  should take you to the Pro plan checkout page
<img width="320" alt="Screenshot on 2022-04-15 at 11-19-22" src="https://user-images.githubusercontent.com/2749938/163545375-25d5bfef-0893-447b-b783-d19b05fbb2f3.png">

##### Blogger Plan site
* Go to the `/themes/upload/[site]` page
* Clicking the `Upgrade to the Pro plan to access the theme install features` banner  should take you to the Pro plan checkout page
<img width="320" alt="Screenshot on 2022-04-19 at 16-27-36" src="https://user-images.githubusercontent.com/2749938/164040023-4a38a2d3-8cdd-4b38-858e-8ebcd83f57da.png">


##### Premium Plan site
* Go to the `/themes/[site]` page
* Clicking the `Upload your own themes with our Pro plan!` banner  should take you to the Pro plan checkout page
<img width="320" alt="Screenshot on 2022-04-15 at 11-19-22" src="https://user-images.githubusercontent.com/2749938/163545375-25d5bfef-0893-447b-b783-d19b05fbb2f3.png">

