### PR TITLE
Jetpack: Redirect my-jetpack connections back to wp-admin

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -273,7 +273,8 @@ export class JetpackAuthorize extends Component {
 			getRoleFromScope( scope ) === 'subscriber' ||
 			this.isJetpackUpgradeFlow() ||
 			this.isFromJetpackConnectionManager() ||
-			this.isFromJetpackSocialPlugin()
+			this.isFromJetpackSocialPlugin() ||
+			this.isFromMyJetpack()
 		) {
 			debug(
 				'Going back to WP Admin.',
@@ -377,6 +378,11 @@ export class JetpackAuthorize extends Component {
 	isFromJetpackSocialPlugin( props = this.props ) {
 		const { from } = props.authQuery;
 		return startsWith( from, 'jetpack-social' );
+	}
+
+	isFromMyJetpack( props = this.props ) {
+		const { from } = props.authQuery;
+		return startsWith( from, 'my-jetpack' );
 	}
 
 	isWooRedirect = ( props = this.props ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a condition to redirect connections from My Jetpack back to wp-admin. 

Why should we do this? If a user is connecting from My Jetpack, then that site has already been connected once and the user that connected it saw our pricing page. Further, if the user is connecting from My Jetpack, then the user is connecting most likely because we're telling them that they _NEED_ to connect because one of their plans requires a connection. In other words, they're connecting to fix an issue.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout https://github.com/Automattic/jetpack/pull/24283 on a Jetpack site. Maybe use JN special ops
* Checkout this branch locally in Calypso
* Click any Set Up Jetpack button in Jetpack
* DO NOT complete the user connection
* Go back to the My Jetpack section of Jetpack
* Click on the link in the connection section to connect your user account
* On the next connection screen click the connection button
* You will now land on the connection screen on WordPress.com
* Click the connection button
* You will now land on the connection screen on WordPress.com
* In the URL bar change `wordpress.com` to `calypso.localhost:3000`
* Approve the connection
* Ensure that you land back in My Jetpack

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Here's a [video of the flow](https://user-images.githubusercontent.com/1126811/167232357-4b1230ef-31fe-49a0-b9c8-004ed362fcb5.mov)