### PR TITLE
Update plugins installation thank you page with links

### DIFF
--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -156,6 +156,7 @@ export const ThankYou = ( props: ThankYouProps ): JSX.Element => {
 		headerTextColor = 'var( --studio-white )',
 		containerClassName,
 		sections,
+		documentationURL,
 		showSupportSection = true,
 		thankYouTitle,
 		thankYouSubtitle,
@@ -195,9 +196,17 @@ export const ThankYou = ( props: ThankYouProps ): JSX.Element => {
 				href: CALYPSO_CONTACT,
 				title: translate( 'Ask a question' ),
 			},
+			...( documentationURL
+				? [
+						{
+							href: documentationURL,
+							title: translate( 'View plugin documentation' ),
+						},
+				  ]
+				: [] ),
 			{
 				href: localizeUrl( SUPPORT_ROOT ),
-				title: translate( 'View support documentation' ),
+				title: translate( 'View WordPress.com support guides' ),
 			},
 		],
 	};

--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -156,7 +156,6 @@ export const ThankYou = ( props: ThankYouProps ): JSX.Element => {
 		headerTextColor = 'var( --studio-white )',
 		containerClassName,
 		sections,
-		documentationURL,
 		showSupportSection = true,
 		thankYouTitle,
 		thankYouSubtitle,
@@ -196,14 +195,6 @@ export const ThankYou = ( props: ThankYouProps ): JSX.Element => {
 				href: CALYPSO_CONTACT,
 				title: translate( 'Ask a question' ),
 			},
-			...( documentationURL
-				? [
-						{
-							href: documentationURL,
-							title: translate( 'View plugin documentation' ),
-						},
-				  ]
-				: [] ),
 			{
 				href: localizeUrl( SUPPORT_ROOT ),
 				title: translate( 'View WordPress.com support guides' ),

--- a/client/components/thank-you/style.scss
+++ b/client/components/thank-you/style.scss
@@ -56,11 +56,6 @@
 	}
 }
 
-.thank-you__step-cta > a.button:not( .is-primary ) {
-	border-color: var( --color-accent );
-	color: var( --color-accent );
-}
-
 .thank-you__help-link {
 	display: flex;
 	font-size: $font-body-small;

--- a/client/components/thank-you/style.scss
+++ b/client/components/thank-you/style.scss
@@ -56,6 +56,11 @@
 	}
 }
 
+.thank-you__step-cta > .button:not( .is-primary ) {
+	border-color: var( --color-accent );
+	color: var( --color-accent );
+}
+
 .thank-you__help-link {
 	display: flex;
 	font-size: $font-body-small;

--- a/client/components/thank-you/types.ts
+++ b/client/components/thank-you/types.ts
@@ -39,6 +39,7 @@ export type ThankYouProps = {
 	sections: ThankYouSectionProps[];
 	showSupportSection?: boolean;
 	customSupportSection?: ThankYouSupportSectionProps;
+	documentationURL?: string;
 	thankYouImage: {
 		alt: string | TranslateResult;
 		src: string;

--- a/client/components/thank-you/types.ts
+++ b/client/components/thank-you/types.ts
@@ -39,7 +39,6 @@ export type ThankYouProps = {
 	sections: ThankYouSectionProps[];
 	showSupportSection?: boolean;
 	customSupportSection?: ThankYouSupportSectionProps;
-	documentationURL?: string;
 	thankYouImage: {
 		alt: string | TranslateResult;
 		src: string;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -166,6 +166,8 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 	const setupURL =
 		pluginOnSiteData?.action_links?.Settings || fallbackSetupUrl || `${ siteAdminUrl }plugins.php`;
 
+	const documentationURL = wpComPluginData?.documentation_url;
+
 	const setupSection = {
 		sectionKey: 'setup_whats_next',
 		sectionTitle: translate( 'What’s next?' ),
@@ -203,6 +205,22 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 					</FullWidthButton>
 				),
 			},
+			...( documentationURL
+				? [
+						{
+							stepKey: 'whats_next_documentation',
+							stepTitle: translate( 'Documentation' ),
+							stepDescription: translate(
+								'Visit the step-by-step guide to learn how to use this plugin.'
+							),
+							stepCta: (
+								<FullWidthButton href={ documentationURL }>
+									{ translate( 'Visit guide' ) }
+								</FullWidthButton>
+							),
+						},
+				  ]
+				: [] ),
 		],
 	};
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -259,6 +259,7 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 					thankYouSubtitle={ pluginOnSite && thankYouSubtitle }
 					headerBackgroundColor="#fff"
 					headerTextColor="#000"
+					documentationURL={ documentationURL }
 				/>
 			</ThankYouContainer>
 		</ThemeProvider>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -188,6 +188,22 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 					</FullWidthButton>
 				),
 			},
+			...( documentationURL
+				? [
+						{
+							stepKey: 'whats_next_documentation',
+							stepTitle: translate( 'Documentation' ),
+							stepDescription: translate(
+								'Visit the step-by-step guide to learn how to use this plugin.'
+							),
+							stepCta: (
+								<FullWidthButton href={ documentationURL }>
+									{ translate( 'Visit guide' ) }
+								</FullWidthButton>
+							),
+						},
+				  ]
+				: [] ),
 			{
 				stepKey: 'whats_next_grow',
 				stepTitle: translate( 'Keep growing' ),
@@ -205,22 +221,6 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 					</FullWidthButton>
 				),
 			},
-			...( documentationURL
-				? [
-						{
-							stepKey: 'whats_next_documentation',
-							stepTitle: translate( 'Documentation' ),
-							stepDescription: translate(
-								'Visit the step-by-step guide to learn how to use this plugin.'
-							),
-							stepCta: (
-								<FullWidthButton href={ documentationURL }>
-									{ translate( 'Visit guide' ) }
-								</FullWidthButton>
-							),
-						},
-				  ]
-				: [] ),
 		],
 	};
 
@@ -259,7 +259,6 @@ const MarketplaceThankYou = ( { productSlug }: IProps ): JSX.Element => {
 					thankYouSubtitle={ pluginOnSite && thankYouSubtitle }
 					headerBackgroundColor="#fff"
 					headerTextColor="#000"
-					documentationURL={ documentationURL }
 				/>
 			</ThankYouContainer>
 		</ThemeProvider>


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Show documentation section when documentation link is provided. PS: Currently it is only available for WP.com products.
* Rename the WP.com support link.

#### Testing instructions

**Positive validation**
* From the plugin details page, install a plugin with a documentation link. Ex: `woocommerce-bookings`
* On the Thank You page you should see the documentation links as the next section

**Negative validation**
* From the plugin details page, install a plugin without a documentation link. Ex: `wordpress-seo`
* On the Thank You page you should see there is no documentation links as shown on the next section

#### Demo
| with documentation links  | without documentation links |
| ------------- | ------------- |
|<img width="731" alt="Screen Shot 2022-04-27 at 09 42 41" src="https://user-images.githubusercontent.com/5039531/165532514-344cfc69-cdb4-4d6a-bf27-2acdc90ffdca.png">|<img width="659" alt="Screen Shot 2022-04-26 at 10 44 26" src="https://user-images.githubusercontent.com/5039531/165328611-ba5b6e10-21ef-4e7d-86ab-a82eaccc7825.png">|





---

Fixes #62578
