### PR TITLE
Prettier: Update bracket same line option name

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,5 @@ printWidth: 100
 singleQuote: true
 bracketSpacing: true
 parenSpacing: true
-jsxBracketSameLine: false
+bracketSameLine: false
 semi: true


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We recently upgraded our Prettier in #62969. Prettier 2.4 renamed the `jsxBracketSameLine` option to `bracketSameLine` and deprecated the former one (see [changelog](https://github.com/prettier/prettier/blob/b32bd61873fcbbc33cf3bd83bf748af7fc5c0e7c/website/blog/2021-09-09-2.4.0.md) for more info). 

This PR updates our prettier config to use the new option name. Without this update, we're getting this warning when committing something:

![](https://cldup.com/PX7lBZ19Uz.png)

#### Testing instructions

* Checkout this branch.
* Commit a change locally.
* Verify you don't get the warning in the screenshot above.
