### PR TITLE
Purchases: Always use purchase siteId for ManagePurchase if possible

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -944,7 +944,7 @@ export default connect( ( state, props ) => {
 			? getByPurchaseId( state, purchase.attachedToPurchaseId )
 			: null;
 	const selectedSiteId = getSelectedSiteId( state );
-	const siteId = selectedSiteId || ( purchase ? purchase.siteId : null );
+	const siteId = purchase?.siteId ?? selectedSiteId ?? null;
 	const purchases = purchase && getSitePurchases( state, purchase.siteId );
 	const userId = getCurrentUserId( state );
 	const isProductOwner = purchase && purchase.userId === userId;

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -137,6 +137,7 @@ class ManagePurchase extends Component {
 		site: PropTypes.object,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string.isRequired,
+		isSiteLevel: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -879,7 +880,7 @@ class ManagePurchase extends Component {
 					eventName="calypso_manage_purchase_view"
 					purchaseId={ this.props.purchaseId }
 				/>
-				{ this.props.siteId ? (
+				{ this.props.isSiteLevel && this.props.siteId ? (
 					<QuerySitePurchases siteId={ this.props.siteId } />
 				) : (
 					<QueryUserPurchases />

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -912,13 +912,11 @@ class ManagePurchase extends Component {
 						getAddNewPaymentMethodUrlFor={ getAddNewPaymentMethodUrlFor }
 					/>
 				) }
-				<AsyncLoad
-					require="calypso/blocks/product-plan-overlap-notices"
-					placeholder={ null }
-					plans={ JETPACK_PLANS }
-					products={ JETPACK_PRODUCTS_LIST }
-					siteId={ siteId }
-					currentPurchase={ purchase }
+				<PlanOverlapNotice
+					isSiteLevel={ this.props.isSiteLevel }
+					selectedSiteId={ this.props.selectedSiteId }
+					siteId={ this.props.siteId }
+					purchase={ this.props.purchase }
 				/>
 				{ this.renderPurchaseDetail( preventRenewal ) }
 				{ site && this.renderNonPrimaryDomainWarningDialog( site, purchase ) }
@@ -936,6 +934,35 @@ function addPaymentMethodLinkText( { purchase, translate } ) {
 		linkText = translate( 'Add Payment Method' );
 	}
 	return linkText;
+}
+
+function PlanOverlapNotice( { isSiteLevel, selectedSiteId, siteId, purchase } ) {
+	if ( isSiteLevel ) {
+		if ( ! selectedSiteId ) {
+			// Probably still loading
+			return null;
+		}
+		return (
+			<AsyncLoad
+				require="calypso/blocks/product-plan-overlap-notices"
+				placeholder={ null }
+				plans={ JETPACK_PLANS }
+				products={ JETPACK_PRODUCTS_LIST }
+				siteId={ selectedSiteId }
+				currentPurchase={ purchase }
+			/>
+		);
+	}
+	return (
+		<AsyncLoad
+			require="calypso/blocks/product-plan-overlap-notices"
+			placeholder={ null }
+			plans={ JETPACK_PLANS }
+			products={ JETPACK_PRODUCTS_LIST }
+			siteId={ siteId }
+			currentPurchase={ purchase }
+		/>
+	);
 }
 
 function PurchasesQueryComponent( { isSiteLevel, selectedSiteId } ) {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -961,7 +961,7 @@ export default connect( ( state, props ) => {
 	return {
 		hasLoadedDomains,
 		hasLoadedSites,
-		hasLoadedPurchasesFromServer: selectedSiteId
+		hasLoadedPurchasesFromServer: props.isSiteLevel
 			? hasLoadedSitePurchasesFromServer( state )
 			: hasLoadedUserPurchasesFromServer( state ),
 		hasNonPrimaryDomainsFlag: getCurrentUser( state )

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -953,6 +953,10 @@ function PlanOverlapNotice( { isSiteLevel, selectedSiteId, siteId, purchase } ) 
 			/>
 		);
 	}
+	if ( ! siteId ) {
+		// Probably still loading
+		return null;
+	}
 	return (
 		<AsyncLoad
 			require="calypso/blocks/product-plan-overlap-notices"

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -97,7 +97,6 @@ import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { getCanonicalTheme } from 'calypso/state/themes/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { cancelPurchase, managePurchase, purchasesRoot } from '../paths';
 import PurchaseSiteHeader from '../purchases-site/header';
 import RemovePurchase from '../remove-purchase';
@@ -944,8 +943,7 @@ export default connect( ( state, props ) => {
 		purchase && purchase.attachedToPurchaseId
 			? getByPurchaseId( state, purchase.attachedToPurchaseId )
 			: null;
-	const selectedSiteId = getSelectedSiteId( state );
-	const siteId = purchase?.siteId ?? selectedSiteId ?? null;
+	const siteId = purchase?.siteId ?? null;
 	const purchases = purchase && getSitePurchases( state, purchase.siteId );
 	const userId = getCurrentUserId( state );
 	const isProductOwner = purchase && purchase.userId === userId;

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -120,6 +120,7 @@ export function PurchaseDetails( {
 				<ManagePurchase
 					cardTitle={ titles.managePurchase }
 					purchaseId={ purchaseId }
+					isSiteLevel
 					siteSlug={ siteSlug }
 					showHeader={ false }
 					purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }


### PR DESCRIPTION
#### Problem

As part of adding site-level purchases pages, in https://github.com/Automattic/wp-calypso/pull/47427 we changed how we query the REST API for purchases. Previously we always queried the user's full purchase list, even for the site-level purchases page, but after that PR we now query the site-level endpoint whenever possible to reduce the amount of data needed by the site-level purchases list.

However, this appears to have introduced a subtle regression (specifically in [this commit](https://github.com/Automattic/wp-calypso/commit/f28ae2b423d38a7de7d189fc877e3a90e2cb4cfa)): since they share components, the account-level purchase page now sometimes makes a query for site-level data; it gets this site ID from the most recently accessed site and that might be different from the site that owns the purchase. The confusion happened because the original PR assumed that in an account-level context like `/me/purchases`, there would never be a selected site, but this is not true.

In practice I think the bugs this causes are quite rare, but could have unexpected effects if not fixed. 

#### Changes proposed in this Pull Request

In this PR we change the purchase page to always default to the purchase's own site, using the selected site only when explicitly in a single-site context.

Fixes https://github.com/Automattic/wp-calypso/issues/62959

#### Testing instructions

- Use an account with at least two sites, and at least one active subscription.
- Visit the calypso home page for the site with the active subscription.
- Using the site picker, click through to the site **without** the active subscription. This step is necessary to make sure the selected site ID is set as visiting the page directly might not set it.
- Using the sidebar, click through to the purchases page for the site **without** the active subscription we're going to view. eg: http://calypso.localhost:3000/purchases/subscriptions/example.com
- Click "View all purchases" to navigate to the account-level purchases page.
- Click on the purchase for the active subscription we're going to view. You should see the purchase page for that subscription. eg: http://calypso.localhost:3000/me/purchases/example.com/10111100
- Reload the page. Verify that you see the same page you just did.

To make sure there are no obvious regressions with site-level purchases:

- Visit the site-level purchases list for a site with an active subscription. eg: http://calypso.localhost:3000/purchases/subscriptions/example.com
- Click to view the active subscription.
- Reload the page and verify that you still see the subscription.