### PR TITLE
Components: Refactor `AutoDirection` tests to `@testing-library/react` and `jest`

### DIFF
--- a/client/components/auto-direction/test/auto-direction.jsx
+++ b/client/components/auto-direction/test/auto-direction.jsx
@@ -1,31 +1,29 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import AutoDirection from '..';
 
 describe( 'AutoDirection', () => {
 	describe( 'component rendering', () => {
 		test( 'adds a direction to RTL text', () => {
-			const wrapper = shallow(
+			render(
 				<AutoDirection>
-					<div>השנה היא 2017.</div>
+					<div data-testid="direction-test">השנה היא 2017.</div>
 				</AutoDirection>
 			);
 
-			expect( wrapper.getElement().props.direction ).to.equal( 'rtl' );
+			expect( screen.getByTestId( 'direction-test' ).getAttribute( 'direction' ) ).toEqual( 'rtl' );
 		} );
 
 		test( "doesn't add a direction to LTR text", () => {
-			const wrapper = shallow(
+			render(
 				<AutoDirection>
-					<div>The year is 2017.</div>
+					<div data-testid="direction-test">The year is 2017.</div>
 				</AutoDirection>
 			);
 
-			expect( wrapper.getElement().props ).to.not.have.property( 'direction' );
+			expect( screen.getByTestId( 'direction-test' ).getAttribute( 'direction' ) ).toBeNull();
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `AutoDirection` component to use `@testing-library/react` instead of `enzyme`.

It's the simplest possible demonstration of migration from `enzyme` to `@testing-library/react` that suggests `data-testid` for locating the elements.

We also use the opportunity to refactor the `chai` usage to `jest`.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/components/auto-direction`