### PR TITLE
Fix page patterns modal when the Gutenberg plugin is not available.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-menu/index.tsx
@@ -1,5 +1,5 @@
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
 import * as React from 'react';
 import { LAUNCH_STORE } from '../stores';
 import LaunchMenuItem from './item';
@@ -12,8 +12,6 @@ interface Props {
 }
 
 const LaunchMenu: React.FunctionComponent< Props > = ( { onMenuItemClick } ) => {
-	const { __ } = useI18n();
-
 	const { currentStep, LaunchStep, LaunchSequence, isStepCompleted, isFlowCompleted } = useSelect(
 		( select ) => {
 			const launchStore = select( LAUNCH_STORE );

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-progress/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-progress/index.tsx
@@ -1,14 +1,11 @@
 import { useSelect } from '@wordpress/data';
-import { sprintf } from '@wordpress/i18n';
-import { useI18n } from '@wordpress/react-i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import * as React from 'react';
 import { LAUNCH_STORE } from '../stores';
 
 import './styles.scss';
 
 const LaunchProgress: React.FunctionComponent = () => {
-	const { __ } = useI18n();
-
 	const { currentStep, LaunchSequence } = useSelect( ( select ) => {
 		const launchStore = select( LAUNCH_STORE );
 		return {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -4,14 +4,13 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useDomainSelection, useSiteDomains, useDomainSearch } from '@automattic/launch';
 import { Title, SubTitle, ActionButtons, BackButton, NextButton } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
-import { useI18n } from '@wordpress/react-i18n';
+import { __, hasTranslation } from '@wordpress/i18n';
 import * as React from 'react';
 import { FLOW_ID } from '../../constants';
 import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
 import { LAUNCH_STORE } from '../../stores';
 
 const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
-	const { __, hasTranslation } = useI18n();
 	const locale = useLocale();
 
 	const { onDomainSelect, onExistingSubdomainSelect, currentDomain } = useDomainSelection();

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -15,9 +15,8 @@ import { ThemeProvider } from '@emotion/react';
 import { Button, Tip } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
+import { sprintf, __, hasTranslation } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import * as React from 'react';
 import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
@@ -41,7 +40,6 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep, on
 		}
 	);
 
-	const { __, hasTranslation } = useI18n();
 	const locale = useLocale();
 
 	const [ plan, planProduct ] = useSelect( ( select ) => [

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -64,7 +64,7 @@ function WelcomeTour() {
 	}
 	const { isInserterOpened, isSidebarOpened, isSettingsOpened } = useSelect( ( select ) => ( {
 		isInserterOpened: select( 'core/edit-post' ).isInserterOpened(),
-		isSidebarOpened: select( 'automattic/block-editor-nav-sidebar' ).isSidebarOpened(),
+		isSidebarOpened: select( 'automattic/block-editor-nav-sidebar' )?.isSidebarOpened() ?? false, // The sidebar store may not always be loaded.
 		isSettingsOpened:
 			select( 'core/interface' ).getActiveComplementaryArea( 'core/edit-post' ) ===
 			'edit-post/document',

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -96,7 +96,6 @@
 		"@wordpress/nux": "^5.0.17",
 		"@wordpress/plugins": "^4.0.7",
 		"@wordpress/primitives": "^3.0.4",
-		"@wordpress/react-i18n": "^3.0.4",
 		"@wordpress/rich-text": "^5.0.7",
 		"@wordpress/scripts": "^19.2.2",
 		"@wordpress/server-side-render": "^3.0.17",

--- a/client/blocks/inline-help/inline-help-contact-page.tsx
+++ b/client/blocks/inline-help/inline-help-contact-page.tsx
@@ -41,8 +41,6 @@ const InlineHelpContactPage: React.FC< Props > = ( { closeContactPage, onSelectR
 };
 
 export const InlineHelpContactPageButton: React.FC< { onClick: () => void } > = ( { onClick } ) => {
-	const { __ } = useI18n();
-
 	return (
 		<Button className="inline-help__contact-button" borderless={ false } onClick={ onClick }>
 			<Gridicon icon={ 'comment' } size={ 24 } fill="" />

--- a/client/blocks/inline-help/inline-help-contact-page.tsx
+++ b/client/blocks/inline-help/inline-help-contact-page.tsx
@@ -1,5 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
 import InlineHelpSearchResults from './inline-help-search-results';
 
 import './inline-help-contact-page.scss';
@@ -10,8 +10,6 @@ interface Props {
 }
 
 const InlineHelpContactPage: React.FC< Props > = ( { closeContactPage, onSelectResource } ) => {
-	const { __ } = useI18n();
-
 	return (
 		<div className="inline-help__contact-page">
 			<Button borderless={ true } onClick={ closeContactPage }>

--- a/client/blocks/inline-help/inline-help-embed-result.tsx
+++ b/client/blocks/inline-help/inline-help-embed-result.tsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Gridicon } from '@automattic/components';
 import { Flex, FlexItem } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
 import React from 'react';
 import ArticleContent from 'calypso/blocks/support-article-dialog/dialog-content';
 import { RESULT_ARTICLE } from './constants';
@@ -21,8 +21,6 @@ interface Props {
 
 const InlineHelpEmbedResult: React.FC< Props > = ( { result, handleBackButton, searchQuery } ) => {
 	const { post_id: postId, link, type = RESULT_ARTICLE } = result;
-	const { __ } = useI18n();
-
 	useEffect( () => {
 		const tracksData = {
 			search_query: searchQuery,

--- a/client/blocks/inline-help/inline-help-more-resources.tsx
+++ b/client/blocks/inline-help/inline-help-more-resources.tsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
 
@@ -26,7 +26,6 @@ const ResourceItem: React.FC< ItemProps > = ( { link, icon, text, svgColor, onCl
 );
 
 const HelpCenterMoreResources = () => {
-	const { __ } = useI18n();
 	const isBusinessOrEcomPlanUser = useSelector( ( state ) => {
 		const purchases = getUserPurchases( state );
 		const purchaseSlugs = purchases && purchases.map( ( purchase ) => purchase.productSlug );

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -3,7 +3,7 @@
  */
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Card } from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { useState } from 'react';
 import Draggable from 'react-draggable';
@@ -21,7 +21,6 @@ const HelpCenterContainer: React.FC< Container > = ( {
 	headerText,
 	footerContent,
 } ) => {
-	const { __ } = useI18n();
 	const [ isMinimized, setIsMinimized ] = useState( false );
 	const [ isVisible, setIsVisible ] = useState( true );
 	const isMobile = useMobileBreakpoint();

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -1,6 +1,6 @@
 import { CardHeader, Button, Flex } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { closeSmall, chevronUp, lineSolid } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { Header } from './types';
 
@@ -12,7 +12,6 @@ const HelpCenterMobileHeader: React.FC< Header > = ( {
 	headerText,
 } ) => {
 	const classNames = classnames( 'help-center__container-header' );
-	const { __ } = useI18n();
 
 	return (
 		<CardHeader className={ classNames }>

--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -39,7 +39,6 @@
 		"@wordpress/i18n": "^4.3.0",
 		"@wordpress/icons": "^6.2.0",
 		"@wordpress/primitives": "^3.0.4",
-		"@wordpress/react-i18n": "^3.0.4",
 		"classnames": "^2.3.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-minimized.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-minimized.tsx
@@ -1,8 +1,7 @@
 import { Button, Flex } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import { Icon, close } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import maximize from '../icons/maximize';
 import type { MinimizedTourRendererProps } from '../../../types';
 
@@ -12,7 +11,6 @@ const WpcomTourKitMinimized: React.FunctionComponent< MinimizedTourRendererProps
 	onDismiss,
 	currentStepIndex,
 } ) => {
-	const { __ } = useI18n();
 	const lastStepIndex = steps.length - 1;
 	const page = currentStepIndex + 1;
 	const numberOfPages = lastStepIndex + 1;

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-rating.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-rating.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { useTourKitContext } from '../../../index';
 import thumbsDown from '../icons/thumbs_down';
@@ -12,7 +12,6 @@ const WpcomTourKitRating: React.FunctionComponent = () => {
 	const context = useTourKitContext();
 	const config = context.config as unknown as WpcomConfig;
 	const tourRating = config.options?.tourRating?.useTourRating?.() ?? tempRating;
-	const { __ } = useI18n();
 
 	let isDisabled = false;
 

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-navigation.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-navigation.tsx
@@ -1,6 +1,6 @@
 import { PaginationControl } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
 import type { WpcomTourStepRendererProps } from '../../../types';
 
 type Props = Omit< WpcomTourStepRendererProps, 'onMinimize' >;
@@ -14,7 +14,6 @@ const WpcomTourKitStepCardNavigation: React.FunctionComponent< Props > = ( {
 	setInitialFocusedElement,
 	steps,
 } ) => {
-	const { __ } = useI18n();
 	const isFirstStep = currentStepIndex === 0;
 	const lastStepIndex = steps.length - 1;
 

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-overlay-controls.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-overlay-controls.tsx
@@ -1,6 +1,6 @@
 import { Button, Flex } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import minimize from '../icons/minimize';
 import type { TourStepRendererProps } from '../../../types';
 
@@ -13,8 +13,6 @@ const WpcomTourKitStepCardOverlayControls: React.FunctionComponent< Props > = ( 
 	onMinimize,
 	onDismiss,
 } ) => {
-	const { __ } = useI18n();
-
 	return (
 		<div className="wpcom-tour-kit-step-card-overlay-controls">
 			<Flex>

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
@@ -1,6 +1,6 @@
 import { getMediaQueryList, isMobile, MOBILE_BREAKPOINT } from '@automattic/viewport';
 import { Button, Card, CardBody, CardFooter, CardMedia } from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
 import WpcomTourKitRating from './wpcom-tour-kit-rating';
 import WpcomTourKitStepCardNavigation from './wpcom-tour-kit-step-card-navigation';
 import WpcomTourKitStepCardOverlayControls from './wpcom-tour-kit-step-card-overlay-controls';
@@ -16,7 +16,6 @@ const WpcomTourKitStepCard: React.FunctionComponent< WpcomTourStepRendererProps 
 	onPreviousStep,
 	setInitialFocusedElement,
 } ) => {
-	const { __ } = useI18n();
 	const lastStepIndex = steps.length - 1;
 	const { descriptions, heading, imgSrc } = steps[ currentStepIndex ].meta;
 	const isLastStep = currentStepIndex === lastStepIndex;

--- a/packages/whats-new/package.json
+++ b/packages/whats-new/package.json
@@ -39,7 +39,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@wordpress/components": "^19.2.0",
-		"@wordpress/react-i18n": "^3.0.4",
+		"@wordpress/i18n": "^4.2.4",
 		"wpcom": "workspace:^",
 		"wpcom-proxy-request": "workspace:^"
 	},

--- a/packages/whats-new/src/index.js
+++ b/packages/whats-new/src/index.js
@@ -1,6 +1,6 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { Guide } from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
 import wpcom from 'wpcom';
 import proxyRequest from 'wpcom-proxy-request';
@@ -9,7 +9,6 @@ import './style.scss';
 
 const WhatsNewGuide = ( { onClose } ) => {
 	const [ whatsNewData, setWhatsNewData ] = useState( null );
-	const __ = useI18n().__;
 	const locale = useLocale();
 
 	// Load What's New list on first site load

--- a/packages/whats-new/src/whats-new-page.js
+++ b/packages/whats-new/src/whats-new-page.js
@@ -1,11 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, GuidePage } from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
 
 function WhatsNewPage( { description, heading, imageSrc, isLastPage, link, pageNumber } ) {
-	const __ = useI18n().__;
-
 	useEffect( () => {
 		recordTracksEvent( 'wpcom_whats_new_slide_view', {
 			slide_number: pageNumber,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,7 +1271,6 @@ __metadata:
     "@wordpress/i18n": ^4.3.0
     "@wordpress/icons": ^6.2.0
     "@wordpress/primitives": ^3.0.4
-    "@wordpress/react-i18n": ^3.0.4
     classnames: ^2.3.1
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -1386,7 +1385,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@wordpress/components": ^19.2.0
-    "@wordpress/react-i18n": ^3.0.4
+    "@wordpress/i18n": ^4.2.4
     wpcom: "workspace:^"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
@@ -1557,7 +1556,6 @@ __metadata:
     "@wordpress/nux": ^5.0.17
     "@wordpress/plugins": ^4.0.7
     "@wordpress/primitives": ^3.0.4
-    "@wordpress/react-i18n": ^3.0.4
     "@wordpress/rich-text": ^5.0.7
     "@wordpress/scripts": ^19.2.2
     "@wordpress/server-side-render": ^3.0.17


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Resolves #62788. TLDR: **ETK code may not directly or indirectly depend on `@wordpress/react-i18n`**

`@wordpress/react-i18n`, a newer i18n library is not yet available in core WordPress. When ETK projects depend directly or indirectly on `@wordpress/react-i18n`, a script dependency is added to the project's asset.php file for `wp-react-i18n`. When this script does not exist, the ETK project does not get loaded correctly. Interestingly, this script _is_ provided by Gutenberg, so everything is successful when the Gutenberg plugin is active.

This has lead to issues when the Gutenberg plugin is _not_ activated, such as the page patterns modal not closing. (This happens because the modal close action relies on the welcome guide store, and the welcome guide store doesn't get registered if react-i18n is not available.) There are likely some other issues as well.

In this PR, I've removed `react-i18n` from ETK directly, and from other Calypso packages ETK now relies on. I've verified the fix by searching the `dist` code for `react-i18n`, and verifying it doesn't get added to any asset.php files. Its uses have been replaced with `@wordpress/i18n`.

Here are the following packages that needed this change:
- ETK
- client/blocks/inline-help
- packages/tour-kit
- packages/whats-new
- packages/help-center

I also fixed an issue related to local development. The block sidebar feature is only loaded when a filter is active, but the selector in the page patterns modal doesn't handle that case. When the block sidebar modal is not loaded, its store is not registered, so the page patterns modal needs to guard against that condition.

### Testing instructions

#### Local testing:
- Load ETK in a local wp-env testing environment. (Run `yarn wp-env start` from the ETK directory.)
- Disable the gutenberg plugin in the wordpress instance.
- Visit http://localhost:4013/wp-admin/post-new.php?post_type=page
- Verify that the page pattern modal works and that you can close it.

#### Atomic testing:
- Download the ETK artifact from TeamCity
- Upload it to an Atomic test site
- Disable Gutenberg on that site
- Load the new _page_ page. 
- Verify the page pattern modal works and that you can close it.

We also need to verify that translations still work in the different apps, TBD.