### PR TITLE
Stepper: Add intent prop on the onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/courses/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/courses/index.tsx
@@ -1,8 +1,10 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import VideosUi from 'calypso/components/videos-ui';
 import { COURSE_SLUGS, useCourseData } from 'calypso/data/courses';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CoursesFooter from './footer';
 import type { Step } from '../../types';
@@ -18,6 +20,7 @@ const CoursesStep: Step = function CoursesStep( { navigation } ) {
 	const courseSlug = COURSE_SLUGS.BLOGGING_QUICK_START;
 	const { isCourseComplete } = useCourseData( courseSlug );
 	const hideSkip = isMobile && isCourseComplete;
+	const { getIntent } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 
 	return (
 		<StepContainer
@@ -42,6 +45,9 @@ const CoursesStep: Step = function CoursesStep( { navigation } ) {
 							onStartWriting={ () => submit?.() }
 						/>
 					) }
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore - It's not recognizing the property as optional
+					intent={ getIntent() }
 				/>
 			}
 			recordTracksEvent={ recordTracksEvent }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the intent prop to the Videos UI component to track the events on the onboarding flow.

#### Testing instructions

* Activate the event debug by running the following command on the browser's console: `localStorage.debug='calypso:analytics'`. You may refresh the page.
* Navigate to `setup/bloggerStartingPoint?siteSlug=<YOUR-SITE-SLUG>`
* Click on "Start Learning"
* Then, play one of the videos
* On the console, the events `calypso_courses_play_click`, `calypso_courses_video_player_play_click` and `calypso_courses_view` should contain the intent prop. 

Related to #63377
Closes #58247
