### PR TITLE
Components: Refactor `ProductExpiration` to use `@testing-library/react`

### DIFF
--- a/client/components/product-expiration/test/index.js
+++ b/client/components/product-expiration/test/index.js
@@ -1,76 +1,79 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { ProductExpiration } from '../index';
 
 describe( 'ProductExpiration', () => {
 	it( 'should return null if not provided dates', () => {
-		const wrapper = shallow( <ProductExpiration translate={ translate } /> );
-		expect( wrapper.isEmptyRender() ).toEqual( true );
+		const { container } = render( <ProductExpiration translate={ translate } /> );
+		expect( container.firstChild ).toBeNull();
 	} );
 
 	it( 'should return the purchase date when refundable', () => {
 		const date = moment( new Date( 2009, 10, 10 ) );
-		const wrapper = shallow(
+		const { container } = render(
 			<ProductExpiration purchaseDateMoment={ date } translate={ translate } isRefundable />
 		);
-		expect( wrapper.text() ).toEqual( 'Purchased on November 10, 2009' );
+		expect( container.textContent ).toEqual( 'Purchased on November 10, 2009' );
 	} );
 
 	it( 'should return the expiry date in past tense when date is in past', () => {
 		const date = moment( new Date( 2009, 10, 10 ) );
-		const wrapper = shallow(
+		const { container } = render(
 			<ProductExpiration expiryDateMoment={ date } translate={ translate } />
 		);
-		expect( wrapper.text() ).toEqual( 'Expired on November 10, 2009' );
+		expect( container.textContent ).toEqual( 'Expired on November 10, 2009' );
 	} );
 
 	it( 'should return the expiry date in future tense when date is in future', () => {
 		const date = moment( new Date( 2100, 10, 10 ) );
-		const wrapper = shallow(
+		const { container } = render(
 			<ProductExpiration expiryDateMoment={ date } translate={ translate } />
 		);
-		expect( wrapper.text() ).toEqual( 'Expires on November 10, 2100' );
+		expect( container.textContent ).toEqual( 'Expires on November 10, 2100' );
 	} );
 
 	it( 'should return the renewal date (same as the expiry date) in when the date is in the future', () => {
 		const date = moment( new Date( 2100, 10, 10 ) );
-		const wrapper = shallow(
+		const { container } = render(
 			<ProductExpiration
 				expiryDateMoment={ date }
 				renewDateMoment={ date }
 				translate={ translate }
 			/>
 		);
-		expect( wrapper.text() ).toEqual( 'Renews on November 10, 2100' );
+		expect( container.textContent ).toEqual( 'Renews on November 10, 2100' );
 	} );
 
 	it( 'should return the renewal date in when the date is in the future', () => {
 		const expiryDate = moment( new Date( 2100, 9, 10 ) );
 		const renewDate = moment( new Date( 2100, 10, 10 ) );
-		const wrapper = shallow(
+		const { container } = render(
 			<ProductExpiration
 				expiryDateMoment={ expiryDate }
 				renewDateMoment={ renewDate }
 				translate={ translate }
 			/>
 		);
-		expect( wrapper.text() ).toEqual( 'Renews on November 10, 2100' );
+		expect( container.textContent ).toEqual( 'Renews on November 10, 2100' );
 	} );
 
 	it( 'should return null when provided an invalid expiry date', () => {
 		const date = moment( NaN );
-		const wrapper = shallow(
+		const { container } = render(
 			<ProductExpiration expiryDateMoment={ date } translate={ translate } />
 		);
-		expect( wrapper.isEmptyRender() ).toEqual( true );
+		expect( container.firstChild ).toBeNull();
 	} );
 
 	it( 'should return null when provided an invalid purchase date and no expiry date', () => {
 		const date = moment( NaN );
-		const wrapper = shallow(
+		const { container } = render(
 			<ProductExpiration purchaseDateMoment={ date } translate={ translate } />
 		);
-		expect( wrapper.isEmptyRender() ).toEqual( true );
+		expect( container.firstChild ).toBeNull();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `ProductExpiration` component to use `@testing-library/react` instead of `enzyme`.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/components/product-expiration/test/index.js`