### PR TITLE
Seller Experience: Hides theme categories on the stepper flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -336,6 +336,7 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 			stepName={ 'design-step' }
 			className={ classnames( {
 				'design-picker__has-categories': showDesignPickerCategories,
+				'design-picker__sell-intent': 'sell' === intent,
 			} ) }
 			hideSkip={ isAnchorSite }
 			skipButtonAlign={ 'top' }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -280,3 +280,12 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		}
 	}
 }
+
+/* Hide categories from the sell intent */
+.design-picker__sell-intent {
+	.design-picker-category-filter__sidebar,
+	.design-picker-category-filter__dropdown,
+	.design-picker__category-heading-0 {
+		display: none;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The theme categories in the seller experience should not be shown on the new stepper flow. 

**Before**
<img width="1512" alt="Screen Shot 2022-04-19 at 16 00 06" src="https://user-images.githubusercontent.com/1234758/164076434-6d383ded-f523-468a-bd98-7e9a237484cf.png">

**After**
<img width="1512" alt="Screen Shot 2022-04-19 at 15 58 46" src="https://user-images.githubusercontent.com/1234758/164076300-2a2b8317-c839-40cf-99ef-4923c26e92af.png">

#### Testing instructions

* Navigate to: http://calypso.localhost:3000/setup/vertical?siteSlug=[YOUR-SITE]
* Select a category and click on the `Continue` button
* Click on the `Start selling` button
* Give your store a name and click on the `Continue` button
* On the `Start simple` section, click on the `Continue` button
* The theme categories will no longer be shown

Closes #62779
