### PR TITLE
Fix domain connection badge message for expiring subscription

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -124,14 +124,14 @@ export function resolveDomainStatus(
 					);
 				}
 
-				if ( isExpiringSoon( domain, 5 ) ) {
+				if ( isExpiringSoon( domain, 7 ) ) {
 					return {
 						statusText: expiresMessage,
-						statusClass: 'status-error',
-						status: translate( 'Expiring soon' ),
+						statusClass: `status-${ domain.autoRenewing ? 'success' : 'error' }`,
+						status: domain.autoRenewing ? translate( 'Active' ) : translate( 'Expiring soon' ),
 						icon: 'info',
 						listStatusText: expiresMessage,
-						listStatusClass: 'alert',
+						listStatusClass: domain.autoRenewing ? 'info' : 'alert',
 						listStatusWeight: 1000,
 						noticeText,
 					};


### PR DESCRIPTION
## Changes proposed in this Pull Request

For domain connections associated with expiring plans, we are showing an "Expiring" badge even if autorenew is active.

This can confuse customers and can be very annoying, specially for monthly plans.

This PR addresses this issue.

![fix-expiring-calypso-before](https://user-images.githubusercontent.com/2797601/167612881-33bbb2b9-7b71-46ae-b461-aaadc7df10a1.png)

![fix-expiring-calypso-after](https://user-images.githubusercontent.com/2797601/167612894-2daf2948-ecbe-4f48-97d5-caeb5c966d3e.png)

## Testing instructions
- Checkout this branch locally or open the Calypso link below
- Select an expiring site (< 7 days) with a Domain Connection
- Verify that the badge shows "Active" if autorenew is on (otherwise, we continue showing "Expiring soon")