### PR TITLE
Checkout: always use override in useCountryList hook

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -160,7 +160,7 @@ export default function CompositeCheckout( {
 		isUserComingFromLoginForm,
 	} );
 
-	const countriesList = useCountryList( overrideCountryList || [] );
+	const countriesList = useCountryList( overrideCountryList );
 
 	const {
 		productsForCart,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-country-list.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-country-list.ts
@@ -13,7 +13,7 @@ export default function useCountryList(
 	overrideCountryList?: CountryListItem[]
 ): CountryListItem[] {
 	// Should we fetch the country list from global state?
-	const shouldFetchList = ( overrideCountryList?.length ?? 0 ) <= 0;
+	const shouldFetchList = ! overrideCountryList;
 
 	const [ countriesList, setCountriesList ] = useState( overrideCountryList ?? [] );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-country-list.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-country-list.ts
@@ -12,9 +12,7 @@ const emptyList: CountryListItem[] = [];
 export default function useCountryList(
 	overrideCountryList?: CountryListItem[]
 ): CountryListItem[] {
-	// Should we fetch the country list from global state?
-	const shouldFetchList = ! overrideCountryList;
-
+	const shouldFetch = ! overrideCountryList;
 	const [ countriesList, setCountriesList ] = useState( overrideCountryList ?? [] );
 
 	const reduxDispatch = useDispatch();
@@ -25,15 +23,19 @@ export default function useCountryList(
 	const isListFetched = globalCountryList.length > 0;
 
 	useEffect( () => {
-		if ( shouldFetchList ) {
+		if ( shouldFetch ) {
 			if ( isListFetched ) {
+				debug( 'countries list is empty; filling with retrieved data' );
 				setCountriesList( globalCountryList );
 			} else {
 				debug( 'countries list is empty; dispatching request for data' );
 				reduxDispatch( fetchPaymentCountries() );
 			}
+			return;
 		}
-	}, [ shouldFetchList, isListFetched, globalCountryList, reduxDispatch ] );
 
-	return countriesList;
+		debug( 'not fetching countries list because override is set' );
+	}, [ isListFetched, globalCountryList, reduxDispatch, shouldFetch ] );
+
+	return overrideCountryList ?? countriesList;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `useCountryList` hook is a convenience React hook that uses the Redux store to fetch and return data from the countries list endpoint. In order to prevent extraneous fetches and to make testing easier, it was built with an override argument; when set the override will be used instead of the Redux data. (It's arguable that this override is not a great idea but removing it is fairly complex and out of scope for this work.) However, there are some bugs with this override which are fixed by this PR.

First, if `useCountryList` is provided with overrides, with this PR we always respect them even if they are empty. Otherwise it's impossible to use them to simulate an empty list of countries in tests.

Second, if `useCountryList` is provided with overrides, with this PR we allow them to be changed after the hook is first called. Previously they would only be used for the initial load and then might be ignored, making it difficult to use them for testing.

Extracted from https://github.com/Automattic/wp-calypso/pull/62980. 

#### Testing instructions

See https://github.com/Automattic/wp-calypso/pull/62980 which includes this.