### PR TITLE
fix: woocommerce signup processing screen visibility improvements

### DIFF
--- a/client/signup/processing-screen/style.scss
+++ b/client/signup/processing-screen/style.scss
@@ -26,6 +26,37 @@
 	}
 }
 
+@keyframes woobackground {
+	0% {
+		background-color: #e9e9e9;
+		opacity: 0.5;
+		filter: blur( 1px );
+	}
+	100% {
+		background-color: var( --studio-woocommerce-purple-80 );
+		opacity: 0.7;
+		filter: blur( 4px );
+	}
+}
+
+@keyframes woofocus {
+	0%, 100% {
+		background-color: var( --studio-woocommerce-purple-80 );
+		opacity: 0.7;
+		filter: blur( 4px );
+	}
+	50% {
+		background-color: var( --studio-woocommerce-purple-60 );
+		opacity: 0.5;
+		filter: blur( 1px );
+	}
+}
+
+.woo .signup-processing-screen__floaties {
+	background-color: var( --color-text );
+	animation: woobackground 1s ease-in-out 0s, woofocus 5s infinite ease-in-out 1s;
+}
+
 .signup-processing-screen__floaties {
 	pointer-events: none;
 	position: fixed;
@@ -144,7 +175,7 @@
 	.gridicons-reader {
 		height: 130px;
 		width: 130px;
-		top: 360px;
+		top: 420px;
 		left: calc( 50% - 170px );
 		transform: rotate( 12deg );
 		animation-delay: 8s;
@@ -152,7 +183,7 @@
 	.gridicons-star {
 		height: 90px;
 		width: 90px;
-		top: 380px;
+		top: 420px;
 		left: calc( 50% + 60px );
 	}
 	.gridicons-video {


### PR DESCRIPTION
On the WooCommerce.com Signup flow, the signup processing screen CSS seems to be unfinished and is hard to read. 


Existing screen looks like this:

![image](https://user-images.githubusercontent.com/27843274/166870348-8de4644e-d486-450e-8106-00206b13bd2c.png)


To reproduce this, visit woocommerce.com and proceed with the signup flow. After submitting email, username and password this is the screen that shows up while it is processing.

Context:
p1651721291090299-slack-C01SFMVEYAK
p1651715179595629-slack-C029GN3KD

#### Changes proposed in this Pull Request

- added a background colour
- moved some icons so that they don't overlap with the text

With proposed changes:

![image](https://user-images.githubusercontent.com/27843274/166889930-255b0450-0de8-4ff1-b95d-208047b65c37.png)




#### Testing instructions

1. Setup wp-calypso environment
2. Go to: http://calypso.localhost:3000/start/wpcc/oauth2-user?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Da009fdb5f85b24b43f942ca7be4bef468d982d25e0ef6aa9e0e57b8939668d1c%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login&oauth2_client_id=50916
3. Fill out the new user details, and submit
4. Should see the processing screen as in the screenshot


Alternatively, for a development shortcut - set `startLoadingScreen` to true on Line 346 in `client/signup/main.jsx` to skip user creation.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->