### PR TITLE
Seller Experience - Stepper: Site data-store selectors to retrieve site options

### DIFF
--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -1,6 +1,6 @@
 import { select } from '@wordpress/data';
 import { STORE_KEY } from './constants';
-import { SiteLaunchStatus } from './types';
+import { SiteLaunchStatus, SiteOption } from './types';
 import type { State } from './reducer';
 
 export const getState = ( state: State ) => state;
@@ -63,6 +63,14 @@ export const getSiteSettings = ( state: State, siteId: number ) => {
 
 export const getSiteSetupError = ( state: State ) => {
 	return state.siteSetupErrors;
+};
+
+export const getSiteOptions = ( state: State, siteId: number ) => {
+	return state.sites[ siteId ]?.options;
+};
+
+export const getSiteOption = ( state: State, siteId: number, optionName: SiteOption ) => {
+	return state.sites[ siteId ]?.options?.[ optionName ];
 };
 
 export const getPrimarySiteDomain = ( _: State, siteId: number ) =>

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -9,7 +9,13 @@
 import { dispatch, select, subscribe } from '@wordpress/data';
 import wpcomRequest from 'wpcom-proxy-request';
 import { AtomicSoftwareStatus, AtomicSoftwareStatusError, register } from '..';
-import { getAtomicSoftwareStatus, getAtomicSoftwareError } from '../selectors';
+import {
+	getAtomicSoftwareStatus,
+	getAtomicSoftwareError,
+	getSiteOptions,
+	getSiteOption,
+} from '../selectors';
+import { SiteDetails } from '../types';
 import type { State } from '../reducer';
 
 jest.mock( 'wpcom-proxy-request', () => ( {
@@ -210,5 +216,68 @@ describe( 'getAtomicSoftwareStatus', () => {
 
 		// Successfuly returns the status
 		expect( getAtomicSoftwareError( state, siteId, softwareSet ) ).toEqual( error );
+	} );
+} );
+
+describe( 'getSiteOptions', () => {
+	const siteId = 1234;
+	const adminUrl = 'https://test.wordpress.com/wp-admin';
+	const options = {
+		admin_url: adminUrl,
+	};
+	const site: SiteDetails = {
+		ID: siteId,
+		name: 'test',
+		description: 'test site',
+		URL: 'https://test.wordpress.com',
+		launch_status: '',
+		jetpack: false,
+		is_fse_eligible: false,
+		is_fse_active: false,
+		options,
+		capabilities: {
+			edit_pages: true,
+			edit_posts: true,
+			edit_others_posts: true,
+			edit_others_pages: true,
+			delete_posts: true,
+			delete_others_posts: true,
+			edit_theme_options: true,
+			edit_users: true,
+			list_users: true,
+			manage_categories: true,
+			manage_options: true,
+			moderate_comments: true,
+			activate_wordads: true,
+			promote_users: true,
+			publish_posts: true,
+			upload_files: true,
+			delete_users: true,
+			remove_users: true,
+			own_site: true,
+			view_hosting: true,
+			view_stats: true,
+			activate_plugins: true,
+		},
+	};
+
+	it( 'Tries to retrive the site options', async () => {
+		const state: State = {
+			sites: {
+				[ siteId ]: site,
+			},
+		};
+
+		expect( getSiteOptions( state, siteId ) ).toEqual( options );
+	} );
+
+	it( 'Tries to retrive a specific site option', async () => {
+		const state: State = {
+			sites: {
+				[ siteId ]: site,
+			},
+		};
+
+		expect( getSiteOption( state, siteId, 'admin_url' ) ).toEqual( adminUrl );
 	} );
 } );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -193,6 +193,8 @@ export interface SiteDetails {
 	};
 }
 
+export type SiteOption = keyof SiteDetails[ 'options' ];
+
 export interface SiteError {
 	error: string;
 	message: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds new selectors to the site data store for retrieving site options.

#### Testing instructions

Run `yarn test-packages ./packages/data-stores/src/site/test/selectors.ts`

Related to #63295
