### PR TITLE
Profile: Use DocumentHead for auto-converted setTitle actions

### DIFF
--- a/client/me/account/controller.js
+++ b/client/me/account/controller.js
@@ -1,18 +1,14 @@
-import { translate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { createElement } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
 import AccountComponent, { noticeId as meSettingsNoticeId } from 'calypso/me/account/main';
-import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 import { successNotice } from 'calypso/state/notices/actions';
 
 export function account( context, next ) {
-	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( translate( 'Account Settings', { textOnly: true } ) ) );
-
 	// Update the url and show the notice after a redirect
 	if ( context.query && context.query.updated === 'success' ) {
 		context.store.dispatch(
-			successNotice( translate( 'Settings saved successfully!' ), {
+			successNotice( i18n.translate( 'Settings saved successfully!' ), {
 				displayOnNextPage: true,
 				id: meSettingsNoticeId,
 			} )
@@ -20,8 +16,17 @@ export function account( context, next ) {
 		page.replace( context.pathname );
 	}
 
-	context.primary = createElement( AccountComponent, {
-		path: context.path,
-	} );
+	const AccountTitle = () => {
+		const translate = useTranslate();
+
+		return <DocumentHead title={ translate( 'Account Settings', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<AccountTitle />
+			<AccountComponent path={ context.path } />
+		</>
+	);
 	next();
 }

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -1,9 +1,9 @@
-import i18n from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { createElement } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
 import AppsComponent from 'calypso/me/get-apps';
 import SidebarComponent from 'calypso/me/sidebar';
-import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 
 export function sidebar( context, next ) {
 	context.secondary = createElement( SidebarComponent, {
@@ -14,24 +14,35 @@ export function sidebar( context, next ) {
 }
 
 export function profile( context, next ) {
-	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'My Profile', { textOnly: true } ) ) );
-
 	const ProfileComponent = require( 'calypso/me/profile' ).default;
+	const ProfileTitle = () => {
+		const translate = useTranslate();
 
-	context.primary = createElement( ProfileComponent, {
-		path: context.path,
-	} );
+		return <DocumentHead title={ translate( 'My Profile', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<ProfileTitle />
+			<ProfileComponent path={ context.path } />
+		</>
+	);
 	next();
 }
 
 export function apps( context, next ) {
-	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Get Apps', { textOnly: true } ) ) );
+	const AppsTitle = () => {
+		const translate = useTranslate();
 
-	context.primary = createElement( AppsComponent, {
-		path: context.path,
-	} );
+		return <DocumentHead title={ translate( 'Get Apps', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<AppsTitle />
+			<AppsComponent path={ context.path } />
+		</>
+	);
 	next();
 }
 

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -1,8 +1,8 @@
-import i18n from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
 import { login } from 'calypso/lib/paths';
 import { CONTACT, SUPPORT_ROOT } from 'calypso/lib/url/support';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 import ContactComponent from './help-contact';
 import CoursesComponent from './help-courses';
 import HelpComponent from './main';
@@ -34,10 +34,18 @@ export function help( context, next ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Help', { textOnly: true } ) ) );
+	const HelpTitle = () => {
+		const translate = useTranslate();
 
-	context.primary = <HelpComponent />;
+		return <DocumentHead title={ translate( 'Help', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<HelpTitle />
+			<HelpComponent path={ context.path } />
+		</>
+	);
 	next();
 }
 

--- a/client/me/notification-settings/controller.js
+++ b/client/me/notification-settings/controller.js
@@ -1,51 +1,70 @@
-import i18n from 'i18n-calypso';
-import { createElement } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
 import CommentSettingsComponent from 'calypso/me/notification-settings/comment-settings';
 import NotificationsComponent from 'calypso/me/notification-settings/main';
 import NotificationSubscriptions from 'calypso/me/notification-settings/reader-subscriptions';
 import WPcomSettingsComponent from 'calypso/me/notification-settings/wpcom-settings';
-import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 
 export function notifications( context, next ) {
-	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) );
+	const NotificationsTitle = () => {
+		const translate = useTranslate();
 
-	context.primary = createElement( NotificationsComponent, {
-		path: context.path,
-	} );
+		return <DocumentHead title={ translate( 'Notifications', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<NotificationsTitle />
+			<NotificationsComponent path={ context.path } />
+		</>
+	);
 	next();
 }
 
 export function comments( context, next ) {
-	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch(
-		setTitle( i18n.translate( 'Comments on other sites', { textOnly: true } ) )
-	);
+	const CommentsTitle = () => {
+		const translate = useTranslate();
 
-	context.primary = createElement( CommentSettingsComponent, {
-		path: context.path,
-	} );
+		return <DocumentHead title={ translate( 'Comments on other sites', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<CommentsTitle />
+			<CommentSettingsComponent path={ context.path } />
+		</>
+	);
 	next();
 }
 
 export function updates( context, next ) {
-	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch(
-		setTitle( i18n.translate( 'Updates from WordPress.com', { textOnly: true } ) )
-	);
+	const UpdatesTitle = () => {
+		const translate = useTranslate();
 
-	context.primary = createElement( WPcomSettingsComponent, {
-		path: context.path,
-	} );
+		return <DocumentHead title={ translate( 'Updates from WordPress.com', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<UpdatesTitle />
+			<WPcomSettingsComponent path={ context.path } />
+		</>
+	);
 	next();
 }
 
 export function subscriptions( context, next ) {
-	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) );
+	const SubscriptionsTitle = () => {
+		const translate = useTranslate();
 
-	context.primary = createElement( NotificationSubscriptions, {
-		path: context.path,
-	} );
+		return <DocumentHead title={ translate( 'Notifications', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<SubscriptionsTitle />
+			<NotificationSubscriptions path={ context.path } />
+		</>
+	);
 	next();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace the auto-converted `setTitle` actions with localized component that uses `DocumentHead` to set the title.

#### Testing instructions

* Confirm document title is properly set on `/me`, /me/account`, `/me/notifications` and `/help`

Related to https://github.com/Automattic/wp-calypso/pull/62908
