### PR TITLE
Inline-Help: explicitly import CSS variables and mixins

### DIFF
--- a/client/blocks/inline-help/inline-help-forum-view.scss
+++ b/client/blocks/inline-help/inline-help-forum-view.scss
@@ -1,3 +1,5 @@
+@import '@automattic/typography/styles/variables';
+
 .inline-help__forum-view {
 	text-align: left;
 }

--- a/client/blocks/inline-help/inline-help-search-card.scss
+++ b/client/blocks/inline-help/inline-help-search-card.scss
@@ -1,3 +1,6 @@
+@import '../../assets/stylesheets/shared/mixins/_breakpoints';
+@import '@automattic/typography/styles/variables';
+
 .inline-help__search .card.search-card {
 	border-radius: 2px 2px 0 0;
 	margin: 0;

--- a/client/blocks/inline-help/inline-help-search-results.scss
+++ b/client/blocks/inline-help/inline-help-search-results.scss
@@ -1,3 +1,6 @@
+@import '@automattic/typography/styles/variables';
+@import '../../assets/stylesheets/shared/mixins/_breakpoints';
+
 .inline-help__empty-results {
 	padding: 8px 16px 0;
 	margin: 0;

--- a/client/blocks/inline-help/popover-content.scss
+++ b/client/blocks/inline-help/popover-content.scss
@@ -1,3 +1,8 @@
+@import '@automattic/typography/styles/variables';
+@import '../../assets/stylesheets/shared/mixins/_breakpoints';
+@import '../../assets/stylesheets/shared/mixins/hide-content-accessibly';
+
+
 .inline-help__popover-content {
 	background-color: var( --color-surface );
 

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -1,3 +1,6 @@
+@import '@automattic/typography/styles/variables';
+@import '../../assets/stylesheets/shared/mixins/_long-content-fade';
+@import '../../assets/stylesheets/shared/mixins/_breakpoints';
 /**
  * Site
  *
@@ -180,7 +183,7 @@
 	color: var( --color-neutral-60 );
 	background-color: var( --color-neutral-5 );
 	font-size: $font-body-extra-small;
-	border-radius: 12px;
+	border-radius: 12px; /* stylelint-disable-line scales/radii */
 	clear: both;
 	display: inline-block;
 	margin-top: 6px;

--- a/client/components/count/style.scss
+++ b/client/components/count/style.scss
@@ -1,8 +1,10 @@
+@import '@automattic/typography/styles/variables';
+
 .count {
 	display: inline-block;
 	padding: 1px 6px;
 	border: solid 1px var( --color-border );
-	border-radius: 12px;
+	border-radius: 12px; /* stylelint-disable-line scales/radii */
 	font-size: $font-body-extra-small;
 	font-weight: 600;
 	line-height: 14px;

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -1,3 +1,7 @@
+@import '../../assets/stylesheets/shared/mixins/_breakpoints';
+@import '../../assets/stylesheets/shared/mixins/_clear-fix';
+@import '@automattic/typography/styles/variables';
+
 // Multisite
 .foldable-card.card {
 	@include clear-fix;

--- a/client/components/forms/form-checkbox/style.scss
+++ b/client/components/forms/form-checkbox/style.scss
@@ -1,5 +1,8 @@
+@import '@automattic/typography/styles/variables';
+@import '../../../assets/stylesheets/shared/_extends-forms';
+
 .form-checkbox {
-	@extend %form-field;
+	@extend %form-field !optional;
 
 	clear: none;
 	cursor: pointer;

--- a/client/components/forms/form-label/style.scss
+++ b/client/components/forms/form-label/style.scss
@@ -1,3 +1,5 @@
+@import '@automattic/typography/styles/variables';
+
 .form-label {
 	display: block;
 	font-size: $font-body-small;

--- a/client/components/forms/form-section-heading/style.scss
+++ b/client/components/forms/form-section-heading/style.scss
@@ -1,3 +1,5 @@
+@import '@automattic/typography/styles/variables';
+
 .form-section-heading {
 	font-size: $font-title-medium;
 	margin: 30px 0 20px;

--- a/client/components/forms/form-text-input/style.scss
+++ b/client/components/forms/form-text-input/style.scss
@@ -1,3 +1,6 @@
+@import '@automattic/typography/styles/variables';
+@import '../../../assets/stylesheets/shared/_extends-forms';
+
 .form-text-input {
 	@at-root {
 		input[type='text']#{&},

--- a/client/components/forms/form-textarea/style.scss
+++ b/client/components/forms/form-textarea/style.scss
@@ -1,3 +1,6 @@
+@import '@automattic/typography/styles/variables';
+@import '../../../assets/stylesheets/shared/_extends-forms';
+
 .form-textarea {
 	@extend %form-field;
 

--- a/client/components/header-cake/style.scss
+++ b/client/components/header-cake/style.scss
@@ -1,3 +1,7 @@
+@import '@automattic/typography/styles/variables';
+@import '../../assets//stylesheets/shared/mixins/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 // ==========================================================================
 // .header-cake
 //

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -1,5 +1,9 @@
+@import '../../assets/stylesheets/shared/mixins/_breakpoints';
+@import '@automattic/typography/styles/variables';
+
 @keyframes notice-loading-pulse {
-	0%, 100% {
+	0%,
+	100% {
 		opacity: 0.75;
 	}
 	50% {
@@ -106,7 +110,7 @@
 	left: calc( 50% - 8px );
 	width: 16px;
 	height: 16px;
-	border-radius: 8px;
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
 	background: var( --color-neutral );
 
 	& + .notice__icon {
@@ -207,8 +211,8 @@ a.notice__action {
 	align-items: center;
 
 	@include breakpoint-deprecated( '>480px' ) {
-			flex-shrink: 1;
-			flex-grow: 0;
+		flex-shrink: 1;
+		flex-grow: 0;
 		align-items: center;
 		font-size: $font-body-small;
 		margin: 0 0 0 auto; // forces the element to the right;
@@ -239,8 +243,8 @@ a.notice__action {
 // Compact notices
 .notice.is-compact {
 	display: inline-flex;
-		flex-wrap: nowrap;
-		flex-direction: row;
+	flex-wrap: nowrap;
+	flex-direction: row;
 	width: auto;
 	min-height: 20px;
 	margin: 0;

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -1,3 +1,6 @@
+@import '@automattic/typography/styles/variables';
+@import '../../assets/stylesheets/shared/mixins/_long-content-fade';
+
 /**
  * @component Search
  */

--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -1,3 +1,6 @@
+
+@import '@automattic/typography/styles/variables';
+
 /**
  * Segmented Control
  *

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -1,3 +1,5 @@
+@import '@automattic/typography/styles/variables';
+
 /**
  * Select Dropdown
  */

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -1,3 +1,8 @@
+@import '@automattic/typography/styles/variables';
+@import '../../assets/stylesheets/shared/mixins/_long-content-fade';
+@import '../../assets/stylesheets/shared/mixins/_breakpoints';
+@import '@automattic/typography/styles/variables';
+
 /**
  * Site Selector
  *

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -1,3 +1,4 @@
+@import '../../assets/stylesheets/shared/mixins/_breakpoints';
 
 .sites-dropdown {
 	&.is-open {

--- a/client/me/help/contact-form-notice/style.scss
+++ b/client/me/help/contact-form-notice/style.scss
@@ -1,3 +1,5 @@
+@import '@automattic/typography/styles/variables';
+
 .contact-form-notice {
 	color: var( --color-neutral-70 );
 	font-size: $font-body-small;

--- a/client/me/help/help-contact-confirmation/style.scss
+++ b/client/me/help/help-contact-confirmation/style.scss
@@ -1,3 +1,6 @@
+@import '../../../assets/stylesheets/shared/mixins/_breakpoints';
+@import '@automattic/typography/styles/variables';
+
 .help-contact-confirmation {
 	text-align: center;
 	display: table;
@@ -54,7 +57,7 @@
 }
 
 .help-contact-confirmation__message {
-	font: 14px/21px $sans;
+	font: 14px/21px $sans; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	color: var( --color-neutral-light );
 	max-width: 340px;
 	display: inline-block;

--- a/client/me/help/help-contact-form/style.scss
+++ b/client/me/help/help-contact-form/style.scss
@@ -1,3 +1,6 @@
+@import '../../../assets/stylesheets/shared/mixins/_breakpoints';
+@import '@automattic/typography/styles/variables';
+
 .help-contact-form {
 	.form-textarea {
 		// Fix the width of our text area so that it can only be resized vertically

--- a/client/me/help/help-contact/style.scss
+++ b/client/me/help/help-contact/style.scss
@@ -1,3 +1,7 @@
+@import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/mixins';
+@import '../../../assets/stylesheets/shared/mixins/_placeholder';
+
 .help-contact__placeholder {
 	color: transparent;
 

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -1,5 +1,7 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
+@import '../../../assets/stylesheets/shared/mixins/_placeholder';
+@import '@automattic/typography/styles/variables';
 
 .help-results {
 	margin-bottom: 16px;

--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -1,3 +1,4 @@
+@import '@automattic/typography/styles/variables';
 /**
  * Site Indicator
  */
@@ -15,7 +16,7 @@
 	align-self: center;
 	background: var( --color-neutral-0 );
 	border: none;
-	border-radius: 50%;
+	border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	box-shadow: none;
 	color: var( --color-neutral-light );
 	cursor: default;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR shouldn't change anything about inline-help. It just imports all CSS variables and mixins wherever they're used.
* This makes the total CSS somewhat smaller than when importing everything in root and adding all variables and mixins to the global SCSS.
* This is needed to be able to import the inline-help outside Calypso.

#### Testing instructions

Make sure inline help works as usual.
