### PR TITLE
Changed plugin rendering to gray out incompatible ones #62644

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -5,10 +5,12 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
+import ExternalLink from 'calypso/components/external-link';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import version_compare from 'calypso/lib/version-compare';
+import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import { PluginPrice } from 'calypso/my-sites/plugins/plugin-price';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
@@ -100,13 +102,19 @@ const PluginsBrowserListElement = ( props ) => {
 		return version_compare( wpVersion, pluginTestedVersion, '>' );
 	}, [ selectedSite, plugin ] );
 
+	const isPluginIncompatible = useMemo( () => {
+		return ! isCompatiblePlugin( plugin.slug );
+	} );
+
 	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );
 
 	if ( isPlaceholder ) {
 		return <Placeholder iconSize={ iconSize } />;
 	}
 
-	const classNames = classnames( 'plugins-browser-item', variant );
+	const classNames = classnames( 'plugins-browser-item', variant, {
+		incompatible: isPluginIncompatible,
+	} );
 	return (
 		<li className={ classNames }>
 			<a
@@ -145,6 +153,11 @@ const PluginsBrowserListElement = ( props ) => {
 							{ translate( 'Untested with your version of WordPress' ) }
 						</span>
 					</div>
+				) }
+				{ isPluginIncompatible && (
+					<ExternalLink icon={ false } href="https://wordpress.com/support/incompatible-plugins/">
+						{ translate( 'Why this plugin is not compatible with WordPress.com?' ) }
+					</ExternalLink>
 				) }
 				<div className="plugins-browser-item__footer">
 					{ variant === PluginsBrowserElementVariant.Extended && (

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -57,6 +57,19 @@
 	@include breakpoint-deprecated( '<960px' ) {
 		width: 100%;
 	}
+
+	&.incompatible {
+		.plugins-browser-item__link {
+			.external-link {
+				margin-bottom: 16px;
+				font-size: $font-body-small;
+			}
+
+			*:not( .external-link ) {
+				opacity: 0.6;
+			}
+		}
+	}
 }
 
 .plugins-browser-item__info {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changed plugin rendering to gray out incompatible ones

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the /plugins page and search for some of the [client/my-sites/plugins/plugin-compatibility.js](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/plugins/plugin-compatibility.js) plugins like `wordfence`. You should see this:

<img width="810" alt="image" src="https://user-images.githubusercontent.com/1044309/164318882-1daeac2e-8720-4d38-802c-8e83fc449517.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62644
