### PR TITLE
Stepper: Add step progress info to onboard store

### DIFF
--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -245,6 +245,13 @@ export const setProgressTitle = ( progressTitle: string | undefined ) => ( {
 	progressTitle,
 } );
 
+export const setStepProgress = (
+	stepProgress: { flowLength: number; currentStep: number } | undefined
+) => ( {
+	type: 'SET_STEP_PROGRESS' as const,
+	stepProgress,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -275,4 +282,5 @@ export type OnboardAction = ReturnType<
 	| typeof setPendingAction
 	| typeof setProgress
 	| typeof setProgressTitle
+	| typeof setStepProgress
 >;

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -246,7 +246,7 @@ export const setProgressTitle = ( progressTitle: string | undefined ) => ( {
 } );
 
 export const setStepProgress = (
-	stepProgress: { flowLength: number; currentStep: number } | undefined
+	stepProgress: { count: number; progress: number } | undefined
 ) => ( {
 	type: 'SET_STEP_PROGRESS' as const,
 	stepProgress,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -284,6 +284,16 @@ const progressTitle: Reducer< string | undefined, OnboardAction > = ( state, act
 	return state;
 };
 
+const stepProgress: Reducer<
+	{ flowLength: number; currentStep: number } | undefined,
+	OnboardAction
+> = ( state, action ) => {
+	if ( action.type === 'SET_STEP_PROGRESS' ) {
+		return action.stepProgress;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	anchorPodcastId,
 	anchorEpisodeId,
@@ -310,6 +320,7 @@ const reducer = combineReducers( {
 	pendingAction,
 	progress,
 	progressTitle,
+	stepProgress,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -284,10 +284,10 @@ const progressTitle: Reducer< string | undefined, OnboardAction > = ( state, act
 	return state;
 };
 
-const stepProgress: Reducer<
-	{ flowLength: number; currentStep: number } | undefined,
-	OnboardAction
-> = ( state, action ) => {
+const stepProgress: Reducer< { count: number; progress: number } | undefined, OnboardAction > = (
+	state,
+	action
+) => {
 	if ( action.type === 'SET_STEP_PROGRESS' ) {
 		return action.stepProgress;
 	}

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -19,6 +19,7 @@ export const getStoreType = ( state: State ) => state.storeType;
 export const getPendingAction = ( state: State ) => state.pendingAction;
 export const getProgress = ( state: State ) => state.progress;
 export const getProgressTitle = ( state: State ) => state.progressTitle;
+export const getStepProgress = ( state: State ) => state.stepProgress;
 export const getState = ( state: State ) => state;
 export const hasPaidDesign = ( state: State ): boolean => {
 	if ( ! state.selectedDesign ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new property to the Onboard store, `stepProgress`, to store information needed to display messages like "Step 3 of 10" on the steps.
* This allow the logic to be outside the step component (flow configuration for ex.), which is preferable since the steps could be in different flows.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The easiest way to test it is by running the branch from [this PR](https://github.com/Automattic/wp-calypso/pull/63518), where the step progress is added to the Woo flow.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/63355
