### PR TITLE
Domains: Show MX record delete confirmation for WPCOM email forwarding record only

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -9,7 +9,6 @@ import { domainConnect } from 'calypso/lib/domains/constants';
 import DnsRecordsListHeader from 'calypso/my-sites/domains/domain-management/dns/dns-records-list-header';
 import { domainManagementDnsEditRecord } from 'calypso/my-sites/domains/paths';
 import { addDns, deleteDns } from 'calypso/state/domains/dns/actions';
-import { isDeletingLastMXRecord } from 'calypso/state/domains/dns/utils';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import DeleteEmailForwardsDialog from './delete-email-forwards-dialog';
 import DnsRecordData from './dns-record-data';
@@ -116,9 +115,8 @@ class DnsRecordsList extends Component {
 
 	deleteDns = ( record, action = 'delete', confirmed = false ) => {
 		const { selectedDomainName, translate } = this.props;
-		const { records } = this.props.dns;
 
-		if ( ! confirmed && isDeletingLastMXRecord( record, records ) ) {
+		if ( ! confirmed && record.protected_field ) {
 			this.openDialog( 'deleteEmailForwards', ( result ) => {
 				if ( result.shouldDeleteEmailForwards ) {
 					this.deleteDns( record, action, true );

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -116,7 +116,7 @@ class DnsRecordsList extends Component {
 	deleteDns = ( record, action = 'delete', confirmed = false ) => {
 		const { selectedDomainName, translate } = this.props;
 
-		if ( ! confirmed && record.protected_field ) {
+		if ( ! confirmed && record.protected_field && 'MX' === record.type ) {
 			this.openDialog( 'deleteEmailForwards', ( result ) => {
 				if ( result.shouldDeleteEmailForwards ) {
 					this.deleteDns( record, action, true );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When deleting the last MX record of any type, we still show the "Email forwards" warning dialog.  
We should only show this dialog when the user is getting ready to remove the actual WPCOM forwarding record.

#### Preview
##### Previous - Wrong validation

The message was displayed if the MX record being deleted was the last one - regardless of being WPCOM-handled or not. This resulted in a wrong validation, like the ones below:

https://user-images.githubusercontent.com/18705930/163900665-0d610cc7-9798-42d5-8038-15603721171c.mov

https://user-images.githubusercontent.com/18705930/163901022-4b077ce5-c0b2-423e-ac51-9e5c41d539f6.mov

##### Updated - Correct validation

With this PR, the confirmation is now displayed if the MX record being deleted is the WPCOM email forwarding one:

https://user-images.githubusercontent.com/18705930/163900895-aa4119d4-28bf-4371-b26b-64e7f4760c14.mov

And no message is displayed if the record isn't a WPCOM one:

https://user-images.githubusercontent.com/18705930/163900980-4e5d35dc-bcc1-4ca5-bb37-761c3f9dab0e.mov


#### Testing instructions
- Try to delete a WPCOM-handled MX record on a domain with email forwarding configured;
- Make sure that the confirmation dialog is displayed;
- Also confirm that the dialog is not displayed if deleting any other MX record (e.g. the last non-WPCOM-handled MX record for that domain). 

Related to #50825.