### PR TITLE
Added test to cover gray out incompatible plugins feature

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/test/index.jsx
@@ -1,0 +1,68 @@
+/** @jest-environment jsdom */
+import { shallow } from 'enzyme';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import PluginsBrowserListElement from '../';
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
+jest.mock( 'calypso/state/ui/selectors' );
+jest.mock( 'calypso/state/plugins/installed/selectors' );
+jest.mock( 'calypso/state/products-list/selectors' );
+jest.mock( 'calypso/state/sites/selectors' );
+jest.mock( 'calypso/state/selectors/is-site-automated-transfer' );
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useDispatch: jest.fn().mockImplementation( () => {} ),
+	useSelector: jest.fn().mockImplementation( ( selector ) => selector() ),
+} ) );
+
+describe( 'PluginsBrowserItem Incompatible Plugins Message', () => {
+	test( 'should render the incompatible plugin message on Simple Sites', () => {
+		isJetpackSite.mockImplementation( () => false );
+		isAtomicSite.mockImplementation( () => false );
+
+		const props = {
+			plugin: { name: 'wordfence', slug: 'wordfence' },
+		};
+
+		const comp = shallow( <PluginsBrowserListElement { ...props } /> );
+		expect( comp.find( 'ExternalLink' ).length ).toBe( 1 );
+	} );
+
+	test( 'should render the incompatible plugin message on Atomic Sites', () => {
+		isJetpackSite.mockImplementation( () => true );
+		isAtomicSite.mockImplementation( () => true );
+
+		const props = {
+			plugin: { name: 'wordfence', slug: 'wordfence' },
+		};
+
+		const comp = shallow( <PluginsBrowserListElement { ...props } /> );
+		expect( comp.find( 'ExternalLink' ).length ).toBe( 1 );
+	} );
+
+	test( 'should NOT render the incompatible plugin message on JetpackSite non Atomic sites', () => {
+		isJetpackSite.mockImplementation( () => true );
+		isAtomicSite.mockImplementation( () => false );
+
+		const props = {
+			plugin: { name: 'wordfence', slug: 'wordfence' },
+		};
+
+		const comp = shallow( <PluginsBrowserListElement { ...props } /> );
+		expect( comp.find( 'ExternalLink' ).length ).toBe( 0 );
+	} );
+
+	test( 'should NOT render the incompatible plugin message if it is not in the list', () => {
+		isJetpackSite.mockImplementation( () => true );
+		isAtomicSite.mockImplementation( () => false );
+
+		const props = {
+			plugin: { name: 'woocommerce', slug: 'woocommerce' },
+		};
+
+		const comp = shallow( <PluginsBrowserListElement { ...props } /> );
+		expect( comp.find( 'ExternalLink' ).length ).toBe( 0 );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added test to cover [gray out incompatible plugins feature](https://github.com/Automattic/wp-calypso/issues/62644)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run the test using: `yarn run test-client:watch my-sites/plugins/plugins-browser-item`
2. Make some changes [in the logic](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/plugins/plugins-browser-item/index.jsx#L112), like removing `&& ! jetpackNonAtomic` and make sure the test will fail

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/62929
