### PR TITLE
Emails: [Draft] Navigation labels for the new Emails Stacked Comparison page

### DIFF
--- a/client/my-sites/domains/email-providers-upsell/index.jsx
+++ b/client/my-sites/domains/email-providers-upsell/index.jsx
@@ -44,6 +44,7 @@ export default function EmailProvidersUpsell( { domain, interval, provider } ) {
 				/>
 			) : (
 				<EmailProvidersStackedComparison
+					backPath={ domainAddNew( selectedSiteSlug ) }
 					comparisonContext="domain-upsell"
 					isDomainInCart={ true }
 					selectedDomainName={ domain }

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -28,6 +28,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 export type EmailProvidersStackedComparisonProps = {
+	backPath?: string;
 	cartDomainName?: string;
 	comparisonContext: string;
 	isDomainInCart?: boolean;
@@ -38,6 +39,7 @@ export type EmailProvidersStackedComparisonProps = {
 };
 
 const EmailProvidersStackedComparison = ( {
+	backPath,
 	comparisonContext,
 	isDomainInCart = false,
 	selectedDomainName,
@@ -129,6 +131,19 @@ const EmailProvidersStackedComparison = ( {
 		return null;
 	}
 
+	const header = (
+		<h1 className="email-providers-stacked-comparison__header">
+			{ isDomainInCart
+				? translate( 'Add a professional email address to %(domainName)s', {
+						args: {
+							domainName: selectedDomainName,
+						},
+						comment: '%(domainName)s is the domain name, e.g example.com',
+				  } )
+				: translate( 'Pick an email solution' ) }
+		</h1>
+	);
+
 	const hasExistingEmailForwards = ! isDomainInCart && hasEmailForwards( domain );
 
 	return (
@@ -139,28 +154,47 @@ const EmailProvidersStackedComparison = ( {
 
 			{ ! isDomainInCart && selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
-			<h1 className="email-providers-stacked-comparison__header">
-				{ translate( 'Pick an email solution' ) }
-			</h1>
+			{ header }
 
 			{ selectedSite && (
 				<div className="email-providers-stacked-comparison__sub-header">
-					{ translate( 'Not sure where to start? {{a}}See how they compare{{/a}}.', {
-						components: {
-							a: (
-								<a
-									href={ emailManagementInDepthComparison(
-										selectedSite.slug,
-										selectedDomainName,
-										currentRoute,
-										null,
-										selectedIntervalLength
-									) }
-									onClick={ handleCompareClick }
-								/>
-							),
-						},
-					} ) }
+					{ isDomainInCart
+						? translate(
+								'Not sure where to start? {{a}}See how they compare{{/a}} or {{skip}}skip this step{{/skip}}.',
+								{
+									components: {
+										a: (
+											<a
+												href={ emailManagementInDepthComparison(
+													selectedSite.slug,
+													selectedDomainName,
+													currentRoute,
+													null,
+													selectedIntervalLength
+												) }
+												onClick={ handleCompareClick }
+											/>
+										),
+										skip: <a href={ `/checkout/${ selectedSite.slug }` } />,
+									},
+								}
+						  )
+						: translate( 'Not sure where to start? {{a}}See how they compare{{/a}}', {
+								components: {
+									a: (
+										<a
+											href={ emailManagementInDepthComparison(
+												selectedSite.slug,
+												selectedDomainName,
+												currentRoute,
+												null,
+												selectedIntervalLength
+											) }
+											onClick={ handleCompareClick }
+										/>
+									),
+								},
+						  } ) }
 				</div>
 			) }
 
@@ -179,6 +213,7 @@ const EmailProvidersStackedComparison = ( {
 			{ ! isDomainInCart && domain && <EmailExistingPaidServiceNotice domain={ domain } /> }
 
 			<ProfessionalEmailCard
+				backPath={ backPath }
 				comparisonContext={ comparisonContext }
 				detailsExpanded={ detailsExpanded.titan }
 				intervalLength={ selectedIntervalLength }
@@ -189,6 +224,7 @@ const EmailProvidersStackedComparison = ( {
 			/>
 
 			<GoogleWorkspaceCard
+				backPath={ backPath }
 				comparisonContext={ comparisonContext }
 				detailsExpanded={ detailsExpanded.google }
 				intervalLength={ selectedIntervalLength }

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -160,10 +160,10 @@ const EmailProvidersStackedComparison = ( {
 				<div className="email-providers-stacked-comparison__sub-header">
 					{ isDomainInCart
 						? translate(
-								'Not sure where to start? {{a}}See how they compare{{/a}} or {{skip}}skip this step{{/skip}}.',
+								'Not sure where to start? {{compare_link}}See how they compare{{/compare_link}} or {{skip_link}}skip this step{{/skip_link}}.',
 								{
 									components: {
-										a: (
+										compare_link: (
 											<a
 												href={ emailManagementInDepthComparison(
 													selectedSite.slug,
@@ -175,11 +175,11 @@ const EmailProvidersStackedComparison = ( {
 												onClick={ handleCompareClick }
 											/>
 										),
-										skip: <a href={ `/checkout/${ selectedSite.slug }` } />,
+										skip_link: <a href={ `/checkout/${ selectedSite.slug }` } />,
 									},
 								}
 						  )
-						: translate( 'Not sure where to start? {{a}}See how they compare{{/a}}', {
+						: translate( 'Not sure where to start? {{a}}See how they compare{{/a}}.', {
 								components: {
 									a: (
 										<a

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -75,6 +75,7 @@ const professionalEmailCardInformation: ProviderCardProps = {
 };
 
 const ProfessionalEmailCard = ( {
+	backPath,
 	comparisonContext,
 	detailsExpanded,
 	intervalLength,
@@ -161,6 +162,7 @@ const ProfessionalEmailCard = ( {
 
 	professionalEmail.formFields = (
 		<TitanNewMailboxList
+			backPath={ backPath }
 			onMailboxesChange={ setTitanMailbox }
 			mailboxes={ titanMailbox }
 			selectedDomainName={ selectedDomainName }

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/provider-card-props.ts
@@ -21,6 +21,7 @@ export interface ProviderCardProps {
 }
 
 export type EmailProvidersStackedCardProps = {
+	backPath?: string;
 	isDomainInCart?: boolean;
 	comparisonContext: string;
 	detailsExpanded: boolean;

--- a/client/my-sites/email/titan-new-mailbox-list/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox-list/index.jsx
@@ -19,6 +19,7 @@ import './style.scss';
 const noop = () => {};
 
 const TitanNewMailboxList = ( {
+	backPath,
 	children,
 	hiddenFieldNames = [],
 	selectedDomainName,
@@ -84,6 +85,7 @@ const TitanNewMailboxList = ( {
 					) }
 
 					<TitanNewMailbox
+						backPath={ backPath }
 						selectedDomainName={ selectedDomainName }
 						onMailboxValueChange={ onMailboxValueChange( mailbox.uuid ) }
 						mailbox={ mailbox }

--- a/client/my-sites/email/titan-new-mailbox/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox/index.jsx
@@ -85,9 +85,11 @@ const TitanNewMailbox = ( {
 		const domain = shoppingCartManager.responseCart?.products.filter(
 			( product ) => product.meta === selectedDomainName
 		)[ 0 ];
+
 		if ( domain ) {
 			await shoppingCartManager.removeProductFromCart( domain.uuid );
 		}
+
 		page( backPath );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is just a proposal and as a proposal, only the Professional Email cart has been developed for this purpose, once discussed I'll add the rest.

#### Testing instructions

1. Apply this branch `git checkout add/navigation-logic-to-stacked-comparison-component` or run this branch via the [calypso live link](https://github.com/Automattic/wp-calypso/pull/63092#issuecomment-1110900820)
2. Go to Upgrades -> Domains
3. Add a domain to your cart
4. Add the following feature flag: `flags=emails/show-new-comparison-component`
5. Assert that back button (under domain in Professional Email card) is removing the domain from the cart and taking you back
6. Assert that the skip button in the top is taking you to the checkout screen
7. Assert that the tile has change to "Add a professional email address to... "

| BEFORE  | AFTER |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/5689927/165510633-e76c1615-5131-4fb0-97c6-80e0ecf7784c.png) | ![image](https://user-images.githubusercontent.com/5689927/165510476-a4f3618c-f492-4ac9-9a23-42d699bc27c8.png) |

Related to 1200182182542585-as-1202183659259431
