### PR TITLE
Woo on Stepper: Removing hasAvailableSiteFeature selector

### DIFF
--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -117,25 +117,8 @@ export const hasActiveSiteFeature = (
 	);
 };
 
-export const hasAvailableSiteFeature = (
-	_: State,
-	siteId: number | undefined,
-	featureKey: string
-): boolean => {
-	return Boolean(
-		siteId && select( STORE_KEY ).getSite( siteId )?.plan?.features.available[ featureKey ]
-	);
-};
-
 export const requiresUpgrade = ( state: State, siteId: number | null ) => {
-	const isWoopFeatureActive = Boolean(
-		siteId && select( STORE_KEY ).hasActiveSiteFeature( siteId, 'woop' )
-	);
-	const hasWoopFeatureAvailable = Boolean(
-		siteId && select( STORE_KEY ).hasAvailableSiteFeature( siteId, 'woop' )
-	);
-
-	return Boolean( ! isWoopFeatureActive && hasWoopFeatureAvailable );
+	return siteId && ! select( STORE_KEY ).hasActiveSiteFeature( siteId, 'woop' );
 };
 
 export function isJetpackSite( state: State, siteId?: number ): boolean {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `hasAvailableSiteFeature` selector.

#### Testing instructions

Since the only place we were using the `hasAvailableSiteFeature` selector was on the `requireUpgrade` selector, we should guarantee that it keeps working:

* Go through the WooCommerce flow on a free site, and reach the last step: `/setup/wooConfirm?siteSlug=<your-slug>`
* On the right side you should see the title `Plan upgrade required`

Closes #63296