### PR TITLE
hasFeature: Update UpsellNudge

### DIFF
--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -2,7 +2,7 @@ import {
 	getPlan,
 	PLAN_WPCOM_PRO,
 	PLAN_PERSONAL,
-	FEATURE_NO_ADS,
+	WPCOM_FEATURES_NO_ADVERTS,
 } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { localize } from 'i18n-calypso';
@@ -62,7 +62,7 @@ class DomainToPlanNudge extends Component {
 				} ) }
 				event="domain_to_personal_nudge" //actually cta_name
 				dismissPreferenceName="domain-to-plan-nudge"
-				feature={ FEATURE_NO_ADS }
+				feature={ WPCOM_FEATURES_NO_ADVERTS }
 				href={ `/checkout/${ siteId }/personal` }
 				list={ [
 					translate( 'Remove WordPress.com Ads' ),

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -8,7 +8,7 @@ import {
 	isEcommercePlan,
 	GROUP_JETPACK,
 	GROUP_WPCOM,
-	FEATURE_NO_ADS,
+	WPCOM_FEATURES_NO_ADVERTS,
 	isFreePlanProduct,
 } from '@automattic/calypso-products';
 import classnames from 'classnames';
@@ -20,7 +20,8 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { getCurrentPlan, hasFeature } from 'calypso/state/sites/plans/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -55,9 +56,9 @@ export const UpsellNudge = ( {
 	onClick,
 	onDismissClick,
 	plan,
-	planHasFeature,
 	price,
 	primaryButton,
+	selectedSiteHasFeature,
 	showIcon = false,
 	site,
 	siteSlug,
@@ -76,9 +77,9 @@ export const UpsellNudge = ( {
 		! site ||
 		typeof site !== 'object' ||
 		typeof site.jetpack !== 'boolean' ||
-		( feature && planHasFeature ) ||
+		( feature && selectedSiteHasFeature ) ||
 		( ! feature && ! isFreePlanProduct( site.plan ) ) ||
-		( feature === FEATURE_NO_ADS && site.options.wordads ) ||
+		( feature === WPCOM_FEATURES_NO_ADVERTS && site.options.wordads ) ||
 		( ! isJetpack && site.jetpack ) ||
 		( isJetpack && ! site.jetpack );
 
@@ -173,7 +174,7 @@ export default connect( ( state, ownProps ) => {
 
 	return {
 		site: getSite( state, siteId ),
-		planHasFeature: hasFeature( state, siteId, ownProps.feature ),
+		selectedSiteHasFeature: siteHasFeature( state, siteId, ownProps.feature ),
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
 		isJetpack: isJetpackSite( state, siteId ),
 		isAtomic: isSiteAutomatedTransfer( state, siteId ),

--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -1,8 +1,8 @@
 import {
 	FEATURE_JETPACK_ESSENTIAL,
-	FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 	FEATURE_ACTIVITY_LOG,
 	PLAN_PERSONAL,
+	WPCOM_FEATURES_FULL_ACTIVITY_LOG,
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
@@ -23,7 +23,7 @@ class UpgradeBanner extends Component {
 					<UpsellNudge
 						callToAction={ translate( 'Upgrade now' ) }
 						event="activity_log_upgrade_click_jetpack"
-						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
+						feature={ WPCOM_FEATURES_FULL_ACTIVITY_LOG }
 						href={ `/checkout/${ siteSlug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_ACTIVITY_LOG ] }` }
 						title={ translate( 'Unlock more activities now' ) }
 						description={ translate(

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -1,7 +1,7 @@
 import {
 	PLAN_WPCOM_PRO,
 	PLAN_JETPACK_SECURITY_DAILY,
-	FEATURE_WORDADS_INSTANT,
+	WPCOM_FEATURES_WORDADS,
 	isPremium,
 	isBusiness,
 	isEcommerce,
@@ -213,7 +213,7 @@ class AdsWrapper extends Component {
 				description={ translate(
 					"By upgrading to the Pro plan, you'll be able to monetize your site through the WordAds program."
 				) }
-				feature={ FEATURE_WORDADS_INSTANT }
+				feature={ WPCOM_FEATURES_WORDADS }
 				href={ bannerURL }
 				showIcon
 				event="calypso_upgrade_nudge_impression"
@@ -241,7 +241,7 @@ class AdsWrapper extends Component {
 					'Make money each time someone visits your site by displaying ads on all your posts and pages.'
 				) }
 				href={ bannerURL }
-				feature={ FEATURE_WORDADS_INSTANT }
+				feature={ WPCOM_FEATURES_WORDADS }
 				showIcon
 				event="calypso_upgrade_nudge_impression"
 				tracksImpressionName="calypso_upgrade_nudge_impression"

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -2,7 +2,7 @@ import {
 	FEATURE_PREMIUM_CONTENT_CONTAINER,
 	FEATURE_DONATIONS,
 	FEATURE_RECURRING_PAYMENTS,
-	FEATURE_MEMBERSHIPS,
+	FEATURE_SIMPLE_PAYMENTS,
 	PLAN_PERSONAL,
 	PLAN_JETPACK_PERSONAL,
 } from '@automattic/calypso-products';
@@ -610,7 +610,7 @@ class MembershipsSection extends Component {
 				<UpsellNudge
 					plan={ this.props.isJetpack ? PLAN_JETPACK_PERSONAL : PLAN_PERSONAL }
 					shouldDisplay={ () => true }
-					feature={ FEATURE_MEMBERSHIPS }
+					feature={ FEATURE_SIMPLE_PAYMENTS }
 					title={ this.props.translate( 'Upgrade to the Pro plan' ) }
 					description={ this.props.translate( 'Upgrade to start selling.' ) }
 					showIcon={ true }

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -1,4 +1,4 @@
-import { FEATURE_NO_ADS } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_NO_ADVERTS } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
@@ -155,7 +155,7 @@ export const Sharing = ( {
 			{ ! isVip && ! isJetpack && (
 				<UpsellNudge
 					event="sharing_no_ads"
-					feature={ FEATURE_NO_ADS }
+					feature={ WPCOM_FEATURES_NO_ADVERTS }
 					description={ translate( 'Prevent ads from showing on your site.' ) }
 					title={ translate( 'No ads with WordPress.com Pro' ) }
 					tracksImpressionName="calypso_upgrade_nudge_impression"

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -1,4 +1,7 @@
-import { FEATURE_VIDEO_UPLOADS, FEATURE_AUDIO_UPLOADS } from '@automattic/calypso-products';
+import {
+	WPCOM_FEATURES_UPLOAD_AUDIO_FILES,
+	WPCOM_FEATURES_UPLOAD_VIDEO_FILES,
+} from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -31,7 +34,9 @@ export const MediaLibraryUpgradeNudge = ( { translate, filter, site } ) => (
 				className="media-library__videopress-nudge-regular"
 				title={ getTitle( filter, translate ) }
 				description={ getSubtitle( filter, translate ) }
-				feature={ 'audio' === filter ? FEATURE_AUDIO_UPLOADS : FEATURE_VIDEO_UPLOADS }
+				feature={
+					'audio' === filter ? WPCOM_FEATURES_UPLOAD_AUDIO_FILES : WPCOM_FEATURES_UPLOAD_VIDEO_FILES
+				}
 				event="calypso_media_uploads_upgrade_nudge"
 				tracksImpressionName="calypso_upgrade_nudge_impression"
 				tracksClickName="calypso_upgrade_nudge_cta_click"

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -1,4 +1,4 @@
-import { FEATURE_NO_ADS } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_NO_ADVERTS } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import classnames from 'classnames';
 import { localize, getLocaleSlug } from 'i18n-calypso';
@@ -280,7 +280,7 @@ class PostTypeList extends Component {
 					<UpsellNudge
 						title={ translate( 'No Ads with WordPress.com Pro' ) }
 						description={ translate( 'Prevent ads from showing on your site.' ) }
-						feature={ FEATURE_NO_ADS }
+						feature={ WPCOM_FEATURES_NO_ADVERTS }
 						event="published_posts_no_ads"
 						tracksImpressionName="calypso_upgrade_nudge_impression"
 						tracksClickName="calypso_upgrade_nudge_cta_click"

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -2,9 +2,9 @@ import {
 	isBusiness,
 	isPro,
 	isWpComAnnualPlan,
-	FEATURE_NO_BRANDING,
 	PLAN_BUSINESS,
 	PLAN_WPCOM_PRO,
+	WPCOM_FEATURES_NO_WPCOM_BRANDING,
 } from '@automattic/calypso-products';
 import { Card, CompactCard, Button, Gridicon } from '@automattic/components';
 import { guessTimezone } from '@automattic/i18n-utils';
@@ -669,7 +669,7 @@ export class SiteSettingsFormGeneral extends Component {
 						</CompactCard>
 						{ upsellPlan && (
 							<UpsellNudge
-								feature={ FEATURE_NO_BRANDING }
+								feature={ WPCOM_FEATURES_NO_WPCOM_BRANDING }
 								plan={ upsellPlan }
 								title={ translate( 'Remove the footer credit entirely with WordPress.com Pro' ) }
 								description={ translate(

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -1,12 +1,13 @@
 import {
 	isJetpackVideoPress,
 	planHasFeature,
-	FEATURE_JETPACK_VIDEOPRESS,
 	FEATURE_VIDEO_UPLOADS,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 	PLAN_JETPACK_SECURITY_DAILY,
 	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+	PRODUCT_JETPACK_VIDEOPRESS,
+	WPCOM_FEATURES_VIDEOPRESS,
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import filesize from 'filesize';
@@ -138,9 +139,9 @@ class MediaSettingsPerformance extends Component {
 				<UpsellNudge
 					title={ upsellMessage }
 					event={ 'jetpack_video_settings' }
-					feature={ FEATURE_JETPACK_VIDEOPRESS }
+					feature={ WPCOM_FEATURES_VIDEOPRESS }
 					showIcon={ true }
-					href={ `/checkout/${ siteSlug }/${ FEATURE_JETPACK_VIDEOPRESS }` }
+					href={ `/checkout/${ siteSlug }/${ PRODUCT_JETPACK_VIDEOPRESS }` }
 				/>
 			)
 		);

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -1,4 +1,4 @@
-import { PLAN_WPCOM_PRO, FEATURE_AUDIO_UPLOADS } from '@automattic/calypso-products';
+import { PLAN_WPCOM_PRO, WPCOM_FEATURES_UPLOAD_AUDIO_FILES } from '@automattic/calypso-products';
 import { Button, Card } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -225,7 +225,7 @@ class PodcastingDetails extends Component {
 							description={ translate(
 								'Embed podcast episodes directly from your media library.'
 							) }
-							feature={ FEATURE_AUDIO_UPLOADS }
+							feature={ WPCOM_FEATURES_UPLOAD_AUDIO_FILES }
 							event="podcasting_details_upload_audio"
 							tracksImpressionName="calypso_upgrade_nudge_impression"
 							tracksClickName="calypso_upgrade_nudge_cta_click"

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -2,9 +2,9 @@ import {
 	isJetpackSearch,
 	isP2Plus,
 	planHasJetpackSearch,
-	FEATURE_SEARCH,
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
 	PRODUCT_WPCOM_SEARCH_MONTHLY,
+	WPCOM_FEATURES_INSTANT_SEARCH,
 	planHasJetpackClassicSearch,
 } from '@automattic/calypso-products';
 import { CompactCard } from '@automattic/components';
@@ -129,7 +129,7 @@ class Search extends Component {
 					) }
 					href={ href }
 					event={ 'calypso_jetpack_search_settings_upgrade_nudge' }
-					feature={ FEATURE_SEARCH }
+					feature={ WPCOM_FEATURES_INSTANT_SEARCH }
 					plan={ siteIsJetpack ? PRODUCT_JETPACK_SEARCH_MONTHLY : PRODUCT_WPCOM_SEARCH_MONTHLY }
 					showIcon={ true }
 				/>

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -1,7 +1,6 @@
 import {
 	isWpComAnnualPlan,
 	FEATURE_ADVANCED_SEO,
-	FEATURE_SEO_PREVIEW_TOOLS,
 	TYPE_BUSINESS,
 	TYPE_PRO,
 	findFirstSimilarPlanKey,
@@ -48,7 +47,6 @@ import {
 	isSavingSiteSettings,
 } from 'calypso/state/site-settings/selectors';
 import { requestSite } from 'calypso/state/sites/actions';
-import { hasFeature } from 'calypso/state/sites/plans/selectors';
 import {
 	getSeoTitleFormatsForSite,
 	isJetpackSite,
@@ -269,12 +267,10 @@ export class SiteSettingsFormSEO extends Component {
 			siteIsJetpack && ! isAtomic
 				? {
 						title: translate( 'Boost your search engine ranking' ),
-						feature: FEATURE_SEO_PREVIEW_TOOLS,
 						href: `/checkout/${ slug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_ADVANCED_SEO ] }`,
 				  }
 				: {
 						title: upsellTitle,
-						feature: FEATURE_ADVANCED_SEO,
 						plan:
 							selectedSite.plan &&
 							findFirstSimilarPlanKey( selectedSite.plan.product_slug, {
@@ -328,6 +324,7 @@ export class SiteSettingsFormSEO extends Component {
 				) }
 				{ ! showAdvancedSeo && selectedSite.plan && (
 					<UpsellNudge
+						feature={ FEATURE_ADVANCED_SEO }
 						forceDisplay={ siteIsJetpack }
 						{ ...upsellProps }
 						description={ translate(
@@ -465,8 +462,6 @@ const mapStateToProps = ( state ) => {
 		isSiteHidden: isHiddenSite( state, siteId ),
 		isSitePrivate: isPrivateSite( state, siteId ),
 		siteIsComingSoon: isSiteComingSoon( state, siteId ),
-		hasAdvancedSEOFeature: hasFeature( state, siteId, FEATURE_ADVANCED_SEO ),
-		hasSeoPreviewFeature: hasFeature( state, siteId, FEATURE_SEO_PREVIEW_TOOLS ),
 		isSaveSuccess: isSiteSettingsSaveSuccessful( state, siteId ),
 		saveError: getSiteSettingsSaveError( state, siteId ),
 		path: getCurrentRouteParameterized( state, siteId ),

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -3,6 +3,7 @@ import {
 	FEATURE_JETPACK_ANTI_SPAM,
 	FEATURE_JETPACK_ANTI_SPAM_MONTHLY,
 	PRODUCT_JETPACK_ANTI_SPAM,
+	WPCOM_FEATURES_ANTISPAM,
 	isJetpackAntiSpam,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
@@ -70,7 +71,7 @@ const SpamFilteringSettings = ( {
 					'Save time, get more responses, give your visitors a better experience - all without lifting a finger.'
 				) }
 				event={ 'calypso_akismet_settings_upgrade_nudge' }
-				feature={ FEATURE_SPAM_AKISMET_PLUS }
+				feature={ WPCOM_FEATURES_ANTISPAM }
 				showIcon={ true }
 				href={ `/checkout/${ siteSlug }/${ PRODUCT_JETPACK_ANTI_SPAM }` }
 			/>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -3,6 +3,7 @@ import {
 	FEATURE_PREMIUM_THEMES,
 	FEATURE_UPLOAD_THEMES,
 	PLAN_WPCOM_PRO,
+	WPCOM_FEATURES_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
 import { Button, Card, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -736,7 +737,7 @@ class ThemeSheet extends Component {
 						)
 					) }
 					event="themes_plan_particular_free_with_plan"
-					feature={ FEATURE_PREMIUM_THEMES }
+					feature={ WPCOM_FEATURES_PREMIUM_THEMES }
 					forceHref={ true }
 					href={ plansUrl }
 					showIcon={ true }

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -1,11 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
-	FEATURE_PREMIUM_THEMES,
 	FEATURE_UPLOAD_THEMES,
 	PLAN_FREE,
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	PLAN_WPCOM_PRO,
+	WPCOM_FEATURES_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -34,7 +34,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 					<UpsellNudge
 						className="themes__showcase-banner"
 						event="calypso_themes_list_premium_themes"
-						feature={ FEATURE_PREMIUM_THEMES }
+						feature={ WPCOM_FEATURES_PREMIUM_THEMES }
 						plan={ PLAN_WPCOM_PRO }
 						title={ translate( 'Unlock ALL premium themes with our Pro plan!' ) }
 						forceHref={ true }

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -213,4 +213,13 @@ export const FEATURE_WOOCOMMERCE = 'woocommerce';
 export const FEATURE_SOCIAL_MEDIA_TOOLS = 'social-media-tools';
 
 // From class-wpcom-features.php in WPCOM
+export const WPCOM_FEATURES_ANTISPAM = 'antispam';
+export const WPCOM_FEATURES_FULL_ACTIVITY_LOG = 'full-activity-log';
+export const WPCOM_FEATURES_INSTANT_SEARCH = 'instant-search';
+export const WPCOM_FEATURES_NO_ADVERTS = 'no-adverts/no-adverts.php';
+export const WPCOM_FEATURES_NO_WPCOM_BRANDING = 'no-wpcom-branding';
 export const WPCOM_FEATURES_PREMIUM_THEMES = 'premium-themes';
+export const WPCOM_FEATURES_UPLOAD_AUDIO_FILES = 'upload-audio-files';
+export const WPCOM_FEATURES_UPLOAD_VIDEO_FILES = 'upload-video-files';
+export const WPCOM_FEATURES_VIDEOPRESS = 'videopress';
+export const WPCOM_FEATURES_WORDADS = 'wordads';


### PR DESCRIPTION
Depends on https://github.com/Automattic/wp-calypso/pull/63385

#### Changes proposed in this Pull Request

* Removes `hasFeature` in favor of `siteHasFeature` in the upsell nudge
* Updates uses of `UpsellNudge` with `wpcom-features` feature names.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Testing with a site on a Free plan, check if those banners show up correctly:
* Activity Log: https://container-agitated-panini.calypso.live/activity-log <img width="928" alt="image" src="https://user-images.githubusercontent.com/1398304/167186577-64922d81-bc79-4d6a-a097-084f49db250f.png">
* Earn Ads: https://container-agitated-panini.calypso.live/earn/ads-earnings <img width="923" alt="image" src="https://user-images.githubusercontent.com/1398304/167187314-78642f4c-bece-4339-ab52-0b7506164191.png">
* Earn Payments: https://container-agitated-panini.calypso.live/earn/payments <img width="571" alt="image" src="https://user-images.githubusercontent.com/1398304/167187853-e2b794b3-46c9-42b3-bd72-a8d29262d41c.png">
* No Ads: https://container-agitated-panini.calypso.live/marketing/tools <img width="918" alt="image" src="https://user-images.githubusercontent.com/1398304/167188080-22c54043-43ae-484d-81cb-29c934e5eb09.png">
* Video uploads: https://container-agitated-panini.calypso.live/media/videos <img width="647" alt="image" src="https://user-images.githubusercontent.com/1398304/167188359-c0cc6107-a3c0-4625-baec-26eebc787dd0.png">
* Audio Uploads: https://container-agitated-panini.calypso.live/media/audio <img width="647" alt="image" src="https://user-images.githubusercontent.com/1398304/167188526-41ea165a-512f-4ed9-9fdc-e938f64e5928.png">
* Footer credit: https://container-agitated-panini.calypso.live/settings/general <img width="738" alt="image" src="https://user-images.githubusercontent.com/1398304/167189076-1058cfc9-94d5-46f5-bdfe-39fec5f65fd3.png">
* Jetpack Search: https://container-agitated-panini.calypso.live/settings/performance <img width="732" alt="image" src="https://user-images.githubusercontent.com/1398304/167189858-71914e5c-b005-4ece-bead-ea528249c92c.png">
* SEO: https://container-agitated-panini.calypso.live/marketing/traffic <img width="920" alt="image" src="https://user-images.githubusercontent.com/1398304/167191982-a563432e-3442-4066-9b10-46e9794365f0.png">
* Premium Theme: https://container-agitated-panini.calypso.live/theme/alonso <img width="632" alt="image" src="https://user-images.githubusercontent.com/1398304/167190589-a758379a-6d61-4e13-ac3b-c0e3c86557ec.png">
* Premium Themes: https://container-agitated-panini.calypso.live/themes <img width="917" alt="image" src="https://user-images.githubusercontent.com/1398304/167190303-fb8afe6a-aaea-4951-abbd-d2a9b7a50a63.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-a66-p2
Depends on https://github.com/Automattic/wp-calypso/pull/63385