### PR TITLE
`ImageEditorCanvas`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -79,11 +79,22 @@ export class ImageEditorCanvas extends Component {
 		this.isMounted = true;
 	}
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( newProps ) {
-		if ( this.props.src !== newProps.src ) {
-			this.getImage( newProps.src );
+	componentDidUpdate( prevProps ) {
+		if ( this.props.src !== prevProps.src ) {
+			this.getImage( this.props.src );
 		}
+
+		this.drawImage();
+		this.updateCanvasPosition();
+	}
+
+	componentWillUnmount() {
+		if ( typeof window !== 'undefined' && this.onWindowResize ) {
+			window.removeEventListener( 'resize', this.onWindowResize );
+			window.cancelAnimationFrame( this.requestAnimationFrameId );
+		}
+
+		this.isMounted = false;
 	}
 
 	fetchImageBlob( src ) {
@@ -138,24 +149,6 @@ export class ImageEditorCanvas extends Component {
 
 		this.props.setImageEditorImageHasLoaded( this.image.width, this.image.height );
 	};
-
-	componentWillUnmount() {
-		if ( typeof window !== 'undefined' && this.onWindowResize ) {
-			window.removeEventListener( 'resize', this.onWindowResize );
-			window.cancelAnimationFrame( this.requestAnimationFrameId );
-		}
-
-		this.isMounted = false;
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( this.props.src !== prevProps.src ) {
-			this.getImage( this.props.src );
-		}
-
-		this.drawImage();
-		this.updateCanvasPosition();
-	}
 
 	toBlob( callback ) {
 		const { leftRatio, topRatio, widthRatio, heightRatio } = this.props.crop;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In this case we just drop the `cWRP` method because the check for `src` is done in `cDU` already. Everything else is just reordering lifecycle methods to group them together.

* `ImageEditorCanvas`: refactor away from `UNSAFE_*`

#### Testing instructions


* Go to `/devdocs/blocks/image-editor`
* Upload an image and verify it's loaded correctly and controls behave as expected
* Upload a new image and verify it's loaded correctly as well

Related to #58453 
