### PR TITLE
Billing: Change copy for non expired jetpack

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -375,7 +375,7 @@ function RenewErrorMessage( { purchase, translate, site } ) {
 					  } ) }
 				&nbsp;
 				{ translate(
-					'Now sure how to reconnect? {{supportPageLink}}Here are the instructions{{/supportPageLink}}.',
+					'Not sure how to reconnect? {{supportPageLink}}Here are the instructions{{/supportPageLink}}.',
 					{
 						args: {
 							siteSlug: purchase.domain,

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -357,13 +357,27 @@ function RenewErrorMessage( { purchase, translate, site } ) {
 	if ( isJetpack ) {
 		return (
 			<div className="manage-purchase__footnotes">
+				{ isExpired( purchase )
+					? translate(
+							'%(purchaseName)s expired on %(siteSlug)s, and the site is no longer connected to WordPress.com. ' +
+								'To renew this purchase, please reconnect %(siteSlug)s to your WordPress.com account, then complete your purchase. ',
+							{
+								args: {
+									purchaseName: getName( purchase ),
+									siteSlug: purchase.domain,
+								},
+							}
+					  )
+					: translate( 'The site %(siteSlug)s is no longer connected to WordPress.com. ', {
+							args: {
+								siteSlug: purchase.domain,
+							},
+					  } ) }
+
 				{ translate(
-					'%(purchaseName)s expired on %(siteSlug)s, and the site is no longer connected to WordPress.com. ' +
-						'To renew this purchase, please reconnect %(siteSlug)s to your WordPress.com account, then complete your purchase. ' +
-						'Now sure how to reconnect? {{supportPageLink}}Here are the instructions{{/supportPageLink}}.',
+					'Now sure how to reconnect? {{supportPageLink}}Here are the instructions{{/supportPageLink}}.',
 					{
 						args: {
-							purchaseName: getName( purchase ),
 							siteSlug: purchase.domain,
 						},
 						components: {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -360,7 +360,7 @@ function RenewErrorMessage( { purchase, translate, site } ) {
 				{ isExpired( purchase )
 					? translate(
 							'%(purchaseName)s expired on %(siteSlug)s, and the site is no longer connected to WordPress.com. ' +
-								'To renew this purchase, please reconnect %(siteSlug)s to your WordPress.com account, then complete your purchase. ',
+								'To renew this purchase, please reconnect %(siteSlug)s to your WordPress.com account, then complete your purchase.',
 							{
 								args: {
 									purchaseName: getName( purchase ),
@@ -368,12 +368,12 @@ function RenewErrorMessage( { purchase, translate, site } ) {
 								},
 							}
 					  )
-					: translate( 'The site %(siteSlug)s is no longer connected to WordPress.com. ', {
+					: translate( 'The site %(siteSlug)s is no longer connected to WordPress.com.', {
 							args: {
 								siteSlug: purchase.domain,
 							},
 					  } ) }
-
+				&nbsp;
 				{ translate(
 					'Now sure how to reconnect? {{supportPageLink}}Here are the instructions{{/supportPageLink}}.',
 					{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- We've changed the copy related to the purchase status of disconnected jetpack sites.
- Before we displayed the website as expired
- Now, the text is different for only disconnected sites that are not expired yet.

**1. Message for expired and disconnected jetpack plans**
![59726_jetpack-disconnected-not-expired_expired](https://user-images.githubusercontent.com/779993/167637699-d424f52a-a26d-485b-8a1b-f9cd9dd76acd.png)

**2. Message for only disconnected jetpack plans**
![59726_jetpack-disconnected-not-expired_disconnected](https://user-images.githubusercontent.com/779993/167637716-5df031f9-0827-4d42-ad03-d2a797451219.png)

#### Testing instructions

1. Connect a jetpack site to your WordPress account
2. Buy any jetpack upgrade
3. Disconnect your site
4. Go to your purchase history: https://wordpress.com/me/purchases
5. Click on the specific jetpack purchase
6. Observe that the text in the purchase footnotes explains how to reconnect the site. Nothing about the expired site.
7. Change the expiration date in the Store Admin to test the case of expired sites.
8. Go back to the purchase detail and refresh.
9. Observe that the same purchase footnotes mention that the site is disconnected and expired.

- Closes: #59726
