### PR TITLE
Fix 3PC hook unmounting and document it better

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import { Button } from '@automattic/components';
-import { useHas3PC } from '@automattic/data-stores';
 import { StepContainer } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Icon } from '@wordpress/icons';
@@ -120,10 +119,6 @@ const SiteOptions: Step = function SiteOptions( { navigation } ) {
 			<Button disabled={ ! site } className="site-options__submit-button" type="submit" primary>
 				{ translate( 'Continue' ) }
 			</Button>
-			<p>
-				<strong>Has 3PC: </strong>
-				{ useHas3PC().hasCookies ? 'yes' : 'no' }
-			</p>
 		</form>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { Button } from '@automattic/components';
+import { useHas3PC } from '@automattic/data-stores';
 import { StepContainer } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Icon } from '@wordpress/icons';
@@ -119,6 +120,10 @@ const SiteOptions: Step = function SiteOptions( { navigation } ) {
 			<Button disabled={ ! site } className="site-options__submit-button" type="submit" primary>
 				{ translate( 'Continue' ) }
 			</Button>
+			<p>
+				<strong>Has 3PC: </strong>
+				{ useHas3PC().hasCookies ? 'yes' : 'no' }
+			</p>
 		</form>
 	);
 

--- a/packages/data-stores/src/queries/use-has-3rd-party-cookies.ts
+++ b/packages/data-stores/src/queries/use-has-3rd-party-cookies.ts
@@ -1,7 +1,15 @@
 import { useEffect, useState } from 'react';
 
-let result: boolean;
+/**
+ * Cache the result for the entire session, since changing 3PC settings requires a refresh
+ */
+let result: boolean | undefined;
 
+/**
+ * Calls a widgets.wp.com endpoint from within an iframe to determine whether the user has 3rd party cookies allowed
+ *
+ * @returns true when cookies are allowed, false when not.
+ */
 export function useHas3PC() {
 	const [ hasCookies, setHasCookies ] = useState( Boolean( result ) );
 
@@ -11,21 +19,22 @@ export function useHas3PC() {
 		function handler( event: MessageEvent ) {
 			const { data } = event;
 			if ( data.type === 'widgets.wp.com-cookie-check' ) {
+				// cache the result
 				result = data.result;
 				setHasCookies( data.result );
 				window.removeEventListener( 'message', handler );
 				iframe.remove();
 			}
 		}
+
+		// only inject the iframe if the result isn't already cached
 		if ( result === undefined ) {
 			iframe.src = 'https://widgets.wp.com/calypso-happychat/check-cookies.html';
 			iframe.style.display = 'none';
 
 			window.addEventListener( 'message', handler );
 			document.body.appendChild( iframe );
-			() => {
-				window.removeEventListener( 'message', handler );
-			};
+			return () => window.removeEventListener( 'message', handler );
 		}
 	}, [] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the unreturned cleanup delegate [here](https://github.com/Automattic/wp-calypso/pull/63378/files#r867909617). 
* Improve the hook's documentation. 

#### Testing instructions

1. Go to http://calypso.localhost:3000/setup/intent?siteSlug=YOUR_SITE
2. Pick “Write”. 
3. You should see the 3rd party cookies status.
4. Type something in the fields to re-render, the 3rd party cookies' status shouldn't reload and be rendered right away.
5. Disable 3PC, refresh, you should get “no”. 
6. Type something, state shouldn't reload.

Related to #63378
