### PR TITLE
Editor: Refactor `EditorDiffViewer` away from `UNSAFE_` methods

### DIFF
--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -10,7 +10,6 @@ import TextDiff from 'calypso/components/text-diff';
 import scrollTo from 'calypso/lib/scroll-to';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPostRevision } from 'calypso/state/posts/selectors/get-post-revision';
-import { getPostRevisionsDiffView } from 'calypso/state/posts/selectors/get-post-revisions-diff-view';
 import './style.scss';
 
 const getCenterOffset = ( node ) =>
@@ -59,16 +58,6 @@ class EditorDiffViewer extends PureComponent {
 
 	componentDidUpdate() {
 		this.tryScrollingToFirstChangeOrTop();
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.selectedRevisionId !== this.props.selectedRevisionId ) {
-			this.setState( { changeOffsets: [] } );
-		}
-		if ( nextProps.diffView !== this.props.diffView ) {
-			this.recomputeChanges( null );
-		}
 	}
 
 	lastScolledRevisionId = null;
@@ -231,7 +220,6 @@ class EditorDiffViewer extends PureComponent {
 export default connect(
 	( state, { siteId, postId, selectedRevisionId } ) => ( {
 		revision: getPostRevision( state, siteId, postId, selectedRevisionId, 'display' ),
-		diffView: getPostRevisionsDiffView( state ),
 	} ),
 	{ recordTracksEvent }
 )( localize( EditorDiffViewer ) );

--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -12,6 +12,7 @@ import { getEditorPostId } from 'calypso/state/editor/selectors';
 import { getPostRevisions } from 'calypso/state/posts/selectors/get-post-revisions';
 import { getPostRevisionsAuthorsId } from 'calypso/state/posts/selectors/get-post-revisions-authors-id';
 import { getPostRevisionsComparisons } from 'calypso/state/posts/selectors/get-post-revisions-comparisons';
+import { getPostRevisionsDiffView } from 'calypso/state/posts/selectors/get-post-revisions-diff-view';
 import { getPostRevisionsSelectedRevisionId } from 'calypso/state/posts/selectors/get-post-revisions-selected-revision-id';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
@@ -22,8 +23,16 @@ class EditorRevisions extends Component {
 	}
 
 	render() {
-		const { authorsIds, comparisons, postId, revisions, selectedDiff, selectedRevisionId, siteId } =
-			this.props;
+		const {
+			authorsIds,
+			comparisons,
+			diffView,
+			postId,
+			revisions,
+			selectedDiff,
+			selectedRevisionId,
+			siteId,
+		} = this.props;
 
 		return (
 			<div className="editor-revisions">
@@ -35,9 +44,11 @@ class EditorRevisions extends Component {
 				<QueryPostRevisionAuthors siteId={ siteId } userIds={ authorsIds } />
 				<EditorDiffViewer
 					diff={ selectedDiff }
+					diffView={ diffView }
 					postId={ postId }
 					selectedRevisionId={ selectedRevisionId }
 					siteId={ siteId }
+					key={ `editor-diff-viewer-${ diffView }-${ selectedRevisionId }` }
 				/>
 				<EditorRevisionsList
 					comparisons={ comparisons }
@@ -55,6 +66,7 @@ EditorRevisions.propTypes = {
 	// connected to state
 	authorsIds: PropTypes.array.isRequired,
 	comparisons: PropTypes.object,
+	diffView: PropTypes.string,
 	postId: PropTypes.number.isRequired,
 	revisions: PropTypes.array.isRequired,
 	selectedDiff: PropTypes.object,
@@ -81,6 +93,7 @@ export default connect(
 		return {
 			authorsIds: getPostRevisionsAuthorsId( state, siteId, postId ),
 			comparisons,
+			diffView: getPostRevisionsDiffView( state ),
 			postId,
 			revisions,
 			selectedDiff,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `EditorDiffViewer` component away from the `UNSAFE_` deprecated React component methods.

We also use the opportunity to fix a bug - when the user was changing the view, the `scrollTop` value was preserved, and it didn't make sense in a different view. The solution is to scroll to the top when we change the view.

Part of #58453.

#### Testing instructions
* Open a post with at least a few revisions
* Open the post settings sidebar.
* Click on "X Revisions" where "X" is the number of revisions for that post.
* Verify the revision diff viewer still works well as you navigate between:
  * The different diff viewer views.
  * The different revisions.
* Verify that after you scroll down in a certain view, when you change the view, the scroll is properly reset.