### PR TITLE
Revert "Login: fix the switch to suggested language and log-in redirection"

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -131,9 +131,6 @@ export function magicLoginUse( context, next ) {
 export function redirectDefaultLocale( context, next ) {
 	// Only handle simple routes
 	if ( context.pathname !== '/log-in/en' && context.pathname !== '/log-in/jetpack/en' ) {
-		if ( ! isUserLoggedIn( context.store.getState() ) && ! context.params.lang ) {
-			context.params.lang = config( 'i18n_default_locale_slug' );
-		}
 		return next();
 	}
 
@@ -153,9 +150,9 @@ export function redirectDefaultLocale( context, next ) {
 	}
 
 	if ( context.params.isJetpack === 'jetpack' ) {
-		page.redirect( '/log-in/jetpack' );
+		context.redirect( '/log-in/jetpack' );
 	} else {
-		page.redirect( '/log-in' );
+		context.redirect( '/log-in' );
 	}
 }
 


### PR DESCRIPTION
Revert the last PR because it caused an infinite loop in `/log-in/en` for non-authenticated users.

Reverts Automattic/wp-calypso#63271