### PR TITLE
Create TC build to upload Gutenberg source-maps to Sentry [PoC/WIP]

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -205,7 +205,6 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 		}
 
 		steps {
-			mergeTrunk()
 			bashNodeScript {
 				name = "Upload source maps to Sentry"
 				scriptContent = """

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -214,8 +214,7 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 					wget https://github.com/WordPress/gutenberg/releases/tag/%GUTENBERG_VERSION%/gutenberg.zip
 					unzip gutenberg.zip -d gutenberg
 					cd gutenberg
-
-					sentry-cli --auth-token %SENTRY_AUTH_TOKEN% releases --org a8c files "wpcom-test-01" delete --all
+					
 					# Upload the .js and .js.map files to Sentry (`wpcom-test-01` release)
 					sentry-cli --auth-token %SENTRY_AUTH_TOKEN% releases --org a8c --project wpcom-gutenberg-wp-admin files wpcom-test-01 upload-sourcemaps . --url-prefix "~/wp-content/plugins/gutenberg-core/v13.1.0/"
 				"""

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -194,20 +194,6 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 		name = "Upload Gutenberg Source Maps to Sentry";
 		id("WPComPlugins_GutenbergUploadSourceMapsToSentry");
 
-		// vcs {
-		//	GitVcsRoot {
-		//		name = "gutenberg"
-		//		url = "git@github.com:fullofcaffeine/gutenberg.git"
-		//		pushUrl = "git@github.com:fullofcaffeine/gutenberg.git"
-		//		branch = "refs/heads/trunk"
-		//		branchSpec = "+:refs/heads/*"
-		//		useTagsAsBranches = true
-		//		authMethod = uploadedKey {
-		//			uploadedKey = "matticbot"
-		//		}
-		//	}
-		// }
-
 		params {
 			text(
 				name = "GUTENBERG_VERSION",

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -231,7 +231,6 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 					cd gutenberg
 
 					sentry-cli --auth-token %SENTRY_AUTH_TOKEN% releases --org a8c files "wpcom-test-01" delete --all
-					cd apps/editing-toolkit/editing-toolkit-plugin
 					# Upload the .js and .js.map files to Sentry (`wpcom-test-01` release)
 					sentry-cli --auth-token %SENTRY_AUTH_TOKEN% releases --org a8c --project wpcom-gutenberg-wp-admin files wpcom-test-01 upload-sourcemaps . --url-prefix "~/wp-content/plugins/gutenberg-core/v13.1.0/"
 				"""

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -1,11 +1,9 @@
 package _self.projects
 
 import _self.bashNodeScript
-import _self.lib.utils.mergeTrunk
 import _self.lib.wpcom.WPComPluginBuild
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
-import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
 
 object WPComPlugins : Project({
 	id("WPComPlugins")
@@ -214,7 +212,7 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 					wget https://github.com/WordPress/gutenberg/releases/tag/%GUTENBERG_VERSION%/gutenberg.zip
 					unzip gutenberg.zip -d gutenberg
 					cd gutenberg
-					
+
 					# Upload the .js and .js.map files to Sentry (`wpcom-test-01` release)
 					sentry-cli --auth-token %SENTRY_AUTH_TOKEN% releases --org a8c --project wpcom-gutenberg-wp-admin files wpcom-test-01 upload-sourcemaps . --url-prefix "~/wp-content/plugins/gutenberg-core/v13.1.0/"
 				"""


### PR DESCRIPTION
Project: p9oQ9f-18L-p2

#### Changes proposed in this Pull Request

Create a dedicated TC build to upload source-maps for a specific GB version to Sentry. For now, it will use the fixed dummy Sentry release `wpcom-test-01` (which we probably should rename, actually). It will clean up all artifacts for this release and re-upload the new ones, each time.

The idea is for this build to be triggered from our installation script. We should only proceed to the actual activation after the source-maps have been uploaded (so we'll need to do some polling in the script to see when the build has finished). 

This implementation is not ideal because it uses a single fixed Sentry release (`wpcom-test-01`). This can cause false-positives due to race conditions when releases:

1. Source-maps finished uploading but the version in WPCOM is still old, there's a window of time when errros can happen and the new source-maps will be used
2. When we activate Sentry for AT, this will be the case most of the time, as there's always a delay for updating Gutenberg on AT.

The scenarios above are not ideal but having source-maps is better than having none. That being said...

### Food for thought for a follow-up:

The ideal implementation will use a new Sentry release for each deployment. The problem is that Sentry is not exclusive to Gutenberg, and its instance shared across the WPAdmin context, which means that a release for the WPAdmin project can't have metadata exclusive to a certain Gutenberg release. We can't create a new Sentry project for Gutenberg either, as it needs to be specified in the Sentry configuration in the frontend, and it's shared across the execution spae for GB, ETK, et al.

The best we can do, I think, is to just have sequential releases, like each release of Gutenberg (which will trigger this build) and other WPCOM plugins just create a new sequential release on Sentry. 

Another possibility is to look at the WPCOM git repo as the consolidator of all these apps that are tracked by the Sentry WPadmin project in the frontend. We can somehow get the commit hash for a deployment and use it to create the new release in Sentry. This has another race-condition downside though: we can only get the hash (AFAIK) after the deployment is done, so in theory, there's going to be a window of time where the release will not have source-maps. Also, we should remember that for each of those releases, the hash should be committed together so that the Sentry configuration in `error-reporting` [can access it and pass it to Sentry](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js#L21) (i.e window.WPCOM_RELEASE or something like that)

### TODO
- [ ] Test the build and:
- [ ] Add the SENTRY_AUTH_TOKEN to the WPComTests project, if not already there
- [ ] How handle failures/success in this build? It should only fail if one of the commands in the bash node script fail, is it already handled by TC?
- [ ] Should the build be part of the WPComPlugins project?  Should we move it somewhere else? Semantically, in part, I think it does, but it doesn't follow the same build pattern as the others, though.
- [ ] If / once it tests well, modify the installation script to trigger this build before deploying.


#### Testing instructions

TBD

Related to #