### PR TITLE
Plans overhaul: Starter Plan for the win

### DIFF
--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -6,6 +6,7 @@ import {
 	PLAN_FREE,
 	PLAN_WPCOM_PRO,
 	PLAN_WPCOM_FLEXIBLE,
+	PLAN_WPCOM_STARTER,
 	isProPlan,
 } from '@automattic/calypso-products';
 import classNames from 'classnames';
@@ -60,8 +61,13 @@ export function PlanStorage( { children, className, siteId } ) {
 		) {
 			mediaStorage.max_storage_bytes = 1024 * 1024 * 1024;
 		}
+
 		if ( sitePlanSlug === PLAN_WPCOM_PRO ) {
 			mediaStorage.max_storage_bytes = 50 * 1024 * 1024 * 1024;
+		}
+
+		if ( sitePlanSlug === PLAN_WPCOM_STARTER ) {
+			mediaStorage.max_storage_bytes = 6 * 1024 * 1024 * 1024;
 		}
 	}
 

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -9,6 +9,7 @@ import {
 	TYPE_PERSONAL,
 	TYPE_BLOGGER,
 	TYPE_FREE,
+	TYPE_STARTER,
 	PLAN_BUSINESS_2_YEARS,
 	PLAN_BUSINESS_ONBOARDING_EXPIRE,
 	PLAN_BUSINESS_2Y_ONBOARDING_EXPIRE,
@@ -242,6 +243,18 @@ export class ProductPurchaseFeaturesList extends Component {
 		);
 	}
 
+	getStarterFeatuers() {
+		const { selectedSite, planHasDomainCredit } = this.props;
+
+		return (
+			<Fragment>
+				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
+				<SiteActivity />
+				<MobileApps onClick={ this.handleMobileAppsClick } />
+			</Fragment>
+		);
+	}
+
 	getJetpackFreeFeatures() {
 		const { isAutomatedTransfer, isPlaceholder, selectedSite } = this.props;
 		return (
@@ -379,6 +392,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				[ TYPE_PERSONAL ]: () => this.getPersonalFeatures(),
 				[ TYPE_BLOGGER ]: () => this.getBloggerFeatures(),
 				[ TYPE_PRO ]: () => this.getProFeatuers(),
+				[ TYPE_STARTER ]: () => this.getStarterFeatuers(),
 			},
 			[ GROUP_JETPACK ]: {
 				[ TYPE_BUSINESS ]: () => this.getJetpackBusinessFeatures(),

--- a/client/my-sites/checkout/checkout-thank-you/starter-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/starter-plan-details.jsx
@@ -1,0 +1,42 @@
+import { isStarter, isGSuiteOrExtraLicenseOrGoogleWorkspace } from '@automattic/calypso-products';
+import { localize } from 'i18n-calypso';
+import { find } from 'lodash';
+import PropTypes from 'prop-types';
+import earnImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
+import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
+import GoogleAppsDetails from './google-apps-details';
+
+const StarterPlanDetails = ( { translate, selectedSite, sitePlans, purchases } ) => {
+	const plan = find( sitePlans.data, isStarter );
+	const googleAppsWasPurchased = purchases.some( isGSuiteOrExtraLicenseOrGoogleWorkspace );
+
+	return (
+		<div>
+			{ googleAppsWasPurchased && <GoogleAppsDetails purchases={ purchases } /> }
+
+			<CustomDomainPurchaseDetail
+				selectedSite={ selectedSite }
+				hasDomainCredit={ plan && plan.hasDomainCredit }
+			/>
+
+			<PurchaseDetail
+				icon={ <img alt={ translate( 'Earn Illustration' ) } src={ earnImage } /> }
+				title={ translate( 'Make money with your website' ) }
+				description={ translate(
+					'Accept credit card payments today for just about anything – physical and digital goods, services, ' +
+						'donations and tips, or access to your exclusive content.'
+				) }
+				buttonText={ translate( 'Start Earning' ) }
+				href={ '/earn/' + selectedSite.slug }
+			/>
+		</div>
+	);
+};
+
+StarterPlanDetails.propTypes = {
+	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ).isRequired,
+	sitePlans: PropTypes.object.isRequired,
+};
+
+export default localize( StarterPlanDetails );

--- a/client/my-sites/plans-comparison/index.tsx
+++ b/client/my-sites/plans-comparison/index.tsx
@@ -1,2 +1,3 @@
 export { PlansComparison as default } from './plans-comparison';
 export { isEligibleForProPlan } from './is-eligible-for-pro-plan';
+export { default as isStarterPlanEnabled } from './is-starter-plan-enabled';

--- a/client/my-sites/plans-comparison/is-starter-plan-enabled.ts
+++ b/client/my-sites/plans-comparison/is-starter-plan-enabled.ts
@@ -1,0 +1,5 @@
+import { isEnabled } from '@automattic/calypso-config';
+
+export default function isStarterPlanEnabled(): boolean {
+	return isEnabled( 'plans/starter-plan' );
+}

--- a/client/my-sites/plans-comparison/plans-comparison-action.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-action.tsx
@@ -5,6 +5,7 @@ import {
 	PLAN_WPCOM_PRO,
 	PLAN_FREE,
 	PLAN_WPCOM_FLEXIBLE,
+	PLAN_WPCOM_STARTER,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
@@ -36,9 +37,11 @@ function getButtonText( props: Partial< Props >, translate: TranslateFunc ): Tra
 	const planSlug = plan?.getStoreSlug();
 
 	if ( planSlug === PLAN_WPCOM_PRO ) {
-		return 'en' === i18n.getLocaleSlug() || i18n.hasTranslation( 'Start with Pro' )
-			? translate( 'Start with Pro' )
+		return 'en' === i18n.getLocaleSlug() || i18n.hasTranslation( 'Choose Pro' )
+			? translate( 'Choose Pro' )
 			: translate( 'Try Pro risk-free' );
+	} else if ( planSlug === PLAN_WPCOM_STARTER ) {
+		return translate( 'Choose Starter' );
 	} else if ( planSlug === PLAN_FREE || planSlug === PLAN_WPCOM_FLEXIBLE ) {
 		return translate( 'Start with Free' );
 	}
@@ -88,12 +91,14 @@ export const PlansComparisonAction: React.FunctionComponent< Props > = ( {
 		manageHref = undefined;
 	}
 
-	if ( ! isInSignup && [ TYPE_FLEXIBLE, TYPE_FREE ].includes( plan.type ) ) {
+	if ( ! isInSignup ) {
 		if ( isCurrentPlan ) {
 			return <Button disabled>{ translate( 'This is your plan' ) }</Button>;
 		}
 
-		return null;
+		if ( [ TYPE_FLEXIBLE, TYPE_FREE ].includes( plan.type ) ) {
+			return null;
+		}
 	}
 
 	return (

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -1,5 +1,6 @@
 import {
 	FEATURE_1GB_STORAGE,
+	FEATURE_6GB_STORAGE,
 	FEATURE_50GB_STORAGE,
 	FEATURE_UNLIMITED_ADMINS,
 	FEATURE_INSTALL_PLUGINS,
@@ -20,6 +21,7 @@ import {
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { translate, numberFormat } from 'i18n-calypso';
+import isStarterPlanEnabled from './is-starter-plan-enabled';
 import type { TranslateResult } from 'i18n-calypso';
 
 export interface PlanComparisonFeature {
@@ -125,6 +127,72 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 				: translate( 'Custom domain name is {{strong}}not{{/strong}} included', {
 						components: { strong: <strong /> },
 				  } );
+		},
+	},
+	{
+		get title() {
+			return translate( 'Website Administrator' );
+		},
+		get description() {
+			return translate(
+				'Pro WordPress lets you have unlimited users editing your site. This is ideal for having multiple collaborators help you have your website built and maintained.'
+			);
+		},
+		features: [ FEATURE_UNLIMITED_ADMINS ],
+		getCellText: ( feature, isMobile = false, isLegacySiteWithHigherLimits = false ) => {
+			const adminCount = 1;
+
+			if ( ! isMobile ) {
+				if ( feature ) {
+					return translate( 'Unlimited' );
+				}
+
+				if ( isLegacySiteWithHigherLimits ) {
+					// Adding "administrator" is redundant here (and differs from the non-legacy
+					// case below), but we're adding it because just having the number crossed
+					// out is hard to read.
+					return translate(
+						'{{del}}%(adminCount)s administrator{{/del}} Unlimited on this site',
+						'{{del}}%(adminCount)s administrators{{/del}} Unlimited on this site',
+						{
+							count: adminCount,
+							components: {
+								del: <del />,
+							},
+							args: { adminCount: numberFormat( adminCount, 0 ) },
+						}
+					);
+				}
+
+				return String( adminCount );
+			}
+
+			if ( feature ) {
+				return translate( 'Unlimited Website Administrators' );
+			}
+
+			if ( isLegacySiteWithHigherLimits ) {
+				return translate(
+					'{{del}}%(adminCount)s Website Administrator{{/del}} Unlimited on this site',
+					'{{del}}%(adminCount)s Website Administrators{{/del}} Unlimited on this site',
+					{
+						count: adminCount,
+						components: {
+							del: <del />,
+						},
+						args: { adminCount: numberFormat( adminCount, 0 ) },
+					}
+				);
+			}
+
+			return translate(
+				'%(adminCount)s Website Administrator',
+				'%(adminCount)s Website Administrators',
+				{
+					count: adminCount,
+					args: { adminCount: numberFormat( adminCount, 0 ) },
+				}
+			);
 		},
 	},
 	{
@@ -240,21 +308,32 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			return translate( 'Storage' );
 		},
 		get description() {
+			if ( isStarterPlanEnabled() ) {
+				return translate(
+					'The Starter plan allows a maximum storage of 6GB, which equals to approximately 1200 high quality images. With WordPress Pro you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.'
+				);
+			}
+
+			// @todo clk remove or update once there's settlement on how many plans we'd ever show in the grid
 			return translate(
 				'The free plan allows a maximum storage of 1GB, which equals to approximately 200 high quality images. With WordPress Pro you may go all the way up to 50GB, enough space for 10,000 high quality images of the same size.'
 			);
 		},
-		features: [ FEATURE_1GB_STORAGE, FEATURE_50GB_STORAGE ],
+		features: [ FEATURE_1GB_STORAGE, FEATURE_6GB_STORAGE, FEATURE_50GB_STORAGE ],
 		getCellText: ( feature, isMobile = false, isLegacySiteWithHigherLimits = false ) => {
-			let storageSize = '1';
-			const legacyStorageSize = '3';
+			const legacyStorageSize = 3;
+			let storageSize = 1;
+
+			if ( feature === FEATURE_6GB_STORAGE ) {
+				storageSize = 6;
+			}
 
 			if ( feature === FEATURE_50GB_STORAGE ) {
-				storageSize = '50';
+				storageSize = 50;
 			}
 
 			if ( isMobile ) {
-				if ( isLegacySiteWithHigherLimits && feature === FEATURE_1GB_STORAGE ) {
+				if ( isLegacySiteWithHigherLimits && legacyStorageSize > storageSize ) {
 					return translate(
 						'{{del}}%(originalStorage)sGB of storage{{/del}} %(modifiedStorage)sGB on this site',
 						{
@@ -274,7 +353,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 				} );
 			}
 
-			if ( isLegacySiteWithHigherLimits && feature === FEATURE_1GB_STORAGE ) {
+			if ( isLegacySiteWithHigherLimits && legacyStorageSize > storageSize ) {
 				return translate(
 					'{{del}}%(originalStorage)sGB{{/del}} %(modifiedStorage)sGB on this site',
 					{
@@ -338,72 +417,6 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 					  } );
 			}
 			return cellText;
-		},
-	},
-	{
-		get title() {
-			return translate( 'Website Administrator' );
-		},
-		get description() {
-			return translate(
-				'Pro WordPress lets you have unlimited users editing your site. This is ideal for having multiple collaborators help you have your website built and maintained.'
-			);
-		},
-		features: [ FEATURE_UNLIMITED_ADMINS ],
-		getCellText: ( feature, isMobile = false, isLegacySiteWithHigherLimits = false ) => {
-			const adminCount = 1;
-
-			if ( ! isMobile ) {
-				if ( feature ) {
-					return translate( 'Unlimited' );
-				}
-
-				if ( isLegacySiteWithHigherLimits ) {
-					// Adding "administrator" is redundant here (and differs from the non-legacy
-					// case below), but we're adding it because just having the number crossed
-					// out is hard to read.
-					return translate(
-						'{{del}}%(adminCount)s administrator{{/del}} Unlimited on this site',
-						'{{del}}%(adminCount)s administrators{{/del}} Unlimited on this site',
-						{
-							count: adminCount,
-							components: {
-								del: <del />,
-							},
-							args: { adminCount: numberFormat( adminCount, 0 ) },
-						}
-					);
-				}
-
-				return String( adminCount );
-			}
-
-			if ( feature ) {
-				return translate( 'Unlimited Website Administrators' );
-			}
-
-			if ( isLegacySiteWithHigherLimits ) {
-				return translate(
-					'{{del}}%(adminCount)s Website Administrator{{/del}} Unlimited on this site',
-					'{{del}}%(adminCount)s Website Administrators{{/del}} Unlimited on this site',
-					{
-						count: adminCount,
-						components: {
-							del: <del />,
-						},
-						args: { adminCount: numberFormat( adminCount, 0 ) },
-					}
-				);
-			}
-
-			return translate(
-				'%(adminCount)s Website Administrator',
-				'%(adminCount)s Website Administrators',
-				{
-					count: adminCount,
-					args: { adminCount: numberFormat( adminCount, 0 ) },
-				}
-			);
 		},
 	},
 	{

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -1,11 +1,4 @@
-import {
-	getPlan,
-	PLAN_WPCOM_FLEXIBLE,
-	PLAN_WPCOM_PRO,
-	TYPE_FREE,
-	TYPE_FLEXIBLE,
-	TYPE_PRO,
-} from '@automattic/calypso-products';
+import { TYPE_FREE, TYPE_FLEXIBLE, TYPE_PRO } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { css, Global } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -17,12 +10,14 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selector
 import isLegacySiteWithHigherLimits from 'calypso/state/selectors/is-legacy-site-with-higher-limits';
 import { getSitePlan } from 'calypso/state/sites/selectors';
 import { SCREEN_BREAKPOINT_SIGNUP, SCREEN_BREAKPOINT_PLANS } from './constant';
+import isStarterPlanEnabled from './is-starter-plan-enabled';
 import { PlansComparisonAction } from './plans-comparison-action';
 import { PlansComparisonColHeader } from './plans-comparison-col-header';
 import { planComparisonFeatures } from './plans-comparison-features';
 import { PlansComparisonRow, DesktopContent, MobileContent } from './plans-comparison-row';
 import { PlansDomainConnectionInfo } from './plans-domain-connection-info';
-import { usePlanPrices, PlanPrices } from './use-plan-prices';
+import usePlanPrices from './use-plan-prices';
+import usePlans from './use-plans';
 import type { WPComPlan } from '@automattic/calypso-products';
 import type { RequestCartProduct as CartItem } from '@automattic/shopping-cart';
 
@@ -445,14 +440,12 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSiteId || null ) );
 	const [ showCollapsibleRows, setShowCollapsibleRows ] = useState( false );
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) ?? '';
-	const plans = [ getPlan( PLAN_WPCOM_FLEXIBLE ), getPlan( PLAN_WPCOM_PRO ) ] as WPComPlan[];
-	const prices: PlanPrices[] = [ { price: 0 }, usePlanPrices( plans[ 1 ] ) ];
-
-	if ( hideFreePlan ) {
-		plans.shift();
-		prices.shift();
-	}
-
+	/*
+	 * @todo clk Use of `hideFreePlan` will cause breakage if we are not showing the free plan at all.
+	 * Potentially remove `hideFreePlan` logic alltogether when plans are finalised.
+	 */
+	const plans = usePlans( hideFreePlan );
+	const prices = usePlanPrices( plans );
 	const translate = useTranslate();
 
 	const toggleCollapsibleRows = useCallback( () => {
@@ -470,7 +463,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 			<ComparisonTable
 				firstColWidth={ 32 }
 				planCount={ plans.length }
-				hideFreePlan={ hideFreePlan }
+				hideFreePlan={ hideFreePlan && ! isStarterPlanEnabled() }
 			>
 				<THead isInSignup={ isInSignup }>
 					<tr>

--- a/client/my-sites/plans-comparison/use-plans.tsx
+++ b/client/my-sites/plans-comparison/use-plans.tsx
@@ -1,0 +1,21 @@
+import {
+	getPlan,
+	PLAN_WPCOM_FLEXIBLE,
+	PLAN_WPCOM_STARTER,
+	PLAN_WPCOM_PRO,
+} from '@automattic/calypso-products';
+import { useMemo } from '@wordpress/element';
+import isStarterPlanEnabled from './is-starter-plan-enabled';
+import type { WPComPlan } from '@automattic/calypso-products';
+
+export default function usePlans( hideFreePlan?: boolean ): WPComPlan[] {
+	return useMemo(
+		() =>
+			[
+				...( ! hideFreePlan && ! isStarterPlanEnabled() ? [ getPlan( PLAN_WPCOM_FLEXIBLE ) ] : [] ),
+				...( isStarterPlanEnabled() ? [ getPlan( PLAN_WPCOM_STARTER ) ] : [] ),
+				getPlan( PLAN_WPCOM_PRO ),
+			] as WPComPlan[],
+		[ hideFreePlan ]
+	);
+}

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -5,6 +5,7 @@ import {
 	PLAN_FREE,
 	PLAN_WPCOM_PRO,
 	PLAN_WPCOM_FLEXIBLE,
+	PLAN_WPCOM_STARTER,
 } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { addQueryArgs } from '@wordpress/url';
@@ -170,7 +171,9 @@ class Plans extends Component {
 
 		if (
 			eligibleForProPlan &&
-			[ PLAN_FREE, PLAN_WPCOM_FLEXIBLE, PLAN_WPCOM_PRO ].includes( currentPlan?.productSlug )
+			[ PLAN_FREE, PLAN_WPCOM_FLEXIBLE, PLAN_WPCOM_STARTER, PLAN_WPCOM_PRO ].includes(
+				currentPlan?.productSlug
+			)
 		) {
 			return (
 				<PlansComparison

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -85,6 +85,7 @@ export default connect( ( state ) => {
 	let shouldShowPlans = true;
 	let isFreeOrFlexible = false;
 
+	// do not show the Plans tab if user is on a Pro plan
 	if ( eligibleForProPlan && currentPlan ) {
 		isFreeOrFlexible = isFreePlanProduct( currentPlan ) || isFlexiblePlanProduct( currentPlan );
 		shouldShowMyPlan = isFreeOrFlexible ? false : true;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -20,7 +20,10 @@ import Notice from 'calypso/components/notice';
 import { getTld, isSubdomain } from 'calypso/lib/domains';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import wp from 'calypso/lib/wp';
-import PlansComparison, { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import PlansComparison, {
+	isEligibleForProPlan,
+	isStarterPlanEnabled,
+} from 'calypso/my-sites/plans-comparison';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -239,6 +242,19 @@ export class PlansStep extends Component {
 		const { hideFreePlan, subHeaderText, translate, eligibleForProPlan, locale } = this.props;
 
 		if ( eligibleForProPlan ) {
+			if ( isStarterPlanEnabled() ) {
+				return hideFreePlan
+					? translate( 'Try risk-free with a 14-day money-back guarantee.' )
+					: translate(
+							'Try risk-free with a 14-day money-back guarantee or {{link}}start with a free site{{/link}}.',
+							{
+								components: {
+									link: <Button onClick={ this.handleFreePlanButtonClick } borderless={ true } />,
+								},
+							}
+					  );
+			}
+
 			return 'en' === locale ||
 				i18n.hasTranslation( 'he WordPress Pro plan comes with a 14-day money back guarantee' )
 				? translate( 'The WordPress Pro plan comes with a 14-day money back guarantee' )

--- a/config/development.json
+++ b/config/development.json
@@ -110,6 +110,7 @@
 		"oauth": false,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"plans/starter-plan": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -67,6 +67,7 @@
 		"me/vat-details": true,
 		"network-connection": true,
 		"p2/p2-plus": true,
+		"plans/starter-plan": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -76,6 +76,7 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"p2/p2-plus": true,
+		"plans/starter-plan": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -75,6 +75,7 @@
 		"me/vat-details": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"plans/starter-plan": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/config/test.json
+++ b/config/test.json
@@ -59,6 +59,7 @@
 		"me/account-close": true,
 		"me/vat-details": true,
 		"network-connection": true,
+		"plans/starter-plan": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -85,6 +85,7 @@
 		"me/vat-details": true,
 		"network-connection": true,
 		"p2/p2-plus": true,
+		"plans/starter-plan": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": true,
 		"post-editor/checkout-overlay": true,

--- a/packages/calypso-products/src/constants/types.ts
+++ b/packages/calypso-products/src/constants/types.ts
@@ -12,6 +12,7 @@ export const TYPE_ALL = 'TYPE_ALL';
 export const TYPE_P2_PLUS = 'TYPE_P2_PLUS';
 export const TYPE_FLEXIBLE = 'TYPE_FLEXIBLE';
 export const TYPE_PRO = 'TYPE_PRO';
+export const TYPE_STARTER = 'TYPE_STARTER';
 
 export const TYPES_LIST = <const>[
 	TYPE_FREE,
@@ -26,4 +27,5 @@ export const TYPES_LIST = <const>[
 	TYPE_P2_PLUS,
 	TYPE_FLEXIBLE,
 	TYPE_PRO,
+	TYPE_STARTER,
 ];

--- a/packages/calypso-products/src/is-starter.ts
+++ b/packages/calypso-products/src/is-starter.ts
@@ -1,0 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
+import { isStarterPlan } from './main';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isStarter( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	return isStarterPlan( camelOrSnakeSlug( product ) );
+}

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -7,6 +7,7 @@ import {
 	TYPE_PRO,
 	TYPE_FREE,
 	TYPE_FLEXIBLE,
+	TYPE_STARTER,
 	TYPE_BLOGGER,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
@@ -81,6 +82,10 @@ export function getPlanClass( planKey: string ): string {
 
 	if ( isFlexiblePlan( planKey ) ) {
 		return 'is-flexible-plan';
+	}
+
+	if ( isStarterPlan( planKey ) ) {
+		return 'is-starter-plan';
 	}
 
 	if ( isBloggerPlan( planKey ) ) {
@@ -277,6 +282,10 @@ export function isFreePlan( planSlug: string ): boolean {
 
 export function isFlexiblePlan( planSlug: string ): boolean {
 	return planMatches( planSlug, { type: TYPE_FLEXIBLE } );
+}
+
+export function isStarterPlan( planSlug: string ): boolean {
+	return planMatches( planSlug, { type: TYPE_STARTER } );
 }
 
 export function isSecurityDailyPlan( planSlug: string ): boolean {

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1584,7 +1584,7 @@ PLANS_LIST[ PLAN_WPCOM_STARTER ] = {
 	getTitle: () => i18n.translate( 'WordPress Starter' ),
 	getProductId: () => 1033,
 	getStoreSlug: () => PLAN_WPCOM_STARTER,
-	getPathSlug: () => 'starter-plan',
+	getPathSlug: () => 'starter',
 	getDescription: () =>
 		i18n.translate( 'Start your WordPress.com website. Limited functionality and storage.' ),
 	getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -176,6 +176,7 @@ import {
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_WPCOM_FLEXIBLE,
+	PLAN_WPCOM_STARTER,
 	PLAN_WPCOM_PRO,
 	PREMIUM_DESIGN_FOR_STORES,
 	TERM_ANNUALLY,
@@ -195,6 +196,7 @@ import {
 	TYPE_SECURITY_T2,
 	TYPE_FLEXIBLE,
 	TYPE_PRO,
+	TYPE_STARTER,
 	FEATURE_TITAN_EMAIL,
 	FEATURE_SOCIAL_MEDIA_TOOLS,
 } from './constants';
@@ -1574,6 +1576,25 @@ PLANS_LIST[ PLAN_P2_FREE ] = {
 };
 
 // Brand new WPCOM plans
+PLANS_LIST[ PLAN_WPCOM_STARTER ] = {
+	...getDotcomPlanDetails(),
+	group: GROUP_WPCOM,
+	type: TYPE_STARTER,
+	term: TERM_ANNUALLY,
+	getTitle: () => i18n.translate( 'WordPress Starter' ),
+	getProductId: () => 1033,
+	getStoreSlug: () => PLAN_WPCOM_STARTER,
+	getPathSlug: () => 'starter-plan',
+	getDescription: () =>
+		i18n.translate( 'Start your WordPress.com website. Limited functionality and storage.' ),
+	getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
+	getPlanCompareFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_UNLIMITED_ADMINS,
+		FEATURE_6GB_STORAGE,
+	],
+};
+
 PLANS_LIST[ PLAN_WPCOM_FLEXIBLE ] = {
 	// Inherits the free plan
 	...PLANS_LIST[ PLAN_FREE ],

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -15,6 +15,7 @@ export { isBlogger } from './is-blogger';
 export { isBundled } from './is-bundled';
 export { isBusiness } from './is-business';
 export { isPro } from './is-pro';
+export { isStarter } from './is-starter';
 export { isChargeback } from './is-chargeback';
 export { isConciergeSession } from './is-concierge-session';
 export { isCredits } from './is-credits';

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -44,6 +44,7 @@ import {
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_WPCOM_FLEXIBLE,
 	PLAN_WPCOM_PRO,
+	PLAN_WPCOM_STARTER,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
 	TERM_MONTHLY,
@@ -122,6 +123,7 @@ describe( 'isFlexiblePlan', () => {
 		expect( isFlexiblePlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
 		expect( isFlexiblePlan( PLAN_BUSINESS ) ).to.equal( false );
 		expect( isFlexiblePlan( PLAN_WPCOM_PRO ) ).to.equal( false );
+		expect( isFlexiblePlan( PLAN_WPCOM_STARTER ) ).to.equal( false );
 		expect( isFlexiblePlan( PLAN_JETPACK_BUSINESS ) ).to.equal( false );
 		expect( isFlexiblePlan( PLAN_ECOMMERCE ) ).to.equal( false );
 		expect( isFlexiblePlan( 'non-existing plan' ) ).to.equal( false );
@@ -214,6 +216,7 @@ describe( 'isProPlan', () => {
 		expect( isProPlan( PLAN_PREMIUM ) ).to.equal( false );
 		expect( isProPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
 		expect( isProPlan( PLAN_ECOMMERCE ) ).to.equal( false );
+		expect( isProPlan( PLAN_WPCOM_STARTER ) ).to.equal( false );
 		expect( isProPlan( 'non-existing plan' ) ).to.equal( false );
 	} );
 } );
@@ -344,6 +347,7 @@ describe( 'isWpComProPlan', () => {
 		expect( isWpComProPlan( PLAN_JETPACK_PREMIUM ) ).to.equal( false );
 		expect( isWpComProPlan( PLAN_BUSINESS ) ).to.equal( false );
 		expect( isWpComProPlan( PLAN_BUSINESS_2_YEARS ) ).to.equal( false );
+		expect( isWpComProPlan( PLAN_WPCOM_STARTER ) ).to.equal( false );
 		expect( isWpComProPlan( 'non-exisWpComting plan' ) ).to.equal( false );
 	} );
 } );
@@ -351,6 +355,7 @@ describe( 'isWpComProPlan', () => {
 describe( 'isWpComAnnualPlan', () => {
 	test( 'should return true for annual plans', () => {
 		expect( isWpComAnnualPlan( PLAN_WPCOM_PRO ) ).to.equal( true );
+		expect( isWpComAnnualPlan( PLAN_WPCOM_STARTER ) ).to.equal( true );
 		expect( isWpComAnnualPlan( PLAN_PERSONAL ) ).to.equal( true );
 		expect( isWpComAnnualPlan( PLAN_PREMIUM ) ).to.equal( true );
 		expect( isWpComAnnualPlan( PLAN_BUSINESS ) ).to.equal( true );
@@ -386,6 +391,7 @@ describe( 'isWpComBiennialPlan', () => {
 
 	test( 'should return false for non-biennial plans', () => {
 		expect( isWpComBiennialPlan( PLAN_WPCOM_PRO ) ).to.equal( false );
+		expect( isWpComBiennialPlan( PLAN_WPCOM_STARTER ) ).to.equal( false );
 		expect( isWpComBiennialPlan( PLAN_PERSONAL ) ).to.equal( false );
 		expect( isWpComBiennialPlan( PLAN_PREMIUM ) ).to.equal( false );
 		expect( isWpComBiennialPlan( PLAN_BUSINESS ) ).to.equal( false );
@@ -412,6 +418,7 @@ describe( 'isWpComMonthlyPlan', () => {
 
 	test( 'should return false for non-monthly plans', () => {
 		expect( isWpComMonthlyPlan( PLAN_WPCOM_PRO ) ).to.equal( false );
+		expect( isWpComMonthlyPlan( PLAN_WPCOM_STARTER ) ).to.equal( false );
 		expect( isWpComMonthlyPlan( PLAN_PERSONAL ) ).to.equal( false );
 		expect( isWpComMonthlyPlan( PLAN_PREMIUM ) ).to.equal( false );
 		expect( isWpComMonthlyPlan( PLAN_BUSINESS ) ).to.equal( false );
@@ -829,6 +836,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_JETPACK_SECURITY_T1_YEARLY,
 			PLAN_JETPACK_SECURITY_T2_YEARLY,
 			PLAN_P2_FREE,
+			PLAN_WPCOM_STARTER,
 			PLAN_WPCOM_FLEXIBLE,
 			PLAN_WPCOM_PRO,
 		] );
@@ -901,6 +909,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_ECOMMERCE_2_YEARS,
 			PLAN_P2_PLUS,
 			PLAN_P2_FREE,
+			PLAN_WPCOM_STARTER,
 			PLAN_WPCOM_FLEXIBLE,
 			PLAN_WPCOM_PRO,
 		] );

--- a/packages/components/src/product-icon/config.ts
+++ b/packages/components/src/product-icon/config.ts
@@ -77,6 +77,7 @@ export type SupportedSlugs =
 	| 'business-bundle-2y'
 	| 'business-bundle-monthly'
 	| 'pro-plan'
+	| 'starter-plan'
 	| 'jetpack_free'
 	| 'jetpack_personal'
 	| 'jetpack_personal_monthly'
@@ -167,6 +168,7 @@ export const iconToProductSlugMap: Record< keyof typeof paths, readonly Supporte
 		'value_bundle-monthly',
 		'value_bundle_monthly',
 		'pro-plan',
+		'starter-plan',
 	],
 	'wpcom-ecommerce': [ 'ecommerce-bundle', 'ecommerce-bundle-2y', 'ecommerce-bundle-monthly' ],
 	'wpcom-business': [ 'business-bundle', 'business-bundle-2y', 'business-bundle-monthly' ],


### PR DESCRIPTION
### Changes proposed in this Pull Request

Addresses 712-gh-Automattic/martech

- Adds the Starter plan to the plans grid in place of the Free plan at `/plans` and `/start/plans`.
- Button & header text based on pdgrnI-WP-p2#comment-1737


Requires backend patch: D80430-code

### Media

#### `/start/plans` (with free domain)

<img width="600" alt="Screenshot 2022-05-11 at 11 54 12 AM" src="https://user-images.githubusercontent.com/1705499/167810731-ba4734c7-3e2e-4957-9647-0daca215c9f3.png">

#### `/plans` (with site on Starter plan)

<img width="600" alt="Screenshot 2022-05-10 at 4 35 55 PM" src="https://user-images.githubusercontent.com/1705499/167641955-47cf0d73-4702-4230-816e-bb0e29a3dbb9.png">


### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**with feature flag set `?flags=plans/starter-plan`**
- Apply D80430-code
- Go to `/start/domains` and do not select a custom/paid domain
    - In `/start/plans` next:
        - Confirm Starter is shown in place of the Free plan, matching the design mock (pdgrnI-WP-p2) and media above.
        - Confirm the link is shown in the header for purchasing a Free plan instead.
        - Click on "Start with Starter" and confirm checkout works (Starter plan in cart next). Should be able to purchase the Starter plan as normal here too.
- Go to `/start/domains` and select a custom/paid domain
    - In `/start/plans` next:
        - Confirm No link to the plan is shown in header.
- Go to `/plans`
        - Confirm Starter is shown in place of the Free plan, matching the design mock (pdgrnI-WP-p2) and media above

**without feature flag set (disable with `-`) `?flags=-plans/starter-plan`**
- Confirm both `/start/plans` and `/plans` show no Starter and the UI remains the same as in `trunk` branch

### TODO
- [x] ~Confirm and update price displays (there are decimals in the design mocks e.g. `$5.00` pdgrnI-WP-p2)~ (moved to https://github.com/Automattic/wp-calypso/issues/63501)
- [x] ~Confirm and update including yearly price in plan description (`per month, billed $60 yearly` in design mocks pdgrnI-WP-p2)~ (moved to https://github.com/Automattic/wp-calypso/issues/63501)
- [x] ~Update My Plan page for Starter with icon and features. Use Personal plan's~ (moved to https://github.com/Automattic/wp-calypso/issues/63499)
- [x] Some state/data missing:
    - to update the Starter plan price in the grid (currently shows 0) 
    - to match a site on the Starter plan with the various UI elements in `/plans`
        - shows "free" in place of the current plan
        - doesn't update the plans grid to show "This is your plan" button

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#712