### PR TITLE
[TeamCity] Fix GH Gutenberg release download URL for the source-maps build

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -209,7 +209,7 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 					# Install the Sentry CLI binary
 					curl -sL https://sentry.io/get-cli/ | bash
 
-					wget https://github.com/WordPress/gutenberg/releases/tag/%GUTENBERG_VERSION%/gutenberg.zip
+					wget https://github.com/WordPress/gutenberg/releases/download/%GUTENBERG_VERSION%/gutenberg.zip
 					unzip gutenberg.zip -d gutenberg
 					cd gutenberg
 


### PR DESCRIPTION
Project: p9oQ9f-18L-p2

#### Changes proposed in this Pull Request

Follow up to: https://github.com/Automattic/wp-calypso/pull/63260

Fixes the GH release download URL.

#### Testing instructions

* `wget https://github.com/WordPress/gutenberg/releases/download/v13.0.0/gutenberg.zip` locally and `unzip gutenberg.zip`. It should be a valid zip and extract fine.
* Build must pass.