### PR TITLE
Hide welcome tour for users authoring P2s

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -79,7 +79,15 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 			$variant = 'tour';
 		}
 
-		if ( has_filter( 'wpcom_block_editor_nux_get_status' ) ) {
+		$blog_id   = get_current_blog_id();
+		$is_p2     = \WPForTeams\is_wpforteams_site( $blog_id );
+		$is_a8cian = is_automattician( wp_get_current_user()->ID );
+
+		if ( $is_p2 && $is_a8cian ) {
+			// disable welcome tour for automatticians authoring P2s.
+			// see: https://a8c.slack.com/archives/C025Q5RK2/p1650559200031119.
+			$nux_status = 'disabled';
+		} elseif ( has_filter( 'wpcom_block_editor_nux_get_status' ) ) {
 			$nux_status = apply_filters( 'wpcom_block_editor_nux_get_status', false );
 		} elseif ( ! metadata_exists( 'user', get_current_user_id(), 'wpcom_block_editor_nux_status' ) ) {
 			$nux_status = 'enabled';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -79,8 +79,12 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 			$variant = 'tour';
 		}
 
-		$blog_id = get_current_blog_id();
-		$is_p2   = \WPForTeams\is_wpforteams_site( $blog_id );
+		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+			$is_p2 = false;
+		} else {
+			$blog_id = get_current_blog_id();
+			$is_p2   = \WPForTeams\is_wpforteams_site( $blog_id );
+		}
 
 		if ( $is_p2 ) {
 			// disable welcome tour for authoring P2s.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -79,12 +79,11 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 			$variant = 'tour';
 		}
 
-		$blog_id   = get_current_blog_id();
-		$is_p2     = \WPForTeams\is_wpforteams_site( $blog_id );
-		$is_a8cian = is_automattician( wp_get_current_user()->ID );
+		$blog_id = get_current_blog_id();
+		$is_p2   = \WPForTeams\is_wpforteams_site( $blog_id );
 
-		if ( $is_p2 && $is_a8cian ) {
-			// disable welcome tour for automatticians authoring P2s.
+		if ( $is_p2 ) {
+			// disable welcome tour for authoring P2s.
 			// see: https://a8c.slack.com/archives/C025Q5RK2/p1650559200031119.
 			$nux_status = 'disabled';
 		} elseif ( has_filter( 'wpcom_block_editor_nux_get_status' ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -88,7 +88,7 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 
 		if ( $is_p2 ) {
 			// disable welcome tour for authoring P2s.
-			// see: https://a8c.slack.com/archives/C025Q5RK2/p1650559200031119.
+			// see: https://github.com/Automattic/wp-calypso/issues/62973.
 			$nux_status = 'disabled';
 		} elseif ( has_filter( 'wpcom_block_editor_nux_get_status' ) ) {
 			$nux_status = apply_filters( 'wpcom_block_editor_nux_get_status', false );


### PR DESCRIPTION
#### Testing instructions

1. Checkout this branch.
2. In `apps/editing-toolkit`, run `yarn dev --sync`.
3. Sandbox a P2 you've never visited like `vertexp2`. 
4. Author a new post in P2 you never visited like `vertexp2` by visiting `https:// THE P2 NAME .wordpress.com/wp-admin/post-new.php`.
5. You shouldn't see a welcome tour.

Context: p1650559200031119-slack-C025Q5RK2

https://github.com/Automattic/wp-calypso/issues/62973