### PR TITLE
Domains: Polish mocking in form component tests

### DIFF
--- a/client/my-sites/domains/components/form/test/hidden-input.js
+++ b/client/my-sites/domains/components/form/test/hidden-input.js
@@ -6,11 +6,21 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { HiddenInput } from '../hidden-input';
 
 describe( 'HiddenInput', () => {
+	let originalScroll;
+	const noop = () => {};
 	const defaultProps = {
 		text: 'Love cannot be hidden.',
 		label: 'Your name',
 	};
-	window.scroll = jest.fn();
+
+	beforeAll( () => {
+		originalScroll = window.scroll;
+		window.scroll = noop;
+	} );
+
+	afterAll( () => {
+		window.scroll = originalScroll;
+	} );
 
 	test( 'it should return expected elements with defaultProps and no props value', () => {
 		render( <HiddenInput { ...defaultProps } /> );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a minor improvement to the tests of the domains form components, a follow-up to https://github.com/Automattic/wp-calypso/pull/63431/files#r869044198 

#### Testing instructions

Verify all tests still pass: `yarn run test-client client/my-sites/domains/components/form/test/hidden-input.js`