### PR TITLE
Onboarding import: configure and update navigation layer of the import module

### DIFF
--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -73,7 +73,7 @@ class ImporterAuthorMapping extends Component {
 				<span className="importer__source-author">
 					{ icon ? (
 						<img
-							class="importer__icon"
+							className="importer__icon"
 							alt={ name }
 							title={ name }
 							src={ icon }

--- a/client/signup/steps/import-from/blogger/index.tsx
+++ b/client/signup/steps/import-from/blogger/index.tsx
@@ -17,8 +17,18 @@ import { getImporterTypeForEngine } from '../util';
 
 export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( props ) => {
 	const importer: Importer = 'blogger';
-	const { job, urlData, siteId, site, siteSlug, fromSite, importSite, startImport, resetImport } =
-		props;
+	const {
+		job,
+		urlData,
+		siteId,
+		site,
+		siteSlug,
+		fromSite,
+		importSite,
+		startImport,
+		resetImport,
+		stepNavigator,
+	} = props;
 
 	/**
 	 * Effects
@@ -111,10 +121,16 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 								siteSlug={ siteSlug }
 								job={ job as ImportJob }
 								resetImport={ resetImport }
+								onSiteViewClick={ stepNavigator?.goToSiteViewPage }
 							/>
 						);
 					} else if ( checkIsFailed() ) {
-						return <ErrorMessage siteSlug={ siteSlug } />;
+						return (
+							<ErrorMessage
+								onStartBuilding={ stepNavigator?.goToIntentPage }
+								onBackToStart={ stepNavigator?.goToImportCapturePage }
+							/>
+						);
 					} else if ( checkProgress() ) {
 						return <ProgressScreen job={ job } />;
 					}

--- a/client/signup/steps/import-from/components/complete-screen/index.tsx
+++ b/client/signup/steps/import-from/components/complete-screen/index.tsx
@@ -9,10 +9,11 @@ interface Props {
 	siteId: number;
 	siteSlug: string;
 	resetImport: ( siteId: number, importerId: string ) => void;
+	onSiteViewClick?: () => void;
 }
 const CompleteScreen: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { job, siteId, siteSlug, resetImport } = props;
+	const { job, siteId, resetImport, onSiteViewClick } = props;
 
 	return (
 		<Hooray>
@@ -20,9 +21,9 @@ const CompleteScreen: React.FunctionComponent< Props > = ( props ) => {
 			<SubTitle>{ __( 'Congratulations. Your content was successfully imported.' ) }</SubTitle>
 			<DoneButton
 				siteId={ siteId }
-				siteSlug={ siteSlug }
 				job={ job as ImportJob }
 				resetImport={ resetImport }
+				onSiteViewClick={ onSiteViewClick }
 			/>
 		</Hooray>
 	);

--- a/client/signup/steps/import-from/components/done-button/index.tsx
+++ b/client/signup/steps/import-from/components/done-button/index.tsx
@@ -1,27 +1,21 @@
 import { NextButton } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
-import page from 'page';
 import React from 'react';
 import { ImportJob } from '../../types';
 
 interface Props {
 	job?: ImportJob;
 	siteId?: number;
-	siteSlug: string;
 	resetImport?: ( siteId: number, importerId: string ) => void;
+	onSiteViewClick?: () => void;
 }
 const DoneButton: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { job, siteId, siteSlug, resetImport } = props;
+	const { job, siteId, resetImport, onSiteViewClick } = props;
 
 	function onButtonClick() {
-		redirectToSiteView();
+		onSiteViewClick?.();
 		job && siteId && resetImport && resetImport( siteId, job?.importerId );
-	}
-
-	function redirectToSiteView() {
-		const destination = '/view/' + ( siteSlug || '' );
-		page( destination );
 	}
 
 	return <NextButton onClick={ onButtonClick }>{ __( 'View site' ) }</NextButton>;

--- a/client/signup/steps/import-from/components/error-message/index.tsx
+++ b/client/signup/steps/import-from/components/error-message/index.tsx
@@ -1,32 +1,20 @@
 import { BackButton, NextButton, SubTitle, Title } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
-import page from 'page';
 import React from 'react';
-import { getStepUrl } from 'calypso/signup/utils';
 
 import './style.scss';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 interface Props {
-	siteSlug: string;
+	onBackToStart?: () => void;
+	onStartBuilding?: () => void;
 }
 
 const ErrorMessage: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { siteSlug } = props;
-
-	/**
-	 ↓ Methods
-	 */
-	const backToStart = (): void => {
-		page( getStepUrl( 'importer', 'capture', '', '', { siteSlug } ) );
-	};
-
-	const backToIntent = (): void => {
-		page( getStepUrl( 'setup-site', 'intent', '', '', { siteSlug } ) );
-	};
+	const { onBackToStart, onStartBuilding } = props;
 
 	return (
 		<div className="import-layout__center">
@@ -40,10 +28,14 @@ const ErrorMessage: React.FunctionComponent< Props > = ( props ) => {
 					<SubTitle>{ __( 'Please try again soon or contact support for help.' ) }</SubTitle>
 
 					<div className="import__buttons-group">
-						<NextButton onClick={ backToIntent }>{ __( 'Start building' ) }</NextButton>
-						<div>
-							<BackButton onClick={ backToStart }>{ __( 'Back to start' ) }</BackButton>
-						</div>
+						{ onStartBuilding && (
+							<NextButton onClick={ onStartBuilding }>{ __( 'Start building' ) }</NextButton>
+						) }
+						{ onBackToStart && (
+							<div>
+								<BackButton onClick={ onBackToStart }>{ __( 'Back to start' ) }</BackButton>
+							</div>
+						) }
 					</div>
 				</div>
 			</div>

--- a/client/signup/steps/import-from/components/not-authorized/index.tsx
+++ b/client/signup/steps/import-from/components/not-authorized/index.tsx
@@ -1,30 +1,19 @@
 import { BackButton, NextButton, SubTitle, Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
-import page from 'page';
 import React from 'react';
-import { getStepUrl } from 'calypso/signup/utils';
 
 import './style.scss';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 interface Props {
-	siteSlug: string;
+	onBackToStart?: () => void;
+	onStartBuilding?: () => void;
 }
 
 const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { siteSlug } = props;
-
-	/**
-	 ↓ Methods
-	 */
-	const backToStart = (): void => {
-		page( getStepUrl( 'importer', 'capture', '', '', { siteSlug } ) );
-	};
-	const backToIntent = (): void => {
-		page( getStepUrl( 'setup-site', 'intent', '', '', { siteSlug } ) );
-	};
+	const { onBackToStart, onStartBuilding } = props;
 
 	return (
 		<div className="import-layout__center">
@@ -34,10 +23,14 @@ const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 					<SubTitle>{ __( 'Please check with your site admin.' ) }</SubTitle>
 
 					<div className="import__buttons-group">
-						<NextButton onClick={ backToIntent }>{ __( 'Start building' ) }</NextButton>
-						<div>
-							<BackButton onClick={ backToStart }>{ __( 'Back to start' ) }</BackButton>
-						</div>
+						{ onStartBuilding && (
+							<NextButton onClick={ onStartBuilding }>{ __( 'Start building' ) }</NextButton>
+						) }
+						{ onBackToStart && (
+							<div>
+								<BackButton onClick={ onBackToStart }>{ __( 'Back to start' ) }</BackButton>
+							</div>
+						) }
 					</div>
 				</div>
 			</div>

--- a/client/signup/steps/import-from/hooks/use-checkout-url.ts
+++ b/client/signup/steps/import-from/hooks/use-checkout-url.ts
@@ -1,0 +1,11 @@
+import { useSelector } from 'react-redux';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+
+export function useCheckoutUrl( siteId: number, siteSlug: string ) {
+	const isSiteEligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, siteId )
+	);
+	const plan = isSiteEligibleForProPlan ? 'pro' : 'business';
+
+	return `/checkout/${ siteSlug }/${ plan }`;
+}

--- a/client/signup/steps/import-from/hooks/use-signup-step-navigator.ts
+++ b/client/signup/steps/import-from/hooks/use-signup-step-navigator.ts
@@ -1,0 +1,67 @@
+import page from 'page';
+import { addQueryArgs } from 'calypso/lib/route';
+import { useCheckoutUrl } from 'calypso/signup/steps/import-from/hooks/use-checkout-url';
+import { StepNavigator } from 'calypso/signup/steps/import-from/types';
+import { WPImportOption } from 'calypso/signup/steps/import-from/wordpress/types';
+import { getWpOrgImporterUrl } from 'calypso/signup/steps/import/util';
+import { getStepUrl } from 'calypso/signup/utils';
+
+export function useSignupStepNavigator(
+	siteId: number,
+	siteSlug: string,
+	fromSite: string
+): StepNavigator {
+	const checkoutUrl = useCheckoutUrl( siteId, siteSlug );
+
+	function goToIntentPage() {
+		page( getStepUrl( 'setup-site', 'intent', '', '', { siteSlug } ) );
+	}
+
+	function goToImportCapturePage() {
+		page( getStepUrl( 'importer', 'capture', '', '', { siteSlug } ) );
+	}
+
+	function goToSiteViewPage() {
+		page( '/view/' + ( siteSlug || '' ) );
+	}
+
+	function goToCheckoutPage() {
+		page( getCheckoutUrl() );
+	}
+
+	function goToWpAdminImportPage() {
+		page( `/import/${ siteSlug }` );
+	}
+
+	function goToWpAdminWordPressPluginPage() {
+		page( getWpOrgImporterUrl( siteSlug, 'wordpress' ) );
+	}
+
+	function getWordpressImportEverythingUrl() {
+		const queryParams = {
+			from: fromSite,
+			to: siteSlug,
+			option: WPImportOption.EVERYTHING,
+			run: true,
+		};
+
+		return getStepUrl( 'from', 'importing', 'wordpress', '', queryParams );
+	}
+
+	function getCheckoutUrl() {
+		const path = checkoutUrl;
+		const queryParams = { redirect_to: getWordpressImportEverythingUrl() };
+
+		return addQueryArgs( queryParams, path );
+	}
+
+	return {
+		goToIntentPage,
+		goToImportCapturePage,
+		goToSiteViewPage,
+		goToCheckoutPage,
+		goToWpAdminImportPage,
+		goToWpAdminWordPressPluginPage,
+		navigate: ( path: string ) => page( path ),
+	};
+}

--- a/client/signup/steps/import-from/index.tsx
+++ b/client/signup/steps/import-from/index.tsx
@@ -21,6 +21,7 @@ import { getSite, getSiteId } from 'calypso/state/sites/selectors';
 import BloggerImporter from './blogger';
 import NotAuthorized from './components/not-authorized';
 import NotFound from './components/not-found';
+import { useSignupStepNavigator } from './hooks/use-signup-step-navigator';
 import MediumImporter from './medium';
 import SquarespaceImporter from './squarespace';
 import { Importer, ImportJob } from './types';
@@ -62,6 +63,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 	const getImportJob = ( engine: Importer ): ImportJob | undefined => {
 		return siteImports.find( ( x ) => x.type === getImporterTypeForEngine( engine ) );
 	};
+	const stepNavigator = useSignupStepNavigator( siteId, siteSlug, fromSite );
 
 	/**
 	 ↓ Effects
@@ -108,10 +110,6 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 		}
 	}
 
-	function shouldHideBackBtn() {
-		return false;
-	}
-
 	function getBackUrl() {
 		if ( stepName === 'importing' ) {
 			return getStepUrl( 'importer', 'capture', '', '', { siteSlug } );
@@ -150,6 +148,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 				siteSlug={ siteSlug }
 				fromSite={ fromSite }
 				urlData={ urlData }
+				stepNavigator={ stepNavigator }
 			/>
 		);
 	}
@@ -164,6 +163,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 				siteSlug={ siteSlug }
 				fromSite={ fromSite }
 				urlData={ urlData }
+				stepNavigator={ stepNavigator }
 			/>
 		);
 	}
@@ -178,6 +178,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 				siteSlug={ siteSlug }
 				fromSite={ fromSite }
 				urlData={ urlData }
+				stepNavigator={ stepNavigator }
 			/>
 		);
 	}
@@ -190,6 +191,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 				siteId={ siteId }
 				siteSlug={ siteSlug }
 				fromSite={ fromSite }
+				stepNavigator={ stepNavigator }
 			/>
 		);
 	}
@@ -201,6 +203,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 				siteId={ siteId }
 				siteSlug={ siteSlug }
 				fromSite={ fromSite }
+				stepNavigator={ stepNavigator }
 			/>
 		);
 	}
@@ -213,7 +216,7 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 				flowName={ 'importer' }
 				stepName={ stepName }
 				hideSkip={ true }
-				hideBack={ shouldHideBackBtn() }
+				hideBack={ false }
 				backUrl={ getBackUrl() }
 				goToPreviousStep={ goToPreviousStep }
 				hideNext={ true }
@@ -234,7 +237,12 @@ const ImportOnboardingFrom: React.FunctionComponent< Props > = ( props ) => {
 								} else if ( ! siteSlug ) {
 									return <NotFound />;
 								} else if ( ! hasPermission() ) {
-									return <NotAuthorized siteSlug={ siteSlug } />;
+									return (
+										<NotAuthorized
+											onStartBuilding={ stepNavigator?.goToIntentPage }
+											onBackToStart={ stepNavigator?.goToImportCapturePage }
+										/>
+									);
 								} else if (
 									engine === 'blogger' &&
 									isEnabled( 'onboarding/import-from-blogger' )

--- a/client/signup/steps/import-from/medium/index.tsx
+++ b/client/signup/steps/import-from/medium/index.tsx
@@ -17,8 +17,18 @@ import { getImporterTypeForEngine } from '../util';
 
 export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( props ) => {
 	const importer: Importer = 'medium';
-	const { job, urlData, siteId, site, siteSlug, fromSite, importSite, startImport, resetImport } =
-		props;
+	const {
+		job,
+		urlData,
+		siteId,
+		site,
+		siteSlug,
+		fromSite,
+		importSite,
+		startImport,
+		resetImport,
+		stepNavigator,
+	} = props;
 
 	/**
 	 * Effects
@@ -117,10 +127,16 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 								siteSlug={ siteSlug }
 								job={ job as ImportJob }
 								resetImport={ resetImport }
+								onSiteViewClick={ stepNavigator?.goToSiteViewPage }
 							/>
 						);
 					} else if ( checkIsFailed() ) {
-						return <ErrorMessage siteSlug={ siteSlug } />;
+						return (
+							<ErrorMessage
+								onStartBuilding={ stepNavigator?.goToIntentPage }
+								onBackToStart={ stepNavigator?.goToImportCapturePage }
+							/>
+						);
 					} else if ( checkProgress() ) {
 						return <ProgressScreen job={ job } />;
 					}

--- a/client/signup/steps/import-from/squarespace/index.tsx
+++ b/client/signup/steps/import-from/squarespace/index.tsx
@@ -17,8 +17,18 @@ import { getImporterTypeForEngine } from '../util';
 
 export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > = ( props ) => {
 	const importer: Importer = 'squarespace';
-	const { job, urlData, siteId, site, siteSlug, fromSite, importSite, startImport, resetImport } =
-		props;
+	const {
+		job,
+		urlData,
+		siteId,
+		site,
+		siteSlug,
+		fromSite,
+		importSite,
+		startImport,
+		resetImport,
+		stepNavigator,
+	} = props;
 
 	/**
 	 * Effects
@@ -111,10 +121,16 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 								siteSlug={ siteSlug }
 								job={ job as ImportJob }
 								resetImport={ resetImport }
+								onSiteViewClick={ stepNavigator?.goToSiteViewPage }
 							/>
 						);
 					} else if ( checkIsFailed() ) {
-						return <ErrorMessage siteSlug={ siteSlug } />;
+						return (
+							<ErrorMessage
+								onStartBuilding={ stepNavigator?.goToIntentPage }
+								onBackToStart={ stepNavigator?.goToImportCapturePage }
+							/>
+						);
 					} else if ( checkProgress() ) {
 						return <ProgressScreen job={ job } />;
 					}

--- a/client/signup/steps/import-from/types.ts
+++ b/client/signup/steps/import-from/types.ts
@@ -7,6 +7,16 @@ export type QueryObject = {
 	to: string;
 };
 
+export type StepNavigator = {
+	goToIntentPage?: () => void;
+	goToImportCapturePage?: () => void;
+	goToSiteViewPage?: () => void;
+	goToCheckoutPage?: () => void;
+	goToWpAdminImportPage?: () => void;
+	goToWpAdminWordPressPluginPage?: () => void;
+	navigate?: ( path: string ) => void;
+};
+
 export interface ImportError {
 	error: boolean;
 	errorType: string;
@@ -53,4 +63,5 @@ export interface ImporterBaseProps {
 	importSite: ( params: ImportJobParams ) => void;
 	startImport: ( siteId: number, type: string ) => void;
 	resetImport: ( siteId: number, importerId: string ) => void;
+	stepNavigator?: StepNavigator;
 }

--- a/client/signup/steps/import-from/wix/index.tsx
+++ b/client/signup/steps/import-from/wix/index.tsx
@@ -1,9 +1,7 @@
 import classnames from 'classnames';
-import page from 'page';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
-import { getStepUrl } from 'calypso/signup/utils';
 import { resetImport, startImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
@@ -12,7 +10,7 @@ import CompleteScreen from '../components/complete-screen';
 import ErrorMessage from '../components/error-message';
 import GettingStartedVideo from '../components/getting-started-video';
 import ProgressScreen from '../components/progress-screen';
-import { Importer, ImportError, ImportJob, ImportJobParams } from '../types';
+import { Importer, ImportError, ImportJob, ImportJobParams, StepNavigator } from '../types';
 import { getImporterTypeForEngine } from '../util';
 
 interface Props {
@@ -25,11 +23,22 @@ interface Props {
 	importSite: ( params: ImportJobParams ) => void;
 	startImport: ( siteId: number, type: string ) => void;
 	resetImport: ( siteId: number, importerId: string ) => void;
+	stepNavigator?: StepNavigator;
 }
 export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 	const importer: Importer = 'wix';
-	const { job, error, run, siteId, siteSlug, fromSite, importSite, startImport, resetImport } =
-		props;
+	const {
+		job,
+		error,
+		run,
+		siteId,
+		siteSlug,
+		fromSite,
+		importSite,
+		startImport,
+		resetImport,
+		stepNavigator,
+	} = props;
 
 	/**
 	 ↓ Effects
@@ -43,7 +52,7 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 	 */
 	function handleImporterReadiness() {
 		if ( ! checkIsImporterReady() ) {
-			redirectToImportCapturePage();
+			stepNavigator?.goToImportCapturePage?.();
 		}
 	}
 
@@ -84,10 +93,6 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 		};
 	}
 
-	function redirectToImportCapturePage() {
-		page( getStepUrl( 'importer', 'capture', '', '', { siteSlug } ) );
-	}
-
 	function checkIsImporterReady() {
 		return job || run;
 	}
@@ -120,7 +125,12 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
 				{ ( () => {
 					if ( checkIsFailed() ) {
-						return <ErrorMessage siteSlug={ siteSlug } />;
+						return (
+							<ErrorMessage
+								onStartBuilding={ stepNavigator?.goToIntentPage }
+								onBackToStart={ stepNavigator?.goToImportCapturePage }
+							/>
+						);
 					} else if ( checkProgress() ) {
 						return <ProgressScreen job={ job } />;
 					} else if ( checkIsSuccess() ) {
@@ -130,6 +140,7 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 								siteSlug={ siteSlug }
 								job={ job as ImportJob }
 								resetImport={ resetImport }
+								onSiteViewClick={ stepNavigator?.goToSiteViewPage }
 							/>
 						);
 					}

--- a/client/signup/steps/import-from/wordpress/import-content-only/index.tsx
+++ b/client/signup/steps/import-from/wordpress/import-content-only/index.tsx
@@ -4,7 +4,12 @@ import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import importerConfig from 'calypso/lib/importer/importer-config';
-import { Importer, ImportJob, ImportJobParams } from 'calypso/signup/steps/import-from/types';
+import {
+	Importer,
+	ImportJob,
+	ImportJobParams,
+	StepNavigator,
+} from 'calypso/signup/steps/import-from/types';
 import { getImporterTypeForEngine } from 'calypso/signup/steps/import-from/util';
 import { UrlData } from 'calypso/signup/steps/import/types';
 import { startImport, resetImport } from 'calypso/state/imports/actions';
@@ -25,6 +30,7 @@ interface Props {
 	siteItem: SitesItem | null;
 	siteSlug: string;
 	siteAnalyzedData: UrlData;
+	stepNavigator?: StepNavigator;
 }
 
 const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
@@ -33,7 +39,7 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 	/**
 	 ↓ Fields
 	 */
-	const { job, importer, siteItem, siteSlug, siteAnalyzedData } = props;
+	const { job, importer, siteItem, siteSlug, siteAnalyzedData, stepNavigator } = props;
 
 	/**
 	 ↓ Effects
@@ -125,6 +131,7 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 				resetImport={ () => {
 					dispatch( resetImport( siteItem?.ID, job?.importerId ) );
 				} }
+				onSiteViewClick={ stepNavigator?.goToSiteViewPage }
 			/>
 		);
 	}
@@ -153,7 +160,12 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 					if ( checkIsSuccess() ) {
 						return renderHooray();
 					} else if ( checkIsFailed() ) {
-						return <ErrorMessage siteSlug={ siteSlug } />;
+						return (
+							<ErrorMessage
+								onStartBuilding={ stepNavigator?.goToIntentPage }
+								onBackToStart={ stepNavigator?.goToImportCapturePage }
+							/>
+						);
 					} else if ( checkProgress() ) {
 						return renderProgress();
 					}

--- a/client/signup/steps/import-from/wordpress/index.tsx
+++ b/client/signup/steps/import-from/wordpress/index.tsx
@@ -1,4 +1,3 @@
-import page from 'page';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -8,8 +7,7 @@ import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { SitesItem } from 'calypso/state/selectors/get-sites-items';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteBySlug, getSite, isJetpackSite } from 'calypso/state/sites/selectors';
-import { getWpOrgImporterUrl } from '../../import/util';
-import { Importer, ImportJob } from '../types';
+import { Importer, ImportJob, StepNavigator } from '../types';
 import { ContentChooser } from './content-chooser';
 import ImportContentOnly from './import-content-only';
 import ImportEverything from './import-everything';
@@ -24,6 +22,7 @@ interface Props {
 	siteId: number;
 	siteSlug: string;
 	fromSite: string;
+	stepNavigator?: StepNavigator;
 }
 
 export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => {
@@ -33,7 +32,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	 ↓ Fields
 	 */
 	const [ option, setOption ] = useState< WPImportOption >();
-	const { job, fromSite, siteSlug, siteId } = props;
+	const { job, fromSite, siteSlug, siteId, stepNavigator } = props;
 	const siteItem = useSelector( ( state ) => getSite( state, siteId ) );
 	const fromSiteItem = useSelector( ( state ) =>
 		getSiteBySlug( state, fromSite ? convertToFriendlyWebsiteName( fromSite ) : '' )
@@ -91,15 +90,15 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	} ) {
 		const currentPath = window.location.pathname + window.location.search;
 
-		page( addQueryArgs( params, currentPath ) );
+		stepNavigator?.navigate?.( addQueryArgs( params, currentPath ) );
 	}
 
 	function redirectToWpAdminImportPage() {
-		return page( `/import/${ siteSlug }` );
+		stepNavigator?.goToWpAdminImportPage?.();
 	}
 
 	function redirectToWpAdminWordPressImporter() {
-		return page( getWpOrgImporterUrl( siteSlug, 'wordpress' ) );
+		stepNavigator?.goToWpAdminWordPressPluginPage?.();
 	}
 
 	/**
@@ -128,6 +127,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 							targetSite={ siteItem as SitesItem }
 							targetSiteId={ siteId }
 							targetSiteSlug={ siteSlug }
+							stepNavigator={ stepNavigator }
 						/>
 					);
 				} else if ( WPImportOption.CONTENT_ONLY === option ) {
@@ -138,6 +138,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 							siteItem={ siteItem as SitesItem }
 							siteSlug={ siteSlug }
 							siteAnalyzedData={ fromSiteAnalyzedData }
+							stepNavigator={ stepNavigator }
 						/>
 					);
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Refactored import module components by eliminating `page` lib dependency and introducing `stepNavigator` implementation for navigating between steps.

#### Testing instructions

- Import onboarding flows remain the same ( `start/importer/capture?siteSlug={SLUG}` )
- e2e tests are passing

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62238
