### PR TITLE
hasFeature: Update Promo Card CTA

### DIFF
--- a/client/components/promo-section/promo-card/README.md
+++ b/client/components/promo-section/promo-card/README.md
@@ -20,13 +20,15 @@ const PromoCardExample = () => {
 				This is a description of the action. It gives a bit more detail and explains what we are
 				inviting the user to do.
 			</p>
-			<PromoCardCta
+			<PromoCardCTA
 				cta={ {
-					feature: FEATURE_SIMPLE_PAYMENTS,
-					upgradeButton: { text: 'Upgrade!', action: clicked },
-					defaultButton: { text: 'Simple Payments', action: clicked },
+					text: translate( 'Upgrade to Pro Plan' ),
+					action: {
+						url: `/checkout/${ siteSlug }/pro`,
+						onClick: onUpgradeClick,
+						selfTarget: true,
+					},
 				} }
-				learnMoreLink="/learn-more"
 			/>
 		</PromoCard>
 	);

--- a/client/components/promo-section/promo-card/README.md
+++ b/client/components/promo-section/promo-card/README.md
@@ -22,9 +22,9 @@ const PromoCardExample = () => {
 			</p>
 			<PromoCardCta
 				cta={ {
-					feature: FEATURE_MEMBERSHIPS,
+					feature: FEATURE_SIMPLE_PAYMENTS,
 					upgradeButton: { text: 'Upgrade!', action: clicked },
-					defaultButton: { text: 'Memberships', action: clicked },
+					defaultButton: { text: 'Simple Payments', action: clicked },
 				} }
 				learnMoreLink="/learn-more"
 			/>

--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -4,7 +4,7 @@ import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { connect } from 'react-redux';
 import ActionPanelCta from 'calypso/components/action-panel/cta';
-import { hasFeature } from 'calypso/state/sites/plans/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { URL } from 'calypso/types';
 
@@ -32,7 +32,7 @@ export type Cta =
 	  };
 
 interface ConnectedProps {
-	hasPlanFeature: boolean;
+	selectedSiteHasFeature: boolean;
 }
 
 export interface Props {
@@ -80,7 +80,7 @@ const PromoCardCta: FunctionComponent< Props & ConnectedProps > = ( {
 	cta,
 	learnMoreLink,
 	isPrimary,
-	hasPlanFeature,
+	selectedSiteHasFeature,
 } ) => {
 	const ctaBtnProps = ( button: CtaButton ) => buttonProps( button, true === isPrimary );
 	let ctaBtn;
@@ -103,7 +103,7 @@ const PromoCardCta: FunctionComponent< Props & ConnectedProps > = ( {
 	if ( isCtaButton( cta ) ) {
 		ctaBtn = <Button { ...ctaBtnProps( cta ) }>{ cta.text }</Button>;
 	} else {
-		ctaBtn = hasPlanFeature ? (
+		ctaBtn = selectedSiteHasFeature ? (
 			<Button { ...ctaBtnProps( cta.defaultButton ) }>{ cta.defaultButton.text }</Button>
 		) : (
 			<Button { ...ctaBtnProps( cta.upgradeButton ) }>{ cta.upgradeButton.text }</Button>
@@ -125,9 +125,9 @@ export default connect< ConnectedProps, unknown, Props >( ( state, { cta } ) => 
 	const selectedSiteId = getSelectedSiteId( state );
 
 	return {
-		hasPlanFeature:
+		selectedSiteHasFeature:
 			selectedSiteId && ! isCtaButton( cta )
-				? hasFeature( state, selectedSiteId, cta.feature )
+				? siteHasFeature( state, selectedSiteId, cta.feature )
 				: false,
 	};
 } )( PromoCardCta );

--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -2,10 +2,7 @@ import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
-import { connect } from 'react-redux';
 import ActionPanelCta from 'calypso/components/action-panel/cta';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { URL } from 'calypso/types';
 
 type ClickCallback = () => void;
@@ -22,27 +19,10 @@ export interface CtaButton {
 	component?: JSX.Element;
 }
 
-export type Cta =
-	| CtaButton
-	| {
-			feature: string;
-			upgradeButton: CtaButton;
-			defaultButton: CtaButton;
-			activatedButton?: CtaButton;
-	  };
-
-interface ConnectedProps {
-	selectedSiteHasFeature: boolean;
-}
-
 export interface Props {
-	cta: Cta;
+	cta: CtaButton;
 	learnMoreLink?: CtaAction | null;
 	isPrimary?: boolean;
-}
-
-function isCtaButton( cta: Cta ): cta is CtaButton {
-	return undefined !== ( cta as CtaButton ).text;
 }
 
 function isCtaAction( action: unknown ): action is CtaAction {
@@ -76,14 +56,8 @@ function buttonProps( button: CtaButton, isPrimary: boolean ) {
 		...actionProps,
 	};
 }
-const PromoCardCta: FunctionComponent< Props & ConnectedProps > = ( {
-	cta,
-	learnMoreLink,
-	isPrimary,
-	selectedSiteHasFeature,
-} ) => {
+const PromoCardCta: FunctionComponent< Props > = ( { cta, learnMoreLink, isPrimary } ) => {
 	const ctaBtnProps = ( button: CtaButton ) => buttonProps( button, true === isPrimary );
-	let ctaBtn;
 	const translate = useTranslate();
 	let learnMore = null;
 
@@ -100,18 +74,9 @@ const PromoCardCta: FunctionComponent< Props & ConnectedProps > = ( {
 			  };
 	}
 
-	if ( isCtaButton( cta ) ) {
-		ctaBtn = <Button { ...ctaBtnProps( cta ) }>{ cta.text }</Button>;
-	} else {
-		ctaBtn = selectedSiteHasFeature ? (
-			<Button { ...ctaBtnProps( cta.defaultButton ) }>{ cta.defaultButton.text }</Button>
-		) : (
-			<Button { ...ctaBtnProps( cta.upgradeButton ) }>{ cta.upgradeButton.text }</Button>
-		);
-	}
 	return (
 		<ActionPanelCta>
-			{ ctaBtn }
+			<Button { ...ctaBtnProps( cta ) }>{ cta.text }</Button>
 			{ learnMore && (
 				<Button borderless className="promo-card__cta-learn-more" { ...learnMore }>
 					{ translate( 'Learn more' ) }
@@ -121,13 +86,4 @@ const PromoCardCta: FunctionComponent< Props & ConnectedProps > = ( {
 	);
 };
 
-export default connect< ConnectedProps, unknown, Props >( ( state, { cta } ) => {
-	const selectedSiteId = getSelectedSiteId( state );
-
-	return {
-		selectedSiteHasFeature:
-			selectedSiteId && ! isCtaButton( cta )
-				? siteHasFeature( state, selectedSiteId, cta.feature )
-				: false,
-	};
-} )( PromoCardCta );
+export default PromoCardCta;

--- a/client/components/promo-section/promo-card/docs/example.jsx
+++ b/client/components/promo-section/promo-card/docs/example.jsx
@@ -1,4 +1,4 @@
-import { FEATURE_MEMBERSHIPS } from '@automattic/calypso-products';
+import { FEATURE_SIMPLE_PAYMENTS } from '@automattic/calypso-products';
 import referralImage from 'calypso/assets/images/earn/referral.svg';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardCta from 'calypso/components/promo-section/promo-card/cta';
@@ -20,9 +20,9 @@ const PromoCardExample = () => {
 					</p>
 					<PromoCardCta
 						cta={ {
-							feature: FEATURE_MEMBERSHIPS,
+							feature: FEATURE_SIMPLE_PAYMENTS,
 							upgradeButton: { text: 'Upgrade!', action: clicked },
-							defaultButton: { text: 'Memberships', action: clicked },
+							defaultButton: { text: 'Simple Payments', action: clicked },
 						} }
 						learnMoreLink="/learn-more"
 					/>

--- a/client/components/promo-section/promo-card/docs/example.jsx
+++ b/client/components/promo-section/promo-card/docs/example.jsx
@@ -1,7 +1,9 @@
-import { FEATURE_SIMPLE_PAYMENTS } from '@automattic/calypso-products';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import referralImage from 'calypso/assets/images/earn/referral.svg';
 import PromoCard from 'calypso/components/promo-section/promo-card';
-import PromoCardCta from 'calypso/components/promo-section/promo-card/cta';
+import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const PromoCardExample = () => {
@@ -9,6 +11,10 @@ const PromoCardExample = () => {
 		path: referralImage,
 		alt: 'Using Props',
 	};
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const translate = useTranslate();
+
 	const clicked = () => alert( 'Clicked!' );
 	return (
 		<div className="design-assets__group">
@@ -18,13 +24,15 @@ const PromoCardExample = () => {
 						This is a description of the action. It gives a bit more detail and explains what we are
 						inviting the user to do.
 					</p>
-					<PromoCardCta
+					<PromoCardCTA
 						cta={ {
-							feature: FEATURE_SIMPLE_PAYMENTS,
-							upgradeButton: { text: 'Upgrade!', action: clicked },
-							defaultButton: { text: 'Simple Payments', action: clicked },
+							text: translate( 'Upgrade to Pro Plan' ),
+							action: {
+								url: `/checkout/${ siteSlug }/pro`,
+								onClick: clicked,
+								selfTarget: true,
+							},
 						} }
-						learnMoreLink="/learn-more"
 					/>
 				</PromoCard>
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moves promo card over to using `siteHasFeature`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

It doesn't look like any consumer of `PromoCard` actually uses this defaultButton vs upgradeButton functionality.
Not sure if this is testable?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-a66-p2
Depends on https://github.com/Automattic/wp-calypso/pull/63386