### PR TITLE
hasFeature: Update Theme main

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import {
-	FEATURE_PREMIUM_THEMES,
 	FEATURE_UPLOAD_THEMES,
 	PLAN_WPCOM_PRO,
 	WPCOM_FEATURES_PREMIUM_THEMES,
@@ -46,7 +45,7 @@ import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { hasFeature } from 'calypso/state/sites/plans/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
 import {
@@ -900,9 +899,9 @@ export default connect(
 			isPremium: isThemePremium( state, id ),
 			isPurchased: isPremiumThemeAvailable( state, id, siteId ),
 			forumUrl: getThemeForumUrl( state, id, siteId ),
-			hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_PREMIUM_THEMES ),
+			hasUnlimitedPremiumThemes: siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),
 			showTryAndCustomize: shouldShowTryAndCustomize( state, id, siteId ),
-			canUserUploadThemes: hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
+			canUserUploadThemes: siteHasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 			// Remove the trailing slash because the page URL doesn't have one either.
 			canonicalUrl: localizeUrl( englishUrl, getLocaleSlug(), false ).replace( /\/$/, '' ),
 			demoUrl: getThemeDemoUrl( state, id, siteId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes `hasFeature` in favor of `siteHasFeature` on single theme pages.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to a single theme view of a premium theme, like: https://container-condescending-kare.calypso.live/theme/videomaker/
* On a free site: Should show the upgrade banner
* On a free Atomic site: Should show the upgrade banner
* As a user with a role other than admin: Should _not_ show upgrade banner.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-a66-p2
Depends on https://github.com/Automattic/wp-calypso/pull/63386