### PR TITLE
Stepper: Add step progress to woo flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/business-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/business-info/index.tsx
@@ -36,26 +36,22 @@ const BusinessInfo: Step = function ( props ): ReactElement | null {
 	const { goNext, goBack, submit } = props.navigation;
 
 	const { __ } = useI18n();
-
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
-
 	const siteSlug = useQuery().get( 'siteSlug' );
-
 	const siteId = useSelect(
 		( select ) => siteSlug && select( SITE_STORE ).getSiteIdBySlug( siteSlug )
 	);
-
 	const settings = useSelect(
 		( select ) => ( siteId && select( SITE_STORE ).getSiteSettings( siteId ) ) || {}
 	);
-
 	const onboardingProfile = settings?.woocommerce_onboarding_profile || {};
-
 	const [ profileChanges, setProfileChanges ] = useState< {
 		[ key: string ]: string | boolean | Array< string > | undefined;
 	} >( {} );
 
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
+
+	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 
 	function updateProductTypes( type: string ) {
 		const productTypes = getProfileValue( 'product_types' ) || [];
@@ -282,6 +278,7 @@ const BusinessInfo: Step = function ( props ): ReactElement | null {
 						/>
 					}
 					stepContent={ getContent() }
+					stepProgress={ stepProgress }
 					recordTracksEvent={ recordTracksEvent }
 				/>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -1,8 +1,10 @@
+import { StepContainer } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { ReactElement, useEffect, useState } from 'react';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useInterval } from 'calypso/lib/interval';
 import type { Step } from '../../types';
 import './style.scss';
@@ -39,6 +41,7 @@ const ProcessingStep: Step = function ( props ): ReactElement | null {
 	const action = useSelect( ( select ) => select( ONBOARD_STORE ).getPendingAction() );
 	const progress = useSelect( ( select ) => select( ONBOARD_STORE ).getProgress() );
 	const progressTitle = useSelect( ( select ) => select( ONBOARD_STORE ).getProgressTitle() );
+	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 
 	const getCurrentMessage = () => {
 		return progressTitle || loadingMessages[ currentMessageIndex ]?.title;
@@ -84,21 +87,33 @@ const ProcessingStep: Step = function ( props ): ReactElement | null {
 	}, [ simulatedProgress, progress, __ ] );
 
 	return (
-		<div className={ 'processing-step' }>
-			<h1 className="processing-step__progress-step">{ getCurrentMessage() }</h1>
-			{ progress >= 0 ? (
-				<div className="processing-step__content woocommerce-install__content">
-					<div
-						className="processing-step__progress-bar"
-						style={
-							{ '--progress': simulatedProgress > 1 ? 1 : simulatedProgress } as React.CSSProperties
-						}
-					/>
+		<StepContainer
+			shouldHideNavButtons={ true }
+			hideFormattedHeader={ true }
+			stepName={ 'processing-step' }
+			isHorizontalLayout={ true }
+			stepContent={
+				<div className={ 'processing-step' }>
+					<h1 className="processing-step__progress-step">{ getCurrentMessage() }</h1>
+					{ progress >= 0 ? (
+						<div className="processing-step__content woocommerce-install__content">
+							<div
+								className="processing-step__progress-bar"
+								style={
+									{
+										'--progress': simulatedProgress > 1 ? 1 : simulatedProgress,
+									} as React.CSSProperties
+								}
+							/>
+						</div>
+					) : (
+						<LoadingEllipsis />
+					) }
 				</div>
-			) : (
-				<LoadingEllipsis />
-			) }
-		</div>
+			}
+			stepProgress={ stepProgress }
+			recordTracksEvent={ recordTracksEvent }
+		/>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -7,7 +7,7 @@ $progress-duration: 800ms;
 	padding: 1em;
 	max-width: 540px;
 	text-align: center;
-	margin: 32vh auto;
+	margin: 16vh auto 0;
 
 	&__progress-step {
 		@include onboarding-font-recoleta;
@@ -48,4 +48,7 @@ $progress-duration: 800ms;
 		bottom: 0;
 		transition: transform $progress-duration ease-out;
 	}
+}
+.site-setup.processing .step-container__content {
+	width: 100%;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
@@ -57,6 +57,7 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 	const { __ } = useI18n();
 	const [ errors, setErrors ] = useState( {} as Record< FormFields, string > );
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
+	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 
 	const [ settingChanges, setSettingChanges ] = useState< {
 		[ key: string ]: string;
@@ -294,6 +295,7 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 			intent={ intent }
 			stepContent={ getContent() }
 			recordTracksEvent={ recordTracksEvent }
+			stepProgress={ stepProgress }
 			hideSkip
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
@@ -13,6 +13,7 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import {
 	AUTOMATED_ELIGIBILITY_STORE,
 	SITE_STORE,
+	ONBOARD_STORE,
 	PRODUCTS_LIST_STORE,
 } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -50,6 +51,7 @@ const WooConfirm: Step = function WooCommerceConfirm( { navigation } ) {
 		select( SITE_STORE ).isSiteAtomic( siteId )
 	);
 	const { requestLatestAtomicTransfer } = useDispatch( SITE_STORE );
+	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 
 	useEffect( () => {
 		if ( ! siteId ) {
@@ -286,6 +288,7 @@ const WooConfirm: Step = function WooCommerceConfirm( { navigation } ) {
 				/>
 			}
 			stepContent={ getContent() }
+			stepProgress={ stepProgress }
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -63,10 +63,30 @@ export const siteSetupFlow: Flow = {
 			select( SITE_STORE ).isSiteAtomic( siteId as number )
 		);
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
-		const { setPendingAction } = useDispatch( ONBOARD_STORE );
+		const { setPendingAction, setStepProgress } = useDispatch( ONBOARD_STORE );
 		const { setIntentOnSite } = useDispatch( SITE_STORE );
 		const { FSEActive } = useFSEStatus();
 		const dispatch = reduxDispatch();
+
+		// Set up Step progress for Woo flow - "Step 2 of 4"
+		if ( intent === 'sell' && storeType === 'power' ) {
+			switch ( currentStep ) {
+				case 'storeAddress':
+					setStepProgress( { progress: 1, count: 4 } );
+					break;
+				case 'businessInfo':
+					setStepProgress( { progress: 2, count: 4 } );
+					break;
+				case 'wooConfirm':
+					setStepProgress( { progress: 3, count: 4 } );
+					break;
+				case 'processing':
+					setStepProgress( { progress: 4, count: 4 } );
+					break;
+			}
+		} else {
+			setStepProgress( undefined );
+		}
 
 		const exitFlow = ( to: string ) => {
 			setPendingAction(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added step progress to woo flow steps.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Woo flow
* Check the top right corner for the steps

---
![image](https://user-images.githubusercontent.com/3801502/167941523-bb436028-daef-47ef-9eee-e7d9c7c321cf.png)
---
![image](https://user-images.githubusercontent.com/3801502/167941554-c6764d5f-3021-41da-a298-55ce128b1ee6.png)
---
![image](https://user-images.githubusercontent.com/3801502/167941754-359ba523-5a0e-4ad5-9917-5d814e2351c4.png)
---
![image](https://user-images.githubusercontent.com/3801502/167941574-20a412f8-dd3d-48e9-9471-25809b3216e2.png)
---

* The step progress shouldn't be visible on other intents/steps.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/63355