### PR TITLE
Checkout: Refactor `CheckoutThankYou` away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -168,22 +168,19 @@ export class CheckoutThankYou extends Component {
 		window.scrollTo( 0, 0 );
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
+	componentDidUpdate( prevProps ) {
+		const { receiptId, selectedSiteSlug, domainOnlySiteFlow } = this.props;
+
 		this.redirectIfThemePurchased();
 
 		if (
-			! this.props.receipt.hasLoadedFromServer &&
-			nextProps.receipt.hasLoadedFromServer &&
-			this.hasPlanOrDomainProduct( nextProps ) &&
+			! prevProps.receipt.hasLoadedFromServer &&
+			this.props.receipt.hasLoadedFromServer &&
+			this.hasPlanOrDomainProduct() &&
 			this.props.selectedSite
 		) {
 			this.props.refreshSitePlans( this.props.selectedSite.ID );
 		}
-	}
-
-	componentDidUpdate( prevProps ) {
-		const { receiptId, selectedSiteSlug, domainOnlySiteFlow } = this.props;
 
 		// Update route when an ecommerce site goes Atomic and site slug changes
 		// from 'wordpress.com` to `wpcomstaging.com`.
@@ -197,8 +194,8 @@ export class CheckoutThankYou extends Component {
 		}
 	}
 
-	hasPlanOrDomainProduct = ( props = this.props ) => {
-		return getPurchases( props ).some(
+	hasPlanOrDomainProduct = () => {
+		return getPurchases( this.props ).some(
 			( purchase ) => isPlan( purchase ) || isDomainProduct( purchase )
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `CheckoutThankYou` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Purchase a premium theme.
* Verify that after the theme purchase, you're still redirected to `/themes/:site`.
* Smoke test checkout with a few other products, and verify that things still work as they did before.
* cc @sirbrillig for additional testing in case I'm missing a specific scenario.