### PR TITLE
DIFM: Adds support for Extra Pages when purchasing DIFM

### DIFF
--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -44,10 +44,8 @@ const PageGrid = styled.div`
 	}
 `;
 
-const GridCellContainer = styled.div< { isClickDisabled: boolean; isSelected: boolean } >`
+const GridCellContainer = styled.div`
 	cursor: default;
-	opacity: ${ ( { isSelected, isClickDisabled } ) =>
-		! isSelected && isClickDisabled ? '0.4' : '1' };
 	border-radius: 4px;
 	position: relative;
 	width: 100%;
@@ -98,15 +96,13 @@ function PageCell( { pageId, popular, required, selectedPages, onClick }: PageCe
 	const translate = useTranslate();
 	const selectedIndex = selectedPages.indexOf( pageId );
 	const isSelected = Boolean( selectedIndex > -1 );
-	const isDisabled = selectedIndex === -1;
 	const title = useTranslatedPageTitles()[ pageId ];
 
 	return (
-		<GridCellContainer isSelected={ isSelected } isClickDisabled={ isDisabled }>
+		<GridCellContainer>
 			<BrowserView
 				onClick={ () => onClick( pageId ) }
 				pageId={ pageId }
-				isClickDisabled={ isDisabled }
 				isSelected={ isSelected }
 				selectedIndex={ selectedIndex >= 0 ? selectedIndex : -1 }
 			/>
@@ -216,6 +212,7 @@ export default function DIFMPagePicker( props: StepProps ) {
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	const submitPickedPages = () => {

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -14,7 +14,6 @@ import {
 	PORTFOLIO_PAGE,
 	FAQ_PAGE,
 	PROFILE_PAGE,
-	PAGE_LIMIT,
 	SERVICES_PAGE,
 	TESTIMONIALS_PAGE,
 	MENU_PAGE,
@@ -98,9 +97,8 @@ interface PageCellType {
 function PageCell( { pageId, popular, required, selectedPages, onClick }: PageCellType ) {
 	const translate = useTranslate();
 	const selectedIndex = selectedPages.indexOf( pageId );
-	const totalSelections = selectedPages.length;
 	const isSelected = Boolean( selectedIndex > -1 );
-	const isDisabled = selectedIndex === -1 && totalSelections >= PAGE_LIMIT;
+	const isDisabled = selectedIndex === -1;
 	const title = useTranslatedPageTitles()[ pageId ];
 
 	return (
@@ -134,7 +132,7 @@ function PageSelector( {
 		if ( pageId !== HOME_PAGE ) {
 			if ( foundIndex > -1 ) {
 				setSelectedPages( selectedPages.filter( ( page, index ) => index !== foundIndex ) );
-			} else if ( selectedPages.length !== PAGE_LIMIT ) {
+			} else {
 				setSelectedPages( [ ...selectedPages, pageId ] );
 			}
 		}

--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -76,6 +76,7 @@ export const WPCOM_MONTHLY_PLANS = <const>[
 
 export const WPCOM_TRAFFIC_GUIDE = 'traffic-guide';
 export const WPCOM_DIFM_LITE = 'wp_difm_lite';
+export const WPCOM_DIFM_EXTRA_PAGE = 'wp_difm_extra_page';
 
 export const PLAN_BUSINESS_ONBOARDING_EXPIRE = '2021-07-31T00:00:00+00:00';
 export const PLAN_BUSINESS_2Y_ONBOARDING_EXPIRE = '2022-07-31T00:00:00+00:00';

--- a/packages/calypso-products/src/is-difm-extra-page-product.ts
+++ b/packages/calypso-products/src/is-difm-extra-page-product.ts
@@ -1,0 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
+import { WPCOM_DIFM_EXTRA_PAGE } from './constants';
+import type { WithCamelCaseSlug, WithSnakeCaseSlug } from './types';
+
+export function isDIFMExtraPageProduct( product: WithCamelCaseSlug | WithSnakeCaseSlug ): boolean {
+	return camelOrSnakeSlug( product ) === WPCOM_DIFM_EXTRA_PAGE;
+}

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -25,6 +25,7 @@ export { isComplete } from './is-complete';
 export { isCustomDesign } from './is-custom-design';
 export { isDelayedDomainTransfer } from './is-delayed-domain-transfer';
 export { isDIFMProduct } from './is-difm-product';
+export { isDIFMExtraPageProduct } from './is-difm-extra-page-product';
 export { isDomainMapping } from './is-domain-mapping';
 export { isDomainProduct } from './is-domain-product';
 export { isDomainRedemption } from './is-domain-redemption';

--- a/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
+++ b/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
@@ -31,7 +31,7 @@ export function canItemBeRemovedFromCart(
 	item: ResponseCartProduct,
 	responseCart: ResponseCart
 ): boolean {
-	const itemTypesThatCannotBeDeleted = [ 'domain_redemption' ];
+	const itemTypesThatCannotBeDeleted = [ 'domain_redemption', 'wp_difm_extra_page' ];
 	if ( itemTypesThatCannotBeDeleted.includes( item.product_slug ) ) {
 		return false;
 	}

--- a/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
+++ b/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
@@ -1,4 +1,4 @@
-import { isPremium, isDIFMProduct } from '@automattic/calypso-products';
+import { isPro, isDIFMProduct } from '@automattic/calypso-products';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 
 /**
@@ -9,10 +9,10 @@ function hasDIFMProduct( cart: ResponseCart ): boolean {
 }
 
 /**
- * Check if the given item is the premium plan product and the DIFM product exists in the provided shopping cart object
+ * Check if the given item is the Pro plan product and the DIFM product exists in the provided shopping cart object
  */
-function isPremiumPlanWithDIFMInTheCart( item: ResponseCartProduct, responseCart: ResponseCart ) {
-	return isPremium( item ) && hasDIFMProduct( responseCart );
+function isProPlanWithDIFMInTheCart( item: ResponseCartProduct, responseCart: ResponseCart ) {
+	return isPro( item ) && hasDIFMProduct( responseCart );
 }
 
 /**
@@ -36,8 +36,8 @@ export function canItemBeRemovedFromCart(
 		return false;
 	}
 
-	// The Premium plan cannot be removed from the cart when in combination with the DIFM lite product
-	if ( isPremiumPlanWithDIFMInTheCart( item, responseCart ) ) {
+	// The Pro plan cannot be removed from the cart when in combination with the DIFM lite product
+	if ( isProPlanWithDIFMInTheCart( item, responseCart ) ) {
 		return false;
 	}
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -13,6 +13,7 @@ import {
 	isGSuiteOrGoogleWorkspaceProductSlug,
 	isJetpackProductSlug,
 	isTitanMail,
+	isDIFMExtraPageProduct,
 } from '@automattic/calypso-products';
 import {
 	CheckoutModal,
@@ -664,6 +665,27 @@ function LineItemSublabelAndPrice( { product }: { product: ResponseCartProduct }
 					comment:
 						'premium label, product type and billing interval, separated by a colon. ex: ".blog domain registration: billed annually" or "Premium .blog domain registration: billed annually"',
 				} ) }
+			</>
+		);
+	}
+
+	if ( isDIFMExtraPageProduct( product ) ) {
+		const itemPrice = product.item_original_cost_for_quantity_one_display;
+		const quantity = product?.quantity || 1;
+
+		return (
+			<>
+				{ translate(
+					'Extra Page: %(itemPrice)s x %(quantity)s page',
+					'Extra Page: %(itemPrice)s x %(quantity)s pages',
+					{
+						args: {
+							itemPrice,
+							quantity,
+						},
+						count: quantity,
+					}
+				) }
 			</>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
PT: pdh1Xd-Oi-p2
* Removes the 5-page limit in the DIFM page selector step. This should allow all pages to be selected.
* Adds a custom line item sublabel for the DIFM Extra Page product in the shopping cart. 
* Removes the "Remove from cart" CTA for the DIFM Extra Page product.
* Minor Fix: If the Premium plan and DIFM product were in the cart, the Premium plan could not be removed from the cart. This condition has now been changed so that the same restriction applies to the Pro plan instead of the Premium plan.
* #64798 (Will be merged after CFT to be rebased with trunk after this PR is shipped)

#### Testing instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and go through the flow steps.
* On the page selector step, confirm that you can select all pages.
* Select more than 5 pages and proceed. 
* On the checkout screen, confirm that the extra quantity of the "Do It For Me: Extra Page" product is displayed correctly.
* Confirm that the "Do It For Me: Extra Page" product cannot be removed from the cart.
* Confirm that the "WordPress.com Pro" product cannot be removed from the cart when the "Do It For Me: Website Design Service" is in the cart.
<img width="600" alt="image" src="https://user-images.githubusercontent.com/5436027/163942007-18f9e219-da1f-489b-bb6e-d6fe4c0b3b0e.png">



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue
-->
Fixes Automattic/martech#836