### PR TITLE
Stepper: go to pro plan (not premium) when eligible

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -63,10 +63,13 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		} ),
 		[]
 	);
-	const isPrivateAtomic = Boolean(
-		site?.launch_status === 'unlaunched' && site?.options?.is_automated_transfer
-	);
 
+	const isAtomic = useSelect( ( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID ) );
+	const isPrivateAtomic = Boolean( site?.launch_status === 'unlaunched' && isAtomic );
+
+	const isEligibleForProPlan = useSelect(
+		( select ) => site && select( SITE_STORE ).isEligibleForProPlan( site.ID )
+	);
 	const showDesignPickerCategories =
 		isEnabled( 'signup/design-picker-categories' ) && ! isAnchorSite;
 	const showDesignPickerCategoriesAllFilter = isEnabled( 'signup/design-picker-categories' );
@@ -74,10 +77,9 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		isEnabled( 'signup/design-picker-generated-designs' ) && intent === 'build' && !! siteVertical;
 
 	const isPremiumThemeAvailable = Boolean(
-		useMemo(
-			() => sitePlanSlug && planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ),
-			[ sitePlanSlug ]
-		)
+		useMemo( () => sitePlanSlug && planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ), [
+			sitePlanSlug,
+		] )
 	);
 
 	const tier =
@@ -190,13 +192,16 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		if ( ! isEnabled( 'signup/design-picker-premium-themes-checkout' ) ) {
 			return null;
 		}
+
+		const plan = isEligibleForProPlan && isEnabled( 'plans/pro-plan' ) ? 'pro' : 'premium';
+
 		if ( siteSlug ) {
 			const params = new URLSearchParams();
 			params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
 
 			window.location.href = `/checkout/${ encodeURIComponent(
 				siteSlug
-			) }/premium?${ params.toString() }`;
+			) }/${ plan }?${ params.toString() }`;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -77,9 +77,10 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		isEnabled( 'signup/design-picker-generated-designs' ) && intent === 'build' && !! siteVertical;
 
 	const isPremiumThemeAvailable = Boolean(
-		useMemo( () => sitePlanSlug && planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ), [
-			sitePlanSlug,
-		] )
+		useMemo(
+			() => sitePlanSlug && planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ),
+			[ sitePlanSlug ]
+		)
 	);
 
 	const tier =

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -49,6 +49,10 @@ export const isSiteAtomic = ( state: State, siteId: number | string ) => {
 	return select( STORE_KEY ).getSite( siteId )?.options.is_wpcom_atomic === true;
 };
 
+export const isSiteWPForTeams = ( state: State, siteId: number | string ) => {
+	return select( STORE_KEY ).getSite( siteId )?.options.is_wpforteams_site === true;
+};
+
 export const getSiteDomains = ( state: State, siteId: number ) => {
 	return state.sitesDomains[ siteId ];
 };
@@ -117,3 +121,22 @@ export const requiresUpgrade = ( state: State, siteId: number | null ) => {
 
 	return Boolean( ! isWoopFeatureActive && hasWoopFeatureAvailable );
 };
+
+export function isJetpackSite( state: State, siteId?: number ): boolean {
+	return Boolean( siteId && select( STORE_KEY ).getSite( siteId )?.jetpack );
+}
+
+export function isEligibleForProPlan( state: State, siteId?: number ): boolean {
+	if ( ! siteId ) {
+		return false;
+	}
+
+	if (
+		( isJetpackSite( state, siteId ) && ! isSiteAtomic( state, siteId ) ) ||
+		isSiteWPForTeams( state, siteId )
+	) {
+		return false;
+	}
+
+	return true;
+}

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -93,6 +93,7 @@ export interface SiteDetails {
 	description: string;
 	URL: string;
 	launch_status: string;
+	jetpack: boolean;
 	options: {
 		admin_url?: string;
 		advanced_seo_front_page_description?: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This changes the redirect of upgrading a plan when picking a premium theme from `premium` to `pro` plan.

#### Testing instructions

1. Go to http://calypso.localhost:3000/setup/intent?siteSlug=YOUR_FREE_SITE.wordpress.com.
2. Go to Build and pick a premium theme. 
3. Click Upgrade. You should be taken to checkout with a Pro plan.

