### PR TITLE
Components: Refactor `Rating` tests to use `@testing-library/react` and `jest`

### DIFF
--- a/client/components/rating/test/index.js
+++ b/client/components/rating/test/index.js
@@ -1,60 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
 import Rating from 'calypso/components/rating';
 
 describe( '<Rating />', () => {
 	describe( 'check props size', () => {
 		test( 'should be set to 18px if no size', () => {
-			const wrapper = shallow( <Rating /> );
+			const { container } = render( <Rating /> );
 
-			const component = wrapper.find( 'div.rating' );
-			expect( component.props().style.width ).to.equal( '90px' ); // 18 * 5 = 120;
+			const component = container.getElementsByClassName( 'rating' )[ 0 ];
+			expect( component.style.width ).to.equal( '90px' ); // 18 * 5 = 120;
 		} );
 
 		test( 'should use size if passed', () => {
 			const size = 48;
-			const wrapper = shallow( <Rating size={ size } /> );
+			const { container } = render( <Rating size={ size } /> );
 
-			const component = wrapper.find( 'div.rating' );
-			expect( component.props().style.width ).to.equal( size * 5 + 'px' );
+			const component = container.getElementsByClassName( 'rating' )[ 0 ];
+			expect( component.style.width ).to.equal( size * 5 + 'px' );
 		} );
 
 		test( 'should use size in each star', () => {
 			const rating = 30;
 			const size = 48;
-			const wrapper = shallow( <Rating rating={ rating } size={ size } /> );
+			const { container } = render( <Rating rating={ rating } size={ size } /> );
+			const icons = container.getElementsByTagName( 'svg' );
 
-			wrapper.find( 'svg' ).forEach( ( node ) => {
-				expect( node.props().style.width ).to.equal( size + 'px' );
-			} );
+			for ( const icon of icons ) {
+				expect( icon.style.width ).to.equal( size + 'px' );
+			}
 		} );
 	} );
 
 	describe( 'check props rating', () => {
 		test( 'should render full width mask for no rating', () => {
 			const size = 24;
-			const wrapper = shallow( <Rating size={ size } /> );
+			const { container } = render( <Rating size={ size } /> );
 
-			const component = wrapper.find( 'div.rating__overlay' );
-			expect( component.props().style.clipPath ).to.equal( 'inset(0 ' + size * 5 + 'px 0 0 )' );
-			expect( component.props().style.clip ).to.equal( 'rect(0, 0px, ' + size + 'px, 0)' );
+			const component = container.getElementsByClassName( 'rating__overlay' )[ 0 ];
+			expect( component.style.clipPath ).to.equal( 'inset(0 ' + size * 5 + 'px 0 0 )' );
+			expect( component.style.clip ).to.equal( 'rect(0px, 0px, ' + size + 'px, 0px)' );
 		} );
 
 		test( 'should render rating clipping mask properly', () => {
 			[ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ].forEach( function ( ratingValue ) {
 				const size = 24;
-				const wrapper = shallow( <Rating rating={ ratingValue } size={ size } /> );
+				const { container } = render( <Rating rating={ ratingValue } size={ size } /> );
 
 				const roundRating = Math.round( ratingValue / 10 ) * 10;
 				const ratingWidth = size * 5;
 				const maskPosition = ( roundRating / 100 ) * ratingWidth;
 				const clipPathMaskPosition = ratingWidth - ( roundRating / 100 ) * ratingWidth;
-				const component = wrapper.find( 'div.rating__overlay' );
-				expect( component.props().style.clipPath ).to.equal(
+				const component = container.getElementsByClassName( 'rating__overlay' )[ 0 ];
+				expect( component.style.clipPath ).to.equal(
 					'inset(0 ' + clipPathMaskPosition + 'px 0 0 )'
 				);
-				expect( component.props().style.clip ).to.equal(
-					'rect(0, ' + maskPosition + 'px, ' + size + 'px, 0)'
+				expect( component.style.clip ).to.equal(
+					'rect(0px, ' + maskPosition + 'px, ' + size + 'px, 0px)'
 				);
 			} );
 		} );

--- a/client/components/rating/test/index.js
+++ b/client/components/rating/test/index.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { render } from '@testing-library/react';
-import { expect } from 'chai';
 import Rating from 'calypso/components/rating';
 
 describe( '<Rating />', () => {
@@ -11,7 +10,7 @@ describe( '<Rating />', () => {
 			const { container } = render( <Rating /> );
 
 			const component = container.getElementsByClassName( 'rating' )[ 0 ];
-			expect( component.style.width ).to.equal( '90px' ); // 18 * 5 = 120;
+			expect( component.style.width ).toEqual( '90px' ); // 18 * 5 = 120;
 		} );
 
 		test( 'should use size if passed', () => {
@@ -19,7 +18,7 @@ describe( '<Rating />', () => {
 			const { container } = render( <Rating size={ size } /> );
 
 			const component = container.getElementsByClassName( 'rating' )[ 0 ];
-			expect( component.style.width ).to.equal( size * 5 + 'px' );
+			expect( component.style.width ).toEqual( size * 5 + 'px' );
 		} );
 
 		test( 'should use size in each star', () => {
@@ -29,7 +28,7 @@ describe( '<Rating />', () => {
 			const icons = container.getElementsByTagName( 'svg' );
 
 			for ( const icon of icons ) {
-				expect( icon.style.width ).to.equal( size + 'px' );
+				expect( icon.style.width ).toEqual( size + 'px' );
 			}
 		} );
 	} );
@@ -40,8 +39,8 @@ describe( '<Rating />', () => {
 			const { container } = render( <Rating size={ size } /> );
 
 			const component = container.getElementsByClassName( 'rating__overlay' )[ 0 ];
-			expect( component.style.clipPath ).to.equal( 'inset(0 ' + size * 5 + 'px 0 0 )' );
-			expect( component.style.clip ).to.equal( 'rect(0px, 0px, ' + size + 'px, 0px)' );
+			expect( component.style.clipPath ).toEqual( 'inset(0 ' + size * 5 + 'px 0 0 )' );
+			expect( component.style.clip ).toEqual( 'rect(0px, 0px, ' + size + 'px, 0px)' );
 		} );
 
 		test( 'should render rating clipping mask properly', () => {
@@ -54,10 +53,10 @@ describe( '<Rating />', () => {
 				const maskPosition = ( roundRating / 100 ) * ratingWidth;
 				const clipPathMaskPosition = ratingWidth - ( roundRating / 100 ) * ratingWidth;
 				const component = container.getElementsByClassName( 'rating__overlay' )[ 0 ];
-				expect( component.style.clipPath ).to.equal(
+				expect( component.style.clipPath ).toEqual(
 					'inset(0 ' + clipPathMaskPosition + 'px 0 0 )'
 				);
-				expect( component.style.clip ).to.equal(
+				expect( component.style.clip ).toEqual(
 					'rect(0px, ' + maskPosition + 'px, ' + size + 'px, 0px)'
 				);
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `Rating` component to use `@testing-library/react` instead of `enzyme` and `jest` instead of `chai`.

#### Testing instructions

Verify tests pass: `yarn run test-client client/components/rating/test/index.js`