### PR TITLE
Kylee Trial Phase - Adding a11y tests

### DIFF
--- a/client/components/action-card/test/index.js
+++ b/client/components/action-card/test/index.js
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { shallow } from 'enzyme';
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend( toHaveNoViolations );
+import ActionCard from '..';
+
+const props = {
+	headerText: 'This is a header text',
+	mainText:
+		'This is a description of the action. It gives a bit more detail and explains what we are inviting the user to do.',
+	buttonText: 'Call to action!',
+	buttonIcon: 'external',
+	buttonPrimary: true,
+	buttonHref: 'https://wordpress.com',
+	buttonTarget: '_blank',
+	buttonOnClick: null,
+};
+
+describe( 'ActionCard basic tests', () => {
+	test( 'should not blow up and have proper CSS class', () => {
+		const comp = shallow( <ActionCard { ...props } /> );
+		expect( comp.find( '.action-card' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should have basic accessibility', async () => {
+		const comp = shallow( <ActionCard { ...props } /> );
+		const results = await axe( comp.html() );
+
+		expect( results ).toHaveNoViolations();
+	} );
+} );

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -192,7 +192,7 @@ export class Banner extends Component {
 		const prices = Array.isArray( price ) ? price : [ price ];
 
 		return (
-			<div className="banner__content">
+			<div className="banner__content" role="banner">
 				{ tracksImpressionName && event && (
 					<TrackComponentView
 						eventName={ tracksImpressionName }

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 jest.mock( 'calypso/blocks/dismissible-card', () => {
 	return function DismissibleCard() {
 		return null;
@@ -12,6 +15,8 @@ jest.mock( 'calypso/lib/analytics/track-component-view', () => {
 
 import { Card, Button } from '@automattic/components';
 import { shallow } from 'enzyme';
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend( toHaveNoViolations );
 import PlanPrice from 'calypso/my-sites/plan-price/';
 import { Banner } from '../index';
 
@@ -161,5 +166,14 @@ describe( 'Banner basic tests', () => {
 		expect( comp.find( Button ) ).toHaveLength( 1 );
 		expect( comp.find( Button ).props().href ).toBeUndefined();
 		expect( comp.find( Button ).props().children ).toBe( 'Go\xA0WordPress!' ); //preventWidows adds \xA0 non-breaking space;
+	} );
+
+	test( 'should not have basic accessibility issues', async () => {
+		const comp = shallow(
+			<Banner { ...props } href={ '/' } callToAction="Go WordPress!" forceHref={ true } />
+		);
+		const results = await axe( comp.html() );
+
+		expect( results ).toHaveNoViolations();
 	} );
 } );

--- a/client/components/button-group/test/index.js
+++ b/client/components/button-group/test/index.js
@@ -1,5 +1,10 @@
+/**
+ * @jest-environment jsdom
+ */
 import { Button } from '@automattic/components';
 import { shallow } from 'enzyme';
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend( toHaveNoViolations );
 import ButtonGroup from '..';
 
 describe( 'ButtonGroup', () => {
@@ -21,5 +26,17 @@ describe( 'ButtonGroup', () => {
 	test( 'should get the busy `is-busy` class when passed the `busy` prop', () => {
 		const buttonGroup = shallow( <ButtonGroup busy /> );
 		expect( buttonGroup.find( '.is-busy' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should not have basic accessibility issues', async () => {
+		const buttonGroup = shallow(
+			<ButtonGroup>
+				<Button>test</Button>
+				<Button>test2</Button>
+			</ButtonGroup>
+		);
+		const results = await axe( buttonGroup.html() );
+
+		expect( results ).toHaveNoViolations();
 	} );
 } );

--- a/client/components/forms/form-phone-input/test/index.jsx
+++ b/client/components/forms/form-phone-input/test/index.jsx
@@ -1,9 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend( toHaveNoViolations );
 import { FormPhoneInput } from '../';
 
 const countriesList = [
@@ -34,9 +34,7 @@ describe( 'FormPhoneInput', () => {
 				/>
 			);
 
-			expect( phoneComponent.instance().getValue().countryData ).to.deep.equal(
-				countriesList[ 1 ]
-			);
+			expect( phoneComponent.instance().getValue().countryData ).toEqual( countriesList[ 1 ] );
 		} );
 
 		test( 'should set country to first element when not specified', () => {
@@ -44,9 +42,7 @@ describe( 'FormPhoneInput', () => {
 				<FormPhoneInput countriesList={ countriesList } { ...localizeProps } />
 			);
 
-			expect( phoneComponent.instance().getValue().countryData ).to.deep.equal(
-				countriesList[ 0 ]
-			);
+			expect( phoneComponent.instance().getValue().countryData ).toEqual( countriesList[ 0 ] );
 		} );
 
 		test( 'should update country on change', () => {
@@ -60,9 +56,7 @@ describe( 'FormPhoneInput', () => {
 				},
 			} );
 
-			expect( phoneComponent.instance().getValue().countryData ).to.deep.equal(
-				countriesList[ 1 ]
-			);
+			expect( phoneComponent.instance().getValue().countryData ).toEqual( countriesList[ 1 ] );
 		} );
 
 		test( 'should have no country with empty countryList', () => {
@@ -70,7 +64,16 @@ describe( 'FormPhoneInput', () => {
 				<FormPhoneInput countriesList={ [] } { ...localizeProps } />
 			);
 
-			expect( phoneComponent.instance().getValue().countryData ).to.equal( undefined );
+			expect( phoneComponent.instance().getValue().countryData ).toEqual( undefined );
+		} );
+
+		test( 'should not have basic accessibility issues', async () => {
+			const phoneComponent = shallow(
+				<FormPhoneInput countriesList={ [] } { ...localizeProps } />
+			);
+			const results = await axe( phoneComponent.html() );
+
+			expect( results ).toHaveNoViolations();
 		} );
 	} );
 } );

--- a/client/components/gravatar/test/index.jsx
+++ b/client/components/gravatar/test/index.jsx
@@ -3,6 +3,8 @@
  */
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend( toHaveNoViolations );
 import { Gravatar } from '../';
 
 describe( 'Gravatar', () => {
@@ -161,6 +163,13 @@ describe( 'Gravatar', () => {
 				expect( span ).toBeUndefined();
 				expect( img.getAttribute( 'src' ) ).toEqual( 'tempImage' );
 				expect( img ).toHaveClass( 'gravatar' );
+			} );
+
+			test( 'should not have basic accessibility issues', async () => {
+				const { container } = render( <Gravatar tempImage={ 'tempImage' } user={ genericUser } /> );
+				const results = await axe( container );
+
+				expect( results ).toHaveNoViolations();
 			} );
 		} );
 	} );

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
 		"debug": "^4.3.3",
 		"i18n-calypso": "workspace:^",
 		"i18n-calypso-cli": "workspace:^",
+		"jest-axe": "^6.0.0",
 		"lodash": "^4.17.21",
 		"photon": "workspace:^",
 		"react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11367,6 +11367,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axe-core@npm:4.4.1":
+  version: 4.4.1
+  resolution: "axe-core@npm:4.4.1"
+  checksum: 97790fd0a2d10e123b02c7cc82b83696b3e8cf5a09fd15a2bc7eb8e4a0a3a5b41970853f435aae576b42dcd75412282d4344fa7b7bd018a2e8d855eee89194cd
+  languageName: node
+  linkType: hard
+
 "axe-core@npm:^4.3.5":
   version: 4.3.5
   resolution: "axe-core@npm:4.3.5"
@@ -13090,6 +13097,16 @@ __metadata:
     escape-string-regexp: ^1.0.5
     supports-color: ^5.3.0
   checksum: e6543f02ec877732e3a2d1c3c3323ddb4d39fbab687c23f526e25bd4c6a9bf3b83a696e8c769d078e04e5754921648f7821b2a2acfd16c550435fd630026e073
+  languageName: node
+  linkType: hard
+
+"chalk@npm:4.1.0":
+  version: 4.1.0
+  resolution: "chalk@npm:4.1.0"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: 3787bd65ecd98ab3a1acc3b4f71d006268a675875e49ee6ea75fb54ba73d268b97544368358c18c42445e408e076ae8ad5cec8fbad36942a2c7ac654883dc61e
   languageName: node
   linkType: hard
 
@@ -15876,6 +15893,13 @@ __metadata:
   version: 27.0.6
   resolution: "diff-sequences@npm:27.0.6"
   checksum: 056d8577794af133534b7f268d87b80da5604fd38bbd2edcd796f79b440485a94cafdc509e2c9a379122dca8b02c9b5982ab20f7ef06dbd93faf1617aaae883e
+  languageName: node
+  linkType: hard
+
+"diff-sequences@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "diff-sequences@npm:27.5.1"
+  checksum: a52566d891b89a666f48ba69f54262fa8293ae6264ae04da82c7bf3b6661cba75561de0729f18463179d56003cc0fd69aa09845f2c2cd7a353b1ec1e1a96beb9
   languageName: node
   linkType: hard
 
@@ -22362,6 +22386,18 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"jest-axe@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "jest-axe@npm:6.0.0"
+  dependencies:
+    axe-core: 4.4.1
+    chalk: 4.1.0
+    jest-matcher-utils: 27.0.2
+    lodash.merge: 4.6.2
+  checksum: 0834b22ff1ad4a490b79ec9ed827923a899623fc9278c811715e13d0035e7b0f72d135011010f1ef4e2d5e3f83b29c41acbe387aa4269bb04da16a3b4fb166fb
+  languageName: node
+  linkType: hard
+
 "jest-changed-files@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-changed-files@npm:26.6.2"
@@ -22594,6 +22630,18 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^27.0.2":
+  version: 27.5.1
+  resolution: "jest-diff@npm:27.5.1"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^27.5.1
+    jest-get-type: ^27.5.1
+    pretty-format: ^27.5.1
+  checksum: 48f008c7b4ea7794108319eb61050315b1723e7391cb01e4377c072cadcab10a984cb09d2a6876cb65f100d06c970fd932996192e092b26006f885c00945e7ad
+  languageName: node
+  linkType: hard
+
 "jest-docblock@npm:^26.0.0":
   version: 26.0.0
   resolution: "jest-docblock@npm:26.0.0"
@@ -22754,6 +22802,13 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"jest-get-type@npm:^27.0.1, jest-get-type@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "jest-get-type@npm:27.5.1"
+  checksum: 42ee0101336bccfc3c1cff598b603c6006db7876b6117e5bd4a9fb7ffaadfb68febdb9ae68d1c47bc3a4174b070153fc6cfb59df995dcd054e81ace5028a7269
+  languageName: node
+  linkType: hard
+
 "jest-get-type@npm:^27.3.1":
   version: 27.3.1
   resolution: "jest-get-type@npm:27.3.1"
@@ -22902,6 +22957,18 @@ fsevents@~2.1.2:
     jest-get-type: ^27.3.1
     pretty-format: ^27.3.1
   checksum: aefa5b9cb39a94ef9dbade5d9ec5d1962e4947381af70123107a6b286467810d7d459190a2a541ee19935f3f75338b111b4278a1880948a858df6369d7c36d1a
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:27.0.2":
+  version: 27.0.2
+  resolution: "jest-matcher-utils@npm:27.0.2"
+  dependencies:
+    chalk: ^4.0.0
+    jest-diff: ^27.0.2
+    jest-get-type: ^27.0.1
+    pretty-format: ^27.0.2
+  checksum: b64484a136ad188e1243b116609dbc9b8c9e7a1b9f2f2d6c32fd9be4eb7a9dc852bab82e726f6725a30a0cd9a7ebaa3b16f04a25082be30d1c118f661355193f
   languageName: node
   linkType: hard
 
@@ -24779,7 +24846,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"lodash.merge@npm:^4.4.0, lodash.merge@npm:^4.6.2":
+"lodash.merge@npm:4.6.2, lodash.merge@npm:^4.4.0, lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: 402fa16a1edd7538de5b5903a90228aa48eb5533986ba7fa26606a49db2572bf414ff73a2c9f5d5fd36b31c46a5d5c7e1527749c07cbcf965ccff5fbdf32c506
@@ -29644,6 +29711,17 @@ fsevents@~2.1.2:
     ansi-styles: ^5.0.0
     react-is: ^17.0.1
   checksum: b255146debac1212b26ef718f26b6433e22b2e3fe5f141bd038fbf73a94494c1fd8141359a98cd2d94ad7256a7440a340ac1ac2b3f81aadfeccc6fcbfbd883d4
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "pretty-format@npm:27.5.1"
+  dependencies:
+    ansi-regex: ^5.0.1
+    ansi-styles: ^5.0.0
+    react-is: ^17.0.1
+  checksum: 0cbda1031aa30c659e10921fa94e0dd3f903ecbbbe7184a729ad66f2b6e7f17891e8c7d7654c458fa4ccb1a411ffb695b4f17bbcd3fe075fabe181027c4040ed
   languageName: node
   linkType: hard
 
@@ -38344,6 +38422,7 @@ testarmada-magellan@11.0.10:
     i18n-calypso: "workspace:^"
     i18n-calypso-cli: "workspace:^"
     jest: ^27.3.1
+    jest-axe: ^6.0.0
     jest-environment-jsdom: ^27.3.1
     jest-teamcity: ^1.9.0
     loader-utils: ^1.2.3


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This pull request is the first of the test additions for Phase 2 of my (Kylee Lanoue's) trial. This PR includes the introduction of axe-core and jest-axe packages and their dependencies. In addition, I've added basic accessibility checks on components: action-card, banner, button-group, form-phone-input, and gravatar. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* While this isn't a bug fix, there are new test results. The test runners have not changed so you can see the result of new tests with 'yarn test.' There are two test failures for accessibility violations with components action-card (it's missing a role) and form-phone-input which has multiple violations.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

For more context, see my trial P2! 😄 
