### PR TITLE
Stepper: Add necessary actions for Woo transfer steps

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -243,6 +243,39 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		siteId,
 	} );
 
+	function* initiateAtomicTransfer( siteId: number, softwareSet: string | undefined ) {
+		yield wpcomRequest( {
+			path: `/sites/${ encodeURIComponent( siteId ) }/atomic/transfers`,
+			apiNamespace: 'wpcom/v2',
+			method: 'POST',
+			...( softwareSet
+				? {
+						body: {
+							software_set: encodeURIComponent( softwareSet ),
+						},
+				  }
+				: {} ),
+		} );
+	}
+
+	function* requestLatestAtomicTransfer( siteId: number ) {
+		yield wpcomRequest( {
+			path: `/sites/${ encodeURIComponent( siteId ) }/atomic/transfers/latest`,
+			apiNamespace: 'wpcom/v2',
+			method: 'GET',
+		} );
+	}
+
+	function* requestAtomicSoftwareStatus( siteId: number, softwareSet: string ) {
+		yield wpcomRequest( {
+			path: `/sites/${ encodeURIComponent( siteId ) }/atomic/software/${ encodeURIComponent(
+				softwareSet
+			) }`,
+			apiNamespace: 'wpcom/v2',
+			method: 'GET',
+		} );
+	}
+
 	return {
 		receiveSiteDomains,
 		receiveSiteSettings,
@@ -270,6 +303,9 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		setCart,
 		setSiteSetupError,
 		clearSiteSetupError,
+		initiateAtomicTransfer,
+		requestLatestAtomicTransfer,
+		requestAtomicSoftwareStatus,
 	};
 }
 

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,6 +1,6 @@
 import { Design } from '@automattic/design-picker/src/types';
 import { wpcomRequest } from '../wpcom-request-controls';
-import { SiteLaunchError } from './types';
+import { SiteLaunchError, AtomicTransferError } from './types';
 import type { WpcomClientCredentials } from '../shared-types';
 import type {
 	CreateSiteParams,
@@ -11,6 +11,7 @@ import type {
 	Cart,
 	Domain,
 	SiteLaunchError as SiteLaunchErrorType,
+	AtomicTransferError as AtomicTransferErrorType,
 	SiteSettings,
 } from './types';
 
@@ -243,19 +244,48 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		siteId,
 	} );
 
+	const atomicTransferStart = ( siteId: number, softwareSet: string | undefined ) => ( {
+		type: 'ATOMIC_TRANSFER_START' as const,
+		siteId,
+		softwareSet,
+	} );
+
+	const atomicTransferSuccess = ( siteId: number, softwareSet: string | undefined ) => ( {
+		type: 'ATOMIC_TRANSFER_SUCCESS' as const,
+		siteId,
+		softwareSet,
+	} );
+
+	const atomicTransferFailure = (
+		siteId: number,
+		softwareSet: string | undefined,
+		error: AtomicTransferErrorType
+	) => ( {
+		type: 'ATOMIC_TRANSFER_FAILURE' as const,
+		siteId,
+		softwareSet,
+		error,
+	} );
+
 	function* initiateAtomicTransfer( siteId: number, softwareSet: string | undefined ) {
-		yield wpcomRequest( {
-			path: `/sites/${ encodeURIComponent( siteId ) }/atomic/transfers`,
-			apiNamespace: 'wpcom/v2',
-			method: 'POST',
-			...( softwareSet
-				? {
-						body: {
-							software_set: encodeURIComponent( softwareSet ),
-						},
-				  }
-				: {} ),
-		} );
+		yield atomicTransferStart( siteId, softwareSet );
+		try {
+			yield wpcomRequest( {
+				path: `/sites/${ encodeURIComponent( siteId ) }/atomic/transfers`,
+				apiNamespace: 'wpcom/v2',
+				method: 'POST',
+				...( softwareSet
+					? {
+							body: {
+								software_set: encodeURIComponent( softwareSet ),
+							},
+					  }
+					: {} ),
+			} );
+			yield atomicTransferSuccess( siteId, softwareSet );
+		} catch ( _ ) {
+			yield atomicTransferFailure( siteId, softwareSet, AtomicTransferError.INTERNAL );
+		}
 	}
 
 	function* requestLatestAtomicTransfer( siteId: number ) {
@@ -304,6 +334,9 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		setSiteSetupError,
 		clearSiteSetupError,
 		initiateAtomicTransfer,
+		atomicTransferStart,
+		atomicTransferSuccess,
+		atomicTransferFailure,
 		requestLatestAtomicTransfer,
 		requestAtomicSoftwareStatus,
 	};
@@ -329,6 +362,9 @@ export type Action =
 			| ActionCreators[ 'launchSiteStart' ]
 			| ActionCreators[ 'launchSiteSuccess' ]
 			| ActionCreators[ 'launchSiteFailure' ]
+			| ActionCreators[ 'atomicTransferStart' ]
+			| ActionCreators[ 'atomicTransferSuccess' ]
+			| ActionCreators[ 'atomicTransferFailure' ]
 	  >
 	// Type added so we can dispatch actions in tests, but has no runtime cost
 	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -7,7 +7,9 @@ import {
 	SiteLaunchState,
 	SiteLaunchStatus,
 	SiteSettings,
+	AtomicTransferStatus,
 } from './types';
+import { AtomicTransferState } from '.';
 import type { Action } from './actions';
 import type { Reducer } from 'redux';
 
@@ -194,6 +196,43 @@ export const siteSetupErrors: Reducer<
 	return state;
 };
 
+export const atomicTransferStatus: Reducer< { [ key: number ]: AtomicTransferState }, Action > = (
+	state = {},
+	action
+) => {
+	if ( action.type === 'ATOMIC_TRANSFER_START' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				status: AtomicTransferStatus.IN_PROGRESS,
+				softwareSet: action.softwareSet,
+				errorCode: undefined,
+			},
+		};
+	}
+	if ( action.type === 'ATOMIC_TRANSFER_SUCCESS' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				status: AtomicTransferStatus.SUCCESS,
+				softwareSet: action.softwareSet,
+				errorCode: undefined,
+			},
+		};
+	}
+	if ( action.type === 'ATOMIC_TRANSFER_FAILURE' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				status: AtomicTransferStatus.FAILURE,
+				softwareSet: action.softwareSet,
+				errorCode: action.error,
+			},
+		};
+	}
+	return state;
+};
+
 const newSite = combineReducers( {
 	data: newSiteData,
 	error: newSiteError,
@@ -208,6 +247,7 @@ const reducer = combineReducers( {
 	sitesDomains,
 	sitesSettings,
 	siteSetupErrors,
+	atomicTransferStatus,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -112,4 +112,60 @@ describe( 'Site Actions', () => {
 			expect( finalResult.done ).toBe( true );
 		} );
 	} );
+
+	describe( 'Atomic Actions', () => {
+		it( 'should start an Atomic transfer', () => {
+			const { initiateAtomicTransfer } = createActions( mockedClientCredentials );
+			const softwareSet = 'woo-on-plans';
+			const generator = initiateAtomicTransfer( siteId, softwareSet );
+
+			const mockedApiResponse = {
+				request: {
+					apiNamespace: 'wpcom/v2',
+					method: 'POST',
+					path: `/sites/${ siteId }/atomic/transfers`,
+					body: { software_set: softwareSet },
+				},
+				type: 'WPCOM_REQUEST',
+			};
+
+			// First iteration: WP_COM_REQUEST is fired
+			expect( generator.next().value ).toEqual( mockedApiResponse );
+		} );
+
+		it( 'should request the Atomic transfer status', () => {
+			const { requestLatestAtomicTransfer } = createActions( mockedClientCredentials );
+			const generator = requestLatestAtomicTransfer( siteId );
+
+			const mockedApiResponse = {
+				request: {
+					apiNamespace: 'wpcom/v2',
+					method: 'GET',
+					path: `/sites/${ siteId }/atomic/transfers/latest`,
+				},
+				type: 'WPCOM_REQUEST',
+			};
+
+			// First iteration: WP_COM_REQUEST is fired
+			expect( generator.next().value ).toEqual( mockedApiResponse );
+		} );
+
+		it( 'should request the Atomic software install status', () => {
+			const { requestAtomicSoftwareStatus } = createActions( mockedClientCredentials );
+			const softwareSet = 'woo-on-plans';
+			const generator = requestAtomicSoftwareStatus( siteId, softwareSet );
+
+			const mockedApiResponse = {
+				request: {
+					apiNamespace: 'wpcom/v2',
+					method: 'GET',
+					path: `/sites/${ siteId }/atomic/software/${ softwareSet }`,
+				},
+				type: 'WPCOM_REQUEST',
+			};
+
+			// First iteration: WP_COM_REQUEST is fired
+			expect( generator.next().value ).toEqual( mockedApiResponse );
+		} );
+	} );
 } );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -299,3 +299,19 @@ export enum SiteLaunchStatus {
 	SUCCESS = 'success',
 	FAILURE = 'failure',
 }
+
+export interface AtomicTransferState {
+	status: AtomicTransferStatus;
+	errorCode: AtomicTransferError | undefined;
+}
+
+export enum AtomicTransferStatus {
+	UNINITIALIZED = 'unintialized',
+	IN_PROGRESS = 'in_progress',
+	SUCCESS = 'success',
+	FAILURE = 'failure',
+}
+
+export enum AtomicTransferError {
+	INTERNAL = 'internal',
+}


### PR DESCRIPTION
Implement actions necessary for implementing WooCommerce transfer steps.

#### Testing
This actions are not being used yet. For the time being you can run:
```
yarn run test-packages packages/data-stores/src/site/test/actions.ts
```
and verify everything passes correctly and read the code to see if it makes sense.

Closes https://github.com/Automattic/wp-calypso/issues/62863