### PR TITLE
Help-center: add support queries store

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -6,8 +6,6 @@ import {
 	LatestAtomicTransferError,
 	AtomicSoftwareStatusError,
 	AtomicSoftwareInstallError,
-	HappyChatAvailability,
-	EmailSupportAvailability,
 } from './types';
 import type { WpcomClientCredentials } from '../shared-types';
 import type {
@@ -45,16 +43,6 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 	const receiveNewSiteFailed = ( error: NewSiteErrorResponse ) => ( {
 		type: 'RECEIVE_NEW_SITE_FAILED' as const,
 		error,
-	} );
-
-	const receiveHappyChatAvailability = ( availability: HappyChatAvailability ) => ( {
-		type: 'RECEIVE_HAPPY_CHAT_AVAILABILITY' as const,
-		availability,
-	} );
-
-	const receiveEmailSupportAvailability = ( availability: EmailSupportAvailability ) => ( {
-		type: 'RECEIVE_EMAIL_SUPPORT_AVAILABILITY' as const,
-		availability,
 	} );
 
 	function* createSite( params: CreateSiteParams ) {
@@ -458,8 +446,6 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveSite,
 		receiveSiteFailed,
 		receiveSiteTagline,
-		receiveEmailSupportAvailability,
-		receiveHappyChatAvailability,
 		receiveSiteVerticalId,
 		saveSiteTagline,
 		reset,
@@ -503,8 +489,6 @@ export type Action =
 			| ActionCreators[ 'receiveNewSiteFailed' ]
 			| ActionCreators[ 'receiveSiteTagline' ]
 			| ActionCreators[ 'receiveSiteVerticalId' ]
-			| ActionCreators[ 'receiveEmailSupportAvailability' ]
-			| ActionCreators[ 'receiveHappyChatAvailability' ]
 			| ActionCreators[ 'receiveSite' ]
 			| ActionCreators[ 'receiveSiteFailed' ]
 			| ActionCreators[ 'reset' ]


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `react-query` removes so much boilerplate.
* Migrated the support fields from the site store to react-query.

#### Testing instructions

None. This is meant to be used in future PRs. I haven't tested them myself but they're meant to be changed to fit the future PRs needs. 