### PR TITLE
`ImageEditor`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -71,22 +71,18 @@ class ImageEditor extends Component {
 
 	editCanvasRef = createRef();
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( newProps ) {
+	componentDidUpdate( prevProps ) {
 		const { media: currentMedia } = this.props;
 
-		if ( newProps.media && ! isEqual( newProps.media, currentMedia ) ) {
+		if ( this.props.media && ! isEqual( prevProps.media, currentMedia ) ) {
 			this.props.resetAllImageEditorState();
-
-			this.updateFileInfo( newProps.media );
-
+			this.updateFileInfo();
 			this.setDefaultAspectRatio();
 		}
 	}
 
 	componentDidMount() {
-		this.updateFileInfo( this.props.media );
-
+		this.updateFileInfo();
 		this.setDefaultAspectRatio();
 	}
 
@@ -98,8 +94,8 @@ class ImageEditor extends Component {
 		);
 	};
 
-	updateFileInfo = ( media ) => {
-		const { site } = this.props;
+	updateFileInfo = () => {
+		const { site, media } = this.props;
 
 		let src;
 		let fileName = 'default';

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -72,9 +72,9 @@ class ImageEditor extends Component {
 	editCanvasRef = createRef();
 
 	componentDidUpdate( prevProps ) {
-		const { media: currentMedia } = this.props;
+		const { media } = this.props;
 
-		if ( this.props.media && ! isEqual( prevProps.media, currentMedia ) ) {
+		if ( media && ! isEqual( prevProps.media, media ) ) {
 			this.props.resetAllImageEditorState();
 			this.updateFileInfo();
 			this.setDefaultAspectRatio();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `ImageEditor`: refactor away from `UNSAFE_*`

#### Testing instructions

* Go to `/devdocs/blocks/image-editor`
* Upload an image and verify it's shown in the image editor and controls work as expected
* Upload a new image and verify the image editor is updated correctly

Related to #58453 
