### PR TITLE
Fixed incompatible plugin text typo

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -103,12 +103,13 @@ const PluginsBrowserListElement = ( props ) => {
 		return version_compare( wpVersion, pluginTestedVersion, '>' );
 	}, [ selectedSite, plugin ] );
 
-	const jetpackAndAtomic = useSelector(
-		( state ) => isJetpackSite( state, selectedSite?.ID ) && isAtomicSite( state, selectedSite?.ID )
+	const jetpackNonAtomic = useSelector(
+		( state ) =>
+			isJetpackSite( state, selectedSite?.ID ) && ! isAtomicSite( state, selectedSite?.ID )
 	);
 
 	const isPluginIncompatible = useMemo( () => {
-		return ! isCompatiblePlugin( plugin.slug ) && jetpackAndAtomic;
+		return ! isCompatiblePlugin( plugin.slug ) && ! jetpackNonAtomic;
 	} );
 
 	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -156,7 +156,7 @@ const PluginsBrowserListElement = ( props ) => {
 				) }
 				{ isPluginIncompatible && (
 					<ExternalLink icon={ false } href="https://wordpress.com/support/incompatible-plugins/">
-						{ translate( 'Why this plugin is not compatible with WordPress.com?' ) }
+						{ translate( 'Why is this plugin not compatible with WordPress.com?' ) }
 					</ExternalLink>
 				) }
 				<div className="plugins-browser-item__footer">

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -18,6 +18,7 @@ import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import { getSitesWithPlugin, getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { PluginsBrowserElementVariant } from './types';
@@ -102,8 +103,12 @@ const PluginsBrowserListElement = ( props ) => {
 		return version_compare( wpVersion, pluginTestedVersion, '>' );
 	}, [ selectedSite, plugin ] );
 
+	const jetpackAndAtomic = useSelector(
+		( state ) => isJetpackSite( state, selectedSite?.ID ) && isAtomicSite( state, selectedSite?.ID )
+	);
+
 	const isPluginIncompatible = useMemo( () => {
-		return ! isCompatiblePlugin( plugin.slug );
+		return ! isCompatiblePlugin( plugin.slug ) && jetpackAndAtomic;
 	} );
 
 	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixed incompatible plugin text typo
* Added a new rule for showing incompatible message to self hosted sites

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the /plugin page and search for `wordfence`, you should see the correct text `Why is this plugin not compatible with WordPress.com?` instead of `Why this plugin is not compatible with WordPress.com?`
* Make sure the message only appears for Atomic sites with Jetpack, and Simple sites
* Create a new jurassic.ninja site, enable Jetpack connection and make sure you don't see the message

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Thanks for finding it @allilevine!

Related to https://github.com/Automattic/wp-calypso/issues/62644
