### PR TITLE
Update the pagination logic in the Payment Methods section of the Licensing Portal to use the new pagination tools.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/style.scss
@@ -1,3 +1,5 @@
+@import 'calypso/jetpack-cloud/sections/partner-portal/mixins.scss';
+
 .payment-method-list__body {
 	display: grid;
 	grid-template-columns: repeat( auto-fill, minmax( 300px, 1fr ) );
@@ -13,19 +15,5 @@
 .payment-method-list__pagination {
 	margin: 64px 0;
 
-	&--is-fetching {
-		button {
-			/* Disable the pointer events during fetching. */
-			pointer-events: none;
-		}
-	}
-
-	&--no-more-items {
-		.is-right {
-			button {
-				/* Disable the next button when there are no more items. */
-				pointer-events: none;
-			}
-		}
-	}
+	@include licensing-portal-cursor-pagination();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the pagination logic in the Payment Methods section of the Licensing Portal to use the new pagination tools.

#### Testing instructions

* Sandbox the API and adjust the PAYMENT_METHODS_PER_PAGE constant to 1 so it's easier to test the pagination.
* Checkout PR and launch Jetpack Cloud.
* Open up http://jetpack.cloud.localhost:3000/partner-portal/payment-methods
* Make sure you have at least 3 payment methods (they may be the same payment method - just add it 3 times)
* Interact with the pagination and make sure it behaves as expected and identically to one on the Invoices page.