### PR TITLE
Plans overhaul: Fix discount coupons not working on plans page

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -7,6 +7,7 @@ import {
 	PLAN_WPCOM_FLEXIBLE,
 } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
+import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -119,10 +120,21 @@ class Plans extends Component {
 	}
 
 	onSelectPlan = ( item ) => {
-		const { selectedSite } = this.props;
+		const {
+			selectedSite,
+			context: {
+				query: { discount },
+			},
+		} = this.props;
 		const checkoutPath = `/checkout/${ selectedSite.slug }/${ item.product_slug }/`;
 
-		page( checkoutPath );
+		page(
+			discount
+				? addQueryArgs( checkoutPath, {
+						coupon: discount,
+				  } )
+				: checkoutPath
+		);
 	};
 
 	renderPlaceholder = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a bug with discount coupons not passed from plans page to checkout.

Reported in Slack: p1650455868930959-slack-C031TFM2NKC

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/plans/[FREE_SITE_URL]?discount=[COUPON_CODE]` with a valid coupon (tested `RBC_BBC2`)
2. From the plans grid click to upgrade to the Pro plan.
3. Should redirect to `/checkout/[FREE_SITE_URL]?coupon=[COUPON_CODE]`. A discount should be applied.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Co-authored with @dzver 