### PR TITLE
Stepper: Add Woo transfer step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
@@ -1,20 +1,106 @@
 /* eslint-disable no-console */
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
-import { ONBOARD_STORE } from '../../../../stores';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { transferStates } from 'calypso/state/atomic/transfers/constants';
+import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import type { Step } from '../../types';
 
 const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 
 const WooTransfer: Step = function WooTransfer( { navigation } ) {
 	const { submit } = navigation;
-	const { setPendingAction, setProgressTitle } = useDispatch( ONBOARD_STORE );
+	const { setPendingAction, setProgress } = useDispatch( ONBOARD_STORE );
+	const {
+		requestAtomicSoftwareStatus,
+		requestLatestAtomicTransfer,
+		initiateAtomicTransfer,
+	} = useDispatch( SITE_STORE );
+	const site = useSite();
+
+	const siteId = site?.ID;
+
+	const {
+		getSiteLatestAtomicTransfer,
+		getSiteLatestAtomicTransferError,
+		getAtomicSoftwareStatus,
+		// getAtomicSoftwareError,
+	} = useSelect( ( select ) => select( SITE_STORE ) );
 
 	useEffect( () => {
+		if ( ! siteId ) return;
+
 		setPendingAction( async () => {
-			setProgressTitle( 'Transfering site' );
-			await wait( 3000 );
-			// TODO actually transfer
+			const startTime = new Date().getTime();
+			const totalTimeout = 1000 * 180;
+			const maxFinishTime = startTime + totalTimeout;
+
+			// Initiate transfer
+			await initiateAtomicTransfer( siteId, 'woo-on-plans' );
+
+			// Poll for transfer status
+			let stopPollingTransfer = false;
+
+			while ( ! stopPollingTransfer ) {
+				await wait( 3000 );
+				await requestLatestAtomicTransfer( siteId );
+				const transfer = getSiteLatestAtomicTransfer( siteId );
+				const transferError = getSiteLatestAtomicTransferError( siteId );
+				const transferStatus = transfer?.status;
+				const isTransferringStatusFailed = transferError && transferError?.status >= 500;
+
+				switch ( transferStatus ) {
+					case transferStates.PENDING:
+						setProgress( 0.2 );
+						break;
+					case transferStates.ACTIVE:
+						setProgress( 0.4 );
+						break;
+					case transferStates.PROVISIONED:
+						setProgress( 0.5 );
+						break;
+					case transferStates.COMPLETED:
+						setProgress( 0.7 );
+						break;
+				}
+
+				if ( isTransferringStatusFailed || transferStatus === transferStates.ERROR ) {
+					throw new Error( 'Transfer error' );
+					// onFailure( {
+					// 	type: 'transfer',
+					// 	error: transferError?.message || softwareError?.message || '',
+					// 	code: transferError?.code || softwareError?.code || '',
+					// } );
+				}
+
+				if ( maxFinishTime < new Date().getTime() ) {
+					throw new Error( 'Timeout error' );
+				}
+
+				stopPollingTransfer = transferStatus === transferStates.COMPLETED;
+			}
+
+			// Poll for software status
+			let stopPollingSoftware = false;
+
+			while ( ! stopPollingSoftware ) {
+				await wait( 3000 );
+				await requestAtomicSoftwareStatus( siteId, 'woo-on-plans' );
+				const softwareStatus = getAtomicSoftwareStatus( siteId, 'woo-on-plans' );
+				// const softwareError = getAtomicSoftwareError( siteId, 'woo-on-plans' );
+				// if ( softwareError ) {
+				// 	throw new Error( 'Software error' );
+				// }
+
+				if ( maxFinishTime < new Date().getTime() ) {
+					throw new Error( 'Timeout error' );
+				}
+
+				stopPollingSoftware = softwareStatus?.applied;
+			}
+			setProgress( 1 );
+			// Allow progress bar to complete
+			await wait( 500 );
 		} );
 
 		submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
@@ -11,11 +11,8 @@ const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 const WooTransfer: Step = function WooTransfer( { navigation } ) {
 	const { submit } = navigation;
 	const { setPendingAction, setProgress } = useDispatch( ONBOARD_STORE );
-	const {
-		requestAtomicSoftwareStatus,
-		requestLatestAtomicTransfer,
-		initiateAtomicTransfer,
-	} = useDispatch( SITE_STORE );
+	const { requestAtomicSoftwareStatus, requestLatestAtomicTransfer, initiateAtomicTransfer } =
+		useDispatch( SITE_STORE );
 	const site = useSite();
 
 	const siteId = site?.ID;
@@ -96,7 +93,9 @@ const WooTransfer: Step = function WooTransfer( { navigation } ) {
 					throw new Error( 'Timeout error' );
 				}
 
-				stopPollingSoftware = softwareStatus?.applied;
+				stopPollingSoftware = !! softwareStatus?.applied;
+
+				if ( ! stopPollingSoftware ) await wait( 3000 );
 			}
 			setProgress( 1 );
 			// Allow progress bar to complete

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
@@ -5,7 +5,6 @@ import { useEffect } from 'react';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
-import { transferStates } from 'calypso/state/atomic/transfers/constants';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import type { Step } from '../../types';
 
@@ -14,6 +13,22 @@ export interface FailureInfo {
 	code: number | string;
 	error: string;
 }
+
+export const transferStates = {
+	PENDING: 'pending',
+	ACTIVE: 'active',
+	PROVISIONED: 'provisioned',
+	COMPLETED: 'completed',
+	ERROR: 'error',
+	REVERTED: 'reverted',
+	RELOCATING_REVERT: 'relocating_revert',
+	RELOCATING_SWITCHEROO: 'relocating_switcheroo',
+	REVERTING: 'reverting',
+	RENAMING: 'renaming',
+	EXPORTING: 'exporting',
+	IMPORTING: 'importing',
+	CLEANUP: 'cleanup',
+} as const;
 
 const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
@@ -60,6 +60,8 @@ const WooTransfer: Step = function WooTransfer( { navigation } ) {
 		if ( ! siteId ) return;
 
 		setPendingAction( async () => {
+			setProgress( 0 );
+
 			const startTime = new Date().getTime();
 			const totalTimeout = 1000 * 180;
 			const maxFinishTime = startTime + totalTimeout;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
@@ -162,8 +162,6 @@ const WooTransfer: Step = function WooTransfer( { navigation } ) {
 				if ( ! stopPollingSoftware ) await wait( 3000 );
 			}
 			setProgress( 1 );
-			// Allow progress bar to complete
-			await wait( 500 );
 		} );
 
 		submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
@@ -118,7 +118,6 @@ const WooTransfer: Step = function WooTransfer( { navigation } ) {
 			let stopPollingSoftware = false;
 
 			while ( ! stopPollingSoftware ) {
-				await wait( 3000 );
 				await requestAtomicSoftwareStatus( siteId, 'woo-on-plans' );
 				const softwareStatus = getAtomicSoftwareStatus( siteId, 'woo-on-plans' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds atomic transfer logic, equivalent to [`/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx`](https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx)
* Related to #62718

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using a non-atomic site on a paid plan, enable the `stepper-woocommerce-poc` flag and go to the Woo flow starting on `/setup/intent?siteSlug=<slug>&flags=stepper-woocommerce-poc` 
* By the end of the process you should be on the `wc-admin` page.

![image](https://user-images.githubusercontent.com/3801502/164559605-67dfd9ac-b8c4-4f95-855d-c65eba6839d8.png)


Closes #62716