### PR TITLE
Help Center: Add title and icons to minimized pages

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/contents.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/contents.js
@@ -56,12 +56,7 @@ rawCurrentUserFetch()
 		store.dispatch( requestHappychatEligibility() );
 	} );
 
-export default function Content( {
-	selectedArticle,
-	setSelectedArticle,
-	setFooterContent,
-	setHeaderText,
-} ) {
+export default function Content( { selectedArticle, setSelectedArticle } ) {
 	const [ contactForm, setContactForm ] = useState( null );
 	const [ openInContactPage, setOpenInContactPage ] = useState( null );
 
@@ -81,16 +76,13 @@ export default function Content( {
 							setContactForm( null );
 						} }
 						siteId={ window._currentSiteId }
-						setHeaderText={ setHeaderText }
 					/>
 				) : (
 					<InlineHelpCenterContent
 						selectedArticle={ selectedArticle }
 						setSelectedArticle={ setSelectedArticle }
-						setHelpCenterFooter={ setFooterContent }
 						setContactFormOpen={ setContactForm }
 						openInContactPage={ openInContactPage }
-						setHeaderText={ setHeaderText }
 					/>
 				) }
 			</>

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/contents.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/contents.js
@@ -56,7 +56,7 @@ rawCurrentUserFetch()
 		store.dispatch( requestHappychatEligibility() );
 	} );
 
-export default function Content( { selectedArticle, setSelectedArticle } ) {
+export default function Content() {
 	const [ contactForm, setContactForm ] = useState( null );
 	const [ openInContactPage, setOpenInContactPage ] = useState( null );
 
@@ -79,8 +79,6 @@ export default function Content( { selectedArticle, setSelectedArticle } ) {
 					/>
 				) : (
 					<InlineHelpCenterContent
-						selectedArticle={ selectedArticle }
-						setSelectedArticle={ setSelectedArticle }
 						setContactFormOpen={ setContactForm }
 						openInContactPage={ openInContactPage }
 					/>

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/contents.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/contents.js
@@ -56,7 +56,12 @@ rawCurrentUserFetch()
 		store.dispatch( requestHappychatEligibility() );
 	} );
 
-export default function Content( { selectedArticle, setSelectedArticle, setFooterContent } ) {
+export default function Content( {
+	selectedArticle,
+	setSelectedArticle,
+	setFooterContent,
+	setHeaderText,
+} ) {
 	const [ contactForm, setContactForm ] = useState( null );
 	const [ openInContactPage, setOpenInContactPage ] = useState( null );
 
@@ -76,6 +81,7 @@ export default function Content( { selectedArticle, setSelectedArticle, setFoote
 							setContactForm( null );
 						} }
 						siteId={ window._currentSiteId }
+						setHeaderText={ setHeaderText }
 					/>
 				) : (
 					<InlineHelpCenterContent
@@ -84,6 +90,7 @@ export default function Content( { selectedArticle, setSelectedArticle, setFoote
 						setHelpCenterFooter={ setFooterContent }
 						setContactFormOpen={ setContactForm }
 						openInContactPage={ openInContactPage }
+						setHeaderText={ setHeaderText }
 					/>
 				) }
 			</>

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -16,7 +16,6 @@ function HelpCenterContent() {
 	const isDesktop = useMediaQuery( '(min-width: 480px)' );
 	const show = useSelect( ( select ) => select( 'automattic/help-center' ).isHelpCenterShown() );
 	const { setShowHelpCenter } = useDispatch( 'automattic/help-center' );
-	const [ selectedArticle, setSelectedArticle ] = useState( null );
 	const [ showHelpIconDot, setShowHelpIconDot ] = useState( false );
 	const { data, isLoading } = useHasSeenWhatsNewModalQuery( window._currentSiteId );
 	useEffect( () => {
@@ -24,12 +23,6 @@ function HelpCenterContent() {
 			setShowHelpIconDot( ! data.has_seen_whats_new_modal );
 		}
 	}, [ data, isLoading ] );
-
-	useEffect( () => {
-		if ( ! show ) {
-			setSelectedArticle( null );
-		}
-	}, [ show ] );
 
 	const content = (
 		<span className="etk-help-center">
@@ -50,15 +43,7 @@ function HelpCenterContent() {
 				</>
 			) }
 			{ show && (
-				<HelpCenter
-					content={
-						<Contents
-							selectedArticle={ selectedArticle }
-							setSelectedArticle={ setSelectedArticle }
-						/>
-					}
-					handleClose={ () => setShowHelpCenter( false ) }
-				/>
+				<HelpCenter content={ <Contents /> } handleClose={ () => setShowHelpCenter( false ) } />
 			) }
 		</>
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -17,8 +17,6 @@ function HelpCenterContent() {
 	const show = useSelect( ( select ) => select( 'automattic/help-center' ).isHelpCenterShown() );
 	const { setShowHelpCenter } = useDispatch( 'automattic/help-center' );
 	const [ selectedArticle, setSelectedArticle ] = useState( null );
-	const [ footerContent, setFooterContent ] = useState( null );
-	const [ headerText, setHeaderText ] = useState( null );
 	const [ showHelpIconDot, setShowHelpIconDot ] = useState( false );
 	const { data, isLoading } = useHasSeenWhatsNewModalQuery( window._currentSiteId );
 	useEffect( () => {
@@ -57,13 +55,9 @@ function HelpCenterContent() {
 						<Contents
 							selectedArticle={ selectedArticle }
 							setSelectedArticle={ setSelectedArticle }
-							setFooterContent={ setFooterContent }
-							setHeaderText={ setHeaderText }
 						/>
 					}
-					headerText={ headerText }
 					handleClose={ () => setShowHelpCenter( false ) }
-					footerContent={ footerContent }
 				/>
 			) }
 		</>

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -18,6 +18,7 @@ function HelpCenterContent() {
 	const { setShowHelpCenter } = useDispatch( 'automattic/help-center' );
 	const [ selectedArticle, setSelectedArticle ] = useState( null );
 	const [ footerContent, setFooterContent ] = useState( null );
+	const [ headerText, setHeaderText ] = useState( null );
 	const [ showHelpIconDot, setShowHelpIconDot ] = useState( false );
 	const { data, isLoading } = useHasSeenWhatsNewModalQuery( window._currentSiteId );
 	useEffect( () => {
@@ -57,9 +58,10 @@ function HelpCenterContent() {
 							selectedArticle={ selectedArticle }
 							setSelectedArticle={ setSelectedArticle }
 							setFooterContent={ setFooterContent }
+							setHeaderText={ setHeaderText }
 						/>
 					}
-					headerText={ selectedArticle?.title }
+					headerText={ headerText }
 					handleClose={ () => setShowHelpCenter( false ) }
 					footerContent={ footerContent }
 				/>

--- a/client/blocks/inline-help/inline-help-center-content.jsx
+++ b/client/blocks/inline-help/inline-help-center-content.jsx
@@ -1,6 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useSupportAvailability } from '@automattic/data-stores';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { Icon, page as pageIcon } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { useState, useEffect, useRef } from 'react';
 import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
@@ -18,8 +20,10 @@ const InlineHelpCenterContent = ( {
 	setHelpCenterFooter,
 	setContactFormOpen,
 	openInContactPage,
+	setHeaderText,
 } ) => {
 	const isMobile = useMobileBreakpoint();
+	const { __ } = useI18n();
 	const [ searchQuery, setSearchQuery ] = useState( '' );
 	const [ activeSecondaryView, setActiveSecondaryView ] = useState(
 		openInContactPage ? VIEW_CONTACT : null
@@ -44,7 +48,20 @@ const InlineHelpCenterContent = ( {
 		if ( contentTitle ) {
 			contentTitle.focus();
 		}
-	}, [ activeSecondaryView ] );
+
+		if ( activeSecondaryView === VIEW_CONTACT ) {
+			setHeaderText( __( 'Contact our WordPress.com experts', 'full-site-editing' ) );
+		} else if ( activeSecondaryView === VIEW_RICH_RESULT ) {
+			setHeaderText(
+				<>
+					<Icon icon={ pageIcon } />
+					{ selectedArticle?.title }
+				</>
+			);
+		} else {
+			setHeaderText( null );
+		}
+	}, [ activeSecondaryView, selectedArticle, setHeaderText, __ ] );
 
 	const openResultView = ( event, result ) => {
 		event.preventDefault();

--- a/client/blocks/inline-help/inline-help-center-content.jsx
+++ b/client/blocks/inline-help/inline-help-center-content.jsx
@@ -15,19 +15,15 @@ import InlineHelpSearchResults from './inline-help-search-results';
 
 import './inline-help-center-content.scss';
 
-const InlineHelpCenterContent = ( {
-	selectedArticle,
-	setSelectedArticle,
-	setContactFormOpen,
-	openInContactPage,
-} ) => {
+const InlineHelpCenterContent = ( { setContactFormOpen, openInContactPage } ) => {
 	const isMobile = useMobileBreakpoint();
 	const { __ } = useI18n();
 	const [ searchQuery, setSearchQuery ] = useState( '' );
 	const [ activeSecondaryView, setActiveSecondaryView ] = useState(
 		openInContactPage ? VIEW_CONTACT : null
 	);
-	const { setHeaderText, setFooterContent } = useContext( HelpCenterContext );
+	const { setHeaderText, setFooterContent, selectedArticle, setSelectedArticle } =
+		useContext( HelpCenterContext );
 	const secondaryViewRef = useRef();
 
 	// prefetch the values

--- a/client/blocks/inline-help/inline-help-center-content.jsx
+++ b/client/blocks/inline-help/inline-help-center-content.jsx
@@ -1,10 +1,11 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useSupportAvailability } from '@automattic/data-stores';
+import { HelpCenterContext } from '@automattic/help-center';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Icon, page as pageIcon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useContext } from 'react';
 import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
 import InlineHelpContactPage, { InlineHelpContactPageButton } from './inline-help-contact-page';
 import InlineHelpEmbedResult from './inline-help-embed-result';
@@ -17,10 +18,8 @@ import './inline-help-center-content.scss';
 const InlineHelpCenterContent = ( {
 	selectedArticle,
 	setSelectedArticle,
-	setHelpCenterFooter,
 	setContactFormOpen,
 	openInContactPage,
-	setHeaderText,
 } ) => {
 	const isMobile = useMobileBreakpoint();
 	const { __ } = useI18n();
@@ -28,6 +27,7 @@ const InlineHelpCenterContent = ( {
 	const [ activeSecondaryView, setActiveSecondaryView ] = useState(
 		openInContactPage ? VIEW_CONTACT : null
 	);
+	const { setHeaderText, setFooterContent } = useContext( HelpCenterContext );
 	const secondaryViewRef = useRef();
 
 	// prefetch the values
@@ -50,7 +50,7 @@ const InlineHelpCenterContent = ( {
 		}
 
 		if ( activeSecondaryView === VIEW_CONTACT ) {
-			setHeaderText( __( 'Contact our WordPress.com experts', 'full-site-editing' ) );
+			setHeaderText( __( 'Contact our WordPress.com experts' ) );
 		} else if ( activeSecondaryView === VIEW_RICH_RESULT ) {
 			setHeaderText(
 				<>
@@ -140,7 +140,7 @@ const InlineHelpCenterContent = ( {
 	};
 
 	useEffect( () => {
-		setHelpCenterFooter(
+		setFooterContent(
 			activeSecondaryView ? null : (
 				<InlineHelpContactPageButton
 					onClick={ openContactView }

--- a/client/blocks/inline-help/inline-help-center-types.ts
+++ b/client/blocks/inline-help/inline-help-center-types.ts
@@ -1,5 +1,0 @@
-export interface Article {
-	title: string;
-	link?: string;
-	icon?: string;
-}

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -6,7 +6,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { ThemeProvider } from '@emotion/react';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent, useState } from 'react';
+import { FunctionComponent, ReactElement, useState } from 'react';
 import { useSelector } from 'react-redux';
 import InlineHelpCenterContent from 'calypso/blocks/inline-help/inline-help-center-content';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -51,6 +51,7 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 	const [ footerContent, setFooterContent ] = useState( undefined );
 	const [ contactForm, setContactForm ] = useState( null );
 	const [ openInContactPage, setOpenInContactPage ] = useState< boolean >( false );
+	const [ headerText, setHeaderText ] = useState< ReactElement | string | null >( null );
 
 	const closeAndLeave = () =>
 		leaveCheckout( {
@@ -142,10 +143,11 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 								setHelpCenterFooter={ setFooterContent }
 								setContactFormOpen={ setContactForm }
 								openInContactPage={ openInContactPage }
+								setHeaderText={ setHeaderText }
 							/>
 						)
 					}
-					headerText={ selectedArticle?.title }
+					headerText={ headerText }
 					handleClose={ () => setIsHelpCenterVisible( false ) }
 					footerContent={ footerContent }
 				/>

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -6,7 +6,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { ThemeProvider } from '@emotion/react';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent, ReactElement, useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { useSelector } from 'react-redux';
 import InlineHelpCenterContent from 'calypso/blocks/inline-help/inline-help-center-content';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -48,10 +48,8 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 	const [ isHelpCenterVisible, setIsHelpCenterVisible ] = useState( false );
 	const [ selectedArticle, setSelectedArticle ] = useState< Article | null >( null );
-	const [ footerContent, setFooterContent ] = useState( undefined );
 	const [ contactForm, setContactForm ] = useState( null );
 	const [ openInContactPage, setOpenInContactPage ] = useState< boolean >( false );
-	const [ headerText, setHeaderText ] = useState< ReactElement | string | null >( null );
 
 	const closeAndLeave = () =>
 		leaveCheckout( {
@@ -140,16 +138,12 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 							<InlineHelpCenterContent
 								selectedArticle={ selectedArticle }
 								setSelectedArticle={ setSelectedArticle }
-								setHelpCenterFooter={ setFooterContent }
 								setContactFormOpen={ setContactForm }
 								openInContactPage={ openInContactPage }
-								setHeaderText={ setHeaderText }
 							/>
 						)
 					}
-					headerText={ headerText }
 					handleClose={ () => setIsHelpCenterVisible( false ) }
-					footerContent={ footerContent }
 				/>
 			) }
 		</Masterbar>

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -18,7 +18,6 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Item from './item';
 import Masterbar from './masterbar';
-import type { Article } from 'calypso/blocks/inline-help/inline-help-center-types';
 
 interface Props {
 	title: string;
@@ -47,7 +46,6 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 	const { responseCart, replaceProductsInCart } = useShoppingCart( cartKey );
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 	const [ isHelpCenterVisible, setIsHelpCenterVisible ] = useState( false );
-	const [ selectedArticle, setSelectedArticle ] = useState< Article | null >( null );
 	const [ contactForm, setContactForm ] = useState( null );
 	const [ openInContactPage, setOpenInContactPage ] = useState< boolean >( false );
 
@@ -136,8 +134,6 @@ const CheckoutMasterbar: FunctionComponent< Props > = ( {
 							/>
 						) : (
 							<InlineHelpCenterContent
-								selectedArticle={ selectedArticle }
-								setSelectedArticle={ setSelectedArticle }
 								setContactFormOpen={ setContactForm }
 								openInContactPage={ openInContactPage }
 							/>

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -13,10 +13,11 @@ import { SitePickerDropDown } from '@automattic/site-picker';
 import { TextControl, CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { Icon, page as pageIcon } from '@wordpress/icons';
 /**
  * Internal Dependencies
  */
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { STORE_KEY } from '../store';
 import { SitePicker } from '../types';
 import { BackButton } from './back-button';
@@ -79,6 +80,7 @@ interface ContactFormProps {
 	onGoHome: () => void;
 	siteId: number | null;
 	onPopupOpen?: () => void;
+	setHeaderText: ( content: React.ReactElement | string ) => void;
 }
 
 const POPUP_TOP_BAR_HEIGHT = 60;
@@ -105,7 +107,12 @@ function openPopup( event: React.MouseEvent< HTMLButtonElement > ): Window {
 	return popup;
 }
 
-const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHome } ) => {
+const ContactForm: React.FC< ContactFormProps > = ( {
+	mode,
+	onBackClick,
+	onGoHome,
+	setHeaderText,
+} ) => {
 	const [ openChat, setOpenChat ] = useState( false );
 	const [ contactSuccess, setContactSuccess ] = useState( false );
 	const [ forumTopicUrl, setForumTopicUrl ] = useState( '' );
@@ -141,6 +148,29 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 			setUserDeclaredSite( userDeclaredSite );
 		}
 	}, [ userDeclaredSite, setUserDeclaredSite ] );
+
+	useEffect( () => {
+		switch ( mode ) {
+			case 'CHAT':
+				if ( openChat ) {
+					setHeaderText(
+						<>
+							<Icon icon={ pageIcon } />
+							{ __( 'Live chat', 'full-site-editing' ) }
+						</>
+					);
+				} else {
+					setHeaderText( __( 'Start live chat', 'full-site-editing' ) );
+				}
+				break;
+			case 'EMAIL':
+				setHeaderText( __( 'Send us an email', 'full-site-editing' ) );
+				break;
+			case 'FORUM':
+				setHeaderText( __( 'Ask in our community forums', 'full-site-editing' ) );
+				break;
+		}
+	}, [ mode, openChat, setHeaderText ] );
 
 	const { hasCookies, isLoading: loadingCookies } = useHas3PC();
 

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -14,10 +14,11 @@ import { TextControl, CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, page as pageIcon } from '@wordpress/icons';
+import React, { useEffect, useState, useContext } from 'react';
 /**
  * Internal Dependencies
  */
-import React, { useEffect, useState } from 'react';
+import { HelpCenterContext } from '../help-center-context';
 import { STORE_KEY } from '../store';
 import { SitePicker } from '../types';
 import { BackButton } from './back-button';
@@ -80,7 +81,6 @@ interface ContactFormProps {
 	onGoHome: () => void;
 	siteId: number | null;
 	onPopupOpen?: () => void;
-	setHeaderText: ( content: React.ReactElement | string ) => void;
 }
 
 const POPUP_TOP_BAR_HEIGHT = 60;
@@ -107,12 +107,7 @@ function openPopup( event: React.MouseEvent< HTMLButtonElement > ): Window {
 	return popup;
 }
 
-const ContactForm: React.FC< ContactFormProps > = ( {
-	mode,
-	onBackClick,
-	onGoHome,
-	setHeaderText,
-} ) => {
+const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHome } ) => {
 	const [ openChat, setOpenChat ] = useState( false );
 	const [ contactSuccess, setContactSuccess ] = useState( false );
 	const [ forumTopicUrl, setForumTopicUrl ] = useState( '' );
@@ -123,7 +118,7 @@ const ContactForm: React.FC< ContactFormProps > = ( {
 	const [ sitePickerChoice, setSitePickerChoice ] = useState< 'CURRENT_SITE' | 'OTHER_SITE' >(
 		'CURRENT_SITE'
 	);
-
+	const { setHeaderText } = useContext( HelpCenterContext );
 	const { selectedSite, subject, message, userDeclaredSiteUrl } = useSelect( ( select ) => {
 		return {
 			selectedSite: select( STORE_KEY ).getSite(),

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -5,11 +5,12 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Card } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { useState, FC } from 'react';
+import React, { useState, FC } from 'react';
 import Draggable, { DraggableProps } from 'react-draggable';
 /**
  * Internal Dependencies
  */
+import { HelpCenterContext } from '../help-center-context';
 import HelpCenterContent from './help-center-content';
 import HelpCenterFooter from './help-center-footer';
 import HelpCenterHeader from './help-center-header';
@@ -29,13 +30,15 @@ const OptionalDraggable: FC< OptionalDraggableProps > = ( { draggable, ...props 
 const HelpCenterContainer: React.FC< Container > = ( {
 	content,
 	handleClose,
-	headerText,
-	footerContent,
+	defaultHeaderText,
+	defaultFooterContext,
 } ) => {
 	const { __ } = useI18n();
 	const [ isMinimized, setIsMinimized ] = useState( false );
 	const [ isVisible, setIsVisible ] = useState( true );
 	const isMobile = useMobileBreakpoint();
+	const [ headerText, setHeaderText ] = useState< React.ReactNode >( defaultHeaderText );
+	const [ footerContent, setFooterContent ] = useState< React.ReactNode >( defaultFooterContext );
 	const classNames = classnames( 'help-center__container', isMobile ? 'is-mobile' : 'is-desktop', {
 		'is-minimized': isMinimized,
 		'no-footer': ! footerContent,
@@ -68,15 +71,19 @@ const HelpCenterContainer: React.FC< Container > = ( {
 			bounds="body"
 		>
 			<Card className={ classNames } { ...animationProps }>
-				<HelpCenterHeader
-					isMinimized={ isMinimized }
-					onMinimize={ () => setIsMinimized( true ) }
-					onMaximize={ () => setIsMinimized( false ) }
-					onDismiss={ onDismiss }
-					headerText={ header }
-				/>
-				<HelpCenterContent isMinimized={ isMinimized } content={ content } />
-				{ footerContent && ! isMinimized && <HelpCenterFooter footerContent={ footerContent } /> }
+				<HelpCenterContext.Provider
+					value={ { headerText, setHeaderText, footerContent, setFooterContent } }
+				>
+					<HelpCenterHeader
+						isMinimized={ isMinimized }
+						onMinimize={ () => setIsMinimized( true ) }
+						onMaximize={ () => setIsMinimized( false ) }
+						onDismiss={ onDismiss }
+						headerText={ header }
+					/>
+					<HelpCenterContent isMinimized={ isMinimized } content={ content } />
+					{ footerContent && ! isMinimized && <HelpCenterFooter footerContent={ footerContent } /> }
+				</HelpCenterContext.Provider>
 			</Card>
 		</OptionalDraggable>
 	);

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -11,10 +11,10 @@ import Draggable, { DraggableProps } from 'react-draggable';
  * Internal Dependencies
  */
 import { HelpCenterContext } from '../help-center-context';
+import { Article, Container } from '../types';
 import HelpCenterContent from './help-center-content';
 import HelpCenterFooter from './help-center-footer';
 import HelpCenterHeader from './help-center-header';
-import type { Container } from '../types';
 
 interface OptionalDraggableProps extends Partial< DraggableProps > {
 	draggable: boolean;
@@ -31,14 +31,15 @@ const HelpCenterContainer: React.FC< Container > = ( {
 	content,
 	handleClose,
 	defaultHeaderText,
-	defaultFooterContext,
+	defaultFooterContent,
 } ) => {
 	const { __ } = useI18n();
 	const [ isMinimized, setIsMinimized ] = useState( false );
 	const [ isVisible, setIsVisible ] = useState( true );
 	const isMobile = useMobileBreakpoint();
 	const [ headerText, setHeaderText ] = useState< React.ReactNode >( defaultHeaderText );
-	const [ footerContent, setFooterContent ] = useState< React.ReactNode >( defaultFooterContext );
+	const [ footerContent, setFooterContent ] = useState< React.ReactNode >( defaultFooterContent );
+	const [ selectedArticle, setSelectedArticle ] = useState< Article | null >( null );
 	const classNames = classnames( 'help-center__container', isMobile ? 'is-mobile' : 'is-desktop', {
 		'is-minimized': isMinimized,
 		'no-footer': ! footerContent,
@@ -72,7 +73,14 @@ const HelpCenterContainer: React.FC< Container > = ( {
 		>
 			<Card className={ classNames } { ...animationProps }>
 				<HelpCenterContext.Provider
-					value={ { headerText, setHeaderText, footerContent, setFooterContent } }
+					value={ {
+						headerText,
+						setHeaderText,
+						footerContent,
+						setFooterContent,
+						selectedArticle,
+						setSelectedArticle,
+					} }
 				>
 					<HelpCenterHeader
 						isMinimized={ isMinimized }

--- a/packages/help-center/src/components/help-center-footer.tsx
+++ b/packages/help-center/src/components/help-center-footer.tsx
@@ -1,9 +1,9 @@
 import { CardFooter } from '@wordpress/components';
 import classnames from 'classnames';
-import { ReactElement } from 'react';
+import type { ReactNode } from 'react';
 
 interface Props {
-	footerContent: ReactElement;
+	footerContent: ReactNode;
 }
 
 const HelpCenterFooter: React.FC< Props > = ( { footerContent } ) => {

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -50,7 +50,7 @@ const HelpCenterMobileHeader: React.FC< Header > = ( {
 	return (
 		<CardHeader className={ classNames }>
 			<Flex>
-				<p style={ { fontSize: 14, fontWeight: 500 } }>
+				<p style={ { fontSize: 14, fontWeight: 500, display: 'flex', alignItems: 'center' } }>
 					{ headerText }
 					<span
 						className="help-center-header__a8c-only-badge"

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -15,7 +15,7 @@ const HelpCenter: React.FC< Container > = ( {
 	content,
 	handleClose,
 	defaultHeaderText,
-	defaultFooterContext,
+	defaultFooterContent,
 } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
 
@@ -38,7 +38,7 @@ const HelpCenter: React.FC< Container > = ( {
 			handleClose={ handleClose }
 			content={ content }
 			defaultHeaderText={ defaultHeaderText }
-			defaultFooterContext={ defaultFooterContext }
+			defaultFooterContent={ defaultFooterContent }
 		/>,
 		portalParent
 	);

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -14,8 +14,8 @@ import '../styles.scss';
 const HelpCenter: React.FC< Container > = ( {
 	content,
 	handleClose,
-	headerText,
-	footerContent,
+	defaultHeaderText,
+	defaultFooterContext,
 } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
 
@@ -37,8 +37,8 @@ const HelpCenter: React.FC< Container > = ( {
 		<HelpCenterContainer
 			handleClose={ handleClose }
 			content={ content }
-			headerText={ headerText }
-			footerContent={ footerContent }
+			defaultHeaderText={ defaultHeaderText }
+			defaultFooterContext={ defaultFooterContext }
 		/>,
 		portalParent
 	);

--- a/packages/help-center/src/help-center-context.ts
+++ b/packages/help-center/src/help-center-context.ts
@@ -1,17 +1,24 @@
 import React, { ReactNode } from 'react';
+import { Article } from './types';
 
 export const HelpCenterContext = React.createContext< {
 	headerText: ReactNode;
 	setHeaderText: ( newHeaderText: ReactNode ) => void;
 	footerContent: ReactNode;
 	setFooterContent: ( content: ReactNode ) => void;
+	selectedArticle?: Article | null;
+	setSelectedArticle: ( article: Article ) => void;
 } >( {
 	headerText: '',
 	footerContent: null,
+	selectedArticle: null,
 	setHeaderText( text ) {
 		return text;
 	},
 	setFooterContent() {
+		return;
+	},
+	setSelectedArticle() {
 		return;
 	},
 } );

--- a/packages/help-center/src/help-center-context.ts
+++ b/packages/help-center/src/help-center-context.ts
@@ -1,0 +1,17 @@
+import React, { ReactNode } from 'react';
+
+export const HelpCenterContext = React.createContext< {
+	headerText: ReactNode;
+	setHeaderText: ( newHeaderText: ReactNode ) => void;
+	footerContent: ReactNode;
+	setFooterContent: ( content: ReactNode ) => void;
+} >( {
+	headerText: '',
+	footerContent: null,
+	setHeaderText( text ) {
+		return text;
+	},
+	setFooterContent() {
+		return;
+	},
+} );

--- a/packages/help-center/src/index.ts
+++ b/packages/help-center/src/index.ts
@@ -5,3 +5,4 @@ export { SuccessScreen } from './components/ticket-success-screen';
 export { BackButton } from './components/back-button';
 export { default as ContactForm } from './components/help-center-contact-form';
 export { useHCWindowCommunicator } from './happychat-window-communicator';
+export { HelpCenterContext } from './help-center-context';

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -1,11 +1,11 @@
 import { SiteDetails } from '@automattic/data-stores/dist/types/site';
-import { ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
 
 export interface Container {
 	content: ReactElement;
 	handleClose: () => void;
-	headerText?: string;
-	footerContent?: ReactElement;
+	defaultHeaderText?: string;
+	defaultFooterContext?: ReactElement;
 }
 
 export interface Content {
@@ -18,7 +18,7 @@ export interface Header {
 	onMinimize?: () => void;
 	onMaximize?: () => void;
 	onDismiss: () => void;
-	headerText: string;
+	headerText: ReactNode;
 }
 
 export interface SuccessScreenProps {

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -5,7 +5,7 @@ export interface Container {
 	content: ReactElement;
 	handleClose: () => void;
 	defaultHeaderText?: string;
-	defaultFooterContext?: ReactElement;
+	defaultFooterContent?: ReactElement;
 }
 
 export interface Content {
@@ -34,3 +34,9 @@ export interface SitePicker {
 
 // ended means the user closed the popup
 export type WindowState = 'open' | 'closed' | 'blurred' | 'ended';
+
+export interface Article {
+	title: string;
+	link?: string;
+	icon?: string;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Context: p1652194080777319/1652191736.493179-slack-C02T4NVL4JJ
![image](https://user-images.githubusercontent.com/52076348/167677353-f5f09a3f-0610-42be-a841-076d376ab7c7.png)

#### Testing instructions

Added the page title to the minimized help center header: 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* checkout
* `yarn dev --sync` from ETK
* open the help center
* verify that the titles match the screenshot above