### PR TITLE
Check if git works in the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@ bin/build-docker.sh
 /.tsc-cache
 /.cache
 .dockerignore
-.git
 .npm-debug.log*
 .vscode
 /.babel-cache

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -120,12 +120,8 @@ object BuildDockerImage : BuildType({
 					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
 					registry.a8c.com/calypso/app:latest
 				""".trimIndent()
-				// /etc/buildAgent is added based on https://github.com/akkadotnet/akka.net/issues/2834#issuecomment-494795604.
-				// The way TeamCity caches VCS info means this directory is needed
-				// for git commands to work, so we mount it as a volume.
 				commandArgs = """
 					--pull
-					--volume /etc/buildAgent/system/git:/etc/buildAgent/system/git
 					--label com.a8c.image-builder=teamcity
 					--label com.a8c.target=calypso-live
 					--label com.a8c.build-id=%teamcity.build.id%

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -63,7 +63,6 @@ object BuildDockerImage : BuildType({
 			name = "Webhook Start"
 			scriptContent = """
 				#!/usr/bin/env bash
-				ls .git
 				if [[ "%teamcity.build.branch.is_default%" != "true" ]]; then
 					exit 0
 				fi
@@ -121,8 +120,12 @@ object BuildDockerImage : BuildType({
 					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
 					registry.a8c.com/calypso/app:latest
 				""".trimIndent()
+				// /etc/buildAgent is added based on https://github.com/akkadotnet/akka.net/issues/2834#issuecomment-494795604.
+				// The way TeamCity caches VCS info means this directory is needed
+				// for git commands to work, so we mount it as a volume.
 				commandArgs = """
 					--pull
+					--volume /etc/buildAgent/system/git:/etc/buildAgent/system/git
 					--label com.a8c.image-builder=teamcity
 					--label com.a8c.target=calypso-live
 					--label com.a8c.build-id=%teamcity.build.id%

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -59,12 +59,11 @@ object BuildDockerImage : BuildType({
 	}
 
 	steps {
-
 		script {
 			name = "Webhook Start"
 			scriptContent = """
 				#!/usr/bin/env bash
-
+				ls .git
 				if [[ "%teamcity.build.branch.is_default%" != "true" ]]; then
 					exit 0
 				fi

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -102,8 +102,6 @@ object BuildDockerImage : BuildType({
 				#!/usr/bin/env bash
 				sudo apt-get install -y git-restore-mtime
 				/usr/lib/git-core/git-restore-mtime --force --commit-time --skip-missing
-
-				echo %teamcity.agent.home.dir%
 			"""
 			dockerImage = "%docker_image_e2e%"
 			dockerRunParameters = "-u %env.UID%"
@@ -135,6 +133,7 @@ object BuildDockerImage : BuildType({
 					--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
 					--build-arg is_default_branch=%teamcity.build.branch.is_default%
 					--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN%
+					--build-arg has_extra_git_dir=true
 					--build-arg extra_git_dir=%teamcity.agent.home.dir%/system/git
 				""".trimIndent().replace("\n"," ")
 			}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -102,6 +102,8 @@ object BuildDockerImage : BuildType({
 				#!/usr/bin/env bash
 				sudo apt-get install -y git-restore-mtime
 				/usr/lib/git-core/git-restore-mtime --force --commit-time --skip-missing
+
+				echo %teamcity.agent.home.dir%
 			"""
 			dockerImage = "%docker_image_e2e%"
 			dockerRunParameters = "-u %env.UID%"
@@ -133,6 +135,7 @@ object BuildDockerImage : BuildType({
 					--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
 					--build-arg is_default_branch=%teamcity.build.branch.is_default%
 					--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN%
+					--build-arg extra_git_dir=%teamcity.agent.home.dir%/system/git
 				""".trimIndent().replace("\n"," ")
 			}
 			param("dockerImage.platform", "linux")

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,10 @@ RUN bash /tmp/env-config.sh
 # dependencies which end up bloating the image.
 # /apps/notifications is not removed because it is required by Calypso
 COPY . /calypso/
+RUN ls
+RUN ls /calypso
 RUN yarn install --immutable --check-cache
-RUN git log
+
 # Build the final layer
 #
 # This contains built environments of Calypso. It will

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ FROM builder-cache-${use_cache} as builder-git-context-false
 ###################
 FROM builder-cache-${use_cache} as builder-git-context-true
 
-COPY $extra_git_dir $extra_git_dir
+COPY ${extra_git_dir} ${extra_git_dir}
 
 ###################
 # run "true" variant if dir exists, run false variant otherwise. The cache variants

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN bash /tmp/env-config.sh
 # /apps/notifications is not removed because it is required by Calypso
 COPY . /calypso/
 RUN yarn install --immutable --check-cache
-
+RUN git log
 # Build the final layer
 #
 # This contains built environments of Calypso. It will

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,6 @@ RUN bash /tmp/env-config.sh
 # dependencies which end up bloating the image.
 # /apps/notifications is not removed because it is required by Calypso
 COPY . /calypso/
-COPY .git /calypso/.git
 RUN ls .git
 RUN git log
 RUN yarn install --immutable --check-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ ARG use_cache=false
 ARG node_version=16.13.2
 ARG base_image=registry.a8c.com/calypso/base:latest
 
-# Used to load extra git context from TeamCity so that git commands work.
-ARG extra_git_dir
 # It's difficult to infer this in Docker, because we'd need to set an environment
 # variable to do so. And if we can't do that before running the FROM steps. But
 # we need the variable to be defined before doing FROM. It's easier to pass it.
@@ -31,7 +29,7 @@ FROM builder-cache-${use_cache} as builder-git-context-false
 
 ###################
 FROM builder-cache-${use_cache} as builder-git-context-true
-
+ARG extra_git_dir
 COPY ${extra_git_dir} ${extra_git_dir}
 
 ###################

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,9 @@ RUN bash /tmp/env-config.sh
 # dependencies which end up bloating the image.
 # /apps/notifications is not removed because it is required by Calypso
 COPY . /calypso/
-RUN ls
-RUN ls /calypso
+COPY .git /calypso/.git
+RUN ls .git
+RUN git log
 RUN yarn install --immutable --check-cache
 
 # Build the final layer

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,13 @@ RUN bash /tmp/env-config.sh
 # dependencies which end up bloating the image.
 # /apps/notifications is not removed because it is required by Calypso
 COPY . /calypso/
-RUN ls .git
+
+# /etc/buildAgent is added based on https://github.com/akkadotnet/akka.net/issues/2834#issuecomment-494795604.
+# The way TeamCity caches VCS info means this directory is needed
+# for git commands to work, so we mount it as a volume.
+COPY /etc/buildAgent/system/git /etc/buildAgent/system/git
 RUN git log
+
 RUN yarn install --immutable --check-cache
 
 # Build the final layer

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,7 @@ COPY --from=builder --chown=nobody:nobody /calypso/build /calypso/build
 COPY --from=builder --chown=nobody:nobody /calypso/public /calypso/public
 COPY --from=builder --chown=nobody:nobody /calypso/config /calypso/config
 COPY --from=builder --chown=nobody:nobody /calypso/package.json /calypso/package.json
+RUN ls /calypso
 
 USER nobody
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
### Changes proposed in this Pull Request
For git integration in Sentry, I'd like to use the existing webpack plugin. This depends on git commands being available in our Docker image build, which I'm unsure about. So far, this PR tests running a git command in the docker image.

After some investigation, we would need to make the following changes:
- The `.git` directory needs to be removed from the docker ignore file, so that it gets copied in the Docker execution space.
- We also need to copy a TeamCity ([based on this comment](https://github.com/akkadotnet/akka.net/issues/2834#issuecomment-494795604)) directory `/etc/buildAgent/system/git` into the docker image, because TeamCity uses mirrors to cache git info on TeamCity agents. As a result, when that directory is missing, git commands fail because they don't have access to the info linked back to that TeamCity directory. This directory is available in normal build steps, but not in the Docker image unless we copy it.

I'm considering whether we really need to make these changes -- we could easily implement the VCS portion of Sentry as a GitHub action instead, and _just_ do sourcemaps here.