### PR TITLE
My Sites: Use DocumentHead for auto-converted setTitle actions

### DIFF
--- a/client/my-sites/customize/controller.js
+++ b/client/my-sites/customize/controller.js
@@ -1,19 +1,26 @@
-import i18n from 'i18n-calypso';
-import { createElement } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
 import CustomizeComponent from 'calypso/my-sites/customize/main';
-import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 
 export function customize( context, next ) {
-	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Customizer', { textOnly: true } ) ) );
+	const CustomizeTitle = () => {
+		const translate = useTranslate();
 
-	context.primary = createElement( CustomizeComponent, {
-		domain: context.params.domain || '',
-		pathname: context.pathname,
-		prevPath: context.prevPath || '',
-		query: context.query,
-		panel: context.params.panel,
-	} );
+		return <DocumentHead title={ translate( 'Customizer', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<CustomizeTitle />
+			<CustomizeComponent
+				domain={ context.params.domain || '' }
+				pathname={ context.pathname }
+				prevPath={ context.prevPath || '' }
+				query={ context.query }
+				panel={ context.params.panel }
+			/>
+		</>
+	);
 
 	next();
 }

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -1,15 +1,14 @@
 import { getLocaleFromPath, removeLocaleFromPath } from '@automattic/i18n-utils';
 import debugModule from 'debug';
-import i18n from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { createElement } from 'react';
 import store from 'store';
+import DocumentHead from 'calypso/components/data/document-head';
 import { navigate } from 'calypso/lib/navigate';
 import InviteAccept from 'calypso/my-sites/invites/invite-accept';
 import { getRedirectAfterAccept } from 'calypso/my-sites/invites/utils';
 import { setUserEmailVerified } from 'calypso/state/current-user/actions';
 import { getCurrentUserEmail, isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 import { acceptInvite as acceptInviteAction } from 'calypso/state/invites/actions';
 
 /**
@@ -26,9 +25,6 @@ export function redirectWithoutLocaleifLoggedIn( context, next ) {
 }
 
 export function acceptInvite( context, next ) {
-	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) ) );
-
 	const acceptedInvite = store.get( 'invite_accepted' );
 	if ( acceptedInvite ) {
 		debug( 'invite_accepted is set in localStorage' );
@@ -52,13 +48,24 @@ export function acceptInvite( context, next ) {
 		return;
 	}
 
-	context.primary = createElement( InviteAccept, {
-		siteId: context.params.site_id,
-		inviteKey: context.params.invitation_key,
-		activationKey: context.params.activation_key,
-		authKey: context.params.auth_key,
-		locale: context.params.locale,
-		path: context.path,
-	} );
+	const AcceptInviteTitle = () => {
+		const translate = useTranslate();
+
+		return <DocumentHead title={ translate( 'Accept Invite', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<AcceptInviteTitle />
+			<InviteAccept
+				siteId={ context.params.site_id }
+				inviteKey={ context.params.invitation_key }
+				activationKey={ context.params.activation_key }
+				authKey={ context.params.auth_key }
+				locale={ context.params.locale }
+				path={ context.path }
+			/>
+		</>
+	);
 	next();
 }

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -1,8 +1,7 @@
-import i18n from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { createElement } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
 import { getSiteFragment } from 'calypso/lib/route';
-import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -56,15 +55,18 @@ function redirectToTeam( context ) {
 }
 
 function renderPeopleList( context, next ) {
-	const filter = context.params.filter;
+	const PeopleListTitle = () => {
+		const translate = useTranslate();
 
-	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Users', { textOnly: true } ) ) );
+		return <DocumentHead title={ translate( 'Users', { textOnly: true } ) } />;
+	};
 
-	context.primary = createElement( PeopleList, {
-		filter: filter,
-		search: context.query.s,
-	} );
+	context.primary = (
+		<>
+			<PeopleListTitle />
+			<PeopleList filter={ context.params.filter } search={ context.query.s } />
+		</>
+	);
 	next();
 }
 
@@ -72,36 +74,65 @@ function renderInvitePeople( context, next ) {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 
-	context.store.dispatch( setTitle( i18n.translate( 'Invite People', { textOnly: true } ) ) ); // FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
+	const InvitePeopleTitle = () => {
+		const translate = useTranslate();
 
-	context.primary = createElement( InvitePeople, {
-		key: site.ID,
-		site,
-	} );
+		return <DocumentHead title={ translate( 'Invite People', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<InvitePeopleTitle />
+			<InvitePeople key={ site.ID } site={ site } />
+		</>
+	);
 	next();
 }
 
 function renderPeopleInvites( context, next ) {
-	context.store.dispatch( setTitle( i18n.translate( 'Invites', { textOnly: true } ) ) );
+	const PeopleInvitesTitle = () => {
+		const translate = useTranslate();
 
-	context.primary = createElement( PeopleInvites );
+		return <DocumentHead title={ translate( 'Invites', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<PeopleInvitesTitle />
+			<PeopleInvites />
+		</>
+	);
 	next();
 }
 
 function renderPeopleInviteDetails( context, next ) {
-	context.store.dispatch( setTitle( i18n.translate( 'Invite Details', { textOnly: true } ) ) );
+	const PeopleInviteDetailsTitle = () => {
+		const translate = useTranslate();
 
-	context.primary = createElement( PeopleInviteDetails, {
-		inviteKey: context.params.invite_key,
-	} );
+		return <DocumentHead title={ translate( 'Invite Details', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<PeopleInviteDetailsTitle />
+			<PeopleInviteDetails inviteKey={ context.params.invite_key } />
+		</>
+	);
 	next();
 }
 
 function renderSingleTeamMember( context, next ) {
-	context.store.dispatch( setTitle( i18n.translate( 'View Team Member', { textOnly: true } ) ) ); // FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
+	const SingleTeamMemberTitle = () => {
+		const translate = useTranslate();
 
-	context.primary = createElement( EditTeamMember, {
-		userLogin: context.params.user_login,
-	} );
+		return <DocumentHead title={ translate( 'View Team Member', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<SingleTeamMemberTitle />
+			<EditTeamMember userLogin={ context.params.user_login } />
+		</>
+	);
 	next();
 }

--- a/client/my-sites/store/app/store-stats/controller.js
+++ b/client/my-sites/store/app/store-stats/controller.js
@@ -1,10 +1,10 @@
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { includes } from 'lodash';
 import moment from 'moment';
 import page from 'page';
 import AsyncLoad from 'calypso/components/async-load';
+import DocumentHead from 'calypso/components/data/document-head';
 import StatsPagePlaceholder from 'calypso/my-sites/stats/stats-page-placeholder';
-import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 import { recordTrack } from '../../lib/analytics';
 import { getQueryDate } from './utils';
 
@@ -34,8 +34,12 @@ export default function StatsController( context, next ) {
 		selectedDate: context.query.startDate || moment().format( 'YYYY-MM-DD' ),
 		queryParams: context.query || {},
 	};
-	// FIXME: Auto-converted from the setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( translate( 'Stats', { textOnly: true } ) ) );
+
+	const StatsTitle = () => {
+		const translate = useTranslate();
+
+		return <DocumentHead title={ translate( 'Stats', { textOnly: true } ) } />;
+	};
 
 	let tracksEvent;
 	switch ( props.type ) {
@@ -86,6 +90,11 @@ export default function StatsController( context, next ) {
 			break;
 	}
 
-	context.primary = asyncComponent;
+	context.primary = (
+		<>
+			<StatsTitle />
+			{ asyncComponent }
+		</>
+	);
 	next();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace the auto-converted `setTitle` actions with localized component that uses `DocumentHead` to set the title.

#### Testing instructions

Test the document title on the following routes:

* `/customize`
* `/people/team/{site}`, `/people/new/{site}`, `/people/invites/{site}`, `/people/invites/{site}/{invitation_id}` 
* `/accept-invite/{site_id}/{invitation_key}/{invitation_key}/{auth_key}` - the link can be obtained from `/people/new`
* `/store/stats/orders/day/{site}` - `{site}` should have WooCommerce installed

Related to https://github.com/Automattic/wp-calypso/pull/62908
