### PR TITLE
Fix access of .length of undefined value in domain email card

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -15,7 +15,9 @@ const DomainEmailInfoCard = ( {
 }: DomainInfoCardProps ): JSX.Element | null => {
 	const translate = useTranslate();
 	const typesUnableToAddEmail = [ domainType.TRANSFER, domainType.SITE_REDIRECT ] as const;
-	const { data, error, isLoading } = useEmailAccountsQuery( selectedSite.ID, domain.name );
+	const { data, error, isLoading } = useEmailAccountsQuery( selectedSite.ID, domain.name, {
+		retry: false,
+	} );
 
 	let emailAddresses: string[] = [];
 
@@ -26,7 +28,7 @@ const DomainEmailInfoCard = ( {
 	if ( ! isLoading && ! error ) {
 		const emailAccounts: EmailAccount[] = data?.accounts;
 
-		if ( emailAccounts.length ) {
+		if ( emailAccounts?.length ) {
 			emailAddresses = emailAccounts
 				.map( ( a ) => a.emails )
 				.flat()


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When I access the domain management page for one specific domain in one of my sites a `TypeError: Cannot read properties of undefined (reading 'length')` error is thrown and breaks Calypso. Weirdly, this doesn't happen in my local build. I don't know why this happens 🤔 my guess is it has something to do with `react-query`'s caching or something weird with my site's state, but couldn't pinpoint the exact reason.

This PR fixes this by adding an optional chaining operator (`?.`) when accessing that property.

#### Testing instructions

- Build this branch locally or open the live Calypso link
- Go to "Upgrade > Domains"
- Open the management page for some of the domains you own and ensure they load without errors