### PR TITLE
Shopping Cart: Add source path to shopping-cart endpoint get requests

### DIFF
--- a/client/my-sites/checkout/cart-manager-client.ts
+++ b/client/my-sites/checkout/cart-manager-client.ts
@@ -2,7 +2,15 @@ import { createShoppingCartManagerClient } from '@automattic/shopping-cart';
 import wp from 'calypso/lib/wp';
 import type { RequestCart, CartKey } from '@automattic/shopping-cart';
 
-const wpcomGetCart = ( cartKey: CartKey ) => wp.req.get( `/me/shopping-cart/${ cartKey }` );
+const wpcomGetCart = ( cartKey: CartKey ) => {
+	let source;
+	try {
+		source = window?.location?.pathname;
+	} catch {
+		// Ignore failures here if window is not present.
+	}
+	return wp.req.get( `/me/shopping-cart/${ cartKey }?source=${ source ?? 'unknown' }` );
+};
 const wpcomSetCart = ( cartKey: CartKey, cartData: RequestCart ) =>
 	wp.req.post( `/me/shopping-cart/${ cartKey }`, cartData );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We get a large number of GET requests to the `/me/shopping-cart` endpoint for sites that do not belong to the user and we can't yet determine why. My guess is that it has something to do with signup and old data from the redux store. In any case, it would be helpful to know from which page these requests are originating. This PR adds a `source` parameter to the GET request query string that should be able to encode the current page's path.

See D80578-code for how this data will be used.

#### Testing instructions

Visit nearly any page in calypso with this PR applied and look at the network tab of your browser's devtools. Verify that the GET requests to `/me/shopping-cart` include `?source=` followed by the path to the current page.