### PR TITLE
Help Center: Add More resources section

### DIFF
--- a/client/blocks/inline-help/inline-help-center-content.jsx
+++ b/client/blocks/inline-help/inline-help-center-content.jsx
@@ -5,6 +5,7 @@ import { useState, useEffect, useRef } from 'react';
 import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
 import InlineHelpContactPage, { InlineHelpContactPageButton } from './inline-help-contact-page';
 import InlineHelpEmbedResult from './inline-help-embed-result';
+import InlineHelpMoreResources from './inline-help-more-resources';
 import InlineHelpSearchCard from './inline-help-search-card';
 import InlineHelpSearchResults from './inline-help-search-results';
 
@@ -104,6 +105,7 @@ const InlineHelpCenterContent = ( {
 						searchQuery={ searchQuery }
 						openAdminInNewTab={ true }
 					/>
+					<InlineHelpMoreResources />
 				</div>
 				{ renderSecondaryView() }
 			</>

--- a/client/blocks/inline-help/inline-help-center-content.jsx
+++ b/client/blocks/inline-help/inline-help-center-content.jsx
@@ -105,7 +105,7 @@ const InlineHelpCenterContent = ( {
 						searchQuery={ searchQuery }
 						openAdminInNewTab={ true }
 					/>
-					<InlineHelpMoreResources />
+					{ ! searchQuery && <InlineHelpMoreResources /> }
 				</div>
 				{ renderSecondaryView() }
 			</>

--- a/client/blocks/inline-help/inline-help-center-content.scss
+++ b/client/blocks/inline-help/inline-help-center-content.scss
@@ -34,17 +34,6 @@
 		.inline-help__secondary-view {
 			display: block;
 		}
-
-		.inline-help__footer {
-			.inline-help__more-button,
-			.inline-help__contact-button {
-				display: none;
-			}
-
-			.inline-help__cancel-button {
-				display: block;
-			}
-		}
 	}
 }
 
@@ -113,51 +102,78 @@
 	}
 }
 
-.inline-help__footer {
-	background: var( --color-neutral-0 );
-	border-top: 1px solid var( --color-neutral-10 );
-	border-radius: 0 0 2px 2px;
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	flex-wrap: wrap;
+.inline-help__section-title {
+	font-weight: bold;
+	line-height: 1.4;
+	display: block;
+	padding: 8px 16px;
+	font-size: $font-body-small;
+	text-align: left;
 
-	.button.is-borderless.inline-help__more-button,
-	.button.is-borderless.inline-help__contact-button,
-	.button.is-borderless.inline-help__cancel-button {
-		text-align: left;
-		position: relative;
-		padding: 12px 8px 12px 46px;
+	&::after {
+		content: ':';
+	}
+}
 
-		.gridicon.inline-help__gridicon-left {
-			margin: 0;
-			position: absolute;
-			top: 11px;
-			left: 13px;
+.inline-help__more-resources {
+	list-style: none;
+	text-align: left;
+	margin: 0;
+	padding: 0;
+
+	.inline-help__resource-item {
+		margin: 0;
+		margin-bottom: 0.6em;
+		font-size: $font-body-small;
+
+		.inline-help__resource-cell {
+			width: 100%;
 		}
-
-		.gridicon.inline-help__gridicon-right {
-			margin: 0;
-			position: absolute;
-			top: 11px;
-			right: 13px;
+	
+		@include breakpoint-deprecated( '>660px' ) {
+			font-size: $font-title-small;
+			line-height: 1.3;
 		}
-
-		&:hover {
-			color: var( --color-primary );
-
+	
+		a {
+			color: #000;
+			text-decoration: none;
+			font-weight: normal;
+			line-height: 1.4;
+			display: flex;
+			align-items: center;
+	
+			span {
+				flex-grow: 2;
+			}
+	
 			.gridicon {
-				fill: var( --color-primary );
+				align-self: baseline;
+				background: var( --color-neutral-0 );
+				color: var( --color-neutral-light );
+				flex-shrink: 0;
+				margin-right: 8px;
+				padding: 10px;
+				position: relative;
+			}
+	
+			&:hover {
+				cursor: pointer;
+				background: var( --color-neutral-0 );
+	
+				.gridicon {
+					color: var( --color-neutral );
+				}
+			}
+	
+			&:focus {
+				background: var( --color-primary );
+				color: var( --color-text-inverted );
+	
+				.gridicon {
+					color: var( --color-text-inverted );
+				}
 			}
 		}
-	}
-
-	.button.is-borderless.inline-help__contact-button {
-		padding-right: 40px;
-	}
-
-	// Hide/Show buttons as needed
-	.inline-help__cancel-button {
-		display: none;
 	}
 }

--- a/client/blocks/inline-help/inline-help-more-resources.tsx
+++ b/client/blocks/inline-help/inline-help-more-resources.tsx
@@ -10,14 +10,15 @@ interface ItemProps {
 	link: string;
 	icon: string;
 	text: string;
+	svgColor: string;
 	onClickHandler?: () => void;
 }
 
-const ResourceItem: React.FC< ItemProps > = ( { link, icon, text, onClickHandler } ) => (
+const ResourceItem: React.FC< ItemProps > = ( { link, icon, text, svgColor, onClickHandler } ) => (
 	<li className="inline-help__resource-item">
 		<div className="inline-help__resource-cell">
 			<a href={ localizeUrl( link ) } onClick={ onClickHandler } rel="noreferrer" target="_blank">
-				<Gridicon icon={ icon } size={ 36 } />
+				<Gridicon icon={ icon } size={ 24 } fill={ svgColor } />
 				<span>{ text }</span>
 			</a>
 		</div>
@@ -45,27 +46,31 @@ const HelpCenterMoreResources = () => {
 	return (
 		<>
 			<h3 className="inline-help__section-title">{ __( 'More Resources' ) }</h3>
-			<ul aria-labelledby="inline-help__more-resources">
-				<ResourceItem
-					link={ localizeUrl( 'https://wordpress.com/webinars' ) }
-					icon="chat"
-					text={ __( 'Webinars' ) }
-					onClickHandler={ trackCoursesButtonClick }
-				/>
+			<ul className="inline-help__more-resources" aria-labelledby="inline-help__more-resources">
 				<ResourceItem
 					link={ localizeUrl( 'https://wordpress.com/support/video-tutorials/' ) }
-					icon="video"
+					icon="play"
 					text={ __( 'Video tutorials' ) }
+					svgColor="#C9356E"
+				/>
+				<ResourceItem
+					link={ localizeUrl( 'https://wordpress.com/webinars' ) }
+					icon="video-camera"
+					text={ __( 'Webinars' ) }
+					onClickHandler={ trackCoursesButtonClick }
+					svgColor="#E68B28"
 				/>
 				<ResourceItem
 					link={ 'https://wpcourses.com/?ref=wpcom-help-more-resources' }
-					icon="mail"
+					icon="computer"
 					text={ __( 'Courses' ) }
+					svgColor="#09B585"
 				/>
 				<ResourceItem
 					link={ 'https://learn.wordpress.com' }
 					icon="list-ordered"
-					text={ __( 'Guides' ) }
+					text={ __( 'Step-by-step guides' ) }
+					svgColor="#B35EB1"
 				/>
 			</ul>
 		</>

--- a/client/blocks/inline-help/inline-help-more-resources.tsx
+++ b/client/blocks/inline-help/inline-help-more-resources.tsx
@@ -1,0 +1,75 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isWpComBusinessPlan, isWpComEcommercePlan } from '@automattic/calypso-products';
+import { Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useI18n } from '@wordpress/react-i18n';
+import { useSelector } from 'react-redux';
+import { getUserPurchases } from 'calypso/state/purchases/selectors';
+
+interface ItemProps {
+	link: string;
+	icon: string;
+	text: string;
+	onClickHandler?: () => void;
+}
+
+const ResourceItem: React.FC< ItemProps > = ( { link, icon, text, onClickHandler } ) => (
+	<li className="inline-help__resource-item">
+		<div className="inline-help__resource-cell">
+			<a href={ localizeUrl( link ) } onClick={ onClickHandler } rel="noreferrer" target="_blank">
+				<Gridicon icon={ icon } size={ 36 } />
+				<span>{ text }</span>
+			</a>
+		</div>
+	</li>
+);
+
+const HelpCenterMoreResources = () => {
+	const { __ } = useI18n();
+	const isBusinessOrEcomPlanUser = useSelector( ( state ) => {
+		const purchases = getUserPurchases( state );
+		const purchaseSlugs = purchases && purchases.map( ( purchase ) => purchase.productSlug );
+
+		return !! (
+			purchaseSlugs &&
+			( purchaseSlugs.some( isWpComBusinessPlan ) || purchaseSlugs.some( isWpComEcommercePlan ) )
+		);
+	} );
+
+	const trackCoursesButtonClick = () => {
+		recordTracksEvent( 'calypso_help_courses_click', {
+			is_business_or_ecommerce_plan_user: isBusinessOrEcomPlanUser,
+		} );
+	};
+
+	return (
+		<>
+			<h3 className="inline-help__section-title">{ __( 'More Resources' ) }</h3>
+			<ul aria-labelledby="inline-help__more-resources">
+				<ResourceItem
+					link={ localizeUrl( 'https://wordpress.com/webinars' ) }
+					icon="chat"
+					text={ __( 'Webinars' ) }
+					onClickHandler={ trackCoursesButtonClick }
+				/>
+				<ResourceItem
+					link={ localizeUrl( 'https://wordpress.com/support/video-tutorials/' ) }
+					icon="video"
+					text={ __( 'Video tutorials' ) }
+				/>
+				<ResourceItem
+					link={ 'https://wpcourses.com/?ref=wpcom-help-more-resources' }
+					icon="mail"
+					text={ __( 'Courses' ) }
+				/>
+				<ResourceItem
+					link={ 'https://learn.wordpress.com' }
+					icon="list-ordered"
+					text={ __( 'Guides' ) }
+				/>
+			</ul>
+		</>
+	);
+};
+
+export default HelpCenterMoreResources;

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -39,8 +39,9 @@ $head-foot-height: 50px;
 		top: calc( $header-height + 16px );
 		right: 16px;
 		width: 410px;
-		max-height: 800px;
+		height: 800px;
 		box-shadow: 0 0 3px 0 rgba( 0, 0, 0, 0.25 );
+		overflow: auto;
 
 		.help-center__container-header {
 			cursor: move;
@@ -53,7 +54,7 @@ $head-foot-height: 50px;
 
 		&.is-minimized {
 			min-height: $head-foot-height;
-			top: calc( 100vh - 91px ); // height of header + bottom breadcrumb bar in the editor + 16px 
+			top: calc( 100vh - 91px ); // height of header + bottom breadcrumb bar in the editor + 16px
 
 			.help-center__container-header {
 				cursor: default;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following [guidance](pbAok1-2D2-p2), we added a "More resources" section in the new help center.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* `yarn dev --sync` from `apps/editing-toolkit`
* if not seeing the help-center, is probably due to [this](https://github.com/Automattic/wp-calypso/blob/add/help-center-contents/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php#L386-L388)
* Verify that the More Resources section is present in the help center. 
![image](https://user-images.githubusercontent.com/52076348/165557155-8189e9f4-4048-4d1f-9c9f-347af91fb728.png)

The other sections will be align in following PRs


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63059
Fixes #63059