### PR TITLE
ColorSchemePicker: fix ESLint warnings and convert to functional

### DIFF
--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -1,4 +1,3 @@
-import { compact } from 'lodash';
 import aquaticImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-aquatic.svg';
 import blueImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-blue.svg';
 import classicBlueImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnail-classic-blue.svg';
@@ -25,7 +24,7 @@ import sunsetImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnai
  */
 
 export default function ( translate ) {
-	return compact( [
+	return [
 		{
 			label: translate( 'Default' ),
 			value: 'classic-dark',
@@ -162,5 +161,5 @@ export default function ( translate ) {
 				imageUrl: sunsetImg,
 			},
 		},
-	] );
+	];
 }

--- a/client/blocks/color-scheme-picker/index.jsx
+++ b/client/blocks/color-scheme-picker/index.jsx
@@ -1,8 +1,6 @@
-import { translate, localize } from 'i18n-calypso';
-import { find } from 'lodash';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { PureComponent } from 'react';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import QueryPreferences from 'calypso/components/data/query-preferences';
 import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
 import { successNotice } from 'calypso/state/notices/actions';
@@ -12,68 +10,56 @@ import getColorSchemesData from './constants';
 
 import './style.scss';
 
-class ColorSchemePicker extends PureComponent {
-	static propTypes = {
-		defaultSelection: PropTypes.string,
-		temporarySelection: PropTypes.bool,
-		onSelection: PropTypes.func,
-		disabled: PropTypes.bool,
-		// Connected props
-		colorSchemePreference: PropTypes.string,
-		saveColorSchemePreference: PropTypes.func,
-	};
+function ColorSchemePicker( { defaultSelection, temporarySelection, onSelection, disabled } ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const colorSchemePreference = useSelector( ( state ) => getPreference( state, 'colorScheme' ) );
 
-	handleColorSchemeSelection = ( event ) => {
-		const { temporarySelection, translate, onSelection, saveColorSchemePreference, successNotice } =
-			this.props;
+	function handleColorSchemeSelection( event ) {
 		const { value } = event.currentTarget;
-		const noticeSettings = {
-			id: 'color-scheme-picker-save',
-			duration: 10000,
-		};
 
 		if ( temporarySelection ) {
 			onSelection( value );
+			dispatch( setPreference( 'colorScheme', value ) );
+		} else {
+			dispatch( savePreference( 'colorScheme', value ) );
 		}
-		saveColorSchemePreference( value, temporarySelection );
 
-		successNotice( translate( 'Settings saved successfully!' ), noticeSettings );
-	};
-
-	render() {
-		const colorSchemesData = getColorSchemesData( translate );
-		const defaultColorScheme = this.props.defaultSelection || colorSchemesData[ 0 ].value;
-		const checkedColorScheme = find( colorSchemesData, [
-			'value',
-			this.props.colorSchemePreference,
-		] )
-			? this.props.colorSchemePreference
-			: defaultColorScheme;
-		return (
-			<div className="color-scheme-picker">
-				<QueryPreferences />
-				<FormRadiosBar
-					isThumbnail
-					checked={ checkedColorScheme }
-					onChange={ this.handleColorSchemeSelection }
-					items={ colorSchemesData }
-					disabled={ this.props.disabled }
-				/>
-			</div>
+		dispatch(
+			successNotice( translate( 'Settings saved successfully!' ), {
+				id: 'color-scheme-picker-save',
+				duration: 10000,
+			} )
 		);
 	}
+
+	const colorSchemesData = getColorSchemesData( translate );
+	const defaultColorScheme = defaultSelection || colorSchemesData[ 0 ].value;
+	const checkedColorScheme = colorSchemesData.some(
+		( { value } ) => value === colorSchemePreference
+	)
+		? colorSchemePreference
+		: defaultColorScheme;
+
+	return (
+		<div className="color-scheme-picker">
+			<QueryPreferences />
+			<FormRadiosBar
+				isThumbnail
+				checked={ checkedColorScheme }
+				onChange={ handleColorSchemeSelection }
+				items={ colorSchemesData }
+				disabled={ disabled }
+			/>
+		</div>
+	);
 }
 
-const saveColorSchemePreference = ( preference, temporarySelection ) =>
-	temporarySelection
-		? setPreference( 'colorScheme', preference )
-		: savePreference( 'colorScheme', preference );
+ColorSchemePicker.propTypes = {
+	defaultSelection: PropTypes.string,
+	temporarySelection: PropTypes.bool,
+	onSelection: PropTypes.func,
+	disabled: PropTypes.bool,
+};
 
-export default connect(
-	( state ) => {
-		return {
-			colorSchemePreference: getPreference( state, 'colorScheme' ),
-		};
-	},
-	{ saveColorSchemePreference, successNotice }
-)( localize( ColorSchemePicker ) );
+export default ColorSchemePicker;

--- a/client/blocks/color-scheme-picker/index.jsx
+++ b/client/blocks/color-scheme-picker/index.jsx
@@ -15,22 +15,21 @@ function ColorSchemePicker( { defaultSelection, temporarySelection, onSelection,
 	const dispatch = useDispatch();
 	const colorSchemePreference = useSelector( ( state ) => getPreference( state, 'colorScheme' ) );
 
-	function handleColorSchemeSelection( event ) {
+	async function handleColorSchemeSelection( event ) {
 		const { value } = event.currentTarget;
 
 		if ( temporarySelection ) {
-			onSelection( value );
 			dispatch( setPreference( 'colorScheme', value ) );
 		} else {
-			dispatch( savePreference( 'colorScheme', value ) );
+			await dispatch( savePreference( 'colorScheme', value ) );
+			dispatch(
+				successNotice( translate( 'Settings saved successfully!' ), {
+					id: 'color-scheme-picker-save',
+					duration: 10000,
+				} )
+			);
 		}
-
-		dispatch(
-			successNotice( translate( 'Settings saved successfully!' ), {
-				id: 'color-scheme-picker-save',
-				duration: 10000,
-			} )
-		);
+		onSelection?.( value );
 	}
 
 	const colorSchemesData = getColorSchemesData( translate );

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -48,7 +48,6 @@ import {
 	getCurrentUserVisibleSiteCount,
 } from 'calypso/state/current-user/selectors';
 import { successNotice, errorNotice, removeNotice } from 'calypso/state/notices/actions';
-import { savePreference } from 'calypso/state/preferences/actions';
 import canDisplayCommunityTranslator from 'calypso/state/selectors/can-display-community-translator';
 import getUnsavedUserSettings from 'calypso/state/selectors/get-unsaved-user-settings';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
@@ -67,8 +66,6 @@ const noticeOptions = {
 };
 
 import './style.scss';
-
-const colorSchemeKey = 'colorScheme';
 
 /**
  * Debug instance
@@ -208,7 +205,6 @@ class Account extends Component {
 	updateColorScheme = ( colorScheme ) => {
 		this.props.recordTracksEvent( 'calypso_color_schemes_select', { color_scheme: colorScheme } );
 		this.props.recordGoogleEvent( 'Me', 'Selected Color Scheme', 'scheme', colorScheme );
-		this.props.saveColorSchemePreference( colorScheme );
 		this.props.recordTracksEvent( 'calypso_color_schemes_save', {
 			color_scheme: colorScheme,
 		} );
@@ -965,7 +961,6 @@ class Account extends Component {
 										{ translate( 'Dashboard color scheme' ) }
 									</FormLabel>
 									<ColorSchemePicker
-										temporarySelection
 										disabled={ this.getDisabledState( INTERFACE_FORM_NAME ) }
 										defaultSelection="classic-dark"
 										onSelection={ this.updateColorScheme }
@@ -1008,8 +1003,6 @@ export default compose(
 			saveUnsavedUserSettings,
 			setUserSetting,
 			successNotice,
-			saveColorSchemePreference: ( newColorScheme ) =>
-				savePreference( colorSchemeKey, newColorScheme ),
 		}
 	)
 )( Account );


### PR DESCRIPTION
I was inspired by this ESLint report I got on #62969:

<img width="641" alt="Screenshot 2022-04-22 at 14 13 47" src="https://user-images.githubusercontent.com/664258/165034696-ce049f44-ba02-45f5-8622-5fb3344b3ff5.png">

There was a direct import of `translate` from `i18n-calypso` instead of using the React-injected version. This PR fixes that and:
- converts the `ColorSchemePicker` component to functional with hooks
- removes Lodash (`find` and `compact`)
- fixes usage where the `temporarySelection` prop was `true` even though we want the selection to be permanent. The `onSelection` callback was doing the `savePreference` call itself. Now we rely only on the `savePreference` _inside_ the component, and `onSelection` does only telemetry and nothing else.

**How to test:**
Verify both usages of the component:
- in `/me/account` it should immediately save the preference (check Network devtool!) and show a notice.
- in Devdocs it should change color scheme only temporarily. After page reload you should get the original scheme again.