### PR TITLE
Help-center: Implement forums support user-declared sites analysis and messaging

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/contents.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/contents.js
@@ -71,6 +71,10 @@ export default function Content( { selectedArticle, setSelectedArticle, setFoote
 							setOpenInContactPage( true );
 							setContactForm( null );
 						} }
+						onGoHome={ () => {
+							setOpenInContactPage( false );
+							setContactForm( null );
+						} }
 						siteId={ window._currentSiteId }
 					/>
 				) : (

--- a/apps/happychat/src/happychat.jsx
+++ b/apps/happychat/src/happychat.jsx
@@ -49,20 +49,13 @@ function ParentConnection( { chatStatus, timeline } ) {
 					dispatch( sendEvent( `Looking at ${ message.route }` ) );
 					break;
 				case 'happy-chat-introduction-data': {
-					if ( message.siteId ) {
+					if ( message.site ) {
 						dispatch(
 							setChatCustomFields( {
 								calypsoSectionName: 'gutenberg-editor',
 								wpcomSiteId: message.siteId.toString(),
 								wpcomSitePlan: message.planSlug,
 							} )
-						);
-					} else {
-						// the user needs help with another site whose ID we don't know.
-						dispatch(
-							sendEvent(
-								`Note: the user needs help with ${ message.otherSiteURL }. This URL is user-entered so it can be inaccurate or non-WPCOM at all.`
-							)
 						);
 					}
 					// send the user's message

--- a/apps/happychat/src/happychat.jsx
+++ b/apps/happychat/src/happychat.jsx
@@ -49,7 +49,7 @@ function ParentConnection( { chatStatus, timeline } ) {
 					dispatch( sendEvent( `Looking at ${ message.route }` ) );
 					break;
 				case 'happy-chat-introduction-data': {
-					if ( message.site ) {
+					if ( message.siteId ) {
 						dispatch(
 							setChatCustomFields( {
 								calypsoSectionName: 'gutenberg-editor',

--- a/client/blocks/inline-help/inline-help-center-content.jsx
+++ b/client/blocks/inline-help/inline-help-center-content.jsx
@@ -26,7 +26,7 @@ const InlineHelpCenterContent = ( {
 	);
 	const secondaryViewRef = useRef();
 
-	//prefetch the values
+	// prefetch the values
 	useSupportAvailability( 'CHAT' );
 	useSupportAvailability( 'EMAIL' );
 

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -129,6 +129,10 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 									setOpenInContactPage( true );
 									setContactForm( null );
 								} }
+								onGoHome={ () => {
+									setOpenInContactPage( false );
+									setContactForm( null );
+								} }
 								siteId={ siteId }
 							/>
 						) : (

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
+		"@automattic/help-center": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/languages": "workspace:^",
 		"@automattic/typography": "workspace:^",

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -1,13 +1,15 @@
+import { SiteDetails } from '../site';
+
 export const setShowHelpCenter = ( show: boolean ) =>
 	( {
 		type: 'HELP_CENTER_SET_SHOW',
 		show,
 	} as const );
 
-export const setSiteId = ( siteId: string | number ) =>
+export const setSite = ( site: SiteDetails | undefined ) =>
 	( {
-		type: 'HELP_CENTER_SET_SITE_ID',
-		siteId,
+		type: 'HELP_CENTER_SET_SITE',
+		site,
 	} as const );
 
 export const setSubject = ( subject: string ) =>
@@ -33,18 +35,25 @@ export const resetPopup = () =>
 		type: 'HELP_CENTER_RESET_POPUP',
 	} as const );
 
-export const setOtherSiteURL = ( url: string ) =>
+export const setUserDeclaredSiteUrl = ( url: string ) =>
 	( {
-		type: 'HELP_CENTER_SET_OTHER_SITE_URL',
+		type: 'HELP_CENTER_SET_USER_DECLARED_SITE_URL',
 		url,
+	} as const );
+
+export const setUserDeclaredSite = ( site: SiteDetails | undefined ) =>
+	( {
+		type: 'HELP_CENTER_SET_USER_DECLARED_SITE',
+		site,
 	} as const );
 
 export type HelpCenterAction = ReturnType<
 	| typeof setShowHelpCenter
-	| typeof setSiteId
+	| typeof setSite
 	| typeof setSubject
 	| typeof setMessage
-	| typeof setOtherSiteURL
+	| typeof setUserDeclaredSite
+	| typeof setUserDeclaredSiteUrl
 	| typeof resetPopup
 	| typeof setPopup
 >;

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -16,6 +16,7 @@ export function register(): typeof STORE_KEY {
 			reducer: reducer as any, // eslint-disable-line @typescript-eslint/no-explicit-any
 			controls,
 			selectors,
+			persist: [ 'site' ],
 		} );
 		isRegistered = true;
 	}

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -1,4 +1,5 @@
 import { combineReducers } from '@wordpress/data';
+import { SiteDetails } from '../site';
 import type { HelpCenterAction } from './actions';
 import type { Reducer } from 'redux';
 
@@ -10,12 +11,9 @@ const showHelpCenter: Reducer< boolean | undefined, HelpCenterAction > = ( state
 	return state;
 };
 
-const siteId: Reducer< string | number | undefined, HelpCenterAction > = (
-	state = window._currentSiteId,
-	action
-) => {
-	if ( action.type === 'HELP_CENTER_SET_SITE_ID' ) {
-		return action.siteId;
+const site: Reducer< SiteDetails | undefined, HelpCenterAction > = ( state, action ) => {
+	if ( action.type === 'HELP_CENTER_SET_SITE' ) {
+		return action.site;
 	}
 	return state;
 };
@@ -34,9 +32,18 @@ const message: Reducer< string | undefined, HelpCenterAction > = ( state, action
 	return state;
 };
 
-const otherSiteURL: Reducer< string | undefined, HelpCenterAction > = ( state, action ) => {
-	if ( action.type === 'HELP_CENTER_SET_OTHER_SITE_URL' ) {
+const userDeclaredSiteUrl: Reducer< string | undefined, HelpCenterAction > = ( state, action ) => {
+	if ( action.type === 'HELP_CENTER_SET_USER_DECLARED_SITE_URL' ) {
 		return action.url;
+	}
+	return state;
+};
+const userDeclaredSite: Reducer< SiteDetails | undefined, HelpCenterAction > = (
+	state,
+	action
+) => {
+	if ( action.type === 'HELP_CENTER_SET_USER_DECLARED_SITE' ) {
+		return action.site;
 	}
 	return state;
 };
@@ -52,10 +59,11 @@ const popup: Reducer< Window | undefined, HelpCenterAction > = ( state, action )
 
 const reducer = combineReducers( {
 	showHelpCenter,
-	siteId,
+	site,
 	subject,
 	message,
-	otherSiteURL,
+	userDeclaredSite,
+	userDeclaredSiteUrl,
 	popup,
 } );
 

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -1,8 +1,9 @@
 import type { State } from './reducer';
 
 export const isHelpCenterShown = ( state: State ) => state.showHelpCenter;
-export const getSiteId = ( state: State ) => state.siteId;
+export const getSite = ( state: State ) => state.site;
 export const getSubject = ( state: State ) => state.subject;
 export const getMessage = ( state: State ) => state.message;
-export const getOtherSiteURL = ( state: State ) => state.otherSiteURL;
+export const getUserDeclaredSiteUrl = ( state: State ) => state.userDeclaredSiteUrl;
 export const getPopup = ( state: State ) => state.popup;
+export const getUserDeclaredSite = ( state: State ) => state.userDeclaredSite;

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -16,9 +16,12 @@ import * as VerticalsTemplates from './verticals-templates';
 import * as WPCOMFeatures from './wpcom-features';
 export { useHappinessEngineersQuery } from './queries/use-happiness-engineers-query';
 export { useHas3PC } from './queries/use-has-3rd-party-cookies';
+export { useSiteAnalysis } from './queries/use-site-analysis';
+export type { AnalysisReport } from './queries/use-site-analysis';
 export { useHasSeenWhatsNewModalQuery } from './queries/use-has-seen-whats-new-modal-query';
 export { useSupportAvailability } from './support-queries/use-support-availability';
 export { useSubmitTicketMutation } from './support-queries/use-submit-support-ticket';
+export { useSubmitForumsMutation } from './support-queries/use-submit-forums-topic';
 
 export {
 	Auth,

--- a/packages/data-stores/src/queries/use-site-analysis.ts
+++ b/packages/data-stores/src/queries/use-site-analysis.ts
@@ -29,7 +29,7 @@ function isHost( string: string | undefined ) {
 }
 
 /**
- * Analyses a site to determine without its a WPCOM site, and if yes, it would give the site information (SiteDetails).
+ * Analyses a site to determine whether its a WPCOM site, and if yes, it would fetch and return the site information (SiteDetails).
  *
  * @param siteURL the site URL
  */
@@ -46,9 +46,7 @@ export function useSiteAnalysis( siteURL: string | undefined ) {
 			( async () => {
 				try {
 					const analysis = await wpcomRequest< Analysis >( {
-						path: `/imports/analyze-url?site_url=${ encodeURIComponent(
-							debouncedSiteUrl as string
-						) }`,
+						path: `/imports/analyze-url?site_url=${ encodeURIComponent( debouncedSiteUrl ) }`,
 						apiNamespace: 'wpcom/v2',
 					} );
 

--- a/packages/data-stores/src/queries/use-site-analysis.ts
+++ b/packages/data-stores/src/queries/use-site-analysis.ts
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { useDebounce } from 'use-debounce';
+import wpcomRequest from 'wpcom-proxy-request';
+import { SiteDetails } from '../site';
+
+type ResultType = 'WPCOM' | 'WPORG' | 'UNKNOWN' | 'NOT_OWNED_BY_USER' | 'UNKNOWN';
+
+export type AnalysisReport = {
+	result: ResultType;
+	site?: SiteDetails;
+};
+
+type Analysis = {
+	url: string;
+	platform: string;
+	meta: {
+		title: string;
+		favicon: string;
+	};
+	platform_data?: { is_wpcom: boolean };
+};
+
+// a simple way to check if a string is host to save on API calls
+function isHost( string: string | undefined ) {
+	if ( string ) {
+		return string.length > 4 && Boolean( string?.match( /\w{2,}\.\w{2,16}/ ) );
+	}
+	return false;
+}
+
+/**
+ * Analyses a site to determine without its a WPCOM site, and if yes, it would give the site information (SiteDetails).
+ *
+ * @param siteURL the site URL
+ */
+export function useSiteAnalysis( siteURL: string | undefined ) {
+	const [ analysis, setAnalysis ] = useState< AnalysisReport | undefined >();
+	const [ debouncedSiteUrl ] = useDebounce( siteURL, 500 );
+
+	useEffect( () => {
+		setAnalysis( undefined );
+		if ( ! isHost( debouncedSiteUrl ) ) {
+			return;
+		}
+		if ( debouncedSiteUrl ) {
+			( async () => {
+				try {
+					const analysis = await wpcomRequest< Analysis >( {
+						path: `/imports/analyze-url?site_url=${ encodeURIComponent(
+							debouncedSiteUrl as string
+						) }`,
+						apiNamespace: 'wpcom/v2',
+					} );
+
+					if ( analysis.platform_data?.is_wpcom ) {
+						try {
+							// if a wpcom site, get its info
+							const site = await wpcomRequest< SiteDetails >( {
+								path: '/sites/' + encodeURIComponent( debouncedSiteUrl ),
+								apiVersion: '1.1',
+							} );
+							setAnalysis( { site, result: 'WPCOM' } );
+						} catch ( error ) {
+							// wpcom site, but not owned by user
+							setAnalysis( { result: 'NOT_OWNED_BY_USER' } );
+						}
+					} else if ( analysis.platform === 'wordpress' ) {
+						setAnalysis( { result: 'WPORG' } );
+					} else {
+						setAnalysis( { result: 'UNKNOWN' } );
+					}
+				} catch ( error ) {
+					setAnalysis( { result: 'UNKNOWN' } );
+				}
+			} )();
+		}
+	}, [ debouncedSiteUrl ] );
+
+	return { ...analysis, isLoading: ! analysis };
+}

--- a/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
+++ b/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
@@ -1,0 +1,55 @@
+import { useMutation } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import { SiteDetails } from '../site';
+
+type ForumTopic = {
+	site: SiteDetails;
+	message: string;
+	subject: string;
+	locale: string;
+	hideInfo: boolean;
+};
+
+type Response = {
+	topic_URL: string;
+};
+
+// for some reason, useMutation isn't returning mutateAsync in its type, this is a bandage for that
+type MutationResult = {
+	isLoading: boolean;
+	mutateAsync: ( topic: ForumTopic ) => Promise< Response >;
+};
+
+export function useSubmitForumsMutation(): MutationResult {
+	return useMutation( ( { site, message, subject, locale, hideInfo }: ForumTopic ) => {
+		const blogHelpMessages = [ message ];
+
+		if ( site.jetpack ) {
+			blogHelpMessages.push( 'WP.com: Unknown' );
+			blogHelpMessages.push( 'Jetpack: Yes' );
+		} else {
+			blogHelpMessages.push( 'WP.com: Yes' );
+		}
+
+		blogHelpMessages.push( 'Correct account: yes' );
+
+		const forumMessage = message + '\n\n' + 'Correct account: yes';
+
+		const requestData = {
+			subject,
+			message: forumMessage,
+			locale,
+			client: 'help-center',
+			hide_blog_info: hideInfo,
+			blog_id: site.ID,
+			blog_url: site.URL,
+		};
+
+		return wpcomRequest< Response >( {
+			path: '/help/forums/support/topics/new',
+			apiVersion: '1.1',
+			method: 'POST',
+			body: requestData,
+		} );
+	} ) as unknown as MutationResult;
+}

--- a/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
+++ b/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
@@ -14,13 +14,7 @@ type Response = {
 	topic_URL: string;
 };
 
-// for some reason, useMutation isn't returning mutateAsync in its type, this is a bandage for that
-type MutationResult = {
-	isLoading: boolean;
-	mutateAsync: ( topic: ForumTopic ) => Promise< Response >;
-};
-
-export function useSubmitForumsMutation(): MutationResult {
+export function useSubmitForumsMutation() {
 	return useMutation( ( { site, message, subject, locale, hideInfo }: ForumTopic ) => {
 		const blogHelpMessages = [ message ];
 
@@ -51,5 +45,5 @@ export function useSubmitForumsMutation(): MutationResult {
 			method: 'POST',
 			body: requestData,
 		} );
-	} ) as unknown as MutationResult;
+	} );
 }

--- a/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
+++ b/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
@@ -9,13 +9,7 @@ type Ticket = {
 	is_chat_overflow: boolean;
 };
 
-// for some reason, useMutation isn't returning mutateAsync, this is a bandage for that
-type MutationResult = {
-	isLoading: boolean;
-	mutateAsync: ( ticket: Ticket ) => Promise< void >;
-};
-
-export function useSubmitTicketMutation(): MutationResult {
+export function useSubmitTicketMutation() {
 	return useMutation( ( newTicket: Ticket ) =>
 		wpcomRequest( {
 			path: '/help/tickets/kayako/new',
@@ -23,5 +17,5 @@ export function useSubmitTicketMutation(): MutationResult {
 			method: 'POST',
 			body: newTicket,
 		} )
-	) as unknown as MutationResult;
+	);
 }

--- a/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
+++ b/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
@@ -9,7 +9,13 @@ type Ticket = {
 	is_chat_overflow: boolean;
 };
 
-export function useSubmitTicketMutation() {
+// for some reason, useMutation isn't returning mutateAsync, this is a bandage for that
+type MutationResult = {
+	isLoading: boolean;
+	mutateAsync: ( ticket: Ticket ) => Promise< void >;
+};
+
+export function useSubmitTicketMutation(): MutationResult {
 	return useMutation( ( newTicket: Ticket ) =>
 		wpcomRequest( {
 			path: '/help/tickets/kayako/new',
@@ -17,5 +23,5 @@ export function useSubmitTicketMutation() {
 			method: 'POST',
 			body: newTicket,
 		} )
-	);
+	) as unknown as MutationResult;
 }

--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -18,6 +18,7 @@ export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'EMAIL' >(
 			} ),
 		{
 			refetchOnWindowFocus: false,
+			keepPreviousData: true,
 		}
 	);
 }

--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -1,4 +1,6 @@
 @import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/variables';
+@import '@automattic/color-studio/dist/color-variables';
 
 .help-center-contact-form__site-picker-hes-tray {
 	margin-top: 16px;
@@ -31,11 +33,30 @@
 }
 
 .help-center-contact-form {
-	input,
-	textarea {
-		padding: 15px 12px;
-		border: 1px solid #c3c4c7;
+	div.components-base-control__field {
+		input,
+		textarea {
+			&.components-text-control__input {
+				// they have very high specificity
+				padding: 15.5px !important;
+				border: 1px solid #c3c4c7 !important;
+				border-radius: 4px !important;
+			}
+		}
 	}
+}
+
+.help-center-contact-form__message {
+	padding: 15.5px;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	width: 100%;
+	display: block;
+}
+
+.help-center-contact-form__message:focus {
+	box-shadow: 0 0 0 1px var( --wp-admin-theme-color );
+	outline: 2px solid transparent;
 }
 
 .help-center-contact-form__site-picker-title {
@@ -45,15 +66,46 @@
 }
 
 .help-center-contact-form__site-picker-form-warning {
-    color: #50575e;
+	color: #50575e;
 }
 
 .help-center-contact-form__site-picker-cta {
 	width: 100%;
-	padding: 5px 16px;
+	padding: 5px 16px !important;
 }
 
-.components-checkbox-control__label {
-    color: #2c3338;
+.help-center-contact-form__label {
+	color: #50575e;
+	margin-bottom: 8px;
+	display: block;
 }
 
+.help-center-notice__positive-feedback {
+	font-size: $font-body-extra-small;
+	color: #50575e;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin: 0;
+}
+
+.help-center-notice__container {
+	background-color: #f6f7f7;
+	border-radius: 4px;
+	color: $studio-gray-80;
+	padding: 16px 21px;
+	font-size: $font-body-small;
+	display: flex;
+	margin-top: 16px;
+
+	p {
+		margin: 0;
+		margin-left: 16px;
+	}
+
+	.dashicon {
+		display: block;
+		color: #d67709;
+		margin-top: 2px;
+	}
+}

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -76,6 +76,7 @@ type Mode = 'CHAT' | 'EMAIL' | 'FORUM';
 interface ContactFormProps {
 	mode: Mode;
 	onBackClick: () => void;
+	onGoHome: () => void;
 	siteId: number | null;
 	onPopupOpen?: () => void;
 }
@@ -104,7 +105,7 @@ function openPopup( event: React.MouseEvent< HTMLButtonElement > ): Window {
 	return popup;
 }
 
-const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick } ) => {
+const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHome } ) => {
 	const [ openChat, setOpenChat ] = useState( false );
 	const [ contactSuccess, setContactSuccess ] = useState( false );
 	const [ forumTopicUrl, setForumTopicUrl ] = useState( '' );
@@ -209,13 +210,14 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick } ) => {
 	}
 
 	if ( contactSuccess || forumTopicUrl ) {
-		return <SuccessScreen forumTopicUrl={ forumTopicUrl } onBack={ onBackClick } />;
+		return <SuccessScreen forumTopicUrl={ forumTopicUrl } onBack={ onGoHome } />;
 	}
 
 	return (
 		<main className="help-center-contact-form">
 			<header>
-				<BackButton onClick={ onBackClick } />
+				{ /* forum users don't have other support options, send them back to home, not the support options screen */ }
+				<BackButton onClick={ mode === 'FORUM' ? onGoHome : onBackClick } />
 			</header>
 			<h1 className="help-center-contact-form__site-picker-title">{ formTitles.formTitle }</h1>
 			{ formTitles.formDisclaimer && (

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -2,30 +2,32 @@
  * External Dependencies
  */
 import { Button, HappinessEngineersTray } from '@automattic/components';
-import { useHas3PC, useSubmitTicketMutation } from '@automattic/data-stores';
+import {
+	useHas3PC,
+	useSubmitTicketMutation,
+	useSubmitForumsMutation,
+	useSiteAnalysis,
+} from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { SitePickerDropDown } from '@automattic/site-picker';
-import { TextareaControl, TextControl, CheckboxControl } from '@wordpress/components';
+import { TextControl, CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal Dependencies
  */
-import './help-center-contact-form.scss';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { STORE_KEY } from '../store';
 import { SitePicker } from '../types';
 import { BackButton } from './back-button';
 import InlineChat from './help-center-inline-chat';
+import { HelpCenterOwnershipNotice } from './help-center-notice';
 import { SuccessScreen } from './ticket-success-screen';
+import './help-center-contact-form.scss';
 
 export const SITE_STORE = 'automattic/site';
 
-const HelpCenterSitePicker: React.FC< SitePicker > = ( { onSelect, siteId } ) => {
-	const currentSite = useSelect( ( select ) =>
-		select( SITE_STORE ).getSite( window._currentSiteId )
-	);
-
+const HelpCenterSitePicker: React.FC< SitePicker > = ( { onSelect, currentSite, siteId } ) => {
 	const otherSite = {
 		name: __( 'Other site', 'full-site-editing' ),
 		ID: 0,
@@ -78,9 +80,6 @@ interface ContactFormProps {
 	onPopupOpen?: () => void;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
-
 const POPUP_TOP_BAR_HEIGHT = 60;
 
 function openPopup( event: React.MouseEvent< HTMLButtonElement > ): Window {
@@ -108,43 +107,100 @@ function openPopup( event: React.MouseEvent< HTMLButtonElement > ): Window {
 const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick } ) => {
 	const [ openChat, setOpenChat ] = useState( false );
 	const [ contactSuccess, setContactSuccess ] = useState( false );
+	const [ forumTopicUrl, setForumTopicUrl ] = useState( '' );
+	const [ hideSiteInfo, setHideSiteInfo ] = useState( false );
 	const locale = useLocale();
-	const { isLoading: submittingTicket, mutateAsync } = useSubmitTicketMutation();
-	const { siteId, subject, message, otherSiteURL } = useSelect( ( select ) => {
+	const { isLoading: submittingTicket, mutateAsync: submitTicket } = useSubmitTicketMutation();
+	const { isLoading: submittingTopic, mutateAsync: submitTopic } = useSubmitForumsMutation();
+	const [ sitePickerChoice, setSitePickerChoice ] = useState< 'CURRENT_SITE' | 'OTHER_SITE' >(
+		'CURRENT_SITE'
+	);
+
+	const { selectedSite, subject, message, userDeclaredSiteUrl } = useSelect( ( select ) => {
 		return {
-			siteId: select( STORE_KEY ).getSiteId(),
+			selectedSite: select( STORE_KEY ).getSite(),
 			subject: select( STORE_KEY ).getSubject(),
 			message: select( STORE_KEY ).getMessage(),
-			otherSiteURL: select( STORE_KEY ).getOtherSiteURL(),
+			userDeclaredSiteUrl: select( STORE_KEY ).getUserDeclaredSiteUrl(),
 		};
 	} );
+
+	const { setSite, setUserDeclaredSiteUrl, setUserDeclaredSite, setSubject, setMessage, setPopup } =
+		useDispatch( STORE_KEY );
+
+	const {
+		result: ownershipResult,
+		isLoading: isAnalysisLoading,
+		site: userDeclaredSite,
+	} = useSiteAnalysis( userDeclaredSiteUrl );
+
+	// record the resolved site
+	useEffect( () => {
+		if ( userDeclaredSite ) {
+			setUserDeclaredSite( userDeclaredSite );
+		}
+	}, [ userDeclaredSite, setUserDeclaredSite ] );
+
 	const { hasCookies, isLoading: loadingCookies } = useHas3PC();
 
-	const isLoading = loadingCookies || submittingTicket;
-
-	const { setSiteId, setOtherSiteURL, setSubject, setMessage, setPopup } = useDispatch( STORE_KEY );
+	const isLoading = loadingCookies || submittingTicket || submittingTopic;
 
 	const formTitles = titles[ mode ];
 
+	const currentSite = useSelect( ( select ) =>
+		select( SITE_STORE ).getSite( window._currentSiteId )
+	);
+
+	let supportSite: typeof currentSite;
+
+	// if the user picked "other site", force them to declare a site
+	if ( sitePickerChoice === 'OTHER_SITE' ) {
+		supportSite = userDeclaredSite;
+	} else {
+		supportSite = selectedSite || currentSite;
+	}
+
 	function handleCTA( event: React.MouseEvent< HTMLButtonElement > ) {
-		switch ( mode ) {
-			case 'CHAT': {
-				if ( hasCookies ) {
-					setOpenChat( true );
+		if ( supportSite ) {
+			switch ( mode ) {
+				case 'CHAT': {
+					if ( hasCookies ) {
+						setOpenChat( true );
+						break;
+					} else {
+						const popup = openPopup( event );
+						setPopup( popup );
+					}
 					break;
-				} else {
-					const popup = openPopup( event );
-					setPopup( popup );
 				}
-			}
-			case 'EMAIL': {
-				mutateAsync( {
-					subject: subject ?? '',
-					message: message ?? '',
-					locale,
-					client: 'browser:help-center',
-					is_chat_overflow: false,
-				} ).then( () => setContactSuccess( true ) );
+				case 'EMAIL': {
+					const ticketMeta = [
+						'How can you help: ' + message,
+						'Site I need help with: ' + supportSite?.URL,
+						'Plan: ' + supportSite?.plan?.product_slug,
+					];
+
+					const kayakoMessage = [ ...ticketMeta, '\n', message ].join( '\n' );
+
+					submitTicket( {
+						subject: subject ?? '',
+						message: kayakoMessage,
+						locale,
+						client: 'browser:help-center',
+						is_chat_overflow: false,
+					} ).then( () => setContactSuccess( true ) );
+					break;
+				}
+				case 'FORUM': {
+					submitTopic( {
+						site: supportSite,
+						message: message ?? '',
+						subject: subject ?? '',
+						locale,
+						hideInfo: hideSiteInfo,
+					} ).then( ( response ) => setForumTopicUrl( response.topic_URL ) );
+					break;
+				}
 			}
 		}
 	}
@@ -152,8 +208,8 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick } ) => {
 		return <InlineChat />;
 	}
 
-	if ( contactSuccess ) {
-		return <SuccessScreen onBack={ onBackClick } />;
+	if ( contactSuccess || forumTopicUrl ) {
+		return <SuccessScreen forumTopicUrl={ forumTopicUrl } onBack={ onBackClick } />;
 	}
 
 	return (
@@ -168,16 +224,34 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick } ) => {
 				</p>
 			) }
 			<section>
-				<HelpCenterSitePicker onSelect={ setSiteId } siteId={ siteId } />
+				<HelpCenterSitePicker
+					currentSite={ currentSite }
+					onSelect={ ( id: string | number ) => {
+						if ( id !== 0 ) {
+							setSite( currentSite );
+						}
+						setSitePickerChoice( id === 0 ? 'OTHER_SITE' : 'CURRENT_SITE' );
+					} }
+					siteId={ sitePickerChoice === 'CURRENT_SITE' ? currentSite?.ID : 0 }
+				/>
 			</section>
-			{ siteId === 0 && (
-				<section>
-					<TextControl
-						label={ __( 'Site address', 'full-site-editing' ) }
-						value={ otherSiteURL ?? '' }
-						onChange={ setOtherSiteURL }
-					/>
-				</section>
+			{ sitePickerChoice === 'OTHER_SITE' && (
+				<>
+					<section>
+						<TextControl
+							label={ __( 'Site address', 'full-site-editing' ) }
+							value={ userDeclaredSiteUrl ?? '' }
+							onChange={ setUserDeclaredSiteUrl }
+						/>
+					</section>
+					{ ownershipResult && (
+						<HelpCenterOwnershipNotice
+							ownershipResult={ ownershipResult }
+							isAnalysisLoading={ isAnalysisLoading }
+							userDeclaredSite={ userDeclaredSite }
+						/>
+					) }
+				</>
 			) }
 
 			{ [ 'FORUM', 'EMAIL' ].includes( mode ) && (
@@ -191,26 +265,33 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick } ) => {
 			) }
 
 			<section>
-				<TextareaControl
+				<label
+					className="help-center-contact-form__label"
+					htmlFor="help-center-contact-form__message"
+				>
+					{ __( 'How can we help you today?', 'full-site-editing' ) }
+				</label>
+				<textarea
+					id="help-center-contact-form__message"
 					rows={ 10 }
-					label={ __( 'How can we help you today?', 'full-site-editing' ) }
 					value={ message ?? '' }
-					onChange={ setMessage }
+					onChange={ ( event ) => setMessage( event.target.value ) }
+					className="help-center-contact-form__message"
 				/>
 			</section>
 
 			{ mode === 'FORUM' && (
 				<section>
 					<CheckboxControl
-						checked
+						checked={ hideSiteInfo }
 						label={ __( 'Don’t display my site’s URL publicly', 'full-site-editing' ) }
-						onChange={ noop }
+						onChange={ ( value ) => setHideSiteInfo( value ) }
 					/>
 				</section>
 			) }
 			<section>
 				<Button
-					disabled={ isLoading }
+					disabled={ isLoading || ! supportSite || ! message }
 					onClick={ handleCTA }
 					primary
 					className="help-center-contact-form__site-picker-cta"

--- a/packages/help-center/src/components/help-center-notice.tsx
+++ b/packages/help-center/src/components/help-center-notice.tsx
@@ -1,0 +1,63 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { ExternalLink, Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import type { AnalysisReport } from '@automattic/data-stores';
+
+type Props = {
+	ownershipResult: AnalysisReport[ 'result' ];
+	isAnalysisLoading: boolean;
+	userDeclaredSite: AnalysisReport[ 'site' ];
+};
+
+const responses: Record< AnalysisReport[ 'result' ], React.ReactChild > = {
+	NOT_OWNED_BY_USER: (
+		<p>
+			{ __(
+				'Your site is linked to another WordPress.com account. If you’re trying to access it, please follow our Account Recovery procedure.',
+				__i18n_text_domain__
+			) }
+			&nbsp;{ ' ' }
+			<ExternalLink href={ localizeUrl( 'https://wordpress.com/wp-login.php?action=recovery' ) }>
+				{ __( 'Learn More', __i18n_text_domain__ ) }
+			</ExternalLink>
+		</p>
+	),
+	WPCOM: '',
+	WPORG: (
+		<p>
+			{ __(
+				'Your site is not hosted on our services. Support for the self-hosted version of WordPress is provided by the WordPress.org community forums, or if the problem relates to a specific plugin or theme, contact support for that product instead. If you’re not sure, share you question with a link, and we’ll point you in the right direction!',
+				__i18n_text_domain__
+			) }
+		</p>
+	),
+	UNKNOWN: (
+		<p>
+			{ __(
+				"We couldn't fetch enough information about this site to determine our ability to support you with it.",
+				__i18n_text_domain__
+			) }
+		</p>
+	),
+};
+
+export function HelpCenterOwnershipNotice( {
+	ownershipResult,
+	isAnalysisLoading,
+	userDeclaredSite,
+}: Props ) {
+	if ( isAnalysisLoading || ownershipResult === 'WPCOM' ) {
+		if ( ownershipResult === 'WPCOM' ) {
+			return <p className="help-center-notice__positive-feedback">{ userDeclaredSite?.name }</p>;
+		}
+		return null;
+	}
+	return (
+		<div className="help-center-notice__container">
+			<div>
+				<Icon icon="info-outline"></Icon>
+			</div>
+			{ responses[ ownershipResult ] }
+		</div>
+	);
+}

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -1,13 +1,14 @@
 /**
  * External Dependencies
  */
+import { useSelect } from '@wordpress/data';
 import { createPortal, useEffect, useRef } from '@wordpress/element';
 /**
  * Internal Dependencies
  */
 import { Container } from '../types';
+import { SITE_STORE } from './help-center-contact-form';
 import HelpCenterContainer from './help-center-container';
-
 import '../styles.scss';
 
 const HelpCenter: React.FC< Container > = ( {
@@ -17,6 +18,9 @@ const HelpCenter: React.FC< Container > = ( {
 	footerContent,
 } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
+
+	// prefetch the current site
+	useSelect( ( select ) => select( SITE_STORE ).getSite( window._currentSiteId ) );
 
 	useEffect( () => {
 		const classes = [ 'help-center' ];

--- a/packages/help-center/src/components/ticket-success-screen.tsx
+++ b/packages/help-center/src/components/ticket-success-screen.tsx
@@ -4,7 +4,7 @@ import { BackButton } from './back-button';
 import { SuccessIcon } from './success-icon';
 import type { SuccessScreenProps } from '../types';
 
-export const SuccessScreen: React.FC< SuccessScreenProps > = ( { onBack } ) => {
+export const SuccessScreen: React.FC< SuccessScreenProps > = ( { onBack, forumTopicUrl } ) => {
 	const { __ } = useI18n();
 
 	return (
@@ -15,12 +15,25 @@ export const SuccessScreen: React.FC< SuccessScreenProps > = ( { onBack } ) => {
 				<h1 className="ticket-success-screen__help-center-heading">
 					{ __( "We're on it!", __i18n_text_domain__ ) }
 				</h1>
-				<p className="ticket-success-screen__help-center-message">
-					{ __(
-						"We've received your message, and you'll hear back from one of our Happiness Engineers shortly.",
-						__i18n_text_domain__
-					) }
-				</p>
+				{ forumTopicUrl ? (
+					<p className="ticket-success-screen__help-center-message">
+						{ __(
+							'Your message has been submitted to our community forums.',
+							__i18n_text_domain__
+						) }
+						&nbsp;
+						<a target="_blank" rel="noopener noreferrer" href={ forumTopicUrl }>
+							{ __( 'View the forums topic here.', __i18n_text_domain__ ) }
+						</a>
+					</p>
+				) : (
+					<p className="ticket-success-screen__help-center-message">
+						{ __(
+							"We've received your message, and you'll hear back from one of our Happiness Engineers shortly.",
+							__i18n_text_domain__
+						) }
+					</p>
+				) }
 			</div>
 		</div>
 	);

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -148,7 +148,9 @@ $head-foot-height: 50px;
 }
 
 button.button.back-button__help-center.is-borderless {
-	color: $studio-gray-80;
+	color: black;
+	font-size: $font-body-small;
+	font-weight: 500;
 }
 
 .help-center__container-content {

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -1,3 +1,4 @@
+import { SiteDetails } from '@automattic/data-stores/dist/types/site';
 import { ReactElement } from 'react';
 
 export interface Container {
@@ -22,9 +23,11 @@ export interface Header {
 
 export interface SuccessScreenProps {
 	onBack: () => void;
+	forumTopicUrl?: string;
 }
 
 export interface SitePicker {
+	currentSite: SiteDetails | undefined;
 	onSelect: ( siteId: number | string ) => void;
 	siteId: string | number | null | undefined;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -36254,6 +36254,7 @@ swiper@4.5.1:
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
     "@automattic/eslint-plugin-json": "workspace:^"
+    "@automattic/help-center": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/languages": "workspace:^"
     "@automattic/typography": "workspace:^"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR makes self-declaring a site a better experience. It now uses site analysis endpoint (originally meant for importer flow) to determine whether a site is a WPCOM site. And only if it is, it fetches the site info from WPCOM API. We message to the user all this information (like in designs).
* Since we fetched the site info, we send to happychat, email tickets, forums topics the entire expected metadata of the site (ID, URL, etc..).
* It implements the ability to post to forums when the user is a free user. Changes the success screen to support this.
* Does some minimal touches to the contact forms CSS.

#### Testing instructions

1. run ETK `yarn dev --sync`.
2. Go to the help center. 
3. Test the above improvements. Please don't hesitate to submit email and forums* tickets with a clear message that you're an a8cian testing. Just send me the forums ticket so I'd ask team chiron to delete it (it's public).

* To submit forum tickets you need to be a free user.