### PR TITLE
Release stepper everywhere except prod - attempt III

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -73,6 +73,10 @@ function getSignupDestination( { domainItem, siteId, siteSlug }, localeSlug ) {
 		queryParam = { siteId };
 	}
 
+	if ( isEnabled( 'signup/stepper-flow' ) ) {
+		return addQueryArgs( queryParam, '/setup/intent' );
+	}
+
 	// Initially ship to English users only, then ship to all users when translations complete
 	if ( englishLocales.includes( localeSlug ) || isEnabled( 'signup/hero-flow-non-en' ) ) {
 		return addQueryArgs( queryParam, '/start/setup-site' );

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -63,7 +63,7 @@ function getSignupDestination( { domainItem, siteId, siteSlug }, localeSlug ) {
 	if ( 'no-site' === siteSlug ) {
 		return '/home';
 	}
-	let queryParam = { siteSlug, loading_ellipsis: 1 };
+	let queryParam = { siteSlug };
 	if ( domainItem ) {
 		// If the user is purchasing a domain then the site's primary url might change from
 		// `siteSlug` to something else during the checkout process, which means the
@@ -79,6 +79,7 @@ function getSignupDestination( { domainItem, siteId, siteSlug }, localeSlug ) {
 
 	// Initially ship to English users only, then ship to all users when translations complete
 	if ( englishLocales.includes( localeSlug ) || isEnabled( 'signup/hero-flow-non-en' ) ) {
+		queryParam.loading_ellipsis = 1;
 		return addQueryArgs( queryParam, '/start/setup-site' );
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -140,6 +140,7 @@
 		"signup/hero-flow-non-en": true,
 		"signup/site-vertical-step": true,
 		"signup/starting-point-courses": true,
+		"signup/stepper-flow": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -90,6 +90,7 @@
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,
+		"signup/stepper-flow": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": false,
 		"themes/premium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -103,6 +103,7 @@
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,
+		"signup/stepper-flow": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": false,
 		"themes/premium": true,

--- a/config/test.json
+++ b/config/test.json
@@ -73,6 +73,7 @@
 		"settings/security/monitor": true,
 		"signup/anchor-fm": false,
 		"signup/social": true,
+		"signup/stepper-flow": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": false,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -111,6 +111,7 @@
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,
+		"signup/stepper-flow": true,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": false,
 		"themes/premium": true,

--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -4,11 +4,11 @@ import envVariables from '../../env-variables';
 const selectors = {
 	// Generic
 	button: ( text: string ) => `button:text("${ text }")`,
-	backLink: 'a:text("Back")',
+	backLink: 'button:text("Back")',
 
 	// Inputs
-	blogNameInput: 'input#siteTitle',
-	taglineInput: 'input#tagline',
+	blogNameInput: 'input#siteTitle:not(:disabled)',
+	taglineInput: 'input#tagline:not(:disabled)',
 
 	// Themes
 	themePickerContainer: '.design-picker',
@@ -72,7 +72,7 @@ export class StartSiteFlow {
 	 * Navigate back one screen in the flow.
 	 */
 	async goBackOneScreen(): Promise< void > {
-		await Promise.all( [ this.page.waitForNavigation(), this.page.click( selectors.backLink ) ] );
+		await this.page.click( selectors.backLink );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -8,7 +8,7 @@ type PlansGridVersion = 'current' | 'legacy';
 type PlansComparisonAction = 'show' | 'hide';
 
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
-export type Plans = 'Free' | 'Pro';
+export type Plans = 'Start with Free' | 'Pro';
 export type LegacyPlans = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
 export type PlansPageTab = 'My Plan' | 'Plans';
 export type PlanActionButton = 'Manage plan' | 'Upgrade';

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -69,7 +69,7 @@ skipDescribeIf( isStagingOrProd )(
 
 			it( 'Select WordPress.com Free plan', async function () {
 				const signupPickPlanPage = new SignupPickPlanPage( page );
-				await signupPickPlanPage.selectPlan( 'Free' );
+				await signupPickPlanPage.selectPlan( 'Start with Free' );
 			} );
 		} );
 
@@ -156,6 +156,11 @@ skipDescribeIf( isStagingOrProd )(
 				await generalSettingsPage.launchSite();
 			} );
 
+			it( 'Search for a domain to reveal Skip Purchase button', async function () {
+				domainSearchComponent = new DomainSearchComponent( page );
+				await domainSearchComponent.search( username + '.live' );
+			} );
+
 			it( 'Skip domain purchasse', async function () {
 				const domainSearchComponent = new DomainSearchComponent( page );
 				await domainSearchComponent.clickButton( 'Skip Purchase' );
@@ -163,7 +168,7 @@ skipDescribeIf( isStagingOrProd )(
 
 			it( 'Keep free plan', async function () {
 				const signupPickPlanPage = new SignupPickPlanPage( page );
-				await signupPickPlanPage.selectPlan( 'Free' );
+				await signupPickPlanPage.selectPlan( 'Start with Free' );
 			} );
 
 			it( 'Confirm site is launched', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR also does some minor adjustments to e2e tests to support Stepper. I couldn't release the two changes separately. Releasing Stepper would break pre-release tests, while changing pre-release tests would make them fail if stepper is unreleased. They have to go together.

* Attempt I: https://github.com/Automattic/wp-calypso/pull/63095
* Attempt II: https://github.com/Automattic/wp-calypso/pull/63056

#### Testing instructions

1. Go to /start
2. Create a free site
3. You should be redirected to /setup, not start/site-setup.

Context: pdDR7T-1B-p2
