### PR TITLE
isAnnualPlanOrUpgradeableAnnualPeriod: use feature checks and rename

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-test/index.jsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.jsx
@@ -53,7 +53,7 @@ export default function MarketplaceTest() {
 	const pluginDetails = useSelector( ( state ) => getPlugins( state, [ selectedSiteId ] ) );
 	const { data = [], isFetching } = useWPCOMPlugins( 'all' );
 
-	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );
+	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSiteId ) );
 
 	const isRequestingForSite = useSelector( ( state ) =>
 		isRequestingForSites( state, [ selectedSiteId ] )

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -5,7 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
-import { hasOrIntendsToBuyLiveSupport } from 'calypso/state/marketplace/selectors';
+import usePluginsSupportText from 'calypso/my-sites/plugins/use-plugins-support-text/';
 import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -61,11 +61,7 @@ const USPS: React.FC< Props > = ( {
 		return getProductDisplayCost( state, eligibleForProPlan ? PLAN_WPCOM_PRO : productSlug );
 	} );
 
-	const isLiveSupport = useSelector( hasOrIntendsToBuyLiveSupport );
-	const supportTextNonPro = isLiveSupport
-		? translate( 'Live chat support 24x7' )
-		: translate( 'Unlimited Email Support' );
-	const supportText = eligibleForProPlan ? translate( 'Premium support' ) : supportTextNonPro;
+	const supportText = usePluginsSupportText();
 
 	const filteredUSPS = [
 		...( isMarketplaceProduct
@@ -131,7 +127,7 @@ const USPS: React.FC< Props > = ( {
 					{
 						id: 'support',
 						image: <Gridicon icon="chat" size={ 16 } />,
-						text: eligibleForProPlan ? translate( 'Premium support' ) : supportText,
+						text: supportText,
 						eligibilities: [ 'needs-upgrade', 'marketplace' ],
 					},
 			  ]

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -5,7 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
-import { isAnnualPlanOrUpgradeableAnnualPeriod } from 'calypso/state/marketplace/selectors';
+import { hasOrIntendsToBuyLiveSupport } from 'calypso/state/marketplace/selectors';
 import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -49,7 +49,7 @@ const USPS: React.FC< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 
-	const isAnnualPlan = useSelector( isAnnualPlanOrUpgradeableAnnualPeriod );
+	const isLiveSupport = useSelector( hasOrIntendsToBuyLiveSupport );
 
 	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
 
@@ -63,7 +63,7 @@ const USPS: React.FC< Props > = ( {
 		return getProductDisplayCost( state, eligibleForProPlan ? PLAN_WPCOM_PRO : productSlug );
 	} );
 
-	const supportText = isAnnualPlan
+	const supportText = isLiveSupport
 		? translate( 'Live chat support 24x7' )
 		: translate( 'Unlimited Email Support' );
 

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -49,8 +49,6 @@ const USPS: React.FC< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 
-	const isLiveSupport = useSelector( hasOrIntendsToBuyLiveSupport );
-
 	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
 
 	const selectedSite = useSelector( getSelectedSite );
@@ -63,9 +61,11 @@ const USPS: React.FC< Props > = ( {
 		return getProductDisplayCost( state, eligibleForProPlan ? PLAN_WPCOM_PRO : productSlug );
 	} );
 
-	const supportText = isLiveSupport
+	const isLiveSupport = useSelector( hasOrIntendsToBuyLiveSupport );
+	const supportTextNonPro = isLiveSupport
 		? translate( 'Live chat support 24x7' )
 		: translate( 'Unlimited Email Support' );
+	const supportText = eligibleForProPlan ? translate( 'Premium support' ) : supportTextNonPro;
 
 	const filteredUSPS = [
 		...( isMarketplaceProduct

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -6,7 +6,7 @@ import support from 'calypso/assets/images/marketplace/support.svg';
 import wooLogo from 'calypso/assets/images/marketplace/woo-logo.svg';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
-import { isAnnualPlanOrUpgradeableAnnualPeriod } from 'calypso/state/marketplace/selectors';
+import { hasOrIntendsToBuyLiveSupport } from 'calypso/state/marketplace/selectors';
 
 const PluginDetailsSidebar = ( {
 	plugin: {
@@ -20,7 +20,7 @@ const PluginDetailsSidebar = ( {
 } ) => {
 	const translate = useTranslate();
 
-	const isAnnualPlan = useSelector( isAnnualPlanOrUpgradeableAnnualPeriod );
+	const isAnnualPlan = useSelector( hasOrIntendsToBuyLiveSupport );
 	const isWooCommercePluginRequired = requirements.plugins?.some(
 		( pluginName ) => pluginName === 'plugins/woocommerce'
 	);

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -1,14 +1,11 @@
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
-import { useSelector } from 'react-redux';
 import eye from 'calypso/assets/images/marketplace/eye.svg';
 import support from 'calypso/assets/images/marketplace/support.svg';
 import wooLogo from 'calypso/assets/images/marketplace/woo-logo.svg';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
-import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
-import { hasOrIntendsToBuyLiveSupport } from 'calypso/state/marketplace/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import usePluginsSupportText from 'calypso/my-sites/plugins/use-plugins-support-text/';
 
 const PluginDetailsSidebar = ( {
 	plugin: {
@@ -26,15 +23,7 @@ const PluginDetailsSidebar = ( {
 		( pluginName ) => pluginName === 'plugins/woocommerce'
 	);
 
-	const selectedSite = useSelector( getSelectedSite );
-	const eligibleForProPlan = useSelector( ( state ) =>
-		isEligibleForProPlan( state, selectedSite?.ID )
-	);
-	const isLiveSupport = useSelector( hasOrIntendsToBuyLiveSupport );
-	const supportTextNonPro = isLiveSupport
-		? translate( 'Live chat support 24x7' )
-		: translate( 'Unlimited Email Support' );
-	const supportText = eligibleForProPlan ? translate( 'Premium support' ) : supportTextNonPro;
+	const supportText = usePluginsSupportText();
 
 	if ( ! isMarketplaceProduct ) {
 		return (

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -5,8 +5,10 @@ import eye from 'calypso/assets/images/marketplace/eye.svg';
 import support from 'calypso/assets/images/marketplace/support.svg';
 import wooLogo from 'calypso/assets/images/marketplace/woo-logo.svg';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
 import { hasOrIntendsToBuyLiveSupport } from 'calypso/state/marketplace/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const PluginDetailsSidebar = ( {
 	plugin: {
@@ -20,10 +22,19 @@ const PluginDetailsSidebar = ( {
 } ) => {
 	const translate = useTranslate();
 
-	const isAnnualPlan = useSelector( hasOrIntendsToBuyLiveSupport );
 	const isWooCommercePluginRequired = requirements.plugins?.some(
 		( pluginName ) => pluginName === 'plugins/woocommerce'
 	);
+
+	const selectedSite = useSelector( getSelectedSite );
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, selectedSite?.ID )
+	);
+	const isLiveSupport = useSelector( hasOrIntendsToBuyLiveSupport );
+	const supportTextNonPro = isLiveSupport
+		? translate( 'Live chat support 24x7' )
+		: translate( 'Unlimited Email Support' );
+	const supportText = eligibleForProPlan ? translate( 'Premium support' ) : supportTextNonPro;
 
 	if ( ! isMarketplaceProduct ) {
 		return (
@@ -102,11 +113,7 @@ const PluginDetailsSidebar = ( {
 				id="support"
 				icon={ { src: support } }
 				title={ translate( 'Support' ) }
-				description={
-					isAnnualPlan
-						? translate( 'Live chat support 24x7' )
-						: translate( 'Unlimited Email Support' )
-				}
+				description={ supportText }
 				links={ supportLinks }
 				first={ ! isWooCommercePluginRequired && ! demo_url }
 			/>

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -112,7 +112,7 @@ const PluginsBrowserListElement = ( props ) => {
 		return ! isCompatiblePlugin( plugin.slug ) && ! jetpackNonAtomic;
 	} );
 
-	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite ) );
+	const shouldUpgrade = useSelector( ( state ) => shouldUpgradeCheck( state, selectedSite?.ID ) );
 
 	if ( isPlaceholder ) {
 		return <Placeholder iconSize={ iconSize } />;

--- a/client/my-sites/plugins/use-plugins-support-text/index.js
+++ b/client/my-sites/plugins/use-plugins-support-text/index.js
@@ -1,0 +1,42 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import { hasOrIntendsToBuyLiveSupport } from 'calypso/state/marketplace/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+/*
+ * Gets text used to describe the support level a user will receive
+ * if buying a marketplace plugin for the selected site.
+ * Example page: /plugins/woocommerce-subscriptions/<sitename>
+ *
+ * If pro plan is active and site is eligible:
+ *    "Premium Support".
+ *
+ * If pro plan is inactive/ineligible, and their current plan has the Live Support feature:
+ *    "Live chat support 24x7".
+ *
+ * If pro plan is inactive/ineligible, they have "Annually" selected in the top right,
+ * meaning they intend to buy an annual plan:
+ *    "Live chat support 24x7".
+ *
+ * If pro plan is inactive/ineligible, and their current plan does not have the Live
+ * Support feature, and they have "monthly" selected in the top right, meaning
+ * they intend to buy a monthly plan:
+ *   "Unlimited Email Support".
+ *
+ * We don't know exactly what plan they're going to buy, so we make an assumption that
+ * all monthly plans don't have live support and all annual ones do.
+ */
+export default function usePluginsSupportText() {
+	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, selectedSite?.ID )
+	);
+	const isLiveSupport = useSelector( hasOrIntendsToBuyLiveSupport );
+	const supportTextNonPro = isLiveSupport
+		? translate( 'Live chat support 24x7' )
+		: translate( 'Unlimited Email Support' );
+	const supportText = eligibleForProPlan ? translate( 'Premium support' ) : supportTextNonPro;
+	return supportText;
+}

--- a/client/state/marketplace/selectors.ts
+++ b/client/state/marketplace/selectors.ts
@@ -1,47 +1,49 @@
-import {
-	isBusiness,
-	isEcommerce,
-	isEnterprise,
-	isPro,
-	isMonthly,
-} from '@automattic/calypso-products';
+import { FEATURE_INSTALL_PLUGINS, WPCOM_FEATURES_LIVE_SUPPORT } from '@automattic/calypso-products';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { default as isVipSite } from 'calypso/state/selectors/is-vip-site';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { IAppState } from 'calypso/state/types';
-import { getSelectedSiteId, getSelectedSite } from 'calypso/state/ui/selectors';
-import type { WithCamelCaseSlug, WithSnakeCaseSlug } from '@automattic/calypso-products';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-const shouldUpgradeCheck = (
-	state: IAppState,
-	selectedSite: { ID: number; plan: WithSnakeCaseSlug | WithCamelCaseSlug }
-) => {
-	return selectedSite
-		? ! (
-				isPro( selectedSite?.plan ) ||
-				isBusiness( selectedSite?.plan ) ||
-				isEnterprise( selectedSite?.plan ) ||
-				isEcommerce( selectedSite?.plan ) ||
-				isJetpackSite( state, selectedSite?.ID ) ||
-				isVipSite( state, selectedSite?.ID )
-		  )
-		: null;
+const shouldUpgradeCheck = ( state: IAppState, siteId: number | null ) => {
+	if ( ! siteId ) {
+		return null;
+	}
+	const canInstallPlugins = siteHasFeature( state, siteId, FEATURE_INSTALL_PLUGINS );
+	const isStandaloneJetpack =
+		isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId );
+	const isVip = isVipSite( state, siteId );
+	return ! canInstallPlugins && ! isStandaloneJetpack && ! isVip;
 };
 
 export const isAnnualPlanOrUpgradeableAnnualPeriod = ( state: IAppState ) => {
-	const selectedSiteId = getSelectedSiteId( state );
-	const currentPlan = selectedSiteId && getCurrentPlan( state, selectedSiteId );
-	const isAnnualPlan = currentPlan && ! isMonthly( currentPlan.productSlug );
+	const siteId = getSelectedSiteId( state );
 
-	const selectedSite = getSelectedSite( state );
-	const shouldUpgrade = selectedSite && shouldUpgradeCheck( state, selectedSite );
+	const hasLiveSupport = siteHasFeature( state, siteId, WPCOM_FEATURES_LIVE_SUPPORT );
+	const needsUpgrade = shouldUpgradeCheck( state, siteId );
 
-	const billingPeriod = getBillingInterval( state );
-	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
+	if ( needsUpgrade ) {
+		/**
+		 * We need to upgrade plans to buy a marketplace addon.
+		 *
+		 * We don't know exactly what plan we're buying, but we do know if the
+		 * user has "monthly" or "yearly" selected in the top right.
+		 * Assume that "yearly" means that they'll get Live Support.
+		 *
+		 * If they already have live support, or if they are looking at annual
+		 * plans, return true.
+		 */
+		const billingPeriod = getBillingInterval( state );
+		// This refers to the top right [ Monthly ] [ Annual ] selection.
+		const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
+		return isAnnualPeriod || hasLiveSupport;
+	}
 
-	return ( ! shouldUpgrade && isAnnualPlan ) || ( shouldUpgrade && isAnnualPeriod );
+	// We do not need to upgrade. Return if we have live support directly.
+	return hasLiveSupport;
 };
 
 export default shouldUpgradeCheck;

--- a/client/state/marketplace/selectors.ts
+++ b/client/state/marketplace/selectors.ts
@@ -8,7 +8,13 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-const shouldUpgradeCheck = ( state: IAppState, siteId: number | null ) => {
+/*
+ * shouldUpgradeCheck:
+ * Does the selected blog need an upgrade before installing marketplace addons?
+ * If it's missing the FEATURE_INSTALL_PLUGINS, shouldUpgradeCheck returns true,
+ * except standalone jetpack and VIP sites always return false.
+ */
+const shouldUpgradeCheck = ( state: IAppState, siteId: number | null ): boolean | null => {
 	if ( ! siteId ) {
 		return null;
 	}
@@ -19,7 +25,15 @@ const shouldUpgradeCheck = ( state: IAppState, siteId: number | null ) => {
 	return ! canInstallPlugins && ! isStandaloneJetpack && ! isVip;
 };
 
-export const isAnnualPlanOrUpgradeableAnnualPeriod = ( state: IAppState ) => {
+/*
+ * hasOrIntendsToBuyLiveSupport:
+ * - Does the selected blog already have a plan or product providing the LIVE_SUPPORT feature?
+ * OR
+ * - Does the user need to purchase an upgrade before installing Marketplace Addons
+ * and do they have the Annual purchase selected?
+ *   ( We assume this means they'll be buying a plan that includes Live Support ).
+ */
+export const hasOrIntendsToBuyLiveSupport = ( state: IAppState ): boolean => {
 	const siteId = getSelectedSiteId( state );
 
 	const hasLiveSupport = siteHasFeature( state, siteId, WPCOM_FEATURES_LIVE_SUPPORT );

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -214,10 +214,11 @@ export const FEATURE_SOCIAL_MEDIA_TOOLS = 'social-media-tools';
 
 // From class-wpcom-features.php in WPCOM
 export const WPCOM_FEATURES_AKISMET = 'akismet';
-export const WPCOM_FEATURES_ATOMIC = 'atomic';
 export const WPCOM_FEATURES_ANTISPAM = 'antispam';
+export const WPCOM_FEATURES_ATOMIC = 'atomic';
 export const WPCOM_FEATURES_FULL_ACTIVITY_LOG = 'full-activity-log';
 export const WPCOM_FEATURES_INSTANT_SEARCH = 'instant-search';
+export const WPCOM_FEATURES_LIVE_SUPPORT = 'live_support';
 export const WPCOM_FEATURES_NO_ADVERTS = 'no-adverts/no-adverts.php';
 export const WPCOM_FEATURES_NO_WPCOM_BRANDING = 'no-wpcom-branding';
 export const WPCOM_FEATURES_PREMIUM_THEMES = 'premium-themes';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is a tricky one! `isAnnualPlanOrUpgradeableAnnualPeriod` is a complex selector. Let's first start out with what it does. Ultimately, it controls some text about support on a marketplace plugins page. Two examples, where the text is in the bottom right:

**(Pro Plan Disabled In Code + Free Plan + Annual selected) = "Live Chat Support"**
![2022-05-11_17-15_1](https://user-images.githubusercontent.com/937354/167956509-27b34bf0-2cf4-4a0d-985c-58086006c9b5.png)

**(Pro Plan Disabled In Code + Free Plan + Monthly selected) = "Unlimited Chat Support"**
![2022-05-11_17-15](https://user-images.githubusercontent.com/937354/167956685-e028b73a-60af-49f7-be4e-bed0905f30b8.png)

* Notes about our current plans:
  * Most plans do provide Live Chat Support, but monthly plans do not.
  * The Pro Plan cannot be bought monthly, so, it always provides Live Chat Support.
  * The Pro Plan has a "master switch" and can be turned on or off for all of Calypso. Currently it's ON. To see any of these changes you will have to temporarily turn it OFF. If the PRO plan is on, the text always reads "Premium Support" and the selector is not even called here.

**(Pro Plan Enabled + Any Plan + Either Annual or Monthly Selected) = "Premium Support"**
![2022-05-11_17-21](https://user-images.githubusercontent.com/937354/167957100-89497464-7cd5-44df-90ad-f8d5c8242471.png)

* **What the selector used to do**
  *  Examine if you need to upgrade plan before purchasing marketplace addons (hardcoded list of plans).
    * If no upgrade is needed, return if the current plan you have is a yearly subscription.
      * Assumption: All yearly subscriptions have live support. 
    * If an upgrade is needed, return if you have selected "Annual" in the top right.
      * Assumption: The yearly subscription you are about to purchase has live support.
* **What the selector does now**
  *  Examine if you need to upgrade plan before purchasing marketplace addons (check install_plugins feature). 
    * If no upgrade is needed, return if you have the live_support feature.
    * If an upgrade is needed, return if you have selected "Annual" in the top right.
      * Assumption: The yearly subscription you are about to purchase has live support. 

I also renamed it `isAnnualPlanOrUpgradeableAnnualPeriod` -> `hasOrIntendsToBuyLiveSupport` to try to make its function clearer.

#### Testing instructions

* STOP! D80582-code must be merged or applied to your sandbox first.
* Visit `/plugins/woocommerce-subscriptions/<site>` across a variety of dimensions:
  * Pro plan **enabled** vs **disabled**
  * The site has a **free plan** vs a **pro plan**
  * In the top right you have clicked either **annual** or **monthly**
Everything should be exactly the same before and after.

![2022-05-11_17-31](https://user-images.githubusercontent.com/937354/167958150-a3fc6542-de85-4cfd-9832-85e6a5c5456f.png)

To disable PRO, apply this patch and run locally:
```diff
diff --git a/client/my-sites/plugins/plugin-details-CTA/usps.tsx b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
index 3d61eca15e..825cdc0d9b 100644
--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -54,9 +54,7 @@ const USPS: React.FC< Props > = ( {
        const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
 
        const selectedSite = useSelector( getSelectedSite );
-       const eligibleForProPlan = useSelector( ( state ) =>
-               isEligibleForProPlan( state, selectedSite?.ID )
-       );
+       const eligibleForProPlan = false;
 
        const planDisplayCost = useSelector( ( state ) => {
                const productSlug = isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY;
```

* Also code review - I have also changed the `shouldUpgradeCheck` function without checking the other places it's used in the UI.

#### History

#59853, #61212, #61365, #61371

Related to p4TIVU-a66-p2