### PR TITLE
Domains: Refactor `TrademarkClaimsNotice` away from `UNSAFE_` methods

### DIFF
--- a/client/components/domains/trademark-claims-notice/index.jsx
+++ b/client/components/domains/trademark-claims-notice/index.jsx
@@ -46,8 +46,7 @@ class TrademarkClaimsNotice extends Component {
 		};
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		if ( isEmpty( this.props.trademarkClaimsNoticeInfo ) && ! this.state.finishedFetching ) {
 			this.checkDomainAvailability().then( ( { trademarkClaimsNoticeInfo } ) => {
 				this.setState( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `TrademarkClaimsNotice` component away from the `UNSAFE_` deprecated React component methods.

See #32552 for more details on how the original functionality works.

Part of #58453.

#### Testing instructions
* Go to `/domains/add/:site` where `:site` is a WP.com simple site.
* Search for "dairyqueen.dev" in the domain search form.
* Click "Select".
* Verify you get the "dairyqueen.dev matches a trademark." message screen.
* Verify that you can still see the trademark notice by clicking the "Show trademark notice" button.
* Verify that after scrolling further down to read the trademark notice, you can continue with the purchase by clicking "Acknowledge Trademark".