### PR TITLE
Updating title and tooltip for a couple of plan features

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -197,7 +197,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 		get description() {
 			return translate(
-				'Customer service isn’t just something we offer. It’s who we are. Over 30% of WordPress.com is dedicated to service. We call it Happiness—real support delivered by real human beings who specialize in launching and fine-tuning WordPress sites.'
+				'Over 30% of WordPress.com is dedicated to customer service. We call it Happiness — real support delivered by real human beings, experts in WordPress sites.'
 			);
 		},
 		features: [ FEATURE_PREMIUM_SUPPORT ],
@@ -455,7 +455,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 	},
 	{
 		get title() {
-			return translate( 'Built in social media tools' );
+			return translate( 'Advanced social media tools' );
 		},
 		get description() {
 			return translate( 'Amplify your voice with our built-in social tools.' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change swaps out the tooltip text seen in the `Premium support` feature. This change also swaps out the title seen in the `Built in social media tools` feature.

#### Testing instructions

1. Open Upgrades --> Plans from the sidebar
2. Review the tooltip text for the `Premium support` feature. Ensure there are no spelling errors. Switch to another locale and ensure that the text is not in English.
3. Review the title for the `Built in social media tools`. This should now read `Advanced social media tools`. Ensure there are no spelling errors. Switch to another locale and ensure that the text is not in English.

