### PR TITLE
Playwright: Editor Tracking -- Add global styles events tests

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-color-picker-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-color-picker-component.ts
@@ -1,0 +1,105 @@
+import { Locator, Page } from 'playwright';
+
+const parentSelector = '.block-editor-color-gradient-control__fieldset';
+
+const selectors = {
+	colorSwatchButton: ( swatchName: ThemeColorPurposes | DefaultColorNames ) =>
+		`${ parentSelector } .components-circular-option-picker__swatches [aria-label="Color: ${ swatchName }"]`,
+
+	colorTypeToggle: ( colorType: ColorType ) =>
+		`${ parentSelector } [aria-label="Select color type"] button[aria-label="${ colorType }"]`,
+};
+
+type ColorType = 'Solid' | 'Gradient';
+
+type ThemeColorPurposes = 'Primary' | 'Secondary' | 'Tertiary' | 'Background' | 'Foreground';
+type DefaultColorNames = 'Black' | 'White'; // Add as needed.
+interface ColorSwatch {
+	colorName: DefaultColorNames | ThemeColorPurposes;
+}
+/**
+ * Type guard to determine if solid color is a DefaultSwatch.
+ *
+ * @param {SolidColor} solidColor The solid color configuration.
+ * @returns Type guard for DefaultSwatch.
+ */
+function isColorSwatch( solidColor: SolidColor ): solidColor is ColorSwatch {
+	return ( solidColor as ColorSwatch ).colorName !== undefined;
+}
+
+interface CustomColor {
+	hexValue: string;
+}
+/**
+ * Type guard to determine if solid color is a CustomColor.
+ *
+ * @param {SolidColor} solidColor The solid color configuration.
+ * @returns Type guard for CustomColor.
+ */
+function isCustomColor( solidColor: SolidColor ): solidColor is CustomColor {
+	return ( solidColor as CustomColor ).hexValue !== undefined;
+}
+
+type SolidColor = ColorSwatch | CustomColor;
+/**
+ *
+ * @param colorSettings
+ * @returns
+ */
+function isSolidColor( colorSettings: ColorSettings ): colorSettings is SolidColor {
+	const solidColor = colorSettings as SolidColor;
+	return isColorSwatch( solidColor ) || isCustomColor( solidColor );
+}
+
+type GradientColor = 'NOT IMPLEMENTED';
+
+export type ColorSettings = SolidColor | GradientColor;
+
+/**
+ * Represents a color picker in the editor (used in blocks and global styles).
+ */
+export class EditorColorPickerComponent {
+	private page: Page;
+	private editor: Locator;
+
+	/**
+	 * Creates an instance of the component.
+	 *
+	 * @param {Page} page Object representing the base page.
+	 * @param {Locator} editor Frame-safe locator to the editor.
+	 */
+	constructor( page: Page, editor: Locator ) {
+		this.page = page;
+		this.editor = editor;
+	}
+
+	/**
+	 *
+	 * @param colorSettings
+	 */
+	async setColor( colorSettings: ColorSettings ): Promise< void > {
+		if ( isSolidColor( colorSettings ) ) {
+			await this.setSolidColor( colorSettings );
+		} else {
+			throw new Error( 'Gradient colors are not implemented yet.' );
+		}
+	}
+
+	/**
+	 *
+	 * @param colorSettings
+	 */
+	private async setSolidColor( colorSettings: SolidColor ): Promise< void > {
+		const solidToggleLocator = this.editor.locator( selectors.colorTypeToggle( 'Solid' ) );
+		await solidToggleLocator.click();
+
+		if ( isCustomColor( colorSettings ) ) {
+			throw new Error( 'Custom colors have not been implemented yet.' );
+		}
+
+		if ( isColorSwatch( colorSettings ) ) {
+			const locator = this.editor.locator( selectors.colorSwatchButton( colorSettings.colorName ) );
+			await locator.click();
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
@@ -3,7 +3,7 @@ import { Page, Locator } from 'playwright';
 const popoverParentSelector = '.popover-slot .components-popover';
 
 const selectors = {
-	menuButton: ( name: string ) => `${ popoverParentSelector } button:has-text("${ name }")`,
+	menuButton: ( name: string ) => `${ popoverParentSelector } button  :text-is("${ name }")`,
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
@@ -3,7 +3,7 @@ import { Page, Locator } from 'playwright';
 const popoverParentSelector = '.popover-slot .components-popover';
 
 const selectors = {
-	menuButton: ( name: string ) => `${ popoverParentSelector } button  :text-is("${ name }")`,
+	menuButton: ( name: string ) => `${ popoverParentSelector } :text-is("${ name }")`,
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
@@ -12,9 +12,10 @@ const selectors = {
 	navigationButton: ( buttonName: string ) =>
 		`${ parentSelector } button.components-navigator-button:has-text("${ buttonName }")`,
 	closeSidebarButton: 'button[aria-label="Close global styles sidebar"]',
+	backButton: `${ parentSelector } button[aria-label="Navigate to the previous view"]`,
 };
 
-type ColorLocation = 'Background' | 'Text' | 'Links';
+export type ColorLocation = 'Background' | 'Text' | 'Links';
 
 /**
  * Represents the site editor site styles sidebar/panel.
@@ -52,7 +53,7 @@ export class EditorSiteStylesComponent {
 	 *
 	 */
 	async closeSiteStyles(): Promise< void > {
-		if ( await this.siteStylesIsOpen ) {
+		if ( await this.siteStylesIsOpen() ) {
 			const locator = this.editor.locator( selectors.closeSidebarButton );
 			await locator.click();
 		}
@@ -67,9 +68,10 @@ export class EditorSiteStylesComponent {
 		colorLocation: ColorLocation,
 		colorSettings: ColorSettings
 	): Promise< void > {
+		await this.returnToTopMenu();
 		await this.clickNavigationButton( 'Colors' );
 		await this.clickNavigationButton( colorLocation );
-		this.editorColorPickerComponent.setColor( colorSettings );
+		await this.editorColorPickerComponent.setColor( colorSettings );
 	}
 
 	// In future: setBlockColor()
@@ -85,6 +87,7 @@ export class EditorSiteStylesComponent {
 		blockName: string,
 		typographySettings: TypographySettings
 	): Promise< void > {
+		await this.returnToTopMenu();
 		await this.clickNavigationButton( 'Blocks' );
 		await this.clickNavigationButton( blockName );
 		await this.clickNavigationButton( 'Typography' );
@@ -98,5 +101,15 @@ export class EditorSiteStylesComponent {
 	private async clickNavigationButton( buttonName: string ): Promise< void > {
 		const locator = this.editor.locator( selectors.navigationButton( buttonName ) );
 		await locator.click();
+	}
+
+	/**
+	 *
+	 */
+	private async returnToTopMenu(): Promise< void > {
+		const backButtonLocator = this.editor.locator( selectors.backButton );
+		while ( ( await backButtonLocator.count() ) > 0 ) {
+			await backButtonLocator.click();
+		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
@@ -38,11 +38,15 @@ export class EditorSiteStylesComponent {
 		this.editor = editor;
 
 		this.editorColorPickerComponent = new EditorColorPickerComponent( page, editor );
-		this.editorTypographyComponent = new EditorTypographyComponent( page, editor, 'site' );
+		this.editorTypographyComponent = new EditorTypographyComponent( page, editor, 'site-styles' );
 	}
 
 	/**
-	 * Click menu button by name.
+	 * Checks if the site styles sidebar/panel is open.
+	 * Not reliable for immediate validation after an open/close action,
+	 * but can be used to determine starting state.
+	 *
+	 * @returns true if the site styles sidebar/panel is open, false otherwise.
 	 */
 	async siteStylesIsOpen(): Promise< boolean > {
 		const locator = this.editor.locator( parentSelector );
@@ -50,7 +54,7 @@ export class EditorSiteStylesComponent {
 	}
 
 	/**
-	 *
+	 * Closes the site styles sidebar/panel.
 	 */
 	async closeSiteStyles(): Promise< void > {
 		if ( await this.siteStylesIsOpen() ) {
@@ -60,9 +64,11 @@ export class EditorSiteStylesComponent {
 	}
 
 	/**
+	 * Sets a color style setting globaly for the site.
+	 * This auto-handles returning to top menu and navigating down.
 	 *
-	 * @param colorLocation
-	 * @param colorSettings
+	 * @param {ColorLocation} colorLocation What part of the site we are updating the color for.
+	 * @param {ColorSettings} colorSettings Settings for the color to set.
 	 */
 	async setGlobalColor(
 		colorLocation: ColorLocation,
@@ -79,9 +85,11 @@ export class EditorSiteStylesComponent {
 	// In future: setGlobalTypography()
 
 	/**
+	 * Sets a typography style for a block.
+	 * This auto-handles returning to top menu and navigating down.
 	 *
-	 * @param blockName
-	 * @param typographySettings
+	 * @param {string} blockName Block name (as appears in list).
+	 * @param {TypographySettings} typographySettings Typography settings to set.
 	 */
 	async setBlockTypography(
 		blockName: string,
@@ -95,8 +103,9 @@ export class EditorSiteStylesComponent {
 	}
 
 	/**
+	 * Clicks a navigation button in the site styles panel/sidebar.
 	 *
-	 * @param buttonName
+	 * @param {string} buttonName Button name.
 	 */
 	private async clickNavigationButton( buttonName: string ): Promise< void > {
 		const locator = this.editor.locator( selectors.navigationButton( buttonName ) );
@@ -104,10 +113,13 @@ export class EditorSiteStylesComponent {
 	}
 
 	/**
-	 *
+	 * Returns to the top-level menu in the site styles sidebar.
 	 */
 	private async returnToTopMenu(): Promise< void > {
 		const backButtonLocator = this.editor.locator( selectors.backButton );
+		// The DOM node of the current active panel is directly replaced on re-render.
+		// This means that we can safely rely on "count()" as an indicator of if there's
+		// back navigation to do.
 		while ( ( await backButtonLocator.count() ) > 0 ) {
 			await backButtonLocator.click();
 		}

--- a/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
@@ -9,10 +9,11 @@ import {
 const parentSelector = '.edit-site-global-styles-sidebar';
 
 const selectors = {
-	navigationButton: ( buttonName: string ) =>
+	menuButton: ( buttonName: string ) =>
 		`${ parentSelector } button.components-navigator-button:has-text("${ buttonName }")`,
-	closeSidebarButton: 'button[aria-label="Close global styles sidebar"]',
+	closeSidebarButton: 'button[aria-label="Close global styles sidebar"]:visible',
 	backButton: `${ parentSelector } button[aria-label="Navigate to the previous view"]`,
+	moreActionsMenuButton: `${ parentSelector } button[aria-label="More Global Styles Actions"]`,
 };
 
 export type ColorLocation = 'Background' | 'Text' | 'Links';
@@ -75,8 +76,8 @@ export class EditorSiteStylesComponent {
 		colorSettings: ColorSettings
 	): Promise< void > {
 		await this.returnToTopMenu();
-		await this.clickNavigationButton( 'Colors' );
-		await this.clickNavigationButton( colorLocation );
+		await this.clickMenuButton( 'Colors' );
+		await this.clickMenuButton( colorLocation );
 		await this.editorColorPickerComponent.setColor( colorSettings );
 	}
 
@@ -96,26 +97,26 @@ export class EditorSiteStylesComponent {
 		typographySettings: TypographySettings
 	): Promise< void > {
 		await this.returnToTopMenu();
-		await this.clickNavigationButton( 'Blocks' );
-		await this.clickNavigationButton( blockName );
-		await this.clickNavigationButton( 'Typography' );
+		await this.clickMenuButton( 'Blocks' );
+		await this.clickMenuButton( blockName );
+		await this.clickMenuButton( 'Typography' );
 		await this.editorTypographyComponent.setTypography( typographySettings );
 	}
 
 	/**
-	 * Clicks a navigation button in the site styles panel/sidebar.
+	 * Clicks a menu button in the site styles sidebar/panel.
 	 *
 	 * @param {string} buttonName Button name.
 	 */
-	private async clickNavigationButton( buttonName: string ): Promise< void > {
-		const locator = this.editor.locator( selectors.navigationButton( buttonName ) );
+	async clickMenuButton( buttonName: string ): Promise< void > {
+		const locator = this.editor.locator( selectors.menuButton( buttonName ) );
 		await locator.click();
 	}
 
 	/**
-	 * Returns to the top-level menu in the site styles sidebar.
+	 * Returns to the top-level menu in the site styles sidebar/panel.
 	 */
-	private async returnToTopMenu(): Promise< void > {
+	async returnToTopMenu(): Promise< void > {
 		const backButtonLocator = this.editor.locator( selectors.backButton );
 		// The DOM node of the current active panel is directly replaced on re-render.
 		// This means that we can safely rely on "count()" as an indicator of if there's
@@ -123,5 +124,13 @@ export class EditorSiteStylesComponent {
 		while ( ( await backButtonLocator.count() ) > 0 ) {
 			await backButtonLocator.click();
 		}
+	}
+
+	/**
+	 * Open the more actions menu in the site styles sidebar/panel.
+	 */
+	async openMoreActionsMenu(): Promise< void > {
+		const locator = this.editor.locator( selectors.moreActionsMenuButton );
+		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
@@ -1,0 +1,102 @@
+import { Page, Locator } from 'playwright';
+import {
+	ColorSettings,
+	EditorColorPickerComponent,
+	EditorTypographyComponent,
+	TypographySettings,
+} from '.';
+
+const parentSelector = '.edit-site-global-styles-sidebar';
+
+const selectors = {
+	navigationButton: ( buttonName: string ) =>
+		`${ parentSelector } button.components-navigator-button:has-text("${ buttonName }")`,
+	closeSidebarButton: 'button[aria-label="Close global styles sidebar"]',
+};
+
+type ColorLocation = 'Background' | 'Text' | 'Links';
+
+/**
+ * Represents the site editor site styles sidebar/panel.
+ */
+export class EditorSiteStylesComponent {
+	private page: Page;
+	private editor: Locator;
+
+	private editorColorPickerComponent: EditorColorPickerComponent;
+	private editorTypographyComponent: EditorTypographyComponent;
+
+	/**
+	 * Creates an instance of the component.
+	 *
+	 * @param {Page} page Object representing the base page.
+	 * @param {Locator} editor Frame-safe locator to the editor.
+	 */
+	constructor( page: Page, editor: Locator ) {
+		this.page = page;
+		this.editor = editor;
+
+		this.editorColorPickerComponent = new EditorColorPickerComponent( page, editor );
+		this.editorTypographyComponent = new EditorTypographyComponent( page, editor, 'site' );
+	}
+
+	/**
+	 * Click menu button by name.
+	 */
+	async siteStylesIsOpen(): Promise< boolean > {
+		const locator = this.editor.locator( parentSelector );
+		return ( await locator.count() ) > 0;
+	}
+
+	/**
+	 *
+	 */
+	async closeSiteStyles(): Promise< void > {
+		if ( await this.siteStylesIsOpen ) {
+			const locator = this.editor.locator( selectors.closeSidebarButton );
+			await locator.click();
+		}
+	}
+
+	/**
+	 *
+	 * @param colorLocation
+	 * @param colorSettings
+	 */
+	async setGlobalColor(
+		colorLocation: ColorLocation,
+		colorSettings: ColorSettings
+	): Promise< void > {
+		await this.clickNavigationButton( 'Colors' );
+		await this.clickNavigationButton( colorLocation );
+		this.editorColorPickerComponent.setColor( colorSettings );
+	}
+
+	// In future: setBlockColor()
+
+	// In future: setGlobalTypography()
+
+	/**
+	 *
+	 * @param blockName
+	 * @param typographySettings
+	 */
+	async setBlockTypography(
+		blockName: string,
+		typographySettings: TypographySettings
+	): Promise< void > {
+		await this.clickNavigationButton( 'Blocks' );
+		await this.clickNavigationButton( blockName );
+		await this.clickNavigationButton( 'Typography' );
+		await this.editorTypographyComponent.setTypography( typographySettings );
+	}
+
+	/**
+	 *
+	 * @param buttonName
+	 */
+	private async clickNavigationButton( buttonName: string ): Promise< void > {
+		const locator = this.editor.locator( selectors.navigationButton( buttonName ) );
+		await locator.click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -43,6 +43,9 @@ const selectors = {
 
 	// More options
 	moreOptionsButton: `${ panel } button[aria-label="Options"]`,
+
+	// Site editor save
+	saveSiteEditorButton: `${ panel } button.edit-site-save-button__button`,
 };
 
 /**
@@ -319,5 +322,15 @@ export class EditorToolbarComponent {
 			const locator = this.editor.locator( selectors.moreOptionsButton );
 			await locator.click();
 		}
+	}
+
+	/** FSE unique buttons */
+
+	/**
+	 * Click the save button (publish equivalent) for the full site editor.
+	 */
+	async saveSiteEditor(): Promise< void > {
+		const locator = this.editor.locator( selectors.saveSiteEditorButton );
+		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -40,6 +40,9 @@ const selectors = {
 	// Undo/Redo
 	undoButton: 'button[aria-disabled=false][aria-label="Undo"]',
 	redoButton: 'button[aria-disabled=false][aria-label="Redo"]',
+
+	// More options
+	moreOptionsButton: `${ panel } button[aria-label="Options"]`,
 };
 
 /**
@@ -306,5 +309,15 @@ export class EditorToolbarComponent {
 	async redo(): Promise< void > {
 		const locator = this.editor.locator( selectors.redoButton );
 		await locator.click();
+	}
+
+	/**
+	 * Opens the more options menu (three dots).
+	 */
+	async openMoreOptionsMenu(): Promise< void > {
+		if ( ! this.targetIsOpen( selectors.moreOptionsButton ) ) {
+			const locator = this.editor.locator( selectors.moreOptionsButton );
+			await locator.click();
+		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -315,7 +315,7 @@ export class EditorToolbarComponent {
 	 * Opens the more options menu (three dots).
 	 */
 	async openMoreOptionsMenu(): Promise< void > {
-		if ( ! this.targetIsOpen( selectors.moreOptionsButton ) ) {
+		if ( ! ( await this.targetIsOpen( selectors.moreOptionsButton ) ) ) {
 			const locator = this.editor.locator( selectors.moreOptionsButton );
 			await locator.click();
 		}

--- a/packages/calypso-e2e/src/lib/components/editor-typography-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-typography-component.ts
@@ -1,18 +1,5 @@
 import { Locator, Page } from 'playwright';
 
-type FontSize = 'Small' | 'Medium' | 'Large' | 'Extra Large'; // expand as needed.
-type FontAppearance = 'Default' | 'Thin' | 'Regular' | 'Medium'; // expand as needed.
-
-export interface TypographySettings {
-	fontSize?: FontSize | number;
-	lineHeight?: number;
-	letterSpacing?: number;
-	appearance?: FontAppearance;
-	// Can add other block editor ones later (like drop cap)
-}
-
-type EditorContext = 'site' | 'block';
-
 const parentSelector = '[class*="typography"]'; // Support block and site.
 const selectors = {
 	appearanceDropdownButton: `${ parentSelector } button[aria-label="Appearance"]`,
@@ -20,8 +7,21 @@ const selectors = {
 		`${ parentSelector } .components-font-appearance-control [role=option]:text-is("${ appearance }")`,
 };
 
+type FontSize = 'Small' | 'Medium' | 'Large' | 'Extra Large'; // expand as needed.
+type FontAppearance = 'Default' | 'Thin' | 'Regular' | 'Medium'; // expand as needed.
+
+export interface TypographySettings {
+	fontSize?: FontSize | number;
+	lineHeight?: number;
+	letterSpacing?: number;
+	fontAppearance?: FontAppearance;
+	// Can add other block editor specific ones later (like drop cap)
+}
+
+type EditorContext = 'site-styles' | 'block';
+
 /**
- * Represents a typography settings component (used in blocks and global styles).
+ * Represents a typography settings component (used in blocks and site styles).
  */
 export class EditorTypographyComponent {
 	private page: Page;
@@ -33,6 +33,7 @@ export class EditorTypographyComponent {
 	 *
 	 * @param {Page} page Object representing the base page.
 	 * @param {Locator} editor Frame-safe locator to the editor.
+	 * @param {EditorContext} context Whether we're in global styles or a block.
 	 */
 	constructor( page: Page, editor: Locator, context: EditorContext ) {
 		this.page = page;
@@ -41,8 +42,9 @@ export class EditorTypographyComponent {
 	}
 
 	/**
+	 * Set typography settings.
 	 *
-	 * @param settings
+	 * @param {TypographySettings} settings Settings to set. Only properties provided will be set.
 	 */
 	async setTypography( settings: TypographySettings ): Promise< void > {
 		if ( settings.fontSize ) {
@@ -57,22 +59,24 @@ export class EditorTypographyComponent {
 			throw new Error( 'Font size is not yet implemented.' );
 		}
 
-		if ( settings.appearance ) {
-			await this.setAppearance( settings.appearance );
+		if ( settings.fontAppearance ) {
+			await this.setAppearance( settings.fontAppearance );
 		}
 	}
 
 	/**
+	 * Sets the typography font appearance.
 	 *
-	 * @param appearance
+	 * @param {FontAppearance} fontAppearance Font appearance to select.
 	 */
-	private async setAppearance( appearance: FontAppearance ): Promise< void > {
-		// In the future, if we're in the block context, we'll probably have to add this field first.
+	private async setAppearance( fontAppearance: FontAppearance ): Promise< void > {
+		// In the future, if we're in the block context, we'll have to add this field first.
 
+		// It's not a real select input. It's a button and a custom control.
 		const dropdownButtonLocator = this.editor.locator( selectors.appearanceDropdownButton );
 		await dropdownButtonLocator.click();
 
-		const selectionLocator = this.editor.locator( selectors.appearanceSelection( appearance ) );
+		const selectionLocator = this.editor.locator( selectors.appearanceSelection( fontAppearance ) );
 		await selectionLocator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-typography-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-typography-component.ts
@@ -1,0 +1,78 @@
+import { Locator, Page } from 'playwright';
+
+export interface TypographySettings {
+	fontSize?: FontSize | number;
+	lineHeight?: number;
+	letterSpacing?: number;
+	appearance?: FontAppearance;
+	// Can add other block editor ones later (like drop cap)
+}
+
+type FontSize = 'Small' | 'Medium' | 'Large' | 'Extra Large'; // expand as needed.
+type FontAppearance = 'Default' | 'Thin' | 'Regular' | 'Medium'; // expand as needed.
+
+type EditorContext = 'site' | 'block';
+
+const parentSelector = '[class*="typography"]'; // Support block and site.
+const selectors = {
+	appearanceDropdownButton: `${ parentSelector } button[aria-label="Appearance"]`,
+	appearanceSelection: ( appearance: FontAppearance ) =>
+		`${ parentSelector } .components-font-appearance-control [role=option]:has-text("${ appearance }")`,
+};
+
+/**
+ * Represents a typography settings component (used in blocks and global styles).
+ */
+export class EditorTypographyComponent {
+	private page: Page;
+	private editor: Locator;
+	private context: EditorContext;
+
+	/**
+	 * Creates an instance of the component.
+	 *
+	 * @param {Page} page Object representing the base page.
+	 * @param {Locator} editor Frame-safe locator to the editor.
+	 */
+	constructor( page: Page, editor: Locator, context: EditorContext ) {
+		this.page = page;
+		this.editor = editor;
+		this.context = context;
+	}
+
+	/**
+	 *
+	 * @param settings
+	 */
+	async setTypography( settings: TypographySettings ): Promise< void > {
+		if ( settings.fontSize ) {
+			throw new Error( 'Font size is not yet implemented.' );
+		}
+
+		if ( settings.lineHeight ) {
+			throw new Error( 'Font size is not yet implemented.' );
+		}
+
+		if ( settings.letterSpacing ) {
+			throw new Error( 'Font size is not yet implemented.' );
+		}
+
+		if ( settings.appearance ) {
+			await this.setAppearance( settings.appearance );
+		}
+	}
+
+	/**
+	 *
+	 * @param appearance
+	 */
+	private async setAppearance( appearance: FontAppearance ): Promise< void > {
+		// In the future, if we're in the block context, we'll probably have to add this field first.
+
+		const dropdownButtonLocator = this.editor.locator( selectors.appearanceDropdownButton );
+		await dropdownButtonLocator.click();
+
+		const selectionLocator = this.editor.locator( selectors.appearanceSelection( appearance ) );
+		await selectionLocator.click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/editor-typography-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-typography-component.ts
@@ -1,5 +1,8 @@
 import { Locator, Page } from 'playwright';
 
+type FontSize = 'Small' | 'Medium' | 'Large' | 'Extra Large'; // expand as needed.
+type FontAppearance = 'Default' | 'Thin' | 'Regular' | 'Medium'; // expand as needed.
+
 export interface TypographySettings {
 	fontSize?: FontSize | number;
 	lineHeight?: number;
@@ -8,16 +11,13 @@ export interface TypographySettings {
 	// Can add other block editor ones later (like drop cap)
 }
 
-type FontSize = 'Small' | 'Medium' | 'Large' | 'Extra Large'; // expand as needed.
-type FontAppearance = 'Default' | 'Thin' | 'Regular' | 'Medium'; // expand as needed.
-
 type EditorContext = 'site' | 'block';
 
 const parentSelector = '[class*="typography"]'; // Support block and site.
 const selectors = {
 	appearanceDropdownButton: `${ parentSelector } button[aria-label="Appearance"]`,
 	appearanceSelection: ( appearance: FontAppearance ) =>
-		`${ parentSelector } .components-font-appearance-control [role=option]:has-text("${ appearance }")`,
+		`${ parentSelector } .components-font-appearance-control [role=option]:text-is("${ appearance }")`,
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/components/full-site-editor-save-panel-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-site-editor-save-panel-component.ts
@@ -1,0 +1,33 @@
+import { Page, Locator } from 'playwright';
+
+const panel = '.entities-saved-states__panel';
+const selectors = {
+	saveButton: `${ panel } button:has-text("Save")`,
+};
+
+/**
+ * Represents an instance of the FSE save confirmation panel (comparable publish panel).
+ */
+export class FullSiteEditorSavePanelComponent {
+	private page: Page;
+	private editor: Locator;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 * @param {Locator} editor Locator or FrameLocator to the editor.
+	 */
+	constructor( page: Page, editor: Locator ) {
+		this.page = page;
+		this.editor = editor;
+	}
+
+	/**
+	 * Publish or schedule the article.
+	 */
+	async confirmSave(): Promise< void > {
+		const locator = this.editor.locator( selectors.saveButton );
+		await locator.click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -27,5 +27,6 @@ export * from './editor-popover-menu-component';
 export * from './editor-site-styles-component';
 export * from './editor-color-picker-component';
 export * from './editor-typography-component';
+export * from './full-site-editor-save-panel-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -24,5 +24,8 @@ export * from './editor-block-list-view-component';
 export * from './editor-sidebar-block-inserter-component';
 export * from './editor-welcome-tour-component';
 export * from './editor-popover-menu-component';
+export * from './editor-site-styles-component';
+export * from './editor-color-picker-component';
+export * from './editor-typography-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -10,6 +10,7 @@ import {
 	ColorSettings,
 	TypographySettings,
 	ColorLocation,
+	FullSiteEditorSavePanelComponent,
 } from '..';
 import { getCalypsoURL } from '../../data-helper';
 import envVariables from '../../env-variables';
@@ -24,6 +25,7 @@ const selectors = {
 	templateLoadingSpinner: '[aria-label="Block: Template Part"] .components-spinner',
 	closeStylesWelcomeGuideButton:
 		'[aria-label="Welcome to styles"] button[aria-label="Close dialog"]',
+	saveConfirmationToast: '.components-snackbar:has-text("Site updated.")',
 };
 
 /**
@@ -40,6 +42,7 @@ export class FullSiteEditorPage {
 	private editorWelcomeTourComponent: EditorWelcomeTourComponent;
 	private editorPopoverMenuComponent: EditorPopoverMenuComponent;
 	private editorSiteStylesComponent: EditorSiteStylesComponent;
+	private fullSiteEditorSavePanelComponent: FullSiteEditorSavePanelComponent;
 
 	/**
 	 * Constructs an instance of the page POM class.
@@ -70,6 +73,10 @@ export class FullSiteEditorPage {
 		this.editorPopoverMenuComponent = new EditorPopoverMenuComponent( page, this.editor );
 		this.editorSiteStylesComponent = new EditorSiteStylesComponent( page, this.editor );
 		this.editorSidebarBlockInserterComponent = new EditorSidebarBlockInserterComponent(
+			page,
+			this.editor
+		);
+		this.fullSiteEditorSavePanelComponent = new FullSiteEditorSavePanelComponent(
 			page,
 			this.editor
 		);
@@ -208,6 +215,29 @@ export class FullSiteEditorPage {
 	}
 
 	/**
+	 * Close the site styles sidebar/panel.
+	 */
+	async closeSiteStyles(): Promise< void > {
+		await this.editorSiteStylesComponent.closeSiteStyles();
+	}
+
+	/**
+	 * Clicks a navigation menu item/button in the site styles sidebar/panel.
+	 *
+	 * @param {string} buttonName Name on the menu item/button.
+	 */
+	async clickStylesMenuButton( buttonName: string ): Promise< void > {
+		await this.editorSiteStylesComponent.clickMenuButton( buttonName );
+	}
+
+	/**
+	 * Returns to the top menu level of the styles sidebar/panel.
+	 */
+	async returnToStylesTopMenu(): Promise< void > {
+		await this.editorSiteStylesComponent.returnToTopMenu();
+	}
+
+	/**
 	 * Sets a color style setting globaly for the site.
 	 * This auto-handles returning to top menu and navigating down.
 	 *
@@ -233,5 +263,34 @@ export class FullSiteEditorPage {
 		typographySettings: TypographySettings
 	): Promise< void > {
 		await this.editorSiteStylesComponent.setBlockTypography( blockName, typographySettings );
+	}
+
+	/**
+	 * Resets the site styles to the defaults for the theme.
+	 */
+	async resetStylesToDefaults(): Promise< void > {
+		await this.editorSiteStylesComponent.openMoreActionsMenu();
+		await this.editorPopoverMenuComponent.clickMenuButton( 'Reset to defaults' );
+	}
+
+	/**
+	 * Save the changes in the full site editor (equivalent of publish).
+	 */
+	async save(): Promise< void > {
+		await this.clearExistingSaveConfirmationToast();
+		await this.editorToolbarComponent.saveSiteEditor();
+		await this.fullSiteEditorSavePanelComponent.confirmSave();
+		const toastLocator = this.editor.locator( selectors.saveConfirmationToast );
+		await toastLocator.waitFor();
+	}
+
+	/**
+	 * Clears existing save confirmation toasts.
+	 */
+	private async clearExistingSaveConfirmationToast(): Promise< void > {
+		const toastLocator = this.editor.locator( selectors.saveConfirmationToast );
+		if ( ( await toastLocator.count() ) > 0 ) {
+			await toastLocator.click();
+		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -8,6 +8,7 @@ import {
 } from '..';
 import { getCalypsoURL } from '../../data-helper';
 import envVariables from '../../env-variables';
+import { EditorPopoverMenuComponent } from '../components';
 
 const wpAdminPath = 'wp-admin/themes.php';
 
@@ -31,6 +32,7 @@ export class FullSiteEditorPage {
 	private editorToolbarComponent: EditorToolbarComponent;
 	private editorSidebarBlockInserterComponent: EditorSidebarBlockInserterComponent;
 	private editorWelcomeTourComponent: EditorWelcomeTourComponent;
+	private editorPopoverMenuComponent: EditorPopoverMenuComponent;
 
 	/**
 	 * Constructs an instance of the page POM class.
@@ -58,6 +60,7 @@ export class FullSiteEditorPage {
 
 		this.editorToolbarComponent = new EditorToolbarComponent( page, this.editor );
 		this.editorWelcomeTourComponent = new EditorWelcomeTourComponent( page, this.editor );
+		this.editorPopoverMenuComponent = new EditorPopoverMenuComponent( page, this.editor );
 		this.editorSidebarBlockInserterComponent = new EditorSidebarBlockInserterComponent(
 			page,
 			this.editor
@@ -162,5 +165,13 @@ export class FullSiteEditorPage {
 	 */
 	async redo(): Promise< void > {
 		await this.editorToolbarComponent.redo();
+	}
+
+	/**
+	 * Opens the site styles sidebar in the site editor.
+	 */
+	async openSiteStyles(): Promise< void > {
+		await this.editorToolbarComponent.openMoreOptionsMenu();
+		await this.editorPopoverMenuComponent.clickMenuButton( 'Styles' );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -177,6 +177,9 @@ export class FullSiteEditorPage {
 
 	/**
 	 * Opens the site styles sidebar in the site editor.
+	 *
+	 * @param {object} param0 Keyed options parameter.
+	 * @param {boolean} param0.closeWelcomeGuide Set if should close welcome guide on opening.
 	 */
 	async openSiteStyles(
 		{ closeWelcomeGuide }: { closeWelcomeGuide: boolean } = { closeWelcomeGuide: true }
@@ -185,7 +188,7 @@ export class FullSiteEditorPage {
 			await this.editorToolbarComponent.openMoreOptionsMenu();
 
 			if ( closeWelcomeGuide ) {
-				// The unawaited promise and no-op catch are intentional here!
+				// The unawaited promise and no-op catch are both intentional here!
 				// We want to close the welcome guide if it opens, but not slow down the test if it doesn't.
 				// This will effectively register a handler that waits for the welcome guide to close it if it appears
 				// but otherwise doesn't affect the following actions.
@@ -197,7 +200,7 @@ export class FullSiteEditorPage {
 	}
 
 	/**
-	 *
+	 * Closes the site styles welcome guide.
 	 */
 	private async closeStylesWelcomeGuide(): Promise< void > {
 		const locator = this.editor.locator( selectors.closeStylesWelcomeGuideButton );
@@ -205,9 +208,11 @@ export class FullSiteEditorPage {
 	}
 
 	/**
+	 * Sets a color style setting globaly for the site.
+	 * This auto-handles returning to top menu and navigating down.
 	 *
-	 * @param colorLocation
-	 * @param colorSettings
+	 * @param {ColorLocation} colorLocation What part of the site we are updating the color for.
+	 * @param {ColorSettings} colorSettings Settings for the color to set.
 	 */
 	async setGlobalColorStlye(
 		colorLocation: ColorLocation,
@@ -217,9 +222,11 @@ export class FullSiteEditorPage {
 	}
 
 	/**
+	 * Sets a typography style for a block.
+	 * This auto-handles returning to top menu and navigating down.
 	 *
-	 * @param blockName
-	 * @param typographySettings
+	 * @param {string} blockName Block name (as appears in list).
+	 * @param {TypographySettings} typographySettings Typography settings to set.
 	 */
 	async setBlockTypographyStyle(
 		blockName: string,

--- a/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
@@ -1,0 +1,244 @@
+/**
+ * @group gutenberg
+ */
+
+import {
+	DataHelper,
+	envVariables,
+	getTestAccountByFeature,
+	envToFeatureKey,
+	TestAccount,
+	EditorTracksEventManager,
+	FullSiteEditorPage,
+	skipDescribeIf,
+} from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' ), function () {
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( { ...features, variant: 'siteEditor' } );
+
+	describe( 'wpcom_block_editor_global_styles_panel_toggle', function () {
+		let page: Page;
+		let testAccount: TestAccount;
+		let fullSiteEditorPage: FullSiteEditorPage;
+		let editorTracksEventManager: EditorTracksEventManager;
+
+		beforeAll( async () => {
+			page = await browser.newPage();
+
+			testAccount = new TestAccount( accountName );
+			await testAccount.authenticate( page );
+
+			editorTracksEventManager = new EditorTracksEventManager( page );
+			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+		} );
+
+		it( 'Visit the site editor', async function () {
+			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+			await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+		} );
+
+		it( 'Open site styles', async function () {
+			await fullSiteEditorPage.openSiteStyles();
+		} );
+
+		it( '"wpcom_block_editor_global_styles_panel_toggle" event fires with "open" === true', async function () {
+			const eventDidFire = await editorTracksEventManager.didEventFire(
+				'wpcom_block_editor_global_styles_panel_toggle',
+				{
+					matchingProperties: {
+						open: true,
+					},
+				}
+			);
+			expect( eventDidFire ).toBe( true );
+		} );
+
+		it( 'Close site styles', async function () {
+			await fullSiteEditorPage.closeSiteStyles();
+		} );
+
+		it( '"wpcom_block_editor_global_styles_panel_toggle" event fires with "open" === false', async function () {
+			const eventDidFire = await editorTracksEventManager.didEventFire(
+				'wpcom_block_editor_global_styles_panel_toggle',
+				{
+					matchingProperties: {
+						open: false,
+					},
+				}
+			);
+			expect( eventDidFire ).toBe( true );
+		} );
+	} );
+
+	describe( 'wpcom_block_editor_global_styles_menu_selected', function () {
+		let page: Page;
+		let testAccount: TestAccount;
+		let fullSiteEditorPage: FullSiteEditorPage;
+		let editorTracksEventManager: EditorTracksEventManager;
+
+		beforeAll( async () => {
+			page = await browser.newPage();
+
+			testAccount = new TestAccount( accountName );
+			await testAccount.authenticate( page );
+
+			editorTracksEventManager = new EditorTracksEventManager( page );
+			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+		} );
+
+		it( 'Visit the site editor', async function () {
+			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+			await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+		} );
+
+		it( 'Open site styles', async function () {
+			await fullSiteEditorPage.openSiteStyles();
+		} );
+
+		it( 'Click on "Typography" menu button', async function () {
+			await fullSiteEditorPage.clickStylesMenuButton( 'Typography' );
+		} );
+
+		it( '"wpcom_block_editor_global_styles_menu_selected" event fires with "menu" === "typography"', async function () {
+			const eventDidFire = await editorTracksEventManager.didEventFire(
+				'wpcom_block_editor_global_styles_menu_selected',
+				{
+					matchingProperties: {
+						menu: 'typography',
+					},
+				}
+			);
+			expect( eventDidFire ).toBe( true );
+		} );
+
+		it( 'Return to top menu level', async function () {
+			await fullSiteEditorPage.returnToStylesTopMenu();
+		} );
+
+		it( 'Click on "Blocks" menu button', async function () {
+			await fullSiteEditorPage.clickStylesMenuButton( 'Blocks' );
+		} );
+
+		it( '"wpcom_block_editor_global_styles_menu_selected" event fires with "menu" === "blocks"', async function () {
+			const eventDidFire = await editorTracksEventManager.didEventFire(
+				'wpcom_block_editor_global_styles_menu_selected',
+				{
+					matchingProperties: {
+						menu: 'blocks',
+					},
+				}
+			);
+			expect( eventDidFire ).toBe( true );
+		} );
+	} );
+
+	describe( 'wpcom_block_editor_global_styles_update', function () {
+		let page: Page;
+		let testAccount: TestAccount;
+		let fullSiteEditorPage: FullSiteEditorPage;
+		let editorTracksEventManager: EditorTracksEventManager;
+
+		beforeAll( async () => {
+			page = await browser.newPage();
+
+			testAccount = new TestAccount( accountName );
+			await testAccount.authenticate( page );
+
+			editorTracksEventManager = new EditorTracksEventManager( page );
+			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+		} );
+
+		it( 'Visit the site editor', async function () {
+			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+			await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+		} );
+
+		it( 'Open site styles', async function () {
+			await fullSiteEditorPage.openSiteStyles();
+		} );
+
+		describe( 'Updating styles directly', function () {
+			it( 'Update the global background color', async function () {
+				// We can always guarantee a target color event if we click a different one first.
+				await fullSiteEditorPage.setGlobalColorStlye( 'Background', {
+					colorName: 'Primary',
+				} );
+				await fullSiteEditorPage.setGlobalColorStlye( 'Background', {
+					colorName: 'Background',
+				} );
+			} );
+
+			it( '"wpcom_block_editor_global_styles_update" event fires with correct color properties', async function () {
+				const eventDidFire = await editorTracksEventManager.didEventFire(
+					'wpcom_block_editor_global_styles_update',
+					{
+						matchingProperties: {
+							section: 'color',
+							field: 'background',
+							field_value: 'var:preset|color|background',
+						},
+						waitForEventMs: 2 * 1000, // Style update events are debounced
+					}
+				);
+				expect( eventDidFire ).toBe( true );
+			} );
+
+			it( 'Update the font appearance for the Heading block', async function () {
+				// We can always guarantee a target font appearance event if we select a different one first.
+				await fullSiteEditorPage.setBlockTypographyStyle( 'Heading', {
+					fontAppearance: 'Thin',
+				} );
+				await fullSiteEditorPage.setBlockTypographyStyle( 'Heading', {
+					fontAppearance: 'Medium',
+				} );
+			} );
+
+			it( '"wpcom_block_editor_global_styles_update" event fires with correct typography properties', async function () {
+				const eventDidFire = await editorTracksEventManager.didEventFire(
+					'wpcom_block_editor_global_styles_update',
+					{
+						matchingProperties: {
+							block_type: 'core/heading',
+							section: 'typography',
+							field: 'fontWeight',
+							field_value: '500',
+						},
+						waitForEventMs: 2 * 1000, // Style update events are debounced
+					}
+				);
+				expect( eventDidFire ).toBe( true );
+			} );
+		} );
+
+		// Can't reset to defaults on mobile
+		skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
+			'Updating by resetting to defaults',
+			function () {
+				it( 'Reset the Tracks events for a clean slate', async function () {
+					await editorTracksEventManager.clearEvents();
+				} );
+
+				it( 'Reset styles to defaults for theme', async function () {
+					await fullSiteEditorPage.resetStylesToDefaults();
+				} );
+
+				it( '"wpcom_block_editor_global_styles_update" event fires with "field_value" === "reset"', async function () {
+					const eventDidFire = await editorTracksEventManager.didEventFire(
+						'wpcom_block_editor_global_styles_update',
+						{
+							matchingProperties: {
+								field_value: 'reset',
+							},
+							waitForEventMs: 2 * 1000, // Style update events are debounced
+						}
+					);
+					expect( eventDidFire ).toBe( true );
+				} );
+			}
+		);
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Background test plan map: pciE2j-QC-p2

This PR adds all the global styles events tests for the site editor except the tests for the style save event. I added the POM structure needed to save styles, but the test design is going to be a bit tricky. Keeping tests deterministic but also triggering the dirty state is harder than I thought! So, I'm punting that to a future PR.

There were several POM component classes that have broad usage generally, but only specific usages for these current specs. I opted to create the architecture needed for broader usage, but only did the actual concrete implementations needed for these current tests.

#### Testing instructions

- [x] Gutenberg desktop passes
- [x] Gutenberg mobile passes

Related to #