### PR TITLE
Dont show "new navigation" popover to new users

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -570,7 +570,7 @@ export default connect(
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
 			hasDismissedThePopover: getPreference( state, MENU_POPOVER_PREFERENCE_KEY ),
 			isFetchingPrefs: isFetchingPreferences( state ),
-			/** If the user is newer than new navigation shipping date, don't tell them this nav is new. Everything is new to them */
+			// If the user is newer than new navigation shipping date, don't tell them this nav is new. Everything is new to them.
 			isUserNewerThanNewNavigation:
 				new Date( getCurrentUserDate( state ) ).getTime() > NEW_MASTERBAR_SHIPPING_DATE,
 		};

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -14,7 +14,11 @@ import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUserSiteCount, getCurrentUser } from 'calypso/state/current-user/selectors';
+import {
+	getCurrentUserSiteCount,
+	getCurrentUser,
+	getCurrentUserDate,
+} from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
@@ -37,6 +41,7 @@ import Masterbar from './masterbar';
 import { MasterBarMobileMenu } from './masterbar-menu';
 import Notifications from './notifications';
 
+const NEW_MASTERBAR_SHIPPING_DATE = new Date( 2022, 3, 14 ).getTime();
 const MENU_POPOVER_PREFERENCE_KEY = 'dismissible-card-masterbar-collapsable-menu-popover';
 
 const MOBILE_BREAKPOINT = '<480px';
@@ -61,6 +66,8 @@ class MasterbarLoggedIn extends Component {
 		isCheckout: PropTypes.bool,
 		isCheckoutPending: PropTypes.bool,
 		isInEditor: PropTypes.bool,
+		hasDismissedThePopover: PropTypes.bool,
+		isUserNewerThanNewNavigation: PropTypes.bool,
 	};
 
 	subscribeToViewPortChanges() {
@@ -396,7 +403,12 @@ class MasterbarLoggedIn extends Component {
 
 	renderMenu() {
 		const { menuBtnRef } = this.state;
-		const { translate, hasDismissedThePopover, isFetchingPrefs } = this.props;
+		const {
+			translate,
+			hasDismissedThePopover,
+			isFetchingPrefs,
+			isUserNewerThanNewNavigation,
+		} = this.props;
 		return (
 			<>
 				<Item
@@ -416,7 +428,9 @@ class MasterbarLoggedIn extends Component {
 				{ menuBtnRef && (
 					<Popover
 						className="masterbar__new-menu-popover"
-						isVisible={ ! isFetchingPrefs && ! hasDismissedThePopover }
+						isVisible={
+							! isFetchingPrefs && ! hasDismissedThePopover && ! isUserNewerThanNewNavigation
+						}
 						context={ menuBtnRef }
 						onClose={ this.dismissPopover }
 						position="bottom left"
@@ -556,6 +570,9 @@ export default connect(
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
 			hasDismissedThePopover: getPreference( state, MENU_POPOVER_PREFERENCE_KEY ),
 			isFetchingPrefs: isFetchingPreferences( state ),
+			/** If the user is newer than new navigation shipping date, don't tell them this nav is new. Everything is new to them */
+			isUserNewerThanNewNavigation:
+				new Date( getCurrentUserDate( state ) ).getTime() > NEW_MASTERBAR_SHIPPING_DATE,
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes https://github.com/Automattic/wp-calypso/issues/62878

#### Testing instructions

1. With your current user, remove the preference that you have already seen the popover following these steps:
a. Untick "dismissed-masterbar-collapsable-menu-popover" and click save.

<img width="967" alt="image" src="https://user-images.githubusercontent.com/17054134/162797982-917d088d-48b1-4196-8a12-d07e70a72b12.png">

2. You should see the popover when you simulate mobile viewport.
3. Using incognito, go to [locahost:3000](http://calypso.localhost:3000/) and signup, create a free site. Then head again to http://calypso.localhost:3000/.
5. You shouldn't see the popover.

