### PR TITLE
Playwright: Add E2E type checking to CI

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -335,6 +335,7 @@ object RunAllUnitTests : BuildType({
 				yarn tsc --build packages/*/tsconfig.json
 				yarn tsc --build apps/editing-toolkit/tsconfig.json
 				yarn tsc --build client/tsconfig.json
+				yarn tsc --build test/e2e/tsconfig.json
 			"""
 		}
 		bashNodeScript {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -34,6 +34,7 @@
 		"@automattic/mocha-debug-reporter": "workspace:^",
 		"@automattic/testarmada-magellan-mocha-plugin": "workspace:^",
 		"@testim/chrome-version": "^1.0.7",
+		"@types/archiver": "^5.3.1",
 		"@types/jest": "^27.0.2",
 		"@xmpp/plugins": "^0.3.0",
 		"archiver": "^5.3.0",

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -216,9 +216,9 @@ describe( 'I18N: Editor', function () {
 	const accountName = getTestAccountByFeature( { ...features, variant: 'i18n' } );
 
 	// Filter out the locales that do not have valid translation content defined above.
-	const locales = Object.keys( translations ).filter( ( locale ) =>
+	const locales: LanguageSlug[] = Object.keys( translations ).filter( ( locale ) =>
 		( envVariables.TEST_LOCALES as ReadonlyArray< string > ).includes( locale )
-	);
+	) as LanguageSlug[];
 	let page: Page;
 	let editorPage: EditorPage;
 
@@ -259,11 +259,13 @@ describe( 'I18N: Editor', function () {
 			} );
 		} );
 
-		describe.each( translations[ locale ].blocks )(
+		// We know these are all defined because of the filtering above. Non-null asserting is safe here.
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		describe.each( translations[ locale ]!.blocks! )(
 			'Translations for block: $blockName',
 			( ...args ) => {
 				const block = args[ 0 ]; // Makes TS stop complaining about incompatible args type
-				let frame: Frame;
+				let frame: Page | Frame;
 				let editorPage: EditorPage;
 
 				const blockTimeout = 10 * 1000;
@@ -277,7 +279,7 @@ describe( 'I18N: Editor', function () {
 					frame = await editorPage.getEditorHandle();
 					// Ensure block contents are translated as expected.
 					await Promise.all(
-						block.blockEditorContent.map( ( content: any ) =>
+						block.blockEditorContent.map( ( content ) =>
 							frame.waitForSelector( `${ block.blockEditorSelector } ${ content }`, {
 								timeout: blockTimeout,
 							} )

--- a/yarn.lock
+++ b/yarn.lock
@@ -6689,6 +6689,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/archiver@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "@types/archiver@npm:5.3.1"
+  dependencies:
+    "@types/glob": "*"
+  checksum: 622c0d3cf54c0009d07db0c78349a4e81ae3a4b699c7f2ea34085c0ebfb13eca8c4a6459aa5e376c2c0f72916280a0986154fad35022a280670a6e5551fff9d2
+  languageName: node
+  linkType: hard
+
 "@types/aria-query@npm:^4.2.0":
   version: 4.2.0
   resolution: "@types/aria-query@npm:4.2.0"
@@ -38339,6 +38348,7 @@ testarmada-magellan@11.0.10:
     "@automattic/testarmada-magellan-mocha-plugin": "workspace:^"
     "@babel/core": ^7.16.0
     "@testim/chrome-version": ^1.0.7
+    "@types/archiver": ^5.3.1
     "@types/jest": ^27.0.2
     "@xmpp/plugins": ^0.3.0
     archiver: ^5.3.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds type checking of our E2E tests to the CI builds. We've always had this available, but it's never been a part of CI. It's to our advantage to keep on top of this!

As a recent example, I accidentally broke pre-release tests (p1649945325082009-slack-C02DQP0FP) because I changed the signature of a POM class method, but missed one script where that needed to be updated. I had no indication that this was broken until I was in the deploy pipeline and the tests failed. This would have easily been caught with a type check!

This also fixes any remaining type errors in our E2E tests so we are currently running clean, 👍 

#### Testing instructions

- [ ] All CI builds should pass

Related to #