### PR TITLE
Reader: Refactor `withDimensions` away from `UNSAFE_` methods

### DIFF
--- a/client/lib/with-dimensions/index.jsx
+++ b/client/lib/with-dimensions/index.jsx
@@ -39,8 +39,8 @@ export default ( EnhancedComponent ) =>
 			height: 0,
 		};
 
-		handleResize = afterLayoutFlush( ( props = this.props ) => {
-			const domElement = props.domTarget || this.setRef || this.divRef;
+		handleResize = afterLayoutFlush( () => {
+			const domElement = this.props.domTarget || this.setRef || this.divRef;
 
 			if ( domElement ) {
 				const dimensions = domElement.getClientRects()[ 0 ];
@@ -64,8 +64,8 @@ export default ( EnhancedComponent ) =>
 			this.handleResize();
 		}
 
-		UNSAFE_componentWillReceiveProps( nextProps ) {
-			this.handleResize( nextProps );
+		componentDidUpdate() {
+			this.handleResize();
 		}
 
 		componentWillUnmount() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `withDimensions` high-order component away from the `UNSAFE_` deprecated React component methods.

Part of #58453.

#### Testing instructions
* Open the reader and navigate to a post with comments.
* Verify that as you resize the window, the comments still look and work well.