### PR TITLE
Fix post-checkout redirect for 'redirectTo' arg with subdirectory sites.

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -1,4 +1,3 @@
-import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
 import {
 	JETPACK_PRODUCTS_LIST,
 	JETPACK_RESET_PLANS,
@@ -13,6 +12,13 @@ import {
 	PLAN_PREMIUM,
 	PLAN_ECOMMERCE,
 } from '@automattic/calypso-products';
+import {
+	URL_TYPE,
+	determineUrlType,
+	format as formatUrl,
+	getUrlParts,
+	getUrlFromParts,
+} from '@automattic/calypso-url';
 import debugFactory from 'debug';
 import {
 	hasRenewalItem,
@@ -37,7 +43,7 @@ import { dangerouslyGetExperimentAssignment } from 'calypso/lib/explat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import { getEligibleTitanDomain } from 'calypso/lib/titan';
-import { addQueryArgs, isExternal, resemblesUrl, urlToSlug } from 'calypso/lib/url';
+import { addQueryArgs, isExternal, resemblesUrl } from 'calypso/lib/url';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import {
 	clearSignupCompleteFlowName,
@@ -101,9 +107,9 @@ export default function getThankYouPageUrl( {
 	// or a Jetpack or WP.com site's block editor (in wp-admin). This is required for Jetpack's
 	// (and WP.com's) paid blocks Upgrade Nudge.
 	if ( redirectTo ) {
-		const { protocol, hostname, port, pathname, query } = parseUrl( redirectTo, true, true );
+		const { protocol, hostname, port, pathname, searchParams } = getUrlParts( redirectTo );
 
-		if ( resemblesUrl( redirectTo ) && hostname && urlToSlug( hostname ) === siteSlug ) {
+		if ( resemblesUrl( redirectTo ) && isRedirectSameSite( redirectTo, siteSlug ) ) {
 			debug( 'has same site redirectTo, so returning that', redirectTo );
 			return redirectTo;
 		}
@@ -114,17 +120,17 @@ export default function getThankYouPageUrl( {
 		// We cannot simply compare `hostname` to `siteSlug`, since the latter
 		// might contain a path in the case of Jetpack subdirectory installs.
 		if ( adminUrl && redirectTo.startsWith( `${ adminUrl }post.php?` ) ) {
-			const sanitizedRedirectTo = formatUrl( {
-				protocol,
-				hostname,
-				port,
-				pathname,
-				query: {
-					post: parseInt( String( query.post ), 10 ),
+			const sanitizedRedirectTo = getUrlFromParts( {
+				protocol: protocol,
+				hostname: hostname,
+				port: port,
+				pathname: pathname,
+				searchParams: new URLSearchParams( {
+					post: searchParams.get( 'post' ) as string,
 					action: 'edit',
-					plan_upgraded: 1,
-				},
-			} );
+					plan_upgraded: '1',
+				} ),
+			} ).href;
 			debug( 'returning sanitized internal redirectTo', redirectTo );
 			return sanitizedRedirectTo;
 		}
@@ -625,19 +631,28 @@ function getNoticeType( cart: ResponseCart | undefined ): Record< string, string
 }
 
 function getUrlWithQueryParam( url: string, queryParams: Record< string, string > ): string {
-	const { protocol, hostname, port, pathname, query, hash } = parseUrl( url, true );
+	const defaultUrl = '/';
+	url = url || defaultUrl;
+	const urlType = determineUrlType( url );
+	if ( urlType === URL_TYPE.INVALID || urlType === URL_TYPE.PATH_RELATIVE ) {
+		return defaultUrl;
+	}
+	const { search, origin, host, ...parsedURL } = getUrlParts( url );
 
-	return formatUrl( {
-		protocol,
-		hostname,
-		port,
-		pathname,
-		query: {
-			...query,
+	// getUrlFromParts can only handle absolute URLs, so add dummy data if needed.
+	// formatUrl will remove it away, to match the previous url type.
+	parsedURL.protocol = parsedURL.protocol || 'https:';
+	parsedURL.hostname = parsedURL.hostname || '__domain__.invalid';
+
+	const urlParts = {
+		...parsedURL,
+		searchParams: new URLSearchParams( {
+			...Object.fromEntries( new URLSearchParams( search ) ),
 			...queryParams,
-		},
-		hash,
-	} );
+		} ),
+	};
+
+	return formatUrl( getUrlFromParts( urlParts ), urlType );
 }
 
 /**
@@ -719,4 +734,18 @@ function getRedirectUrlFromCart( cart: ResponseCart ): string | null {
 		firstProductWithUrl?.extra.afterPurchaseUrl
 	);
 	return firstProductWithUrl?.extra.afterPurchaseUrl ?? null;
+}
+
+function isRedirectSameSite( redirectTo: string, siteSlug?: string ) {
+	if ( ! siteSlug ) {
+		return false;
+	}
+	const { hostname, pathname } = getUrlParts( redirectTo );
+	// For subdirectory site, check that both hostname and subdirectory matches the siteSlug (host.name::subdirectory).
+	if ( siteSlug.indexOf( '::' ) !== -1 ) {
+		const slugParts = siteSlug.split( '::' );
+		return hostname === slugParts[ 0 ] && pathname?.startsWith( `/${ slugParts[ 1 ] }` );
+	}
+	// For standard non-subdirectory site, check that hostname matches the siteSlug.
+	return hostname === siteSlug;
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -131,7 +131,7 @@ export default function getThankYouPageUrl( {
 					plan_upgraded: '1',
 				} ),
 			} ).href;
-			debug( 'returning sanitized internal redirectTo', redirectTo );
+			debug( 'returning sanitized internal redirectTo', sanitizedRedirectTo );
 			return sanitizedRedirectTo;
 		}
 
@@ -744,7 +744,11 @@ function isRedirectSameSite( redirectTo: string, siteSlug?: string ) {
 	// For subdirectory site, check that both hostname and subdirectory matches the siteSlug (host.name::subdirectory).
 	if ( siteSlug.indexOf( '::' ) !== -1 ) {
 		const slugParts = siteSlug.split( '::' );
-		return hostname === slugParts[ 0 ] && pathname?.startsWith( `/${ slugParts[ 1 ] }` );
+		const hostnameFromSlug = slugParts[ 0 ];
+		const subDirectoryPathFromSlug = slugParts.splice( 1 ).join( '/' );
+		return (
+			hostname === hostnameFromSlug && pathname?.startsWith( `/${ subDirectoryPathFromSlug }` )
+		);
 	}
 	// For standard non-subdirectory site, check that hostname matches the siteSlug.
 	return hostname === siteSlug;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -630,12 +630,10 @@ function getNoticeType( cart: ResponseCart | undefined ): Record< string, string
 	return {};
 }
 
-function getUrlWithQueryParam( url: string, queryParams: Record< string, string > ): string {
-	const defaultUrl = '/';
-	url = url || defaultUrl;
+function getUrlWithQueryParam( url = '/', queryParams: Record< string, string > = {} ): string {
 	const urlType = determineUrlType( url );
 	if ( urlType === URL_TYPE.INVALID || urlType === URL_TYPE.PATH_RELATIVE ) {
-		return defaultUrl;
+		return url;
 	}
 	const { search, origin, host, ...parsedURL } = getUrlParts( url );
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -1162,12 +1162,22 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd?d=traffic-guide' );
 	} );
 
-	it( 'redirects to a url on the site we are checking out', () => {
+	it( 'redirects to a url on the same site we are checking out', () => {
 		const redirectTo = 'https://foo.bar/some-path?with-args=yes';
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			redirectTo,
 			siteSlug: 'foo.bar',
+		} );
+		expect( url ).toBe( redirectTo );
+	} );
+
+	it( 'redirects to a url on the same subdirectory site we are checking out', () => {
+		const redirectTo = 'https://foo.bar/subdirectory/some-path?with-args=yes';
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			redirectTo,
+			siteSlug: 'foo.bar::subdirectory',
 		} );
 		expect( url ).toBe( redirectTo );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an issue where the post-checkout `redirectTo` query arg was not applying the proper redirect for WordPress subdirectory sites.

**Implementation notes:**
- ** Also refactored the file to use/import the `@automattic/calypso-url` library functions, replacing the Node's `'url'` package (depreciated). I had to refactor a couple functions because the two libraries are quite different.
- Also added a new unit-test case for `redirectTo` redirects to WordPress subdirectory sites.

Related to: p1649925643073129-slack-CQXNTE9K9
Fixes: 1164141197617539-as-1202121461592303/f

#### Testing instructions

1. Checkout this PR and `yarn start`.
1. Go to https://jurassic.ninja, click "Want more options?",  Select include Jetpack Beta --> with Jetpack Boost Branch, Master/bleeding edge --> and finally click "Launch Multisite on subdirs".
2. In the site wp-admin, create a new subdirectory site:
    - My Sites --> Network admin --> Sites --> Add new
    - Enter a subdirectory name, site title, admin email, and click "Add site".
3. In the dashboard of the new subdirectory site, select "Plugins" and Activate the Jetpack Boost plugin, Then select Boost "Settings" and finally click, "Get Started" button.
4. In wp-admin, go to the Boost dashboard (Jetpack --> Boost)
5. Turn on "Optimize CSS Loading",  Select "Upgrade Jetpack Boost". Select "Upgrade Jetpack Boost" again.
6. Once on the checkout page, in the url replace `wordpress.com/` with `calypso.localhost:3000` and reload checkout.
7. Complete the purchase in calypso and you should be redirected to the Boost checkout thank you page. (see screencasts)

**Run unit tests:**
`yarn test-client client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js`

**Before: (redirect not working)**

https://user-images.githubusercontent.com/11078128/165002278-84c79076-871d-409c-a901-4e41a1aa941e.mp4

**After: (redirect working correctly)**

https://user-images.githubusercontent.com/11078128/165002265-f131b405-699f-4ec2-bd98-d88196165842.mp4


