### PR TITLE
Comments: Fix z-index of resend button in a reply

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -81,6 +81,7 @@ $z-layers: (
 		'.web-preview__loading-message-wrapper': 1,
 		'.comment-detail.card.is-collapsed:hover': 1,
 		'.comment-detail.card.accessible-focus:focus': 1,
+		'.comments__form .button:not(.components-button)': 1,
 		'.web-preview__inner .spinner-line': 1,
 		'.is-section-purchases .search': 1,
 		'.checklist__task': 1,

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -28,7 +28,8 @@
 		}
 
 		&.is-visible {
-			position: static;
+			position: relative;
+			z-index: z-index( 'root', '.comments__form .button:not(.components-button)' );
 			float: right;
 			opacity: 1;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While testing #63087, I discovered that on Chrome, resending a reply doesn't work because the button gets behind the error message:

![](https://cldup.com/3anfKmrwMi.png)

This PR fixes that by adjusting the button's z-index.

#### Testing instructions

* Open a post with comments in the Reader.
* Post some reply.
* Try to post the same reply and get an error.
* Change the comment and hit the button to resend.
* Verify you can now click the button properly.