### PR TITLE
Revert isPremiumThemeAvailable: Use the features endpoint to determine if a site has unlimited premium themes (#63024)

### DIFF
--- a/client/state/themes/selectors/is-premium-theme-available.js
+++ b/client/state/themes/selectors/is-premium-theme-available.js
@@ -1,5 +1,5 @@
-import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
-import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
+import { FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
+import { hasFeature } from 'calypso/state/sites/plans/selectors';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 
 import 'calypso/state/themes/init';
@@ -15,6 +15,6 @@ import 'calypso/state/themes/init';
 export function isPremiumThemeAvailable( state, themeId, siteId ) {
 	return (
 		isThemePurchased( state, themeId, siteId ) ||
-		hasActiveSiteFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES )
+		hasFeature( state, siteId, FEATURE_PREMIUM_THEMES )
 	);
 }

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -3,7 +3,6 @@ import {
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
 	PLAN_ECOMMERCE,
-	WPCOM_FEATURES_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
 import { expect } from 'chai';
 import ThemeQueryManager from 'calypso/lib/query-manager/theme';
@@ -2349,7 +2348,6 @@ describe( 'themes selectors', () => {
 		} );
 
 		test( 'given a premium squared theme and a site with the premium upgrade, should return true', () => {
-			const active = [ WPCOM_FEATURES_PREMIUM_THEMES ];
 			const isAvailable = isPremiumThemeAvailable(
 				{
 					sites: {
@@ -2364,13 +2362,6 @@ describe( 'themes selectors', () => {
 										productSlug: PLAN_PREMIUM,
 									},
 								],
-							},
-						},
-						features: {
-							2916284: {
-								data: {
-									active,
-								},
 							},
 						},
 					},
@@ -2393,7 +2384,6 @@ describe( 'themes selectors', () => {
 		} );
 
 		test( 'given a site with the unlimited premium themes bundle, should return true', () => {
-			const active = [ WPCOM_FEATURES_PREMIUM_THEMES ];
 			[ PLAN_BUSINESS, PLAN_ECOMMERCE ].forEach( ( plan ) => {
 				const isAvailable = isPremiumThemeAvailable(
 					{
@@ -2409,13 +2399,6 @@ describe( 'themes selectors', () => {
 											productSlug: plan,
 										},
 									],
-								},
-							},
-							features: {
-								2916284: {
-									data: {
-										active,
-									},
 								},
 							},
 						},

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -211,6 +211,3 @@ export const FEATURE_UNLIMITED_ADMINS = 'unlimited-admins';
 export const FEATURE_ADDITIONAL_SITES = 'additional-sites';
 export const FEATURE_WOOCOMMERCE = 'woocommerce';
 export const FEATURE_SOCIAL_MEDIA_TOOLS = 'social-media-tools';
-
-// From class-wpcom-features.php in WPCOM
-export const WPCOM_FEATURES_PREMIUM_THEMES = 'premium-themes';


### PR DESCRIPTION
Staging a revert when pre-release E2E tests failed for #63024.
![2022-04-27_10-01](https://user-images.githubusercontent.com/937354/165549128-fee41993-5682-4be9-98e4-cda42b55f297.png)

