### PR TITLE
webpack-rtl-plugin: Merge css-diff to update postcss dep

### DIFF
--- a/packages/webpack-rtl-plugin/CHANGELOG.md
+++ b/packages/webpack-rtl-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Merged in code from [@romainberger/css-diff](https://github.com/romainberger/css-diff) to update the postcss dependency version.
+
 ## 5.1.0 - 2021-11-02
 
 ### Added

--- a/packages/webpack-rtl-plugin/LICENSE.md
+++ b/packages/webpack-rtl-plugin/LICENSE.md
@@ -1,4 +1,4 @@
-webpack-rtl-plugin adapted from [webpack-rtl-plugin](https://github.com/romainberger/webpack-rtl-plugin), released by Romain Berger under the MIT License (MIT):
+webpack-rtl-plugin adapted from [webpack-rtl-plugin](https://github.com/romainberger/webpack-rtl-plugin) and [@romainberger/css-diff](https://github.com/romainberger/css-diff), released by Romain Berger under the MIT License (MIT):
 
 MIT License
 

--- a/packages/webpack-rtl-plugin/package.json
+++ b/packages/webpack-rtl-plugin/package.json
@@ -33,7 +33,6 @@
 		"webpack": "^5.68.0"
 	},
 	"dependencies": {
-		"lodash.merge": "^4.6.2",
 		"postcss": "^8.4.5",
 		"rtlcss": "^3.1.2"
 	}

--- a/packages/webpack-rtl-plugin/package.json
+++ b/packages/webpack-rtl-plugin/package.json
@@ -33,7 +33,8 @@
 		"webpack": "^5.68.0"
 	},
 	"dependencies": {
-		"@romainberger/css-diff": "^1.0.3",
+		"lodash.merge": "^4.6.2",
+		"postcss": "^8.4.5",
 		"rtlcss": "^3.1.2"
 	}
 }

--- a/packages/webpack-rtl-plugin/src/css-diff.js
+++ b/packages/webpack-rtl-plugin/src/css-diff.js
@@ -1,5 +1,17 @@
-const merge = require( 'lodash.merge' );
 const { parse: postcssParse } = require( 'postcss' );
+
+// Simple merge for JS builtin types. That's all we need here, no need for lodash.
+const mergeObjects = ( a, b ) => {
+	if ( typeof a === 'object' && a !== null && typeof b === 'object' && b !== null ) {
+		const ret = Array.isArray( a ) ? [ ...a ] : { ...a };
+		for ( const k of Object.keys( b ) ) {
+			ret[ k ] = mergeObjects( ret[ k ], b[ k ] );
+		}
+		return ret;
+	}
+
+	return typeof b === 'undefined' ? a : b;
+};
 
 const parse = ( css ) => {
 	const ast = postcssParse( css );
@@ -16,7 +28,7 @@ const parse = ( css ) => {
 				declarations[ dcl.prop ] = dcl.value;
 			} );
 
-			result = merge( result, { [ node.selector ]: declarations } );
+			result = mergeObjects( result, { [ node.selector ]: declarations } );
 		}
 	} );
 

--- a/packages/webpack-rtl-plugin/src/css-diff.js
+++ b/packages/webpack-rtl-plugin/src/css-diff.js
@@ -1,0 +1,90 @@
+const merge = require( 'lodash.merge' );
+const { parse: postcssParse } = require( 'postcss' );
+
+const parse = ( css ) => {
+	const ast = postcssParse( css );
+	let result = {};
+
+	ast.nodes.forEach( ( node ) => {
+		if ( node.type === 'rule' ) {
+			const declarations = {};
+
+			node.nodes.forEach( ( dcl ) => {
+				if ( dcl.type !== 'decl' ) {
+					return;
+				}
+				declarations[ dcl.prop ] = dcl.value;
+			} );
+
+			result = merge( result, { [ node.selector ]: declarations } );
+		}
+	} );
+
+	return result;
+};
+
+const toString = ( css ) => {
+	let result = '';
+
+	Object.keys( css ).forEach( ( selector ) => {
+		result = `${ result }${ selector } {\n`;
+
+		Object.keys( css[ selector ] ).forEach( ( prop ) => {
+			result = `${ result }  ${ prop }: ${ css[ selector ][ prop ] };\n`;
+		} );
+
+		result = `${ result }}\n`;
+	} );
+
+	return result;
+};
+
+const addProp = ( diff, selector, prop, value ) => {
+	if ( diff[ selector ] ) {
+		diff[ selector ][ prop ] = value;
+	} else {
+		diff[ selector ] = {
+			[ prop ]: value,
+		};
+	}
+
+	return diff;
+};
+
+const cssDiff = ( source, reversed ) => {
+	let isStringified = false;
+
+	try {
+		source = JSON.parse( source );
+		reversed = JSON.parse( reversed );
+		isStringified = true;
+	} catch ( e ) {}
+
+	const sourceObject = parse( source );
+	const reversedObject = parse( reversed );
+	let diff = {};
+
+	Object.keys( reversedObject ).forEach( ( selector ) => {
+		Object.keys( reversedObject[ selector ] ).forEach( ( prop ) => {
+			if ( sourceObject[ selector ][ prop ] ) {
+				if ( sourceObject[ selector ][ prop ] !== reversedObject[ selector ][ prop ] ) {
+					diff = addProp( diff, selector, prop, reversedObject[ selector ][ prop ] );
+				}
+			} else {
+				diff = addProp( diff, selector, prop, reversedObject[ selector ][ prop ] );
+			}
+		} );
+	} );
+
+	diff = toString( diff );
+
+	if ( isStringified ) {
+		diff = JSON.stringify( diff );
+	}
+
+	return diff;
+};
+
+module.exports = cssDiff;
+module.exports.parse = parse;
+module.exports.toString = toString;

--- a/packages/webpack-rtl-plugin/src/index.js
+++ b/packages/webpack-rtl-plugin/src/index.js
@@ -1,6 +1,6 @@
-const cssDiff = require( '@romainberger/css-diff' );
 const rtlcss = require( 'rtlcss' );
 const { ConcatSource } = require( 'webpack' ).sources;
+const cssDiff = require( './css-diff.js' );
 
 const pluginName = 'WebpackRTLPlugin';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1399,9 +1399,10 @@ __metadata:
   resolution: "@automattic/webpack-rtl-plugin@workspace:packages/webpack-rtl-plugin"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@romainberger/css-diff": ^1.0.3
     css-loader: ^6.5.1
+    lodash.merge: ^4.6.2
     mini-css-extract-plugin: ^1.6.2
+    postcss: ^8.4.5
     rtlcss: ^3.1.2
     webpack: ^5.68.0
   peerDependencies:
@@ -4826,16 +4827,6 @@ __metadata:
   peerDependencies:
     rollup: ^1.20.0||^2.0.0
   checksum: 7151753160d15ba2b259461a6c25b3932150994ea52dba8fd3144f634c7647c2e56733d986e2c15de67c4d96a9ee7d6278efa6d2e626a7169898fd64adc0f90c
-  languageName: node
-  linkType: hard
-
-"@romainberger/css-diff@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "@romainberger/css-diff@npm:1.0.3"
-  dependencies:
-    lodash.merge: ^4.4.0
-    postcss: ^5.0.21
-  checksum: 6d7891d5c46060e0735f0d09ebddd7c3228834f0c8150795d7c4c6a64c0c205009cfa06b1db04e234fe143054078157ba459abd5f26206b37ea470565fd60fec
   languageName: node
   linkType: hard
 
@@ -19403,13 +19394,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-flag@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "has-flag@npm:1.0.0"
-  checksum: d0ad4bebbbc005edccfa1e2c0600c89375be5663d23f49a129e0f817187405748b0b515abfc5b3c209c92692e39bb0481c83c0ee4df69433d6ffd0242183100b
-  languageName: node
-  linkType: hard
-
 "has-flag@npm:^3.0.0":
   version: 3.0.0
   resolution: "has-flag@npm:3.0.0"
@@ -22437,7 +22421,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-base64@npm:^2.1.9, js-base64@npm:^2.6.1":
+"js-base64@npm:^2.6.1":
   version: 2.6.4
   resolution: "js-base64@npm:2.6.4"
   checksum: 95d93c4eca0bbe0f2d5ffe8682d9acd23051e5c0ad71873ff5a48dd46a5f19025de9f7b36e63fa3f02f342ae4a8ca4c56e7b590d7300ebb6639ce09675e0fd02
@@ -28041,18 +28025,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^5.0.21":
-  version: 5.2.18
-  resolution: "postcss@npm:5.2.18"
-  dependencies:
-    chalk: ^1.1.3
-    js-base64: ^2.1.9
-    source-map: ^0.5.6
-    supports-color: ^3.2.3
-  checksum: 1f9f6673dd24d52f1ed33b800248e6ef752d6b6a092fe268021e398df0d7e0956f00fb961781647264d659240c3d67f5bfd3df9bf1b7af985aa996be619d30b1
-  languageName: node
-  linkType: hard
-
 "postcss@npm:^6.0.23":
   version: 6.0.23
   resolution: "postcss@npm:6.0.23"
@@ -33479,15 +33451,6 @@ resolve@^2.0.0-next.3:
   version: 2.0.0
   resolution: "supports-color@npm:2.0.0"
   checksum: 570e0b63be36cccdd25186350a6cb2eaad332a95ff162fa06d9499982315f2fe4217e69dd98e862fbcd9c81eaff300a825a1fe7bf5cc752e5b84dfed042b0dda
-  languageName: node
-  linkType: hard
-
-"supports-color@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "supports-color@npm:3.2.3"
-  dependencies:
-    has-flag: ^1.0.0
-  checksum: d39a57dbd75c3b5740654f8ec16aaf7203b8d12b8a51314507bed590c9081120805f105b4ce741db13105e6f842ac09700e4bd665b9ffc46eb0b34ba54720bd3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,7 +1400,6 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     css-loader: ^6.5.1
-    lodash.merge: ^4.6.2
     mini-css-extract-plugin: ^1.6.2
     postcss: ^8.4.5
     rtlcss: ^3.1.2


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`@romainberger/css-diff` hasn't been updated since 2016 and depends on
postcss 5. Since it's fairly small, just merge it in to the existing
package so we can update the postcss dep to a more modern version.

Note this doesn't do anything to try to fix the `diffOnly` option, it should work
exactly as it did before with respect to things like ignoring `@media` queries.
But now someone else could have a better chance of fixing that if they want to.

I considered forking to an "`@automattic/css-diff`" package instead of merging
it into this one, but in the end I decided YAGNI and I'd go for the simpler option.
Someone could easily enough do that if they decide they need css diffing
in another context.

I also considered just dropping the `diffOnly` option since we don't use it,
it doesn't look like you use it, and a search on GitHub only turned up one
project that was still using webpack 4 and `@romainberger/webpack-rtl-plugin`
but mentioned this package in a comment for if they ever switch to webpack 5. :shrug:
But since this was easy enough, I decided to forgo the breaking change for now.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There's a CI test for the `diffOnly` option. I suppose someone might manually try some similar cases.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
