### PR TITLE
E2E: add new spec to test the WordPress.com Free plan.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -136,19 +136,28 @@ export class SidebarComponent {
 	/**
 	 * Returns the current plan name as shown on the sidebar.
 	 *
-	 * Note, the plan name shown in the sidebar may not be
-	 * accurate.
+	 * Note, the plan name shown in the sidebar may not always be
+	 * accurate due to race conditions. Consider this method as
+	 * secondary validation.
 	 *
-	 * On mobile viewports, if the page is on Upgrades > Plans
-	 * the plan name is hidden from view. It is suggested to
-	 * use this method while the page is not displaying Plans.
+	 * Additionally, on mobile viewports if the current page is
+	 * Upgrades > Plans the plan name is not visible in the sidebar.
+	 * This method should be used after navigating away from the
+	 * Plans page.
 	 *
 	 * @returns {Promise<string>} Name of the plan.
+	 * @throws {Error} If the viewport is mobile and the currently displayed page is Upgrades > Plans.
 	 */
 	async getCurrentPlanName(): Promise< string > {
 		await this.waitForSidebarInitialization();
 
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			if ( this.page.url().includes( getCalypsoURL( 'plans' ) ) ) {
+				throw new Error(
+					'Unable to retrieve current plan name on mobile sidebar.\nNavigate away from Upgrades > Plans page and try again.'
+				);
+			}
+
 			await this.openMobileSidebar();
 		}
 

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -12,6 +12,7 @@ const selectors = {
 
 	// Buttons and links within Sidebar
 	linkWithText: ( text: string ) => `a:has-text("${ text }")`,
+	planName: '.sidebar__inline-text',
 };
 
 /**
@@ -130,6 +131,29 @@ export class SidebarComponent {
 			this.page.waitForNavigation(),
 			this.page.click( selectors.linkWithText( 'Add New Site' ) ),
 		] );
+	}
+
+	/**
+	 * Returns the current plan name as shown on the sidebar.
+	 *
+	 * Note, the plan name shown in the sidebar may not be
+	 * accurate.
+	 *
+	 * On mobile viewports, if the page is on Upgrades > Plans
+	 * the plan name is hidden from view. It is suggested to
+	 * use this method while the page is not displaying Plans.
+	 *
+	 * @returns {Promise<string>} Name of the plan.
+	 */
+	async getCurrentPlanName(): Promise< string > {
+		await this.waitForSidebarInitialization();
+
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			await this.openMobileSidebar();
+		}
+
+		const planNameLocator = this.page.locator( selectors.planName );
+		return await planNameLocator.innerText();
 	}
 
 	/* Viewport-specific methods */

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -12,7 +12,7 @@ const selectors = {
 
 	// Buttons and links within Sidebar
 	linkWithText: ( text: string ) => `a:has-text("${ text }")`,
-	planName: '.sidebar__inline-text',
+	planName: ':text-is("Upgrades"):visible .sidebar__inline-text',
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -8,7 +8,7 @@ type PlansGridVersion = 'current' | 'legacy';
 type PlansComparisonAction = 'show' | 'hide';
 
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
-export type Plans = 'start with a free site' | 'Pro';
+export type Plans = 'Free' | 'Pro';
 export type LegacyPlans = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
 export type PlansPageTab = 'My Plan' | 'Plans';
 export type PlanActionButton = 'Manage plan' | 'Upgrade';
@@ -33,7 +33,6 @@ const selectors = {
 	// Overhauled plans view
 	selectPlanButton: ( type: Plans ) =>
 		`.formatted-header button.button:has-text("${ type }"), tr th button.button:has-text("${ type }")`,
-	// upgradeToProButton: 'th button.is-primary',
 	planComparisonActionButton: ( action: PlansComparisonAction ) => {
 		const buttonText = `${ toTitleCase( action ) } full plan comparison`;
 		return `button:text("${ buttonText }")`;

--- a/packages/calypso-e2e/src/lib/pages/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/user-signup-page.ts
@@ -1,6 +1,12 @@
 import { Page } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 import envVariables from '../../env-variables';
+import { NewUserResponse } from '../../rest-api-client';
+
+export interface NewUserDetails {
+	ID: number;
+	bearer_token: string;
+}
 
 const selectors = {
 	// Fields
@@ -53,7 +59,7 @@ export class UserSignupPage {
 	 * @param {string} username Username of the new user.
 	 * @param {string} password Password of the new user.
 	 */
-	async signup( email: string, username: string, password: string ): Promise< void > {
+	async signup( email: string, username: string, password: string ): Promise< NewUserDetails > {
 		await this.page.fill( selectors.emailInput, email );
 		await this.page.fill( selectors.usernameInput, username );
 		await this.page.fill( selectors.passwordInput, password );
@@ -63,10 +69,18 @@ export class UserSignupPage {
 		// user to this page.
 		// Example: invite => Signup & Follow
 		//          signup from login => Create your account
-		await Promise.all( [
+		const [ , response ] = await Promise.all( [
 			this.page.waitForNavigation(),
+			this.page.waitForResponse( /.*new\?.*/ ),
 			this.page.click( selectors.submitButton ),
 		] );
+
+		if ( ! response ) {
+			throw new Error( 'Failed to create new user at signup.' );
+		}
+
+		const responseBody: NewUserResponse = JSON.parse( ( await response.body() ).toString() );
+		return { ID: responseBody.body.user_id, bearer_token: responseBody.body.bearer_token };
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -1,7 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
 import chalk from 'chalk';
-import fetch from 'node-fetch';
 import { BrowserContext, Page } from 'playwright';
 import { TestAccountName } from '..';
 import {
@@ -11,17 +10,8 @@ import {
 	getCalypsoURL,
 } from '../data-helper';
 import envVariables from '../env-variables';
-import { SecretsManager } from '../secrets';
 import { TOTPClient } from '../totp-client';
 import { LoginPage } from './pages/login-page';
-
-interface BearerTokenResponse {
-	success: string;
-	data: {
-		bearer_token: string;
-		token_links: string[];
-	};
-}
 
 /**
  * Represents the WPCOM test account.
@@ -29,7 +19,6 @@ interface BearerTokenResponse {
 export class TestAccount {
 	readonly accountName: TestAccountName;
 	readonly credentials: AccountCredentials;
-	private bearerToken: string | null;
 
 	/**
 	 * Constructs an instance of the TestAccount for the given account name.
@@ -38,7 +27,6 @@ export class TestAccount {
 	constructor( accountName: TestAccountName ) {
 		this.accountName = accountName;
 		this.credentials = getAccountCredential( accountName );
-		this.bearerToken = null;
 	}
 
 	/**
@@ -161,40 +149,6 @@ export class TestAccount {
 		const { cookies } = JSON.parse( storageStateFile );
 
 		return cookies;
-	}
-
-	/**
-	 * Returns the bearer token for the user.
-	 *
-	 * If the token has been previously obtained, this method returns the value.
-	 * Otherwise, an API call is made to obtain the bearer token.
-	 *
-	 * @returns {Promise<string>} String representing the bearer token.
-	 */
-	async getBearerToken(): Promise< string > {
-		if ( ! this.bearerToken === null ) {
-			return this.bearerToken as string;
-		}
-
-		const loginEndpoint = 'https://wordpress.com/wp-login.php?action=login-endpoint';
-
-		// Set the form parameters
-		const params = new URLSearchParams();
-		params.append( 'username', this.credentials.username );
-		params.append( 'password', this.credentials.password );
-		params.append( 'client_id', SecretsManager.secrets.calypsoOauthApplication.client_id );
-		params.append( 'client_secret', SecretsManager.secrets.calypsoOauthApplication.client_secret );
-		params.append( 'get_bearer_token', '1' );
-
-		// Request the bearer token for the user.
-		const response = await fetch( loginEndpoint, {
-			method: 'post',
-			body: params,
-		} );
-		const decodedResponse: BearerTokenResponse = await response.json();
-
-		this.bearerToken = decodedResponse.data.bearer_token;
-		return this.bearerToken;
 	}
 
 	/**

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -44,6 +44,8 @@ export class RestAPIClient {
 		this.bearerToken = null;
 	}
 
+	/* Request builder methods */
+
 	/**
 	 * Returns the bearer token for the user.
 	 *

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -226,27 +226,38 @@ export class RestAPIClient {
 		// This portion validates whether the user represented by the
 		// instance of the RestAPIClient is in fact a test user.
 		if ( ! accountInformation.email.includes( 'mailosaur' ) ) {
-			throw new Error(
+			console.warn(
 				'Aborting account closure: email address provided is not for an e2e test user.'
 			);
+			return { success: false };
 		}
 
 		if ( ! accountInformation.username.includes( 'e2eflowtesting' ) ) {
-			throw new Error( 'Aborting account closure: username is not for a test user.' );
+			console.warn( 'Aborting account closure: username is not for a test user.' );
+			return { success: false };
 		}
 
 		// This portion validates that supplied account details match
 		// the user represented by the instance of RestAPIClient.
 		if ( expectedAccountDetails.userID !== accountInformation.ID ) {
-			throw new Error( `Failed to close account: target account user ID did not match.` );
+			console.warn(
+				`Failed to close account: target account user ID did not match.\nExpected: ${ accountInformation.ID }, Got: ${ expectedAccountDetails.userID }`
+			);
+			return { success: false };
 		}
 
 		if ( expectedAccountDetails.username !== accountInformation.username ) {
-			throw new Error( `Failed to close account: target account username did not match.` );
+			console.warn(
+				`Failed to close account: target account username did not match.\nExpected: ${ accountInformation.username }, Got: ${ expectedAccountDetails.username }`
+			);
+			return { success: false };
 		}
 
 		if ( expectedAccountDetails.email !== accountInformation.email ) {
-			throw new Error( `Failed to close account: target account email did not match.` );
+			console.warn(
+				`Failed to close account: target account email did not match.\nExpected: ${ accountInformation.email }, Got: ${ expectedAccountDetails.email }`
+			);
+			return { success: false };
 		}
 
 		const params: RequestParams = {

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -171,7 +171,7 @@ skipDescribeIf( isStagingOrProd )(
 
 			it( 'Keep free plan', async function () {
 				const signupPickPlanPage = new SignupPickPlanPage( page );
-				await signupPickPlanPage.selectPlan( 'Fre' );
+				await signupPickPlanPage.selectPlan( 'Free' );
 			} );
 
 			it( 'Confirm site is launched', async function () {

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -70,7 +70,7 @@ skipDescribeIf( isStagingOrProd )(
 
 			it( 'Select WordPress.com Free plan', async function () {
 				const signupPickPlanPage = new SignupPickPlanPage( page );
-				await signupPickPlanPage.selectPlan( 'start with a free site' );
+				await signupPickPlanPage.selectPlan( 'Free' );
 			} );
 		} );
 
@@ -171,7 +171,7 @@ skipDescribeIf( isStagingOrProd )(
 
 			it( 'Keep free plan', async function () {
 				const signupPickPlanPage = new SignupPickPlanPage( page );
-				await signupPickPlanPage.selectPlan( 'start with a free site' );
+				await signupPickPlanPage.selectPlan( 'Fre' );
 			} );
 
 			it( 'Confirm site is launched', async function () {

--- a/test/e2e/specs/plans/plans__signup-free.ts
+++ b/test/e2e/specs/plans/plans__signup-free.ts
@@ -1,0 +1,119 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	DomainSearchComponent,
+	SignupPickPlanPage,
+	StartSiteFlow,
+	SidebarComponent,
+	SecretsManager,
+	PlansPage,
+	RestAPIClient,
+	UserSignupPage,
+	LoginPage,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe(
+	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Free site as new user' ),
+	function () {
+		const username = `e2eflowtestingfree${ DataHelper.getTimestamp() }`;
+		const password = SecretsManager.secrets.passwordForNewTestSignUps;
+		const email = DataHelper.getTestEmailAddress( {
+			inboxId: SecretsManager.secrets.mailosaur.inviteInboxId,
+			prefix: username,
+		} );
+		const blogName = DataHelper.getBlogName();
+
+		let page: Page;
+		let userID: number;
+		let bearerToken: string;
+		let userCreatedFlag = false;
+
+		beforeAll( async () => {
+			page = await browser.newPage();
+		} );
+
+		describe( 'Register as new user', function () {
+			it( 'Navigate to Signup page', async function () {
+				const loginPage = new LoginPage( page );
+				await loginPage.visit();
+				await loginPage.clickSignUp();
+			} );
+
+			it( 'Sign up as new user', async function () {
+				const userSignupPage = new UserSignupPage( page );
+				const details = await userSignupPage.signup( email, username, password );
+				userID = details.ID;
+				bearerToken = details.bearer_token;
+
+				userCreatedFlag = true;
+			} );
+		} );
+
+		describe( 'Onboarding', function () {
+			it( 'Select a free .wordpress.com domain', async function () {
+				const domainSearchComponent = new DomainSearchComponent( page );
+				await domainSearchComponent.search( blogName );
+				await domainSearchComponent.selectDomain( '.wordpress.com' );
+			} );
+
+			it( 'Select WordPress.com Free plan', async function () {
+				const signupPickPlanPage = new SignupPickPlanPage( page );
+				await signupPickPlanPage.selectPlan( 'Start with Free' );
+			} );
+
+			it( 'Skip to dashboard', async function () {
+				const startSiteFlow = new StartSiteFlow( page );
+				await Promise.all( [
+					page.waitForNavigation( { url: /.*\/home\/.*/ } ),
+					startSiteFlow.clickButton( 'Skip to dashboard' ),
+				] );
+			} );
+		} );
+
+		describe( 'Validate WordPress.com Free functionality', function () {
+			let sidebarComponent: SidebarComponent;
+
+			it( 'User is on WordPress.com Free plan', async function () {
+				sidebarComponent = new SidebarComponent( page );
+				const plan = await sidebarComponent.getCurrentPlanName();
+				expect( plan ).toBe( 'Free' );
+			} );
+
+			it( 'Navigate to Upgrades > Plans', async function () {
+				sidebarComponent = new SidebarComponent( page );
+				await sidebarComponent.navigate( 'Upgrade', 'Plans' );
+			} );
+
+			it( 'View plan comparison', async function () {
+				const plansPage = new PlansPage( page, 'current' );
+				await plansPage.showPlanComparison();
+			} );
+		} );
+
+		afterAll( async function () {
+			if ( ! userCreatedFlag ) {
+				return;
+			}
+
+			const restAPIClient = new RestAPIClient(
+				{ username: username, password: password },
+				bearerToken
+			);
+
+			const response = await restAPIClient.closeUserAccount( userID, username, email );
+
+			if ( response.success !== true ) {
+				console.log( `Failed to delete user ID ${ userID }` );
+			} else {
+				console.log( `Successfully deleted user ID ${ userID }` );
+			}
+			return response;
+		} );
+	}
+);

--- a/test/e2e/specs/plans/plans__signup-free.ts
+++ b/test/e2e/specs/plans/plans__signup-free.ts
@@ -19,7 +19,7 @@ import { Page, Browser } from 'playwright';
 declare const browser: Browser;
 
 describe(
-	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Free site as new user' ),
+	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Free site as a new user' ),
 	function () {
 		const username = `e2eflowtestingfree${ DataHelper.getTimestamp() }`;
 		const password = SecretsManager.secrets.passwordForNewTestSignUps;
@@ -64,7 +64,7 @@ describe(
 
 			it( 'Select WordPress.com Free plan', async function () {
 				const signupPickPlanPage = new SignupPickPlanPage( page );
-				await signupPickPlanPage.selectPlan( 'Start with Free' );
+				await signupPickPlanPage.selectPlan( 'start with a free site' );
 			} );
 
 			it( 'Skip to dashboard', async function () {
@@ -106,7 +106,7 @@ describe(
 				bearerToken
 			);
 
-			const response = await restAPIClient.closeUserAccount( userID, username, email );
+			const response = await restAPIClient.closeAccount( userID, username, email );
 
 			if ( response.success !== true ) {
 				console.log( `Failed to delete user ID ${ userID }` );

--- a/test/e2e/specs/plans/plans__signup-free.ts
+++ b/test/e2e/specs/plans/plans__signup-free.ts
@@ -64,7 +64,7 @@ describe(
 
 			it( 'Select WordPress.com Free plan', async function () {
 				const signupPickPlanPage = new SignupPickPlanPage( page );
-				await signupPickPlanPage.selectPlan( 'start with a free site' );
+				await signupPickPlanPage.selectPlan( 'Free' );
 			} );
 
 			it( 'Skip to dashboard', async function () {

--- a/test/e2e/specs/plans/plans__signup-free.ts
+++ b/test/e2e/specs/plans/plans__signup-free.ts
@@ -109,7 +109,7 @@ describe(
 			const response = await restAPIClient.closeAccount( userID, username, email );
 
 			if ( response.success !== true ) {
-				console.log( `Failed to delete user ID ${ userID }` );
+				console.warn( `Failed to delete user ID ${ userID }` );
 			} else {
 				console.log( `Successfully deleted user ID ${ userID }` );
 			}

--- a/test/e2e/specs/plans/plans__signup-free.ts
+++ b/test/e2e/specs/plans/plans__signup-free.ts
@@ -106,7 +106,11 @@ describe(
 				bearerToken
 			);
 
-			const response = await restAPIClient.closeAccount( userID, username, email );
+			const response = await restAPIClient.closeAccount( {
+				userID: userID,
+				username: username,
+				email: email,
+			} );
 
 			if ( response.success !== true ) {
 				console.warn( `Failed to delete user ID ${ userID }` );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds new methods and spec to test the WordPress.com Free plan.

Key changes:
1. addition of new WP REST API methods.
2. addition of new spec file to teset the WordPress.com Free plan.

Details:
1. new method are added to interact with the WP REST API with the ultimate goal to support future specs. New methods added include interaction with the following endpoints:
  - /me
  - /me/account/close

2. this new spec corresponds to the `Plans: Sign up for Free plan` entry in the [project thread](pciE2j-Uk-p2), with a minor adjustment to use the UI for the signup process.

The rough outline of the spec is as follows:
- create a new account
- select the free plan
- navigate directly to the dashboard, ignoring any onboarding flows
- verify the plans grid under /plans
- delete the account

#### Testing instructions

Trigger the `Pre-Release` tests manually and verify that this spec does not fail.

Related to #