### PR TITLE
Plans: Update product order on mobile to 'Backup,' 'Security,' 'Complete'

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/section.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/section.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { TranslateResult } from 'i18n-calypso';
 import * as React from 'react';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 type Props = {
 	title?: TranslateResult;
@@ -9,7 +10,11 @@ type Props = {
 };
 
 const ProductGridSection: React.FC< Props > = ( { title, className, children } ) => (
-	<section className={ classNames( 'product-grid__section', className ) }>
+	<section
+		className={ classNames( 'product-grid__section', className, {
+			'is-jetpack-cloud': isJetpackCloud(),
+		} ) }
+	>
 		{ title && <h2 className="product-grid__section-title">{ title }</h2> }
 		{ children }
 	</section>

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -12,6 +12,15 @@
 	}
 }
 
+// Retain horizontal padding on Jetpack Cloud,
+// otherwise the product grid reach the edge of the screen
+.is-jetpack-cloud.product-grid__section {
+	@include breakpoint-deprecated( '>660px' ) {
+		padding-left: 16px;
+		padding-right: 16px;
+	}
+}
+
 .product-grid__section:first-of-type > .product-grid__section-title {
 	margin-bottom: 15px;
 }

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -48,18 +48,6 @@
 	}
 }
 
-.product-grid__plan-grid {
-	> li.is-featured {
-		// Put featured item(s) in first position
-		order: -2;
-	}
-
-	> li:last-child {
-		// Put last item below featured items
-		order: -1;
-	}
-}
-
 .product-grid__plan-grid.has-top-padding {
 	padding-top: 32px;
 }
@@ -70,9 +58,6 @@
 
 	// Considering there are 3 plans
 	> li {
-		// Reset mobile and tablet positions
-		order: 0;
-
 		&:first-child {
 			position: relative;
 			left: 8px;
@@ -81,10 +66,6 @@
 		&:last-child {
 			position: relative;
 			left: -8px;
-		}
-
-		&.is-featured {
-			order: 0;
 		}
 	}
 }


### PR DESCRIPTION
Resolves `1164141197617539-as-1202175092562843`.

### Changes proposed in this Pull Request

* Remove `order` style rules that altered the original ordering of featured products on smaller screens.
* Add a conditional `is-jetpack-cloud` class to the `ProductGridSection` component when it's rendered in Calypso Green.
* Use the aforementioned class to restore padding on the left and right edges of smaller screens, so product cards don't run directly up to the screen edge.

### Testing instructions

#### Product ordering

1. Apply this PR to your testing environment.
2. In both Calypso Blue and Green, check that the ordering of the top section of products is consistently "Backup," "Security," and then "Complete." Experiment with different screen widths, but especially mobile-sized (<660px) screen widths.

##### Before / after

<img height="350" src="https://user-images.githubusercontent.com/670067/166952861-50806a0b-852e-4c2e-95d6-95ae8099eae0.png"> <img height="350" src="https://user-images.githubusercontent.com/670067/166952856-eadf2823-f2a1-4872-b40d-28896e91b672.png"> <img height="350" src="https://user-images.githubusercontent.com/670067/166952851-b8baa233-40f1-4ded-84c1-3ee829320e85.png">
<img height="350" src="https://user-images.githubusercontent.com/670067/166951944-1b38dcd6-7d3d-4f0c-8b27-811f522f7745.png"> <img height="350" src="https://user-images.githubusercontent.com/670067/166951945-f05cf2b0-9790-4dd1-bcd8-75249f25bcb8.png"> <img height="350" src="https://user-images.githubusercontent.com/670067/166951946-570c2d32-a20c-448b-b53a-580291b35275.png">

<img height="350" src="https://user-images.githubusercontent.com/670067/166951940-589a06a1-0748-4256-8cc6-a7ac88a1d567.png"> <img height="350" src="https://user-images.githubusercontent.com/670067/166951942-10283166-308f-406b-b7cb-18e8ee5bf1e8.png"> <img height="350" src="https://user-images.githubusercontent.com/670067/166951943-22eb593f-00d0-4a68-954c-40a2d80a5d69.png">
<img height="350" src="https://user-images.githubusercontent.com/670067/166952862-6da3075e-b6ce-4df6-b2bb-b0ea1666f6db.png"> <img height="350" src="https://user-images.githubusercontent.com/670067/166952864-029275f7-cedb-409a-8465-f00811cf023e.png"> <img height="350" src="https://user-images.githubusercontent.com/670067/166952865-82c664ef-bb56-4eba-a04b-39ea8cf885b3.png">

#### Screen padding

1. On Jetpack Cloud, verify that for all screen widths, product cards have a small amount of padding on each side of the screen and do not touch the screen edge itself.
2. Verify padding for product cards is completely unchanged in Calypso Blue.

##### Before / after

<img height="550" src="https://user-images.githubusercontent.com/670067/166952856-eadf2823-f2a1-4872-b40d-28896e91b672.png"> <img height="550" src="https://user-images.githubusercontent.com/670067/166951945-f05cf2b0-9790-4dd1-bcd8-75249f25bcb8.png">