### PR TITLE
Woo on Stepper: Fix message on Woo confirm screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
@@ -1,7 +1,6 @@
 import { StepContainer } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import DomainEligibilityWarning from 'calypso/components/eligibility-warnings/domain-warning';
@@ -168,13 +167,7 @@ const WooConfirm: Step = function WooCommerceConfirm( { navigation } ) {
 			`/checkout/${ wpcomDomain }/${ upgradingPlan?.product_slug ?? '' }`
 		),
 		productName,
-		description: productName
-			? sprintf(
-					/* translators: %s: The upgrading plan name (ex.: WordPress.com Business) */
-					__( 'Upgrade to the %s plan and set up your WooCommerce store.' ),
-					productName
-			  )
-			: __( 'Upgrade to set up your WooCommerce store.' ),
+		description: __( 'Upgrade to the Pro plan and set up your WooCommerce store.' ),
 	};
 
 	const domain = stagingDomain;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
@@ -166,7 +166,6 @@ const WooConfirm: Step = function WooCommerceConfirm( { navigation } ) {
 			},
 			`/checkout/${ wpcomDomain }/${ upgradingPlan?.product_slug ?? '' }`
 		),
-		productName,
 		description: __( 'Upgrade to the Pro plan and set up your WooCommerce store.' ),
 	};
 


### PR DESCRIPTION
Changes WooCommerce upsell message on confirm screen.

| Before  | After |
| ------------- | ------------- |
| <img width="532" alt="image" src="https://user-images.githubusercontent.com/375980/167470739-56633602-e5b2-4229-81b9-72ef48ce8eee.png">  | <img width="493" alt="image" src="https://user-images.githubusercontent.com/375980/167470808-e1134f95-5c4f-483c-9c2b-0139fc6d1a87.png"> |

#### Testing
1. Apply this PR.
2. Go to `http://calypso.localhost:3000/setup/wooConfirm?siteSlug=<YOUR_SITE>` where `<YOUR_SITE>` is a free site.
3. Verify that the messsage to upgrade reads: `Upgrade to the Pro plan and set up your WooCommerce store`.

Closes https://github.com/Automattic/wp-calypso/issues/63356