### PR TITLE
E2E: add temporary spec to test the WordPress.com Pro upgrade button, Part 2.

### DIFF
--- a/client/my-sites/plans-comparison/is-eligible-for-pro-plan.ts
+++ b/client/my-sites/plans-comparison/is-eligible-for-pro-plan.ts
@@ -1,15 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { isE2ETest } from 'calypso/lib/e2e';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import type { AppState } from 'calypso/types';
 
 export function isEligibleForProPlan( state: AppState, siteId?: number ): boolean {
-	if ( isE2ETest() ) {
-		return false;
-	}
-
 	if (
 		siteId &&
 		( ( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||

--- a/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/gutenboarding-flow.ts
@@ -1,6 +1,6 @@
 import { Page } from 'playwright';
 import envVariables from '../../env-variables';
-import type { Plans } from '../../types';
+import { LegacyPlans } from '../pages/plans-page';
 
 export type Features =
 	| 'Custom domains'
@@ -231,7 +231,7 @@ export class GutenboardingFlow {
 	 *
 	 * @param {string} name Name of the plan.
 	 */
-	async selectPlan( name: Plans ): Promise< void > {
+	async selectPlan( name: LegacyPlans ): Promise< void > {
 		// First, expand the accordion.
 		await this.expandAllPlans();
 		await this.page.click( selectors.selectPlanButton( name ) );
@@ -240,9 +240,9 @@ export class GutenboardingFlow {
 	/**
 	 * Checks if the recommended plan matches the expected name.
 	 *
-	 * @param {Plans} name Name of the plan.
+	 * @param {LegacyPlans} name Name of the plan.
 	 */
-	async validateRecommendedPlan( name: Plans ): Promise< void > {
+	async validateRecommendedPlan( name: LegacyPlans ): Promise< void > {
 		// The plan item with the `has-badge` attribute is the one that is recommended based on features.
 		const elementHandle = await this.page.waitForSelector( `${ selectors.planItem }.has-badge` );
 		await elementHandle.waitForSelector( `div:text-is("${ name }")` );

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -1,10 +1,15 @@
 import { Page } from 'playwright';
+import { toTitleCase } from '../../data-helper';
 import { clickNavTab } from '../../element-helper';
 import envVariables from '../../env-variables';
 
+// Differentiates between the legacy and current (overhauled) plans.
+type PlansGridVersion = 'current' | 'legacy';
+type PlansComparisonAction = 'show' | 'hide';
+
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
-export type Plan = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
-export type PlansPageTab = 'My Plan' | 'Plans';
+export type LegacyPlans = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
+export type PlansPageTab = 'My Plan' | 'Plans' | 'New Plans';
 export type PlanActionButton = 'Manage plan' | 'Upgrade';
 
 const selectors = {
@@ -17,16 +22,24 @@ const selectors = {
 	activeNavigationTab: ( tabName: PlansPageTab ) =>
 		`.is-selected.section-nav-tab:has-text("${ tabName }")`,
 
-	actionButton: ( { plan, buttonText }: { plan: Plan; buttonText: PlanActionButton } ) => {
+	actionButton: ( { plan, buttonText }: { plan: LegacyPlans; buttonText: PlanActionButton } ) => {
 		const viewportSuffix = envVariables.VIEWPORT_NAME === 'mobile' ? 'mobile' : 'table';
 		return `.plan-features__${ viewportSuffix } >> .plan-features__actions-button.is-${ plan.toLowerCase() }-plan:has-text("${ buttonText }")`;
 	},
 
-	// Plans view
-	plansGrid: '.plans-features-main',
+	// Legacy plans view
+	legacyPlansGrid: '.plans-features-main',
+
+	// Overhauled plans view
+	overhauledPlansGrid: 'div.plans > table',
+	upgradeToProButton: 'th button.is-primary',
+	planComparisonActionButton: ( action: PlansComparisonAction ) => {
+		const buttonText = `${ toTitleCase( action ) } full plan comparison`;
+		return `button:text("${ buttonText }")`;
+	},
 
 	// My Plans view
-	myPlanTitle: ( planName: Plan ) => `.my-plan-card__title:has-text("${ planName }")`,
+	myPlanTitle: ( planName: LegacyPlans ) => `.my-plan-card__title:has-text("${ planName }")`,
 };
 
 /**
@@ -34,14 +47,16 @@ const selectors = {
  */
 export class PlansPage {
 	private page: Page;
+	private version: PlansGridVersion;
 
 	/**
 	 * Constructs an instance of the Plans POM.
 	 *
 	 * @param {Page} page Instance of the Playwright page
 	 */
-	constructor( page: Page ) {
+	constructor( page: Page, version: PlansGridVersion ) {
 		this.page = page;
+		this.version = version;
 	}
 
 	/**
@@ -51,14 +66,54 @@ export class PlansPage {
 		await this.page.waitForLoadState( 'load' );
 	}
 
+	/* Current Plans */
+
+	/**
+	 * Clicks on the button to initiate upgrade to WordPress.com Pro plan.
+	 */
+	async upgradeToPro(): Promise< void > {
+		const locator = this.page.locator( selectors.upgradeToProButton );
+		await Promise.all( [
+			this.page.waitForNavigation( { url: /.*checkout.*/ } ),
+			locator.click(),
+		] );
+	}
+
+	/**
+	 * Clicks on the Show/Hide Plan Comparison button at the bottom of the table.
+	 *
+	 * @param {PlansComparisonAction} action Action to perform on the Plans comparison button.
+	 */
+	async clickPlanComparisonActionButton( action: PlansComparisonAction ): Promise< void > {
+		const buttonLocator = this.page.locator( selectors.planComparisonActionButton( action ) );
+		await buttonLocator.click();
+
+		if ( action === 'show' ) {
+			const hideButtonLocator = this.page.locator( selectors.planComparisonActionButton( 'hide' ) );
+			await hideButtonLocator.waitFor();
+		}
+		if ( action === 'hide' ) {
+			const showButtonLocator = this.page.locator( selectors.planComparisonActionButton( 'show' ) );
+			await showButtonLocator.waitFor();
+		}
+	}
+
+	/* Legacy Plans */
+
 	/**
 	 * Clicks on the navigation tab (desktop) or dropdown (mobile).
 	 *
 	 * @param {PlansPageTab} targetTab Name of the tab.
 	 */
 	async clickTab( targetTab: PlansPageTab ): Promise< void > {
-		const currentSelectedLocator = this.page.locator( selectors.activeNavigationTab( targetTab ) );
+		// Plans page against the current WordPress.com Plans do not
+		// require any clicking of navigation tabs.
+		if ( this.version === 'current' ) {
+			return;
+		}
+
 		// If the target tab is already active, short circuit.
+		const currentSelectedLocator = this.page.locator( selectors.activeNavigationTab( targetTab ) );
 		if ( ( await currentSelectedLocator.count() ) > 0 ) {
 			return;
 		}
@@ -66,7 +121,7 @@ export class PlansPage {
 		if ( targetTab === 'My Plan' ) {
 			// User is currently on the Plans tab and going to My Plans.
 			// Wait for the Plans grid to fully render.
-			const plansGridLocator = this.page.locator( selectors.plansGrid );
+			const plansGridLocator = this.page.locator( selectors.legacyPlansGrid );
 			await plansGridLocator.waitFor();
 		}
 		if ( targetTab === 'Plans' ) {
@@ -82,10 +137,10 @@ export class PlansPage {
 	/**
 	 * Validates that the provided plan name is the title of the active plan in the My Plan tab of the Plans page. Throws if it isn't.
 	 *
-	 * @param {Plan} expectedPlan Name of the expected plan.
+	 * @param {LegacyPlans} expectedPlan Name of the expected plan.
 	 * @throws If the expected plan title is not found in the timeout period.
 	 */
-	async validateActivePlanInMyPlanTab( expectedPlan: Plan ): Promise< void > {
+	async validateActivePlanInMyPlanTab( expectedPlan: LegacyPlans ): Promise< void > {
 		const expectedPlanLocator = this.page.locator( selectors.myPlanTitle( expectedPlan ) );
 		await expectedPlanLocator.waitFor();
 	}
@@ -114,14 +169,14 @@ export class PlansPage {
 	 * Click a plan action button (on the plan cards on the "Plans" tab) based on expected plan name and button text.
 	 *
 	 * @param {object} param0 Object containing plan name and button text
-	 * @param {Plan} param0.plan Name of the plan (e.g. "Premium")
+	 * @param {LegacyPlans} param0.plan Name of the plan (e.g. "Premium")
 	 * @param {PlanActionButton} param0.buttonText Expected action button text (e.g. "Upgrade")
 	 */
 	async clickPlanActionButton( {
 		plan,
 		buttonText,
 	}: {
-		plan: Plan;
+		plan: LegacyPlans;
 		buttonText: PlanActionButton;
 	} ): Promise< void > {
 		const selector = selectors.actionButton( {

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -152,16 +152,16 @@ export class PlansPage {
 	 * @throws If the expected tab name is not the active tab.
 	 */
 	async validateActiveNavigationTab( expectedTab: PlansPageTab ): Promise< void > {
-		await this.waitUntilLoaded();
-
-		// For mobile sized viewport, the currently selected tab name will be shown alongside the
-		// dropdown toggle button, so verify the expected tab name is shown there.
+		// For mobile sized viewport, the currently selected tab name
+		// is hidden behind a pseudo-dropdown.
+		// Therefore the valicdation will look for hidden element.
+		const currentSelectedLocator = this.page.locator(
+			selectors.activeNavigationTab( expectedTab )
+		);
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			await this.page.waitForSelector(
-				`${ selectors.mobileNavTabsToggle }:has-text("${ expectedTab }")`
-			);
+			await currentSelectedLocator.waitFor( { state: 'hidden' } );
 		} else {
-			await this.page.waitForSelector( selectors.activeNavigationTab( expectedTab ) );
+			await currentSelectedLocator.waitFor();
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -8,6 +8,7 @@ type PlansGridVersion = 'current' | 'legacy';
 type PlansComparisonAction = 'show' | 'hide';
 
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
+export type Plans = 'Free' | 'Pro';
 export type LegacyPlans = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
 export type PlansPageTab = 'My Plan' | 'Plans';
 export type PlanActionButton = 'Manage plan' | 'Upgrade';
@@ -30,7 +31,8 @@ const selectors = {
 	},
 
 	// Overhauled plans view
-	upgradeToProButton: 'th button.is-primary',
+	selectPlanButton: ( type: Plans ) => `tr th button.button:has-text("${ type }")`,
+	// upgradeToProButton: 'th button.is-primary',
 	planComparisonActionButton: ( action: PlansComparisonAction ) => {
 		const buttonText = `${ toTitleCase( action ) } full plan comparison`;
 		return `button:text("${ buttonText }")`;
@@ -69,12 +71,21 @@ export class PlansPage {
 	/**
 	 * Clicks on the button to initiate upgrade to WordPress.com Pro plan.
 	 */
-	async upgradeToPro(): Promise< void > {
-		const locator = this.page.locator( selectors.upgradeToProButton );
-		await Promise.all( [
-			this.page.waitForNavigation( { url: /.*checkout.*/ } ),
-			locator.click(),
-		] );
+	// async upgradeToPro(): Promise< void > {
+	// const locator = this.page.locator( selectors.upgradeToProButton );
+	// await Promise.all( [
+	// this.page.waitForNavigation( { url: /.*checkout.*/ } ),
+	// locator.click(),
+	// ] );
+	// }
+
+	/**
+	 *
+	 * @param plan
+	 */
+	async selectPlan( plan: Plans ): Promise< void > {
+		const locator = this.page.locator( selectors.selectPlanButton( plan ) );
+		await Promise.all( [ this.page.waitForNavigation(), locator.click() ] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -31,7 +31,6 @@ const selectors = {
 	legacyPlansGrid: '.plans-features-main',
 
 	// Overhauled plans view
-	overhauledPlansGrid: 'div.plans > table',
 	upgradeToProButton: 'th button.is-primary',
 	planComparisonActionButton: ( action: PlansComparisonAction ) => {
 		const buttonText = `${ toTitleCase( action ) } full plan comparison`;
@@ -80,22 +79,29 @@ export class PlansPage {
 	}
 
 	/**
-	 * Clicks on the Show/Hide Plan Comparison button at the bottom of the table.
+	 * Shows the full Plan comparison table.
 	 *
-	 * @param {PlansComparisonAction} action Action to perform on the Plans comparison button.
+	 * This method is applicable only to the overhauled plans.
 	 */
-	async clickPlanComparisonActionButton( action: PlansComparisonAction ): Promise< void > {
-		const buttonLocator = this.page.locator( selectors.planComparisonActionButton( action ) );
+	async showPlanComparison(): Promise< void > {
+		const buttonLocator = this.page.locator( selectors.planComparisonActionButton( 'show' ) );
 		await buttonLocator.click();
 
-		if ( action === 'show' ) {
-			const hideButtonLocator = this.page.locator( selectors.planComparisonActionButton( 'hide' ) );
-			await hideButtonLocator.waitFor();
-		}
-		if ( action === 'hide' ) {
-			const showButtonLocator = this.page.locator( selectors.planComparisonActionButton( 'show' ) );
-			await showButtonLocator.waitFor();
-		}
+		const hideButtonLocator = this.page.locator( selectors.planComparisonActionButton( 'hide' ) );
+		await hideButtonLocator.waitFor();
+	}
+
+	/**
+	 * Hides the full Plan comparison table.
+	 *
+	 * This method is applicable only to the overhauled plans.
+	 */
+	async hidePlanComparison(): Promise< void > {
+		const buttonLocator = this.page.locator( selectors.planComparisonActionButton( 'hide' ) );
+		await buttonLocator.click();
+
+		const showButtonLocator = this.page.locator( selectors.planComparisonActionButton( 'show' ) );
+		await showButtonLocator.waitFor();
 	}
 
 	/* Legacy Plans */

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -9,7 +9,7 @@ type PlansComparisonAction = 'show' | 'hide';
 
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
 export type LegacyPlans = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
-export type PlansPageTab = 'My Plan' | 'Plans' | 'New Plans';
+export type PlansPageTab = 'My Plan' | 'Plans';
 export type PlanActionButton = 'Manage plan' | 'Upgrade';
 
 const selectors = {
@@ -22,13 +22,12 @@ const selectors = {
 	activeNavigationTab: ( tabName: PlansPageTab ) =>
 		`.is-selected.section-nav-tab:has-text("${ tabName }")`,
 
+	// Legacy plans view
+	legacyPlansGrid: '.plans-features-main',
 	actionButton: ( { plan, buttonText }: { plan: LegacyPlans; buttonText: PlanActionButton } ) => {
 		const viewportSuffix = envVariables.VIEWPORT_NAME === 'mobile' ? 'mobile' : 'table';
 		return `.plan-features__${ viewportSuffix } >> .plan-features__actions-button.is-${ plan.toLowerCase() }-plan:has-text("${ buttonText }")`;
 	},
-
-	// Legacy plans view
-	legacyPlansGrid: '.plans-features-main',
 
 	// Overhauled plans view
 	upgradeToProButton: 'th button.is-primary',

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -69,19 +69,9 @@ export class PlansPage {
 	/* Current Plans */
 
 	/**
-	 * Clicks on the button to initiate upgrade to WordPress.com Pro plan.
-	 */
-	// async upgradeToPro(): Promise< void > {
-	// const locator = this.page.locator( selectors.upgradeToProButton );
-	// await Promise.all( [
-	// this.page.waitForNavigation( { url: /.*checkout.*/ } ),
-	// locator.click(),
-	// ] );
-	// }
-
-	/**
+	 * Selects the target plan on the plans grid.
 	 *
-	 * @param plan
+	 * @param {Plans} plan Plan to select.
 	 */
 	async selectPlan( plan: Plans ): Promise< void > {
 		const locator = this.page.locator( selectors.selectPlanButton( plan ) );

--- a/packages/calypso-e2e/src/lib/pages/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup-pick-plan-page.ts
@@ -1,16 +1,14 @@
 import { Page } from 'playwright';
-import type { Plans } from '../../types';
-
-const selectors = {
-	freePlan: 'button:text("start with a free site")',
-	paidPlan: ( target: Plans ) => `button.is-${ target.toLowerCase() }-plan`,
-};
+import { PlansPage, Plans } from './plans-page';
 
 /**
- * Class representing Signup > Pick a Plan page.
+ * Represents the Signup > Pick a Plan page.
+ *
+ * With the overhauled Plans, this class is a thin wrapper around the PlansPage object.
  */
 export class SignupPickPlanPage {
 	private page: Page;
+	private plansPage: PlansPage;
 
 	/**
 	 * Constructs an instance of the component.
@@ -19,6 +17,7 @@ export class SignupPickPlanPage {
 	 */
 	constructor( page: Page ) {
 		this.page = page;
+		this.plansPage = new PlansPage( page, 'current' );
 	}
 
 	/**
@@ -27,17 +26,6 @@ export class SignupPickPlanPage {
 	 * @param {Plans} name Name of the plan.
 	 */
 	async selectPlan( name: Plans ): Promise< void > {
-		if ( name === 'Free' ) {
-			await Promise.all( [
-				this.page.waitForNavigation( { timeout: 60000, waitUntil: 'load' } ),
-				this.page.click( selectors.freePlan ),
-			] );
-		} else {
-			await Promise.all( [
-				// Extend timeout in case the site creation step takes longer than expected.
-				this.page.waitForNavigation( { timeout: 60000, waitUntil: 'load' } ),
-				this.page.click( selectors.paidPlan( name ) ),
-			] );
-		}
+		await this.plansPage.selectPlan( name );
 	}
 }

--- a/packages/calypso-e2e/src/types.d.ts
+++ b/packages/calypso-e2e/src/types.d.ts
@@ -1,9 +1,5 @@
 import { Browser } from 'playwright';
 
-// TODO: These doesn't seem to be used?
-export type Plans = typeof PlansArray[ number ];
-export const PlansArray = [ 'Free', 'Personal', 'Premium', 'Business', 'eCommerce' ] as const;
-
 // Because these types are ultimately accessed on "window", adding them here.
 export interface TracksEventProperties {
 	[ key: string ]: boolean | number | string;

--- a/test/e2e/specs/martech/tos-screenshots__checkout.ts
+++ b/test/e2e/specs/martech/tos-screenshots__checkout.ts
@@ -78,7 +78,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		} );
 
 		it( 'Click on the "Plans" navigation tab', async function () {
-			plansPage = new PlansPage( page );
+			plansPage = new PlansPage( page, 'legacy' );
 			await plansPage.clickTab( 'Plans' );
 		} );
 

--- a/test/e2e/specs/onboarding/signup__paid.ts
+++ b/test/e2e/specs/onboarding/signup__paid.ts
@@ -173,7 +173,7 @@ skipDescribeIf( isStagingOrProd )(
 			} );
 
 			it( 'Manage plan', async function () {
-				const plansPage = new PlansPage( page );
+				const plansPage = new PlansPage( page, 'legacy' );
 				await plansPage.clickTab( 'Plans' );
 				await plansPage.clickPlanActionButton( { plan: 'Personal', buttonText: 'Manage plan' } );
 			} );

--- a/test/e2e/specs/onboarding/signup__paid.ts
+++ b/test/e2e/specs/onboarding/signup__paid.ts
@@ -75,7 +75,7 @@ skipDescribeIf( isStagingOrProd )(
 
 			it( 'Select WordPress.com Personal plan', async function () {
 				const signupPickPlanPage = new SignupPickPlanPage( page );
-				await signupPickPlanPage.selectPlan( 'Personal' );
+				await signupPickPlanPage.selectPlan( 'Pro' );
 			} );
 
 			it( 'See secure payment', async function () {

--- a/test/e2e/specs/plans/plans__add-upgrade-cart.ts
+++ b/test/e2e/specs/plans/plans__add-upgrade-cart.ts
@@ -1,0 +1,58 @@
+/**
+ * @group calypso-pr
+ */
+
+import {
+	DataHelper,
+	SidebarComponent,
+	PlansPage,
+	CartCheckoutPage,
+	TestAccount,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Plans: Add Upgrade to Cart' ), function () {
+	let page: Page;
+	let plansPage: PlansPage;
+	let cartCheckoutPage: CartCheckoutPage;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+
+		const testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
+		await testAccount.authenticate( page );
+	} );
+
+	it( 'Navigate to Upgrades > Plans', async function () {
+		const sidebarComponent = new SidebarComponent( page );
+		await sidebarComponent.navigate( 'Upgrades', 'Plans' );
+	} );
+
+	describe( 'View Plans comparison', function () {
+		it( 'Show full details of the plan', async function () {
+			plansPage = new PlansPage( page, 'current' );
+			await plansPage.clickPlanComparisonActionButton( 'show' );
+		} );
+	} );
+
+	describe( 'Add WordPress.com Pro to cart', function () {
+		it( `Click button to upgrade to WordPress.com Pro`, async function () {
+			await plansPage.upgradeToPro();
+		} );
+
+		it( `WordPress.com Pro is added to cart`, async function () {
+			cartCheckoutPage = new CartCheckoutPage( page );
+			await cartCheckoutPage.validateCartItem( `WordPress.com Pro` );
+		} );
+
+		it( 'Remove plan from cart', async function () {
+			await cartCheckoutPage.removeCartItem( `WordPress.com Pro` );
+		} );
+
+		it( 'Automatically navigated back to Plans page', async function () {
+			await plansPage.validateActiveNavigationTab( 'New Plans' );
+		} );
+	} );
+} );

--- a/test/e2e/specs/plans/plans__add-upgrade-cart.ts
+++ b/test/e2e/specs/plans/plans__add-upgrade-cart.ts
@@ -39,7 +39,7 @@ describe( DataHelper.createSuiteTitle( 'Plans: Add Upgrade to Cart' ), function 
 
 	describe( 'Add WordPress.com Pro to cart', function () {
 		it( `Click button to upgrade to WordPress.com Pro`, async function () {
-			await plansPage.upgradeToPro();
+			await plansPage.selectPlan( 'Pro' );
 		} );
 
 		it( `WordPress.com Pro is added to cart`, async function () {

--- a/test/e2e/specs/plans/plans__add-upgrade-cart.ts
+++ b/test/e2e/specs/plans/plans__add-upgrade-cart.ts
@@ -33,7 +33,7 @@ describe( DataHelper.createSuiteTitle( 'Plans: Add Upgrade to Cart' ), function 
 	describe( 'View Plans comparison', function () {
 		it( 'Show full details of the plan', async function () {
 			plansPage = new PlansPage( page, 'current' );
-			await plansPage.clickPlanComparisonActionButton( 'show' );
+			await plansPage.showPlanComparison();
 		} );
 	} );
 

--- a/test/e2e/specs/plans/plans__add-upgrade-cart.ts
+++ b/test/e2e/specs/plans/plans__add-upgrade-cart.ts
@@ -52,7 +52,7 @@ describe( DataHelper.createSuiteTitle( 'Plans: Add Upgrade to Cart' ), function 
 		} );
 
 		it( 'Automatically navigated back to Plans page', async function () {
-			await plansPage.validateActiveNavigationTab( 'New Plans' );
+			await plansPage.validateActiveNavigationTab( 'Plans' );
 		} );
 	} );
 } );

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -27,7 +27,7 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 
 		const testAccount = new TestAccount( 'simpleSitePersonalPlanUser' );
 		await testAccount.authenticate( page );
-		plansPage = new PlansPage( page );
+		plansPage = new PlansPage( page, 'legacy' );
 	} );
 
 	it( 'Navigate to Upgrades > Plans', async function () {

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -14,7 +14,7 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Plans: Upgrade' ), function () {
+describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () {
 	const planTier = 'Personal';
 	const planName = `WordPress.com ${ planTier }`;
 	let page: Page;

--- a/test/e2e/specs/plans/plans__legacy-upgrade.ts
+++ b/test/e2e/specs/plans/plans__legacy-upgrade.ts
@@ -24,7 +24,7 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 
 		const testAccount = new TestAccount( 'simpleSitePersonalPlanUser' );
 		await testAccount.authenticate( page );
-		plansPage = new PlansPage( page );
+		plansPage = new PlansPage( page, 'legacy' );
 	} );
 
 	it( 'Navigate to Upgrades > Plans', async function () {
@@ -51,7 +51,6 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 		} );
 
 		it( 'Automatically return to Plans page', async function () {
-			plansPage = new PlansPage( page );
 			await plansPage.validateActiveNavigationTab( 'Plans' );
 		} );
 	} );

--- a/test/e2e/specs/plans/plans__legacy-upgrade.ts
+++ b/test/e2e/specs/plans/plans__legacy-upgrade.ts
@@ -13,7 +13,7 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Plans: Upgrade' ), function () {
+describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () {
 	const planName = 'Business';
 	let page: Page;
 	let plansPage: PlansPage;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For original description, see https://github.com/Automattic/wp-calypso/pull/62563.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


