### PR TITLE
Adds DIFM intent to the Intent Screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/intents.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/intents.tsx
@@ -47,15 +47,6 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 
 	return [
 		{
-			show: true,
-			key: 'wpadmin',
-			description: translate( "Know what you're doing?" ),
-			value: 'wpadmin',
-			disable: false,
-			disableText: '',
-			actionText: translate( 'Start from scratch' ),
-		},
-		{
 			show: isEnabled( 'onboarding/import' ),
 			key: 'import',
 			description: translate( 'Already have an existing website?' ),
@@ -76,7 +67,7 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 			key: 'difm',
 			description: translate( 'Let our experts create your dream site' ),
 			value: 'difm',
-			actionText: translate( 'Let our experts create your dream site' ),
+			actionText: translate( 'Get Started' ),
 			disable: false,
 			disableText: <></>,
 		},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/intents.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/intents.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { englishLocales, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
 import { SelectItem, SelectItemAlt } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { build, write, shoppingCart } from 'calypso/signup/icons';
@@ -63,7 +64,9 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 			),
 		},
 		{
-			show: isEnabled( 'onboarding/difm' ),
+			show:
+				isEnabled( 'onboarding/difm' ) &&
+				englishLocales.includes( translate.localeSlug || i18nDefaultLocaleSlug ),
 			key: 'difm',
 			description: translate( 'Let our experts create your dream site' ),
 			value: 'difm',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/intents.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/intents.tsx
@@ -71,5 +71,14 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 				}
 			),
 		},
+		{
+			show: true,
+			key: 'difm',
+			description: translate( 'Let our experts create your dream site' ),
+			value: 'difm',
+			actionText: translate( 'Let our experts create your dream site' ),
+			disable: false,
+			disableText: <></>,
+		},
 	];
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/intents.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/intents.tsx
@@ -72,7 +72,7 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 			),
 		},
 		{
-			show: true,
+			show: isEnabled( 'onboarding/difm' ),
 			key: 'difm',
 			description: translate( 'Let our experts create your dream site' ),
 			value: 'difm',

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -184,6 +184,9 @@ export const siteSetupFlow: Flow = {
 						case 'write': {
 							return navigate( 'options' );
 						}
+						case 'difm': {
+							return exitFlow( `/start/website-design-services/?siteSlug=${ siteSlug }` );
+						}
 						default: {
 							return navigate( submittedIntent as StepPath );
 						}

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -424,7 +424,6 @@ export function generateFlows( {
 		{
 			name: 'website-design-services',
 			steps: [
-				'user',
 				'choose-service',
 				'difm-options',
 				'social-profiles',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -421,6 +421,21 @@ export function generateFlows( {
 			lastModified: '2022-03-10',
 			enableBranchSteps: true,
 		},
+		{
+			name: 'website-design-services',
+			steps: [
+				'user',
+				'choose-service',
+				'difm-options',
+				'social-profiles',
+				'difm-design-setup-site',
+				'difm-page-picker',
+			],
+			destination: getDIFMSignupDestination,
+			description: 'A flow for DIFM onboarding',
+			excludeFromManageSiteFlows: true,
+			lastModified: '2022-05-02',
+		},
 
 		{
 			name: 'site-content-collection',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -71,6 +71,7 @@ const stepNameToModuleName = {
 	'plans-premium-monthly': 'plans',
 	'design-setup-site': 'design-picker',
 	'new-or-existing-site': 'new-or-existing-site',
+	'choose-service': 'choose-service',
 	'difm-site-picker': 'difm-site-picker',
 	'difm-design-setup-site': 'design-picker',
 	'difm-options': 'site-options',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -689,6 +689,11 @@ export function generateSteps( {
 			},
 		},
 
+		'choose-service': {
+			stepName: 'choose-service',
+			providesDependencies: [ 'siteSlug' ],
+		},
+
 		'new-or-existing-site': {
 			stepName: 'new-or-existing-site',
 			fulfilledStepCallback: isNewOrExistingSiteFulfilled,
@@ -709,7 +714,6 @@ export function generateSteps( {
 			stepName: 'difm-design-setup-site',
 			apiRequestFunction: setDIFMLiteDesign,
 			delayApiRequestUntilComplete: true,
-			dependencies: [ 'newOrExistingSiteChoice' ],
 			providesDependencies: [
 				'isFSEActive',
 				'selectedDesign',

--- a/client/signup/icons/index.tsx
+++ b/client/signup/icons/index.tsx
@@ -269,7 +269,7 @@ export const award: ReactElement = (
 	</svg>
 );
 
-export const headset: ReactElement = (
+export const frame: ReactElement = (
 	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<mask id="mask0_2727_2533" maskUnits="userSpaceOnUse" x="3" y="4" width="18" height="16">
 			<path
@@ -282,5 +282,71 @@ export const headset: ReactElement = (
 		<g mask="url(#mask0_2727_2533)">
 			<rect width="24" height="24" fill="#8C8F94" />
 		</g>
+	</svg>
+);
+
+export const headset: ReactElement = (
+	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path
+			d="M7 17C8.105 17 9 16.105 9 15V11C9 9.895 8.105 9 7 9C5.895 9 5 9.895 5 11V15C5 16.105 5.895 17 7 17Z"
+			stroke="#8C8F94"
+			stroke-width="1.6"
+			stroke-miterlimit="10"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		/>
+		<path
+			d="M17 17C18.105 17 19 16.105 19 15V11C19 9.895 18.105 9 17 9C15.895 9 15 9.895 15 11V15C15 16.105 15.895 17 17 17Z"
+			stroke="#8C8F94"
+			stroke-width="1.6"
+			stroke-miterlimit="10"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		/>
+		<path
+			d="M1 13V12C1 5.925 5.925 1 12 1C18.075 1 23 5.925 23 12V17C23 19.209 21.209 21 19 21H14"
+			stroke="#8C8F94"
+			stroke-width="1.6"
+			stroke-miterlimit="10"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		/>
+		<path
+			d="M12 23C13.1046 23 14 22.1046 14 21C14 19.8954 13.1046 19 12 19C10.8954 19 10 19.8954 10 21C10 22.1046 10.8954 23 12 23Z"
+			stroke="#8C8F94"
+			stroke-width="1.6"
+			stroke-miterlimit="10"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		/>
+	</svg>
+);
+
+export const mouse: ReactElement = (
+	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path
+			d="M5 9H19"
+			stroke="#8C8F94"
+			stroke-width="1.6"
+			stroke-miterlimit="10"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		/>
+		<path
+			d="M12 1V9"
+			stroke="#8C8F94"
+			stroke-width="1.6"
+			stroke-miterlimit="10"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		/>
+		<path
+			d="M12 23C8.134 23 5 19.866 5 16V5C5 2.791 6.791 1 9 1H15C17.209 1 19 2.791 19 5V16C19 19.866 15.866 23 12 23Z"
+			stroke="#8C8F94"
+			stroke-width="1.6"
+			stroke-miterlimit="10"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		/>
 	</svg>
 );

--- a/client/signup/icons/index.tsx
+++ b/client/signup/icons/index.tsx
@@ -127,16 +127,16 @@ export const check: ReactElement = (
 		<path
 			d="M82.4086 41.9906C82.4086 52.7052 78.1522 62.9811 70.5758 70.5575C62.9995 78.1338 52.7237 82.3903 42.0091 82.3903C31.2944 82.3903 21.0186 78.1338 13.4422 70.5575C5.86583 62.9811 1.60947 52.7052 1.60947 41.9906C1.60392 39.5124 1.83224 37.0391 2.29135 34.6038C4.13398 24.702 9.60875 15.8456 17.6423 9.77087C25.6759 3.69614 35.6889 0.841432 45.7181 1.76611C55.7473 2.69079 65.0695 7.3283 71.8569 14.7695C78.6444 22.2107 82.4075 31.9188 82.4086 41.9906V41.9906Z"
 			stroke="#003A5F"
-			stroke-width="1.68"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.68"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 		<path
 			d="M28 45.4943L37.8102 54.0742L56.5989 28.4102"
 			stroke="#003A5F"
-			stroke-width="3"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="3"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 	</svg>
 );
@@ -290,34 +290,34 @@ export const headset: ReactElement = (
 		<path
 			d="M7 17C8.105 17 9 16.105 9 15V11C9 9.895 8.105 9 7 9C5.895 9 5 9.895 5 11V15C5 16.105 5.895 17 7 17Z"
 			stroke="#8C8F94"
-			stroke-width="1.6"
-			stroke-miterlimit="10"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.6"
+			strokeMiterlimit="10"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 		<path
 			d="M17 17C18.105 17 19 16.105 19 15V11C19 9.895 18.105 9 17 9C15.895 9 15 9.895 15 11V15C15 16.105 15.895 17 17 17Z"
 			stroke="#8C8F94"
-			stroke-width="1.6"
-			stroke-miterlimit="10"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.6"
+			strokeMiterlimit="10"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 		<path
 			d="M1 13V12C1 5.925 5.925 1 12 1C18.075 1 23 5.925 23 12V17C23 19.209 21.209 21 19 21H14"
 			stroke="#8C8F94"
-			stroke-width="1.6"
-			stroke-miterlimit="10"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.6"
+			strokeMiterlimit="10"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 		<path
 			d="M12 23C13.1046 23 14 22.1046 14 21C14 19.8954 13.1046 19 12 19C10.8954 19 10 19.8954 10 21C10 22.1046 10.8954 23 12 23Z"
 			stroke="#8C8F94"
-			stroke-width="1.6"
-			stroke-miterlimit="10"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.6"
+			strokeMiterlimit="10"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 	</svg>
 );
@@ -327,26 +327,26 @@ export const mouse: ReactElement = (
 		<path
 			d="M5 9H19"
 			stroke="#8C8F94"
-			stroke-width="1.6"
-			stroke-miterlimit="10"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.6"
+			strokeMiterlimit="10"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 		<path
 			d="M12 1V9"
 			stroke="#8C8F94"
-			stroke-width="1.6"
-			stroke-miterlimit="10"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.6"
+			strokeMiterlimit="10"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 		<path
 			d="M12 23C8.134 23 5 19.866 5 16V5C5 2.791 6.791 1 9 1H15C17.209 1 19 2.791 19 5V16C19 19.866 15.866 23 12 23Z"
 			stroke="#8C8F94"
-			stroke-width="1.6"
-			stroke-miterlimit="10"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.6"
+			strokeMiterlimit="10"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 	</svg>
 );

--- a/client/signup/steps/choose-service/index.tsx
+++ b/client/signup/steps/choose-service/index.tsx
@@ -9,107 +9,106 @@ import { IntentScreen } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import difmImage from 'calypso/assets/images/difm/difm.svg';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { preventWidows } from 'calypso/lib/formatting';
-import useBranchSteps from 'calypso/signup/hooks/use-branch-steps';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import {
 	getProductDisplayCost,
 	isProductsListFetching,
 } from 'calypso/state/products-list/selectors';
-import { removeSiteSlugDependency } from 'calypso/state/signup/actions';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { award, frame } from '../../icons';
+import { mouse, headset } from '../../icons';
 import { ChoiceType } from './types';
 import type { SelectItem } from '@automattic/onboarding';
 
 import './style.scss';
 
 interface Props {
+	signupDependencies: any;
+	existingSiteCount: number;
 	goToNextStep: () => void;
 	submitSignupStep: ( { stepName, wasSkipped }: { stepName: string; wasSkipped: boolean } ) => void;
 	goToStep: ( stepName: string ) => void;
 	stepName: string;
+	queryObject: {
+		siteSlug?: string;
+		siteId?: string;
+	};
 }
 
-type NewOrExistingSiteIntent = SelectItem< ChoiceType >;
+type DIFMOrBuiltByIntent = SelectItem< ChoiceType >;
 
-const Placeholder = () => <span className="new-or-existing-site__placeholder">&nbsp;</span>;
+const Placeholder = () => <span className="choose-service__placeholder">&nbsp;</span>;
 
-export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
+export default function ChooseServiceStep( props: Props ): React.ReactNode {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const displayCost = useSelector( ( state ) => getProductDisplayCost( state, WPCOM_DIFM_LITE ) );
 	const isLoading = useSelector( isProductsListFetching );
 
-	const headerText = translate( 'Do It For Me' );
+	const headerText = translate( 'Let our experts create your dream site' );
 
 	const subHeaderText = translate(
-		'Get a professionally designed, mobile-optimized website in %(fulfillmentDays)d business days or less for a one-time fee of {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}} plus a one year subscription of the %(plan)s plan.',
-		{
-			args: {
-				displayCost,
-				fulfillmentDays: 4,
-				plan: isEnabled( 'plans/pro-plan' )
-					? getPlan( PLAN_WPCOM_PRO )?.getTitle()
-					: getPlan( PLAN_PREMIUM )?.getTitle(),
-			},
-			components: {
-				PriceWrapper: isLoading ? <Placeholder /> : <strong />,
-			},
-		}
+		'Get your business up quickly with our experts building your responsive, professional website. Select your best option.'
 	);
 
-	const intents: NewOrExistingSiteIntent[] = [
+	const intents: DIFMOrBuiltByIntent[] = [
 		{
-			key: 'new-site',
-			title: translate( 'New site' ),
+			key: 'difm',
+			title: translate( 'Do It For Me' ),
 			description: (
 				<p>
 					{ translate(
-						'Start fresh. We will build your new site from scratch using the content you provide in the following steps.'
+						'Get a professionally designed, mobile-optimized website in %(fulfillmentDays)d business days or less for a one-time fee of {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}} plus a one year subscription of the %(plan)s plan.',
+						{
+							args: {
+								displayCost,
+								fulfillmentDays: 4,
+								plan: isEnabled( 'plans/pro-plan' )
+									? getPlan( PLAN_WPCOM_PRO )?.getTitle()
+									: getPlan( PLAN_PREMIUM )?.getTitle(),
+							},
+							components: {
+								PriceWrapper: isLoading ? <Placeholder /> : <strong />,
+							},
+						}
 					) }
 				</p>
 			),
-			icon: award,
-			value: 'new-site',
-			actionText: translate( 'Start a new site' ),
+			icon: mouse,
+			value: 'difm',
+			actionText: translate( 'Get Started' ),
 		},
 		{
-			key: 'existing-site',
-			title: translate( 'Existing WordPress.com site' ),
+			key: 'builtby',
+			title: translate( 'Built by WordPress.com - Concierge' ),
 			description: (
 				<p>
 					{ translate(
-						'Use an existing site. Any existing content will be deleted, but you will be able to submit your content for your new site in later steps.'
+						'Curabitur elementum lectus mi, quis venenatis metus tincidunt ac. Integer non lorem erat.'
 					) }
 				</p>
 			),
-			icon: frame,
-			value: 'existing-site',
-			actionText: translate( 'Select a site' ),
+			icon: headset,
+			value: 'builtby',
+			actionText: translate( 'Learn More' ),
 		},
 	];
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName: props.stepName } ) );
-	}, [ dispatch, props.stepName ] );
+	}, [] );
 
-	const branchSteps = useBranchSteps( props.stepName, () => [ 'difm-site-picker' ] );
-
-	const newOrExistingSiteSelected = ( value: ChoiceType ) => {
-		// If 'new-site' is selected, skip the `difm-site-picker` step.
-		if ( 'new-site' === value ) {
-			branchSteps( {} );
-			dispatch( removeSiteSlugDependency() );
+	const onSelect = ( value: ChoiceType ) => {
+		if ( 'builtby' === value ) {
+			window.location.href = 'https://builtbywp.com/';
+			return;
 		}
 		dispatch(
 			submitSignupStep(
 				{ stepName: props.stepName },
 				{
-					newOrExistingSiteChoice: value,
-					forceAutoGeneratedBlogName: true,
+					siteSlug: props.queryObject.siteSlug || props.queryObject.siteId,
 				}
 			)
 		);
@@ -127,7 +126,7 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 				stepContent={
 					<IntentScreen
 						intents={ intents }
-						onSelect={ newOrExistingSiteSelected }
+						onSelect={ onSelect }
 						preventWidows={ preventWidows }
 						intentsAlt={ [] }
 					/>
@@ -136,7 +135,6 @@ export default function NewOrExistingSiteStep( props: Props ): React.ReactNode {
 				hideSkip
 				isHorizontalLayout={ true }
 				isWideLayout={ true }
-				headerImageUrl={ difmImage }
 				{ ...props }
 			/>
 		</>

--- a/client/signup/steps/choose-service/index.tsx
+++ b/client/signup/steps/choose-service/index.tsx
@@ -57,38 +57,31 @@ export default function ChooseServiceStep( props: Props ): React.ReactNode {
 		{
 			key: 'difm',
 			title: translate( 'Do It For Me' ),
-			description: (
-				<p>
-					{ translate(
-						'Get a professionally designed, mobile-optimized website in %(fulfillmentDays)d business days or less for a one-time fee of {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}} plus a one year subscription of the %(plan)s plan.',
-						{
-							args: {
-								displayCost,
-								fulfillmentDays: 4,
-								plan: isEnabled( 'plans/pro-plan' )
-									? getPlan( PLAN_WPCOM_PRO )?.getTitle()
-									: getPlan( PLAN_PREMIUM )?.getTitle(),
-							},
-							components: {
-								PriceWrapper: isLoading ? <Placeholder /> : <strong />,
-							},
-						}
-					) }
-				</p>
+			description: translate(
+				'Get a professionally designed, mobile-optimized website in %(fulfillmentDays)d business days or less for a one-time fee of {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}} plus a one year subscription of the %(plan)s plan.',
+				{
+					args: {
+						displayCost,
+						fulfillmentDays: 4,
+						plan: isEnabled( 'plans/pro-plan' )
+							? getPlan( PLAN_WPCOM_PRO )?.getTitle()
+							: getPlan( PLAN_PREMIUM )?.getTitle(),
+					},
+					components: {
+						PriceWrapper: isLoading ? <Placeholder /> : <strong />,
+					},
+				}
 			),
 			icon: mouse,
 			value: 'difm',
 			actionText: translate( 'Get Started' ),
+			isPrimary: true,
 		},
 		{
 			key: 'builtby',
 			title: translate( 'Built by WordPress.com - Concierge' ),
-			description: (
-				<p>
-					{ translate(
-						'Curabitur elementum lectus mi, quis venenatis metus tincidunt ac. Integer non lorem erat.'
-					) }
-				</p>
+			description: translate(
+				'Curabitur elementum lectus mi, quis venenatis metus tincidunt ac. Integer non lorem erat.'
 			),
 			icon: headset,
 			value: 'builtby',

--- a/client/signup/steps/choose-service/index.tsx
+++ b/client/signup/steps/choose-service/index.tsx
@@ -24,7 +24,6 @@ import type { SelectItem } from '@automattic/onboarding';
 import './style.scss';
 
 interface Props {
-	signupDependencies: any;
 	existingSiteCount: number;
 	goToNextStep: () => void;
 	submitSignupStep: ( { stepName, wasSkipped }: { stepName: string; wasSkipped: boolean } ) => void;
@@ -89,7 +88,13 @@ export default function ChooseServiceStep( props: Props ): React.ReactNode {
 	];
 
 	useEffect( () => {
+		if ( ! props.queryObject.siteSlug && ! props.queryObject.siteId ) {
+			throw new Error(
+				'website-design-services did not provide the site slug or site id it is configured to.'
+			);
+		}
 		dispatch( saveSignupStep( { stepName: props.stepName } ) );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	const onSelect = ( value: ChoiceType ) => {

--- a/client/signup/steps/choose-service/index.tsx
+++ b/client/signup/steps/choose-service/index.tsx
@@ -12,7 +12,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { preventWidows } from 'calypso/lib/formatting';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { getStepUrl } from 'calypso/signup/utils';
 import {
 	getProductDisplayCost,
 	isProductsListFetching,
@@ -125,9 +124,7 @@ export default function ChooseServiceStep( props: Props ): React.ReactNode {
 						intentsAlt={ [] }
 					/>
 				}
-				backUrl={ getStepUrl( 'setup-site', 'intent', undefined, '', {
-					siteSlug: props.queryObject.siteSlug,
-				} ) }
+				backUrl={ `/setup/intent?siteSlug=${ props.queryObject.siteSlug }` }
 				hideBack={ false }
 				allowBackFirstStep={ true }
 				align={ 'left' }

--- a/client/signup/steps/choose-service/index.tsx
+++ b/client/signup/steps/choose-service/index.tsx
@@ -79,7 +79,7 @@ export default function ChooseServiceStep( props: Props ): React.ReactNode {
 			key: 'builtby',
 			title: translate( 'Built by WordPress.com - Concierge' ),
 			description: translate(
-				'Curabitur elementum lectus mi, quis venenatis metus tincidunt ac. Integer non lorem erat.'
+				'Perfect for those looking for advanced features (e.g., e-commerce, migrations), customized designs, or who prefer a custom, consultative experience.'
 			),
 			icon: headset,
 			value: 'builtby',

--- a/client/signup/steps/choose-service/index.tsx
+++ b/client/signup/steps/choose-service/index.tsx
@@ -1,10 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
-import {
-	getPlan,
-	PLAN_PREMIUM,
-	PLAN_WPCOM_PRO,
-	WPCOM_DIFM_LITE,
-} from '@automattic/calypso-products';
+import { getPlan, PLAN_WPCOM_PRO, WPCOM_DIFM_LITE } from '@automattic/calypso-products';
 import { IntentScreen } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -61,9 +55,7 @@ export default function ChooseServiceStep( props: Props ): React.ReactNode {
 					args: {
 						displayCost,
 						fulfillmentDays: 4,
-						plan: isEnabled( 'plans/pro-plan' )
-							? getPlan( PLAN_WPCOM_PRO )?.getTitle()
-							: getPlan( PLAN_PREMIUM )?.getTitle(),
+						plan: getPlan( PLAN_WPCOM_PRO )?.getTitle(),
 					},
 					components: {
 						PriceWrapper: isLoading ? <Placeholder /> : <strong />,

--- a/client/signup/steps/choose-service/index.tsx
+++ b/client/signup/steps/choose-service/index.tsx
@@ -12,6 +12,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { preventWidows } from 'calypso/lib/formatting';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import { getStepUrl } from 'calypso/signup/utils';
 import {
 	getProductDisplayCost,
 	isProductsListFetching,
@@ -131,6 +132,11 @@ export default function ChooseServiceStep( props: Props ): React.ReactNode {
 						intentsAlt={ [] }
 					/>
 				}
+				backUrl={ getStepUrl( 'setup-site', 'intent', undefined, '', {
+					siteSlug: props.queryObject.siteSlug,
+				} ) }
+				hideBack={ false }
+				allowBackFirstStep={ true }
 				align={ 'left' }
 				hideSkip
 				isHorizontalLayout={ true }

--- a/client/signup/steps/choose-service/style.scss
+++ b/client/signup/steps/choose-service/style.scss
@@ -9,8 +9,7 @@
 .signup__step .is-choose-service {
 	.select-items__item:first-child {
 		.button {
-			background-color: var( --color-accent );
-			color: #ffffff;
+			color: var( --color-text-inverted );
 		}
 	}
 }

--- a/client/signup/steps/choose-service/style.scss
+++ b/client/signup/steps/choose-service/style.scss
@@ -9,6 +9,7 @@
 .signup__step .is-choose-service {
 	.select-items__item:first-child {
 		.button {
+			border-color: var( --color-accent );
 			color: var( --color-text-inverted );
 		}
 	}

--- a/client/signup/steps/choose-service/style.scss
+++ b/client/signup/steps/choose-service/style.scss
@@ -1,0 +1,16 @@
+.choose-service-site__placeholder {
+	padding: 0 20px;
+	animation: pulse-light 800ms ease-in-out infinite;
+	background-color: var( --color-neutral-10 );
+	color: transparent;
+	min-height: $font-title-small;
+}
+
+.signup__step .is-choose-service {
+	.select-items__item:first-child {
+		.button {
+			background-color: var( --color-accent );
+			color: #ffffff;
+		}
+	}
+}

--- a/client/signup/steps/choose-service/types.ts
+++ b/client/signup/steps/choose-service/types.ts
@@ -1,0 +1,1 @@
+export type ChoiceType = 'difm' | 'builtby';

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -76,19 +76,6 @@ export default function DIFMSitePickerStep( props: Props ): React.ReactElement {
 				}
 			)
 		);
-		//Skip domains step
-		dispatch(
-			submitSignupStep(
-				{
-					stepName: 'domains',
-					wasSkipped: true,
-				},
-				{
-					domainItem: undefined,
-					themeItem: undefined,
-				}
-			)
-		);
 
 		goToNextStep();
 	};

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -43,6 +43,7 @@ export const EXCLUDED_STEPS: { [ key: string ]: string[] } = {
 
 const EXTERNAL_FLOW: { [ key: string ]: string } = {
 	import: 'importer',
+	difm: 'website-design-services',
 };
 
 const getExcludedSteps = ( providedDependencies?: Dependencies ) =>

--- a/client/signup/steps/intent/index.tsx
+++ b/client/signup/steps/intent/index.tsx
@@ -43,7 +43,6 @@ export const EXCLUDED_STEPS: { [ key: string ]: string[] } = {
 
 const EXTERNAL_FLOW: { [ key: string ]: string } = {
 	import: 'importer',
-	difm: 'website-design-services',
 };
 
 const getExcludedSteps = ( providedDependencies?: Dependencies ) =>

--- a/client/signup/steps/intent/intents.tsx
+++ b/client/signup/steps/intent/intents.tsx
@@ -73,7 +73,7 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 			),
 		},
 		{
-			show: true,
+			show: isEnabled( 'onboarding/difm' ),
 			key: 'difm',
 			description: translate( 'Let our experts create your dream site' ),
 			value: 'difm',

--- a/client/signup/steps/intent/intents.tsx
+++ b/client/signup/steps/intent/intents.tsx
@@ -72,5 +72,14 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 				}
 			),
 		},
+		{
+			show: true,
+			key: 'difm',
+			description: translate( 'Let our experts create your dream site' ),
+			value: 'difm',
+			actionText: translate( 'Let our experts create your dream site' ),
+			disable: false,
+			disableText: <></>,
+		},
 	];
 };

--- a/client/signup/steps/intent/intents.tsx
+++ b/client/signup/steps/intent/intents.tsx
@@ -48,6 +48,15 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 
 	return [
 		{
+			show: true,
+			key: 'wpadmin',
+			description: translate( "Know what you're doing?" ),
+			value: 'wpadmin',
+			disable: false,
+			disableText: '',
+			actionText: translate( 'Start from scratch' ),
+		},
+		{
 			show: isEnabled( 'onboarding/import' ),
 			key: 'import',
 			description: translate( 'Already have an existing website?' ),
@@ -62,15 +71,6 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 					},
 				}
 			),
-		},
-		{
-			show: isEnabled( 'onboarding/difm' ),
-			key: 'difm',
-			description: translate( 'Let our experts create your dream site' ),
-			value: 'difm',
-			actionText: translate( 'Get Started' ),
-			disable: false,
-			disableText: <></>,
 		},
 	];
 };

--- a/client/signup/steps/intent/intents.tsx
+++ b/client/signup/steps/intent/intents.tsx
@@ -48,15 +48,6 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 
 	return [
 		{
-			show: true,
-			key: 'wpadmin',
-			description: translate( "Know what you're doing?" ),
-			value: 'wpadmin',
-			disable: false,
-			disableText: '',
-			actionText: translate( 'Start from scratch' ),
-		},
-		{
 			show: isEnabled( 'onboarding/import' ),
 			key: 'import',
 			description: translate( 'Already have an existing website?' ),
@@ -77,7 +68,7 @@ export const useIntentsAlt = ( canImport: boolean ): IntentAlt[] => {
 			key: 'difm',
 			description: translate( 'Let our experts create your dream site' ),
 			value: 'difm',
-			actionText: translate( 'Let our experts create your dream site' ),
+			actionText: translate( 'Get Started' ),
 			disable: false,
 			disableText: <></>,
 		},

--- a/client/signup/steps/intent/types.ts
+++ b/client/signup/steps/intent/types.ts
@@ -1,1 +1,1 @@
-export type IntentFlag = 'build' | 'write' | 'import' | 'sell' | 'wpadmin';
+export type IntentFlag = 'build' | 'write' | 'import' | 'sell' | 'wpadmin' | 'difm';

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -182,6 +182,7 @@
 		"setup-site",
 		"account",
 		"do-it-for-me",
+		"website-design-services",
 		"desktop",
 		"developer",
 		"site-content-collection",

--- a/config/development.json
+++ b/config/development.json
@@ -62,6 +62,7 @@
 		"google-my-business": true,
 		"google-drive": true,
 		"gutenboarding/alpha-templates": false,
+		"onboarding/difm": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/production.json
+++ b/config/production.json
@@ -38,6 +38,7 @@
 		"fullstory": true,
 		"gdpr-banner": true,
 		"google-my-business": true,
+		"onboarding/difm": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/production.json
+++ b/config/production.json
@@ -38,7 +38,7 @@
 		"fullstory": true,
 		"gdpr-banner": true,
 		"google-my-business": true,
-		"onboarding/difm": false,
+		"onboarding/difm": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -37,6 +37,7 @@
 		"fullstory": true,
 		"gdpr-banner": false,
 		"google-my-business": true,
+		"onboarding/difm": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,6 +44,7 @@
 		"gdpr-banner": true,
 		"google-my-business": true,
 		"gutenboarding/alpha-templates": false,
+		"onboarding/difm": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/packages/onboarding/src/select-items-alt/style.scss
+++ b/packages/onboarding/src/select-items-alt/style.scss
@@ -55,6 +55,7 @@
 		color: #101517;
 		text-decoration: underline;
 		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		text-align: end;
 
 		@include break-mobile {
 			margin-top: 0;

--- a/packages/onboarding/src/select-items/index.tsx
+++ b/packages/onboarding/src/select-items/index.tsx
@@ -12,6 +12,7 @@ export interface SelectItem< T > {
 	value: T;
 	actionText: TranslateResult;
 	hidden?: boolean;
+	isPrimary?: boolean;
 }
 
 interface Props< T > {
@@ -29,7 +30,7 @@ function SelectItems< T >( {
 }: Props< T > ): React.ReactElement {
 	return (
 		<div className={ classnames( 'select-items', className ) }>
-			{ items.map( ( { key, title, description, icon, actionText, value } ) => (
+			{ items.map( ( { key, title, description, icon, actionText, value, isPrimary } ) => (
 				<div key={ key } className="select-items__item">
 					<Icon className="select-items__item-icon" icon={ icon } size={ 24 } />
 					<div className="select-items__item-info-wrapper">
@@ -37,7 +38,11 @@ function SelectItems< T >( {
 							<h2 className="select-items__item-title">{ preventWidows( title ) }</h2>
 							<div className="select-items__item-description">{ preventWidows( description ) }</div>
 						</div>
-						<Button className="select-items__item-button" onClick={ () => onSelect( value ) }>
+						<Button
+							primary={ isPrimary }
+							className="select-items__item-button"
+							onClick={ () => onSelect( value ) }
+						>
 							{ actionText }
 						</Button>
 					</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

P2: pdh1Xd-RZ-p2
* Adds a new flow `website-design-services` that can be accessed at `/start/website-design-services`.
* Adds a DIFM intent to the stepper-intent step.
* Clicking on the DIFM intent CTA will redirect to `/start/website-design-services`. 
* Also removes the "Start from scratch" item. More context here: pdh1Xd-RZ-p2#comment-1106

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start`
* Select a free domain and free plan.
* On the Intent screen, confirm that you can see the "Let our experts create your dream site" option. Click on that link.
* On the next screen, confirm that you can see two options - one for "Do It For Me" and the other for "Built by WordPress.com - Concierge"
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/5436027/166862001-fae65aa0-4c80-4a49-a0be-0098c684f69c.png">
(Copy will be updated soon)

* Clicking on the "Learn More" option should redirect to https://builtbywp.com/.
* Clicking on the "Get Started" option should show the Title/Tagline step.
* Proceed through the steps and confirm that you can complete checkout.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->