### PR TITLE
Media: Refactor `ShortcodeFrame` away from `UNSAFE_` methods

### DIFF
--- a/client/blocks/shortcode/frame.js
+++ b/client/blocks/shortcode/frame.js
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { isEqual, omit } from 'lodash';
+import { omit } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ResizableIframe from 'calypso/components/resizable-iframe';
@@ -20,36 +20,15 @@ export default class ShortcodeFrame extends Component {
 		allowSameOrigin: false,
 	};
 
-	state = {
-		html: '',
-	};
-
-	componentDidMount() {
-		this.updateHtmlState( this.props );
+	shouldComponentUpdate( nextProps ) {
+		return generateEmbedFrameMarkup( this.props ) !== generateEmbedFrameMarkup( nextProps );
 	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( ! isEqual( this.props, nextProps ) ) {
-			this.updateHtmlState( nextProps );
-		}
-	}
-
-	shouldComponentUpdate( nextProps, nextState ) {
-		return nextState.html !== this.state.html;
-	}
-
-	updateHtmlState = ( props ) => {
-		this.setState( {
-			html: generateEmbedFrameMarkup( props ),
-		} );
-	};
 
 	onFrameLoad = ( event ) => {
 		// Transmit message to assign frame markup
 		event.target.contentWindow.postMessage(
 			JSON.stringify( {
-				content: this.state.html,
+				content: generateEmbedFrameMarkup( this.props ),
 			} ),
 			'*'
 		);
@@ -60,7 +39,7 @@ export default class ShortcodeFrame extends Component {
 	render() {
 		const classes = classNames( 'shortcode-frame', this.props.className );
 
-		if ( ! this.state.html ) {
+		if ( ! generateEmbedFrameMarkup( this.props ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `ShortcodeFrame` component away from the `UNSAFE_` deprecated React component methods.

Instead of storing the generated markup in the component state, we just generate it inline where necessary.

Part of #58453.

#### Testing instructions
* Start writing a new post.
* Insert the classic block.
* Click the button to insert a media.
* Select multiple images (at least 3) to insert a gallery shortcode.
* Tinker with the gallery settings.
* Verify that when changing the settings, the iframe preview reacts accordingly. 