### PR TITLE
Woo on Stepper: Added selector for atomic software error

### DIFF
--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -75,12 +75,16 @@ export const getSiteLatestAtomicTransfer = ( state: State, siteId: number ) => {
 	return state.latestAtomicTransferStatus[ siteId ]?.transfer;
 };
 
+export const getSiteLatestAtomicTransferError = ( state: State, siteId: number ) => {
+	return state.latestAtomicTransferStatus[ siteId ]?.errorCode;
+};
+
 export const getAtomicSoftwareStatus = ( state: State, siteId: number, softwareSet: string ) => {
 	return state.atomicSoftwareStatus[ siteId ]?.[ softwareSet ]?.status;
 };
 
-export const getSiteLatestAtomicTransferError = ( state: State, siteId: number ) => {
-	return state.latestAtomicTransferStatus[ siteId ]?.errorCode;
+export const getAtomicSoftwareError = ( state: State, siteId: number, softwareSet: string ) => {
+	return state.atomicSoftwareStatus[ siteId ]?.[ softwareSet ]?.error;
 };
 
 export const hasActiveSiteFeature = (

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -8,8 +8,8 @@
 
 import { dispatch, select, subscribe } from '@wordpress/data';
 import wpcomRequest from 'wpcom-proxy-request';
-import { AtomicSoftwareStatus, register } from '..';
-import { getAtomicSoftwareStatus } from '../selectors';
+import { AtomicSoftwareStatus, AtomicSoftwareStatusError, register } from '..';
+import { getAtomicSoftwareStatus, getAtomicSoftwareError } from '../selectors';
 import type { State } from '../reducer';
 
 jest.mock( 'wpcom-proxy-request', () => ( {
@@ -185,5 +185,30 @@ describe( 'getAtomicSoftwareStatus', () => {
 
 		// Should return undefined when the site ID is not found
 		expect( getAtomicSoftwareStatus( state, 123456, softwareSet ) ).toEqual( undefined );
+	} );
+
+	it( 'Fails to retrive the Atomic Software Status', async () => {
+		const siteId = 1234;
+		const softwareSet = 'non-existing-software-set';
+		const error: AtomicSoftwareStatusError = {
+			name: 'NotFoundError',
+			status: 404,
+			message: 'Transfer not found',
+			code: 'no_transfer_record',
+		};
+
+		const state: State = {
+			atomicSoftwareStatus: {
+				[ siteId ]: {
+					[ softwareSet ]: {
+						status: undefined,
+						error: error,
+					},
+				},
+			},
+		};
+
+		// Successfuly returns the status
+		expect( getAtomicSoftwareError( state, siteId, softwareSet ) ).toEqual( error );
 	} );
 } );


### PR DESCRIPTION
Adds a selector for errors querying atomic software.

### Testing
1. Apply this PR.
2. Run `yarn test-packages packages/data-stores/src/site/test/selectors.ts -t getAtomicSoftwareStatus`