### PR TITLE
Tests: Refactor `AppPromo` tests to `@testing-library/react` and `jest`

### DIFF
--- a/client/blocks/app-promo/test/index.jsx
+++ b/client/blocks/app-promo/test/index.jsx
@@ -1,9 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-
+import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import { shallow, mount } from 'enzyme';
 
 describe( 'AppPromo', () => {
 	const appPromoDetails = {
@@ -31,25 +30,25 @@ describe( 'AppPromo', () => {
 
 	describe( 'readering', () => {
 		test( 'should render the primary components', () => {
-			const wrapper = shallow( AppPromoComponent );
+			const { container } = render( AppPromoComponent );
 
-			expect( wrapper.find( '.app-promo' ) ).to.have.lengthOf( 1 );
-			expect( wrapper.find( '.app-promo__dismiss' ) ).to.have.lengthOf( 1 );
-			expect( wrapper.find( '.app-promo__icon' ) ).to.have.lengthOf( 1 );
+			expect( container.getElementsByClassName( 'app-promo' ) ).to.have.lengthOf( 1 );
+			expect( container.getElementsByClassName( 'app-promo__dismiss' ) ).to.have.lengthOf( 1 );
+			expect( container.getElementsByClassName( 'app-promo__icon' ) ).to.have.lengthOf( 1 );
 		} );
 
 		test( 'should render the promo text', () => {
-			const wrapper = mount( AppPromoComponent );
+			const { container } = render( AppPromoComponent );
 
-			expect( wrapper.text() ).to.contain( appPromoDetails.message );
+			expect( container.textContent ).to.contain( appPromoDetails.message );
 		} );
 
 		test( 'should render the promo link', () => {
-			const wrapper = shallow( AppPromoComponent );
+			const { container } = render( AppPromoComponent );
 
-			const promoLink = wrapper.find( '.app-promo__link' );
+			const promoLink = container.getElementsByClassName( 'app-promo__link' );
 			expect( promoLink ).to.have.lengthOf( 1 );
-			expect( promoLink.prop( 'href' ) ).to.equal( appPromoLink );
+			expect( promoLink[ 0 ].getAttribute( 'href' ) ).to.equal( appPromoLink );
 		} );
 	} );
 

--- a/client/blocks/app-promo/test/index.jsx
+++ b/client/blocks/app-promo/test/index.jsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { render } from '@testing-library/react';
-import { expect } from 'chai';
 
 describe( 'AppPromo', () => {
 	const appPromoDetails = {
@@ -32,23 +31,23 @@ describe( 'AppPromo', () => {
 		test( 'should render the primary components', () => {
 			const { container } = render( AppPromoComponent );
 
-			expect( container.getElementsByClassName( 'app-promo' ) ).to.have.lengthOf( 1 );
-			expect( container.getElementsByClassName( 'app-promo__dismiss' ) ).to.have.lengthOf( 1 );
-			expect( container.getElementsByClassName( 'app-promo__icon' ) ).to.have.lengthOf( 1 );
+			expect( container.getElementsByClassName( 'app-promo' ) ).toHaveLength( 1 );
+			expect( container.getElementsByClassName( 'app-promo__dismiss' ) ).toHaveLength( 1 );
+			expect( container.getElementsByClassName( 'app-promo__icon' ) ).toHaveLength( 1 );
 		} );
 
 		test( 'should render the promo text', () => {
 			const { container } = render( AppPromoComponent );
 
-			expect( container.textContent ).to.contain( appPromoDetails.message );
+			expect( container.textContent ).toEqual( expect.stringContaining( appPromoDetails.message ) );
 		} );
 
 		test( 'should render the promo link', () => {
 			const { container } = render( AppPromoComponent );
 
 			const promoLink = container.getElementsByClassName( 'app-promo__link' );
-			expect( promoLink ).to.have.lengthOf( 1 );
-			expect( promoLink[ 0 ].getAttribute( 'href' ) ).to.equal( appPromoLink );
+			expect( promoLink ).toHaveLength( 1 );
+			expect( promoLink[ 0 ].getAttribute( 'href' ) ).toBe( appPromoLink );
 		} );
 	} );
 
@@ -66,11 +65,15 @@ describe( 'AppPromo', () => {
 		};
 
 		test( 'should render a mobile link when the mobile promo code is passed in', () => {
-			expect( getPromoLink( 'reader', mobilePromo ) ).to.include( 'mobile' );
+			expect( getPromoLink( 'reader', mobilePromo ) ).toEqual(
+				expect.stringContaining( 'mobile' )
+			);
 		} );
 
 		test( 'should render a desktop link when the desktop promo code is passed in', () => {
-			expect( getPromoLink( 'reader', desktopPromo ) ).to.include( 'desktop' );
+			expect( getPromoLink( 'reader', desktopPromo ) ).toEqual(
+				expect.stringContaining( 'desktop' )
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

React 18 is out, and `enzyme`, which we use broadly for component testing, doesn't (and will likely never) support it. As part of our preparation to upgrade to React to v18, we need to refactor all tests that use `enzyme` to a modern component testing library, like `testing-library` for example.

This PR is a small demonstration of how straightforward it is to migrate the tests of a simple component (`AppPromo`) from `enzyme` to `@testing-library/react`. I've also used the opportunity to migrate assertions from `chai` to the preferred `jest`.

#### Testing instructions

Verify tests still pass:`yarn run test-client client/blocks/app-promo`