### PR TITLE
[E2E][GB 13.1.0] Fix E2E tests (take 2)

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
@@ -1,5 +1,4 @@
 import { BlockFlow, EditorContext, PublishedPostContext } from '..';
-import envVariables from '../../../env-variables';
 
 interface ConfigurationData {
 	phoneNumber: number | string;
@@ -30,11 +29,7 @@ export class WhatsAppButtonFlow implements BlockFlow {
 	 */
 	constructor( configurationData: ConfigurationData ) {
 		this.configurationData = configurationData;
-		// The parent selector for the block changes between mobile and desktop viewport.
-		this.blockEditorSelector =
-			envVariables.VIEWPORT_NAME === 'desktop'
-				? 'div[aria-label="Block: WhatsApp Button"]'
-				: 'div[aria-label="Block: Send A Message"]';
+		this.blockEditorSelector = 'div[aria-label="Block: WhatsApp Button"]';
 	}
 
 	blockSidebarName = 'WhatsApp Button';


### PR DESCRIPTION
Follow up to: https://github.com/Automattic/wp-calypso/pull/63228

#### Changes proposed in this Pull Request

* Fix some failures that only happen in the mobile viewport (simple sites)

#### Testing instructions

* The Gutenberg simple mobile build should pass from this branch (or only expected failures should show, if any).


Tracking issue: https://github.com/Automattic/wp-calypso/issues/62859
