### PR TITLE
ToS acceptance tracking: For the checkout page, remove legacy Business plan

### DIFF
--- a/test/e2e/specs/martech/tos-screenshots__checkout.ts
+++ b/test/e2e/specs/martech/tos-screenshots__checkout.ts
@@ -19,7 +19,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), function () {
 	const blogName = 'e2eflowtestingtos1.wordpress.com';
-	const cartItemForBusinessPlan = 'WordPress.com Business';
+	const cartItemForProPlan = 'WordPress.com Pro';
 	let page: Page;
 	let plansPage: PlansPage;
 
@@ -80,13 +80,13 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 			await plansPage.clickTab( 'Plans' );
 		} );
 
-		it( 'Click on "Upgrade" button for WordPress.com Business plan', async function () {
-			await plansPage.clickPlanActionButton( { plan: 'Business', buttonText: 'Upgrade' } );
+		it( 'Click on "Upgrade" button for WordPress.com Pro plan', async function () {
+			await plansPage.selectPlan( 'Pro' );
 		} );
 
-		it( 'WordPress.com Business is added to cart', async function () {
+		it( 'WordPress.com Pro is added to cart', async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
-			await cartCheckoutPage.validateCartItem( cartItemForBusinessPlan );
+			await cartCheckoutPage.validateCartItem( cartItemForProPlan );
 		} );
 
 		it( 'Screenshot checkout page for all en and non-en locales', async function () {
@@ -97,8 +97,6 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 				await changeUILanguageFlow.changeUILanguage( locale as LanguageSlug );
 				await page.goto( DataHelper.getCalypsoURL( 'home' ), { waitUntil: 'networkidle' } );
 				await cartCheckoutPage.visit( blogName );
-				const paymentDetails = DataHelper.getTestPaymentDetails();
-				await cartCheckoutPage.enterBillingDetails( paymentDetails );
 				await cartCheckoutPage.validatePaymentForm();
 				await page.screenshot( {
 					path: `tos_checkout_desktop_${ locale }.png`,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Since the Business plan is deprecated for new sites, this PR makes changes to add the Pro plan to cart, so that the ToS link is visible in the checkout page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the setup instructions in https://github.com/Automattic/wp-calypso/pull/62574 and verify that the checkout page screenshots are saved in the tos blog media directory.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


