### PR TITLE
Add dummy data- attribute

### DIFF
--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -35,7 +35,7 @@ function FormattedHeader( {
 	return (
 		<header id={ id } className={ classes }>
 			{ ! isSecondary && (
-				<h1 className={ headerClasses }>
+				<h1 className={ headerClasses } data-hello="world">
 					{ preventWidows( headerText, 2 ) } { tooltip }
 				</h1>
 			) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a dummy data-hello attribute to /home heading
* Update components/formatted-header to add the attribute

#### Testing instructions
* Heading to https://wordpress.com/home/$site
* Inspect the heading to check the data- attribute apprear correctly
![image](https://user-images.githubusercontent.com/90233168/164150066-6f9ac1e5-6cf8-47a7-9eb5-98d16316186a.png)

Related to #62899 
