### PR TITLE
Stepper: Added tracks event before leaving Woo install

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,6 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useDesignsBySite } from '@automattic/design-picker';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch as reduxDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useFSEStatus } from '../hooks/use-fse-status';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
@@ -60,6 +62,7 @@ export const siteSetupFlow: Flow = {
 		const { setPendingAction } = useDispatch( ONBOARD_STORE );
 		const { setIntentOnSite } = useDispatch( SITE_STORE );
 		const { FSEActive } = useFSEStatus();
+		const dispatch = reduxDispatch();
 
 		const exitFlow = ( to: string ) => {
 			setPendingAction(
@@ -104,8 +107,7 @@ export const siteSetupFlow: Flow = {
 
 					// End of woo flow
 					if ( storeType === 'power' ) {
-						// eslint-disable-next-line no-console
-						console.log( 'end woo flow here' );
+						dispatch( recordTracksEvent( 'calypso_woocommerce_dashboard_redirect' ) );
 					}
 
 					if ( FSEActive && intent !== 'write' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added tracks event before leaving Woo install flow. 
* Same event from the original step, `calypso_woocommerce_dashboard_redirect`.

#### Testing instructions

* Go to the end of the Woo flow until you are redirected to the wc-admin page.
* Check if the `calypso_woocommerce_dashboard_redirect` event was tracked.
* Finishing other flows shouldn't register this event.


