### PR TITLE
Seller Experience - Stepper: Clean up isReadyToStart logic on the woo-confirm step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
@@ -148,7 +148,7 @@ const WooConfirm: Step = function WooCommerceConfirm( { navigation } ) {
 		latestAtomicTransfer && ( ! transferringDataIsAvailable || transferringBlockers?.length > 0 );
 
 	// when the site is not Atomic, ...
-	if ( isReadyToStart && ! isAtomicSite ) {
+	if ( ! isAtomicSite ) {
 		isReadyToStart =
 			isReadyToStart &&
 			! isTransferringBlocked && // there is no blockers from eligibility (holds).


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Clean up isReadyToStart logic on the woo-confirm step. See conversation here: https://github.com/Automattic/wp-calypso/pull/62821#discussion_r867912243
