### PR TITLE
Add featured suggestions to the vertical question screen

### DIFF
--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -2,7 +2,11 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDebounce } from 'use-debounce';
 import FormLabel from 'calypso/components/forms/form-label';
-import { useSiteVerticalQueryById, useSiteVerticalsQuery } from 'calypso/data/site-verticals';
+import {
+	useSiteVerticalQueryById,
+	useSiteVerticalsQuery,
+	useSiteVerticalsFeatured,
+} from 'calypso/data/site-verticals';
 import SuggestionSearch from './suggestion-search';
 import type { Vertical } from './types';
 import type { SiteVerticalsResponse } from 'calypso/data/site-verticals';
@@ -22,10 +26,13 @@ const SelectVertical: React.FC< Props > = ( { defaultVertical, isSkipSynonyms, o
 	const { data: defaultValue, isLoading: isLoadingDefaultVertical } = useSiteVerticalQueryById(
 		defaultVertical || ''
 	);
+
 	const { data: suggestions, isLoading: isLoadingSuggestions } = useSiteVerticalsQuery( {
 		term: debouncedSearchTerm,
 		skip_synonyms: isSkipSynonyms,
 	} );
+
+	const { data: featured } = useSiteVerticalsFeatured();
 
 	const mapOneSiteVerticalsResponseToVertical = ( vertical: SiteVerticalsResponse ): Vertical => ( {
 		value: vertical.id,
@@ -55,7 +62,11 @@ const SelectVertical: React.FC< Props > = ( { defaultVertical, isSkipSynonyms, o
 				placeholder={ String( translate( 'Ex. Cafe, Education, Photography' ) ) }
 				searchTerm={ searchTerm }
 				suggestions={
-					! isDebouncing ? mapManySiteVerticalsResponseToVertical( suggestions || [] ) : []
+					! isDebouncing
+						? mapManySiteVerticalsResponseToVertical(
+								( searchTerm === '' ? featured : suggestions ) || []
+						  )
+						: []
 				}
 				isLoading={ isDebouncing || isLoadingDefaultVertical || isLoadingSuggestions }
 				isDisableInput={ isLoadingDefaultVertical }

--- a/client/components/select-vertical/style.scss
+++ b/client/components/select-vertical/style.scss
@@ -1,3 +1,4 @@
+@import '@automattic/color-studio/dist/color-variables';
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
@@ -10,6 +11,11 @@
     width: auto;
 
     &.is-focused {
+        input.form-text-input[type='text'] {
+            border-color: #646970;
+            box-shadow: 0 0 0 2px #e2eaf1;
+        }
+
         .select-vertical__suggestion-search-dropdown {
             border-color: #646970;
             box-shadow: 1px 1px 0 1px #e2eaf1, -1px 1px 0 1px #e2eaf1;
@@ -17,9 +23,16 @@
     }
 
     &.is-show-suggestions {
-        &.is-focused {
-            input.form-text-input[type='text'] {
-                box-shadow: 0 0 0 2px #e2eaf1;
+        input.form-text-input[type='text'] {
+            border-bottom: 0;
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: 0;
+            box-shadow: 1px -1px 0 1px #e2eaf1, -1px -1px 0 1px #e2eaf1;
+        }
+
+        .components-button {
+            .gridicon {
+                transform: rotate( -180deg );
             }
         }
     }
@@ -29,26 +42,46 @@
         height: 44px;
         font-size: $font-body;
         line-height: 20px;
-        padding: 12px 48px 12px 16px;
+        padding: 12px 86px 12px 16px;
+        transition: none;
 
         &::placeholder {
             font-size: $font-body-small;
-        }
-
-        &:focus {
-            border-color: #646970;
-            box-shadow: none;
         }
     }
 
     .spinner {
         position: absolute;
-        right: 16px;
+        right: 50px;
         top: 12px;
     }
 
     @include break-small() {
         width: 504px;
+    }
+}
+
+.select-vertical__suggestion-input {
+    position: relative;
+    z-index: 20;
+
+    .components-button {
+        height: 100%;
+        position: absolute;
+        right: 4px;
+        top: 0;
+
+        &:focus:not( :disabled ) {
+            box-shadow: none;
+        }
+
+        &:focus-visible:not( :disabled ) {
+            box-shadow: inset 0 0 0 var( --wp-admin-border-width-focus ) var( --wp-admin-theme-color );
+        }
+
+        .gridicon {
+            transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
+        }
     }
 }
 
@@ -61,27 +94,28 @@
     border-width: 0 1px 1px;
     box-sizing: border-box;
     left: 0;
-    margin-top: -12px;
-    max-height: 350px;
+    max-height: 420px;
     overflow: auto;
-    padding: 10px 0;
+    padding: 0 0 12px;
     position: absolute;
     right: 0;
-    top: 42px;
-    transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+    top: 40px;
+    transition: none;
 
     .suggestions__category-heading {
         background-color: #fff;
         border: 0;
         color: #646970;
         font-size: $font-body-extra-small;
+        font-weight: normal;
         line-height: 20px;
         padding: 6px 16px;
     }
 
     .suggestions__item {
         border: 0;
-        line-height: normal;
+        font-size: $font-body;
+        line-height: 20px;
         padding: 6px 16px;
     }
 

--- a/client/data/site-verticals/index.ts
+++ b/client/data/site-verticals/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export { default as useSiteVerticalsQuery } from './use-site-verticals-query';
+export { default as useSiteVerticalsFeatured } from './use-site-verticals-featured';
 export { default as useSiteVerticalQueryById } from './use-site-vertical-query-by-id';

--- a/client/data/site-verticals/use-site-verticals-featured.ts
+++ b/client/data/site-verticals/use-site-verticals-featured.ts
@@ -1,0 +1,25 @@
+import { useQuery, UseQueryResult, QueryKey } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+import type { SiteVerticalsResponse } from './types';
+
+const useSiteVerticalsFeatured = (): UseQueryResult< SiteVerticalsResponse[] > => {
+	return useQuery( getCacheKey(), () => fetchSiteVerticalsFeatured(), {
+		enabled: true,
+		staleTime: Infinity,
+		refetchInterval: false,
+		refetchOnMount: 'always',
+	} );
+};
+
+export function fetchSiteVerticalsFeatured(): Promise< SiteVerticalsResponse[] > {
+	return wpcom.req.get( {
+		apiNamespace: 'wpcom/v2',
+		path: '/site-verticals/featured',
+	} );
+}
+
+export function getCacheKey(): QueryKey {
+	return [ 'site-verticals', 'featured' ];
+}
+
+export default useSiteVerticalsFeatured;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -33,8 +33,8 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const handleSubmit = async ( event: React.FormEvent ) => {
 		event.preventDefault();
 
-		if ( site && vertical ) {
-			const { value, label } = vertical;
+		if ( site ) {
+			const { value = '', label = '' } = vertical || {};
 
 			setIsBusy( true );
 			await saveSiteSettings( site.ID, { site_vertical_id: value } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds featured vertical suggestions to the vertical questions screen. 
Featured vertical suggestions will be shown to users when they initially click on the empty vertical question input field without having typed anything yet. Note that the list of featured vertical suggestions is not finalized and is very likely to be updated.

The idea behind displaying featured suggestions is two-fold:
1. Showing what the input field is for, and what they can expect from it.
2. Showing the most popular verticals chosen by users (or perhaps the most "verticalization-ready" ones).

![Screen Shot 2022-04-19 at 10 43 35 AM](https://user-images.githubusercontent.com/797888/163909792-643ff5f2-d1e3-4b6a-9a5a-3d76da2ae0a9.png)

#### Testing instructions
1. Head to the vertical question screen `/setup/vertical?flags=signup/site-vertical-step&siteSlug={siteSlug}`
2. Click on the input text.
3. Expect to see the list of featured verticals in the suggestion dropdown.
4. Type something.
5. Expect to see the list of verticals refined to what you typed.
6. Clear what you wrote.
7. Expect to see the list of featured verticals shown again.

Related to #61526


