### PR TITLE
Add starter plan signup flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -60,6 +60,14 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
+			name: 'starter',
+			steps: [ 'user', 'domains', 'plans-starter' ],
+			destination: getSignupDestination,
+			description: 'Create an account and a blog and then add the starter plan to the users cart.',
+			lastModified: '2022-05-05',
+			showRecaptcha: true,
+		},
+		{
 			name: 'free',
 			steps: [ 'user', 'domains' ],
 			destination: getSignupDestination,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -26,6 +26,7 @@ const stepNameToModuleName = {
 	'plans-business': 'plans',
 	'plans-ecommerce': 'plans',
 	'plans-pro': 'plans',
+	'plans-starter': 'plans',
 	'plans-import': 'plans',
 	'plans-launch': 'plans',
 	'plans-personal': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -9,6 +9,7 @@ import {
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_ECOMMERCE_MONTHLY,
 	PLAN_WPCOM_PRO,
+	PLAN_WPCOM_STARTER,
 	TYPE_FREE,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
@@ -289,6 +290,17 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 			defaultDependencies: {
 				cartItem: PLAN_WPCOM_PRO,
+			},
+		},
+
+		'plans-starter': {
+			stepName: 'plans-starter',
+			apiRequestFunction: addPlanToCart,
+			fulfilledStepCallback: isPlanFulfilled,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+			defaultDependencies: {
+				cartItem: PLAN_WPCOM_STARTER,
 			},
 		},
 

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -203,6 +203,7 @@
 		"ecommerce",
 		"ecommerce-monthly",
 		"pro",
+		"starter",
 		"domain"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js"

--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -32,6 +32,7 @@ export const PLAN_P2_PLUS = 'wp_p2_plus_monthly';
 export const PLAN_P2_FREE = 'p2_free_plan'; // Not a real plan; it's a renamed WP.com Free for the P2 project.
 export const PLAN_WPCOM_FLEXIBLE = 'wpcom-flexible'; // Not a real plan; it's a renamed WP.com Free for the plans overhaul.
 export const PLAN_WPCOM_PRO = 'pro-plan';
+export const PLAN_WPCOM_STARTER = 'starter-plan';
 
 export const WPCOM_PLANS = <const>[
 	PLAN_BUSINESS_MONTHLY,
@@ -57,6 +58,7 @@ export const WPCOM_PLANS = <const>[
 	PLAN_P2_FREE,
 	PLAN_WPCOM_FLEXIBLE,
 	PLAN_WPCOM_PRO,
+	PLAN_WPCOM_STARTER,
 ];
 
 export const WPCOM_MONTHLY_PLANS = <const>[


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the Starter plan signup flow.

#### Testing instructions

* With a new user go to /start/starter and proceed
* You should be able to see the checkout with the Starter Plan added
<img width="320" alt="Screenshot on 2022-05-06 at 12-13-15" src="https://user-images.githubusercontent.com/2749938/167104834-dc995aba-268d-42af-9096-b297236053cd.png">

