### PR TITLE
Seller Experience: Rename hasActiveSiteFeature selector

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-features/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-features/index.tsx
@@ -27,10 +27,10 @@ const StoreFeatures: Step = function StartingPointStep( { navigation } ) {
 	const siteSlug = useSiteSlugParam();
 	const site = useSite();
 	const hasPaymentsFeature = useSelect( ( select ) =>
-		select( SITE_STORE ).hasActiveSiteFeature( site?.ID, FEATURE_SIMPLE_PAYMENTS )
+		select( SITE_STORE ).siteHasFeature( site?.ID, FEATURE_SIMPLE_PAYMENTS )
 	);
 	const hasWooFeature = useSelect( ( select ) =>
-		select( SITE_STORE ).hasActiveSiteFeature( site?.ID, FEATURE_WOOP )
+		select( SITE_STORE ).siteHasFeature( site?.ID, FEATURE_WOOP )
 	);
 	const { getIntent } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 	const trackSupportLinkClick = ( storeType: StoreFeatureSet ) => {

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -107,7 +107,7 @@ export const getAtomicSoftwareInstallError = (
 	return state.atomicSoftwareInstallStatus[ siteId ]?.[ softwareSet ]?.error;
 };
 
-export const hasActiveSiteFeature = (
+export const siteHasFeature = (
 	_: State,
 	siteId: number | undefined,
 	featureKey: string
@@ -118,7 +118,7 @@ export const hasActiveSiteFeature = (
 };
 
 export const requiresUpgrade = ( state: State, siteId: number | null ) => {
-	return siteId && ! select( STORE_KEY ).hasActiveSiteFeature( siteId, 'woop' );
+	return siteId && ! select( STORE_KEY ).siteHasFeature( siteId, 'woop' );
 };
 
 export function isJetpackSite( state: State, siteId?: number ): boolean {

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -312,3 +312,46 @@ describe( 'getSiteOptions', () => {
 		expect( getSiteOption( state, siteId, 'admin_url' ) ).toEqual( adminUrl );
 	} );
 } );
+
+describe( 'siteHasFeature', () => {
+	it( 'Test if site has features', async () => {
+		const siteId = 924785;
+		const siteSlug = `http://mytestsite${ siteId }.wordpress.com`;
+		const apiResponse = {
+			URL: siteSlug,
+			ID: siteId,
+			plan: {
+				features: {
+					active: [ 'woop' ],
+					available: {
+						woop: 'This is a test feature',
+					},
+				},
+			},
+		};
+
+		( wpcomRequest as jest.Mock ).mockResolvedValue( apiResponse );
+
+		const listenForStateUpdate = () => {
+			return new Promise( ( resolve ) => {
+				const unsubscribe = subscribe( () => {
+					unsubscribe();
+					resolve();
+				} );
+			} );
+		};
+
+		// First call returns undefined
+		expect( select( store ).getSite( siteId ) ).toEqual( undefined );
+
+		// In the first state update, the resolver starts resolving
+		await listenForStateUpdate();
+
+		// In the second update, the resolver is finished resolving and we can read the result in state
+		await listenForStateUpdate();
+
+		expect( select( store ).siteHasFeature( siteId, 'woop' ) ).toEqual( true );
+
+		expect( select( store ).siteHasFeature( siteId, 'loop' ) ).toEqual( false );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename `hasActiveSiteFeature` selector to `siteHasFeature` to simplify the API and clarifies what the selectors do.

#### Testing instructions

The selector was being used only inside the selector file and in the Store Feature step. To test the Store Feature step follow the steps below:

* Go to `/setup/storeFeatures?siteSlug=<your-site-slug>`
* Switch between a free and paid site.
* You should see the text `Included in your plan`:
  - Below `Start simple` if the feature `simple-payments` is **enabled**.
  - Below `More power` if the feature `woop` is **enabled**.
* You should see the text `Requires a Pro plan`:
  - Below `Start simple` if the feature `simple-payments` is **disabled**.
  - Below `More power` if the feature `woop` is **disabled**.


Related to #63296