### PR TITLE
Adding e2e tests for all hero flow logic paths

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -7,7 +7,7 @@ const selectors = {
 	backLink: 'button:text("Back")',
 
 	// Inputs
-	blogNameInput: 'input#siteTitle:not(:disabled)',
+	siteTitleInput: 'input#siteTitle:not(:disabled)',
 	taglineInput: 'input#tagline:not(:disabled)',
 
 	// Themes
@@ -17,6 +17,14 @@ const selectors = {
 	previewThemeButtonMobile: ( name: string ) =>
 		`button.design-picker__design-option:has-text("${ name }")`,
 	themePreviewIframe: 'iframe[title=Preview]',
+	startWithThemeButton: ( name: string ) => `button:has-text("Start with ${ name }")`,
+
+	// Store
+	storeFeaturesContainer: 'div.signup__step.is-store-features',
+	wooCommerceSignupContainer: '.signup.is-woocommerce-install',
+
+	// Blog
+	coursesContianer: 'div.signup__step.is-courses',
 };
 
 /**
@@ -44,21 +52,42 @@ export class StartSiteFlow {
 	}
 
 	/**
-	 * Enter blog name.
+	 * Enter optional site title.
 	 *
-	 * @param {string} name Name for the blog.
+	 * @param {string} name Name for the blog or store.
 	 */
-	async enterBlogName( name: string ): Promise< void > {
-		await this.page.fill( selectors.blogNameInput, name );
+	async enterSiteName( name: string ): Promise< void > {
+		await this.page.fill( selectors.siteTitleInput, name );
 	}
 
 	/**
-	 * Enter blog tagline.
+	 * Enter optional tagline.
 	 *
-	 * @param {string} tagline Tagline for the blog.
+	 * @param {string} tagline Tagline for the blog or store flow.
 	 */
 	async enterTagline( tagline: string ): Promise< void > {
 		await this.page.fill( selectors.taglineInput, tagline );
+	}
+
+	/**
+	 * Validates we've landed on the courses screen.
+	 */
+	async validateOnCoursesScreen(): Promise< void > {
+		await this.page.waitForSelector( selectors.coursesContianer );
+	}
+
+	/**
+	 * Validates we've landed on the store features screen.
+	 */
+	async validateOnStoreFeaturesScreen(): Promise< void > {
+		await this.page.waitForSelector( selectors.storeFeaturesContainer );
+	}
+
+	/**
+	 * Validates we've landed on the WooCommerce signup screen.
+	 */
+	async validateOnWooCommerceScreen(): Promise< void > {
+		await this.page.waitForSelector( selectors.wooCommerceSignupContainer );
 	}
 
 	/**
@@ -97,5 +126,20 @@ export class StartSiteFlow {
 	async getThemePreviewIframe(): Promise< Frame > {
 		const elementHandle = await this.page.waitForSelector( selectors.themePreviewIframe );
 		return ( await elementHandle.contentFrame() ) as Frame;
+	}
+
+	/**
+	 * Clicks button to select a specific theme from theme selection screen.
+	 *
+	 * @param {string} themeName Name of theme, e.g. "Zoologist".
+	 */
+	async selectTheme( themeName: string ): Promise< void > {
+		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
+			await this.page.hover( selectors.individualThemeContainer( themeName ) );
+			await this.page.click( selectors.startWithThemeButton( themeName ) );
+		} else {
+			await this.page.click( selectors.previewThemeButtonMobile( themeName ) );
+			await this.page.click( selectors.startWithThemeButton( themeName ) );
+		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -126,6 +126,13 @@ export class EditorPage {
 	}
 
 	/**
+	 * Validates we've landed on the editor page after navigation.
+	 */
+	async validateOnEditorPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.editorFrame );
+	}
+
+	/**
 	 * Return the editor frame. Could be the top-level frame (i.e WPAdmin).
 	 * an iframe (Calypso/Gutenframe).
 	 *

--- a/packages/calypso-e2e/src/lib/pages/general-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/general-settings-page.ts
@@ -12,6 +12,8 @@ const selectors = {
 	launchSiteButton: 'a:text("Launch site")',
 
 	// Site Tools
+	siteSearchInput: `input[type="search"]`,
+	confirmSiteLink: ( title: string ) => `a[title="${ title }"]`,
 	deleteSiteLinkItem: `p:text-is("Delete your site permanently")`,
 	deleteSiteConfirmInput: `input[id="confirmDomainChangeInput"]`,
 	deleteSiteConfirmationSpan: 'span:has-text("is being deleted")',
@@ -40,6 +42,24 @@ export class GeneralSettingsPage {
 			this.page.waitForNavigation(),
 			this.page.click( selectors.launchSiteButton ),
 		] );
+	}
+
+	/**
+	 * Given title, clicks on the first instance of the link with the text.
+	 *
+	 * @param {string} title User-visible text on the button.
+	 */
+	async clickConfirmSiteLink( title: string ): Promise< void > {
+		await this.page.click( selectors.confirmSiteLink( title ) );
+	}
+
+	/**
+	 * Given text, clicks on the first instance of the link with the text.
+	 *
+	 * @param {string} url URL of the site to be deleted.
+	 */
+	async confirmSiteToDelete( url: string ): Promise< void > {
+		await this.page.fill( selectors.siteSearchInput, url );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/my-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/my-home-page.ts
@@ -2,6 +2,7 @@ import { Page } from 'playwright';
 
 const selectors = {
 	visitSiteButton: '.button >> text=Visit site',
+	myHomeContainer: '.customer-home__main',
 
 	// Task card (topmost card)
 	taskHeadingMessage: ( message: string ) => `div.task h2:has-text("${ message }")`,
@@ -42,5 +43,12 @@ export class MyHomePage {
 	 */
 	async validateTaskHeadingMessage( message: string ): Promise< void > {
 		await this.page.waitForSelector( selectors.taskHeadingMessage( message ) );
+	}
+
+	/**
+	 * Validates we've landed on the home page.
+	 */
+	async validateOnMyHomePage(): Promise< void > {
+		await this.page.waitForSelector( selectors.myHomeContainer );
 	}
 }

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -81,7 +81,7 @@ skipDescribeIf( isStagingOrProd )(
 			} );
 
 			it( 'Enter blog name', async function () {
-				await startSiteFlow.enterBlogName( blogName );
+				await startSiteFlow.enterSiteName( blogName );
 			} );
 
 			it( 'Enter tagline', async function () {

--- a/test/e2e/specs/onboarding/start__build.ts
+++ b/test/e2e/specs/onboarding/start__build.ts
@@ -1,0 +1,122 @@
+/**
+ * @group calypso-pr
+ */
+
+import {
+	DataHelper,
+	DomainSearchComponent,
+	EditorPage,
+	GeneralSettingsPage,
+	MyHomePage,
+	SignupPickPlanPage,
+	StartSiteFlow,
+	TestAccount,
+} from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Hero Flow: Build' ), () => {
+	const themeName = 'Blockbase';
+	const siteName = DataHelper.getBlogName();
+	const siteSlug = siteName + '.wordpress.com';
+
+	let page: Page;
+	let startSiteFlow: StartSiteFlow;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		startSiteFlow = new StartSiteFlow( page );
+
+		const testAccount = new TestAccount( 'calypsoPreReleaseUser' );
+		await testAccount.authenticate( page );
+
+		/**
+		 * Create a new site using existing test user 'calypsoPreReleaseUser'
+		 * with a WordPress.com domain and a free plan
+		 *
+		 * @param siteName Site subdomain
+		 */
+		await page.goto( DataHelper.getCalypsoURL( '/start' ) );
+
+		// Select a free domain
+		const domainSearchComponent = new DomainSearchComponent( page );
+		await domainSearchComponent.search( siteName );
+		await domainSearchComponent.selectDomain( '.wordpress.com' );
+
+		// Select the free plan
+		const signupPickPlanPage = new SignupPickPlanPage( page );
+		await signupPickPlanPage.selectPlan( 'Start with Free' );
+	} );
+
+	/**
+	 * Navigate to the set up site screen for the Build flow as a resusable function
+	 *
+	 */
+	const navigateToBuildPath = () => {
+		it( 'Navigate to intent screen', async () => {
+			await page.goto( DataHelper.getCalypsoURL( '/start/setup-site/intent', { siteSlug } ) );
+		} );
+
+		it( 'Select Build', async () => {
+			await startSiteFlow.clickButton( 'Start building' );
+		} );
+
+		it( 'See select theme screen', async () => {
+			await startSiteFlow.validateOnDesignPickerScreen();
+		} );
+	};
+
+	/**
+	 * Select a theme to finish onboarding and land in the editor
+	 *
+	 * @param themeName Theme to select from theme picker
+	 */
+	describe( 'Complete onboarding', () => {
+		navigateToBuildPath();
+
+		it( 'Choose a theme', async () => {
+			await startSiteFlow.selectTheme( themeName );
+		} );
+
+		it( 'See the site editor', async () => {
+			const editorPage = new EditorPage( page );
+			await editorPage.validateOnEditorPage();
+		} );
+	} );
+
+	/**
+	 * Skip selecting a theme and land on MyHome
+	 *
+	 */
+	describe( 'Skip onboarding', () => {
+		navigateToBuildPath();
+
+		it( 'Click Skip for now button', async () => {
+			await startSiteFlow.clickButton( 'Skip for now' );
+		} );
+
+		it( 'See the home page', async () => {
+			const myHomePage = new MyHomePage( page );
+			await myHomePage.validateOnMyHomePage();
+		} );
+	} );
+
+	afterAll( async () => {
+		/**
+		 * Delete the site created in this spec
+		 *
+		 * @param siteName Subdomain of the site
+		 * @param siteSlug Full site URL
+		 */
+		await page.goto( DataHelper.getCalypsoURL( '/settings/general/', { siteSlug } ) );
+
+		// Select which site will be deleted
+		const generalSettingsPage = new GeneralSettingsPage( page );
+		await generalSettingsPage.confirmSiteToDelete( siteSlug );
+		await generalSettingsPage.clickConfirmSiteLink( `${ siteName }.wordpress.com` );
+
+		// Delete the site
+		await generalSettingsPage.deleteSite( `${ siteName }.wordpress.com` );
+	} );
+} );

--- a/test/e2e/specs/onboarding/start__sell.ts
+++ b/test/e2e/specs/onboarding/start__sell.ts
@@ -1,0 +1,185 @@
+/**
+ * @group calypso-pr
+ */
+
+import {
+	DataHelper,
+	DomainSearchComponent,
+	EditorPage,
+	GeneralSettingsPage,
+	SignupPickPlanPage,
+	StartSiteFlow,
+	TestAccount,
+} from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Hero Flow: Sell' ), () => {
+	const themeName = 'Dorna';
+	const storeName = DataHelper.getBlogName();
+	const tagline = `${ storeName } tagline`;
+	const siteSlug = storeName + '.wordpress.com';
+
+	let page: Page;
+	let startSiteFlow: StartSiteFlow;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		startSiteFlow = new StartSiteFlow( page );
+
+		const testAccount = new TestAccount( 'calypsoPreReleaseUser' );
+		await testAccount.authenticate( page );
+
+		/**
+		 * Create a new site using existing test user 'calypsoPreReleaseUser'
+		 * with a WordPress.com domain and a free plan
+		 *
+		 * @param storeName Site subdomain
+		 */
+		await page.goto( DataHelper.getCalypsoURL( '/start' ) );
+
+		// Select a free domain
+		const domainSearchComponent = new DomainSearchComponent( page );
+		await domainSearchComponent.search( storeName );
+		await domainSearchComponent.selectDomain( '.wordpress.com' );
+
+		// Select the free plan
+		const signupPickPlanPage = new SignupPickPlanPage( page );
+		await signupPickPlanPage.selectPlan( 'Start with Free' );
+	} );
+
+	/**
+	 * Navigate to the set up site screen for the Sell flow as a resusable function
+	 *
+	 */
+	const navigateToSellPath = () => {
+		it( 'Navigate to intent screen', async () => {
+			await page.goto( DataHelper.getCalypsoURL( '/start/setup-site/intent', { siteSlug } ) );
+		} );
+
+		it( 'Select Sell', async () => {
+			await startSiteFlow.clickButton( 'Start selling' );
+		} );
+	};
+
+	/**
+	 * Skip optional site setup screen, select start simple options, and verify navigation to design picker screen
+	 */
+	const selectStartSimpleStore = () => {
+		it( 'Click Skip This Step button', async () => {
+			await startSiteFlow.clickButton( 'Skip this step' );
+		} );
+
+		it( 'Select start simple option', async () => {
+			await startSiteFlow.clickButton( 'Continue' );
+		} );
+
+		it( 'See design picker screen', async () => {
+			await startSiteFlow.validateOnDesignPickerScreen();
+		} );
+	};
+
+	/**
+	 * Complete optional site setup screen and verify navigation to store features screen
+	 *
+	 * @param storeName Site subdomain
+	 * @param tagline Store tagline
+	 */
+	describe( 'Complete optional store settings', () => {
+		navigateToSellPath();
+
+		it( 'Enter Store name', async () => {
+			await startSiteFlow.enterSiteName( storeName );
+		} );
+
+		it( 'Enter Store tagline', async () => {
+			await startSiteFlow.enterTagline( tagline );
+		} );
+
+		it( 'Click continue button', async () => {
+			await startSiteFlow.clickButton( 'Continue' );
+		} );
+
+		it( 'See store features screen', async () => {
+			await startSiteFlow.validateOnStoreFeaturesScreen();
+		} );
+	} );
+
+	/**
+	 * Select a theme to finish onboarding and land in the editor
+	 *
+	 * @param themeName Theme to select from theme picker
+	 */
+	describe( 'Complete onbaording', () => {
+		navigateToSellPath();
+
+		selectStartSimpleStore();
+
+		it( 'Choose a theme', async () => {
+			await startSiteFlow.selectTheme( themeName );
+		} );
+
+		it( 'See the site editor', async () => {
+			const editorPage = new EditorPage( page );
+			await editorPage.validateOnEditorPage();
+		} );
+	} );
+
+	/**
+	 * Skip selecting a theme and land in editor
+	 *
+	 */
+	describe( 'Skip onboarding', () => {
+		navigateToSellPath();
+
+		selectStartSimpleStore();
+
+		it( 'Click Skip for now button', async () => {
+			await startSiteFlow.clickButton( 'Skip for now' );
+		} );
+
+		it( 'See the site editor', async () => {
+			const editorPage = new EditorPage( page );
+			await editorPage.validateOnEditorPage();
+		} );
+	} );
+
+	/**
+	 * Skip optional site setup screen, select more power option, and verify navigation to store address screen
+	 * This test stops at the start of the path setup WooCommerce
+	 */
+	describe( 'Select more power store path', () => {
+		navigateToSellPath();
+
+		it( 'Click Skip This Step button', async () => {
+			await startSiteFlow.clickButton( 'Skip this step' );
+		} );
+
+		it( 'Select more power option', async () => {
+			await startSiteFlow.clickButton( 'Upgrade' );
+		} );
+
+		it( 'See the WooCommerce sign up screen', async () => {
+			await startSiteFlow.validateOnWooCommerceScreen();
+		} );
+	} );
+
+	afterAll( async () => {
+		/**
+		 * Delete the site created in this spec
+		 *
+		 * @param siteSlug Site full url
+		 * @param storeName Site subdomain
+		 */
+		await page.goto( DataHelper.getCalypsoURL( '/settings/general/', { siteSlug } ) );
+
+		// Select which site will be deleted
+		const generalSettingsPage = new GeneralSettingsPage( page );
+		await generalSettingsPage.confirmSiteToDelete( siteSlug );
+		await generalSettingsPage.clickConfirmSiteLink( `${ storeName }.wordpress.com` );
+
+		// Delete the site
+		await generalSettingsPage.deleteSite( `${ storeName }.wordpress.com` );
+	} );
+} );

--- a/test/e2e/specs/onboarding/start__write.ts
+++ b/test/e2e/specs/onboarding/start__write.ts
@@ -1,0 +1,192 @@
+/**
+ * @group calypso-pr
+ */
+
+import {
+	DataHelper,
+	DomainSearchComponent,
+	GeneralSettingsPage,
+	StartSiteFlow,
+	SignupPickPlanPage,
+	TestAccount,
+	EditorPage,
+} from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Hero Flow: Write' ), () => {
+	const themeName = 'Blockbase';
+	const blogName = DataHelper.getBlogName();
+	const siteSlug = blogName + '.wordpress.com';
+
+	let page: Page;
+	let startSiteFlow: StartSiteFlow;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		startSiteFlow = new StartSiteFlow( page );
+
+		const testAccount = new TestAccount( 'calypsoPreReleaseUser' );
+		await testAccount.authenticate( page );
+
+		/**
+		 * Create a new site using existing test user 'calypsoPreReleaseUser'
+		 * with a WordPress.com domain and a free plan
+		 *
+		 * @param blogName Site subdomain
+		 */
+		await page.goto( DataHelper.getCalypsoURL( '/start' ) );
+
+		// Select a free domain
+		const domainSearchComponent = new DomainSearchComponent( page );
+		await domainSearchComponent.search( blogName );
+		await domainSearchComponent.selectDomain( '.wordpress.com' );
+
+		// Select the free plan
+		const signupPickPlanPage = new SignupPickPlanPage( page );
+		await signupPickPlanPage.selectPlan( 'Start with Free' );
+	} );
+
+	/**
+	 * Complete the intent page and site setup page for the Write FLow
+	 *
+	 */
+	const navigateToWritePath = () => {
+		it( 'Navigate to intent page', async () => {
+			await page.goto( DataHelper.getCalypsoURL( '/start/setup-site/intent', { siteSlug } ) );
+		} );
+
+		it( 'Select Write', async () => {
+			await startSiteFlow.clickButton( 'Start writing' );
+		} );
+	};
+
+	/**
+	 * Complete optional but settings
+	 *
+	 * @param blogName The site subdomain
+	 */
+	describe( 'Complete optional blog settings', () => {
+		navigateToWritePath();
+
+		it( 'Enter Blog name', async () => {
+			await startSiteFlow.enterSiteName( blogName );
+		} );
+
+		it( 'Enter Blog tagline', async () => {
+			await startSiteFlow.enterTagline( 'Hero Flow Blog' );
+		} );
+
+		it( 'Click continue button', async () => {
+			await startSiteFlow.clickButton( 'Continue' );
+		} );
+	} );
+
+	/**
+	 * Select start writing and go directly to the editor
+	 */
+	describe( 'Go directly to the editor', () => {
+		navigateToWritePath();
+
+		it( 'Click Skip this step button', async () => {
+			await startSiteFlow.clickButton( 'Skip this step' );
+		} );
+
+		it( 'Click Start writing', async () => {
+			await startSiteFlow.clickButton( 'Start writing ' );
+		} );
+
+		it( 'See the Courses screen', async () => {
+			const editorPage = new EditorPage( page );
+			await editorPage.validateOnEditorPage();
+		} );
+	} );
+
+	/**
+	 * Select start learning to view educational courses
+	 */
+	describe( 'Watch blogging videos', () => {
+		navigateToWritePath();
+
+		it( 'Click Skip this step button', async () => {
+			await startSiteFlow.clickButton( 'Skip this step' );
+		} );
+
+		it( 'Click Start learning button', async () => {
+			await startSiteFlow.clickButton( 'Start learning ' );
+		} );
+
+		it( 'See the Courses screen', async () => {
+			await startSiteFlow.validateOnCoursesScreen();
+		} );
+	} );
+
+	/**
+	 * Select a theme and land in the editor
+	 *
+	 * @param themeName Theme to select from theme picker
+	 */
+	describe( 'Choose a theme', () => {
+		navigateToWritePath();
+
+		it( 'Click Skip this step button', async () => {
+			await startSiteFlow.clickButton( 'Skip this step' );
+		} );
+
+		it( 'Click View designs button ', async () => {
+			await startSiteFlow.clickButton( 'View designs' );
+		} );
+
+		it( 'Choose a theme', async () => {
+			await startSiteFlow.selectTheme( themeName );
+		} );
+
+		it( 'See the site editor', async () => {
+			const editorPage = new EditorPage( page );
+			await editorPage.validateOnEditorPage();
+		} );
+	} );
+
+	/**
+	 * Skip selecting a theme and land in the editor
+	 */
+	describe( 'Skip selecting a theme', () => {
+		navigateToWritePath();
+
+		it( 'Click Skip this step button', async () => {
+			await startSiteFlow.clickButton( 'Skip this step' );
+		} );
+
+		it( 'Click View designs button ', async () => {
+			await startSiteFlow.clickButton( 'View designs' );
+		} );
+
+		it( 'Click Skip and draft first post button', async () => {
+			await startSiteFlow.clickButton( 'Skip and draft first post' );
+		} );
+
+		it( 'See the site editor', async () => {
+			const editorPage = new EditorPage( page );
+			await editorPage.validateOnEditorPage();
+		} );
+	} );
+
+	afterAll( async () => {
+		/**
+		 * Delete the site created in this spec
+		 *
+		 * @param blogName The subdomain of the site
+		 * @param siteSlug The full site url
+		 */
+		await page.goto( DataHelper.getCalypsoURL( '/settings/general/', { siteSlug } ) );
+
+		// Select which site will be deleted
+		const generalSettingsPage = new GeneralSettingsPage( page );
+		await generalSettingsPage.confirmSiteToDelete( siteSlug );
+		await generalSettingsPage.clickConfirmSiteLink( `${ blogName }.wordpress.com` );
+
+		// Delete the site
+		await generalSettingsPage.deleteSite( `${ blogName }.wordpress.com` );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This pull request adds e2e tests for all logic paths of the hero flow. It's TOO BIG but as this is for a trial, it will have to do.
* Each spec file creates a new site under an existing test user account for tests in that spec. It deletes the new site after all tests have run.
* For more details, see the trial P2!

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run e2e tests in the onboarding folder, or run just the new specs specifically at onboarding/start__write.ts,
 onboarding/start__sell.ts, and onboarding__build.ts
* There was an onboarding test that fails in the onboarding/signup__domain.ts spec where a button for Domain Only isn't
 available.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
