### PR TITLE
Fix bulk Domain Contact Email editing

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-edit-contact-info.jsx
+++ b/client/my-sites/domains/domain-management/list/bulk-edit-contact-info.jsx
@@ -128,6 +128,7 @@ class BulkEditContactInfo extends Component {
 					{
 						contactInformation: contactDetails,
 						domainNames: this.props.domainNamesList ?? [],
+						validateOnlyEmail: this.props.emailOnly,
 					},
 					camelToSnakeCase
 				)


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes a bug that prevent domain contact email from being updated - using bulk editing action - when some of the domains required some specific tld checks.

Sometimes, after having entered a valid email address, the update button remained disabled. This happened because we tried to validate the entire contact data, not only the email.

This PR depend on D80223-code

![fix-email-validation](https://user-images.githubusercontent.com/2797601/166977418-7bff291a-8adf-4e8b-9b3f-3e8410282439.png)

## Testing instructions

* Build this branch locally or open the live Calypso link
* Register a `.ca` domain (or another domain with a tld that requires some special fields, such `.fr`)
* Register a `.com` domain (this will replace previous contact info in db)
* Go to `/domains/manage?action=edit-contact-email`
* Select new registered domain and fill email field with a new valid email
* Verify that `Save contact info` button is enabled
* _(Optional) Click the button and verify that the email has been correctly updated on that domains_