### PR TITLE
Help: Switch useRouteModal to addQueryArgs from calypso

### DIFF
--- a/client/lib/route-modal/use-route-modal.tsx
+++ b/client/lib/route-modal/use-route-modal.tsx
@@ -1,6 +1,7 @@
-import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
+import { removeQueryArgs } from '@wordpress/url';
 import page from 'page';
 import { useSelector } from 'react-redux';
+import { addQueryArgs } from 'calypso/lib/url';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 
@@ -10,7 +11,7 @@ export interface RouteModalData {
 	/** The value of query key */
 	value: unknown;
 	/** Set the query key to value */
-	openModal: ( currentValue?: unknown ) => void;
+	openModal: ( currentValue?: string ) => void;
 	/** Clears the query key */
 	closeModal: () => void;
 }
@@ -18,7 +19,7 @@ export interface RouteModalData {
 /**
  * React hook providing utils to control opening and closing modal via query string.
  */
-const useRouteModal = ( queryKey: string, defaultValue: unknown = '' ): RouteModalData => {
+const useRouteModal = ( queryKey: string, defaultValue = '' ): RouteModalData => {
 	const currentQuery = useSelector( getCurrentQueryArguments );
 	const previousRoute = useSelector( getPreviousRoute );
 
@@ -26,13 +27,15 @@ const useRouteModal = ( queryKey: string, defaultValue: unknown = '' ): RouteMod
 
 	const isModalOpen = value != null;
 
-	const openModal = ( currentValue: unknown = defaultValue ) => {
+	const openModal = ( currentValue: string = defaultValue ) => {
 		const url = window.location.href.replace( window.location.origin, '' );
 		const queryParams = {
 			[ queryKey ]: currentValue,
 		};
 
-		page( addQueryArgs( url, queryParams ) );
+		// Note: addQueryArgs in wordpress/url has a bug which means we cannot use
+		// it. See https://github.com/Automattic/wp-calypso/issues/63185
+		page( addQueryArgs( queryParams, url ) );
 	};
 
 	const closeModal = () => {

--- a/client/lib/route-modal/with-route-modal.tsx
+++ b/client/lib/route-modal/with-route-modal.tsx
@@ -7,7 +7,7 @@ interface WithRouteModalProps {
 
 export default function withRouteModal< ComponentProps >(
 	queryKey: string,
-	defaultValue?: unknown
+	defaultValue?: string
 ) {
 	return createHigherOrderComponent< ComponentProps, ComponentProps & WithRouteModalProps >(
 		( WrappedComponent ) => ( props ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `useRouteModal` React hook (and `withRouteModal` HOC) rely on setting the query string of the page. However, they use the `addQueryArgs()` function of the `@wordpress/url` package which has [a major bug](https://github.com/WordPress/gutenberg/issues/16655) that prevents it from working if there is a page fragment (aka hash) in the URL.

This PR switches these hooks to use `addQueryArgs()` from calypso instead.

Fixes https://github.com/Automattic/wp-calypso/issues/63185.

#### Testing instructions

- Add a product to your cart in calypso and visit checkout.
- Complete the billing information/contact information step so that the page will have a fragment in the URL like `#step2`.
- Click the "?" icon in the lower-right of the page.
- Click "WordPress.com Plans".
- Click the "Read More" button.
- Verify that a help modal appears.


<img width="341" alt="Screen Shot 2022-04-29 at 5 22 49 PM" src="https://user-images.githubusercontent.com/2036909/166071055-46b9b80a-080f-4091-9966-996a0714397a.png">

<img width="338" alt="Screen Shot 2022-04-29 at 5 22 56 PM" src="https://user-images.githubusercontent.com/2036909/166071039-bacc154e-b2f3-4c23-bab6-f73b1080733d.png">

<img width="1310" alt="Screen Shot 2022-04-29 at 5 24 31 PM" src="https://user-images.githubusercontent.com/2036909/166071173-dd8e244f-2b85-4c78-bdcd-bb3c285c507a.png">

