### PR TITLE
Redirect to the proper home page link

### DIFF
--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -50,6 +50,8 @@ export const anchorFmFlow: Flow = {
 				case 'podcastTitle':
 					return navigate( 'designSetup' );
 				case 'designSetup':
+					return navigate( 'processing' );
+				case 'processing':
 					return redirect( `/page/${ siteSlug }/home` );
 				default:
 					return navigate( 'podcastTitle' );

--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -30,7 +30,7 @@ export const anchorFmFlow: Flow = {
 				case 'designSetup':
 					return navigate( 'processing' );
 				case 'processing':
-					return redirect( `/page/home/${ siteSlug }` );
+					return redirect( `/page/${ siteSlug }/home` );
 			}
 		}
 
@@ -50,7 +50,7 @@ export const anchorFmFlow: Flow = {
 				case 'podcastTitle':
 					return navigate( 'designSetup' );
 				case 'designSetup':
-					return redirect( `/page/home/${ siteSlug }` );
+					return redirect( `/page/${ siteSlug }/home` );
 				default:
 					return navigate( 'podcastTitle' );
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the redirect to the Home page when creating a site on the anchor.fm flow. The users were being redirected to `/page/[siteSlug]/?site=home`. 

#### Testing instructions

* Go to the Anchor.fm flow
* When you select a design on the "Design Setup" step, the site will be created, and you'll now be redirected to `/page/[siteSlug]/home/` instead of `/page/[siteSlug]/?site=home`

Closes #63213
