### PR TITLE
Jetpack section: Use feature checks

### DIFF
--- a/client/components/jetpack/business-at-switch/index.tsx
+++ b/client/components/jetpack/business-at-switch/index.tsx
@@ -38,7 +38,7 @@ const Placeholder = () => (
 const BusinessATSwitch = ( { UpsellComponent }: Props ): ReactElement => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 
-	const featuresLoaded: boolean = useSelector(
+	const featuresNotLoaded: boolean = useSelector(
 		( state ) =>
 			null === getFeaturesBySiteId( state, siteId ) && ! isRequestingSiteFeatures( state, siteId )
 	);
@@ -47,7 +47,7 @@ const BusinessATSwitch = ( { UpsellComponent }: Props ): ReactElement => {
 	);
 
 	// If we're not sure, show a loading screen.
-	if ( ! featuresLoaded ) {
+	if ( featuresNotLoaded ) {
 		return (
 			<Main className="business-at-switch__loading">
 				<QuerySiteFeatures siteIds={ [ siteId ] } />

--- a/client/components/jetpack/business-at-switch/index.tsx
+++ b/client/components/jetpack/business-at-switch/index.tsx
@@ -1,12 +1,14 @@
+import { WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import { ReactElement, ComponentType } from 'react';
 import { useSelector } from 'react-redux';
-import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WPCOMBusinessAT from 'calypso/components/jetpack/wpcom-business-at';
 import Main from 'calypso/components/main';
-import isSiteOnAtomicPlan from 'calypso/state/selectors/is-site-on-atomic-plan';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
+import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -36,16 +38,19 @@ const Placeholder = () => (
 const BusinessATSwitch = ( { UpsellComponent }: Props ): ReactElement => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 
-	const currentPlan: Record< string, unknown > | null = useSelector( ( state ) =>
-		getCurrentPlan( state, siteId )
+	const featuresLoaded: boolean = useSelector(
+		( state ) =>
+			null === getFeaturesBySiteId( state, siteId ) && ! isRequestingSiteFeatures( state, siteId )
 	);
-	const isATPlan = useSelector( ( state ) => isSiteOnAtomicPlan( state, siteId ) );
+	const canTransfer: boolean = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC )
+	);
 
 	// If we're not sure, show a loading screen.
-	if ( ! currentPlan ) {
+	if ( ! featuresLoaded ) {
 		return (
 			<Main className="business-at-switch__loading">
-				<QuerySitePlans siteId={ siteId } />
+				<QuerySiteFeatures siteIds={ [ siteId ] } />
 				<Placeholder />
 			</Main>
 		);
@@ -53,7 +58,7 @@ const BusinessATSwitch = ( { UpsellComponent }: Props ): ReactElement => {
 
 	// We know the site is not AT as it's not Jetpack,
 	// so show the activation for Atomic plans.
-	if ( isATPlan ) {
+	if ( canTransfer ) {
 		return <WPCOMBusinessAT />;
 	}
 

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -214,6 +214,7 @@ export const FEATURE_SOCIAL_MEDIA_TOOLS = 'social-media-tools';
 
 // From class-wpcom-features.php in WPCOM
 export const WPCOM_FEATURES_AKISMET = 'akismet';
+export const WPCOM_FEATURES_ATOMIC = 'atomic';
 export const WPCOM_FEATURES_ANTISPAM = 'antispam';
 export const WPCOM_FEATURES_FULL_ACTIVITY_LOG = 'full-activity-log';
 export const WPCOM_FEATURES_INSTANT_SEARCH = 'instant-search';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates plan check to a feature check.
* Updates query component to query features and not plans.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prerequisite: non-Atomic Business site plan.
* Go to Jetpack > Backup or visit https://container-stoic-mccarthy.calypso.live/backup/
* Verify that you see the placeholder/loading page (you might not be able to see this if the eligibility query/request happens too fast).
* Verify that you see the Automated Transfer page.
* On sites without an Atomic-eligible plan, it should prompt you to upgrade your plan.
