### PR TITLE
Anchor: Add starting Tracks event

### DIFF
--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -1,4 +1,6 @@
 import { useSelect } from '@wordpress/data';
+import { useEffect } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { SITE_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
@@ -13,6 +15,10 @@ export const anchorFmFlow: Flow = {
 	name: 'anchor-fm',
 
 	useSteps() {
+		useEffect( () => {
+			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
+		}, [] );
+
 		return [ 'podcastTitle', 'designSetup', 'processing' ] as StepPath[];
 	},
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a Tracks event that fires when landing on the first step of the Anchor flow called `calypso_signup_start`, with a `flow` property of the flow name.
* Related to #63066

<img width="1523" alt="Screen Shot 2022-05-04 at 11 15 55 AM" src="https://user-images.githubusercontent.com/2124984/166717910-f7ac0576-b187-49bd-9ee4-169cd82c66d4.png">


#### Testing instructions

* Switch to this PR
* Open the browser inspector and add the following line to log tracks events: `localStorage.debug='calypso:analytics'`; hit "Enter" and refresh your browser to see the events (you may need to adjust the types of messages shown in the Console if you don't see them right away)
* Navigate to `/setup/?anchor_podcast=[your podcast ID]`
* You should see the `calypso_signup_start` event fire with a property of `flow: 'anchor-fm'` when landing on the podcast title step.