### PR TITLE
Stepper: add AT transfer status

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -10,6 +10,7 @@ import type {
 	SiteError,
 	Cart,
 	Domain,
+	LatestAtomicTransfer,
 	SiteLaunchError as SiteLaunchErrorType,
 	AtomicTransferError as AtomicTransferErrorType,
 	LatestAtomicTransferError as LatestAtomicTransferErrorType,
@@ -305,9 +306,10 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		siteId,
 	} );
 
-	const latestAtomicTransferSuccess = ( siteId: number ) => ( {
+	const latestAtomicTransferSuccess = ( siteId: number, transfer: LatestAtomicTransfer ) => ( {
 		type: 'LATEST_ATOMIC_TRANSFER_SUCCESS' as const,
 		siteId,
+		transfer,
 	} );
 
 	const latestAtomicTransferFailure = (
@@ -323,14 +325,14 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		yield latestAtomicTransferStart( siteId );
 
 		try {
-			yield wpcomRequest( {
+			const transfer: LatestAtomicTransfer = yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/atomic/transfers/latest`,
 				apiNamespace: 'wpcom/v2',
 				method: 'GET',
 			} );
-			yield latestAtomicTransferSuccess( siteId );
-		} catch ( _ ) {
-			yield latestAtomicTransferFailure( siteId, LatestAtomicTransferError.INTERNAL );
+			yield latestAtomicTransferSuccess( siteId, transfer );
+		} catch ( err ) {
+			yield latestAtomicTransferFailure( siteId, err as LatestAtomicTransferError );
 		}
 	}
 

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -243,6 +243,7 @@ export const latestAtomicTransferStatus: Reducer<
 			...state,
 			[ action.siteId ]: {
 				status: LatestAtomicTransferStatus.IN_PROGRESS,
+				transfer: undefined,
 				errorCode: undefined,
 			},
 		};
@@ -262,6 +263,7 @@ export const latestAtomicTransferStatus: Reducer<
 			...state,
 			[ action.siteId ]: {
 				status: LatestAtomicTransferStatus.FAILURE,
+				transfer: undefined,
 				errorCode: action.error,
 			},
 		};

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -8,8 +8,9 @@ import {
 	SiteLaunchStatus,
 	SiteSettings,
 	AtomicTransferStatus,
+	LatestAtomicTransferStatus,
 } from './types';
-import { AtomicTransferState } from '.';
+import { AtomicTransferState, LatestAtomicTransferState } from '.';
 import type { Action } from './actions';
 import type { Reducer } from 'redux';
 
@@ -233,6 +234,40 @@ export const atomicTransferStatus: Reducer< { [ key: number ]: AtomicTransferSta
 	return state;
 };
 
+export const latestAtomicTransferStatus: Reducer<
+	{ [ key: number ]: LatestAtomicTransferState },
+	Action
+> = ( state = {}, action ) => {
+	if ( action.type === 'LATEST_ATOMIC_TRANSFER_START' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				status: LatestAtomicTransferStatus.IN_PROGRESS,
+				errorCode: undefined,
+			},
+		};
+	}
+	if ( action.type === 'LATEST_ATOMIC_TRANSFER_SUCCESS' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				status: LatestAtomicTransferStatus.SUCCESS,
+				errorCode: undefined,
+			},
+		};
+	}
+	if ( action.type === 'LATEST_ATOMIC_TRANSFER_FAILURE' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				status: LatestAtomicTransferStatus.FAILURE,
+				errorCode: action.error,
+			},
+		};
+	}
+	return state;
+};
+
 const newSite = combineReducers( {
 	data: newSiteData,
 	error: newSiteError,
@@ -248,6 +283,7 @@ const reducer = combineReducers( {
 	sitesSettings,
 	siteSetupErrors,
 	atomicTransferStatus,
+	latestAtomicTransferStatus,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -252,6 +252,7 @@ export const latestAtomicTransferStatus: Reducer<
 			...state,
 			[ action.siteId ]: {
 				status: LatestAtomicTransferStatus.SUCCESS,
+				transfer: action.transfer,
 				errorCode: undefined,
 			},
 		};

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -71,6 +71,10 @@ export const getSiteSubdomain = ( _: State, siteId: number ) =>
 		.getSiteDomains( siteId )
 		?.find( ( domain ) => domain.is_subdomain );
 
+export const getSiteLatestAtomicTransfer = ( state: State, siteId: number ) => {
+	return state.latestAtomicTransferStatus[ siteId ]?.transfer;
+};
+
 export const hasActiveSiteFeature = (
 	_: State,
 	siteId: number | undefined,

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -328,6 +328,7 @@ export interface LatestAtomicTransfer {
 
 export interface LatestAtomicTransferState {
 	status: LatestAtomicTransferStatus;
+	transfer: LatestAtomicTransfer | undefined;
 	errorCode: LatestAtomicTransferError | undefined;
 }
 

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -316,6 +316,16 @@ export enum AtomicTransferError {
 	INTERNAL = 'internal',
 }
 
+export interface LatestAtomicTransfer {
+	atomic_transfer_id: number;
+	blog_id: number;
+	status: string;
+	created_at: string;
+	is_stuck: boolean;
+	is_stuck_reset: boolean;
+	in_lossless_revert: boolean;
+}
+
 export interface LatestAtomicTransferState {
 	status: LatestAtomicTransferStatus;
 	errorCode: LatestAtomicTransferError | undefined;
@@ -328,6 +338,9 @@ export enum LatestAtomicTransferStatus {
 	FAILURE = 'failure',
 }
 
-export enum LatestAtomicTransferError {
-	INTERNAL = 'internal',
+export interface LatestAtomicTransferError {
+	name: string; // "NotFoundError"
+	status: number; // 404
+	message: string; // "Transfer not found"
+	code: string; // "no_transfer_record"
 }

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -315,3 +315,19 @@ export enum AtomicTransferStatus {
 export enum AtomicTransferError {
 	INTERNAL = 'internal',
 }
+
+export interface LatestAtomicTransferState {
+	status: LatestAtomicTransferStatus;
+	errorCode: LatestAtomicTransferError | undefined;
+}
+
+export enum LatestAtomicTransferStatus {
+	UNINITIALIZED = 'unintialized',
+	IN_PROGRESS = 'in_progress',
+	SUCCESS = 'success',
+	FAILURE = 'failure',
+}
+
+export enum LatestAtomicTransferError {
+	INTERNAL = 'internal',
+}


### PR DESCRIPTION
Adding Atomic transfer selector, types and intermediate steps. This can be refined in the near future when this selector is used for the Transfer step.

#### Testing

I've added tests for the intermediate actions that can be run with the following command:
```
 yarn run test-packages packages/data-stores/src/site/test/actions.ts
```

Related: https://github.com/Automattic/wp-calypso/issues/62716