### PR TITLE
Jetpack Connect: Update auth redirect for Jetpack Social plugin

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -277,7 +277,8 @@ export class JetpackAuthorize extends Component {
 			this.shouldRedirectJetpackStart() ||
 			getRoleFromScope( scope ) === 'subscriber' ||
 			this.isJetpackUpgradeFlow() ||
-			this.isFromJetpackConnectionManager()
+			this.isFromJetpackConnectionManager() ||
+			this.isFromJetpackSocialPlugin()
 		) {
 			debug(
 				'Going back to WP Admin.',
@@ -376,6 +377,11 @@ export class JetpackAuthorize extends Component {
 	isFromJetpackSearchPlugin( props = this.props ) {
 		const { from } = props.authQuery;
 		return startsWith( from, 'jetpack-search' );
+	}
+
+	isFromJetpackSocialPlugin( props = this.props ) {
+		const { from } = props.authQuery;
+		return startsWith( from, 'jetpack-social' );
 	}
 
 	isWooRedirect = ( props = this.props ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If the Jetpack connection is initiated from the Jetpack Social plugin, redirect to the `redirectAfterAuth`. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There's probably a better way to do this, but here's how I tested: 
- Initiate the connection from the Jetpack Social plugin
- When on the Calypso auth screen, manually replace the `https://wordpress.com/` with `http://calypso.localhost:3000/`, preserving all the params and stuff after it.  
- Click authorize
- You should be taken back to the site, as prescribed by the `redirect_after_auth` param in the URL.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

p1650382049238109-slack-C02JJ910CNL