### PR TITLE
Add sourcemaps to inline-help

### DIFF
--- a/apps/inline-help/webpack.config.js
+++ b/apps/inline-help/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
 	bail: ! isDevelopment,
 	entry: path.join( __dirname, 'src', 'app' ),
 	mode: isDevelopment ? 'development' : 'production',
-	devtool: false,
+	devtool: 'source-map',
 	output: {
 		path: outputPath,
 		filename: 'build.min.js',


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The main purpose of this is to test sourcemap integration in Sentry. In particular, after deploying this, I expect the sourcemap files to be available over HTTP, which might make the Sentry integration easier.

This is a safe change because this app is not used in production anywhere.

#### Testing instructions
Inspect the generated build artifact in teamcity and verify that .map files were created.