### PR TITLE
Components: Refactor `SortedGrid` tests to `@testing-library/react` and `jest`

### DIFF
--- a/client/components/sorted-grid/test/index.jsx
+++ b/client/components/sorted-grid/test/index.jsx
@@ -1,18 +1,15 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import SortedGrid from '../';
-import Label from '../label';
 
 describe( 'SortedGrid', () => {
 	const nullfunc = () => {};
 	const getItemGroup = () => 'item-group';
 
 	test( 'should not render labels if the group label is an empty string', () => {
-		const wrapper = shallow(
+		const { container } = render(
 			<SortedGrid
 				getItemGroup={ getItemGroup }
 				getGroupLabel={ nullfunc }
@@ -30,6 +27,6 @@ describe( 'SortedGrid', () => {
 				className="test__sortedgrid"
 			/>
 		);
-		expect( wrapper.find( Label ) ).to.have.length( 0 );
+		expect( container.getElementsByClassName( 'sorted-grid__label' ) ).toHaveLength( 0 );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `SortedGrid` component to use `@testing-library/react` instead of `enzyme`.

It also uses the opportunity to migrate `chai` assertions to `jest`.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/components/sorted-grid/test/index.jsx`