### PR TITLE
Anchor: Add test for usePodcastTitle

### DIFF
--- a/client/landing/stepper/hooks/test/use-podcast-title.ts
+++ b/client/landing/stepper/hooks/test/use-podcast-title.ts
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { renderHook } from '@testing-library/react-hooks';
+import { usePodcastTitle } from '../use-podcast-title';
+import * as hook from '../use-podcast-title';
+
+jest.mock( '../use-podcast-title' );
+
+describe( 'use-podcast-title test', () => {
+	test( 'Returns the correct title from the response', () => {
+		const spy = jest.spyOn( hook, 'usePodcastTitle' ).mockReturnValue( 'My Podcast Title' );
+		const title = renderHook( () => usePodcastTitle() );
+
+		expect( spy ).toHaveBeenCalled();
+		expect( title.result.current ).toBe( 'My Podcast Title' );
+
+		spy.mockRestore();
+	} );
+} );

--- a/client/landing/stepper/hooks/test/use-podcast-title.ts
+++ b/client/landing/stepper/hooks/test/use-podcast-title.ts
@@ -3,14 +3,14 @@
  */
 import '@testing-library/jest-dom/extend-expect';
 import { renderHook } from '@testing-library/react-hooks';
-import { usePodcastTitle } from '../use-podcast-title';
+import usePodcastTitle from '../use-podcast-title';
 import * as hook from '../use-podcast-title';
 
 jest.mock( '../use-podcast-title' );
 
 describe( 'use-podcast-title test', () => {
 	test( 'Returns the correct title from the response', () => {
-		const spy = jest.spyOn( hook, 'usePodcastTitle' ).mockReturnValue( 'My Podcast Title' );
+		const spy = jest.spyOn( hook, 'default' ).mockReturnValue( 'My Podcast Title' );
 		const title = renderHook( () => usePodcastTitle() );
 
 		expect( spy ).toHaveBeenCalled();

--- a/client/landing/stepper/hooks/use-podcast-title.ts
+++ b/client/landing/stepper/hooks/use-podcast-title.ts
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { ONBOARD_STORE } from '../stores';
 import { useAnchorFmParams } from './use-anchor-fm-params';
 
-export function usePodcastTitle(): string | null {
+export default function usePodcastTitle(): string | null {
 	const { siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const { setSiteTitle } = useDispatch( ONBOARD_STORE );
 	const { anchorFmPodcastId } = useAnchorFmParams();

--- a/client/landing/stepper/hooks/use-podcast-title.ts
+++ b/client/landing/stepper/hooks/use-podcast-title.ts
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { ONBOARD_STORE } from '../stores';
 import { useAnchorFmParams } from './use-anchor-fm-params';
 
-export default function usePodcastTitle(): string | null {
+export function usePodcastTitle(): string | null {
 	const { siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const { setSiteTitle } = useDispatch( ONBOARD_STORE );
 	const { anchorFmPodcastId } = useAnchorFmParams();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Mock the `usePodcastTitle` API call and check to ensure we're getting the correct title as a result

#### Testing instructions

* Switch to this PR
* Run `jest landing/stepper/hooks/test/use-podcast-title.ts`
* Test should pass!

Related to #63049
