### PR TITLE
Add siteId as a useEffect dependency on the wooTransfer step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-transfer/index.tsx
@@ -167,7 +167,7 @@ const WooTransfer: Step = function WooTransfer( { navigation } ) {
 		submit?.();
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [ siteId ] );
 
 	return null;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This ensures that the transfer step will kick off when it's hit directly (as opposed to via `navigate()`), specifically in the case where we've gone from wooConfirm to the checkout back, then back to wooTransfer
