### PR TITLE
[ETK][wpcom-block-editor][Sentry] Generate source-map files

### DIFF
--- a/apps/editing-toolkit/webpack.config.js
+++ b/apps/editing-toolkit/webpack.config.js
@@ -96,7 +96,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 				},
 			} ),
 		],
-		devtool: isDevelopment ? 'inline-cheap-source-map' : false,
+		devtool: isDevelopment ? 'inline-cheap-source-map' : 'source-map',
 		stats: 'minimal',
 	};
 }

--- a/apps/wpcom-block-editor/webpack.config.js
+++ b/apps/wpcom-block-editor/webpack.config.js
@@ -50,7 +50,7 @@ function getWebpackConfig(
 
 	return {
 		...webpackConfig,
-		devtool: isDevelopment ? 'inline-cheap-source-map' : false,
+		devtool: isDevelopment ? 'inline-cheap-source-map' : 'source-map',
 		optimization: {
 			...webpackConfig.optimization,
 			// disable module concatenation so that instances of `__()` are not renamed


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Generate (separate) source-map files for the production releases of `ETK` and the `wpcom-block-editor` Calypso sub-apps. This is the simplest way to add support for source-maps for Sentry, with the added plus of adding it to the browser devtools, too.


Project:  p9oQ9f-18L-p2

The main goal here is to serve the `.map.js` files alongside the minified files. The benefit is twofold:
* Error reporting tools like Sentry can access them and provide a sane backtrace;
* Errors that happen locally will have a sane backtrace.

Note: there's a side-effect of generating source maps for CSS files, too and I didn't try to disable that. This is not problematic at this time as there are not a lot of CSS files bundled with either app and plus, having source-maps for the CSS files is actually a good thing if you need to debug a CSS issue in production.

#### Testing instructions

Throw an error from one of the `ETK` or `wpcom-block-editor` source files. Sync the custom *production* build to your sandbox, ie:

```
yarn build && rsync -ahz . wpcom-sandbox:~/public_html/wp-content/plugins/editing-toolkit-plugin/prod --delete --exclude node_modules --verbose
```

Trigger the error and the stacktrace should point to the actual original source file where the error happen, not a minified or transpiled js file.

#### Things to keep in mind

* The addition of source-maps might mean we'll hit the svn commit limit for these apps. We might have to find a workaround for that. It's that or uploading them to Sentry and then removing them from the final zip before installing them on WPCOM. Either way, we need the source-maps to be generated,
 
 Alternative: we might be able to prevent committing the source-maps to svn, but for that we'd need to upload them to Sentry. That works (tested locally), but it would be tricky to implement that as part of our `install-script.sh` as we'd need to either install `sentry-cli` in the sandbox or use the sentry rest API (not ideal, as `sentry-cli` provides a better abstraction that's much simpler to use).
 
 The rationale from running it from the sandbox would be to properly implement the use of Sentry release tags. For that, we'd need the commit hash from WPCOM, and we can only get that from the sandbox, after we deploy.

A much simpler way for now might be to change the ETK/wpcom-block-editor TC builds to build the source-maps locally and upload the artifacts to Sentry. We can't get a deploy commit hash from there, but w can start with a fixed release tag in Sentry. I'll try that and if it works, we might be able to abandon this approach for now.