### PR TITLE
Seller Experience-Stepper: WooCommerce upgrade eligibility data store

### DIFF
--- a/client/landing/stepper/stores.ts
+++ b/client/landing/stepper/stores.ts
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Onboard, Site, ProductsList, User } from '@automattic/data-stores';
+import { Onboard, Site, ProductsList, User, AutomatedTransferEligibility } from '@automattic/data-stores';
 
 export const ONBOARD_STORE = Onboard.register();
 export const SITE_STORE = Site.register( {
@@ -7,7 +7,10 @@ export const SITE_STORE = Site.register( {
 	client_secret: config( 'wpcom_signup_key' ),
 } );
 export const PRODUCTS_LIST_STORE = ProductsList.register();
+
 export const USER_STORE = User.register( {
 	client_id: config( 'wpcom_signup_id' ),
 	client_secret: config( 'wpcom_signup_key' ),
 } );
+
+export const WOOCOMMERCE_ELIGIBILITY_STORE = AutomatedTransferEligibility.register();

--- a/client/landing/stepper/stores.ts
+++ b/client/landing/stepper/stores.ts
@@ -1,5 +1,11 @@
 import config from '@automattic/calypso-config';
-import { Onboard, Site, ProductsList, User, AutomatedTransferEligibility } from '@automattic/data-stores';
+import {
+	Onboard,
+	Site,
+	ProductsList,
+	User,
+	AutomatedTransferEligibility,
+} from '@automattic/data-stores';
 
 export const ONBOARD_STORE = Onboard.register();
 export const SITE_STORE = Site.register( {

--- a/packages/data-stores/src/automated-transfer-eligibility/actions.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/actions.ts
@@ -1,0 +1,15 @@
+import { TransferEligibility } from './types';
+
+export const receiveTransferEligibility = (
+	transferEligibility: TransferEligibility,
+	siteId: number
+) => ( {
+	type: 'TRANSFER_ELIGIBILITY_RECEIVE' as const,
+	transferEligibility,
+	siteId,
+} );
+
+export type Action =
+	| ReturnType< typeof receiveTransferEligibility >
+	// Type added so we can dispatch actions in tests, but has no runtime cost
+	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/automated-transfer-eligibility/constants.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/constants.ts
@@ -1,0 +1,44 @@
+import { StatusMapping } from './types';
+
+export const STORE_KEY = 'automattic/automated-transfer-eligibility';
+
+const eligibilityHolds = {
+	BLOCKED_ATOMIC_TRANSFER: 'BLOCKED_ATOMIC_TRANSFER',
+	TRANSFER_ALREADY_EXISTS: 'TRANSFER_ALREADY_EXISTS',
+	NO_BUSINESS_PLAN: 'NO_BUSINESS_PLAN',
+	NO_JETPACK_SITES: 'NO_JETPACK_SITES',
+	NO_VIP_SITES: 'NO_VIP_SITES',
+	SITE_PRIVATE: 'SITE_PRIVATE',
+	// SITE_UNLAUNCHED is a client constant to differentiate between launched private sites, and unlaunched sites.
+	// See: client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+	SITE_UNLAUNCHED: 'SITE_UNLAUNCHED',
+	SITE_GRAYLISTED: 'SITE_GRAYLISTED',
+	NON_ADMIN_USER: 'NON_ADMIN_USER',
+	NOT_RESOLVING_TO_WPCOM: 'NOT_RESOLVING_TO_WPCOM',
+	NO_SSL_CERTIFICATE: 'NO_SSL_CERTIFICATE',
+	EMAIL_UNVERIFIED: 'EMAIL_UNVERIFIED',
+	EXCESSIVE_DISK_SPACE: 'EXCESSIVE_DISK_SPACE',
+};
+
+/**
+ * Maps the constants used in the WordPress.com API with
+ * those used inside of Calypso. Somewhat redundant, this
+ * provides safety for when the API changes. We need not
+ * changes the constants in the Calypso side, only here
+ * in the code directly dealing with the API.
+ */
+
+export const statusMapping: StatusMapping = {
+	blocked_atomic_transfer: eligibilityHolds.BLOCKED_ATOMIC_TRANSFER,
+	transfer_already_exists: eligibilityHolds.TRANSFER_ALREADY_EXISTS,
+	no_business_plan: eligibilityHolds.NO_BUSINESS_PLAN,
+	no_jetpack_sites: eligibilityHolds.NO_JETPACK_SITES,
+	no_vip_sites: eligibilityHolds.NO_VIP_SITES,
+	site_private: eligibilityHolds.SITE_PRIVATE,
+	site_graylisted: eligibilityHolds.SITE_GRAYLISTED,
+	non_admin_user: eligibilityHolds.NON_ADMIN_USER,
+	not_resolving_to_wpcom: eligibilityHolds.NOT_RESOLVING_TO_WPCOM,
+	no_ssl_certificate: eligibilityHolds.NO_SSL_CERTIFICATE,
+	email_unverified: eligibilityHolds.EMAIL_UNVERIFIED,
+	excessive_disk_space: eligibilityHolds.EXCESSIVE_DISK_SPACE,
+};

--- a/packages/data-stores/src/automated-transfer-eligibility/index.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/index.ts
@@ -1,0 +1,32 @@
+import { registerStore } from '@wordpress/data';
+import { controls } from '../wpcom-request-controls';
+import * as actions from './actions';
+import { STORE_KEY } from './constants';
+import reducer, { RootState as State } from './reducer';
+import * as resolvers from './resolvers';
+import * as selectors from './selectors';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+
+export * from './types';
+export type { State };
+export { STORE_KEY };
+
+let isRegistered = false;
+export function register(): typeof STORE_KEY {
+	if ( ! isRegistered ) {
+		isRegistered = true;
+		registerStore< State >( STORE_KEY, {
+			actions,
+			controls: controls as any,
+			reducer,
+			resolvers,
+			selectors,
+		} );
+	}
+	return STORE_KEY;
+}
+
+declare module '@wordpress/data' {
+	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
+}

--- a/packages/data-stores/src/automated-transfer-eligibility/index.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/index.ts
@@ -1,5 +1,4 @@
 import { registerStore } from '@wordpress/data';
-import { controls } from '../wpcom-request-controls';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { RootState as State } from './reducer';
@@ -17,7 +16,6 @@ export function register(): typeof STORE_KEY {
 		isRegistered = true;
 		registerStore< State >( STORE_KEY, {
 			actions,
-			controls: controls as any,
 			reducer,
 			resolvers,
 			selectors,

--- a/packages/data-stores/src/automated-transfer-eligibility/index.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/index.ts
@@ -20,6 +20,9 @@ export function register(): typeof STORE_KEY {
 			reducer,
 			resolvers,
 			selectors,
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore Object literal may only specify known properties
+			__experimentalUseThunks: true,
 		} );
 	}
 	return STORE_KEY;

--- a/packages/data-stores/src/automated-transfer-eligibility/index.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/index.ts
@@ -1,9 +1,10 @@
 import { registerStore } from '@wordpress/data';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
-import reducer, { RootState as State } from './reducer';
+import reducer from './reducer';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
+import { State } from './types';
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 
 export * from './types';

--- a/packages/data-stores/src/automated-transfer-eligibility/index.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/index.ts
@@ -19,6 +19,8 @@ export function register(): typeof STORE_KEY {
 			actions,
 			reducer,
 			resolvers,
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore Until createRegistrySelector is typed correctly
 			selectors,
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore Object literal may only specify known properties

--- a/packages/data-stores/src/automated-transfer-eligibility/reducer.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/reducer.ts
@@ -1,0 +1,25 @@
+import { combineReducers } from '@wordpress/data';
+import { State } from './types';
+import type { Action } from './actions';
+import type { Reducer } from 'redux';
+
+export const transferEligibility: Reducer< State, Action > = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case 'TRANSFER_ELIGIBILITY_RECEIVE': {
+			return {
+				...state,
+				[ action.siteId ]: action.transferEligibility,
+			};
+		}
+	}
+
+	return state;
+};
+
+const reducer = combineReducers( {
+	transferEligibility,
+} );
+
+export type RootState = ReturnType< typeof reducer >;
+
+export default reducer;

--- a/packages/data-stores/src/automated-transfer-eligibility/reducer.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/reducer.ts
@@ -15,6 +15,4 @@ export const transferEligibility: Reducer< State, Action > = ( state = {}, actio
 	return state;
 };
 
-export type RootState = ReturnType< typeof transferEligibility >;
-
 export default transferEligibility;

--- a/packages/data-stores/src/automated-transfer-eligibility/reducer.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/reducer.ts
@@ -1,4 +1,3 @@
-import { combineReducers } from '@wordpress/data';
 import { State } from './types';
 import type { Action } from './actions';
 import type { Reducer } from 'redux';
@@ -16,10 +15,6 @@ export const transferEligibility: Reducer< State, Action > = ( state = {}, actio
 	return state;
 };
 
-const reducer = combineReducers( {
-	transferEligibility,
-} );
+export type RootState = ReturnType< typeof transferEligibility >;
 
-export type RootState = ReturnType< typeof reducer >;
-
-export default reducer;
+export default transferEligibility;

--- a/packages/data-stores/src/automated-transfer-eligibility/resolvers.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/resolvers.ts
@@ -1,0 +1,17 @@
+import wpcomRequest from 'wpcom-proxy-request';
+import { TransferEligibility, Dispatch } from './types';
+
+/**
+ * Requests the site's transfer eligibility from the WPCOM API.
+ *
+ * @param   {number} siteId The id of the site to retrieve
+ */
+export const getAutomatedTransferEligibility =
+	( siteId: number ) =>
+	async ( { dispatch }: Dispatch ) => {
+		const transferEligibility: TransferEligibility = await wpcomRequest( {
+			path: `/sites/${ siteId }/automated-transfers/eligibility`,
+			apiVersion: '1',
+		} );
+		dispatch.receiveTransferEligibility( transferEligibility, siteId );
+	};

--- a/packages/data-stores/src/automated-transfer-eligibility/selectors.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/selectors.ts
@@ -1,0 +1,85 @@
+import { select } from '@wordpress/data';
+import { STORE_KEY, statusMapping } from './constants';
+import { RootState as State } from './reducer';
+import { TransferEligibilityWarning, TransferEligibilityError, TransferEligibility } from './types';
+
+export const getAutomatedTransferEligibility = (
+	state: State,
+	siteId: number | null
+): TransferEligibility | null => {
+	if ( ! siteId ) {
+		return null;
+	}
+	return state.transferEligibility[ siteId ];
+};
+
+export const getEligibilityHolds = (
+	state: State,
+	siteId: number | null
+): TransferEligibilityError[] | null => {
+	const transferEligibility = select( STORE_KEY ).getAutomatedTransferEligibility( siteId );
+
+	if ( ! transferEligibility ) {
+		return null;
+	}
+
+	const { errors } = transferEligibility;
+
+	if ( ! errors ) {
+		return null;
+	}
+
+	return errors.map( ( { code } ) => {
+		return statusMapping[ code ] ?? '';
+	} );
+};
+
+export const getEligibilityWarnings = (
+	state: State,
+	siteId: number | null
+): TransferEligibilityWarning[] | null => {
+	const transferEligibility = select( STORE_KEY ).getAutomatedTransferEligibility( siteId );
+
+	if ( ! transferEligibility ) {
+		return null;
+	}
+
+	const { warnings } = transferEligibility;
+
+	if ( ! warnings ) {
+		return null;
+	}
+
+	// combine plugin and theme warnings into one list
+	const combined = Object.values( warnings ).flat();
+
+	return combined.map( ( { description, name, supportUrl, id } ) => ( {
+		id,
+		name,
+		description,
+		supportUrl,
+	} ) );
+};
+
+export const getNonSubdomainWarnings = (
+	state: State,
+	siteId: number | null
+): TransferEligibilityWarning[] | null => {
+	const eligibilityWarnings = select( STORE_KEY ).getEligibilityWarnings( siteId );
+
+	if ( ! eligibilityWarnings ) {
+		return null;
+	}
+
+	return eligibilityWarnings?.filter( ( { id } ) => id !== 'wordpress_subdomain' ) ?? null;
+};
+
+export const getWpcomSubdomainWarning = (
+	state: State,
+	siteId: number | null
+): TransferEligibilityWarning | null => {
+	const eligibilityWarnings = select( STORE_KEY ).getEligibilityWarnings( siteId );
+	const warning = eligibilityWarnings?.find( ( { id } ) => id === 'wordpress_subdomain' );
+
+	return warning || null;
+};

--- a/packages/data-stores/src/automated-transfer-eligibility/selectors.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/selectors.ts
@@ -1,7 +1,11 @@
 import { select } from '@wordpress/data';
 import { STORE_KEY, statusMapping } from './constants';
-import { RootState as State } from './reducer';
-import { TransferEligibilityWarning, TransferEligibilityError, TransferEligibility } from './types';
+import {
+	State,
+	TransferEligibilityWarning,
+	TransferEligibilityError,
+	TransferEligibility,
+} from './types';
 
 export const getAutomatedTransferEligibility = (
 	state: State,
@@ -10,7 +14,7 @@ export const getAutomatedTransferEligibility = (
 	if ( ! siteId ) {
 		return null;
 	}
-	return state.transferEligibility[ siteId ];
+	return state[ siteId ];
 };
 
 export const getEligibilityHolds = (

--- a/packages/data-stores/src/automated-transfer-eligibility/selectors.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/selectors.ts
@@ -1,4 +1,4 @@
-import { select } from '@wordpress/data';
+import { createRegistrySelector } from '@wordpress/data';
 import { STORE_KEY, statusMapping } from './constants';
 import {
 	State,
@@ -17,73 +17,81 @@ export const getAutomatedTransferEligibility = (
 	return state[ siteId ];
 };
 
-export const getEligibilityHolds = (
-	state: State,
-	siteId: number | null
-): TransferEligibilityError[] | null => {
-	const transferEligibility = select( STORE_KEY ).getAutomatedTransferEligibility( siteId );
+export const getEligibilityHolds = createRegistrySelector(
+	( select ) =>
+		( state: State, siteId: number | null ): TransferEligibilityError[] | null => {
+			const transferEligibility = select( STORE_KEY ).getAutomatedTransferEligibility( siteId );
 
-	if ( ! transferEligibility ) {
-		return null;
-	}
+			if ( ! transferEligibility ) {
+				return null;
+			}
 
-	const { errors } = transferEligibility;
+			const { errors } = transferEligibility;
 
-	if ( ! errors ) {
-		return null;
-	}
+			if ( ! errors ) {
+				return null;
+			}
 
-	return errors.map( ( { code } ) => {
-		return statusMapping[ code ] ?? '';
-	} );
-};
+			return errors.map( ( { code } ) => {
+				return statusMapping[ code ] ?? '';
+			} );
+		}
+);
 
-export const getEligibilityWarnings = (
-	state: State,
-	siteId: number | null
-): TransferEligibilityWarning[] | null => {
-	const transferEligibility = select( STORE_KEY ).getAutomatedTransferEligibility( siteId );
+export const getEligibilityWarnings = createRegistrySelector(
+	( select ) =>
+		( state: State, siteId: number | null ): TransferEligibilityWarning[] | null => {
+			const transferEligibility = select( STORE_KEY ).getAutomatedTransferEligibility( siteId );
 
-	if ( ! transferEligibility ) {
-		return null;
-	}
+			if ( ! transferEligibility ) {
+				return null;
+			}
 
-	const { warnings } = transferEligibility;
+			const { warnings } = transferEligibility;
 
-	if ( ! warnings ) {
-		return null;
-	}
+			if ( ! warnings ) {
+				return null;
+			}
 
-	// combine plugin and theme warnings into one list
-	const combined = Object.values( warnings ).flat();
+			// combine plugin and theme warnings into one list
+			const combined = Object.values( warnings ).flat();
 
-	return combined.map( ( { description, name, supportUrl, id } ) => ( {
-		id,
-		name,
-		description,
-		supportUrl,
-	} ) );
-};
+			return combined.map( ( { description, name, supportUrl, id } ) => ( {
+				id,
+				name,
+				description,
+				supportUrl,
+			} ) );
+		}
+);
 
-export const getNonSubdomainWarnings = (
-	state: State,
-	siteId: number | null
-): TransferEligibilityWarning[] | null => {
-	const eligibilityWarnings = select( STORE_KEY ).getEligibilityWarnings( siteId );
+export const getNonSubdomainWarnings = createRegistrySelector(
+	( select ) =>
+		( state: State, siteId: number | null ): TransferEligibilityWarning[] | null => {
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore Until createRegistrySelector is typed correctly
+			const eligibilityWarnings = select( STORE_KEY ).getEligibilityWarnings( siteId );
 
-	if ( ! eligibilityWarnings ) {
-		return null;
-	}
+			if ( ! eligibilityWarnings ) {
+				return null;
+			}
 
-	return eligibilityWarnings?.filter( ( { id } ) => id !== 'wordpress_subdomain' ) ?? null;
-};
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore Until createRegistrySelector is typed correctly
+			return eligibilityWarnings?.filter( ( { id } ) => id !== 'wordpress_subdomain' ) ?? null;
+		}
+);
 
-export const getWpcomSubdomainWarning = (
-	state: State,
-	siteId: number | null
-): TransferEligibilityWarning | null => {
-	const eligibilityWarnings = select( STORE_KEY ).getEligibilityWarnings( siteId );
-	const warning = eligibilityWarnings?.find( ( { id } ) => id === 'wordpress_subdomain' );
+export const getWpcomSubdomainWarning = createRegistrySelector(
+	( select ) =>
+		( state: State, siteId: number | null ): TransferEligibilityWarning | null => {
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore Until createRegistrySelector is typed correctly
+			const eligibilityWarnings = select( STORE_KEY ).getEligibilityWarnings( siteId );
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore Until createRegistrySelector is typed correctly
+			const warning = eligibilityWarnings?.find( ( { id } ) => id === 'wordpress_subdomain' );
 
-	return warning || null;
-};
+			return warning || null;
+		}
+);

--- a/packages/data-stores/src/automated-transfer-eligibility/test/reducer.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/test/reducer.ts
@@ -1,0 +1,60 @@
+import { transferEligibility } from '../reducer';
+import { TransferEligibility } from '../types';
+
+describe( 'reducer', () => {
+	it( 'returns the correct default state', () => {
+		const state = transferEligibility( undefined, { type: 'TEST_ACTION' } );
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'keys transfer eligibility by site id', () => {
+		let state = {};
+		const expectedTransferEligibility: TransferEligibility = {
+			errors: [],
+			warnings: {
+				plugins: [],
+				widgets: [],
+				subdomain: [],
+			},
+			is_eligible: false,
+		};
+		const updatedExpectedTransferEligibility: TransferEligibility = {
+			errors: [ { code: '1234', message: 'error 1234' } ],
+			warnings: {
+				plugins: [],
+				widgets: [],
+				subdomain: [],
+			},
+			is_eligible: true,
+		};
+
+		state = transferEligibility( state, {
+			type: 'TRANSFER_ELIGIBILITY_RECEIVE',
+			siteId: 1234,
+			transferEligibility: expectedTransferEligibility,
+		} );
+		expect( state ).toEqual( {
+			[ 1234 ]: expectedTransferEligibility,
+		} );
+
+		state = transferEligibility( state, {
+			type: 'TRANSFER_ELIGIBILITY_RECEIVE',
+			siteId: 4321,
+			transferEligibility: expectedTransferEligibility,
+		} );
+		expect( state ).toEqual( {
+			[ 1234 ]: expectedTransferEligibility,
+			[ 4321 ]: expectedTransferEligibility,
+		} );
+
+		state = transferEligibility( state, {
+			type: 'TRANSFER_ELIGIBILITY_RECEIVE',
+			siteId: 1234,
+			transferEligibility: updatedExpectedTransferEligibility,
+		} );
+		expect( state ).toEqual( {
+			[ 1234 ]: updatedExpectedTransferEligibility,
+			[ 4321 ]: expectedTransferEligibility,
+		} );
+	} );
+} );

--- a/packages/data-stores/src/automated-transfer-eligibility/types.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/types.ts
@@ -1,0 +1,42 @@
+import * as actions from './actions';
+import type { DispatchFromMap } from '../mapped-types';
+
+export interface Dispatch {
+	dispatch: DispatchFromMap< typeof actions >;
+}
+
+export interface TransferEligibilityError {
+	code: string;
+	message: string;
+}
+
+export interface TransferEligibilityWarning {
+	description: string;
+	id: string;
+	name: string;
+	supportUrl: string | undefined;
+}
+
+export interface TransferEligibilityWarningsType {
+	[ index: string ]: TransferEligibilityWarning[];
+
+	plugins: TransferEligibilityWarning[];
+	widgets: TransferEligibilityWarning[];
+	subdomain: TransferEligibilityWarning[];
+}
+
+export interface TransferEligibility {
+	[ index: number ]: TransferEligibility;
+
+	errors: TransferEligibilityError[];
+	is_eligible: boolean;
+	warnings: TransferEligibilityWarningsType;
+}
+
+export type State = {
+	[ key: number ]: TransferEligibility;
+};
+
+export interface StatusMapping {
+	[ key: string ]: any;
+}

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -1,4 +1,5 @@
 import * as Auth from './auth';
+import * as AutomatedTransferEligibility from './automated-transfer-eligibility';
 import * as DomainSuggestions from './domain-suggestions';
 import * as HelpCenter from './help-center';
 import * as I18n from './i18n';
@@ -30,6 +31,7 @@ export {
 	Onboard,
 	persistenceConfigFactory,
 	ProductsList,
+	AutomatedTransferEligibility,
 };
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Data store for checking WooCommerce upgrade eligibility
    
Based on `client/state/data-layer/wpcom/sites/automated-transfer/eligibility`
    
Includes selectors for:
    
- The complete set of transfer eligibility data
- Eligibility holds
- Eligibility warnings
- General subdomain warnings
- WordPress.com subdomain warnings

#### Testing instructions

`yarn test-packages packages/data-stores/src/woocommerce-eligibility/test/`

Related to #62714
Fixes #62914