### PR TITLE
Licensing Portal: fix broken selected state of Sidebar menu items

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
@@ -7,6 +7,7 @@ import Sidebar from 'calypso/layout/sidebar';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import SidebarRegion from 'calypso/layout/sidebar/region';
+import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import 'calypso/components/jetpack/sidebar/style.scss';
 
@@ -54,7 +55,7 @@ class PartnerPortalSidebar extends Component< Props > {
 							} ) }
 							link="/partner-portal/licenses"
 							onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Licenses' ) }
-							selected={ path === '/partner-portal/licenses' }
+							selected={ itemLinkMatches( '/partner-portal/licenses', path ) }
 						/>
 
 						{ config.isEnabled( 'jetpack/partner-portal-payment' ) && (
@@ -65,7 +66,7 @@ class PartnerPortalSidebar extends Component< Props > {
 								} ) }
 								link="/partner-portal/payment-methods"
 								onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Payment Methods' ) }
-								selected={ path === '/partner-portal/payment-methods' }
+								selected={ itemLinkMatches( '/partner-portal/payment-methods', path ) }
 							/>
 						) }
 
@@ -77,7 +78,7 @@ class PartnerPortalSidebar extends Component< Props > {
 								} ) }
 								link="/partner-portal/invoices"
 								onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Invoices' ) }
-								selected={ path === '/partner-portal/invoices' }
+								selected={ itemLinkMatches( '/partner-portal/invoices', path ) }
 							/>
 						) }
 					</SidebarMenu>

--- a/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
@@ -7,7 +7,6 @@ import Sidebar from 'calypso/layout/sidebar';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import SidebarRegion from 'calypso/layout/sidebar/region';
-import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import 'calypso/components/jetpack/sidebar/style.scss';
 
@@ -55,7 +54,7 @@ class PartnerPortalSidebar extends Component< Props > {
 							} ) }
 							link="/partner-portal/licenses"
 							onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Licenses' ) }
-							selected={ itemLinkMatches( '/partner-portal/licenses', path ) }
+							selected={ path === '/partner-portal/licenses' }
 						/>
 
 						{ config.isEnabled( 'jetpack/partner-portal-payment' ) && (
@@ -66,7 +65,7 @@ class PartnerPortalSidebar extends Component< Props > {
 								} ) }
 								link="/partner-portal/payment-methods"
 								onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Payment Methods' ) }
-								selected={ itemLinkMatches( '/partner-portal/payment-methods', path ) }
+								selected={ path === '/partner-portal/payment-methods' }
 							/>
 						) }
 
@@ -78,7 +77,7 @@ class PartnerPortalSidebar extends Component< Props > {
 								} ) }
 								link="/partner-portal/invoices"
 								onNavigate={ this.onNavigate( 'Jetpack Cloud / Partner Portal / Invoices' ) }
-								selected={ itemLinkMatches( '/partner-portal/invoices', path ) }
+								selected={ path === '/partner-portal/invoices' }
 							/>
 						) }
 					</SidebarMenu>

--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -44,7 +44,8 @@ export const itemLinkMatches = ( path, currentPath ) => {
 		}
 	}
 
-	// The Jetpack Licensing Portal follows a different pattern than other sections of Jetpack Cloud.
+	// All URLs in the Licensing Portal start with 'partner-portal', so we need to compare them at the
+	// second position (i.e., compare whatever comes after partner-portal/).
 	if ( isJetpackCloud() && pathIncludes( currentPath, 'partner-portal', 1 ) ) {
 		return fragmentIsEqual( path, currentPath, 2 );
 	}

--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -44,5 +44,10 @@ export const itemLinkMatches = ( path, currentPath ) => {
 		}
 	}
 
+	// The Jetpack Licensing Portal follows a different pattern than other sections of Jetpack Cloud.
+	if ( isJetpackCloud() && pathIncludes( currentPath, 'partner-portal', 1 ) ) {
+		return fragmentIsEqual( path, currentPath, 2 );
+	}
+
 	return fragmentIsEqual( path, currentPath, 1 );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes 1164141197617539-as-1202190566177646.

https://github.com/Automattic/wp-calypso/pull/61903 introduced a regression that broke the selected state of the Sidebar menu items in the Licensing Portal.

This PR fixes this by replacing calls to `itemLinkMatches` with a simple `===` comparison. `itemLinkMatches` won't work for the Licensing Portal as is because the URLs all start with the same pattern (`/partner-portal`), which doesn't happen outside of the portal, so the function does not work for both cases at the same time.

#### Testing instructions
* Download this PR.
* Start Jetpack cloud with `yarn start-jetpack-cloud`.
* Go to `http://jetpack.cloud.localhost:3000/`.
* Make sure the Sidebar items are highlighted correctly (i.e., if you visit the Scan section, make sure the Scan item is the only one highlighted).
* Go to `http://jetpack.cloud.localhost:3000/partner-portal/`.
* Make sure the Sidebar items are highlighted correctly.

#### Demo — before
![image](https://user-images.githubusercontent.com/3418513/165781009-f5ccea86-db4c-4ac1-ba74-382fa4e77215.png)

#### Demo — after
<img width="273" alt="image" src="https://user-images.githubusercontent.com/3418513/165781122-9b1b63df-e43a-4c1c-acbe-3c0d3fd0596c.png">


