### PR TITLE
Search: update link to search dashboard

### DIFF
--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -8,7 +8,9 @@ import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import versionCompare from 'calypso/lib/version-compare';
 import getSiteSetting from 'calypso/state/selectors/get-site-setting';
+import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -30,10 +32,19 @@ export default function SearchMain(): ReactElement {
 	const isCloud = isJetpackCloud();
 	const onSettingsClick = useTrackCallback( undefined, 'calypso_jetpack_search_settings' );
 
+	const siteJetpackVersion = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'jetpack_version' )
+	);
+
+	let searchDashboardUrl = 'admin.php?page=jetpack-search';
+	if ( siteJetpackVersion && versionCompare( siteJetpackVersion, '10.0-beta', '<' ) ) {
+		searchDashboardUrl = 'admin.php?page=jetpack#/performance';
+	}
+
 	// Send Jetpack Cloud users to wp-admin settings and everyone else to Calypso blue
 	const settingsUrl =
 		isCloud && site?.options?.admin_url
-			? `${ site.options.admin_url }admin.php?page=jetpack#/performance`
+			? `${ site.options.admin_url }${ searchDashboardUrl }`
 			: `/settings/performance/${ siteSlug }`;
 
 	return (

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -36,10 +36,10 @@ export default function SearchMain(): ReactElement {
 		getSiteOption( state, siteId, 'jetpack_version' )
 	);
 
-	let searchDashboardUrl = 'admin.php?page=jetpack-search';
-	if ( siteJetpackVersion && versionCompare( siteJetpackVersion, '10.0-beta', '<' ) ) {
-		searchDashboardUrl = 'admin.php?page=jetpack#/performance';
-	}
+	const searchDashboardUrl =
+		siteJetpackVersion && versionCompare( siteJetpackVersion, '10.0-beta', '<' )
+			? 'admin.php?page=jetpack#/performance'
+			: 'admin.php?page=jetpack-search';
 
 	// Send Jetpack Cloud users to wp-admin settings and everyone else to Calypso blue
 	const settingsUrl =


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/24255

#### Changes proposed in this Pull Request

If Jetpack version is empty or greater than `10.0-beta` linking the setting button to `admin.php?page=jetpack-search` otherwise `'admin.php?page=jetpack#/performance'`.

#### Testing instructions
- Start JP Green locally: `CALYPSO_ENV=jetpack-cloud-development yarn start`
- Navigate to search section of a site with Jetpack Search subscription in http://jetpack.cloud.localhost:3000/
- Ensure the `Settings` button takes user to `admin.php?page=jetpack-search` 
- Change site `jetpack_version` or hardcode JP version < `10.0-beta`
- Ensure the `Settings` button takes user to 'admin.php?page=jetpack#/performance'

![image](https://user-images.githubusercontent.com/1425433/167529998-55e0c007-a404-47ea-be4c-f2c7542519d5.png)


