### PR TITLE
popup-monitor: Add missing dependency on `events`

### DIFF
--- a/packages/popup-monitor/CHANGELOG.md
+++ b/packages/popup-monitor/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Add missing dependency on `events`. Webpack 5 no longer supplies it by default.
+
+## 1.0.0 - 2020-04-21
+
+Initial publication.

--- a/packages/popup-monitor/package.json
+++ b/packages/popup-monitor/package.json
@@ -32,6 +32,7 @@
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"dependencies": {
+		"events": "^3.3.0",
 		"lodash": "^4.17.21"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17361,14 +17361,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"events@npm:^3.0.0, events@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "events@npm:3.2.0"
-  checksum: 8bd3ca31bd0b3ae3f7e1d5e6e6a2eaca826b4a3e1094eff498d887b83f07c9c0cf04871be1f7020405ed43eb8c9a2ded6f6ea01e373fca5d03b9d92f10e78d5c
-  languageName: node
-  linkType: hard
-
-"events@npm:^3.3.0":
+"events@npm:^3.0.0, events@npm:^3.2.0, events@npm:^3.3.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,6 +1148,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     chai: ^4.3.4
+    events: ^3.3.0
     lodash: ^4.17.21
   languageName: unknown
   linkType: soft
@@ -17364,6 +17365,13 @@ __metadata:
   version: 3.2.0
   resolution: "events@npm:3.2.0"
   checksum: 8bd3ca31bd0b3ae3f7e1d5e6e6a2eaca826b4a3e1094eff498d887b83f07c9c0cf04871be1f7020405ed43eb8c9a2ded6f6ea01e373fca5d03b9d92f10e78d5c
+  languageName: node
+  linkType: hard
+
+"events@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Webpack 4 used to supply a polyfill for this package by default. That is
no longer the case in Webpack 5.

Instead of requiring every user to configure Webpack (or other bundler)
to supply it, the package should depend on what it needs.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Nothing should change as a result of this PR.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
