### PR TITLE
Fixes button gap on DIFM In-progress page

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.scss
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.scss
@@ -16,4 +16,8 @@
 		color: var( --studio-gray-60 );
 		font-size: 1rem;
 	}
+
+	.empty-content__action {
+		margin-inline-start: 10px;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: p1650459898387419/1650433476.162879-slack-C037Q77CVAQ

Adds a gap between the action buttons on the DIFM In-Progress page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Login and switch to site which is in progress for DIFM Lite and the content has been submitted.
* If there is no such site, go to /start/do-it-for-me, proceed through the flow steps, purchase and submit the content in the website content form.
* On the Calypso logged-in home page, confirm that there is a gap between the action buttons:
<img width="722" alt="image" src="https://user-images.githubusercontent.com/5436027/167834413-f2b1a666-b707-4b20-bfb3-97bac9d1f59e.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1201454687238941-as-1202160700568672/f