### PR TITLE
Update PlanPrice to use productDisplayPrice prop

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -74,6 +74,7 @@ function createPurchaseObject( purchase ) {
 		productId: Number( purchase.product_id ),
 		productName: purchase.product_name,
 		productSlug: purchase.product_slug,
+		productDisplayPrice: purchase.product_display_price,
 		totalRefundAmount: Number( purchase.total_refund_amount ),
 		totalRefundText: purchase.total_refund_text,
 		refundAmount: Number( purchase.refund_amount ),

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -797,6 +797,7 @@ class ManagePurchase extends Component {
 							) : (
 								<PlanPrice
 									rawPrice={ getRenewalPrice( purchase ) }
+									productDisplayPrice={ purchase.productDisplayPrice }
 									currencyCode={ purchase.currencyCode }
 									taxText={ purchase.taxText }
 									isOnSale={ !! purchase.saleAmount }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -797,7 +797,6 @@ class ManagePurchase extends Component {
 							) : (
 								<PlanPrice
 									rawPrice={ getRenewalPrice( purchase ) }
-									productDisplayPrice={ purchase.productDisplayPrice }
 									currencyCode={ purchase.currencyCode }
 									taxText={ purchase.taxText }
 									isOnSale={ !! purchase.saleAmount }

--- a/client/my-sites/plan-price/README.md
+++ b/client/my-sites/plan-price/README.md
@@ -12,15 +12,15 @@ PlanPrice can take a `productDisplayPrice` or a `rawPrice`  (deprecated) prop, t
 A `productDisplayPrice` can be passed from the `/purchases` or `/plans` REST endpoints to a Redux store, for example:
 
 ```jsx
-	import { connect } from 'react-redux';
+import { connect } from "react-redux";
 
-	const { productDisplayPrice } = purchase;
+const { productDisplayPrice } = purchase;
 
-	export default connect( ( state, props ) => {
-		const purchase = getByPurchaseId( state, props.purchaseId );
-		
-		return purchase;
-	});
+export default connect((state, props) => {
+  const purchase = getByPurchaseId(state, props.purchaseId);
+
+  return purchase;
+});
 ```
 `productDisplayPrice` is preferred because it provides an HTML wrapped, geo-IDed, and properly formatted currency string. Whereas, `rawPrice` is not geo-IDed and requires extra work to format correctly on the front end.
 

--- a/client/my-sites/plan-price/README.md
+++ b/client/my-sites/plan-price/README.md
@@ -1,14 +1,56 @@
 # PlanPrice Component
 
-PlanPrice component is a React component used to display plan's price with a currency and a discount, if any.
-It can be used anywhere where a plan's price is required.
+The PlanPrice component is a React component used to display a plan's price with a currency and a discount, if any. It can be used anywhere where a plan's price is required.
 
 If you want to emphasize that a plan's price is discounted, use two `<PlanPrice>` components as below and wrap them in a
 flexbox container.
 
+## Usage
+
+PlanPrice can take a `productDisplayPrice` or a `rawPrice`  (deprecated) prop, though `productDisplayPrice` is the preferred option.
+
+A `productDisplayPrice` can be passed from the `/purchases` or `/plans` REST endpoints to a Redux store, for example:
+
+```jsx
+	import { connect } from 'react-redux';
+
+	const { productDisplayPrice } = purchase;
+
+	export default connect( ( state, props ) => {
+		const purchase = getByPurchaseId( state, props.purchaseId );
+		...more props
+		return {
+			purchase,
+			...more props,
+		}
+	});
+```
+`productDisplayPrice` is preferred because it provides an HTML wrapped, geo-IDed, and properly formatted currency string. Whereas, `rawPrice` is not geo-IDed and requires extra work to format correctly on the front end.
+
+You can pass along `rawPrice` (not required) with `productDisplayPrice` and when available the `productDisplayPrice` will be used by default.
+
+**Preferred usage**
+```jsx
+<PlanPrice
+	productDisplayPrice={ purchase.productDisplayPrice }
+	taxText={ purchase.taxText }
+	isOnSale={ !! purchase.saleAmount }
+/>
+```
+
+**Backwards compatible usage**
+```jsx
+<PlanPrice
+	productDisplayPrice={ purchase.productDisplayPrice }
+	rawPrice={ getRenewalPrice( purchase ) }
+	currencyCode={ purchase.currencyCode }
+	taxText={ purchase.taxText }
+	isOnSale={ !! purchase.saleAmount }
+/>
+```
+
 If you pass an array of two numbers in the `rawPrice` prop, a range of prices will be displayed.
 
-## Usage
 
 ```jsx
 import PlanPrice from 'calypso/my-sites/plan-price';
@@ -36,10 +78,11 @@ export default class extends React.Component {
 ## Props
 
 | Prop         | Type           | Description                                             |
-| ------------ | -------------- | ------------------------------------------------------- |
-| rawPrice     | number / array | Price or price range of the plan                        |
-| original     | bool           | Is the price discounted and this is the original one?   |
-| discounted   | bool           | Is the price discounted and this is the discounted one? |
-| isOnSale     | bool           | Is the product this price is for on sale?               |
-| currencyCode | string         | Currency of the price                                   |
-| className    | string         | If you need to add additional classes                   |
+| ------------------- | -------------- | ------------------------------------------------------- |
+| productDisplayPrice | number         | HTML wrapped display price                              |
+| rawPrice            | number / array | Price or price range of the plan                        |
+| original            | bool           | Is the price discounted and this is the original one?   |
+| discounted          | bool           | Is the price discounted and this is the discounted one? |
+| isOnSale            | bool           | Is the product this price is for on sale?               |
+| currencyCode        | string         | Currency of the price                                   |
+| className           | string         | If you need to add additional classes                   |

--- a/client/my-sites/plan-price/README.md
+++ b/client/my-sites/plan-price/README.md
@@ -18,11 +18,8 @@ A `productDisplayPrice` can be passed from the `/purchases` or `/plans` REST end
 
 	export default connect( ( state, props ) => {
 		const purchase = getByPurchaseId( state, props.purchaseId );
-		...more props
-		return {
-			purchase,
-			...more props,
-		}
+		
+		return purchase;
 	});
 ```
 `productDisplayPrice` is preferred because it provides an HTML wrapped, geo-IDed, and properly formatted currency string. Whereas, `rawPrice` is not geo-IDed and requires extra work to format correctly on the front end.

--- a/client/my-sites/plan-price/README.md
+++ b/client/my-sites/plan-price/README.md
@@ -7,35 +7,33 @@ flexbox container.
 
 ## Usage
 
-PlanPrice can take a `productDisplayPrice` or a `rawPrice`  (deprecated) prop, though `productDisplayPrice` is the preferred option.
+PlanPrice can take a `productDisplayPrice` or a `rawPrice` (deprecated) prop, though `productDisplayPrice` is the preferred option.
 
-A `productDisplayPrice` can be passed from the `/purchases` or `/plans` REST endpoints to a Redux store, for example:
+A `productDisplayPrice` can be retrieved from the `/purchases` or `/plans` REST endpoints and are stored in Redux; for example:
 
 ```jsx
-import { connect } from "react-redux";
-
-const { productDisplayPrice } = purchase;
-
-export default connect((state, props) => {
-  const purchase = getByPurchaseId(state, props.purchaseId);
-
-  return purchase;
-});
+function MyComponent( { purchaseId } ) {
+	const { productDisplayPrice } = useSelector( ( state ) => getByPurchaseId( state, purchaseId ) );
+	return <PlanPrice productDisplayPrice={ productDisplayPrice } />;
+}
 ```
+
 `productDisplayPrice` is preferred because it provides an HTML wrapped, geo-IDed, and properly formatted currency string. Whereas, `rawPrice` is not geo-IDed and requires extra work to format correctly on the front end.
 
 You can pass along `rawPrice` (not required) with `productDisplayPrice` and when available the `productDisplayPrice` will be used by default.
 
 **Preferred usage**
+
 ```jsx
 <PlanPrice
 	productDisplayPrice={ purchase.productDisplayPrice }
 	taxText={ purchase.taxText }
 	isOnSale={ !! purchase.saleAmount }
-/>
+/>;
 ```
 
 **Backwards compatible usage**
+
 ```jsx
 <PlanPrice
 	productDisplayPrice={ purchase.productDisplayPrice }
@@ -43,11 +41,10 @@ You can pass along `rawPrice` (not required) with `productDisplayPrice` and when
 	currencyCode={ purchase.currencyCode }
 	taxText={ purchase.taxText }
 	isOnSale={ !! purchase.saleAmount }
-/>
+/>;
 ```
 
 If you pass an array of two numbers in the `rawPrice` prop, a range of prices will be displayed.
-
 
 ```jsx
 import PlanPrice from 'calypso/my-sites/plan-price';

--- a/client/my-sites/plan-price/README.md
+++ b/client/my-sites/plan-price/README.md
@@ -74,7 +74,7 @@ export default class extends React.Component {
 
 ## Props
 
-| Prop         | Type           | Description                                             |
+| Prop                | Type           | Description                                             |
 | ------------------- | -------------- | ------------------------------------------------------- |
 | productDisplayPrice | number         | HTML wrapped display price                              |
 | rawPrice            | number / array | Price or price range of the plan                        |

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -31,7 +31,7 @@ export class PlanPrice extends Component {
 		} );
 
 		// productDisplayPrice is returned from Store Price and provides a geo-IDed currency format
-		if ( productDisplayPrice && ! Array.isArray( rawPrice ) ) {
+		if ( ( productDisplayPrice && ! Array.isArray( rawPrice ) ) || rawPrice.length === 1 ) {
 			return (
 				<h4 className={ classes }>
 					<span

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -31,7 +31,10 @@ export class PlanPrice extends Component {
 		} );
 
 		// productDisplayPrice is returned from Store Price and provides a geo-IDed currency format
-		if ( ( productDisplayPrice && ! Array.isArray( rawPrice ) ) || rawPrice.length === 1 ) {
+		if (
+			( productDisplayPrice && ! Array.isArray( rawPrice ) ) ||
+			( Array.isArray( rawPrice ) && rawPrice.length === 1 )
+		) {
 			return (
 				<h4 className={ classes }>
 					<span

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -31,10 +31,19 @@ export class PlanPrice extends Component {
 		} );
 
 		// productDisplayPrice is returned from Store Price and provides a geo-IDed currency format
-		if (
-			( productDisplayPrice && ! Array.isArray( rawPrice ) ) ||
-			( Array.isArray( rawPrice ) && rawPrice.length === 1 )
-		) {
+		const shouldUseDisplayPrice = () => {
+			if ( ! productDisplayPrice ) {
+				return false;
+			}
+			if ( rawPrice ) {
+				if ( Array.isArray( rawPrice ) && rawPrice.length > 1 ) {
+					return false;
+				}
+			}
+			return true;
+		};
+
+		if ( shouldUseDisplayPrice() ) {
 			return (
 				<h4 className={ classes }>
 					<span

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -28,11 +28,6 @@ export class PlanPrice extends Component {
 		if ( ! currencyCode || rawPrice === undefined ) {
 			return null;
 		}
-		// Dangerously set innerHTML display price
-		// eslint-disable-next-line no-unused-vars
-		function setDisplayPrice() {
-			return { __html: productDisplayPrice };
-		}
 
 		// "Normalize" the input price or price range.
 		const rawPriceRange = Array.isArray( rawPrice ) ? rawPrice.slice( 0, 2 ) : [ rawPrice ];
@@ -76,6 +71,18 @@ export class PlanPrice extends Component {
 							comment: 'The price range for a particular product',
 						} ) }
 				</span>
+			);
+		}
+
+		if ( productDisplayPrice ) {
+			return (
+				<h4 className={ classes }>
+					<span
+						className="plan-price__integer"
+						// eslint-disable-next-line react/no-danger
+						dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
+					/>
+				</h4>
 			);
 		}
 

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -17,8 +17,6 @@ export class PlanPrice extends Component {
 			className,
 			displayFlatPrice,
 			displayPerMonthNotation,
-			displayShortPerMonthNotation,
-			originalPricePrefix,
 			productDisplayPrice,
 			isOnSale,
 			taxText,

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -17,6 +17,9 @@ export class PlanPrice extends Component {
 			className,
 			displayFlatPrice,
 			displayPerMonthNotation,
+			displayShortPerMonthNotation,
+			originalPricePrefix,
+			productDisplayPrice,
 			isOnSale,
 			taxText,
 			translate,
@@ -24,6 +27,11 @@ export class PlanPrice extends Component {
 
 		if ( ! currencyCode || rawPrice === undefined ) {
 			return null;
+		}
+		// Dangerously set innerHTML display price
+		// eslint-disable-next-line no-unused-vars
+		function setDisplayPrice() {
+			return { __html: productDisplayPrice };
 		}
 
 		// "Normalize" the input price or price range.

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -25,6 +25,24 @@ export class PlanPrice extends Component {
 			translate,
 		} = this.props;
 
+		const classes = classNames( 'plan-price', className, {
+			'is-original': original,
+			'is-discounted': discounted,
+		} );
+
+		// productDisplayPrice is returned from Store Price and provides a geo-IDed currency format
+		if ( productDisplayPrice && ! Array.isArray( rawPrice ) ) {
+			return (
+				<h4 className={ classes }>
+					<span
+						className="plan-price__integer"
+						// eslint-disable-next-line react/no-danger
+						dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
+					/>
+				</h4>
+			);
+		}
+
 		if ( ! currencyCode || rawPrice === undefined ) {
 			return null;
 		}
@@ -42,11 +60,6 @@ export class PlanPrice extends Component {
 				price: getCurrencyObject( item, currencyCode ),
 				raw: item,
 			};
-		} );
-
-		const classes = classNames( 'plan-price', className, {
-			'is-original': original,
-			'is-discounted': discounted,
 		} );
 
 		const renderPrice = ( priceObj ) => {
@@ -71,18 +84,6 @@ export class PlanPrice extends Component {
 							comment: 'The price range for a particular product',
 						} ) }
 				</span>
-			);
-		}
-
-		if ( productDisplayPrice ) {
-			return (
-				<h4 className={ classes }>
-					<span
-						className="plan-price__integer"
-						// eslint-disable-next-line react/no-danger
-						dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
-					/>
-				</h4>
 			);
 		}
 
@@ -146,6 +147,7 @@ PlanPrice.propTypes = {
 	translate: PropTypes.func.isRequired,
 	displayPerMonthNotation: PropTypes.bool,
 	currencyFormatOptions: PropTypes.object,
+	productDisplayPrice: PropTypes.string,
 };
 
 PlanPrice.defaultProps = {

--- a/client/my-sites/plan-price/test/index.js
+++ b/client/my-sites/plan-price/test/index.js
@@ -29,4 +29,34 @@ describe( 'PlanPrice', () => {
 		render( <PlanPrice rawPrice={ [ 10, 0 ] } /> );
 		expect( document.body ).not.toHaveTextContent( '$10-0' );
 	} );
+	it( 'will use productDisplayPrice when rawPrice is an integer', () => {
+		render(
+			<PlanPrice
+				rawPrice={ 10 }
+				productDisplayPrice={ '<abbr title="United States Dollars">$</abbr>96.00' }
+			/>
+		);
+		expect( document.body ).toHaveTextContent( '$96.00' );
+		expect( document.body ).not.toHaveTextContent( '$10' );
+	} );
+	it( 'will use productDisplayPrice when rawPrice is an array with length of 1', () => {
+		render(
+			<PlanPrice
+				rawPrice={ [ 10 ] }
+				productDisplayPrice={ '<abbr title="United States Dollars">$</abbr>96.00' }
+			/>
+		);
+		expect( document.body ).toHaveTextContent( '$96.00' );
+		expect( document.body ).not.toHaveTextContent( '$10' );
+	} );
+	it( 'will use rawPrice when rawPrice is passed an array with length > 1', () => {
+		render(
+			<PlanPrice
+				rawPrice={ [ 5, 10 ] }
+				productDisplayPrice={ '<abbr title="United States Dollars">$</abbr>96.00' }
+			/>
+		);
+		expect( document.body ).toHaveTextContent( '$5-10' );
+		expect( document.body ).not.toHaveTextContent( '$96.00' );
+	} );
 } );

--- a/client/state/sites/plans/assembler.js
+++ b/client/state/sites/plans/assembler.js
@@ -24,6 +24,7 @@ export const createSitePlanObject = ( plan ) => {
 		isDomainUpgrade: Boolean( plan.is_domain_upgrade ),
 		productName: plan.product_name,
 		productSlug: plan.product_slug,
+		productDisplayPrice: plan.product_display_price,
 		rawDiscount: plan.raw_discount,
 		rawPrice: plan.raw_price,
 		subscribedDate: plan.subscribed_date,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As proposed [here](https://github.com/Automattic/wp-calypso/issues/50064#issuecomment-1124022316), this PR implements a conditional that decides whether to use the old `rawPrice` value to create a pricing format within PlanPrice, or, use the newer `productDisplayPrice` value to pass in an HTML value from the backend.

See: #50064
