### PR TITLE
Help-center: move what's new queryclient from help-center to common

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/what-new-query-client.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/what-new-query-client.tsx
@@ -1,0 +1,3 @@
+import { QueryClient } from 'react-query';
+
+export const whatsNewQueryClient = new QueryClient();

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/index.js
@@ -1,6 +1,5 @@
 import './src/config';
 import { HelpCenter } from '@automattic/data-stores';
 import './src/help-center';
-export { whatsNewQueryClient } from './src/help-center';
 
 HelpCenter.register();

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -7,11 +7,10 @@ import { PinnedItems } from '@wordpress/interface';
 import { registerPlugin } from '@wordpress/plugins';
 import cx from 'classnames';
 import { useEffect, useState } from 'react';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClientProvider } from 'react-query';
+import { whatsNewQueryClient } from '../../common/what-new-query-client';
 import Contents from './contents';
 import './help-center.scss';
-
-export const whatsNewQueryClient = new QueryClient();
 
 function HelpCenterContent() {
 	const isDesktop = useMediaQuery( '(min-width: 480px)' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/whats-new/src/whats-new.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { useState } from 'react';
 import { QueryClientProvider } from 'react-query';
-import { whatsNewQueryClient } from '../../help-center';
+import { whatsNewQueryClient } from '../../common/what-new-query-client';
 
 function WhatsNewMenuItem() {
 	const [ showGuide, setShowGuide ] = useState( false );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the whats-new query client away from help-center. To avoid making the help center public.

#### Testing
1. Make sure the help-center is only visible behind a flag `enable-help-center`.