### PR TITLE
E2E: reload published post page if needed in Editor: Advanced Post flow.

### DIFF
--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -70,9 +70,11 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 			const testPage = await browser.newPage();
 			await testPage.goto( postURL.href );
 
-			await ElementHelper.reloadAndRetry( testPage, loadPublishedPage );
+			// Work around issue:
+			// https://github.com/Automattic/wp-calypso/issues/57503
+			await ElementHelper.reloadAndRetry( testPage, validatePublishedPage );
 
-			async function loadPublishedPage(): Promise< void > {
+			async function validatePublishedPage(): Promise< void > {
 				await ParagraphBlock.validatePublishedContent( testPage, [ originalContent ] );
 			}
 

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -13,6 +13,7 @@ import {
 	SnackbarNotificationComponent,
 	getTestAccountByFeature,
 	envToFeatureKey,
+	ElementHelper,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
@@ -69,7 +70,12 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 			const testPage = await browser.newPage();
 			await testPage.goto( postURL.href );
 
-			await ParagraphBlock.validatePublishedContent( testPage, [ originalContent ] );
+			await ElementHelper.reloadAndRetry( testPage, loadPublishedPage );
+
+			async function loadPublishedPage(): Promise< void > {
+				await ParagraphBlock.validatePublishedContent( testPage, [ originalContent ] );
+			}
+
 			await testPage.close();
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the `reloadAndRetry` mechanism to the test step immediately after the initial publication of a post.

Key changes:
- define a closure within the test step `Validate post` to deal with known issue of post returning a HTTP 404 if visited immediately after publish.

#### Testing instructions

Ensure the following:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)

Closes to #63036