### PR TITLE
Attempt base image build which caches sourcemaps

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -30,8 +30,8 @@ RUN cd / \
 	&& nvm install \
 	# Prime yarn cache
 	&& yarn \
-	# Prime webpack caches
-	&& NODE_ENV=production yarn build-client
+	# Prime webpack caches, including sourcemaps.
+	&& NODE_ENV=production SOURCEMAP=hidden-source-map yarn build-client
 
 ENTRYPOINT [ "/bin/bash" ]
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -405,7 +405,6 @@ const webpackConfig = {
 						shouldMinify,
 						process.env.ENTRY_LIMIT,
 						process.env.SECTION_LIMIT,
-						sourceMapType,
 						process.env.NODE_ENV,
 						process.env.CALYPSO_ENV,
 					].join( '-' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request
When I enabled sourcemaps, I overlooked that the webpack cache is invalidated based on a version string which _includes_ whether sourcemaps are generated. As a result, trunk builds likely aren't taking advantage of the base image cache any longer, since the base image build doesn't include sourcemaps.

Essentially, a trunk build would have a cache key like "foo-source-map-bar", but the base build would have something "foo-bar" (since the base build doesn't define a devtool.) So no trunk build is able to find the cache because the key is different. 

My theory is that we can simply remove the sourcemap option from the version string altogether. I don't see why the cache would _need_ to invalidated based on whether sourcemaps are enabled or disabled, but that could depend on webpack internals that I don't understand. If my theory is correct, we can build the cache using sourcemaps, and then get a nice speed up on every build.

#### Testing instructions
I'll run a base image build from this branch, and then run a normal build using that base image once with sourcemaps and once without.

1. [Base image build](https://teamcity.a8c.com/buildConfiguration/calypso_BuildBaseImages/7840529). **15:21,** about 6 minutes longer than the typical 9 minutes.
2. [Normal build, without sourcemaps](https://teamcity.a8c.com/buildConfiguration/calypso_BuildDockerImage/7840572). **3:50**. About a minute faster than the typical 5 minutes. This could be because the cache is _very_ warm.
3. [Normal build with sourcemaps](https://teamcity.a8c.com/buildConfiguration/calypso_BuildDockerImage/7840583). **3:21**. Very fast. And it includes sourcemaps, and created a [sentry release](https://sentry.io/organizations/a8c/releases/calypso_29b2eb19eb032b1dbad22395e1cdb91611ce225c/?project=6313676).

This matches what I expect: after spending a long time with sourcemaps in the base image, that work can be reused for the other steps. 