### PR TITLE
Checkout: Add tests for useCachedDomainContactDetails

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -80,7 +80,7 @@ function useCachedContactDetailsForCheckoutForm(
 		debug( 'using fetched cached contact details for checkout data store', cachedContactDetails );
 		loadDomainContactDetailsFromCache( {
 			...cachedContactDetails,
-			postalCode: arePostalCodesSupported ? cachedContactDetails.postalCode : undefined,
+			postalCode: arePostalCodesSupported ? cachedContactDetails.postalCode : '',
 		} );
 	}, [
 		cachedContactDetails,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -29,25 +29,10 @@ function areTaxFieldsDifferent(
 	return true;
 }
 
-/**
- * Load cached contact details from the server and use them to populate the
- * checkout contact form and the shopping cart tax location.
- */
-export default function useCachedDomainContactDetails(
-	overrideCountryList?: CountryListItem[]
-): void {
+function useCachedContactDetails(): PossiblyCompleteDomainContactDetails | null {
 	const reduxDispatch = useReduxDispatch();
-	const countriesList = useCountryList( overrideCountryList );
 	const haveRequestedCachedDetails = useRef( false );
-	const previousDetailsForCart = useRef< PossiblyCompleteDomainContactDetails >();
-	const previousDetailsForForm = useRef< PossiblyCompleteDomainContactDetails >();
-	const cartKey = useCartKey();
-	const {
-		updateLocation: updateCartLocation,
-		isLoading: isLoadingCart,
-		loadingError: cartLoadingError,
-	} = useShoppingCart( cartKey );
-
+	const cachedContactDetails = useSelector( getContactDetailsCache );
 	useEffect( () => {
 		if ( ! haveRequestedCachedDetails.current ) {
 			debug( 'requesting cached domain contact details' );
@@ -55,15 +40,28 @@ export default function useCachedDomainContactDetails(
 			haveRequestedCachedDetails.current = true;
 		}
 	}, [ reduxDispatch ] );
+	return cachedContactDetails;
+}
 
-	const cachedContactDetails = useSelector( getContactDetailsCache );
+function useCachedContactDetailsForCheckoutForm(
+	cachedContactDetails: PossiblyCompleteDomainContactDetails | null,
+	overrideCountryList?: CountryListItem[]
+): void {
+	const countriesList = useCountryList( overrideCountryList );
+	const previousDetailsForForm = useRef< PossiblyCompleteDomainContactDetails >();
 
 	const arePostalCodesSupported =
 		countriesList.length && cachedContactDetails?.countryCode
 			? getCountryPostalCodeSupport( countriesList, cachedContactDetails.countryCode )
 			: true;
 
-	const { loadDomainContactDetailsFromCache } = useDispatch( 'wpcom-checkout' );
+	const checkoutStoreActions = useDispatch( 'wpcom-checkout' );
+	if ( ! checkoutStoreActions?.loadDomainContactDetailsFromCache ) {
+		throw new Error(
+			'useCachedContactDetailsForCheckoutForm must be run after the checkout data store has been initialized'
+		);
+	}
+	const { loadDomainContactDetailsFromCache } = checkoutStoreActions;
 
 	// When we have fetched or loaded contact details, send them to the
 	// `wpcom-checkout` data store for use by the checkout contact form.
@@ -79,7 +77,7 @@ export default function useCachedDomainContactDetails(
 			return;
 		}
 		previousDetailsForForm.current = cachedContactDetails;
-		debug( 'using fetched cached domain contact details', cachedContactDetails );
+		debug( 'using fetched cached contact details for checkout data store', cachedContactDetails );
 		loadDomainContactDetailsFromCache( {
 			...cachedContactDetails,
 			postalCode: arePostalCodesSupported ? cachedContactDetails.postalCode : undefined,
@@ -90,6 +88,25 @@ export default function useCachedDomainContactDetails(
 		loadDomainContactDetailsFromCache,
 		countriesList,
 	] );
+}
+
+function useCachedContactDetailsForCart(
+	cachedContactDetails: PossiblyCompleteDomainContactDetails | null,
+	overrideCountryList?: CountryListItem[]
+): void {
+	const countriesList = useCountryList( overrideCountryList );
+	const previousDetailsForCart = useRef< PossiblyCompleteDomainContactDetails >();
+	const cartKey = useCartKey();
+	const {
+		updateLocation: updateCartLocation,
+		isLoading: isLoadingCart,
+		loadingError: cartLoadingError,
+	} = useShoppingCart( cartKey );
+
+	const arePostalCodesSupported =
+		countriesList.length && cachedContactDetails?.countryCode
+			? getCountryPostalCodeSupport( countriesList, cachedContactDetails.countryCode )
+			: true;
 
 	// When we have fetched or loaded contact details, send them to the
 	// to the shopping cart for calculating taxes.
@@ -126,4 +143,16 @@ export default function useCachedDomainContactDetails(
 		arePostalCodesSupported,
 		countriesList,
 	] );
+}
+
+/**
+ * Load cached contact details from the server and use them to populate the
+ * checkout contact form and the shopping cart tax location.
+ */
+export default function useCachedDomainContactDetails(
+	overrideCountryList?: CountryListItem[]
+): void {
+	const cachedContactDetails = useCachedContactDetails();
+	useCachedContactDetailsForCheckoutForm( cachedContactDetails, overrideCountryList );
+	useCachedContactDetailsForCart( cachedContactDetails, overrideCountryList );
 }

--- a/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
@@ -22,8 +22,6 @@ import {
 } from './util';
 import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
 
-const countryCode = 'US';
-const postalCode = '10001';
 const initialCart = getEmptyResponseCart();
 const getCart = mockGetCartEndpointWith( initialCart );
 const setCart = mockSetCartEndpointWith( initialCart );
@@ -40,17 +38,13 @@ function MyTestWrapper() {
 	);
 }
 
-function mockCachedContactDetailsEndpoint() {
+function mockCachedContactDetailsEndpoint( data ) {
 	const endpoint = jest.fn();
 	endpoint.mockReturnValue( true );
-	const mockDomainContactResponse = () => [
-		200,
-		{ country_code: countryCode, postal_code: postalCode },
-	];
+	const mockDomainContactResponse = () => [ 200, data ];
 	nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.1/me/domain-contact-information' )
-		.reply( mockDomainContactResponse )
-		.persist();
+		.reply( mockDomainContactResponse );
 }
 
 function MyTestContent() {
@@ -62,17 +56,28 @@ function MyTestContent() {
 	);
 	return (
 		<div>
-			<div>Tax Country: { responseCart.tax.location.country_code }</div>
-			<div>Tax Postal: { responseCart.tax.location.postal_code }</div>
-			<div>Form Country: { contactInfo.countryCode?.value }</div>
-			<div>Form Postal: { contactInfo.postalCode?.value }</div>
+			{ responseCart.tax.location.country_code && (
+				<div>Tax Country: { responseCart.tax.location.country_code }</div>
+			) }
+			{ responseCart.tax.location.postal_code && (
+				<div>Tax Postal: { responseCart.tax.location.postal_code }</div>
+			) }
+			{ contactInfo.countryCode?.value && (
+				<div>Form Country: { contactInfo.countryCode?.value }</div>
+			) }
+			{ contactInfo.postalCode?.value && <div>Form Postal: { contactInfo.postalCode?.value }</div> }
 		</div>
 	);
 }
 
 describe( 'useCachedDomainContactDetails', () => {
-	it( 'sends the postal code and country from the contact details endpoint to the cart', async () => {
-		mockCachedContactDetailsEndpoint();
+	it( 'sends the postal code and country from the contact details endpoint to the cart for country with postal code', async () => {
+		const countryCode = 'US';
+		const postalCode = '10001';
+		mockCachedContactDetailsEndpoint( {
+			country_code: countryCode,
+			postal_code: postalCode,
+		} );
 		render( <MyTestWrapper /> );
 		await waitFor( () => {
 			expect( screen.queryByText( `Tax Country: ${ countryCode }` ) ).toBeInTheDocument();
@@ -80,12 +85,43 @@ describe( 'useCachedDomainContactDetails', () => {
 		} );
 	} );
 
-	it( 'sends the postal code and country from the contact details endpoint to the checkout data store', async () => {
-		mockCachedContactDetailsEndpoint();
+	it( 'sends the country from the contact details endpoint to the cart for country without postal code', async () => {
+		mockCachedContactDetailsEndpoint( {
+			country_code: 'CW',
+			postal_code: '10001',
+		} );
+		render( <MyTestWrapper /> );
+		await waitFor( () => {
+			expect( screen.queryByText( `Tax Country: CW` ) ).toBeInTheDocument();
+			expect( screen.queryByText( `Tax Postal:` ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	it( 'sends the postal code and country from the contact details endpoint to the checkout data store for country with postal code', async () => {
+		const countryCode = 'US';
+		const postalCode = '10001';
+		mockCachedContactDetailsEndpoint( {
+			country_code: countryCode,
+			postal_code: postalCode,
+		} );
 		render( <MyTestWrapper /> );
 		await waitFor( () => {
 			expect( screen.queryByText( `Form Country: ${ countryCode }` ) ).toBeInTheDocument();
 			expect( screen.queryByText( `Form Postal: ${ postalCode }` ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'sends the country from the contact details endpoint to the checkout data store for country without postal code', async () => {
+		const countryCode = 'CW';
+		const postalCode = '10001';
+		mockCachedContactDetailsEndpoint( {
+			country_code: countryCode,
+			postal_code: postalCode,
+		} );
+		render( <MyTestWrapper /> );
+		await waitFor( () => {
+			expect( screen.queryByText( `Form Country: ${ countryCode }` ) ).toBeInTheDocument();
+			expect( screen.queryByText( `Form Postal: ${ postalCode }` ) ).not.toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
@@ -10,7 +10,6 @@ import {
 import '@testing-library/jest-dom/extend-expect';
 import { render, screen, waitFor } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
-import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
 import useCachedDomainContactDetails from 'calypso/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details';
 import { useWpcomStore } from 'calypso/my-sites/checkout/composite-checkout/hooks/wpcom-store';
@@ -19,8 +18,10 @@ import {
 	createTestReduxStore,
 	mockGetCartEndpointWith,
 	mockSetCartEndpointWith,
+	mockCachedContactDetailsEndpoint,
+	verifyThatTextNeverAppears,
 } from './util';
-import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
+import type { CountryListItem, ManagedContactDetails } from '@automattic/wpcom-checkout';
 
 const initialCart = getEmptyResponseCart();
 const getCart = mockGetCartEndpointWith( initialCart );
@@ -28,34 +29,26 @@ const setCart = mockSetCartEndpointWith( initialCart );
 const cartManagerClient = createShoppingCartManagerClient( { getCart, setCart } );
 const reduxStore = createTestReduxStore();
 
-function MyTestWrapper() {
+function MyTestWrapper( { countries }: { countries: CountryListItem[] } ) {
 	return (
 		<ReduxProvider store={ reduxStore }>
 			<ShoppingCartProvider managerClient={ cartManagerClient }>
-				<MyTestContent />
+				<MyTestContent countries={ countries } />
 			</ShoppingCartProvider>
 		</ReduxProvider>
 	);
 }
 
-function mockCachedContactDetailsEndpoint( data ) {
-	const endpoint = jest.fn();
-	endpoint.mockReturnValue( true );
-	const mockDomainContactResponse = () => [ 200, data ];
-	nock( 'https://public-api.wordpress.com' )
-		.get( '/rest/v1.1/me/domain-contact-information' )
-		.reply( mockDomainContactResponse );
-}
-
-function MyTestContent() {
+function MyTestContent( { countries }: { countries: CountryListItem[] } ) {
 	useWpcomStore();
 	const { responseCart } = useShoppingCart( initialCart.cart_key );
-	useCachedDomainContactDetails( countryList );
+	useCachedDomainContactDetails( countries );
 	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
 		select( 'wpcom-checkout' ).getContactInfo()
 	);
 	return (
 		<div>
+			<div>Test content</div>
 			{ responseCart.tax.location.country_code && (
 				<div>Tax Country: { responseCart.tax.location.country_code }</div>
 			) }
@@ -78,7 +71,7 @@ describe( 'useCachedDomainContactDetails', () => {
 			country_code: countryCode,
 			postal_code: postalCode,
 		} );
-		render( <MyTestWrapper /> );
+		render( <MyTestWrapper countries={ countryList } /> );
 		await waitFor( () => {
 			expect( screen.queryByText( `Tax Country: ${ countryCode }` ) ).toBeInTheDocument();
 			expect( screen.queryByText( `Tax Postal: ${ postalCode }` ) ).toBeInTheDocument();
@@ -90,10 +83,23 @@ describe( 'useCachedDomainContactDetails', () => {
 			country_code: 'CW',
 			postal_code: '10001',
 		} );
-		render( <MyTestWrapper /> );
+		render( <MyTestWrapper countries={ countryList } /> );
 		await waitFor( () => {
 			expect( screen.queryByText( `Tax Country: CW` ) ).toBeInTheDocument();
-			expect( screen.queryByText( `Tax Postal:` ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( `Tax Postal: 10001` ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	it( 'does not send the country from the contact details endpoint to the cart if countries have not loaded', async () => {
+		mockCachedContactDetailsEndpoint( {
+			country_code: 'US',
+			postal_code: '10001',
+		} );
+		render( <MyTestWrapper countries={ [] } /> );
+		await verifyThatTextNeverAppears( 'Tax Country: US' );
+		await verifyThatTextNeverAppears( 'Tax Postal: 10001' );
+		await waitFor( () => {
+			expect( screen.queryByText( 'Test content' ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -104,7 +110,7 @@ describe( 'useCachedDomainContactDetails', () => {
 			country_code: countryCode,
 			postal_code: postalCode,
 		} );
-		render( <MyTestWrapper /> );
+		render( <MyTestWrapper countries={ countryList } /> );
 		await waitFor( () => {
 			expect( screen.queryByText( `Form Country: ${ countryCode }` ) ).toBeInTheDocument();
 			expect( screen.queryByText( `Form Postal: ${ postalCode }` ) ).toBeInTheDocument();
@@ -118,10 +124,25 @@ describe( 'useCachedDomainContactDetails', () => {
 			country_code: countryCode,
 			postal_code: postalCode,
 		} );
-		render( <MyTestWrapper /> );
+		render( <MyTestWrapper countries={ countryList } /> );
 		await waitFor( () => {
 			expect( screen.queryByText( `Form Country: ${ countryCode }` ) ).toBeInTheDocument();
 			expect( screen.queryByText( `Form Postal: ${ postalCode }` ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	it( 'does not send the country from the contact details endpoint to the checkout data store if countries have not loaded', async () => {
+		const countryCode = 'US';
+		const postalCode = '10001';
+		mockCachedContactDetailsEndpoint( {
+			country_code: countryCode,
+			postal_code: postalCode,
+		} );
+		render( <MyTestWrapper countries={ [] } /> );
+		await verifyThatTextNeverAppears( 'Form Country: US' );
+		await verifyThatTextNeverAppears( 'Form Postal: 10001' );
+		await waitFor( () => {
+			expect( screen.queryByText( 'Test content' ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
@@ -9,6 +9,7 @@ import {
 } from '@automattic/shopping-cart';
 import '@testing-library/jest-dom/extend-expect';
 import { render, screen, waitFor } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
 import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
 import useCachedDomainContactDetails from 'calypso/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details';
@@ -19,6 +20,7 @@ import {
 	mockGetCartEndpointWith,
 	mockSetCartEndpointWith,
 } from './util';
+import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
 
 const countryCode = 'US';
 const postalCode = '10001';
@@ -55,10 +57,15 @@ function MyTestContent() {
 	useWpcomStore();
 	const { responseCart } = useShoppingCart( initialCart.cart_key );
 	useCachedDomainContactDetails( countryList );
+	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
+		select( 'wpcom-checkout' ).getContactInfo()
+	);
 	return (
 		<div>
-			<div>Country: { responseCart.tax.location.country_code }</div>
-			<div>Postal: { responseCart.tax.location.postal_code }</div>
+			<div>Tax Country: { responseCart.tax.location.country_code }</div>
+			<div>Tax Postal: { responseCart.tax.location.postal_code }</div>
+			<div>Form Country: { contactInfo.countryCode?.value }</div>
+			<div>Form Postal: { contactInfo.postalCode?.value }</div>
 		</div>
 	);
 }
@@ -68,8 +75,17 @@ describe( 'useCachedDomainContactDetails', () => {
 		mockCachedContactDetailsEndpoint();
 		render( <MyTestWrapper /> );
 		await waitFor( () => {
-			expect( screen.queryByText( `Country: ${ countryCode }` ) ).toBeInTheDocument();
-			expect( screen.queryByText( `Postal: ${ postalCode }` ) ).toBeInTheDocument();
+			expect( screen.queryByText( `Tax Country: ${ countryCode }` ) ).toBeInTheDocument();
+			expect( screen.queryByText( `Tax Postal: ${ postalCode }` ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'sends the postal code and country from the contact details endpoint to the checkout data store', async () => {
+		mockCachedContactDetailsEndpoint();
+		render( <MyTestWrapper /> );
+		await waitFor( () => {
+			expect( screen.queryByText( `Form Country: ${ countryCode }` ) ).toBeInTheDocument();
+			expect( screen.queryByText( `Form Postal: ${ postalCode }` ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	ShoppingCartProvider,
+	useShoppingCart,
+	createShoppingCartManagerClient,
+	getEmptyResponseCart,
+} from '@automattic/shopping-cart';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { Provider as ReduxProvider } from 'react-redux';
+import useCachedDomainContactDetails from 'calypso/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details';
+import { useWpcomStore } from 'calypso/my-sites/checkout/composite-checkout/hooks/wpcom-store';
+import {
+	countryList,
+	createTestReduxStore,
+	mockGetCartEndpointWith,
+	mockSetCartEndpointWith,
+} from './util';
+
+const countryCode = 'US';
+const postalCode = '10001';
+const initialCart = getEmptyResponseCart();
+const getCart = mockGetCartEndpointWith( initialCart );
+const setCart = mockSetCartEndpointWith( initialCart );
+const cartManagerClient = createShoppingCartManagerClient( { getCart, setCart } );
+const reduxStore = createTestReduxStore();
+
+function MyTestWrapper() {
+	return (
+		<ReduxProvider store={ reduxStore }>
+			<ShoppingCartProvider managerClient={ cartManagerClient }>
+				<MyTestContent />
+			</ShoppingCartProvider>
+		</ReduxProvider>
+	);
+}
+
+function mockCachedContactDetailsEndpoint() {
+	const endpoint = jest.fn();
+	endpoint.mockReturnValue( true );
+	const mockDomainContactResponse = () => [
+		200,
+		{ country_code: countryCode, postal_code: postalCode },
+	];
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me/domain-contact-information' )
+		.reply( mockDomainContactResponse )
+		.persist();
+}
+
+function MyTestContent() {
+	useWpcomStore();
+	const { responseCart } = useShoppingCart( initialCart.cart_key );
+	useCachedDomainContactDetails( countryList );
+	return (
+		<div>
+			<div>Country: { responseCart.tax.location.country_code }</div>
+			<div>Postal: { responseCart.tax.location.postal_code }</div>
+		</div>
+	);
+}
+
+describe( 'useCachedDomainContactDetails', () => {
+	it( 'sends the postal code and country from the contact details endpoint to the cart', async () => {
+		mockCachedContactDetailsEndpoint();
+		render( <MyTestWrapper /> );
+		await waitFor( () => {
+			expect( screen.queryByText( `Country: ${ countryCode }` ) ).toBeInTheDocument();
+			expect( screen.queryByText( `Postal: ${ postalCode }` ) ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
@@ -19,7 +19,6 @@ import {
 	createTestReduxStore,
 	mockCartEndpoint,
 	mockCachedContactDetailsEndpoint,
-	verifyThatTextNeverAppears,
 } from './util';
 import type { CountryListItem, ManagedContactDetails } from '@automattic/wpcom-checkout';
 
@@ -120,11 +119,8 @@ describe( 'useCachedDomainContactDetails', () => {
 			postal_code: '10001',
 		} );
 		render( <MyTestWrapper countries={ [] } /> );
-		await verifyThatTextNeverAppears( 'Tax Country: US' );
-		await verifyThatTextNeverAppears( 'Tax Postal: 10001' );
-		await waitFor( () => {
-			expect( screen.queryByText( 'Test content' ) ).toBeInTheDocument();
-		} );
+		await expect( screen.findByText( 'Tax Country: US' ) ).toNeverAppear();
+		await expect( screen.findByText( 'Tax Postal: 10001' ) ).toNeverAppear();
 	} );
 
 	it( 'does not send the country from the contact details endpoint to the cart if the cart reloads after they have already been sent', async () => {
@@ -154,7 +150,7 @@ describe( 'useCachedDomainContactDetails', () => {
 
 		// Reload the cart and verify that the hook does not revert the cart info.
 		fireEvent.click( await screen.findByText( 'Click to reload cart' ) );
-		await verifyThatTextNeverAppears( 'Tax Postal: 10001' );
+		await expect( screen.findByText( 'Tax Postal: 10001' ) ).toNeverAppear();
 		await waitFor( () => {
 			expect( screen.queryByText( 'Tax Postal: 90210' ) ).toBeInTheDocument();
 		} );
@@ -196,10 +192,7 @@ describe( 'useCachedDomainContactDetails', () => {
 			postal_code: postalCode,
 		} );
 		render( <MyTestWrapper countries={ [] } /> );
-		await verifyThatTextNeverAppears( 'Form Country: US' );
-		await verifyThatTextNeverAppears( 'Form Postal: 10001' );
-		await waitFor( () => {
-			expect( screen.queryByText( 'Test content' ) ).toBeInTheDocument();
-		} );
+		await expect( screen.findByText( 'Form Country: US' ) ).toNeverAppear();
+		await expect( screen.findByText( 'Form Postal: 10001' ) ).toNeverAppear();
 	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -4,6 +4,7 @@ import {
 	getEmptyResponseCartProduct,
 	RequestCartProduct,
 } from '@automattic/shopping-cart';
+import { screen } from '@testing-library/react';
 import nock from 'nock';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
@@ -877,3 +878,19 @@ export const expectedCreateAccountRequest = {
 	client_id: config( 'wpcom_signup_id' ),
 	client_secret: config( 'wpcom_signup_key' ),
 };
+
+export function mockCachedContactDetailsEndpoint( data ): void {
+	const endpoint = jest.fn();
+	endpoint.mockReturnValue( true );
+	const mockDomainContactResponse = () => [ 200, data ];
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me/domain-contact-information' )
+		.reply( mockDomainContactResponse );
+}
+
+// This is a little tricky because we need to verify that text never appears,
+// even after some time passes, so we use this slightly convoluted technique:
+// https://stackoverflow.com/a/68318058/2615868
+export async function verifyThatTextNeverAppears( text: string ): Promise< void > {
+	await expect( screen.findByText( text ) ).rejects.toThrow();
+}

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -319,8 +319,8 @@ export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
 			sub_total_with_taxes_display: 'R$156',
 			sub_total_with_taxes_integer: totalInteger,
 			tax: {
-				location: requestCart.tax.location ?? {},
-				display_taxes: !! requestCart.tax.location.postal_code,
+				location: requestCart.tax?.location ?? {},
+				display_taxes: !! requestCart.tax?.location?.postal_code,
 			},
 			total_cost: 0,
 			total_cost_display: 'R$156',

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -1,19 +1,17 @@
 import config from '@automattic/calypso-config';
-import {
-	getEmptyResponseCart,
-	getEmptyResponseCartProduct,
-	RequestCartProduct,
-} from '@automattic/shopping-cart';
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import { screen } from '@testing-library/react';
 import nock from 'nock';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import domainManagementReducer from 'calypso/state/domains/management/reducer';
 import type {
+	CartKey,
 	SetCart,
 	RequestCart,
 	ResponseCart,
 	ResponseCartProduct,
+	RequestCartProduct,
 } from '@automattic/shopping-cart';
 import type {
 	CountryListItem,
@@ -496,6 +494,20 @@ function convertRequestProductToResponseProduct(
 			item_subtotal_integer: 0,
 			item_tax: 0,
 		};
+	};
+}
+
+export function mockCartEndpoint( initialCart: ResponseCart, currency: string, locale: string ) {
+	let cart = initialCart;
+	const mockSetCart = mockSetCartEndpointWith( { currency, locale } );
+	const setCart = async ( cartKey: CartKey, val: RequestCart ) => {
+		cart = await mockSetCart( cartKey, val );
+		return cart;
+	};
+
+	return {
+		getCart: async () => cart,
+		setCart,
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds unit tests for the `useCachedDomainContactDetails` hook that checkout uses to pass data from the cached contact details endpoint to the checkout data store and the shopping-cart endpoint.

Amongst other things, these tests will guard against the bug and the regression that were fixed by https://github.com/Automattic/wp-calypso/pull/62790.

Along the way, it makes a few changes, a few of which are in their own PRs to make them easier to review:

- Remove the arguments to `useWpcomStore`: https://github.com/Automattic/wp-calypso/pull/63019
- If `useCountryList` is provided with overrides, always respect them: https://github.com/Automattic/wp-calypso/pull/63018
- Refactor `useCachedDomainContactDetails` to separate the update to the checkout store and the cart store.
- Explicitly erase the postal code from the checkout form data store if a country is selected that does not support postal codes. This was a bug!

Fixes https://github.com/Automattic/wp-calypso/issues/62828

#### Testing instructions

Automated tests are included.

To verify that this does not break anything in checkout, add a product to your cart, visit checkout, and try changing the contact details/billing details step to make sure it works.

To prove that both bugs in https://github.com/Automattic/wp-calypso/pull/62790 are covered by these tests, you can manually recreate them and make sure that the tests fail. Here's how.

<details>
<summary>To recreate the bug where we were not waiting for the countries list to load, apply the following diff.</summary>

```diff
diff --git a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
index 62d99865f6..eceb07fb51 100644
--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -54,10 +54,9 @@ function useCachedContactDetailsForCheckoutForm(
 	const countriesList = useCountryList( overrideCountryList );
 	const previousDetailsForForm = useRef< PossiblyCompleteDomainContactDetails >();
 
-	const arePostalCodesSupported =
-		countriesList.length && cachedContactDetails?.countryCode
-			? getCountryPostalCodeSupport( countriesList, cachedContactDetails.countryCode )
-			: true;
+	const arePostalCodesSupported = cachedContactDetails?.countryCode
+		? getCountryPostalCodeSupport( countriesList, cachedContactDetails.countryCode )
+		: true;
 
 	const checkoutStoreActions = useDispatch( 'wpcom-checkout' );
 	if ( ! checkoutStoreActions?.loadDomainContactDetailsFromCache ) {
@@ -75,10 +74,6 @@ function useCachedContactDetailsForCheckoutForm(
 			debug( 'cached contact details for form have not loaded' );
 			return;
 		}
-		if ( ! countriesList.length ) {
-			debug( 'cached contact details for form are waiting for the countries list' );
-			return;
-		}
 		// Do nothing if the cached data has not changed since the last time we
 		// sent the data to the form (this typically will only ever need to be
 		// activated once).
@@ -113,16 +108,15 @@ function useCachedContactDetailsForCart(
 		loadingError: cartLoadingError,
 	} = useShoppingCart( cartKey );
 
-	const arePostalCodesSupported =
-		countriesList.length && cachedContactDetails?.countryCode
-			? getCountryPostalCodeSupport( countriesList, cachedContactDetails.countryCode )
-			: true;
+	const arePostalCodesSupported = cachedContactDetails?.countryCode
+		? getCountryPostalCodeSupport( countriesList, cachedContactDetails.countryCode )
+		: true;
 
 	// When we have fetched or loaded contact details, send them to the
 	// to the shopping cart for calculating taxes.
 	useEffect( () => {
 		// Do nothing if the cart is loading, the contact details are loading, or the countries are loading.
-		if ( isLoadingCart || cartLoadingError || ! cachedContactDetails || ! countriesList.length ) {
+		if ( isLoadingCart || cartLoadingError || ! cachedContactDetails ) {
 			return;
 		}
 		if (
```

</details>

<details>
<summary>To recreate the bug where the cart reloading could send the wrong details to the cart endpoint, apply the following diff.</summary>

```diff
diff --git a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
index 62d99865f6..cc23e8d53a 100644
--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -132,12 +132,6 @@ function useCachedContactDetailsForCart(
 		) {
 			return;
 		}
-		// Do nothing if the cached data has not changed since the last time we
-		// sent the data to the cart endpoint (this typically will only ever need
-		// to be activated once).
-		if ( ! areTaxFieldsDifferent( previousDetailsForCart.current, cachedContactDetails ) ) {
-			return;
-		}
 		previousDetailsForCart.current = cachedContactDetails;
 		debug( 'updating cart tax details with cached contact details', cachedContactDetails );
 		updateCartLocation( {
```

</details>