### PR TITLE
Scopes the CSS for the store-address step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
@@ -1,6 +1,6 @@
 @import '../style';
 
-body.is-group-stepper.is-section-stepper {
+.step-container.store-address {
 	.components-combobox-control__input {
 		padding: 7px 14px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the scope of the styles for the Store Address step. The styles were leaking into other contexts, which added left padding to the `step-container__content` class.

#### Before
<img width="1512" alt="Screen Shot 2022-05-06 at 15 36 38" src="https://user-images.githubusercontent.com/1234758/167198463-b434b839-9ffe-43cf-8d40-a69144bf977d.png">

#### After
<img width="1512" alt="Screen Shot 2022-05-06 at 15 36 22" src="https://user-images.githubusercontent.com/1234758/167198507-eb402fa8-923c-46c7-ab62-6be13ba286a2.png">

#### Testing instructions

* Go to `/setup/podcastTitle?anchor_podcast=<your-podcast-id>`
* Look for the `div` with the class `step-container__content`
* It should not have a left padding anymore.
