### PR TITLE
[E2E][GB 13.1.0] Fix E2E tests

### DIFF
--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -81,7 +81,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 		const expectedBlockPatternCount = 50;
 		const frame = await editorPage.getEditorHandle();
 		const actualBlockPatternCount = await frame.evaluate(
-			`window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns.length`
+			`window.wp.data.select( 'core' ).getBlockPatterns().length`
 		);
 
 		expect( actualBlockPatternCount ).toBeGreaterThanOrEqual( expectedBlockPatternCount );


### PR DESCRIPTION
Follow up to: https://github.com/Automattic/wp-calypso/pull/63160

#### Changes proposed in this Pull Request

* Fix E2E tests for the upcoming 13.1.0 release on WPCOM. More info in each commit's descriptions. 

#### Testing instructions


* Edge tests should pass when running from this branch.

Tracking issue: https://github.com/Automattic/wp-calypso/issues/62859
