### PR TITLE
Track what users typed before they select a vertical suggestion

### DIFF
--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -14,10 +14,16 @@ import type { SiteVerticalsResponse } from 'calypso/data/site-verticals';
 interface Props {
 	defaultVertical?: string;
 	isSkipSynonyms?: boolean;
-	onSelect?: ( vertical: Vertical, term?: string ) => void;
+	onInputChange?: ( searchTerm: string ) => void;
+	onSelect?: ( vertical: Vertical ) => void;
 }
 
-const SelectVertical: React.FC< Props > = ( { defaultVertical, isSkipSynonyms, onSelect } ) => {
+const SelectVertical: React.FC< Props > = ( {
+	defaultVertical,
+	isSkipSynonyms,
+	onInputChange,
+	onSelect,
+} ) => {
 	const translate = useTranslate();
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 150 );
@@ -70,8 +76,14 @@ const SelectVertical: React.FC< Props > = ( { defaultVertical, isSkipSynonyms, o
 				}
 				isLoading={ isDebouncing || isLoadingDefaultVertical || isLoadingSuggestions }
 				isDisableInput={ isLoadingDefaultVertical }
-				onInputChange={ setSearchTerm }
-				onSelect={ onSelect }
+				onInputChange={ ( searchTerm: string ) => {
+					setSearchTerm( searchTerm );
+					onInputChange?.( searchTerm );
+				} }
+				onSelect={ ( vertical: Vertical ) => {
+					setSearchTerm( vertical.label );
+					onSelect?.( vertical );
+				} }
 			/>
 		</>
 	);

--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -14,7 +14,7 @@ import type { SiteVerticalsResponse } from 'calypso/data/site-verticals';
 interface Props {
 	defaultVertical?: string;
 	isSkipSynonyms?: boolean;
-	onSelect?: ( vertical: Vertical ) => void;
+	onSelect?: ( vertical: Vertical, term?: string ) => void;
 }
 
 const SelectVertical: React.FC< Props > = ( { defaultVertical, isSkipSynonyms, onSelect } ) => {

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -15,7 +15,7 @@ interface Props {
 	isDisableInput?: boolean | undefined;
 	isLoading?: boolean | undefined;
 	onInputChange?: ( value: string ) => void;
-	onSelect?: ( vertical: Vertical ) => void;
+	onSelect?: ( vertical: Vertical, term?: string ) => void;
 }
 
 const SelectVerticalSuggestionSearch: FC< Props > = ( {
@@ -117,9 +117,9 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 		( { label, value }: { label: string; value?: string } ) => {
 			setIsShowSuggestions( false );
 			onInputChange?.( label );
-			onSelect?.( { label, value } as Vertical );
+			onSelect?.( { label, value } as Vertical, searchTerm );
 		},
-		[ setIsShowSuggestions ]
+		[ setIsShowSuggestions, searchTerm ]
 	);
 
 	const getSuggestions = useMemo( () => {

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -2,7 +2,7 @@ import { Gridicon, Suggestions } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { FC, useCallback, useMemo, useRef, useState } from 'react';
+import { FC, useMemo, useRef, useState } from 'react';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import Spinner from 'calypso/components/spinner';
 import type { Vertical } from './types';
@@ -15,7 +15,7 @@ interface Props {
 	isDisableInput?: boolean | undefined;
 	isLoading?: boolean | undefined;
 	onInputChange?: ( value: string ) => void;
-	onSelect?: ( vertical: Vertical, term?: string ) => void;
+	onSelect?: ( vertical: Vertical ) => void;
 }
 
 const SelectVerticalSuggestionSearch: FC< Props > = ( {
@@ -34,93 +34,74 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 	const toggleIconRef = useRef( null );
 	const translate = useTranslate();
 
-	const handleTextInputBlur = useCallback(
-		( event ) => {
-			// Hide the suggestion dropdown unless the focus is moved to the toggle icon.
-			if ( event && event.relatedTarget?.contains( toggleIconRef.current ) ) {
-				return;
-			}
+	const handleTextInputBlur = ( event: React.FocusEvent ) => {
+		// Hide the suggestion dropdown unless the focus is moved to the toggle icon.
+		if ( event && event.relatedTarget?.contains( toggleIconRef.current ) ) {
+			return;
+		}
 
-			setIsShowSuggestions( false );
-			setIsFocused( false );
-		},
-		[ setIsShowSuggestions, setIsFocused ]
-	);
+		setIsShowSuggestions( false );
+		setIsFocused( false );
+	};
 
-	const handleTextInputFocus = useCallback( () => {
+	const handleTextInputFocus = () => {
 		setIsShowSuggestions( true );
 		setIsFocused( true );
-	}, [ setIsShowSuggestions, setIsFocused ] );
+	};
 
-	const handleTextInputChange = useCallback(
-		( event: React.ChangeEvent< HTMLInputElement > ) => {
-			// Reset the vertical selection if input field is empty.
-			// This is so users don't need to explicitly select "Something else" to clear previous selection.
-			if ( event.target.value.trim().length === 0 ) {
-				onSelect?.( { value: '', label: '' } );
-			}
+	const handleTextInputChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
+		// Reset the vertical selection if input field is empty.
+		// This is so users don't need to explicitly select "Something else" to clear previous selection.
+		if ( event.target.value.trim().length === 0 ) {
+			onSelect?.( { value: '', label: '' } );
+		}
 
-			setIsShowSuggestions( true );
-			onInputChange?.( event.target.value );
-		},
-		[ setIsShowSuggestions ]
-	);
+		setIsShowSuggestions( true );
+		onInputChange?.( event.target.value );
+	};
 
-	const handleToggleSuggestionsBlur = useCallback(
-		( event ) => {
-			// Hide the suggestion dropdown unless the focus is moved to the input field.
-			if ( event && event.relatedTarget?.contains( inputRef.current ) ) {
-				return;
-			}
+	const handleToggleSuggestionsBlur = ( event: React.FocusEvent ) => {
+		// Hide the suggestion dropdown unless the focus is moved to the input field.
+		if ( event && event.relatedTarget?.contains( inputRef.current ) ) {
+			return;
+		}
 
-			setIsShowSuggestions( false );
-			setIsFocused( false );
-		},
-		[ setIsFocused ]
-	);
+		setIsShowSuggestions( false );
+		setIsFocused( false );
+	};
 
-	const handleToggleSuggestionsClick = useCallback( () => {
+	const handleToggleSuggestionsClick = () => {
 		if ( isDisableInput ) {
 			return;
 		}
 
 		setIsShowSuggestions( ! isShowSuggestions );
-	}, [ setIsShowSuggestions, isShowSuggestions, isDisableInput ] );
+	};
 
-	const handleToggleSuggestionsKeyDown = useCallback(
-		( event: React.KeyboardEvent< HTMLButtonElement > ) => {
-			if ( event.key === 'Escape' || event.key === 'Tab' ) {
-				setIsShowSuggestions( false );
-			}
-		},
-		[ setIsShowSuggestions ]
-	);
-
-	const handleTextInputKeyDown = useCallback(
-		( event: KeyboardEvent ) => {
-			if ( event.key === 'Enter' && isShowSuggestions ) {
-				event.preventDefault();
-			}
-
-			if ( event.key === 'Escape' ) {
-				setIsShowSuggestions( false );
-			}
-
-			if ( suggestionsRef.current ) {
-				( suggestionsRef.current as Suggestions ).handleKeyEvent( event );
-			}
-		},
-		[ setIsShowSuggestions, isShowSuggestions, suggestionsRef ]
-	);
-
-	const handleSuggestionsSelect = useCallback(
-		( { label, value }: { label: string; value?: string } ) => {
+	const handleToggleSuggestionsKeyDown = ( event: React.KeyboardEvent< HTMLButtonElement > ) => {
+		if ( event.key === 'Escape' || event.key === 'Tab' ) {
 			setIsShowSuggestions( false );
-			onInputChange?.( label );
-			onSelect?.( { label, value } as Vertical, searchTerm );
-		},
-		[ setIsShowSuggestions, searchTerm ]
-	);
+		}
+	};
+
+	const handleTextInputKeyDown = ( event: KeyboardEvent ) => {
+		if ( event.key === 'Enter' && isShowSuggestions ) {
+			event.preventDefault();
+		}
+
+		if ( event.key === 'Escape' ) {
+			setIsShowSuggestions( false );
+		}
+
+		if ( suggestionsRef.current ) {
+			( suggestionsRef.current as Suggestions ).handleKeyEvent( event );
+		}
+	};
+
+	const handleSuggestionsSelect = ( { label, value }: { label: string; value?: string } ) => {
+		setIsShowSuggestions( false );
+		onSelect?.( { label, value } as Vertical );
+	};
 
 	const getSuggestions = useMemo( () => {
 		if ( isLoading || ! isShowSuggestions ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
@@ -13,7 +13,7 @@ interface Props {
 	defaultVertical?: string;
 	isSkipSynonyms?: boolean;
 	isBusy?: boolean;
-	onSelect?: ( vertical: Vertical ) => void;
+	onSelect?: ( vertical: Vertical, term?: string ) => void;
 	onSubmit?: ( event: React.FormEvent ) => void;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
@@ -13,8 +13,8 @@ interface Props {
 	defaultVertical?: string;
 	isSkipSynonyms?: boolean;
 	isBusy?: boolean;
-	onSelect?: ( vertical: Vertical, term?: string ) => void;
-	onSubmit?: ( event: React.FormEvent ) => void;
+	onSelect?: ( vertical: Vertical ) => void;
+	onSubmit?: ( event: React.FormEvent, userInput: string ) => void;
 }
 
 const SiteVerticalForm: React.FC< Props > = ( {
@@ -25,13 +25,20 @@ const SiteVerticalForm: React.FC< Props > = ( {
 	onSubmit,
 } ) => {
 	const translate = useTranslate();
+	const [ userInput, setUserInput ] = React.useState( '' );
 
 	return (
-		<form className="site-vertical__form" onSubmit={ onSubmit }>
+		<form
+			className="site-vertical__form"
+			onSubmit={ ( event: React.FormEvent ) => {
+				onSubmit?.( event, userInput );
+			} }
+		>
 			<FormFieldset className="site-vertical__form-fieldset">
 				<SelectVertical
 					defaultVertical={ defaultVertical }
 					isSkipSynonyms={ isSkipSynonyms }
+					onInputChange={ setUserInput }
 					onSelect={ onSelect }
 				/>
 				<FormSettingExplanation>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -15,6 +15,7 @@ import type { Vertical } from 'calypso/components/select-vertical/types';
 const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const { goNext, submit } = navigation;
 	const [ vertical, setVertical ] = React.useState< Vertical | null >();
+	const [ userInput, setUserInput ] = React.useState( '' );
 	const [ isBusy, setIsBusy ] = React.useState( false );
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
 	const site = useSite();
@@ -26,8 +27,9 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const subHeaderText = translate( 'Choose a category that defines your website the best.' );
 	const isSkipSynonyms = useQuery().get( 'isSkipSynonyms' );
 
-	const handleSiteVerticalSelect = ( vertical: Vertical ) => {
+	const handleSiteVerticalSelect = ( vertical: Vertical, term?: string ) => {
 		setVertical( vertical );
+		setUserInput( term || '' );
 	};
 
 	const handleSubmit = async ( event: React.FormEvent ) => {
@@ -39,6 +41,7 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 			setIsBusy( true );
 			await saveSiteSettings( site.ID, { site_vertical_id: value } );
 			recordTracksEvent( 'calypso_signup_site_vertical_submit', {
+				user_input: userInput,
 				vertical_id: value,
 				vertical_title: label,
 			} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -15,7 +15,6 @@ import type { Vertical } from 'calypso/components/select-vertical/types';
 const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const { goNext, submit } = navigation;
 	const [ vertical, setVertical ] = React.useState< Vertical | null >();
-	const [ userInput, setUserInput ] = React.useState( '' );
 	const [ isBusy, setIsBusy ] = React.useState( false );
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
 	const site = useSite();
@@ -27,12 +26,11 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const subHeaderText = translate( 'Choose a category that defines your website the best.' );
 	const isSkipSynonyms = useQuery().get( 'isSkipSynonyms' );
 
-	const handleSiteVerticalSelect = ( vertical: Vertical, term?: string ) => {
+	const handleSiteVerticalSelect = ( vertical: Vertical ) => {
 		setVertical( vertical );
-		setUserInput( term || '' );
 	};
 
-	const handleSubmit = async ( event: React.FormEvent ) => {
+	const handleSubmit = async ( event: React.FormEvent, userInput: string ) => {
 		event.preventDefault();
 
 		if ( site ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new property `user_input` to the event `calypso_signup_site_vertical_submit`. 
The property `user_input` is what users have typed into the vertical suggestion input field before they selected one of the suggestions.

For instance, the user types in "Lego" and ends up selecting the vertical "Toys". In this case, `user_input` will be "Lego". 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the vertical question screen `/setup/vertical`
* Type "Lego" in the input field.
* Select "Toys" from the suggestion dropdown.
* Click on the Continue button.
* Expect to see the track event to have the property `user_input: Lego`.

![Screen Shot 2022-04-21 at 5 23 18 PM](https://user-images.githubusercontent.com/797888/164423888-6bcab4a7-9e7e-445f-9855-e81138bf0f19.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Dev tasks
* [x] 799-gh-Automattic/tracks-events-registration

Related to #62754