### PR TITLE
Anchor: Adds Error Step layout specific to Anchor flow

### DIFF
--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -19,7 +19,7 @@ export const anchorFmFlow: Flow = {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 		}, [] );
 
-		return [ 'podcastTitle', 'designSetup', 'processing' ] as StepPath[];
+		return [ 'podcastTitle', 'designSetup', 'processing', 'error' ] as StepPath[];
 	},
 
 	useStepNavigation( currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -26,12 +26,17 @@ const ErrorStep: Step = function ErrorStep( { navigation, flow } ) {
 		domain = siteDomains[ 0 ].domain;
 	}
 
+	const defaultBodyText =
+		flow !== 'anchor-fm'
+			? __(
+					'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
+			  )
+			: __(
+					'It looks like something went wrong while setting up your site. Return to Anchor or continue with site creation.'
+			  );
+
 	const headerText = siteSetupError?.error || __( "We've hit a snag" );
-	const bodyText =
-		siteSetupError?.message ||
-		__(
-			'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
-		);
+	const bodyText = siteSetupError?.message || defaultBodyText;
 
 	const getContent = () => {
 		if ( flow === 'anchor-fm' ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -1,5 +1,6 @@
 import { StepContainer } from '@automattic/onboarding';
 import styled from '@emotion/styled';
+import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -13,7 +14,7 @@ const WarningsOrHoldsSection = styled.div`
 	margin-top: 40px;
 `;
 
-const ErrorStep: Step = function ErrorStep( { navigation } ) {
+const ErrorStep: Step = function ErrorStep( { navigation, flow } ) {
 	const { goBack, goNext } = navigation;
 	const { __ } = useI18n();
 	const siteDomains = useSiteDomains();
@@ -33,6 +34,19 @@ const ErrorStep: Step = function ErrorStep( { navigation } ) {
 		);
 
 	const getContent = () => {
+		if ( flow === 'anchor-fm' ) {
+			return (
+				<WarningsOrHoldsSection>
+					<Button isPrimary href="/setup">
+						<span>{ __( 'Continue' ) }</span>
+					</Button>
+					<Button className="error-step__link" isLink href="https://anchor.fm">
+						<span>{ __( 'Back to Anchor.fm' ) }</span>
+					</Button>
+				</WarningsOrHoldsSection>
+			);
+		}
+
 		return (
 			<WarningsOrHoldsSection>
 				<SupportCard domain={ domain } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -1,6 +1,6 @@
+import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import styled from '@emotion/styled';
-import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -37,11 +37,11 @@ const ErrorStep: Step = function ErrorStep( { navigation, flow } ) {
 		if ( flow === 'anchor-fm' ) {
 			return (
 				<WarningsOrHoldsSection>
-					<Button isPrimary href="/setup">
-						<span>{ __( 'Continue' ) }</span>
+					<Button className="error-step__button" href="/setup" primary>
+						{ __( 'Continue' ) }
 					</Button>
-					<Button className="error-step__link" isLink href="https://anchor.fm">
-						<span>{ __( 'Back to Anchor.fm' ) }</span>
+					<Button className="error-step__link" borderless href="https://anchor.fm">
+						{ __( 'Back to Anchor.fm' ) }
 					</Button>
 				</WarningsOrHoldsSection>
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/style.scss
@@ -9,3 +9,17 @@
 		margin: 40px 0;
 	}
 }
+
+.error-step__link {
+	&.components-button.is-link {
+		margin: 0 1em;
+	}
+	&.components-button.is-link:not( :disabled ),
+	&.components-button.is-link:not( :disabled ) {
+		color: var( --studio-gray-40 );
+	}
+	&.components-button.is-link:hover:not( :disabled ),
+	&.components-button.is-link:active:not( :disabled ) {
+		color: var( --studio-gray-60 );
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/style.scss
@@ -2,6 +2,9 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
 
+$design-button-primary-color: var( --color-primary );
+$design-button-primary-hover-color: var( --color-primary-60 );
+
 .step-container.error-step {
 	padding: 1rem;
 
@@ -10,9 +13,24 @@
 	}
 }
 
+.error-step__button {
+	background: $design-button-primary-color;
+	border-color: $design-button-primary-color;
+	padding: 9px 48px;
+	border-radius: 4px;
+	font-weight: 500;
+	box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;
+
+	&:hover,
+	&:focus {
+		background: $design-button-primary-hover-color;
+		border-color: $design-button-primary-hover-color;
+	}
+}
+
 .error-step__link {
-	&.components-button.is-link {
-		margin: 0 1em;
+	&.button.is-borderless {
+		padding: 10px 14px;
 	}
 	&.components-button.is-link:not( :disabled ),
 	&.components-button.is-link:not( :disabled ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a button to `Continue` and link to go `Back to Anchor.fm`, when the users fall on the Error Step on the Anchor.fm flow.

<img width="1110" alt="Screen Shot 2022-05-06 at 16 17 40" src="https://user-images.githubusercontent.com/1234758/167203597-1770e77b-0ad3-46c8-a4d7-75adb405a14c.png">


p1651686256459099/1651685453.883429-slack-C0Q664T29

#### Testing instructions

* Access `/setup/error?anchor_podcast=<podcast-id>` and you'll see the Error Step with the button to `Continue` and the link to go `Back to Anchor.fm`.

Related to #63216