### PR TITLE
Reinstate /browse/:category/:site

### DIFF
--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -39,7 +39,7 @@ const Categories = ( { selected }: { selected?: string } ) => {
 
 		let url;
 		if ( category.slug !== 'discover' ) {
-			url = `/plugins/${ category.slug }/${ domain || '' }`;
+			url = `/plugins/browse/${ category.slug }/${ domain || '' }`;
 		} else {
 			url = `/plugins/${ domain || '' }`;
 		}

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -7,12 +7,12 @@ import {
 	selectSiteIfLoggedIn,
 } from 'calypso/my-sites/controller';
 import {
-	browsePlugins,
-	browsePluginsOrPlugin,
+	renderPlugin,
+	renderBrowsePlugins,
 	renderPluginWarnings,
 	renderProvisionPlugins,
 	jetpackCanUpdate,
-	plugins,
+	renderPlugins,
 	scrollTopIfNoHash,
 	upload,
 } from './controller';
@@ -36,17 +36,24 @@ export default function () {
 		clientRender
 	);
 
-	page( '/plugins/browse/:category/:site', ( context ) => {
-		const { category, site } = context.params;
-		page.redirect( `/plugins/${ category }/${ site }` );
-	} );
+	page(
+		'/plugins/browse/:category/:site',
+		scrollTopIfNoHash,
+		siteSelection,
+		navigation,
+		renderBrowsePlugins,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/plugins/browse/:category',
+		scrollTopIfNoHash,
+		siteSelection,
+		sites,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/plugins/browse/:siteOrCategory?', ( context ) => {
-		const { siteOrCategory } = context.params;
-		page.redirect( '/plugins' + ( siteOrCategory ? '/' + siteOrCategory : '' ) );
-	} );
-
-	page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
 	page(
 		'/plugins/upload/:site',
 		scrollTopIfNoHash,
@@ -56,46 +63,24 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
-
-	page( '/plugins', selectSiteIfLoggedIn, navigation, makeLayout, clientRender );
-
-	page(
-		'/plugins/:site',
-		scrollTopIfNoHash,
-		siteSelection,
-		navigation,
-		browsePlugins,
-		makeLayout,
-		clientRender
-	);
+	page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
 
 	page(
 		'/plugins/manage/:site',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
-		plugins,
+		renderPlugins,
 		makeLayout,
 		clientRender
 	);
-
 	page(
 		'/plugins/:pluginFilter(active|inactive|updates)/:site',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
 		jetpackCanUpdate,
-		plugins,
-		makeLayout,
-		clientRender
-	);
-
-	page(
-		'/plugins/:plugin/:site',
-		scrollTopIfNoHash,
-		siteSelection,
-		navigation,
-		browsePluginsOrPlugin,
+		renderPlugins,
 		makeLayout,
 		clientRender
 	);
@@ -109,4 +94,24 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+	page(
+		'/plugins/:plugin/:site',
+		scrollTopIfNoHash,
+		siteSelection,
+		navigation,
+		renderPlugin,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/plugins/:site',
+		scrollTopIfNoHash,
+		siteSelection,
+		navigation,
+		renderBrowsePlugins,
+		makeLayout,
+		clientRender
+	);
+	page( '/plugins', selectSiteIfLoggedIn, navigation, makeLayout, clientRender );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* wip

Todo:
- `/plugins/browse/:category` conflicts with existing route `/plugins/browse/:site` - can we fix the url in the one email that references this?
- The breadcrumbs look confused when searching from a /browse/cat page - I think this might already be the case
- ^ can we move category to a search query param yet? It'd solve our conflict and we could drop /browse completely once its all running through query params: /plugins/:site/?s=:search&c=:category

#### Testing instructions

* Should decompose `/plugins/:pluginOrCategorySlug/:site` route into: `/plugins/:plugin/:site` and `/plugins/browse/:cateogry/:site`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/63030
