### PR TITLE
Domains: Fix name servers card styling

### DIFF
--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -13,6 +13,8 @@ import {
 } from 'calypso/state/analytics/actions';
 import CustomNameserversRow from './custom-nameservers-row';
 
+import './style.scss';
+
 const MIN_NAMESERVER_LENGTH = 2;
 const MAX_NAMESERVER_LENGTH = 4;
 

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -1,9 +1,3 @@
-.name-servers .notice {
-	font-size: $font-body-extra-small;
-	margin-top: 10px;
-	padding-right: 15px;
-}
-
 .name-servers__dns {
 	.name-servers__toggle {
 		.components-base-control__field {
@@ -24,29 +18,6 @@
 		font-size: $font-body-small;
 		font-style: italic;
 		margin-bottom: 0;
-	}
-}
-
-.name-servers.is-placeholder {
-	.name-servers__dns {
-		.name-servers__toggle {
-			display: none;
-		}
-
-		.name-servers__explanation,
-		.name-servers__explanation a {
-			@include placeholder();
-		}
-	}
-
-	.vertical-nav-item {
-		span:nth-of-type( 1 ) {
-			@include placeholder();
-		}
-
-		span:nth-of-type( 2 ) {
-			display: none;
-		}
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

When #62626 was deployed and removed the old `NameServers` component, it also inadvertently orphaned the `/name-servers/style.scss` file. Because of that, the styling for the name servers card was affected.

This PR fixes the styling by importing that `style.scss` file again.

#### Screenshots

-Before

<img width="704" alt="Screen Shot 2022-05-09 at 18 54 23" src="https://user-images.githubusercontent.com/5324818/167505054-d8263686-2411-4832-a218-04be02d7c14c.png">

- After

<img width="705" alt="Screen Shot 2022-05-09 at 18 52 21" src="https://user-images.githubusercontent.com/5324818/167505076-ff91432e-974c-49de-be31-8c61ce8b98c5.png">

### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to "Upgrades > Domains"
- Select a domain you own
- Open the name servers management card and edit them
- Ensure the card looks like the screenshot above
  - The trash icon should appear inside the name server input
  - The "By using custom name servers..." notice should have a bottom margin