### PR TITLE
Site Selector: Update the Jetpack site filter

### DIFF
--- a/client/lib/jetpack/has-jetpack-plugin-active-connection.ts
+++ b/client/lib/jetpack/has-jetpack-plugin-active-connection.ts
@@ -1,3 +1,5 @@
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+
 type Site = {
 	options?: {
 		jetpack_connection_active_plugins?: Array< string >;
@@ -14,7 +16,9 @@ type Site = {
  */
 export default function hasJetpackPluginActiveConnection( site: Site ): boolean {
 	const activeJetpackPlugins = site?.options?.jetpack_connection_active_plugins;
-	const plugins = [ 'jetpack', 'jetpack-search', 'jetpack-backup', 'jetpack-social' ];
+	const plugins = [ 'jetpack' ].concat(
+		isJetpackCloud() ? [ 'jetpack-search', 'jetpack-backup', 'jetpack-social' ] : []
+	);
 	return (
 		! activeJetpackPlugins ||
 		activeJetpackPlugins.some( ( plugin: string ) => plugins.includes( plugin ) )

--- a/client/lib/jetpack/has-jetpack-plugin-active-connection.ts
+++ b/client/lib/jetpack/has-jetpack-plugin-active-connection.ts
@@ -1,0 +1,22 @@
+type Site = {
+	options?: {
+		jetpack_connection_active_plugins?: Array< string >;
+	};
+};
+
+/**
+ * Returns true if the site has Jetpack, or a valid Jetpack product plugin with an active connection.
+ * It checks the `jetpack_connection_active_plugins` option. If that is missing then it is assumed
+ * to be a WPCOM simple site, which will have a valid Jetpack connection.
+ *
+ * @param   {Site}    site Site object that optionally includes the properties regarding active connections.
+ * @returns {boolean}      Whether the site has a valid plugin with an active connection.
+ */
+export default function hasJetpackPluginActiveConnection( site: Site ): boolean {
+	const activeJetpackPlugins = site?.options?.jetpack_connection_active_plugins;
+	const plugins = [ 'jetpack', 'jetpack-search', 'jetpack-backup', 'jetpack-social' ];
+	return (
+		! activeJetpackPlugins ||
+		activeJetpackPlugins.some( ( plugin: string ) => plugins.includes( plugin ) )
+	);
+}

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -4,6 +4,7 @@ import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
 import CloseOnEscape from 'calypso/components/close-on-escape';
 import SiteSelector from 'calypso/components/site-selector';
+import hasJetpackPluginActiveConnection from 'calypso/lib/jetpack/has-jetpack-plugin-active-connection';
 import { hasTouch } from 'calypso/lib/touch-detect';
 import { setNextLayoutFocus, setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
@@ -77,12 +78,6 @@ class SitePicker extends Component {
 		this.closePicker( null );
 	};
 
-	filterSites = ( site ) => {
-		return site?.options?.jetpack_connection_active_plugins
-			? site.options.jetpack_connection_active_plugins.includes( 'jetpack' )
-			: true;
-	};
-
 	render() {
 		return (
 			<div>
@@ -98,7 +93,7 @@ class SitePicker extends Component {
 					autoFocus={ this.state.isAutoFocused }
 					onClose={ this.onClose }
 					groups={ true }
-					filter={ this.filterSites }
+					filter={ hasJetpackPluginActiveConnection }
 				/>
 			</div>
 		);

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -7,6 +7,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import SiteSelector from 'calypso/components/site-selector';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import hasJetpackPluginActiveConnection from 'calypso/lib/jetpack/has-jetpack-plugin-active-connection';
 
 import './style.scss';
 
@@ -28,12 +29,7 @@ class Sites extends Component {
 
 	filterSites = ( site ) => {
 		// only show Jetpack sites with the full Plugin or Backup/Search Plugin
-		if (
-			site?.options?.jetpack_connection_active_plugins &&
-			! site.options.jetpack_connection_active_plugins.includes( 'jetpack' ) &&
-			! site.options.jetpack_connection_active_plugins.includes( 'jetpack-backup' ) &&
-			! site.options.jetpack_connection_active_plugins.includes( 'jetpack-search' )
-		) {
+		if ( ! hasJetpackPluginActiveConnection( site ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While testing some work on the new Jetpack Social plugin, we discovered
that sites weren't showing in the site selector. There is a filter used
to check that we have an active Jetpack connection and one of either the
Jetpack plugin, or the Jetpack product plugins available.

But this filter is defined differently based on if the site selector is
on initial load, or if it is shown when switching site in the sidebar.

This PR consolidates the check into a helper function that can be used
in both places. At the same time it includes the new Jetpack Social
plugin in the list of valid product plugins.

#### Testing instructions

- Install a Jetpack product plugin (especially Jetpack Social), and ensure that the Jetpack plugin isn't running on the site
- Create a Jetpack connection on the site
- Go to https://cloud.jetpack.com
- If the product is social, the site won't be listed in the site selector
- Go to https://cloud.jetpack.com/backup/<the site domain>
- Click switch site in the sidebar
- The site won't be listed in the site selector
- With this branch, repeat from the third step using the appropriate URL in place of cloud.jetpack.com and the site should appear in both site selectors
- On Calypso, check that only sites with the full Jetpack plugin are displayed in the site selectors
- But also check that you can still access `/backup/<site domain>` for a site with just a standalone plugin 

