### PR TITLE
Replace siteHasRealtimeBackups with siteHasFeature check

### DIFF
--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -1,3 +1,4 @@
+import { WPCOM_FEATURES_REAL_TIME_BACKUPS } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useRef } from 'react';
@@ -14,7 +15,8 @@ import {
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import { useIsDateVisible } from 'calypso/my-sites/backup/hooks';
 import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
-import { getInProgressBackupForSite, siteHasRealtimeBackups } from 'calypso/state/rewind/selectors';
+import { getInProgressBackupForSite } from 'calypso/state/rewind/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import BackupFailed from './status-card/backup-failed';
 import BackupInProgress from './status-card/backup-in-progress';
@@ -45,7 +47,9 @@ const DailyBackupStatus = ( {
 		[ dispatch, siteId ]
 	);
 
-	const hasRealtimeBackups = useSelector( ( state ) => siteHasRealtimeBackups( state, siteId ) );
+	const hasRealtimeBackups = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_REAL_TIME_BACKUPS )
+	);
 	const backupCurrentlyInProgress = useSelector( ( state ) =>
 		getInProgressBackupForSite( state, siteId )
 	);

--- a/client/components/jetpack/daily-backup-status/test/index.jsx
+++ b/client/components/jetpack/daily-backup-status/test/index.jsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { WPCOM_FEATURES_REAL_TIME_BACKUPS } from '@automattic/calypso-products';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 import {
@@ -9,7 +10,7 @@ import {
 	isSuccessfulRealtimeBackup,
 } from 'calypso/lib/jetpack/backup-utils';
 import { useIsDateVisible } from 'calypso/my-sites/backup/hooks';
-import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
+import getSiteFeatures from 'calypso/state/selectors/get-site-features';
 import DailyBackupStatus from '..';
 import BackupFailed from '../status-card/backup-failed';
 import BackupScheduled from '../status-card/backup-scheduled';
@@ -34,7 +35,7 @@ jest.mock( 'calypso/state/selectors/get-site-timezone-value' );
 jest.mock( 'calypso/state/selectors/get-site-gmt-offset' );
 
 jest.mock( 'calypso/state/selectors/get-rewind-backups' );
-jest.mock( 'calypso/state/selectors/get-rewind-capabilities' );
+jest.mock( 'calypso/state/selectors/get-site-features' );
 
 jest.mock( 'calypso/lib/jetpack/backup-utils' );
 
@@ -53,7 +54,7 @@ describe( 'DailyBackupStatus', () => {
 
 	beforeEach( () => {
 		useIsDateVisible.mockImplementation( () => () => true );
-		getRewindCapabilities.mockReset();
+		getSiteFeatures.mockReset();
 		isSuccessfulDailyBackup.mockReset();
 		isSuccessfulRealtimeBackup.mockReset();
 	} );
@@ -95,7 +96,9 @@ describe( 'DailyBackupStatus', () => {
 	} );
 
 	test( 'shows "backup failed" for Backup Real-time sites when a failed real-time backup is provided', () => {
-		getRewindCapabilities.mockImplementation( () => [ 'backup-realtime' ] );
+		getSiteFeatures.mockImplementation( () => ( {
+			active: [ WPCOM_FEATURES_REAL_TIME_BACKUPS ],
+		} ) );
 		isSuccessfulRealtimeBackup.mockImplementation( () => false );
 
 		const status = getStatus( <DailyBackupStatus selectedDate={ ARBITRARY_DATE } backup={ {} } /> );
@@ -111,7 +114,9 @@ describe( 'DailyBackupStatus', () => {
 	} );
 
 	test( 'shows "backup successful" for Backup Real-time sites when a successful real-time backup is provided', () => {
-		getRewindCapabilities.mockImplementation( () => [ 'backup-realtime' ] );
+		getSiteFeatures.mockImplementation( () => ( {
+			active: [ WPCOM_FEATURES_REAL_TIME_BACKUPS ],
+		} ) );
 		isSuccessfulRealtimeBackup.mockImplementation( () => true );
 
 		const status = getStatus( <DailyBackupStatus selectedDate={ ARBITRARY_DATE } backup={ {} } /> );

--- a/client/state/rewind/selectors/index.ts
+++ b/client/state/rewind/selectors/index.ts
@@ -6,4 +6,3 @@ export { default as getRewindSizeRequestStatus } from './get-rewind-size-request
 export { default as isRequestingRewindPolicies } from './is-requesting-rewind-policies';
 export { default as isRequestingRewindSize } from './is-requesting-rewind-size';
 export { default as siteHasBackupInProgress } from './site-has-backup-in-progress';
-export { default as siteHasRealtimeBackups } from './site-has-realtime-backups';

--- a/client/state/rewind/selectors/site-has-realtime-backups.ts
+++ b/client/state/rewind/selectors/site-has-realtime-backups.ts
@@ -1,9 +1,0 @@
-import getRewindCapabilities from 'calypso/state/selectors/get-rewind-capabilities';
-import { AppState } from 'calypso/types';
-
-const siteHasRealtimeBackups = ( state: AppState, siteId: number ): boolean => {
-	const capabilities = getRewindCapabilities( state, siteId );
-	return Array.isArray( capabilities ) && capabilities.includes( 'backup-realtime' );
-};
-
-export default siteHasRealtimeBackups;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace `siteHasRealtimeBackups` with `siteHasFeature( ...  WPCOM_FEATURES_REAL_TIME_BACKUPS )`

#### Replace this check?

I know we want to replace plan checks, but I'm not sure if getRewindCapabilities checks should be replaced. I don't know what the ultimate source of this information is, but I'm trying to find it.

Here it is: `WPCOM_REST_API_V2_Endpoint_Site_Rewind_Capabilities` -> `Jetpack\Rewind\Permissions\get_site_capabilities` -> `wp-content/lib/activity-log/rewind-permissions.php` -> `get_site_capabilities` -> `ultimately feature checks`, so it seems like a more convoluted way to get the same data

### Testing Instructions (jest)

`yarn run test-client client/components/jetpack/daily-backup-status/test/index.jsx ` 

### Testing instructions (`daily-backup-status/index.jsx`)

This PR changes how `hasRealtimeBackups` is calculated, which is used to [choose between two backup status checking methods](https://github.com/Automattic/wp-calypso/blob/6ce215454f6aa2a96c7af009470f129853e8746d/client/components/jetpack/daily-backup-status/index.jsx#L115).  For realtime backups, it checks to see if they'er successful, for daily backups, it checks to see if they're successful: [Link](https://github.com/Automattic/wp-calypso/blob/6ce215454f6aa2a96c7af009470f129853e8746d/client/lib/jetpack/backup-utils.js#L72-L90. 

There's nothing obvious to check, other than `/backup/<site>` on a Jetpack site with backups continues to work the same.

![2022-05-11_10-43](https://user-images.githubusercontent.com/937354/167891537-82294919-b1ba-4935-ac18-01f119388779.png)



Related to p4TIVU-a66-p2
