### PR TITLE
DesignPicker: Prefetch designs for a smooth UX

### DIFF
--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -34,7 +34,9 @@ export const exampleFlow: Flow = {
 
 ## The API
 
-To create a flow, you only have to define `useSteps` and `useStepNavigation`. `useSteps` just returns an array of step keys, `useStepNavigation` is the engine where you make navigation decisions. This hook returns an object of type [`NavigationControls`](./declarative-flow/internals/types.ts):
+To create a flow, you only have to implement `useSteps` and `useStepNavigation`. `useSteps` just returns an array of step keys, `useStepNavigation` is the engine where you make navigation decisions. This hook returns an object of type [`NavigationControls`](./declarative-flow/internals/types.ts):
+
+There is also an optional `useSideEffect` hook. You can implement this hook to run any side-effects to the flow. You can prefetch information, send track events when something changes, etc...
 
 ```tsx
 // prettier-ignore

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -30,6 +30,8 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const pathToClass = ( path: string ) =>
 		path.replace( /([a-z0-9])([A-Z])/g, '$1-$2' ).toLowerCase();
 
+	flow.useSideEffect?.();
+
 	useEffect( () => {
 		window.scrollTo( 0, 0 );
 	}, [ location ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -7,7 +7,7 @@ import DesignPicker, {
 	isBlankCanvasDesign,
 	getDesignPreviewUrl,
 	useGeneratedDesigns,
-	useThemeDesignsQuery,
+	useDesignsBySite,
 } from '@automattic/design-picker';
 import { useLocale, englishLocales } from '@automattic/i18n-utils';
 import { shuffle } from '@automattic/js-utils';
@@ -20,7 +20,6 @@ import { useMemo, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview/content';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useFSEStatus } from '../../../../hooks/use-fse-status';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
@@ -83,21 +82,7 @@ const designSetup: Step = function DesignSetup( { navigation } ) {
 		)
 	);
 
-	const tier =
-		isPremiumThemeAvailable || isEnabled( 'signup/design-picker-premium-themes-checkout' )
-			? 'all'
-			: 'free';
-
-	const { FSEEligible, isLoading } = useFSEStatus();
-	const themeFilters = FSEEligible
-		? 'auto-loading-homepage,full-site-editing'
-		: 'auto-loading-homepage';
-
-	const { data: themeDesigns = [] } = useThemeDesignsQuery(
-		{ filter: themeFilters, tier },
-		// Wait until block editor settings have loaded to load themes
-		{ enabled: ! isLoading }
-	);
+	const { data: themeDesigns = [] } = useDesignsBySite( site );
 
 	const staticDesigns = themeDesigns;
 

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -41,6 +41,10 @@ export type Flow = {
 	useSteps: UseStepHook;
 	useStepNavigation: UseStepNavigationHook;
 	useAssertConditions?: UseAssertConditionsHook;
+	/**
+	 * A hook that is called in the flow's root at every render. You can use this hook to setup side-effects, call other hooks, etc..
+	 */
+	useSideEffect?: () => void;
 };
 
 export type StepProps = {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,6 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { useDesignsBySite } from '@automattic/design-picker';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useFSEStatus } from '../hooks/use-fse-status';
+import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { ONBOARD_STORE, SITE_STORE } from '../stores';
@@ -33,7 +35,11 @@ export const siteSetupFlow: Flow = {
 			'wooInstallPlugins',
 		] as StepPath[];
 	},
-
+	useSideEffect() {
+		const site = useSite();
+		// prefetch designs for a smooth design picker UX
+		useDesignsBySite( site );
+	},
 	useStepNavigation( currentStep, navigate ) {
 		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 		const startingPoint = useSelect( ( select ) => select( ONBOARD_STORE ).getStartingPoint() );

--- a/client/landing/stepper/hooks/use-fse-status.ts
+++ b/client/landing/stepper/hooks/use-fse-status.ts
@@ -1,32 +1,10 @@
-import React from 'react';
-import wpcom from 'calypso/lib/wp';
 import { useSite } from './use-site';
-
-type Response = {
-	is_fse_eligible: boolean;
-	is_fse_active: boolean;
-};
 
 export function useFSEStatus() {
 	const site = useSite();
-	const [ FSEEligible, setFSEEligible ] = React.useState< boolean >( false );
-	const [ FSEActive, setFSEActive ] = React.useState< boolean >( false );
-	const [ isLoading, setIsLoading ] = React.useState< boolean >( true );
-
-	React.useEffect( () => {
-		if ( site ) {
-			wpcom.req
-				.get( {
-					path: `/sites/${ site.ID }/block-editor`,
-					apiNamespace: 'wpcom/v2',
-				} )
-				.then( ( { is_fse_eligible, is_fse_active }: Response ) => {
-					setFSEEligible( is_fse_eligible );
-					setFSEActive( is_fse_active );
-					setIsLoading( false );
-				} );
-		}
-	}, [ site ] );
+	const FSEEligible = site?.is_fse_eligible;
+	const FSEActive = site?.is_fse_active;
+	const isLoading = !! site;
 
 	return { FSEEligible, FSEActive, isLoading };
 }

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -94,6 +94,8 @@ export interface SiteDetails {
 	URL: string;
 	launch_status: string;
 	jetpack: boolean;
+	is_fse_eligible: boolean;
+	is_fse_active: boolean;
 	options: {
 		admin_url?: string;
 		advanced_seo_front_page_description?: string;

--- a/packages/design-picker/src/hooks/use-designs-by-site.ts
+++ b/packages/design-picker/src/hooks/use-designs-by-site.ts
@@ -1,0 +1,38 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { planHasFeature, FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
+import { SiteDetails } from '@automattic/data-stores/src/site';
+import { useMemo } from 'react';
+import { useThemeDesignsQuery } from './use-theme-designs-query';
+
+/**
+ * Fetches the designs based on the site information
+ *
+ * @param site the site
+ */
+export function useDesignsBySite( site: SiteDetails | null ) {
+	const sitePlanSlug = site?.plan?.product_slug;
+
+	const isPremiumThemeAvailable = Boolean(
+		useMemo(
+			() => sitePlanSlug && planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ),
+			[ sitePlanSlug ]
+		)
+	);
+
+	const tier =
+		isPremiumThemeAvailable || isEnabled( 'signup/design-picker-premium-themes-checkout' )
+			? 'all'
+			: 'free';
+
+	const FSEEligible = site?.is_fse_eligible;
+
+	const themeFilters = FSEEligible
+		? 'auto-loading-homepage,full-site-editing'
+		: 'auto-loading-homepage';
+
+	return useThemeDesignsQuery(
+		{ filter: themeFilters, tier },
+		// Wait until FSS eligibility is loaded to load themes
+		{ enabled: !! site }
+	);
+}

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -15,3 +15,4 @@ export type { FontPair, Design, Category } from './types';
 export { useCategorization } from './hooks/use-categorization';
 export { useGeneratedDesigns } from './hooks/use-generated-designs';
 export { useThemeDesignsQuery } from './hooks/use-theme-designs-query';
+export { useDesignsBySite } from '././hooks/use-designs-by-site';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR introduces `useDesignsBySite` hook to `DesignPicker`. It makes fetching themes much easier by simply passing the site. Since all the deps to decide what to fetch are properties of the site.
* Then I use this hook to prefetch the themes asynchronously on the mounting of the flow. This makes the design picker much faster!
* This also removes a 3 extraneous HTTP requests to fetch FSE status, one of these requests was blocking design picker from loading themes. We don't need to request these given this info is already inside the site object.

#### Testing instructions
1. Go to /setup/intent?siteSlug=YOUR_SITE
2. Go to Write. Skip.
3. Pick "Choose a design". You should see themes instantly.
