### PR TITLE
P2: release pre-approved domains settings to prod

### DIFF
--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { connect } from 'react-redux';
 import GeneralForm from 'calypso/my-sites/site-settings/form-general';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -10,9 +9,7 @@ import SiteTools from './site-tools';
 const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2Hub } ) => (
 	<div className="site-settings__main general-settings">
 		<GeneralForm site={ site } />
-		{ isWPForTeamsSite && isP2Hub && isEnabled( 'p2/preapproved-domains' ) && (
-			<P2PreapprovedDomainsForm siteId={ site?.ID } />
-		) }
+		{ isWPForTeamsSite && isP2Hub && <P2PreapprovedDomainsForm siteId={ site?.ID } /> }
 		<SiteTools />
 	</div>
 );

--- a/config/development.json
+++ b/config/development.json
@@ -106,7 +106,6 @@
 		"network-connection": true,
 		"oauth": false,
 		"p2/p2-plus": true,
-		"p2/preapproved-domains": true,
 		"page/export": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -65,7 +65,6 @@
 		"me/vat-details": true,
 		"network-connection": true,
 		"p2/p2-plus": true,
-		"p2/preapproved-domains": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -69,7 +69,6 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"p2/p2-plus": true,
-		"p2/preapproved-domains": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -67,7 +67,6 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"p2/p2-plus": true,
-		"p2/preapproved-domains": true,
 		"page/export": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": true,

--- a/config/test.json
+++ b/config/test.json
@@ -58,7 +58,6 @@
 		"me/account-close": true,
 		"me/vat-details": true,
 		"network-connection": true,
-		"p2/preapproved-domains": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,7 +82,6 @@
 		"me/vat-details": true,
 		"network-connection": true,
 		"p2/p2-plus": true,
-		"p2/preapproved-domains": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": true,
 		"post-editor/checkout-overlay": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* With https://github.com/Automattic/wp-calypso/pull/62905 deployed, we can now remove the feature flag check for the settings section, and release it to production.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* You will need to test on a P2 hub site that you're an admin of.
* Visit `calypso.localhost:3000/settings/general/<YOUR-P2-HUB>.wordpress.com`, and verify that the page loads without errors.
* You should still see the "Joining this workspace" settings section.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 4326-gh-Automattic/p2