### PR TITLE
Fix unlocalized links on Domain Management Screens

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -1,6 +1,4 @@
-import { localizeUrl } from '@automattic/i18n-utils';
-
-const root = localizeUrl( 'https://wordpress.com/support/' ).replace( /\/$/, '' );
+const root = 'https://wordpress.com/support';
 
 export const ADDING_GSUITE_TO_YOUR_SITE = `${ root }/add-email/adding-google-workspace-to-your-site/`;
 export const ADDING_TITAN_TO_YOUR_SITE = `${ root }/add-email/adding-professional-email-to-your-site/`;

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
@@ -50,7 +51,7 @@ class CustomNameserversForm extends PureComponent {
 			<div className="name-servers__custom-nameservers-form-explanation">
 				{ translate( 'Not sure what name servers to use?' ) }{ ' ' }
 				<a
-					href={ CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS }
+					href={ localizeUrl( CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS ) }
 					target="_blank"
 					rel="noopener noreferrer"
 					onClick={ this.handleLookUpClick }
@@ -142,7 +143,7 @@ class CustomNameserversForm extends PureComponent {
 			components: {
 				link: (
 					<a
-						href={ CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS }
+						href={ localizeUrl( CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS ) }
 						target="_blank"
 						rel="noopener noreferrer"
 						onClick={ this.handleLookUpClick }

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
@@ -1,4 +1,5 @@
 import { Button, Card } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -56,7 +57,7 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ): JSX.Element => {
 						'Privacy protection is not available due to the registry’s policies. {{a}}Learn more{{/a}}',
 						{
 							components: {
-								a: <a href={ PRIVACY_PROTECTION } target="blank" />,
+								a: <a href={ localizeUrl( PRIVACY_PROTECTION ) } target="blank" />,
 							},
 						}
 					) }
@@ -69,7 +70,7 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ): JSX.Element => {
 							"Privacy protection must be enabled due to the registry's policies. {{a}}Learn more{{/a}}",
 							{
 								components: {
-									a: <a href={ PRIVACY_PROTECTION } target="blank" />,
+									a: <a href={ localizeUrl( PRIVACY_PROTECTION ) } target="blank" />,
 								},
 							}
 						) }
@@ -99,7 +100,7 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ): JSX.Element => {
 			<p className="contact-information__toggle-item">
 				{ translate( 'We recommend keeping privacy protection on. {{a}}Learn more{{/a}}', {
 					components: {
-						a: <a href={ PUBLIC_VS_PRIVATE } target="blank" />,
+						a: <a href={ localizeUrl( PUBLIC_VS_PRIVATE ) } target="blank" />,
 					},
 				} ) }
 			</p>

--- a/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Icon, lock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { sslStatuses } from 'calypso/lib/domains/constants';
@@ -29,7 +30,7 @@ const DomainSecurityDetails = ( { domain }: DetailsCardProps ): JSX.Element | nu
 			default:
 				return translate(
 					'There is an issue with your certificate. Contact us to {{a}}learn more{{/a}}.',
-					{ components: { a: <a href={ CONTACT } /> } }
+					{ components: { a: <a href={ localizeUrl( CONTACT ) } /> } }
 				);
 		}
 	};
@@ -55,7 +56,7 @@ const DomainSecurityDetails = ( { domain }: DetailsCardProps ): JSX.Element | nu
 				<div className="domain-security-details__description-help-text">
 					{ translate(
 						'We give you strong HTTPS encryption with your domain for free. This provides a trust indicator for your visitors and keeps their connection to your site secure. {{a}}Learn more{{/a}}',
-						{ components: { a: <a href={ HTTPS_SSL } /> } }
+						{ components: { a: <a href={ localizeUrl( HTTPS_SSL ) } /> } }
 					) }
 				</div>
 			</div>

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -119,7 +120,7 @@ const NameServersCard = ( {
 
 		const link = (
 			<a
-				href={ CHANGE_NAME_SERVERS }
+				href={ localizeUrl( CHANGE_NAME_SERVERS ) }
 				target="_blank"
 				rel="noopener noreferrer"
 				onClick={ handleLearnMoreClick }


### PR DESCRIPTION

#### Changes proposed in this Pull Request

The `localizeUrl` call in [support.js](https://github.com/Automattic/wp-calypso/blob/78d4fef671d22c470657e8420263d1b3469f51bf/client/lib/url/support.js#L3) sets the constants to English URLs.
Making these constants dynamic by converting them to object fields seemed like a solution. The fields would be accessed via [getters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get).
For example:
```js
/// support.js
const root = () => localizeUrl(  'https://wordpress.com/support/'  ).replace( /\/$/, '' );
const titles = {
	get ADDING_GSUITE_TO_YOUR_SITE() {
		return `${ root() }/add-email/adding-google-workspace-to-your-site/`;
	},
}

export default titles;
```
 However, all imports that use `support.js` need to be modified to recognize this syntax. For example,
```js
import titles from 'calypso/lib/url/support';

console.log( titles.ADDING_GSUITE_TO_YOUR_SITE );
```
Therefore, this implementation fixes the URLs by calling localizeUrl at the point where it
is used.


#### Testing instructions

1. Go to https://wordpress.com/domains/manage/ and select a site with a domain.
2. Click on the 3 dots to see the domain settings.
3. Expand the DNS Servers, Contact Information, and Domain Security sections
4.  Verify that the URLs are localized.


Related to 381-gh-Automattic/i18n-issues
