### PR TITLE
Sidebar: Fix responsiveness in Jetpack Cloud

### DIFF
--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -288,6 +288,13 @@ html {
 	border-right: 1px solid var( --color-sidebar-border );
 }
 
+.layout.focus-content .layout__secondary {
+	@media only screen and ( max-width: 782px ) and ( min-width: 660px ) {
+		transform: none;
+		padding: 0;
+	}
+}
+
 .masterbar {
 	font-size: $font-body;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a responsiveness issue in Jetpack Cloud introduced in #61916 (issue originally reported in p1650970345331099-slack-C0D96691V).

Before | After
--- | ---
<img width="616" alt="Screen Shot 2022-04-26 at 13 19 42" src="https://user-images.githubusercontent.com/1233880/165289074-14716cca-d8a3-40b1-b77f-83fccc1cb14a.png"> | <img width="643" alt="Screen Shot 2022-04-26 at 13 20 03" src="https://user-images.githubusercontent.com/1233880/165289099-9a9620a5-d06f-40e2-9562-d89551f940ab.png">

#### Testing instructions

- Use the Jetpack Cloud live link below.
- Use the responsiveness tools of your browser and change the screen width to something between 660px and 782px.
- Make sure the sidebar is visible.
- Make sure there are no regression in other widths.