### PR TITLE
Stepper: Implement software status in store

### DIFF
--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -10,7 +10,7 @@ import {
 	AtomicTransferStatus,
 	LatestAtomicTransferStatus,
 } from './types';
-import { AtomicTransferState, LatestAtomicTransferState } from '.';
+import { AtomicTransferState, LatestAtomicTransferState, AtomicSoftwareStatusState } from '.';
 import type { Action } from './actions';
 import type { Reducer } from 'redux';
 
@@ -271,6 +271,46 @@ export const latestAtomicTransferStatus: Reducer<
 	return state;
 };
 
+export const atomicSoftwareStatus: Reducer<
+	{ [ key: number ]: AtomicSoftwareStatusState },
+	Action
+> = ( state = {}, action ) => {
+	if ( action.type === 'ATOMIC_SOFTWARE_STATUS_START' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				[ action.softwareSet ]: {
+					status: undefined,
+					error: undefined,
+				},
+			},
+		};
+	}
+	if ( action.type === 'ATOMIC_SOFTWARE_STATUS_SUCCESS' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				[ action.softwareSet ]: {
+					status: action.status,
+					error: undefined,
+				},
+			},
+		};
+	}
+	if ( action.type === 'ATOMIC_SOFTWARE_STATUS_FAILURE' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				[ action.softwareSet ]: {
+					status: undefined,
+					error: action.error,
+				},
+			},
+		};
+	}
+	return state;
+};
+
 const newSite = combineReducers( {
 	data: newSiteData,
 	error: newSiteError,
@@ -287,6 +327,7 @@ const reducer = combineReducers( {
 	siteSetupErrors,
 	atomicTransferStatus,
 	latestAtomicTransferStatus,
+	atomicSoftwareStatus,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -75,6 +75,10 @@ export const getSiteLatestAtomicTransfer = ( state: State, siteId: number ) => {
 	return state.latestAtomicTransferStatus[ siteId ]?.transfer;
 };
 
+export const getAtomicSoftwareStatus = ( state: State, siteId: number, softwareSet: string ) => {
+	return state.atomicSoftwareStatus[ siteId ]?.[ softwareSet ]?.status;
+};
+
 export const hasActiveSiteFeature = (
 	_: State,
 	siteId: number | undefined,
@@ -83,25 +87,4 @@ export const hasActiveSiteFeature = (
 	return Boolean(
 		siteId && select( STORE_KEY ).getSite( siteId )?.plan?.features.active.includes( featureKey )
 	);
-};
-
-export const hasAvailableSiteFeature = (
-	_: State,
-	siteId: number | undefined,
-	featureKey: string
-): boolean => {
-	return Boolean(
-		siteId && select( STORE_KEY ).getSite( siteId )?.plan?.features.available[ featureKey ]
-	);
-};
-
-export const requiresUpgrade = ( state: State, siteId: number | null ) => {
-	const isWoopFeatureActive = Boolean(
-		siteId && select( STORE_KEY ).hasActiveSiteFeature( siteId, 'woop' )
-	);
-	const hasWoopFeatureAvailable = Boolean(
-		siteId && select( STORE_KEY ).hasAvailableSiteFeature( siteId, 'woop' )
-	);
-
-	return Boolean( ! isWoopFeatureActive && hasWoopFeatureAvailable );
 };

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -88,3 +88,24 @@ export const hasActiveSiteFeature = (
 		siteId && select( STORE_KEY ).getSite( siteId )?.plan?.features.active.includes( featureKey )
 	);
 };
+
+export const hasAvailableSiteFeature = (
+	_: State,
+	siteId: number | undefined,
+	featureKey: string
+): boolean => {
+	return Boolean(
+		siteId && select( STORE_KEY ).getSite( siteId )?.plan?.features.available[ featureKey ]
+	);
+};
+
+export const requiresUpgrade = ( state: State, siteId: number | null ) => {
+	const isWoopFeatureActive = Boolean(
+		siteId && select( STORE_KEY ).hasActiveSiteFeature( siteId, 'woop' )
+	);
+	const hasWoopFeatureAvailable = Boolean(
+		siteId && select( STORE_KEY ).hasAvailableSiteFeature( siteId, 'woop' )
+	);
+
+	return Boolean( ! isWoopFeatureActive && hasWoopFeatureAvailable );
+};

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -345,3 +345,24 @@ export interface LatestAtomicTransferError {
 	message: string; // "Transfer not found"
 	code: string; // "no_transfer_record"
 }
+
+export interface AtomicSoftwareStatus {
+	blog_id: number;
+	software_set: Record< string, { path: string; state: string } >;
+	applied: boolean;
+}
+
+export interface AtomicSoftwareStatusError {
+	name: string; // "NotFoundError"
+	status: number; // 404
+	message: string; // "Transfer not found"
+	code: string; // "no_transfer_record"
+}
+
+export type AtomicSoftwareStatusState = Record<
+	string,
+	{
+		status: AtomicSoftwareStatus | undefined;
+		error: AtomicSoftwareStatusError | undefined;
+	}
+>;


### PR DESCRIPTION
Implements selectors, types, actions and reducers necessary to handle the Atomic Software Status in the data store.

Closes https://github.com/Automattic/wp-calypso/issues/62922
