### PR TITLE
CI: Add Gutenberg Atomic Edge builds.

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -40,6 +40,9 @@ object WPComTests : Project({
 	// Gutenberg Atomic
 	buildType(gutenbergPlaywrightBuildType("desktop", "c341e9b9-1118-48e9-a569-325100f5fd9" , atomic=true, edge=false));
 	buildType(gutenbergPlaywrightBuildType("mobile", "e0f7e412-ae6c-41d3-9eec-c57c94dd8385", atomic=true, edge=false));
+	// Gutenberg Atomic Edge
+	buildType(gutenbergPlaywrightBuildType("desktop", "4c66d90d-99c6-4ecb-9507-18bc2f44b551" , atomic=true, edge=true));
+	buildType(gutenbergPlaywrightBuildType("mobile", "ba0f925b-497b-4156-977e-5bfbe94f5744", atomic=true, edge=true));
 
 	buildType(coblocksPlaywrightBuildType("desktop", "08f88b93-993e-4de8-8d80-4a94981d9af4"));
 	buildType(coblocksPlaywrightBuildType("mobile", "cbcd44d5-4d31-4adc-b1b5-97f1225c6a7c"));


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the missing Atomic Edge builds that were missed in https://github.com/Automattic/wp-calypso/pull/63035.

#### Testing instructions

No builds should fail with a VCS error.

Related to https://github.com/Automattic/wp-calypso/pull/63035.