### PR TITLE
Add new category selector

### DIFF
--- a/client/my-sites/plugins/categories/README.md
+++ b/client/my-sites/plugins/categories/README.md
@@ -1,0 +1,15 @@
+# Categories
+
+This component is used to render the category dropdown and discover section of the plugin marketplace.
+
+## How to use
+
+```jsx
+import Discover from 'calypso/my-sites/plugins/categories';
+
+<Categories selected="seo" />;
+```
+
+## Props
+
+- `selected`: Selected category slug.

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -1,0 +1,83 @@
+import { Gridicon } from '@automattic/components';
+import page from 'page';
+import { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useCategories } from './use-categories';
+import './style.scss';
+
+export type Category = {
+	name: string;
+	slug: string;
+	tags: string[];
+	description?: string;
+	icon?: string;
+	separator?: boolean;
+};
+
+const Categories = ( { selected }: { selected?: string } ) => {
+	const dispatch = useDispatch();
+
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+
+	const categories = useCategories();
+
+	const [ selecting, setSelecting ] = useState( false );
+	const toggleSelecting = () => setSelecting( ! selecting );
+
+	const onClick = ( category: Category ) => {
+		dispatch(
+			recordTracksEvent( 'calypso_plugins_category_select', {
+				tag: category.slug || '',
+			} )
+		);
+
+		setSelecting( false );
+
+		let url;
+		if ( category.slug !== 'discover' ) {
+			url = `/plugins/${ category.slug }/${ domain || '' }`;
+		} else {
+			url = `/plugins/${ domain || '' }`;
+		}
+
+		page( url );
+	};
+
+	const current = categories[ selected || 'discover' ] || categories.discover;
+
+	return (
+		<div className="categories__discover">
+			<button className="categories__header" onClick={ toggleSelecting }>
+				{ current.name }
+				&nbsp;
+				{ ! selecting && <Gridicon icon="chevron-right" /> }
+				{ selecting && <Gridicon icon="chevron-down" /> }
+			</button>
+			{ selecting && (
+				<ul className="categories__select-list">
+					{ Object.values( categories ).map( ( category, n ) => (
+						<li key={ 'categories-' + n }>
+							{ category.separator && <hr /> }
+							{ ! category.separator && (
+								<span
+									onClick={ () => onClick( category ) }
+									onKeyPress={ () => onClick( category ) }
+									role="link"
+									tabIndex={ 0 }
+								>
+									{ category.name }
+								</span>
+							) }
+						</li>
+					) ) }
+				</ul>
+			) }
+		</div>
+	);
+};
+
+export default Categories;

--- a/client/my-sites/plugins/categories/style.scss
+++ b/client/my-sites/plugins/categories/style.scss
@@ -1,0 +1,37 @@
+.categories__discover {
+	.categories__header {
+		@extend .wp-brand-font;
+		font-size: $font-title-large;
+		display: flex;
+		align-items: center;
+		cursor: pointer;
+	}
+
+	.categories__select-list {
+		background: #656667;
+		border: 1px solid #000000;
+		box-sizing: border-box;
+		border-radius: 15px; /* stylelint-disable-line */
+		max-width: 210px;
+		margin: 0;
+		list-style: none;
+		padding: 18px 5px;
+		color: var( --studio-white );
+		position: absolute;
+		z-index: 10;
+
+		span {
+			padding: 2px 10px;
+			border-radius: 5px; /* stylelint-disable-line */
+			display: block;
+			cursor: pointer;
+		}
+		span:hover {
+			background-color: #82a7ec;
+		}
+
+		hr {
+			margin: 15px 10px;
+		}
+	}
+}

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -28,7 +28,7 @@ export function useCategories(): Record< string, Category > {
 
 	const categories = {
 		discover: { name: __( 'Discover' ), slug: 'discover', tags: [] },
-		paid: { name: __( 'Top premium plugins' ), slug: 'paid', tags: [] },
+		paid: { name: __( 'Top paid plugins' ), slug: 'paid', tags: [] },
 		popular: { name: __( 'Top free plugins' ), slug: 'popular', tags: [] },
 		featured: { name: __( 'Editor’s pick' ), slug: 'featured', tags: [] },
 		analytics: {

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -1,0 +1,144 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { useSelector } from 'react-redux';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { Category } from '.';
+
+export const allowedCategories = [ 'discover', 'paid', 'popular', 'featured' ];
+
+export function useCategories(): Record< string, Category > {
+	const { __ } = useI18n();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+
+	const isJetpack = useSelector(
+		( state ) => isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId )
+	);
+
+	// Only showing these top level categories for now
+	const allowed = allowedCategories.slice();
+
+	// The featured category is currently broken, lets hide until it's fixed.
+	allowed.splice( allowed.indexOf( 'featured' ), 1 );
+
+	// Jetpack sites shouldn't see paid plugins
+	if ( isJetpack && allowed.indexOf( 'paid' ) >= 0 ) {
+		allowed.splice( allowed.indexOf( 'paid' ), 1 );
+	}
+
+	const categories = {
+		discover: { name: __( 'Discover' ), slug: 'discover', tags: [] },
+		paid: { name: __( 'Top premium plugins' ), slug: 'paid', tags: [] },
+		popular: { name: __( 'Top free plugins' ), slug: 'popular', tags: [] },
+		featured: { name: __( 'Editor’s pick' ), slug: 'featured', tags: [] },
+		analytics: {
+			name: __( 'Analytics' ),
+			description: __( 'Analytics' ),
+			icon: 'grid',
+			slug: 'analytics',
+			tags: [ 'analytics' ],
+		},
+		business: {
+			name: __( 'Business' ),
+			description: __( 'Business' ),
+			icon: 'grid',
+			slug: 'business',
+			tags: [ 'business' ],
+		},
+		customer: {
+			name: __( 'Customer Service' ),
+			description: __( 'Customer Service' ),
+			icon: 'grid',
+			slug: 'customer',
+			tags: [ 'customer-service' ],
+		},
+		design: {
+			name: __( 'Design' ),
+			description: __( 'Design' ),
+			icon: 'grid',
+			slug: 'design',
+			tags: [ 'design' ],
+		},
+		ecommerce: {
+			name: __( 'Ecommerce' ),
+			description: __( 'Ecommerce' ),
+			icon: 'grid',
+			slug: 'ecommerce',
+			tags: [ 'ecommerce', 'woocommerce' ],
+		},
+		education: {
+			name: __( 'Education' ),
+			description: __( 'Education' ),
+			icon: 'grid',
+			slug: 'education',
+			tags: [ 'education' ],
+		},
+		finance: {
+			name: __( 'Finance' ),
+			description: __( 'Finance' ),
+			icon: 'grid',
+			slug: 'finance',
+			tags: [ 'finance' ],
+		},
+		marketing: {
+			name: __( 'Marketing' ),
+			description: __( 'Marketing' ),
+			icon: 'grid',
+			slug: 'marketing',
+			tags: [ 'marketing' ],
+		},
+		seo: {
+			name: __( 'Search Optimization' ),
+			description: __( 'Search Optimization' ),
+			icon: 'grid',
+			slug: 'seo',
+			tags: [ 'seo' ],
+		},
+		photo: {
+			name: __( 'Photo & Video' ),
+			description: __( 'Photo & Video' ),
+			icon: 'grid',
+			slug: 'photo',
+			tags: [ 'photo', 'video', 'media' ],
+		},
+		social: {
+			name: __( 'Social' ),
+			description: __( 'Social' ),
+			icon: 'grid',
+			slug: 'social',
+			tags: [ 'social', 'facebook', 'twitter', 'instagram', 'tiktok', 'youtube', 'pinterest' ],
+		},
+		widgets: {
+			name: __( 'Widgets' ),
+			description: __( 'Widgets' ),
+			icon: 'grid',
+			slug: 'widgets',
+			tags: [ 'widgets' ],
+		},
+		email: {
+			name: __( 'Email' ),
+			description: __( 'Email' ),
+			icon: 'grid',
+			slug: 'email',
+			tags: [ 'email' ],
+		},
+		security: {
+			name: __( 'Security' ),
+			description: __( 'Security' ),
+			icon: 'grid',
+			slug: 'security',
+			tags: [ 'security' ],
+		},
+		posts: {
+			name: __( 'Posts & Posting' ),
+			description: __( 'Posts & Posting' ),
+			icon: 'grid',
+			slug: 'posts',
+			tags: [ 'posts', 'post', 'page', 'pages' ],
+		},
+	};
+
+	return Object.fromEntries(
+		Object.entries( categories ).filter( ( [ key ] ) => allowed.includes( key ) )
+	);
+}

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -5,16 +5,13 @@ import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { getSiteFragment, sectionify } from 'calypso/lib/route';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { allowedCategories } from './categories/use-categories';
 import PlanSetup from './jetpack-plugins-setup';
 import PluginListComponent from './main';
 import PluginDetails from './plugin-details';
 import PluginEligibility from './plugin-eligibility';
 import PluginUpload from './plugin-upload';
 import PluginBrowser from './plugins-browser';
-/**
- * Module variables
- */
-const allowedCategoryNames = [ 'new', 'popular', 'featured', 'paid' ];
 
 let lastPluginsListVisited;
 let lastPluginsQuerystring;
@@ -68,7 +65,7 @@ function renderPluginList( context, basePath ) {
 // The plugin browser can be rendered by the `/plugins/:plugin/:site_id?` route. In that case,
 // the `:plugin` param is actually the side ID or category.
 function getCategoryForPluginsBrowser( context ) {
-	if ( context.params.plugin && includes( allowedCategoryNames, context.params.plugin ) ) {
+	if ( context.params.plugin && includes( allowedCategories, context.params.plugin ) ) {
 		return context.params.plugin;
 	}
 
@@ -130,7 +127,7 @@ export function browsePluginsOrPlugin( context, next ) {
 	if (
 		( context.params.plugin &&
 			( ( siteUrl && context.params.plugin === siteUrl.toString() ) ||
-				includes( allowedCategoryNames, context.params.plugin ) ) ) ||
+				includes( allowedCategories, context.params.plugin ) ) ) ||
 		context.query?.s
 	) {
 		browsePlugins( context, next );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -71,7 +71,7 @@ import {
 	getSelectedSite,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-
+import Categories from '../categories';
 import './style.scss';
 
 /**
@@ -82,30 +82,11 @@ const SHORT_LIST_LENGTH = 6;
 const translateCategory = ( { category, translate } ) => {
 	switch ( category ) {
 		case 'popular':
-			return translate( 'Popular', {
-				context: 'Category description for the plugin browser.',
-			} );
+			return translate( 'Top free plugins' );
 		case 'featured':
-			return translate( 'Featured', {
-				context: 'Category description for the plugin browser.',
-			} );
+			return translate( 'Editor’s pick' );
 		case 'paid':
-			return translate( 'Premium', {
-				context: 'Category description for the plugin browser.',
-			} );
-		default:
-			return translate( 'Plugins' );
-	}
-};
-
-const translateCategoryTitle = ( { category, translate } ) => {
-	switch ( category ) {
-		case 'popular':
-			return translate( 'All Popular Plugins' );
-		case 'featured':
-			return translate( 'All Featured Plugins' );
-		case 'paid':
-			return translate( 'All Premium Plugins' );
+			return translate( 'Top paid plugins' );
 		default:
 			return translate( 'Plugins' );
 	}
@@ -205,18 +186,20 @@ const PluginsBrowser = ( {
 				),
 			},
 		];
+
+		if ( category ) {
+			items.push( {
+				label: translateCategory( { category, translate } ),
+				href: `/plugins/${ category }/${ siteSlug || '' }`,
+				id: 'category',
+			} );
+		}
+
 		if ( search ) {
 			items.push( {
 				label: translate( 'Search Results' ),
 				href: `/plugins/${ siteSlug || '' }?s=${ search }`,
 				id: 'plugins-search',
-			} );
-		}
-		if ( category ) {
-			items.push( {
-				label: translateCategoryTitle( { category, translate } ),
-				href: `/plugins/${ category }/${ siteSlug || '' }`,
-				id: 'category',
 			} );
 		}
 
@@ -316,6 +299,7 @@ const PluginsBrowser = ( {
 				hasBusinessPlan={ hasBusinessPlan }
 				siteSlug={ siteSlug }
 			/>
+
 			<SearchBoxHeader
 				popularSearchesRef={ searchHeaderRef }
 				isSticky={ isAboveElement }
@@ -324,6 +308,7 @@ const PluginsBrowser = ( {
 				title={ translate( 'Plugins you need to get your projects done' ) }
 				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
 			/>
+			{ ! search && <Categories selected={ category } /> }
 			<PluginBrowserContent
 				pluginsByCategoryPopular={ pluginsByCategoryPopular }
 				isFetchingPluginsByCategoryPopular={ isFetchingPluginsByCategoryPopular }
@@ -482,7 +467,6 @@ const FullListView = ( {
 				<PluginsBrowserList
 					plugins={ isPaidCategory ? paidPlugins : plugins }
 					listName={ category }
-					title={ translateCategoryTitle( { category, translate } ) }
 					site={ siteSlug }
 					showPlaceholders={ isPaidCategory ? isFetchingPaidPlugins : isFetching }
 					currentSites={ sites }

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -34,6 +34,9 @@ const selectors = {
 		`.plugin-site-jetpack__container .components-toggle-control:has(span:text("${ target }")) span.components-form-toggle`,
 	installButton: 'button:text("Install and activate")',
 	removeButton: 'button.plugin-remove-button__remove-button',
+
+	// Category selector
+	selectedCategory: ( categoryTitle: string ) => `.categories__header:text("${ categoryTitle }")`,
 };
 
 /**
@@ -79,6 +82,13 @@ export class PluginsPage {
 	 */
 	async validateHasSection( section: string ): Promise< void > {
 		await this.page.waitForSelector( selectors.sectionTitle( section ) );
+	}
+
+	/**
+	 * Validate page has the right category selected
+	 */
+	async validateSelectedCategory( categoryTitle: string ): Promise< void > {
+		await this.page.waitForSelector( selectors.selectedCategory( categoryTitle ) );
 	}
 
 	/**

--- a/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
+++ b/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
@@ -25,7 +25,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			await pluginsPage.visit();
 		} );
 
-		it.each( [ 'Premium', 'Featured', 'Popular' ] )(
+		it.each( [ 'Top paid plugins', 'Editor’s pick', 'Top free plugins' ] )(
 			'Plugins page loads %s section',
 			async function ( section: string ) {
 				await pluginsPage.validateHasSection( section );
@@ -34,7 +34,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 
 		it( 'Can browse all popular plugins', async function () {
 			await pluginsPage.clickBrowseAllPopular();
-			await pluginsPage.validateHasSection( 'All Popular Plugins' );
+			await pluginsPage.validateSelectedCategory( 'Top free plugins' );
 		} );
 
 		it( 'Can return via breadcrumb', async function () {
@@ -43,7 +43,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			} else {
 				await pluginsPage.clickBackBreadcrumb();
 			}
-			await pluginsPage.validateHasSection( 'Premium' );
+			await pluginsPage.validateHasSection( 'Top paid plugins' );
 		} );
 
 		it.each( [
@@ -64,7 +64,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			await pluginsPage.visit( siteUrl );
 		} );
 
-		it.each( [ 'Premium', 'Featured', 'Popular' ] )(
+		it.each( [ 'Top paid plugins', 'Editor’s pick', 'Top free plugins' ] )(
 			'Plugins page loads %s section',
 			async function ( section: string ) {
 				await pluginsPage.validateHasSection( section );

--- a/test/e2e/specs/plugins/plugins__browser-jetpack-user.ts
+++ b/test/e2e/specs/plugins/plugins__browser-jetpack-user.ts
@@ -30,7 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:jetpack-site' ), 
 		await pluginsPage.visit( siteUrl );
 	} );
 
-	it.each( [ 'Featured', 'Popular' ] )(
+	it.each( [ 'Editor’s pick', 'Top free plugins' ] )(
 		'Plugins page loads %s section',
 		async function ( section: string ) {
 			await pluginsPage.validateHasSection( section );
@@ -39,6 +39,6 @@ describe( DataHelper.createSuiteTitle( 'Plugins page /plugins/:jetpack-site' ), 
 
 	// We don't support marketplace plugin purchases on self hosted sites. (Source code download restrictions)
 	it( 'Plugins page does not load premium plugins on Jetpack sites', async function () {
-		await pluginsPage.validateNotHasSection( 'Premium' );
+		await pluginsPage.validateNotHasSection( 'Top paid plugins' );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add new category selector
* Replaces https://github.com/Automattic/wp-calypso/pull/62685

#### Testing instructions

* http://calypso.localhost:3000/plugins
* Select different categories from the dropdown

#### Screenshot

![Screenshot 2022-04-19 at 17-58-43 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/163954562-6be1534c-f394-406e-86a4-e20cf92a8e00.png)


Related to https://github.com/Automattic/wp-calypso/issues/62264
