### PR TITLE
Marketplace: Add site selector when no site selected on `/plugins`

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -494,6 +494,9 @@ export function siteSelection( context, next ) {
 					}
 				} else if ( shouldRedirectToJetpackAuthorize( context, site ) ) {
 					navigate( getJetpackAuthorizeURL( context, site ) );
+				} else if ( 'plugins' === context.path.split( '?' )[ 0 ].split( '/' )[ 1 ] ) {
+					// When path start with /plugins, redirect won't use site as query param. In plugins the param could be a site, plugin or category.
+					page.redirect( sectionify( context.path, siteFragment ) );
 				} else {
 					// If the site has loaded but siteId is still invalid then redirect to allSitesPath.
 					const allSitesPath = addQueryArgs(

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -1,11 +1,6 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import {
-	navigation,
-	siteSelection,
-	sites,
-	selectSiteIfLoggedIn,
-} from 'calypso/my-sites/controller';
+import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	browsePlugins,
@@ -74,7 +69,7 @@ export default function () {
 		clientRender
 	);
 
-	page( '/plugins', selectSiteIfLoggedIn, siteSelection, navigation, makeLayout, clientRender );
+	page( '/plugins', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
 
 	page(
 		'/plugins/:site',

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -74,15 +74,7 @@ export default function () {
 		clientRender
 	);
 
-	page(
-		'/plugins',
-		selectSiteIfLoggedIn,
-		siteSelection,
-		navigation,
-		browsePlugins,
-		makeLayout,
-		clientRender
-	);
+	page( '/plugins', selectSiteIfLoggedIn, siteSelection, navigation, makeLayout, clientRender );
 
 	page(
 		'/plugins/:site',

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -1,6 +1,11 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import {
+	navigation,
+	siteSelection,
+	sites,
+	selectSiteIfLoggedIn,
+} from 'calypso/my-sites/controller';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	browsePlugins,

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -1,6 +1,11 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import {
+	navigation,
+	siteSelection,
+	sites,
+	selectSiteIfLoggedIn,
+} from 'calypso/my-sites/controller';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	browsePlugins,
@@ -71,6 +76,16 @@ export default function () {
 
 	page(
 		'/plugins',
+		selectSiteIfLoggedIn,
+		siteSelection,
+		navigation,
+		browsePlugins,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/plugins/:site',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -80,7 +95,7 @@ export default function () {
 	);
 
 	page(
-		'/plugins/manage/:site?',
+		'/plugins/manage/:site',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -90,7 +105,7 @@ export default function () {
 	);
 
 	page(
-		'/plugins/:pluginFilter(active|inactive|updates)/:site_id?',
+		'/plugins/:pluginFilter(active|inactive|updates)/:site_id',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -101,7 +116,7 @@ export default function () {
 	);
 
 	page(
-		'/plugins/:plugin/:site_id?',
+		'/plugins/:plugin/:site_id',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -60,7 +60,7 @@ export default function () {
 
 	page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
 	page(
-		'/plugins/upload/:site_id',
+		'/plugins/upload/:site',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -69,7 +69,7 @@ export default function () {
 		clientRender
 	);
 
-	page( '/plugins', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
+	page( '/plugins', selectSiteIfLoggedIn, navigation, makeLayout, clientRender );
 
 	page(
 		'/plugins/:site',
@@ -92,7 +92,7 @@ export default function () {
 	);
 
 	page(
-		'/plugins/:pluginFilter(active|inactive|updates)/:site_id',
+		'/plugins/:pluginFilter(active|inactive|updates)/:site',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -103,7 +103,7 @@ export default function () {
 	);
 
 	page(
-		'/plugins/:plugin/:site_id',
+		'/plugins/:plugin/:site',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -113,7 +113,7 @@ export default function () {
 	);
 
 	page(
-		'/plugins/:plugin/eligibility/:site_id',
+		'/plugins/:plugin/eligibility/:site',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,

--- a/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
+++ b/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
@@ -24,6 +24,13 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			pluginsPage = new PluginsPage( page );
 			await pluginsPage.visit();
 		} );
+	} );
+
+	describe( 'Plugins page /plugins/:wpcom-site', function () {
+		it( 'Visit plugins page', async function () {
+			pluginsPage = new PluginsPage( page );
+			await pluginsPage.visit( siteUrl );
+		} );
 
 		it.each( [ 'Top paid plugins', 'Editor’s pick', 'Top free plugins' ] )(
 			'Plugins page loads %s section',
@@ -56,19 +63,5 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 		] )( 'Featured Plugins section should show the %s plugin', async function ( plugin: string ) {
 			await pluginsPage.validateHasPluginOnSection( 'featured', plugin );
 		} );
-	} );
-
-	describe( 'Plugins page /plugins/:wpcom-site', function () {
-		it( 'Visit plugins page', async function () {
-			pluginsPage = new PluginsPage( page );
-			await pluginsPage.visit( siteUrl );
-		} );
-
-		it.each( [ 'Top paid plugins', 'Editor’s pick', 'Top free plugins' ] )(
-			'Plugins page loads %s section',
-			async function ( section: string ) {
-				await pluginsPage.validateHasSection( section );
-			}
-		);
 	} );
 } );

--- a/test/e2e/specs/plugins/plugins__pricing.ts
+++ b/test/e2e/specs/plugins/plugins__pricing.ts
@@ -10,16 +10,18 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Plugins page pricing toggle' ), function () {
 	let page: Page;
 	let pluginsPage: PluginsPage;
+	let siteUrl: string;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
+		siteUrl = testAccount.getSiteURL( { protocol: false } );
 	} );
 
 	it( 'Visit plugins page', async function () {
 		pluginsPage = new PluginsPage( page );
-		await pluginsPage.visit();
+		await pluginsPage.visit( siteUrl );
 		await pluginsPage.validateIsMonthlyPricing();
 	} );
 

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -10,16 +10,18 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 	let page: Page;
 	let pluginsPage: PluginsPage;
+	let siteUrl: string;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
+		siteUrl = testAccount.getSiteURL( { protocol: false } );
 	} );
 
 	it( 'Visit plugins page', async function () {
 		pluginsPage = new PluginsPage( page );
-		await pluginsPage.visit();
+		await pluginsPage.visit( siteUrl );
 	} );
 
 	it( 'Search for ecommerce', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When no site is selected, `/plugins` redirect the user to site selection.
* Also remove `/plugins` routes when no site is selected such as `/plugins/:plugin` or `/plugins/:category`.

#### Testing instructions

* Go to `/plugins` with no site selected and you will see the site selector.

Related to #62912 
