### PR TITLE
Checkout: Keep checkout loading until countriesList loads

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -498,6 +498,7 @@ export default function CompositeCheckout( {
 		arePaymentMethodsLoading ||
 		paymentMethods.length < 1 ||
 		responseCart.products.length < 1 ||
+		countriesList.length < 1 ||
 		isLoadingIntroOffers;
 	if ( isLoading ) {
 		debug( 'still loading because one of these is true', {
@@ -505,6 +506,7 @@ export default function CompositeCheckout( {
 			paymentMethods: paymentMethods.length < 1,
 			arePaymentMethodsLoading: arePaymentMethodsLoading,
 			items: responseCart.products.length < 1,
+			countriesList: countriesList.length < 1,
 			isLoadingIntroOffers,
 		} );
 	} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some parts of checkout (particularly `useCachedContactDetailsForCart()`) rely on having data from the countries list endpoint (`/me/transactions/supported-countries/`), as returned by the `useCountryList()` hook. If that data is not yet loaded, it could potentially result in a race condition where the form is submitted with invalid data.

This PR modifies checkout to show its loading screen while the list of countries is still loading.

Possibly related to 508-gh-Automattic/payments-shilling

#### Testing instructions

- First, break the countries list endpoint by applying D80580-code and sandboxing the API.
- Using this branch, add a product to your cart and visit checkout. 
- Verify that checkout never finishes loading.
- Revert the patch on the endpoint to make it work again.
- Reload checkout and verify that it loads successfully.