### PR TITLE
Media: Refactor image editor tests to `@testing-library/react` and `jest`

### DIFF
--- a/client/blocks/image-editor/test/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/test/image-editor-canvas.jsx
@@ -1,39 +1,21 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { ImageEditorCanvas } from '../image-editor-canvas';
 
-jest.mock( 'calypso/blocks/image-editor/image-editor-crop', () => {
-	const { Component } = require( 'react' );
-
-	class ImageEditorCropMock extends Component {
-		render() {
-			return <dfn />;
-		}
-	}
-
-	return ImageEditorCropMock;
-} );
+jest.mock( 'calypso/blocks/image-editor/image-editor-crop', () => () => (
+	<div data-testid="image-editor-crop-mock" />
+) );
 
 describe( 'ImageEditorToolbar', () => {
-	let wrapper;
-
-	beforeEach( () => {
-		wrapper = shallow( <ImageEditorCanvas isImageLoaded={ true } />, {
-			disableLifecycleMethods: true,
-		} );
-	} );
-
 	test( 'should render cropping area when the image meets the minimum height and width', () => {
-		wrapper.setProps( { showCrop: true } );
-		expect( wrapper.find( 'ImageEditorCropMock' ) ).to.have.length( 1 );
+		render( <ImageEditorCanvas isImageLoaded showCrop /> );
+		expect( screen.queryByTestId( 'image-editor-crop-mock' ) ).toBeDefined();
 	} );
 
 	test( 'should not render cropping area when the image is smaller than the minimum dimensions', () => {
-		wrapper.setProps( { showCrop: false } );
-		expect( wrapper.find( 'ImageEditorCropMock' ) ).to.have.length( 0 );
+		render( <ImageEditorCanvas isImageLoaded showCrop={ false } /> );
+		expect( screen.queryByTestId( 'image-editor-crop-mock' ) ).toBeNull();
 	} );
 } );

--- a/client/blocks/image-editor/test/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/test/image-editor-toolbar.jsx
@@ -1,96 +1,102 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { ImageEditorToolbar } from '../image-editor-toolbar';
 
 describe( 'ImageEditorToolbar', () => {
 	let defaultProps;
-	let wrapper;
 
 	useSandbox( ( sandbox ) => {
 		defaultProps = {
 			onShowNotice: sandbox.spy(),
+			translate: ( string ) => string,
 		};
 	} );
 
-	beforeEach( () => {
-		wrapper = shallow(
-			<ImageEditorToolbar { ...defaultProps } translate={ ( string ) => string } />
-		);
-	} );
-
 	test( 'should not add `is-disabled` class to aspect ratio toolbar button by default', () => {
-		expect( wrapper.find( '.image-editor__toolbar-button' ).at( 1 ).hasClass( 'is-disabled' ) ).to
-			.be.false;
+		const { container } = render( <ImageEditorToolbar { ...defaultProps } /> );
+		expect(
+			container
+				.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ]
+				.classList.contains( 'is-disabled' )
+		).toBe( false );
 	} );
 
 	test(
-		'should add `is-disabled` class to aspect ratio toolbar button' +
+		'should add `is-disabled` class to aspect ratio toolbar button ' +
 			'when image is smaller than minimum dimensions',
 		() => {
-			wrapper.setProps( { isAspectRatioDisabled: true } );
-			expect( wrapper.find( '.image-editor__toolbar-button' ).at( 1 ).hasClass( 'is-disabled' ) ).to
-				.be.true;
+			const { container } = render(
+				<ImageEditorToolbar { ...defaultProps } isAspectRatioDisabled />
+			);
+			expect(
+				container
+					.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ]
+					.classList.contains( 'is-disabled' )
+			).toBe( true );
 		}
 	);
 
 	test(
-		'should not trigger the method `onShowNotice`' +
+		'should not trigger the method `onShowNotice` ' +
 			'when image width and height meet the minimum dimensions',
 		() => {
-			wrapper.setProps( { isAspectRatioDisabled: false } );
-			wrapper
-				.find( '.image-editor__toolbar-button' )
-				.at( 1 )
-				.simulate( 'click', { preventDefault() {} } );
-			expect( defaultProps.onShowNotice.called ).to.be.false;
+			const { container } = render(
+				<ImageEditorToolbar { ...defaultProps } isAspectRatioDisabled={ false } />
+			);
+
+			fireEvent.click( container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ] );
+
+			expect( defaultProps.onShowNotice.called ).toBe( false );
 		}
 	);
 
 	test(
-		'should trigger the method `onShowNotice` with correct translation string' +
+		'should trigger the method `onShowNotice` with correct translation string ' +
 			'when the user clicks on a disabled aspect ratio toolbar button',
 		() => {
-			wrapper.setProps( { isAspectRatioDisabled: true } );
-			wrapper
-				.find( '.image-editor__toolbar-button' )
-				.at( 1 )
-				.simulate( 'click', { preventDefault() {} } );
+			const { container } = render(
+				<ImageEditorToolbar { ...defaultProps } isAspectRatioDisabled />
+			);
+			fireEvent.click( container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ] );
+
 			expect(
 				defaultProps.onShowNotice.calledWith(
 					'To change the aspect ratio, the height and width must be bigger than {{strong}}%(width)dpx{{/strong}}.'
 				)
-			).to.be.true;
+			).toBe( true );
 		}
 	);
 
 	test(
-		'should show aspect ratio popover display' +
+		'should show aspect ratio popover display ' +
 			'when image width and height meet the minimum dimensions',
-		() => {
-			wrapper.setProps( { isAspectRatioDisabled: false } );
-			wrapper
-				.find( '.image-editor__toolbar-button' )
-				.at( 1 )
-				.simulate( 'click', { preventDefault() {} } );
-			expect( wrapper.state( 'showAspectPopover' ) ).to.be.true;
+		async () => {
+			const { container } = render(
+				<ImageEditorToolbar { ...defaultProps } isAspectRatioDisabled={ false } />
+			);
+			fireEvent.click( container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ] );
+
+			await waitFor( () => {
+				expect( screen.queryByRole( 'tooltip' ) ).toBeDefined();
+			} );
 		}
 	);
 
 	test(
 		'should prevent aspect ratio popover display' +
 			'when image width and height do not meet the minimum dimensions',
-		() => {
-			wrapper.setProps( { isAspectRatioDisabled: true } );
-			wrapper
-				.find( '.image-editor__toolbar-button' )
-				.at( 1 )
-				.simulate( 'click', { preventDefault() {} } );
-			expect( wrapper.state( 'showAspectPopover' ) ).to.be.false;
+		async () => {
+			const { container } = render(
+				<ImageEditorToolbar { ...defaultProps } isAspectRatioDisabled />
+			);
+			fireEvent.click( container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ] );
+
+			await waitFor( () => {
+				expect( screen.queryByRole( 'tooltip' ) ).toBeNull();
+			} );
 		}
 	);
 } );

--- a/client/blocks/image-editor/test/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/test/image-editor-toolbar.jsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { ImageEditorToolbar } from '../image-editor-toolbar';
 
@@ -73,30 +73,26 @@ describe( 'ImageEditorToolbar', () => {
 	test(
 		'should show aspect ratio popover display ' +
 			'when image width and height meet the minimum dimensions',
-		async () => {
+		() => {
 			const { container } = render(
 				<ImageEditorToolbar { ...defaultProps } isAspectRatioDisabled={ false } />
 			);
 			fireEvent.click( container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ] );
 
-			await waitFor( () => {
-				expect( screen.queryByRole( 'tooltip' ) ).toBeDefined();
-			} );
+			expect( screen.queryByRole( 'tooltip' ) ).toBeDefined();
 		}
 	);
 
 	test(
 		'should prevent aspect ratio popover display' +
 			'when image width and height do not meet the minimum dimensions',
-		async () => {
+		() => {
 			const { container } = render(
 				<ImageEditorToolbar { ...defaultProps } isAspectRatioDisabled />
 			);
 			fireEvent.click( container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ] );
 
-			await waitFor( () => {
-				expect( screen.queryByRole( 'tooltip' ) ).toBeNull();
-			} );
+			expect( screen.queryByRole( 'tooltip' ) ).toBeNull();
 		}
 	);
 } );

--- a/client/blocks/image-editor/test/utils.js
+++ b/client/blocks/image-editor/test/utils.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { AspectRatios } from 'calypso/state/editor/image-editor/constants';
 import { getDefaultAspectRatio } from '../utils';
 
@@ -9,7 +8,7 @@ describe( 'getDefaultAspectRatio', () => {
 				const expected = 'ASPECT_1X1';
 				const actual = getDefaultAspectRatio( 'ASPECT_1X1' );
 
-				expect( actual ).to.equal( expected );
+				expect( actual ).toEqual( expected );
 			} );
 		} );
 
@@ -18,7 +17,7 @@ describe( 'getDefaultAspectRatio', () => {
 				const expected = AspectRatios.FREE;
 				const actual = getDefaultAspectRatio( 'INVALID_ASPECT' );
 
-				expect( actual ).to.equal( expected );
+				expect( actual ).toEqual( expected );
 			} );
 		} );
 	} );
@@ -29,7 +28,7 @@ describe( 'getDefaultAspectRatio', () => {
 				const expected = 'ASPECT_1X1';
 				const actual = getDefaultAspectRatio( null, [ 'ASPECT_1X1' ] );
 
-				expect( actual ).to.equal( expected );
+				expect( actual ).toEqual( expected );
 			} );
 		} );
 
@@ -38,7 +37,7 @@ describe( 'getDefaultAspectRatio', () => {
 				const expected = AspectRatios.FREE;
 				const actual = getDefaultAspectRatio( null, [ 'INVALID_ASPECT' ] );
 
-				expect( actual ).to.equal( expected );
+				expect( actual ).toEqual( expected );
 			} );
 		} );
 	} );
@@ -50,7 +49,7 @@ describe( 'getDefaultAspectRatio', () => {
 					const expected = 'ASPECT_1X1';
 					const actual = getDefaultAspectRatio( 'ASPECT_1X1', [ 'INVALID_ASPECT', 'ASPECT_1X1' ] );
 
-					expect( actual ).to.equal( expected );
+					expect( actual ).toEqual( expected );
 				} );
 			} );
 
@@ -62,7 +61,7 @@ describe( 'getDefaultAspectRatio', () => {
 						'ASPECT_1X1',
 					] );
 
-					expect( actual ).to.equal( expected );
+					expect( actual ).toEqual( expected );
 				} );
 			} );
 		} );
@@ -73,7 +72,7 @@ describe( 'getDefaultAspectRatio', () => {
 					const expected = 'ASPECT_1X1';
 					const actual = getDefaultAspectRatio( 'INVALID_ASPECT', [ 'ASPECT_1X1' ] );
 
-					expect( actual ).to.equal( expected );
+					expect( actual ).toEqual( expected );
 				} );
 			} );
 
@@ -82,7 +81,7 @@ describe( 'getDefaultAspectRatio', () => {
 					const expected = AspectRatios.FREE;
 					const actual = getDefaultAspectRatio( 'OTHER_INVALID_ASPECT', [ 'INVALID_ASPECT' ] );
 
-					expect( actual ).to.equal( expected );
+					expect( actual ).toEqual( expected );
 				} );
 			} );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the media image editor components and utils to use `@testing-library/react` instead of `enzyme`.

We also use the opportunity to migrate away from `chai` to `jest` for assertions.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/blocks/image-editor`