### PR TITLE
HelpCenter: add popover for domain sharing option

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -118,6 +118,10 @@
 .popover.is-top-left {
 	z-index: 9999;
 
+	.popover__arrow {
+		z-index: 1;
+	}
+
 	.popover__inner span {
 		display: block;
 		padding: 16px;

--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -114,3 +114,21 @@
 		display: none;
 	}
 }
+
+.popover.is-top-left {
+	z-index: 9999;
+
+	.popover__inner span {
+		display: block;
+		padding: 16px;
+	}
+}
+
+.help-center-contact-form__domain-sharing .components-checkbox-control {
+	display: flex;
+
+	.components-base-control__help {
+		margin: 0;
+		padding-left: 8px;
+	}
+}

--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -130,5 +130,9 @@
 	.components-base-control__help {
 		margin: 0;
 		padding-left: 8px;
+
+		svg {
+			fill: var( --studio-gray-50 );
+		}
 	}
 }

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -262,8 +262,6 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 					aria-haspopup
 					aria-label={ __( 'More information' ) }
 					onClick={ () => setOpen( ! isOpen ) }
-					onMouseEnter={ () => setOpen( true ) }
-					onMouseLeave={ () => setOpen( false ) }
 				>
 					<Icon icon={ info } size={ 18 } />
 				</Button>
@@ -349,16 +347,19 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 				/>
 			</section>
 
-			{ mode === 'FORUM' && <section></section> }
+			{ mode === 'FORUM' && (
+				<section>
+					<div className="help-center-contact-form__domain-sharing">
+						<CheckboxControl
+							checked={ hideSiteInfo }
+							label={ __( 'Don’t display my site’s URL publicly', 'full-site-editing' ) }
+							help={ <InfoTip /> }
+							onChange={ ( value ) => setHideSiteInfo( value ) }
+						/>
+					</div>
+				</section>
+			) }
 			<section>
-				<div className="help-center-contact-form__domain-sharing">
-					<CheckboxControl
-						checked={ hideSiteInfo }
-						label={ __( 'Don’t display my site’s URL publicly', 'full-site-editing' ) }
-						help={ <InfoTip /> }
-						onChange={ ( value ) => setHideSiteInfo( value ) }
-					/>
-				</div>
 				<Button
 					disabled={ isLoading || ! supportSite || ! message }
 					onClick={ handleCTA }

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { Button } from '@automattic/components';
+import { Button, Popover } from '@automattic/components';
 import {
 	useHas3PC,
 	useSubmitTicketMutation,
@@ -13,7 +13,7 @@ import { SitePickerDropDown } from '@automattic/site-picker';
 import { TextControl, CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { Icon, page as pageIcon } from '@wordpress/icons';
+import { Icon, info, page as pageIcon } from '@wordpress/icons';
 import React, { useEffect, useState, useContext } from 'react';
 /**
  * Internal Dependencies
@@ -250,6 +250,36 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 		return <SuccessScreen forumTopicUrl={ forumTopicUrl } onBack={ onGoHome } />;
 	}
 
+	const InfoTip = () => {
+		const [ ref, setRef ] = useState< any >();
+		const [ isOpen, setOpen ] = useState( false );
+
+		return (
+			<>
+				<Button
+					borderless
+					ref={ ( reference ) => ref !== reference && setRef( reference ) }
+					aria-haspopup
+					aria-label={ __( 'More information' ) }
+					onClick={ () => setOpen( ! isOpen ) }
+					onMouseEnter={ () => setOpen( true ) }
+					onMouseLeave={ () => setOpen( false ) }
+				>
+					<Icon icon={ info } size={ 18 } />
+				</Button>
+				<Popover isVisible={ isOpen } context={ ref } position="top left">
+					<span>
+						This may result in a longer response time,
+						<br />
+						but WordPress.com staff in the forums will
+						<br />
+						still be able to view your site's URL.
+					</span>
+				</Popover>
+			</>
+		);
+	};
+
 	return (
 		<main className="help-center-contact-form">
 			<header>
@@ -321,11 +351,14 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 
 			{ mode === 'FORUM' && (
 				<section>
-					<CheckboxControl
-						checked={ hideSiteInfo }
-						label={ __( 'Don’t display my site’s URL publicly', 'full-site-editing' ) }
-						onChange={ ( value ) => setHideSiteInfo( value ) }
-					/>
+					<div className="help-center-contact-form__domain-sharing">
+						<CheckboxControl
+							checked={ hideSiteInfo }
+							label={ __( 'Don’t display my site’s URL publicly', 'full-site-editing' ) }
+							help={ <InfoTip /> }
+							onChange={ ( value ) => setHideSiteInfo( value ) }
+						/>
+					</div>
 				</section>
 			) }
 			<section>

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -349,19 +349,16 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 				/>
 			</section>
 
-			{ mode === 'FORUM' && (
-				<section>
-					<div className="help-center-contact-form__domain-sharing">
-						<CheckboxControl
-							checked={ hideSiteInfo }
-							label={ __( 'Don’t display my site’s URL publicly', 'full-site-editing' ) }
-							help={ <InfoTip /> }
-							onChange={ ( value ) => setHideSiteInfo( value ) }
-						/>
-					</div>
-				</section>
-			) }
+			{ mode === 'FORUM' && <section></section> }
 			<section>
+				<div className="help-center-contact-form__domain-sharing">
+					<CheckboxControl
+						checked={ hideSiteInfo }
+						label={ __( 'Don’t display my site’s URL publicly', 'full-site-editing' ) }
+						help={ <InfoTip /> }
+						onChange={ ( value ) => setHideSiteInfo( value ) }
+					/>
+				</div>
 				<Button
 					disabled={ isLoading || ! supportSite || ! message }
 					onClick={ handleCTA }


### PR DESCRIPTION
## Changes proposed in this Pull Request

This adds an "info" icon to the end of the checkbox for "Don’t display my site’s URL publicly" that displays more info in a popup: "This may result in a longer response time, but WordPress.com staff in the forums will still be able to view your site's URL."

### 2 questions...

1. If the screen is short, then the help-center jumps back to the top when you toggle the popover. Not sure how to prevent this.
2. Currently it activates on hover or click. Do we need both or should it be one or the other?

<img width="358" alt="Markup 2022-05-10 at 18 34 27" src="https://user-images.githubusercontent.com/33258733/167678594-86fa183f-a66f-4b92-94c5-981a483b2941.png">

<img width="314" alt="Markup 2022-05-10 at 18 38 51" src="https://user-images.githubusercontent.com/33258733/167679398-12ad45e4-c306-4c38-a7e6-49aa162d8d39.png">

## Testing instructions

1. Pull branch and `cd apps/editing-toolkit && yarn dev --sync`
3. Log in to your sandbox and pull up a free user account
4. Navigate to the help center and to the forum contact form.
5. Observe the hover magic.
