### PR TITLE
Stepper: Added email field to storeAdress page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { ComboboxControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
+import emailValidator from 'email-validator';
 import { FormEvent, ReactElement, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -23,7 +24,8 @@ type FormFields =
 	| 'store_address_2'
 	| 'store_city'
 	| 'store_postcode'
-	| 'store_country';
+	| 'store_country'
+	| 'store_email';
 
 const CityZipRow = styled.div`
 	display: -ms-grid;
@@ -48,6 +50,7 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 	const [ storeCity, setStoreCity ] = useState( storeAddress.store_city );
 	const [ storePostcode, setStorePostcode ] = useState( storeAddress.store_postcode );
 	const [ storeCountry, setStoreCountry ] = useState( storeAddress.store_country );
+	const [ storeEmail, setStoreEmail ] = useState( storeAddress.store_email );
 	const { setStoreAddressValue } = useDispatch( ONBOARD_STORE );
 
 	if ( ! countries ) {
@@ -79,6 +82,10 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 					setStorePostcode( event.currentTarget.value );
 					errors[ 'store_postcode' ] = '';
 					break;
+				case 'store_email':
+					setStoreEmail( event.currentTarget.value );
+					errors[ 'store_email' ] = '';
+					break;
 			}
 
 			setErrors( errors );
@@ -91,6 +98,9 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 		errors[ 'store_address_1' ] = ! storeAddress1 ? __( 'Please add an address' ) : '';
 		errors[ 'store_city' ] = ! storeCity ? __( 'Please add a city' ) : '';
 		errors[ 'store_country' ] = ! storeCountry ? __( 'Please select a country / region' ) : '';
+		errors[ 'store_email' ] = ! emailValidator.validate( storeEmail )
+			? __( 'Please add a valid email address' )
+			: '';
 
 		setErrors( errors );
 
@@ -105,19 +115,14 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 				return;
 			}
 
-			await setStoreAddressValue( 'store_address_1', storeAddress1 );
-			await setStoreAddressValue( 'store_address_2', storeAddress2 || '' );
-			await setStoreAddressValue( 'store_city', storeCity );
-			await setStoreAddressValue( 'store_postcode', storePostcode );
-			await setStoreAddressValue( 'store_country', storeCountry );
+			setStoreAddressValue( 'store_address_1', storeAddress1 );
+			setStoreAddressValue( 'store_address_2', storeAddress2 || '' );
+			setStoreAddressValue( 'store_city', storeCity );
+			setStoreAddressValue( 'store_postcode', storePostcode );
+			setStoreAddressValue( 'store_country', storeCountry );
+			setStoreAddressValue( 'store_email', storeEmail );
 
-			submit?.( {
-				storeAddress1,
-				storeAddress2,
-				storeCity,
-				storePostcode,
-				storeCountry,
-			} );
+			submit?.();
 		}
 	};
 
@@ -180,8 +185,8 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 					</CityZipRow>
 
 					<FormFieldset>
+						<FormLabel htmlFor="store_postcode">{ __( 'Country / State' ) }</FormLabel>
 						<ComboboxControl
-							label={ __( 'Country / State' ) }
 							value={ storeCountry }
 							onChange={ ( value: string | null ) => {
 								if ( value ) {
@@ -196,6 +201,18 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 							className={ errors[ 'store_country' ] ? 'is-error' : '' }
 						/>
 						<ControlError error={ errors[ 'store_country' ] || '' } />
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="store_email">{ __( 'Email address' ) }</FormLabel>
+						<FormInput
+							value={ storeEmail }
+							name="store_email"
+							id="store_email"
+							onChange={ onChange }
+							className={ errors[ 'store_email' ] ? 'is-error' : '' }
+						/>
+						<ControlError error={ errors[ 'store_email' ] } />
 					</FormFieldset>
 
 					<ActionSection>
@@ -213,30 +230,26 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 	};
 
 	return (
-		<div className="store-address__signup is-woocommerce-install">
-			<div className="store-address__is-store-address">
-				<StepContainer
-					stepName={ 'store-address' }
-					className={ `is-step-${ intent }` }
-					skipButtonAlign={ 'top' }
-					goBack={ goBack }
-					goNext={ goNext }
-					isHorizontalLayout={ true }
-					formattedHeader={
-						<FormattedHeader
-							id={ 'site-options-header' }
-							headerText={ headerText }
-							subHeaderText={ __(
-								'This will be used as your default business address. You can change it later if you need to.'
-							) }
-							align={ 'left' }
-						/>
-					}
-					stepContent={ getContent() }
-					recordTracksEvent={ recordTracksEvent }
+		<StepContainer
+			stepName={ 'store-address' }
+			className={ `is-step-${ intent }` }
+			skipButtonAlign={ 'top' }
+			goBack={ goBack }
+			goNext={ goNext }
+			isHorizontalLayout={ true }
+			formattedHeader={
+				<FormattedHeader
+					id={ 'site-options-header' }
+					headerText={ headerText }
+					subHeaderText={ __(
+						'This will be used as your default business address. You can change it later if you need to.'
+					) }
+					align={ 'left' }
 				/>
-			</div>
-		</div>
+			}
+			stepContent={ getContent() }
+			recordTracksEvent={ recordTracksEvent }
+		/>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
@@ -249,6 +249,7 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 			}
 			stepContent={ getContent() }
 			recordTracksEvent={ recordTracksEvent }
+			hideSkip
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
@@ -1,16 +1,20 @@
 @import '../style';
 
 body.is-group-stepper.is-section-stepper {
-	.store-address__is-store-address {
-		.components-form-token-field__suggestions-list {
-			width: min-content;
-		}
-
-		.components-base-control__label {
-			display: block;
-			font-size: 0.875rem;
-			font-weight: 600;
-			margin-bottom: 5px;
+	.components-combobox-control__input {
+		padding: 7px 14px;
+	}
+	.components-combobox-control__suggestions-container {
+		width: unset;
+		border-color: var( --color-neutral-10 );
+	}
+	.step-container__header {
+		flex: 1;
+	}
+	.step-container__content {
+		flex: 1;
+		@include break-mobile {
+			padding-left: 40px;
 		}
 	}
 }

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -259,6 +259,7 @@ const storeAddress: Reducer< StoreAddress, OnboardAction > = (
 		store_city: '',
 		store_postcode: '',
 		store_country: '',
+		store_email: '',
 	},
 	action
 ) => {

--- a/packages/data-stores/src/shared-types.ts
+++ b/packages/data-stores/src/shared-types.ts
@@ -9,4 +9,5 @@ export interface StoreAddress {
 	store_city: string;
 	store_postcode: string;
 	store_country: string;
+	store_email: string;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As shown in #63288, the email field was missing from the storeAddress form.
* The border border of the inputs were not consistent
* The dropdown was shorter and wider than the other fields
* The title/subtitle div was too wide comparing to the original

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Stepper Woo flow until to storeAddress step

* Before:
 
| Desktop  | Mobile |
| ------------- | ------------- |
| <img width="1118" alt="image" src="https://user-images.githubusercontent.com/375980/166702235-4ed0b478-46b2-40e9-8144-88689a03266d.png">  | <img width="401" alt="image" src="https://user-images.githubusercontent.com/375980/166702159-6cefe758-ce23-4e44-8cd4-8b643bfa6009.png">  |


* After

| Desktop  | Mobile |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/3801502/166836133-c34a6568-b5e5-4195-b9b8-c8090689af42.png) | ![image](https://user-images.githubusercontent.com/3801502/166836296-ba25a83a-e8ae-41d3-9e94-200a32ffb5d6.png) |


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #63288
Closes #63290