### PR TITLE
Plugins Browser: Remove unneeded hasBusinessPlan variable

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,10 +1,6 @@
 import {
-	isBusiness,
-	isEcommerce,
-	isEnterprise,
-	isPro,
+	FEATURE_INSTALL_PLUGINS,
 	findFirstSimilarPlanKey,
-	FEATURE_UPLOAD_PLUGINS,
 	TYPE_BUSINESS,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
@@ -94,13 +90,6 @@ const PluginsBrowser = ( {
 
 	// Billing period switcher.
 	const billingPeriod = useSelector( getBillingInterval );
-
-	const hasBusinessPlan =
-		sitePlan &&
-		( isBusiness( sitePlan ) ||
-			isEnterprise( sitePlan ) ||
-			isEcommerce( sitePlan ) ||
-			isPro( sitePlan ) );
 
 	const { plugins: paidPlugins = [], isFetching: isFetchingPaidPlugins } = usePlugins( {
 		category: 'paid',
@@ -292,7 +281,6 @@ const PluginsBrowser = ( {
 				sitePlan={ sitePlan }
 				isVip={ isVip }
 				jetpackNonAtomic={ jetpackNonAtomic }
-				hasBusinessPlan={ hasBusinessPlan }
 				siteSlug={ siteSlug }
 			/>
 
@@ -533,20 +521,13 @@ const PluginBrowserContent = ( props ) => {
 	);
 };
 
-const UpgradeNudge = ( {
-	selectedSite,
-	sitePlan,
-	isVip,
-	jetpackNonAtomic,
-	hasBusinessPlan,
-	siteSlug,
-} ) => {
+const UpgradeNudge = ( { selectedSite, sitePlan, isVip, jetpackNonAtomic, siteSlug } ) => {
 	const translate = useTranslate();
 	const eligibleForProPlan = useSelector( ( state ) =>
 		isEligibleForProPlan( state, selectedSite?.ID )
 	);
 
-	if ( ! selectedSite?.ID || ! sitePlan || isVip || jetpackNonAtomic || hasBusinessPlan ) {
+	if ( ! selectedSite?.ID || ! sitePlan || isVip || jetpackNonAtomic ) {
 		return null;
 	}
 
@@ -565,7 +546,7 @@ const UpgradeNudge = ( {
 			event="calypso_plugins_browser_upgrade_nudge"
 			showIcon={ true }
 			href={ bannerURL }
-			feature={ FEATURE_UPLOAD_PLUGINS }
+			feature={ FEATURE_INSTALL_PLUGINS }
 			plan={ plan }
 			title={ title }
 		/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Plugins Browser page: Remove unneeded `hasBusinessPlan` variable gating upsell
  * Because `UpsellNudge` is now feature gated ( c5b665214f0 ), it will correctly determine if it should display without us needing to calculate this
* Plugins Browser page: Change `FEATURE_UPLOAD_PLUGINS` to `FEATURE_INSTALL_PLUGINS`
  * The upsell reads "... to install plugins"

#### Testing instructions


* Visit `/plugins/<site>` on a pro site and on a free/personal/premium site
* The pro site should not see the upsell banner at the top, the free/personal/premium site should
![2022-05-11_13-45](https://user-images.githubusercontent.com/937354/167923331-27b5de65-ba6a-4b85-a83a-c5a1bd435994.png)
* With public-api sandboxed, edit `class-wpcom-features.php`
* Empty `self::INSTALL_PLUGINS               => array( ),` (line 546)
* Refresh the pro site and it should also see the upsell


Related to [p4TIVU-a66-p2](https://href.li/?p4TIVU-a66-p2)