### PR TITLE
Tests: Add thunk middleware to testing library helpers

### DIFF
--- a/client/test-helpers/config/testing-library.jsx
+++ b/client/test-helpers/config/testing-library.jsx
@@ -1,6 +1,7 @@
 import { render as rtlRender } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { createStore } from 'redux';
+import { applyMiddleware, createStore } from 'redux';
+import thunkMiddleware from 'redux-thunk';
 import initialReducer from 'calypso/state/reducer';
 
 const render = ( ui, { initialState, store, reducers, ...renderOptions } = {} ) => {
@@ -13,7 +14,7 @@ const render = ( ui, { initialState, store, reducers, ...renderOptions } = {} ) 
 			}
 		}
 
-		store = createStore( reducer, initialState );
+		store = createStore( reducer, initialState, applyMiddleware( thunkMiddleware ) );
 	}
 
 	const Wrapper = ( { children } ) => <Provider store={ store }>{ children }</Provider>;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR introduces the thunk middleware to the `@testing-library/react` test helper. Necessary to run tests with `@testing-library/react` on components where thunks are dispatched.

While part of #62920 currently, I'd like to land this separately, as it's a separate change. You can use #62920 to test this change, though.

#### Testing instructions

* Verify all tests still pass.
* Head to #62920 for more thorough testing.