### PR TITLE
Remove the site scoping for the Error Step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -25,12 +25,12 @@ const ErrorStep: Step = function ErrorStep( { navigation } ) {
 		domain = siteDomains[ 0 ].domain;
 	}
 
-	const headerText = siteSetupError ? siteSetupError.error : __( "We've hit a snag" );
-	const bodyText = siteSetupError
-		? siteSetupError.message
-		: __(
-				'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
-		  );
+	const headerText = siteSetupError?.error || __( "We've hit a snag" );
+	const bodyText =
+		siteSetupError?.message ||
+		__(
+			'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
+		);
 
 	const getContent = () => {
 		return (

--- a/client/landing/stepper/hooks/use-site-setup-error.ts
+++ b/client/landing/stepper/hooks/use-site-setup-error.ts
@@ -1,12 +1,6 @@
 import { useSelect } from '@wordpress/data';
 import { SITE_STORE } from '../stores';
-import { useQuery } from './use-query';
 
 export function useSiteSetupError() {
-	const siteSlug = useQuery().get( 'siteSlug' );
-	const siteId = useSelect(
-		( select ) => siteSlug && select( SITE_STORE ).getSiteIdBySlug( siteSlug )
-	);
-
-	return useSelect( ( select ) => siteId && select( SITE_STORE ).getSiteSetupError( siteId ) );
+	return useSelect( ( select ) => select( SITE_STORE ).getSiteSetupError() );
 }

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -275,9 +275,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		return data?.is_fse_active ?? false;
 	}
 
-	const setSiteSetupError = ( siteId: number, error: string, message: string ) => ( {
+	const setSiteSetupError = ( error: string, message: string ) => ( {
 		type: 'SET_SITE_SETUP_ERROR',
-		siteId,
 		error,
 		message,
 	} );

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -196,32 +196,27 @@ export const launchStatus: Reducer< { [ key: number ]: SiteLaunchState }, Action
 };
 
 export const siteSetupErrors: Reducer<
-	{ [ key: number ]: any | undefined },
+	{
+		error?: string;
+		message?: string;
+	},
 	{
 		type: string;
-		siteId: number;
 		error?: string;
 		message?: string;
 	}
 > = ( state = {}, action ) => {
 	if ( action.type === 'SET_SITE_SETUP_ERROR' ) {
-		const { siteId, error, message } = action;
+		const { error, message } = action;
 
 		return {
-			...state,
-			[ siteId ]: {
-				error,
-				message,
-			},
+			error,
+			message,
 		};
 	}
 
 	if ( action.type === 'CLEAR_SITE_SETUP_ERROR' ) {
-		const newState = {
-			...state,
-		};
-
-		delete newState[ action.siteId ];
+		return {};
 	}
 
 	return state;

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -61,8 +61,8 @@ export const getSiteSettings = ( state: State, siteId: number ) => {
 	return state.sitesSettings[ siteId ];
 };
 
-export const getSiteSetupError = ( state: State, siteId: number ) => {
-	return state.siteSetupErrors[ siteId ] || null;
+export const getSiteSetupError = ( state: State ) => {
+	return state.siteSetupErrors;
 };
 
 export const getPrimarySiteDomain = ( _: State, siteId: number ) =>

--- a/packages/data-stores/src/site/test/reducer.ts
+++ b/packages/data-stores/src/site/test/reducer.ts
@@ -144,7 +144,7 @@ describe( 'Site', () => {
 		} );
 
 		it( 'should default to the initial state when an unknown action is dispatched', () => {
-			const state = siteSetupErrors( undefined, { type: 'TEST_ACTION', siteId } );
+			const state = siteSetupErrors( undefined, { type: 'TEST_ACTION' } );
 			expect( state ).toStrictEqual( {} );
 		} );
 
@@ -154,12 +154,10 @@ describe( 'Site', () => {
 			const error = 'test_error';
 			const message = 'This is a test error';
 
-			const action = setSiteSetupError( siteId, error, message );
+			const action = setSiteSetupError( error, message );
 			const expected = {
-				[ siteId ]: {
-					error,
-					message,
-				},
+				error,
+				message,
 			};
 
 			expect( siteSetupErrors( originalState, action ) ).toEqual( expected );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The Error Step no longer is required to be scoped by the site.
* The scoping of the Error Step difficulted the use cases where the site has not been created yet.

p1651608810976479/1651597210.555879-slack-C0Q664T29

#### Testing instructions

* Go to `/setup/error?siteSlug=<your-site>` and you'll see the Error Step with the default message.
* For unit testing, run the following command:
```
node 'node_modules/.bin/jest' './packages/data-stores/src/site/test/reducer.ts' -c './packages/data-stores/jest.config.js'
```

Related to #63216