### PR TITLE
Stepper: Added FlowProgress component to stepper

### DIFF
--- a/packages/onboarding/src/flow-progress/index.tsx
+++ b/packages/onboarding/src/flow-progress/index.tsx
@@ -1,21 +1,17 @@
+import { useTranslate } from 'i18n-calypso';
 import './style.scss';
 
 interface Props {
-	flowLength: number;
-	positionInFlow: number;
-	translate: any;
+	count: number;
+	progress: number;
 }
 
-const FlowProgress: React.FC< Props > = ( { flowLength, positionInFlow, translate } ) => {
-	if ( flowLength > 1 ) {
+const FlowProgress: React.FC< Props > = ( { count, progress } ) => {
+	const translate = useTranslate();
+	if ( count > 1 ) {
 		return (
 			<div className="flow-progress">
-				{ translate( 'Step %(stepNumber)d of %(stepTotal)d', {
-					args: {
-						stepNumber: positionInFlow + 1,
-						stepTotal: flowLength,
-					},
-				} ) }
+				{ translate( 'Step %(progress)d of %(count)d', { args: { progress, count } } ) }
 			</div>
 		);
 	}

--- a/packages/onboarding/src/flow-progress/index.tsx
+++ b/packages/onboarding/src/flow-progress/index.tsx
@@ -1,0 +1,26 @@
+import './style.scss';
+
+interface Props {
+	flowLength: number;
+	positionInFlow: number;
+	translate: any;
+}
+
+const FlowProgress: React.FC< Props > = ( { flowLength, positionInFlow, translate } ) => {
+	if ( flowLength > 1 ) {
+		return (
+			<div className="flow-progress">
+				{ translate( 'Step %(stepNumber)d of %(stepTotal)d', {
+					args: {
+						stepNumber: positionInFlow + 1,
+						stepTotal: flowLength,
+					},
+				} ) }
+			</div>
+		);
+	}
+
+	return null;
+};
+
+export default FlowProgress;

--- a/packages/onboarding/src/flow-progress/style.scss
+++ b/packages/onboarding/src/flow-progress/style.scss
@@ -1,6 +1,5 @@
 .flow-progress {
 	color: var( --studio-gray-30 );
-	font-size: $font-body-small;
 	font-weight: 600;
 	margin: 0 10px;
 }

--- a/packages/onboarding/src/flow-progress/style.scss
+++ b/packages/onboarding/src/flow-progress/style.scss
@@ -1,0 +1,6 @@
+.flow-progress {
+	color: var( --studio-gray-30 );
+	font-size: $font-body-small;
+	font-weight: 600;
+	margin: 0 10px;
+}

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -35,7 +35,7 @@ interface Props {
 	goNext?: () => void;
 	flowName?: string;
 	intent?: string;
-	stepProgress?: { flowLength: number; currentStep: number };
+	stepProgress?: { count: number; progress: number };
 	recordTracksEvent: ( eventName: string, eventProperties: object ) => void;
 }
 
@@ -131,13 +131,7 @@ const StepContainer: React.FC< Props > = ( {
 
 	function ProgressIndicator() {
 		if ( ! stepProgress ) return null;
-		return (
-			<FlowProgress
-				flowLength={ stepProgress?.flowLength }
-				positionInFlow={ stepProgress?.currentStep }
-				translate={ translate }
-			/>
-		);
+		return <FlowProgress count={ stepProgress?.count } progress={ stepProgress?.progress } />;
 	}
 
 	function NextButton() {

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { ReactChild, ReactElement } from 'react';
 import ActionButtons from '../action-buttons';
+import FlowProgress from '../flow-progress';
 import StepNavigationLink from '../step-navigation-link';
 import './style.scss';
 
@@ -34,6 +35,7 @@ interface Props {
 	goNext?: () => void;
 	flowName?: string;
 	intent?: string;
+	stepProgress?: { flowLength: number; currentStep: number };
 	recordTracksEvent: ( eventName: string, eventProperties: object ) => void;
 }
 
@@ -65,6 +67,7 @@ const StepContainer: React.FC< Props > = ( {
 	flowName,
 	intent,
 	stepSectionName,
+	stepProgress,
 	recordTracksEvent,
 } ) => {
 	const translate = useTranslate();
@@ -126,6 +129,17 @@ const StepContainer: React.FC< Props > = ( {
 		);
 	}
 
+	function ProgressIndicator() {
+		if ( ! stepProgress ) return null;
+		return (
+			<FlowProgress
+				flowLength={ stepProgress?.flowLength }
+				positionInFlow={ stepProgress?.currentStep }
+				translate={ translate }
+			/>
+		);
+	}
+
 	function NextButton() {
 		if ( shouldHideNavButtons || ! goNext ) {
 			return null;
@@ -162,6 +176,7 @@ const StepContainer: React.FC< Props > = ( {
 				{ ! hideSkip && skipButtonAlign === 'top' && <SkipButton /> }
 				{ ! hideNext && <NextButton /> }
 				{ customizedActionButtons }
+				<ProgressIndicator />
 			</ActionButtons>
 			{ ! hideFormattedHeader && (
 				<div className="step-container__header">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added a new component, `FlowProgress`, that shows information like "Step 2 of 10".

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you want to show the `FlowProgress` in a step you should add a new prop to `StepContainer`:

```
...
const stepProgress = { flowLength: 10, currentStep: 4 };
...

<StepContainer
   ...
   stepProgress={ stepProgress }
   ...
/>
```

![image](https://user-images.githubusercontent.com/3801502/167406910-d7174d8b-6b60-47fc-acf2-338b6c7a499b.png)


In this example the values are hard-coded, but the idea is to store this information in the `ONBOARD_STORE`, so it's manageable from the flow configuration instead on the step (since the step may be used in different flows).
The store changes are on [a different PR](https://github.com/Automattic/wp-calypso/pull/63414).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63355
