### PR TITLE
Framework: Refactor away from `_.take()`

### DIFF
--- a/client/blocks/jitm/templates/modal.jsx
+++ b/client/blocks/jitm/templates/modal.jsx
@@ -1,5 +1,4 @@
 import { Button, Guide } from '@wordpress/components';
-import { take } from 'lodash-es/array';
 import { useState } from 'react';
 import './modal-style.scss';
 import Visual from './plans-visual.svg';
@@ -50,7 +49,7 @@ export default function ModalTemplate( {
 										{ CTA.message }
 									</Button>
 								</p>
-								{ take( disclaimer, 2 ).map( ( line ) => (
+								{ disclaimer.slice( 0, 2 ).map( ( line ) => (
 									<p className="modal__disclaimer">{ line }</p>
 								) ) }
 							</div>

--- a/client/blocks/reader-full-post/header-tags.jsx
+++ b/client/blocks/reader-full-post/header-tags.jsx
@@ -1,4 +1,4 @@
-import { take, values } from 'lodash';
+import { values } from 'lodash';
 import PropTypes from 'prop-types';
 
 const TAGS_TO_SHOW = 5;
@@ -6,7 +6,7 @@ const TAGS_TO_SHOW = 5;
 const ReaderFullPostHeaderTags = ( { tags } ) => {
 	let tagsInOccurrenceOrder = values( tags );
 	tagsInOccurrenceOrder.sort( ( a, b ) => b.post_count - a.post_count );
-	tagsInOccurrenceOrder = take( tagsInOccurrenceOrder, TAGS_TO_SHOW );
+	tagsInOccurrenceOrder = tagsInOccurrenceOrder.slice( 0, TAGS_TO_SHOW );
 
 	const listItems = tagsInOccurrenceOrder.map( ( tag ) => {
 		return (

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -1,5 +1,5 @@
 import { Gridicon } from '@automattic/components';
-import { get, map, take, values } from 'lodash';
+import { get, map, values } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
@@ -82,7 +82,7 @@ class PostByline extends Component {
 		const feedIcon = get( feed, 'image' );
 		let tagsInOccurrenceOrder = values( post.tags );
 		tagsInOccurrenceOrder.sort( ( a, b ) => b.post_count - a.post_count );
-		tagsInOccurrenceOrder = take( tagsInOccurrenceOrder, TAGS_TO_SHOW );
+		tagsInOccurrenceOrder = tagsInOccurrenceOrder.slice( 0, TAGS_TO_SHOW );
 		const tags = map( tagsInOccurrenceOrder, ( tag ) => <TagLink tag={ tag } key={ tag.slug } /> );
 
 		/* eslint-disable wpcalypso/jsx-gridicon-size */

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -1,4 +1,4 @@
-import { map, take, filter } from 'lodash';
+import { map, filter } from 'lodash';
 import PropTypes from 'prop-types';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import AutoDirection from 'calypso/components/auto-direction';
@@ -17,7 +17,7 @@ function getGalleryWorthyImages( post ) {
 	}
 
 	const worthyImages = filter( images, imageIsBigEnoughForGallery );
-	return take( worthyImages, numberOfImagesToDisplay );
+	return worthyImages.slice( 0, numberOfImagesToDisplay );
 }
 
 const PostGallery = ( { post, children, isDiscover } ) => {

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -6,7 +6,6 @@ import {
 	pickBy,
 	without,
 	isEmpty,
-	take,
 	filter,
 	map,
 	sortBy,
@@ -210,7 +209,7 @@ class KeyedSuggestions extends Component {
 			otherSuggestions.unshift( filterText );
 			// limit or show all
 			filtered[ taxonomy ] =
-				showAll === taxonomy ? otherSuggestions : take( otherSuggestions, limit );
+				showAll === taxonomy ? otherSuggestions : otherSuggestions.slice( 0, limit );
 			return filtered;
 		}
 
@@ -284,17 +283,14 @@ class KeyedSuggestions extends Component {
 					return max_seen > SEARCH_THRESHOLD;
 				};
 
-				filtered[ key ] = take(
-					filter(
-						map( terms[ key ], ( term, k ) =>
-							cleanFilterTerm === '' ||
-							matcher( term.name.toLowerCase(), cleanFilterTerm.toLowerCase() )
-								? k
-								: null
-						)
-					),
-					limit
-				);
+				filtered[ key ] = filter(
+					map( terms[ key ], ( term, k ) =>
+						cleanFilterTerm === '' ||
+						matcher( term.name.toLowerCase(), cleanFilterTerm.toLowerCase() )
+							? k
+							: null
+					)
+				).slice( 0, limit );
 			}
 		}
 		return this.removeEmptySuggestions( filtered );

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import debugFactory from 'debug';
-import { clone, difference, forEach, last, map, some, take } from 'lodash';
+import { clone, difference, forEach, last, map, some } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import isSuggestionLabel from './helpers';
@@ -353,7 +353,7 @@ class TokenField extends PureComponent {
 			suggestions = startsWithMatch.concat( containsMatch );
 		}
 
-		return take( suggestions, this.props.maxSuggestions );
+		return suggestions.slice( 0, this.props.maxSuggestions );
 	};
 
 	_getSelectedSuggestion = () => {

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -1,5 +1,5 @@
 import debugFactory from 'debug';
-import { filter, find, forEach, map, take } from 'lodash';
+import { filter, find, forEach, map } from 'lodash';
 import { deduceImageWidthAndHeight, thumbIsLikelyImage } from './utils';
 
 const debug = debugFactory( 'calypso:post-normalizer:wait-for-images-to-load' );
@@ -112,7 +112,7 @@ export default function waitForImagesToLoad( post ) {
 		// convert to image objects to start the load process
 		// only check the first x images
 		const NUMBER_OF_IMAGES_TO_CHECK = 10;
-		let promises = map( take( imagesToCheck, NUMBER_OF_IMAGES_TO_CHECK ), ( imageUrl ) => {
+		let promises = map( imagesToCheck.slice( 0, NUMBER_OF_IMAGES_TO_CHECK ), ( imageUrl ) => {
 			if ( imageUrl in knownImages ) {
 				return Promise.resolve( knownImages[ imageUrl ] );
 			}

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -1,7 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { take, times } from 'lodash';
+import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -77,7 +77,7 @@ class FollowingManageSearchFeedsResults extends Component {
 						showLastUpdatedDate: false,
 						followSource: READER_FOLLOWING_MANAGE_SEARCH_RESULT,
 					} }
-					items={ showMoreResults ? searchResults : take( searchResults, 10 ) }
+					items={ showMoreResults ? searchResults : searchResults.slice( 0, 10 ) }
 					width={ width }
 					fetchNextPage={ this.fetchNextPage }
 					hasNextPage={ showMoreResults ? this.hasNextPage : undefined }

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -1,6 +1,6 @@
 import { CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { trim, debounce, random, take, reject, includes } from 'lodash';
+import { trim, debounce, random, reject, includes } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
@@ -251,7 +251,7 @@ class FollowingManage extends Component {
 					</div>
 					{ ! sitesQuery && (
 						<RecommendedSites
-							sites={ take( filteredRecommendedSites, 2 ) }
+							sites={ filteredRecommendedSites.slice( 0, 2 ) }
 							followSource={ READER_FOLLOWING_MANAGE_RECOMMENDATION }
 						/>
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors away from Lodash's `take()` method. The refactor is pretty trivial and supported by native JS.

#### Testing instructions

* Inspecting the response of a request to the `jitm` endpoint, verify that the JITM message always has a `disclaimer` array in the `content` property.
* Verify that a full post in the Reader with tags still loads and renders without issues.
* Verify that a post with a gallery still appears well in a Reader feed.
* Go to `/themes/:site` and verify that the search keyed suggestions still work (try with "menu" or "sidebar").
* Verify the token fields still work well: `/devdocs/design/token-fields`
* Verify that posts with classic blocks with images still load well in the editor.
* Verify that `/following/manage` and the search form there still work well.
* Verify all tests still pass.