### PR TITLE
Bundle react-i18n in ETK

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -64,7 +64,7 @@ function WelcomeTour() {
 	}
 	const { isInserterOpened, isSidebarOpened, isSettingsOpened } = useSelect( ( select ) => ( {
 		isInserterOpened: select( 'core/edit-post' ).isInserterOpened(),
-		isSidebarOpened: select( 'automattic/block-editor-nav-sidebar' ).isSidebarOpened(),
+		isSidebarOpened: select( 'automattic/block-editor-nav-sidebar' )?.isSidebarOpened() ?? false, // The sidebar store may not always be loaded.
 		isSettingsOpened:
 			select( 'core/interface' ).getActiveComplementaryArea( 'core/edit-post' ) ===
 			'edit-post/document',

--- a/apps/editing-toolkit/webpack.config.js
+++ b/apps/editing-toolkit/webpack.config.js
@@ -93,6 +93,12 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 								throw new Error( `Received unknown module request ${ request }.` );
 						}
 					}
+					// The extraction logic will only extract a package if requestToExternal
+					// explicitly returns undefined for the given request. Null
+					// shortcuts the logic such that react-i18n will be bundled.
+					if ( request === '@wordpress/react-i18n' ) {
+						return null;
+					}
 				},
 			} ),
 		],


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Simpler alternative to #63190 which bundles react-i18n instead of not using it. This solves the externalization problem, where react-i18n may not be available in core WordPress. We should revert the webpack change once react-i18n is available in core WP.

This works because a request (e.g. "@wordpress/react-i18n") is only externalized when the override function `requestToExternal` returns undefined for a given request. (See here: https://github.com/WordPress/gutenberg/blob/a233dc45f1316ab05764840eebcb94373400add4/packages/dependency-extraction-webpack-plugin/lib/index.js#L55-L78)

When we return null, the plugin won't apply the default treatment, and it also won't add it to the list of deps which need to be externalized. As a result, normal webpack behavior applies and the dependency isn't extracted.

Resolves #62788.

#### Testing instructions
Verify that `react-i18n` doesn't appear in any of ETK's *.asset.php files.

#### Local testing (✅)
- Load ETK in a local wp-env testing environment. (Run `yarn wp-env start` from the ETK directory.)
- Disable the gutenberg plugin in the wordpress instance.
- Visit http://localhost:4013/wp-admin/post-new.php?post_type=page
- Verify that the page pattern modal works and that you can close it.

#### Atomic testing (✅)
- Download the ETK artifact from TeamCity
- Upload it to an Atomic test site
- Disable Gutenberg on that site
- Load the new _page_ page. 
- Verify the page pattern modal works and that you can close it.
