### PR TITLE
Show the Starter Plan Thank you page after checkout

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -49,6 +49,7 @@ import {
 } from 'calypso/my-sites/domains/paths';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import TitanSetUpThankYou from 'calypso/my-sites/email/titan-set-up-thank-you';
+import { isStarterPlanEnabled } from 'calypso/my-sites/plans-comparison';
 import { fetchAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
 import { transferStates } from 'calypso/state/atomic-transfer/constants';
 import {
@@ -88,7 +89,6 @@ import ProPlanDetails from './pro-plan-details';
 import SiteRedirectDetails from './site-redirect-details';
 import StarterPlanDetails from './starter-plan-details';
 import TransferPending from './transfer-pending';
-
 import './style.scss';
 
 function getPurchases( props ) {
@@ -379,6 +379,7 @@ export class CheckoutThankYou extends Component {
 		let failedPurchases = [];
 		let wasJetpackPlanPurchased = false;
 		let wasEcommercePlanPurchased = false;
+		let showHappinessSupport = ! this.props.isSimplified;
 		let wasDIFMProduct = false;
 		let delayedTransferPurchase = false;
 		let wasDomainProduct = false;
@@ -394,6 +395,7 @@ export class CheckoutThankYou extends Component {
 			failedPurchases = getFailedPurchases( this.props );
 			wasJetpackPlanPurchased = purchases.some( isJetpackPlan );
 			wasEcommercePlanPurchased = purchases.some( isEcommerce );
+			showHappinessSupport = showHappinessSupport && ! purchases.some( isStarter ); // Don't show support if Starter was purchased
 			delayedTransferPurchase = find( purchases, isDelayedDomainTransfer );
 			wasDomainProduct = purchases.some(
 				( purchase ) =>
@@ -403,6 +405,9 @@ export class CheckoutThankYou extends Component {
 			);
 			wasDIFMProduct = purchases.some( isDIFMProduct );
 			wasTitanEmailOnlyProduct = purchases.length === 1 && purchases.some( isTitanMail );
+		} else if ( isStarterPlanEnabled() ) {
+			// Don't show the Happiness support until we figure out the user doesn't have a starter plan
+			showHappinessSupport = false;
 		}
 
 		// this placeholder is using just wp logo here because two possible states do not share a common layout
@@ -505,7 +510,7 @@ export class CheckoutThankYou extends Component {
 				<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 
 				<Card className="checkout-thank-you__content">{ this.productRelatedMessages() }</Card>
-				{ ! this.props.isSimplified && (
+				{ showHappinessSupport && (
 					<Card className="checkout-thank-you__footer">
 						<HappinessSupport
 							isJetpack={ wasJetpackPlanPurchased }

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -17,6 +17,7 @@ import {
 	isBusiness,
 	isSiteRedirect,
 	isTheme,
+	isStarter,
 	isTitanMail,
 	isJetpackBusinessPlan,
 	shouldFetchSitePlans,
@@ -85,6 +86,7 @@ import PersonalPlanDetails from './personal-plan-details';
 import PremiumPlanDetails from './premium-plan-details';
 import ProPlanDetails from './pro-plan-details';
 import SiteRedirectDetails from './site-redirect-details';
+import StarterPlanDetails from './starter-plan-details';
 import TransferPending from './transfer-pending';
 
 import './style.scss';
@@ -569,6 +571,8 @@ export class CheckoutThankYou extends Component {
 				return [ BloggerPlanDetails, find( purchases, isBlogger ) ];
 			} else if ( purchases.some( isPersonal ) ) {
 				return [ PersonalPlanDetails, find( purchases, isPersonal ) ];
+			} else if ( purchases.some( isStarter ) ) {
+				return [ StarterPlanDetails, find( purchases, isStarter ) ];
 			} else if ( purchases.some( isPremium ) ) {
 				return [ PremiumPlanDetails, find( purchases, isPremium ) ];
 			} else if ( purchases.some( isBusiness ) ) {

--- a/client/my-sites/checkout/checkout-thank-you/starter-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/starter-plan-details.jsx
@@ -1,0 +1,52 @@
+import { isStarter, isGSuiteOrExtraLicenseOrGoogleWorkspace } from '@automattic/calypso-products';
+import { localize } from 'i18n-calypso';
+import { find } from 'lodash';
+import PropTypes from 'prop-types';
+import earnImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
+import adsRemovedImage from 'calypso/assets/images/illustrations/removed-ads.svg';
+import PurchaseDetail from 'calypso/components/purchase-detail';
+import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
+import GoogleAppsDetails from './google-apps-details';
+
+const StarterPlanDetails = ( { translate, selectedSite, sitePlans, purchases } ) => {
+	const plan = find( sitePlans.data, isStarter );
+	const googleAppsWasPurchased = purchases.some( isGSuiteOrExtraLicenseOrGoogleWorkspace );
+
+	return (
+		<div>
+			{ googleAppsWasPurchased && <GoogleAppsDetails purchases={ purchases } /> }
+
+			<CustomDomainPurchaseDetail
+				selectedSite={ selectedSite }
+				hasDomainCredit={ plan && plan.hasDomainCredit }
+			/>
+
+			<PurchaseDetail
+				icon={ <img alt={ translate( 'Earn Illustration' ) } src={ earnImage } /> }
+				title={ translate( 'Make money with your website' ) }
+				description={ translate(
+					'Accept credit card payments today for just about anything – physical and digital goods, services, ' +
+						'donations and tips, or access to your exclusive content.'
+				) }
+				buttonText={ translate( 'Start Earning' ) }
+				href={ '/earn/' + selectedSite.slug }
+			/>
+
+			<PurchaseDetail
+				icon={ <img alt="" src={ adsRemovedImage } /> }
+				title={ translate( 'Advertising Removed' ) }
+				description={ translate(
+					'With your plan, all WordPress.com advertising has been removed from your site. ' +
+						'You can upgrade to a Pro plan to also remove the WordPress.com footer credit.'
+				) }
+			/>
+		</div>
+	);
+};
+
+StarterPlanDetails.propTypes = {
+	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ).isRequired,
+	sitePlans: PropTypes.object.isRequired,
+};
+
+export default localize( StarterPlanDetails );

--- a/client/my-sites/checkout/checkout-thank-you/starter-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/starter-plan-details.jsx
@@ -3,7 +3,6 @@ import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import earnImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
-import adsRemovedImage from 'calypso/assets/images/illustrations/removed-ads.svg';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
@@ -30,15 +29,6 @@ const StarterPlanDetails = ( { translate, selectedSite, sitePlans, purchases } )
 				) }
 				buttonText={ translate( 'Start Earning' ) }
 				href={ '/earn/' + selectedSite.slug }
-			/>
-
-			<PurchaseDetail
-				icon={ <img alt="" src={ adsRemovedImage } /> }
-				title={ translate( 'Advertising Removed' ) }
-				description={ translate(
-					'With your plan, all WordPress.com advertising has been removed from your site. ' +
-						'You can upgrade to a Pro plan to also remove the WordPress.com footer credit.'
-				) }
 			/>
 		</div>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This shows the Thank You page after purchasing a Starter Plan. The page is based on the one from the Personal Plan with a few changes:
- includes custom domain feature
- doesn't have Ads Removed
- doesn't have Priority Support

#### Testing instructions

* On a Free site go to /plans/[site]?flags=plans/pro-plan
* Select the Starter plan and proceeded through the Checkout
* You should now see the Thank You page:

<img width="320" alt="Screenshot on 2022-05-13 at 13-11-24" src="https://user-images.githubusercontent.com/2749938/168262712-24cd694a-d32f-4bee-a884-f565ba32e092.png">

NOTE: This relies on changes made in #63247 and will need for that PR to be merged before proceeding

Fixes #63376