### PR TITLE
Seller Experience - Stepper: Redirect to the WC admin at the end of the woo flow

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -56,6 +56,9 @@ export const siteSetupFlow: Flow = {
 		const siteId = useSelect(
 			( select ) => siteSlug && select( SITE_STORE ).getSiteIdBySlug( siteSlug )
 		);
+		const adminUrl = useSelect(
+			( select ) => siteSlug && select( SITE_STORE ).getSiteOption( siteId as number, 'admin_url' )
+		);
 		const isAtomic = useSelect( ( select ) =>
 			select( SITE_STORE ).isSiteAtomic( siteId as number )
 		);
@@ -109,6 +112,8 @@ export const siteSetupFlow: Flow = {
 					// End of woo flow
 					if ( storeType === 'power' ) {
 						dispatch( recordTracksEvent( 'calypso_woocommerce_dashboard_redirect' ) );
+
+						return exitFlow( `${ adminUrl }/wp-admin/admin.php?page=wc-admin` );
 					}
 
 					if ( FSEActive && intent !== 'write' ) {

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -36,6 +36,7 @@ export function register(): typeof STORE_KEY {
 			'selectedFonts',
 			'selectedSite',
 			'siteTitle',
+			'storeType',
 			'intent',
 		],
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Redirect to the WC admin at the end of the woo flow. Previously we redirected to `/home`


https://user-images.githubusercontent.com/917632/166747394-d0e998fe-8560-4bee-b1a9-52fabd6f2341.mp4


#### Testing instructions

1. Go to http://calypso.localhost:3000/start/?flags=stepper-woocommerce-poc
2. Go through the "Sell" intent and "More power" 
3. At the end of the process, you should be redirected to the wc admin page instead of `/home`

Fixes #63295
