### PR TITLE
Jetpack Benefits: Use feature checks for plan features

### DIFF
--- a/client/blocks/jetpack-benefits/general-benefits.tsx
+++ b/client/blocks/jetpack-benefits/general-benefits.tsx
@@ -1,11 +1,12 @@
 import {
-	isBusinessPlan,
-	isCompletePlan,
-	isJetpackPlanSlug,
-	isPersonalPlan,
-	isPremiumPlan,
-	isSecurityDailyPlan,
-	isSecurityRealTimePlan,
+	planHasFeature,
+	FEATURE_GOOGLE_ANALYTICS,
+	FEATURE_PREMIUM_SUPPORT,
+	FEATURE_SIMPLE_PAYMENTS,
+	FEATURE_STANDARD_SECURITY_TOOLS,
+	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
+	FEATURE_WORDADS_INSTANT,
+	WPCOM_FEATURES_VIDEOPRESS,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
@@ -20,27 +21,12 @@ interface Props {
 	productSlug: string;
 }
 
-const JetpackGeneralBenefits: React.FC< Props > = ( props ) => {
+const JetpackGeneralBenefits: React.FC< Props > = ( { productSlug } ) => {
 	const translate = useTranslate();
-	const { productSlug } = props;
-	const hasSecurityDailyPlan = isSecurityDailyPlan( productSlug );
-	const hasSecurityRealTimePlan = isSecurityRealTimePlan( productSlug );
-	const hasCompletePlan = isCompletePlan( productSlug );
-	const hasPersonalPlan = isPersonalPlan( productSlug );
-	const hasPremiumPlan = isPremiumPlan( productSlug );
-	const hasBusinessPlan = isBusinessPlan( productSlug );
-	const hasJetpackPlanSlug = isJetpackPlanSlug( productSlug );
 	const benefits = [];
 
 	// Priority Support
-	if (
-		hasSecurityDailyPlan ||
-		hasSecurityRealTimePlan ||
-		hasCompletePlan ||
-		hasPersonalPlan ||
-		hasPremiumPlan ||
-		hasBusinessPlan
-	) {
+	if ( planHasFeature( productSlug, FEATURE_PREMIUM_SUPPORT ) ) {
 		benefits.push(
 			<React.Fragment>
 				{ translate(
@@ -56,15 +42,7 @@ const JetpackGeneralBenefits: React.FC< Props > = ( props ) => {
 	}
 
 	// Payment Collection
-	// Ad Program
-	// Google Analytics
-	if (
-		hasSecurityDailyPlan ||
-		hasSecurityRealTimePlan ||
-		hasCompletePlan ||
-		hasPremiumPlan ||
-		hasBusinessPlan
-	) {
+	if ( planHasFeature( productSlug, FEATURE_SIMPLE_PAYMENTS ) ) {
 		benefits.push(
 			<React.Fragment>
 				{ translate( 'The ability to {{strong}}collect payments{{/strong}}.', {
@@ -74,6 +52,10 @@ const JetpackGeneralBenefits: React.FC< Props > = ( props ) => {
 				} ) }
 			</React.Fragment>
 		);
+	}
+
+	// Ad Program
+	if ( planHasFeature( productSlug, FEATURE_WORDADS_INSTANT ) ) {
 		benefits.push(
 			<React.Fragment>
 				{ translate( 'The {{strong}}Ad program{{/strong}} for WordPress.', {
@@ -83,6 +65,10 @@ const JetpackGeneralBenefits: React.FC< Props > = ( props ) => {
 				} ) }
 			</React.Fragment>
 		);
+	}
+
+	// Google Analytics
+	if ( planHasFeature( productSlug, FEATURE_GOOGLE_ANALYTICS ) ) {
 		benefits.push(
 			<React.Fragment>
 				{ translate( 'The {{strong}}Google Analytics{{/strong}} integration.', {
@@ -95,7 +81,7 @@ const JetpackGeneralBenefits: React.FC< Props > = ( props ) => {
 	}
 
 	// 13GB of video hosting
-	if ( hasPremiumPlan || hasSecurityDailyPlan ) {
+	if ( planHasFeature( productSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PRO ) ) {
 		benefits.push(
 			<React.Fragment>
 				{ translate( 'Up to 13GB of {{strong}}high-speed video hosting{{/strong}}.', {
@@ -108,7 +94,7 @@ const JetpackGeneralBenefits: React.FC< Props > = ( props ) => {
 	}
 
 	// Unlimited Video Hosting
-	if ( hasBusinessPlan || hasSecurityRealTimePlan || hasCompletePlan ) {
+	if ( planHasFeature( productSlug, WPCOM_FEATURES_VIDEOPRESS ) ) {
 		benefits.push(
 			<React.Fragment>
 				{ translate( 'Unlimited {{strong}}high-speed video hosting{{/strong}}.', {
@@ -121,7 +107,7 @@ const JetpackGeneralBenefits: React.FC< Props > = ( props ) => {
 	}
 
 	// General benefits of all Jetpack Plans (brute force protection, CDN)
-	if ( hasJetpackPlanSlug ) {
+	if ( planHasFeature( productSlug, FEATURE_STANDARD_SECURITY_TOOLS ) ) {
 		benefits.push(
 			<React.Fragment>
 				{ translate(

--- a/client/blocks/jetpack-benefits/general-benefits.tsx
+++ b/client/blocks/jetpack-benefits/general-benefits.tsx
@@ -1,12 +1,12 @@
 import {
 	planHasFeature,
 	FEATURE_GOOGLE_ANALYTICS,
+	FEATURE_JETPACK_VIDEOPRESS,
 	FEATURE_PREMIUM_SUPPORT,
 	FEATURE_SIMPLE_PAYMENTS,
 	FEATURE_STANDARD_SECURITY_TOOLS,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 	FEATURE_WORDADS_INSTANT,
-	WPCOM_FEATURES_VIDEOPRESS,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
@@ -80,11 +80,11 @@ const JetpackGeneralBenefits: React.FC< Props > = ( { productSlug } ) => {
 		);
 	}
 
-	// 13GB of video hosting
-	if ( planHasFeature( productSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PRO ) ) {
+	// 1TB of Video Hosting
+	if ( planHasFeature( productSlug, FEATURE_JETPACK_VIDEOPRESS ) ) {
 		benefits.push(
 			<React.Fragment>
-				{ translate( 'Up to 13GB of {{strong}}high-speed video hosting{{/strong}}.', {
+				{ translate( 'Up to 1TB of {{strong}}high-speed video hosting{{/strong}}.', {
 					components: {
 						strong: <strong />,
 					},
@@ -92,12 +92,11 @@ const JetpackGeneralBenefits: React.FC< Props > = ( { productSlug } ) => {
 			</React.Fragment>
 		);
 	}
-
-	// Unlimited Video Hosting
-	if ( planHasFeature( productSlug, WPCOM_FEATURES_VIDEOPRESS ) ) {
+	// 13GB of Video Hosting
+	else if ( planHasFeature( productSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PRO ) ) {
 		benefits.push(
 			<React.Fragment>
-				{ translate( 'Unlimited {{strong}}high-speed video hosting{{/strong}}.', {
+				{ translate( 'Up to 13GB of {{strong}}high-speed video hosting{{/strong}}.', {
 					components: {
 						strong: <strong />,
 					},

--- a/client/blocks/jetpack-benefits/general-benefits.tsx
+++ b/client/blocks/jetpack-benefits/general-benefits.tsx
@@ -4,7 +4,6 @@ import {
 	FEATURE_JETPACK_VIDEOPRESS,
 	FEATURE_PREMIUM_SUPPORT,
 	FEATURE_SIMPLE_PAYMENTS,
-	FEATURE_STANDARD_SECURITY_TOOLS,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 	FEATURE_WORDADS_INSTANT,
 } from '@automattic/calypso-products';
@@ -106,32 +105,26 @@ const JetpackGeneralBenefits: React.FC< Props > = ( { productSlug } ) => {
 	}
 
 	// General benefits of all Jetpack Plans (brute force protection, CDN)
-	if ( planHasFeature( productSlug, FEATURE_STANDARD_SECURITY_TOOLS ) ) {
-		benefits.push(
-			<React.Fragment>
-				{ translate(
-					'Brute force {{strong}}attack protection{{/strong}} and {{strong}}downtime monitoring{{/strong}}.',
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				) }
-			</React.Fragment>
-		);
-	}
+	benefits.push(
+		<React.Fragment>
+			{ translate(
+				'Brute force {{strong}}attack protection{{/strong}} and {{strong}}downtime monitoring{{/strong}}.',
+				{
+					components: {
+						strong: <strong />,
+					},
+				}
+			) }
+		</React.Fragment>
+	);
 
-	if ( benefits.length > 0 ) {
-		return (
-			<ul className="jetpack-benefits__general-benefit-list">
-				{ benefits.map( ( benefit, idx ) => {
-					return <li key={ idx }>{ benefit }</li>;
-				} ) }
-			</ul>
-		);
-	}
-
-	return null;
+	return (
+		<ul className="jetpack-benefits__general-benefit-list">
+			{ benefits.map( ( benefit, idx ) => {
+				return <li key={ idx }>{ benefit }</li>;
+			} ) }
+		</ul>
+	);
 };
 
 export default JetpackGeneralBenefits;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes plan checks to feature checks for Jetpack Benefits.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Visual Testing**
- Make sure your Wordpress.com account has at least one site (ideally a test site) with a Jetpack plan or product
- Visit the calypso.live link that contains this branch (linked by the matticbot below)
- Using the site switcher, select your site and navigate to Upgrades > Purchases
- Select the Individual Jetpack product you want to cancel from this page, this will take you to the individual purchase page
- From the Individual purchase page, click the button at the bottom of the page to remove the purchase:
![Screen Shot 2021-07-20 at 10 11 24 AM](https://user-images.githubusercontent.com/18016357/126338989-f701dafd-f47e-4551-9c8d-ff4b076b1b55.png)
- This will present you with the new cancellation flow modal. Each step in the flow is outlined in more detail below.

Jetpack Benefits Step
When the cancellation flow first opens, the first step will show some of the benefits Jetpack provides for the current plan or product. These can vary by plan or product. This PR changed the plan checks for the "additional benefits" at the bottom. Try testing multiple sites with different plans or products to see different outputs.

Jetpack Complete Example:
![image](https://user-images.githubusercontent.com/5714212/131520308-4907f624-3846-49df-85be-8a48012ee54c.png)

