### PR TITLE
Add siteHasFeature selector

### DIFF
--- a/client/state/selectors/site-has-feature.tsx
+++ b/client/state/selectors/site-has-feature.tsx
@@ -1,0 +1,26 @@
+import getSiteFeatures from 'calypso/state/selectors/get-site-features';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Whether a given feature is available to the specified site.
+ *
+ * @see 2c4dd-pb/#plain
+ * @param  {object}  state       Global state tree
+ * @param  {number}  siteId      The ID of the site we're querying
+ * @param  {string}  featureSlug The dotcom feature to check. This corresponds to the feature values in WPCOM_Features
+ *                               on the wpcom side.
+ * @returns {boolean} True if the feature is active. Otherwise, False.
+ */
+export default function siteHasFeature(
+	state: AppState,
+	siteId: number | null,
+	featureSlug: string
+) {
+	const siteFeatures = getSiteFeatures( state, siteId );
+
+	if ( ! siteFeatures?.active ) {
+		return false;
+	}
+
+	return siteFeatures.active.indexOf( featureSlug ) >= 0;
+}

--- a/client/state/selectors/test/site-has-feature.js
+++ b/client/state/selectors/test/site-has-feature.js
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+
+describe( 'selectors', () => {
+	describe( '#siteHasFeature()', () => {
+		test( 'should return False when no site id', () => {
+			const active = [ 'feature_active_01', 'feature_active_02', 'feature_active_03' ];
+			const state = {
+				sites: {
+					features: {
+						123001: {
+							data: {
+								active,
+							},
+						},
+					},
+				},
+			};
+
+			const activeFeature = siteHasFeature( state );
+			expect( activeFeature ).to.eql( false );
+		} );
+
+		test( 'should return False when site does not exist', () => {
+			const active = [ 'feature_active_01', 'feature_active_02', 'feature_active_03' ];
+
+			const state = {
+				sites: {
+					features: {
+						123001: {
+							data: {
+								active,
+							},
+						},
+					},
+				},
+			};
+
+			const activeFeature = siteHasFeature( state, 0 );
+			expect( activeFeature ).to.eql( false );
+		} );
+
+		test( 'should return False when feature param is not defined', () => {
+			const active = [ 'feature_active_01', 'feature_active_02', 'feature_active_03' ];
+
+			const state = {
+				sites: {
+					features: {
+						123001: {
+							data: {
+								active,
+							},
+						},
+					},
+				},
+			};
+
+			const activeFeature = siteHasFeature( state, 123001 );
+			expect( activeFeature ).to.eql( false );
+		} );
+
+		test( 'should return False when feature is not defined in the active array', () => {
+			const active = [ 'feature_active_01', 'feature_active_02', 'feature_active_03' ];
+
+			const state = {
+				sites: {
+					features: {
+						123001: {
+							data: {
+								active,
+							},
+						},
+					},
+				},
+			};
+
+			const activeFeature = siteHasFeature( state, 123001, 'unknown-feature' );
+			expect( activeFeature ).to.eql( false );
+		} );
+
+		test( 'should return True when feature is defined in the active array', () => {
+			const active = [ 'feature_active_01', 'feature_active_02', 'feature_active_03' ];
+
+			const state = {
+				sites: {
+					features: {
+						123001: {
+							data: {
+								active,
+							},
+						},
+					},
+				},
+			};
+
+			const activeFeature = siteHasFeature( state, 123001, 'feature_active_01' );
+			expect( activeFeature ).to.eql( true );
+		} );
+	} );
+} );

--- a/client/state/themes/selectors/get-jetpack-upgrade-url-if-premium-theme.js
+++ b/client/state/themes/selectors/get-jetpack-upgrade-url-if-premium-theme.js
@@ -1,5 +1,5 @@
-import { PLAN_JETPACK_COMPLETE, FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
-import { hasFeature } from 'calypso/state/sites/plans/selectors';
+import { PLAN_JETPACK_COMPLETE, WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 
@@ -17,7 +17,7 @@ export function getJetpackUpgradeUrlIfPremiumTheme( state, themeId, siteId ) {
 	if (
 		isJetpackSite( state, siteId ) &&
 		isThemePremium( state, themeId ) &&
-		! hasFeature( state, siteId, FEATURE_PREMIUM_THEMES )
+		! siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES )
 	) {
 		return `/checkout/${ getSiteSlug( state, siteId ) }/${ PLAN_JETPACK_COMPLETE }`;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new `siteHasFeature` selector. See p4TIVU-a66-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

It doesn't look like premium themes are available to Jetpack sites anymore?
So I'm not sure how to functionally test it, but automated tests should pass :)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-a66-p2