### PR TITLE
P2 signup flow: add step indicator, logout link

### DIFF
--- a/client/assets/stylesheets/_p2-extends.scss
+++ b/client/assets/stylesheets/_p2-extends.scss
@@ -123,6 +123,18 @@
 	}
 }
 
+%p2-button-link {
+	background: none;
+	color: var( --p2-color-link );
+	text-decoration: underline;
+	font-family: var( --p2-font-inter );
+
+	&:hover:not( :disabled ):not( .disabled ) {
+		background: none;
+		color: var( --p2-color-link-dark );
+	}
+}
+
 %p2-link {
 	color: var( --p2-color-link );
 	text-decoration: none;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -399,6 +399,11 @@
 			padding: 12px 0;
 			width: auto;
 		}
+
+		&.login__form-change-username:hover:not( :disabled ):not( .disabled ) {
+			background: none;
+			color: var( --p2-color-link-dark );
+		}
 	}
 
 	.wp-login__links {

--- a/client/signup/p2-step-wrapper/index.jsx
+++ b/client/signup/p2-step-wrapper/index.jsx
@@ -1,9 +1,11 @@
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG, Button } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import { redirectToLogout } from 'calypso/state/current-user/actions';
 import './style.scss';
 function P2StepWrapper( {
 	flowName,
@@ -12,11 +14,13 @@ function P2StepWrapper( {
 	headerText,
 	subHeaderText,
 	stepIndicator,
+	showHeaderLogout,
 	positionInFlow,
 	children,
 	className,
 } ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	return (
 		<div className={ classnames( 'p2-step-wrapper', className ) }>
@@ -51,6 +55,17 @@ function P2StepWrapper( {
 				{ stepIndicator && (
 					<div className="p2-step-wrapper__header-step-indicator">{ stepIndicator }</div>
 				) }
+				{ ! stepIndicator && showHeaderLogout && (
+					<div className="p2-step-wrapper__header-logout">
+						<Button
+							onClick={ () => {
+								dispatch( redirectToLogout() );
+							} }
+						>
+							{ translate( 'Log out' ) }
+						</Button>
+					</div>
+				) }
 			</div>
 			<StepWrapper
 				hideFormattedHeader
@@ -79,6 +94,7 @@ P2StepWrapper.propTypes = {
 	headerText: PropTypes.node,
 	subHeaderText: PropTypes.node,
 	stepIndicator: PropTypes.string,
+	showHeaderLogout: PropTypes.bool,
 	flowName: PropTypes.string,
 	stepName: PropTypes.string,
 	positionInFlow: PropTypes.number,

--- a/client/signup/p2-step-wrapper/index.jsx
+++ b/client/signup/p2-step-wrapper/index.jsx
@@ -11,6 +11,7 @@ function P2StepWrapper( {
 	headerIcon,
 	headerText,
 	subHeaderText,
+	stepIndicator,
 	positionInFlow,
 	children,
 	className,
@@ -47,6 +48,9 @@ function P2StepWrapper( {
 				) }
 				{ headerText && <h1 className="p2-step-wrapper__header-text">{ headerText }</h1> }
 				{ subHeaderText && <p className="p2-step-wrapper__subheader-text">{ subHeaderText }</p> }
+				{ stepIndicator && (
+					<div className="p2-step-wrapper__header-step-indicator">{ stepIndicator }</div>
+				) }
 			</div>
 			<StepWrapper
 				hideFormattedHeader
@@ -74,6 +78,7 @@ function P2StepWrapper( {
 P2StepWrapper.propTypes = {
 	headerText: PropTypes.node,
 	subHeaderText: PropTypes.node,
+	stepIndicator: PropTypes.string,
 	flowName: PropTypes.string,
 	stepName: PropTypes.string,
 	positionInFlow: PropTypes.number,

--- a/client/signup/p2-step-wrapper/style.scss
+++ b/client/signup/p2-step-wrapper/style.scss
@@ -46,13 +46,21 @@
 	}
 }
 
-.p2-step-wrapper__header-step-indicator {
+.p2-step-wrapper__header-step-indicator,
+.p2-step-wrapper__header-logout {
 	position: absolute;
 	right: 24px;
 	top: 24px;
-	color: var( --p2-color-text-light );
 	font-size: 0.875rem;
+}
+
+.p2-step-wrapper__header-step-indicator {
+	color: var( --p2-color-text-light );
 	font-weight: 500;
+}
+
+.p2-step-wrapper__header-logout button {
+	@extend %p2-button-link;
 }
 
 .p2-step-wrapper button.is-primary {

--- a/client/signup/p2-step-wrapper/style.scss
+++ b/client/signup/p2-step-wrapper/style.scss
@@ -46,6 +46,15 @@
 	}
 }
 
+.p2-step-wrapper__header-step-indicator {
+	position: absolute;
+	right: 24px;
+	top: 24px;
+	color: var( --p2-color-text-light );
+	font-size: 0.875rem;
+	font-weight: 500;
+}
+
 .p2-step-wrapper button.is-primary {
 	@extend %p2-form-button;
 }

--- a/client/signup/steps/p2-complete-profile/index.jsx
+++ b/client/signup/steps/p2-complete-profile/index.jsx
@@ -1,6 +1,6 @@
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -108,7 +108,12 @@ function P2CompleteProfile( {
 			subHeaderText={ __(
 				'Using a recognizable photo and name will help your team to identify you more easily.'
 			) }
-			stepIndicator={ __( 'Step 3 of 3' ) }
+			stepIndicator={ sprintf(
+				/* translators: for example, Step 1 of 3 */
+				__( 'Step %(currentStep)s of %(totalSteps)s' ),
+				3,
+				3
+			) }
 		>
 			<div className="p2-complete-profile">
 				<div className="p2-complete-profile__avatar-wrapper">

--- a/client/signup/steps/p2-complete-profile/index.jsx
+++ b/client/signup/steps/p2-complete-profile/index.jsx
@@ -108,6 +108,7 @@ function P2CompleteProfile( {
 			subHeaderText={ __(
 				'Using a recognizable photo and name will help your team to identify you more easily.'
 			) }
+			stepIndicator={ __( 'Step 3 of 3' ) }
 		>
 			<div className="p2-complete-profile">
 				<div className="p2-complete-profile__avatar-wrapper">

--- a/client/signup/steps/p2-complete-profile/index.jsx
+++ b/client/signup/steps/p2-complete-profile/index.jsx
@@ -109,8 +109,8 @@ function P2CompleteProfile( {
 				'Using a recognizable photo and name will help your team to identify you more easily.'
 			) }
 			stepIndicator={ sprintf(
-				/* translators: for example, Step 1 of 3 */
-				__( 'Step %(currentStep)s of %(totalSteps)s' ),
+				/* translators: %1$d and %2$d are numbers. For example, Step 1 of 3 */
+				__( 'Step %1$d of %2$d' ),
 				3,
 				3
 			) }

--- a/client/signup/steps/p2-complete-profile/style.scss
+++ b/client/signup/steps/p2-complete-profile/style.scss
@@ -31,8 +31,8 @@
 
 	&:hover {
 		background: none;
-		color: var( --p2-color-link-hover );
-		border-color: var( --p2-color-link-hover );
+		color: var( --p2-color-link-dark );
+		border-color: var( --p2-color-link-dark );
 		cursor: pointer;
 	}
 }
@@ -61,7 +61,7 @@
 
 	&:hover {
 		background: none;
-		color: var( --p2-color-link-hover );
+		color: var( --p2-color-link-dark );
 	}
 }
 

--- a/client/signup/steps/p2-confirm-email/index.jsx
+++ b/client/signup/steps/p2-confirm-email/index.jsx
@@ -138,6 +138,7 @@ function P2ConfirmEmail( {
 				headerText={
 					isEmailVerified ? translate( 'Email confirmed' ) : translate( 'Check your email' )
 				}
+				stepIndicator={ translate( 'Step 2 of 3' ) }
 			>
 				<div className="p2-confirm-email">
 					{ isEmailVerified ? renderPostConfirmationNotice() : renderCheckEmailNotice() }

--- a/client/signup/steps/p2-confirm-email/index.jsx
+++ b/client/signup/steps/p2-confirm-email/index.jsx
@@ -138,7 +138,12 @@ function P2ConfirmEmail( {
 				headerText={
 					isEmailVerified ? translate( 'Email confirmed' ) : translate( 'Check your email' )
 				}
-				stepIndicator={ translate( 'Step 2 of 3' ) }
+				stepIndicator={ translate( 'Step %(currentStep)s of %(totalSteps)s', {
+					args: {
+						currentStep: 2,
+						totalSteps: 3,
+					},
+				} ) }
 			>
 				<div className="p2-confirm-email">
 					{ isEmailVerified ? renderPostConfirmationNotice() : renderCheckEmailNotice() }

--- a/client/signup/steps/p2-join-workspace/index.jsx
+++ b/client/signup/steps/p2-join-workspace/index.jsx
@@ -224,6 +224,7 @@ function P2JoinWorkspace( { flowName, goToNextStep, positionInFlow, stepName, su
 				positionInFlow={ positionInFlow }
 				headerText={ getHeaderText() }
 				subHeaderText={ getSubHeaderText() }
+				showHeaderLogout={ true }
 			>
 				<div className="p2-join-workspace">
 					{ isLoading ? (

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -479,7 +479,12 @@ export class UserStep extends Component {
 						components: { strong: <strong /> },
 					}
 				) }
-				stepIndicator={ this.props.translate( 'Step 1 of 3' ) }
+				stepIndicator={ this.props.translate( 'Step %(currentStep)s of %(totalSteps)s', {
+					args: {
+						currentStep: 1,
+						totalSteps: 3,
+					},
+				} ) }
 			>
 				{ this.renderSignupForm() }
 			</P2StepWrapper>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -479,6 +479,7 @@ export class UserStep extends Component {
 						components: { strong: <strong /> },
 					}
 				) }
+				stepIndicator={ this.props.translate( 'Step 1 of 3' ) }
 			>
 				{ this.renderSignupForm() }
 			</P2StepWrapper>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add step indicators to the following steps: 
    * `user` (Step 1 of 3), 
    * `p2-confirm-email` (Step 2 of 3)
    * `p2-complete-profile` (Step 3 of 3)
* Add a logout button to the `p2-join-workspace` step.
* Fix some CSS issues
    * hover state of "Change username" button in the P2 login screen
    * fix non-existent hover color variables for `p2-complete-profile` 

#### Testing instructions
`ENABLE_FEATURES=no-force-sympathy yarn start` if testing on local.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow as a new user (if on incognito, please turn of "Block third-party cookies" while testing on calypso.localhost:3000)
* Verify that the step indicators are shown
* Verify that the logout button is shown and works as expected

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Screens
<img width="800" alt="Screen Shot 2022-04-26 at 11 42 32 PM" src="https://user-images.githubusercontent.com/730823/165339737-08a14108-e5e6-42a7-b48a-49bf1e17a4ec.png">


Related to 4740-gh-Automattic/p2
