### PR TITLE
Me: Remove Lodash from blog notification settings header

### DIFF
--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -1,6 +1,5 @@
 import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { countBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import SiteInfo from 'calypso/blocks/site';
@@ -54,17 +53,21 @@ class BlogSettingsHeader extends PureComponent {
 			return restDevice;
 		} );
 
-		const { true: onCount, false: offCount } = countBy(
-			// Here we're flattening the values of both sets of settings
-			// as both sets have two 'streams' of settings: 'email' and 'timeline'
-			[
-				...Object.values( filteredSettings )
-					.map( ( set ) => Object.values( set ) )
-					.flat(),
-				...Object.values( devicesSettings )
-					.map( ( device ) => Object.values( device ) )
-					.flat(),
-			]
+		const allSettings = [
+			...Object.values( filteredSettings )
+				.map( ( set ) => Object.values( set ) )
+				.flat(),
+			...Object.values( devicesSettings )
+				.map( ( device ) => Object.values( device ) )
+				.flat(),
+		];
+		const { onCount, offCount } = allSettings.reduce(
+			( acc, isOn ) => {
+				const key = isOn ? 'onCount' : 'offCount';
+				acc[ key ] += 1;
+				return acc;
+			},
+			{ onCount: 0, offCount: 0 }
 		);
 
 		if ( ! onCount ) {

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -1,6 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { countBy, map, values, flatten } from 'lodash';
+import { countBy, flatten } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import SiteInfo from 'calypso/blocks/site';
@@ -49,7 +49,7 @@ class BlogSettingsHeader extends PureComponent {
 			...filteredSettings
 		} = settings;
 		// Ignore the device_id of each device found.
-		const devicesSettings = map( settings.devices, ( device ) => {
+		const devicesSettings = Object.values( settings.devices ).map( ( device ) => {
 			const { device_id, ...restDevice } = device;
 			return restDevice;
 		} );
@@ -57,8 +57,8 @@ class BlogSettingsHeader extends PureComponent {
 			// Here we're flattening the values of both sets of settings
 			// as both sets have two 'streams' of settings: 'email' and 'timeline'
 			[
-				...flatten( map( filteredSettings, values ) ),
-				...flatten( map( devicesSettings, values ) ),
+				...flatten( Object.values( filteredSettings ).map( ( set ) => Object.values( set ) ) ),
+				...flatten( Object.values( devicesSettings ).map( ( device ) => Object.values( device ) ) ),
 			]
 		);
 

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -54,13 +54,12 @@ class BlogSettingsHeader extends PureComponent {
 		} );
 
 		const allSettings = [
-			...Object.values( filteredSettings )
-				.map( ( set ) => Object.values( set ) )
-				.flat(),
-			...Object.values( devicesSettings )
-				.map( ( device ) => Object.values( device ) )
-				.flat(),
-		];
+			...Object.values( filteredSettings ),
+			...Object.values( devicesSettings ),
+		]
+			.map( ( set ) => Object.values( set ) )
+			.flat();
+
 		const { onCount, offCount } = allSettings.reduce(
 			( acc, isOn ) => {
 				const key = isOn ? 'onCount' : 'offCount';

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -48,7 +48,7 @@ class BlogSettingsHeader extends PureComponent {
 			...filteredSettings
 		} = settings;
 		// Ignore the device_id of each device found.
-		const devicesSettings = Object.values( settings.devices ).map( ( device ) => {
+		const devicesSettings = Object.values( devices ).map( ( device ) => {
 			const { device_id, ...restDevice } = device;
 			return restDevice;
 		} );

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -1,6 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { countBy, flatten } from 'lodash';
+import { countBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import SiteInfo from 'calypso/blocks/site';
@@ -53,12 +53,17 @@ class BlogSettingsHeader extends PureComponent {
 			const { device_id, ...restDevice } = device;
 			return restDevice;
 		} );
+
 		const { true: onCount, false: offCount } = countBy(
 			// Here we're flattening the values of both sets of settings
 			// as both sets have two 'streams' of settings: 'email' and 'timeline'
 			[
-				...flatten( Object.values( filteredSettings ).map( ( set ) => Object.values( set ) ) ),
-				...flatten( Object.values( devicesSettings ).map( ( device ) => Object.values( device ) ) ),
+				...Object.values( filteredSettings )
+					.map( ( set ) => Object.values( set ) )
+					.flat(),
+				...Object.values( devicesSettings )
+					.map( ( device ) => Object.values( device ) )
+					.flat(),
 			]
 		);
 

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -1,6 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { countBy, map, omit, values, flatten } from 'lodash';
+import { countBy, map, values, flatten } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import SiteInfo from 'calypso/blocks/site';
@@ -39,16 +39,20 @@ class BlogSettingsHeader extends PureComponent {
 
 	getLegend = () => {
 		const { settings } = this.props;
-		const filteredSettings = omit( settings, [
-			'blog_id',
-			'devices',
-			'email.achievement',
-			'email.store_order',
-			'email.scheduled_publicize',
-			'timeline.store_order',
-		] );
+		const {
+			blog_id,
+			devices,
+			'email.achievement': emailAchievement,
+			'email.store_order': emailStoreOrder,
+			'email.scheduled_publicize': emailScheduledPublicize,
+			'timeline.store_order': timelineStoreOrder,
+			...filteredSettings
+		} = settings;
 		// Ignore the device_id of each device found.
-		const devicesSettings = map( settings.devices, ( device ) => omit( device, 'device_id' ) );
+		const devicesSettings = map( settings.devices, ( device ) => {
+			const { device_id, ...restDevice } = device;
+			return restDevice;
+		} );
 		const { true: onCount, false: offCount } = countBy(
 			// Here we're flattening the values of both sets of settings
 			// as both sets have two 'streams' of settings: 'email' and 'timeline'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes all Lodash from the `BlogSettingsHeader` component. 

Initially, I was aiming to remove the last instance of `_.countBy()`, however this component, but this component was hiding a few more potential Lodash removals, so I took the advantage to address them.

#### Testing instructions

* Go to `/me/notifications`
* Expand the notification settings for a site.
* Verify that if all are enabled, you see a "All notifications" label in the header.
* Verify that if not all are enabled, you see a "Some notifications" label in the header.

Note: for some reason, there are notifications settings that can't be disabled (because there's no UI for that), due to which we can't really test the "No notifications" scenario at this point. That behavior is the same as in production and I'm not aiming to change it in any way in this PR.