### PR TITLE
Jetpack cloud: fix broken Scan button

### DIFF
--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -390,12 +390,10 @@ export default connect(
 			scanPageVisitCount,
 		};
 	},
-	() => ( {
-		// Typescript is unhappy with the object shorthand notation, but a function
-		// returning that same object is apparently ok.
+	{
 		dispatchRecordTracksEvent: recordTracksEvent,
 		dispatchScanRun: triggerScanRun,
 		dispatchIncrementCounter: incrementCounter,
 		dispatchSetReviewPromptValid: setValidFrom,
-	} )
+	}
 )( withLocalizedMoment( withApplySiteOffset( ScanPage ) ) );

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -55,9 +55,9 @@ interface Props {
 	};
 	applySiteOffset: applySiteOffsetType | null;
 	dispatchRecordTracksEvent: typeof recordTracksEvent;
-	dispatchScanRun: typeof triggerScanRun;
-	dispatchIncrementCounter: typeof incrementCounter;
-	dispatchSetReviewPromptValid: typeof setValidFrom;
+	dispatchScanRun: ( arg0: number ) => void;
+	dispatchIncrementCounter: ( arg0: string, arg1: boolean, arg2: boolean ) => void;
+	dispatchSetReviewPromptValid: ( arg0: 'restore' | 'scan', arg1: number | null ) => void;
 
 	isAdmin: boolean;
 	siteSettingsUrl?: string | null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes: 7416-gh-Automattic/jpop-issues

* Fix the `Scan now` button located in the Jetpack cloud Scan section.

**What is the issue?**
The current way `connect`'s `mapDispatchToProps` is configured does not work because we are not binding the `dispatch` function (see https://react-redux.js.org/using-react-redux/connect-mapdispatch#two-forms-of-mapdispatchtoprops).

**Notes**
~This PR won't fix the underlying TS issue that the PR (https://github.com/Automattic/wp-calypso/pull/60161) that introduced the issue tried to solve. It will have to be fixed in a follow-up PR.~

#### Testing instructions

* Download this PR.
* Start Jetpack cloud with `yarn start-jetpack-cloud`.
* Go to `http://jetpack.cloud.localhost:3000/scan/:site` (buy a Jetpack Scan subscription if the site does not have one).
* Click on the `Scan now` button.
* Verify that the button works.

Related to 1164141197617539-as-1202246871750617

#### Demo
<img width="1179" alt="Screen Shot 2022-05-09 at 15 58 30" src="https://user-images.githubusercontent.com/3418513/167487939-e137c165-617f-491c-95b9-dde1c351899a.png">
<img width="1179" alt="Screen Shot 2022-05-09 at 15 58 35" src="https://user-images.githubusercontent.com/3418513/167487968-e3dde2cb-c4a3-4b91-be90-2415dd136e57.png">
<img width="1179" alt="Screen Shot 2022-05-09 at 15 58 58" src="https://user-images.githubusercontent.com/3418513/167487975-174ac5d4-2bc6-4af6-8dc7-c7244c786d8b.png">

