### PR TITLE
Woo on Stepper: Add WooCommerce install step to stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-install-plugins/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-install-plugins/index.tsx
@@ -54,7 +54,6 @@ const WooInstallPlugins: Step = function WooInstallPlugins( { navigation } ) {
 
 		setPendingAction( async () => {
 			setProgressTitle( 'Installing WooCommerce' );
-			//http://calypso.localhost:3000/setup/intent?siteSlug=testsite176507503.wpcomstaging.com
 			initiateSoftwareInstall( site.ID, softwareSet );
 
 			const timeoutMs = 1000 * 60 * 3;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-install-plugins/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-install-plugins/index.tsx
@@ -1,25 +1,107 @@
 /* eslint-disable no-console */
-import { useDispatch } from '@wordpress/data';
+import config from '@automattic/calypso-config';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
-import { ONBOARD_STORE } from '../../../../stores';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { logToLogstash } from 'calypso/lib/logstash';
+import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import type { Step } from '../../types';
+import type { AtomicSoftwareStatus } from 'calypso/../packages/data-stores/src/site';
 
 const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 
+export interface FailureInfo {
+	type: string;
+	code: number | string;
+	error: string;
+}
+
 const WooInstallPlugins: Step = function WooInstallPlugins( { navigation } ) {
 	const { submit } = navigation;
-	const { setPendingAction, setProgressTitle } = useDispatch( ONBOARD_STORE );
+	const { setPendingAction, setProgressTitle, setProgress } = useDispatch( ONBOARD_STORE );
+	const { initiateSoftwareInstall, requestAtomicSoftwareStatus } = useDispatch( SITE_STORE );
+	const { getAtomicSoftwareInstallError, getAtomicSoftwareStatus, getAtomicSoftwareError } =
+		useSelect( ( select ) => select( SITE_STORE ) );
+	const site = useSite();
+	const softwareSet = 'woo-on-plans';
+
+	const handleTransferFailure = ( failureInfo: FailureInfo ) => {
+		recordTracksEvent( 'calypso_woocommerce_dashboard_snag_error', {
+			action: failureInfo.type,
+			site: site?.URL,
+			code: failureInfo.code,
+			error: failureInfo.error,
+		} );
+
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: failureInfo.error,
+			severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+			blog_id: site?.ID,
+			properties: {
+				env: config( 'env_id' ),
+				type: 'calypso_woocommerce_dashboard_snag_error',
+				action: failureInfo.type,
+				site: site?.URL,
+				code: failureInfo.code,
+			},
+		} );
+	};
 
 	useEffect( () => {
+		if ( ! site?.ID ) return;
+
 		setPendingAction( async () => {
-			setProgressTitle( 'Installing plugins' );
-			await wait( 3000 );
-			// TODO actually install plugins
+			setProgressTitle( 'Installing WooCommerce' );
+			//http://calypso.localhost:3000/setup/intent?siteSlug=testsite176507503.wpcomstaging.com
+			initiateSoftwareInstall( site.ID, softwareSet );
+
+			const timeoutMs = 1000 * 60 * 3;
+			const maxFinishTime = new Date().getTime() + timeoutMs;
+
+			let status: AtomicSoftwareStatus | undefined;
+			let currentProgress = 0;
+			const expectedStepCount = 5;
+			const progressStep = 1 / expectedStepCount;
+			while ( ! status?.applied ) {
+				if ( maxFinishTime < new Date().getTime() ) {
+					handleTransferFailure( {
+						type: 'transfer_timeout',
+						error: 'transfer took too long',
+						code: 'transfer_timeout',
+					} );
+					throw new Error( 'transfer timeout' );
+				}
+
+				requestAtomicSoftwareStatus( site.ID, softwareSet );
+
+				await wait( 3000 );
+
+				// Error making the request to install the software.
+				const installError = getAtomicSoftwareInstallError( site.ID, softwareSet );
+				// There was something wrong with the installation.
+				const statusError = getAtomicSoftwareError( site.ID, softwareSet );
+
+				if ( statusError || installError ) {
+					const error = statusError ? statusError : installError!;
+					handleTransferFailure( {
+						type: error.name,
+						code: error.code,
+						error: error.message,
+					} );
+					throw new Error( 'Transfer error' );
+				}
+
+				status = getAtomicSoftwareStatus( site.ID, softwareSet );
+				currentProgress += progressStep;
+				setProgress( currentProgress );
+			}
+
+			setProgress( 1 );
 		} );
 
 		submit?.();
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	return null;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-install-plugins/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-install-plugins/index.tsx
@@ -54,6 +54,7 @@ const WooInstallPlugins: Step = function WooInstallPlugins( { navigation } ) {
 
 		setPendingAction( async () => {
 			setProgressTitle( 'Installing WooCommerce' );
+			setProgress( 0 );
 			initiateSoftwareInstall( site.ID, softwareSet );
 
 			const timeoutMs = 1000 * 60 * 3;

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -424,12 +424,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 				body: {},
 			} );
 			yield atomicSoftwareInstallSuccess( siteId, softwareSet );
-		} catch ( _ ) {
-			yield atomicSoftwareInstallFailure(
-				siteId,
-				softwareSet,
-				AtomicSoftwareInstallError.INTERNAL
-			);
+		} catch ( err ) {
+			yield atomicSoftwareInstallFailure( siteId, softwareSet, err as AtomicSoftwareInstallError );
 		}
 	}
 

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -349,7 +349,7 @@ export const atomicSoftwareInstallStatus: Reducer<
 			[ action.siteId ]: {
 				[ action.softwareSet ]: {
 					status: AtomicSoftwareInstallStatus.FAILURE,
-					error: undefined,
+					error: action.error,
 				},
 			},
 		};

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -91,6 +91,14 @@ export const getAtomicSoftwareError = ( state: State, siteId: number, softwareSe
 	return state.atomicSoftwareStatus[ siteId ]?.[ softwareSet ]?.error;
 };
 
+export const getAtomicSoftwareInstallError = (
+	state: State,
+	siteId: number,
+	softwareSet: string
+) => {
+	return state.atomicSoftwareInstallStatus[ siteId ]?.[ softwareSet ]?.error;
+};
+
 export const hasActiveSiteFeature = (
 	_: State,
 	siteId: number | undefined,

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -381,6 +381,9 @@ export type AtomicSoftwareInstallState = Record<
 		error: AtomicSoftwareInstallError | undefined;
 	}
 >;
-export enum AtomicSoftwareInstallError {
-	INTERNAL = 'internal',
+export interface AtomicSoftwareInstallError {
+	name: string;
+	status: number;
+	message: string;
+	code: string;
 }


### PR DESCRIPTION
Implements the WooCommerce install step
### Testing
1. Apply this PR.
2. Setup an Atomic site without Woo installed.
3. Go to `http://calypso.localhost:3000/setup/intent?siteSlug=<YOUR_SITE>`.
4. Follow the seller flow selecting `More Power`.
5. Verify you get redirected to the `Installing WooCommerce` step and then you end up on the site editor and with WooCommerce installed on your site.

Closes https://github.com/Automattic/wp-calypso/issues/62717
