### PR TITLE
Plans overhaul: my-plan features and icon for Starter

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -9,6 +9,7 @@ import {
 	TYPE_PERSONAL,
 	TYPE_BLOGGER,
 	TYPE_FREE,
+	TYPE_STARTER,
 	PLAN_BUSINESS_2_YEARS,
 	PLAN_BUSINESS_ONBOARDING_EXPIRE,
 	PLAN_BUSINESS_2Y_ONBOARDING_EXPIRE,
@@ -242,6 +243,20 @@ export class ProductPurchaseFeaturesList extends Component {
 		);
 	}
 
+	getStarterFeatuers() {
+		const { isPlaceholder, selectedSite, planHasDomainCredit } = this.props;
+
+		return (
+			<Fragment>
+				<HappinessSupportCard isPlaceholder={ isPlaceholder } />
+				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
+				<AdvertisingRemoved isEligiblePlan selectedSite={ selectedSite } />
+				<SiteActivity />
+				<MobileApps onClick={ this.handleMobileAppsClick } />
+			</Fragment>
+		);
+	}
+
 	getJetpackFreeFeatures() {
 		const { isAutomatedTransfer, isPlaceholder, selectedSite } = this.props;
 		return (
@@ -379,6 +394,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				[ TYPE_PERSONAL ]: () => this.getPersonalFeatures(),
 				[ TYPE_BLOGGER ]: () => this.getBloggerFeatures(),
 				[ TYPE_PRO ]: () => this.getProFeatuers(),
+				[ TYPE_STARTER ]: () => this.getStarterFeatuers(),
 			},
 			[ GROUP_JETPACK ]: {
 				[ TYPE_BUSINESS ]: () => this.getJetpackBusinessFeatures(),

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -244,13 +244,11 @@ export class ProductPurchaseFeaturesList extends Component {
 	}
 
 	getStarterFeatuers() {
-		const { isPlaceholder, selectedSite, planHasDomainCredit } = this.props;
+		const { selectedSite, planHasDomainCredit } = this.props;
 
 		return (
 			<Fragment>
-				<HappinessSupportCard isPlaceholder={ isPlaceholder } />
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
-				<AdvertisingRemoved isEligiblePlan selectedSite={ selectedSite } />
 				<SiteActivity />
 				<MobileApps onClick={ this.handleMobileAppsClick } />
 			</Fragment>

--- a/packages/components/src/product-icon/config.ts
+++ b/packages/components/src/product-icon/config.ts
@@ -77,6 +77,7 @@ export type SupportedSlugs =
 	| 'business-bundle-2y'
 	| 'business-bundle-monthly'
 	| 'pro-plan'
+	| 'starter-plan'
 	| 'jetpack_free'
 	| 'jetpack_personal'
 	| 'jetpack_personal_monthly'
@@ -167,6 +168,7 @@ export const iconToProductSlugMap: Record< keyof typeof paths, readonly Supporte
 		'value_bundle-monthly',
 		'value_bundle_monthly',
 		'pro-plan',
+		'starter-plan',
 	],
 	'wpcom-ecommerce': [ 'ecommerce-bundle', 'ecommerce-bundle-2y', 'ecommerce-bundle-monthly' ],
 	'wpcom-business': [ 'business-bundle', 'business-bundle-2y', 'business-bundle-monthly' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Addresses https://github.com/Automattic/wp-calypso/issues/63499

#### Media

<img width="900" alt="Screenshot 2022-05-11 at 5 54 57 PM" src="https://user-images.githubusercontent.com/1705499/167882040-ac6bac31-bb8b-41ae-9356-cc35469a9d97.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `plans/my-plan/[SITE_ON_STARTER]` with a site on the Starter plan
* Confirm features and icon are shown as in media above

#### TODO

- [ ] If Google Analytics are to be enabled and it's an easy affair, may as well all along here p1652216666465639-slack-C031TFM2NKC

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/wp-calypso#63499