### PR TITLE
Tooltip: Fix positioning with RTL text direction

### DIFF
--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -12,12 +12,9 @@ function Tooltip( props ) {
 		return null;
 	}
 
-	const classes = classnames(
-		'tooltip',
-		`is-${ props.status }`,
-		`is-${ props.position }`,
-		props.className
-	);
+	const classes = classnames( [ 'tooltip', props.className ], {
+		[ `is-${ props.status }` ]: props.status,
+	} );
 
 	return (
 		<Popover

--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -9,7 +9,6 @@
 		.popover__arrow {
 			border-bottom-color: var( --color-neutral-60 );
 			top: 4px;
-			right: 10px;
 
 			&::before {
 				display: none;
@@ -41,7 +40,6 @@
 		.popover__arrow {
 			border-top-color: var( --color-neutral-60 );
 			bottom: 4px;
-			right: 10px;
 
 			&::before {
 				display: none;
@@ -67,10 +65,26 @@
 		}
 	}
 
+	&.is-bottom-right,
+	&.is-top-right {
+		.popover__arrow {
+			left: 15px #{'/*rtl:ignore*/'};
+			margin-left: -6px #{'/*rtl:ignore*/'};
+		}
+	}
+
+	&.is-bottom-left,
+	&.is-top-left {
+		.popover__arrow {
+			right: 15px #{'/*rtl:ignore*/'};
+			margin-right: -6px #{'/*rtl:ignore*/'};
+		}
+	}
+
 	&.is-top,
 	&.is-bottom {
 		.popover__arrow {
-			margin-left: -6px;
+			margin-left: -6px #{'/*rtl:ignore*/'};
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix tooltip class names
  * Change `is-{status}` class name to be conditional, so that it doesn't print `is-undefined` when status prop is not provided.
  * Remove `is-{position}` class name, since Popover component would already set the class name dynamically with the actual tooltip position, whereas the tooltip component's position class name is always based on the position prop.
* Change the left/right offsets of the arrow so that it matches the [offset of the Popover component](https://github.com/Automattic/wp-calypso/blob/trunk/packages/components/src/popover/util.js#L178).
* Disable auto-rtl conversion for left/right offsets and margin properties.

**Before:**
![CleanShot 2022-05-05 at 12 36 21](https://user-images.githubusercontent.com/2722412/166899506-b243a878-bf5d-47d2-a50b-ad6ce33bb1d8.png)

**After:**
![CleanShot 2022-05-05 at 12 36 40](https://user-images.githubusercontent.com/2722412/166899521-d0d56018-eec1-43b7-8d17-a725abc40369.png)


#### Testing instructions

* Change UI to Hebrew, or any other RTL language
* Go to `/stats/day/` and select a site
* Mouse over the the graph bars and confirm the tooltip and its arrow are positioned correctly.
* Change the UI to any LTR language and repeat the same steps as above
* Can be tested additionally with https://github.com/Automattic/wp-calypso/pull/63327