### PR TITLE
Unify mailbox forms:  Add missing validator methods and improve test coverage

### DIFF
--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -64,7 +64,7 @@ class MailboxForm< T extends EmailProvider > {
 	hasValidValues() {
 		return Object.values( this.formFields as MailboxFormFields )
 			.filter( ( field ) => field.required ?? false )
-			.some(
+			.every(
 				( field ) =>
 					field.typeName === Boolean.name.toLowerCase() || `${ field.value }`.trim() !== ''
 			);

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -57,7 +57,26 @@ class MailboxForm< T extends EmailProvider > {
 		}
 	}
 
+	hasErrors() {
+		return Object.values( this.formFields ).some( ( field ) => field.error !== null );
+	}
+
+	hasValidValues() {
+		return Object.values( this.formFields as MailboxFormFields )
+			.filter( ( field ) => field.required ?? false )
+			.some(
+				( field ) =>
+					field.typeName === Boolean.name.toLowerCase() || `${ field.value }`.trim() !== ''
+			);
+	}
+
+	isValid() {
+		return ! this.hasErrors() && this.hasValidValues();
+	}
+
 	validate() {
+		this.clearErrors();
+
 		for ( const [ fieldName, validator ] of this.validators ) {
 			if ( ! fieldName ) {
 				continue;

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -56,7 +56,7 @@ class MailboxForm< T extends EmailProvider > {
 		const domainName = domainField?.value ?? '';
 		const mailboxHasDomainError = Boolean( domainField?.error );
 		const minimumPasswordLength = this.provider === EmailProvider.Titan ? 10 : 12;
-		const supportsApostrophes = this.provider === EmailProvider.Google;
+		const areApostrophesSupported = this.provider === EmailProvider.Google;
 
 		return [
 			[ FIELD_ALTERNATIVE_EMAIL, new RequiredValidator< string >() ],
@@ -72,7 +72,7 @@ class MailboxForm< T extends EmailProvider > {
 			[ FIELD_MAILBOX, new ExistingMailboxNamesValidator( this.existingMailboxNames ) ],
 			[
 				FIELD_MAILBOX,
-				new MailboxNameValidator( domainName, mailboxHasDomainError, supportsApostrophes ),
+				new MailboxNameValidator( domainName, mailboxHasDomainError, areApostrophesSupported ),
 			],
 			[ FIELD_PASSWORD, new RequiredValidator< string >() ],
 			[ FIELD_PASSWORD, new PasswordValidator( minimumPasswordLength ) ],

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -37,7 +37,7 @@ class MailboxForm< T extends EmailProvider > {
 		this.provider = provider;
 	}
 
-	#getFormField< T >( fieldName: FormFieldNames ): MailboxFormFieldBase< T > | null {
+	private getFormField< T >( fieldName: FormFieldNames ): MailboxFormFieldBase< T > | null {
 		if ( fieldName in this.formFields ) {
 			const field = Reflect.get( this.formFields, fieldName );
 			if ( field ) {
@@ -48,7 +48,7 @@ class MailboxForm< T extends EmailProvider > {
 		return null;
 	}
 
-	#getValidators(): [ ValidatorFieldNames, Validator< unknown > ][] {
+	private getValidators(): [ ValidatorFieldNames, Validator< unknown > ][] {
 		const minimumPasswordLength = this.provider === EmailProvider.Titan ? 10 : 12;
 
 		return [
@@ -93,14 +93,14 @@ class MailboxForm< T extends EmailProvider > {
 	}
 
 	setFieldIsVisible( fieldName: FormFieldNames, isVisible: boolean ) {
-		const field = this.#getFormField( fieldName );
+		const field = this.getFormField( fieldName );
 		if ( field ) {
 			field.isVisible = isVisible;
 		}
 	}
 
 	setFieldIsRequired( fieldName: FormFieldNames, isRequired: boolean ) {
-		const field = this.#getFormField( fieldName );
+		const field = this.getFormField( fieldName );
 		if ( field ) {
 			field.isRequired = isRequired;
 		}
@@ -109,12 +109,12 @@ class MailboxForm< T extends EmailProvider > {
 	validate() {
 		this.clearErrors();
 
-		for ( const [ fieldName, validator ] of this.#getValidators() ) {
+		for ( const [ fieldName, validator ] of this.getValidators() ) {
 			if ( ! fieldName ) {
 				continue;
 			}
 
-			const field = this.#getFormField( fieldName );
+			const field = this.getFormField( fieldName );
 			if ( ! field || field.error ) {
 				continue;
 			}

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -54,7 +54,7 @@ class MailboxForm< T extends EmailProvider > {
 	private getValidators(): [ ValidatorFieldNames, Validator< unknown > ][] {
 		const domainField = this.getFormField< string >( FIELD_DOMAIN );
 		const domainName = domainField?.value ?? '';
-		const mailboxHasDomainError = Boolean( domainField?.value );
+		const mailboxHasDomainError = Boolean( domainField?.error );
 		const minimumPasswordLength = this.provider === EmailProvider.Titan ? 10 : 12;
 		const supportsApostrophes = this.provider === EmailProvider.Google;
 

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -50,10 +50,11 @@ class MailboxForm< T extends EmailProvider > {
 	}
 
 	private getValidators(): [ ValidatorFieldNames, Validator< unknown > ][] {
-		const minimumPasswordLength = this.provider === EmailProvider.Titan ? 10 : 12;
 		const domainField = this.getFormField< string >( FIELD_DOMAIN );
 		const domainName = domainField?.value ?? '';
 		const mailboxHasDomainError = Boolean( domainField?.value );
+		const minimumPasswordLength = this.provider === EmailProvider.Titan ? 10 : 12;
+		const supportsApostrophes = this.provider === EmailProvider.Google;
 
 		return [
 			[ FIELD_ALTERNATIVE_EMAIL, new AlternateEmailValidator( domainName ) ],
@@ -64,7 +65,10 @@ class MailboxForm< T extends EmailProvider > {
 			[ FIELD_LASTNAME, new StringLengthValidator( 60 ) ],
 			[ FIELD_MAILBOX, new RequiredValidator< string >() ],
 			[ FIELD_MAILBOX, new ExistingMailboxesValidator( this.existingMailboxes ) ],
-			[ FIELD_MAILBOX, new MailboxNameValidator( domainName, mailboxHasDomainError ) ],
+			[
+				FIELD_MAILBOX,
+				new MailboxNameValidator( domainName, mailboxHasDomainError, supportsApostrophes ),
+			],
 			[ FIELD_PASSWORD, new RequiredValidator< string >() ],
 			[ FIELD_PASSWORD, new PasswordValidator( minimumPasswordLength ) ],
 			[ FIELD_UUID, new RequiredValidator< string >() ],

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -18,6 +18,7 @@ import {
 	MailboxNameValidator,
 	PasswordValidator,
 	RequiredValidator,
+	StringLengthValidator,
 } from 'calypso/my-sites/email/form/mailboxes/validators';
 import type {
 	FormFieldNames,
@@ -50,15 +51,20 @@ class MailboxForm< T extends EmailProvider > {
 
 	private getValidators(): [ ValidatorFieldNames, Validator< unknown > ][] {
 		const minimumPasswordLength = this.provider === EmailProvider.Titan ? 10 : 12;
+		const domainField = this.getFormField< string >( FIELD_DOMAIN );
+		const domainName = domainField?.value ?? '';
+		const mailboxHasDomainError = Boolean( domainField?.value );
 
 		return [
-			[ FIELD_ALTERNATIVE_EMAIL, new AlternateEmailValidator< T >( this ) ],
+			[ FIELD_ALTERNATIVE_EMAIL, new AlternateEmailValidator( domainName ) ],
 			[ FIELD_DOMAIN, new RequiredValidator< string >() ],
 			[ FIELD_FIRSTNAME, new RequiredValidator< string >() ],
+			[ FIELD_FIRSTNAME, new StringLengthValidator( 60 ) ],
 			[ FIELD_LASTNAME, new RequiredValidator< string >() ],
+			[ FIELD_LASTNAME, new StringLengthValidator( 60 ) ],
 			[ FIELD_MAILBOX, new RequiredValidator< string >() ],
 			[ FIELD_MAILBOX, new ExistingMailboxesValidator( this.existingMailboxes ) ],
-			[ FIELD_MAILBOX, new MailboxNameValidator< T >( this ) ],
+			[ FIELD_MAILBOX, new MailboxNameValidator( domainName, mailboxHasDomainError ) ],
 			[ FIELD_PASSWORD, new RequiredValidator< string >() ],
 			[ FIELD_PASSWORD, new PasswordValidator( minimumPasswordLength ) ],
 			[ FIELD_UUID, new RequiredValidator< string >() ],

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -4,6 +4,7 @@ import {
 	FIELD_FIRSTNAME,
 	FIELD_LASTNAME,
 	FIELD_MAILBOX,
+	FIELD_NAME,
 	FIELD_PASSWORD,
 	FIELD_UUID,
 } from 'calypso/my-sites/email/form/mailboxes/constants';
@@ -18,7 +19,8 @@ import {
 	MailboxNameValidator,
 	PasswordValidator,
 	RequiredValidator,
-	StringLengthValidator,
+	RequiredIfVisibleValidator,
+	MaximumStringLengthValidator,
 } from 'calypso/my-sites/email/form/mailboxes/validators';
 import type {
 	FormFieldNames,
@@ -57,13 +59,16 @@ class MailboxForm< T extends EmailProvider > {
 		const supportsApostrophes = this.provider === EmailProvider.Google;
 
 		return [
+			[ FIELD_ALTERNATIVE_EMAIL, new RequiredValidator< string >() ],
 			[ FIELD_ALTERNATIVE_EMAIL, new AlternateEmailValidator( domainName ) ],
 			[ FIELD_DOMAIN, new RequiredValidator< string >() ],
 			[ FIELD_FIRSTNAME, new RequiredValidator< string >() ],
-			[ FIELD_FIRSTNAME, new StringLengthValidator( 60 ) ],
+			[ FIELD_FIRSTNAME, new MaximumStringLengthValidator( 60 ) ],
 			[ FIELD_LASTNAME, new RequiredValidator< string >() ],
-			[ FIELD_LASTNAME, new StringLengthValidator( 60 ) ],
+			[ FIELD_LASTNAME, new MaximumStringLengthValidator( 60 ) ],
 			[ FIELD_MAILBOX, new RequiredValidator< string >() ],
+			[ FIELD_NAME, new RequiredIfVisibleValidator() ],
+			[ FIELD_NAME, new MaximumStringLengthValidator( 60 ) ],
 			[ FIELD_MAILBOX, new ExistingMailboxNamesValidator( this.existingMailboxNames ) ],
 			[
 				FIELD_MAILBOX,

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -91,16 +91,13 @@ class MailboxForm< T extends EmailProvider > {
 	}
 
 	hasErrors() {
-		return Object.values( this.formFields ).some( ( field ) => field.error !== null );
+		return Object.values( this.formFields ).some( ( field ) => field.hasError() );
 	}
 
 	hasValidValues() {
 		return Object.values( this.formFields as MailboxFormFields )
-			.filter( ( field ) => field.required ?? false )
-			.every(
-				( field ) =>
-					field.typeName === Boolean.name.toLowerCase() || `${ field.value }`.trim() !== ''
-			);
+			.filter( ( field ) => field.isRequired ?? false )
+			.every( ( field ) => field.hasValidValue() );
 	}
 
 	isValid() {

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -14,7 +14,7 @@ import {
 } from 'calypso/my-sites/email/form/mailboxes/types';
 import {
 	AlternateEmailValidator,
-	ExistingMailboxesValidator,
+	ExistingMailboxNamesValidator,
 	MailboxNameValidator,
 	PasswordValidator,
 	RequiredValidator,
@@ -28,12 +28,12 @@ import type {
 import type { Validator } from 'calypso/my-sites/email/form/mailboxes/validators';
 
 class MailboxForm< T extends EmailProvider > {
-	existingMailboxes: string[];
+	existingMailboxNames: string[];
 	formFields: MailboxFormFields;
 	provider: T;
 
-	constructor( provider: T, domain: string, existingMailboxes: string[] = [] ) {
-		this.existingMailboxes = existingMailboxes;
+	constructor( provider: T, domain: string, existingMailboxNames: string[] = [] ) {
+		this.existingMailboxNames = existingMailboxNames;
 		this.formFields = MailboxFormFieldsFactory.create( provider, domain );
 		this.provider = provider;
 	}
@@ -64,7 +64,7 @@ class MailboxForm< T extends EmailProvider > {
 			[ FIELD_LASTNAME, new RequiredValidator< string >() ],
 			[ FIELD_LASTNAME, new StringLengthValidator( 60 ) ],
 			[ FIELD_MAILBOX, new RequiredValidator< string >() ],
-			[ FIELD_MAILBOX, new ExistingMailboxesValidator( this.existingMailboxes ) ],
+			[ FIELD_MAILBOX, new ExistingMailboxNamesValidator( this.existingMailboxNames ) ],
 			[
 				FIELD_MAILBOX,
 				new MailboxNameValidator( domainName, mailboxHasDomainError, supportsApostrophes ),

--- a/client/my-sites/email/form/mailboxes/test/validators.ts
+++ b/client/my-sites/email/form/mailboxes/test/validators.ts
@@ -3,60 +3,224 @@
  */
 
 import { MailboxForm } from 'calypso/my-sites/email/form/mailboxes';
-import { EmailProvider, TitanMailboxFormFields } from 'calypso/my-sites/email/form/mailboxes/types';
+import {
+	FIELD_ALTERNATIVE_EMAIL,
+	FIELD_FIRSTNAME,
+	FIELD_LASTNAME,
+	FIELD_MAILBOX,
+	FIELD_NAME,
+	FIELD_PASSWORD,
+} from 'calypso/my-sites/email/form/mailboxes/constants';
+import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
+import {
+	AlternateEmailValidator,
+	ExistingMailboxNamesValidator,
+	MailboxNameValidator,
+} from 'calypso/my-sites/email/form/mailboxes/validators';
+import type {
+	FieldError,
+	FormFieldNames,
+	GoogleFormFieldNames,
+	MailboxFormFieldBase,
+	TitanFormFieldNames,
+	TitanMailboxFormFields,
+} from 'calypso/my-sites/email/form/mailboxes/types';
+
+type VisibleOrRequired = Partial<
+	Pick< MailboxFormFieldBase< unknown >, 'isVisible' | 'isRequired' >
+>;
+type FieldValue = string | boolean | VisibleOrRequired | null;
+type NonNullFieldError = Exclude< FieldError, null >;
+type GoogleTestDataType = Partial< Record< GoogleFormFieldNames, FieldValue > >;
+type TitanTestDataType = Partial< Record< TitanFormFieldNames, FieldValue > >;
+
+const provideEmailProviderTestData = (
+	provider: EmailProvider,
+	title: string,
+	existingMailboxNames: string[],
+	fieldValueMap: Partial< Record< FormFieldNames, FieldValue > >,
+	expectedFieldErrorMap: Partial< Record< FormFieldNames, NonNullFieldError > >
+) => {
+	return {
+		provider,
+		title: `${ provider }: ${ title }`,
+		existingMailboxNames,
+		fieldValueMap,
+		expectedFieldErrorMap,
+	};
+};
+
+const provideGoogleTestData = (
+	title: string,
+	fieldValueMap: GoogleTestDataType,
+	expectedFieldErrorMap: Partial< Record< GoogleFormFieldNames, NonNullFieldError > > = {},
+	existingMailboxNames: string[] = []
+) =>
+	provideEmailProviderTestData(
+		EmailProvider.Google,
+		title,
+		existingMailboxNames,
+		fieldValueMap,
+		expectedFieldErrorMap
+	);
+
+const provideTitanTestData = (
+	title: string,
+	fieldValueMap: TitanTestDataType,
+	expectedFieldErrorMap: Partial< Record< TitanFormFieldNames, NonNullFieldError > > = {},
+	existingMailboxNames: string[] = []
+) =>
+	provideEmailProviderTestData(
+		EmailProvider.Titan,
+		title,
+		existingMailboxNames,
+		fieldValueMap,
+		expectedFieldErrorMap
+	);
+
+const createTestDataForGoogle = ( overrides: GoogleTestDataType = {} ): GoogleTestDataType => {
+	return {
+		...{
+			[ FIELD_FIRSTNAME ]: 'First',
+			[ FIELD_LASTNAME ]: 'Last',
+			[ FIELD_MAILBOX ]: 'info',
+			[ FIELD_PASSWORD ]: 'some@password',
+		},
+		...overrides,
+	};
+};
+
+const createTestDataForTitan = ( overrides: TitanTestDataType = {} ): TitanTestDataType => {
+	return {
+		...{
+			[ FIELD_ALTERNATIVE_EMAIL ]: 'email.000@gmail.com',
+			[ FIELD_NAME ]: 'Name',
+			[ FIELD_MAILBOX ]: 'info',
+			[ FIELD_PASSWORD ]: '--password',
+		},
+		...overrides,
+	};
+};
+
+const finalTestDataForAllCases = [
+	provideGoogleTestData( 'Valid fields', createTestDataForGoogle() ),
+	provideTitanTestData( 'Valid fields', createTestDataForTitan() ),
+	provideGoogleTestData(
+		'Existing mailboxes should fail validation',
+		createTestDataForGoogle(),
+		{
+			[ FIELD_MAILBOX ]: ExistingMailboxNamesValidator.getExistingMailboxError(),
+		},
+		[ 'info' ]
+	),
+	provideTitanTestData(
+		'Existing mailboxes should fail validation',
+		createTestDataForTitan(),
+		{
+			[ FIELD_MAILBOX ]: ExistingMailboxNamesValidator.getExistingMailboxError(),
+		},
+		[ 'info' ]
+	),
+	provideGoogleTestData(
+		'Mailbox names with invalid characters should fail validation',
+		createTestDataForGoogle( {
+			[ FIELD_MAILBOX ]: 'user @',
+		} ),
+		{
+			[ FIELD_MAILBOX ]: MailboxNameValidator.getUnsupportedCharacterError( true ),
+		}
+	),
+	provideTitanTestData(
+		'Mailbox names with invalid characters should fail validation',
+		createTestDataForTitan( {
+			[ FIELD_MAILBOX ]: 'user¨" +',
+		} ),
+		{
+			[ FIELD_MAILBOX ]: MailboxNameValidator.getUnsupportedCharacterError( false ),
+		}
+	),
+	provideTitanTestData(
+		'Alternative email on the same domain should fail validation',
+		createTestDataForTitan( { [ FIELD_ALTERNATIVE_EMAIL ]: 'email@example.com' } ),
+		{
+			[ FIELD_ALTERNATIVE_EMAIL ]: AlternateEmailValidator.getSameDomainError( 'example.com' ),
+		}
+	),
+	provideGoogleTestData(
+		'Passwords must follow the approved pattern or fail validation',
+		createTestDataForGoogle( {
+			[ FIELD_PASSWORD ]: 'some-passwo', // a character short
+		} ),
+		{
+			[ FIELD_PASSWORD ]: MailboxNameValidator.getUnsupportedCharacterError( true ),
+		}
+	),
+	provideTitanTestData(
+		'Passwords must follow the approved pattern or fail validation',
+		createTestDataForTitan( {
+			[ FIELD_PASSWORD ]: 'my-passw', // 2 characters short
+		} ),
+		{
+			[ FIELD_PASSWORD ]: MailboxNameValidator.getUnsupportedCharacterError( false ),
+		}
+	),
+];
+
+describe( 'Mailbox form validation', () => {
+	it.each( finalTestDataForAllCases )(
+		'$title',
+		( { existingMailboxNames, provider, fieldValueMap, expectedFieldErrorMap } ) => {
+			const mailboxForm = new MailboxForm( provider, 'example.com', existingMailboxNames );
+
+			Object.keys( fieldValueMap ).forEach( ( key ) => {
+				if ( Reflect.has( mailboxForm.formFields, key ) ) {
+					let fieldValue = fieldValueMap[ key ];
+
+					if ( typeof fieldValue === 'object' ) {
+						if ( typeof fieldValue.isVisible === 'boolean' ) {
+							mailboxForm.setFieldIsVisible( key as FormFieldNames, fieldValue.isVisible );
+						}
+
+						if ( typeof fieldValue.isRequired === 'boolean' ) {
+							mailboxForm.setFieldIsRequired( key as FormFieldNames, fieldValue.isRequired );
+						}
+
+						if ( ! fieldValue.value ) {
+							return;
+						}
+
+						fieldValue = fieldValue.value;
+					}
+
+					const field = Reflect.get( mailboxForm.formFields, key );
+					Reflect.set( field, 'value', fieldValue );
+				}
+			} );
+
+			mailboxForm.validate();
+
+			Object.keys( expectedFieldErrorMap ).forEach( ( key ) => {
+				if ( ! Reflect.has( mailboxForm.formFields, key ) ) {
+					return;
+				}
+
+				const field = Reflect.get( mailboxForm.formFields, key );
+				expect( field.error ).toEqual( expectedFieldErrorMap[ key ] );
+			} );
+
+			const fieldErrorMap = Object.fromEntries(
+				Object.entries( mailboxForm.formFields )
+					.filter( ( [ , field ] ) => Boolean( field.error ) )
+					.map( ( [ key, field ] ) => [ key, field.error ] )
+			);
+
+			expect( fieldErrorMap ).toStrictEqual( expectedFieldErrorMap );
+			expect( mailboxForm.hasErrors() ).toBe( Object.keys( expectedFieldErrorMap ).length > 0 );
+		}
+	);
+} );
 
 describe( 'mailboxFormValidation', () => {
-	it( 'should validate mailbox form correctly', () => {
-		const mb = new MailboxForm( EmailProvider.Titan, 'example.com', [] );
-		const formFields: TitanMailboxFormFields = mb.formFields;
-
-		formFields.mailbox.value = 'user';
-		formFields.alternativeEmail.value = 'user@test.com';
-		formFields.password.value = 'v4l1dPassWord!';
-		formFields.name.value = 'Letero';
-
-		mb.validate();
-
-		expect( formFields.mailbox.error ).toBeNull();
-		expect( formFields.alternativeEmail.error ).toBeNull();
-		expect( formFields.password.error ).toBeNull();
-		expect( formFields.uuid.error ).toBeNull();
-		expect( formFields.domain.error ).toBeNull();
-	} );
-
-	it( 'should fail validating alternative email', () => {
-		const mb = new MailboxForm( EmailProvider.Titan, 'example.com', [] );
-		const formFields: TitanMailboxFormFields = mb.formFields;
-
-		formFields.alternativeEmail.value = 'sample@example.com';
-
-		mb.validate();
-
-		expect( formFields.alternativeEmail.error ).toBeTruthy();
-	} );
-
-	it( 'should fail validating existing mailboxes', () => {
-		const mb = new MailboxForm( EmailProvider.Titan, 'example.com', [ 'user' ] );
-		const formFields: TitanMailboxFormFields = mb.formFields;
-
-		formFields.mailbox.value = 'user';
-
-		mb.validate();
-
-		expect( formFields.mailbox.error ).toBeTruthy();
-	} );
-
-	it( 'should fail validating alternative existing mailboxes with invalid characters', () => {
-		const mb = new MailboxForm( EmailProvider.Titan, 'example.com', [] );
-		const formFields: TitanMailboxFormFields = mb.formFields;
-
-		formFields.mailbox.value = 'user ¨ +';
-
-		mb.validate();
-
-		expect( formFields.mailbox.error ).toBeTruthy();
-	} );
-
 	it( 'should fail validating password', () => {
 		const mb = new MailboxForm( EmailProvider.Titan, 'example.com', [] );
 		const formFields: TitanMailboxFormFields = mb.formFields;

--- a/client/my-sites/email/form/mailboxes/test/validators.ts
+++ b/client/my-sites/email/form/mailboxes/test/validators.ts
@@ -108,17 +108,17 @@ const finalTestDataForAllCases = [
 	provideGoogleTestData( 'Valid fields', createTestDataForGoogle() ),
 	provideTitanTestData( 'Valid fields', createTestDataForTitan() ),
 	provideGoogleTestData(
-		'Empty value for required fields should fail validation',
+		'Empty value for the password field should fail validation',
 		createTestDataForGoogle( { [ FIELD_PASSWORD ]: null } ),
 		{ [ FIELD_PASSWORD ]: RequiredValidator.getRequiredFieldError() }
 	),
 	provideTitanTestData(
-		'Empty value for required fields should fail validation',
+		'Empty value for the mailbox field should fail validation',
 		createTestDataForTitan( { [ FIELD_MAILBOX ]: null } ),
 		{ [ FIELD_MAILBOX ]: RequiredValidator.getRequiredFieldError() }
 	),
 	provideTitanTestData(
-		'Empty value for required fields should fail validation',
+		'Empty value for the name field should fail validation',
 		createTestDataForTitan( { [ FIELD_NAME ]: null } ),
 		{ [ FIELD_NAME ]: RequiredValidator.getRequiredFieldError() }
 	),

--- a/client/my-sites/email/form/mailboxes/types.ts
+++ b/client/my-sites/email/form/mailboxes/types.ts
@@ -11,11 +11,19 @@ enum EmailProvider {
 interface MailboxFormField< Type > {
 	error: FieldError;
 	value: Type;
+	readonly typeName: string;
+	readonly required: boolean;
 }
 
 abstract class MailboxFormFieldBase< T > implements MailboxFormField< T > {
 	error: FieldError = null;
 	value!: T;
+	readonly typeName = String.name.toLowerCase();
+	readonly required;
+
+	constructor( required = true ) {
+		this.required = required;
+	}
 }
 
 class DataMailboxFormField extends MailboxFormFieldBase< string > {
@@ -28,6 +36,7 @@ class TextMailboxFormField extends MailboxFormFieldBase< string > {
 
 class BooleanMailboxFormField extends MailboxFormFieldBase< boolean > {
 	value = false;
+	readonly typeName = Boolean.name.toLowerCase();
 }
 
 interface IBaseMailboxFormFields {
@@ -66,7 +75,7 @@ class GoogleMailboxFormFields extends MailboxFormFields implements IGoogleMailbo
 
 class TitanMailboxFormFields extends MailboxFormFields implements ITitanMailboxFormFields {
 	alternativeEmail? = new TextMailboxFormField();
-	isAdmin? = new BooleanMailboxFormField();
+	isAdmin? = new BooleanMailboxFormField( false );
 	name? = new TextMailboxFormField();
 }
 

--- a/client/my-sites/email/form/mailboxes/types.ts
+++ b/client/my-sites/email/form/mailboxes/types.ts
@@ -12,17 +12,17 @@ interface MailboxFormField< Type > {
 	error: FieldError;
 	value: Type;
 	readonly typeName: string;
-	readonly required: boolean;
+	readonly isRequired: boolean;
 }
 
 abstract class MailboxFormFieldBase< T > implements MailboxFormField< T > {
 	error: FieldError = null;
 	value!: T;
 	readonly typeName = String.name.toLowerCase();
-	readonly required;
+	readonly isRequired;
 
-	constructor( required = true ) {
-		this.required = required;
+	constructor( isRequired = true ) {
+		this.isRequired = isRequired;
 	}
 }
 

--- a/client/my-sites/email/form/mailboxes/types.ts
+++ b/client/my-sites/email/form/mailboxes/types.ts
@@ -17,7 +17,19 @@ interface MailboxFormField< Type > {
 }
 
 abstract class MailboxFormFieldBase< T > implements MailboxFormField< T > {
-	error: FieldError = null;
+	private _error: FieldError = null;
+
+	public get error() {
+		return this._error;
+	}
+
+	public set error( _error: FieldError ) {
+		if ( ! _error || ( typeof _error === 'string' && _error.trim() === '' ) ) {
+			_error = null;
+		}
+		this._error = _error;
+	}
+
 	value!: T;
 	isRequired;
 	isVisible = true;
@@ -25,6 +37,10 @@ abstract class MailboxFormFieldBase< T > implements MailboxFormField< T > {
 
 	constructor( isRequired = true ) {
 		this.isRequired = isRequired;
+	}
+
+	hasError(): boolean {
+		return Boolean( this._error );
 	}
 }
 

--- a/client/my-sites/email/form/mailboxes/types.ts
+++ b/client/my-sites/email/form/mailboxes/types.ts
@@ -42,6 +42,10 @@ abstract class MailboxFormFieldBase< T > implements MailboxFormField< T > {
 	hasError(): boolean {
 		return Boolean( this._error );
 	}
+
+	hasValidValue(): boolean {
+		return Boolean( this.value );
+	}
 }
 
 class DataMailboxFormField extends MailboxFormFieldBase< string > {
@@ -50,6 +54,10 @@ class DataMailboxFormField extends MailboxFormFieldBase< string > {
 
 class TextMailboxFormField extends MailboxFormFieldBase< string > {
 	value = '';
+
+	hasValidValue(): boolean {
+		return super.hasValidValue() && this.value.trim() !== '';
+	}
 }
 
 class BooleanMailboxFormField extends MailboxFormFieldBase< boolean > {

--- a/client/my-sites/email/form/mailboxes/types.ts
+++ b/client/my-sites/email/form/mailboxes/types.ts
@@ -86,7 +86,9 @@ const MailboxFormFieldsMap = {
 	[ EmailProvider.Titan ]: TitanMailboxFormFields,
 };
 
-type FormFieldNames = keyof GoogleMailboxFormFields | keyof TitanMailboxFormFields;
+type GoogleFormFieldNames = keyof GoogleMailboxFormFields;
+type TitanFormFieldNames = keyof TitanMailboxFormFields;
+type FormFieldNames = GoogleFormFieldNames | TitanFormFieldNames;
 type ValidatorFieldNames = FormFieldNames | null;
 
 type ProviderKeys = keyof typeof MailboxFormFieldsMap;
@@ -100,10 +102,13 @@ class MailboxFormFieldsFactory {
 }
 
 export type {
+	FieldError,
 	FormFieldNames,
+	GoogleFormFieldNames,
 	GoogleMailboxFormFields,
 	MailboxFormFieldBase,
 	MailboxFormFields,
+	TitanFormFieldNames,
 	TitanMailboxFormFields,
 	ValidatorFieldNames,
 };

--- a/client/my-sites/email/form/mailboxes/types.ts
+++ b/client/my-sites/email/form/mailboxes/types.ts
@@ -10,16 +10,18 @@ enum EmailProvider {
 
 interface MailboxFormField< Type > {
 	error: FieldError;
-	value: Type;
+	isRequired: boolean;
+	isVisible: boolean;
 	readonly typeName: string;
-	readonly isRequired: boolean;
+	value: Type;
 }
 
 abstract class MailboxFormFieldBase< T > implements MailboxFormField< T > {
 	error: FieldError = null;
 	value!: T;
+	isRequired;
+	isVisible = true;
 	readonly typeName = String.name.toLowerCase();
-	readonly isRequired;
 
 	constructor( isRequired = true ) {
 		this.isRequired = isRequired;
@@ -84,7 +86,8 @@ const MailboxFormFieldsMap = {
 	[ EmailProvider.Titan ]: TitanMailboxFormFields,
 };
 
-type ValidatorFieldNames = keyof GoogleMailboxFormFields | keyof TitanMailboxFormFields | null;
+type FormFieldNames = keyof GoogleMailboxFormFields | keyof TitanMailboxFormFields;
+type ValidatorFieldNames = FormFieldNames | null;
 
 type ProviderKeys = keyof typeof MailboxFormFieldsMap;
 type ProviderTypes = typeof MailboxFormFieldsMap[ ProviderKeys ];
@@ -97,6 +100,7 @@ class MailboxFormFieldsFactory {
 }
 
 export type {
+	FormFieldNames,
 	GoogleMailboxFormFields,
 	MailboxFormFieldBase,
 	MailboxFormFields,

--- a/client/my-sites/email/form/mailboxes/types.ts
+++ b/client/my-sites/email/form/mailboxes/types.ts
@@ -18,17 +18,17 @@ interface MailboxFormField< Type > {
 }
 
 abstract class MailboxFormFieldBase< T > implements MailboxFormField< T > {
-	private _error: FieldError = null;
+	private fieldError: FieldError = null;
 
 	public get error() {
-		return this._error;
+		return this.fieldError;
 	}
 
-	public set error( _error: FieldError ) {
-		if ( ! _error || ( typeof _error === 'string' && _error.trim() === '' ) ) {
-			_error = null;
+	public set error( error: FieldError ) {
+		if ( ! error || ( typeof error === 'string' && error.trim() === '' ) ) {
+			error = null;
 		}
-		this._error = _error;
+		this.fieldError = error;
 	}
 
 	value!: T;
@@ -41,7 +41,7 @@ abstract class MailboxFormFieldBase< T > implements MailboxFormField< T > {
 	}
 
 	hasError(): boolean {
-		return Boolean( this._error );
+		return Boolean( this.fieldError );
 	}
 
 	hasValidValue(): boolean {

--- a/client/my-sites/email/form/mailboxes/types.ts
+++ b/client/my-sites/email/form/mailboxes/types.ts
@@ -1,4 +1,5 @@
 import { v4 as uuid_v4 } from 'uuid';
+import { FIELD_DOMAIN, FIELD_UUID } from 'calypso/my-sites/email/form/mailboxes/constants';
 import type { TranslateResult } from 'i18n-calypso';
 
 type FieldError = TranslateResult | null;
@@ -66,7 +67,7 @@ class BooleanMailboxFormField extends MailboxFormFieldBase< boolean > {
 }
 
 interface IBaseMailboxFormFields {
-	readonly domain: TextMailboxFormField;
+	readonly domain: DataMailboxFormField;
 	mailbox: TextMailboxFormField;
 	password: TextMailboxFormField;
 	readonly uuid: DataMailboxFormField;
@@ -113,6 +114,7 @@ const MailboxFormFieldsMap = {
 type GoogleFormFieldNames = keyof GoogleMailboxFormFields;
 type TitanFormFieldNames = keyof TitanMailboxFormFields;
 type FormFieldNames = GoogleFormFieldNames | TitanFormFieldNames;
+type MutableFormFieldNames = Exclude< FormFieldNames, typeof FIELD_DOMAIN | typeof FIELD_UUID >;
 type ValidatorFieldNames = FormFieldNames | null;
 
 type ProviderKeys = keyof typeof MailboxFormFieldsMap;
@@ -132,6 +134,7 @@ export type {
 	GoogleMailboxFormFields,
 	MailboxFormFieldBase,
 	MailboxFormFields,
+	MutableFormFieldNames,
 	TitanFormFieldNames,
 	TitanMailboxFormFields,
 	ValidatorFieldNames,

--- a/client/my-sites/email/form/mailboxes/validators.ts
+++ b/client/my-sites/email/form/mailboxes/validators.ts
@@ -48,10 +48,12 @@ class StringLengthValidator implements Validator< string > {
 class MailboxNameValidator implements Validator< string > {
 	domainName: string;
 	mailboxHasDomainError: boolean;
+	supportsApostrophes: boolean;
 
-	constructor( domainName: string, mailboxHasDomainError: boolean ) {
+	constructor( domainName: string, mailboxHasDomainError: boolean, supportsApostrophes: boolean ) {
 		this.domainName = domainName;
 		this.mailboxHasDomainError = mailboxHasDomainError;
+		this.supportsApostrophes = supportsApostrophes;
 	}
 
 	validate( field?: MailboxFormFieldBase< string > ): void {
@@ -59,10 +61,16 @@ class MailboxNameValidator implements Validator< string > {
 			return;
 		}
 
-		if ( ! /^[\da-z_-](\.?[\da-z_-])*$/i.test( field.value ) ) {
-			field.error = i18n.translate(
-				'Only numbers, letters, dashes, underscores, and periods are allowed.'
-			);
+		const regex = this.supportsApostrophes
+			? /^[\da-z_'-](\.?[\da-z_'-])*$/i
+			: /^[\da-z_-](\.?[\da-z_-])*$/i;
+
+		if ( ! regex.test( field.value ) ) {
+			field.error = this.supportsApostrophes
+				? i18n.translate(
+						'Only numbers, letters, dashes, underscores, apostrophes and periods are allowed.'
+				  )
+				: i18n.translate( 'Only numbers, letters, dashes, underscores, and periods are allowed.' );
 			return;
 		}
 

--- a/client/my-sites/email/form/mailboxes/validators.ts
+++ b/client/my-sites/email/form/mailboxes/validators.ts
@@ -75,15 +75,19 @@ class MaximumStringLengthValidator extends BaseValidator< string > {
 }
 
 class MailboxNameValidator extends BaseValidator< string > {
+	areApostrophesSupported: boolean;
 	domainName: string;
 	mailboxHasDomainError: boolean;
-	supportsApostrophes: boolean;
 
-	constructor( domainName: string, mailboxHasDomainError: boolean, supportsApostrophes: boolean ) {
+	constructor(
+		domainName: string,
+		mailboxHasDomainError: boolean,
+		areApostrophesSupported: boolean
+	) {
 		super();
 		this.domainName = domainName;
 		this.mailboxHasDomainError = mailboxHasDomainError;
-		this.supportsApostrophes = supportsApostrophes;
+		this.areApostrophesSupported = areApostrophesSupported;
 	}
 
 	static getInvalidEmailError(): FieldError {
@@ -99,12 +103,14 @@ class MailboxNameValidator extends BaseValidator< string > {
 	}
 
 	validateField( field: MailboxFormFieldBase< string > ): void {
-		const regex = this.supportsApostrophes
+		const regex = this.areApostrophesSupported
 			? /^[\da-z_'-](\.?[\da-z_'-])*$/i
 			: /^[\da-z_-](\.?[\da-z_-])*$/i;
 
 		if ( ! regex.test( field.value ) ) {
-			field.error = MailboxNameValidator.getUnsupportedCharacterError( this.supportsApostrophes );
+			field.error = MailboxNameValidator.getUnsupportedCharacterError(
+				this.areApostrophesSupported
+			);
 			return;
 		}
 

--- a/client/my-sites/email/form/mailboxes/validators.ts
+++ b/client/my-sites/email/form/mailboxes/validators.ts
@@ -260,7 +260,7 @@ class ExistingMailboxNamesValidator extends BaseValidator< string > {
 	}
 
 	static getExistingMailboxError(): FieldError {
-		return i18n.translate( 'Please use unique mailboxes' );
+		return i18n.translate( 'Please use unique mailboxes.' );
 	}
 
 	validateField( field: MailboxFormFieldBase< string > ): void {

--- a/client/my-sites/email/form/mailboxes/validators.ts
+++ b/client/my-sites/email/form/mailboxes/validators.ts
@@ -181,11 +181,11 @@ class PasswordValidator implements Validator< string > {
 	}
 }
 
-class ExistingMailboxesValidator implements Validator< string > {
-	existingMailboxes: string[];
+class ExistingMailboxNamesValidator implements Validator< string > {
+	existingMailboxNames: string[];
 
-	constructor( existingMailboxes: string[] ) {
-		this.existingMailboxes = existingMailboxes;
+	constructor( existingMailboxNames: string[] ) {
+		this.existingMailboxNames = existingMailboxNames;
 	}
 
 	validate( field?: MailboxFormFieldBase< string > ): void {
@@ -193,13 +193,13 @@ class ExistingMailboxesValidator implements Validator< string > {
 			return;
 		}
 
-		const existingMailboxes = this.existingMailboxes ?? [];
-		if ( ! existingMailboxes ) {
+		const existingMailboxNames = this.existingMailboxNames ?? [];
+		if ( ! existingMailboxNames ) {
 			return;
 		}
 
 		if (
-			existingMailboxes
+			existingMailboxNames
 				.map( ( item ) => item.toLowerCase() )
 				.includes( field.value?.toLowerCase() ?? '' )
 		) {
@@ -212,7 +212,7 @@ export type { Validator };
 
 export {
 	AlternateEmailValidator,
-	ExistingMailboxesValidator,
+	ExistingMailboxNamesValidator,
 	MailboxNameValidator,
 	PasswordValidator,
 	RequiredValidator,


### PR DESCRIPTION
This is a follow up to #63038
#### Changes proposed in this Pull Request

* Add methods to ascertain a mailbox form is valid
* Ensures validation works interchangeably across providers
* Cover more parts of the validation logic in tests
* Decouple validators from the form by passing dependencies

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Unit test: ` yarn test-client "client/my-sites/email/form/mailboxes/test/validators.ts" `

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63038
