### PR TITLE
[WIP] Seller Experience: Rename has active site feature

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-features/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-features/index.tsx
@@ -27,10 +27,10 @@ const StoreFeatures: Step = function StartingPointStep( { navigation } ) {
 	const siteSlug = useSiteSlugParam();
 	const site = useSite();
 	const hasPaymentsFeature = useSelect( ( select ) =>
-		select( SITE_STORE ).hasActiveSiteFeature( site?.ID, FEATURE_SIMPLE_PAYMENTS )
+		select( SITE_STORE ).siteHasFeature( site?.ID, FEATURE_SIMPLE_PAYMENTS )
 	);
 	const hasWooFeature = useSelect( ( select ) =>
-		select( SITE_STORE ).hasActiveSiteFeature( site?.ID, FEATURE_WOOP )
+		select( SITE_STORE ).siteHasFeature( site?.ID, FEATURE_WOOP )
 	);
 	const { getIntent } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 	const trackSupportLinkClick = ( storeType: StoreFeatureSet ) => {

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -107,7 +107,7 @@ export const getAtomicSoftwareInstallError = (
 	return state.atomicSoftwareInstallStatus[ siteId ]?.[ softwareSet ]?.error;
 };
 
-export const hasActiveSiteFeature = (
+export const siteHasFeature = (
 	_: State,
 	siteId: number | undefined,
 	featureKey: string
@@ -118,7 +118,7 @@ export const hasActiveSiteFeature = (
 };
 
 export const requiresUpgrade = ( state: State, siteId: number | null ) => {
-	return siteId && ! select( STORE_KEY ).hasActiveSiteFeature( siteId, 'woop' );
+	return siteId && ! select( STORE_KEY ).siteHasFeature( siteId, 'woop' );
 };
 
 export function isJetpackSite( state: State, siteId?: number ): boolean {

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -114,6 +114,45 @@ describe( 'getSite', () => {
 	} );
 } );
 
+describe( 'siteHasFeature', () => {
+	it( 'Test if site has features', async () => {
+		const siteId = 12345;
+		const apiResponse = {
+			URL: 'http://mytestsite12345.wordpress.com',
+			ID: siteId,
+			plan: {
+				features: {
+					active: [ 'woop' ],
+				},
+			},
+		};
+
+		( wpcomRequest as jest.Mock ).mockResolvedValue( apiResponse );
+
+		// First call returns undefined
+		expect( select( store ).getSite( 'plan' ) ).toEqual( undefined );
+
+		const listenForStateUpdate = () => {
+			return new Promise( ( resolve ) => {
+				const unsubscribe = subscribe( () => {
+					unsubscribe();
+					resolve();
+				} );
+			} );
+		};
+
+		// In the first state update, the resolver starts resolving
+		await listenForStateUpdate();
+
+		// In the second update, the resolver is finished resolving and we can read the result in state
+		await listenForStateUpdate();
+
+		expect( select( store ).siteHasFeature( siteId, 'woop' ) ).toEqual( true );
+
+		expect( select( store ).siteHasFeature( siteId, 'loop' ) ).toEqual( false );
+	} );
+} );
+
 describe( 'requiresUpgrade', () => {
 	it( 'Retrieves an available site feature from the store', async () => {
 		const siteId = 12345;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename `hasActiveSiteFeature` selector to `siteHasFeature` to simplify the API and clarifies what the selectors do.

#### Testing instructions

- TBD

Depends on #63503
Related to #63296
