### PR TITLE
Update license issuing to accept a site_id

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -83,10 +83,10 @@ export function licensesContext( context: PageJS.Context, next: () => void ): vo
 }
 
 export function issueLicenseContext( context: PageJS.Context, next: () => void ): void {
-	const { site_id } = context.query;
+	const { siteId } = context.query;
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
-	context.primary = <IssueLicense site_id={ site_id } />;
+	context.primary = <IssueLicense siteId={ siteId } />;
 	next();
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -84,7 +84,7 @@ export function licensesContext( context: PageJS.Context, next: () => void ): vo
 }
 
 export function issueLicenseContext( context: PageJS.Context, next: () => void ): void {
-	const { siteId } = context.query;
+	const { site_id: siteId } = context.query;
 	const state = context.store.getState();
 	const sites = getSitesItems( state );
 	const selectedSite = sites.hasOwnProperty( siteId ) ? siteId : null;

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -87,7 +87,7 @@ export function issueLicenseContext( context: PageJS.Context, next: () => void )
 	const { site_id: siteId } = context.query;
 	const state = context.store.getState();
 	const sites = getSitesItems( state );
-	const selectedSite = sites.hasOwnProperty( siteId ) ? siteId : null;
+	const selectedSite = sites[ siteId ] ? siteId : null;
 
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -83,9 +83,10 @@ export function licensesContext( context: PageJS.Context, next: () => void ): vo
 }
 
 export function issueLicenseContext( context: PageJS.Context, next: () => void ): void {
+	const { site_id } = context.query;
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
-	context.primary = <IssueLicense />;
+	context.primary = <IssueLicense site_id={ site_id } />;
 	next();
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -29,6 +29,7 @@ import {
 } from 'calypso/state/partner-portal/partner/selectors';
 import { ToSConsent } from 'calypso/state/partner-portal/types';
 import getSites from 'calypso/state/selectors/get-sites';
+import getSitesItems from 'calypso/state/selectors/get-sites-items';
 import Header from './header';
 import type PageJS from 'page';
 
@@ -84,9 +85,13 @@ export function licensesContext( context: PageJS.Context, next: () => void ): vo
 
 export function issueLicenseContext( context: PageJS.Context, next: () => void ): void {
 	const { siteId } = context.query;
+	const state = context.store.getState();
+	const sites = getSitesItems( state );
+	const selectedSite = sites.hasOwnProperty( siteId ) ? siteId : null;
+
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
-	context.primary = <IssueLicense siteId={ siteId } />;
+	context.primary = <IssueLicense selectedSite={ selectedSite } />;
 	next();
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -22,7 +22,7 @@ function selectProductOptions( families: APIProductFamily[] ): APIProductFamilyP
 }
 
 interface Props {
-	selectedSite?: number;
+	selectedSite?: number | null;
 }
 
 export default function IssueLicenseForm( { selectedSite }: Props ): ReactElement {

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -8,7 +8,7 @@ import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sid
 import AssignLicenseStepProgress from '../../assign-license-step-progress';
 
 interface Props {
-	selectedSite?: number;
+	selectedSite?: number | null;
 }
 
 export default function IssueLicense( { selectedSite }: Props ): ReactElement {

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -8,10 +8,10 @@ import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sid
 import AssignLicenseStepProgress from '../../assign-license-step-progress';
 
 interface Props {
-	siteId?: number;
+	selectedSite?: number;
 }
 
-export default function IssueLicense( { siteId }: Props ): ReactElement {
+export default function IssueLicense( { selectedSite }: Props ): ReactElement {
 	const translate = useTranslate();
 
 	useEffect( () => {
@@ -32,7 +32,7 @@ export default function IssueLicense( { siteId }: Props ): ReactElement {
 			<AssignLicenseStepProgress currentStep={ 1 } />
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
-			<IssueLicenseForm selectedSite={ siteId } />
+			<IssueLicenseForm selectedSite={ selectedSite } />
 		</Main>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -7,7 +7,11 @@ import IssueLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/issu
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import AssignLicenseStepProgress from '../../assign-license-step-progress';
 
-export default function IssueLicense(): ReactElement {
+interface Props {
+	site_id?: number;
+}
+
+export default function IssueLicense( { site_id }: Props ): ReactElement {
 	const translate = useTranslate();
 
 	useEffect( () => {
@@ -28,7 +32,7 @@ export default function IssueLicense(): ReactElement {
 			<AssignLicenseStepProgress currentStep={ 1 } />
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
-			<IssueLicenseForm />
+			<IssueLicenseForm selectedSite={ site_id } />
 		</Main>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -8,10 +8,10 @@ import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sid
 import AssignLicenseStepProgress from '../../assign-license-step-progress';
 
 interface Props {
-	site_id?: number;
+	siteId?: number;
 }
 
-export default function IssueLicense( { site_id }: Props ): ReactElement {
+export default function IssueLicense( { siteId }: Props ): ReactElement {
 	const translate = useTranslate();
 
 	useEffect( () => {
@@ -32,7 +32,7 @@ export default function IssueLicense( { site_id }: Props ): ReactElement {
 			<AssignLicenseStepProgress currentStep={ 1 } />
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
-			<IssueLicenseForm selectedSite={ site_id } />
+			<IssueLicenseForm selectedSite={ siteId } />
 		</Main>
 	);
 }


### PR DESCRIPTION
Update issuing a license to allow for a site_id to be passed. This will cause the issued license to be automatically assigned to the site_id that is passed and bypass the step to assign the license.

#### Changes proposed in this Pull Request

* An option `site_id` query param can now be passed to the `issue-license` endpoint. If the `site_id` is present the endpoint will assign the license to the site immediately and bypass the assignment step. A redirect to the existing final step that displays the license will be done after the license is assigned

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch and start calypso first `yarn start` followed by Jetpack cloud `yarn start-jetpack-cloud-p`
* Visit the licensing dashboard and click the button to Issue A New License.
* Add the query param `site_id={your_site_id}` to the query string. The `site_id` is the blog id for the site that the license will be assigned to.
* Select the product you would like to issue the license for and issue the license. 
* Ensure that you are redirected to `licenses` page and the new license is displayed and not the `assign-licenses` page to select your site.
* Repeat the steps above without the optional param and ensure that you are able to get to the `assign-license` page, select a site and have the license assigned to the site.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
