### PR TITLE
Follow up to #62976:  do not show welcome tours to P2s

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -73,8 +73,6 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 
 		$should_open_patterns_panel = (bool) get_option( 'was_created_with_blank_canvas_design' );
 
-		$reason = '';
-
 		if ( $should_open_patterns_panel ) {
 			$variant = 'blank-canvas-tour';
 		} else {
@@ -92,16 +90,12 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 			// disable welcome tour for authoring P2s.
 			// see: https://github.com/Automattic/wp-calypso/issues/62973.
 			$nux_status = 'disabled';
-			$reason     = 'P2s do not get a welcome tour';
 		} elseif ( has_filter( 'wpcom_block_editor_nux_get_status' ) ) {
 			$nux_status = apply_filters( 'wpcom_block_editor_nux_get_status', false );
-			$reason     = 'wpcom_block_editor_nux_get_status filter responded with: ' . $nux_status;
 		} elseif ( ! metadata_exists( 'user', get_current_user_id(), 'wpcom_block_editor_nux_status' ) ) {
 			$nux_status = 'enabled';
-			$reason     = "Meta data for user_id didn't have wpcom_block_editor_nux_status record";
 		} else {
 			$nux_status = get_user_meta( get_current_user_id(), 'wpcom_block_editor_nux_status', true );
-			$reason     = "User's meta data has a value of: " . $nux_status;
 		}
 
 		$show_welcome_guide = $this->show_wpcom_welcome_guide( $nux_status );
@@ -110,7 +104,6 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 			array(
 				'show_welcome_guide' => $show_welcome_guide,
 				'variant'            => $variant,
-				'reason'             => $reason,
 			)
 		);
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -95,13 +95,13 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 			$reason     = 'P2s do not get a welcome tour';
 		} elseif ( has_filter( 'wpcom_block_editor_nux_get_status' ) ) {
 			$nux_status = apply_filters( 'wpcom_block_editor_nux_get_status', false );
-			$reason     = 'wpcom_block_editor_nux_get_status filtered responded with: ' . $nux_status;
+			$reason     = 'wpcom_block_editor_nux_get_status filter responded with: ' . $nux_status;
 		} elseif ( ! metadata_exists( 'user', get_current_user_id(), 'wpcom_block_editor_nux_status' ) ) {
 			$nux_status = 'enabled';
 			$reason     = "Meta data for user_id didn't have wpcom_block_editor_nux_status record";
 		} else {
 			$nux_status = get_user_meta( get_current_user_id(), 'wpcom_block_editor_nux_status', true );
-			$reason     = "User's meta data had a value of: " . $nux_status;
+			$reason     = "User's meta data has a value of: " . $nux_status;
 		}
 
 		$show_welcome_guide = $this->show_wpcom_welcome_guide( $nux_status );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -73,6 +73,8 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 
 		$should_open_patterns_panel = (bool) get_option( 'was_created_with_blank_canvas_design' );
 
+		$reason = '';
+
 		if ( $should_open_patterns_panel ) {
 			$variant = 'blank-canvas-tour';
 		} else {
@@ -90,12 +92,16 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 			// disable welcome tour for authoring P2s.
 			// see: https://github.com/Automattic/wp-calypso/issues/62973.
 			$nux_status = 'disabled';
+			$reason     = 'P2s do not get a welcome tour';
 		} elseif ( has_filter( 'wpcom_block_editor_nux_get_status' ) ) {
 			$nux_status = apply_filters( 'wpcom_block_editor_nux_get_status', false );
+			$reason     = 'wpcom_block_editor_nux_get_status filtered responded with: ' . $nux_status;
 		} elseif ( ! metadata_exists( 'user', get_current_user_id(), 'wpcom_block_editor_nux_status' ) ) {
 			$nux_status = 'enabled';
+			$reason     = "Meta data for user_id didn't have wpcom_block_editor_nux_status record";
 		} else {
 			$nux_status = get_user_meta( get_current_user_id(), 'wpcom_block_editor_nux_status', true );
+			$reason     = "User's meta data had a value of: " . $nux_status;
 		}
 
 		$show_welcome_guide = $this->show_wpcom_welcome_guide( $nux_status );
@@ -104,6 +110,7 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 			array(
 				'show_welcome_guide' => $show_welcome_guide,
 				'variant'            => $variant,
+				'reason'             => $reason,
 			)
 		);
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
@@ -23,14 +23,12 @@ subscribe( () => {
 	}
 	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
-		dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true, {
-			openedManually: true,
-		} );
+		// if core side has the welcome guide feature is on, ask WPCOM server if we should turn it on as well
+		dispatch( 'automattic/wpcom-welcome-guide' ).fetchWelcomeGuideStatus();
 	}
 	if ( select( 'core/edit-site' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-site' ).toggleFeature( 'welcomeGuide' );
-		dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true, {
-			openedManually: true,
-		} );
+		// if core side has the welcome guide feature is on, ask WPCOM server if we should turn it on as well
+		dispatch( 'automattic/wpcom-welcome-guide' ).fetchWelcomeGuideStatus();
 	}
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
@@ -23,12 +23,20 @@ subscribe( () => {
 	}
 	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
-		// if core side has the welcome guide feature is on, ask WPCOM server if we should turn it on as well
-		dispatch( 'automattic/wpcom-welcome-guide' ).fetchWelcomeGuideStatus();
+		// On mounting, the welcomeGuide feature is turned on by default. This opens the welcome guide despite `welcomeGuideStatus` value.
+		// This check ensures that we only listen to `welcomeGuide` changes if the welcomeGuideStatus value is loaded and respected
+		if ( select( 'automattic/wpcom-welcome-guide' ).isWelcomeGuideStatusLoaded() ) {
+			dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true, {
+				openedManually: true,
+			} );
+		}
 	}
 	if ( select( 'core/edit-site' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-site' ).toggleFeature( 'welcomeGuide' );
-		// if core side has the welcome guide feature is on, ask WPCOM server if we should turn it on as well
-		dispatch( 'automattic/wpcom-welcome-guide' ).fetchWelcomeGuideStatus();
+		if ( select( 'automattic/wpcom-welcome-guide' ).isWelcomeGuideStatusLoaded() ) {
+			dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true, {
+				openedManually: true,
+			} );
+		}
 	}
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* https://github.com/Automattic/wp-calypso/pull/62976 changed the server side to hide the welcome tour in P2s. But it turns out we have other logic on the client side that was overriding the server decision (by not asking entirely). In that code (shown in the diff), we checked if core has the welcome tour enabled, we intercepted the call and enabled our tour instead, but without consulting the server, making the change in https://github.com/Automattic/wp-calypso/pull/62976 meaningless.
* This change makes sure the client had asked the server before enabling dotcom's tour.

#### Testing instructions

1. Checkout this branch.
2. In apps/editing-toolkit, run yarn dev --sync.
3. Sandbox a P2 you've never visited like vertexp2.
4. Author a new post in P2 you never visited like vertexp2 by visiting https:// THE P2 NAME .wordpress.com/wp-admin/post-new.php.
5. In console, type `localStorage.clear()`.
6. Refresh the page.
7. You shouldn't see a welcome tour.
8. Repeat for officetoday blog (non-P2). 
9. You should see the welcome tour.