### PR TITLE
Components: Refactor `Gravatar` tests to use `@testing-library/react` and `jest`

### DIFF
--- a/client/components/gravatar/test/index.jsx
+++ b/client/components/gravatar/test/index.jsx
@@ -1,5 +1,8 @@
-import { expect } from 'chai';
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { Gravatar } from '../';
 
 describe( 'Gravatar', () => {
@@ -20,54 +23,54 @@ describe( 'Gravatar', () => {
 
 	describe( 'rendering', () => {
 		test( 'should render an image given a user with valid avatar_URL, with default width and height 32', () => {
-			const gravatar = shallow( <Gravatar user={ genericUser } /> );
-			const img = gravatar.find( 'img' );
+			const { container } = render( <Gravatar user={ genericUser } /> );
+			const img = container.getElementsByTagName( 'img' )[ 0 ];
 
-			expect( img.length ).to.equal( 1 );
-			expect( img.prop( 'src' ) ).to.equal( avatarUrl );
-			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
-			expect( img.prop( 'width' ) ).to.equal( 32 );
-			expect( img.prop( 'height' ) ).to.equal( 32 );
-			expect( img.prop( 'alt' ) ).to.equal( 'Bob The Tester' );
+			expect( img ).toBeDefined();
+			expect( img.getAttribute( 'src' ) ).toEqual( avatarUrl );
+			expect( img ).toHaveClass( 'gravatar' );
+			expect( img.getAttribute( 'width' ) ).toEqual( '32' );
+			expect( img.getAttribute( 'height' ) ).toEqual( '32' );
+			expect( img.getAttribute( 'alt' ) ).toEqual( 'Bob The Tester' );
 		} );
 
 		test( 'should update the width and height when given a size attribute', () => {
-			const gravatar = shallow( <Gravatar user={ genericUser } size={ 100 } /> );
-			const img = gravatar.find( 'img' );
+			const { container } = render( <Gravatar user={ genericUser } size={ 100 } /> );
+			const img = container.getElementsByTagName( 'img' )[ 0 ];
 
-			expect( img.length ).to.equal( 1 );
-			expect( img.prop( 'src' ) ).to.equal( avatarUrl );
-			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
-			expect( img.prop( 'width' ) ).to.equal( 100 );
-			expect( img.prop( 'height' ) ).to.equal( 100 );
-			expect( img.prop( 'alt' ) ).to.equal( 'Bob The Tester' );
+			expect( img ).toBeDefined();
+			expect( img.getAttribute( 'src' ) ).toEqual( avatarUrl );
+			expect( img ).toHaveClass( 'gravatar' );
+			expect( img.getAttribute( 'width' ) ).toEqual( '100' );
+			expect( img.getAttribute( 'height' ) ).toEqual( '100' );
+			expect( img.getAttribute( 'alt' ) ).toEqual( 'Bob The Tester' );
 		} );
 
 		test( 'should update source image when given imgSize attribute', () => {
-			const gravatar = shallow( <Gravatar user={ genericUser } imgSize={ 200 } /> );
-			const img = gravatar.find( 'img' );
+			const { container } = render( <Gravatar user={ genericUser } imgSize={ 200 } /> );
+			const img = container.getElementsByTagName( 'img' )[ 0 ];
 
-			expect( img.length ).to.equal( 1 );
-			expect( img.prop( 'src' ) ).to.equal(
+			expect( img ).toBeDefined();
+			expect( img.getAttribute( 'src' ) ).toEqual(
 				`https://0.gravatar.com/avatar/${ gravatarHash }?s=200&d=mm`
 			);
-			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
-			expect( img.prop( 'width' ) ).to.equal( 32 );
-			expect( img.prop( 'height' ) ).to.equal( 32 );
-			expect( img.prop( 'alt' ) ).to.equal( 'Bob The Tester' );
+			expect( img ).toHaveClass( 'gravatar' );
+			expect( img.getAttribute( 'width' ) ).toEqual( '32' );
+			expect( img.getAttribute( 'height' ) ).toEqual( '32' );
+			expect( img.getAttribute( 'alt' ) ).toEqual( 'Bob The Tester' );
 		} );
 
 		test( 'should serve a default image if no avatar_URL available', () => {
 			const noImageUser = { display_name: 'Bob The Tester' };
-			const gravatar = shallow( <Gravatar user={ noImageUser } /> );
-			const img = gravatar.find( 'img' );
+			const { container } = render( <Gravatar user={ noImageUser } /> );
+			const img = container.getElementsByTagName( 'img' )[ 0 ];
 
-			expect( img.length ).to.equal( 1 );
-			expect( img.prop( 'src' ) ).to.equal( 'https://www.gravatar.com/avatar/0?s=96&d=mm' );
-			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
-			expect( img.prop( 'width' ) ).to.equal( 32 );
-			expect( img.prop( 'height' ) ).to.equal( 32 );
-			expect( img.prop( 'alt' ) ).to.equal( 'Bob The Tester' );
+			expect( img ).toBeDefined();
+			expect( img.getAttribute( 'src' ) ).toEqual( 'https://www.gravatar.com/avatar/0?s=96&d=mm' );
+			expect( img ).toHaveClass( 'gravatar' );
+			expect( img.getAttribute( 'width' ) ).toEqual( '32' );
+			expect( img.getAttribute( 'height' ) ).toEqual( '32' );
+			expect( img.getAttribute( 'alt' ) ).toEqual( 'Bob The Tester' );
 		} );
 
 		test( 'should also pick up the default alt from the name prop', () => {
@@ -75,15 +78,15 @@ describe( 'Gravatar', () => {
 				avatar_URL: avatarUrl,
 				name: 'Bob The Tester',
 			};
-			const gravatar = shallow( <Gravatar user={ userFromSiteApi } /> );
-			const img = gravatar.find( 'img' );
+			const { container } = render( <Gravatar user={ userFromSiteApi } /> );
+			const img = container.getElementsByTagName( 'img' )[ 0 ];
 
-			expect( img.length ).to.equal( 1 );
-			expect( img.prop( 'src' ) ).to.equal( avatarUrl );
-			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
-			expect( img.prop( 'width' ) ).to.equal( 32 );
-			expect( img.prop( 'height' ) ).to.equal( 32 );
-			expect( img.prop( 'alt' ) ).to.equal( 'Bob The Tester' );
+			expect( img ).toBeDefined();
+			expect( img.getAttribute( 'src' ) ).toEqual( avatarUrl );
+			expect( img ).toHaveClass( 'gravatar' );
+			expect( img.getAttribute( 'width' ) ).toEqual( '32' );
+			expect( img.getAttribute( 'height' ) ).toEqual( '32' );
+			expect( img.getAttribute( 'alt' ) ).toEqual( 'Bob The Tester' );
 		} );
 
 		test( 'should prefer display_name for the alt', () => {
@@ -92,72 +95,72 @@ describe( 'Gravatar', () => {
 				name: 'Bob The Tester',
 				display_name: 'Bob',
 			};
-			const gravatar = shallow( <Gravatar user={ userFromSiteApi } /> );
-			const img = gravatar.find( 'img' );
+			const { container } = render( <Gravatar user={ userFromSiteApi } /> );
+			const img = container.getElementsByTagName( 'img' )[ 0 ];
 
-			expect( img.length ).to.equal( 1 );
-			expect( img.prop( 'src' ) ).to.equal( avatarUrl );
-			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
-			expect( img.prop( 'width' ) ).to.equal( 32 );
-			expect( img.prop( 'height' ) ).to.equal( 32 );
-			expect( img.prop( 'alt' ) ).to.equal( 'Bob' );
+			expect( img ).toBeDefined();
+			expect( img.getAttribute( 'src' ) ).toEqual( avatarUrl );
+			expect( img ).toHaveClass( 'gravatar' );
+			expect( img.getAttribute( 'width' ) ).toEqual( '32' );
+			expect( img.getAttribute( 'height' ) ).toEqual( '32' );
+			expect( img.getAttribute( 'alt' ) ).toEqual( 'Bob' );
 		} );
 
 		test( 'should allow overriding the alt attribute', () => {
-			const gravatar = shallow( <Gravatar user={ genericUser } alt="Another Alt" /> );
-			const img = gravatar.find( 'img' );
+			const { container } = render( <Gravatar user={ genericUser } alt="Another Alt" /> );
+			const img = container.getElementsByTagName( 'img' )[ 0 ];
 
-			expect( img.length ).to.equal( 1 );
-			expect( img.prop( 'src' ) ).to.equal( avatarUrl );
-			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
-			expect( img.prop( 'width' ) ).to.equal( 32 );
-			expect( img.prop( 'height' ) ).to.equal( 32 );
-			expect( img.prop( 'alt' ) ).to.equal( 'Another Alt' );
+			expect( img ).toBeDefined();
+			expect( img.getAttribute( 'src' ) ).toEqual( avatarUrl );
+			expect( img ).toHaveClass( 'gravatar' );
+			expect( img.getAttribute( 'width' ) ).toEqual( '32' );
+			expect( img.getAttribute( 'height' ) ).toEqual( '32' );
+			expect( img.getAttribute( 'alt' ) ).toEqual( 'Another Alt' );
 		} );
 
 		// I believe jetpack sites could have custom avatars, so can't assume it's always a gravatar
 		test( 'should promote non-secure avatar urls to secure', () => {
 			const nonSecureUrlUser = { avatar_URL: 'http://www.example.com/avatar' };
-			const gravatar = shallow( <Gravatar user={ nonSecureUrlUser } /> );
-			const img = gravatar.find( 'img' );
+			const { container } = render( <Gravatar user={ nonSecureUrlUser } /> );
+			const img = container.getElementsByTagName( 'img' )[ 0 ];
 
-			expect( img.length ).to.equal( 1 );
-			expect( img.prop( 'src' ) ).to.equal(
+			expect( img ).toBeDefined();
+			expect( img.getAttribute( 'src' ) ).toEqual(
 				'https://i0.wp.com/www.example.com/avatar?resize=96%2C96'
 			);
-			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
-			expect( img.prop( 'width' ) ).to.equal( 32 );
-			expect( img.prop( 'height' ) ).to.equal( 32 );
+			expect( img ).toHaveClass( 'gravatar' );
+			expect( img.getAttribute( 'width' ) ).toEqual( '32' );
+			expect( img.getAttribute( 'height' ) ).toEqual( '32' );
 		} );
 
 		describe( 'when Gravatar fails to load', () => {
 			test( 'should render a span element', () => {
-				const gravatar = shallow( <Gravatar user={ genericUser } /> );
+				const { container } = render( <Gravatar user={ genericUser } /> );
 
 				// simulate the Gravatar not loading
-				gravatar.setState( { failedToLoad: true } );
+				const img = container.getElementsByTagName( 'img' )[ 0 ];
+				fireEvent.error( img );
 
-				const img = gravatar.find( 'img' );
-				const span = gravatar.find( 'span' );
+				const span = container.getElementsByTagName( 'span' )[ 0 ];
 
-				expect( img.length ).to.equal( 0 );
-				expect( span.length ).to.equal( 1 );
-				expect( span.hasClass( 'is-missing' ) ).to.equal( true );
+				expect( img ).toBeDefined();
+				expect( span ).toBeDefined();
+				expect( span ).toHaveClass( 'is-missing' );
 			} );
 
 			test( 'should show temp image if it exists', () => {
-				const gravatar = shallow( <Gravatar tempImage={ 'tempImage' } user={ genericUser } /> );
+				const { container } = render( <Gravatar tempImage={ 'tempImage' } user={ genericUser } /> );
 
 				// simulate the Gravatar not loading
-				gravatar.setState( { failedToLoad: true } );
+				const img = container.getElementsByTagName( 'img' )[ 0 ];
+				fireEvent.error( img );
 
-				const img = gravatar.find( 'img' );
-				const span = gravatar.find( 'span' );
+				const span = container.getElementsByTagName( 'span' )[ 0 ];
 
-				expect( img.length ).to.equal( 1 );
-				expect( span.length ).to.equal( 0 );
-				expect( img.prop( 'src' ) ).to.equal( 'tempImage' );
-				expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+				expect( img ).toBeDefined();
+				expect( span ).toBeUndefined();
+				expect( img.getAttribute( 'src' ) ).toEqual( 'tempImage' );
+				expect( img ).toHaveClass( 'gravatar' );
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the Reader `Gravatar` component tests to use `@testing-library/react` instead of `enzyme`.

It's a good example of how we can for the presence of classes using the `toHaveClass` assertion that is provided by importing `@testing-library/jest-dom`.

We also use the opportunity to refactor away from `chai` to `jest`.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/components/gravatar/test/index.jsx`