### PR TITLE
Marketplace: Remove masterbar routes

### DIFF
--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -6,7 +6,6 @@ import {
 	sites,
 	selectSiteIfLoggedIn,
 } from 'calypso/my-sites/controller';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	browsePlugins,
 	browsePluginsOrPlugin,
@@ -17,13 +16,6 @@ import {
 	scrollTopIfNoHash,
 	upload,
 } from './controller';
-
-function trackViewRef( context, next ) {
-	if ( context?.query?.ref === 'wpcom-masterbar-redirect' ) {
-		context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_view_click' ) );
-	}
-	next();
-}
 
 export default function () {
 	page(
@@ -71,7 +63,6 @@ export default function () {
 		'/plugins/:site',
 		scrollTopIfNoHash,
 		siteSelection,
-		trackViewRef,
 		navigation,
 		browsePlugins,
 		makeLayout,

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -18,6 +18,13 @@ import {
 	upload,
 } from './controller';
 
+function trackViewRef( context, next ) {
+	if ( context?.query?.ref === 'wpcom-masterbar-redirect' ) {
+		context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_view_click' ) );
+	}
+	next();
+}
+
 export default function () {
 	page(
 		'/plugins/setup',
@@ -36,21 +43,6 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
-
-	page( '/plugins/wpcom-masterbar-redirect/:site', ( context ) => {
-		context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_view_click' ) );
-		page.redirect( `/plugins/${ context.params.site }` );
-	} );
-
-	page( '/plugins/browse/wpcom-masterbar-redirect/:site', ( context ) => {
-		context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_add_click' ) );
-		page.redirect( `/plugins/browse/${ context.params.site }` );
-	} );
-
-	page( '/plugins/manage/wpcom-masterbar-redirect/:site', ( context ) => {
-		context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_manage_click' ) );
-		page.redirect( `/plugins/manage/${ context.params.site }` );
-	} );
 
 	page( '/plugins/browse/:category/:site', ( context ) => {
 		const { category, site } = context.params;
@@ -79,6 +71,7 @@ export default function () {
 		'/plugins/:site',
 		scrollTopIfNoHash,
 		siteSelection,
+		trackViewRef,
 		navigation,
 		browsePlugins,
 		makeLayout,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes `/plugins/wpcom-masterbar-redirect/:site` redirect routes, as they're no longer used. (masterbar removed this button a long time ago)

#### Testing instructions

* These redirect routes e.g. https://calypso.localhost:3000/plugins/manage/wpcom-masterbar-redirect/example.com should wsod (we're still missing a 404 for the plugin route, there is an issue somewhere)

Related to https://github.com/Automattic/wp-calypso/issues/63030
