### PR TITLE
Anchor: Add error handling for invalid podcast ID

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -42,7 +42,7 @@ const ErrorStep: Step = function ErrorStep( { navigation, flow } ) {
 		if ( flow === 'anchor-fm' ) {
 			return (
 				<WarningsOrHoldsSection>
-					<Button className="error-step__button" href="/setup" primary>
+					<Button className="error-step__button" href="/start" primary>
 						{ __( 'Continue' ) }
 					</Button>
 					<Button className="error-step__link" borderless href="https://anchor.fm">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
@@ -13,7 +13,7 @@ import getTextWidth from 'calypso/landing/gutenboarding/onboarding-block/acquire
 import { useAnchorFmParams } from 'calypso/landing/stepper/hooks/use-anchor-fm-params';
 import useDetectMatchingAnchorSite from 'calypso/landing/stepper/hooks/use-detect-matching-anchor-site';
 import useSiteTitle from 'calypso/landing/stepper/hooks/use-site-title';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { tip } from 'calypso/signup/icons';
 import type { Step } from '../../types';
@@ -23,6 +23,7 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 	const { goBack, submit, goToStep } = navigation;
 	const { __ } = useI18n();
 	const { isAnchorFmPodcastIdError } = useAnchorFmParams();
+	const { setSiteSetupError } = useDispatch( SITE_STORE );
 
 	//Check to see if there is a site with a matching anchor podcast ID
 	const isLookingUpMatchingAnchorSites = useDetectMatchingAnchorSite();
@@ -105,6 +106,11 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 
 	useEffect( () => {
 		if ( isAnchorFmPodcastIdError ) {
+			const error = __( "We're sorry!" );
+			const message = __(
+				"We're unable to locate your podcast. Return to Anchor or continue with site creation."
+			);
+			setSiteSetupError( error, message );
 			return goToStep?.( 'error' );
 		}
 	}, [ isAnchorFmPodcastIdError ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
@@ -20,8 +20,9 @@ import type { Step } from '../../types';
 import './style.scss';
 
 const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
-	const { goBack, submit } = navigation;
+	const { goBack, submit, goToStep } = navigation;
 	const { __ } = useI18n();
+	const { isAnchorFmPodcastIdError } = useAnchorFmParams();
 
 	//Check to see if there is a site with a matching anchor podcast ID
 	const isLookingUpMatchingAnchorSites = useDetectMatchingAnchorSite();
@@ -101,6 +102,12 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 			</form>
 		);
 	};
+
+	useEffect( () => {
+		if ( isAnchorFmPodcastIdError ) {
+			return goToStep?.( 'error' );
+		}
+	}, [ isAnchorFmPodcastIdError ] );
 
 	return (
 		<StepContainer


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the error step on the Anchor.fm flow when the `anchor_podcast` param is invalid.

<img width="756" alt="Screen Shot 2022-05-10 at 15 54 27" src="https://user-images.githubusercontent.com/1234758/167701843-b71c6192-84bb-423c-bd45-fa2c03022b96.png">

#### Testing instructions

* Go to `/setup/error?anchor_podcast=invalid` and you should be redirected to the error step.

Depends on #63284

Closes #63216
