### PR TITLE
Design Picker: Use the stylesheet from the recipe and add pattern_ids arg to theme-setup

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -243,10 +243,12 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 	}
 
 	function* setDesignOnSite( siteSlug: string, selectedDesign: Design ) {
+		const { theme, recipe } = selectedDesign;
+
 		yield wpcomRequest( {
 			path: `/sites/${ siteSlug }/themes/mine`,
 			apiVersion: '1.1',
-			body: { theme: selectedDesign.theme, dont_change_homepage: true },
+			body: { theme: recipe?.stylesheet?.split( '/' )[ 1 ] || theme, dont_change_homepage: true },
 			method: 'POST',
 		} );
 
@@ -259,7 +261,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup`,
 				apiNamespace: 'wpcom/v2',
-				body: { trim_content: true },
+				body: { trim_content: true, pattern_ids: recipe?.patternIds },
 				method: 'POST',
 			} );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the theme value is empty if you choose the generated design
* Add `pattern_ids` arg to theme-setup API so that we could run headstart with those patterns

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/vertical?siteSlug=<your_site>`
* Select a vertical
* Select build intent
* Select any of the generated design
* Check the network request to see the `theme` arg is correct

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/165734722-767cfcbe-d656-4e2f-8a28-35b453f82551.png) | ![image](https://user-images.githubusercontent.com/13596067/165734486-b7d3a110-2b19-47ae-81eb-bd609ee19934.png) |

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/ganon-issues#23
