### PR TITLE
Stepper: Add inline help component

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/style.scss
@@ -46,6 +46,15 @@ $input-max-width: 448px;
     .podcast-title__explanation {
         display: flex;
         flex-direction: column;
+        input[type='text'] {
+            @include break-medium {
+                font-size: 4rem; /* stylelint-disable-line scales/font-sizes */
+            }
+            padding: 0;
+            border: 0;
+            line-height: 1;
+        }
+
     }
 
     input[type='text'],

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -8,6 +8,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { requestAllBlogsAccess } from 'wpcom-proxy-request';
+import AsyncLoad from 'calypso/components/async-load';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
 import { createReduxStore } from 'calypso/state';
 import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
@@ -79,6 +80,7 @@ window.AppBoot = async () => {
 					<BrowserRouter basename="setup">
 						<FlowWrapper />
 					</BrowserRouter>
+					<AsyncLoad require="calypso/blocks/inline-help" placeholder={ null } />
 				</QueryClientProvider>
 			</Provider>
 		</LocaleContext>,

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -11,10 +11,13 @@ import { requestAllBlogsAccess } from 'wpcom-proxy-request';
 import AsyncLoad from 'calypso/components/async-load';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
 import { createReduxStore } from 'calypso/state';
+import { setCurrentUser } from 'calypso/state/current-user/actions';
+import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
 import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
 import { loadPersistedState } from 'calypso/state/persisted-state';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
+import { requestSites } from 'calypso/state/sites/actions';
 import { LocaleContext } from '../gutenboarding/components/locale-context';
 import { WindowLocaleEffectManager } from '../gutenboarding/components/window-locale-effect-manager';
 import { setupWpDataDebug } from '../gutenboarding/devtools';
@@ -31,6 +34,12 @@ function generateGetSuperProps() {
 		site_id_label: 'wpcom',
 		client: config( 'client_slug' ),
 	} );
+}
+
+function setupHappyChat( reduxStore: any, user: CurrentUser ) {
+	reduxStore.dispatch( requestHappychatEligibility() );
+	reduxStore.dispatch( setCurrentUser( user ) );
+	reduxStore.dispatch( requestSites() );
 }
 
 const FlowWrapper: React.FC = () => {
@@ -71,6 +80,7 @@ window.AppBoot = async () => {
 	const initialState = getInitialState( initialReducer, userId );
 	const reduxStore = createReduxStore( initialState, initialReducer );
 	setStore( reduxStore, getStateFromCache( userId ) );
+	user && setupHappyChat( reduxStore, user as CurrentUser );
 
 	ReactDom.render(
 		<LocaleContext>


### PR DESCRIPTION
This should enable access to inline help across all the Stepper framework.

#### Testing
1. Apply this PR.
2. Navigate through different stepper flows and verify that you can see a help button on the bottom right of the screen. 
<img width="150" alt="image" src="https://user-images.githubusercontent.com/375980/167689371-cd147c7c-eee1-4111-a9dc-66b8fb6b9861.png">
3. Open the inline help to verify everything works as expected. <img width="501" alt="image" src="https://user-images.githubusercontent.com/375980/167689410-f50cdd2f-a13e-4063-9383-97a5db973f27.png">

Closes https://github.com/Automattic/wp-calypso/issues/63354