### PR TITLE
Stepper: disable site options form until site ready

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -93,7 +93,7 @@ const SiteOptions: Step = function SiteOptions( { navigation } ) {
 
 	const stepContent = (
 		<form className="site-options__form" onSubmit={ handleSubmit }>
-			<FormFieldset className="site-options__form-fieldset">
+			<FormFieldset disabled={ ! site } className="site-options__form-fieldset">
 				<FormLabel htmlFor="siteTitle" optional={ ! isSiteTitleRequired }>
 					{ siteTitleLabel }
 				</FormLabel>
@@ -106,7 +106,7 @@ const SiteOptions: Step = function SiteOptions( { navigation } ) {
 				/>
 				{ siteTitleError && <FormInputValidation isError text={ siteTitleError } /> }
 			</FormFieldset>
-			<FormFieldset className="site-options__form-fieldset">
+			<FormFieldset disabled={ ! site } className="site-options__form-fieldset">
 				<FormLabel htmlFor="tagline" optional={ ! isTaglineRequired }>
 					{ translate( 'Tagline' ) }
 				</FormLabel>
@@ -123,7 +123,7 @@ const SiteOptions: Step = function SiteOptions( { navigation } ) {
 					{ taglineExplanation }
 				</FormSettingExplanation>
 			</FormFieldset>
-			<Button className="site-options__submit-button" type="submit" primary>
+			<Button disabled={ ! site } className="site-options__submit-button" type="submit" primary>
 				{ translate( 'Continue' ) }
 			</Button>
 		</form>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* To appease E2E tests, and actually improve UX, disable the site info form until site is ready. This is good because you can't submit your site title until site is ready anyways.

#### Testing instructions

1. Go to /setup/intent?siteSlug=YOUR_SITE
2. Go to "Write".
3. The form should be disabled for a second.
