### PR TITLE
Themes: Use Tooltip for theme description instead

### DIFF
--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -294,3 +294,6 @@ $theme-info-height: 54px;
 	text-transfrom: capitalize;
 }
 
+.theme__tooltip {
+	max-width: 300px;
+}

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -14,6 +14,8 @@ exports[`Theme rendering with default display buttonContents should match snapsh
       className="theme__thumbnail"
       href="javascript:;"
       onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
         className="theme__thumbnail-label"
@@ -25,6 +27,17 @@ exports[`Theme rendering with default display buttonContents should match snapsh
         srcSet="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"
       />
     </a>
+    <Tooltip
+      context={null}
+      isVisible={false}
+      position="top"
+      showDelay={1000}
+      showOnMobile={false}
+    >
+      <div
+        className="theme__tooltip"
+      />
+    </Tooltip>
     <div
       className="theme__info"
     >


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use Tooltip component to render themes description on mouse over on the themes listing screen, as it provides more control compared to the use of title attribute and the browser native tooltips.

**Before:**
![CleanShot 2022-05-05 at 13 21 18](https://user-images.githubusercontent.com/2722412/166905499-da6c3da3-aa72-4e10-bc28-5c8938e0f593.png)

**After:**
![CleanShot 2022-05-05 at 13 20 40](https://user-images.githubusercontent.com/2722412/166905521-55bdda37-d4f9-4f1b-a1f5-1cf1f92ce179.png)

#### Merge instructions

Should be merged after https://github.com/Automattic/wp-calypso/pull/63325.

#### Testing instructions

* Checkout branch locally or use calypso.live build
* Go to `/themes` and confirm the tooltips render as expected
* Test with RTL language (i.e. change UI language, or go to `/he/themes` logged-out)

Related to 307-gh-Automattic/i18n-issues
