### PR TITLE
Mobile navbar: My Profile in navbar

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -368,16 +368,14 @@ class MasterbarLoggedIn extends Component {
 			>
 				<Gravatar
 					className="masterbar__item-me-gravatar"
-					user={ this.props.user }
+					user={ user }
 					alt={ translate( 'My Profile' ) }
 					size={ 18 }
 				/>
 				<span className="masterbar__item-me-label">
-					{ isMobile
-						? user?.display_name
-						: translate( 'My Profile', {
-								context: 'Toolbar, must be shorter than ~12 chars',
-						  } ) }
+					{ translate( 'My Profile', {
+						context: 'Toolbar, must be shorter than ~12 chars',
+					} ) }
 				</span>
 			</Item>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following pbAok1-2FX-p2#comment-5045, we changed from displaying the user name+surname to "My Profile"

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* `yarn start`
* Switch to mobile
* Verify that the menu item is now 'My Profile'
* 
![image](https://user-images.githubusercontent.com/52076348/164736205-8a8a12a1-71e4-4439-a1ae-18626b9250ba.png)

Related to #62971
Fixes #62971
