### PR TITLE
Navigation Block: Open manage menus in parent frame

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -589,7 +589,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 		}
 		e.preventDefault();
 		calypsoPort.postMessage( {
-			action: 'viewPost',
+			action: 'openLinkInParentFrame',
 			payload: { postUrl: e.target.href },
 		} );
 	} );
@@ -716,8 +716,26 @@ async function openLinksInParentFrame( calypsoPort ) {
 					const manageReusableBlocksAnchorElem = node.querySelector(
 						'a[href$="edit.php?post_type=wp_block"]'
 					);
+					const manageNavigationMenusAnchorElem = node.querySelector(
+						'a[href$="edit.php?post_type=wp_navigation"]'
+					);
+
 					manageReusableBlocksAnchorElem &&
 						replaceWithManageReusableBlocksHref( manageReusableBlocksAnchorElem );
+
+					if ( manageNavigationMenusAnchorElem ) {
+						manageNavigationMenusAnchorElem.addEventListener(
+							'click',
+							( e ) => {
+								calypsoPort.postMessage( {
+									action: 'openLinkInParentFrame',
+									payload: { postUrl: manageNavigationMenusAnchorElem.href },
+								} );
+								e.preventDefault();
+							},
+							false
+						);
+					}
 				}
 			}
 		}

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -115,6 +115,7 @@ enum EditorActions {
 	GetCheckoutModalStatus = 'getCheckoutModalStatus',
 	OpenRevisions = 'openRevisions',
 	PostStatusChange = 'postStatusChange',
+	OpenLinkInParentFrame = 'openLinkInParentFrame',
 	ViewPost = 'viewPost',
 	SetDraftId = 'draftIdSet',
 	TrashPost = 'trashPost',
@@ -404,6 +405,11 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		}
 
 		if ( EditorActions.ViewPost === action ) {
+			const { postUrl } = payload;
+			window.open( postUrl, '_top' );
+		}
+
+		if ( EditorActions.OpenLinkInParentFrame === action ) {
 			const { postUrl } = payload;
 			window.open( postUrl, '_top' );
 		}


### PR DESCRIPTION
## Changes proposed in this Pull Request

The Calypso iframe attempts to navigate itself to a different origin than the origin of the page in which it is embedded when clicking the manage menus button. These changes open the link in the parent frame instead of the iframe.

**Note:**
We want to rename the calypso iframe message `ViewPost` to a more generic `OpenLinkInParentFrame`. To do so, we'll add `OpenLinkInParentFrame` in this PR and remove references to the [ViewPost message](https://github.com/Automattic/wp-calypso/pull/62868/files#diff-94cbcc079892f7f8fb113398707b6a9b6394766e051b1f2c28f98334ad25015fL406-L409
) in a follow-up.

We handle renaming in this way because changes to `client/gutenberg/editor/calypsoify-iframe.tsx` are deployed immediately when merged to Calypso, while changes to the `wpcom-block-editor/src/calypso/features/iframe-bridge-server.js` are not. If we were to rename everything in a single PR, the stale version of `wpcom-block-editor` would reference non-existent messages in `client/gutenberg/editor/calypsoify-iframe.tsx`.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Site Editor

* SSH into your sandbox
* Sandbox `widgets.wp.com`
* Check out this PR
* Spin up a local calypso environment with `yarn start`
* Open a separate terminal
* Navigate to `apps/wpcom-block-editor`
* Run `yarn dev --sync`
* Visit the site editor
* Select a navigation menu
* In the block toolbar open the "Select Menu" dropdown.
* Select the "manage menus" option
* Verify that the window is redirected to the navigation menus management screen

![2022-04-18 15 04 26](https://user-images.githubusercontent.com/5414230/163886218-72d48504-1998-4632-9e44-c0b38a08b8ae.gif)

### Post Editor

* Update or save a post in the post editor
* Click on the `View Post` link in the toast notification
* Verify that the window still redirects properly and doesn't display the "refused to connect" error

<img width="1281" alt="Screen Shot 2022-04-18 at 3 12 18 PM" src="https://user-images.githubusercontent.com/5414230/163885898-56942b91-444b-42bb-a833-5441f7381cb5.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/60932
