### PR TITLE
Fix tslib dependency for format-currency

### DIFF
--- a/packages/format-currency/CHANGELOG.md
+++ b/packages/format-currency/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 1.0.0 - 2022-04-25
 ### Fixed
 - Fixed tslib dependency
 

--- a/packages/format-currency/CHANGELOG.md
+++ b/packages/format-currency/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed tslib dependency
+
 ## 1.0.0 - 2022-04-20
 ### Added
 - Initial release

--- a/packages/format-currency/package.json
+++ b/packages/format-currency/package.json
@@ -29,12 +29,11 @@
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
-	"peerDependencies": {
-		"react": "^17.0.2"
+	"dependencies": {
+		"tslib": "^2.3.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"tslib": "^2.3.0",
 		"typescript": "^4.5.5"
 	},
 	"files": [

--- a/packages/format-currency/package.json
+++ b/packages/format-currency/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/format-currency",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "JavaScript library for formatting currency.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,8 +598,6 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: ^2.3.0
     typescript: ^4.5.5
-  peerDependencies:
-    react: ^17.0.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
`tslib` must be a runtime dependency for all the packages that produce a CommonJS output. Otherwise there are errors as seen in #62981.

#### Changes proposed in this Pull Request

* Move `tslib` from `devDependencies` to `dependencies` for `format-currency` package
* Remove `react` from `peerDependencies` for it, because it doesn't need React at all.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Boot up this PR and run `yarn && yarn build-packages`
- Create a new project with this `package.json`
```json
{
    "name": "test",
    "type": "module",
}
```
- Run `yarn add file:<path/to/wp-calypso/packages/format-currency/>` to install the local package in your new project.
- Create this `index.js`
```js
import fc from '@automattic/format-currency';

const formatCurrency = fc.default || fc;

console.log( formatCurrency( 1.23, 'USD' ) );
```
- Do `yarn install`.
- Run it as `node index.js`
- Confirm that the command succeeds and the output is `$1.23`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #62981 
