### PR TITLE
Update the message shown for domains in aftermarket auctions.

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -10,7 +10,7 @@ import {
 	INCOMING_DOMAIN_TRANSFER_STATUSES,
 	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS,
 	GDPR_POLICIES,
-	DOMAIN_EXPIRATION_AUCTION,
+	DOMAIN_EXPIRATION,
 } from 'calypso/lib/url/support';
 import {
 	domainManagementEdit,
@@ -220,20 +220,18 @@ export function resolveDomainStatus(
 
 		case domainTypes.REGISTERED:
 			if ( domain.aftermarketAuction ) {
-				const statusMessage = translate( 'Expiry auction' );
+				const statusMessage = translate( 'Expired' );
 				return {
 					statusText: statusMessage,
 					statusClass: 'status-warning',
 					status: statusMessage,
 					icon: 'info',
 					noticeText: translate(
-						'Your domain expired over 30 days ago and has been offered for sale at auction. If it is not sold you may be able to restore the domain to your account by paying a redemption fee starting on {{strong}}%(renewableUntil)s{{/strong}}. Until then, you will not be able to make any changes or transfer the domain. {{a}}Learn more{{/a}}',
+						'This domain expired more than 30 days ago and is no longer available to manage or renew. We may be able to restore it after {{strong}}%(renewableUntil)s{{/strong}}. {{a}}Learn more{{/a}}',
 						{
 							components: {
 								strong: <strong />,
-								a: (
-									<a href={ DOMAIN_EXPIRATION_AUCTION } rel="noopener noreferrer" target="_blank" />
-								),
+								a: <a href={ DOMAIN_EXPIRATION } rel="noopener noreferrer" target="_blank" />,
 							},
 							args: {
 								renewableUntil: moment.utc( domain.renewableUntil ).format( 'LL' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We are simplifying the language shown in the notice when domains are in an active expiry auction

#### Testing instructions

Hack the back-end do that a test domain will appear to be in an active aftermarket auction. Make sure that the following notice is shown in the domains list:

![Cursor_and_Domains_‹_A8C_Test_Site_—_WordPress_com](https://user-images.githubusercontent.com/1379730/166069361-30259cc3-f855-4e0b-b6f6-ece0d247437b.jpg)

Make sure that the following message is shown in the domain management page:

![A8C_Test_Site_—_WordPress_com](https://user-images.githubusercontent.com/1379730/166069434-1c7ab3bc-4be0-4aea-b61b-808cd7bc6f92.jpg)

