### PR TITLE
Onboarding step for showcasing verticalized designs

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -25,10 +25,6 @@ const sortBlogToTop = makeSortCategoryToTop( CATEGORY_BLOG );
 const sortStoreToTop = makeSortCategoryToTop( CATEGORY_STORE );
 const sortGeneratedToTop = makeSortCategoryToTop( CATEGORY_GENERATED );
 
-export function getGeneratedDesignsCategory( name: string ): Category {
-	return { slug: CATEGORY_GENERATED, name };
-}
-
 export function getCategorizationOptions(
 	intent: string,
 	showAllFilter: boolean,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -294,75 +294,75 @@ $design-button-primary-color: rgb( 17, 122, 201 );
  * Generated Design Picker
  */
 .design-picker__is-generated {
-    .step-container__header {
-        align-items: center;
-        display: flex;
-        margin: 48px 0;
-        row-gap: 1.5rem;
-        flex-wrap: wrap;
+	.step-container__header {
+		align-items: center;
+		display: flex;
+		margin: 48px 0;
+		row-gap: 1.5rem;
+		flex-wrap: wrap;
 
-        .button {
-            border-radius: 4px;
-            font-weight: 500;
-            padding: 9px 48px;
+		.button {
+			border-radius: 4px;
+			font-weight: 500;
+			padding: 9px 48px;
 
-            // Override unnecessary super specificity added by another class.
-            box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;
-        }
-    }
+			// Override unnecessary super specificity added by another class.
+			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;
+		}
+	}
 
-    .generated_design-picker__content {
-        display: flex;
-        flex-direction: column;
+	.generated_design-picker__content {
+		display: flex;
+		flex-direction: column;
 
-        @include break-small {
-            flex-direction: row;
-        }
-    }
+		@include break-small {
+			flex-direction: row;
+		}
+	}
 
-    .generated-design-picker__thumbnails {
-        display: flex;
-        flex-direction: column;
-        flex-grow: 1;
-        margin-bottom: 98px;
-        row-gap: 24px;
+	.generated-design-picker__thumbnails {
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+		margin-bottom: 98px;
+		row-gap: 24px;
 
-        @include break-medium {
-            flex: 0 248px;
-            margin-bottom: 0;
-            padding-right: 2rem;
-        }
-    }
+		@include break-medium {
+			flex: 0 248px;
+			margin-bottom: 0;
+			padding-right: 2rem;
+		}
+	}
 
-    .generated-design-picker__previews {
-        display: none;
+	.generated-design-picker__previews {
+		display: none;
 
-        .mshots-image__container {
-            width: 100%;
-        }
+		.mshots-image__container {
+			width: 100%;
+		}
 
-        @include break-medium {
-            display: flex;
-            flex: 1;
-            flex-direction: column;
-            row-gap: 24px;
-            margin-bottom: 162px;
+		@include break-medium {
+			display: flex;
+			flex: 1;
+			flex-direction: column;
+			row-gap: 24px;
+			margin-bottom: 162px;
 
-            > div {
-                display: none;
+			> div {
+				display: none;
 
-                &:first-of-type {
-                    display: block;
-                }
-            }
-        }
-    }
+				&:first-of-type {
+					display: block;
+				}
+			}
+		}
+	}
 
-    .generated-design-picker__view-more {
-        border-radius: 4px;
-        font-weight: 500;
-        line-height: 1.25rem;
-        margin: 8px 0;
-        width: 100%;
-    }
+	.generated-design-picker__view-more {
+		border-radius: 4px;
+		font-weight: 500;
+		line-height: 1.25rem;
+		margin: 8px 0;
+		width: 100%;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -289,3 +289,80 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		display: none;
 	}
 }
+
+/**
+ * Generated Design Picker
+ */
+.design-picker__is-generated {
+    .step-container__header {
+        align-items: center;
+        display: flex;
+        margin: 48px 0;
+        row-gap: 1.5rem;
+        flex-wrap: wrap;
+
+        .button {
+            border-radius: 4px;
+            font-weight: 500;
+            padding: 9px 48px;
+
+            // Override unnecessary super specificity added by another class.
+            box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;
+        }
+    }
+
+    .generated_design-picker__content {
+        display: flex;
+        flex-direction: column;
+
+        @include break-small {
+            flex-direction: row;
+        }
+    }
+
+    .generated-design-picker__thumbnails {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        margin-bottom: 98px;
+        row-gap: 24px;
+
+        @include break-medium {
+            flex: 0 248px;
+            margin-bottom: 0;
+            padding-right: 2rem;
+        }
+    }
+
+    .generated-design-picker__previews {
+        display: none;
+
+        .mshots-image__container {
+            width: 100%;
+        }
+
+        @include break-medium {
+            display: flex;
+            flex: 1;
+            flex-direction: column;
+            row-gap: 24px;
+            margin-bottom: 162px;
+
+            > div {
+                display: none;
+
+                &:first-of-type {
+                    display: block;
+                }
+            }
+        }
+    }
+
+    .generated-design-picker__view-more {
+        border-radius: 4px;
+        font-weight: 500;
+        line-height: 1.25rem;
+        margin: 8px 0;
+        width: 100%;
+    }
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -313,11 +313,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 	.generated_design-picker__content {
 		display: flex;
-		flex-direction: column;
-
-		@include break-small {
-			flex-direction: row;
-		}
+		flex-direction: row;
 	}
 
 	.generated-design-picker__thumbnails {
@@ -326,6 +322,11 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		flex-grow: 1;
 		margin-bottom: 98px;
 		row-gap: 24px;
+
+		@include break-small {
+			flex: 0 154px;
+			padding-right: 1.5rem;
+		}
 
 		@include break-medium {
 			flex: 0 248px;
@@ -341,7 +342,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 			width: 100%;
 		}
 
-		@include break-medium {
+		@include break-small {
 			display: flex;
 			flex: 1;
 			flex-direction: column;

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -4,7 +4,6 @@ import { Button } from '@automattic/components';
 import { MShotsImage } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import { getDesignPreviewUrl } from '../utils';
-import { DesignPreviewImage } from './index';
 import type { Design } from '../types';
 import type { MShotsOptions } from '@automattic/onboarding';
 import './style.scss';
@@ -13,6 +12,13 @@ const thumbnailImageOptions: MShotsOptions = {
 	vpw: 1600,
 	vph: 1040,
 	w: 600,
+	screen_height: 3600,
+};
+
+const previewImageOptions: MShotsOptions = {
+	vpw: 1600,
+	vph: 1040,
+	w: 2399,
 	screen_height: 3600,
 };
 
@@ -40,7 +46,7 @@ const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
 				<MShotsImage
 					url={ thumbnailUrl }
 					alt=""
-					aria-labelledby={ `design-picker-category-filter__item-thumbnail__${ slug }` }
+					aria-labelledby={ `generated-design-thumbnail__image__${ slug }` }
 					options={ thumbnailImageOptions }
 					scrollable={ false }
 				/>
@@ -50,11 +56,14 @@ const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
 };
 
 interface GeneratedDesignPreviewProps {
-	design: Design;
-	locale: string;
+	slug: string;
+	previewUrl: string;
 }
 
-const GeneratedDesignPreview: React.FC< GeneratedDesignPreviewProps > = ( { design, locale } ) => {
+const GeneratedDesignPreview: React.FC< GeneratedDesignPreviewProps > = ( {
+	slug,
+	previewUrl,
+} ) => {
 	return (
 		<div className="generated-design-preview">
 			<div className="generated-design-preview__header">
@@ -67,7 +76,13 @@ const GeneratedDesignPreview: React.FC< GeneratedDesignPreviewProps > = ( { desi
 				</svg>
 			</div>
 			<div className="generated-design-preview__frame">
-				<DesignPreviewImage design={ design } locale={ locale } highRes />
+				<MShotsImage
+					url={ previewUrl }
+					alt=""
+					aria-labelledby={ `generated-design-preview__image__${ slug }` }
+					options={ previewImageOptions }
+					scrollable={ false }
+				/>
 			</div>
 		</div>
 	);
@@ -106,7 +121,11 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 				<div className="generated-design-picker__previews">
 					{ designs &&
 						designs.map( ( design ) => (
-							<GeneratedDesignPreview key={ design.slug } design={ design } locale={ locale } />
+							<GeneratedDesignPreview
+								key={ design.slug }
+								slug={ design.slug }
+								previewUrl={ getDesignPreviewUrl( design, { language: locale } ) }
+							/>
 						) ) }
 				</div>
 			</div>

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -19,7 +19,6 @@ const thumbnailImageOptions: MShotsOptions = {
 interface GeneratedDesignThumbnailProps {
 	slug: string;
 	thumbnailUrl: string;
-	onSelect: ( selectedSlug: string | null ) => void;
 }
 
 const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
@@ -78,15 +77,12 @@ export interface GeneratedDesignPickerProps {
 	designs: Design[];
 	locale: string;
 	heading?: React.ReactElement;
-	viewMoreFooter?: React.ReactNode;
-	onSelect: ( selectedSlug: string | null ) => void;
 }
 
 const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 	designs,
 	locale,
 	heading,
-	onSelect,
 } ) => {
 	const { __ } = useI18n();
 
@@ -101,7 +97,6 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 								key={ design.slug }
 								slug={ design.slug }
 								thumbnailUrl={ getDesignPreviewUrl( design, { language: locale } ) }
-								onSelect={ onSelect }
 							/>
 						) ) }
 					<Button className="generated-design-picker__view-more">

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -1,0 +1,122 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+import { Button } from '@automattic/components';
+import { MShotsImage } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
+import { getDesignPreviewUrl } from '../utils';
+import { DesignPreviewImage } from './index';
+import type { Design } from '../types';
+import type { MShotsOptions } from '@automattic/onboarding';
+import './style.scss';
+
+const thumbnailImageOptions: MShotsOptions = {
+	vpw: 1600,
+	vph: 1040,
+	w: 600,
+	screen_height: 3600,
+};
+
+interface GeneratedDesignThumbnailProps {
+	slug: string;
+	thumbnailUrl: string;
+	onSelect: ( selectedSlug: string | null ) => void;
+}
+
+const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
+	slug,
+	thumbnailUrl,
+} ) => {
+	return (
+		<button type="button" className="generated-design-thumbnail">
+			<span className="generated-design-thumbnail__header">
+				<svg width="28" height="6">
+					<g>
+						<rect width="6" height="6" rx="3" />
+						<rect x="11" width="6" height="6" rx="3" />
+						<rect x="22" width="6" height="6" rx="3" />
+					</g>
+				</svg>
+			</span>
+			<span className="generated-design-thumbnail__image">
+				<MShotsImage
+					url={ thumbnailUrl }
+					alt=""
+					aria-labelledby={ `design-picker-category-filter__item-thumbnail__${ slug }` }
+					options={ thumbnailImageOptions }
+					scrollable={ false }
+				/>
+			</span>
+		</button>
+	);
+};
+
+interface GeneratedDesignPreviewProps {
+	design: Design;
+	locale: string;
+}
+
+const GeneratedDesignPreview: React.FC< GeneratedDesignPreviewProps > = ( { design, locale } ) => {
+	return (
+		<div className="generated-design-preview">
+			<div className="generated-design-preview__header">
+				<svg width="36" height="8">
+					<g>
+						<rect width="8" height="8" rx="4" />
+						<rect x="14" width="8" height="8" rx="4" />
+						<rect x="28" width="8" height="8" rx="4" />
+					</g>
+				</svg>
+			</div>
+			<div className="generated-design-preview__frame">
+				<DesignPreviewImage design={ design } locale={ locale } highRes />
+			</div>
+		</div>
+	);
+};
+
+export interface GeneratedDesignPickerProps {
+	designs: Design[];
+	locale: string;
+	heading?: React.ReactElement;
+	viewMoreFooter?: React.ReactNode;
+	onSelect: ( selectedSlug: string | null ) => void;
+}
+
+const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
+	designs,
+	locale,
+	heading,
+	onSelect,
+} ) => {
+	const { __ } = useI18n();
+
+	return (
+		<div className="generated-design-picker">
+			{ heading }
+			<div className="generated_design-picker__content">
+				<div className="generated-design-picker__thumbnails">
+					{ designs &&
+						designs.map( ( design ) => (
+							<GeneratedDesignThumbnail
+								key={ design.slug }
+								slug={ design.slug }
+								thumbnailUrl={ getDesignPreviewUrl( design, { language: locale } ) }
+								onSelect={ onSelect }
+							/>
+						) ) }
+					<Button className="generated-design-picker__view-more">
+						{ __( 'View more options' ) }
+					</Button>
+				</div>
+				<div className="generated-design-picker__previews">
+					{ designs &&
+						designs.map( ( design ) => (
+							<GeneratedDesignPreview key={ design.slug } design={ design } locale={ locale } />
+						) ) }
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default GeneratedDesignPicker;

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -301,4 +301,4 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	);
 };
 
-export default DesignPicker;
+export { DesignPicker as default, DesignPreviewImage };

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -387,3 +387,109 @@
 		}
 	}
 }
+
+
+.generated-design-thumbnail {
+    align-items: stretch;
+    box-shadow: inset 0 0 0 1px #fff, 0 0 0 1px #dddddd;
+    border-radius: 4px;
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    height: 355px;
+    padding: 0;
+    overflow: hidden;
+    width: 100%;
+
+    .generated-design-thumbnail__header {
+        border-bottom: 1px solid #dddddd;
+		box-sizing: border-box;
+		display: block;
+        height: 23px;
+		max-width: 100%;
+        padding: 0 12px;
+		position: relative;
+        text-align: left;
+
+		svg {
+			fill: var( --studio-gray-5 );
+		}
+    }
+
+    .generated-design-thumbnail__image {
+        flex: 1;
+        overflow: hidden;
+
+        .mshots-image-visible {
+            object-fit: cover;
+            object-position: top;
+            width: 100%;
+        }
+    }
+
+    @include break-medium {
+        border-radius: 2px;
+        height: 170px;
+        padding: 8px;
+
+        .generated-design-thumbnail__header {
+            display: none;
+        }
+    }
+}
+
+.generated-design-preview {
+    .generated-design-preview__header {
+		align-items: center;
+		border-radius: 4px 4px 0 0; /* stylelint-disable-line scales/radii */
+        border: 1px solid var( --studio-gray-5 );
+		box-sizing: border-box;
+		display: flex;
+        height: 23px;
+		justify-content: center;
+		margin: 0 auto;
+		max-width: 100%;
+		position: relative;
+
+		svg {
+			fill: var( --studio-gray-5 );
+			left: 8px;
+			position: absolute;
+		}
+    }
+
+    .generated-design-preview__frame {
+        border: 1px solid var( --studio-gray-5 );
+		border-radius: 0 0 4px 4px; /* stylelint-disable-line scales/radii */
+        border-top: 0;
+		box-sizing: border-box;
+		display: block;
+        line-height: 0;
+        max-height: 334px;
+		overflow: hidden;
+		position: relative;
+		width: 100%;
+    }
+
+    @include break-medium {
+        .generated-design-preview__header {
+            border-radius: 8px 8px 0 0; /* stylelint-disable-line scales/radii */
+            height: 34px;
+
+            svg {
+                left: 12px;
+                transform: scale( 1 );
+            }
+        }
+
+        .generated-design-preview__frame {
+            border-radius: 0 0 8px 8px; /* stylelint-disable-line scales/radii */
+            max-height: none;
+        }
+
+        .generated-design-preview__name {
+            display: none;
+        }
+    }
+}

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -428,7 +428,7 @@
 		}
 	}
 
-	@include break-medium {
+	@include break-small {
 		border-radius: 2px;
 		height: 170px;
 		padding: 8px;
@@ -472,7 +472,7 @@
 		width: 100%;
 	}
 
-	@include break-medium {
+	@include break-small {
 		.generated-design-preview__header {
 			border-radius: 8px 8px 0 0; /* stylelint-disable-line scales/radii */
 			height: 34px;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -390,63 +390,63 @@
 
 
 .generated-design-thumbnail {
-    align-items: stretch;
-    box-shadow: inset 0 0 0 1px #fff, 0 0 0 1px #dddddd;
-    border-radius: 4px;
-    box-sizing: border-box;
-    cursor: pointer;
-    display: flex;
-    flex-direction: column;
-    height: 355px;
-    padding: 0;
-    overflow: hidden;
-    width: 100%;
+	align-items: stretch;
+	box-shadow: inset 0 0 0 1px #fff, 0 0 0 1px #dddddd;
+	border-radius: 4px;
+	box-sizing: border-box;
+	cursor: pointer;
+	display: flex;
+	flex-direction: column;
+	height: 355px;
+	padding: 0;
+	overflow: hidden;
+	width: 100%;
 
-    .generated-design-thumbnail__header {
-        border-bottom: 1px solid #dddddd;
+	.generated-design-thumbnail__header {
+		border-bottom: 1px solid #dddddd;
 		box-sizing: border-box;
 		display: block;
-        height: 23px;
+		height: 23px;
 		max-width: 100%;
-        padding: 0 12px;
+		padding: 0 12px;
 		position: relative;
-        text-align: left;
+		text-align: left;
 
 		svg {
 			fill: var( --studio-gray-5 );
 		}
     }
 
-    .generated-design-thumbnail__image {
-        flex: 1;
-        overflow: hidden;
+	.generated-design-thumbnail__image {
+		flex: 1;
+		overflow: hidden;
 
-        .mshots-image-visible {
-            object-fit: cover;
-            object-position: top;
-            width: 100%;
-        }
-    }
+		.mshots-image-visible {
+			object-fit: cover;
+			object-position: top;
+			width: 100%;
+		}
+	}
 
-    @include break-medium {
-        border-radius: 2px;
-        height: 170px;
-        padding: 8px;
+	@include break-medium {
+		border-radius: 2px;
+		height: 170px;
+		padding: 8px;
 
-        .generated-design-thumbnail__header {
-            display: none;
-        }
-    }
+		.generated-design-thumbnail__header {
+			display: none;
+		}
+	}
 }
 
 .generated-design-preview {
-    .generated-design-preview__header {
+	.generated-design-preview__header {
 		align-items: center;
 		border-radius: 4px 4px 0 0; /* stylelint-disable-line scales/radii */
-        border: 1px solid var( --studio-gray-5 );
+		border: 1px solid var( --studio-gray-5 );
 		box-sizing: border-box;
 		display: flex;
-        height: 23px;
+		height: 23px;
 		justify-content: center;
 		margin: 0 auto;
 		max-width: 100%;
@@ -457,39 +457,39 @@
 			left: 8px;
 			position: absolute;
 		}
-    }
+	}
 
-    .generated-design-preview__frame {
-        border: 1px solid var( --studio-gray-5 );
+	.generated-design-preview__frame {
+		border: 1px solid var( --studio-gray-5 );
 		border-radius: 0 0 4px 4px; /* stylelint-disable-line scales/radii */
-        border-top: 0;
+		border-top: 0;
 		box-sizing: border-box;
 		display: block;
-        line-height: 0;
-        max-height: 334px;
+		line-height: 0;
+		max-height: 334px;
 		overflow: hidden;
 		position: relative;
 		width: 100%;
-    }
+	}
 
-    @include break-medium {
-        .generated-design-preview__header {
-            border-radius: 8px 8px 0 0; /* stylelint-disable-line scales/radii */
-            height: 34px;
+	@include break-medium {
+		.generated-design-preview__header {
+			border-radius: 8px 8px 0 0; /* stylelint-disable-line scales/radii */
+			height: 34px;
 
-            svg {
-                left: 12px;
-                transform: scale( 1 );
-            }
-        }
+			svg {
+				left: 12px;
+				transform: scale( 1 );
+			}
+		}
 
-        .generated-design-preview__frame {
-            border-radius: 0 0 8px 8px; /* stylelint-disable-line scales/radii */
-            max-height: none;
-        }
+		.generated-design-preview__frame {
+			border-radius: 0 0 8px 8px; /* stylelint-disable-line scales/radii */
+			max-height: none;
+		}
 
-        .generated-design-preview__name {
-            display: none;
-        }
-    }
+		.generated-design-preview__name {
+			display: none;
+		}
+	}
 }

--- a/packages/design-picker/src/generated-designs-config.json
+++ b/packages/design-picker/src/generated-designs-config.json
@@ -7,7 +7,7 @@
 			"patternIds": [ 1707, 1163, 1190, 1163, 1538, 655 ]
 		},
 		"is_premium": false,
-		"categories": [],
+		"categories": [ { "slug": "business", "name": "Business" } ],
 		"features": [],
 		"theme": "",
 		"template": ""
@@ -20,7 +20,7 @@
 			"patternIds": [ 2077, 2080, 2082, 1768, 2088 ]
 		},
 		"is_premium": false,
-		"categories": [],
+		"categories": [ { "slug": "portfolio", "name": "Portfolio" } ],
 		"features": [],
 		"theme": "",
 		"template": ""
@@ -33,7 +33,7 @@
 			"patternIds": [ 1243, 2118, 2266, 2121, 1812 ]
 		},
 		"is_premium": false,
-		"categories": [],
+		"categories": [ { "slug": "blog", "name": "Blog" } ],
 		"features": [],
 		"theme": "",
 		"template": ""

--- a/packages/design-picker/src/hooks/use-generated-designs.ts
+++ b/packages/design-picker/src/hooks/use-generated-designs.ts
@@ -1,16 +1,14 @@
 import { useMemo } from 'react';
 import rawGeneratedDesignsConfig from '../generated-designs-config.json';
-import { Category, Design } from '../types';
+import { Design } from '../types';
 
-export function useGeneratedDesigns( category?: Category ): Design[] {
+export function useGeneratedDesigns(): Design[] {
 	// TODO: fetch designs from backend
 	return useMemo( () => {
-		if ( ! category ) {
-			return [];
-		}
 		return ( rawGeneratedDesignsConfig as Design[] ).map( ( design ) => ( {
 			...design,
-			categories: [ ...design.categories, category ],
+			preview: 'static',
+			categories: [ ...design.categories ],
 		} ) );
-	}, [ category ] );
+	}, [] );
 }

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -1,4 +1,5 @@
 export { default } from './components';
+export { default as GeneratedDesignPicker } from './components/generated-design-picker';
 
 export { default as FeaturedPicksButtons } from './components/featured-picks-buttons';
 export { default as PremiumBadge } from './components/premium-badge';
@@ -9,6 +10,7 @@ export {
 	getDesignUrl,
 	getDesignPreviewUrl,
 	isBlankCanvasDesign,
+	mShotOptions,
 } from './utils';
 export { FONT_PAIRINGS, ANCHORFM_FONT_PAIRINGS } from './constants';
 export type { FontPair, Design, Category } from './types';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds an onboarding step where sites with vertical data will be shown verticalized designs instead of non-verticalized ones. In order to keep the scope small, this PR will focus on the onboarding flow and screen layout. 

#### What to test

* Verticalized design picker is implemented as shown in 42PgVsdlQ1v2wpk6lmmrnq-fi-1697%3A54130 for both desktop and mobile resolutions. 
* Traditional design picker works as before, and not broken because of the changes in this PR.

#### What not to test

* Thumbnail/preview content.
* Interactions such as clicking on thumbnails, "View more options" button, or "Continue" button.
* Improvements to the traditional design picker.
* Good-to-have layout optimizations:
  * Dynamic thumbnail height
  * Onboarding progress bar
  * "Continue" button to be always visible.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the onboarding screen `/setup/intent?siteSlug=${site_slug}`
* Click on the "Start building" button, and expect to land on the verticalized design picker. 
* Check that the screen is as per spec.
* Change resolution to mobile ( < 600px).
* Check that the screen is as per spec.
* Click on the "Back" button, back to the onboarding screen.
* Click on the "Start writing" button, click the "Continue" button, and expect to land on the traditional design picker.
* Expect that the traditional design picker looks and works as before.

Desktop:
![Screen Shot 2022-05-04 at 10 47 29 AM](https://user-images.githubusercontent.com/797888/166617116-5ced512e-10bc-4574-a343-d1d5b495a615.png)

Mobile:
![Screen Shot 2022-05-04 at 10 47 45 AM](https://user-images.githubusercontent.com/797888/166617122-36a7ea07-6842-45ed-b3b1-050ed155657b.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62237