### PR TITLE
Help Center: External translated links in notice

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -108,4 +108,7 @@
 		color: #d67709;
 		margin-top: 2px;
 	}
+	.components-external-link__icon {
+		display: none;
+	}
 }

--- a/packages/help-center/src/components/help-center-notice.tsx
+++ b/packages/help-center/src/components/help-center-notice.tsx
@@ -1,5 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ExternalLink, Icon } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import type { AnalysisReport } from '@automattic/data-stores';
 
@@ -25,9 +26,19 @@ const responses: Record< AnalysisReport[ 'result' ], React.ReactChild > = {
 	WPCOM: '',
 	WPORG: (
 		<p>
-			{ __(
-				'Your site is not hosted on our services. Support for the self-hosted version of WordPress is provided by the WordPress.org community forums, or if the problem relates to a specific plugin or theme, contact support for that product instead. If you’re not sure, share you question with a link, and we’ll point you in the right direction!',
-				__i18n_text_domain__
+			{ createInterpolateElement(
+				__(
+					'Your site is not <hosted_on_our_services>hosted on our services</hosted_on_our_services>. Support for the self-hosted version of WordPress is provided by the <wordpress_org_community_forums>WordPress.org community forums</wordpress_org_community_forums>, or if the problem relates to a specific plugin or theme, contact support for that product instead. If you’re not sure, share you question with a link, and we’ll point you in the right direction!',
+					__i18n_text_domain__
+				),
+				{
+					hosted_on_our_services: (
+						<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/com-vs-org/' ) } />
+					),
+					wordpress_org_community_forums: (
+						<ExternalLink href={ localizeUrl( 'https://wordpress.org/support/forums/' ) } />
+					),
+				}
 			) }
 		</p>
 	),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the external links in the notice

![image](https://user-images.githubusercontent.com/52076348/167425692-a074f70c-891f-4257-9012-328d687e4c9d.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. run ETK `yarn dev --sync`.
2. Go to the help center
3. Try to send an email from a non wpcom website
4. Links should work

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
