### PR TITLE
isPremiumThemeAvailable: Use the features endpoint to determine if a site has unlimited premium themes

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -210,7 +210,7 @@ const sections = [
 		module: 'calypso/my-sites/themes',
 		enableLoggedOut: true,
 		group: 'sites',
-		isomorphic: true,
+		isomorphic: false,
 		title: 'Themes',
 	},
 	{
@@ -219,7 +219,7 @@ const sections = [
 		module: 'calypso/my-sites/theme',
 		enableLoggedOut: true,
 		group: 'sites',
-		isomorphic: true,
+		isomorphic: false,
 		title: 'Themes',
 		trackLoadPerformance: true,
 	},

--- a/client/sections.js
+++ b/client/sections.js
@@ -210,7 +210,7 @@ const sections = [
 		module: 'calypso/my-sites/themes',
 		enableLoggedOut: true,
 		group: 'sites',
-		isomorphic: false,
+		isomorphic: true,
 		title: 'Themes',
 	},
 	{
@@ -219,7 +219,7 @@ const sections = [
 		module: 'calypso/my-sites/theme',
 		enableLoggedOut: true,
 		group: 'sites',
-		isomorphic: false,
+		isomorphic: true,
 		title: 'Themes',
 		trackLoadPerformance: true,
 	},

--- a/client/state/themes/selectors/is-premium-theme-available.js
+++ b/client/state/themes/selectors/is-premium-theme-available.js
@@ -1,3 +1,4 @@
+import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 
@@ -14,6 +15,6 @@ import 'calypso/state/themes/init';
 export function isPremiumThemeAvailable( state, themeId, siteId ) {
 	return (
 		isThemePurchased( state, themeId, siteId ) ||
-		hasActiveSiteFeature( state, siteId, 'premium-themes' )
+		hasActiveSiteFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES )
 	);
 }

--- a/client/state/themes/selectors/is-premium-theme-available.js
+++ b/client/state/themes/selectors/is-premium-theme-available.js
@@ -1,5 +1,4 @@
-import { FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
-import { hasFeature } from 'calypso/state/sites/plans/selectors';
+import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 
 import 'calypso/state/themes/init';
@@ -15,6 +14,6 @@ import 'calypso/state/themes/init';
 export function isPremiumThemeAvailable( state, themeId, siteId ) {
 	return (
 		isThemePurchased( state, themeId, siteId ) ||
-		hasFeature( state, siteId, FEATURE_PREMIUM_THEMES )
+		hasActiveSiteFeature( state, siteId, 'premium-themes' )
 	);
 }

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -2348,6 +2348,7 @@ describe( 'themes selectors', () => {
 		} );
 
 		test( 'given a premium squared theme and a site with the premium upgrade, should return true', () => {
+			const active = [ 'premium-themes' ];
 			const isAvailable = isPremiumThemeAvailable(
 				{
 					sites: {
@@ -2362,6 +2363,13 @@ describe( 'themes selectors', () => {
 										productSlug: PLAN_PREMIUM,
 									},
 								],
+							},
+						},
+						features: {
+							2916284: {
+								data: {
+									active,
+								},
 							},
 						},
 					},
@@ -2384,6 +2392,7 @@ describe( 'themes selectors', () => {
 		} );
 
 		test( 'given a site with the unlimited premium themes bundle, should return true', () => {
+			const active = [ 'premium-themes' ];
 			[ PLAN_BUSINESS, PLAN_ECOMMERCE ].forEach( ( plan ) => {
 				const isAvailable = isPremiumThemeAvailable(
 					{
@@ -2399,6 +2408,13 @@ describe( 'themes selectors', () => {
 											productSlug: plan,
 										},
 									],
+								},
+							},
+							features: {
+								2916284: {
+									data: {
+										active,
+									},
 								},
 							},
 						},

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -3,6 +3,7 @@ import {
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
 	PLAN_ECOMMERCE,
+	WPCOM_FEATURES_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
 import { expect } from 'chai';
 import ThemeQueryManager from 'calypso/lib/query-manager/theme';
@@ -2348,7 +2349,7 @@ describe( 'themes selectors', () => {
 		} );
 
 		test( 'given a premium squared theme and a site with the premium upgrade, should return true', () => {
-			const active = [ 'premium-themes' ];
+			const active = [ WPCOM_FEATURES_PREMIUM_THEMES ];
 			const isAvailable = isPremiumThemeAvailable(
 				{
 					sites: {
@@ -2392,7 +2393,7 @@ describe( 'themes selectors', () => {
 		} );
 
 		test( 'given a site with the unlimited premium themes bundle, should return true', () => {
-			const active = [ 'premium-themes' ];
+			const active = [ WPCOM_FEATURES_PREMIUM_THEMES ];
 			[ PLAN_BUSINESS, PLAN_ECOMMERCE ].forEach( ( plan ) => {
 				const isAvailable = isPremiumThemeAvailable(
 					{

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -211,3 +211,6 @@ export const FEATURE_UNLIMITED_ADMINS = 'unlimited-admins';
 export const FEATURE_ADDITIONAL_SITES = 'additional-sites';
 export const FEATURE_WOOCOMMERCE = 'woocommerce';
 export const FEATURE_SOCIAL_MEDIA_TOOLS = 'social-media-tools';
+
+// From class-wpcom-features.php in WPCOM
+export const WPCOM_FEATURES_PREMIUM_THEMES = 'premium-themes';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Calypso will now use the **wpcom backend's feature endpoint** definition of which sites have the unlimited premium themes feature.
  * Before this PR, calypso uses a hardcoded definition of which plans have which features.
  * Currently: The free plan does not have unlimited premium themes, and the pro plan does have unlimited premium themes. Both work as expected in Calypso. This PR changes the source of truth only, not behavior.

#### Testing instructions

* Apply this patch to your sandbox to simulate free sites getting the premium theme feature: D79460-code
* (Optional) Apply this patch to calypso to allow `/theme` URLs to be loaded directly:
```diff
diff --git a/client/sections.js b/client/sections.js
index df38259967..65d1fc36e3 100644
--- a/client/sections.js
+++ b/client/sections.js
@@ -210,7 +210,7 @@ const sections = [
                module: 'calypso/my-sites/themes',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               isomorphic: false,
                title: 'Themes',
        },
        {
@@ -219,7 +219,7 @@ const sections = [
                module: 'calypso/my-sites/theme',
                enableLoggedOut: true,
                group: 'sites',
-               isomorphic: true,
+               isomorphic: false,
                title: 'Themes',
                trackLoadPerformance: true,
        },
```
* Visit the theme showcase for a free site (`http://calypso.localhost:3000/themes/<SITE>`)
* Without this PR, you will not be able to activate a premium theme (like Videomaker) on a free plan site
* With the PR, you should be able to almost activate a premium theme on a free plan site - Calypso will allow you to, but there will be a backend error (another patch for this: D79465-code).

#### Open Question - WPCOM Feature constants in Calypso

Calypso has its own feature constants, different from the ones we use in wpcom.
Calypso: [export const FEATURE_PREMIUM_THEMES = 'unlimited-premium-themes';](https://github.com/Automattic/wp-calypso/blob/863c091d26996d640f3980bd891fbe3f887f6749/packages/calypso-products/src/constants/features.ts#L97)
WPCOM: `	public const PREMIUM_THEMES                = 'premium-themes';`

What should we do here?
* Find a syncing solution between calypso & wpcom+wpcomsh
* Manually copy only the needed constants
* Use strings
* Other?

### More checks using Calypso as source of truth

I found some more checks using calypso's source of truth. What's in this PR is the bare minimum I needed to see a premium theme and activate it. Not sure if I should expand this PR to incorporate these checks or to make new PRs for them?

#### hasFeature (easier)

* [getJetpackUpgradeUrlIfPremiumTheme](https://github.com/Automattic/wp-calypso/blob/863c091d26996d640f3980bd891fbe3f887f6749/client/state/themes/selectors/get-jetpack-upgrade-url-if-premium-theme.js#L20)
* [theme/main.jsx](https://github.com/Automattic/wp-calypso/blob/863c091d26996d640f3980bd891fbe3f887f6749/client/my-sites/theme/main.jsx#L902)

#### planHasFeature (harder, there is no api for this)

These are tough because we have no API to answer the question 'does a plan have a feature'. Worth further discussion.

* [design-picker/index](https://github.com/Automattic/wp-calypso/blob/863c091d26996d640f3980bd891fbe3f887f6749/client/signup/steps/design-picker/index.jsx#L49-L52)
* [theme-selection](https://github.com/Automattic/wp-calypso/blob/863c091d26996d640f3980bd891fbe3f887f6749/client/my-sites/themes/themes-selection.jsx#L215)
* [design-setup/index](https://github.com/Automattic/wp-calypso/blob/863c091d26996d640f3980bd891fbe3f887f6749/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx#L76-L81)