### PR TITLE
Anchor: Add submit logic to stepper flow

### DIFF
--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -11,7 +11,7 @@ export const anchorFmFlow: Flow = {
 	name: 'anchor-fm',
 
 	useSteps() {
-		return [ 'podcastTitle', 'designSetup' ] as StepPath[];
+		return [ 'podcastTitle', 'designSetup', 'processing' ] as StepPath[];
 	},
 
 	useStepNavigation( currentStep, navigate ) {
@@ -24,6 +24,8 @@ export const anchorFmFlow: Flow = {
 				case 'podcastTitle':
 					return navigate( 'designSetup' );
 				case 'designSetup':
+					return navigate( 'processing' );
+				case 'processing':
 					return redirect( `/page/home/${ siteSlug }` );
 			}
 		}

--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -1,4 +1,6 @@
+import { useSelect } from '@wordpress/data';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { SITE_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
@@ -15,10 +17,12 @@ export const anchorFmFlow: Flow = {
 	},
 
 	useStepNavigation( currentStep, navigate ) {
-		const siteSlug = useSiteSlugParam();
+		const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) );
+		const siteSlugParam = useSiteSlugParam();
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, 'anchor-fm', currentStep );
+			const siteSlug = siteSlugParam || getNewSite()?.site_slug;
 
 			switch ( currentStep ) {
 				case 'podcastTitle':
@@ -40,12 +44,13 @@ export const anchorFmFlow: Flow = {
 		};
 
 		const goNext = () => {
+			const siteSlug = siteSlugParam || getNewSite()?.site_slug;
+
 			switch ( currentStep ) {
 				case 'podcastTitle':
 					return navigate( 'designSetup' );
 				case 'designSetup':
 					return redirect( `/page/home/${ siteSlug }` );
-
 				default:
 					return navigate( 'podcastTitle' );
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -19,11 +19,12 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview/content';
+import { useNewSiteVisibility } from 'calypso/landing/gutenboarding/hooks/use-selected-plan';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useFSEStatus } from '../../../../hooks/use-fse-status';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
-import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
+import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../../../../stores';
 import { getAnchorPodcastId } from '../../../get-anchor-podcast-id';
 import { ANCHOR_FM_THEMES } from './anchor-fm-themes';
 import { getCategorizationOptions, getGeneratedDesignsCategory } from './categories';
@@ -43,7 +44,7 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	const translate = useTranslate();
 	const locale = useLocale();
 	const site = useSite();
-	const { setSelectedDesign, setPendingAction } = useDispatch( ONBOARD_STORE );
+	const { setSelectedDesign, setPendingAction, createSite } = useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
 
 	const anchorPodcastId = getAnchorPodcastId();
@@ -115,6 +116,8 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		[ staticDesigns, generatedDesigns ]
 	);
 
+	const visibility = useNewSiteVisibility();
+
 	function headerText() {
 		if ( showDesignPickerCategories ) {
 			return translate( 'Themes' );
@@ -161,6 +164,8 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		showGeneratedDesigns
 	);
 	const categorization = useCategorization( designs, categorizationOptions );
+	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
+	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
 
 	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
 		setSelectedDesign( _selectedDesign );
@@ -172,6 +177,29 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 				selectedSiteCategory: categorization.selection,
 			};
 			submit?.( providedDependencies );
+		} else if ( isAnchorSite && _selectedDesign ) {
+			setPendingAction( async () => {
+				if ( ! currentUser ) {
+					return;
+				}
+
+				await createSite( {
+					username: currentUser?.username,
+					languageSlug: locale,
+					bearerToken: undefined,
+					visibility,
+					anchorFmPodcastId: anchorPodcastId,
+					anchorFmEpisodeId: null,
+					anchorFmSpotifyUrl: null,
+				} );
+
+				if ( ! newSite || ! newSite.site_slug ) {
+					return;
+				}
+
+				return setDesignOnSite( newSite.site_slug, _selectedDesign );
+			} );
+			submit?.();
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -21,6 +21,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview/content';
 import { useNewSiteVisibility } from 'calypso/landing/gutenboarding/hooks/use-selected-plan';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useAnchorFmEpisodeId } from '../../../../hooks/use-anchor-fm-params';
 import { useFSEStatus } from '../../../../hooks/use-fse-status';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
@@ -166,6 +167,7 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	const categorization = useCategorization( designs, categorizationOptions );
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) );
+	const anchorFmEpisodeId = useAnchorFmEpisodeId();
 
 	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
 		setSelectedDesign( _selectedDesign );
@@ -189,7 +191,7 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 					bearerToken: undefined,
 					visibility,
 					anchorFmPodcastId: anchorPodcastId,
-					anchorFmEpisodeId: null,
+					anchorFmEpisodeId,
 					anchorFmSpotifyUrl: null,
 				} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -165,7 +165,7 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 	);
 	const categorization = useCategorization( designs, categorizationOptions );
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
-	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
+	const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) );
 
 	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
 		setSelectedDesign( _selectedDesign );
@@ -192,6 +192,8 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 					anchorFmEpisodeId: null,
 					anchorFmSpotifyUrl: null,
 				} );
+
+				const newSite = getNewSite();
 
 				if ( ! newSite || ! newSite.site_slug ) {
 					return;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -186,7 +186,7 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 				}
 
 				await createSite( {
-					username: currentUser?.username,
+					username: currentUser.username,
 					languageSlug: locale,
 					bearerToken: undefined,
 					visibility,

--- a/client/landing/stepper/hooks/test/use-anchor-fm-params.ts
+++ b/client/landing/stepper/hooks/test/use-anchor-fm-params.ts
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { renderHook } from '@testing-library/react-hooks';
+import { useAnchorFmEpisodeId } from '../use-anchor-fm-params';
+
+jest.mock( 'react-router-dom', () => ( {
+	useLocation: jest.fn().mockImplementation( () => ( {
+		pathname: '/setup',
+		search: '?anchor_episode=e1hmk1m',
+		hash: '',
+		state: undefined,
+	} ) ),
+} ) );
+
+describe( 'use-anchor-fm-params hook', () => {
+	test( 'returns anchor episode id', async () => {
+		const { result } = renderHook( () => useAnchorFmEpisodeId() );
+		expect( result.current ).toEqual( 'e1hmk1m' );
+	} );
+} );

--- a/client/landing/stepper/hooks/use-anchor-fm-params.ts
+++ b/client/landing/stepper/hooks/use-anchor-fm-params.ts
@@ -1,0 +1,5 @@
+import { useQuery } from './use-query';
+
+export function useAnchorFmEpisodeId(): string | null {
+	return useQuery().get( 'anchor_episode' );
+}

--- a/client/landing/stepper/stores.ts
+++ b/client/landing/stepper/stores.ts
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Onboard, Site, ProductsList } from '@automattic/data-stores';
+import { Onboard, Site, ProductsList, User } from '@automattic/data-stores';
 
 export const ONBOARD_STORE = Onboard.register();
 export const SITE_STORE = Site.register( {
@@ -7,3 +7,7 @@ export const SITE_STORE = Site.register( {
 	client_secret: config( 'wpcom_signup_key' ),
 } );
 export const PRODUCTS_LIST_STORE = ProductsList.register();
+export const USER_STORE = User.register( {
+	client_id: config( 'wpcom_signup_id' ),
+	client_secret: config( 'wpcom_signup_key' ),
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the submit logic for anchor.fm implementation to trigger all necessary actions to start the user's site and import their episode information.
* Remove the Font Pairing step from the anchor.fm flow

#### Testing instructions

* Access `http://calypso.localhost:3000/setup/designSetup?anchor_podcast=<YOUR_PODCAST_ID>`.
* Choose a theme.
* The site will be created and you'll be redirected to the editor.

Closes #62670
