### PR TITLE
Woo on Stepper: Add install software action

### DIFF
--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -10,7 +10,13 @@ import {
 	AtomicTransferStatus,
 	LatestAtomicTransferStatus,
 } from './types';
-import { AtomicTransferState, LatestAtomicTransferState, AtomicSoftwareStatusState } from '.';
+import {
+	AtomicTransferState,
+	LatestAtomicTransferState,
+	AtomicSoftwareStatusState,
+	AtomicSoftwareInstallState,
+	AtomicSoftwareInstallStatus,
+} from '.';
 import type { Action } from './actions';
 import type { Reducer } from 'redux';
 
@@ -311,6 +317,46 @@ export const atomicSoftwareStatus: Reducer<
 	return state;
 };
 
+export const atomicSoftwareInstallStatus: Reducer<
+	{ [ key: number ]: AtomicSoftwareInstallState },
+	Action
+> = ( state = {}, action ) => {
+	if ( action.type === 'ATOMIC_SOFTWARE_INSTALL_START' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				[ action.softwareSet ]: {
+					status: AtomicSoftwareInstallStatus.IN_PROGRESS,
+					error: undefined,
+				},
+			},
+		};
+	}
+	if ( action.type === 'ATOMIC_SOFTWARE_INSTALL_SUCCESS' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				[ action.softwareSet ]: {
+					status: AtomicSoftwareInstallStatus.SUCCESS,
+					error: undefined,
+				},
+			},
+		};
+	}
+	if ( action.type === 'ATOMIC_SOFTWARE_INSTALL_FAILURE' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				[ action.softwareSet ]: {
+					status: AtomicSoftwareInstallStatus.FAILURE,
+					error: undefined,
+				},
+			},
+		};
+	}
+	return state;
+};
+
 const newSite = combineReducers( {
 	data: newSiteData,
 	error: newSiteError,
@@ -328,6 +374,7 @@ const reducer = combineReducers( {
 	atomicTransferStatus,
 	latestAtomicTransferStatus,
 	atomicSoftwareStatus,
+	atomicSoftwareInstallStatus,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -343,5 +343,37 @@ describe( 'Site Actions', () => {
 				status,
 			} );
 		} );
+		it( 'should start an Atomic software install', () => {
+			const { initiateSoftwareInstall } = createActions( mockedClientCredentials );
+			const softwareSet = 'woo-on-plans';
+			const generator = initiateSoftwareInstall( siteId, softwareSet );
+
+			const mockedApiResponse = {
+				request: {
+					apiNamespace: 'wpcom/v2',
+					method: 'POST',
+					path: `/sites/${ siteId }/atomic/software/${ softwareSet }`,
+					body: {},
+				},
+				type: 'WPCOM_REQUEST',
+			};
+
+			// First iteration: ATOMIC_SOFTWARE_INSTALL_START is fired
+			expect( generator.next().value ).toEqual( {
+				type: 'ATOMIC_SOFTWARE_INSTALL_START',
+				siteId,
+				softwareSet,
+			} );
+
+			// Second iteration: WP_COM_REQUEST is fired
+			expect( generator.next().value ).toEqual( mockedApiResponse );
+
+			// Third iteration: ATOMIC_SOFTWARE_INSTALL_SUCCESS is fired
+			expect( generator.next().value ).toEqual( {
+				type: 'ATOMIC_SOFTWARE_INSTALL_SUCCESS',
+				siteId,
+				softwareSet,
+			} );
+		} );
 	} );
 } );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -366,3 +366,20 @@ export type AtomicSoftwareStatusState = Record<
 		error: AtomicSoftwareStatusError | undefined;
 	}
 >;
+
+export enum AtomicSoftwareInstallStatus {
+	UNINITIALIZED = 'unintialized',
+	IN_PROGRESS = 'in_progress',
+	SUCCESS = 'success',
+	FAILURE = 'failure',
+}
+export type AtomicSoftwareInstallState = Record<
+	string,
+	{
+		status: AtomicSoftwareInstallStatus | undefined;
+		error: AtomicSoftwareInstallError | undefined;
+	}
+>;
+export enum AtomicSoftwareInstallError {
+	INTERNAL = 'internal',
+}


### PR DESCRIPTION
This PR adds the install software action. This is using the generator method (instead of thunks) since it's in the `SITE_STORE`.

### Test
1. Apply this PR.
2. Run the unit tests using: ` yarn run test-packages packages/data-stores/src/site/test/actions.ts` and verify everything passes.

Related to https://github.com/Automattic/wp-calypso/issues/62717
