### PR TITLE
Help Center: update style selector ( 1min review )

### DIFF
--- a/client/blocks/inline-help/inline-help-center-content.scss
+++ b/client/blocks/inline-help/inline-help-center-content.scss
@@ -6,22 +6,24 @@
 * GENERAL STYLING - Content
 */
 .inline-help-center__content {
-	background-color: var( --color-surface );
+	&:not( .is-secondary-view-richresult ) {
+		background-color: var( --color-surface );
 
-	a {
-		font-size: $font-body-small !important;
-		color: var( --studio-gray-100 );
-		text-decoration: none;
+		a {
+			font-size: $font-body-small !important;
+			color: var( --studio-gray-100 );
+			text-decoration: none;
 
-		&:hover {
+			&:hover {
+				color: var( --studio-gray-100 );
+			}
+		}
+
+		h3 {
+			font-size: $font-body-small !important;
+			font-weight: 500;
 			color: var( --studio-gray-100 );
 		}
-	}
-
-	h3 {
-		font-size: $font-body-small !important;
-		font-weight: 500;
-		color: var( --studio-gray-100 );
 	}
 
 	&.is-secondary-view-active {

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -1,9 +1,9 @@
 /* stylelint-disable */
+@use './inline-help-center-content.scss';
+
 @import '@automattic/typography/styles/variables';
 @import '../../assets/stylesheets/shared/mixins/_breakpoints';
 @import '../../assets/stylesheets/shared/mixins/hide-content-accessibly';
-
-@use './inline-help-center-content.scss';
 
 // GENERAL - Content
 .inline-help {

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -1,7 +1,7 @@
 /* stylelint-disable */
-@use '@automattic/typography/styles/variables';
-@use '../../assets/stylesheets/shared/mixins/_breakpoints';
-@use '../../assets/stylesheets/shared/mixins/hide-content-accessibly';
+@import '@automattic/typography/styles/variables';
+@import '../../assets/stylesheets/shared/mixins/_breakpoints';
+@import '../../assets/stylesheets/shared/mixins/hide-content-accessibly';
 
 @use './inline-help-center-content.scss';
 


### PR DESCRIPTION
Remove new help-center styling from the embedded article. This is a quick fix. Just adding more specificity to the CSS.