### PR TITLE
Experiment with cheap sourcemaps

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -58,7 +58,7 @@ const shouldCreateSentryRelease =
 	process.env.SENTRY_AUTH_TOKEN?.length > 1;
 let sourceMapType = process.env.SOURCEMAP;
 if ( ! sourceMapType && shouldCreateSentryRelease ) {
-	sourceMapType = 'hidden-source-map';
+	sourceMapType = 'hidden-cheap-source-map';
 } else if ( ! sourceMapType && isDevelopment ) {
 	sourceMapType = 'eval';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR will experiment with different sourcemap generation options in CI. Can we get a speedup using cheap sourcemaps? Are they still of high enough quality for sentry? Let's find out!

Alright, so my first test has cheap source maps taking about a minute longer. (7:10min vs 6min). However, less than 10 files are uploaded to Sentry, which makes me concerned about what we're actually covering with these sourcemaps. I'm honestly pretty confused by that. Looking locally, nearly every bundle does _not_ have a source map generated for it.

