### PR TITLE
Checkout: Update useWpcomStore to remove arguments

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -25,7 +25,6 @@ import {
 } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-payment-method-names';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { updateContactDetailsCache } from 'calypso/state/domains/management/actions';
 import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
 import getIsIntroOfferRequesting from 'calypso/state/selectors/get-is-requesting-into-offers';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
@@ -60,7 +59,6 @@ import { translateResponseCartToWPCOMCart } from './lib/translate-cart';
 import weChatProcessor from './lib/we-chat-processor';
 import webPayProcessor from './lib/web-pay-processor';
 import { StoredCard } from './types/stored-cards';
-import { emptyManagedContactDetails } from './types/wpcom-store-state';
 import type { PaymentProcessorOptions } from './types/payment-processors';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type {
@@ -245,7 +243,7 @@ export default function CompositeCheckout( {
 
 	const contactDetailsType = getContactDetailsType( responseCart );
 
-	useWpcomStore( emptyManagedContactDetails, updateContactDetailsCache );
+	useWpcomStore();
 
 	useDetectedCountryCode();
 	useCachedDomainContactDetails( countriesList );

--- a/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
@@ -1,6 +1,7 @@
 import { registerStore } from '@wordpress/data';
 import { useRef } from 'react';
 import {
+	emptyManagedContactDetails,
 	getInitialWpcomStoreState,
 	managedContactDetailsUpdaters as updaters,
 } from '../types/wpcom-store-state';
@@ -33,10 +34,7 @@ type WpcomStoreAction =
 			payload: PossiblyCompleteDomainContactDetails;
 	  };
 
-export function useWpcomStore(
-	managedContactDetails: ManagedContactDetails,
-	updateContactDetailsCache: ( _: DomainContactDetails ) => void
-): void {
+export function useWpcomStore(): void {
 	// Only register once
 	const registerIsComplete = useRef< boolean >( false );
 	if ( registerIsComplete.current ) {
@@ -50,7 +48,6 @@ export function useWpcomStore(
 	): ManagedContactDetails {
 		switch ( action.type ) {
 			case 'UPDATE_DOMAIN_CONTACT_FIELDS': {
-				updateContactDetailsCache( action.payload );
 				return updaters.updateDomainContactFields( state, action.payload );
 			}
 			case 'UPDATE_VAT_ID':
@@ -92,7 +89,7 @@ export function useWpcomStore(
 	registerStore( 'wpcom-checkout', {
 		reducer( state: WpcomStoreState | undefined, action: WpcomStoreAction ): WpcomStoreState {
 			const checkedState =
-				state === undefined ? getInitialWpcomStoreState( managedContactDetails ) : state;
+				state === undefined ? getInitialWpcomStoreState( emptyManagedContactDetails ) : state;
 			return {
 				contactDetails: contactReducer( checkedState.contactDetails, action ),
 				recaptchaClientId: recaptchaClientIdReducer( checkedState.recaptchaClientId, action ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Checkout uses a `@wordpress/data` store called `wpcom-checkout` to hold the data from its various forms (eg: the domain contact and billing details forms). That store is initialized by the `useWpcomStore` React hook. When calling the hook, the caller must provide two arguments, but I believe both of them are unnecessary and this PR removes them.

1. The first argument is the initial state of the store. However, the store is only initialized in one place, and it is always initialized with an placeholder empty data object. We can easily just move this object inline into the hook itself. This will also prevent confusion about the purpose of that argument since it wasn't well named.
2. The second argument is a function that will update the Redux copy of the form data. This store was used by checkout before the checkout redesign and the function here was a way to keep the old Redux data in sync with the new store. However, because old checkout has been removed and because https://github.com/Automattic/wp-calypso/pull/62784 sends any updated data directly to the cached contact details endpoint (where the Redux store's data comes from), this should no longer be needed.

Extracted from https://github.com/Automattic/wp-calypso/pull/62980.

#### Testing instructions

See https://github.com/Automattic/wp-calypso/pull/62980 which includes this.