### PR TITLE
Masterbar: set hover styling only desktop

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -279,12 +279,14 @@ $autobar-height: 20px;
 	}
 
 	&:hover {
-		background: var( --color-masterbar-item-hover-background );
-		color: var( --color-masterbar-text );
+		@include breakpoint-deprecated( '>480px' ) {
+			background: var( --color-masterbar-item-hover-background );
+			color: var( --color-masterbar-text );
 
-		.is-section-checkout.is-jetpack-site & {
-			background: var( --color-jetpack-masterbar-item-hover-background );
-			color: var( --color-jetpack-masterbar-text );
+			.is-section-checkout.is-jetpack-site & {
+				background: var( --color-jetpack-masterbar-item-hover-background );
+				color: var( --color-jetpack-masterbar-text );
+			}
 		}
 	}
 
@@ -693,7 +695,6 @@ $autobar-height: 20px;
 	font-weight: 500;
 	color: var( --color-text );
 
-	
 	@include breakpoint-deprecated( '>480px' ) {
 		border-left: 1px solid var( --studio-gray-5 );
 	}


### PR DESCRIPTION
## Changes proposed in this Pull Request

Masterbar item background is changing color in mobile after clicking off of it. This PR specifies the hover styling to only apply to larger resolution sites.

## Testing instructions

1. Pull branch and `yarn start`
2. Check masterbar icons in mobile and desktop orientations.
3. There should be a hover effect in the desktop but not mobile
