### PR TITLE
HelpCenter: article styling

### DIFF
--- a/client/blocks/inline-help/inline-help-center-content.scss
+++ b/client/blocks/inline-help/inline-help-center-content.scss
@@ -328,19 +328,29 @@
 	}
 
 	h1.support-article-dialog__header-title-link {
-		color: var( --color-neutral-100 );
-		font-size: $font-title-small;
-		font-weight: 600;
+		font-size: $font-title-medium;
 	}
 
+	h2 {
+		font-size: $font-title-small;
+	}
+
+	h3,
 	h4 {
 		font-size: $font-body;
-		font-weight: 600;
 	}
 
 	h5 {
 		font-size: $font-body-small;
+	}
+
+	h2,
+	h3,
+	h4,
+	h5 {
 		font-weight: 600;
+		color: var( --color-neutral-100 );
+		margin: 8px 0;
 	}
 
 	a:not( .support-article-dialog__header-title-link ) {
@@ -359,7 +369,11 @@
 
 		ol {
 			list-style-type: none;
-			margin-left: 1em;
+			margin: 0;
+		}
+
+		li a {
+			font-size: $font-body-small;
 		}
 	}
 
@@ -393,6 +407,7 @@
 	.wp-block-separator {
 		margin: auto;
 		border-bottom: 1px solid var( --color-neutral-10 );
+		width: 100%;
 	}
 
 	.wp-block-group__inner-container {
@@ -406,6 +421,14 @@
 		border-radius: 2px;
 		padding: 5px;
 		width: 100%;
+	}
+
+	.callout .wp-block-column {
+		background-color: var( --color-neutral-0 );
+
+		.wp-block-quote {
+			margin: 0;
+		}
 	}
 }
 /**

--- a/client/blocks/inline-help/inline-help-center-content.scss
+++ b/client/blocks/inline-help/inline-help-center-content.scss
@@ -319,6 +319,96 @@
 }
 
 /**
+* ARTICLE EMBED
+*/
+.help-center .help-center__container .inline-help__embed-result {
+	svg.gridicons-external {
+		height: 20px;
+		width: 20px;
+	}
+
+	h1.support-article-dialog__header-title-link {
+		color: var( --color-neutral-100 );
+		font-size: 20;
+		font-weight: 600;
+	}
+
+	h4 {
+		font-size: 16;
+		font-weight: 600;
+	}
+
+	h5 {
+		font-size: 14;
+		font-weight: 600;
+	}
+
+	a:not( .support-article-dialog__header-title-link ) {
+		color: var( --studio-blue-50 );
+		text-decoration: none;
+	}
+
+	a[name='toc'] span {
+		color: var( --color-neutral-80 );
+		font-size: 16;
+	}
+
+	.wp-block-a8c-support-table-of-contents {
+		background-color: var( --studio-blue-0 );
+		padding: 16px;
+
+		ol {
+			list-style-type: none;
+			margin-left: 1em;
+		}
+	}
+
+	p {
+		font-size: 14;
+		color: var( --color-neutral-80 );
+	}
+
+	.support-article-dialog__story {
+		padding: 0;
+	}
+
+	ul {
+		font-size: 14;
+		color: var( --color-neutral-80 );
+		list-style-type: circle;
+		list-style-position: inside;
+	}
+
+	span.noticon.noticon-star {
+		color: var( --studio-yellow-20 );
+	}
+
+	.wp-block-quote {
+		background-color: var( --color-neutral-0 );
+		border-left: none;
+		padding: 16px;
+		color: var( --color-neutral-80 );
+	}
+
+	.wp-block-separator {
+		margin: auto;
+		border-bottom: 1px solid var( --color-neutral-10 );
+	}
+
+	.wp-block-group__inner-container {
+		background-color: ( var( --color-neutral-0 ) );
+		padding: 16px 0;
+	}
+
+	.wp-block-button__link {
+		background-color: transparent;
+		border: 1px solid var( --studio-gray-10 );
+		border-radius: 2px;
+		padding: 5px;
+		width: 100%;
+	}
+}
+/**
 * FOOTER - high specificity to overwrite base styling
 */
 .help-center__container-footer {

--- a/client/blocks/inline-help/inline-help-center-content.scss
+++ b/client/blocks/inline-help/inline-help-center-content.scss
@@ -329,17 +329,17 @@
 
 	h1.support-article-dialog__header-title-link {
 		color: var( --color-neutral-100 );
-		font-size: 20;
+		font-size: $font-title-small;
 		font-weight: 600;
 	}
 
 	h4 {
-		font-size: 16;
+		font-size: $font-body;
 		font-weight: 600;
 	}
 
 	h5 {
-		font-size: 14;
+		font-size: $font-body-small;
 		font-weight: 600;
 	}
 
@@ -350,7 +350,7 @@
 
 	a[name='toc'] span {
 		color: var( --color-neutral-80 );
-		font-size: 16;
+		font-size: $font-body;
 	}
 
 	.wp-block-a8c-support-table-of-contents {
@@ -364,7 +364,7 @@
 	}
 
 	p {
-		font-size: 14;
+		font-size: $font-body-small;
 		color: var( --color-neutral-80 );
 	}
 
@@ -373,7 +373,7 @@
 	}
 
 	ul {
-		font-size: 14;
+		font-size: $font-body-small;
 		color: var( --color-neutral-80 );
 		list-style-type: circle;
 		list-style-position: inside;

--- a/client/blocks/inline-help/inline-help-center-content.scss
+++ b/client/blocks/inline-help/inline-help-center-content.scss
@@ -92,9 +92,9 @@
 					svg {
 						margin-right: 15px;
 						display: block;
-						padding: 5px;
+						padding: 8px;
 						background: var( --studio-gray-0 );
-						fill: var( --studio-blue-70 );
+						fill: var( --studio-blue-50 );
 					}
 
 					span {
@@ -103,16 +103,6 @@
 					}
 				}
 			}
-		}
-	}
-
-	/**
-	* RICH RESULTS
-	*/
-	.inline-help__secondary-view.inline-help__richresult {
-		button.button.is-borderless {
-			font-size: $font-body-small;
-			color: var( --studio-gray-100 );
 		}
 	}
 
@@ -127,10 +117,10 @@
 			.inline-help__resource-cell button {
 				display: flex;
 
-				svg {
+				svg:first-of-type {
 					margin-right: 15px;
 					display: block;
-					padding: 5px;
+					padding: 8px;
 					background: var( --studio-gray-0 );
 				}
 
@@ -172,10 +162,12 @@
 					> :first-child {
 						fill: var( --studio-blue-70 );
 					}
+
 					span {
 						text-decoration: none;
 						color: var( --studio-gray-100 );
 					}
+
 					> svg:last-child {
 						align-self: auto;
 						background: none;
@@ -183,6 +175,21 @@
 						padding-left: 8px;
 					}
 				}
+			}
+		}
+	}
+
+	/**
+	* SECONDARY-VIEW HEADER
+	*/
+	.inline-help__secondary-view {
+		&.inline-help__richresult,
+		&.inline-help__contact {
+			button.button.is-borderless {
+				display: flex;
+				align-items: center;
+				font-size: $font-body-small;
+				color: var( --studio-gray-100 );
 			}
 		}
 	}
@@ -322,11 +329,6 @@
 * ARTICLE EMBED
 */
 .help-center .help-center__container .inline-help__embed-result {
-	svg.gridicons-external {
-		height: 20px;
-		width: 20px;
-	}
-
 	h1.support-article-dialog__header-title-link {
 		font-size: $font-title-medium;
 	}
@@ -415,7 +417,12 @@
 		padding: 16px 0;
 	}
 
-	.wp-block-button__link {
+	:where( .wp-block-group.has-background ) {
+		padding: 0;
+	}
+
+	.wp-block-button__link,
+	.button-primary {
 		background-color: transparent;
 		border: 1px solid var( --studio-gray-10 );
 		border-radius: 2px;

--- a/client/blocks/inline-help/inline-help-contact-page.tsx
+++ b/client/blocks/inline-help/inline-help-contact-page.tsx
@@ -1,6 +1,6 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useSupportAvailability } from '@automattic/data-stores';
-import { Icon, comment } from '@wordpress/icons';
+import { Icon, comment, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import React, { useEffect } from 'react';
@@ -43,7 +43,7 @@ const InlineHelpContactPage: React.FC< Props > = ( {
 	return (
 		<div className="inline-help__contact-page">
 			<Button borderless={ true } onClick={ closeContactPage } className="inline-help__back-button">
-				<Gridicon icon={ 'chevron-left' } size={ 18 } />
+				<Icon icon={ chevronLeft } size={ 18 } />
 				{ __( 'Back' ) }
 			</Button>
 			<div className="inline-help__contact-content">

--- a/client/blocks/inline-help/inline-help-embed-result.tsx
+++ b/client/blocks/inline-help/inline-help-embed-result.tsx
@@ -1,7 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { Flex, FlexItem } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
+import { Icon, external, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import ArticleContent from 'calypso/blocks/support-article-dialog/dialog-content';
@@ -38,13 +39,13 @@ const InlineHelpEmbedResult: React.FC< Props > = ( { result, handleBackButton, s
 			<Flex justify="space-between">
 				<FlexItem>
 					<Button borderless={ true } onClick={ handleBackButton }>
-						<Gridicon icon={ 'chevron-left' } size={ 18 } />
+						<Icon icon={ chevronLeft } size={ 20 } />
 						{ __( 'Back' ) }
 					</Button>
 				</FlexItem>
 				<FlexItem>
 					<Button borderless={ true } href={ link } target="_blank">
-						<Gridicon icon={ 'external' } size={ 18 } />
+						<Icon icon={ external } size={ 20 } />
 					</Button>
 				</FlexItem>
 			</Flex>


### PR DESCRIPTION
## Changes proposed in this Pull Request

Applying styling to embed article result for help-center. This does not apply to other places where inline-help is being used.

<img width="410" alt="Markup 2022-05-06 at 00 45 45" src="https://user-images.githubusercontent.com/33258733/167037107-51396d16-2816-4897-bdb7-ff817982459c.png">

<img width="411" alt="Markup 2022-05-06 at 00 46 11" src="https://user-images.githubusercontent.com/33258733/167037175-1a6ef6b0-4ccc-413f-a3bd-001c8342555e.png">

## Testing instructions

1. Pull branch & `cd apps/editing-toolkit && yarn dev --sync`
2. Login to sandboxed site
3. Check help-center article from editor

Fixes #63275