### PR TITLE
Help Center: Show in the Site Editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -68,14 +68,12 @@ function HelpCenterContent() {
 	);
 }
 
-const HelpCenterRender = () => {
-	return (
-		<QueryClientProvider client={ whatsNewQueryClient }>
-			<HelpCenterContent />,
-		</QueryClientProvider>
-	);
-};
-
 registerPlugin( 'etk-help-center', {
-	render: HelpCenterRender,
+	render: () => {
+		return (
+			<QueryClientProvider client={ whatsNewQueryClient }>
+				<HelpCenterContent />,
+			</QueryClientProvider>
+		);
+	},
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -79,8 +79,3 @@ const HelpCenterRender = () => {
 registerPlugin( 'etk-help-center', {
 	render: HelpCenterRender,
 } );
-
-registerPlugin( 'etk-help-center-fse', {
-	render: HelpCenterRender,
-	scope: 'core/edit-site',
-} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -35,15 +35,26 @@ function HelpCenterContent() {
 	return (
 		<>
 			{ isDesktop && (
-				<PinnedItems scope="core/edit-post">
-					<span className="etk-help-center">
-						<Button
-							className={ cx( 'entry-point-button', { 'is-active': show } ) }
-							onClick={ () => setShowHelpCenter( ! show ) }
-							icon={ <HelpIcon newItems={ showHelpIconDot } active={ show } /> }
-						></Button>
-					</span>
-				</PinnedItems>
+				<>
+					<PinnedItems scope="core/edit-post">
+						<span className="etk-help-center">
+							<Button
+								className={ cx( 'entry-point-button', { 'is-active': show } ) }
+								onClick={ () => setShowHelpCenter( ! show ) }
+								icon={ <HelpIcon newItems={ showHelpIconDot } active={ show } /> }
+							></Button>
+						</span>
+					</PinnedItems>
+					<PinnedItems scope="core/edit-site">
+						<span className="etk-help-center">
+							<Button
+								className={ cx( 'entry-point-button', { 'is-active': show } ) }
+								onClick={ () => setShowHelpCenter( ! show ) }
+								icon={ <HelpIcon newItems={ showHelpIconDot } active={ show } /> }
+							></Button>
+						</span>
+					</PinnedItems>
+				</>
 			) }
 			{ show && (
 				<HelpCenter
@@ -63,12 +74,19 @@ function HelpCenterContent() {
 	);
 }
 
+const HelpCenterRender = () => {
+	return (
+		<QueryClientProvider client={ whatsNewQueryClient }>
+			<HelpCenterContent />,
+		</QueryClientProvider>
+	);
+};
+
 registerPlugin( 'etk-help-center', {
-	render: () => {
-		return (
-			<QueryClientProvider client={ whatsNewQueryClient }>
-				<HelpCenterContent />,
-			</QueryClientProvider>
-		);
-	},
+	render: HelpCenterRender,
+} );
+
+registerPlugin( 'etk-help-center-fse', {
+	render: HelpCenterRender,
+	scope: 'core/edit-site',
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -32,28 +32,22 @@ function HelpCenterContent() {
 		}
 	}, [ show ] );
 
+	const content = (
+		<span className="etk-help-center">
+			<Button
+				className={ cx( 'entry-point-button', { 'is-active': show } ) }
+				onClick={ () => setShowHelpCenter( ! show ) }
+				icon={ <HelpIcon newItems={ showHelpIconDot } active={ show } /> }
+			></Button>
+		</span>
+	);
+
 	return (
 		<>
 			{ isDesktop && (
 				<>
-					<PinnedItems scope="core/edit-post">
-						<span className="etk-help-center">
-							<Button
-								className={ cx( 'entry-point-button', { 'is-active': show } ) }
-								onClick={ () => setShowHelpCenter( ! show ) }
-								icon={ <HelpIcon newItems={ showHelpIconDot } active={ show } /> }
-							></Button>
-						</span>
-					</PinnedItems>
-					<PinnedItems scope="core/edit-site">
-						<span className="etk-help-center">
-							<Button
-								className={ cx( 'entry-point-button', { 'is-active': show } ) }
-								onClick={ () => setShowHelpCenter( ! show ) }
-								icon={ <HelpIcon newItems={ showHelpIconDot } active={ show } /> }
-							></Button>
-						</span>
-					</PinnedItems>
+					<PinnedItems scope="core/edit-post">{ content }</PinnedItems>
+					<PinnedItems scope="core/edit-site">{ content }</PinnedItems>
 				</>
 			) }
 			{ show && (


### PR DESCRIPTION
The Site Editor requires its own scope. It's tricky because omitting it is effectively the same thing as `core/edit-post` due to back compat issues when there weren't multiple editors yet. See https://github.com/WordPress/gutenberg/pull/27438 for more on scope.

#### Changes proposed in this Pull Request

* show the Help Center in the Site Editor

#### Testing instructions

Load the Site Editor while your proxy is active. You should see the Help Center now.

<img width="352" alt="Screen Shot 2022-05-09 at 14 39 13" src="https://user-images.githubusercontent.com/195089/167484987-c8806cbf-e9b4-48a5-af1a-fff255a916d0.png">
 