### PR TITLE
Rewind: Refactor `RewindFormCreds` away from `UNSAFE_` methods

### DIFF
--- a/client/signup/steps/rewind-form-creds/index.jsx
+++ b/client/signup/steps/rewind-form-creds/index.jsx
@@ -25,12 +25,9 @@ class RewindFormCreds extends Component {
 
 	/**
 	 * Before component updates, check if credentials were correctly saved and go to next step.
-	 *
-	 * @param {object} nextProps Props received by component for next update.
 	 */
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillUpdate( nextProps ) {
-		if ( nextProps.rewindIsNowActive ) {
+	componentDidUpdate() {
+		if ( this.props.rewindIsNowActive ) {
 			this.props.submitSignupStep( { stepName: this.props.stepName }, { rewindconfig: true } );
 			this.props.goToNextStep();
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `RewindFormCreds` component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Go to `/start/rewind-setup/rewind-form-creds?siteSlug=SITE` where `SITE` is the site slug of one of your Jetpack sites.
* Open the "Components" tab in your dev tools.
* Find the innermost "RewindFormCreds" component.
* Toggle its `rewindIsNowActive` prop to `true`.
* Verify you're still redirected to the next step.