### PR TITLE
Site Settings: Refactor `DateTimeFormat` away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/site-settings/date-time-format/index.jsx
+++ b/client/my-sites/site-settings/date-time-format/index.jsx
@@ -35,30 +35,27 @@ export class DateTimeFormat extends Component {
 	state = {
 		customDateFormat: false,
 		customTimeFormat: false,
-		isLoadingSettings: true,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
+	static getDerivedStateFromProps( props ) {
 		const {
 			fields: { date_format: dateFormat, time_format: timeFormat },
-		} = nextProps;
-
-		const localeDifferent = this.props.locale !== nextProps.locale;
+			isRequestingSettings,
+			isSavingSettings,
+		} = props;
 
 		if (
-			( ! this.state.isLoadingSettings && ! localeDifferent ) ||
+			( ! isRequestingSettings && ! isSavingSettings ) ||
 			'' === dateFormat ||
 			'' === timeFormat
 		) {
 			return;
 		}
 
-		this.setState( {
+		return {
 			customDateFormat: ! includes( getDefaultDateFormats(), dateFormat ),
 			customTimeFormat: ! includes( getDefaultTimeFormats(), timeFormat ),
-			isLoadingSettings: false,
-		} );
+		};
 	}
 
 	setFormat = ( name, defaultFormats, event ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `DateTimeFormat` component away from the `UNSAFE_` deprecated React component methods.

Essentially, we refactor the component to deal with all prior use cases without having to manage the internal component state at all. This is possible by live-checking whether a date or a time format is custom, and by omitting the rest of the state that wasn't actually used.

I'm also using the opportunity to remove the remaining Lodash usage from this component.

Part of #58453.

#### Testing instructions
* Go to `/settings/writing/:site` where `:site` is the slug of a WP.com simple site.
* Expand the Date Format component.
* Play with the date/time format and verify everything works as it did before.
* Verify tests still pass.