### PR TITLE
Sentry enhancements in Calypso

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -115,6 +115,8 @@ object BuildDockerImage : BuildType({
 			val toggledSentryRelease = "%CREATE_SENTRY_RELEASE%" === "true"
 			val isDefaultBranch = "%teamcity.build.branch.is_default%" === "true"
 			val shouldMakeSentryRelease = toggledSentryRelease || isDefaultBranch
+			println("Sentry release debug info:")
+			println("Is Toggled: $toggledSentryRelease, Is Default Branch: $isDefaultBranch, Release Enabled: $shouldMakeSentryRelease")
 			name = "Build docker image"
 			commandType = build {
 				source = file {
@@ -135,7 +137,7 @@ object BuildDockerImage : BuildType({
 					--build-arg use_cache=true
 					--build-arg base_image=%base_image%
 					--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
-					--build-arg create_sentry_release="$shouldMakeSentryRelease"
+					--build-arg create_sentry_release="${shouldMakeSentryRelease}"
 					--build-arg sentry_auth_token="%SENTRY_AUTH_TOKEN%"
 				""".trimIndent().replace("\n"," ")
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -137,7 +137,7 @@ object BuildDockerImage : BuildType({
 					--build-arg use_cache=true
 					--build-arg base_image=%base_image%
 					--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
-					--build-arg create_sentry_release="${shouldMakeSentryRelease}"
+					--build-arg create_sentry_release="%CREATE_SENTRY_RELEASE%"
 					--build-arg sentry_auth_token="%SENTRY_AUTH_TOKEN%"
 				""".trimIndent().replace("\n"," ")
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -135,8 +135,8 @@ object BuildDockerImage : BuildType({
 					--build-arg use_cache=true
 					--build-arg base_image=%base_image%
 					--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
-					--build-arg create_sentry_release="$shouldMakeSentryRelease" // Computed in Kotlin above.
-					--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN%
+					--build-arg create_sentry_release="$shouldMakeSentryRelease"
+					--build-arg sentry_auth_token="%SENTRY_AUTH_TOKEN%"
 				""".trimIndent().replace("\n"," ")
 			}
 			param("dockerImage.platform", "linux")

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -123,6 +123,7 @@ object BuildDockerImage : BuildType({
 					--build-arg node_memory=32768
 					--build-arg use_cache=true
 					--build-arg base_image=%base_image%
+					--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
 				""".trimIndent().replace("\n"," ")
 			}
 			param("dockerImage.platform", "linux")

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -44,7 +44,7 @@ object BuildDockerImage : BuildType({
 	params {
 		text("base_image", "registry.a8c.com/calypso/base:latest", label = "Base docker image", description = "Base docker image", allowEmpty = false)
 		checkbox(
-			name = "CREATE_SENTRY_RELEASE",
+			name = "MANUAL_SENTRY_RELEASE",
 			value = "false",
 			label = "Create a sentry release.",
 			description = "Generate and upload sourcemaps to Sentry as a new release for this commit.",
@@ -132,8 +132,9 @@ object BuildDockerImage : BuildType({
 					--build-arg use_cache=true
 					--build-arg base_image=%base_image%
 					--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
-					--build-arg create_sentry_release="${ "%CREATE_SENTRY_RELEASE%" === "true" || "%teamcity.build.branch.is_default%" === "true" }"
-					--build-arg sentry_auth_token="%SENTRY_AUTH_TOKEN%"
+					--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
+					--build-arg is_default_branch=%teamcity.build.branch.is_default%
+					--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN%
 				""".trimIndent().replace("\n"," ")
 			}
 			param("dockerImage.platform", "linux")

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -112,11 +112,6 @@ object BuildDockerImage : BuildType({
 		}
 
 		dockerCommand {
-			val toggledSentryRelease = "%CREATE_SENTRY_RELEASE%" === "true"
-			val isDefaultBranch = "%teamcity.build.branch.is_default%" === "true"
-			val shouldMakeSentryRelease = toggledSentryRelease || isDefaultBranch
-			println("Sentry release debug info:")
-			println("Is Toggled: $toggledSentryRelease, Is Default Branch: $isDefaultBranch, Release Enabled: $shouldMakeSentryRelease")
 			name = "Build docker image"
 			commandType = build {
 				source = file {
@@ -137,7 +132,7 @@ object BuildDockerImage : BuildType({
 					--build-arg use_cache=true
 					--build-arg base_image=%base_image%
 					--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
-					--build-arg create_sentry_release="%CREATE_SENTRY_RELEASE%"
+					--build-arg create_sentry_release="${ "%CREATE_SENTRY_RELEASE%" === "true" || "%teamcity.build.branch.is_default%" === "true" }"
 					--build-arg sentry_auth_token="%SENTRY_AUTH_TOKEN%"
 				""".trimIndent().replace("\n"," ")
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -39,7 +39,7 @@ object WebApp : Project({
 object BuildDockerImage : BuildType({
 	uuid = "89fff49e-c79b-4e68-a012-a7ba405359b6"
 	name = "Docker image"
-	description = "checkBuild docker image containing Calypso"
+	description = "Build docker image containing Calypso"
 
 	params {
 		text("base_image", "registry.a8c.com/calypso/base:latest", label = "Base docker image", description = "Base docker image", allowEmpty = false)

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -71,6 +71,7 @@ project {
 		password("mc_teamcity_webhook", "credentialsJSON:7a711930-afd4-4058-b33f-39af8a0b7f91", display = ParameterDisplay.HIDDEN)
 		password("TRANSLATE_GH_APP_SECRET", "credentialsJSON:083cc9f7-4e9a-461f-b213-bc306baaeb28", display = ParameterDisplay.HIDDEN)
 		password("TRANSLATE_GH_APP_ID", "credentialsJSON:c03b1958-5ec3-4f4c-ab1c-ca1bf0e629f5", display = ParameterDisplay.HIDDEN)
+		password("SENTRY_AUTH_TOKEN", "", display = ParameterDisplay.HIDDEN)
 
 		// Fetch all heads. This is used for builds that merge trunk before running tests
 		param("teamcity.git.fetchAllHeads", "true")

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -71,7 +71,7 @@ project {
 		password("mc_teamcity_webhook", "credentialsJSON:7a711930-afd4-4058-b33f-39af8a0b7f91", display = ParameterDisplay.HIDDEN)
 		password("TRANSLATE_GH_APP_SECRET", "credentialsJSON:083cc9f7-4e9a-461f-b213-bc306baaeb28", display = ParameterDisplay.HIDDEN)
 		password("TRANSLATE_GH_APP_ID", "credentialsJSON:c03b1958-5ec3-4f4c-ab1c-ca1bf0e629f5", display = ParameterDisplay.HIDDEN)
-		password("SENTRY_AUTH_TOKEN", "credentialsJSON:6b927b24-85d6-4fad-a114-9acffc0b0dce", display = ParameterDisplay.HIDDEN)
+		password("SENTRY_AUTH_TOKEN", "credentialsJSON:e266a488-d639-4baa-b681-0e11be59ebc1", display = ParameterDisplay.HIDDEN)
 
 		// Fetch all heads. This is used for builds that merge trunk before running tests
 		param("teamcity.git.fetchAllHeads", "true")

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -71,7 +71,7 @@ project {
 		password("mc_teamcity_webhook", "credentialsJSON:7a711930-afd4-4058-b33f-39af8a0b7f91", display = ParameterDisplay.HIDDEN)
 		password("TRANSLATE_GH_APP_SECRET", "credentialsJSON:083cc9f7-4e9a-461f-b213-bc306baaeb28", display = ParameterDisplay.HIDDEN)
 		password("TRANSLATE_GH_APP_ID", "credentialsJSON:c03b1958-5ec3-4f4c-ab1c-ca1bf0e629f5", display = ParameterDisplay.HIDDEN)
-		password("SENTRY_AUTH_TOKEN", "", display = ParameterDisplay.HIDDEN)
+		password("SENTRY_AUTH_TOKEN", "credentialsJSON:6b927b24-85d6-4fad-a114-9acffc0b0dce", display = ParameterDisplay.HIDDEN)
 
 		// Fetch all heads. This is used for builds that merge trunk before running tests
 		param("teamcity.git.fetchAllHeads", "true")

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,9 @@ RUN yarn install --immutable --check-cache
 ENV NODE_ENV production
 RUN yarn run build
 
+RUN [[ "$CREATE_SENTRY_RELEASE" == "true" ]] \
+  && rm -fr /calypso/build/**/*.*.map /calypso/build/*.*.map /calypso/public/**/*.*.map \
+  || echo "Not deleting sourcemaps because DEVTOOL arg was set."
 
 ###################
 FROM node:${node_version}-alpine as app

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,14 @@ FROM builder-cache-${use_cache} as builder
 ARG commit_sha="(unknown)"
 ARG workers=4
 ARG node_memory=8192
+ARG create_sentry_release=false
+ARG sentry_auth_token=''
 ENV CONTAINER 'docker'
 ENV PROFILE=true
 ENV COMMIT_SHA $commit_sha
 ENV CALYPSO_ENV production
+ENV CREATE_SENTRY_RELEASE $create_sentry_release
+ENV SENTRY_AUTH_TOKEN $sentry_auth_token
 ENV WORKERS $workers
 ENV BUILD_TRANSLATION_CHUNKS true
 ENV CHROMEDRIVER_SKIP_DOWNLOAD true

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,11 @@ ENV READONLY_CACHE=true
 ###################
 FROM builder-cache-${use_cache} as builder
 
-# Information for Sentry Releases. Not added to ENV as they are not needed after
-# webpack has completed.
+# Information for Sentry Releases.
 ARG create_sentry_release=false
 ARG sentry_auth_token=''
+ENV CREATE_SENTRY_RELEASE $create_sentry_release
+ENV SENTRY_AUTH_TOKEN $sentry_auth_token
 
 ARG commit_sha="(unknown)"
 ARG workers=4

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,11 @@ ENV READONLY_CACHE=true
 FROM builder-cache-${use_cache} as builder
 
 # Information for Sentry Releases.
-ARG create_sentry_release=false
+ARG manual_sentry_release=false
+ARG is_default_branch=false
 ARG sentry_auth_token=''
-ENV CREATE_SENTRY_RELEASE $create_sentry_release
+ENV MANUAL_SENTRY_RELEASE $manual_sentry_release
+ENV IS_DEFAULT_BRANCH $is_default_branch
 ENV SENTRY_AUTH_TOKEN $sentry_auth_token
 
 ARG commit_sha="(unknown)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ ENV NODE_ENV production
 RUN yarn run build
 
 # Delete any sourcemaps which may have been generated to avoid creating a large artifact.
-RUN find build public -name "*.*.map" -exec rm {} \;
+RUN find /calypso/build /calypso/public -name "*.*.map" -exec rm {} \;
 
 ###################
 FROM node:${node_version}-alpine as app

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,17 +18,18 @@ ENV READONLY_CACHE=true
 ###################
 FROM builder-cache-${use_cache} as builder
 
+# Information for Sentry Releases. Not added to ENV as they are not needed after
+# webpack has completed.
+ARG create_sentry_release=false
+ARG sentry_auth_token=''
+
 ARG commit_sha="(unknown)"
 ARG workers=4
 ARG node_memory=8192
-ARG create_sentry_release=false
-ARG sentry_auth_token=''
 ENV CONTAINER 'docker'
 ENV PROFILE=true
 ENV COMMIT_SHA $commit_sha
 ENV CALYPSO_ENV production
-ENV CREATE_SENTRY_RELEASE $create_sentry_release
-ENV SENTRY_AUTH_TOKEN $sentry_auth_token
 ENV WORKERS $workers
 ENV BUILD_TRANSLATION_CHUNKS true
 ENV CHROMEDRIVER_SKIP_DOWNLOAD true

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,8 @@ RUN yarn install --immutable --check-cache
 ENV NODE_ENV production
 RUN yarn run build
 
-RUN [[ "$CREATE_SENTRY_RELEASE" == "true" ]] \
-  && rm -fr /calypso/build/**/*.*.map /calypso/build/*.*.map /calypso/public/**/*.*.map \
-  || echo "Not deleting sourcemaps because DEVTOOL arg was set."
+# Delete any sourcemaps which may have been generated to avoid creating a large artifact.
+RUN find build public -name "*.*.map" -exec rm {} \;
 
 ###################
 FROM node:${node_version}-alpine as app

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -252,7 +252,7 @@ function setupErrorLogger( reduxStore ) {
 	// Note that Sentry can disable itself and do some cleanup if needed, so we
 	// run it before the catch-js-errors check. (Otherwise, cleanup would never
 	// never happen.)
-	initSentry( { beforeSend } );
+	initSentry( { beforeSend, userId: getCurrentUserId( reduxStore.getState() ) } );
 
 	if ( ! config.isEnabled( 'catch-js-errors' ) ) {
 		return;

--- a/client/lib/sentry/index.ts
+++ b/client/lib/sentry/index.ts
@@ -115,8 +115,9 @@ function beforeBreadcrumb( breadcrumb: SentryApi.Breadcrumb ): SentryApi.Breadcr
 
 interface SentryOptions {
 	beforeSend: ( e: SentryApi.Event ) => SentryApi.Event | null;
+	userId?: number;
 }
-export async function initSentry( { beforeSend }: SentryOptions ) {
+export async function initSentry( { beforeSend, userId }: SentryOptions ) {
 	// Make sure we don't throw
 	try {
 		// No Sentry loading on the server.
@@ -185,6 +186,9 @@ export async function initSentry( { beforeSend }: SentryOptions ) {
 			// See configuration docs: https://docs.sentry.io/clients/javascript/config
 			Sentry.init( {
 				...SENTRY_CONFIG,
+				initialScope: {
+					user: { id: userId?.toString() },
+				},
 				environment,
 				release,
 				beforeBreadcrumb,

--- a/client/package.json
+++ b/client/package.json
@@ -208,6 +208,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",
+		"@sentry/webpack-plugin": "^1.18.8",
 		"@testing-library/jest-dom": "^5.16.2",
 		"@testing-library/react": "^12.1.3",
 		"@testing-library/react-hooks": "7.0.2",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -54,7 +54,8 @@ const shouldUseReadonlyCache = process.env.READONLY_CACHE === 'true';
 const shouldProfile = process.env.PROFILE === 'true';
 
 const shouldCreateSentryRelease =
-	process.env.CREATE_SENTRY_RELEASE === 'true' && process.env.SENTRY_AUTH_TOKEN?.length > 1;
+	( process.env.MANUAL_SENTRY_RELEASE === 'true' || process.env.IS_DEFAULT_BRANCH === 'true' ) &&
+	process.env.SENTRY_AUTH_TOKEN?.length > 1;
 let sourceMapType = process.env.SOURCEMAP;
 if ( ! sourceMapType && shouldCreateSentryRelease ) {
 	sourceMapType = 'hidden-source-map';

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -60,7 +60,7 @@ let sourceMapType = process.env.SOURCEMAP;
 if ( ! sourceMapType && shouldCreateSentryRelease ) {
 	sourceMapType = 'hidden-source-map';
 } else if ( ! sourceMapType && isDevelopment ) {
-	sourceMapType = 'hidden';
+	sourceMapType = 'eval';
 }
 
 if ( shouldCreateSentryRelease ) {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -54,7 +54,7 @@ const shouldUseReadonlyCache = process.env.READONLY_CACHE === 'true';
 const shouldProfile = process.env.PROFILE === 'true';
 
 const shouldCreateSentryRelease =
-	process.env.CREATE_SENTRY_RELEASE === 'true' && process.env.SENTRY_AUTH_TOKEN?.length > 1;
+	process.env.create_sentry_release === 'true' && process.env.sentry_auth_token?.length > 1;
 let sourceMapType = process.env.SOURCEMAP;
 if ( ! sourceMapType && shouldCreateSentryRelease ) {
 	sourceMapType = 'hidden-source-map';
@@ -381,7 +381,7 @@ const webpackConfig = {
 			new SentryCliPlugin( {
 				org: 'a8c',
 				project: 'calypso',
-				authToken: process.env.SENTRY_AUTH_TOKEN,
+				authToken: process.env.sentry_auth_token,
 				release: process.env.COMMIT_SHA,
 				include: filePaths.path,
 				urlPrefix: `~${ filePaths.publicPath }`,

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -377,7 +377,7 @@ const webpackConfig = {
 
 		shouldUsePersistentCache && shouldUseReadonlyCache && new ReadOnlyCachePlugin(),
 
-		// NOTE: Must be last.
+		// NOTE: Sentry should be the last webpack plugin in the array.
 		shouldCreateSentryRelease &&
 			new SentryCliPlugin( {
 				org: 'a8c',
@@ -386,7 +386,6 @@ const webpackConfig = {
 				release: process.env.COMMIT_SHA,
 				include: filePaths.path,
 				urlPrefix: `~${ filePaths.publicPath }`,
-				configFile: 'sentry.properties',
 			} ),
 	].filter( Boolean ),
 	externals: [ 'keytar' ],

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -54,7 +54,7 @@ const shouldUseReadonlyCache = process.env.READONLY_CACHE === 'true';
 const shouldProfile = process.env.PROFILE === 'true';
 
 const shouldCreateSentryRelease =
-	process.env.create_sentry_release === 'true' && process.env.sentry_auth_token?.length > 1;
+	process.env.CREATE_SENTRY_RELEASE === 'true' && process.env.SENTRY_AUTH_TOKEN?.length > 1;
 let sourceMapType = process.env.SOURCEMAP;
 if ( ! sourceMapType && shouldCreateSentryRelease ) {
 	sourceMapType = 'hidden-source-map';
@@ -381,7 +381,7 @@ const webpackConfig = {
 			new SentryCliPlugin( {
 				org: 'a8c',
 				project: 'calypso',
-				authToken: process.env.sentry_auth_token,
+				authToken: process.env.SENTRY_AUTH_TOKEN,
 				release: process.env.COMMIT_SHA,
 				include: filePaths.path,
 				urlPrefix: `~${ filePaths.publicPath }`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -26974,16 +26974,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.2.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.6":
-  version: 2.6.6
-  resolution: "node-fetch@npm:2.6.6"
-  dependencies:
-    whatwg-url: ^5.0.0
-  checksum: f9b5c8789c7bcd393a2fb70d752e36d5b5e84eb52bd5bffceb4fb64ac81dce1a1f55ca023a990e51bbf8594fc502ea9bea3004037e6eab65205cd84e8af94fc9
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.2.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.6, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5083,6 +5083,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/cli@npm:^1.73.0":
+  version: 1.74.3
+  resolution: "@sentry/cli@npm:1.74.3"
+  dependencies:
+    https-proxy-agent: ^5.0.0
+    mkdirp: ^0.5.5
+    node-fetch: ^2.6.7
+    npmlog: ^4.1.2
+    progress: ^2.0.3
+    proxy-from-env: ^1.1.0
+    which: ^2.0.2
+  bin:
+    sentry-cli: bin/sentry-cli
+  checksum: 6e5ba95f9d7c756e8a7d6f6ec010cde8c39588dd19dc3994c628910a245db0feb32f411fb2410157a6af2c7352165625f58092f82d1191aa493d385eed7a2887
+  languageName: node
+  linkType: hard
+
 "@sentry/core@npm:6.19.6":
   version: 6.19.6
   resolution: "@sentry/core@npm:6.19.6"
@@ -5161,6 +5178,15 @@ __metadata:
     "@sentry/types": 6.19.6
     tslib: ^1.9.3
   checksum: 4e7afdf023f93ef7ddccd85ad7847342b030bdc1189110eeb7cb53349f89882e6184149ec29182e41d7fc45f161e19196f2b488138e75185b3fd114f84dac0d6
+  languageName: node
+  linkType: hard
+
+"@sentry/webpack-plugin@npm:^1.18.8":
+  version: 1.18.8
+  resolution: "@sentry/webpack-plugin@npm:1.18.8"
+  dependencies:
+    "@sentry/cli": ^1.73.0
+  checksum: cad2e8a03804889db9521b05cfd1ce24221d1598acc54f5922fc91d16a4bc96806e55b86b4f21f1d62b42b2358239454ba00f6d98d6d14662551048f5e126618
   languageName: node
   linkType: hard
 
@@ -12719,6 +12745,7 @@ __metadata:
     "@emotion/styled": ^11.3.0
     "@github/webauthn-json": ^0.4.1
     "@sentry/react": ^6.19.4
+    "@sentry/webpack-plugin": ^1.18.8
     "@stripe/react-stripe-js": ^1.4.1
     "@stripe/stripe-js": ^1.17.1
     "@testing-library/jest-dom": ^5.16.2
@@ -26953,6 +26980,20 @@ fsevents@~2.1.2:
   dependencies:
     whatwg-url: ^5.0.0
   checksum: f9b5c8789c7bcd393a2fb70d752e36d5b5e84eb52bd5bffceb4fb64ac81dce1a1f55ca023a990e51bbf8594fc502ea9bea3004037e6eab65205cd84e8af94fc9
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.7":
+  version: 2.6.7
+  resolution: "node-fetch@npm:2.6.7"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: fcae80f5ac52fbf5012f5e19df2bd3915e67d3b3ad51cb5942943df2238d32ba15890fecabd0e166876a9f98a581ab50f3f10eb942b09405c49ef8da36b826c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
Some follow-up enhancements to Calypso

* Include the user ID when logging errors. This makes the impact of an issue more clear, as we can tell how many users were effected.
* Fix the global `window.COMMIT_SHA` value. Not sure when it got broken, but we just need to pass it in as an arg to the Docker build.
* Create releases and upload sourcemaps using the webpack plugin. (You can see sentry running in the build log here: https://teamcity.a8c.com/buildConfiguration/calypso_BuildDockerImage/7786712?showRootCauses=false&showLog=7786712_5738_220)

### The webpack plugin
The main problem to solve is that the plugin runs in dev mode, calypso.live, everything. We _don't_ want to create releases all the time. I think we should only create releases for prod. But not _just_ the environment being production, but trunk production builds in TeamCity. (This has been solved by passing data in to Docker/Webpack via TeamCity.)

The remaining problem is that enabling sourcemaps & sentry will make the build take longer. A normal build time right now can be about 5:15, but the example build with source maps was about 7:15. However, it's hard to measure exactly how much longer it is. I noticed many normal builds are above 7 minutes as well, so it's hard to say if this much of an increase would be normal.

The problem is that it would be fairly hard to solve that problem. Ideally, I would run a separate TeamCity step. But that means the sourcemaps were not generated as part of the same build which generated the files deployed to production. That could be problematic. But the only way to avoid that is to enable sourcemaps for prod builds... which defeats the purpose of generating them separately. 

However, the impact could be low because we only have sourcemaps on for trunk builds. So branch builds, like PRs, aren't impacted by sourcemaps being turned on.
  
### Testing instructions

* Load calypso.live for the branch
* Verify that `window.COMMIT_SHA` is the expected value. (it contains '(unknown)' on trunk)
