### PR TITLE
Add missing translation to bottom of Settings > Performance page

### DIFF
--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -147,7 +147,7 @@ class SiteSettingsPerformance extends Component {
 				{ ( ! siteIsJetpack || siteIsAtomic ) && (
 					<CompactCard>
 						<InlineSupportLink supportContext="site-speed" showIcon={ false }>
-							Learn more about site speed and performance
+							{ translate( 'Learn more about site speed and performance' ) }
 						</InlineSupportLink>
 					</CompactCard>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add translations for text that exists at the bottom of the Settings > Performance page. 

#### Testing instructions
Check that text appears in GlotPress after it's wrapped in translation.

Related to 430-gh-Automattic/i18n-issues
