### PR TITLE
Stepper: Reimplement `USEFseStatus` hook (3 minutres review)

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -97,7 +97,7 @@ export const siteSetupFlow: Flow = {
 						return navigate( 'error' );
 					}
 
-					// If the user skips starting point, redirect them to My Home
+					// If the user skips starting point, redirect them to the post editor
 					if ( intent === 'write' && startingPoint !== 'skip-to-my-home' ) {
 						if ( startingPoint !== 'write' ) {
 							window.sessionStorage.setItem( 'wpcom_signup_complete_show_draft_post_modal', '1' );

--- a/client/landing/stepper/hooks/use-fse-status.ts
+++ b/client/landing/stepper/hooks/use-fse-status.ts
@@ -1,10 +1,30 @@
+import { useQuery } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
 import { useSite } from './use-site';
+
+type Response = {
+	is_fse_eligible: boolean;
+	is_fse_active: boolean;
+};
 
 export function useFSEStatus() {
 	const site = useSite();
-	const FSEEligible = site?.is_fse_eligible;
-	const FSEActive = site?.is_fse_active;
-	const isLoading = !! site;
 
-	return { FSEEligible, FSEActive, isLoading };
+	const { data, isLoading } = useQuery< Response >(
+		site?.ID.toString() ?? 'no-site',
+		() =>
+			wpcomRequest( {
+				path: `/sites/${ site?.ID }/block-editor`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		{
+			enabled: !! site,
+		}
+	);
+
+	return {
+		FSEEligible: Boolean( data?.is_fse_eligible ),
+		FSEActive: Boolean( data?.is_fse_active ),
+		isLoading,
+	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* [That PR](https://github.com/Automattic/wp-calypso/pull/63129) broke the FSE eligibility check of stepper because I was bitten by [this](paYE8P-13L-p2#comment-1039). 
* This PR implement the check again, but with react-query. This caches the response and doesn't regress to loading FSE status every time, which was the a reason behind the original PR. 


#### Testing instructions

1. Go to /setup/intent?siteSlug=YOUR_SITE
2. Choose build.
3. Pick a theme.
4. You should land in the site editor. 

Context: pdDR7T-4D-p2#comment-45