### PR TITLE
Help-Center Container: UX improvements

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -5,8 +5,8 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Card } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { useState } from 'react';
-import Draggable from 'react-draggable';
+import { useState, FC } from 'react';
+import Draggable, { DraggableProps } from 'react-draggable';
 /**
  * Internal Dependencies
  */
@@ -14,6 +14,17 @@ import HelpCenterContent from './help-center-content';
 import HelpCenterFooter from './help-center-footer';
 import HelpCenterHeader from './help-center-header';
 import { Container } from './types';
+
+interface OptionalDraggableProps extends Partial< DraggableProps > {
+	draggable: boolean;
+}
+
+const OptionalDraggable: FC< OptionalDraggableProps > = ( { draggable, ...props } ) => {
+	if ( ! draggable ) {
+		return <>{ props.children }</>;
+	}
+	return <Draggable { ...props } />;
+};
 
 const HelpCenterContainer: React.FC< Container > = ( {
 	content,
@@ -49,42 +60,24 @@ const HelpCenterContainer: React.FC< Container > = ( {
 
 	const header = isMinimized ? headerText ?? __( 'Help Center' ) : __( 'Help Center' );
 
-	const containerContent = (
-		<>
-			<HelpCenterHeader
-				isMinimized={ isMinimized }
-				onMinimize={ () => setIsMinimized( true ) }
-				onMaximize={ () => setIsMinimized( false ) }
-				onDismiss={ onDismiss }
-				headerText={ header }
-			/>
-			{ ! isMinimized && (
-				<>
-					<HelpCenterContent content={ content } />
-					{ footerContent && <HelpCenterFooter footerContent={ footerContent } /> }
-				</>
-			) }
-		</>
-	);
-
-	if ( isMobile ) {
-		return (
-			<Card { ...animationProps } className={ classNames }>
-				{ containerContent }
-			</Card>
-		);
-	}
-
-	return isMinimized ? (
-		<Card className={ classNames } { ...animationProps }>
-			{ containerContent }
-		</Card>
-	) : (
-		<Draggable>
+	return (
+		<OptionalDraggable
+			disabled={ isMinimized }
+			draggable={ ! isMobile }
+			handle=".help-center__container-header"
+		>
 			<Card className={ classNames } { ...animationProps }>
-				{ containerContent }
+				<HelpCenterHeader
+					isMinimized={ isMinimized }
+					onMinimize={ () => setIsMinimized( true ) }
+					onMaximize={ () => setIsMinimized( false ) }
+					onDismiss={ onDismiss }
+					headerText={ header }
+				/>
+				<HelpCenterContent isMinimized={ isMinimized } content={ content } />
+				{ footerContent && ! isMinimized && <HelpCenterFooter footerContent={ footerContent } /> }
 			</Card>
-		</Draggable>
+		</OptionalDraggable>
 	);
 };
 

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -2,11 +2,11 @@ import { CardBody } from '@wordpress/components';
 import classnames from 'classnames';
 import { Content } from './types';
 
-const HelpCenterContent: React.FC< Content > = ( { content } ) => {
+const HelpCenterContent: React.FC< Content > = ( { content, isMinimized } ) => {
 	const className = classnames( 'help-center__container-content' );
 
 	return (
-		<CardBody className={ className }>
+		<CardBody hidden={ isMinimized } className={ className }>
 			<div>{ content }</div>
 		</CardBody>
 	);

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -2,6 +2,7 @@ import { CardHeader, Button, Flex } from '@wordpress/components';
 import { closeSmall, chevronUp, lineSolid } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
+import React from 'react';
 import { Header } from './types';
 
 const HelpCenterMobileHeader: React.FC< Header > = ( {

--- a/packages/help-center/src/components/types.ts
+++ b/packages/help-center/src/components/types.ts
@@ -9,6 +9,7 @@ export interface Container {
 
 export interface Content {
 	content: ReactElement;
+	isMinimized: boolean;
 }
 
 export interface Header {

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -55,7 +55,7 @@ $head-foot-height: 50px;
 		&.is-minimized {
 			min-height: $head-foot-height;
 			top: unset;
-			bottom: 0;
+			bottom: 41px;
 			transform: unset !important; // revert dragging translation when minimized
 			.help-center__container-header {
 				cursor: default;

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -54,8 +54,9 @@ $head-foot-height: 50px;
 
 		&.is-minimized {
 			min-height: $head-foot-height;
-			top: calc( 100vh - 91px ); // height of header + bottom breadcrumb bar in the editor + 16px
-
+			top: unset;
+			bottom: 0;
+			transform: unset !important; // revert dragging translation when minimized
 			.help-center__container-header {
 				cursor: default;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes some improvements to the help center container:

1. Makes the header the dragging handle (vs the entire thing).
2. Preserves the state when minimized.
3. Improves the CSS a bit (use `bottom: 0` instead of calculating the right `top`).

#### Testing instructions

1. Run ETK.
2. Visit https://YOUR_SITE.wordpress.com/wp-admin/post-new.php?enable-help-center on a sandboxed site.
3. Test the above experiences.
4. Make sure to test on mobile as well.

