### PR TITLE
Create an ignore revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Ignore prettier format done in #62969
+9fb7ac149e55361c0c3a9639ad0caa5e15fc88b0


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Based on https://github.com/WordPress/gutenberg/pull/40542#issuecomment-1109371237.

We can use this file to avoid polluting the git blame with changes from reformatting the codebase. 

#### Testing instructions
none

