### PR TITLE
Playwright: Editor Tracking -- Add e2e test for global style save event

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-dimensions-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-dimensions-component.ts
@@ -1,0 +1,71 @@
+import { Locator, Page } from 'playwright';
+import { EditorPopoverMenuComponent } from './editor-popover-menu-component';
+
+const selectors = {
+	paddingInput: 'input[aria-label="Padding"]',
+	optionsButton:
+		'.components-tools-panel-header:has-text("Dimensions") button[aria-label="View options"]',
+};
+
+export interface DimensionsSettings {
+	padding?: number;
+	margin?: number;
+}
+
+type EditorContext = 'site-styles' | 'block';
+
+/**
+ * Represents a dimenstions settings component (used in blocks and site styles).
+ */
+export class EditorDimensionsComponent {
+	// Usually low-level components don't contain other components like this.
+	// In this case however, because the popover is always used whereever this component is,
+	// and tieing it together at a higher level is kind of messy, it makes sense to add it here.
+	private editorPopoverMenuComponent: EditorPopoverMenuComponent;
+
+	/**
+	 * Creates an instance of the component.
+	 *
+	 * @param {Page} page Object representing the base page.
+	 * @param {Locator} editor Frame-safe locator to the editor.
+	 * @param {EditorContext} context Whether we're in global styles or a block.
+	 */
+	constructor( private page: Page, private editor: Locator, private context: EditorContext ) {
+		this.editorPopoverMenuComponent = new EditorPopoverMenuComponent( page, editor );
+	}
+
+	/**
+	 * Set dimension settings.
+	 *
+	 * @param {DimensionsSettings} settings Settings to set. Only properties provided will be set.
+	 */
+	async setDimensions( settings: DimensionsSettings ): Promise< void > {
+		if ( settings.margin !== undefined ) {
+			throw new Error( 'Margin is not yet implemented.' );
+		}
+
+		if ( settings.padding !== undefined ) {
+			await this.setPadding( settings.padding );
+		}
+	}
+
+	/**
+	 * Reset all of the dimension settings.
+	 */
+	async resetAll(): Promise< void > {
+		const optionsButtonLocator = this.editor.locator( selectors.optionsButton );
+		await optionsButtonLocator.click();
+		await this.editorPopoverMenuComponent.clickMenuButton( 'Reset all' );
+	}
+
+	/**
+	 * Sets the padding.
+	 *
+	 * @param {number} padding Padding dimension to select.
+	 */
+	private async setPadding( padding: number ): Promise< void > {
+		const locator = this.editor.locator( selectors.paddingInput );
+		await locator.fill( padding.toString() );
+		await locator.press( 'Enter' ); // Confirm rounding.
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
@@ -1,4 +1,5 @@
 import { Page, Locator } from 'playwright';
+import { DimensionsSettings, EditorDimensionsComponent } from './editor-dimensions-component';
 import {
 	ColorSettings,
 	EditorColorPickerComponent,
@@ -27,6 +28,7 @@ export class EditorSiteStylesComponent {
 
 	private editorColorPickerComponent: EditorColorPickerComponent;
 	private editorTypographyComponent: EditorTypographyComponent;
+	private editorDimensionsComponent: EditorDimensionsComponent;
 
 	/**
 	 * Creates an instance of the component.
@@ -40,6 +42,7 @@ export class EditorSiteStylesComponent {
 
 		this.editorColorPickerComponent = new EditorColorPickerComponent( page, editor );
 		this.editorTypographyComponent = new EditorTypographyComponent( page, editor, 'site-styles' );
+		this.editorDimensionsComponent = new EditorDimensionsComponent( page, editor, 'site-styles' );
 	}
 
 	/**
@@ -101,6 +104,28 @@ export class EditorSiteStylesComponent {
 		await this.clickMenuButton( blockName );
 		await this.clickMenuButton( 'Typography' );
 		await this.editorTypographyComponent.setTypography( typographySettings );
+	}
+
+	/**
+	 * Set global layout settings for the site.
+	 * Note that only the "Padding" dimension is available globally.
+	 *
+	 * @param {DimensionsSettings} settings The dimensions settings to set.
+	 */
+	async setGlobalLayout( settings: DimensionsSettings ): Promise< void > {
+		await this.returnToTopMenu();
+		await this.clickMenuButton( 'Layout' );
+		await this.editorDimensionsComponent.setDimensions( settings );
+	}
+
+	/**
+	 * Reset the global layout dimensions.
+	 * (To empty layout defaults, not the theme defaults.)
+	 */
+	async resetGlobalLayout(): Promise< void > {
+		await this.returnToTopMenu();
+		await this.clickMenuButton( 'Layout' );
+		await this.editorDimensionsComponent.resetAll();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -32,5 +32,6 @@ export * from './editor-block-toolbar-component';
 export * from './template-part-list-component';
 export * from './template-part-modal-component';
 export * from './full-side-editor-nav-sidebar-component';
+export * from './editor-dimensions-component';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -17,11 +17,12 @@ import {
 	FullSiteEditorNavSidebarComponent,
 	TemplatePartModalComponent,
 	OpenInlineInserter,
+	EditorInlineBlockInserterComponent,
+	DimensionsSettings,
 } from '..';
 import { getCalypsoURL } from '../../data-helper';
 import { getIdFromBlock } from '../../element-helper';
 import envVariables from '../../env-variables';
-import { EditorInlineBlockInserterComponent } from '../components';
 
 const wpAdminPath = 'wp-admin/themes.php';
 
@@ -381,7 +382,10 @@ export class FullSiteEditorPage {
 				// We want to close the welcome guide if it opens, but not slow down the test if it doesn't.
 				// This will effectively register a handler that waits for the welcome guide to close it if it appears
 				// but otherwise doesn't affect the following actions.
-				const safelyWatchForWelcomeGuide = () => this.closeStylesWelcomeGuide().catch();
+				const safelyWatchForWelcomeGuide = () =>
+					this.closeStylesWelcomeGuide().catch( () => {
+						// No-op
+					} );
 				safelyWatchForWelcomeGuide();
 			}
 			await this.editorPopoverMenuComponent.clickMenuButton( 'Styles' );
@@ -445,6 +449,24 @@ export class FullSiteEditorPage {
 		typographySettings: TypographySettings
 	): Promise< void > {
 		await this.editorSiteStylesComponent.setBlockTypography( blockName, typographySettings );
+	}
+
+	/**
+	 * Set global layout settings for the site.
+	 * Note that only the "Padding" dimension is available globally.
+	 * This auto-handles returning to top menu and navigating down.
+	 *
+	 * @param {DimensionsSettings} dimensionsSettings The dimensions settings to set.
+	 */
+	async setGlobalLayoutStyle( dimensionsSettings: DimensionsSettings ): Promise< void > {
+		await this.editorSiteStylesComponent.setGlobalLayout( dimensionsSettings );
+	}
+
+	/**
+	 * Resets the global layout style to the layout defaults (empty).
+	 */
+	async resetGlobalLayoutStyle(): Promise< void > {
+		await this.editorSiteStylesComponent.resetGlobalLayout();
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

From this test plan map: pciE2j-QC-p2...

... This adds the style-saving piece of the `editor-tracking__global-styles-events.ts` script. Because saving requires some special handling, it has been broken out into its own describe block.

#### Testing instructions

- [x] Gutenberg desktop passes
- [x] Gutenberg mobile passes

Related to #