### PR TITLE
Bound help-center to body

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -65,6 +65,7 @@ const HelpCenterContainer: React.FC< Container > = ( {
 			disabled={ isMinimized }
 			draggable={ ! isMobile }
 			handle=".help-center__container-header"
+			bounds="body"
 		>
 			<Card className={ classNames } { ...animationProps }>
 				<HelpCenterHeader


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a `body` selector to bound the help-center to the body.

