### PR TITLE
Update wording for eligibility message on monthly plans

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -7,7 +7,9 @@ import { useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
+import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { isAtomicSiteWithoutBusinessPlan } from './utils';
 
@@ -15,7 +17,8 @@ import { isAtomicSiteWithoutBusinessPlan } from './utils';
 function getHoldMessages(
 	context: string | null,
 	translate: LocalizeProps[ 'translate' ],
-	eligibleForProPlan: boolean
+	eligibleForProPlan: boolean,
+	billingPeriod?: string
 ) {
 	return {
 		NO_BUSINESS_PLAN: {
@@ -26,6 +29,12 @@ function getHoldMessages(
 				if ( context === 'themes' ) {
 					return translate(
 						"You'll also get to install custom plugins, have more storage, and access live support."
+					);
+				}
+
+				if ( billingPeriod === IntervalLength.MONTHLY ) {
+					return translate(
+						"You'll also get to install custom themes, have more storage, and access email support."
 					);
 				}
 
@@ -197,7 +206,8 @@ export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) 
 	const eligibleForProPlan = useSelector( ( state ) =>
 		isEligibleForProPlan( state, selectedSite?.ID )
 	);
-	const holdMessages = getHoldMessages( context, translate, eligibleForProPlan );
+	const billingPeriod = useSelector( getBillingInterval );
+	const holdMessages = getHoldMessages( context, translate, eligibleForProPlan, billingPeriod );
 	const blockingMessages = getBlockingMessages( translate );
 
 	const blockingHold = holds.find( ( h ) => isHardBlockingHoldType( h, blockingMessages ) );

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -49,6 +49,7 @@ function createState( {
 		siteSettings: {
 			saveRequests: {},
 		},
+		marketplace: { billingInterval: { interval: 'ANNUALLY' } },
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update wording for eligibility message on monthly plans

#### Testing instructions
* Start on a free WordPress.com site.
* Go to a plugin details page. Ex: `/plugins/woocommerce-bookings/{site}`
* Select `Monthly` on the billing period selector
* Click on Purchase and activate
* You should see the message *You'll also get to install custom themes, have more storage, and access email support.* 
* Click out of the modal
* Select `Annually` on the billing period selector
* Click on Purchase and activate
* You should see the message *Y"You'll also get to install custom themes, have more storage, and access live support.* 

| Monthly  | Annually |
| ------------- | ------------- |
|<img width="1139" alt="Screen Shot 2022-04-25 at 16 34 11" src="https://user-images.githubusercontent.com/5039531/165172158-855e4bd0-82a3-4595-9ba6-15225d0bdb94.png">|<img width="1139" alt="Screen Shot 2022-04-25 at 16 34 19" src="https://user-images.githubusercontent.com/5039531/165171978-f424b8db-2a79-41dc-9100-6ae3e5f01739.png">|


----
Fixes #62280
