### PR TITLE
Tests: Refactor `PlanStorage` tests to `@testing-library/react` and `jest`

### DIFF
--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -16,7 +16,6 @@ import {
 	PLAN_FREE,
 } from '@automattic/calypso-products';
 import { render, screen } from '@testing-library/react';
-import { assert } from 'chai';
 import '@testing-library/jest-dom';
 import { PlanStorageBar } from '../bar';
 
@@ -33,106 +32,106 @@ describe( 'PlanStorageBar basic tests', () => {
 
 	test( 'should not blow up and have class .plan-storage-bar', () => {
 		const { container } = render( <PlanStorageBar { ...props } /> );
-		assert.lengthOf( container.getElementsByClassName( 'plan-storage__bar' ), 1 );
+		expect( container.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render ProgressBar', () => {
 		render( <PlanStorageBar { ...props } /> );
 		const progressBar = screen.queryByRole( 'progressbar' );
-		assert.isDefined( progressBar );
+		expect( progressBar ).toBeDefined();
 		expect( progressBar ).toHaveAttribute( 'aria-valuenow', '10' );
 	} );
 
 	test( 'should render when storage is limited', () => {
 		const { container: premContainer } = render( <PlanStorageBar { ...props } /> );
 		render( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_PREMIUM } /> );
-		assert.lengthOf( premContainer.getElementsByClassName( 'plan-storage__bar' ), 1 );
+		expect( premContainer.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 
 		const { container: prem2Container } = render(
 			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_PREMIUM_2_YEARS } />
 		);
-		assert.lengthOf( prem2Container.getElementsByClassName( 'plan-storage__bar' ), 1 );
+		expect( prem2Container.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 
 		const { container: persContailer } = render(
 			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_PERSONAL } />
 		);
-		assert.lengthOf( persContailer.getElementsByClassName( 'plan-storage__bar' ), 1 );
+		expect( persContailer.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 
 		const { container: pers2Container } = render(
 			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_PERSONAL_2_YEARS } />
 		);
-		assert.lengthOf( pers2Container.getElementsByClassName( 'plan-storage__bar' ), 1 );
+		expect( pers2Container.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 
 		const { container: freeContainer } = render(
 			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_FREE } />
 		);
-		assert.lengthOf( freeContainer.getElementsByClassName( 'plan-storage__bar' ), 1 );
+		expect( freeContainer.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 
 		const { container: busContainer } = render(
 			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_BUSINESS } />
 		);
-		assert.lengthOf( busContainer.getElementsByClassName( 'plan-storage__bar' ), 1 );
+		expect( busContainer.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 
 		const { container: bus2Container } = render(
 			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_BUSINESS_2_YEARS } />
 		);
-		assert.lengthOf( bus2Container.getElementsByClassName( 'plan-storage__bar' ), 1 );
+		expect( bus2Container.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 
 		const { container: ecomContainer } = render(
 			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_ECOMMERCE } />
 		);
-		assert.lengthOf( ecomContainer.getElementsByClassName( 'plan-storage__bar' ), 1 );
+		expect( ecomContainer.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 
 		const { container: ecom2Container } = render(
 			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_ECOMMERCE_2_YEARS } />
 		);
-		assert.lengthOf( ecom2Container.getElementsByClassName( 'plan-storage__bar' ), 1 );
+		expect( ecom2Container.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not render when storage has valid max_storage_bytes', () => {
 		const { container: storage1 } = render(
 			<PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 1 } } />
 		);
-		assert.lengthOf( storage1.getElementsByClassName( 'plan-storage__bar' ), 1 );
+		expect( storage1.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 
 		const { container: storage0 } = render(
 			<PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 0 } } />
 		);
-		assert.lengthOf( storage0.getElementsByClassName( 'plan-storage__bar' ), 1 );
+		expect( storage0.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 
 		const { container: storage50 } = render(
 			<PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 50 } } />
 		);
-		assert.lengthOf( storage50.getElementsByClassName( 'plan-storage__bar' ), 1 );
+		expect( storage50.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not render when storage is falsey or -1', () => {
 		const { container: storage0 } = render( <PlanStorageBar { ...props } mediaStorage={ 0 } /> );
-		assert.lengthOf( storage0.getElementsByClassName( 'plan-storage__bar' ), 0 );
+		expect( storage0.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 0 );
 
 		const { container: storageFalse } = render(
 			<PlanStorageBar { ...props } mediaStorage={ false } />
 		);
-		assert.lengthOf( storageFalse.getElementsByClassName( 'plan-storage__bar' ), 0 );
+		expect( storageFalse.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 0 );
 
 		const { container: storageNull } = render(
 			<PlanStorageBar { ...props } mediaStorage={ null } />
 		);
-		assert.lengthOf( storageNull.getElementsByClassName( 'plan-storage__bar' ), 0 );
+		expect( storageNull.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 0 );
 
 		const { container: storageUnlimited } = render(
 			<PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: -1 } } />
 		);
-		assert.lengthOf( storageUnlimited.getElementsByClassName( 'plan-storage__bar' ), 0 );
+		expect( storageUnlimited.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should include upgrade link when displayUpgradeLink is true', () => {
 		const { container } = render( <PlanStorageBar { ...props } displayUpgradeLink={ true } /> );
-		assert.lengthOf( container.getElementsByClassName( 'plan-storage__storage-link' ), 1 );
+		expect( container.getElementsByClassName( 'plan-storage__storage-link' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not include upgrade link when displayUpgradeLink is false', () => {
 		const { container } = render( <PlanStorageBar { ...props } displayUpgradeLink={ false } /> );
-		assert.lengthOf( container.getElementsByClassName( 'plan-storage__storage-link' ), 0 );
+		expect( container.getElementsByClassName( 'plan-storage__storage-link' ) ).toHaveLength( 0 );
 	} );
 } );

--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 const translate = ( x ) => x;
 
 import {
@@ -11,8 +15,9 @@ import {
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_FREE,
 } from '@automattic/calypso-products';
+import { render, screen } from '@testing-library/react';
 import { assert } from 'chai';
-import { shallow } from 'enzyme';
+import '@testing-library/jest-dom';
 import { PlanStorageBar } from '../bar';
 
 describe( 'PlanStorageBar basic tests', () => {
@@ -27,84 +32,107 @@ describe( 'PlanStorageBar basic tests', () => {
 	};
 
 	test( 'should not blow up and have class .plan-storage-bar', () => {
-		const bar = shallow( <PlanStorageBar { ...props } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+		const { container } = render( <PlanStorageBar { ...props } /> );
+		assert.lengthOf( container.getElementsByClassName( 'plan-storage__bar' ), 1 );
 	} );
 
 	test( 'should render ProgressBar', () => {
-		const bar = shallow( <PlanStorageBar { ...props } /> );
-		const progressBar = bar.find( 'ProgressBar' );
-		assert.lengthOf( progressBar, 1 );
-		assert.equal( progressBar.props().value, 10 );
+		render( <PlanStorageBar { ...props } /> );
+		const progressBar = screen.queryByRole( 'progressbar' );
+		assert.isDefined( progressBar );
+		expect( progressBar ).toHaveAttribute( 'aria-valuenow', '10' );
 	} );
 
 	test( 'should render when storage is limited', () => {
-		let bar;
+		const { container: premContainer } = render( <PlanStorageBar { ...props } /> );
+		render( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_PREMIUM } /> );
+		assert.lengthOf( premContainer.getElementsByClassName( 'plan-storage__bar' ), 1 );
 
-		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_PREMIUM } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+		const { container: prem2Container } = render(
+			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_PREMIUM_2_YEARS } />
+		);
+		assert.lengthOf( prem2Container.getElementsByClassName( 'plan-storage__bar' ), 1 );
 
-		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_PREMIUM_2_YEARS } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+		const { container: persContailer } = render(
+			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_PERSONAL } />
+		);
+		assert.lengthOf( persContailer.getElementsByClassName( 'plan-storage__bar' ), 1 );
 
-		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_PERSONAL } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+		const { container: pers2Container } = render(
+			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_PERSONAL_2_YEARS } />
+		);
+		assert.lengthOf( pers2Container.getElementsByClassName( 'plan-storage__bar' ), 1 );
 
-		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_PERSONAL_2_YEARS } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+		const { container: freeContainer } = render(
+			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_FREE } />
+		);
+		assert.lengthOf( freeContainer.getElementsByClassName( 'plan-storage__bar' ), 1 );
 
-		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_FREE } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+		const { container: busContainer } = render(
+			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_BUSINESS } />
+		);
+		assert.lengthOf( busContainer.getElementsByClassName( 'plan-storage__bar' ), 1 );
 
-		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_BUSINESS } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+		const { container: bus2Container } = render(
+			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_BUSINESS_2_YEARS } />
+		);
+		assert.lengthOf( bus2Container.getElementsByClassName( 'plan-storage__bar' ), 1 );
 
-		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_BUSINESS_2_YEARS } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+		const { container: ecomContainer } = render(
+			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_ECOMMERCE } />
+		);
+		assert.lengthOf( ecomContainer.getElementsByClassName( 'plan-storage__bar' ), 1 );
 
-		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_ECOMMERCE } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
-
-		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_ECOMMERCE_2_YEARS } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+		const { container: ecom2Container } = render(
+			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_ECOMMERCE_2_YEARS } />
+		);
+		assert.lengthOf( ecom2Container.getElementsByClassName( 'plan-storage__bar' ), 1 );
 	} );
 
 	test( 'should not render when storage has valid max_storage_bytes', () => {
-		let bar;
+		const { container: storage1 } = render(
+			<PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 1 } } />
+		);
+		assert.lengthOf( storage1.getElementsByClassName( 'plan-storage__bar' ), 1 );
 
-		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 1 } } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+		const { container: storage0 } = render(
+			<PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 0 } } />
+		);
+		assert.lengthOf( storage0.getElementsByClassName( 'plan-storage__bar' ), 1 );
 
-		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 0 } } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
-
-		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 50 } } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
+		const { container: storage50 } = render(
+			<PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 50 } } />
+		);
+		assert.lengthOf( storage50.getElementsByClassName( 'plan-storage__bar' ), 1 );
 	} );
 
 	test( 'should not render when storage is falsey or -1', () => {
-		let bar;
+		const { container: storage0 } = render( <PlanStorageBar { ...props } mediaStorage={ 0 } /> );
+		assert.lengthOf( storage0.getElementsByClassName( 'plan-storage__bar' ), 0 );
 
-		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ 0 } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
+		const { container: storageFalse } = render(
+			<PlanStorageBar { ...props } mediaStorage={ false } />
+		);
+		assert.lengthOf( storageFalse.getElementsByClassName( 'plan-storage__bar' ), 0 );
 
-		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ false } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
+		const { container: storageNull } = render(
+			<PlanStorageBar { ...props } mediaStorage={ null } />
+		);
+		assert.lengthOf( storageNull.getElementsByClassName( 'plan-storage__bar' ), 0 );
 
-		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ null } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
-
-		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: -1 } } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
+		const { container: storageUnlimited } = render(
+			<PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: -1 } } />
+		);
+		assert.lengthOf( storageUnlimited.getElementsByClassName( 'plan-storage__bar' ), 0 );
 	} );
 
 	test( 'should include upgrade link when displayUpgradeLink is true', () => {
-		const bar = shallow( <PlanStorageBar { ...props } displayUpgradeLink={ true } /> );
-		assert.lengthOf( bar.find( '.plan-storage__storage-link' ), 1 );
+		const { container } = render( <PlanStorageBar { ...props } displayUpgradeLink={ true } /> );
+		assert.lengthOf( container.getElementsByClassName( 'plan-storage__storage-link' ), 1 );
 	} );
 
 	test( 'should not include upgrade link when displayUpgradeLink is false', () => {
-		const bar = shallow( <PlanStorageBar { ...props } displayUpgradeLink={ false } /> );
-		assert.lengthOf( bar.find( '.plan-storage__storage-link' ), 0 );
+		const { container } = render( <PlanStorageBar { ...props } displayUpgradeLink={ false } /> );
+		assert.lengthOf( container.getElementsByClassName( 'plan-storage__storage-link' ), 0 );
 	} );
 } );

--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -43,8 +43,9 @@ describe( 'PlanStorageBar basic tests', () => {
 	} );
 
 	test( 'should render when storage is limited', () => {
-		const { container: premContainer } = render( <PlanStorageBar { ...props } /> );
-		render( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_PREMIUM } /> );
+		const { container: premContainer } = render(
+			<PlanStorageBar { ...props } sitePlanSlug={ PLAN_PREMIUM } />
+		);
 		expect( premContainer.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 
 		const { container: prem2Container } = render(

--- a/client/blocks/plan-storage/test/plan-storage.jsx
+++ b/client/blocks/plan-storage/test/plan-storage.jsx
@@ -12,15 +12,16 @@ import {
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_FREE,
 } from '@automattic/calypso-products';
+import { render, screen } from '@testing-library/react';
 import { assert } from 'chai';
-import { mount } from 'enzyme';
+import nock from 'nock';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import { PlanStorage } from '../index';
 
 const siteId = 123;
 
-function render( component, additionalState = {}, planSlug = 'free_plan' ) {
+function renderComponent( component, additionalState = {}, planSlug = 'free_plan' ) {
 	const queryClient = new QueryClient();
 	const store = {
 		getState: () => ( {
@@ -46,7 +47,7 @@ function render( component, additionalState = {}, planSlug = 'free_plan' ) {
 		subscribe: () => {},
 		dispatch: () => {},
 	};
-	return mount(
+	return render(
 		<QueryClientProvider client={ queryClient }>
 			<Provider store={ store }>{ component }</Provider>
 		</QueryClientProvider>
@@ -54,50 +55,91 @@ function render( component, additionalState = {}, planSlug = 'free_plan' ) {
 }
 
 describe( 'PlanStorage basic tests', () => {
+	beforeAll( () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.persist()
+			.get( '/rest/v1.1/sites/123/media-storage' )
+			.reply( 200 );
+	} );
+
 	test( 'should not blow up and have class .plan-storage', () => {
-		const storage = render( <PlanStorage siteId={ siteId } /> );
-		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+		const { container } = renderComponent( <PlanStorage siteId={ siteId } /> );
+		assert.lengthOf( container.getElementsByClassName( 'plan-storage' ), 1 );
 	} );
 
 	test( 'should render a PlanStorageBar', () => {
-		const storage = render( <PlanStorage siteId={ siteId } /> );
-		const bar = storage.find( 'Localized(PlanStorageBar)' );
-		assert.lengthOf( bar, 1 );
+		renderComponent( <PlanStorage siteId={ siteId } /> );
+		const progressBar = screen.queryByRole( 'progressbar' );
+		assert.isDefined( progressBar );
 	} );
 
 	test( 'should render when storage is limited', () => {
-		let storage;
+		const { container: premContainer } = renderComponent(
+			<PlanStorage siteId={ siteId } />,
+			{},
+			PLAN_PREMIUM
+		);
+		assert.lengthOf( premContainer.getElementsByClassName( 'plan-storage' ), 1 );
 
-		storage = render( <PlanStorage siteId={ siteId } />, {}, PLAN_PREMIUM );
-		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+		const { container: prem2Container } = renderComponent(
+			<PlanStorage siteId={ siteId } />,
+			{},
+			PLAN_PREMIUM_2_YEARS
+		);
+		assert.lengthOf( prem2Container.getElementsByClassName( 'plan-storage' ), 1 );
 
-		storage = render( <PlanStorage siteId={ siteId } />, {}, PLAN_PREMIUM_2_YEARS );
-		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+		const { container: persContainer } = renderComponent(
+			<PlanStorage siteId={ siteId } />,
+			{},
+			PLAN_PERSONAL
+		);
+		assert.lengthOf( persContainer.getElementsByClassName( 'plan-storage' ), 1 );
 
-		storage = render( <PlanStorage siteId={ siteId } />, {}, PLAN_PERSONAL );
-		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+		const { container: pers2Container } = renderComponent(
+			<PlanStorage siteId={ siteId } />,
+			{},
+			PLAN_PERSONAL_2_YEARS
+		);
+		assert.lengthOf( pers2Container.getElementsByClassName( 'plan-storage' ), 1 );
 
-		storage = render( <PlanStorage siteId={ siteId } />, {}, PLAN_PERSONAL_2_YEARS );
-		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+		const { container: freeContainer } = renderComponent(
+			<PlanStorage siteId={ siteId } />,
+			{},
+			PLAN_FREE
+		);
+		assert.lengthOf( freeContainer.getElementsByClassName( 'plan-storage' ), 1 );
 
-		storage = render( <PlanStorage siteId={ siteId } />, {}, PLAN_FREE );
-		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+		const { container: busContainer } = renderComponent(
+			<PlanStorage siteId={ siteId } />,
+			{},
+			PLAN_BUSINESS
+		);
+		assert.lengthOf( busContainer.getElementsByClassName( 'plan-storage' ), 1 );
 
-		storage = render( <PlanStorage siteId={ siteId } />, {}, PLAN_BUSINESS );
-		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+		const { container: bus2Container } = renderComponent(
+			<PlanStorage siteId={ siteId } />,
+			{},
+			PLAN_BUSINESS_2_YEARS
+		);
+		assert.lengthOf( bus2Container.getElementsByClassName( 'plan-storage' ), 1 );
 
-		storage = render( <PlanStorage siteId={ siteId } />, {}, PLAN_BUSINESS_2_YEARS );
-		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+		const { container: ecomContainer } = renderComponent(
+			<PlanStorage siteId={ siteId } />,
+			{},
+			PLAN_ECOMMERCE
+		);
+		assert.lengthOf( ecomContainer.getElementsByClassName( 'plan-storage' ), 1 );
 
-		storage = render( <PlanStorage siteId={ siteId } />, {}, PLAN_ECOMMERCE );
-		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
-
-		storage = render( <PlanStorage siteId={ siteId } />, {}, PLAN_ECOMMERCE_2_YEARS );
-		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+		const { container: ecom2Container } = renderComponent(
+			<PlanStorage siteId={ siteId } />,
+			{},
+			PLAN_ECOMMERCE_2_YEARS
+		);
+		assert.lengthOf( ecom2Container.getElementsByClassName( 'plan-storage' ), 1 );
 	} );
 
 	test( 'should render for atomic sites', () => {
-		const storage = render( <PlanStorage siteId={ siteId } />, {
+		const { container } = renderComponent( <PlanStorage siteId={ siteId } />, {
 			sites: {
 				items: {
 					[ siteId ]: {
@@ -113,11 +155,11 @@ describe( 'PlanStorage basic tests', () => {
 				},
 			},
 		} );
-		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+		assert.lengthOf( container.getElementsByClassName( 'plan-storage' ), 1 );
 	} );
 
 	test( 'should not render for jetpack sites', () => {
-		const storage = render( <PlanStorage siteId={ siteId } />, {
+		const { container } = renderComponent( <PlanStorage siteId={ siteId } />, {
 			sites: {
 				items: {
 					[ siteId ]: {
@@ -130,11 +172,11 @@ describe( 'PlanStorage basic tests', () => {
 				},
 			},
 		} );
-		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
+		assert.lengthOf( container.getElementsByClassName( 'plan-storage' ), 0 );
 	} );
 
 	test( 'should not render for contributors', () => {
-		const storage = render( <PlanStorage siteId={ siteId } />, {
+		const { container } = renderComponent( <PlanStorage siteId={ siteId } />, {
 			currentUser: {
 				capabilities: {
 					[ siteId ]: {
@@ -143,11 +185,11 @@ describe( 'PlanStorage basic tests', () => {
 				},
 			},
 		} );
-		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
+		assert.lengthOf( container.getElementsByClassName( 'plan-storage' ), 0 );
 	} );
 
 	test( 'should not render when site plan slug is empty', () => {
-		const storage = render( <PlanStorage siteId={ siteId } />, {}, null );
-		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
+		const { container } = renderComponent( <PlanStorage siteId={ siteId } />, {}, null );
+		assert.lengthOf( container.getElementsByClassName( '.plan-storage' ), 0 );
 	} );
 } );

--- a/client/blocks/plan-storage/test/plan-storage.jsx
+++ b/client/blocks/plan-storage/test/plan-storage.jsx
@@ -13,7 +13,6 @@ import {
 	PLAN_FREE,
 } from '@automattic/calypso-products';
 import { render, screen } from '@testing-library/react';
-import { assert } from 'chai';
 import nock from 'nock';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
@@ -64,13 +63,13 @@ describe( 'PlanStorage basic tests', () => {
 
 	test( 'should not blow up and have class .plan-storage', () => {
 		const { container } = renderComponent( <PlanStorage siteId={ siteId } /> );
-		assert.lengthOf( container.getElementsByClassName( 'plan-storage' ), 1 );
+		expect( container.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render a PlanStorageBar', () => {
 		renderComponent( <PlanStorage siteId={ siteId } /> );
 		const progressBar = screen.queryByRole( 'progressbar' );
-		assert.isDefined( progressBar );
+		expect( progressBar ).toBeDefined();
 	} );
 
 	test( 'should render when storage is limited', () => {
@@ -79,63 +78,63 @@ describe( 'PlanStorage basic tests', () => {
 			{},
 			PLAN_PREMIUM
 		);
-		assert.lengthOf( premContainer.getElementsByClassName( 'plan-storage' ), 1 );
+		expect( premContainer.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
 
 		const { container: prem2Container } = renderComponent(
 			<PlanStorage siteId={ siteId } />,
 			{},
 			PLAN_PREMIUM_2_YEARS
 		);
-		assert.lengthOf( prem2Container.getElementsByClassName( 'plan-storage' ), 1 );
+		expect( prem2Container.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
 
 		const { container: persContainer } = renderComponent(
 			<PlanStorage siteId={ siteId } />,
 			{},
 			PLAN_PERSONAL
 		);
-		assert.lengthOf( persContainer.getElementsByClassName( 'plan-storage' ), 1 );
+		expect( persContainer.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
 
 		const { container: pers2Container } = renderComponent(
 			<PlanStorage siteId={ siteId } />,
 			{},
 			PLAN_PERSONAL_2_YEARS
 		);
-		assert.lengthOf( pers2Container.getElementsByClassName( 'plan-storage' ), 1 );
+		expect( pers2Container.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
 
 		const { container: freeContainer } = renderComponent(
 			<PlanStorage siteId={ siteId } />,
 			{},
 			PLAN_FREE
 		);
-		assert.lengthOf( freeContainer.getElementsByClassName( 'plan-storage' ), 1 );
+		expect( freeContainer.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
 
 		const { container: busContainer } = renderComponent(
 			<PlanStorage siteId={ siteId } />,
 			{},
 			PLAN_BUSINESS
 		);
-		assert.lengthOf( busContainer.getElementsByClassName( 'plan-storage' ), 1 );
+		expect( busContainer.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
 
 		const { container: bus2Container } = renderComponent(
 			<PlanStorage siteId={ siteId } />,
 			{},
 			PLAN_BUSINESS_2_YEARS
 		);
-		assert.lengthOf( bus2Container.getElementsByClassName( 'plan-storage' ), 1 );
+		expect( bus2Container.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
 
 		const { container: ecomContainer } = renderComponent(
 			<PlanStorage siteId={ siteId } />,
 			{},
 			PLAN_ECOMMERCE
 		);
-		assert.lengthOf( ecomContainer.getElementsByClassName( 'plan-storage' ), 1 );
+		expect( ecomContainer.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
 
 		const { container: ecom2Container } = renderComponent(
 			<PlanStorage siteId={ siteId } />,
 			{},
 			PLAN_ECOMMERCE_2_YEARS
 		);
-		assert.lengthOf( ecom2Container.getElementsByClassName( 'plan-storage' ), 1 );
+		expect( ecom2Container.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render for atomic sites', () => {
@@ -155,7 +154,7 @@ describe( 'PlanStorage basic tests', () => {
 				},
 			},
 		} );
-		assert.lengthOf( container.getElementsByClassName( 'plan-storage' ), 1 );
+		expect( container.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not render for jetpack sites', () => {
@@ -172,7 +171,7 @@ describe( 'PlanStorage basic tests', () => {
 				},
 			},
 		} );
-		assert.lengthOf( container.getElementsByClassName( 'plan-storage' ), 0 );
+		expect( container.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should not render for contributors', () => {
@@ -185,11 +184,11 @@ describe( 'PlanStorage basic tests', () => {
 				},
 			},
 		} );
-		assert.lengthOf( container.getElementsByClassName( 'plan-storage' ), 0 );
+		expect( container.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should not render when site plan slug is empty', () => {
 		const { container } = renderComponent( <PlanStorage siteId={ siteId } />, {}, null );
-		assert.lengthOf( container.getElementsByClassName( '.plan-storage' ), 0 );
+		expect( container.getElementsByClassName( '.plan-storage' ) ).toHaveLength( 0 );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

React 18 is out, and `enzyme`, which we use broadly for component testing, doesn't (and will likely never) support it. As part of our preparation to upgrade to React to v18, we need to refactor all tests that use `enzyme` to a modern component testing library, like `testing-library` for example.

This PR refactors the tests of `<PlanStorage />` from `enzyme` to `@testing-library/react`. I've also used the opportunity to migrate assertions from `chai` to the preferred `jest`. While it looks large, it's relatively straightforward.

#### Testing instructions

Verify tests still pass:`yarn run test-client client/blocks/plan-storage`.