### PR TITLE
ToS tracking: Remove the line that navigates to home page

### DIFF
--- a/test/e2e/specs/martech/tos-screenshots__checkout.ts
+++ b/test/e2e/specs/martech/tos-screenshots__checkout.ts
@@ -95,7 +95,6 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 				page.setViewportSize( { width: 1280, height: 720 } );
 				await page.goto( DataHelper.getCalypsoURL( 'home' ), { waitUntil: 'networkidle' } );
 				await changeUILanguageFlow.changeUILanguage( locale as LanguageSlug );
-				await page.goto( DataHelper.getCalypsoURL( 'home' ) );
 				await page.reload( { waitUntil: 'networkidle' } );
 				await cartCheckoutPage.visit( blogName );
 				await cartCheckoutPage.validatePaymentForm();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For some unknown and weird reason, the line that navigates to the Home page is timing out and the test is aborting. So, removing this line to see if it makes a difference.

<img width="1167" alt="Screenshot 2022-05-06 at 1 36 08 PM" src="https://user-images.githubusercontent.com/1269602/167106852-d1609eba-065f-4d3a-8a35-104d15c6d3ad.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the checkout test completes successfully. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
