### PR TITLE
Marketplace: controller function cleanup

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -87,7 +87,7 @@ function renderPluginsBrowser( context ) {
 	} );
 }
 
-function renderPluginWarnings( context ) {
+export function renderPluginWarnings( context, next ) {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 	const pluginSlug = decodeURIComponent( context.params.plugin );
@@ -96,12 +96,14 @@ function renderPluginWarnings( context ) {
 		siteSlug: site.slug,
 		pluginSlug,
 	} );
+	next();
 }
 
-function renderProvisionPlugins( context ) {
+export function renderProvisionPlugins( context, next ) {
 	context.primary = createElement( PlanSetup, {
 		forSpecificPlugin: context.query.only || false,
 	} );
+	next();
 }
 
 export function plugins( context, next ) {
@@ -165,16 +167,6 @@ export function jetpackCanUpdate( context, next ) {
 			return;
 		}
 	}
-	next();
-}
-
-export function setupPlugins( context, next ) {
-	renderProvisionPlugins( context );
-	next();
-}
-
-export function eligibility( context, next ) {
-	renderPluginWarnings( context );
 	next();
 }
 

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -10,12 +10,12 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	browsePlugins,
 	browsePluginsOrPlugin,
-	eligibility,
+	renderPluginWarnings,
+	renderProvisionPlugins,
 	jetpackCanUpdate,
 	plugins,
 	resetHistory,
 	scrollTopIfNoHash,
-	setupPlugins,
 	upload,
 } from './controller';
 
@@ -24,7 +24,7 @@ export default function () {
 		'/plugins/setup',
 		scrollTopIfNoHash,
 		siteSelection,
-		setupPlugins,
+		renderProvisionPlugins,
 		makeLayout,
 		clientRender
 	);
@@ -33,7 +33,7 @@ export default function () {
 		'/plugins/setup/:site',
 		scrollTopIfNoHash,
 		siteSelection,
-		setupPlugins,
+		renderProvisionPlugins,
 		makeLayout,
 		clientRender
 	);
@@ -122,7 +122,7 @@ export default function () {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
-		eligibility,
+		renderPluginWarnings,
 		makeLayout,
 		clientRender
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* inlines `renderProvisionPlugins` and  `renderPluginWarnings` in order to remove `setupPlugins` and `eligibility` 

#### Testing instructions

* Smoke test https://calypso.localhost:3000/plugins, should be no changes.

Related to https://github.com/Automattic/wp-calypso/issues/63030