### PR TITLE
`PostCommentForm`: refactor away from `UNSAFE_*`

### DIFF
--- a/client/blocks/comments/autoresizing-form-textarea.jsx
+++ b/client/blocks/comments/autoresizing-form-textarea.jsx
@@ -8,18 +8,7 @@ import withPasteToLink from 'calypso/lib/paste-to-link';
 import './autoresizing-form-textarea.scss';
 
 const AutoresizingFormTextarea = (
-	{
-		hasFocus,
-		value,
-		placeholder,
-		onKeyUp,
-		onKeyDown,
-		onFocus,
-		onBlur,
-		onChange,
-		siteId,
-		enableAutoFocus,
-	},
+	{ hasFocus, value, placeholder, onKeyUp, onKeyDown, onFocus, onBlur, onChange, enableAutoFocus },
 	forwardedRef
 ) => {
 	const classes = classnames( 'expanding-area', { focused: hasFocus } );
@@ -39,7 +28,6 @@ const AutoresizingFormTextarea = (
 					onFocus={ onFocus }
 					onBlur={ onBlur }
 					onChange={ onChange }
-					siteId={ siteId }
 					// eslint-disable-next-line jsx-a11y/no-autofocus
 					autoFocus={ enableAutoFocus }
 					forwardedRef={ forwardedRef }

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -37,11 +37,6 @@ class PostCommentForm extends Component {
 		} );
 	}
 
-	handleSubmit = ( event ) => {
-		event.preventDefault();
-		this.submit();
-	};
-
 	handleKeyDown = ( event ) => {
 		// Use Ctrl+Enter to submit comment
 		if ( event.keyCode === 13 && ( event.ctrlKey || event.metaKey ) ) {
@@ -68,29 +63,18 @@ class PostCommentForm extends Component {
 		this.setState( { haveFocus: true } );
 	};
 
-	handleTextChange = ( commentText ) => {
+	handleTextChange = ( event ) => {
+		const commentText = event.target.value;
+
 		this.setState( { commentText } );
 
 		// Update the comment text in the container's state
 		this.props.onUpdateCommentText( commentText );
 	};
 
-	handleTextChangeEvent = ( event ) => {
-		this.handleTextChange( event.target.value );
-	};
+	handleSubmit = ( event ) => {
+		event.preventDefault();
 
-	resetCommentText() {
-		this.setState( { commentText: '' } );
-
-		// Update the comment text in the container's state
-		this.props.onUpdateCommentText( '' );
-	}
-
-	hasCommentText() {
-		return this.state.commentText.trim().length > 0;
-	}
-
-	submit() {
 		const post = this.props.post;
 		const commentText = this.state.commentText.trim();
 
@@ -121,6 +105,17 @@ class PostCommentForm extends Component {
 		this.props.onCommentSubmit();
 
 		return true;
+	};
+
+	resetCommentText() {
+		this.setState( { commentText: '' } );
+
+		// Update the comment text in the container's state
+		this.props.onUpdateCommentText( '' );
+	}
+
+	hasCommentText() {
+		return this.state.commentText.trim().length > 0;
 	}
 
 	renderError() {
@@ -185,7 +180,7 @@ class PostCommentForm extends Component {
 				onKeyDown={ this.handleKeyDown }
 				onFocus={ this.handleFocus }
 				onBlur={ this.handleBlur }
-				onChange={ this.handleTextChangeEvent }
+				onChange={ this.handleTextChange }
 				siteId={ this.props.post.site_ID }
 				enableAutoFocus={ isReply }
 			/>

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -21,21 +21,9 @@ import './form.scss';
 const noop = () => {};
 
 class PostCommentForm extends Component {
-	constructor( props ) {
-		super();
-
-		this.state = {
-			commentText: props.commentText || '',
-			haveFocus: false,
-		};
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		this.setState( {
-			commentText: nextProps.commentText || '',
-		} );
-	}
+	state = {
+		haveFocus: false,
+	};
 
 	handleKeyDown = ( event ) => {
 		// Use Ctrl+Enter to submit comment
@@ -64,19 +52,15 @@ class PostCommentForm extends Component {
 	};
 
 	handleTextChange = ( event ) => {
-		const commentText = event.target.value;
-
-		this.setState( { commentText } );
-
 		// Update the comment text in the container's state
-		this.props.onUpdateCommentText( commentText );
+		this.props.onUpdateCommentText( event.target.value );
 	};
 
 	handleSubmit = ( event ) => {
 		event.preventDefault();
 
 		const post = this.props.post;
-		const commentText = this.state.commentText.trim();
+		const commentText = this.props.commentText.trim();
 
 		if ( ! commentText ) {
 			this.resetCommentText(); // Clean up any newlines
@@ -108,14 +92,12 @@ class PostCommentForm extends Component {
 	};
 
 	resetCommentText() {
-		this.setState( { commentText: '' } );
-
 		// Update the comment text in the container's state
 		this.props.onUpdateCommentText( '' );
 	}
 
 	hasCommentText() {
-		return this.state.commentText.trim().length > 0;
+		return this.props.commentText.trim().length > 0;
 	}
 
 	renderError() {
@@ -174,7 +156,7 @@ class PostCommentForm extends Component {
 			/>
 		) : (
 			<AutoresizingFormTextarea
-				value={ this.state.commentText }
+				value={ this.props.commentText }
 				placeholder={ translate( 'Enter your comment here…' ) }
 				onKeyUp={ this.handleKeyUp }
 				onKeyDown={ this.handleKeyDown }
@@ -195,7 +177,7 @@ class PostCommentForm extends Component {
 					{ formTextarea }
 					<Button
 						className={ buttonClasses }
-						disabled={ this.state.commentText.length === 0 }
+						disabled={ this.props.commentText.length === 0 }
 						onClick={ this.handleSubmit }
 					>
 						{ this.props.error ? translate( 'Resend' ) : translate( 'Send' ) }
@@ -223,6 +205,7 @@ PostCommentForm.propTypes = {
 };
 
 PostCommentForm.defaultProps = {
+	commentText: '',
 	onCommentSubmit: noop,
 };
 

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -28,12 +28,6 @@ class PostCommentForm extends Component {
 			commentText: props.commentText || '',
 			haveFocus: false,
 		};
-
-		// bind event handlers to this instance
-		Object.getOwnPropertyNames( PostCommentForm.prototype )
-			.filter( ( prop ) => prop.indexOf( 'handle' ) === 0 )
-			.filter( ( prop ) => typeof this[ prop ] === 'function' )
-			.forEach( ( prop ) => ( this[ prop ] = this[ prop ].bind( this ) ) );
 	}
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
@@ -43,12 +37,12 @@ class PostCommentForm extends Component {
 		} );
 	}
 
-	handleSubmit( event ) {
+	handleSubmit = ( event ) => {
 		event.preventDefault();
 		this.submit();
-	}
+	};
 
-	handleKeyDown( event ) {
+	handleKeyDown = ( event ) => {
 		// Use Ctrl+Enter to submit comment
 		if ( event.keyCode === 13 && ( event.ctrlKey || event.metaKey ) ) {
 			event.preventDefault();
@@ -68,18 +62,18 @@ class PostCommentForm extends Component {
 				);
 			}
 		}
-	}
+	};
 
-	handleFocus() {
+	handleFocus = () => {
 		this.setState( { haveFocus: true } );
-	}
+	};
 
-	handleTextChange( commentText ) {
+	handleTextChange = ( commentText ) => {
 		this.setState( { commentText } );
 
 		// Update the comment text in the container's state
 		this.props.onUpdateCommentText( commentText );
-	}
+	};
 
 	handleTextChangeEvent = ( event ) => {
 		this.handleTextChange( event.target.value );

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -181,7 +181,6 @@ class PostCommentForm extends Component {
 				onFocus={ this.handleFocus }
 				onBlur={ this.handleBlur }
 				onChange={ this.handleTextChange }
-				siteId={ this.props.post.site_ID }
 				enableAutoFocus={ isReply }
 			/>
 		);

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
-import { translate } from 'i18n-calypso';
+import { localize, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -19,6 +19,17 @@ import AutoresizingFormTextarea from './autoresizing-form-textarea';
 import './form.scss';
 
 const noop = () => {};
+
+function PostCommentFormError( { type } ) {
+	const translate = useTranslate();
+
+	const message =
+		type === 'comment_duplicate'
+			? translate( "Duplicate comment detected. It looks like you've already said that!" )
+			: translate( 'Sorry - there was a problem posting your comment.' );
+
+	return <FormInputValidation isError text={ message } />;
+}
 
 class PostCommentForm extends Component {
 	state = {
@@ -100,31 +111,8 @@ class PostCommentForm extends Component {
 		return this.props.commentText.trim().length > 0;
 	}
 
-	renderError() {
-		const error = this.props.error;
-		let message;
-
-		if ( ! error ) {
-			return null;
-		}
-
-		switch ( this.props.errorType ) {
-			case 'comment_duplicate':
-				message = translate(
-					"Duplicate comment detected. It looks like you've already said that!"
-				);
-				break;
-
-			default:
-				message = translate( 'Sorry - there was a problem posting your comment.' );
-				break;
-		}
-
-		return <FormInputValidation isError text={ message } />;
-	}
-
 	render() {
-		const post = this.props.post;
+		const { post, error, errorType, translate } = this.props;
 
 		// Don't display the form if comments are closed
 		if (
@@ -182,7 +170,7 @@ class PostCommentForm extends Component {
 					>
 						{ this.props.error ? translate( 'Resend' ) : translate( 'Send' ) }
 					</Button>
-					{ this.renderError() }
+					{ error && <PostCommentFormError type={ errorType } /> }
 				</FormFieldset>
 			</form>
 		);
@@ -214,4 +202,4 @@ export default connect(
 		currentUser: getCurrentUser( state ),
 	} ),
 	{ writeComment, deleteComment, replyComment }
-)( PostCommentForm );
+)( localize( PostCommentForm ) );

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -87,6 +87,7 @@ class PostCommentList extends Component {
 
 	state = {
 		amountOfCommentsToTake: this.props.initialSize,
+		commentText: '',
 	};
 
 	shouldFetchInitialComment = () => {
@@ -213,7 +214,7 @@ class PostCommentList extends Component {
 				activeReplyCommentId={ this.props.activeReplyCommentId }
 				onReplyClick={ this.onReplyClick }
 				onReplyCancel={ this.onReplyCancel }
-				commentText={ this.commentText }
+				commentText={ this.state.commentText }
 				onUpdateCommentText={ this.onUpdateCommentText }
 				onCommentSubmit={ this.resetActiveReplyComment }
 				depth={ 0 }

--- a/client/blocks/comments/post-comment-with-error.jsx
+++ b/client/blocks/comments/post-comment-with-error.jsx
@@ -1,50 +1,51 @@
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { useState } from 'react';
 import PostCommentForm from './form';
 
 import './post-comment.scss'; // intentional, shares styles
 import './post-comment-with-error.scss';
 
-export default class PostCommentWithError extends Component {
-	renderCommentForm() {
-		const { post, commentsTree, commentId, onUpdateCommentText, activeReplyCommentId } = this.props;
-		const commentText = get( commentsTree, [ commentId, 'data', 'content' ] );
-		const commentParentId = get( commentsTree, [ commentId, 'data', 'parent', 'ID' ], null );
-		const placeholderError = get( commentsTree, [ commentId, 'data', 'placeholderError' ] );
-		const placeholderErrorType = get( commentsTree, [ commentId, 'data', 'placeholderErrorType' ] );
+function PostCommentWithError( {
+	activeReplyCommentId,
+	commentId,
+	commentsTree,
+	post,
+	repliesList,
+} ) {
+	const commentParentId = get( commentsTree, [ commentId, 'data', 'parent', 'ID' ], null );
+	const commentText = get( commentsTree, [ commentId, 'data', 'content' ] );
+	const placeholderError = get( commentsTree, [ commentId, 'data', 'placeholderError' ] );
+	const placeholderErrorType = get( commentsTree, [ commentId, 'data', 'placeholderErrorType' ] );
 
-		if ( activeReplyCommentId !== commentParentId ) {
-			return null;
-		}
+	const [ comment, setComment ] = useState( commentText );
 
-		return (
+	if ( activeReplyCommentId !== commentParentId ) {
+		return null;
+	}
+
+	return (
+		<li className="comments__comment is-error">
 			<PostCommentForm
-				post={ post }
-				parentCommentId={ commentParentId }
-				commentText={ commentText }
-				onUpdateCommentText={ onUpdateCommentText }
-				placeholderId={ commentId }
+				commentText={ comment }
 				error={ placeholderError }
 				errorType={ placeholderErrorType }
+				onUpdateCommentText={ setComment }
+				parentCommentId={ commentParentId }
+				placeholderId={ commentId }
+				post={ post }
 			/>
-		);
-	}
-
-	render() {
-		return (
-			<li className="comments__comment is-error">
-				{ this.renderCommentForm() }
-				{ this.props.repliesList }
-			</li>
-		);
-	}
+			{ repliesList }
+		</li>
+	);
 }
 
 PostCommentWithError.propTypes = {
-	post: PropTypes.object.isRequired,
-	repliesList: PropTypes.object,
+	commentId: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,
 	commentsTree: PropTypes.object.isRequired,
 	onUpdateCommentText: PropTypes.func.isRequired,
-	commentId: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,
+	post: PropTypes.object.isRequired,
+	repliesList: PropTypes.object,
 };
+
+export default PostCommentWithError;

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -232,6 +232,7 @@ class PostComment extends PureComponent {
 								onReplyClick={ this.props.onReplyClick }
 								onReplyCancel={ this.props.onReplyCancel }
 								activeReplyCommentId={ this.props.activeReplyCommentId }
+								commentText={ this.props.commentText }
 								onUpdateCommentText={ this.props.onUpdateCommentText }
 								onCommentSubmit={ this.props.onCommentSubmit }
 								shouldHighlightNew={ this.props.shouldHighlightNew }

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -64,10 +64,10 @@ export class ConversationCommentList extends Component {
 	};
 
 	state = {
-		commentText: null,
+		commentText: '',
 	};
 
-	onUpdateCommentText = ( commentText ) => this.setState( { commentText: commentText } );
+	onUpdateCommentText = ( commentText ) => this.setState( { commentText } );
 
 	onReplyClick = ( commentId ) => {
 		this.setActiveReplyComment( commentId );
@@ -80,7 +80,7 @@ export class ConversationCommentList extends Component {
 	};
 
 	onReplyCancel = () => {
-		this.setState( { commentText: null } );
+		this.setState( { commentText: '' } );
 		recordAction( 'comment_reply_cancel_click' );
 		recordGaEvent( 'Clicked Cancel Reply to Comment' );
 		this.props.recordReaderTracksEvent( 'calypso_reader_comment_reply_cancel_click', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `PostCommentForm`: refactor away from `UNSAFE_*`

This PR contains a few stylistic drive-by changes. The most relevant change related to refactoring away from `cWRP` is removing the internal `commentText` state of `<PostCommentForm />` and make it a responsibility of the wrapping component. This was already the case for all usages except for `<PostCommentWithError />`.

#### Testing instructions

* Open the Reader and choose a post of yours you can comment on
* Write a comment and hit _Send_, it should appear as normal
* Try to write the exact same comment, you should receive an error message about duplicates
* Using that form adjust the comment and hit _Resend_
* Make sure the above works for replies as well

Now go to `/read/conversations` (or `/read/conversations/a8c`) and find a conversation you can comment on. The form to post a comment should behave exactly like on prod.

Related to #58453 
