### PR TITLE
WooCommerce Install: Fix gap between action section items

### DIFF
--- a/client/signup/steps/woocommerce-install/index.tsx
+++ b/client/signup/steps/woocommerce-install/index.tsx
@@ -44,6 +44,7 @@ export const ActionSection = styled.div`
 	align-items: baseline;
 	flex-wrap: wrap;
 	margin-top: 40px;
+	gap: 4%;
 
 	@media ( max-width: 320px ) {
 		align-items: center;

--- a/client/signup/steps/woocommerce-install/style.scss
+++ b/client/signup/steps/woocommerce-install/style.scss
@@ -71,6 +71,7 @@
 		.step-business-info__instructions-container,
 		.step-store-address__instructions-container,
 		.confirm__instructions-container {
+			flex: 1 1 auto;
 			font-size: 0.875rem;
 			letter-spacing: -0.16px;
 			color: var( --studio-gray-60 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add gap between the action section items in WooCommerce Install form.

**Before:**
![CleanShot 2022-05-03 at 14 38 31](https://user-images.githubusercontent.com/2722412/166447479-7b02780b-e4e1-4adc-8b96-3a9e9373b65f.png)

**After:**
![CleanShot 2022-05-03 at 14 38 11](https://user-images.githubusercontent.com/2722412/166447490-ef831f76-0ef2-4681-842b-5f5296218a46.png)

#### Testing instructions

* Change UI to Hebrew.
* Confirm the help text and the Continue button on the second step (business info) are now separated.

Related to 429-gh-Automattic/i18n-issues
