### PR TITLE
When checking out with multiple products, display refund windows separately in checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -195,8 +195,9 @@ function CheckoutSummaryFeaturesList( props: {
 				if ( isDomainProduct( product ) ) {
 					productName = product.meta;
 				} else if ( isGoogleWorkspace( product ) || isTitanMail( product ) ) {
-					if ( product.extra?.email_users?.[ 0 ] ) {
-						productName = product.extra?.email_users?.[ 0 ].email;
+					if ( product.extra?.email_users?.length ) {
+						const emailUsers = product.extra?.email_users?.map( ( user ) => user.email );
+						productName = emailUsers.join( ', ' );
 					}
 				}
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -1,14 +1,16 @@
 import {
-	isPlan,
-	isMonthly,
-	getYearlyPlanByMonthly,
 	getPlan,
+	getYearlyPlanByMonthly,
 	isDomainProduct,
 	isDomainTransfer,
-	isWpComPersonalPlan,
-	isWpComPlan,
+	isGoogleWorkspace,
+	isMonthly,
+	isPlan,
+	isTitanMail,
 	isWpComBusinessPlan,
 	isWpComEcommercePlan,
+	isWpComPersonalPlan,
+	isWpComPlan,
 	isWpComPremiumPlan,
 	isStarterPlan,
 } from '@automattic/calypso-products';
@@ -31,10 +33,9 @@ import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getPlanFeatures from '../lib/get-plan-features';
+import getRefundDays from '../lib/get-refund-days';
 import getRefundText from '../lib/get-refund-text';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -79,11 +80,7 @@ export default function WPCheckoutOrderSummary( {
 				{ isCartUpdating ? (
 					<LoadingCheckoutSummaryFeaturesList />
 				) : (
-					<CheckoutSummaryFeaturesList
-						siteId={ siteId }
-						hasMonthlyPlanInCart={ hasMonthlyPlanInCart }
-						nextDomainIsFree={ nextDomainIsFree }
-					/>
+					<CheckoutSummaryFeaturesList siteId={ siteId } nextDomainIsFree={ nextDomainIsFree } />
 				) }
 			</CheckoutSummaryFeatures>
 			{ ! isCartUpdating && ! hasRenewalInCart && plan && hasMonthlyPlanInCart && (
@@ -146,10 +143,9 @@ function SwitchToAnnualPlan( {
 
 function CheckoutSummaryFeaturesList( props: {
 	siteId: number | undefined;
-	hasMonthlyPlanInCart: boolean;
 	nextDomainIsFree: boolean;
 } ) {
-	const { hasMonthlyPlanInCart = false, siteId, nextDomainIsFree } = props;
+	const { siteId, nextDomainIsFree } = props;
 
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
@@ -163,20 +159,25 @@ function CheckoutSummaryFeaturesList( props: {
 	const plans = responseCart.products.filter( ( product ) => isPlan( product ) );
 	const hasPlanInCart = plans.length > 0;
 
-	const translate = useTranslate();
-	const isJetpackNotAtomic = useSelector( ( state ) =>
-		siteId ? isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) : undefined
+	const refundableProducts = responseCart.products.filter(
+		( product ) =>
+			product.cost &&
+			( isDomainProduct( product ) ||
+				isDomainTransfer( product ) ||
+				isPlan( product ) ||
+				isGoogleWorkspace( product ) ||
+				isTitanMail( product ) )
 	);
-
-	const showRefundText = responseCart.total_cost > 0;
-
-	let refundDays = 0;
-	if ( hasDomainsInCart && ! hasPlanInCart ) {
-		refundDays = 4;
-	} else if ( hasPlanInCart && ! hasDomainsInCart ) {
-		refundDays = hasMonthlyPlanInCart ? 7 : 14;
-	}
-	const refundText = getRefundText( refundDays, null, translate );
+	const uniqueRefundableProducts = refundableProducts.reduce< ResponseCartProduct[] >(
+		( acc, p ) => {
+			if ( ! acc.some( ( pp ) => pp.product_name === p.product_name ) ) {
+				acc.push( p );
+			}
+			return acc;
+		},
+		[]
+	);
+	const translate = useTranslate();
 
 	const hasOnlyStarterPlan =
 		plans.filter( ( plan ) => isStarterPlan( plan.product_slug ) ).length === plans.length;
@@ -196,36 +197,21 @@ function CheckoutSummaryFeaturesList( props: {
 			{ ! hasOnlyStarterPlan && (
 				<CheckoutSummaryFeaturesListItem>
 					<WPCheckoutCheckIcon id="features-list-support-text" />
-					<SupportText plans={ plans } isJetpackNotAtomic={ isJetpackNotAtomic } />
+					{ translate( 'Customer support via email' ) }
 				</CheckoutSummaryFeaturesListItem>
 			) }
 
 			{ ! hasPlanInCart && <CheckoutSummaryChatIfAvailable siteId={ siteId } /> }
 
-			{ showRefundText && (
-				<CheckoutSummaryFeaturesListItem>
-					<WPCheckoutCheckIcon id="features-list-refund-text" />
-					{ refundText }
-				</CheckoutSummaryFeaturesListItem>
-			) }
+			{ uniqueRefundableProducts.length &&
+				uniqueRefundableProducts.map( ( product ) => (
+					<CheckoutSummaryFeaturesListItem key={ product.uuid }>
+						<WPCheckoutCheckIcon id="features-list-refund-text" />
+						{ getRefundText( getRefundDays( product ), product.product_name, translate ) }
+					</CheckoutSummaryFeaturesListItem>
+				) ) }
 		</CheckoutSummaryFeaturesListWrapper>
 	);
-}
-
-function SupportText( {
-	plans,
-	isJetpackNotAtomic,
-}: {
-	plans: Array< ResponseCartProduct >;
-	isJetpackNotAtomic?: boolean | null;
-} ) {
-	const translate = useTranslate();
-
-	if ( plans.length && ! isJetpackNotAtomic ) {
-		return <span>{ translate( 'Unlimited customer support via email' ) }</span>;
-	}
-
-	return <span>{ translate( 'Customer support via email' ) }</span>;
 }
 
 function CheckoutSummaryFeaturesListDomainItem( { domain }: { domain: ResponseCartProduct } ) {

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -212,16 +212,18 @@ function CheckoutSummaryFeaturesList( props: {
 			{ ! hasPlanInCart && <CheckoutSummaryChatIfAvailable siteId={ siteId } /> }
 
 			{ uniqueRefundableProducts.length &&
-				uniqueRefundableProducts.map( ( product ) => (
-					<CheckoutSummaryFeaturesListItem key={ product.uuid }>
-						<WPCheckoutCheckIcon id="features-list-refund-text" />
-						{ getRefundText(
-							getRefundDays( product ),
-							isDomainProduct( product ) ? 'Domain Registration' : product.product_name,
-							translate
-						) }
-					</CheckoutSummaryFeaturesListItem>
-				) ) }
+				uniqueRefundableProducts.map( ( product ) => {
+					const productName = isDomainProduct( product )
+						? translate( 'Domain Registration', { textOnly: true } )
+						: product.product_name;
+
+					return (
+						<CheckoutSummaryFeaturesListItem key={ product.uuid }>
+							<WPCheckoutCheckIcon id="features-list-refund-text" />
+							{ getRefundText( getRefundDays( product ), productName, translate ) }
+						</CheckoutSummaryFeaturesListItem>
+					);
+				} ) }
 		</CheckoutSummaryFeaturesListWrapper>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/lib/get-refund-days.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-refund-days.ts
@@ -2,6 +2,7 @@ import {
 	isDomainProduct,
 	isDomainTransfer,
 	isGoogleWorkspace,
+	isGoogleWorkspaceExtraLicence,
 	isGoogleWorkspaceMonthly,
 	isMonthly,
 	isPlan,
@@ -26,6 +27,10 @@ export default function getRefundDays( product: ResponseCartProduct ): number {
 	}
 
 	if ( isGoogleWorkspace( product ) ) {
+		if ( isGoogleWorkspaceExtraLicence( product ) ) {
+			return 0;
+		}
+
 		return isGoogleWorkspaceMonthly( product ) ? 7 : 14;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/lib/get-refund-days.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-refund-days.ts
@@ -1,0 +1,37 @@
+import {
+	isDomainProduct,
+	isDomainTransfer,
+	isGoogleWorkspace,
+	isGoogleWorkspaceMonthly,
+	isMonthly,
+	isPlan,
+	isTitanMail,
+	isTitanMailMonthly,
+} from '@automattic/calypso-products';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
+
+/**
+ * Returns the length of the refund window for a single cart product.
+ *
+ * @param product The cart product
+ * @returns The number of days in the product's refund window
+ */
+export default function getRefundDays( product: ResponseCartProduct ): number {
+	if ( isDomainProduct( product ) || isDomainTransfer( product ) ) {
+		return 4;
+	}
+
+	if ( isPlan( product ) ) {
+		return isMonthly( product.product_slug ) ? 7 : 14;
+	}
+
+	if ( isGoogleWorkspace( product ) ) {
+		return isGoogleWorkspaceMonthly( product ) ? 7 : 14;
+	}
+
+	if ( isTitanMail( product ) ) {
+		return isTitanMailMonthly( product ) ? 7 : 14;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Having a domain and a plan in the cart at the same time would previously cause a conflict with the refund text in the checkout sidebar. The Pro plan is refundable within 14 days, but a domain is only refundable within 4 days. We resolved this by not specifying the exact number of refund days (instead just saying "Money back guarantee").

With this change, we take a different approach – we show multiple rows of refund window info in the checkout summary (one for every product type). 

I have also changed the checkout summary to never show the string `Unlimited customer support via email`. This string is used in other places for marketing purposes, but there is no need to distinguish between "Unlimited" and not in this context.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the checkout screen for these scenarios:

| Test case (products in cart)                          | Expected output             |Screenshot|
|------------------------------------|-----------------------------|-----------------------------|
| Pro plan, 1 domain | Two refund rows: 14 days and 4 days | ![Pro plan, domain](https://user-images.githubusercontent.com/1101677/167816357-1074eeb9-d8ed-4b49-b76d-e324f69750f9.png) |
| Pro plan | One refund row: 14 days | ![Pro plan](https://user-images.githubusercontent.com/1101677/167816445-ce81eed4-3bdc-41cf-8a94-e12ce2ea642f.png) |
| 3 domains (different TLDs), Google Workspace monthly plan | Four refund rows: 3 × 4 days, 7 days | ![With pro plan, 3 domains, Google Workspace](https://user-images.githubusercontent.com/1101677/167816948-ccf21c2c-46d8-479e-b94f-57cc25ffaef1.png) |
| 3 domains (different TLDs) | Three refund rows: 3 × 4 days | ![With pro plan, 3 domains](https://user-images.githubusercontent.com/1101677/167817121-b7dbcee0-ae25-4ece-9617-d506c9ec1649.png) |
| 3 domains (same TLD) | One refund row: 4 days | ![3 domains, same TLD](https://user-images.githubusercontent.com/1101677/167820265-110af825-abde-4d10-b8e3-7350099704e9.png) |

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow up of #54210
