### PR TITLE
PlanPrice Component: Update rawPrice conditionals to allow arrays again

### DIFF
--- a/client/my-sites/plan-price/docs/example.jsx
+++ b/client/my-sites/plan-price/docs/example.jsx
@@ -9,6 +9,9 @@ function PlanPriceExample() {
 			<h3>Plan with a price range</h3>
 			<PlanPrice rawPrice={ [ 99.99, 139.99 ] } />
 			<br />
+			<h3>Plan with a price of '0'</h3>
+			<PlanPrice rawPrice={ 0 } />
+			<br />
 			<h3>Plan with discounted price</h3>
 			<div style={ { display: 'flex' } }>
 				<PlanPrice rawPrice={ 8.25 } original />

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -30,7 +30,9 @@ export class PlanPrice extends Component {
 
 		// "Normalize" the input price or price range.
 		const rawPriceRange = Array.isArray( rawPrice ) ? rawPrice.slice( 0, 2 ) : [ rawPrice ];
-		if ( rawPrice > 0 && rawPriceRange.includes( 0 ) ) {
+
+		// If zero is in an array of length 2, render nothing
+		if ( Array.isArray( rawPrice ) && rawPriceRange.includes( 0 ) ) {
 			return null;
 		}
 

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -24,13 +24,13 @@ export class PlanPrice extends Component {
 			translate,
 		} = this.props;
 
-		if ( ! currencyCode || ! ( typeof rawPrice === 'number' ) ) {
+		if ( ! currencyCode || rawPrice === undefined ) {
 			return null;
 		}
 
 		// "Normalize" the input price or price range.
 		const rawPriceRange = Array.isArray( rawPrice ) ? rawPrice.slice( 0, 2 ) : [ rawPrice ];
-		if ( rawPrice !== 0 && rawPriceRange.includes( 0 ) ) {
+		if ( rawPrice > 0 && rawPriceRange.includes( 0 ) ) {
 			return null;
 		}
 

--- a/client/my-sites/plan-price/test/index.js
+++ b/client/my-sites/plan-price/test/index.js
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import PlanPrice from '../index';
+import '@testing-library/jest-dom/extend-expect';
+
+describe( 'PlanPrice', () => {
+	it( 'renders a zero when rawPrice is passed a "0"', () => {
+		render( <PlanPrice rawPrice={ 0 } /> );
+		expect( document.body ).toHaveTextContent( '$0' );
+	} );
+	it( 'renders a rawPrice of $50', () => {
+		render( <PlanPrice rawPrice={ 50 } /> );
+		expect( document.body ).toHaveTextContent( '$50' );
+	} );
+	it( 'renders a rawPrice with a decimal', () => {
+		render( <PlanPrice rawPrice={ 50.01 } /> );
+		expect( document.body ).toHaveTextContent( '$50.01' );
+	} );
+	it( 'renders a range of prices', () => {
+		render( <PlanPrice rawPrice={ [ 10, 50 ] } /> );
+		expect( document.body ).toHaveTextContent( '$10-50' );
+	} );
+	it( 'renders a range of prices with decimals', () => {
+		render( <PlanPrice rawPrice={ [ 10, 50.01 ] } /> );
+		expect( document.body ).toHaveTextContent( '$10-50.01' );
+	} );
+	it( 'will not render a range of prices with a 0', () => {
+		render( <PlanPrice rawPrice={ [ 10, 0 ] } /> );
+		expect( document.body ).not.toHaveTextContent( '$10-0' );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Recent [changes to PlanPrice](https://github.com/Automattic/wp-calypso/blob/7f30ae92e681842aac8f812bc7f7192d54c3a2db/client/my-sites/plan-price/index.jsx#L27) added a conditional to check if `rawPrice` is a number, but this broke the functionality for supplying an array of numbers to PlanPrice to create a pricing range:

<img width="657" alt="image" src="https://user-images.githubusercontent.com/16580129/167516516-ab53eed0-d1ac-4819-8417-d7d828b5415e.png">

I'm not entirely sure if removing the ability to add a range of prices was on purpose, but it seems we still allow for an array of numbers in the component prop-types so I suspect perhaps it was unintended.

Maybe @mattgawarecki or @monsieur-z could shed some light here as it looks like you did some work on this component some time ago.

There also seems to be some back and forth as to whether we should allow a price of zero to be added as a prop to `PlanPrice`. This PR sets the conditional check to `if ( rawPrice > 0 && rawPriceRange.includes( 0 ) )` to explicitly check if rawPrice is a number greater than zero. 

Updated the dev docs to demonstrate this as well. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open http://calypso.localhost:3000/devdocs/blocks/plan-price while on this branch
* You should see the 'Plan with a price range' working as expected
* You should also see an example using a price of zero

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

