### PR TITLE
Stepper: Fixed back button from businessInfo step

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -202,6 +202,9 @@ export const siteSetupFlow: Flow = {
 				case 'storeAddress':
 					return navigate( 'storeFeatures' );
 
+				case 'businessInfo':
+					return navigate( 'storeAddress' );
+
 				case 'courses':
 					return navigate( 'bloggerStartingPoint' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changed site-setup flow so if you use the Back button from the `businessInfo` step you go to back the `storeAddress` step.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Woo flow until the `businessInfo` step
 
![image](https://user-images.githubusercontent.com/3801502/165824873-5736a7c3-ed61-4d79-933e-b868f25260c7.png)

* Click Back button
![image](https://user-images.githubusercontent.com/3801502/165824958-e4f19eb2-bedd-44ce-a76f-c96bde6c3732.png)

* Check if you are now on the `storeAddress` step
![image](https://user-images.githubusercontent.com/3801502/165825081-83cca8a3-bc9e-413f-bc9e-86f8b4f88454.png)



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #63137 
