### PR TITLE
Change lables in membeship subscriptions

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -111,7 +111,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		// Space isn't included in the translatable string to prevent it being easily missed.
 		return isNonAtomicJetpack
 			? ' ' + jetpackText
-			: ' ' + translate( 'Available with any paid plan.' );
+			: ' ' + translate( 'Available with any paid plan — no plugin required.' );
 	};
 
 	const getPremiumPlanNames = () => {
@@ -179,6 +179,10 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getRecurringPaymentsCard = () => {
+		const hasConnectionCtaTitle = translate( 'Manage Payment Button' );
+		const noConnectionCtaTitle = translate( 'Enable Payment Button' );
+		const ctaTitle = hasConnectedAccount ? hasConnectionCtaTitle : noConnectionCtaTitle;
+
 		const cta = isFreePlan
 			? {
 					text: translate( 'Unlock this feature' ),
@@ -188,15 +192,13 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					},
 			  }
 			: {
-					text: translate( 'Collect payments' ),
+					text: ctaTitle,
 					action: () => {
 						trackCtaButton( 'recurring-payments' );
 						page( `/earn/payments/${ selectedSiteSlug }` );
 					},
 			  };
-		const hasConnectionTitle = translate( 'Manage payments' );
-		const noConnectionTitle = translate( 'Collect payments' );
-		const title = hasConnectedAccount ? hasConnectionTitle : noConnectionTitle;
+		const title = translate( 'Collect payments' );
 
 		const hasConnectionBody = translate(
 			"Manage your customers and subscribers, or your current subscription options and review the total revenue that you've made from payments."
@@ -204,7 +206,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		const noConnectionBody = (
 			<>
 				{ translate(
-					'Accept one-time and recurring credit card payments for physical products, services, memberships, subscriptions, and donations.'
+					'Let visitors pay for digital goods and services or make quick, pre-set donations by enabling the Payment Button block.'
 				) }
 				{ isFreePlan && <em>{ getAnyPlanNames() }</em> }
 			</>
@@ -213,7 +215,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 
 		const learnMoreLink = isFreePlan
 			? {
-					url: 'https://wordpress.com/support/recurring-payments/',
+					url: 'https://wordpress.com/payments-donations/',
 					onClick: () => trackLearnLink( 'recurring-payments' ),
 			  }
 			: null;
@@ -234,6 +236,10 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getDonationsCard = () => {
+		const hasConnectionCtaTitle = translate( 'Manage Donations Form' );
+		const noConnectionCtaTitle = translate( 'Enable Donations Form' );
+		const ctaTitle = hasConnectedAccount ? hasConnectionCtaTitle : noConnectionCtaTitle;
+
 		const cta = isFreePlan
 			? {
 					text: translate( 'Unlock this feature' ),
@@ -243,7 +249,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					},
 			  }
 			: {
-					text: translate( 'Manage donations' ),
+					text: ctaTitle,
 					action: () => {
 						trackCtaButton( 'donations' );
 						page( `/earn/payments/${ selectedSiteSlug }` );
@@ -254,14 +260,14 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		const body = (
 			<>
 				{ translate(
-					'Collect donations, tips, and contributions for your creative pursuits, organization, or whatever your website is about.'
+					'Accept one-time and recurring donations by enabling the Donations Form block.'
 				) }
 				{ isFreePlan && <em>{ getAnyPlanNames() }</em> }
 			</>
 		);
 
 		const learnMoreLink = {
-			url: localizeUrl( 'https://wordpress.com/support/donations/' ),
+			url: localizeUrl( 'https://wordpress.com/payments-donations/' ),
 			onClick: () => trackLearnLink( 'donations' ),
 		};
 
@@ -282,6 +288,10 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getPremiumContentCard = () => {
+		const hasConnectionCtaTitle = translate( 'Manage Premium Content' );
+		const noConnectionCtaTitle = translate( 'Enable Premium Content' );
+		const ctaTitle = hasConnectedAccount ? hasConnectionCtaTitle : noConnectionCtaTitle;
+
 		const cta = isFreePlan
 			? {
 					text: translate( 'Unlock this feature' ),
@@ -291,18 +301,18 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					},
 			  }
 			: {
-					text: translate( 'Add premium content subscriptions' ),
+					text: ctaTitle,
 					action: () => {
 						trackCtaButton( 'premium-content' );
 						page( `/earn/payments/${ selectedSiteSlug }` );
 					},
 			  };
 		const title = hasConnectedAccount
-			? translate( 'Manage your premium content' )
-			: translate( 'Collect payments for content' );
+			? translate( 'Profit from subscriber-only content' )
+			: translate( 'Profit from subscriber-only content' );
 		const body = hasConnectedAccount ? (
 			translate(
-				'Create paid subscription options to share premium content like text, images, video, and any other content on your website. Browse our {{a}}docs{{/a}} for the details.',
+				'Create paid subscriptions so only subscribers can see selected content on your site — everyone else will see a paywall.',
 				{
 					components: {
 						a: (

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -509,14 +509,14 @@ class MembershipsSection extends Component {
 						<p className="memberships__onboarding-paragraph">
 							{ preventWidows(
 								translate(
-									'WordPress.com Payments makes it easy to sell physical and digital goods, accept donations, charge for in-person services, build subscription newsletters, and more.'
+									'Our payments blocks make it easy to add a buy button for digital goods or services, collect donations via a form, or limit access for specific content to subscribers-only.'
 								)
 							) }
 						</p>
 						<p className="memberships__onboarding-paragraph">
 							{ preventWidows(
 								translate(
-									'One-time, monthly, and yearly credit and debit card payment options are supported. {{link}}Learn more about payments.{{/link}}',
+									'The Payment Button, Donations Form, and Premium Content blocks all require you to first connect your bank account details with our secure payment processor, Stripe.',
 									{
 										components: {
 											link: (
@@ -531,7 +531,7 @@ class MembershipsSection extends Component {
 						<p className="memberships__onboarding-paragraph memberships__onboarding-paragraph-disclaimer">
 							{ preventWidows(
 								translate(
-									'Payments are securely processed by Stripe, a payment partner for all credit and debit card payments.'
+									'All credit and debit card payments made through these blocks are securely and seamlessly processed by Stripe.'
 								)
 							) }
 						</p>
@@ -542,33 +542,31 @@ class MembershipsSection extends Component {
 				</div>
 				<div className="memberships__onboarding-benefits">
 					<div>
-						<h3>{ translate( 'Payments for anything' ) }</h3>
+						<h3>{ translate( 'No plugin required' ) }</h3>
 						{ preventWidows(
 							translate(
-								'Send paid newsletters and offer premium content, services, physical and digital goods, accept donations, and more.'
+								'No additional installs or purchases. Simply connect your banking details with our payment processor, Stripe, and insert a block to get started.'
 							)
 						) }
 					</div>
 					<div>
-						<h3>{ translate( 'Flexibile options' ) }</h3>
+						<h3>{ translate( 'One-time and recurring options' ) }</h3>
 						{ preventWidows(
 							translate(
-								'Add as many one-time, monthly, yearly, and lifetime subscription options as you need.'
+								'Accept one-time, monthly, and yearly payments from your visitors. This is perfect for a single purchase or tip — or a recurring donation, membership fee, or subscription.'
 							)
 						) }
 					</div>
 					<div>
-						<h3>{ translate( "You're in control" ) }</h3>
-						{ preventWidows(
-							translate(
-								'You choose which content requires payment. Easily manage subscribers and payment plans.'
-							)
-						) }
+						<h3>{ translate( 'No membership fees' ) }</h3>
+						{ preventWidows( translate( 'No monthly or annual fees charged.' ) ) }
 					</div>
 					<div>
-						<h3>{ translate( 'Global payments' ) }</h3>
+						<h3>{ translate( 'Join thousands of others' ) }</h3>
 						{ preventWidows(
-							translate( 'Collect payments in 135 countries to reach customers around the world.' )
+							translate(
+								'Sites that actively promoted their businesses and causes on social media, email, and other platforms have collected tens of thousands of dollars through these blocks.'
+							)
 						) }
 					</div>
 				</div>
@@ -611,7 +609,7 @@ class MembershipsSection extends Component {
 					shouldDisplay={ () => true }
 					feature={ FEATURE_MEMBERSHIPS }
 					title={ this.props.translate( 'Upgrade to the Pro plan' ) }
-					description={ this.props.translate( 'Upgrade to start selling.' ) }
+					description={ this.props.translate( 'Upgrade to enable Payment Blocks.' ) }
 					showIcon={ true }
 					event="calypso_memberships_upsell_nudge"
 					tracksImpressionName="calypso_upgrade_nudge_impression"

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -165,9 +165,9 @@ export const MarketingTools: FunctionComponent = () => {
 				) }
 
 				<MarketingToolsFeature
-					title={ translate( 'Build your community, following, and income with Earn tools' ) }
+					title={ translate( 'Monetize your site' ) }
 					description={ translate(
-						'Increase engagement and income on your site by accepting payments for just about anything – physical and digital goods, services, donations, or access to exclusive content.'
+						'Accept payments or donations with our native payment blocks, limit content to paid subscribers only, opt into our ad network to earn revenue, and refer friends to WordPress.com for credits.'
 					) }
 					imagePath={ earnIllustration }
 				>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change labels for payment block and donation block in 3 pages: 
/earn/
/earn/payments/
/marketing/tools/

#### Testing instructions

Foreach 3 types of account: free plan, paid stripe disconnected and paid stripe connected:
1. go to /earn/[my-site]
2. compare text for 3 cards with issue https://github.com/Automattic/wp-calypso/issues/62721

<img width="1067" alt="earn" src="https://user-images.githubusercontent.com/82798599/165724939-38cec138-3282-470b-86b0-1a8e795f5b0d.png">

3. go to /marketing/tools/[my-site]
4. compare text for Earn Tool card with issue https://github.com/Automattic/wp-calypso/issues/62721

<img width="1069" alt="marketing-tools" src="https://user-images.githubusercontent.com/82798599/165725161-ccd7564b-589e-4032-815c-287b19bf549a.png">

For 2 types of account: free plan and paid stripe disconnected:
1. go to /earn/payments/[my-site]
2. compare text in whole page with issue https://github.com/Automattic/wp-calypso/issues/62721

<img width="1080" alt="earn-payments" src="https://user-images.githubusercontent.com/82798599/165725188-6465b7d9-1113-4779-a406-1c202c55e937.png">

####  Related to 
https://github.com/Automattic/wp-calypso/issues/62721

