### PR TITLE
Components: Refactor `PopoverMenuItem` to use `@testing-library/react`

### DIFF
--- a/client/components/popover-menu/test/menu-item.jsx
+++ b/client/components/popover-menu/test/menu-item.jsx
@@ -1,25 +1,28 @@
-import { shallow } from 'enzyme';
-import ExternalLink from 'calypso/components/external-link';
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 
 describe( 'PopoverMenuItem', () => {
 	test( 'should be a button by default', () => {
-		const wrapper = shallow( <PopoverMenuItem /> );
-		expect( wrapper.type() ).toEqual( 'button' );
+		const { container } = render( <PopoverMenuItem /> );
+		expect( container.firstChild.tagName ).toEqual( 'BUTTON' );
 	} );
 
 	test( 'should be a div if the itemComponent prop is provided', () => {
-		const wrapper = shallow( <PopoverMenuItem itemComponent={ 'div' } /> );
-		expect( wrapper.type() ).toEqual( 'div' );
+		const { container } = render( <PopoverMenuItem itemComponent={ 'div' } /> );
+		expect( container.firstChild.tagName ).toEqual( 'DIV' );
 	} );
 
 	test( 'should be a link if the href prop is set', () => {
-		const wrapper = shallow( <PopoverMenuItem href={ 'xyz' } /> );
-		expect( wrapper.type() ).toEqual( 'a' );
+		const { container } = render( <PopoverMenuItem href={ 'xyz' } /> );
+		expect( container.firstChild.tagName ).toEqual( 'A' );
 	} );
 
 	test( 'should be an ExternalLink if the isExternalLink prop is true and the href prop is set', () => {
-		const wrapper = shallow( <PopoverMenuItem isExternalLink={ true } href={ 'xyz' } /> );
-		expect( wrapper.type() ).toEqual( ExternalLink );
+		const { container } = render( <PopoverMenuItem isExternalLink={ true } href={ 'xyz' } /> );
+		expect( container.firstChild.tagName ).toEqual( 'A' );
+		expect( container.firstChild.getAttribute( 'target' ) ).toEqual( '_blank' );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `PopoverMenuItem` component to use `@testing-library/react` instead of `enzyme`.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/components/popover-menu/test/menu-item.jsx`