### PR TITLE
Fix property access error

### DIFF
--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -426,7 +426,8 @@ function refreshNotes() {
 }
 
 function handleStorageEvent( event ) {
-	if ( ! event ) {
+	// Both event and its key property should exist.
+	if ( ! event?.key ) {
 		return;
 	}
 


### PR DESCRIPTION
Resolves https://sentry.io/organizations/a8c/issues/3227829379/.

### Changes proposed in this Pull Request

A sentry event reports that in `event.key.substring`, the key value can sometimes be null. Ensure the key actually exists before doing anything with the event.
