### PR TITLE
Fix variable font styling in threat descriptions

### DIFF
--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -117,14 +117,16 @@ const ThreatItem: React.FC< Props > = ( {
 		}
 
 		return (
-			<p className="threat-item threat-description__section-text">
-				{ getThreatFix( threat.fixable ) }
-				<p>
+			<>
+				<p className="threat-item threat-description__section-text">
 					{ translate(
 						'Jetpack Scan is able to automatically fix this threat for you. Since it will replace the affected file or directory the site’s look-and-feel or features can be compromised. We recommend that you check if your latest backup was performed successfully in case a restore is needed.'
 					) }
 				</p>
-			</p>
+				<p className="threat-item threat-description__section-text">
+					{ getThreatFix( threat.fixable ) }
+				</p>
+			</>
 		);
 	}, [ threat ] );
 


### PR DESCRIPTION
Fixes 7366-gh-Automattic/jpop-issues

#### Changes proposed in this Pull Request

* Fixes nested paragraphs in `.threat-item` description.
* Re-orders paragraphs.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `git checkout fix/threat-description-font-size` and `yarn start`
* Visit http://calypso.localhost:3000/scan/[SITE_URL] and view a vulnerability.
* Validate the screenshots below.

#### Screenshots

Before

<img width="596" alt="Screen Shot 2022-04-18 at 2 08 47 PM" src="https://user-images.githubusercontent.com/10933065/163870234-fcdd01fa-1e71-42ed-bb74-49703f6cc502.png">

After

<img width="609" alt="Screen Shot 2022-04-18 at 2 08 20 PM" src="https://user-images.githubusercontent.com/10933065/163870256-9de4cf75-f742-4419-a9df-b4d85c9c009b.png">
