### PR TITLE
Stepper: don't automatically populate the site title and leave it empty like in /start

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -30,13 +30,6 @@ const SiteOptions: Step = function SiteOptions( { navigation } ) {
 
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
 
-	React.useEffect( () => {
-		if ( site ) {
-			setSiteTitle( site.name ?? '' );
-			setTagline( site.description );
-		}
-	}, [ site ] );
-
 	const handleSubmit = async ( event: React.FormEvent ) => {
 		event.preventDefault();
 		if ( site ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In stepper, we populate the site title with the exisitng value. This breaks the e2e tests.
* This fixes mimics the exact behavior in /start where the site title field is left empty.

#### Testing instructions

1. Go to /setup/intent?siteSlug=YOUR_SITE
2. Click Write.
3. Site title should be empty.
