### PR TITLE
Generated design picker: Only show when images exist for the site vertical

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -62,7 +62,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		( select ) => ( site && select( SITE_STORE ).getSiteVerticalId( site.ID ) ) || undefined
 	);
 	const { data: siteVerticalImages = [], isLoading: isLoadingSiteVerticalImages } =
-		useVerticalImagesQuery( siteVerticalId || '' );
+		useVerticalImagesQuery( siteVerticalId || '', { limit: 1 } );
 	const isVerticalizedWithImages = !! siteVerticalId && siteVerticalImages.length > 0;
 	const isAtomic = useSelect( ( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID ) );
 	const isPrivateAtomic = Boolean( site?.launch_status === 'unlaunched' && isAtomic );

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -22,6 +22,7 @@ export { useHasSeenWhatsNewModalQuery } from './queries/use-has-seen-whats-new-m
 export { useSupportAvailability } from './support-queries/use-support-availability';
 export { useSubmitTicketMutation } from './support-queries/use-submit-support-ticket';
 export { useSubmitForumsMutation } from './support-queries/use-submit-forums-topic';
+export { useVerticalImagesQuery } from './verticals-queries/use-vertical-images-query';
 
 export {
 	Auth,

--- a/packages/data-stores/src/verticals-queries/types.ts
+++ b/packages/data-stores/src/verticals-queries/types.ts
@@ -1,0 +1,13 @@
+export interface VerticalImage {
+	ID: string;
+	guid: string;
+	post_tile: string;
+	post_excerpt: string;
+	post_description: string;
+	width: number;
+	height: number;
+	size: string;
+	filename: string;
+	extension: string;
+	meta: Record< string, unknown >;
+}

--- a/packages/data-stores/src/verticals-queries/use-vertical-images-query.ts
+++ b/packages/data-stores/src/verticals-queries/use-vertical-images-query.ts
@@ -1,0 +1,21 @@
+import { useQuery, UseQueryResult } from 'react-query';
+import wpcom from 'calypso/lib/wp'; // eslint-disable-line no-restricted-imports
+import type { VerticalImage } from './types';
+
+export function useVerticalImagesQuery( id: string ): UseQueryResult< VerticalImage[] > {
+	return useQuery( getCacheKey( id ), () => fetchVerticalImages( id ), {
+		enabled: typeof id === 'string' && id !== '',
+		staleTime: Infinity,
+	} );
+}
+
+function fetchVerticalImages( id: string ): Promise< VerticalImage[] > {
+	return wpcom.req.get( {
+		apiNamespace: 'wpcom/v2',
+		path: `/site-verticals/${ id }/images`,
+	} );
+}
+
+function getCacheKey( id: string ): QueryKey {
+	return [ 'vertical-images', id ];
+}

--- a/packages/data-stores/src/verticals-queries/use-vertical-images-query.ts
+++ b/packages/data-stores/src/verticals-queries/use-vertical-images-query.ts
@@ -1,5 +1,5 @@
-import { useQuery, UseQueryResult } from 'react-query';
-import wpcom from 'calypso/lib/wp'; // eslint-disable-line no-restricted-imports
+import { useQuery, UseQueryResult, QueryKey } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
 import type { VerticalImage } from './types';
 
 export function useVerticalImagesQuery( id: string ): UseQueryResult< VerticalImage[] > {
@@ -10,9 +10,10 @@ export function useVerticalImagesQuery( id: string ): UseQueryResult< VerticalIm
 }
 
 function fetchVerticalImages( id: string ): Promise< VerticalImage[] > {
-	return wpcom.req.get( {
+	return wpcomRequest( {
 		apiNamespace: 'wpcom/v2',
 		path: `/site-verticals/${ id }/images`,
+		query: { include_parents: true },
 	} );
 }
 

--- a/packages/data-stores/src/verticals-queries/use-vertical-images-query.ts
+++ b/packages/data-stores/src/verticals-queries/use-vertical-images-query.ts
@@ -3,18 +3,34 @@ import { useQuery, UseQueryResult, QueryKey } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { VerticalImage } from './types';
 
-export function useVerticalImagesQuery( id: string ): UseQueryResult< VerticalImage[] > {
-	return useQuery( getCacheKey( id ), () => fetchVerticalImages( id ), {
+const defaults = {
+	limit: 10,
+	include_parents: true,
+};
+
+interface VerticalImagesQueryParams {
+	limit?: number;
+	include_parents?: boolean;
+}
+
+export function useVerticalImagesQuery(
+	id: string,
+	options: VerticalImagesQueryParams = {}
+): UseQueryResult< VerticalImage[] > {
+	return useQuery( getCacheKey( id ), () => fetchVerticalImages( id, options ), {
 		enabled: typeof id === 'string' && id !== '',
 		staleTime: Infinity,
 	} );
 }
 
-function fetchVerticalImages( id: string ): Promise< VerticalImage[] > {
+function fetchVerticalImages(
+	id: string,
+	options: VerticalImagesQueryParams
+): Promise< VerticalImage[] > {
 	return wpcomRequest< VerticalImage[] >( {
 		apiNamespace: 'wpcom/v2',
 		path: `/site-verticals/${ id }/images`,
-		query: stringify( { include_parents: true } ),
+		query: stringify( { ...defaults, ...options } ),
 	} );
 }
 

--- a/packages/data-stores/src/verticals-queries/use-vertical-images-query.ts
+++ b/packages/data-stores/src/verticals-queries/use-vertical-images-query.ts
@@ -1,3 +1,4 @@
+import { stringify } from 'qs';
 import { useQuery, UseQueryResult, QueryKey } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { VerticalImage } from './types';
@@ -10,10 +11,10 @@ export function useVerticalImagesQuery( id: string ): UseQueryResult< VerticalIm
 }
 
 function fetchVerticalImages( id: string ): Promise< VerticalImage[] > {
-	return wpcomRequest( {
+	return wpcomRequest< VerticalImage[] >( {
 		apiNamespace: 'wpcom/v2',
 		path: `/site-verticals/${ id }/images`,
-		query: { include_parents: true },
+		query: stringify( { include_parents: true } ),
 	} );
 }
 

--- a/packages/design-picker/src/hooks/use-generated-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-generated-designs-query.ts
@@ -31,5 +31,3 @@ function apiBlockRecipeToDesign( recipe: BlockRecipe ): Design {
 		theme: '',
 	};
 }
-
-export default useGeneratedDesignsQuery;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a check to determine whether the chosen site vertical has images that
can be replaced in the generated designs. The expectation is that we should only show
the generated design picker if there are images available.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the vertical question screen `/setup/vertical?siteSlug=${site_slug}` and select "Arts & Entertainment"
* Click on the "Continue" button, land on the site intent screen, and click on the "Start building" button.
* Expect to land on the generated design picker.
* Now, click the "Back" button all the way back to the vertical question screen, and select "Education"
* Click on the "Continue" button, land on the site intent screen, and click on the "Start building" button.
* Expect to land on the traditional design picker.

 <!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/wp-calypso#62237
