### PR TITLE
Licensing Portal: Add an error notice when the payment methods list request fails

### DIFF
--- a/client/state/partner-portal/stored-cards/actions.ts
+++ b/client/state/partner-portal/stored-cards/actions.ts
@@ -1,5 +1,6 @@
 import i18n from 'i18n-calypso';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import { errorNotice } from 'calypso/state/notices/actions';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 import type { AnyAction, Dispatch } from 'redux';
 
@@ -37,10 +38,15 @@ export const fetchStoredCards = ( paging: { startingAfter: string; endingBefore:
 			} );
 		} )
 		.catch( ( error: Error ) => {
+			const errorMessage =
+				error.message || i18n.translate( 'There was a problem retrieving stored cards.' );
+
 			dispatch( {
 				type: 'STORED_CARDS_FETCH_FAILED',
-				error: error.message || i18n.translate( 'There was a problem retrieving stored cards.' ),
+				error: errorMessage,
 			} );
+
+			dispatch( errorNotice( errorMessage, { id: 'partner-portal-fetch-payment-methods-error' } ) );
 
 			return Promise.reject( error );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Display an error notice when the request to pull the user's payment methods in the Licensing Portal fails.

#### Testing instructions

* Trigger a fake `throw new \Stripe\Error\InvalidRequest( 'fake error', null );` Stripe error in the payment methods API OR reject the promise in deleteStoredCard so catch() is triggered.
* Apply this PR and run Jetpack Cloud.
* Open up http://jetpack.cloud.localhost:3000/partner-portal/payment-methods and confirm you get an error notice.