### PR TITLE
hasFeature: Update post share block

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -29,6 +29,7 @@ import getScheduledPublicizeShareActionTime from 'calypso/state/selectors/get-sc
 import isPublicizeEnabled from 'calypso/state/selectors/is-publicize-enabled';
 import isSchedulingPublicizeShareAction from 'calypso/state/selectors/is-scheduling-publicize-share-action';
 import isSchedulingPublicizeShareActionError from 'calypso/state/selectors/is-scheduling-publicize-share-action-error';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
 	fetchConnections as requestConnections,
 	sharePost,
@@ -42,10 +43,7 @@ import {
 	sharePostFailure,
 	sharePostSuccessMessage,
 } from 'calypso/state/sharing/publicize/selectors';
-import {
-	hasFeature,
-	isRequestingSitePlans as siteIsRequestingPlans,
-} from 'calypso/state/sites/plans/selectors';
+import { isRequestingSitePlans as siteIsRequestingPlans } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug, getSitePlanSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import ConnectionsList from './connections-list';
 import NoConnectionsNotice from './no-connections-notice';
@@ -630,7 +628,7 @@ export default connect(
 			isJetpack: isJetpackSite( state, siteId ),
 			hasFetchedConnections: siteHasFetchedConnections( state, siteId ),
 			isRequestingSitePlans: siteIsRequestingPlans( state, siteId ),
-			hasRepublicizeFeature: hasFeature( state, siteId, FEATURE_REPUBLICIZE ),
+			hasRepublicizeFeature: siteHasFeature( state, siteId, FEATURE_REPUBLICIZE ),
 			siteSlug: getSiteSlug( state, siteId ),
 			isPublicizeEnabled: isPublicizeEnabled( state, siteId, postType ),
 			scheduling: isSchedulingPublicizeShareAction( state, siteId, postId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes `hasFeature` in favor of `siteHasFeature` in Post share.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the post list: https://container-gallant-turing.calypso.live/posts
* Click the ellipses menu on the right for one of your posts
* Click on "Share"
* Optional: If you haven't connected a social account, it will ask you to do so now.
* On a free site make sure it shows an upgrade banner <img width="1061" alt="image" src="https://user-images.githubusercontent.com/1398304/167219989-f27ddf62-e692-429c-9ef3-12ef015bb0df.png">
* On a site with a Premium plan or up, make sure it shows the republicize functionality <img width="1060" alt="image" src="https://user-images.githubusercontent.com/1398304/167220009-49c4f11b-7d49-4437-b24e-3a2eaf257f11.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-a66-p2
Depends on https://github.com/Automattic/wp-calypso/pull/63386