### PR TITLE
Replace the UrlSearch wrapper with a useUrlSearch hook

### DIFF
--- a/client/lib/url-search/test/index.js
+++ b/client/lib/url-search/test/index.js
@@ -1,10 +1,12 @@
 import { expect } from 'chai';
 import { buildSearchUrl } from '../';
+import { buildSearchUrl as useUrlSearchBuildSearchUrl } from '../use-url-search';
 
 describe( '#buildSearchUrl', () => {
 	test( 'should return original url if there is no search', () => {
 		const params = { uri: 'chicken.com' };
 		expect( buildSearchUrl( params ) ).eql( 'chicken.com' );
+		expect( useUrlSearchBuildSearchUrl( params ) ).eql( 'chicken.com' );
 	} );
 
 	test( 'should add add the default params of s to built query', () => {
@@ -12,8 +14,9 @@ describe( '#buildSearchUrl', () => {
 			uri: 'google.com',
 			search: 'hello',
 		};
-		const url = buildSearchUrl( params );
-		expect( url ).eql( 'google.com?s=hello' );
+		const expectedResult = 'google.com?s=hello';
+		expect( buildSearchUrl( params ) ).eql( expectedResult );
+		expect( useUrlSearchBuildSearchUrl( params ) ).eql( expectedResult );
 	} );
 
 	test( 'should replace current query with new one even when using custom query key', () => {
@@ -22,8 +25,9 @@ describe( '#buildSearchUrl', () => {
 			search: 'reader is super awesome',
 			queryKey: 'q',
 		};
-		const url = buildSearchUrl( params );
-		expect( url ).eql( 'wordpress.com/read/search?q=reader+is+super+awesome' );
+		const expectedResult = 'wordpress.com/read/search?q=reader+is+super+awesome';
+		expect( buildSearchUrl( params ) ).eql( expectedResult );
+		expect( useUrlSearchBuildSearchUrl( params ) ).eql( expectedResult );
 	} );
 
 	test( 'should remove the query if search is empty', () => {
@@ -31,7 +35,8 @@ describe( '#buildSearchUrl', () => {
 			uri: 'wordpress.com/read/search?q=reader+is+awesome',
 			queryKey: 'q',
 		};
-		const url = buildSearchUrl( params );
-		expect( url ).eql( 'wordpress.com/read/search' );
+		const expectedResult = 'wordpress.com/read/search';
+		expect( buildSearchUrl( params ) ).eql( expectedResult );
+		expect( useUrlSearchBuildSearchUrl( params ) ).eql( expectedResult );
 	} );
 } );

--- a/client/lib/url-search/test/index.js
+++ b/client/lib/url-search/test/index.js
@@ -1,12 +1,10 @@
 import { expect } from 'chai';
 import { buildSearchUrl } from '../';
-import { buildSearchUrl as useUrlSearchBuildSearchUrl } from '../use-url-search';
 
 describe( '#buildSearchUrl', () => {
 	test( 'should return original url if there is no search', () => {
 		const params = { uri: 'chicken.com' };
 		expect( buildSearchUrl( params ) ).eql( 'chicken.com' );
-		expect( useUrlSearchBuildSearchUrl( params ) ).eql( 'chicken.com' );
 	} );
 
 	test( 'should add add the default params of s to built query', () => {
@@ -14,9 +12,8 @@ describe( '#buildSearchUrl', () => {
 			uri: 'google.com',
 			search: 'hello',
 		};
-		const expectedResult = 'google.com?s=hello';
-		expect( buildSearchUrl( params ) ).eql( expectedResult );
-		expect( useUrlSearchBuildSearchUrl( params ) ).eql( expectedResult );
+		const url = buildSearchUrl( params );
+		expect( url ).eql( 'google.com?s=hello' );
 	} );
 
 	test( 'should replace current query with new one even when using custom query key', () => {
@@ -25,9 +22,8 @@ describe( '#buildSearchUrl', () => {
 			search: 'reader is super awesome',
 			queryKey: 'q',
 		};
-		const expectedResult = 'wordpress.com/read/search?q=reader+is+super+awesome';
-		expect( buildSearchUrl( params ) ).eql( expectedResult );
-		expect( useUrlSearchBuildSearchUrl( params ) ).eql( expectedResult );
+		const url = buildSearchUrl( params );
+		expect( url ).eql( 'wordpress.com/read/search?q=reader+is+super+awesome' );
 	} );
 
 	test( 'should remove the query if search is empty', () => {
@@ -35,8 +31,7 @@ describe( '#buildSearchUrl', () => {
 			uri: 'wordpress.com/read/search?q=reader+is+awesome',
 			queryKey: 'q',
 		};
-		const expectedResult = 'wordpress.com/read/search';
-		expect( buildSearchUrl( params ) ).eql( expectedResult );
-		expect( useUrlSearchBuildSearchUrl( params ) ).eql( expectedResult );
+		const url = buildSearchUrl( params );
+		expect( url ).eql( 'wordpress.com/read/search' );
 	} );
 } );

--- a/client/lib/url-search/test/use-url-search.js
+++ b/client/lib/url-search/test/use-url-search.js
@@ -1,42 +1,36 @@
-import { useState } from '@wordpress/element';
 import page from 'page';
+import { useState } from 'react';
 import useUrlSearch, { buildSearchUrl } from '../use-url-search';
 
-jest.mock( '@wordpress/element' );
+jest.mock( 'react' );
 jest.mock( 'page' );
 
 describe( '#buildSearchUrl', () => {
 	test( 'should return original url if there is no search', () => {
-		const params = { uri: 'https://wordpress.com/plugins' };
-		expect( buildSearchUrl( params ) ).toBe( '/plugins' );
+		const uri = 'https://wordpress.com/plugins';
+		expect( buildSearchUrl( uri ) ).toBe( '/plugins' );
 	} );
 
 	test( 'should add add the default params of s to built query', () => {
-		const params = {
-			uri: 'https://wordpress.com',
-			search: 'hello',
-		};
+		const uri = 'https://wordpress.com';
+		const search = 'hello';
 		const expectedResult = '?s=hello';
-		expect( buildSearchUrl( params ) ).toBe( expectedResult );
+		expect( buildSearchUrl( uri, search ) ).toBe( expectedResult );
 	} );
 
 	test( 'should replace current query with new one even when using custom query key', () => {
-		const params = {
-			uri: 'https://wordpress.com/read/search?q=reader+is+awesome',
-			search: 'reader is super awesome',
-			queryKey: 'q',
-		};
+		const uri = 'https://wordpress.com/read/search?q=reader+is+awesome';
+		const search = 'reader is super awesome';
+		const queryKey = 'q';
 		const expectedResult = '/read/search?q=reader+is+super+awesome';
-		expect( buildSearchUrl( params ) ).toBe( expectedResult );
+		expect( buildSearchUrl( uri, search, queryKey ) ).toBe( expectedResult );
 	} );
 
 	test( 'should remove the query if search is empty', () => {
-		const params = {
-			uri: 'https://wordpress.com/read/search?q=reader+is+awesome',
-			queryKey: 'q',
-		};
+		const uri = 'https://wordpress.com/read/search?q=reader+is+awesome';
+		const queryKey = 'q';
 		const expectedResult = '/read/search';
-		expect( buildSearchUrl( params ) ).toBe( expectedResult );
+		expect( buildSearchUrl( uri, '', queryKey ) ).toBe( expectedResult );
 	} );
 } );
 
@@ -75,6 +69,18 @@ describe( '#useUrlSearch', () => {
 
 		expect( mockSetSearchOpen ).toHaveBeenLastCalledWith( true );
 		expect( page.replace ).toHaveBeenLastCalledWith( expectedUrl );
+	} );
+
+	test( 'searchTerm should contain the last searchTerm performed on doSearch', () => {
+		const newSearchTerm = 'replaced-search-term';
+		const mockSetSearch = jest.fn();
+		useState.mockImplementation( () => [ newSearchTerm, mockSetSearch ] );
+
+		const urlSearchHook2 = useUrlSearch();
+		urlSearchHook2.doSearch( newSearchTerm );
+
+		expect( mockSetSearch ).toBeCalledWith( newSearchTerm );
+		expect( urlSearchHook2.searchTerm ).toBe( 'replaced-search-term' );
 	} );
 
 	test( 'should return the correct values for getSearchOpen accordingly to isSearchOpen and queryKey values', () => {

--- a/client/lib/url-search/test/use-url-search.js
+++ b/client/lib/url-search/test/use-url-search.js
@@ -1,0 +1,90 @@
+import { useState } from '@wordpress/element';
+import page from 'page';
+import useUrlSearch, { buildSearchUrl } from '../use-url-search';
+
+jest.mock( '@wordpress/element' );
+jest.mock( 'page' );
+
+describe( '#buildSearchUrl', () => {
+	test( 'should return original url if there is no search', () => {
+		const params = { uri: 'chicken.com' };
+		expect( buildSearchUrl( params ) ).toBe( 'chicken.com' );
+	} );
+
+	test( 'should add add the default params of s to built query', () => {
+		const params = {
+			uri: 'google.com',
+			search: 'hello',
+		};
+		const expectedResult = 'google.com?s=hello';
+		expect( buildSearchUrl( params ) ).toBe( expectedResult );
+	} );
+
+	test( 'should replace current query with new one even when using custom query key', () => {
+		const params = {
+			uri: 'wordpress.com/read/search?q=reader+is+awesome',
+			search: 'reader is super awesome',
+			queryKey: 'q',
+		};
+		const expectedResult = 'wordpress.com/read/search?q=reader+is+super+awesome';
+		expect( buildSearchUrl( params ) ).toBe( expectedResult );
+	} );
+
+	test( 'should remove the query if search is empty', () => {
+		const params = {
+			uri: 'wordpress.com/read/search?q=reader+is+awesome',
+			queryKey: 'q',
+		};
+		const expectedResult = 'wordpress.com/read/search';
+		expect( buildSearchUrl( params ) ).toBe( expectedResult );
+	} );
+} );
+
+describe( '#useUrlSearch', () => {
+	const mockSetSearchOpen = jest.fn();
+	const mockIsSearchOpen = false;
+
+	const useStateMock = () => [ mockIsSearchOpen, mockSetSearchOpen ];
+	useState.mockImplementation( useStateMock );
+	const urlSearchHook = useUrlSearch();
+
+	global.window = {
+		location: {
+			href: '',
+		},
+	};
+
+	test( 'should navigate to a page without a query search', () => {
+		global.window.location.href = 'wordpress.com';
+		page.mockImplementation( jest.fn() );
+		urlSearchHook.doSearch( '' );
+
+		expect( mockSetSearchOpen ).toBeCalledWith( false );
+		expect( page ).toBeCalledWith( global.window.location.href );
+	} );
+
+	test( 'should replace page url on a query search', () => {
+		const baseUrl = 'wordpress.com';
+		global.window.location.href = baseUrl + '?s=test';
+
+		const newSearchTerm = 'replaced-search-term';
+		const expectedUrl = baseUrl + '?s=' + newSearchTerm;
+
+		page.replace.mockImplementation( () => {} );
+		urlSearchHook.doSearch( newSearchTerm );
+
+		expect( mockSetSearchOpen ).toHaveBeenLastCalledWith( true );
+		expect( page.replace ).toHaveBeenLastCalledWith( expectedUrl );
+	} );
+
+	test( 'should return the correct values for getSearchOpen accordingly to isSearchOpen and queryKey values', () => {
+		useState.mockImplementation( () => [ false, () => {} ] );
+		expect( useUrlSearch( '' ).getSearchOpen() ).toBe( false );
+
+		useState.mockImplementation( () => [ true, () => {} ] );
+		expect( useUrlSearch( '' ).getSearchOpen() ).toBe( true );
+
+		useState.mockImplementation( () => [ false, () => {} ] );
+		expect( useUrlSearch( 's' ).getSearchOpen() ).toBe( true );
+	} );
+} );

--- a/client/lib/url-search/test/use-url-search.js
+++ b/client/lib/url-search/test/use-url-search.js
@@ -7,35 +7,35 @@ jest.mock( 'page' );
 
 describe( '#buildSearchUrl', () => {
 	test( 'should return original url if there is no search', () => {
-		const params = { uri: 'chicken.com' };
-		expect( buildSearchUrl( params ) ).toBe( 'chicken.com' );
+		const params = { uri: 'https://wordpress.com/plugins' };
+		expect( buildSearchUrl( params ) ).toBe( '/plugins' );
 	} );
 
 	test( 'should add add the default params of s to built query', () => {
 		const params = {
-			uri: 'google.com',
+			uri: 'https://wordpress.com',
 			search: 'hello',
 		};
-		const expectedResult = 'google.com?s=hello';
+		const expectedResult = '?s=hello';
 		expect( buildSearchUrl( params ) ).toBe( expectedResult );
 	} );
 
 	test( 'should replace current query with new one even when using custom query key', () => {
 		const params = {
-			uri: 'wordpress.com/read/search?q=reader+is+awesome',
+			uri: 'https://wordpress.com/read/search?q=reader+is+awesome',
 			search: 'reader is super awesome',
 			queryKey: 'q',
 		};
-		const expectedResult = 'wordpress.com/read/search?q=reader+is+super+awesome';
+		const expectedResult = '/read/search?q=reader+is+super+awesome';
 		expect( buildSearchUrl( params ) ).toBe( expectedResult );
 	} );
 
 	test( 'should remove the query if search is empty', () => {
 		const params = {
-			uri: 'wordpress.com/read/search?q=reader+is+awesome',
+			uri: 'https://wordpress.com/read/search?q=reader+is+awesome',
 			queryKey: 'q',
 		};
-		const expectedResult = 'wordpress.com/read/search';
+		const expectedResult = '/read/search';
 		expect( buildSearchUrl( params ) ).toBe( expectedResult );
 	} );
 } );
@@ -55,20 +55,20 @@ describe( '#useUrlSearch', () => {
 	};
 
 	test( 'should navigate to a page without a query search', () => {
-		global.window.location.href = 'wordpress.com';
+		global.window.location.href = 'https://wordpress.com';
 		page.mockImplementation( jest.fn() );
 		urlSearchHook.doSearch( '' );
 
 		expect( mockSetSearchOpen ).toBeCalledWith( false );
-		expect( page ).toBeCalledWith( global.window.location.href );
+		expect( page ).toBeCalledWith( '/' );
 	} );
 
 	test( 'should replace page url on a query search', () => {
-		const baseUrl = 'wordpress.com';
+		const baseUrl = 'https://wordpress.com';
 		global.window.location.href = baseUrl + '?s=test';
 
 		const newSearchTerm = 'replaced-search-term';
-		const expectedUrl = baseUrl + '?s=' + newSearchTerm;
+		const expectedUrl = '?s=' + newSearchTerm;
 
 		page.replace.mockImplementation( () => {} );
 		urlSearchHook.doSearch( newSearchTerm );

--- a/client/lib/url-search/use-url-search.ts
+++ b/client/lib/url-search/use-url-search.ts
@@ -1,7 +1,7 @@
-import { useState } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import debugFactory from 'debug';
 import page from 'page';
+import { useState } from 'react';
 const debug = debugFactory( 'calypso:url-search' );
 
 /**
@@ -13,21 +13,12 @@ const debug = debugFactory( 'calypso:url-search' );
  *     queryKey: 'q',
  *    } --> '/read/search?q=reader+is+super+awesome'
  *
- * @param {object} options the options object
- * @param {string} options.uri the uri to modify and add a query to
- * @param {string} options.search the search term
- * @param {string} [options.queryKey = s] the key to place in the url.  defaults to s
+ * @param {string} uri the uri to modify and add a query to
+ * @param {string} search the search term
+ * @param {string} [queryKey = s] the key to place in the url.  defaults to s
  * @returns {string} The built search url
  */
-export const buildSearchUrl = ( {
-	uri,
-	search,
-	queryKey = 's',
-}: {
-	uri: string;
-	search: string;
-	queryKey?: string;
-} ) => {
+export const buildSearchUrl = ( uri: string, search: string, queryKey = 's' ) => {
 	const parsedUrl = new URL( uri );
 
 	if ( search ) {
@@ -41,15 +32,13 @@ export const buildSearchUrl = ( {
 
 function useUrlSearch( queryKey = 's' ) {
 	const [ isSearchOpen, setSearchOpen ] = useState( false );
+	const [ searchTerm, setSearchTerm ] = useState( '' );
 
 	function doSearch( query: string ) {
+		setSearchTerm( query );
 		setSearchOpen( '' !== query );
 
-		const searchURL = buildSearchUrl( {
-			uri: window.location.href,
-			search: query,
-			queryKey: queryKey,
-		} );
+		const searchURL = buildSearchUrl( window.location.href, query, queryKey );
 
 		debug( 'search for: %s', query );
 		if ( queryKey && query ) {
@@ -62,12 +51,13 @@ function useUrlSearch( queryKey = 's' ) {
 	}
 
 	function getSearchOpen() {
-		return isSearchOpen !== false || !! queryKey;
+		return isSearchOpen || !! queryKey;
 	}
 
 	return {
-		doSearch: doSearch,
-		getSearchOpen: getSearchOpen,
+		doSearch,
+		getSearchOpen,
+		searchTerm,
 	};
 }
 

--- a/client/lib/url-search/use-url-search.ts
+++ b/client/lib/url-search/use-url-search.ts
@@ -1,7 +1,6 @@
-import url from 'url';
 import { useState } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
 import debugFactory from 'debug';
-import { pick } from 'lodash';
 import page from 'page';
 
 const debug = debugFactory( 'calypso:url-search' );
@@ -27,18 +26,22 @@ export const buildSearchUrl = ( {
 	queryKey = 's',
 }: {
 	uri: string;
-	search: string;
-	queryKey: string;
+	search?: string;
+	queryKey?: string;
 } ) => {
-	const parsedUrl = pick( url.parse( uri, true ), 'pathname', 'hash', 'query' );
+	const query = addQueryArgs( uri, { [ queryKey ]: search } );
 
-	if ( search ) {
-		parsedUrl.query[ queryKey ] = search;
-	} else {
-		delete parsedUrl.query[ queryKey ];
+	if ( ! search ) {
+		const queryStringIndex = uri.indexOf( '?' );
+
+		if ( queryStringIndex !== -1 ) {
+			return uri.substring( 0, queryStringIndex );
+		}
+
+		return uri;
 	}
 
-	return url.format( parsedUrl ).replace( /%20/g, '+' );
+	return query.replace( /%20/g, '+' );
 };
 
 function useUrlSearch( queryKey = 's' ) {

--- a/client/lib/url-search/use-url-search.ts
+++ b/client/lib/url-search/use-url-search.ts
@@ -2,20 +2,19 @@ import { useState } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import debugFactory from 'debug';
 import page from 'page';
-
 const debug = debugFactory( 'calypso:url-search' );
 
 /**
  * Function for constructing the url to page to. Here are some examples:
- * 1. { uri: 'google.com', search:'hello' } --> 'google.com?s=hello'
+ * 1. { uri: 'https://wordpress.com/plugins', search:'hello' } --> '/plugins?s=hello'
  * 2. {
- *     uri: 'wordpress.com/read/search?q=reader+is+awesome',
+ *     uri: 'https://wordpress.com/read/search?q=reader+is+awesome',
  *     search: 'reader is super awesome'
  *     queryKey: 'q',
- *    } --> 'wordpress.com/read/search?q=reader+is+super+awesome'
+ *    } --> '/read/search?q=reader+is+super+awesome'
  *
  * @param {object} options the options object
- * @param {string} options.uri the base uri to modify and add a query to
+ * @param {string} options.uri the uri to modify and add a query to
  * @param {string} options.search the search term
  * @param {string} [options.queryKey = s] the key to place in the url.  defaults to s
  * @returns {string} The built search url
@@ -26,22 +25,18 @@ export const buildSearchUrl = ( {
 	queryKey = 's',
 }: {
 	uri: string;
-	search?: string;
+	search: string;
 	queryKey?: string;
 } ) => {
-	const query = addQueryArgs( uri, { [ queryKey ]: search } );
+	const parsedUrl = new URL( uri );
 
-	if ( ! search ) {
-		const queryStringIndex = uri.indexOf( '?' );
-
-		if ( queryStringIndex !== -1 ) {
-			return uri.substring( 0, queryStringIndex );
-		}
-
-		return uri;
+	if ( search ) {
+		const baseUrl = uri.replace( parsedUrl.origin, '' );
+		const query = addQueryArgs( baseUrl, { [ queryKey ]: search } );
+		return query.replace( /%20/g, '+' );
 	}
 
-	return query.replace( /%20/g, '+' );
+	return parsedUrl.pathname;
 };
 
 function useUrlSearch( queryKey = 's' ) {

--- a/client/lib/url-search/use-url-search.ts
+++ b/client/lib/url-search/use-url-search.ts
@@ -1,0 +1,76 @@
+import url from 'url';
+import { useState } from '@wordpress/element';
+import debugFactory from 'debug';
+import { pick } from 'lodash';
+import page from 'page';
+
+const debug = debugFactory( 'calypso:url-search' );
+
+/**
+ * Function for constructing the url to page to. Here are some examples:
+ * 1. { uri: 'google.com', search:'hello' } --> 'google.com?s=hello'
+ * 2. {
+ *     uri: 'wordpress.com/read/search?q=reader+is+awesome',
+ *     search: 'reader is super awesome'
+ *     queryKey: 'q',
+ *    } --> 'wordpress.com/read/search?q=reader+is+super+awesome'
+ *
+ * @param {object} options the options object
+ * @param {string} options.uri the base uri to modify and add a query to
+ * @param {string} options.search the search term
+ * @param {string} [options.queryKey = s] the key to place in the url.  defaults to s
+ * @returns {string} The built search url
+ */
+export const buildSearchUrl = ( {
+	uri,
+	search,
+	queryKey = 's',
+}: {
+	uri: string;
+	search: string;
+	queryKey: string;
+} ) => {
+	const parsedUrl = pick( url.parse( uri, true ), 'pathname', 'hash', 'query' );
+
+	if ( search ) {
+		parsedUrl.query[ queryKey ] = search;
+	} else {
+		delete parsedUrl.query[ queryKey ];
+	}
+
+	return url.format( parsedUrl ).replace( /%20/g, '+' );
+};
+
+function useUrlSearch( queryKey = 's' ) {
+	const [ isSearchOpen, setSearchOpen ] = useState( false );
+
+	function doSearch( query: string ) {
+		setSearchOpen( '' !== query );
+
+		const searchURL = buildSearchUrl( {
+			uri: window.location.href,
+			search: query,
+			queryKey: queryKey,
+		} );
+
+		debug( 'search for: %s', query );
+		if ( queryKey && query ) {
+			debug( 'replacing URL: %s', searchURL );
+			page.replace( searchURL );
+		} else {
+			debug( 'setting URL: %s', searchURL );
+			page( searchURL );
+		}
+	}
+
+	function getSearchOpen() {
+		return isSearchOpen !== false || !! queryKey;
+	}
+
+	return {
+		doSearch: doSearch,
+		getSearchOpen: getSearchOpen,
+	};
+}
+
+export default useUrlSearch;

--- a/client/lib/url-search/use-url-search.ts
+++ b/client/lib/url-search/use-url-search.ts
@@ -18,7 +18,7 @@ const debug = debugFactory( 'calypso:url-search' );
  * @param {string} [queryKey = s] the key to place in the url.  defaults to s
  * @returns {string} The built search url
  */
-export const buildSearchUrl = ( uri: string, search: string, queryKey = 's' ) => {
+function buildSearchUrl( uri: string, search: string, queryKey = 's' ): string {
 	const parsedUrl = new URL( uri );
 
 	if ( search ) {
@@ -28,7 +28,7 @@ export const buildSearchUrl = ( uri: string, search: string, queryKey = 's' ) =>
 	}
 
 	return parsedUrl.pathname;
-};
+}
 
 function useUrlSearch( queryKey = 's' ) {
 	const [ isSearchOpen, setSearchOpen ] = useState( false );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -35,7 +35,7 @@ import {
 	useWPORGInfinitePlugins,
 } from 'calypso/data/marketplace/use-wporg-plugin-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import UrlSearch from 'calypso/lib/url-search';
+import useUrlSearch from 'calypso/lib/url-search/use-url-search';
 import useScrollAboveElement from 'calypso/lib/use-scroll-above-element';
 import NoResults from 'calypso/my-sites/no-results';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
@@ -82,20 +82,14 @@ import './style.scss';
  */
 const SHORT_LIST_LENGTH = 6;
 
-const PluginsBrowser = ( {
-	trackPageViews = true,
-	category,
-	search,
-	searchTitle,
-	hideHeader,
-	doSearch,
-} ) => {
+const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle, hideHeader } ) => {
 	const {
 		isAboveElement,
 		targetRef: searchHeaderRef,
 		referenceRef: navigationHeaderRef,
 	} = useScrollAboveElement();
 
+	const { doSearch } = useUrlSearch();
 	const breadcrumbs = useSelector( getBreadcrumbs );
 
 	const selectedSite = useSelector( getSelectedSite );
@@ -751,4 +745,4 @@ function isNotBlocked( plugin ) {
 	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;
 }
 
-export default UrlSearch( PluginsBrowser );
+export default PluginsBrowser;

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -1,5 +1,6 @@
 /** @jest-environment jsdom */
 
+jest.mock( 'page' );
 jest.mock( 'react-query', () => ( {
 	useQuery: () => [],
 } ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replaced UrlSearch HOC to a new useUrlSearch hook in /plugins search (I plan to change all uses of it)
* Reimplemented `buildSearchUrl` [from the original file](https://github.com/Automattic/wp-calypso/blob/replace_urlsearch_wrapper/client/lib/url-search/index.js#L25), in the [client/lib/url-search/use-url-search.ts](https://github.com/Automattic/wp-calypso/compare/replace_urlsearch_wrapper?expand=1#diff-d8019c76796786c7b76529edfcd3f48b18888d8858092e2ee8746303e2aca711) to avoid using deprecated `url` library
* Added new [unit test](client/lib/url-search/test/use-url-search.js) to cover `useUrlSearch`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open /plugins page and make sure everything related to search works as expected

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/63013
