### PR TITLE
Stepper: Fixed storeAddress step glitch

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
@@ -2,6 +2,10 @@
 
 body.is-group-stepper.is-section-stepper {
 	.store-address__is-store-address {
+		.components-form-token-field__suggestions-list {
+			width: min-content;
+		}
+
 		.components-base-control__label {
 			display: block;
 			font-size: 0.875rem;


### PR DESCRIPTION
On the stepper storeAddress step, the form width changes when the Country dropdown is focused

![image](https://user-images.githubusercontent.com/3801502/166230802-ed9326e4-e05d-46fd-87b7-607678ea2cf2.png)

![image](https://user-images.githubusercontent.com/3801502/166230817-b5437133-a468-4180-b1a5-2de718460a38.png)

## How to test

- Use the stepper Woo flow to get to the storeAddress step.
- Click on the Country dropdown
- Pay attention to the form width. It shouldn't change when the dropdown opens.

Fixes to #63205
