### PR TITLE
Use correct release prefix for sourcemap upload

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -383,7 +383,7 @@ const webpackConfig = {
 				org: 'a8c',
 				project: 'calypso',
 				authToken: process.env.SENTRY_AUTH_TOKEN,
-				release: process.env.COMMIT_SHA,
+				release: `calypso_${ process.env.COMMIT_SHA }`,
 				include: filePaths.path,
 				urlPrefix: `~${ filePaths.publicPath }`,
 			} ),


### PR DESCRIPTION
### Changes proposed in this Pull Request
In #62965, I forgot to add the `calypso_` preset to the release when uploading sourcemaps. I did add that prefix to client reporting. This means that uploaded files won't get matched to issues in Sentry until the two match.

### Testing instructions

Verify the prefix matches the one found in the client implementation