### PR TITLE
Onboarding import: update wording on the progress screen

### DIFF
--- a/client/signup/steps/import-from/components/progress-screen/index.tsx
+++ b/client/signup/steps/import-from/components/progress-screen/index.tsx
@@ -22,7 +22,9 @@ const ProgressScreen: React.FunctionComponent< Props > = ( props ) => {
 				value={ Number.isNaN( progress ) ? 0 : progress }
 			/>
 			<SubTitle>
-				{ __( "This may take a few minutes. We'll notify you by email when it's done." ) }
+				{ __(
+					'This may take long depending on your content. No need to wait, we’ll notify you by email when it’s done.'
+				) }
 			</SubTitle>
 		</Progress>
 	);

--- a/client/signup/steps/import-from/components/progress-screen/index.tsx
+++ b/client/signup/steps/import-from/components/progress-screen/index.tsx
@@ -1,4 +1,5 @@
 import { Progress, SubTitle, Title } from '@automattic/onboarding';
+import { createElement, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import { ProgressBar } from 'calypso/devdocs/design/playground-scope';
@@ -22,8 +23,11 @@ const ProgressScreen: React.FunctionComponent< Props > = ( props ) => {
 				value={ Number.isNaN( progress ) ? 0 : progress }
 			/>
 			<SubTitle>
-				{ __(
-					'This may take long depending on your content. No need to wait, we’ll notify you by email when it’s done.'
+				{ createInterpolateElement(
+					__(
+						"This may take long depending on your content.<br />No need to wait, we'll notify you by email when it's done."
+					),
+					{ br: createElement( 'br' ) }
 				) }
 			</SubTitle>
 		</Progress>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  Update wording on the progress screen

#### Testing instructions

* No need for testing.

#### Screenshot
<img width="598" alt="Screenshot 2022-04-20 at 11 30 45" src="https://user-images.githubusercontent.com/1241413/164198660-7d2391d6-f809-4b5c-897b-f433c7eecc30.png">


Related to #62875
