### PR TITLE
Show documentation link on Plugin Details page when its provided.

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -93,6 +93,7 @@ export function getAllowedPluginData( plugin ) {
 		'short_description',
 		'detailsFetched',
 		'downloaded',
+		'documentation_url',
 		'homepage',
 		'icons',
 		'id',
@@ -165,11 +166,10 @@ export function normalizeCompatibilityList( compatibilityList ) {
 		}
 		return splittedVersion;
 	}
-	const sortedCompatibility = sortBy( Object.keys( compatibilityList ).map( splitInNumbers ), [
-		0,
-		1,
-		2,
-	] );
+	const sortedCompatibility = sortBy(
+		Object.keys( compatibilityList ).map( splitInNumbers ),
+		[ 0, 1, 2 ]
+	);
 	return sortedCompatibility.map( function ( version ) {
 		if ( version.length && version[ version.length - 1 ] === 0 ) {
 			version.pop();

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -165,10 +165,11 @@ export function normalizeCompatibilityList( compatibilityList ) {
 		}
 		return splittedVersion;
 	}
-	const sortedCompatibility = sortBy(
-		Object.keys( compatibilityList ).map( splitInNumbers ),
-		[ 0, 1, 2 ]
-	);
+	const sortedCompatibility = sortBy( Object.keys( compatibilityList ).map( splitInNumbers ), [
+		0,
+		1,
+		2,
+	] );
 	return sortedCompatibility.map( function ( version ) {
 		if ( version.length && version[ version.length - 1 ] === 0 ) {
 			version.pop();

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -63,7 +63,7 @@ const PluginDetailsSidebar = ( {
 	];
 	documentation_url &&
 		supportLinks.unshift( {
-			href: { documentation_url },
+			href: documentation_url,
 			label: translate( 'View documentation' ),
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Show documentation link on Plugin Details page when its provided.

#### Testing instructions
* Go to the Plugin Details page of a plugin with a documentation URL. Ex: `/plugins/woocommerce-subscriptions`
* Check if the documentation link is shown as below:

| Before  | After |
| ------------- | ------------- |
|<img width="281" alt="Screen Shot 2022-04-25 at 17 28 40" src="https://user-images.githubusercontent.com/5039531/165178640-b730b1d5-4c54-4d45-8d64-b2a90e239f3a.png">|<img width="281" alt="Screen Shot 2022-04-25 at 17 28 11" src="https://user-images.githubusercontent.com/5039531/165178681-b3313ffd-ab4a-47e6-9066-73e7782fb1e4.png">|

---
Related to #62578
