### PR TITLE
Do not show the legacy plan notice to the Business plan sites and the eCommerce plan sites.

### DIFF
--- a/client/my-sites/plans/legacy-plan-notice.jsx
+++ b/client/my-sites/plans/legacy-plan-notice.jsx
@@ -1,20 +1,19 @@
-import { isFreePlanProduct, isPro } from '@automattic/calypso-products';
+import { isBlogger, isPersonal, isPremium } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import Notice from 'calypso/components/notice';
 
 /**
- * Renders a "You're on a legacy plan" for users on legacy plans (excluding legacy free plan users).
+ * Renders a "You're on a legacy plan" for sites on legacy plans (excluding free, business, and ecommerce plan).
  *
  * @param {boolean} eligibleForProPlan - Is the user eligible for pro plan?
  * @param {object} selectedSite - Site object from store.
+ * @param {object} selectedSite.plan - The plan object nested inside the selectedSite object.
  * @returns - Legacy plan Notice component.
  */
-const maybeRenderLegacyPlanNotice = ( eligibleForProPlan, selectedSite ) => {
-	if (
-		eligibleForProPlan &&
-		! isFreePlanProduct( selectedSite.plan ) &&
-		! isPro( selectedSite.plan )
-	) {
+const maybeRenderLegacyPlanNotice = ( eligibleForProPlan, { plan } ) => {
+	const eligibleLegacyPlan = isBlogger( plan ) || isPersonal( plan ) || isPremium( plan );
+
+	if ( eligibleForProPlan && eligibleLegacyPlan ) {
 		return (
 			<Notice
 				status="is-info"

--- a/client/my-sites/plans/test/legacy-plan-notice.js
+++ b/client/my-sites/plans/test/legacy-plan-notice.js
@@ -1,92 +1,45 @@
+import { shallow } from 'enzyme';
 import legacyPlanNotice from 'calypso/my-sites/plans/legacy-plan-notice';
 
 describe( 'Shows legacy plan notice for ex-plans', () => {
-	let fakeLegacySiteSlice;
-
-	beforeAll( () => {
-		// Sites from store.
-		fakeLegacySiteSlice = {
-			sites: {
-				items: {
-					// Free plan site.
-					1: {
-						ID: 1,
-						name: 'Free Inc.',
-						jetpack: false,
-						is_wpcom_atomic: false,
-						options: {},
-						plan: {
-							product_id: 1,
-							product_slug: 'FREE_PLAN',
-							product_name_short: 'free',
-							expired: false,
-							user_is_owner: false,
-							is_free: true,
-						},
-					},
-					// Legacy Business plan site.
-					2: {
-						ID: 2,
-						name: 'Business Inc.',
-						jetpack: false,
-						is_wpcom_atomic: true,
-						options: {},
-						plan: {
-							product_id: 1008,
-							product_slug: 'value_bundle',
-							product_name_short: 'Business',
-							expired: false,
-							user_is_owner: false,
-							is_free: false,
-						},
-					},
-					// Site with pro plan.
-					3: {
-						ID: 3,
-						name: 'Pro Inc.',
-						jetpack: false,
-						is_wpcom_atomic: true,
-						options: {},
-						plan: {
-							product_id: 1032,
-							product_slug: 'pro-plan',
-							product_name_short: 'Pro',
-							expired: false,
-							user_is_owner: true,
-							is_free: false,
-						},
-					},
-				},
-			},
-		};
+	test( 'Do not show legacy plan notice for sites on Free plan', () => {
+		expect(
+			legacyPlanNotice( true, { plan: { product_slug: 'free_plan', is_free: true } } )
+		).toBeUndefined();
 	} );
 
-	test( 'Do not show legacy plan notice for users on Free plan', () => {
-		const freePlanSite = fakeLegacySiteSlice.sites.items[ '1' ];
-		const siteIsEligibleForProPlan = true;
-		const legacyPlanNoticeComponent = legacyPlanNotice( siteIsEligibleForProPlan, freePlanSite );
-
-		expect( legacyPlanNoticeComponent ).toBeUndefined;
+	test( 'Do not show legacy plan notice to sites on Business plan', () => {
+		expect(
+			legacyPlanNotice( true, { plan: { product_slug: 'business-bundle' } } )
+		).toBeUndefined();
 	} );
 
-	test( 'Show legacy plan notice to users on Business plan', () => {
-		const legacyBusinessPlanSite = fakeLegacySiteSlice.sites.items[ '2' ];
-		const siteIsEligibleForProPlan = true;
-		const legacyPlanNoticeComponent = legacyPlanNotice(
-			siteIsEligibleForProPlan,
-			legacyBusinessPlanSite
+	test( 'Do not show legacy plan notice to sites on eCommerce plan', () => {
+		expect(
+			legacyPlanNotice( true, { plan: { product_slug: 'ecommerce-bundle' } } )
+		).toBeUndefined();
+	} );
+
+	test( 'Do not show legacy plan notice to sites on Pro plan', () => {
+		expect( legacyPlanNotice( true, { plan: { product_slug: 'pro-plan' } } ) ).toBeUndefined();
+	} );
+
+	test( 'Show legacy plan notice to sites on Blogger plan', () => {
+		const wrapper = shallow(
+			legacyPlanNotice( true, { plan: { product_slug: 'blogger-bundle' } } )
 		);
-
-		expect( legacyPlanNoticeComponent.props.text ).toContain( 'You’re currently on a legacy plan' );
+		expect( wrapper.is( 'Notice' ) ).toBe( true );
 	} );
 
-	test( 'Do not show legacy plan notice to users on Pro plan', () => {
-		const proPlanSite = fakeLegacySiteSlice.sites.items[ '3' ];
+	test( 'Show legacy plan notice to sites on Personal plan', () => {
+		const wrapper = shallow(
+			legacyPlanNotice( true, { plan: { product_slug: 'personal-bundle' } } )
+		);
+		expect( wrapper.is( 'Notice' ) ).toBe( true );
+	} );
 
-		// Even with this set to true, the notice should not show as the plan is checked for whether it's "pro-plan" or not.
-		const siteIsEligibleForProPlan = true;
-		const legacyPlanNoticeComponent = legacyPlanNotice( siteIsEligibleForProPlan, proPlanSite );
-
-		expect( legacyPlanNoticeComponent ).toBeUndefined;
+	test( 'Show legacy plan notice to sites on Premium plan', () => {
+		const wrapper = shallow( legacyPlanNotice( true, { plan: { product_slug: 'value_bundle' } } ) );
+		expect( wrapper.is( 'Notice' ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates `maybeRenderLegacyPlanNotice()` to not show the notice to the Business plan sites and the eCommerce plan sites. Using the term "users" here is not precise since the logic determines per site, not per user. The 

e.g. on a Premium site:

<img width="963" alt="截圖 2022-04-27 下午4 00 30" src="https://user-images.githubusercontent.com/1842898/165471983-21b6e263-f5b6-4069-ab2d-6b85a00c83e2.png">

on a Business site:
<img width="966" alt="image" src="https://user-images.githubusercontent.com/1842898/165472035-3cbd5b49-6b01-48a7-839d-deaf51aec0b7.png">

#### Testing instructions

* On a Pro/eCommerce/Business site, the nudge doesn't show up on /plans or /plans/my-plan
* On a Blogger/Personal/Premium site, the nudge does show up on /plans and /plans/my-plan 
