### PR TITLE
Seller Experience - Stepper: WooCommerce confirm step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -18,6 +18,7 @@ export { default as wooTransfer } from './woo-transfer';
 export { default as wooInstallPlugins } from './woo-install-plugins';
 export { default as processing } from './processing-step';
 export { default as error } from './error-step';
+export { default as wooConfirm } from './woo-confirm';
 
 export type StepPath =
 	| 'courses'
@@ -39,4 +40,5 @@ export type StepPath =
 	| 'vertical'
 	| 'wooTransfer'
 	| 'wooInstallPlugins'
-	| 'error';
+	| 'error'
+	| 'wooConfirm';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
@@ -1,0 +1,299 @@
+import { StepContainer } from '@automattic/onboarding';
+import styled from '@emotion/styled';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
+import DomainEligibilityWarning from 'calypso/components/eligibility-warnings/domain-warning';
+import PlanWarning from 'calypso/components/eligibility-warnings/plan-warning';
+import EligibilityWarningsList from 'calypso/components/eligibility-warnings/warnings-list';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import WarningCard from 'calypso/components/warning-card';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import {
+	AUTOMATED_ELIGIBILITY_STORE,
+	SITE_STORE,
+	PRODUCTS_LIST_STORE,
+} from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { addQueryArgs } from 'calypso/lib/url';
+import { ActionSection, StyledNextButton } from 'calypso/signup/steps/woocommerce-install';
+import { eligibilityHolds as eligibilityHoldsConstants } from 'calypso/state/automated-transfer/constants';
+import SupportCard from '../store-address/support-card';
+import type { Step } from '../../types';
+import type { TransferEligibilityError } from '@automattic/data-stores/src/automated-transfer-eligibility/types';
+import './style.scss';
+
+const Divider = styled.hr`
+	border-top: 1px solid #eee;
+	background: none;
+	margin-bottom: 40px;
+`;
+
+const WarningsOrHoldsSection = styled.div`
+	margin-bottom: 40px;
+`;
+
+const TRANSFERRING_NOT_BLOCKERS = [
+	eligibilityHoldsConstants.NO_BUSINESS_PLAN, // Plans are upgraded in the install flow.
+	eligibilityHoldsConstants.TRANSFER_ALREADY_EXISTS, // Already Atomic sites are handled in the install flow.
+];
+
+const WooConfirm: Step = function WooCommerceConfirm( { navigation } ) {
+	const { goBack, submit } = navigation;
+	const { __ } = useI18n();
+	const site = useSite();
+	const siteId = site && site?.ID;
+	const isAtomicSite = useSelect( ( select ) =>
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore Until createRegistrySelector is typed correctly
+		select( SITE_STORE ).isSiteAtomic( siteId )
+	);
+	const { requestLatestAtomicTransfer } = useDispatch( SITE_STORE );
+
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		requestLatestAtomicTransfer( siteId );
+	}, [ requestLatestAtomicTransfer, siteId ] );
+
+	const eligibilityHolds = useSelect( ( select ) =>
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore Until createRegistrySelector is typed correctly
+		select( AUTOMATED_ELIGIBILITY_STORE ).getEligibilityHolds( siteId )
+	);
+	const eligibilityWarnings = useSelect( ( select ) =>
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore Until createRegistrySelector is typed correctly
+		select( AUTOMATED_ELIGIBILITY_STORE ).getEligibilityWarnings( siteId )
+	);
+	const wpcomSubdomainWarning = useSelect( ( select ) =>
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore Until createRegistrySelector is typed correctly
+		select( AUTOMATED_ELIGIBILITY_STORE ).getWpcomSubdomainWarning( siteId )
+	);
+	const warnings: any = useSelect( ( select ) =>
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore Until createRegistrySelector is typed correctly
+		select( AUTOMATED_ELIGIBILITY_STORE ).getNonSubdomainWarnings( siteId )
+	);
+	const latestAtomicTransfer = useSelect( ( select ) =>
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore Until createRegistrySelector is typed correctly
+		select( SITE_STORE ).getSiteLatestAtomicTransfer( siteId || 0 )
+	);
+	const latestAtomicTransferError = useSelect( ( select ) =>
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore Until createRegistrySelector is typed correctly
+		select( SITE_STORE ).getSiteLatestAtomicTransferError( siteId || 0 )
+	);
+	const productsList = useSelect( ( select ) => select( PRODUCTS_LIST_STORE ).getProductsList() );
+	const requiresUpgrade = useSelect( ( select ) => select( SITE_STORE ).requiresUpgrade( siteId ) );
+
+	const wpcomDomain = site?.URL?.replace( /http[s]*:\/\//, '' );
+	const stagingDomain = wpcomDomain?.replace( /\b\.wordpress\.com/, '.wpcomstaging.com' ) || null;
+
+	const productName =
+		site?.plan?.features?.available?.woop && site?.plan?.features?.available?.woop[ 0 ];
+	const upgradingPlan = productName ? productsList?.[ productName ] : null;
+
+	// Filter the Woop transferring blockers.
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore Until createRegistrySelector is typed correctly
+	const transferringBlockers = eligibilityHolds?.filter(
+		( hold: TransferEligibilityError ) => ! TRANSFERRING_NOT_BLOCKERS.includes( hold.code )
+	);
+
+	const isTransferStuck = latestAtomicTransfer?.is_stuck || false;
+	const isBlockByTransferStatus = latestAtomicTransferError || false;
+
+	// Add blocked-transfer-hold when something is wrong in the transfer status.
+	if (
+		! transferringBlockers?.includes( {
+			code: eligibilityHoldsConstants.BLOCKED_ATOMIC_TRANSFER,
+			message: '',
+		} ) &&
+		( isBlockByTransferStatus || isTransferStuck )
+	) {
+		transferringBlockers?.push( {
+			code: eligibilityHoldsConstants.BLOCKED_ATOMIC_TRANSFER,
+			message: '',
+		} );
+	}
+
+	const transferringDataIsAvailable =
+		typeof transferringBlockers !== 'undefined' &&
+		( typeof latestAtomicTransfer !== 'undefined' ||
+			typeof latestAtomicTransferError !== 'undefined' );
+
+	const isDataReady = transferringDataIsAvailable;
+
+	/*
+	 * the site is Ready to Start when:
+	 * - siteId is defined
+	 * - data is ready
+	 * - does not require an upgrade, based on store `woop` feature
+	 */
+	let isReadyToStart = !! ( siteId && transferringDataIsAvailable && ! requiresUpgrade );
+
+	/*
+	 * Check whether the site transferring is blocked.
+	 * True as default, meaning it's True when requesting data.
+	 */
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore Until createRegistrySelector is typed correctly
+	const isTransferringBlocked =
+		latestAtomicTransfer && ( ! transferringDataIsAvailable || transferringBlockers?.length > 0 );
+
+	// when the site is not Atomic, ...
+	if ( isReadyToStart && ! isAtomicSite ) {
+		isReadyToStart =
+			isReadyToStart &&
+			! isTransferringBlocked && // there is no blockers from eligibility (holds).
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore Until createRegistrySelector is typed correctly
+			! ( eligibilityWarnings && eligibilityWarnings?.length ); // there is no warnings from eligibility (warnings).
+	}
+
+	const siteUpgrading = {
+		required: requiresUpgrade,
+		checkoutUrl: addQueryArgs(
+			{
+				redirect_to: addQueryArgs( { siteSlug: wpcomDomain }, '/setup/wooTransfer' ),
+				cancel_to: addQueryArgs( { siteSlug: wpcomDomain }, '/setup/wooConfirm' ),
+			},
+			`/checkout/${ wpcomDomain }/${ upgradingPlan?.product_slug ?? '' }`
+		),
+		productName,
+		description: productName
+			? sprintf(
+					/* translators: %s: The upgrading plan name (ex.: WordPress.com Business) */
+					__( 'Upgrade to the %s plan and set up your WooCommerce store.' ),
+					productName
+			  )
+			: __( 'Upgrade to set up your WooCommerce store.' ),
+	};
+
+	const domain = stagingDomain;
+	const backUrl = window.location.pathname + window.location.search;
+
+	function getWPComSubdomainWarningContent() {
+		if ( ! wpcomSubdomainWarning ) {
+			return null;
+		}
+
+		return (
+			<DomainEligibilityWarning wpcomDomain={ wpcomDomain || '' } stagingDomain={ stagingDomain } />
+		);
+	}
+
+	function getCheckoutContent() {
+		if ( ! siteUpgrading.required ) {
+			return null;
+		}
+
+		return (
+			<div className="woo-confirm__upgrade-required">
+				<PlanWarning title={ __( 'Plan upgrade required' ) }>
+					{ siteUpgrading.description }
+				</PlanWarning>
+			</div>
+		);
+	}
+
+	function getWarningsOrHoldsSection() {
+		if ( isTransferringBlocked ) {
+			return (
+				<WarningsOrHoldsSection>
+					<WarningCard
+						message={ __(
+							'There is an error that is stopping us from being able to install this product, please contact support.'
+						) }
+					/>
+				</WarningsOrHoldsSection>
+			);
+		}
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore Until createRegistrySelector is typed correctly
+		if ( warnings?.length ) {
+			return (
+				<WarningsOrHoldsSection>
+					<Divider />
+					<EligibilityWarningsList warnings={ warnings } />
+				</WarningsOrHoldsSection>
+			);
+		}
+
+		return null;
+	}
+
+	function getContent() {
+		return (
+			<>
+				<div className="woo-confirm__info-section" />
+				<div className="woo-confirm__instructions-container">
+					{ getWPComSubdomainWarningContent() }
+					{ getCheckoutContent() }
+					{ getWarningsOrHoldsSection() }
+					<ActionSection>
+						<SupportCard domain={ domain || '' } backUrl={ backUrl } />
+						<StyledNextButton
+							disabled={ isTransferringBlocked || ! isDataReady }
+							onClick={ () => {
+								recordTracksEvent( 'calypso_woocommerce_dashboard_confirm_submit', {
+									site: wpcomDomain,
+									upgrade_required: siteUpgrading.required,
+								} );
+
+								const providedDependencies = {
+									checkoutUrl: siteUpgrading.checkoutUrl,
+								};
+								submit?.( providedDependencies, siteUpgrading.checkoutUrl );
+							} }
+						>
+							{ __( 'Confirm' ) }
+						</StyledNextButton>
+					</ActionSection>
+				</div>
+			</>
+		);
+	}
+
+	if ( site === null || ! site.ID || ! isDataReady || isReadyToStart ) {
+		return (
+			<div className="woo-confirm__info-section">
+				<LoadingEllipsis />
+			</div>
+		);
+	}
+
+	const headerText = __( 'One final step' );
+	const subHeaderText = __(
+		'We’ve highlighted a few important details you should review before we create your store. '
+	);
+
+	return (
+		<StepContainer
+			stepName={ 'woo-confirm' }
+			goBack={ goBack }
+			hideSkip
+			isHorizontalLayout={ true }
+			formattedHeader={
+				<FormattedHeader
+					id={ 'woo-confirm-title-header' }
+					headerText={ headerText }
+					subHeaderText={ subHeaderText }
+					align={ 'left' }
+				/>
+			}
+			stepContent={ getContent() }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default WooConfirm;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/style.scss
@@ -1,0 +1,124 @@
+@import '@wordpress/base-styles/variables';
+
+body.is-section-stepper {
+	// Two column layout.
+	.step-container.woo-confirm {
+			@media ( min-width: 660px ) {
+				display: flex;
+			}
+
+			.step-container__header {
+				@media ( min-width: 660px ) {
+					margin-top: 0 !important;
+				}
+
+				.formatted-header {
+					text-align: inherit;
+
+					@media ( min-width: 1024px ) {
+						margin-left: 24px;
+					}
+
+					.formatted-header__title {
+						text-align: inherit;
+
+						@media ( max-width: 660px ) {
+							padding: 0 10px 0 0;
+						}
+					}
+
+					.formatted-header__subtitle {
+						@media ( max-width: 660px ) {
+							margin-top: 8px;
+							padding: 0 10px 0 0;
+						}
+
+						margin-top: 20px;
+						text-align: inherit;
+						max-width: 448px;
+					}
+				}
+			}
+
+		.step-container__content {
+			@media ( min-width: 660px ) {
+				display: flex;
+				margin: 0 24px;
+			}
+
+			.woo-confirm__instructions-container {
+				font-size: 0.875rem;
+				letter-spacing: -0.16px;
+				color: var( --studio-gray-60 );
+				flex-direction: column;
+				max-width: 520px;
+
+				@media ( max-width: 660px ) {
+					max-width: 90vw;
+				}
+
+				p {
+					margin-top: 16px;
+				}
+
+				.woo-confirm__upgrade-required {
+					margin-top: 1rem;
+				}
+
+				.components-base-control {
+					font-size: $default-font-size;
+					line-height: $default-line-height;
+					margin-bottom: $grid-unit-30;
+
+					.components-base-control__label,
+					.components-input-control__label {
+						font-size: $editor-font-size;
+						margin-bottom: $grid-unit;
+						padding: 0;
+					}
+
+					.components-checkbox-control__label,
+					.components-select-control__input,
+					.components-text-control__input,
+					.components-combobox-control__input {
+						color: var( --color-neutral-70 );
+					}
+
+					.components-combobox-control__suggestions-container,
+					.components-select-control__input,
+					.components-text-control__input {
+						line-height: 18px;
+						padding: $grid-unit-15 $grid-unit-20;
+					}
+
+					.components-select-control__input {
+						box-sizing: initial;
+						height: auto;
+						line-height: 20px;
+						min-height: auto;
+					}
+
+					.components-combobox-control__input {
+						padding: 0;
+					}
+				}
+
+				.components-text-control__input {
+					box-sizing: border-box;
+				}
+			}
+		}
+	}
+}
+
+.site-setup.woo-confirm {
+		.woo-confirm__info-section {
+			display: flex;
+			justify-content: center;
+
+			.wpcom__loading-ellipsis {
+				display: block;
+				margin: 0 auto;
+			}
+		}
+}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -41,6 +41,7 @@ export const siteSetupFlow: Flow = {
 			'error',
 			'wooTransfer',
 			'wooInstallPlugins',
+			'wooConfirm',
 		] as StepPath[];
 	},
 	useSideEffect() {
@@ -183,6 +184,16 @@ export const siteSetupFlow: Flow = {
 					if ( isAtomic ) {
 						return navigate( 'wooInstallPlugins' );
 					}
+					return navigate( 'wooConfirm' );
+				}
+
+				case 'wooConfirm': {
+					const [ checkoutUrl ] = params;
+
+					if ( checkoutUrl ) {
+						return exitFlow( checkoutUrl.toString() );
+					}
+
 					return navigate( 'wooTransfer' );
 				}
 
@@ -223,6 +234,9 @@ export const siteSetupFlow: Flow = {
 
 				case 'businessInfo':
 					return navigate( 'storeAddress' );
+
+				case 'wooConfirm':
+					return navigate( 'businessInfo' );
 
 				case 'courses':
 					return navigate( 'bloggerStartingPoint' );

--- a/client/landing/stepper/stores.ts
+++ b/client/landing/stepper/stores.ts
@@ -21,4 +21,4 @@ export const USER_STORE = User.register( {
 	client_secret: config( 'wpcom_signup_key' ),
 } );
 
-export const WOOCOMMERCE_ELIGIBILITY_STORE = AutomatedTransferEligibility.register();
+export const AUTOMATED_ELIGIBILITY_STORE = AutomatedTransferEligibility.register();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

WooCommerce Confirm step
    
This is the final step when setting up a new WooCommerce site. The user is shown any subdomain changes and plan upgrades prior to the final site transfer.
    
If a plan upgrade is required, they're taking to the checkout page and then to the wooTransfer step.

_NOTE:_ There are a number of `ts-ignore` comments in this step as well as a couple of `: any` types that will be removed once some of the latest type updates in `@wordpress/data` are complete.

![image](https://user-images.githubusercontent.com/917632/166528979-220f0b79-5dc3-48a6-bb24-171d15e5121d.png)

#### Testing instructions

##### Free Plan
1. Checkout this PR and go to http://calypso.localhost:3000/start/?flags=stepper-woocommerce-poc
2. Create a new site on the Free Plan
3. Go through the WooCommerce upgrade path
4. After the "Confirm" step, you should be taken to the checkout url to pay for the Pro Plan.
5. After completing checkout, you should be redirected to the `wooTransfer` step to complete the process.

##### Pro Plan
1. Checkout this PR and go to http://calypso.localhost:3000/start/?flags=stepper-woocommerce-poc
2. Create a new site and select the Pro Plan
3. Go through the WooCommerce upgrade path
4. After the "Confirm" step, you should be taken to the `wooTransfer` step to complete the process.

Closes #62714
