### PR TITLE
Shopping Cart: Disable StaleCartItemsNotice

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -32,7 +32,7 @@
 		"comments/filters-in-posts": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
-		"current-site/stale-cart-notice": true,
+		"current-site/stale-cart-notice": false,
 		"checkout/google-pay": true,
 		"desktop-promo": true,
 		"devdocs": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -18,7 +18,7 @@
 		"composite-checkout-testing": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
-		"current-site/stale-cart-notice": true,
+		"current-site/stale-cart-notice": false,
 		"checkout/google-pay": true,
 		"devdocs": false,
 		"domains/gdpr-consent-page": true,

--- a/config/production.json
+++ b/config/production.json
@@ -21,7 +21,7 @@
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
-		"current-site/stale-cart-notice": true,
+		"current-site/stale-cart-notice": false,
 		"checkout/google-pay": true,
 		"desktop-promo": true,
 		"domains/gdpr-consent-page": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -19,7 +19,7 @@
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
-		"current-site/stale-cart-notice": true,
+		"current-site/stale-cart-notice": false,
 		"checkout/google-pay": true,
 		"desktop-promo": true,
 		"dev/preferences-helper": true,

--- a/config/test.json
+++ b/config/test.json
@@ -29,7 +29,7 @@
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
-		"current-site/stale-cart-notice": true,
+		"current-site/stale-cart-notice": false,
 		"checkout/google-pay": true,
 		"desktop-promo": true,
 		"devdocs": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -20,7 +20,7 @@
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
-		"current-site/stale-cart-notice": true,
+		"current-site/stale-cart-notice": false,
 		"checkout/google-pay": true,
 		"desktop-promo": true,
 		"devdocs": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We get a large number of GET requests to the `/me/shopping-cart` endpoint for sites that do not belong to the user and we can't yet determine why (see 410-gh-Automattic/payments-shilling). The issue appears on tons of pages, many of which do not perform any cart actions, leading me to believe that the triggering event is either `StaleCartItemsNotice` or `MasterbarCartButton` which are present on most pages. https://github.com/Automattic/wp-calypso/pull/63530 should help reduce the usage of `MasterbarCartButton` and  this PR disables `StaleCartItemsNotice`.

Partially this is an experiment to see if this helps the issue, but also we've discussed disabling the notice anyway now that we have the `MasterbarCartButton` (640-gh-Automattic/payments-shilling).

Whether this helps or not, we can re-enable it fairly easily in a future PR (or remove it entirely if we decide it's no longer needed).

#### Testing instructions

None should be needed.