### PR TITLE
Domains: Refactor form component tests to `@testing-library/react`

### DIFF
--- a/client/my-sites/domains/components/form/test/__snapshots__/select.js.snap
+++ b/client/my-sites/domains/components/form/test/__snapshots__/select.js.snap
@@ -1,36 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Select /> should render expected output 1`] = `
-<div
-  className="mega-selectzilla select"
->
-  <FormLabel
-    htmlFor="select"
+<div>
+  <div
+    class="mega-selectzilla select"
   >
-    Select label
-  </FormLabel>
-  <FormSelect
-    aria-describedby="validation-field-select"
-    disabled={false}
-    id="select"
-    isError={false}
-    name="select"
-    onChange={[MockFunction]}
-    onClick={[Function]}
-    value=""
-  >
-    <option
-      key="1"
-      value={1}
+    <label
+      class="form-label"
+      for="select"
     >
-      uno
-    </option>
-    <option
-      key="2"
-      value={2}
+      Select label
+    </label>
+    <select
+      aria-describedby="validation-field-select"
+      class="form-select"
+      id="select"
+      name="select"
     >
-      due
-    </option>
-  </FormSelect>
+      <option
+        value="1"
+      >
+        uno
+      </option>
+      <option
+        value="2"
+      >
+        due
+      </option>
+    </select>
+  </div>
 </div>
 `;

--- a/client/my-sites/domains/components/form/test/hidden-input.js
+++ b/client/my-sites/domains/components/form/test/hidden-input.js
@@ -1,43 +1,37 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { HiddenInput } from '../hidden-input';
 
 describe( 'HiddenInput', () => {
 	const defaultProps = {
 		text: 'Love cannot be hidden.',
+		label: 'Your name',
 	};
+	window.scroll = jest.fn();
 
 	test( 'it should return expected elements with defaultProps and no props value', () => {
-		const wrapper = shallow( <HiddenInput { ...defaultProps } /> );
-		expect( wrapper.state( 'toggled' ) ).to.be.false;
-		expect( wrapper.find( '.form__hidden-input' ) ).to.have.length( 1 );
-		expect( wrapper.find( '.form__hidden-input a' ).text() ).to.equal( defaultProps.text );
-		const inputComponent = wrapper.find( 'Input' );
-		expect( inputComponent ).to.have.length( 0 );
+		render( <HiddenInput { ...defaultProps } /> );
+		expect( screen.queryByText( 'Love cannot be hidden.' ) ).toBeVisible();
+		expect( screen.queryByPlaceholderText( 'Your name' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'it should hide toggle link and render a full input field when the field value is not empty', () => {
 		const fieldValue = 'Not empty';
-		const wrapper = shallow( <HiddenInput { ...defaultProps } value={ fieldValue } /> );
-		expect( wrapper.state( 'toggled' ) ).to.be.true;
-		expect( wrapper.find( '.form__hidden-input' ) ).to.have.length( 0 );
-		const inputComponent = wrapper.find( 'Input' );
-		expect( inputComponent ).to.have.length( 1 );
-		expect( inputComponent.get( 0 ).props.value ).to.equal( fieldValue );
+		render( <HiddenInput { ...defaultProps } value={ fieldValue } /> );
+		expect( screen.queryByText( 'Love cannot be hidden.' ) ).not.toBeInTheDocument();
+		expect( screen.queryByPlaceholderText( 'Your name' ).getAttribute( 'value' ) ).toEqual(
+			fieldValue
+		);
 	} );
 
 	test( 'it should toggle input field when the toggle link is clicked', () => {
-		const wrapper = shallow( <HiddenInput { ...defaultProps } /> );
-		expect( wrapper.state( 'toggled' ) ).to.be.false;
-		expect( wrapper.find( '.form__hidden-input' ) ).to.have.length( 1 );
-		wrapper.find( '.form__hidden-input a' ).simulate( 'click', { preventDefault() {} } );
-		expect( wrapper.state( 'toggled' ) ).to.be.true;
-		expect( wrapper.find( '.form__hidden-input' ) ).to.have.length( 0 );
-		const inputComponent = wrapper.find( 'Input' );
-		expect( inputComponent ).to.have.length( 1 );
+		const { container } = render( <HiddenInput { ...defaultProps } /> );
+		expect( screen.queryByText( 'Love cannot be hidden.' ) ).toBeVisible();
+		fireEvent.click( container.getElementsByTagName( 'a' )[ 0 ] );
+		expect( screen.queryByText( 'Love cannot be hidden.' ) ).not.toBeInTheDocument();
+		expect( screen.queryByPlaceholderText( 'Your name' ) ).toBeVisible();
 	} );
 } );

--- a/client/my-sites/domains/components/form/test/hidden-input.js
+++ b/client/my-sites/domains/components/form/test/hidden-input.js
@@ -22,9 +22,7 @@ describe( 'HiddenInput', () => {
 		const fieldValue = 'Not empty';
 		render( <HiddenInput { ...defaultProps } value={ fieldValue } /> );
 		expect( screen.queryByText( 'Love cannot be hidden.' ) ).not.toBeInTheDocument();
-		expect( screen.queryByPlaceholderText( 'Your name' ).getAttribute( 'value' ) ).toEqual(
-			fieldValue
-		);
+		expect( screen.queryByPlaceholderText( 'Your name' ) ).toHaveAttribute( 'value', fieldValue );
 	} );
 
 	test( 'it should toggle input field when the toggle link is clicked', () => {

--- a/client/my-sites/domains/components/form/test/select.js
+++ b/client/my-sites/domains/components/form/test/select.js
@@ -1,8 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import Select from '../select';
 
 describe( '<Select />', () => {
@@ -20,8 +20,8 @@ describe( '<Select />', () => {
 	};
 
 	test( 'should render expected output', () => {
-		const wrapper = shallow( <Select { ...defaultProps } /> );
-		expect( wrapper ).toMatchSnapshot();
+		const { container } = render( <Select { ...defaultProps } /> );
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render form validation when there is an error', () => {
@@ -29,7 +29,7 @@ describe( '<Select />', () => {
 			...defaultProps,
 			errorMessage: 'Duh duh duh!',
 		};
-		const wrapper = shallow( <Select { ...newProps } /> );
-		expect( wrapper.find( 'FormInputValidation' ) ).toHaveLength( 1 );
+		render( <Select { ...newProps } /> );
+		expect( screen.getByText( 'Duh duh duh!' ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `Notice` component to use `@testing-library/react` instead of `enzyme`.

It also uses the opportunity to migrate `chai` assertions to `jest`.

Part of #63409.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/my-sites/domains/components/form/test`