### PR TITLE
Media: Remove redundant availability check

### DIFF
--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -10,7 +10,6 @@ import { selectMediaItems } from 'calypso/state/media/actions';
 import getMediaErrors from 'calypso/state/selectors/get-media-errors';
 import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
 import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
-import hasAvailableSiteFeature from 'calypso/state/selectors/has-available-site-feature';
 import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
 import {
 	isKeyringConnectionsFetching,
@@ -119,14 +118,7 @@ class MediaLibrary extends Component {
 	};
 
 	filterRequiresUpgrade() {
-		const {
-			filter,
-			site,
-			source,
-			isJetpack,
-			hasVideoUploadFeature,
-			hasVideoUploadAvailableFeature,
-		} = this.props;
+		const { filter, site, source, isJetpack, hasVideoUploadFeature } = this.props;
 		if ( source ) {
 			return false;
 		}
@@ -136,7 +128,7 @@ class MediaLibrary extends Component {
 				return ! ( ( site && site.options.upgraded_filetypes_enabled ) || isJetpack );
 
 			case 'videos':
-				return ! hasVideoUploadFeature && !! hasVideoUploadAvailableFeature;
+				return ! hasVideoUploadFeature;
 		}
 
 		return false;
@@ -215,11 +207,6 @@ export default connect(
 		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
 		isJetpack: isJetpackSite( state, site?.ID ),
 		hasVideoUploadFeature: hasActiveSiteFeature( state, site?.ID, 'upload-video-files' ),
-		hasVideoUploadAvailableFeature: hasAvailableSiteFeature(
-			state,
-			site?.ID,
-			'upload-video-files'
-		),
 	} ),
 	{
 		requestKeyringConnections,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes uses of `hasAvailableSiteFeature`. All features are available through upgrades.

See p4TIVU-a66-p2


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Media Library / video section in calypso: http://calypso.localhost:3000/media/videos/<testing-site>
* Confirm that the app allows/does not allow uploading video files depending on the site type and the site plan/products.

Reference

| site plan \ site type | Simple | Atomic | Jetpack |
|---|----|----|----|
| Free | 🍎 | 🍎 | 🍏 |
| Personal | 🍎 | 🍎 | 🍏  |
| Premium | 🍏 | 🍏 | 🍏 |
| Business | 🍏 | 🍏 | 🍏 |
| eCommerce | 🍏 | 🍏 | ✖️ |
| Security Daily |  ✖️| ✖️ | 🍏 |


### running tests

```
> yarn run test-client client/state/selectors/test/has-available-site-feature.js
```
