### PR TITLE
Framework: Refactor away from `_.sample()`

### DIFF
--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -1,7 +1,6 @@
 import { Dialog, Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
-import { sample } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -45,7 +44,7 @@ const getRandomPromo = () => {
 		},
 	];
 
-	return sample( promoOptions );
+	return promoOptions[ Math.floor( Math.random() * promoOptions.length ) ];
 };
 
 export const getPromoLink = ( location, promoDetails ) => {

--- a/client/reader/following/vote-banner.jsx
+++ b/client/reader/following/vote-banner.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { sample } from 'lodash';
 import { connect } from 'react-redux';
 import Banner from 'calypso/components/banner';
 import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
@@ -28,7 +27,8 @@ const FollowingVoteBanner = ( props ) => {
 	];
 
 	// Show the early voting message if it's not election day yet
-	const electionDayMessage = sample( electionDayMessages );
+	const electionDayMessage =
+		electionDayMessages[ Math.floor( Math.random() * electionDayMessages.length ) ];
 	const description = now < electionDayStart ? earlyVotingMessage : electionDayMessage;
 
 	return (

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -1,7 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { sample } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -14,6 +13,10 @@ import { getTagImages } from 'calypso/state/reader/tags/images/selectors';
 
 const TAG_HEADER_WIDTH = 800;
 const TAG_HEADER_HEIGHT = 140;
+
+function sample( array ) {
+	return array[ Math.floor( Math.random() * array.length ) ];
+}
 
 class TagStreamHeader extends Component {
 	static propTypes = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors away from Lodash's `sample()` method. The refactor is pretty trivial and supported by a simple vanilla JS function.

#### Testing instructions

* Go to the Reader and pick a post with tags.
* Verify it appears well both in feeds and in full post view.
* Vote banner is not used, so no testing is necessary.
* Delete the app banner preference and open Reader on the mobile view; verify it still works well.