### PR TITLE
Stepper: fix ESLINT warning

### DIFF
--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -37,6 +37,7 @@ export const exampleFlow: Flow = {
 To create a flow, you only have to define `useSteps` and `useStepNavigation`. `useSteps` just returns an array of step keys, `useStepNavigation` is the engine where you make navigation decisions. This hook returns an object of type [`NavigationControls`](./declarative-flow/internals/types.ts):
 
 ```tsx
+// prettier-ignore
 /**
  * This is the return type of useStepNavigation hook
  */


### PR DESCRIPTION
## Changes proposed in this Pull Request

Prettier error is causing a TeamCity error. Prettier wants us to format the TSX code using commas instead of semicolons, but this is not correct. I wasn't sure how to update the config so I just added an ignore for the code block.

https://teamcity.a8c.com/viewLog.html?buildId=7737095&tab=Inspection&buildTypeId=calypso_CheckCodeStyleBranch

#### Testing instructions

View the `README.md`