### PR TITLE
FoldableCard: Add new prop to hide summary space in header

### DIFF
--- a/client/components/foldable-card/README.md
+++ b/client/components/foldable-card/README.md
@@ -2,6 +2,8 @@
 
 This component is used to display a box that can be clicked to expand a hidden section with its contents.
 
+The component's header contains two adjacent content areas that are set by the `header` and `summary` props (also see the `expandedSummary` prop); both are optional, but both areas take up space inside the card even if they are not set. To cause the `header` content area to take up the whole header card, set the `hideSummary` prop.
+
 ## Usage
 
 ```js
@@ -10,7 +12,7 @@ import FoldableCard from 'calypso/components/foldable-card';
 function render() {
 	return (
 		<div>
-			<FoldableCard header="title">{ content }</FoldableCard>
+			<FoldableCard header="title" hideSummary>{ content }</FoldableCard>
 		</div>
 	);
 }
@@ -34,5 +36,6 @@ function render() {
 | `onClose`              | `function`  | null           | Function to be executed in addition to the expand action when the card is closed.                                                                    |
 | `onOpen`               | `function`  | null           | Function to be executed in addition to the expand action when the card is opened.                                                                    |
 | `summary`              | `string`    | null           | A string or component to show next to the action button when closed.                                                                                 |
+| `hideSummary`          | `bool`      | false          | Indicates if the summary area should be hidden.                                                                                                      |
 | `clickableHeader`      | `bool`      | false          | Indicates if the whole header can be clicked to open the card.                                                                                       |
 | `highlight`            | `string`    | null           | Displays a colored highlight. If specified (default is no highlight), can be one of `info`, `success`, `error`, or `warning`.                        |

--- a/client/components/foldable-card/README.md
+++ b/client/components/foldable-card/README.md
@@ -11,9 +11,9 @@ import FoldableCard from 'calypso/components/foldable-card';
 
 function render() {
 	return (
-		<div>
-			<FoldableCard header="title" hideSummary>{ content }</FoldableCard>
-		</div>
+		<FoldableCard header="title" hideSummary>
+			{ content }
+		</FoldableCard>
 	);
 }
 ```

--- a/client/components/foldable-card/docs/example.jsx
+++ b/client/components/foldable-card/docs/example.jsx
@@ -15,6 +15,25 @@ export default class FoldableCardExample extends PureComponent {
 				</div>
 
 				<div>
+					<FoldableCard
+						header="This is a foldable card with a really long header content area that might wrap depending on the page width of the browser being used to view this page when the summary area is not hidden."
+						screenReaderText="More"
+					>
+						These are the card's contents.
+					</FoldableCard>
+				</div>
+
+				<div>
+					<FoldableCard
+						header="This is a foldable card with a really long header content area that might wrap depending on the page width of the browser being used to view this page when the summary area is hidden."
+						hideSummary
+						screenReaderText="More"
+					>
+						These are the card's contents.
+					</FoldableCard>
+				</div>
+
+				<div>
 					<FoldableCard header="This is a compact card" compact screenReaderText="More">
 						I'm tiny! :D
 					</FoldableCard>

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -129,14 +129,17 @@ class FoldableCard extends Component {
 			this.props.header,
 			this.renderActionButton()
 		);
+		const hasSummary = this.props.expandedSummary || this.props.summary;
 
 		return (
 			<div className={ headerClasses } role="presentation" onClick={ headerClickAction }>
 				{ header }
-				<span className="foldable-card__secondary">
-					{ summary }
-					{ expandedSummary }
-				</span>
+				{ hasSummary && (
+					<span className="foldable-card__secondary">
+						{ summary }
+						{ expandedSummary }
+					</span>
+				) }
 			</div>
 		);
 	}

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -26,6 +26,7 @@ class FoldableCard extends Component {
 		onOpen: PropTypes.func,
 		screenReaderText: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		summary: PropTypes.node,
+		hideSummary: PropTypes.bool,
 		highlight: PropTypes.string,
 	};
 
@@ -129,12 +130,11 @@ class FoldableCard extends Component {
 			this.props.header,
 			this.renderActionButton()
 		);
-		const hasSummary = this.props.expandedSummary || this.props.summary;
 
 		return (
 			<div className={ headerClasses } role="presentation" onClick={ headerClickAction }>
 				{ header }
-				{ hasSummary && (
+				{ ! this.props.hideSummary && (
 					<span className="foldable-card__secondary">
 						{ summary }
 						{ expandedSummary }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `FoldableCard` UI element includes two content areas in its collapsed section: `header` and `summary`. The two areas sit side-by-side inside the box, with `header` on the left and `summary` on the right, just before the action button that toggles the card's collapsed state. However, if `summary` is not provided, it still takes up space in the card, forcing the `header` content to wrap only inside the left-half of the card's area. This is inconvenient if the card needs only a single content area and contains content that will not easily fit on the left-half of the card.

Originally I thought it would be wise to change `FoldableCard` such that if the `summary` (and its companion `expandedSummary`) prop is not provided, its area is not rendered at all, allowing `header` to take up the full horizontal width of the card. This still seems like a good idea, but `FoldableCard` is one of the original components in calypso and is used in over a hundred different places, so making this sort of breaking change seems unsafe.

To that end, I've added a new prop called `hideSummary` which will hide the summary area if it is set, allowing the previous behavior to continue unless opting in to the full width.

I added a devdocs example so you can see what this does:

<img width="1014" alt="Screen Shot 2022-04-29 at 2 29 52 PM" src="https://user-images.githubusercontent.com/2036909/166004332-8295512f-0715-423b-a89c-0d7c43d72f21.png">

Extracted from https://github.com/Automattic/wp-calypso/pull/62576

#### Testing instructions

This just adds a prop so it should be safe.