### PR TITLE
DevDocs: Fix SupportArticleDialog devdocs modal

### DIFF
--- a/client/blocks/support-article-dialog/docs/example.jsx
+++ b/client/blocks/support-article-dialog/docs/example.jsx
@@ -1,7 +1,9 @@
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { compose } from '@wordpress/compose';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { withRouteModal } from 'calypso/lib/route-modal';
 import { openSupportArticleDialog } from 'calypso/state/inline-support-article/actions';
 
 const postId = 143180;
@@ -12,6 +14,7 @@ const postUrl = localizeUrl(
 class SupportArticleDialogExample extends Component {
 	handleClick = () => {
 		this.props.openSupportArticleDialog( { postId, postUrl } );
+		this.props.routeModalData.openModal( postId );
 	};
 
 	render() {
@@ -23,9 +26,12 @@ class SupportArticleDialogExample extends Component {
 	}
 }
 
-const ConnectedExample = connect( null, {
-	openSupportArticleDialog,
-} )( SupportArticleDialogExample );
+const ConnectedExample = compose(
+	connect( null, {
+		openSupportArticleDialog,
+	} ),
+	withRouteModal( 'support-article' )
+)( SupportArticleDialogExample );
 
 ConnectedExample.displayName = 'SupportArticleDialog';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While working on the new Help Center, I stumbled upon the Support Article Dialog example in [Calypso devdocs](http://calypso.localhost:3000/devdocs/blocks/support-article-dialog)

I fixed the modal, as it was not working, missing the use of `route-modal`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* `yarn start`
* [Visit the docs](http://calypso.localhost:3000/devdocs/blocks/support-article-dialog) and click on `Show Support Article`
* The modal should appear
