### PR TITLE
Reword low-severity threat tooltip

### DIFF
--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -231,7 +231,7 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 					{ maxSeverity < 3 && (
 						<InfoPopover position="top" screenReaderText={ translate( 'Learn more' ) }>
 							{ translate(
-								"Low risk items don't have a negative impact on your site and can be safely ignored."
+								'Low risk items could have a negative impact on your site and should either be fixed or ignored at your convenience.'
 							) }
 						</InfoPopover>
 					) }

--- a/client/components/jetpack/threat-low-risk-item-header/index.tsx
+++ b/client/components/jetpack/threat-low-risk-item-header/index.tsx
@@ -16,7 +16,7 @@ const ThreatLowRiskItemHeader: React.FC< Props > = ( { threatCount } ) => {
 			) }
 			<InfoPopover position="top" screenReaderText={ translate( 'Learn more' ) }>
 				{ translate(
-					"Low risk items don't have a negative impact on your site and can be safely ignored."
+					'Low risk items could have a negative impact on your site and should either be fixed or ignored at your convenience.'
 				) }
 			</InfoPopover>
 		</>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Asana Task: [1202211719604598](https://app.asana.com/0/1201069996155224/1202211719604598)

* The purpose of this PR is to reword the tooltip displayed for low-severity threats to provide more clarity and reduce any potential confusion. 
* The original string: `Low risk items don't have a negative impact on your site and can be safely ignored.`
* The updated string: `Low risk items could have a negative impact on your site and should either be fixed or ignored at your convenience` 
<img width="600" alt="Screen Shot 2022-05-11 at 2 20 10 PM" src="https://user-images.githubusercontent.com/43220201/167950768-28f78cc4-8795-4e4b-9dad-e2b17380d87a.png">

#### Testing instructions
- Checkout this branch
- Add a low-severity threat to a test site (eg. The plugin [WooCommerce](https://en-ca.wordpress.org/plugins/woocommerce/advanced/) (version 6.2.2) has a known low-severity vulnerability)
- If you haven't already, add `127.0.0.1 calypso.localhost` to your local hosts file.
- For **Calypso Blue**
   - Execute `yarn` and then `yarn start` from the root directory of the branch
   - Open [calypso.localhost:3000](http://calypso.localhost:3000/) in your browser.
- For **Calypso Green** 
   - Closeout your Calypso Blue environment, only one can be run at a time 
   - Execute `yarn` and then `yarn start-jetpack-cloud` from the root directory of the branch
   - Open [jetpack.cloud.localhost:3000](http://jetpack.cloud.localhost:3000/) in your browser
-  Proceed to **Jetpack > Scan**
- Click on the tooltip icon next to the text "1 low risk item found" and "Review 1 low risk item" and verify that the text presented is as [expected](https://d.pr/i/DmKif4/fBWe2CyFrM). 

