### PR TITLE
Login: Remove unused `isRequestingTwoFactorAuth` state

### DIFF
--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -320,19 +320,6 @@ export const twoFactorAuth = ( state = null, action ) => {
 	return state;
 };
 
-export const isRequestingTwoFactorAuth = ( state = false, action ) => {
-	switch ( action.type ) {
-		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST:
-			return true;
-		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE:
-			return false;
-		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS:
-			return false;
-	}
-
-	return state;
-};
-
 export const twoFactorAuthRequestError = ( state = null, action ) => {
 	switch ( action.type ) {
 		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST:
@@ -444,7 +431,6 @@ const combinedReducer = combineReducers( {
 	authAccountType,
 	isFormDisabled,
 	isRequesting,
-	isRequestingTwoFactorAuth,
 	lastCheckedUsernameOrEmail,
 	magicLogin,
 	redirectTo,

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -47,14 +47,6 @@ export const getTwoFactorPushToken = ( state ) => state.login.twoFactorAuth?.pus
 export const isTwoFactorEnabled = ( state ) => state.login.twoFactorAuth != null;
 
 /**
- * Determines whether a request to authenticate 2FA is being made.
- *
- * @param  {object}   state  Global state tree
- * @returns {boolean}         Whether a request to authenticate 2FA is being made.
- */
-export const isRequestingTwoFactorAuth = ( state ) => state.login.isRequestingTwoFactorAuth;
-
-/**
  * Returns the error for a request to authenticate 2FA.
  *
  * @param  {object}   state  Global state tree

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -23,7 +23,6 @@ import {
 import reducer, {
 	isRequesting,
 	isFormDisabled,
-	isRequestingTwoFactorAuth,
 	requestError,
 	requestNotice,
 	requestSuccess,
@@ -39,7 +38,6 @@ describe( 'reducer', () => {
 			'authAccountType',
 			'isFormDisabled',
 			'isRequesting',
-			'isRequestingTwoFactorAuth',
 			'lastCheckedUsernameOrEmail',
 			'magicLogin',
 			'redirectTo',
@@ -142,38 +140,6 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.be.true;
-		} );
-	} );
-
-	describe( 'isRequestingTwoFactorAuth', () => {
-		test( 'should default to a false', () => {
-			const state = isRequestingTwoFactorAuth( undefined, {} );
-
-			expect( state ).to.be.false;
-		} );
-
-		test( 'should set isRequesting to true value if a request is initiated', () => {
-			const state = isRequestingTwoFactorAuth( undefined, {
-				type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST,
-			} );
-
-			expect( state ).to.be.true;
-		} );
-
-		test( 'should set isRequesting to false value if a request was unsuccessful', () => {
-			const state = isRequestingTwoFactorAuth( undefined, {
-				type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE,
-			} );
-
-			expect( state ).to.be.false;
-		} );
-
-		test( 'should set isRequesting to false value if a request was successful', () => {
-			const state = isRequestingTwoFactorAuth( undefined, {
-				type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS,
-			} );
-
-			expect( state ).to.be.false;
 		} );
 	} );
 

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -8,7 +8,6 @@ import {
 	getTwoFactorSupportedAuthTypes,
 	getTwoFactorUserId,
 	isRequesting,
-	isRequestingTwoFactorAuth,
 	isTwoFactorAuthTypeSupported,
 	isTwoFactorEnabled,
 	isFormDisabled,
@@ -80,32 +79,6 @@ describe( 'selectors', () => {
 			);
 
 			expect( nonce ).toBe( 'abcdef123456' );
-		} );
-	} );
-
-	describe( 'isRequestingTwoFactorAuth', () => {
-		test( 'should return false by default', () => {
-			expect( isRequestingTwoFactorAuth( EMPTY_STATE ) ).toBe( false );
-		} );
-
-		test( 'should return true if the request is in progress', () => {
-			expect(
-				isRequestingTwoFactorAuth( {
-					login: {
-						isRequestingTwoFactorAuth: true,
-					},
-				} )
-			).toBe( true );
-		} );
-
-		test( 'should return false if the request is not in progress', () => {
-			expect(
-				isRequestingTwoFactorAuth( {
-					login: {
-						isRequestingTwoFactorAuth: false,
-					},
-				} )
-			).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the `isRequestingTwoFactorAuth` reducer and selector, since it's never been used since its creation in #13635.

#### Testing instructions

* Verify removed code is not in use.
* Verify tests pass.
* Smoke test `/log-in` with a user with 2FA enabled.