### PR TITLE
Components: Migrate `Notice` tests to `@testing-library/react` and `jest`

### DIFF
--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -120,7 +120,7 @@ export class Notice extends Component {
 		const iconNeedsDrop = GRIDICONS_WITH_DROP.includes( iconName );
 
 		return (
-			<div className={ classes }>
+			<div className={ classes } role="status" aria-label={ translate( 'Notice' ) }>
 				<span className="notice__icon-wrapper">
 					{ iconNeedsDrop && <span className="notice__icon-wrapper-drop" /> }
 					<Gridicon className="notice__icon" icon={ iconName } size={ 24 } />

--- a/client/components/notice/test/index.js
+++ b/client/components/notice/test/index.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import { Notice } from '../index';
 
 describe( 'Notice', () => {

--- a/client/components/notice/test/index.js
+++ b/client/components/notice/test/index.js
@@ -1,59 +1,62 @@
-import { assert } from 'chai';
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { Notice } from '../index';
 
 describe( 'Notice', () => {
 	const translate = ( string ) => string;
 
 	test( 'should output the component', () => {
-		const wrapper = shallow( <Notice translate={ translate } /> );
-		assert.isOk( wrapper.find( '.notice' ).length );
+		const { container } = render( <Notice translate={ translate } /> );
+		expect( container.firstChild ).toHaveClass( 'notice' );
 	} );
 
 	test( 'should have dismiss button when showDismiss passed as true', () => {
-		const wrapper = shallow( <Notice showDismiss={ true } translate={ translate } /> );
-		assert.isOk( wrapper.find( '.is-dismissable' ).length );
+		const { container } = render( <Notice showDismiss={ true } translate={ translate } /> );
+		expect( container.firstChild ).toHaveClass( 'is-dismissable' );
 	} );
 
 	test( 'should have dismiss button by default if isCompact is false', () => {
-		const wrapper = shallow( <Notice isCompact={ false } translate={ translate } /> );
-		assert.isOk( wrapper.find( '.is-dismissable' ).length );
+		const { container } = render( <Notice isCompact={ false } translate={ translate } /> );
+		expect( container.firstChild ).toHaveClass( 'is-dismissable' );
 	} );
 
 	test( 'should have compact look when isCompact passed as true', () => {
-		const wrapper = shallow( <Notice isCompact={ true } translate={ translate } /> );
-		assert.isOk( wrapper.find( '.is-compact' ).length );
+		const { container } = render( <Notice isCompact={ true } translate={ translate } /> );
+		expect( container.firstChild ).toHaveClass( 'is-compact' );
 	} );
 
 	test( 'should not have dismiss button by default if isCompact is true', () => {
-		const wrapper = shallow( <Notice isCompact={ true } translate={ translate } /> );
-		assert.isOk( wrapper.find( '.is-dismissable' ).length === 0 );
+		const { container } = render( <Notice isCompact={ true } translate={ translate } /> );
+		expect( container.firstChild ).not.toHaveClass( 'is-dismissable' );
 	} );
 
 	test( 'should have dismiss button when showDismiss is true and isCompact is true', () => {
-		const wrapper = shallow(
+		const { container } = render(
 			<Notice isCompact={ true } showDismiss={ true } translate={ translate } />
 		);
-		assert.isOk( wrapper.find( '.is-dismissable' ).length );
+		expect( container.firstChild ).toHaveClass( 'is-dismissable' );
 	} );
 
 	test( 'should have proper class for is-info status parameter', () => {
-		const wrapper = shallow( <Notice status="is-info" translate={ translate } /> );
-		assert.isOk( wrapper.find( '.is-info' ).length );
+		const { container } = render( <Notice status="is-info" translate={ translate } /> );
+		expect( container.firstChild ).toHaveClass( 'is-info' );
 	} );
 
 	test( 'should have proper class for is-success status parameter', () => {
-		const wrapper = shallow( <Notice status="is-success" translate={ translate } /> );
-		assert.isOk( wrapper.find( '.is-success' ).length );
+		const { container } = render( <Notice status="is-success" translate={ translate } /> );
+		expect( container.firstChild ).toHaveClass( 'is-success' );
 	} );
 
 	test( 'should have proper class for is-error status parameter', () => {
-		const wrapper = shallow( <Notice status="is-error" translate={ translate } /> );
-		assert.isOk( wrapper.find( '.is-error' ).length );
+		const { container } = render( <Notice status="is-error" translate={ translate } /> );
+		expect( container.firstChild ).toHaveClass( 'is-error' );
 	} );
 
 	test( 'should have proper class for is-warning status parameter', () => {
-		const wrapper = shallow( <Notice status="is-warning" translate={ translate } /> );
-		assert.isOk( wrapper.find( '.is-warning' ).length );
+		const { container } = render( <Notice status="is-warning" translate={ translate } /> );
+		expect( container.firstChild ).toHaveClass( 'is-warning' );
 	} );
 } );

--- a/client/components/notice/test/index.js
+++ b/client/components/notice/test/index.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Notice } from '../index';
 
@@ -9,54 +9,52 @@ describe( 'Notice', () => {
 	const translate = ( string ) => string;
 
 	test( 'should output the component', () => {
-		const { container } = render( <Notice translate={ translate } /> );
-		expect( container.firstChild ).toHaveClass( 'notice' );
+		render( <Notice translate={ translate } /> );
+		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'notice' );
 	} );
 
 	test( 'should have dismiss button when showDismiss passed as true', () => {
-		const { container } = render( <Notice showDismiss={ true } translate={ translate } /> );
-		expect( container.firstChild ).toHaveClass( 'is-dismissable' );
+		render( <Notice showDismiss={ true } translate={ translate } /> );
+		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-dismissable' );
 	} );
 
 	test( 'should have dismiss button by default if isCompact is false', () => {
-		const { container } = render( <Notice isCompact={ false } translate={ translate } /> );
-		expect( container.firstChild ).toHaveClass( 'is-dismissable' );
+		render( <Notice isCompact={ false } translate={ translate } /> );
+		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-dismissable' );
 	} );
 
 	test( 'should have compact look when isCompact passed as true', () => {
-		const { container } = render( <Notice isCompact={ true } translate={ translate } /> );
-		expect( container.firstChild ).toHaveClass( 'is-compact' );
+		render( <Notice isCompact={ true } translate={ translate } /> );
+		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-compact' );
 	} );
 
 	test( 'should not have dismiss button by default if isCompact is true', () => {
-		const { container } = render( <Notice isCompact={ true } translate={ translate } /> );
-		expect( container.firstChild ).not.toHaveClass( 'is-dismissable' );
+		render( <Notice isCompact={ true } translate={ translate } /> );
+		expect( screen.queryByRole( 'status' ) ).not.toHaveClass( 'is-dismissable' );
 	} );
 
 	test( 'should have dismiss button when showDismiss is true and isCompact is true', () => {
-		const { container } = render(
-			<Notice isCompact={ true } showDismiss={ true } translate={ translate } />
-		);
-		expect( container.firstChild ).toHaveClass( 'is-dismissable' );
+		render( <Notice isCompact={ true } showDismiss={ true } translate={ translate } /> );
+		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-dismissable' );
 	} );
 
 	test( 'should have proper class for is-info status parameter', () => {
-		const { container } = render( <Notice status="is-info" translate={ translate } /> );
-		expect( container.firstChild ).toHaveClass( 'is-info' );
+		render( <Notice status="is-info" translate={ translate } /> );
+		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-info' );
 	} );
 
 	test( 'should have proper class for is-success status parameter', () => {
-		const { container } = render( <Notice status="is-success" translate={ translate } /> );
-		expect( container.firstChild ).toHaveClass( 'is-success' );
+		render( <Notice status="is-success" translate={ translate } /> );
+		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-success' );
 	} );
 
 	test( 'should have proper class for is-error status parameter', () => {
-		const { container } = render( <Notice status="is-error" translate={ translate } /> );
-		expect( container.firstChild ).toHaveClass( 'is-error' );
+		render( <Notice status="is-error" translate={ translate } /> );
+		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-error' );
 	} );
 
 	test( 'should have proper class for is-warning status parameter', () => {
-		const { container } = render( <Notice status="is-warning" translate={ translate } /> );
-		expect( container.firstChild ).toHaveClass( 'is-warning' );
+		render( <Notice status="is-warning" translate={ translate } /> );
+		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-warning' );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `Notice` component to use `@testing-library/react` instead of `enzyme`.

It also uses the opportunity to migrate `chai` assertions to `jest`.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/components/notice/test/index.js`