### PR TITLE
Swap out Manage Plans' product price with backend HTML display price

### DIFF
--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -14,6 +14,7 @@ export interface Purchase {
 	renewDate: string;
 	mostRecentRenewDate?: string;
 	productSlug: string;
+	productDisplayPrice: string;
 	siteId: number;
 	subscribedDate: string;
 	payment: PurchasePayment;

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -797,6 +797,7 @@ class ManagePurchase extends Component {
 							) : (
 								<PlanPrice
 									rawPrice={ getRenewalPrice( purchase ) }
+									productDisplayPrice={ purchase.productDisplayPrice }
 									currencyCode={ purchase.currencyCode }
 									taxText={ purchase.taxText }
 									isOnSale={ !! purchase.saleAmount }

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -227,20 +227,18 @@ function PurchaseMetaPrice( { purchase } ) {
 	let period = translate( 'year' );
 
 	if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
-		return (
-			<>
-				<span
-					// eslint-disable-next-line react/no-danger
-					dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
-				/>
-
-				{ translate( '{{period}} (one-time){{/period}}', {
-					components: {
-						period: <span className="manage-purchase__time-period" />,
-					},
-				} ) }
-			</>
-		);
+		// translators: displayPrice is the price of the purchase with localized currency (i.e. "C$10")
+		return translate( '{{displayPrice/}} {{period}}(one-time){{/period}}', {
+			components: {
+				displayPrice: (
+					<span
+						// eslint-disable-next-line react/no-danger
+						dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
+					/>
+				),
+				period: <span className="manage-purchase__time-period" />,
+			},
+		} );
 	}
 
 	if ( isIncludedWithPlan( purchase ) ) {
@@ -263,22 +261,19 @@ function PurchaseMetaPrice( { purchase } ) {
 		period = translate( 'month' );
 	}
 
-	// translators: %(period)s is how long the plan is active (i.e. "year")
-	return (
-		<>
-			<span
-				// eslint-disable-next-line react/no-danger
-				dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
-			/>
-
-			{ translate( '{{period}} / %(period)s{{/period}}', {
-				args: { period },
-				components: {
-					period: <span className="manage-purchase__time-period" />,
-				},
-			} ) }
-		</>
-	);
+	// translators: displayPrice is the price of the purchase with localized currency (i.e. "C$10"), %(period)s is how long the plan is active (i.e. "year")
+	return translate( '{{displayPrice/}} {{period}}/ %(period)s{{/period}}', {
+		args: { period },
+		components: {
+			displayPrice: (
+				<span
+					// eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
+				/>
+			),
+			period: <span className="manage-purchase__time-period" />,
+		},
+	} );
 }
 
 function PurchaseMetaIntroductoryOfferDetail( { purchase } ) {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -222,18 +222,25 @@ function PurchaseMetaOwner( { owner } ) {
 
 function PurchaseMetaPrice( { purchase } ) {
 	const translate = useTranslate();
-	const { priceText, productSlug } = purchase;
+	const { productSlug, productDisplayPrice } = purchase;
 	const plan = getPlan( productSlug ) || getProductFromSlug( productSlug );
 	let period = translate( 'year' );
 
 	if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
-		// translators: %(priceText)s is the price of the purchase with localized currency (i.e. "C$10")
-		return translate( '%(priceText)s {{period}}(one-time){{/period}}', {
-			args: { priceText },
-			components: {
-				period: <span className="manage-purchase__time-period" />,
-			},
-		} );
+		return (
+			<>
+				<span
+					// eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
+				/>
+
+				{ translate( '{{period}} (one-time){{/period}}', {
+					components: {
+						period: <span className="manage-purchase__time-period" />,
+					},
+				} ) }
+			</>
+		);
 	}
 
 	if ( isIncludedWithPlan( purchase ) ) {
@@ -256,13 +263,22 @@ function PurchaseMetaPrice( { purchase } ) {
 		period = translate( 'month' );
 	}
 
-	// translators: %(priceText)s is the price of the purchase with localized currency (i.e. "C$10"), %(period)s is how long the plan is active (i.e. "year")
-	return translate( '%(priceText)s {{period}}/ %(period)s{{/period}}', {
-		args: { priceText, period },
-		components: {
-			period: <span className="manage-purchase__time-period" />,
-		},
-	} );
+	// translators: %(period)s is how long the plan is active (i.e. "year")
+	return (
+		<>
+			<span
+				// eslint-disable-next-line react/no-danger
+				dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
+			/>
+
+			{ translate( '{{period}} / %(period)s{{/period}}', {
+				args: { period },
+				components: {
+					period: <span className="manage-purchase__time-period" />,
+				},
+			} ) }
+		</>
+	);
 }
 
 function PurchaseMetaIntroductoryOfferDetail( { purchase } ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

In this PR the HTML display price has been added to the /purchases/ endpoint as `product_display_price`.

This display price is imported into the manage plans section as `purchases.productDisplayPrice` and can be used to set the geo-IDed symbol/price on the page. 

### Test

- First, apply D80584-code
- Make sure you have a legacy plan on a site
- Go to My Plan > Manage Plan
- Check to make sure the plan price and meta-price are showing the new format (note the currency is properly aligned and has a title attribute)

Ex:
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/16580129/168662553-71d5eb0b-b38f-4548-a658-2af38600b85a.png">


This change is based on the discussion from the following issue: https://github.com/Automattic/wp-calypso/issues/50064

Depends on https://github.com/Automattic/wp-calypso/pull/63524 being merged first!