### PR TITLE
Show Download CTA for Traffic Guide at checkout

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -517,6 +517,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		if (
 			isDataLoaded &&
+			! isTrafficGuidePurchase &&
 			( ! primaryPurchase || ! selectedSite || ( selectedSite.jetpack && ! isAtomic ) )
 		) {
 			return (

--- a/client/my-sites/checkout/checkout-thank-you/test/header.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/header.js
@@ -23,6 +23,9 @@ const translate = ( x ) => x;
 describe( 'CheckoutThankYouHeader', () => {
 	const defaultProps = {
 		translate,
+		recordTracksEvent: () => {},
+		recordStartTransferClickInThankYou: () => {},
+		titanAppsUrlPrefix: '',
 		primaryPurchase: {
 			product_slug: 'business-bundle',
 		},
@@ -70,6 +73,23 @@ describe( 'CheckoutThankYouHeader', () => {
 				comp.find( '.checkout-thank-you__success-message-item:last-child div' ).text()
 			).toEqual(
 				"Your site has been launched. You can share it with the world whenever you're ready."
+			);
+		} );
+	} );
+
+	describe( 'Traffic Guide Purchases', () => {
+		test( 'should display the download button', () => {
+			const comp = shallow(
+				<CheckoutThankYouHeader
+					{ ...defaultProps }
+					primaryPurchase={ null }
+					isDataLoaded={ true }
+					translate={ translate }
+					displayMode="traffic-guide"
+				/>
+			);
+			expect( comp.find( '.checkout-thank-you__header-button > button' ).text() ).toEqual(
+				'Click here to download your copy now.'
 			);
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Slack: p1652069017743219-slack-C042CJ2NH

After the Traffic Guide product is purchased, we show a download button on the "thank you" page. However, #59932 caused a regression which hid this button and showed a generic 'Go to My Home' button instead.

This change adds an exception for the Traffic Guide and also adds a test to ensure this does not break in the future.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/marketing/ultimate-traffic-guide/, select a site and proceed to purchase the product.
* On the thank you page, the button text will be  'Go to My Home'.
* Replace https://wordpress.com in the URL with the calypso.live link from this PR or http://calypso.localhost:3000/ if testing on local.
* Confirm that the button text is 'Click here to download your copy now.'
* Confirm that clicking on the button downloads the Traffic Guide.

|Before|After|
|---|---|
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/5436027/167402859-850fafef-2930-4d3b-bfc3-09c51e3165d9.png">|<img width="939" alt="image" src="https://user-images.githubusercontent.com/5436027/167403269-a4e8e1f7-5a5a-4c7f-8f1e-db865a703e75.png">|


