### PR TITLE
Domains: Refactor contact form fieldset tests to `@testing-library/react` and `jest`

### DIFF
--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { render, screen } from '@testing-library/react';
-import { expect } from 'chai';
 import EuAddressFieldset from '../eu-address-fieldset';
 
 jest.mock( 'i18n-calypso', () => ( {
@@ -24,23 +23,23 @@ describe( 'EU Address Fieldset', () => {
 
 	test( 'should render correctly with default props', () => {
 		const { container } = render( <EuAddressFieldset { ...defaultProps } /> );
-		expect( container.getElementsByClassName( 'eu-address-fieldset' ) ).to.have.length( 1 );
+		expect( container.getElementsByClassName( 'eu-address-fieldset' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render expected input components', () => {
 		render( <EuAddressFieldset { ...defaultProps } /> );
-		expect( screen.queryByLabelText( 'City' ) ).to.exist;
-		expect( screen.queryByLabelText( 'Postal Code' ) ).to.exist;
+		expect( screen.queryByLabelText( 'City' ) ).toBeDefined();
+		expect( screen.queryByLabelText( 'Postal Code' ) ).toBeDefined();
 	} );
 
 	test( 'should not render a state select components', () => {
 		render( <EuAddressFieldset { ...defaultProps } /> );
-		expect( screen.queryByLabelText( 'State' ) ).to.not.exist;
+		expect( screen.queryByLabelText( 'State' ) ).toBeNull();
 	} );
 
 	test( 'should render all expected input components but postal code', () => {
 		render( <EuAddressFieldset { ...propsWithoutPostalCode } /> );
-		expect( screen.queryByLabelText( 'City' ) ).to.exist;
-		expect( screen.queryByLabelText( 'Postal Code' ) ).to.not.exist;
+		expect( screen.queryByLabelText( 'City' ) ).toBeDefined();
+		expect( screen.queryByLabelText( 'Postal Code' ) ).toBeNull();
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
@@ -1,14 +1,14 @@
 /**
  * @jest-environment jsdom
  */
-
+import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
 import EuAddressFieldset from '../eu-address-fieldset';
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: ( x ) => x,
 	translate: ( x ) => x,
+	useTranslate: () => ( x ) => x,
 } ) );
 
 describe( 'EU Address Fieldset', () => {
@@ -23,24 +23,24 @@ describe( 'EU Address Fieldset', () => {
 	};
 
 	test( 'should render correctly with default props', () => {
-		const wrapper = shallow( <EuAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '.eu-address-fieldset' ) ).to.have.length( 1 );
+		const { container } = render( <EuAddressFieldset { ...defaultProps } /> );
+		expect( container.getElementsByClassName( 'eu-address-fieldset' ) ).to.have.length( 1 );
 	} );
 
 	test( 'should render expected input components', () => {
-		const wrapper = shallow( <EuAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '[name="city"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="postal-code"]' ) ).to.have.length( 1 );
+		const { container } = render( <EuAddressFieldset { ...defaultProps } /> );
+		expect( container.querySelectorAll( '[name="city"]' ) ).to.have.length( 1 );
+		expect( container.querySelectorAll( '[name="postal-code"]' ) ).to.have.length( 1 );
 	} );
 
 	test( 'should not render a state select components', () => {
-		const wrapper = shallow( <EuAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '[name="state"]' ) ).to.have.length( 0 );
+		const { container } = render( <EuAddressFieldset { ...defaultProps } /> );
+		expect( container.querySelectorAll( '[name="state"]' ) ).to.have.length( 0 );
 	} );
 
 	test( 'should render all expected input components but postal code', () => {
-		const wrapper = shallow( <EuAddressFieldset { ...propsWithoutPostalCode } /> );
-		expect( wrapper.find( '[name="city"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="postal-code"]' ) ).to.have.length( 0 );
+		const { container } = render( <EuAddressFieldset { ...propsWithoutPostalCode } /> );
+		expect( container.querySelectorAll( '[name="city"]' ) ).to.have.length( 1 );
+		expect( container.querySelectorAll( '[name="postal-code"]' ) ).to.have.length( 0 );
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { expect } from 'chai';
 import EuAddressFieldset from '../eu-address-fieldset';
 
@@ -28,19 +28,19 @@ describe( 'EU Address Fieldset', () => {
 	} );
 
 	test( 'should render expected input components', () => {
-		const { container } = render( <EuAddressFieldset { ...defaultProps } /> );
-		expect( container.querySelectorAll( '[name="city"]' ) ).to.have.length( 1 );
-		expect( container.querySelectorAll( '[name="postal-code"]' ) ).to.have.length( 1 );
+		render( <EuAddressFieldset { ...defaultProps } /> );
+		expect( screen.queryByLabelText( 'City' ) ).to.exist;
+		expect( screen.queryByLabelText( 'Postal Code' ) ).to.exist;
 	} );
 
 	test( 'should not render a state select components', () => {
-		const { container } = render( <EuAddressFieldset { ...defaultProps } /> );
-		expect( container.querySelectorAll( '[name="state"]' ) ).to.have.length( 0 );
+		render( <EuAddressFieldset { ...defaultProps } /> );
+		expect( screen.queryByLabelText( 'State' ) ).to.not.exist;
 	} );
 
 	test( 'should render all expected input components but postal code', () => {
-		const { container } = render( <EuAddressFieldset { ...propsWithoutPostalCode } /> );
-		expect( container.querySelectorAll( '[name="city"]' ) ).to.have.length( 1 );
-		expect( container.querySelectorAll( '[name="postal-code"]' ) ).to.have.length( 0 );
+		render( <EuAddressFieldset { ...propsWithoutPostalCode } /> );
+		expect( screen.queryByLabelText( 'City' ) ).to.exist;
+		expect( screen.queryByLabelText( 'Postal Code' ) ).to.not.exist;
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
@@ -1,9 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { render, screen } from 'calypso/test-helpers/config/testing-library';
 import {
 	CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES,
 	CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES,
@@ -13,6 +12,7 @@ import { RegionAddressFieldsets } from '../region-address-fieldsets';
 jest.mock( 'i18n-calypso', () => ( {
 	localize: ( x ) => x,
 	translate: ( x ) => x,
+	useTranslate: () => ( x ) => x,
 } ) );
 
 describe( 'Region Address Fieldsets', () => {
@@ -35,51 +35,51 @@ describe( 'Region Address Fieldsets', () => {
 	};
 
 	test( 'should render `<UsAddressFieldset />` with default props', () => {
-		const wrapper = shallow( <RegionAddressFieldsets { ...defaultProps } /> );
-		expect( wrapper.find( 'UsAddressFieldset' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="address-1"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="address-2"]' ) ).to.have.length( 1 );
+		const { container } = render( <RegionAddressFieldsets { ...defaultProps } /> );
+		expect( container.getElementsByClassName( 'us-address-fieldset' ) ).to.have.length( 1 );
+		expect( screen.queryByLabelText( 'Address' ) ).to.exist;
+		expect( screen.queryByText( '+ Add Address Line 2' ) ).to.exist;
 	} );
 
 	test( 'should render `<UkAddressFieldset />` with a UK region countryCode', () => {
-		const wrapper = shallow(
+		const { container } = render(
 			<RegionAddressFieldsets
 				{ ...defaultProps }
 				countryCode={ CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES[ 0 ] }
 			/>
 		);
-		expect( wrapper.find( 'UkAddressFieldset' ) ).to.have.length( 1 );
+		expect( container.getElementsByClassName( 'uk-address-fieldset' ) ).to.have.length( 1 );
 	} );
 
 	test( 'should render `<EuAddressFieldset />` with an EU region countryCode', () => {
-		const wrapper = shallow(
+		const { container } = render(
 			<RegionAddressFieldsets
 				{ ...defaultProps }
 				countryCode={ CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES[ 0 ] }
 			/>
 		);
-		expect( wrapper.find( 'EuAddressFieldset' ) ).to.have.length( 1 );
+		expect( container.getElementsByClassName( 'eu-address-fieldset' ) ).to.have.length( 1 );
 	} );
 
 	test( 'should render `<UsAddressFieldset />` with an EU region country that has states', () => {
-		const wrapper = shallow(
+		const { container } = render(
 			<RegionAddressFieldsets
 				{ ...propsWithStates }
 				countryCode={ CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES[ 0 ] }
 			/>
 		);
-		expect( wrapper.find( 'UsAddressFieldset' ) ).to.have.length( 1 );
-		expect( wrapper.find( 'EuAddressFieldset' ) ).to.have.length( 0 );
+		expect( container.getElementsByClassName( 'us-address-fieldset' ) ).to.have.length( 1 );
+		expect( container.getElementsByClassName( 'eu-address-fieldset' ) ).to.have.length( 0 );
 	} );
 
 	test( 'should render `<UsAddressFieldset />` with a UK region country that has states', () => {
-		const wrapper = shallow(
+		const { container } = render(
 			<RegionAddressFieldsets
 				{ ...propsWithStates }
 				countryCode={ CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES[ 0 ] }
 			/>
 		);
-		expect( wrapper.find( 'UsAddressFieldset' ) ).to.have.length( 1 );
-		expect( wrapper.find( 'UkAddressFieldset' ) ).to.have.length( 0 );
+		expect( container.getElementsByClassName( 'us-address-fieldset' ) ).to.have.length( 1 );
+		expect( container.getElementsByClassName( 'uk-address-fieldset' ) ).to.have.length( 0 );
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import { expect } from 'chai';
 import { render, screen } from 'calypso/test-helpers/config/testing-library';
 import {
 	CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES,
@@ -36,9 +35,9 @@ describe( 'Region Address Fieldsets', () => {
 
 	test( 'should render `<UsAddressFieldset />` with default props', () => {
 		const { container } = render( <RegionAddressFieldsets { ...defaultProps } /> );
-		expect( container.getElementsByClassName( 'us-address-fieldset' ) ).to.have.length( 1 );
-		expect( screen.queryByLabelText( 'Address' ) ).to.exist;
-		expect( screen.queryByText( '+ Add Address Line 2' ) ).to.exist;
+		expect( container.getElementsByClassName( 'us-address-fieldset' ) ).toHaveLength( 1 );
+		expect( screen.queryByLabelText( 'Address' ) ).toBeDefined();
+		expect( screen.queryByText( '+ Add Address Line 2' ) ).toBeDefined();
 	} );
 
 	test( 'should render `<UkAddressFieldset />` with a UK region countryCode', () => {
@@ -48,7 +47,7 @@ describe( 'Region Address Fieldsets', () => {
 				countryCode={ CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES[ 0 ] }
 			/>
 		);
-		expect( container.getElementsByClassName( 'uk-address-fieldset' ) ).to.have.length( 1 );
+		expect( container.getElementsByClassName( 'uk-address-fieldset' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render `<EuAddressFieldset />` with an EU region countryCode', () => {
@@ -58,7 +57,7 @@ describe( 'Region Address Fieldsets', () => {
 				countryCode={ CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES[ 0 ] }
 			/>
 		);
-		expect( container.getElementsByClassName( 'eu-address-fieldset' ) ).to.have.length( 1 );
+		expect( container.getElementsByClassName( 'eu-address-fieldset' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render `<UsAddressFieldset />` with an EU region country that has states', () => {
@@ -68,8 +67,8 @@ describe( 'Region Address Fieldsets', () => {
 				countryCode={ CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES[ 0 ] }
 			/>
 		);
-		expect( container.getElementsByClassName( 'us-address-fieldset' ) ).to.have.length( 1 );
-		expect( container.getElementsByClassName( 'eu-address-fieldset' ) ).to.have.length( 0 );
+		expect( container.getElementsByClassName( 'us-address-fieldset' ) ).toHaveLength( 1 );
+		expect( container.getElementsByClassName( 'eu-address-fieldset' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render `<UsAddressFieldset />` with a UK region country that has states', () => {
@@ -79,7 +78,7 @@ describe( 'Region Address Fieldsets', () => {
 				countryCode={ CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES[ 0 ] }
 			/>
 		);
-		expect( container.getElementsByClassName( 'us-address-fieldset' ) ).to.have.length( 1 );
-		expect( container.getElementsByClassName( 'uk-address-fieldset' ) ).to.have.length( 0 );
+		expect( container.getElementsByClassName( 'us-address-fieldset' ) ).toHaveLength( 1 );
+		expect( container.getElementsByClassName( 'uk-address-fieldset' ) ).toHaveLength( 0 );
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
@@ -1,14 +1,14 @@
 /**
  * @jest-environment jsdom
  */
-
+import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
 import UkAddressFieldset from '../uk-address-fieldset';
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: ( x ) => x,
 	translate: ( x ) => x,
+	useTranslate: () => ( x ) => x,
 } ) );
 
 describe( 'UK Address Fieldset', () => {
@@ -23,24 +23,24 @@ describe( 'UK Address Fieldset', () => {
 	};
 
 	test( 'should render correctly with default props', () => {
-		const wrapper = shallow( <UkAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '.uk-address-fieldset' ) ).to.have.length( 1 );
+		const { container } = render( <UkAddressFieldset { ...defaultProps } /> );
+		expect( container.getElementsByClassName( 'uk-address-fieldset' ) ).to.have.length( 1 );
 	} );
 
 	test( 'should render expected input components', () => {
-		const wrapper = shallow( <UkAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '[name="city"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="postal-code"]' ) ).to.have.length( 1 );
+		const { container } = render( <UkAddressFieldset { ...defaultProps } /> );
+		expect( container.querySelectorAll( '[name="city"]' ) ).to.have.length( 1 );
+		expect( container.querySelectorAll( '[name="postal-code"]' ) ).to.have.length( 1 );
 	} );
 
 	test( 'should not render a state select components', () => {
-		const wrapper = shallow( <UkAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '[name="state"]' ) ).to.have.length( 0 );
+		const { container } = render( <UkAddressFieldset { ...defaultProps } /> );
+		expect( container.querySelectorAll( '[name="state"]' ) ).to.have.length( 0 );
 	} );
 
 	test( 'should render all expected input components but postal code', () => {
-		const wrapper = shallow( <UkAddressFieldset { ...propsWithoutPostalCode } /> );
-		expect( wrapper.find( '[name="city"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="postal-code"]' ) ).to.have.length( 0 );
+		const { container } = render( <UkAddressFieldset { ...propsWithoutPostalCode } /> );
+		expect( container.querySelectorAll( '[name="city"]' ) ).to.have.length( 1 );
+		expect( container.querySelectorAll( '[name="postal-code"]' ) ).to.have.length( 0 );
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { render, screen } from '@testing-library/react';
-import { expect } from 'chai';
 import UkAddressFieldset from '../uk-address-fieldset';
 
 jest.mock( 'i18n-calypso', () => ( {
@@ -24,23 +23,23 @@ describe( 'UK Address Fieldset', () => {
 
 	test( 'should render correctly with default props', () => {
 		const { container } = render( <UkAddressFieldset { ...defaultProps } /> );
-		expect( container.getElementsByClassName( 'uk-address-fieldset' ) ).to.have.length( 1 );
+		expect( container.getElementsByClassName( 'uk-address-fieldset' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render expected input components', () => {
 		render( <UkAddressFieldset { ...defaultProps } /> );
-		expect( screen.queryByLabelText( 'City' ) ).to.exist;
-		expect( screen.queryByLabelText( 'Postal Code' ) ).to.exist;
+		expect( screen.queryByLabelText( 'City' ) ).toBeDefined();
+		expect( screen.queryByLabelText( 'Postal Code' ) ).toBeDefined();
 	} );
 
 	test( 'should not render a state select components', () => {
 		render( <UkAddressFieldset { ...defaultProps } /> );
-		expect( screen.queryByLabelText( 'State' ) ).to.not.exist;
+		expect( screen.queryByLabelText( 'State' ) ).toBeNull();
 	} );
 
 	test( 'should render all expected input components but postal code', () => {
 		render( <UkAddressFieldset { ...propsWithoutPostalCode } /> );
-		expect( screen.queryByLabelText( 'City' ) ).to.exist;
-		expect( screen.queryByLabelText( 'Postal Code' ) ).to.not.exist;
+		expect( screen.queryByLabelText( 'City' ) ).toBeDefined();
+		expect( screen.queryByLabelText( 'Postal Code' ) ).toBeNull();
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { expect } from 'chai';
 import UkAddressFieldset from '../uk-address-fieldset';
 
@@ -28,19 +28,19 @@ describe( 'UK Address Fieldset', () => {
 	} );
 
 	test( 'should render expected input components', () => {
-		const { container } = render( <UkAddressFieldset { ...defaultProps } /> );
-		expect( container.querySelectorAll( '[name="city"]' ) ).to.have.length( 1 );
-		expect( container.querySelectorAll( '[name="postal-code"]' ) ).to.have.length( 1 );
+		render( <UkAddressFieldset { ...defaultProps } /> );
+		expect( screen.queryByLabelText( 'City' ) ).to.exist;
+		expect( screen.queryByLabelText( 'Postal Code' ) ).to.exist;
 	} );
 
 	test( 'should not render a state select components', () => {
-		const { container } = render( <UkAddressFieldset { ...defaultProps } /> );
-		expect( container.querySelectorAll( '[name="state"]' ) ).to.have.length( 0 );
+		render( <UkAddressFieldset { ...defaultProps } /> );
+		expect( screen.queryByLabelText( 'State' ) ).to.not.exist;
 	} );
 
 	test( 'should render all expected input components but postal code', () => {
-		const { container } = render( <UkAddressFieldset { ...propsWithoutPostalCode } /> );
-		expect( container.querySelectorAll( '[name="city"]' ) ).to.have.length( 1 );
-		expect( container.querySelectorAll( '[name="postal-code"]' ) ).to.have.length( 0 );
+		render( <UkAddressFieldset { ...propsWithoutPostalCode } /> );
+		expect( screen.queryByLabelText( 'City' ) ).to.exist;
+		expect( screen.queryByLabelText( 'Postal Code' ) ).to.not.exist;
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
@@ -1,14 +1,14 @@
 /**
  * @jest-environment jsdom
  */
-
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { render } from 'calypso/test-helpers/config/testing-library';
 import UsAddressFieldset from '../us-address-fieldset';
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: ( x ) => x,
 	translate: ( x ) => x,
+	useTranslate: () => ( x ) => x,
 } ) );
 
 describe( 'US Address Fieldset', () => {
@@ -24,21 +24,21 @@ describe( 'US Address Fieldset', () => {
 	};
 
 	test( 'should render correctly with default props', () => {
-		const wrapper = shallow( <UsAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '.us-address-fieldset' ) ).to.have.length( 1 );
+		const { container } = render( <UsAddressFieldset { ...defaultProps } /> );
+		expect( container.getElementsByClassName( 'us-address-fieldset' ) ).to.have.length( 1 );
 	} );
 
 	test( 'should render expected input components', () => {
-		const wrapper = shallow( <UsAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '[name="city"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="state"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="postal-code"]' ) ).to.have.length( 1 );
+		const { container } = render( <UsAddressFieldset { ...defaultProps } /> );
+		expect( container.querySelectorAll( '[name="city"]' ) ).to.have.length( 1 );
+		expect( container.querySelectorAll( '[name="state"]' ) ).to.have.length( 1 );
+		expect( container.querySelectorAll( '[name="postal-code"]' ) ).to.have.length( 1 );
 	} );
 
 	test( 'should render all expected input components but postal code', () => {
-		const wrapper = shallow( <UsAddressFieldset { ...propsWithoutPostalCode } /> );
-		expect( wrapper.find( '[name="city"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="state"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="postal-code"]' ) ).to.have.length( 0 );
+		const { container } = render( <UsAddressFieldset { ...propsWithoutPostalCode } /> );
+		expect( container.querySelectorAll( '[name="city"]' ) ).to.have.length( 1 );
+		expect( container.querySelectorAll( '[name="state"]' ) ).to.have.length( 1 );
+		expect( container.querySelectorAll( '[name="postal-code"]' ) ).to.have.length( 0 );
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import { expect } from 'chai';
 import { render, screen } from 'calypso/test-helpers/config/testing-library';
 import UsAddressFieldset from '../us-address-fieldset';
 
@@ -25,20 +24,20 @@ describe( 'US Address Fieldset', () => {
 
 	test( 'should render correctly with default props', () => {
 		const { container } = render( <UsAddressFieldset { ...defaultProps } /> );
-		expect( container.getElementsByClassName( 'us-address-fieldset' ) ).to.have.length( 1 );
+		expect( container.getElementsByClassName( 'us-address-fieldset' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render expected input components', () => {
 		render( <UsAddressFieldset { ...defaultProps } /> );
-		expect( screen.queryByLabelText( 'City' ) ).to.exist;
-		expect( screen.queryByLabelText( 'State' ) ).to.exist;
-		expect( screen.queryByLabelText( 'ZIP code' ) ).to.exist;
+		expect( screen.queryByLabelText( 'City' ) ).toBeDefined();
+		expect( screen.queryByLabelText( 'State' ) ).toBeDefined();
+		expect( screen.queryByLabelText( 'ZIP code' ) ).toBeDefined();
 	} );
 
 	test( 'should render all expected input components but postal code', () => {
 		render( <UsAddressFieldset { ...propsWithoutPostalCode } /> );
-		expect( screen.queryByLabelText( 'City' ) ).to.exist;
-		expect( screen.queryByLabelText( 'State' ) ).to.exist;
-		expect( screen.queryByLabelText( 'Postal Code' ) ).to.not.exist;
+		expect( screen.queryByLabelText( 'City' ) ).toBeDefined();
+		expect( screen.queryByLabelText( 'State' ) ).toBeDefined();
+		expect( screen.queryByLabelText( 'Postal Code' ) ).toBeNull();
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { expect } from 'chai';
-import { render } from 'calypso/test-helpers/config/testing-library';
+import { render, screen } from 'calypso/test-helpers/config/testing-library';
 import UsAddressFieldset from '../us-address-fieldset';
 
 jest.mock( 'i18n-calypso', () => ( {
@@ -29,16 +29,16 @@ describe( 'US Address Fieldset', () => {
 	} );
 
 	test( 'should render expected input components', () => {
-		const { container } = render( <UsAddressFieldset { ...defaultProps } /> );
-		expect( container.querySelectorAll( '[name="city"]' ) ).to.have.length( 1 );
-		expect( container.querySelectorAll( '[name="state"]' ) ).to.have.length( 1 );
-		expect( container.querySelectorAll( '[name="postal-code"]' ) ).to.have.length( 1 );
+		render( <UsAddressFieldset { ...defaultProps } /> );
+		expect( screen.queryByLabelText( 'City' ) ).to.exist;
+		expect( screen.queryByLabelText( 'State' ) ).to.exist;
+		expect( screen.queryByLabelText( 'ZIP code' ) ).to.exist;
 	} );
 
 	test( 'should render all expected input components but postal code', () => {
-		const { container } = render( <UsAddressFieldset { ...propsWithoutPostalCode } /> );
-		expect( container.querySelectorAll( '[name="city"]' ) ).to.have.length( 1 );
-		expect( container.querySelectorAll( '[name="state"]' ) ).to.have.length( 1 );
-		expect( container.querySelectorAll( '[name="postal-code"]' ) ).to.have.length( 0 );
+		render( <UsAddressFieldset { ...propsWithoutPostalCode } /> );
+		expect( screen.queryByLabelText( 'City' ) ).to.exist;
+		expect( screen.queryByLabelText( 'State' ) ).to.exist;
+		expect( screen.queryByLabelText( 'Postal Code' ) ).to.not.exist;
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

React 18 is out, and `enzyme`, which we use broadly for component testing, doesn't (and will likely never) support it. As part of our preparation to upgrade to React to v18, we need to refactor all tests that use `enzyme` to a modern component testing library, like `testing-library` for example.

This PR refactors the tests of the `ContactDetailsFormFields` fieldsets from `enzyme` to `@testing-library/react`. I've also used the opportunity to migrate assertions from `chai` to the preferred `jest`. Finally, I've used more accessible and less implementation-detail-based mechanisms to find elements, as recommended by the `testing-library` conventions.

#### Testing instructions

* Verify these tests still pass: `yarn run test-client client/components/domains/contact-details-form-fields/custom-form-fieldsets`.
* Verify all client tests still pass: `yarn run test-client`.