### PR TITLE
Add marketing/tools description string for preemptive translation

### DIFF
--- a/client/my-sites/marketing/tools/tools-translation-strings.js
+++ b/client/my-sites/marketing/tools/tools-translation-strings.js
@@ -1,0 +1,5 @@
+import { translate } from 'i18n-calypso';
+
+translate(
+	"We've added premium plugins to boost your site's capabilities. From bookings and subscriptions to email marketing and SEO tools, we have you covered."
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Added a preemptive translation for the `/marketing/tools` description to use when `Yoast` is released

#### Screenshot
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/402286/164275545-b50d18fb-4da0-4711-ad0d-0e9ddc905e97.png">

Related to #62916 