### PR TITLE
Release: Enable Stepper in development.json horizon.json stage.json wpcalypso.json wpcalypso.json (all except production)

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -63,18 +63,23 @@ function getSignupDestination( { domainItem, siteId, siteSlug }, localeSlug ) {
 	if ( 'no-site' === siteSlug ) {
 		return '/home';
 	}
-	let queryParam = { siteSlug, loading_ellipsis: 1 };
+	let queryParam = { siteSlug };
 	if ( domainItem ) {
 		// If the user is purchasing a domain then the site's primary url might change from
 		// `siteSlug` to something else during the checkout process, which means the
-		// `/start/setup-site?siteSlug=${ siteSlug }` url would become invalid. So in this
+		// `/setup/intent?siteSlug=${ siteSlug }` url would become invalid. So in this
 		// case we use the ID because we know it won't change depending on whether the user
 		// successfully completes the checkout process or not.
 		queryParam = { siteId };
 	}
 
+	if ( isEnabled( 'signup/stepper-flow' ) ) {
+		return addQueryArgs( queryParam, '/setup/intent' );
+	}
+
 	// Initially ship to English users only, then ship to all users when translations complete
 	if ( englishLocales.includes( localeSlug ) || isEnabled( 'signup/hero-flow-non-en' ) ) {
+		queryParam.loading_ellipsis = 1;
 		return addQueryArgs( queryParam, '/start/setup-site' );
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -138,6 +138,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
 		"signup/hero-flow-non-en": true,
+		"signup/stepper-flow": true,
 		"signup/site-vertical-step": true,
 		"signup/starting-point-courses": true,
 		"site-indicator": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -88,6 +88,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": false,
 		"signup/hero-flow-non-en": true,
+		"signup/stepper-flow": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,
 		"site-indicator": true,

--- a/config/production.json
+++ b/config/production.json
@@ -101,7 +101,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": false,
 		"signup/hero-flow-non-en": true,
-		"signup/stepper-flow": true,
+		"signup/stepper-flow": false,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,
 		"site-indicator": true,

--- a/config/production.json
+++ b/config/production.json
@@ -101,6 +101,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": false,
 		"signup/hero-flow-non-en": true,
+		"signup/stepper-flow": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,
 		"site-indicator": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -101,6 +101,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": false,
 		"signup/hero-flow-non-en": true,
+		"signup/stepper-flow": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,
 		"site-indicator": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -109,6 +109,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": false,
 		"signup/hero-flow-non-en": true,
+		"signup/stepper-flow": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,
 		"site-indicator": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR enables stepper as the main post-signup flow

#### Testing instructions

1. Go to /start
2. Create a free site
3. You should be redirected to /setup, not `start/site-setup`.


Context: pdDR7T-1B-p2