### PR TITLE
Fix bug preventing some users from adding Titan mailboxes

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -245,7 +245,7 @@ const EmailPlan = ( props ) => {
 	function renderAddNewMailboxesOrRenewNavItem() {
 		const { canAddMailboxes, domain, hasSubscription, purchase, translate } = props;
 
-		if ( hasTitanMailWithUs( domain ) && ! hasSubscription && canAddMailboxes ) {
+		if ( hasTitanMailWithUs( domain ) && ! hasSubscription ) {
 			return (
 				<VerticalNavItem { ...getAddMailboxProps() }>
 					{ translate( 'Add new mailboxes' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the issue reported in #63318, which was originally introduced in #62556. The core issue is that the special logic to show the "Add new mailboxes" button when Titan manages billing for the subscription was updated to also require subscription data from our billing system (as embodied by the `canAddMailboxes` prop), which will never be true. The fix is to remove the `canAddMailboxes` condition from that specific check.

#### Testing instructions

* Testing instructions require some internal tools, so I have documented the instructions here: pcyqBp-pb-p2#comment-1269

Fixes #63318