### PR TITLE
Bump `phone` to 3.1.17 to get new US area codes.

### DIFF
--- a/client/lib/phone-validation/index.jsx
+++ b/client/lib/phone-validation/index.jsx
@@ -33,7 +33,7 @@ export default function ( phoneNumber ) {
 	}
 
 	// phone module validates mobile numbers
-	if ( ! phone( phoneNumber ).length ) {
+	if ( ! phone( phoneNumber ).isValid ) {
 		return {
 			error: 'phone_number_invalid',
 			message: i18n.translate( 'That phone number does not appear to be valid' ),

--- a/client/lib/phone-validation/test/index.jsx
+++ b/client/lib/phone-validation/test/index.jsx
@@ -23,8 +23,8 @@ describe( 'Phone Validation Library', () => {
 	test( 'should pass a valid number', () => {
 		assert.strictEqual( phoneValidation( '+447941952721' ).info, 'phone_number_valid' );
 	} );
-	test( 'should fail an invalid 9-digit argentine number', () => {
-		assert.strictEqual( phoneValidation( '+54299123456' ).error, 'phone_number_invalid' );
+	test( 'should pass a valid number in US 463 area code', () => {
+		assert.strictEqual( phoneValidation( '+14631234567' ).info, 'phone_number_valid' );
 	} );
 	test( 'should pass a valid 10 digit argentine without leading 9 number', () => {
 		assert.strictEqual( phoneValidation( '+542231234567' ).info, 'phone_number_valid' );
@@ -65,7 +65,7 @@ describe( 'Phone Validation Library', () => {
 	test( 'should pass a valid myanmar number with 9 digits after leading 9', () => {
 		assert.strictEqual( phoneValidation( '+959426123456' ).info, 'phone_number_valid' );
 	} );
-	test( 'should pass a valid Brazilian number starting with 49', () => {
-		assert.strictEqual( phoneValidation( '+554912345678' ).info, 'phone_number_valid' );
+	test( 'should pass a valid Brazilian number starting with 119', () => {
+		assert.strictEqual( phoneValidation( '+5511961231234' ).info, 'phone_number_valid' );
 	} );
 } );

--- a/client/package.json
+++ b/client/package.json
@@ -154,7 +154,7 @@
 		"page": "^1.11.5",
 		"path-browserify": "^1.0.1",
 		"percentage-regex": "^3.0.0",
-		"phone": "^2.4.2",
+		"phone": "^3.1.17",
 		"photon": "workspace:^",
 		"postcss": "^8.4.5",
 		"prismjs": "^1.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12813,7 +12813,7 @@ __metadata:
     page: ^1.11.5
     path-browserify: ^1.0.1
     percentage-regex: ^3.0.0
-    phone: ^2.4.2
+    phone: ^3.1.17
     photon: "workspace:^"
     pkg-dir: ^5.0.0
     postcss: ^8.4.5
@@ -28480,10 +28480,10 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"phone@npm:^2.4.2":
-  version: 2.4.2
-  resolution: "phone@npm:2.4.2"
-  checksum: 1ad1507f213b2f7709cff36912d78035f52b7c468f356abb14402da7e1be00768ad444d31f236f23b2105f08c59863d89f627f1b4a893f7007a74067f43e91f0
+"phone@npm:^3.1.17":
+  version: 3.1.17
+  resolution: "phone@npm:3.1.17"
+  checksum: fa74eed9f299df316d2b463e14432f3b1a4ba21909907c41e87cc9c602ba9ad18e8c7830feb67aae2e3bff35000656a2ccc9a60edc410792688fe5f2775c5d0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This bumps the `phone` package used in `client/lib/phone-validation` to
ensure we have [the latest US area codes](https://github.com/AfterShip/phone/pull/291). In the process, we go from 2.x
to 3.x, which has [a different return signature](https://github.com/AfterShip/phone/tree/3.1.17#migrate-from-v2).

I also added a test case for a US area code we were previously missing,
as reporting in #61392. And I adjusted some of our other test cases as
well. I don't know why a couple of our test numbers are no longer
considered valid after moving to 3.x, but looking at the data used by
the library for each country, the results make sense.

I think it's better to stay up-to-date with this dependency, if we're
going to rely on it for this purpose. It gets fairly frequent updates
for new area codes and changes.

#### Testing instructions

1. Ensure tests pass.
2. Try entering an Indiana phone number with area code 463 (e.g. 4631234567) on `/me/security/two-step`.

Related to #61392
