### PR TITLE
Marketplace: infinite scroll fixes

### DIFF
--- a/client/data/marketplace/utils.ts
+++ b/client/data/marketplace/utils.ts
@@ -11,14 +11,10 @@ export const getPluginsListKey = (
 		options.searchTerm || '',
 		options.pageSize || '',
 		options.locale || '',
+		options.page || '',
+		infinite ? 'infinite' : '',
+		options.tag && ! options.searchTerm ? options.tag : '',
 	];
-	if ( infinite ) {
-		keyParams.push( 'infinite' );
-	} else {
-		keyParams.push( options.page || '' );
-	}
-	if ( options.tag && ! options.searchTerm ) {
-		keyParams.push( options.tag );
-	}
+
 	return [ key, ...keyParams ];
 };

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -310,7 +310,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 				siteId={ siteId }
 				jetpackNonAtomic={ jetpackNonAtomic }
 			/>
-			<EducationFooter />
+			{ category === 'discover' && <EducationFooter /> }
 		</MainComponent>
 	);
 };

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -128,6 +128,11 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 		wporgEnabled: !! search,
 	} );
 
+	// Triggers initial search result rendering
+	useEffect( () => {
+		fetchNextPage && fetchNextPage();
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps -- Run only once on mount
+
 	const pluginsByCategoryPopular = filterPopularPlugins(
 		popularPlugins,
 		pluginsByCategoryFeatured

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -128,11 +128,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 		wporgEnabled: !! search,
 	} );
 
-	// Triggers initial search result rendering
-	useEffect( () => {
-		fetchNextPage && fetchNextPage();
-	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps -- Run only once on mount
-
 	const pluginsByCategoryPopular = filterPopularPlugins(
 		popularPlugins,
 		pluginsByCategoryFeatured

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -122,6 +122,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 		pagination: pluginsPagination,
 		fetchNextPage,
 	} = usePlugins( {
+		infinite: true,
 		search,
 		wpcomEnabled: !! search,
 		wporgEnabled: !! search,

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -310,7 +310,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 				siteId={ siteId }
 				jetpackNonAtomic={ jetpackNonAtomic }
 			/>
-			{ category === 'discover' && <EducationFooter /> }
+			{ ! category && ! search && <EducationFooter /> }
 		</MainComponent>
 	);
 };

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -91,12 +91,18 @@ const usePlugins = ( {
 		enabled: ! infinite && ! WPORG_CATEGORIES_BLOCKLIST.includes( category || '' ) && wporgEnabled,
 	} ) as WPORGResponse;
 
+	// For this to be enabled it should:
+	// 1. The request should be marked as infinite and wporg fetching should be enabled (wporgEnabled)
+	// 2. Either we have a search term or we have a valid category (when searching from the top-paid or top-free page)
 	const {
 		data: { plugins: wporgPluginsInfinite = [], pagination: wporgPaginationInfinite } = {},
 		isLoading: isFetchingWPORGInfinite,
 		fetchNextPage,
 	} = searchHook( wporgPluginsOptions, {
-		enabled: infinite && ! WPORG_CATEGORIES_BLOCKLIST.includes( category || '' ) && wporgEnabled,
+		enabled:
+			infinite &&
+			!! ( search || ! WPORG_CATEGORIES_BLOCKLIST.includes( category || '' ) ) &&
+			wporgEnabled,
 	} ) as WPORGResponse;
 
 	const dotOrgPlugins = infinite ? wporgPluginsInfinite : wporgPlugins;
@@ -152,6 +158,7 @@ const usePlugins = ( {
 
 	function fetchNextPageAndStop() {
 		if (
+			infinite &&
 			dotOrgPagination?.page &&
 			dotOrgPagination?.pages &&
 			dotOrgPagination.page >= dotOrgPagination.pages

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -96,7 +96,7 @@ const usePlugins = ( {
 		isLoading: isFetchingWPORGInfinite,
 		fetchNextPage,
 	} = searchHook( wporgPluginsOptions, {
-		enabled: infinite && WPORG_CATEGORIES_BLOCKLIST.includes( category || '' ) && wporgEnabled,
+		enabled: infinite && ! WPORG_CATEGORIES_BLOCKLIST.includes( category || '' ) && wporgEnabled,
 	} ) as WPORGResponse;
 
 	const dotOrgPlugins = infinite ? wporgPluginsInfinite : wporgPlugins;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables infinite scroll search results - suspect missed during hook change

#### Testing instructions

- [x] Search results should auto load new results as you scroll down the page
- [x] Search results should auto load new results even if you scroll through the bottom of results and into the footer (we may just need to hide the footer on search result pages)
- [x] Mobile viewports and whatever timing? bug discussed below in the failing test should no longer fail under any scenarios (note, this was hard to reliably trigger, got lots of false negative runs in my testing)

Unit test in question, specifically "Search for ecommerce":
```
yarn workspace @automattic/calypso-e2e build && CALYPSO_BASE_URL="http://calypso.localhost:3000" VIEWPORT_NAME=mobile yarn jest specs/plugins/plugins__search.ts
```

Fixes https://github.com/Automattic/wp-calypso/issues/63532 https://github.com/Automattic/wp-calypso/issues/63938

