### PR TITLE
Marketplace: Stop requesting pages once we've loaded them all

### DIFF
--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -18,6 +18,7 @@ interface WPORGResponse {
 		pagination: {
 			results: number;
 			page: number;
+			pages: number;
 		};
 	};
 	isLoading: boolean;
@@ -149,12 +150,25 @@ const usePlugins = ( {
 			break;
 	}
 
+	function fetchNextPageAndStop() {
+		if (
+			dotOrgPagination?.page &&
+			dotOrgPagination?.pages &&
+			dotOrgPagination.page >= dotOrgPagination.pages
+		) {
+			return;
+		}
+
+		fetchNextPage && fetchNextPage();
+	}
+
 	return {
 		plugins,
 		isFetching,
-		fetchNextPage,
+		fetchNextPage: fetchNextPageAndStop,
 		pagination: {
 			page: dotOrgPagination?.page,
+			pages: dotOrgPagination?.pages,
 			results,
 		},
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes https://github.com/Automattic/wp-calypso/issues/63315 by adding a stop condition to fetchNextPage, [this is required by `InfiniteQuery`](https://github.com/Automattic/wp-calypso/blob/trunk/client/components/infinite-scroll/README.md#example-implementation).

#### Testing instructions

- [x] Search network traffic should cease when there are no more pages to load
- [x] Search network traffic should cease when there is only a few results (e.g. http://calypso.localhost:3000/plugins/wooptest18282home.wpcomstaging.com?s=developer:%22elemntor%22)

Fixes #63315
