### PR TITLE
Components: Fix layout of `SectionNav` with `Search` on small screens

### DIFF
--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -116,6 +116,8 @@ class SectionNav extends Component {
 			if ( child.type === Search ) {
 				if ( child.props.pinned ) {
 					this.hasPinnedSearch = true;
+
+					extraProps.onSearchOpen = this.generateOnSearchOpen( child.props.onSearchOpen );
 				}
 
 				extraProps.onSearch = this.generateOnSearch( child.props.onSearch );
@@ -148,6 +150,13 @@ class SectionNav extends Component {
 	generateOnSearch( existingOnSearch ) {
 		return ( ...args ) => {
 			existingOnSearch( ...args );
+			this.closeMobilePanel();
+		};
+	}
+
+	generateOnSearchOpen( existingOnSearchOpen ) {
+		return ( ...args ) => {
+			existingOnSearchOpen( ...args );
 			this.closeMobilePanel();
 		};
 	}

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -196,4 +196,12 @@
 // -------- Search --------
 .section-nav .search {
 	overflow: hidden;
+
+	&.is-expanded-to-container {
+		height: 45px;
+
+		@include breakpoint-deprecated( '>480px' ) {
+			height: 100%;
+		}
+	}
 }


### PR DESCRIPTION
While working on Jetpack Cloud Licensing Portal, I've encountered an issue with the `SectionNav` component that contains a `Search` component.

- `SectionNav` with child `Search` has an UI glitch on mobile layout that with you open `SectionNav`'s dropdown and then click on the search icon, it would open a "bigger than usual" search box.
- The search icon on the `SectionNav` opened dropdown overlaps the dropdown UI by filling all the height of the parent element.

#### Changes proposed in this Pull Request

- `SectionNav` dropdown is closed when opening the search box on small mobile layouts, to avoid displaying a very tall search box.
- `Search` icon is now only `45px` tall to be inset with the `SectionNav` dropdown header that is `46px` tall and not to overlap the dropdown UI.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> This change should be visible anywhere there is a `SectionNav` component containing a `Search` component being rendered on mobile with `Search`'s `pinned` prop set as `true`.

- You will have to have a wordpress.com website, if you don't just create a new one.
- Go to the "All Posts" section of you site, it has a `SectionNav` component useful for testing this. It should be something like https://calypso.localhost:3000/posts/yournewlycreatedsite.wordpress.com
- Set your browser viewport width to lesser than `480px` which is the breakpoint used to cause the UI glitch.
- Click on `Published` on the `SectionNav` and it should open the dropdown, the search icon should be level with the dropdown header and clicking the search icon should close the dropdown and open the search box.

*Doing the same steps on wordpress.com will cause the UI glitch as you can see below*

| Step 1 | Step 2 |
| ------------- | ------------- |
| Version with glitch | Version with glitch |
|  ![image](https://user-images.githubusercontent.com/5550190/165980080-f0cf191e-b501-4449-92d8-80b92fbd2b2d.png) |    ![image](https://user-images.githubusercontent.com/5550190/165980126-ee41c469-102e-4c3c-a2f1-c1e396e416c3.png) |
| Version without glitch | Version without glitch |
| ![image](https://user-images.githubusercontent.com/5550190/165981458-e5816427-64c3-411c-96bc-86ec37a9489a.png) | ![image](https://user-images.githubusercontent.com/5550190/165981541-13f8719f-45eb-41c4-b287-af8718dc4040.png) |


Components documentation reference:
[`Search` component](https://wpcalypso.wordpress.com/devdocs/design/search)
[`SectionNav` component](https://wpcalypso.wordpress.com/devdocs/design/section-nav)