### PR TITLE
Notifications: Refactor `EmptyMessage` away from `UNSAFE_` methods

### DIFF
--- a/apps/notifications/src/panel/templates/empty-message.jsx
+++ b/apps/notifications/src/panel/templates/empty-message.jsx
@@ -5,8 +5,7 @@ import { bumpStat } from '../rest-client/bump-stat';
 const TITLE_OFFSET = 38;
 
 export class EmptyMessage extends Component {
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		if ( this.props.showing ) {
 			bumpStat( 'notes-empty-message', this.props.name + '_shown' );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `EmptyMessage` notifications app component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Get setup to test the notifications app by either:
  * Following the instructions in PCYsg-elI-p2 for testing this, or
  * Building and syncing manually:
    * Checkout this branch locally.
    * Go to `/apps/notifications`
    * Run `yarn build`
    * Copy all the files from `dist` into `widgets.wp.com/notifications` on your sandbox.
    * Sandbox `widgets.wp.com`
* Log in as a new user.
* Click the Notifications button in the Masterbar.
* Click on "Follows" or "Unread"
* Verify that the message still looks like it did before.

Note: ESLint errors are pre-existing and I'm intentionally not fixing them.