### PR TITLE
Tests: Globally import `@testing-library/jest-dom`

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -12,6 +12,19 @@ module.exports = {
 			'error',
 			{ packageDir: [ __dirname, path.join( __dirname, '..' ) ] },
 		],
+		// No need to import @testing-library/jest-dom - it is already globally provided by our test setup framework.
+		'no-restricted-imports': [
+			'error',
+			{
+				patterns: [
+					{
+						group: [ '@testing-library/jest-dom*' ],
+						message:
+							'@testing-library/jest-dom is already globally provided by our test setup framework.',
+					},
+				],
+			},
+		],
 	},
 	overrides: [
 		{

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -9,8 +9,6 @@ import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import EligibilityWarnings from '..';
 
-import '@testing-library/jest-dom/extend-expect';
-
 jest.mock( 'page', () => ( {
 	redirect: jest.fn(),
 } ) );

--- a/client/blocks/follow-button/test/button.js
+++ b/client/blocks/follow-button/test/button.js
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import FollowButton from '../button';
 

--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -16,7 +16,6 @@ import {
 	PLAN_FREE,
 } from '@automattic/calypso-products';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import { PlanStorageBar } from '../bar';
 
 describe( 'PlanStorageBar basic tests', () => {

--- a/client/components/backup-storage-space/test/hooks.js
+++ b/client/components/backup-storage-space/test/hooks.js
@@ -14,7 +14,6 @@ jest.mock( 'calypso/state/ui/selectors/get-selected-site-slug', () =>
 );
 jest.mock( 'calypso/lib/jetpack/is-jetpack-cloud' );
 
-import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { useStorageUsageText } from 'calypso/components/backup-storage-space/hooks';

--- a/client/components/bulk-select/test/index.js
+++ b/client/components/bulk-select/test/index.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { fireEvent, render } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import { BulkSelect } from '../index';
 
 const noop = () => {};

--- a/client/components/forms/form-text-input/test/index.jsx
+++ b/client/components/forms/form-text-input/test/index.jsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import FormTextInput from '../';
 

--- a/client/components/has-site-purchases-switch/test/index.jsx
+++ b/client/components/has-site-purchases-switch/test/index.jsx
@@ -6,7 +6,6 @@ import { reducer as purchases } from 'calypso/state/purchases/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import HasSitePurchasesSwitch from '../index';
 
-import '@testing-library/jest-dom/extend-expect';
 jest.mock( 'calypso/components/data/query-site-purchases', () => () => <p>Query</p> );
 
 const siteId = 1;

--- a/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/test/add-stored-credit-card.jsx
+++ b/client/jetpack-cloud/sections/partner-portal/add-stored-credit-card/test/add-stored-credit-card.jsx
@@ -3,7 +3,6 @@
  */
 
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import AddStoredCreditCard from '../index';

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/test/credit-card-fields.jsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/test/credit-card-fields.jsx
@@ -7,7 +7,6 @@ import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { render } from '@testing-library/react';
 import { useSelect, useDispatch } from '@wordpress/data';
-import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import CreditCardFields from '../index';

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/test/credit-card-submit-button.jsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/test/credit-card-submit-button.jsx
@@ -6,7 +6,6 @@ import { useFormStatus } from '@automattic/composite-checkout';
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { render, screen, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import { useSelect } from '@wordpress/data';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/test/set-as-primary-payment-method.jsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/test/set-as-primary-payment-method.jsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { render, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import SetAsPrimaryPaymentMethod from '../set-as-primary-payment-method';

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/test/payment-method-add.jsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/test/payment-method-add.jsx
@@ -3,7 +3,6 @@
  */
 
 import { render, act } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import PaymentMethodAdd from '../index';

--- a/client/jetpack-cloud/sections/settings/loading/test/index.jsx
+++ b/client/jetpack-cloud/sections/settings/loading/test/index.jsx
@@ -3,7 +3,6 @@
  */
 
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
-import '@testing-library/jest-dom/extend-expect';
 import AdvancedCredentialsLoadingPlaceholder from '../index';
 
 describe( 'AdvancedCredentialsLoadingPlaceholder', () => {

--- a/client/jetpack-cloud/sections/settings/test/empty-content.jsx
+++ b/client/jetpack-cloud/sections/settings/test/empty-content.jsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import '@testing-library/jest-dom/extend-expect';
 import { JETPACK_PRICING_PAGE } from 'calypso/lib/url/support';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import NoSitePurchasesMessage from '../empty-content';

--- a/client/landing/stepper/hooks/test/use-anchor-fm-params.tsx
+++ b/client/landing/stepper/hooks/test/use-anchor-fm-params.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import '@testing-library/jest-dom/extend-expect';
 import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 import { MemoryRouter as Router } from 'react-router-dom';

--- a/client/landing/stepper/hooks/test/use-countries.jsx
+++ b/client/landing/stepper/hooks/test/use-countries.jsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import '@testing-library/jest-dom/extend-expect';
 import { renderHook } from '@testing-library/react-hooks';
 import nock from 'nock';
 import { QueryClient, QueryClientProvider } from 'react-query';

--- a/client/landing/stepper/hooks/test/use-is-anchor-fm.tsx
+++ b/client/landing/stepper/hooks/test/use-is-anchor-fm.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import '@testing-library/jest-dom/extend-expect';
 import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 import { MemoryRouter as Router } from 'react-router-dom';

--- a/client/landing/stepper/hooks/test/use-podcast-title.ts
+++ b/client/landing/stepper/hooks/test/use-podcast-title.ts
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import '@testing-library/jest-dom/extend-expect';
 import { renderHook } from '@testing-library/react-hooks';
 import usePodcastTitle from '../use-podcast-title';
 import * as hook from '../use-podcast-title';

--- a/client/landing/stepper/hooks/test/use-site-id-param.ts
+++ b/client/landing/stepper/hooks/test/use-site-id-param.ts
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import '@testing-library/jest-dom/extend-expect';
 import { renderHook } from '@testing-library/react-hooks';
 import { useSiteIdParam } from '../use-site-id-param';
 

--- a/client/lib/logmein/test/index.js
+++ b/client/lib/logmein/test/index.js
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import '@testing-library/jest-dom/extend-expect';
-
 import config from '@automattic/calypso-config';
 import { createStore } from 'redux';
 import {

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -6,7 +6,6 @@ import { render, screen } from '@testing-library/react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
 import PurchaseNotice from '../notices';
-import '@testing-library/jest-dom/extend-expect';
 
 describe( 'PurchaseNotice', () => {
 	const store = createReduxStore();

--- a/client/me/purchases/manage-purchase/test/payment-info-block.js
+++ b/client/me/purchases/manage-purchase/test/payment-info-block.js
@@ -7,7 +7,6 @@
 
 import { render, screen } from '@testing-library/react';
 import PaymentInfoBlock from '../payment-info-block';
-import '@testing-library/jest-dom/extend-expect';
 
 describe( 'PaymentInfoBlock', () => {
 	describe.each( [

--- a/client/me/purchases/upcoming-renewals/test/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/test/upcoming-renewals-dialog.tsx
@@ -7,7 +7,6 @@ import moment from 'moment';
 import { unmountComponentAtNode } from 'react-dom';
 import Modal from 'react-modal';
 import UpcomingRenewalsDialog from '../upcoming-renewals-dialog';
-import '@testing-library/jest-dom/extend-expect';
 
 describe( '<UpcomingRenewalsDialog>', () => {
 	let modalRoot;

--- a/client/my-sites/checkout/composite-checkout/components/test/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/test/secondary-cart-promotions.tsx
@@ -11,7 +11,6 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import SecondaryCartPromotions from '../secondary-cart-promotions';
 import { responseCartWithRenewal, storeData } from './lib/fixtures';
-import '@testing-library/jest-dom/extend-expect';
 
 const mockConfig = config as unknown as { isEnabled: jest.Mock };
 jest.mock( '@automattic/calypso-config', () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -6,7 +6,6 @@ import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automatt
 import { render, fireEvent, screen, within, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
-import '@testing-library/jest-dom/extend-expect';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import getIntroOfferPrice from 'calypso/state/selectors/get-intro-offer-price';

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -15,7 +15,6 @@ import {
 import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
 import { navigate } from 'calypso/lib/navigate';
-import '@testing-library/jest-dom/extend-expect';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';

--- a/client/my-sites/checkout/composite-checkout/test/credit-card.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/credit-card.tsx
@@ -9,7 +9,6 @@ import {
 	makeSuccessResponse,
 	CheckoutFormSubmit,
 } from '@automattic/composite-checkout';
-import '@testing-library/jest-dom/extend-expect';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';

--- a/client/my-sites/checkout/composite-checkout/test/existing-credit-card.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/existing-credit-card.tsx
@@ -8,7 +8,6 @@ import {
 	makeSuccessResponse,
 	CheckoutFormSubmit,
 } from '@automattic/composite-checkout';
-import '@testing-library/jest-dom/extend-expect';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import nock from 'nock';
 import { QueryClient, QueryClientProvider } from 'react-query';

--- a/client/my-sites/checkout/composite-checkout/test/form-field-annotation.js
+++ b/client/my-sites/checkout/composite-checkout/test/form-field-annotation.js
@@ -6,7 +6,6 @@
 import { matchers } from '@emotion/jest';
 import { ThemeProvider } from '@emotion/react';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import FormFieldAnnotation from '../components/form-field-annotation';
 
 // Add the custom matchers provided by '@emotion/jest'

--- a/client/my-sites/checkout/composite-checkout/test/netbanking.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/netbanking.tsx
@@ -8,7 +8,6 @@ import {
 	makeSuccessResponse,
 	CheckoutFormSubmit,
 } from '@automattic/composite-checkout';
-import '@testing-library/jest-dom/extend-expect';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';

--- a/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
@@ -7,7 +7,6 @@ import {
 	createShoppingCartManagerClient,
 	getEmptyResponseCart,
 } from '@automattic/shopping-cart';
-import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
 import { useState } from 'react';

--- a/client/my-sites/domains/components/form/test/hidden-input.js
+++ b/client/my-sites/domains/components/form/test/hidden-input.js
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { HiddenInput } from '../hidden-input';
 

--- a/client/my-sites/domains/components/form/test/select.js
+++ b/client/my-sites/domains/components/form/test/select.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import Select from '../select';
 
 describe( '<Select />', () => {

--- a/client/my-sites/plan-price/test/index.js
+++ b/client/my-sites/plan-price/test/index.js
@@ -3,7 +3,6 @@
  */
 import { render } from '@testing-library/react';
 import PlanPrice from '../index';
-import '@testing-library/jest-dom/extend-expect';
 
 describe( 'PlanPrice', () => {
 	it( 'renders a zero when rawPrice is passed a "0"', () => {

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import '@testing-library/jest-dom/extend-expect';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';

--- a/client/my-sites/themes/test/thanks-modal.jsx
+++ b/client/my-sites/themes/test/thanks-modal.jsx
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import '@testing-library/jest-dom/extend-expect';
 import { render, screen, waitFor } from '@testing-library/react';
 import ReactModal from 'react-modal';
 import { Provider as ReduxProvider } from 'react-redux';

--- a/client/state/test/data-fetching-persistence.tsx
+++ b/client/state/test/data-fetching-persistence.tsx
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import '@testing-library/jest-dom/extend-expect';
 import { render, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider, useQuery, setLogger } from 'react-query';
 import { createWebStoragePersistor } from 'react-query/createWebStoragePersistor-experimental';

--- a/client/test-helpers/testing-library/index.js
+++ b/client/test-helpers/testing-library/index.js
@@ -1,4 +1,5 @@
 import { render as rtlRender } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import { applyMiddleware, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
@@ -8,6 +9,8 @@ export const renderWithProvider = (
 	ui,
 	{ initialState, store, reducers, ...renderOptions } = {}
 ) => {
+	const queryClient = new QueryClient();
+
 	if ( ! store ) {
 		let reducer = initialReducer;
 
@@ -20,7 +23,11 @@ export const renderWithProvider = (
 		store = createStore( reducer, initialState, applyMiddleware( thunkMiddleware ) );
 	}
 
-	const Wrapper = ( { children } ) => <Provider store={ store }>{ children }</Provider>;
+	const Wrapper = ( { children } ) => (
+		<QueryClientProvider client={ queryClient }>
+			<Provider store={ store }>{ children }</Provider>
+		</QueryClientProvider>
+	);
 
 	return rtlRender( ui, { wrapper: Wrapper, ...renderOptions } );
 };

--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
 		"@babel/runtime": "^7.17.2",
 		"@bartekbp/typescript-checkstyle": "^5.0.0",
 		"@signal-noise/stylelint-scales": "^2.0.3",
+		"@testing-library/jest-dom": "^5.16.2",
 		"@typescript-eslint/eslint-plugin": "^5.7.0",
 		"@typescript-eslint/parser": "^5.7.0",
 		"@wordpress/eslint-plugin": "^12.1.0",

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -1,3 +1,5 @@
+import '@testing-library/jest-dom';
+
 const nock = require( 'nock' );
 
 // Disables all network requests for all tests.

--- a/yarn.lock
+++ b/yarn.lock
@@ -36267,6 +36267,7 @@ swiper@4.5.1:
     "@babel/runtime": ^7.17.2
     "@bartekbp/typescript-checkstyle": ^5.0.0
     "@signal-noise/stylelint-scales": ^2.0.3
+    "@testing-library/jest-dom": ^5.16.2
     "@types/cookie": ^0.4.1
     "@types/debug": ^4.1.7
     "@types/enzyme": ^3.10.11


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a first step towards improving the code style of our `@testing-library` tests. 

Currently, we import `@testing-library/jest-dom` manually in every test file as needed. However, it provides a more idiomatic way to assert various things about the state of a DOM, and it's recommended by the library maintainers. It's also used quite often, and will be used even more in the future, so importing it manually becomes repetitive.  

This PR aims to remove the need to import `@testing-library/jest-dom` manually in a test file. Because there were a few blockers to make this happen, this PR is also taking care of a few more problems. Here's a thorough list:

* **Refactoring `enzyme` to `@testing-library/react`** in the `client/my-sites/site-settings/test/form-general.jsx` tests. Necessary because importing `enzyme` will still overwrite the jest matchers with its own ones. This ticks an item in #63409.
* **Add `QueryClientProvider` to `renderWithProvider`** - necessary to allow us to test components that use `react-query` queries.
* **Globally import `@testing-library/jest-dom`** - in order to no longer require manual importing in each and every test file that makes use of the idiomatic jest dom matchers.
* **Remove explicit imports of `@testing-library/jest-dom`** - because they're no longer necessary.
* **In Calypso's client, introduce an ESLint rule to prevent importing @testing-library/jest-dom and family** - just in case someone tries to import `@testing-library/jest-dom` or any of its submodules, they'd get an ESLint error. 

If you think it's too much for a single PR, I'm happy to split it up further, but it felt to me that this can be considered an atomic change.

#### Testing instructions

* Verify all client tests pass: `yarn run test-client`.
* Verify there are no new ESLint errors introduced.