### PR TITLE
Anchor: Handle established sites redirect

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
@@ -10,6 +10,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
 import getTextWidth from 'calypso/landing/gutenboarding/onboarding-block/acquire-intent/get-text-width';
+import useDetectMatchingAnchorSite from 'calypso/landing/stepper/hooks/use-detect-matching-anchor-site';
 import useSiteTitle from 'calypso/landing/stepper/hooks/use-site-title';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -20,6 +21,9 @@ import './style.scss';
 const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 	const { goBack, submit } = navigation;
 	const { __ } = useI18n();
+
+	//Check to see if there is a site with a matching anchor podcast ID
+	const isLookingUpMatchingAnchorSites = useDetectMatchingAnchorSite();
 
 	const PodcastTitleForm: React.FC = () => {
 		//Sets the site title from the API on first load if a custom title has not been set
@@ -42,6 +46,12 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 			setFormTouched( true );
 			setSiteTitle( event.currentTarget.value );
 		};
+
+		//If we're still checking for matching Anchor sites, don't show the form
+		if ( isLookingUpMatchingAnchorSites ) {
+			return <div />;
+		}
+
 		return (
 			<form
 				className="podcast-title__form"

--- a/client/landing/stepper/hooks/use-detect-matching-anchor-site.ts
+++ b/client/landing/stepper/hooks/use-detect-matching-anchor-site.ts
@@ -1,0 +1,72 @@
+import { useSelect } from '@wordpress/data';
+import { useState, useEffect } from 'react';
+import wpcom from 'calypso/lib/wp';
+import { USER_STORE } from '../stores';
+import { useAnchorFmParams } from './use-anchor-fm-params';
+import { useIsAnchorFm } from './use-is-anchor-fm';
+
+interface AnchorEndpointResult {
+	location: string | false;
+}
+
+// useDetectMatchingAnchorSite:
+// If I'm making a new site and anchor parameters are available, check wpcom backend to
+// see if there's already a site that belongs to me that matches these parameters.
+// If it's found, redirect the browser to it
+export default function useDetectMatchingAnchorSite(): boolean {
+	const {
+		anchorFmPodcastId,
+		anchorFmEpisodeId,
+		anchorFmSpotifyUrl,
+		anchorFmSite,
+		anchorFmPost,
+		anchorFmIsNewSite,
+	} = useAnchorFmParams();
+	const isAnchorFm = useIsAnchorFm();
+	const currentUserExists = useSelect( ( select ) => !! select( USER_STORE ).getCurrentUser() );
+	const [ isLoading, setIsLoading ] = useState( !! ( isAnchorFm && currentUserExists ) );
+
+	useEffect( () => {
+		// Must be a logged-in user on anchor FM to check
+		if ( ! isAnchorFm || ! currentUserExists || anchorFmIsNewSite ) {
+			setIsLoading( false );
+			return;
+		}
+
+		setIsLoading( true );
+
+		// construct query object from entries that are not null or undefined
+		const query = Object.fromEntries(
+			[
+				[ 'podcast', anchorFmPodcastId ],
+				[ 'episode', anchorFmEpisodeId ],
+				[ 'spotify_url', anchorFmSpotifyUrl ],
+				[ 'site', anchorFmSite ],
+				[ 'post', anchorFmPost ],
+			].filter( ( [ , value ] ) => value != null )
+		);
+
+		wpcom.req
+			.get( { path: '/anchor', apiNamespace: 'wpcom/v2' }, query )
+			.then( ( result: AnchorEndpointResult ) => {
+				if ( result.location ) {
+					window.location.href = result.location;
+				} else {
+					setIsLoading( false );
+				}
+			} )
+			.catch( () => {
+				setIsLoading( false );
+			} );
+	}, [
+		isAnchorFm,
+		currentUserExists,
+		anchorFmPodcastId,
+		anchorFmEpisodeId,
+		anchorFmSpotifyUrl,
+		anchorFmSite,
+		anchorFmPost,
+		anchorFmIsNewSite,
+	] );
+	return isLoading;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move over hook from Gutenboarding that checks for an existing site with the same `anchor_podcast` ID and redirects to that site's editor if it finds one. This prevents the creation of multiple sites with the same podcast ID.
* Apply the hook on the podcast title step.

**Visual**

In the first step, I create a new site with my podcast ID. When I return to signup using the same podcast ID in the query param, it automatically redirects me to the editor with my latest episode:


https://user-images.githubusercontent.com/2124984/166323370-b9985802-7b17-46d2-8eaa-785c07438fbc.mov



#### Testing instructions

* Switch to this PR
* Create a brand new Anchor.fm podcast and get the ID -- under Podcast Availability go to Enable RSS and get the ID from there. Alternatively, you can use an existing podcast ID if you delete any test sites it might be associated with (there may be a cache/delay here)
* Navigate to `/setup/?anchor_podcast=[your new podcast ID]` and create your new site.
* Go back to `/setup/?anchor_podcast=[your new podcast ID]`
* You should not see the podcast title form input; instead, you should be redirected to the page editor with your latest podcast episode pre-filled in the content.

Fixes #63215
