### PR TITLE
Seller Experience-Stepper: Add selectors for available site features and requires Woo upgrade to

### DIFF
--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -84,3 +84,24 @@ export const hasActiveSiteFeature = (
 		siteId && select( STORE_KEY ).getSite( siteId )?.plan?.features.active.includes( featureKey )
 	);
 };
+
+export const hasAvailableSiteFeature = (
+	_: State,
+	siteId: number | undefined,
+	featureKey: string
+): boolean => {
+	return Boolean(
+		siteId && select( STORE_KEY ).getSite( siteId )?.plan?.features.available[ featureKey ]
+	);
+};
+
+export const requiresUpgrade = ( state: State, siteId: number | null ) => {
+	const isWoopFeatureActive = Boolean(
+		siteId && select( STORE_KEY ).hasActiveSiteFeature( siteId, 'woop' )
+	);
+	const hasWoopFeatureAvailable = Boolean(
+		siteId && select( STORE_KEY ).hasAvailableSiteFeature( siteId, 'woop' )
+	);
+
+	return Boolean( ! isWoopFeatureActive && hasWoopFeatureAvailable );
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add selectors for available site features and requires Woo upgrade to the site data-store

#### Testing instructions

`yarn run test-packages ./packages/data-stores/src/site/test/selectors.ts`

Related to #62714
Closes #62918
