### PR TITLE
Woo on Stepper: Remove checkout redirection if an upgrade is not needed

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
@@ -244,7 +244,10 @@ const WooConfirm: Step = function WooCommerceConfirm( { navigation } ) {
 								const providedDependencies = {
 									checkoutUrl: siteUpgrading.checkoutUrl,
 								};
-								submit?.( providedDependencies, siteUpgrading.checkoutUrl );
+								submit?.(
+									providedDependencies,
+									siteUpgrading.required ? siteUpgrading.checkoutUrl : ''
+								);
 							} }
 						>
 							{ __( 'Confirm' ) }


### PR DESCRIPTION
Removes double checkout step in Woo flow.

#### Testing
1. Apply this PR.
2. Go through the site-flow and buy a Pro plan after the Domain step.
3. Continue through the Woo flow.
4. When clicking `Continue` in the wooConfirm step you should be redirected to wc-admin and NOT to the checkout page.

Closes https://github.com/Automattic/wp-calypso/issues/63294
