### PR TITLE
Help Center: small styling tweaks ( 1min review )

### DIFF
--- a/packages/help-center/src/components/help-icon.tsx
+++ b/packages/help-center/src/components/help-icon.tsx
@@ -26,7 +26,7 @@ const HelpIcon: React.FC< Props > = ( { newItems, active } ) => (
 				cy="8"
 				r="5"
 				stroke={ active ? '#1e1e1e' : 'white' }
-				fill="#0675C4"
+				fill="currentColor"
 				strokeWidth="2"
 			/>
 		) }

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -34,7 +34,6 @@ $head-foot-height: 50px;
 		top: calc( $header-height + 16px );
 		right: 16px;
 		width: 410px;
-		min-height: 80vh;
 		max-height: 800px;
 		box-shadow: 0 0 3px 0 rgba( 0, 0, 0, 0.25 );
 
@@ -58,10 +57,11 @@ $head-foot-height: 50px;
 	}
 
 	&.is-mobile {
-		top: 0;
+		top: 47px;
 		bottom: 0;
 		left: 0;
 		right: 0;
+		max-height: 100%;
 
 		.help-center__container-content {
 			height: calc( 100% - $head-foot-height * 2 );


### PR DESCRIPTION
## Changes proposed in this Pull Request

While testing another PR I noticed a few bugs that needed to be addressed.

* Help center height in tall windows
* Account for masterbar when viewing in mobile
* Allow notification color to use layout theme color
