### PR TITLE
CI: separate Gutenberg Edge builds into its own configuration.

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -32,14 +32,14 @@ object WPComTests : Project({
 	}
 
 	// Gutenberg Simple
-	buildType(gutenbergPlaywrightBuildType("desktop", "fab2e82e-d27b-4ba2-bbd7-232df944e75c", false, false));
-	buildType(gutenbergPlaywrightBuildType("mobile", "77a5a0f1-9644-4c04-9d27-0066cd2d4ada", false, false));
+	buildType(gutenbergPlaywrightBuildType("desktop", "fab2e82e-d27b-4ba2-bbd7-232df944e75c", atomic=false, edge=false));
+	buildType(gutenbergPlaywrightBuildType("mobile", "77a5a0f1-9644-4c04-9d27-0066cd2d4ada", atomic=false, edge=false));
 	// Gutenberg Simple Edge
-	buildType(gutenbergPlaywrightBuildType("desktop", "e8817ab4-ec4e-4d58-a215-d1f87b2227b6", false, true));
-	buildType(gutenbergPlaywrightBuildType("mobile", "a655d304-4dcf-4864-8d82-8b22dba29feb", false, true));
+	buildType(gutenbergPlaywrightBuildType("desktop", "e8817ab4-ec4e-4d58-a215-d1f87b2227b6", atomic=false, edge=true));
+	buildType(gutenbergPlaywrightBuildType("mobile", "a655d304-4dcf-4864-8d82-8b22dba29feb", atomic=false, edge=true));
 	// Gutenberg Atomic
-	buildType(gutenbergPlaywrightBuildType("desktop", "c341e9b9-1118-48e9-a569-325100f5fd9" , true, false));
-	buildType(gutenbergPlaywrightBuildType("mobile", "e0f7e412-ae6c-41d3-9eec-c57c94dd8385", true, false));
+	buildType(gutenbergPlaywrightBuildType("desktop", "c341e9b9-1118-48e9-a569-325100f5fd9" , atomic=true, edge=false));
+	buildType(gutenbergPlaywrightBuildType("mobile", "e0f7e412-ae6c-41d3-9eec-c57c94dd8385", atomic=true, edge=false));
 
 	buildType(coblocksPlaywrightBuildType("desktop", "08f88b93-993e-4de8-8d80-4a94981d9af4"));
 	buildType(coblocksPlaywrightBuildType("mobile", "cbcd44d5-4d31-4adc-b1b5-97f1225c6a7c"));
@@ -51,7 +51,7 @@ object WPComTests : Project({
 	buildType(P2E2ETests)
 })
 
-fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomic: Boolean = false ): E2EBuildType {
+fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomic: Boolean = false, edge: Boolean = false ): E2EBuildType {
 	var siteType = if (atomic) "atomic" else "simple";
 	var edgeType = if (edge) "edge" else "production";
 

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -31,11 +31,15 @@ object WPComTests : Project({
 		}
 	}
 
-	// Keep the previous ID in order to preserve the historical data
-	buildType(gutenbergPlaywrightBuildType("desktop", "fab2e82e-d27b-4ba2-bbd7-232df944e75c"));
-	buildType(gutenbergPlaywrightBuildType("mobile", "77a5a0f1-9644-4c04-9d27-0066cd2d4ada"));
-	buildType(gutenbergPlaywrightBuildType("desktop", "c341e9b9-1118-48e9-a569-325100f5fd9" , true));
-	buildType(gutenbergPlaywrightBuildType("mobile", "e0f7e412-ae6c-41d3-9eec-c57c94dd8385", true));
+	// Gutenberg Simple
+	buildType(gutenbergPlaywrightBuildType("desktop", "fab2e82e-d27b-4ba2-bbd7-232df944e75c", false, false));
+	buildType(gutenbergPlaywrightBuildType("mobile", "77a5a0f1-9644-4c04-9d27-0066cd2d4ada", false, false));
+	// Gutenberg Simple Edge
+	buildType(gutenbergPlaywrightBuildType("desktop", "", false, true));
+	buildType(gutenbergPlaywrightBuildType("mobile", "", false, true));
+	// Gutenberg Atomic
+	buildType(gutenbergPlaywrightBuildType("desktop", "c341e9b9-1118-48e9-a569-325100f5fd9" , true, false));
+	buildType(gutenbergPlaywrightBuildType("mobile", "e0f7e412-ae6c-41d3-9eec-c57c94dd8385", true, false));
 
 	buildType(coblocksPlaywrightBuildType("desktop", "08f88b93-993e-4de8-8d80-4a94981d9af4"));
 	buildType(coblocksPlaywrightBuildType("mobile", "cbcd44d5-4d31-4adc-b1b5-97f1225c6a7c"));
@@ -49,6 +53,7 @@ object WPComTests : Project({
 
 fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomic: Boolean = false ): E2EBuildType {
 	var siteType = if (atomic) "atomic" else "simple";
+	var edgeType = if (edge) "Edge" else "";
 
     return E2EBuildType (
 		buildId = "WPComTests_gutenberg_Playwright_${siteType}_$targetDevice",
@@ -64,14 +69,14 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 				description = "URL to test against",
 				allowEmpty = false
 			)
-			checkbox(
-				name = "env.GUTENBERG_EDGE",
-				value = "false",
-				label = "Use gutenberg-edge",
-				description = "Use a blog with gutenberg-edge sticker",
-				checked = "true",
-				unchecked = "false"
-			)
+			// checkbox(
+			// 	name = "env.GUTENBERG_EDGE",
+			// 	value = "false",
+			// 	label = "Use gutenberg-edge",
+			// 	description = "Use a blog with gutenberg-edge sticker",
+			// 	checked = "true",
+			// 	unchecked = "false"
+			// )
 			checkbox(
 				name = "env.COBLOCKS_EDGE",
 				value = "false",
@@ -90,7 +95,12 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 			)
 			param("env.AUTHENTICATE_ACCOUNTS", "gutenbergSimpleSiteEdgeUser,gutenbergSimpleSiteUser,coBlocksSimpleSiteEdgeUser,simpleSitePersonalPlanUser")
 			param("env.VIEWPORT_NAME", "$targetDevice")
-			if (atomic) param("env.TEST_ON_ATOMIC", "true")
+			if (atomic) {
+				param("env.TEST_ON_ATOMIC", "true")
+			}
+			if (edge) {
+				param("env.GUTENBERG_EDGE", "true")
+			}
 		},
 		buildFeatures = {
 			notifications {

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -56,9 +56,9 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 	var edgeType = if (edge) "edge" else "production";
 
     return E2EBuildType (
-		buildId = "WPComTests_gutenberg_Playwright_${siteType}_${edgeType}_$targetDevice",
+		buildId = "WPComTests_gutenberg_${siteType}_${edgeType}_$targetDevice",
 		buildUuid = buildUuid,
-		buildName = "Gutenberg $siteType E2E tests ($targetDevice)",
+		buildName = "Gutenberg $siteType E2E tests $edgeType ($targetDevice)",
 		buildDescription = "Runs Gutenberg $siteType E2E tests on $targetDevice size",
 		testGroup = "gutenberg",
 		buildParams = {
@@ -74,14 +74,6 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 				value = "false",
 				label = "Use coblocks-edge",
 				description = "Use a blog with coblocks-edge sticker",
-				checked = "true",
-				unchecked = "false"
-			)
-			checkbox(
-				name = "env.TEST_ON_ATOMIC",
-				value = "false",
-				label = "Test on Atomic",
-				description = "Use an Atomic blog to test against",
 				checked = "true",
 				unchecked = "false"
 			)

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -35,8 +35,8 @@ object WPComTests : Project({
 	buildType(gutenbergPlaywrightBuildType("desktop", "fab2e82e-d27b-4ba2-bbd7-232df944e75c", false, false));
 	buildType(gutenbergPlaywrightBuildType("mobile", "77a5a0f1-9644-4c04-9d27-0066cd2d4ada", false, false));
 	// Gutenberg Simple Edge
-	buildType(gutenbergPlaywrightBuildType("desktop", "", false, true));
-	buildType(gutenbergPlaywrightBuildType("mobile", "", false, true));
+	buildType(gutenbergPlaywrightBuildType("desktop", "e8817ab4-ec4e-4d58-a215-d1f87b2227b6", false, true));
+	buildType(gutenbergPlaywrightBuildType("mobile", "a655d304-4dcf-4864-8d82-8b22dba29feb", false, true));
 	// Gutenberg Atomic
 	buildType(gutenbergPlaywrightBuildType("desktop", "c341e9b9-1118-48e9-a569-325100f5fd9" , true, false));
 	buildType(gutenbergPlaywrightBuildType("mobile", "e0f7e412-ae6c-41d3-9eec-c57c94dd8385", true, false));
@@ -53,10 +53,10 @@ object WPComTests : Project({
 
 fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomic: Boolean = false ): E2EBuildType {
 	var siteType = if (atomic) "atomic" else "simple";
-	var edgeType = if (edge) "Edge" else "";
+	var edgeType = if (edge) "edge" else "production";
 
     return E2EBuildType (
-		buildId = "WPComTests_gutenberg_Playwright_${siteType}_$targetDevice",
+		buildId = "WPComTests_gutenberg_Playwright_${siteType}_${edgeType}_$targetDevice",
 		buildUuid = buildUuid,
 		buildName = "Gutenberg $siteType E2E tests ($targetDevice)",
 		buildDescription = "Runs Gutenberg $siteType E2E tests on $targetDevice size",
@@ -69,14 +69,6 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 				description = "URL to test against",
 				allowEmpty = false
 			)
-			// checkbox(
-			// 	name = "env.GUTENBERG_EDGE",
-			// 	value = "false",
-			// 	label = "Use gutenberg-edge",
-			// 	description = "Use a blog with gutenberg-edge sticker",
-			// 	checked = "true",
-			// 	unchecked = "false"
-			// )
 			checkbox(
 				name = "env.COBLOCKS_EDGE",
 				value = "false",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new configuration for the EDGE variant of Gutenberg in order to separate out the EDGE runs from non-EDGE runs.

Practically speaking, this means that for every Gutenberg e2e spec, there are 3 variables at play:
- device type (mobile / desktop)
- site type (simple / atomic)
- Gutenberg version (edge / production)

The full matrix will result in 8 build configurations. 
At this time, we have not yet implemented a build configuration for Atomic / Edge, so there exists 6 build configurations for Gutenberg e2e tests.

Key changes:
1. add new parameter to `gutenbergPlaywrightBuildType` to allow specifying of Gutenberg version.
2. set GUTENBERG_EDGE environment variable dynamically based on the parameter value.

#### Testing instructions

Ensure the following:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Unit Tests

