### PR TITLE
WordAds: Add Support for Security T1 and T2 plans

### DIFF
--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -4,6 +4,8 @@ import {
 	isEcommerce,
 	isSecurityDaily,
 	isSecurityRealTime,
+	isSecurityT1,
+	isSecurityT2,
 	isComplete,
 	isPro,
 } from '@automattic/calypso-products';
@@ -16,6 +18,8 @@ export function hasWordAdsPlan( site ) {
 		isEcommerce( site.plan ) ||
 		isSecurityDaily( site.plan ) ||
 		isSecurityRealTime( site.plan ) ||
+		isSecurityT1( site.plan ) ||
+		isSecurityT2( site.plan ) ||
 		isComplete( site.plan ) ||
 		isPro( site.plan )
 	);

--- a/packages/calypso-products/src/is-security-t1.ts
+++ b/packages/calypso-products/src/is-security-t1.ts
@@ -1,0 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
+import { isSecurityT1Plan } from './main';
+import type { WithCamelCaseSlug, WithSnakeCaseSlug } from './types';
+
+export function isSecurityT1( product: WithCamelCaseSlug | WithSnakeCaseSlug ): boolean {
+	return isSecurityT1Plan( camelOrSnakeSlug( product ) );
+}

--- a/packages/calypso-products/src/is-security-t2.ts
+++ b/packages/calypso-products/src/is-security-t2.ts
@@ -1,0 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
+import { isSecurityT2Plan } from './main';
+import type { WithCamelCaseSlug, WithSnakeCaseSlug } from './types';
+
+export function isSecurityT2( product: WithCamelCaseSlug | WithSnakeCaseSlug ): boolean {
+	return isSecurityT2Plan( camelOrSnakeSlug( product ) );
+}

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -12,6 +12,8 @@ import {
 	TYPE_PREMIUM,
 	TYPE_SECURITY_DAILY,
 	TYPE_SECURITY_REALTIME,
+	TYPE_SECURITY_T1,
+	TYPE_SECURITY_T2,
 	TYPE_ALL,
 	GROUP_WPCOM,
 	GROUP_JETPACK,
@@ -111,6 +113,14 @@ export function getPlanClass( planKey: string ): string {
 
 	if ( isSecurityRealTimePlan( planKey ) ) {
 		return 'is-realtime-security-plan';
+	}
+
+	if ( isSecurityT1Plan( planKey ) ) {
+		return 'is-security-t1';
+	}
+
+	if ( isSecurityT2Plan( planKey ) ) {
+		return 'is-security-t2';
 	}
 
 	if ( isCompletePlan( planKey ) ) {
@@ -275,6 +285,14 @@ export function isSecurityDailyPlan( planSlug: string ): boolean {
 
 export function isSecurityRealTimePlan( planSlug: string ): boolean {
 	return planMatches( planSlug, { type: TYPE_SECURITY_REALTIME } );
+}
+
+export function isSecurityT1Plan( planSlug: string ): boolean {
+	return planMatches( planSlug, { type: TYPE_SECURITY_T1 } );
+}
+
+export function isSecurityT2Plan( planSlug: string ): boolean {
+	return planMatches( planSlug, { type: TYPE_SECURITY_T2 } );
 }
 
 export function isCompletePlan( planSlug: string ): boolean {

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -75,6 +75,8 @@ export { isSpaceUpgrade } from './is-space-upgrade';
 export * from './is-superseding-jetpack-item';
 export { isSecurityDaily } from './is-security-daily';
 export { isSecurityRealTime } from './is-security-realtime';
+export { isSecurityT1 } from './is-security-t1';
+export { isSecurityT2 } from './is-security-t2';
 export { isJetpackSecuritySlug } from './is-jetpack-security-slug';
 export { isTheme } from './is-theme';
 export { isTitanMail } from './is-titan-mail';


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Fixes an issue where WordAds was not able to be enabled from Calypso if someone had a Jetpack security plan.

Fixes https://github.com/Automattic/jpop-issues/issues/7382

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a new site with Jetpack, connect, and add a Jetpack Security plan
* Go to wordpress.com/earn/your-site-here and click "View ad dashboard"
* You should be prompted to opt into WordAds
* Without this patch, adding a Security plan will just render a blank page on that screen.
* Make sure there's no regressions for adding other plans, etc.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/jpop-issues/issues/7382
