### PR TITLE
Anchor: Update setDesignOnSite to account for Anchor templates

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -250,12 +250,19 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			method: 'POST',
 		} );
 
-		yield wpcomRequest( {
-			path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup`,
-			apiNamespace: 'wpcom/v2',
-			body: { trim_content: true },
-			method: 'POST',
-		} );
+		/*
+		 * Anchor themes are set up directly via Headstart on the server side
+		 * so exclude them from theme setup.
+		 */
+		const anchorDesigns = [ 'hannah', 'gilbert', 'riley' ];
+		if ( anchorDesigns.indexOf( selectedDesign.template ) < 0 ) {
+			yield wpcomRequest( {
+				path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup`,
+				apiNamespace: 'wpcom/v2',
+				body: { trim_content: true },
+				method: 'POST',
+			} );
+		}
 
 		const data: { is_fse_active: boolean } = yield wpcomRequest( {
 			path: `/sites/${ siteSlug }/block-editor`,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Don't fire `theme-setup` for Anchor sites since theme setup overrides the theme's unique annotations, which are applied on Headstart when the theme is initially set.

**Before**

Home page after choosing Hannah theme:

<img width="1490" alt="Screen Shot 2022-05-02 at 4 02 54 PM" src="https://user-images.githubusercontent.com/2124984/166317341-f074c3b1-51ce-4557-ab59-10213fe265be.png">


**After**

<img width="1493" alt="Screen Shot 2022-05-02 at 3 50 42 PM" src="https://user-images.githubusercontent.com/2124984/166315611-89db1470-59b6-4d22-89e1-cb193ecfcb97.png">


#### Testing instructions

* Switch to this PR, navigate to `/setup/?anchor_podcast=[your podcast ID]`
* Title your site and select one of the three available designs
* You'll land on `/page/[your new site url]/home`; the home page design should look like the design you chose during signup
* Make sure the regular flow at `/setup?siteSlug=yoursite.wordpress.com` operates as expected

Fixes #63218
