### PR TITLE
Domains: Trim name servers when updating them

### DIFF
--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -111,7 +111,7 @@ class CustomNameserversForm extends PureComponent {
 
 	handleChange = ( nameserver, index ) => {
 		const nameservers = [ ...this.props.nameservers ];
-		nameservers[ index ] = nameserver;
+		nameservers[ index ] = ( nameserver || '' ).trim();
 		this.props.onChange( nameservers );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With the logging introduced by D67625-code, we noticed some name server update errors happened because of extraneous whitespace at the beginning or end of the strings. A tab character (\t) is a semi-frequent cause of problems and can be difficult to spot when copy-pasting in the browser.

This PR trims whitespace around name servers when updating them, helping fix this problem.

#### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to "Upgrades > Domains"
- Select a domain you own
- Edit its name servers and try to add spaces or tabs at the beginning or the end
- Ensure it's not possible to do that