### PR TITLE
Filter URL protocol, path, query string from "Use a domain I own" input

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -107,7 +107,7 @@ function UseMyDomain( props ) {
 	}, [] );
 
 	const filterDomainName = useCallback( ( domain ) => {
-		return domain.replace( /(?:^http(?:s){0,1}:\/\/){0,1}([^/]*)(?:.*)$/gi, '$1' );
+		return domain.replace( /(?:^http(?:s)?:)?(?:[/]*)([^/?]*)(?:.*)$/gi, '$1' );
 	}, [] );
 
 	const setTransferStepsAndLockStatus = useCallback(

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -100,11 +100,15 @@ function UseMyDomain( props ) {
 		}
 	};
 
-	const validateDomainName = useCallback( () => {
-		const errorMessage = getDomainNameValidationErrorMessage( domainName );
+	const validateDomainName = useCallback( ( domain ) => {
+		const errorMessage = getDomainNameValidationErrorMessage( domain );
 		setDomainNameValidationError( errorMessage );
 		return ! errorMessage;
-	}, [ domainName ] );
+	}, [] );
+
+	const filterDomainName = useCallback( ( domain ) => {
+		return domain.replace( /(?:^http(?:s){0,1}:\/\/){0,1}([^/]*)(?:.*)$/gi, '$1' );
+	}, [] );
 
 	const setTransferStepsAndLockStatus = useCallback(
 		( isDomainUnlocked ) => {
@@ -155,7 +159,10 @@ function UseMyDomain( props ) {
 	}, [ domainName, setTransferStepsAndLockStatus ] );
 
 	const onNext = useCallback( async () => {
-		if ( ! validateDomainName() ) {
+		const filteredDomainName = filterDomainName( domainName );
+		// setDomainName( filteredDomainName );
+
+		if ( ! validateDomainName( filteredDomainName ) ) {
 			return;
 		}
 
@@ -164,21 +171,22 @@ function UseMyDomain( props ) {
 
 		try {
 			const availabilityData = await wpcom
-				.domain( domainName )
+				.domain( filteredDomainName )
 				.isAvailable( { apiVersion: '1.3', blog_id: selectedSite?.ID, is_cart_pre_check: false } );
 
+			setDomainName( filteredDomainName );
 			await setDomainTransferData();
 
 			const availabilityErrorMessage = getAvailabilityErrorMessage( {
 				availabilityData,
-				domainName,
+				filteredDomainName,
 				selectedSite,
 			} );
 
 			if ( availabilityErrorMessage ) {
 				setDomainNameValidationError( availabilityErrorMessage );
 			} else {
-				onNextStep?.( { mode: inputMode.transferOrConnect, domain: domainName } );
+				onNextStep?.( { mode: inputMode.transferOrConnect, domain: filteredDomainName } );
 				setMode( inputMode.transferOrConnect );
 				setDomainAvailabilityData( availabilityData );
 			}
@@ -187,7 +195,14 @@ function UseMyDomain( props ) {
 		} finally {
 			setIsFetchingAvailability( false );
 		}
-	}, [ domainName, selectedSite, setDomainTransferData, validateDomainName, onNextStep ] );
+	}, [
+		filterDomainName,
+		domainName,
+		validateDomainName,
+		selectedSite,
+		setDomainTransferData,
+		onNextStep,
+	] );
 
 	const onDomainNameChange = ( event ) => {
 		setDomainName( event.target.value.trim() );

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -160,8 +160,6 @@ function UseMyDomain( props ) {
 
 	const onNext = useCallback( async () => {
 		const filteredDomainName = filterDomainName( domainName );
-		// setDomainName( filteredDomainName );
-
 		if ( ! validateDomainName( filteredDomainName ) ) {
 			return;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When someone enters a full URL including a protocol, path, and query string, we should filter the input to operate just on the domain.

#### Testing instructions

- Visit `http://calypso.localhost:3000/start/domains/use-your-domain?step=domain-input&initialQuery=https://foo.com/bar?baz=qux` and make sure that the non-domain parts (everything except foo.com) is filtered out.
- Make sure that this also works for strings like:
    - `foo.com/bar?baz=qux`
    - `foo.com/bar`
    - `/foo.com/bar`
    - `/foo.com/`
    - `foo.com/`
    - `foo.com/?baz`
    - `foo.com?baz=qux`
    - `foo.com?baz`
    - `foo.com`
    - etc...
- Make sure that strings that contain invalid domain names like `foo`  (with no TLD) or `foo___bar.com` show an error as being invalid.
