### PR TITLE
Fix Office 365 MX record generation

### DIFF
--- a/client/my-sites/domains/domain-management/email-setup/index.jsx
+++ b/client/my-sites/domains/domain-management/email-setup/index.jsx
@@ -58,7 +58,7 @@ class EmailSetup extends Component {
 					dnsTemplateService: dnsTemplates.MICROSOFT_OFFICE365.SERVICE,
 					modifyVariables: ( variables ) =>
 						Object.assign( {}, variables, {
-							mxdata: variables.domain.replace( '.', '-' ) + '.mail.protection.outlook.com',
+							mxdata: variables.domain.replaceAll( '.', '-' ) + '.mail.protection.outlook.com',
 						} ),
 				},
 				{


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes a bug that preventing Office 365 MX records from being correctly generating for multi-level tlds (or subdomains).

Closes #62126

![mx-office-365-fixed](https://user-images.githubusercontent.com/2797601/166265535-9952bce7-0975-41e0-8ba9-8ecc315a45a1.png)

## Testing instructions
- Build this branch locally or open the live Calypso link
- Register a new multilevel domain (e.g. _co.uk_)
- Open domain dns page
- Expand Email setup accordion
- Select "Office 365" and enter this validation token `MS=ms00000000`
- Verify that MX record is well formatted (`yourdomain-co-uk.mail.protection.outlook.com`)