### PR TITLE
Checkout: Add tracks event when skipping to last checkout step

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-skip-to-last-step-if-form-complete.js
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-skip-to-last-step-if-form-complete.js
@@ -1,12 +1,15 @@
 import { useSetStepComplete } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
 import { useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-skip-to-last-step-if-form-complete' );
 
 export default function useSkipToLastStepIfFormComplete( isCachedContactFormValid ) {
 	const hasDecided = useRef( false );
 	const setStepCompleteStatus = useSetStepComplete();
+	const reduxDispatch = useDispatch();
 
 	useEffect( () => {
 		if ( ! isCachedContactFormValid ) {
@@ -19,9 +22,11 @@ export default function useSkipToLastStepIfFormComplete( isCachedContactFormVali
 				debug( 'Contact details are already populated; skipping to payment method step' );
 				saveStepNumberToUrl( 2 ); // TODO: can we do this dynamically somehow in case the step numbers change?
 				setStepCompleteStatus( 1, true ); // TODO: can we do this dynamically somehow in case the step numbers change?
+
+				reduxDispatch( recordTracksEvent( 'calypso_checkout_skip_to_last_step' ) );
 			}
 		}
-	}, [ isCachedContactFormValid, setStepCompleteStatus ] );
+	}, [ isCachedContactFormValid, setStepCompleteStatus, reduxDispatch ] );
 }
 
 function saveStepNumberToUrl( stepNumber ) {

--- a/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
@@ -127,6 +127,8 @@ export async function validateContactDetails(
 ): Promise< boolean > {
 	debug( 'validating contact details; shouldDisplayErrors', shouldDisplayErrors );
 
+	reduxDispatch( recordTracksEvent( 'calypso_checkout_validating_contact_info', contactInfo ) );
+
 	const completeValidationCheck = ( validationResult: unknown ): boolean => {
 		debug( 'validating contact details result', validationResult );
 		if ( shouldDisplayErrors ) {

--- a/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
@@ -127,7 +127,12 @@ export async function validateContactDetails(
 ): Promise< boolean > {
 	debug( 'validating contact details; shouldDisplayErrors', shouldDisplayErrors );
 
-	reduxDispatch( recordTracksEvent( 'calypso_checkout_validating_contact_info', contactInfo ) );
+	reduxDispatch(
+		recordTracksEvent( 'calypso_checkout_validating_contact_info', {
+			country: contactInfo.countryCode?.value,
+			postal: contactInfo.postalCode?.value,
+		} )
+	);
 
 	const completeValidationCheck = ( validationResult: unknown ): boolean => {
 		debug( 'validating contact details result', validationResult );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a Tracks analytics event when `useSkipToLastStepIfFormComplete` skips the contact details/billing information step. The event is `calypso_checkout_skip_to_last_step`.

#### Testing instructions

- Use an account which has saved cached contact details (typically an account that's made a purchase before).
- Visit calypso on this branch.
- Enter `localStorage.setItem('debug', 'calypso:analytics')` in your JS console and reload calypso.
- Add a product to your cart and visit checkout.
- Verify that you see the `calypso_checkout_skip_to_last_step` and `calypso_checkout_validating_contact_info` event recorded by watching the JS console.

<img width="605" alt="Screen Shot 2022-05-06 at 4 25 18 PM" src="https://user-images.githubusercontent.com/2036909/167211726-f1a514e0-683c-426a-88ba-b4e8d6a4031e.png">
<img width="581" alt="Screen Shot 2022-05-06 at 4 43 51 PM" src="https://user-images.githubusercontent.com/2036909/167213941-87dc0d5a-4d60-4223-a529-1ca40b51d659.png">

