### PR TITLE
Help Center: Loading state when submitting or connecting to chat

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -50,17 +50,20 @@ const titles: {
 		trayText?: string;
 		formDisclaimer?: string;
 		buttonLabel: string;
+		buttonDisabledLabel: string;
 	};
 } = {
 	CHAT: {
 		formTitle: __( 'Start live chat', 'full-site-editing' ),
 		trayText: __( 'Our WordPress experts will be with you right away', 'full-site-editing' ),
 		buttonLabel: __( 'Chat with us', 'full-site-editing' ),
+		buttonDisabledLabel: __( 'Connecting to chat', 'full-site-editing' ),
 	},
 	EMAIL: {
 		formTitle: __( 'Send us an email', 'full-site-editing' ),
 		trayText: __( 'Our WordPress experts will get back to you soon', 'full-site-editing' ),
 		buttonLabel: __( 'Email us', 'full-site-editing' ),
+		buttonDisabledLabel: __( 'Sending email', 'full-site-editing' ),
 	},
 	FORUM: {
 		formTitle: __( 'Ask in our community forums', 'full-site-editing' ),
@@ -69,6 +72,7 @@ const titles: {
 			'full-site-editing'
 		),
 		buttonLabel: __( 'Ask in the forums', 'full-site-editing' ),
+		buttonDisabledLabel: __( 'Posting in the forums', 'full-site-editing' ),
 	},
 };
 
@@ -144,7 +148,8 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 
 	const { hasCookies, isLoading: loadingCookies } = useHas3PC();
 
-	const isLoading = loadingCookies || submittingTicket || submittingTopic;
+	const isSubmitting = submittingTicket || submittingTopic;
+	const isLoading = loadingCookies || isSubmitting;
 
 	const formTitles = titles[ mode ];
 
@@ -298,7 +303,7 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 					primary
 					className="help-center-contact-form__site-picker-cta"
 				>
-					{ formTitles.buttonLabel }
+					{ isSubmitting ? formTitles.buttonDisabledLabel : formTitles.buttonLabel }
 				</Button>
 			</section>
 			{ [ 'CHAT', 'EMAIL' ].includes( mode ) && (

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -50,20 +50,20 @@ const titles: {
 		trayText?: string;
 		formDisclaimer?: string;
 		buttonLabel: string;
-		buttonDisabledLabel: string;
+		buttonLoadingLabel: string;
 	};
 } = {
 	CHAT: {
 		formTitle: __( 'Start live chat', 'full-site-editing' ),
 		trayText: __( 'Our WordPress experts will be with you right away', 'full-site-editing' ),
 		buttonLabel: __( 'Chat with us', 'full-site-editing' ),
-		buttonDisabledLabel: __( 'Connecting to chat', 'full-site-editing' ),
+		buttonLoadingLabel: __( 'Connecting to chat', 'full-site-editing' ),
 	},
 	EMAIL: {
 		formTitle: __( 'Send us an email', 'full-site-editing' ),
 		trayText: __( 'Our WordPress experts will get back to you soon', 'full-site-editing' ),
 		buttonLabel: __( 'Email us', 'full-site-editing' ),
-		buttonDisabledLabel: __( 'Sending email', 'full-site-editing' ),
+		buttonLoadingLabel: __( 'Sending email', 'full-site-editing' ),
 	},
 	FORUM: {
 		formTitle: __( 'Ask in our community forums', 'full-site-editing' ),
@@ -72,7 +72,7 @@ const titles: {
 			'full-site-editing'
 		),
 		buttonLabel: __( 'Ask in the forums', 'full-site-editing' ),
-		buttonDisabledLabel: __( 'Posting in the forums', 'full-site-editing' ),
+		buttonLoadingLabel: __( 'Posting in the forums', 'full-site-editing' ),
 	},
 };
 
@@ -303,7 +303,7 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 					primary
 					className="help-center-contact-form__site-picker-cta"
 				>
-					{ isSubmitting ? formTitles.buttonDisabledLabel : formTitles.buttonLabel }
+					{ isSubmitting ? formTitles.buttonLoadingLabel : formTitles.buttonLabel }
 				</Button>
 			</section>
 			{ [ 'CHAT', 'EMAIL' ].includes( mode ) && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Changes the button text when the help center is connecting to chat or submitting a ticket/creating a forum topic.

Email
![image](https://user-images.githubusercontent.com/52076348/167612136-4d8989d6-e047-4c44-b78e-0d73c4106289.png)
Forum
![image](https://user-images.githubusercontent.com/52076348/167612174-e7faed7c-6a5a-4ff9-be4b-b909becc63e0.png)
Chat
"Connecting to chat"

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. run ETK `yarn dev --sync`.
2. Go to the help center. 
3. Test the above improvements. Please don't hesitate to submit email and forums* tickets with a clear message that you're an a8cian testing. Just follow the link to the forum ticket and trash it.

* To submit forum tickets you need to be a free user.

