### PR TITLE
Notifications: Refactor `ImageLoader` away from `UNSAFE_` methods

### DIFF
--- a/apps/notifications/src/panel/templates/image-loader.jsx
+++ b/apps/notifications/src/panel/templates/image-loader.jsx
@@ -19,40 +19,22 @@ export class ImageLoader extends Component {
 		children: PropTypes.node,
 	};
 
-	state = {
-		status: LoadStatus.PENDING,
-	};
+	constructor( props ) {
+		super( props );
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		this.createLoader();
-	}
+		this.image = new Image();
+		this.image.src = props.src;
+		this.image.onload = this.onLoadComplete;
+		this.image.onerror = this.onLoadComplete;
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.src !== this.props.src ) {
-			this.createLoader( nextProps );
-		}
+		this.state = {
+			status: LoadStatus.LOADING,
+		};
 	}
 
 	componentWillUnmount() {
 		this.destroyLoader();
 	}
-
-	createLoader = ( nextProps ) => {
-		const src = ( nextProps || this.props ).src;
-
-		this.destroyLoader();
-
-		this.image = new Image();
-		this.image.src = src;
-		this.image.onload = this.onLoadComplete;
-		this.image.onerror = this.onLoadComplete;
-
-		this.setState( {
-			status: LoadStatus.LOADING,
-		} );
-	};
 
 	destroyLoader = () => {
 		if ( ! this.image ) {

--- a/apps/notifications/src/panel/templates/summary-in-list.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-list.jsx
@@ -39,6 +39,7 @@ export class SummaryInList extends Component {
 				<div className="wpnc__note-icon">
 					<ImagePreloader
 						src={ this.props.note.icon }
+						key={ `image-preloader-${ this.props.note.icon }` }
 						placeholder={
 							<img src="https://www.gravatar.com/avatar/ad516503a11cd5ca435acc9bb6523536?s=128" />
 						}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `ImageLoader` notifications app component away from the `UNSAFE_` deprecated React component methods.

We use the `key` approach for resetting the component in order to be able to benefit from the component state management without any unintended side effects.

Part of #58453.

#### Testing instructions
* Get setup to test the notifications app by either:
  * Following the instructions in PCYsg-elI-p2 for testing this, or
  * Building and syncing manually:
    * Checkout this branch locally.
    * Go to `/apps/notifications`
    * Run `yarn build`
    * Copy all the files from `dist` into `widgets.wp.com/notifications` on your sandbox.
    * Sandbox `widgets.wp.com`
* Click the Notifications button in the Masterbar.
* Verify that avatars of all notifications continue to load correctly as you scroll down.

Note: ESLint errors are pre-existing and I'm intentionally not fixing them.