### PR TITLE
Stepper: Add persistence to storeAddress step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
@@ -11,7 +11,7 @@ import FormInputValidation from 'calypso/components/forms/form-input-validation'
 import FormLabel from 'calypso/components/forms/form-label';
 import FormInput from 'calypso/components/forms/form-text-input';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ActionSection, StyledNextButton } from 'calypso/signup/steps/woocommerce-install';
 import { useCountries } from '../../../../hooks/use-countries';
@@ -27,6 +27,15 @@ type FormFields =
 	| 'store_country'
 	| 'store_email';
 
+type WooAddressSettings = {
+	woocommerce_store_address?: string;
+	woocommerce_store_address_2?: string;
+	woocommerce_store_city?: string;
+	woocommerce_store_postcode?: string;
+	woocommerce_default_country?: string;
+	woocommerce_onboarding_profile?: { store_email: string };
+};
+
 const CityZipRow = styled.div`
 	display: -ms-grid;
 	display: grid;
@@ -40,18 +49,18 @@ const CityZipRow = styled.div`
 const StoreAddress: Step = function StoreAddress( { navigation } ) {
 	const { goBack, goNext, submit } = navigation;
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
-	const storeAddress = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreAddress() );
 	const site = useSite();
+	const settings = useSelect(
+		( select ) => ( site?.ID && select( SITE_STORE ).getSiteSettings( site.ID ) ) || {}
+	);
 	const { data: countries } = useCountries();
 	const { __ } = useI18n();
 	const [ errors, setErrors ] = useState( {} as Record< FormFields, string > );
-	const [ storeAddress1, setStoreAddress1 ] = useState( storeAddress.store_address_1 );
-	const [ storeAddress2, setStoreAddress2 ] = useState( storeAddress.store_address_2 );
-	const [ storeCity, setStoreCity ] = useState( storeAddress.store_city );
-	const [ storePostcode, setStorePostcode ] = useState( storeAddress.store_postcode );
-	const [ storeCountry, setStoreCountry ] = useState( storeAddress.store_country );
-	const [ storeEmail, setStoreEmail ] = useState( storeAddress.store_email );
-	const { setStoreAddressValue } = useDispatch( ONBOARD_STORE );
+	const { saveSiteSettings } = useDispatch( SITE_STORE );
+
+	const [ settingChanges, setSettingChanges ] = useState< {
+		[ key: string ]: string;
+	} >( {} );
 
 	if ( ! countries ) {
 		return null;
@@ -62,43 +71,58 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 		return { value: key, label: value };
 	} );
 
-	const onChange = ( event: React.FormEvent< HTMLInputElement > ) => {
-		if ( site ) {
-			const errors = {} as Record< FormFields, string >;
-
-			switch ( event.currentTarget.name ) {
-				case 'store_address_1':
-					setStoreAddress1( event.currentTarget.value );
-					errors[ 'store_address_1' ] = '';
-					break;
-				case 'store_address_2':
-					setStoreAddress2( event.currentTarget.value );
-					break;
-				case 'store_city':
-					setStoreCity( event.currentTarget.value );
-					errors[ 'store_city' ] = '';
-					break;
-				case 'store_postcode':
-					setStorePostcode( event.currentTarget.value );
-					errors[ 'store_postcode' ] = '';
-					break;
-				case 'store_email':
-					setStoreEmail( event.currentTarget.value );
-					errors[ 'store_email' ] = '';
-					break;
-			}
-
-			setErrors( errors );
+	function getSettingsValue( key: FormFields ) {
+		if ( key in settingChanges ) {
+			return settingChanges[ key ];
 		}
+
+		switch ( key ) {
+			case 'store_email':
+				return settings?.[ 'woocommerce_onboarding_profile' ]?.[ 'store_email' ] || '';
+
+			case 'store_address_1':
+				return settings?.[ 'woocommerce_store_address' ] || '';
+
+			case 'store_country':
+				return settings?.[ 'woocommerce_default_country' ] || '';
+
+			default:
+				return settings?.[ 'woocommerce_' + key ] || '';
+		}
+	}
+
+	function updateSettingsValue( key: FormFields, value: string ) {
+		setSettingChanges( {
+			...settingChanges,
+			[ key ]: value,
+		} );
+	}
+
+	const onChange = ( key: FormFields, value: string ) => {
+		if ( site ) {
+			updateSettingsValue( key, value );
+			setErrors( {
+				...errors,
+				[ key ]: '',
+			} );
+		}
+	};
+
+	const elementChange = ( event: React.FormEvent< HTMLInputElement > ) => {
+		onChange( event.currentTarget.name as FormFields, event.currentTarget.value );
 	};
 
 	const validate = (): boolean => {
 		const errors = {} as Record< FormFields, string >;
 
-		errors[ 'store_address_1' ] = ! storeAddress1 ? __( 'Please add an address' ) : '';
-		errors[ 'store_city' ] = ! storeCity ? __( 'Please add a city' ) : '';
-		errors[ 'store_country' ] = ! storeCountry ? __( 'Please select a country / region' ) : '';
-		errors[ 'store_email' ] = ! emailValidator.validate( storeEmail )
+		errors[ 'store_address_1' ] = ! getSettingsValue( 'store_address_1' )
+			? __( 'Please add an address' )
+			: '';
+		errors[ 'store_city' ] = ! getSettingsValue( 'store_city' ) ? __( 'Please add a city' ) : '';
+		errors[ 'store_country' ] = ! getSettingsValue( 'store_country' )
+			? __( 'Please select a country / region' )
+			: '';
+		errors[ 'store_email' ] = ! emailValidator.validate( getSettingsValue( 'store_email' ) )
 			? __( 'Please add a valid email address' )
 			: '';
 
@@ -115,12 +139,38 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 				return;
 			}
 
-			setStoreAddressValue( 'store_address_1', storeAddress1 );
-			setStoreAddressValue( 'store_address_2', storeAddress2 || '' );
-			setStoreAddressValue( 'store_city', storeCity );
-			setStoreAddressValue( 'store_postcode', storePostcode );
-			setStoreAddressValue( 'store_country', storeCountry );
-			setStoreAddressValue( 'store_email', storeEmail );
+			if ( site?.ID ) {
+				const changes: WooAddressSettings = {};
+
+				if ( 'store_address_1' in settingChanges ) {
+					changes[ 'woocommerce_store_address' ] = settingChanges[ 'store_address_1' ];
+				}
+
+				if ( 'store_address_2' in settingChanges ) {
+					changes[ 'woocommerce_store_address_2' ] = settingChanges[ 'store_address_2' ];
+				}
+
+				if ( 'store_city' in settingChanges ) {
+					changes[ 'woocommerce_store_city' ] = settingChanges[ 'store_city' ];
+				}
+
+				if ( 'store_postcode' in settingChanges ) {
+					changes[ 'woocommerce_store_postcode' ] = settingChanges[ 'store_postcode' ];
+				}
+
+				if ( 'store_country' in settingChanges ) {
+					changes[ 'woocommerce_default_country' ] = settingChanges[ 'store_country' ];
+				}
+
+				if ( 'store_email' in settingChanges ) {
+					changes[ 'woocommerce_onboarding_profile' ] = {
+						...settings?.woocommerce_onboarding_profile,
+						store_email: settingChanges.store_email,
+					};
+				}
+
+				saveSiteSettings( site.ID, changes );
+			}
 
 			submit?.();
 		}
@@ -133,10 +183,10 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 					<FormFieldset>
 						<FormLabel htmlFor="store_address_1">{ __( 'Address line 1' ) }</FormLabel>
 						<FormInput
-							value={ storeAddress1 }
+							value={ getSettingsValue( 'store_address_1' ) }
 							name="store_address_1"
 							id="store_address_1"
-							onChange={ onChange }
+							onChange={ elementChange }
 							className={ errors[ 'store_address_1' ] ? 'is-error' : '' }
 						/>
 						<ControlError error={ errors[ 'store_address_1' ] || '' } />
@@ -145,10 +195,10 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 					<FormFieldset>
 						<FormLabel htmlFor="store_address_2">{ __( 'Address line 2 (optional)' ) }</FormLabel>
 						<FormInput
-							value={ storeAddress2 }
+							value={ getSettingsValue( 'store_address_2' ) }
 							name="store_address_2"
 							id="store_address_2"
-							onChange={ onChange }
+							onChange={ elementChange }
 							className={ errors[ 'store_address_2' ] ? 'is-error' : '' }
 						/>
 						<ControlError error={ errors[ 'store_address_2' ] || '' } />
@@ -159,10 +209,10 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 							<FormFieldset>
 								<FormLabel htmlFor="store_city">{ __( 'City' ) }</FormLabel>
 								<FormInput
-									value={ storeCity }
+									value={ getSettingsValue( 'store_city' ) }
 									name="store_city"
 									id="store_city"
-									onChange={ onChange }
+									onChange={ elementChange }
 									className={ errors[ 'store_city' ] ? 'is-error' : '' }
 								/>
 								<ControlError error={ errors[ 'store_city' ] || '' } />
@@ -173,10 +223,10 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 							<FormFieldset>
 								<FormLabel htmlFor="store_postcode">{ __( 'Postcode' ) }</FormLabel>
 								<FormInput
-									value={ storePostcode }
+									value={ getSettingsValue( 'store_postcode' ) }
 									name="store_postcode"
 									id="store_postcode"
-									onChange={ onChange }
+									onChange={ elementChange }
 									className={ errors[ 'store_postcode' ] ? 'is-error' : '' }
 								/>
 								<ControlError error={ errors[ 'store_postcode' ] || '' } />
@@ -187,15 +237,9 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 					<FormFieldset>
 						<FormLabel htmlFor="store_postcode">{ __( 'Country / State' ) }</FormLabel>
 						<ComboboxControl
-							value={ storeCountry }
+							value={ getSettingsValue( 'store_country' ) }
 							onChange={ ( value: string | null ) => {
-								if ( value ) {
-									setStoreCountry( value );
-									setErrors( {
-										...errors,
-										store_country: '',
-									} );
-								}
+								onChange( 'store_country', value || '' );
 							} }
 							options={ countriesAsOptions }
 							className={ errors[ 'store_country' ] ? 'is-error' : '' }
@@ -206,10 +250,10 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 					<FormFieldset>
 						<FormLabel htmlFor="store_email">{ __( 'Email address' ) }</FormLabel>
 						<FormInput
-							value={ storeEmail }
+							value={ getSettingsValue( 'store_email' ) }
 							name="store_email"
 							id="store_email"
-							onChange={ onChange }
+							onChange={ elementChange }
 							className={ errors[ 'store_email' ] ? 'is-error' : '' }
 						/>
 						<ControlError error={ errors[ 'store_email' ] } />

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -1,5 +1,4 @@
 import { combineReducers } from '@wordpress/data';
-import { StoreAddress } from '../shared-types';
 import type { DomainSuggestion } from '../domain-suggestions/types';
 import type { FeatureId } from '../wpcom-features/types';
 import type { OnboardAction } from './actions';
@@ -252,28 +251,6 @@ const storeType: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	return state;
 };
 
-const storeAddress: Reducer< StoreAddress, OnboardAction > = (
-	state = {
-		store_address_1: '',
-		store_address_2: '',
-		store_city: '',
-		store_postcode: '',
-		store_country: '',
-		store_email: '',
-	},
-	action
-) => {
-	if ( action.type === 'SET_STORE_ADDRESS_VALUE' ) {
-		const { store_address_field, store_address_value } = action;
-
-		return {
-			...state,
-			[ store_address_field ]: store_address_value,
-		};
-	}
-	return state;
-};
-
 const pendingAction: Reducer< undefined | ( () => Promise< any > ), OnboardAction > = (
 	state,
 	action
@@ -330,7 +307,6 @@ const reducer = combineReducers( {
 	lastLocation,
 	intent,
 	startingPoint,
-	storeAddress,
 	pendingAction,
 	progress,
 	progressTitle,

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -16,7 +16,6 @@ export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
 export const getIntent = ( state: State ) => state.intent;
 export const getStartingPoint = ( state: State ) => state.startingPoint;
 export const getStoreType = ( state: State ) => state.storeType;
-export const getStoreAddress = ( state: State ) => state.storeAddress;
 export const getPendingAction = ( state: State ) => state.pendingAction;
 export const getProgress = ( state: State ) => state.progress;
 export const getProgressTitle = ( state: State ) => state.progressTitle;

--- a/packages/data-stores/src/shared-types.ts
+++ b/packages/data-stores/src/shared-types.ts
@@ -2,12 +2,3 @@ export interface WpcomClientCredentials {
 	client_id: string;
 	client_secret: string;
 }
-
-export interface StoreAddress {
-	store_address_1: string;
-	store_address_2?: string;
-	store_city: string;
-	store_postcode: string;
-	store_country: string;
-	store_email: string;
-}

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -172,6 +172,12 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		settings,
 	} );
 
+	const updateSiteSettings = ( siteId: number, settings: SiteSettings ) => ( {
+		type: 'UPDATE_SITE_SETTINGS' as const,
+		siteId,
+		settings,
+	} );
+
 	function* setCart( siteId: number, cartData: Cart ) {
 		const success: Cart = yield wpcomRequest( {
 			path: '/me/shopping-cart/' + siteId,
@@ -188,6 +194,11 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			blogname?: string;
 			blogdescription?: string;
 			site_vertical_id?: string;
+			woocommerce_store_address?: string;
+			woocommerce_store_address_2?: string;
+			woocommerce_store_city?: string;
+			woocommerce_store_postcode?: string;
+			woocommerce_defaut_country?: string;
 			woocommerce_onboarding_profile?: { [ key: string ]: any };
 		}
 	) {
@@ -208,6 +219,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			if ( 'site_vertical_id' in settings ) {
 				yield receiveSiteVerticalId( siteId, settings.site_vertical_id );
 			}
+			yield updateSiteSettings( siteId, settings );
 		} catch ( e ) {}
 	}
 
@@ -455,6 +467,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveSiteFailed,
 		receiveSiteTagline,
 		receiveSiteVerticalId,
+		updateSiteSettings,
 		saveSiteTagline,
 		reset,
 		launchSite,
@@ -499,6 +512,7 @@ export type Action =
 			| ActionCreators[ 'receiveSiteVerticalId' ]
 			| ActionCreators[ 'receiveSite' ]
 			| ActionCreators[ 'receiveSiteFailed' ]
+			| ActionCreators[ 'updateSiteSettings' ]
 			| ActionCreators[ 'reset' ]
 			| ActionCreators[ 'resetNewSiteFailed' ]
 			| ActionCreators[ 'launchSiteStart' ]

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -140,6 +140,15 @@ export const sitesSettings: Reducer< { [ key: number ]: SiteSettings }, Action >
 	if ( action.type === 'RECEIVE_SITE_SETTINGS' ) {
 		return { ...state, [ action.siteId ]: action.settings };
 	}
+	if ( action.type === 'UPDATE_SITE_SETTINGS' ) {
+		return {
+			...state,
+			[ action.siteId ]: {
+				...state?.[ action.siteId ],
+				...action.settings,
+			},
+		};
+	}
 	return state;
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Built on top on https://github.com/Automattic/wp-calypso/pull/63307
* Removed store address information from the `ONBOARD_STORE` and used the site settings instead, through the `SITE_STORE` 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Woo stepper flow until the storeAddress step
* Fill the form
* Hit Continue
* Click Back - the info should still be there
* Refresh the page - the info should still be there
* Test the validation
