### PR TITLE
Domains: Mobile add browser chrome to domain selection

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -411,6 +411,7 @@ class RegisterDomainStep extends Component {
 						/>
 					) }
 					{ this.renderFilterContent() }
+					{ this.renderBrowserChrome() }
 					{ this.renderSideContent() }
 					<QueryContactDetailsCache />
 				</div>
@@ -586,6 +587,23 @@ class RegisterDomainStep extends Component {
 					illustrationWidth={ 280 }
 				/>
 			</>
+		);
+	}
+
+	renderBrowserChrome() {
+		return (
+			<div className="register-domain-step__domain-side-content-container-browser-chrome">
+				<span></span>
+				<span></span>
+				<span className="register-domain-step__domain-side-content-container-browser-chrome-url">
+					https://
+					{ this.props.translate( 'yoursitename', {
+						comment: 'example url used to explain what a domain is.',
+					} ) }
+					.com
+				</span>
+				<span></span>
+			</div>
 		);
 	}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -411,7 +411,7 @@ class RegisterDomainStep extends Component {
 						/>
 					) }
 					{ this.renderFilterContent() }
-					{ this.renderBrowserChrome() }
+					{ this.renderDomainExplanationImage() }
 					{ this.renderSideContent() }
 					<QueryContactDetailsCache />
 				</div>
@@ -590,12 +590,12 @@ class RegisterDomainStep extends Component {
 		);
 	}
 
-	renderBrowserChrome() {
+	renderDomainExplanationImage() {
 		return (
-			<div className="register-domain-step__domain-side-content-container-browser-chrome">
+			<div className="register-domain-step__domain-side-content-container-domain-explanation-image">
 				<span></span>
 				<span></span>
-				<span className="register-domain-step__domain-side-content-container-browser-chrome-url">
+				<span className="register-domain-step__domain-side-content-container-domain-explanation-image-url">
 					https://
 					{ this.props.translate( 'yoursitename', {
 						comment: 'example url used to explain what a domain is.',

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -295,12 +295,12 @@ body.is-section-signup.is-white-signup {
 }
 .register-domain-step__placeholder {
 	display: none;
-	
+
 	@include break-large {
 		display: block;
 	}
 }
-.register-domain-step__domain-side-content-container-browser-chrome {
+.register-domain-step__domain-side-content-container-domain-explanation-image {
 	position: relative;
 	background-color: #d9d8da;
 	border-top-right-radius: 4px;
@@ -336,7 +336,7 @@ body.is-section-signup.is-white-signup {
 		margin: 3px 6px;
 	}
 }
-.register-domain-step__domain-side-content-container-browser-chrome-url {
+.register-domain-step__domain-side-content-container-domain-explanation-image-url {
 	flex-grow: 2;
 	padding: 0 10px;
 	line-height: 32px;

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -293,3 +293,55 @@ body.is-section-signup.is-white-signup {
 		color: var( --color-link );
 	}
 }
+.register-domain-step__placeholder {
+	display: none;
+	
+	@include break-large {
+		display: block;
+	}
+}
+.register-domain-step__domain-side-content-container-browser-chrome {
+	position: relative;
+	background-color: #d9d8da;
+	border-top-right-radius: 4px;
+	border-top-left-radius: 4px;
+	display: flex;
+	padding: 10px 5px 30px;
+	justify-content: space-between;
+	margin: 20px auto;
+	max-width: 600px;
+
+	@include break-large {
+		display: none;
+	}
+
+	&::after {
+		content: '';
+		width: auto;
+		height: 20px;
+		background-color:  #f5f5f5;
+		position: absolute;
+		border-top-right-radius: 4px;
+		border-top-left-radius: 4px;
+		bottom: 0;
+		left: 10px;
+		right: 10px;
+	}
+
+	span {
+		width: 32px;
+		height: 32px;
+		background: #fff;
+		border-radius: 4px;
+		margin: 3px 6px;
+	}
+}
+.register-domain-step__domain-side-content-container-browser-chrome-url {
+	flex-grow: 2;
+	padding: 0 10px;
+	line-height: 32px;
+	font-size: $font-body-extra-small;
+	text-overflow: ellipsis;
+	overflow: hidden;
+}
+

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -1,11 +1,9 @@
 import config from '@automattic/calypso-config';
-import { isMobile } from '@automattic/viewport';
 import { isEmpty } from 'lodash';
 import page from 'page';
 import { createElement } from 'react';
 import store from 'store';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { login } from 'calypso/lib/paths';
 import { sectionify } from 'calypso/lib/route';
 import flows from 'calypso/signup/config/flows';
@@ -278,11 +276,6 @@ export default {
 			! isManageSiteFlow
 		) {
 			context.store.dispatch( setSelectedSiteId( null ) );
-		}
-
-		// Pre-fetching the experiment
-		if ( isMobile() && [ 'onboarding', 'launch-site', 'free', 'pro' ].includes( flowName ) ) {
-			loadExperimentAssignment( 'calypso_signup_domain_mobile_browser_chrome_added_v4' );
 		}
 
 		context.primary = createElement( SignupComponent, {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,4 +1,3 @@
-import { isMobile } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
 import page from 'page';
@@ -21,7 +20,6 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { getDomainProductSlug, TRUENAME_COUPONS, TRUENAME_TLDS } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { ProvideExperimentData } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -437,72 +435,26 @@ class DomainsStep extends Component {
 		) : null;
 
 		return (
-			<ProvideExperimentData
-				name="calypso_signup_domain_mobile_browser_chrome_added_v4"
-				options={ {
-					isEligible:
-						isMobile() &&
-						[ 'onboarding', 'launch-site', 'free', 'pro' ].includes( this.props.flowName ),
-				} }
-			>
-				{ ( isLoading, experimentAssignment ) => {
-					if ( isLoading ) {
-						return null;
-					}
-
-					if ( experimentAssignment?.variationName === 'treatment' ) {
-						return (
-							<div className="domains__domain-side-content-container domains__domain-side-content-container-mobile-experiment">
-								<div className="domains__domain-side-content-container-browser-chrome">
-									<span></span>
-									<span></span>
-									<span className="domains__domain-side-content-container-browser-chrome-url">
-										https://
-										{ this.props.translate( 'yoursitename', {
-											comment: 'example url used to explain what a domain is.',
-										} ) }
-										.com
-									</span>
-									<span></span>
-								</div>
-								{ ! this.shouldHideDomainExplainer() &&
-									this.props.isPlanSelectionAvailableLaterInFlow && (
-										<div className="domains__domain-side-content domains__free-domain">
-											<ReskinSideExplainer
-												onClick={ this.handleDomainExplainerClick }
-												type={ 'free-domain-explainer' }
-											/>
-										</div>
-									) }
-								{ useYourDomain }
-							</div>
-						);
-					}
-					return (
-						<div className="domains__domain-side-content-container">
-							{ ! this.shouldHideDomainExplainer() &&
-								this.props.isPlanSelectionAvailableLaterInFlow && (
-									<div className="domains__domain-side-content domains__free-domain">
-										<ReskinSideExplainer
-											onClick={ this.handleDomainExplainerClick }
-											type={ 'free-domain-explainer' }
-											flowName={ this.props.flowName }
-										/>
-									</div>
-								) }
-							{ useYourDomain }
-							{ this.shouldDisplayDomainOnlyExplainer() && (
-								<div className="domains__domain-side-content">
-									<ReskinSideExplainer
-										onClick={ this.handleDomainExplainerClick }
-										type={ 'free-domain-only-explainer' }
-									/>
-								</div>
-							) }
-						</div>
-					);
-				} }
-			</ProvideExperimentData>
+			<div className="domains__domain-side-content-container">
+				{ ! this.shouldHideDomainExplainer() && this.props.isPlanSelectionAvailableLaterInFlow && (
+					<div className="domains__domain-side-content domains__free-domain">
+						<ReskinSideExplainer
+							onClick={ this.handleDomainExplainerClick }
+							type={ 'free-domain-explainer' }
+							flowName={ this.props.flowName }
+						/>
+					</div>
+				) }
+				{ useYourDomain }
+				{ this.shouldDisplayDomainOnlyExplainer() && (
+					<div className="domains__domain-side-content">
+						<ReskinSideExplainer
+							onClick={ this.handleDomainExplainerClick }
+							type={ 'free-domain-only-explainer' }
+						/>
+					</div>
+				) }
+			</div>
 		);
 	};
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -123,24 +123,6 @@ body.is-section-signup.is-white-signup {
 			}
 		}
 
-		.register-domain-step .domains__domain-side-content-container-mobile-experiment {
-			display: flex;
-			
-			justify-content: space-between;
-			flex-direction: column;
-			
-			.domains__domain-side-content {
-				border-top: 1px solid var( --studio-gray-5 );
-				border-bottom: 0;
-				padding: 16px 0;
-				margin: 0;
-
-				@include break-large {
-					display: none;
-				}
-			}
-		}
-
 		.domains__free-domain .reskin-side-explainer__subtitle-2 {
 			display: none;
 			
@@ -326,47 +308,3 @@ body.is-section-signup:not( .is-white-signup ) {
 
 }
 
-/* The domain browser chrome used in the domain mobile experiement */
-.domains__domain-side-content-container-browser-chrome {
-	position: relative;
-	background-color: #d9d8da;
-	border-top-right-radius: 4px;
-	border-top-left-radius: 4px;
-	display: flex;
-	padding: 10px 5px 30px;
-	justify-content: space-between;
-	margin-bottom: 20px;
-
-	@include break-large {
-		display: none;
-	}
-
-	&::after {
-		content: '';
-		width: auto;
-		height: 20px;
-		background-color:  #f5f5f5;
-		position: absolute;
-		border-top-right-radius: 4px;
-		border-top-left-radius: 4px;
-		bottom: 0;
-		left: 10px;
-		right: 10px;
-	}
-
-	span {
-		width: 32px;
-		height: 32px;
-		background: #fff;
-		border-radius: 4px;
-		margin: 3px 6px;
-	}
-}
-.domains__domain-side-content-container-browser-chrome-url {
-	flex-grow: 2;
-	padding: 0 10px;
-	line-height: 32px;
-	font-size: $font-body-extra-small;
-	text-overflow: ellipsis;
-	overflow: hidden;
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the browser chrome to the domain registration flow on mobile devices. 

Related
https://github.com/Automattic/wp-calypso/pull/61665

pbxNRc-1t7-p2

<table>
<tr><td>

Before:

Mobile
<img width="300" src="https://user-images.githubusercontent.com/115071/167005824-71f0742f-1ef4-41f3-a8fb-587969c62ed1.png" />

Desktop
<img width="300" src="https://user-images.githubusercontent.com/115071/167005856-26446433-7a49-4611-9f19-06c34836d126.png" />

</td>
<td>

After:

Mobile
<img width="300" src="https://user-images.githubusercontent.com/115071/167005915-8e66a155-72ca-468b-8a25-4111e06b0b7f.png" />

Tablet
<img width="300" src="https://user-images.githubusercontent.com/115071/167006165-6efcec2b-b1fe-4e05-830d-2f50ffd11032.png" />

Desktop no difference. 

</td></tr></table>
// Add new domain flow. 
<table><tr><td>

Before:

<img width="300" src="https://user-images.githubusercontent.com/115071/167006232-6804108e-cc04-4e3d-8066-881603458cae.png" />

<img width="300" src="https://user-images.githubusercontent.com/115071/167006237-749b82f8-769a-40c8-aafa-56baa6135fde.png" />
</td>
<td>
After:

<img width="300" src="https://user-images.githubusercontent.com/115071/167006293-601a321d-dad8-4c12-b102-73d9c710f248.png" />

Desktop no difference. 
</td></tr></table>

#### Testing instructions

visit /start/domains

and resize the browser window. Notice that the screen looks like you would expect. 

visit /domains/add/example.wordpress.com

and resize the browser window. Notice that the screen looks like you would expect. 

visit the domains page on the mobile device. Using the QR code. and visit the urls ^ and notice that the experience works as expected. 

Related to https://github.com/Automattic/wp-calypso/pull/61665, pbxNRc-1t7-p2