### PR TITLE
Components: Refactor `ExternalLink` tests to `@testing-library/react`

### DIFF
--- a/client/components/external-link/test/index.js
+++ b/client/components/external-link/test/index.js
@@ -1,51 +1,60 @@
-import { Gridicon } from '@automattic/components';
-import { assert } from 'chai';
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
 import ExternalLink from '../index';
 
 describe( 'External Link', () => {
 	test( 'should have external-link class', () => {
-		const externalLink = shallow( <ExternalLink /> );
-		assert.lengthOf( externalLink.find( '.external-link' ), 1 );
+		const { container } = render( <ExternalLink /> );
+		expect( container.getElementsByClassName( 'external-link' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should have className if provided', () => {
-		const externalLink = shallow( <ExternalLink className="test__foobar" /> );
-		assert.lengthOf( externalLink.find( '.test__foobar' ), 1 );
+		const { container } = render( <ExternalLink className="test__foobar" /> );
+		expect( container.getElementsByClassName( 'test__foobar' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should have href if provided', () => {
-		const externalLink = shallow( <ExternalLink href="http://foobar.bang" /> );
-		assert.lengthOf( externalLink.find( { href: 'http://foobar.bang' } ), 1 );
+		const { container } = render( <ExternalLink href="http://foobar.bang" /> );
+		expect( container.getElementsByTagName( 'a' )[ 0 ].getAttribute( 'href' ) ).toEqual(
+			'http://foobar.bang'
+		);
 	} );
 
 	test( 'should have icon if provided', () => {
-		const externalLink = shallow( <ExternalLink icon={ true } /> );
-		assert.lengthOf( externalLink.find( Gridicon ), 1 );
+		const { container } = render( <ExternalLink icon={ true } /> );
+		expect( container.getElementsByTagName( 'svg' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should have a target if given one', () => {
-		const externalLink = shallow( <ExternalLink target="_blank" /> );
-		assert.lengthOf( externalLink.find( { target: '_blank' } ), 1 );
+		const { container } = render( <ExternalLink target="_blank" /> );
+		expect( container.getElementsByTagName( 'a' )[ 0 ].getAttribute( 'target' ) ).toEqual(
+			'_blank'
+		);
 	} );
 
 	test( 'should have an icon className if specified', () => {
-		const externalLink = shallow( <ExternalLink icon={ true } iconClassName="foo" /> );
-		assert.equal( 'foo', externalLink.find( Gridicon ).prop( 'className' ) );
+		const { container } = render( <ExternalLink icon={ true } iconClassName="foo" /> );
+		expect( container.querySelectorAll( 'svg.foo' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should have an icon default size of 18', () => {
-		const externalLink = shallow( <ExternalLink icon={ true } iconClassName="foo" /> );
-		assert.equal( '18', externalLink.find( Gridicon ).prop( 'size' ) );
+		const { container } = render( <ExternalLink icon={ true } iconClassName="foo" /> );
+		const gridicon = container.getElementsByTagName( 'svg' )[ 0 ];
+		expect( gridicon.getAttribute( 'width' ) ).toEqual( '18' );
+		expect( gridicon.getAttribute( 'height' ) ).toEqual( '18' );
 	} );
 
 	test( 'should have an icon size that is provided', () => {
-		const externalLink = shallow( <ExternalLink icon={ true } iconSize={ 20 } /> );
-		assert.equal( '20', externalLink.find( Gridicon ).prop( 'size' ) );
+		const { container } = render( <ExternalLink icon={ true } iconSize={ 20 } /> );
+		const gridicon = container.getElementsByTagName( 'svg' )[ 0 ];
+		expect( gridicon.getAttribute( 'width' ) ).toEqual( '20' );
+		expect( gridicon.getAttribute( 'height' ) ).toEqual( '20' );
 	} );
 
 	test( 'should have icon first if specified', () => {
-		const externalLink = shallow( <ExternalLink icon={ true } iconClassName="foo" /> );
-		assert.isTrue( externalLink.children().first().is( Gridicon ) );
+		const { container } = render( <ExternalLink icon={ true } iconClassName="foo" /> );
+		expect( container.getElementsByTagName( 'a' )[ 0 ].children[ 0 ].tagName ).toEqual( 'svg' );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the Reader `ExternalLink` component to use `@testing-library/react` instead of `enzyme`.

It also uses the opportunity to migrate `chai` assertions to `jest`.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/components/external-link/test/index.js`