### PR TITLE
Help Center: Checkout entry point 

### DIFF
--- a/client/blocks/inline-help/inline-help-center-types.ts
+++ b/client/blocks/inline-help/inline-help-center-types.ts
@@ -1,0 +1,5 @@
+export interface Article {
+	title: string;
+	link?: string;
+	icon?: string;
+}

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -1,8 +1,11 @@
 import { checkoutTheme, CheckoutModal } from '@automattic/composite-checkout';
+import HelpCenter, { HelpIcon } from '@automattic/help-center';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { ThemeProvider } from '@emotion/react';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useState } from 'react';
+import InlineHelpCenterContent from 'calypso/blocks/inline-help/inline-help-center-content';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -11,6 +14,7 @@ import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import Item from './item';
 import Masterbar from './masterbar';
+
 interface Props {
 	title: string;
 	isJetpackNotAtomic?: boolean;
@@ -33,6 +37,10 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 	const cartKey = useCartKey();
 	const { responseCart, replaceProductsInCart } = useShoppingCart( cartKey );
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
+	const [ isHelpCenterVisible, setIsHelpCenterVisible ] = useState( false );
+	const [ selectedArticle, setSelectedArticle ] = useState( null );
+	const [ footerContent, setFooterContent ] = useState( null );
+
 	const closeAndLeave = () =>
 		leaveCheckout( {
 			siteSlug,
@@ -77,6 +85,13 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 				<span className="masterbar__secure-checkout-text">{ translate( 'Secure checkout' ) }</span>
 			</div>
 			<Item className="masterbar__item-title">{ title }</Item>
+			<Item
+				onClick={ () => setIsHelpCenterVisible( ! isHelpCenterVisible ) }
+				className={ classnames( 'masterbar__item-help', {
+					'is-active': isHelpCenterVisible,
+				} ) }
+				icon={ <HelpIcon newItems active={ isHelpCenterVisible } /> }
+			/>
 			<CheckoutModal
 				title={ modalTitleText }
 				copy={ modalBodyText }
@@ -87,6 +102,20 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 				secondaryButtonCTA={ modalSecondaryText }
 				secondaryAction={ clearCartAndLeave }
 			/>
+			{ isHelpCenterVisible && (
+				<HelpCenter
+					content={
+						<InlineHelpCenterContent
+							selectedArticle={ selectedArticle }
+							setSelectedArticle={ setSelectedArticle }
+							setHelpCenterFooter={ setFooterContent }
+						/>
+					}
+					headerText={ selectedArticle?.title }
+					handleClose={ () => setIsHelpCenterVisible( false ) }
+					footerContent={ footerContent }
+				/>
+			) }
 		</Masterbar>
 	);
 };

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -40,7 +40,7 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 	const [ isHelpCenterVisible, setIsHelpCenterVisible ] = useState( false );
 	const [ selectedArticle, setSelectedArticle ] = useState< Article | null >( null );
-	const [ footerContent, setFooterContent ] = useState( null );
+	const [ footerContent, setFooterContent ] = useState( undefined );
 
 	const closeAndLeave = () =>
 		leaveCheckout( {

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -14,6 +14,7 @@ import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import Item from './item';
 import Masterbar from './masterbar';
+import type { Article } from 'calypso/blocks/inline-help/inline-help-center-types';
 
 interface Props {
 	title: string;
@@ -38,7 +39,7 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 	const { responseCart, replaceProductsInCart } = useShoppingCart( cartKey );
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 	const [ isHelpCenterVisible, setIsHelpCenterVisible ] = useState( false );
-	const [ selectedArticle, setSelectedArticle ] = useState( null );
+	const [ selectedArticle, setSelectedArticle ] = useState< Article | null >( null );
 	const [ footerContent, setFooterContent ] = useState( null );
 
 	const closeAndLeave = () =>

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { checkoutTheme, CheckoutModal } from '@automattic/composite-checkout';
 import HelpCenter, { HelpIcon } from '@automattic/help-center';
 import { useShoppingCart } from '@automattic/shopping-cart';
@@ -69,6 +70,8 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 		closeAndLeave();
 	};
 
+	const isHelpCenterEnabled = config.isEnabled( 'editor/help-center' );
+
 	return (
 		<Masterbar>
 			<div className="masterbar__secure-checkout">
@@ -86,13 +89,15 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 				<span className="masterbar__secure-checkout-text">{ translate( 'Secure checkout' ) }</span>
 			</div>
 			<Item className="masterbar__item-title">{ title }</Item>
-			<Item
-				onClick={ () => setIsHelpCenterVisible( ! isHelpCenterVisible ) }
-				className={ classnames( 'masterbar__item-help', {
-					'is-active': isHelpCenterVisible,
-				} ) }
-				icon={ <HelpIcon newItems active={ isHelpCenterVisible } /> }
-			/>
+			{ isHelpCenterEnabled && (
+				<Item
+					onClick={ () => setIsHelpCenterVisible( ! isHelpCenterVisible ) }
+					className={ classnames( 'masterbar__item-help', {
+						'is-active': isHelpCenterVisible,
+					} ) }
+					icon={ <HelpIcon newItems active={ isHelpCenterVisible } /> }
+				/>
+			) }
 			<CheckoutModal
 				title={ modalTitleText }
 				copy={ modalBodyText }
@@ -103,7 +108,7 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 				secondaryButtonCTA={ modalSecondaryText }
 				secondaryAction={ clearCartAndLeave }
 			/>
-			{ isHelpCenterVisible && (
+			{ isHelpCenterEnabled && isHelpCenterVisible && (
 				<HelpCenter
 					content={
 						<InlineHelpCenterContent

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -343,6 +343,11 @@ $masterbar-color-secondary: #101517;
 		}
 	}
 
+	&.masterbar__item-help {
+		cursor: pointer;
+		flex: 0;
+	}
+
 	.is-support-session &.is-active {
 		background: var( --studio-orange-70 );
 	}

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -29,18 +29,14 @@ const HelpCenter: React.FC< Container > = ( {
 		};
 	}, [ portalParent ] );
 
-	return (
-		<div>
-			{ createPortal(
-				<HelpCenterContainer
-					handleClose={ handleClose }
-					content={ content }
-					headerText={ headerText }
-					footerContent={ footerContent }
-				/>,
-				portalParent
-			) }
-		</div>
+	return createPortal(
+		<HelpCenterContainer
+			handleClose={ handleClose }
+			content={ content }
+			headerText={ headerText }
+			footerContent={ footerContent }
+		/>,
+		portalParent
 	);
 };
 

--- a/packages/help-center/src/components/help-icon.tsx
+++ b/packages/help-center/src/components/help-icon.tsx
@@ -25,8 +25,7 @@ const HelpIcon: React.FC< Props > = ( { newItems, active } ) => (
 				cx="20"
 				cy="8"
 				r="5"
-				stroke={ active ? '#1e1e1e' : 'white' }
-				fill="currentColor"
+				fill="var( --color-masterbar-unread-dot-background )"
 				strokeWidth="2"
 			/>
 		) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Added the help center in checkout. 
Didn't have to set the section to checkout, as in checkout we do not have ETK, and we're in calypso so the section is already correctly set.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* `yarn start`
* Visit `http://calypso.localhost:3000/checkout/yoursite.wordpress.com`
* Verify that the help center works correctly

CSS not touched much since it is already being worked on. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63060
Fixes #63060
