### PR TITLE
Show WooCommerce USP only when the WooCommerce plugin is required

### DIFF
--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -15,11 +15,15 @@ const PluginDetailsSidebar = ( {
 		isMarketplaceProduct = false,
 		demo_url = null,
 		documentation_url = null,
+		requirements = {},
 	},
 } ) => {
 	const translate = useTranslate();
 
 	const isAnnualPlan = useSelector( isAnnualPlanOrUpgradeableAnnualPeriod );
+	const isWooCommercePluginRequired = requirements.plugins?.some(
+		( pluginName ) => pluginName === 'plugins/woocommerce'
+	);
 
 	if ( ! isMarketplaceProduct ) {
 		return (
@@ -65,20 +69,22 @@ const PluginDetailsSidebar = ( {
 
 	return (
 		<div className="plugin-details-sidebar__plugin-details-content">
-			<PluginDetailsSidebarUSP
-				id="woo"
-				icon={ { src: wooLogo } }
-				title={ translate( 'Your store foundations' ) }
-				description={ translate(
-					'This plugin requires the WooCommerce plugin to work.{{br/}}If you do not have it installed, it will be installed automatically for free.',
-					{
-						components: {
-							br: <br />,
-						},
-					}
-				) }
-				first
-			/>
+			{ isWooCommercePluginRequired && (
+				<PluginDetailsSidebarUSP
+					id="woo"
+					icon={ { src: wooLogo } }
+					title={ translate( 'Your store foundations' ) }
+					description={ translate(
+						'This plugin requires the WooCommerce plugin to work.{{br/}}If you do not have it installed, it will be installed automatically for free.',
+						{
+							components: {
+								br: <br />,
+							},
+						}
+					) }
+					first
+				/>
+			) }
 			{ demo_url && (
 				<PluginDetailsSidebarUSP
 					id="demo"

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -94,6 +94,7 @@ const PluginDetailsSidebar = ( {
 						'Take a look at the posibilities of this plugin before your commit.'
 					) }
 					links={ [ { href: { demo_url }, label: translate( 'View live demo' ) } ] }
+					first={ ! isWooCommercePluginRequired }
 				/>
 			) }
 
@@ -107,6 +108,7 @@ const PluginDetailsSidebar = ( {
 						: translate( 'Unlimited Email Support' )
 				}
 				links={ supportLinks }
+				first={ ! isWooCommercePluginRequired && ! demo_url }
 			/>
 		</div>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show WooCommerce USP only when the WooCommerce plugin is required
* Remove the top border when the first element

#### Testing instructions
* Go to a plugin page that requires Woocomerce. Ex: `/plugins/woocommerce-shipping-ups`
* Check the USP is being shown
* Go to a plugin page that **DOESN'T** require Woocomerce. Ex: `/plugins/woocommerce-shipping-fedex`
* Check the USP is **NOT** being shown

| WooCommerce  | Non-WooCommerce |
| ------------- | ------------- |
|<img width="1215" alt="Screen Shot 2022-04-18 at 18 42 42" src="https://user-images.githubusercontent.com/5039531/163889753-40d59acf-666f-4cd9-9e0d-67d2b26cab51.png">|<img width="1215" alt="Screen Shot 2022-04-18 at 18 43 43" src="https://user-images.githubusercontent.com/5039531/163889800-a3e70eac-e335-4c86-ac2d-9276b5edfa0f.png">|



---


Fixes #62764
