### PR TITLE
Fix checkout cancel flow not respecting checkoutBackUrl

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
@@ -5,8 +5,12 @@ import { resemblesUrl } from 'calypso/lib/url';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 
 const getAllowedHosts = ( siteSlug?: string ) => {
-	const basicHosts = [ 'jetpack.com', 'jetpack.cloud.localhost', 'cloud.jetpack.com' ];
-	siteSlug && basicHosts.push( siteSlug );
+	const basicHosts = [
+		'jetpack.com',
+		'jetpack.cloud.localhost',
+		'cloud.jetpack.com',
+		...( ( siteSlug && [ siteSlug ] ) || [] ),
+	];
 
 	const languageSpecificJetpackHosts = getLanguageSlugs().map(
 		( lang: string ) => `${ lang }.jetpack.com`

--- a/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
@@ -4,8 +4,9 @@ import { useSelector } from 'react-redux';
 import { resemblesUrl } from 'calypso/lib/url';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 
-const getAllowedHosts = ( siteSlug: string ) => {
-	const basicHosts = [ 'jetpack.com', 'jetpack.cloud.localhost', 'cloud.jetpack.com', siteSlug ];
+const getAllowedHosts = ( siteSlug?: string ) => {
+	const basicHosts = [ 'jetpack.com', 'jetpack.cloud.localhost', 'cloud.jetpack.com' ];
+	siteSlug && basicHosts.push( siteSlug );
 
 	const languageSpecificJetpackHosts = getLanguageSlugs().map(
 		( lang: string ) => `${ lang }.jetpack.com`
@@ -18,7 +19,7 @@ const useValidCheckoutBackUrl = ( siteSlug: string | undefined ): string | undef
 	const { checkoutBackUrl } = useSelector( getInitialQueryArguments ) ?? {};
 
 	return useMemo( () => {
-		if ( ! siteSlug || ! checkoutBackUrl ) {
+		if ( ! siteSlug && ! checkoutBackUrl ) {
 			return undefined;
 		}
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
@@ -23,7 +23,7 @@ const useValidCheckoutBackUrl = ( siteSlug: string | undefined ): string | undef
 	const { checkoutBackUrl } = useSelector( getInitialQueryArguments ) ?? {};
 
 	return useMemo( () => {
-		if ( ! siteSlug && ! checkoutBackUrl ) {
+		if ( ! checkoutBackUrl ) {
 			return undefined;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On the checkout page, when you click on the close icon(X) while logged out, it directs you to the wordpress.com login page and not to the value of `checkoutBackUrl` where you came from. This PR fixes this issue.

Asana task: 1164141197617539-as-1202166098975550/f

#### Testing instructions

- Checkout this PR and spin up Calypso blue (`yarn start`).
- In an incognito window (logged out) visit https://cloud.jetpack.com/pricing
- Click to purchase any Jetpack product, ie- Jetpack Backup.
- On the checkout page, in the url, replace `https://wordpress.com` with `http://localhost:3000` and reload the page.
- Click the 'Remove from cart" link, to remove the product from the cart.
- In the Dialog popup, click Continue.
- You should be redirected back to the Jetpack Cloud pricing page, and not to wordpress.com/

To reproduce/see the issue, repeat the above steps on production (wordpress.com) and observe that you will not be redirected back to the /pricing page, but rather wordpress.com.

