### PR TITLE
Updated plugin section names

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -88,15 +88,15 @@ const SHORT_LIST_LENGTH = 6;
 const translateCategory = ( { category, translate } ) => {
 	switch ( category ) {
 		case 'popular':
-			return translate( 'Popular', {
+			return translate( 'Top Free Plugins', {
 				context: 'Category description for the plugin browser.',
 			} );
 		case 'featured':
-			return translate( 'Featured', {
+			return translate( "Editor's Pick", {
 				context: 'Category description for the plugin browser.',
 			} );
 		case 'paid':
-			return translate( 'Premium', {
+			return translate( 'Top Premium Plugins', {
 				context: 'Category description for the plugin browser.',
 			} );
 		default:
@@ -107,11 +107,11 @@ const translateCategory = ( { category, translate } ) => {
 const translateCategoryTitle = ( { category, translate } ) => {
 	switch ( category ) {
 		case 'popular':
-			return translate( 'Top free plugins' );
+			return translate( 'All Top Free Plugins' );
 		case 'featured':
-			return translate( "Editor's pick" );
+			return translate( "All Editor's Pick" );
 		case 'paid':
-			return translate( 'Top premium plugins' );
+			return translate( 'All Top Premium Plugins' );
 		default:
 			return translate( 'Plugins' );
 	}

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -107,11 +107,11 @@ const translateCategory = ( { category, translate } ) => {
 const translateCategoryTitle = ( { category, translate } ) => {
 	switch ( category ) {
 		case 'popular':
-			return translate( 'All Popular Plugins' );
+			return translate( 'Top free plugins' );
 		case 'featured':
-			return translate( 'All Featured Plugins' );
+			return translate( "Editor's pick" );
 		case 'paid':
-			return translate( 'All Premium Plugins' );
+			return translate( 'Top premium plugins' );
 		default:
 			return translate( 'Plugins' );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updated plugin section names

Task-related: https://github.com/Automattic/wp-calypso/issues/62495

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


- [ ] Open [/plugins page](http://calypso.localhost:3000/plugins/) and make sure all sections are renamed according to [this comment](https://github.com/Automattic/wp-calypso/issues/62495#issuecomment-1101757967).
- [ ] Click on **Browse all** and make sure the title is as expected

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

