### PR TITLE
Video-UI: Adding support to intent prop

### DIFF
--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -40,7 +40,7 @@ const VideosUi = ( {
 		recordTracksEvent( 'calypso_courses_play_click', {
 			course: course.slug,
 			video: videoSlug,
-			intent,
+			...( intent ? { intent } : [] ),
 		} );
 
 		setCurrentVideoKey( videoSlug );
@@ -92,7 +92,7 @@ const VideosUi = ( {
 		if ( course ) {
 			recordTracksEvent( 'calypso_courses_view', {
 				course: course.slug,
-				intent,
+				...( intent ? { intent } : [] ),
 			} );
 		}
 	}, [ course ] );

--- a/client/components/videos-ui/index.jsx
+++ b/client/components/videos-ui/index.jsx
@@ -19,6 +19,7 @@ const VideosUi = ( {
 	HeaderBar,
 	FooterBar,
 	areVideosTranslated = true,
+	intent = undefined,
 } ) => {
 	const translate = useTranslate();
 	const isEnglish = config( 'english_locales' ).includes( translate.localeSlug );
@@ -39,6 +40,7 @@ const VideosUi = ( {
 		recordTracksEvent( 'calypso_courses_play_click', {
 			course: course.slug,
 			video: videoSlug,
+			intent,
 		} );
 
 		setCurrentVideoKey( videoSlug );
@@ -90,6 +92,7 @@ const VideosUi = ( {
 		if ( course ) {
 			recordTracksEvent( 'calypso_courses_view', {
 				course: course.slug,
+				intent,
 			} );
 		}
 	}, [ course ] );
@@ -155,6 +158,7 @@ const VideosUi = ( {
 							onVideoPlayStatusChanged={ ( isVideoPlaying ) => setIsPlaying( isVideoPlaying ) }
 							isPlaying={ isPlaying }
 							course={ course }
+							intent={ intent }
 							onVideoCompleted={ markVideoCompleted }
 						/>
 					) }

--- a/client/components/videos-ui/test/index.jsx
+++ b/client/components/videos-ui/test/index.jsx
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { mount } from 'enzyme';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import ModalFooterBar from 'calypso/components/videos-ui/modal-footer-bar';
+import ModalHeaderBar from 'calypso/components/videos-ui/modal-header-bar';
+import { COURSE_SLUGS } from '../../../data/courses';
+import VideoUI from '../index';
+import VideoChapters from '../video-chapters';
+
+const useCourseData = () => {
+	return {
+		course: {
+			videos: [],
+			cta: {
+				action: 'action',
+			},
+			slug: COURSE_SLUGS.BLOGGING_QUICK_START,
+		},
+		isCourseComplete: () => false,
+	};
+};
+
+const useUpdateUserCourseProgressionMutation = () => {
+	return {
+		updateUserCourseProgression: jest.fn(),
+	};
+};
+
+jest.mock( 'calypso/data/courses', () => ( {
+	COURSE_SLUGS: {
+		BLOGGING_QUICK_START: 'blogging-quick-start',
+	},
+	useCourseData,
+	useUpdateUserCourseProgressionMutation,
+} ) );
+
+describe( 'Video-UI', () => {
+	beforeEach( () => {
+		window._tkq = {
+			push: jest.fn(),
+		};
+	} );
+
+	test( 'Track event with intent prop', () => {
+		const useStateMock = ( useState ) => [ useState, jest.fn() ];
+		jest.spyOn( React, 'useState' ).mockImplementation( useStateMock );
+		const initialState = {
+			ui: { section: 'test' },
+			documentHead: { unreadCount: 1 },
+		};
+		const store = createStore( ( state ) => state, initialState );
+
+		const result = mount(
+			<Provider store={ store }>
+				<VideoUI
+					store={ store }
+					FooterBar={ ( footerProps ) => <ModalFooterBar { ...footerProps } /> }
+					HeaderBar={ ( headerProps ) => <ModalHeaderBar { ...headerProps } /> }
+					intent="build"
+				/>
+			</Provider>
+		);
+
+		result.find( VideoChapters ).first().prop( 'onVideoPlayClick' )();
+
+		expect( window._tkq.push ).toHaveBeenCalledWith( [
+			'recordEvent',
+			'calypso_courses_view',
+			{
+				course: COURSE_SLUGS.BLOGGING_QUICK_START,
+				intent: 'build',
+			},
+		] );
+
+		expect( window._tkq.push ).toHaveBeenCalledWith( [
+			'recordEvent',
+			'calypso_courses_play_click',
+			{
+				course: COURSE_SLUGS.BLOGGING_QUICK_START,
+				intent: 'build',
+			},
+		] );
+	} );
+
+	test( 'Track event without intent prop', () => {
+		const useStateMock = ( useState ) => [ useState, jest.fn() ];
+		jest.spyOn( React, 'useState' ).mockImplementation( useStateMock );
+		const initialState = {
+			ui: { section: 'test' },
+			documentHead: { unreadCount: 1 },
+		};
+		const store = createStore( ( state ) => state, initialState );
+
+		const result = mount(
+			<Provider store={ store }>
+				<VideoUI
+					store={ store }
+					FooterBar={ ( footerProps ) => <ModalFooterBar { ...footerProps } /> }
+					HeaderBar={ ( headerProps ) => <ModalHeaderBar { ...headerProps } /> }
+				/>
+			</Provider>
+		);
+
+		result.find( VideoChapters ).first().prop( 'onVideoPlayClick' )();
+
+		expect( window._tkq.push ).toHaveBeenCalledWith( [
+			'recordEvent',
+			'calypso_courses_view',
+			{
+				course: COURSE_SLUGS.BLOGGING_QUICK_START,
+			},
+		] );
+
+		expect( window._tkq.push ).toHaveBeenCalledWith( [
+			'recordEvent',
+			'calypso_courses_play_click',
+			{
+				course: COURSE_SLUGS.BLOGGING_QUICK_START,
+			},
+		] );
+	} );
+} );

--- a/client/components/videos-ui/test/video-player.jsx
+++ b/client/components/videos-ui/test/video-player.jsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import ShallowRenderer from 'react-test-renderer/shallow';
+import VideoPlayer from '../video-player';
+
+describe( 'Video player', () => {
+	let renderer;
+
+	const videoData = {
+		poster: 'image.png',
+		url: 'video.mp4',
+	};
+	const course = { slug: 'course-slug' };
+
+	beforeEach( () => {
+		renderer = new ShallowRenderer();
+
+		window._tkq = {
+			push: jest.fn(),
+		};
+	} );
+
+	test( 'Track event with intent prop', () => {
+		renderer.render( <VideoPlayer intent="build" course={ course } videoData={ videoData } /> );
+		const result = renderer.getRenderOutput();
+
+		result.props.children.props.onPlay();
+
+		expect( window._tkq.push ).toHaveBeenCalledWith( [
+			'recordEvent',
+			'calypso_courses_video_player_play_click',
+			{
+				course: 'course-slug',
+				intent: 'build',
+			},
+		] );
+	} );
+
+	test( 'Track event without intent prop', () => {
+		renderer.render( <VideoPlayer course={ course } videoData={ videoData } /> );
+		const result = renderer.getRenderOutput();
+
+		result.props.children.props.onPlay();
+
+		expect( window._tkq.push ).toHaveBeenCalledWith( [
+			'recordEvent',
+			'calypso_courses_video_player_play_click',
+			{
+				course: 'course-slug',
+			},
+		] );
+	} );
+} );

--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -7,7 +7,7 @@ const VideoPlayer = ( {
 	course,
 	onVideoPlayStatusChanged,
 	onVideoCompleted,
-	intent,
+	intent = undefined,
 } ) => {
 	const [ shouldCheckForVideoComplete, setShouldCheckForVideoComplete ] = useState( true );
 
@@ -47,7 +47,7 @@ const VideoPlayer = ( {
 		recordTracksEvent( 'calypso_courses_video_player_play_click', {
 			course: course.slug,
 			video: videoData.slug,
-			intent,
+			...( intent ? { intent } : [] ),
 		} );
 	};
 

--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -7,6 +7,7 @@ const VideoPlayer = ( {
 	course,
 	onVideoPlayStatusChanged,
 	onVideoCompleted,
+	intent,
 } ) => {
 	const [ shouldCheckForVideoComplete, setShouldCheckForVideoComplete ] = useState( true );
 
@@ -46,6 +47,7 @@ const VideoPlayer = ( {
 		recordTracksEvent( 'calypso_courses_video_player_play_click', {
 			course: course.slug,
 			video: videoData.slug,
+			intent,
 		} );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the intent prop to the Video-UI component to allow us to track events with the intent.

#### Testing instructions

* The intent prop is not being used yet in this PR.
* To test it, I created unit tests for the components, which can be run with the following commands:
```
node 'node_modules/.bin/jest' './client/components/videos-ui/test/index.jsx' -c './test/client/jest.config.js' -t 'Video-UI'
```
```
node 'node_modules/.bin/jest' './client/components/videos-ui/test/video-player.jsx' -c './test/client/jest.config.js' -t 'Video player'
```

Related to #58247
