### PR TITLE
Seller Experience - Stepper: Added a products-list data-store package

### DIFF
--- a/client/landing/stepper/stores.ts
+++ b/client/landing/stepper/stores.ts
@@ -1,8 +1,9 @@
 import config from '@automattic/calypso-config';
-import { Onboard, Site } from '@automattic/data-stores';
+import { Onboard, Site, ProductsList } from '@automattic/data-stores';
 
 export const ONBOARD_STORE = Onboard.register();
 export const SITE_STORE = Site.register( {
 	client_id: config( 'wpcom_signup_id' ),
 	client_secret: config( 'wpcom_signup_key' ),
 } );
+export const PRODUCTS_LIST_STORE = ProductsList.register();

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -6,6 +6,7 @@ import * as Launch from './launch';
 import * as Onboard from './onboard';
 import persistenceConfigFactory from './persistence-config-factory';
 import * as Plans from './plans';
+import * as ProductsList from './products-list';
 import * as Reader from './reader';
 import * as Site from './site';
 import * as User from './user';
@@ -28,6 +29,7 @@ export {
 	Reader,
 	Onboard,
 	persistenceConfigFactory,
+	ProductsList,
 };
 
 /**

--- a/packages/data-stores/src/products-list/actions.ts
+++ b/packages/data-stores/src/products-list/actions.ts
@@ -1,0 +1,23 @@
+import type { ProductsList, ProductsListFailure } from './types';
+
+export const receiveProductsList = ( productsList: ProductsList ) => {
+	return {
+		type: 'PRODUCTS_LIST_RECEIVE' as const,
+		productsList,
+	};
+};
+
+export const requestProductsList = () => ( {
+	type: 'PRODUCTS_LIST_REQUEST' as const,
+} );
+
+export const receiveProductsListFailure = ( error: ProductsListFailure ) => ( {
+	type: 'PRODUCTS_LIST_REQUEST_FAILURE' as const,
+	error,
+} );
+
+export type Action =
+	| ReturnType<
+			typeof receiveProductsList | typeof requestProductsList | typeof receiveProductsListFailure
+	  >
+	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/products-list/constants.ts
+++ b/packages/data-stores/src/products-list/constants.ts
@@ -1,0 +1,1 @@
+export const STORE_KEY = 'automattic/products-list';

--- a/packages/data-stores/src/products-list/index.ts
+++ b/packages/data-stores/src/products-list/index.ts
@@ -1,0 +1,32 @@
+import { registerStore } from '@wordpress/data';
+import { controls } from '../wpcom-request-controls';
+import * as actions from './actions';
+import { STORE_KEY } from './constants';
+import reducer, { State } from './reducer';
+import * as resolvers from './resolvers';
+import * as selectors from './selectors';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+
+export * from './types';
+export type { State };
+export { STORE_KEY };
+
+let isRegistered = false;
+export function register(): typeof STORE_KEY {
+	if ( ! isRegistered ) {
+		isRegistered = true;
+		registerStore< State >( STORE_KEY, {
+			actions,
+			controls: controls as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+			reducer: reducer as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+			resolvers,
+			selectors,
+		} );
+	}
+	return STORE_KEY;
+}
+
+declare module '@wordpress/data' {
+	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
+}

--- a/packages/data-stores/src/products-list/reducer.ts
+++ b/packages/data-stores/src/products-list/reducer.ts
@@ -1,0 +1,40 @@
+import { combineReducers } from '@wordpress/data';
+import { ProductsList } from './types';
+import type { Action } from './actions';
+import type { Reducer } from 'redux';
+
+// Stores the complete list of products, indexed by the product key
+export const productsList: Reducer< ProductsList | undefined, Action > = ( state, action ) => {
+	switch ( action.type ) {
+		case 'PRODUCTS_LIST_RECEIVE':
+			return action.productsList;
+	}
+
+	return state;
+};
+
+// Tracks product list fetching state
+export const isFetchingProductsList: Reducer< boolean | undefined, Action > = (
+	state = false,
+	action
+) => {
+	switch ( action.type ) {
+		case 'PRODUCTS_LIST_REQUEST':
+			return true;
+		case 'PRODUCTS_LIST_RECEIVE':
+			return false;
+		case 'PRODUCTS_LIST_REQUEST_FAILURE':
+			return false;
+	}
+
+	return state;
+};
+
+const reducer = combineReducers( {
+	isFetchingProductsList,
+	productsList,
+} );
+
+export type State = ReturnType< typeof reducer >;
+
+export default reducer;

--- a/packages/data-stores/src/products-list/resolvers.ts
+++ b/packages/data-stores/src/products-list/resolvers.ts
@@ -1,0 +1,27 @@
+import { wpcomRequest } from '../wpcom-request-controls';
+import { requestProductsList, receiveProductsList, receiveProductsListFailure } from './actions';
+import { ProductsList, ProductsListFailure } from './types';
+
+/**
+ * Requests the list of all products from the WPCOM API.
+ */
+export function* getProductsList() {
+	yield requestProductsList();
+
+	try {
+		const productsList: ProductsList = yield wpcomRequest( {
+			path: '/products',
+			apiVersion: '1.1',
+		} );
+
+		// Since the request succeeded, productsList should be guaranteed non-null;
+		// thus, we don't have any safety checks before this line.
+		for ( const product of Object.values( productsList ) ) {
+			product.cost = Number( product.cost );
+		}
+
+		yield receiveProductsList( productsList );
+	} catch ( err ) {
+		yield receiveProductsListFailure( err as ProductsListFailure );
+	}
+}

--- a/packages/data-stores/src/products-list/selectors.ts
+++ b/packages/data-stores/src/products-list/selectors.ts
@@ -1,0 +1,11 @@
+import type { State } from './reducer';
+
+export const getState = ( state: State ) => state;
+
+export const getProductsList = ( state: State ) => {
+	return state.productsList;
+};
+
+export const getProductBySlug = ( state: State, slug: string ) => {
+	return state.productsList?.[ slug ];
+};

--- a/packages/data-stores/src/products-list/test/actions.ts
+++ b/packages/data-stores/src/products-list/test/actions.ts
@@ -1,0 +1,55 @@
+import { requestProductsList, receiveProductsListFailure, receiveProductsList } from '../actions';
+import { ProductsList } from '../types';
+
+describe( 'actions', () => {
+	it( 'should return a PRODUCTS_LIST_REQUEST action', () => {
+		const expected = {
+			type: 'PRODUCTS_LIST_REQUEST',
+		};
+
+		expect( requestProductsList() ).toEqual( expected );
+	} );
+
+	it( 'should return a PRODUCTS_LIST_REQUEST_FAILURE action', () => {
+		const error = {
+			message: 'test error',
+		};
+
+		const expected = {
+			type: 'PRODUCTS_LIST_REQUEST_FAILURE',
+			error,
+		};
+
+		expect( receiveProductsListFailure( error ) ).toEqual( expected );
+	} );
+
+	it( 'should return a PRODUCTS_LIST_RECEIVE action', () => {
+		const productsList = {
+			test_product: {
+				available: true,
+				combined_cost_display: '$20.00',
+				cost: 20,
+				cost_display: '$20.00',
+				currency_code: 'USD',
+				description: 'test product',
+				is_domain_registration: false,
+				price_tier_list: [],
+				price_tier_slug: '',
+				price_tier_usage_quantity: null,
+				price_tiers: [],
+				product_id: 9,
+				product_name: '10GB',
+				product_slug: '1gb_space_upgrade',
+				product_term: 'year',
+				product_type: 'space',
+			},
+		} as ProductsList;
+
+		const expected = {
+			type: 'PRODUCTS_LIST_RECEIVE',
+			productsList,
+		};
+
+		expect( receiveProductsList( productsList ) ).toEqual( expected );
+	} );
+} );

--- a/packages/data-stores/src/products-list/test/reducer.ts
+++ b/packages/data-stores/src/products-list/test/reducer.ts
@@ -1,0 +1,25 @@
+import { productsList } from '../reducer';
+import { ProductsList } from '../types';
+
+describe( 'reducer', () => {
+	it( 'returns the correct default state', () => {
+		const state = productsList( undefined, { type: 'TEST_ACTION' } );
+		expect( state ).toEqual( undefined );
+	} );
+
+	it( 'returns the products list', () => {
+		const expectedProductsList = {
+			test_product: {
+				available: true,
+				cost: 20,
+			},
+		} as ProductsList;
+
+		const state = productsList( undefined, {
+			type: 'PRODUCTS_LIST_RECEIVE',
+			productsList: expectedProductsList,
+		} );
+
+		expect( state ).toEqual( expectedProductsList );
+	} );
+} );

--- a/packages/data-stores/src/products-list/test/resolvers.ts
+++ b/packages/data-stores/src/products-list/test/resolvers.ts
@@ -1,0 +1,39 @@
+/*
+ * These tests shouldn't require the jsdom environment,
+ * but we're waiting for this PR to merge:
+ * https://github.com/WordPress/gutenberg/pull/20486
+ *
+ * @jest-environment jsdom
+ */
+import { register } from '..';
+import { getProductsList } from '../resolvers';
+
+beforeAll( () => {
+	register();
+} );
+
+describe( 'getProductsList', () => {
+	it( 'should dispatch a requestProductsList action and return a receiveProductsList action', async () => {
+		const generator = getProductsList();
+		const apiResponse = {};
+
+		expect( await generator.next().value ).toEqual( {
+			type: 'PRODUCTS_LIST_REQUEST',
+		} );
+
+		expect( await generator.next().value ).toEqual( {
+			type: 'WPCOM_REQUEST',
+			request: expect.objectContaining( {
+				path: '/products',
+				apiVersion: '1.1',
+			} ),
+		} );
+
+		expect( await generator.next( apiResponse ).value ).toEqual( {
+			type: 'PRODUCTS_LIST_RECEIVE',
+			productsList: {},
+		} );
+
+		expect( generator.next().done ).toBe( true );
+	} );
+} );

--- a/packages/data-stores/src/products-list/test/selectors.ts
+++ b/packages/data-stores/src/products-list/test/selectors.ts
@@ -1,0 +1,54 @@
+/*
+ * These tests shouldn't require the jsdom environment,
+ * but we're waiting for this PR to merge:
+ * https://github.com/WordPress/gutenberg/pull/20486
+ *
+ * @jest-environment jsdom
+ */
+import { select, subscribe } from '@wordpress/data';
+import wpcomRequest from 'wpcom-proxy-request';
+import { register } from '..';
+
+jest.mock( 'wpcom-proxy-request', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+	requestAllBlogsAccess: jest.fn( () => Promise.resolve() ),
+} ) );
+
+let store: ReturnType< typeof register >;
+
+beforeAll( () => {
+	store = register();
+} );
+
+beforeEach( () => {
+	( wpcomRequest as jest.Mock ).mockReset();
+} );
+
+describe( 'selectors', () => {
+	it( 'resolves the state via an API call', async () => {
+		const apiResponse = {};
+
+		( wpcomRequest as jest.Mock ).mockResolvedValue( apiResponse );
+
+		const listenForStateUpdate = () => {
+			return new Promise( ( resolve ) => {
+				const unsubscribe = subscribe( () => {
+					unsubscribe();
+					resolve();
+				} );
+			} );
+		};
+
+		// First call returns undefined
+		expect( select( store ).getProductsList() ).toEqual( undefined );
+
+		// In the first state update, the resolver starts resolving
+		await listenForStateUpdate();
+
+		// In the second update, the resolver is finished resolving and we can read the result in state
+		await listenForStateUpdate();
+
+		expect( select( store ).getProductsList() ).toEqual( apiResponse );
+	} );
+} );

--- a/packages/data-stores/src/products-list/types.ts
+++ b/packages/data-stores/src/products-list/types.ts
@@ -1,0 +1,23 @@
+export interface ProductsListItem {
+	available: boolean;
+	combined_cost_display: string;
+	cost: number;
+	currency_code: string;
+	description: string;
+	is_domain_registration: boolean;
+	price_tier_list: any;
+	price_tier_lug: string;
+	price_tier_usage_quantity: number | null;
+	price_tiers: any;
+	product_id: number;
+	product_name: string;
+	product_slug: string;
+	product_term: string;
+	product_type: string;
+}
+
+export type ProductsList = Record< string, ProductsListItem >;
+
+export interface ProductsListFailure {
+	message: string;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is based on [client/state/products-list](https://github.com/Automattic/wp-calypso/tree/trunk/client/state/products-list) but only has the selector to return the complete list of products. The other selectors can be ported over as they're needed.

#### Testing instructions

Run `yarn run test-packages ./packages/data-stores/src/products-list/test/`

Related to #62714
Fixes #62913
