### PR TITLE
Data-stores: add email support eligiblity check in site store

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -7,6 +7,7 @@ import {
 	AtomicSoftwareStatusError,
 	AtomicSoftwareInstallError,
 	HappyChatAvailability,
+	EmailSupportAvailability,
 } from './types';
 import type { WpcomClientCredentials } from '../shared-types';
 import type {
@@ -48,6 +49,11 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 
 	const receiveHappyChatAvailability = ( availability: HappyChatAvailability ) => ( {
 		type: 'RECEIVE_HAPPY_CHAT_AVAILABILITY' as const,
+		availability,
+	} );
+
+	const receiveEmailSupportAvailability = ( availability: EmailSupportAvailability ) => ( {
+		type: 'RECEIVE_EMAIL_SUPPORT_AVAILABILITY' as const,
 		availability,
 	} );
 
@@ -456,6 +462,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveSite,
 		receiveSiteFailed,
 		receiveSiteTagline,
+		receiveEmailSupportAvailability,
 		receiveHappyChatAvailability,
 		receiveSiteVerticalId,
 		saveSiteTagline,
@@ -500,6 +507,7 @@ export type Action =
 			| ActionCreators[ 'receiveNewSiteFailed' ]
 			| ActionCreators[ 'receiveSiteTagline' ]
 			| ActionCreators[ 'receiveSiteVerticalId' ]
+			| ActionCreators[ 'receiveEmailSupportAvailability' ]
 			| ActionCreators[ 'receiveHappyChatAvailability' ]
 			| ActionCreators[ 'receiveSite' ]
 			| ActionCreators[ 'receiveSiteFailed' ]

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -10,6 +10,7 @@ import {
 	AtomicTransferStatus,
 	LatestAtomicTransferStatus,
 	HappyChatAvailability,
+	EmailSupportAvailability,
 } from './types';
 import {
 	AtomicTransferState,
@@ -88,6 +89,17 @@ export const happyChatAvailability: Reducer< HappyChatAvailability | undefined, 
 ) => {
 	switch ( action.type ) {
 		case 'RECEIVE_HAPPY_CHAT_AVAILABILITY':
+			return action.availability;
+	}
+	return state;
+};
+
+export const emailSupportAvailability: Reducer< EmailSupportAvailability | undefined, Action > = (
+	state,
+	action
+) => {
+	switch ( action.type ) {
+		case 'RECEIVE_EMAIL_SUPPORT_AVAILABILITY':
 			return action.availability;
 	}
 	return state;
@@ -384,6 +396,7 @@ const reducer = combineReducers( {
 	sitesSettings,
 	siteSetupErrors,
 	happyChatAvailability,
+	emailSupportAvailability,
 	atomicTransferStatus,
 	latestAtomicTransferStatus,
 	atomicSoftwareStatus,

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -1,7 +1,13 @@
 import { dispatch } from '@wordpress/data';
 import { wpcomRequest } from '../wpcom-request-controls';
 import { STORE_KEY } from './constants';
-import type { SiteDetails, Domain, SiteSettings, HappyChatAvailability } from './types';
+import type {
+	SiteDetails,
+	Domain,
+	SiteSettings,
+	HappyChatAvailability,
+	EmailSupportAvailability,
+} from './types';
 
 /**
  * Attempt to find a site based on its id, and if not return undefined.
@@ -45,6 +51,14 @@ export function* getHappyChatAvailability() {
 		apiVersion: '1.1',
 	} );
 	dispatch( STORE_KEY ).receiveHappyChatAvailability( userConfiguration );
+}
+
+export function* getEmailSupportAvailability() {
+	const userConfiguration: EmailSupportAvailability = yield wpcomRequest( {
+		path: '/help/tickets/kayako/mine',
+		apiVersion: '1.1',
+	} );
+	dispatch( STORE_KEY ).receiveEmailSupportAvailability( userConfiguration );
 }
 
 /**

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -144,3 +144,7 @@ export function isEligibleForProPlan( state: State, siteId?: number ): boolean {
 export function getHappyChatAvailability( state: State ) {
 	return state.happyChatAvailability;
 }
+
+export function getEmailSupportAvailability( state: State ) {
+	return state.emailSupportAvailability;
+}

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -406,3 +406,7 @@ export interface HappyChatAvailability {
 	isClosed: boolean;
 	availability: Availability;
 }
+
+export interface EmailSupportAvailability {
+	is_user_eligible: boolean;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is a twin PR for https://github.com/Automattic/wp-calypso/pull/63136.

I tested it locally.
