### PR TITLE
Generated design picker: Pass vertical ID to preview endpoint  

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -57,7 +57,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	const siteTitle = site?.name;
 	const isReskinned = true;
 	const sitePlanSlug = site?.plan?.product_slug;
-	const siteVertical = useSelect(
+	const siteVerticalId = useSelect(
 		( select ) => ( site && select( SITE_STORE ).getSiteVerticalId( site.ID ) ) || undefined
 	);
 	const isAtomic = useSelect( ( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID ) );
@@ -71,7 +71,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	const showGeneratedDesigns =
 		isEnabled( 'signup/design-picker-generated-designs' ) &&
 		intent === 'build' &&
-		!! siteVertical &&
+		!! siteVerticalId &&
 		! isForceStaticDesigns;
 	const showDesignPickerCategoriesAllFilter = isEnabled( 'signup/design-picker-categories' );
 
@@ -312,7 +312,10 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		const stepContent = (
 			<GeneratedDesignPreview
 				slug={ design.slug }
-				previewUrl={ getDesignPreviewUrl( design, { language: locale, verticalId: siteVertical } ) }
+				previewUrl={ getDesignPreviewUrl( design, {
+					language: locale,
+					verticalId: siteVerticalId,
+				} ) }
 				isSelected
 			/>
 		);
@@ -357,7 +360,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		<GeneratedDesignPicker
 			selectedDesign={ ! isMobile ? selectedDesign || shuffledGeneratedDesigns[ 0 ] : undefined }
 			designs={ shuffledGeneratedDesigns }
-			verticalId={ siteVertical }
+			verticalId={ siteVerticalId }
 			locale={ locale }
 			heading={
 				<div className={ classnames( 'step-container__header', 'design-setup__header' ) }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -57,15 +57,9 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	const siteTitle = site?.name;
 	const isReskinned = true;
 	const sitePlanSlug = site?.plan?.product_slug;
-	const siteVertical = useMemo(
-		() => ( {
-			// TODO: fetch from store/site settings
-			id: '439',
-			name: 'Photographic & Digital Arts',
-		} ),
-		[]
+	const siteVertical = useSelect(
+		( select ) => ( site && select( SITE_STORE ).getSiteVerticalId( site.ID ) ) || undefined
 	);
-
 	const isAtomic = useSelect( ( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID ) );
 	const isPrivateAtomic = Boolean( site?.launch_status === 'unlaunched' && isAtomic );
 
@@ -318,7 +312,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		const stepContent = (
 			<GeneratedDesignPreview
 				slug={ design.slug }
-				previewUrl={ getDesignPreviewUrl( design, { language: locale } ) }
+				previewUrl={ getDesignPreviewUrl( design, { language: locale, verticalId: siteVertical } ) }
 				isSelected
 			/>
 		);
@@ -363,6 +357,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		<GeneratedDesignPicker
 			selectedDesign={ ! isMobile ? selectedDesign || shuffledGeneratedDesigns[ 0 ] : undefined }
 			designs={ shuffledGeneratedDesigns }
+			verticalId={ siteVertical }
 			locale={ locale }
 			heading={
 				<div className={ classnames( 'step-container__header', 'design-setup__header' ) }>

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -102,6 +102,7 @@ const GeneratedDesignPreview: React.FC< GeneratedDesignPreviewProps > = ( {
 export interface GeneratedDesignPickerProps {
 	selectedDesign?: Design;
 	designs: Design[];
+	verticalId: string;
 	locale: string;
 	heading?: React.ReactElement;
 	onPreview: ( design: Design ) => void;
@@ -111,6 +112,7 @@ export interface GeneratedDesignPickerProps {
 const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 	selectedDesign,
 	designs,
+	verticalId,
 	locale,
 	heading,
 	onPreview,
@@ -128,7 +130,7 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 							<GeneratedDesignThumbnail
 								key={ design.slug }
 								slug={ design.slug }
-								thumbnailUrl={ getDesignPreviewUrl( design, { language: locale } ) }
+								thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
 								isSelected={ selectedDesign?.slug === design.slug }
 								onPreview={ () => onPreview( design ) }
 							/>
@@ -144,7 +146,7 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 								key={ design.slug }
 								slug={ design.slug }
 								isSelected={ selectedDesign?.slug === design.slug }
-								previewUrl={ getDesignPreviewUrl( design, { language: locale } ) }
+								previewUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
 							/>
 						) ) }
 				</div>

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -50,6 +50,7 @@ export interface Design {
 
 export interface DesignPreviewOptions {
 	language?: string;
+	verticalId?: string;
 	siteTitle?: string;
 }
 

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -20,11 +20,12 @@ describe( 'Design Picker designs utils', () => {
 		it( 'should append the preview options to the query params', () => {
 			const options: DesignPreviewOptions = {
 				language: 'id',
+				verticalId: '3',
 				siteTitle: 'Design Title',
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&language=id&viewport_height=700&source_site=patternboilerplates.wordpress.com&site_title=Design%20Title'
+				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&vertical_id=3&language=id&viewport_height=700&source_site=patternboilerplates.wordpress.com&site_title=Design%20Title'
 			);
 		} );
 

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -14,6 +14,7 @@ export const getDesignPreviewUrl = (
 	let url = addQueryArgs( 'https://public-api.wordpress.com/wpcom/v2/block-previews/site', {
 		stylesheet: recipe?.stylesheet,
 		pattern_ids: recipe?.patternIds?.join( ',' ),
+		vertical_id: options.verticalId,
 		language: options.language,
 		viewport_height: 700,
 		source_site: 'patternboilerplates.wordpress.com',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fetches the site vertical ID from site settings, and passes it down to the `/block-previews/site` endpoint (as parameter `vertical_id`) in order to generate verticalized designs.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/vertical?siteSlug=${site_slug}`, and select one of the following verticals ("Arts & Entertainment" or "Computers & Electronics"). Currently, these verticals have enough verticalized images.
* Click on "Continue", and on the intent screen click on "Start building".
* Expect to land on the generated design picker, and in the generated designs find that the images have been verticalized.

Caveat: The number of verticalized images will depend on how many suitable images are found. 

Arts & Entertainment:
![Screen Shot 2022-05-09 at 12 28 33 PM](https://user-images.githubusercontent.com/797888/167340775-8cbfff91-0402-4eb8-872c-b790bfc531e9.png)

Computers & Electronics:
![Screen Shot 2022-05-09 at 12 28 18 PM](https://user-images.githubusercontent.com/797888/167340794-b0dc3a3a-0073-4384-9b7f-b894012f0c2b.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62237
