### PR TITLE
My Home: add styling for SVG in help-results

### DIFF
--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -114,10 +114,11 @@ $min_results_height: 180px;
 			overflow: hidden;
 			text-overflow: ellipsis;
 
-			.gridicon {
+			.gridicon,
+			svg {
 				margin: 0 5px -3px 0;
 				position: relative;
-				top: 0;
+				top: 2px;
 			}
 
 			&:hover,


### PR DESCRIPTION
#### Before
<img width="712" alt="Markup 2022-05-04 at 16 46 59" src="https://user-images.githubusercontent.com/33258733/166707013-3302901d-5177-479d-8304-d96275f0cbec.png">


#### After
<img width="704" alt="Markup 2022-05-04 at 16 37 23" src="https://user-images.githubusercontent.com/33258733/166706871-959b0b36-da8b-4363-babb-f4f4edb26a22.png">

#### Testing
Pull branch and `yarn start`
