### PR TITLE
[ETK/StarterPageTemplates] Fix patterns modal closing upon editor init when creating a new page in Gutenberg >= 13.1

### DIFF
--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -309,7 +309,7 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 			<Modal
 				title="" // We're providing the title with the `aria.labelledby` prop
 				className="page-pattern-modal"
-				/* eslist-disable-next-line @typescript-eslint/ban-ts-comment */
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore `onRequestClose`'s type is () => void but ideally it should eslint-disable-line
 				// specify the `FocusEvent` object that's passed. Ignoring the error until
 				// the `Modal` component type is updated in Gutenberg.

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -160,9 +160,9 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 		// As of Gutenberg 13.1, the editor will auto-focus on the title block
 		// automatically. See: https://github.com/WordPress/gutenberg/pull/40195.
 		// This ends up triggering an `blur` event on the Modal that causes it
-		// to close just after the editor loads. To circunvent this, we check if
+		// to close just after the editor loads. To circumvent this, we check if
 		// the `blur` event is related to the title auto-focus and if so,
-		// we ignore it so that the Modal stays open. It's importnat to note
+		// we ignore it so that the Modal stays open. It's important to note
 		// that this callback handles more than the  event, though. See the
 		// `CloseModalEvent` type for more info.
 

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -320,10 +320,11 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 			<Modal
 				title="" // We're providing the title with the `aria.labelledby` prop
 				className="page-pattern-modal"
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore `onRequestClose`'s type is () => void but ideally it should eslint-disable-line
-				// specify the `FocusEvent` object that's passed. Ignoring the error until
-				// the `Modal` component type is updated in Gutenberg.
+				// @ts-expect-error `onRequestClose`'s type is () => void but ideally but
+				// in reality, it might receive an event object that might be one of multiple
+				// types (see the `CloseModalEvent` type above for more info). We ignore the
+				// error for now until the type is updated in DefinitelyTyped.
+				// DT PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60127.
 				onRequestClose={ this.closeModal }
 				aria={ {
 					labelledby: `page-pattern-modal__heading-${ instanceId }`,

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -159,7 +159,7 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 	closeModal = ( event: CloseModalEvent ) => {
 		// As of Gutenberg 13.1, the editor will auto-focus on the title block
 		// automatically. See: https://github.com/WordPress/gutenberg/pull/40195.
-		// This ends up triggering an `blur` event on the Modal that causes it
+		// This ends up triggering a `blur` event on the Modal that causes it
 		// to close just after the editor loads. To circumvent this, we check if
 		// the `blur` event is related to the title auto-focus and if so,
 		// we ignore it so that the Modal stays open. It's important to note
@@ -168,8 +168,8 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 
 		// Let's narrow-down the types to be able to safely handle the `blur` scenario
 		// `KeyboardEvent` doesn't have a `relatedTarget` property, and the `MouseEvent`'s
-		// relatedTarget type doesn't have a `className` property, though for those events
-		// the Modal can just close and we don't need the piece of logic below.
+		// `relatedTarget` type doesn't have a `className` property, though for those events
+		// the Modal can just close and we don't need the piece of logic below:
 		if ( 'relatedTarget' in event && event.relatedTarget && 'className' in event.relatedTarget ) {
 			if ( event.relatedTarget?.className?.match( /wp-block-post-title/ ) ) {
 				event.stopPropagation();

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -161,7 +161,7 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 		// to close just after the editor loads. To circunvent this, we check if
 		//the `onBlur` event is related to the title auto-focus and if so,
 		// we ignore it so that the Modal stays open.
-		if ( event.relatedTarget?.getAttribute( 'aria-label' ) === 'Add title' ) {
+		if ( event.relatedTarget?.className?.match( /wp-block-post-title/ ) ) {
 			event.stopPropagation();
 			return;
 		}

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -309,6 +309,9 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 			<Modal
 				title="" // We're providing the title with the `aria.labelledby` prop
 				className="page-pattern-modal"
+				// @ts-ignore `onRequestClose`'s type is () => void but ideally it should
+				// specify the `FocusEvent` object that's passed. Ignoring the error until
+				// the `Modal` component type is updated in Gutenberg.
 				onRequestClose={ this.closeModal }
 				aria={ {
 					labelledby: `page-pattern-modal__heading-${ instanceId }`,

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -309,7 +309,8 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 			<Modal
 				title="" // We're providing the title with the `aria.labelledby` prop
 				className="page-pattern-modal"
-				// @ts-ignore `onRequestClose`'s type is () => void but ideally it should
+				/* eslist-disable-next-line @typescript-eslint/ban-ts-comment */
+				// @ts-ignore `onRequestClose`'s type is () => void but ideally it should eslint-disable-line
 				// specify the `FocusEvent` object that's passed. Ignoring the error until
 				// the `Modal` component type is updated in Gutenberg.
 				onRequestClose={ this.closeModal }

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -159,7 +159,7 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 		// automatically. See: https://github.com/WordPress/gutenberg/pull/40195.
 		// This ends up triggering an `onBlur` event on the Modal that causes it
 		// to close just after the editor loads. To circunvent this, we check if
-		//the `onBlur` event is related to the title auto-focus and if so,
+		// the `onBlur` event is related to the title auto-focus and if so,
 		// we ignore it so that the Modal stays open.
 		if ( event.relatedTarget?.className?.match( /wp-block-post-title/ ) ) {
 			event.stopPropagation();

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -12,6 +12,7 @@ import replacePlaceholders from '../utils/replace-placeholders';
 import { trackDismiss, trackSelection, trackView } from '../utils/tracking';
 import PatternSelectorControl from './pattern-selector-control';
 import type { PatternCategory, PatternDefinition } from '../pattern-definition';
+import type { FocusEvent } from 'react';
 
 interface PagePatternModalProps {
 	areTipsEnabled?: boolean;
@@ -153,7 +154,18 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 		this.setState( { selectedCategory } );
 	};
 
-	closeModal = () => {
+	closeModal = ( event: FocusEvent ) => {
+		// As of Gutenberg 13.1, the editor will auto-focus on the title block
+		// automatically. See: https://github.com/WordPress/gutenberg/pull/40195.
+		// This ends up triggering an `onBlur` event on the Modal that causes it
+		// to close just after the editor loads. To circunvent this, we check if
+		//the `onBlur` event is related to the title auto-focus and if so,
+		// we ignore it so that the Modal stays open.
+		if ( event.relatedTarget?.getAttribute( 'aria-label' ) === 'Add title' ) {
+			event.stopPropagation();
+			return;
+		}
+
 		trackDismiss();
 		this.props.onClose();
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As of Gutenberg 13.1, the editor will auto-focus on the title block automatically. See: https://github.com/WordPress/gutenberg/pull/40195. This ends up triggering (most of the time, though this seems to be a race condition) an `onBlur` event on the Modal that causes it to close just after the editor loads. To circumvent this, we check if the `onBlur` event is related to the title auto-focus and if so, we ignore it so that the Modal stays open.


#### Testing instructions

* Build ETK from this branch and sync to your sandbox
* Clear your localstorage in devtools
* Create a new page and the starter page template modal should render normally without closing itself. Closing it later on manually should work fine, as well as when selecting a pattern.


Related to #
