### PR TITLE
FormTextInput: use `testing-library` for testing

### DIFF
--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import { omit } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
@@ -64,15 +63,7 @@ export default class FormTextInput extends PureComponent {
 	};
 
 	render() {
-		const props = omit(
-			this.props,
-			'isError',
-			'isValid',
-			'selectOnFocus',
-			'inputRef',
-			'onChange',
-			'value'
-		);
+		const { isError, isValid, selectOnFocus, inputRef, onChange, value, ...rest } = this.props;
 
 		const classes = classNames( 'form-text-input', this.props.className, {
 			'is-error': this.props.isError,
@@ -82,7 +73,7 @@ export default class FormTextInput extends PureComponent {
 		return (
 			<input
 				type="text"
-				{ ...props }
+				{ ...rest }
 				value={ this.state.value }
 				ref={ this.textFieldRef }
 				className={ classes }

--- a/client/components/forms/form-text-input/test/index.jsx
+++ b/client/components/forms/form-text-input/test/index.jsx
@@ -1,63 +1,65 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
 import FormTextInput from '../';
 
 describe( '<FormTextInput />', () => {
 	test( 'should add the provided class names', () => {
-		const wrapper = shallow( <FormTextInput className="test" isError isValid /> );
+		render( <FormTextInput className="test" isError isValid /> );
 
-		expect( wrapper.hasClass( 'test' ) ).toBe( true );
-		expect( wrapper.hasClass( 'is-error' ) ).toBe( true );
-		expect( wrapper.hasClass( 'is-valid' ) ).toBe( true );
+		const input = screen.getByRole( 'textbox' );
+
+		expect( input ).toHaveClass( 'test' );
+		expect( input ).toHaveClass( 'is-error' );
+		expect( input ).toHaveClass( 'is-valid' );
 	} );
 
 	test( 'should have form-text-input class name', () => {
-		const wrapper = shallow( <FormTextInput /> );
+		render( <FormTextInput /> );
 
-		expect( wrapper.hasClass( 'form-text-input' ) ).toBe( true );
+		const input = screen.getByRole( 'textbox' );
+
+		expect( input ).toHaveClass( 'form-text-input' );
 	} );
 
 	test( "should not pass component's own props down to the input", () => {
-		const wrapper = shallow( <FormTextInput isValid isError selectOnFocus /> );
+		const spy = jest.spyOn( console, 'error' );
+		render( <FormTextInput isValid isError selectOnFocus /> );
 
-		expect( wrapper.prop( 'isValid' ) ).toBeUndefined();
-		expect( wrapper.prop( 'isError' ) ).toBeUndefined();
-		expect( wrapper.prop( 'selectOnFocus' ) ).toBeUndefined();
+		expect( spy ).not.toHaveBeenCalled();
 	} );
 
 	test( "should pass props aside from component's own to the input", () => {
-		const wrapper = shallow( <FormTextInput placeholder="test placeholder" /> );
+		render( <FormTextInput placeholder="test placeholder" /> );
 
-		expect( wrapper.prop( 'placeholder' ) ).toBe( 'test placeholder' );
+		const input = screen.getByRole( 'textbox' );
+
+		expect( input ).toHaveAttribute( 'placeholder', 'test placeholder' );
 	} );
 
 	test( 'should call select if selectOnFocus is true', () => {
-		const wrapper = shallow( <FormTextInput selectOnFocus={ true } /> );
-		const event = {
-			target: {
-				select: () => {},
-			},
-		};
+		render( <FormTextInput selectOnFocus={ true } /> );
+		const select = jest.fn();
+		const event = { target: { select } };
 
-		const spy = jest.spyOn( event.target, 'select' );
-		wrapper.simulate( 'click', event );
+		const input = screen.getByRole( 'textbox' );
 
-		expect( spy ).toHaveBeenCalledTimes( 1 );
+		fireEvent.click( input, event );
 
-		spy.mockRestore();
+		expect( select ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	test( 'should not call select if selectOnFocus is false', () => {
-		const wrapper = shallow( <FormTextInput selectOnFocus={ false } /> );
-		const event = {
-			target: {
-				select: () => {},
-			},
-		};
+		render( <FormTextInput selectOnFocus={ false } /> );
+		const select = jest.fn();
+		const event = { target: { select } };
 
-		const spy = jest.spyOn( event.target, 'select' );
-		wrapper.simulate( 'click', event );
+		const input = screen.getByRole( 'textbox' );
 
-		expect( spy ).not.toHaveBeenCalled();
-		spy.mockRestore();
+		fireEvent.click( input, event );
+
+		expect( select ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/components/forms/form-text-input/test/index.jsx
+++ b/client/components/forms/form-text-input/test/index.jsx
@@ -1,35 +1,33 @@
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { spy } from 'sinon';
 import FormTextInput from '../';
 
 describe( '<FormTextInput />', () => {
 	test( 'should add the provided class names', () => {
 		const wrapper = shallow( <FormTextInput className="test" isError isValid /> );
 
-		expect( wrapper.hasClass( 'test' ) ).to.equal( true );
-		expect( wrapper.hasClass( 'is-error' ) ).to.equal( true );
-		expect( wrapper.hasClass( 'is-valid' ) ).to.equal( true );
+		expect( wrapper.hasClass( 'test' ) ).toBe( true );
+		expect( wrapper.hasClass( 'is-error' ) ).toBe( true );
+		expect( wrapper.hasClass( 'is-valid' ) ).toBe( true );
 	} );
 
 	test( 'should have form-text-input class name', () => {
 		const wrapper = shallow( <FormTextInput /> );
 
-		expect( wrapper.hasClass( 'form-text-input' ) ).to.equal( true );
+		expect( wrapper.hasClass( 'form-text-input' ) ).toBe( true );
 	} );
 
 	test( "should not pass component's own props down to the input", () => {
 		const wrapper = shallow( <FormTextInput isValid isError selectOnFocus /> );
 
-		expect( wrapper.prop( 'isValid' ) ).to.equal( undefined );
-		expect( wrapper.prop( 'isError' ) ).to.equal( undefined );
-		expect( wrapper.prop( 'selectOnFocus' ) ).to.equal( undefined );
+		expect( wrapper.prop( 'isValid' ) ).toBeUndefined();
+		expect( wrapper.prop( 'isError' ) ).toBeUndefined();
+		expect( wrapper.prop( 'selectOnFocus' ) ).toBeUndefined();
 	} );
 
 	test( "should pass props aside from component's own to the input", () => {
 		const wrapper = shallow( <FormTextInput placeholder="test placeholder" /> );
 
-		expect( wrapper.prop( 'placeholder' ) ).to.equal( 'test placeholder' );
+		expect( wrapper.prop( 'placeholder' ) ).toBe( 'test placeholder' );
 	} );
 
 	test( 'should call select if selectOnFocus is true', () => {
@@ -40,10 +38,12 @@ describe( '<FormTextInput />', () => {
 			},
 		};
 
-		spy( event.target, 'select' );
+		const spy = jest.spyOn( event.target, 'select' );
 		wrapper.simulate( 'click', event );
 
-		expect( event.target.select ).to.have.been.calledOnce;
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+
+		spy.mockRestore();
 	} );
 
 	test( 'should not call select if selectOnFocus is false', () => {
@@ -54,9 +54,10 @@ describe( '<FormTextInput />', () => {
 			},
 		};
 
-		spy( event.target, 'select' );
+		const spy = jest.spyOn( event.target, 'select' );
 		wrapper.simulate( 'click', event );
 
-		expect( event.target.select ).to.not.have.been.called;
+		expect( spy ).not.toHaveBeenCalled();
+		spy.mockRestore();
 	} );
 } );

--- a/client/components/forms/form-text-input/test/index.jsx
+++ b/client/components/forms/form-text-input/test/index.jsx
@@ -24,13 +24,6 @@ describe( '<FormTextInput />', () => {
 		expect( input ).toHaveClass( 'form-text-input' );
 	} );
 
-	test( "should not pass component's own props down to the input", () => {
-		const spy = jest.spyOn( console, 'error' );
-		render( <FormTextInput isValid isError selectOnFocus /> );
-
-		expect( spy ).not.toHaveBeenCalled();
-	} );
-
 	test( "should pass props aside from component's own to the input", () => {
 		render( <FormTextInput placeholder="test placeholder" /> );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* FormTextInput: migrate tests to `testing-library`

#### Testing instructions

* Verify related tests still pass via `yarn test-client client/components/forms/form-text-input`
