### PR TITLE
Woo eligibility store: Remove experimental flag

### DIFF
--- a/packages/data-stores/src/automated-transfer-eligibility/index.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/index.ts
@@ -22,9 +22,6 @@ export function register(): typeof STORE_KEY {
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore Until createRegistrySelector is typed correctly
 			selectors,
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore Object literal may only specify known properties
-			__experimentalUseThunks: true,
 		} );
 	}
 	return STORE_KEY;


### PR DESCRIPTION
Removes the experimental flag from the Eligibility Store. It was needed for the previous wordpress/data version, but for the current (6.7.0) it's not needed anymore.

#### Testing

1. Apply this PR
2. Go to a page that loads a component that uses some selector from the Eligibility Store.
3. Verify there are no thunks related errors in the console.
4. Verify that the network request is being made correctly.
