### PR TITLE
Use source sites for v13n

### DIFF
--- a/packages/design-picker/src/generated-designs-config.json
+++ b/packages/design-picker/src/generated-designs-config.json
@@ -30,7 +30,7 @@
 		"title": "Blog",
 		"recipe": {
 			"stylesheet": "pub/zoologist",
-			"patternIds": [ 1243, 2118, 2121, 1812 ]
+			"patternIds": [ 1243, 2118, 2266, 2121, 1812 ]
 		},
 		"is_premium": false,
 		"categories": [],

--- a/packages/design-picker/src/generated-designs-config.json
+++ b/packages/design-picker/src/generated-designs-config.json
@@ -3,13 +3,12 @@
 		"slug": "business",
 		"title": "Business",
 		"recipe": {
-			"stylesheet": "pub/winkel",
-			"patternIds": [ 1603, 162, 157 ]
+			"stylesheet": "pub/zoologist",
+			"patternIds": [ 1707, 1163, 1190, 1163, 1538, 655 ]
 		},
 		"is_premium": false,
 		"categories": [],
 		"features": [],
-
 		"theme": "",
 		"template": ""
 	},
@@ -17,13 +16,12 @@
 		"slug": "portfolio",
 		"title": "Portfolio",
 		"recipe": {
-			"stylesheet": "pub/quadrat-white",
-			"patternIds": [ 1349 ]
+			"stylesheet": "pub/zoologist",
+			"patternIds": [ 2077, 2080, 2082, 1768, 2088 ]
 		},
 		"is_premium": false,
 		"categories": [],
 		"features": [],
-
 		"theme": "",
 		"template": ""
 	},
@@ -31,12 +29,12 @@
 		"slug": "blog",
 		"title": "Blog",
 		"recipe": {
-			"stylesheet": "pub/zoologist"
+			"stylesheet": "pub/zoologist",
+			"patternIds": [ 1243, 2118, 2121, 1812 ]
 		},
 		"is_premium": false,
 		"categories": [],
 		"features": [],
-
 		"theme": "",
 		"template": ""
 	}

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -13,7 +13,7 @@ describe( 'Design Picker designs utils', () => {
 
 		it( 'should return the block-previews/site endpoint with the correct query params', () => {
 			expect( getDesignPreviewUrl( design, {} ) ).toEqual(
-				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=700&site_title=Zoologist'
+				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=700&source_site=patternboilerplates.wordpress.com&site_title=Zoologist'
 			);
 		} );
 

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -24,7 +24,7 @@ describe( 'Design Picker designs utils', () => {
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&language=id&viewport_height=700&site_title=Design%20Title'
+				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&language=id&viewport_height=700&source_site=patternboilerplates.wordpress.com&site_title=Design%20Title'
 			);
 		} );
 
@@ -36,7 +36,7 @@ describe( 'Design Picker designs utils', () => {
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=700&site_title=Mock%28Design%29%28Title%29'
+				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=700&source_site=patternboilerplates.wordpress.com&site_title=Mock%28Design%29%28Title%29'
 			);
 		} );
 	} );

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -11,12 +11,12 @@ export const getDesignPreviewUrl = (
 	if ( [ 'hannah', 'riley', 'gilbert' ].indexOf( slug ) >= 0 ) {
 		return `https://${ slug }starter.wordpress.com`;
 	}
-
 	let url = addQueryArgs( 'https://public-api.wordpress.com/wpcom/v2/block-previews/site', {
 		stylesheet: recipe?.stylesheet,
 		pattern_ids: recipe?.patternIds?.join( ',' ),
 		language: options.language,
 		viewport_height: 700,
+		source_site: 'patternboilerplates.wordpress.com',
 	} );
 
 	const siteTitle = options.siteTitle || design.title;

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -16,11 +16,8 @@ export const getDesignPreviewUrl = (
 		pattern_ids: recipe?.patternIds?.join( ',' ),
 		language: options.language,
 		viewport_height: 700,
+		source_site: 'patternboilerplates.wordpress.com',
 	} );
-
-	if ( recipe?.patternIds?.length ) {
-		url += '&source_site=patternboilerplates.wordpress.com';
-	}
 
 	const siteTitle = options.siteTitle || design.title;
 	if ( siteTitle ) {

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -16,8 +16,11 @@ export const getDesignPreviewUrl = (
 		pattern_ids: recipe?.patternIds?.join( ',' ),
 		language: options.language,
 		viewport_height: 700,
-		source_site: 'patternboilerplates.wordpress.com',
 	} );
+
+	if ( recipe?.patternIds?.length ) {
+		url += '&source_site=patternboilerplates.wordpress.com';
+	}
 
 	const siteTitle = options.siteTitle || design.title;
 	if ( siteTitle ) {


### PR DESCRIPTION
Use dM0oz-p2 as the source site for patterns shown in the design picker.
I recreated the patterns shown pbxlJb-1Ax-p2 portfolio001, business001, & blog001 to use as templates.

### Testing instructions 

Go to `/setup/vertical?siteSlug=$siteSlug` and select a vertical. Then select _build_
Observe the three previews.
Click to view the previews, they should roughly match the designs from pbxlJb-1Ax-p2 

<img width="1716" alt="Screen Shot 2022-04-27 at 12 15 12 pm" src="https://user-images.githubusercontent.com/22446385/165425409-6dd0ba7f-4576-4cad-b1a4-1f4fa3492c19.png">
<img width="1661" alt="Screen Shot 2022-04-27 at 12 15 04 pm" src="https://user-images.githubusercontent.com/22446385/165425421-83956712-49fb-41d8-924d-4410c559b866.png">

Expand other deisgn options, they should work as before


