### PR TITLE
Marketplace: plugin route cleanup

### DIFF
--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -9,7 +9,6 @@ import {
 import {
 	browsePlugins,
 	browsePluginsOrPlugin,
-	renderPluginWarnings,
 	renderProvisionPlugins,
 	jetpackCanUpdate,
 	plugins,
@@ -91,16 +90,6 @@ export default function () {
 		siteSelection,
 		navigation,
 		browsePluginsOrPlugin,
-		makeLayout,
-		clientRender
-	);
-
-	page(
-		'/plugins/:plugin/eligibility/:site',
-		scrollTopIfNoHash,
-		siteSelection,
-		navigation,
-		renderPluginWarnings,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -1,11 +1,6 @@
 import page from 'page';
 import { makeLayout, render } from 'calypso/controller';
-import {
-	navigation,
-	siteSelection,
-	sites,
-	selectSiteIfLoggedIn,
-} from 'calypso/my-sites/controller';
+import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
 	browsePlugins,
 	browsePluginsOrPlugin,
@@ -51,7 +46,7 @@ export default function () {
 		render
 	);
 
-	page( '/plugins', selectSiteIfLoggedIn, navigation, makeLayout, render );
+	page( '/plugins', scrollTopIfNoHash, siteSelection, sites, makeLayout, render );
 
 	page(
 		'/plugins/:site',

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -36,11 +36,6 @@ export default function () {
 		clientRender
 	);
 
-	page( '/plugins/browse/:category/:site', ( context ) => {
-		const { category, site } = context.params;
-		page.redirect( `/plugins/${ category }/${ site }` );
-	} );
-
 	page( '/plugins/browse/:siteOrCategory?', ( context ) => {
 		const { siteOrCategory } = context.params;
 		page.redirect( '/plugins' + ( siteOrCategory ? '/' + siteOrCategory : '' ) );

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -1,5 +1,5 @@
 import page from 'page';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, render } from 'calypso/controller';
 import {
 	navigation,
 	siteSelection,
@@ -23,7 +23,7 @@ export default function () {
 		siteSelection,
 		renderProvisionPlugins,
 		makeLayout,
-		clientRender
+		render
 	);
 
 	page(
@@ -32,7 +32,7 @@ export default function () {
 		siteSelection,
 		renderProvisionPlugins,
 		makeLayout,
-		clientRender
+		render
 	);
 
 	page( '/plugins/browse/:siteOrCategory?', ( context ) => {
@@ -40,7 +40,7 @@ export default function () {
 		page.redirect( '/plugins' + ( siteOrCategory ? '/' + siteOrCategory : '' ) );
 	} );
 
-	page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
+	page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, render );
 	page(
 		'/plugins/upload/:site',
 		scrollTopIfNoHash,
@@ -48,10 +48,10 @@ export default function () {
 		navigation,
 		upload,
 		makeLayout,
-		clientRender
+		render
 	);
 
-	page( '/plugins', selectSiteIfLoggedIn, navigation, makeLayout, clientRender );
+	page( '/plugins', selectSiteIfLoggedIn, navigation, makeLayout, render );
 
 	page(
 		'/plugins/:site',
@@ -60,7 +60,7 @@ export default function () {
 		navigation,
 		browsePlugins,
 		makeLayout,
-		clientRender
+		render
 	);
 
 	page(
@@ -70,7 +70,7 @@ export default function () {
 		navigation,
 		plugins,
 		makeLayout,
-		clientRender
+		render
 	);
 
 	page(
@@ -81,7 +81,7 @@ export default function () {
 		jetpackCanUpdate,
 		plugins,
 		makeLayout,
-		clientRender
+		render
 	);
 
 	page(
@@ -91,6 +91,6 @@ export default function () {
 		navigation,
 		browsePluginsOrPlugin,
 		makeLayout,
-		clientRender
+		render
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* wip
* Clean up in the router
* Removed dead routes (See geekbot for ref to traffic data)
* Not sure if I want to go ahead with this, didn't make the progress I was expecting to with this approach. More likely want to go with something like https://github.com/Automattic/wp-calypso/pull/63404 - where we can clean up the routes as a side effect.

#### Testing instructions

* tbd

Related to https://github.com/Automattic/wp-calypso/issues/63030
