### PR TITLE
Jetpack Agency Dashboard: Add disconnect flow to Jetpack Cloud

### DIFF
--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -53,6 +53,9 @@ export const showNotAuthorizedForNonAdmins: PageJS.Callback = ( context, next ) 
 export const disconnectSite: PageJS.Callback = ( context, next ) => {
 	context.primary = (
 		<DisconnectSite
+			// Ignore type checking because TypeScript is incorrectly inferring the prop type due to the redirectNonJetpack HOC.
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			//@ts-ignore
 			reason={ context.params.reason }
 			type={ context.query.type }
 			backHref={ '/dashboard' }
@@ -65,6 +68,9 @@ export const disconnectSiteConfirm: PageJS.Callback = ( context, next ) => {
 	const { reason, type, text } = context.query;
 	context.primary = (
 		<ConfirmDisconnection
+			// Ignore type checking because TypeScript is incorrectly inferring the prop type due to the redirectNonJetpack HOC.
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			//@ts-ignore
 			reason={ reason }
 			type={ type }
 			text={ text }

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -63,6 +63,7 @@ export const disconnectSiteConfirm: PageJS.Callback = ( context, next ) => {
 			type={ type }
 			text={ text }
 			disconnectHref={ '/dashboard' }
+			stayConnectedHref={ '/dashboard' }
 		/>
 	);
 	next();

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -51,7 +51,13 @@ export const showNotAuthorizedForNonAdmins: PageJS.Callback = ( context, next ) 
 };
 
 export const disconnectSite: PageJS.Callback = ( context, next ) => {
-	context.primary = <DisconnectSite reason={ context.params.reason } type={ context.query.type } />;
+	context.primary = (
+		<DisconnectSite
+			reason={ context.params.reason }
+			type={ context.query.type }
+			backHref={ '/dashboard' }
+		/>
+	);
 	next();
 };
 

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -2,6 +2,7 @@ import AdvancedCredentials from 'calypso/components/advanced-credentials';
 import HasSitePurchasesSwitch from 'calypso/components/has-site-purchases-switch';
 import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
 import NotAuthorizedPage from 'calypso/components/jetpack/not-authorized-page';
+import DisconnectSite from 'calypso/my-sites/site-settings/disconnect-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NoSitesPurchasesMessage from './empty-content';
 import HasSiteCredentialsSwitch from './has-site-credentials-switch';
@@ -45,5 +46,10 @@ export const showNotAuthorizedForNonAdmins: PageJS.Callback = ( context, next ) 
 		/>
 	);
 
+	next();
+};
+
+export const disconnectSite: PageJS.Callback = ( context, next ) => {
+	context.primary = <DisconnectSite reason={ context.params.reason } type={ context.query.type } />;
 	next();
 };

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -3,6 +3,7 @@ import HasSitePurchasesSwitch from 'calypso/components/has-site-purchases-switch
 import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
 import NotAuthorizedPage from 'calypso/components/jetpack/not-authorized-page';
 import DisconnectSite from 'calypso/my-sites/site-settings/disconnect-site';
+import ConfirmDisconnection from 'calypso/my-sites/site-settings/disconnect-site/confirm';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NoSitesPurchasesMessage from './empty-content';
 import HasSiteCredentialsSwitch from './has-site-credentials-switch';
@@ -51,5 +52,18 @@ export const showNotAuthorizedForNonAdmins: PageJS.Callback = ( context, next ) 
 
 export const disconnectSite: PageJS.Callback = ( context, next ) => {
 	context.primary = <DisconnectSite reason={ context.params.reason } type={ context.query.type } />;
+	next();
+};
+
+export const disconnectSiteConfirm: PageJS.Callback = ( context, next ) => {
+	const { reason, type, text } = context.query;
+	context.primary = (
+		<ConfirmDisconnection
+			reason={ reason }
+			type={ type }
+			text={ text }
+			disconnectHref={ '/dashboard' }
+		/>
+	);
 	next();
 };

--- a/client/jetpack-cloud/sections/settings/index.js
+++ b/client/jetpack-cloud/sections/settings/index.js
@@ -2,12 +2,13 @@ import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import {
-	settings,
 	advancedCredentials,
+	disconnectSite,
 	showNotAuthorizedForNonAdmins,
+	settings,
 } from 'calypso/jetpack-cloud/sections/settings/controller';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { settingsPath } from 'calypso/lib/jetpack/paths';
+import { settingsPath, disconnectPath } from 'calypso/lib/jetpack/paths';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 
 export default function () {
@@ -22,5 +23,6 @@ export default function () {
 			makeLayout,
 			clientRender
 		);
+		page( disconnectPath( ':site' ), disconnectSite, siteSelection, makeLayout, clientRender );
 	}
 }

--- a/client/jetpack-cloud/sections/settings/index.js
+++ b/client/jetpack-cloud/sections/settings/index.js
@@ -4,11 +4,12 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import {
 	advancedCredentials,
 	disconnectSite,
+	disconnectSiteConfirm,
 	showNotAuthorizedForNonAdmins,
 	settings,
 } from 'calypso/jetpack-cloud/sections/settings/controller';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { settingsPath, disconnectPath } from 'calypso/lib/jetpack/paths';
+import { confirmDisconnectPath, disconnectPath, settingsPath } from 'calypso/lib/jetpack/paths';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 
 export default function () {
@@ -24,5 +25,12 @@ export default function () {
 			clientRender
 		);
 		page( disconnectPath( ':site' ), disconnectSite, siteSelection, makeLayout, clientRender );
+		page(
+			confirmDisconnectPath( ':site' ),
+			disconnectSiteConfirm,
+			siteSelection,
+			makeLayout,
+			clientRender
+		);
 	}
 }

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -22,6 +22,9 @@ export const settingsHostSelectionPath = ( siteSlug: string | null ): string =>
 export const settingsCredentialsPath = ( siteSlug: string, host: string ): string =>
 	settingsPath( siteSlug, `credentials/${ host }` );
 
+export const disconnectPath = ( siteSlug: string ): string =>
+	settingsPath( siteSlug, 'disconnect-site' );
+
 export const purchasesBasePath = () => '/purchases';
 export const purchasesPath = ( siteSlug: string | null ): string =>
 	siteSlug ? `${ purchasesBasePath() }/${ siteSlug }` : purchasesBasePath();

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -25,6 +25,9 @@ export const settingsCredentialsPath = ( siteSlug: string, host: string ): strin
 export const disconnectPath = ( siteSlug: string ): string =>
 	settingsPath( siteSlug, 'disconnect-site' );
 
+export const confirmDisconnectPath = ( siteSlug: string ): string =>
+	settingsPath( siteSlug, 'disconnect-site/confirm' );
+
 export const purchasesBasePath = () => '/purchases';
 export const purchasesPath = ( siteSlug: string | null ): string =>
 	siteSlug ? `${ purchasesBasePath() }/${ siteSlug }` : purchasesBasePath();

--- a/client/my-sites/site-settings/disconnect-site/confirm.jsx
+++ b/client/my-sites/site-settings/disconnect-site/confirm.jsx
@@ -22,6 +22,7 @@ class ConfirmDisconnection extends Component {
 		reason: PropTypes.string,
 		type: PropTypes.string,
 		text: PropTypes.oneOfType( [ PropTypes.string, PropTypes.arrayOf( PropTypes.string ) ] ),
+		disconnectHref: PropTypes.string,
 		// Provided by HOCs
 		purchase: PropTypes.object,
 		siteId: PropTypes.number,
@@ -60,7 +61,7 @@ class ConfirmDisconnection extends Component {
 	};
 
 	render() {
-		const { type, siteId, siteSlug, translate } = this.props;
+		const { disconnectHref, type, siteId, siteSlug, translate } = this.props;
 
 		const backHref =
 			`/settings/disconnect-site/${ siteSlug }` +
@@ -76,7 +77,7 @@ class ConfirmDisconnection extends Component {
 					) }
 				/>
 				<DisconnectJetpack
-					disconnectHref="/stats"
+					disconnectHref={ disconnectHref ?? '/stats' }
 					isBroken={ false }
 					onDisconnectClick={ this.submitSurvey }
 					showTitle={ false }

--- a/client/my-sites/site-settings/disconnect-site/confirm.jsx
+++ b/client/my-sites/site-settings/disconnect-site/confirm.jsx
@@ -23,6 +23,7 @@ class ConfirmDisconnection extends Component {
 		type: PropTypes.string,
 		text: PropTypes.oneOfType( [ PropTypes.string, PropTypes.arrayOf( PropTypes.string ) ] ),
 		disconnectHref: PropTypes.string,
+		stayConnectedHref: PropTypes.string,
 		// Provided by HOCs
 		purchase: PropTypes.object,
 		siteId: PropTypes.number,
@@ -61,7 +62,7 @@ class ConfirmDisconnection extends Component {
 	};
 
 	render() {
-		const { disconnectHref, type, siteId, siteSlug, translate } = this.props;
+		const { disconnectHref, siteId, siteSlug, stayConnectedHref, translate, type } = this.props;
 
 		const backHref =
 			`/settings/disconnect-site/${ siteSlug }` +
@@ -82,7 +83,7 @@ class ConfirmDisconnection extends Component {
 					onDisconnectClick={ this.submitSurvey }
 					showTitle={ false }
 					siteId={ siteId }
-					stayConnectedHref={ '/settings/manage-connection/' + siteSlug }
+					stayConnectedHref={ stayConnectedHref ?? '/settings/manage-connection/' + siteSlug }
 				/>
 				<div className="disconnect-site__navigation-links">
 					<NavigationLink href={ backHref } direction="back" />

--- a/client/my-sites/site-settings/disconnect-site/index.jsx
+++ b/client/my-sites/site-settings/disconnect-site/index.jsx
@@ -7,12 +7,17 @@ import SurveyFlow from './survey-flow';
 
 import './style.scss';
 
-const DisconnectSite = ( { reason, type, site } ) => {
+const DisconnectSite = ( { backHref, reason, site, type } ) => {
 	const confirmHref = `/settings/disconnect-site/confirm/${ site.slug }`;
 
-	let backHref = '/settings/manage-connection/' + site.slug;
 	if ( reason ) {
+		// If a reason is given then this is being rendered on the confirm screen,
+		// so navigating back should always go to the disconnect-site screen.
 		backHref = '/settings/disconnect-site/' + site.slug;
+	} else {
+		// If a reason wasn't given then navigating back should go to what was given as a prop,
+		// or to /settings/manage-connection/:site by default.
+		backHref = backHref ?? '/settings/manage-connection/' + site.slug;
 	}
 
 	if ( type === 'down' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the disconnect flow found in Calypso at `/settings/disconnect-site` to cloud.jetpack.com for use with the Agency Dashboard.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `jetpack.cloud.localhost:3001/settings/disconnect-site/:site_slug?type=down` for a site that is connected to Jetpack and verify that the page shows.
2. Click the "Disconnect Jetpack" option.
3. Verify that you are taken to `jetpack.cloud.localhost:3001/settings/disconnect-site/confirm/:site_slug?type=down`.
4. Click the "Stay connected" option.
5. Verify that you are taken to `jetpack.cloud.localhost:3001/dashboard` and that your site is not disconnected.
6. Return to the confirmation page.
7. Click the "Disconnect" option.
8. Verify that you are taken to `jetpack.cloud.localhost:3001/dashboard` and that your site is disconnected.
9. Verify that these URLs and their CTAs are unchanged on Calypso.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
--
