### PR TITLE
Checkout: Remove products list guards when adding new products

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -465,7 +465,6 @@ function createItemToAddToCart( {
 	isJetpackCheckout,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
-	privacy,
 	source,
 }: {
 	productSlug: string;
@@ -473,7 +472,6 @@ function createItemToAddToCart( {
 	isJetpackCheckout?: boolean;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
-	privacy?: boolean;
 	source?: string;
 } ): RequestCartProduct {
 	// Allow setting meta (theme name or domain name) from products in the URL by
@@ -482,16 +480,7 @@ function createItemToAddToCart( {
 	// Some meta values contain slashes, so we decode them
 	const cartMeta = meta ? decodeProductFromUrl( meta ) : '';
 
-	debug(
-		'creating product with',
-		productSlug,
-		'from alias',
-		productAlias,
-		'with meta',
-		cartMeta,
-		'and privacy',
-		privacy
-	);
+	debug( 'creating product with', productSlug, 'from alias', productAlias, 'with meta', cartMeta );
 
 	return createRequestCartProduct( {
 		product_slug: productSlug,
@@ -499,7 +488,6 @@ function createItemToAddToCart( {
 			isJetpackCheckout,
 			jetpackSiteSlug,
 			jetpackPurchaseToken,
-			privacy,
 			context: 'calypstore',
 			source: source ?? undefined,
 		},

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -254,15 +254,10 @@ function useAddRenewalItems( {
 } ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const isFetchingProducts = useSelector( isProductsListFetching );
-	const products = useSelector( getProductsList );
 	const translate = useTranslate();
 
 	useEffect( () => {
 		if ( addHandler !== 'addRenewalItems' ) {
-			return;
-		}
-		if ( isFetchingProducts || Object.keys( products || {} ).length < 1 ) {
-			debug( 'waiting on products fetch for renewal' );
 			return;
 		}
 		const productSlugs = productAlias?.split( ',' ) ?? [];
@@ -299,7 +294,6 @@ function useAddRenewalItems( {
 		addHandler,
 		translate,
 		isFetchingProducts,
-		products,
 		originalPurchaseId,
 		productAlias,
 		dispatch,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -217,19 +217,9 @@ function useAddProductsFromLocalStorage( {
 	addHandler: AddHandler;
 } ) {
 	const translate = useTranslate();
-	const products: Record<
-		string,
-		{
-			product_slug: string;
-		}
-	> = useSelector( getProductsList );
 
 	useEffect( () => {
 		if ( addHandler !== 'addFromLocalStorage' ) {
-			return;
-		}
-		if ( Object.keys( products || {} ).length < 1 ) {
-			debug( 'waiting on products fetch' );
 			return;
 		}
 
@@ -248,7 +238,7 @@ function useAddProductsFromLocalStorage( {
 
 		debug( 'preparing products requested in localStorage', productsForCart );
 		dispatch( { type: 'PRODUCTS_ADD', products: productsForCart } );
-	}, [ addHandler, dispatch, translate, products ] );
+	}, [ addHandler, dispatch, translate ] );
 }
 
 function useAddRenewalItems( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -253,7 +253,6 @@ function useAddRenewalItems( {
 	addHandler: AddHandler;
 } ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
-	const isFetchingProducts = useSelector( isProductsListFetching );
 	const translate = useTranslate();
 
 	useEffect( () => {
@@ -290,15 +289,7 @@ function useAddRenewalItems( {
 		}
 		debug( 'preparing renewals requested in url', productsForCart );
 		dispatch( { type: 'RENEWALS_ADD', products: productsForCart } );
-	}, [
-		addHandler,
-		translate,
-		isFetchingProducts,
-		originalPurchaseId,
-		productAlias,
-		dispatch,
-		selectedSiteSlug,
-	] );
+	}, [ addHandler, translate, originalPurchaseId, productAlias, dispatch, selectedSiteSlug ] );
 }
 
 function useAddProductFromSlug( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -284,24 +284,6 @@ function useAddRenewalItems( {
 				if ( ! productSlug ) {
 					return null;
 				}
-				const [ encodedSlug ] = productSlug.split( ':' );
-				const decodedSlug = decodeProductFromUrl( encodedSlug );
-				const product = products[ decodedSlug ];
-				if ( ! product ) {
-					debug( 'no renewal product found with slug', productSlug );
-					dispatch( {
-						type: 'PRODUCTS_ADD_ERROR',
-						message: String(
-							translate(
-								"I tried and failed to create a renewal product matching the identifier '%(productSlug)s'",
-								{
-									args: { productSlug },
-								}
-							)
-						),
-					} );
-					return null;
-				}
 				return createRenewalItemToAddToCart( productSlug, subscriptionId );
 			} )
 			.filter( isValueTruthy );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -315,6 +315,7 @@ function useAddProductFromSlug( {
 } ) {
 	const products = useSelector( getProductsList );
 	const translate = useTranslate();
+	const isFetchingProducts = useSelector( isProductsListFetching );
 
 	// If `productAliasFromUrl` has a comma ',' in it, we will assume it's because it's
 	// referencing more than one product. Because of this, the rest of this function will
@@ -345,7 +346,7 @@ function useAddProductFromSlug( {
 		// There is a selector for isFetchingProducts, but it seems to be sometimes
 		// inaccurate (possibly before the fetch has started) so instead we just
 		// wait for there to be products.
-		if ( Object.keys( products || {} ).length < 1 ) {
+		if ( isFetchingProducts || Object.keys( products || {} ).length < 1 ) {
 			debug( 'waiting on products fetch' );
 			return;
 		}
@@ -388,6 +389,7 @@ function useAddProductFromSlug( {
 		);
 		dispatch( { type: 'PRODUCTS_ADD', products: cartProducts } );
 	}, [
+		isFetchingProducts,
 		addHandler,
 		translate,
 		isPrivate,

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -363,7 +363,6 @@ export interface ResponseCartProductExtra {
 	google_apps_users?: GSuiteProductUser[];
 	google_apps_registration_data?: DomainContactDetails;
 	purchaseType?: string;
-	privacy?: boolean;
 	afterPurchaseUrl?: string;
 	isJetpackCheckout?: boolean;
 	is_marketplace_product?: boolean;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Checkout has a React hook called `usePrepareProductsForCart()` which takes product slugs from the URL or from localStorage and creates cart items from them that will later be added to the cart via another hook. This system waits for the list of products from the products endpoint to load before operating and then validates each product slug. The original reason for this is that the shopping cart endpoint used to require a product ID for each product so we needed to be able to map from the slug to the ID. Since https://github.com/Automattic/wp-calypso/pull/59365, this is no longer used and we send the slug directly.

Aside from being unnecessary, it seems that the data from the products endpoint (which is stored in Redux) may sometimes be inaccurate. There seems to be an intermittent bug where the products endpoint returns data for a Jetpack site and then that data remains even when operating on a non-Jetpack site. As a result, the validation performed when adding cart items can fail, displaying an error to the user even though the product slug is correct.

This PR removes the dependency on the products data from `usePrepareProductsForCart()`.

The only thing that this removes which might be important is setting the `privacy` property on a cart item (this is different from the `privacy_available` property!). Prior to this PR that property was set based on the `is_privacy_protection_product_purchase_allowed` property of the data from the products endpoint, but this seems unnecessary to me for three reasons:

1. I can't find any use of that property on the backend (unless it gets transferred to the payment object). Also, this PR removes the property from the cart TypeScript type entirely and there are no TypeScript errors, so I'm pretty sure it's not used by the frontend either.
2. If we do need it, why not get it directly on the backend inside the cart endpoint rather than requiring the frontend to fetch it from a different endpoint?
3. That property was not set until https://github.com/Automattic/wp-calypso/pull/60308 which was for gutenboarding and I believe gutenboarding is deprecated. Prior to that, it was not being set, at least since the cart was refactored several years ago.

Fixes https://github.com/Automattic/wp-calypso/issues/63291

#### Testing instructions

To test this, we'll need to try adding products to the cart via URL. Here's some URL paths that should correctly add a product to your cart (replace example.com with a real site):

- `/checkout/example.com/pro`
- `/checkout/example.com/personal`
- `/checkout/example.com/premium`
- `/checkout/example.com/domain_reg:lajdlakdjlkjdalkfdgegrgrsdjasldjs.com`
- `/checkout/example.com/domain-mapping:ajdlakdjlkjdalksdjasldjsadadsads.com`

Verify that the following path does not add a product to your cart and that you see an error message to that effect:

- `/checkout/example.com/hiwjdlakdjlkjdalksdjasldjs`