### PR TITLE
Reader: Refactor `FeaturedImage` to `@testing-library/react`

### DIFF
--- a/client/blocks/reader-full-post/test/featured-image.jsx
+++ b/client/blocks/reader-full-post/test/featured-image.jsx
@@ -1,16 +1,16 @@
 /**
  * @jest-environment jsdom
  */
-import { mount } from 'enzyme';
+import { fireEvent, render } from '@testing-library/react';
 import FeaturedImage from '../featured-image';
 
 describe( 'FeaturedImage', () => {
 	test( 'sets the source to an empty string if the image fails to load', () => {
 		const nonExistentImage = 'http://sketchy-feed.com/missing-image-2.jpg';
-		const wrapper = mount( <FeaturedImage src={ nonExistentImage } /> );
-		const div = wrapper.find( '.reader-full-post__featured-image' ).at( 0 ).getDOMNode();
+		const { container } = render( <FeaturedImage src={ nonExistentImage } /> );
+		const div = container.getElementsByClassName( 'reader-full-post__featured-image' )[ 0 ];
 
-		wrapper.find( 'img' ).simulate( 'error' );
+		fireEvent.error( div.getElementsByTagName( 'img' )[ 0 ] );
 
 		expect( getComputedStyle( div ).getPropertyValue( 'display' ) ).toBe( 'none' );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the Reader `FeaturedImage` component to use `@testing-library/react` instead of `enzyme`.

It's the simplest possible demonstration of migration from `enzyme` to `@testing-library/react` that requires simulating an event.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/blocks/reader-full-post/test/featured-image.jsx`