### PR TITLE
Generated design picker: User interactions

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -2,7 +2,6 @@ import { Category } from '@automattic/design-picker';
 
 const CATEGORY_BLOG = 'blog';
 const CATEGORY_STORE = 'store';
-const CATEGORY_GENERATED = 'generated';
 
 /**
  * Ensures the category appears at the top of the design category list
@@ -23,13 +22,8 @@ function makeSortCategoryToTop( slug: string ) {
 
 const sortBlogToTop = makeSortCategoryToTop( CATEGORY_BLOG );
 const sortStoreToTop = makeSortCategoryToTop( CATEGORY_STORE );
-const sortGeneratedToTop = makeSortCategoryToTop( CATEGORY_GENERATED );
 
-export function getCategorizationOptions(
-	intent: string,
-	showAllFilter: boolean,
-	showGeneratedDesigns: boolean
-) {
+export function getCategorizationOptions( intent: string, showAllFilter: boolean ) {
 	const result = {
 		showAllFilter,
 		defaultSelection: null,
@@ -38,14 +32,6 @@ export function getCategorizationOptions(
 		defaultSelection: string | null;
 		sort: ( a: Category, b: Category ) => 0 | 1 | -1;
 	};
-
-	if ( showGeneratedDesigns ) {
-		return {
-			...result,
-			defaultSelection: CATEGORY_GENERATED,
-			sort: sortGeneratedToTop,
-		};
-	}
 
 	switch ( intent ) {
 		case 'write':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -157,10 +157,9 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	const categorizationOptions = getCategorizationOptions(
 		intent,
-		showDesignPickerCategoriesAllFilter,
-		showGeneratedDesigns
+		showDesignPickerCategoriesAllFilter || showGeneratedDesigns
 	);
-	const categorization = useCategorization( shuffledStaticDesigns, categorizationOptions );
+	const categorization = useCategorization( staticDesigns, categorizationOptions );
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -3,6 +3,7 @@ import { planHasFeature, FEATURE_PREMIUM_THEMES } from '@automattic/calypso-prod
 import { Button } from '@automattic/components';
 import DesignPicker, {
 	GeneratedDesignPicker,
+	GeneratedDesignPreview,
 	PremiumBadge,
 	useCategorization,
 	isBlankCanvasDesign,
@@ -239,17 +240,16 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	}
 
 	const handleBackClick = () => {
-		if ( selectedDesign && ! showGeneratedDesigns ) {
-			setSelectedDesign( undefined );
-			setIsPreviewingDesign( false );
-		} else {
+		if ( ! selectedDesign || ( showGeneratedDesigns && ! isMobile ) ) {
 			goBack();
+			return null;
 		}
+
+		setSelectedDesign( undefined );
+		setIsPreviewingDesign( false );
 	};
 
-	let stepContent = <div />;
-
-	if ( selectedDesign && isPreviewingDesign && ! showGeneratedDesigns ) {
+	function previewStaticDesign() {
 		const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
 		const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
 		const shouldUpgrade = selectedDesign.is_premium && ! isPremiumThemeAvailable;
@@ -259,7 +259,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 			siteTitle: intent === 'write' ? siteTitle : undefined,
 		} );
 
-		stepContent = (
+		const stepContent = (
 			<WebPreview
 				showPreview
 				showClose={ false }
@@ -308,6 +308,42 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 				recordTracksEvent={ recordTracksEvent }
 			/>
 		);
+	}
+
+	function previewGeneratedDesign() {
+		const stepContent = (
+			<GeneratedDesignPreview
+				slug={ selectedDesign.slug }
+				previewUrl={ getDesignPreviewUrl( selectedDesign, { language: locale } ) }
+			/>
+		);
+
+		return (
+			<StepContainer
+				stepName={ 'design-setup' }
+				stepContent={ stepContent }
+				hideSkip
+				hideNext={ false }
+				className={ classnames( 'design-setup__preview', 'design-picker__is-generated' ) }
+				nextLabelText={ 'Continue' }
+				backLabelText={ 'Pick another' }
+				goBack={ handleBackClick }
+				goNext={ () => pickDesign() }
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		);
+	}
+
+	let stepContent = <div />;
+
+	if ( selectedDesign && isPreviewingDesign ) {
+		if ( showGeneratedDesigns && isMobile ) {
+			return previewGeneratedDesign();
+		}
+
+		if ( ! showGeneratedDesigns ) {
+			return previewStaticDesign();
+		}
 	}
 
 	const heading = (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -249,11 +249,11 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		setIsPreviewingDesign( false );
 	};
 
-	function previewStaticDesign() {
-		const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
-		const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
-		const shouldUpgrade = selectedDesign.is_premium && ! isPremiumThemeAvailable;
-		const previewUrl = getDesignPreviewUrl( selectedDesign, {
+	function previewStaticDesign( design: Design ) {
+		const isBlankCanvas = isBlankCanvasDesign( design );
+		const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : design.title;
+		const shouldUpgrade = design.is_premium && ! isPremiumThemeAvailable;
+		const previewUrl = getDesignPreviewUrl( design, {
 			language: locale,
 			// If the user fills out the site title with write intent, we show it on the design preview
 			siteTitle: intent === 'write' ? siteTitle : undefined,
@@ -310,11 +310,11 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		);
 	}
 
-	function previewGeneratedDesign() {
+	function previewGeneratedDesign( design: Design ) {
 		const stepContent = (
 			<GeneratedDesignPreview
-				slug={ selectedDesign.slug }
-				previewUrl={ getDesignPreviewUrl( selectedDesign, { language: locale } ) }
+				slug={ design.slug }
+				previewUrl={ getDesignPreviewUrl( design, { language: locale } ) }
 			/>
 		);
 
@@ -338,11 +338,11 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	if ( selectedDesign && isPreviewingDesign ) {
 		if ( showGeneratedDesigns && isMobile ) {
-			return previewGeneratedDesign();
+			return previewGeneratedDesign( selectedDesign );
 		}
 
 		if ( ! showGeneratedDesigns ) {
-			return previewStaticDesign();
+			return previewStaticDesign( selectedDesign );
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -319,6 +319,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 			<GeneratedDesignPreview
 				slug={ design.slug }
 				previewUrl={ getDesignPreviewUrl( design, { language: locale } ) }
+				isSelected
 			/>
 		);
 
@@ -360,7 +361,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	const stepContent = showGeneratedDesigns ? (
 		<GeneratedDesignPicker
-			selectedDesign={ ! isMobile ? selectedDesign || shuffledGeneratedDesigns[ 0 ] : null }
+			selectedDesign={ ! isMobile ? selectedDesign || shuffledGeneratedDesigns[ 0 ] : undefined }
 			designs={ shuffledGeneratedDesigns }
 			locale={ locale }
 			heading={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -374,14 +374,6 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 			flex-direction: column;
 			row-gap: 24px;
 			margin-bottom: 162px;
-
-			> div {
-				display: none;
-
-				&:first-of-type {
-					display: block;
-				}
-			}
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -294,6 +294,32 @@ $design-button-primary-color: rgb( 17, 122, 201 );
  * Generated Design Picker
  */
 .design-picker__is-generated {
+	&.design-setup__preview {
+		padding: 0;
+
+		.step-container__header {
+			margin: 0;
+		}
+
+		.step-container__content {
+			height: calc( 100vh - 157px );
+			margin-top: 48px;
+			overflow: scroll;
+			padding: 0 24px;
+		}
+
+		.generated-design-preview__frame {
+			max-height: none;
+			margin-bottom: 24px;
+
+			.mshots-image__container {
+				object-fit: cover;
+				object-position: top;
+				width: 100%;
+			}
+		}
+	}
+
 	.step-container__header {
 		align-items: center;
 		display: flex;

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -149,4 +149,4 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 	);
 };
 
-export default GeneratedDesignPicker;
+export { GeneratedDesignPicker as default, GeneratedDesignPreview };

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -67,14 +67,16 @@ const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
 interface GeneratedDesignPreviewProps {
 	slug: string;
 	previewUrl: string;
+	isSelected: boolean;
 }
 
 const GeneratedDesignPreview: React.FC< GeneratedDesignPreviewProps > = ( {
 	slug,
 	previewUrl,
+	isSelected,
 } ) => {
 	return (
-		<div className="generated-design-preview">
+		<div className={ classnames( 'generated-design-preview', { 'is-selected': isSelected } ) }>
 			<div className="generated-design-preview__header">
 				<svg width="36" height="8">
 					<g>
@@ -136,13 +138,15 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 					</Button>
 				</div>
 				<div className="generated-design-picker__previews">
-					{ selectedDesign && (
-						<GeneratedDesignPreview
-							key={ selectedDesign.slug }
-							slug={ selectedDesign.slug }
-							previewUrl={ getDesignPreviewUrl( selectedDesign, { language: locale } ) }
-						/>
-					) }
+					{ designs &&
+						designs.map( ( design ) => (
+							<GeneratedDesignPreview
+								key={ design.slug }
+								slug={ design.slug }
+								isSelected={ selectedDesign?.slug === design.slug }
+								previewUrl={ getDesignPreviewUrl( design, { language: locale } ) }
+							/>
+						) ) }
 				</div>
 			</div>
 		</div>

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@automattic/components';
 import { MShotsImage } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
 import { getDesignPreviewUrl } from '../utils';
 import type { Design } from '../types';
 import type { MShotsOptions } from '@automattic/onboarding';
@@ -25,14 +26,22 @@ const previewImageOptions: MShotsOptions = {
 interface GeneratedDesignThumbnailProps {
 	slug: string;
 	thumbnailUrl: string;
+	isSelected: boolean;
+	onPreview: () => void;
 }
 
 const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
 	slug,
 	thumbnailUrl,
+	isSelected,
+	onPreview,
 } ) => {
 	return (
-		<button type="button" className="generated-design-thumbnail">
+		<button
+			type="button"
+			className={ classnames( 'generated-design-thumbnail', { 'is-selected': isSelected } ) }
+			onClick={ onPreview }
+		>
 			<span className="generated-design-thumbnail__header">
 				<svg width="28" height="6">
 					<g>
@@ -89,15 +98,21 @@ const GeneratedDesignPreview: React.FC< GeneratedDesignPreviewProps > = ( {
 };
 
 export interface GeneratedDesignPickerProps {
+	selectedDesign?: Design;
 	designs: Design[];
 	locale: string;
 	heading?: React.ReactElement;
+	onPreview: ( slug: string ) => void;
+	onViewMore: () => void;
 }
 
 const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
+	selectedDesign,
 	designs,
 	locale,
 	heading,
+	onPreview,
+	onViewMore,
 } ) => {
 	const { __ } = useI18n();
 
@@ -112,21 +127,22 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 								key={ design.slug }
 								slug={ design.slug }
 								thumbnailUrl={ getDesignPreviewUrl( design, { language: locale } ) }
+								isSelected={ selectedDesign?.slug === design.slug }
+								onPreview={ () => onPreview( design ) }
 							/>
 						) ) }
-					<Button className="generated-design-picker__view-more">
+					<Button className="generated-design-picker__view-more" onClick={ onViewMore }>
 						{ __( 'View more options' ) }
 					</Button>
 				</div>
 				<div className="generated-design-picker__previews">
-					{ designs &&
-						designs.map( ( design ) => (
-							<GeneratedDesignPreview
-								key={ design.slug }
-								slug={ design.slug }
-								previewUrl={ getDesignPreviewUrl( design, { language: locale } ) }
-							/>
-						) ) }
+					{ selectedDesign && (
+						<GeneratedDesignPreview
+							key={ selectedDesign.slug }
+							slug={ selectedDesign.slug }
+							previewUrl={ getDesignPreviewUrl( selectedDesign, { language: locale } ) }
+						/>
+					) }
 				</div>
 			</div>
 		</div>

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -102,7 +102,7 @@ export interface GeneratedDesignPickerProps {
 	designs: Design[];
 	locale: string;
 	heading?: React.ReactElement;
-	onPreview: ( slug: string ) => void;
+	onPreview: ( design: Design ) => void;
 	onViewMore: () => void;
 }
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -391,7 +391,7 @@
 
 .generated-design-thumbnail {
 	align-items: stretch;
-	box-shadow: inset 0 0 0 1px #fff, 0 0 0 1px #dddddd;
+	border: 1px solid #dddddd;
 	border-radius: 4px;
 	box-sizing: border-box;
 	cursor: pointer;
@@ -400,7 +400,19 @@
 	height: 355px;
 	padding: 0;
 	overflow: hidden;
+	transition: border-color 0.15s ease-in-out;
 	width: 100%;
+
+	&:hover,
+	&.is-selected {
+		border-color: #117ac9;
+		outline: 0;
+	}
+
+	&:focus-visible {
+		border-color: #dddddd;
+		outline: 2px solid var( --studio-blue-30 );
+	}
 
 	.generated-design-thumbnail__header {
 		border-bottom: 1px solid #dddddd;
@@ -486,10 +498,6 @@
 		.generated-design-preview__frame {
 			border-radius: 0 0 8px 8px; /* stylelint-disable-line scales/radii */
 			max-height: none;
-		}
-
-		.generated-design-preview__name {
-			display: none;
 		}
 	}
 }

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -485,6 +485,12 @@
 	}
 
 	@include break-small {
+		display: none;
+
+		&.is-selected {
+			display: block;
+		}
+
 		.generated-design-preview__header {
 			border-radius: 8px 8px 0 0; /* stylelint-disable-line scales/radii */
 			height: 34px;

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -1,5 +1,8 @@
 export { default } from './components';
-export { default as GeneratedDesignPicker } from './components/generated-design-picker';
+export {
+	default as GeneratedDesignPicker,
+	GeneratedDesignPreview,
+} from './components/generated-design-picker';
 
 export { default as FeaturedPicksButtons } from './components/featured-picks-buttons';
 export { default as PremiumBadge } from './components/premium-badge';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds several user interactions to the generated design picker:

The ordering of thumbnails is now randomized.
![Screen Shot 2022-05-06 at 12 08 25 PM](https://user-images.githubusercontent.com/797888/167065484-f38056b9-03fd-405c-a99c-7c8d8e59c782.png)
![Screen Shot 2022-05-06 at 12 08 35 PM](https://user-images.githubusercontent.com/797888/167065493-d038f191-6c34-4a80-9564-61420ff658d8.png)

(Desktop resolution) Clicking on a thumbnail will show its preview on the side.
![Screen Shot 2022-05-06 at 12 08 50 PM](https://user-images.githubusercontent.com/797888/167065508-62341efd-a71a-4e12-9dd6-1bf3cc1147f0.png)

(Mobile resolution) Clicking on a thumbnail will show its preview front and center of screen. 
![Screen Shot 2022-05-06 at 12 09 04 PM](https://user-images.githubusercontent.com/797888/167065531-cb9940e9-422e-4568-ad78-d8496f382676.png)

(Mobile resolution) While on preview mode, clicking on the "Pick another" button will hide the preview and show thumbnails instead.
![Screen Shot 2022-05-06 at 12 09 04 PM](https://user-images.githubusercontent.com/797888/167065578-ccfb61a4-b04b-4faf-8cd5-985f14c6f1c4.png)

Clicking on "View more options" button will show the tranditional design picker.
![Screen Shot 2022-05-06 at 12 08 50 PM](https://user-images.githubusercontent.com/797888/167065612-b4439d0e-e3e3-4d15-be7e-6f14b8084ec7.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the intent screen `/setup/intent?siteSlug=${site_slug}`
* Then click on "Start building" and expect to land on the generated design picker.
* Test: The ordering of thumbnails is now randomized.
  * Refresh the page a couple of times, expect the thumbnail ordering to be randomized each time.  
* Test: (Desktop resolution) Clicking on a thumbnail will show its preview on the side.
  * Click on a thumbnail, expect the preview on the right side to change according to the thumbnail selection.
* Test: (Mobile resolution) Clicking on a thumbnail will show its preview front and center of screen. 
  * Click on a thumbnail, expect the preview to show up prominent at the center of the screen (refer to the screenshot in the description)
* Test: (Mobile resolution) While in preview mode, clicking on the "Pick another" button will hide the preview and show thumbnails instead.
  * Click on the "Pick another" button, expect the preview to hide and go back to thumbnail selection screen.
* Test: Clicking on "View more options" button will show the traditional design picker.
  * Click on "View more options", expect the generated design picker to be replaced with the traditional design picker.

Caveat:
At the moment, forcing the traditional design picker "View more options" doesn't persist across once you navigate away from the page. This means that if users refresh the page, or goes back to the intent screen and click again on the "Start building" button, they will land on the generated design screen again (@saygun can confirm what's the expected behavior on this).

Another caveat is that once in the traditional design screen, there's no way to switch back to the generated design picker unless navigating away as described above.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62237
