### PR TITLE
hasFeature: Update spam filtering settings

### DIFF
--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -1,8 +1,6 @@
 import {
-	FEATURE_SPAM_AKISMET_PLUS,
-	FEATURE_JETPACK_ANTI_SPAM,
-	FEATURE_JETPACK_ANTI_SPAM_MONTHLY,
 	PRODUCT_JETPACK_ANTI_SPAM,
+	WPCOM_FEATURES_AKISMET,
 	WPCOM_FEATURES_ANTISPAM,
 	isJetpackAntiSpam,
 } from '@automattic/calypso-products';
@@ -22,7 +20,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import SupportInfo from 'calypso/components/support-info';
 import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import isJetpackSettingsSaveFailure from 'calypso/state/selectors/is-jetpack-settings-save-failure';
-import { hasFeature } from 'calypso/state/sites/plans/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteProducts } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -160,10 +158,8 @@ export default connect( ( state, { dirtyFields, fields } ) => {
 	const hasAkismetKeyError =
 		isJetpackSettingsSaveFailure( state, selectedSiteId, fields ) &&
 		includes( dirtyFields, 'wordpress_api_key' );
-	const hasAkismetFeature = hasFeature( state, selectedSiteId, FEATURE_SPAM_AKISMET_PLUS );
-	const hasAntiSpamFeature =
-		hasFeature( state, selectedSiteId, FEATURE_JETPACK_ANTI_SPAM ) ||
-		hasFeature( state, selectedSiteId, FEATURE_JETPACK_ANTI_SPAM_MONTHLY );
+	const hasAkismetFeature = siteHasFeature( state, selectedSiteId, WPCOM_FEATURES_AKISMET );
+	const hasAntiSpamFeature = siteHasFeature( state, selectedSiteId, WPCOM_FEATURES_ANTISPAM );
 	const hasJetpackAntiSpamProduct =
 		getSiteProducts( state, selectedSiteId )?.filter( isJetpackAntiSpam ).length > 0;
 

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -213,6 +213,7 @@ export const FEATURE_WOOCOMMERCE = 'woocommerce';
 export const FEATURE_SOCIAL_MEDIA_TOOLS = 'social-media-tools';
 
 // From class-wpcom-features.php in WPCOM
+export const WPCOM_FEATURES_AKISMET = 'akismet';
 export const WPCOM_FEATURES_ANTISPAM = 'antispam';
 export const WPCOM_FEATURES_FULL_ACTIVITY_LOG = 'full-activity-log';
 export const WPCOM_FEATURES_INSTANT_SEARCH = 'instant-search';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes `hasFeature` in favor of `siteHasFeature` in spam filtering settings.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Settings > Security on a Jetpack site (not Atomic): https://container-vibrant-galois.calypso.live/settings/security
* Make sure you see an upgrade nudge under "Anti-spam" if the site doesn't have spam protection. <img width="731" alt="image" src="https://user-images.githubusercontent.com/1398304/167218849-c33c6088-5908-4898-9c97-6d1cdfaf0b22.png">
* Make sure it says "Your site is protected from spam." if it does have the feature. <img width="743" alt="image" src="https://user-images.githubusercontent.com/1398304/167218809-2485f1b3-9510-40c5-88e9-0d7f45acf61a.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-a66-p2
Depends on https://github.com/Automattic/wp-calypso/pull/63386