### PR TITLE
Add alphabetically sorted product list

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import sortBy from 'lodash/sortBy';
 import page from 'page';
 import { ReactElement, useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -21,6 +22,12 @@ function selectProductOptions( families: APIProductFamily[] ): APIProductFamilyP
 	return families.flatMap( ( family ) => family.products );
 }
 
+function alphabeticallySortedProductOptions(
+	families: APIProductFamily[]
+): APIProductFamilyProduct[] {
+	return sortBy( selectProductOptions( families ), ( product ) => product.name );
+}
+
 interface Props {
 	selectedSite?: number | null;
 }
@@ -29,7 +36,7 @@ export default function IssueLicenseForm( { selectedSite }: Props ): ReactElemen
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const products = useProductsQuery( {
-		select: selectProductOptions,
+		select: alphabeticallySortedProductOptions,
 	} );
 
 	const assignLicense = useAssignLicenseMutation( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Alphabetically sorting products list on license issuing on Licensing Portal
* In accordance to pdpAdu-ng-p2#comment-403

#### Testing instructions

* Make sure to have a Partner Account 👉🏻 PCYsg-zPi-p2
* Issue some license
* The list of products should be in alphabetical order. (Current order is however it comes from the API response)


#### Screenshots
![image](https://user-images.githubusercontent.com/5550190/167943046-5d1bda8e-fba5-4f3c-b930-76f94d145e79.png)
