### PR TITLE
Fix pending transfer domain delete button

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -1,7 +1,9 @@
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { type as domainType } from 'calypso/lib/domains/constants';
+import { isCancelable, isRemovable } from 'calypso/lib/purchases';
 import RemovePurchase from 'calypso/me/purchases/remove-purchase';
+import { getCancelPurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import {
 	getByPurchaseId,
 	hasLoadedSitePurchasesFromServer,
@@ -56,14 +58,28 @@ const DomainDeleteInfoCard = ( {
 		</RemovePurchase>
 	);
 
-	if ( ! removePurchaseRenderedComponent ) return null;
+	if ( isRemovable( purchase ) ) {
+		return (
+			<DomainInfoCard
+				type="custom"
+				title={ title }
+				description={ getDescription() }
+				cta={ removePurchaseRenderedComponent }
+			/>
+		);
+	}
 
+	if ( ! isCancelable( purchase ) ) {
+		return null;
+	}
+	const link = getCancelPurchaseUrlFor( selectedSite.slug, purchase.id );
 	return (
 		<DomainInfoCard
-			type="custom"
+			type="href"
+			ctaText={ translate( 'Delete' ) }
 			title={ title }
 			description={ getDescription() }
-			cta={ removePurchaseRenderedComponent }
+			href={ link }
 		/>
 	);
 };


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes a bug in domain settings that prevented pending transfer domain (bought without using free credits) from being canceled.

Related to #62941 

![transfer-before](https://user-images.githubusercontent.com/2797601/164489631-b2e917e5-2318-4b4e-9c9f-28340b871fae.png)

![transfer-after](https://user-images.githubusercontent.com/2797601/164489665-0f34956a-520e-40ab-9075-ddeaf91565a8.png)

## Testing instructions

In order to test this, you need a pending transfer domain (not bought with free credits).

- Build this branch locally or open the live Calypso link
- Go to domain settings page and verify that "Delete" button is rendered on the right column.

