### PR TITLE
Sharing buttons: Hide the more button when there are no services enabled

### DIFF
--- a/client/my-sites/marketing/buttons/preview-buttons.jsx
+++ b/client/my-sites/marketing/buttons/preview-buttons.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { filter, isEqual } from 'lodash';
@@ -18,7 +19,6 @@ class SharingButtonsPreviewButtons extends Component {
 		style: PropTypes.oneOf( [ 'icon', 'icon-text', 'text', 'official' ] ),
 		onButtonClick: PropTypes.func,
 		showMore: PropTypes.bool,
-		forceMorePreviewVisible: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -26,7 +26,6 @@ class SharingButtonsPreviewButtons extends Component {
 		style: 'icon',
 		onButtonClick: function () {},
 		showMore: false,
-		forceMorePreviewVisible: false,
 	};
 
 	previewIframeRef = createRef();
@@ -47,7 +46,7 @@ class SharingButtonsPreviewButtons extends Component {
 		this.maybeListenForWidgetMorePreview();
 
 		if (
-			prevProps.forceMorePreviewVisible !== this.props.forceMorePreviewVisible ||
+			prevProps.showMore !== this.props.showMore ||
 			! isEqual( prevProps.buttons, this.props.buttons )
 		) {
 			// We trigger an update to the preview visibility if buttons have
@@ -106,7 +105,7 @@ class SharingButtonsPreviewButtons extends Component {
 	};
 
 	updateMorePreviewVisibility = () => {
-		if ( ! this.props.forceMorePreviewVisible ) {
+		if ( ! this.props.showMore ) {
 			this.hideMorePreview();
 		} else {
 			this.showMorePreview();
@@ -159,7 +158,7 @@ class SharingButtonsPreviewButtons extends Component {
 	};
 
 	hideMorePreview = () => {
-		if ( ! this.props.forceMorePreviewVisible && this.state.morePreviewVisible ) {
+		if ( ! this.props.showMore && this.state.morePreviewVisible ) {
 			this.setState( { morePreviewVisible: false } );
 		}
 	};

--- a/client/my-sites/marketing/buttons/preview.jsx
+++ b/client/my-sites/marketing/buttons/preview.jsx
@@ -178,10 +178,7 @@ class SharingButtonsPreview extends Component {
 					buttons={ enabledButtons }
 					visibility="visible"
 					style={ this.props.style }
-					showMore={
-						'hidden' === this.state.buttonsTrayVisibility ||
-						some( this.props.buttons, { visibility: 'hidden' } )
-					}
+					showMore={ some( this.props.buttons, { visibility: 'hidden' } ) }
 				/>
 			);
 		}

--- a/client/my-sites/marketing/buttons/preview.jsx
+++ b/client/my-sites/marketing/buttons/preview.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { filter, some } from 'lodash';
@@ -132,13 +133,13 @@ class SharingButtonsPreview extends Component {
 	getReblogButtonElement = () => {
 		if ( this.props.showReblog ) {
 			return (
-				<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__reblog">
+				<div className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__reblog">
 					{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 					{ /* 16 is used in the preview to match the buttons on the frontend of the website. */ }
 					<Gridicon icon="reblog" size={ 16 } />
 					{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 					{ this.props.translate( 'Reblog' ) }
-				</a>
+				</div>
 			);
 		}
 	};
@@ -147,15 +148,18 @@ class SharingButtonsPreview extends Component {
 		if ( this.props.showLike ) {
 			return (
 				<span>
-					<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__like">
+					<div className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__like">
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						{ /* 16 is used in the preview to match the buttons on the frontend of the website. */ }
 						<Gridicon icon="star" size={ 16 } />
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						{ this.props.translate( 'Like' ) }
-					</a>
+					</div>
 					<div className="sharing-buttons-preview__fake-user">
-						<img src="https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60" />
+						<img
+							src="https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60"
+							alt="Matt Mullenweg"
+						/>
 					</div>
 					<div className="sharing-buttons-preview__fake-like">
 						{ this.props.translate( 'One blogger likes this.' ) }
@@ -178,7 +182,6 @@ class SharingButtonsPreview extends Component {
 						'hidden' === this.state.buttonsTrayVisibility ||
 						some( this.props.buttons, { visibility: 'hidden' } )
 					}
-					forceMorePreviewVisible={ 'hidden' === this.state.buttonsTrayVisibility }
 				/>
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removed the `forceMorePreviewVisible` prop to simplify the logic related to the show more button visibility.
- Before this PR the show more button was always visible showing an empty tooltip in the first place.
- For consistency with the front-end the more button is invisible until one service is enabled.

**Before**
<img width="1020" alt="Screenshot 2022-05-03 at 10 28 03" src="https://user-images.githubusercontent.com/779993/166431422-a129553b-ad61-4fd9-8a85-adb5a7ba4b05.png">

**After**
<img width="1026" alt="Screenshot 2022-05-03 at 10 28 43" src="https://user-images.githubusercontent.com/779993/166431507-858f1f90-7632-4538-ba08-61090a504ce3.png">

#### Testing instructions

1. Go to "Tools > Marketing > Sharing Buttons"
2. Click on `Add sharing buttons`
3. Add any service
4. Close the sharing button dialog
5. Click on `Add "More" buttons`
6. Observe that the `More` button is not visible until you add one service.


Closes #63040
