### PR TITLE
Emails: Expand Google Card when there is a google-sale

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -115,6 +115,7 @@ export default {
 					referrer={ pageContext.query.referrer }
 					selectedDomainName={ pageContext.params.domain }
 					selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
+					source={ pageContext.query.source }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -31,6 +31,7 @@ const EmailProvidersInDepthComparison = ( {
 	referrer,
 	selectedDomainName,
 	selectedIntervalLength = IntervalLength.ANNUALLY,
+	source,
 }: EmailProvidersInDepthComparisonProps ): JSX.Element => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -51,6 +52,7 @@ const EmailProvidersInDepthComparison = ( {
 			recordTracksEvent( 'calypso_email_providers_in_depth_billing_interval_toggle_click', {
 				domain_name: selectedDomainName,
 				new_interval: newIntervalLength,
+				source,
 			} )
 		);
 
@@ -59,7 +61,7 @@ const EmailProvidersInDepthComparison = ( {
 				selectedSite.slug,
 				selectedDomainName,
 				referrer,
-				null,
+				source,
 				newIntervalLength
 			)
 		);
@@ -74,11 +76,13 @@ const EmailProvidersInDepthComparison = ( {
 			recordTracksEvent( 'calypso_email_providers_in_depth_select_provider_click', {
 				domain_name: selectedDomainName,
 				provider: emailProviderSlug,
+				source,
 			} )
 		);
 		const path = `${ referrer }?${ stringify( {
 			interval: selectedIntervalLength,
 			provider: emailProviderSlug,
+			source,
 		} ) }`;
 
 		page( path );
@@ -89,7 +93,7 @@ const EmailProvidersInDepthComparison = ( {
 	return (
 		<Main wideLayout>
 			<PageViewTracker
-				path={ emailManagementInDepthComparison( ':site', ':domain' ) }
+				path={ emailManagementInDepthComparison( ':site', ':domain', null, source ) }
 				title="Email Comparison > In-Depth Comparison"
 			/>
 

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -41,6 +41,7 @@ export type EmailProvidersInDepthComparisonProps = {
 	referrer: string;
 	selectedDomainName: string;
 	selectedIntervalLength?: IntervalLength;
+	source?: string;
 };
 
 export type LearnMoreLinkProps = {

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -78,18 +78,15 @@ const EmailProvidersStackedComparison = ( {
 		)
 	);
 
+	const isGSuiteSupported =
+		domain && canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );
+
+	const shouldPromoteGoogleWorkspace = isGSuiteSupported && source === 'google-sale';
+
 	const [ detailsExpanded, setDetailsExpanded ] = useState( () => {
 		const hasDiscountForGSuite = hasDiscount( gSuiteProduct );
 
-		const isGSuiteSupported =
-			domain && canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );
-
-		if (
-			isGSuiteSupported &&
-			source === 'google-sale' &&
-			hasDiscountForGSuite &&
-			! selectedEmailProviderSlug
-		) {
+		if ( shouldPromoteGoogleWorkspace && ! selectedEmailProviderSlug && hasDiscountForGSuite ) {
 			return {
 				google: true,
 				titan: false,
@@ -168,6 +165,27 @@ const EmailProvidersStackedComparison = ( {
 
 	const hasExistingEmailForwards = ! isDomainInCart && hasEmailForwards( domain );
 
+	const emailProviderCards = [
+		<ProfessionalEmailCard
+			comparisonContext={ comparisonContext }
+			detailsExpanded={ detailsExpanded.titan }
+			intervalLength={ selectedIntervalLength }
+			isDomainInCart={ isDomainInCart }
+			onExpandedChange={ changeExpandedState }
+			selectedDomainName={ selectedDomainName }
+			source={ source }
+		/>,
+		<GoogleWorkspaceCard
+			comparisonContext={ comparisonContext }
+			detailsExpanded={ detailsExpanded.google }
+			intervalLength={ selectedIntervalLength }
+			isDomainInCart={ isDomainInCart }
+			onExpandedChange={ changeExpandedState }
+			selectedDomainName={ selectedDomainName }
+			source={ source }
+		/>,
+	];
+
 	return (
 		<Main wideLayout>
 			<QueryProductsList />
@@ -215,25 +233,9 @@ const EmailProvidersStackedComparison = ( {
 
 			{ ! isDomainInCart && domain && <EmailExistingPaidServiceNotice domain={ domain } /> }
 
-			<ProfessionalEmailCard
-				comparisonContext={ comparisonContext }
-				detailsExpanded={ detailsExpanded.titan }
-				intervalLength={ selectedIntervalLength }
-				isDomainInCart={ isDomainInCart }
-				onExpandedChange={ changeExpandedState }
-				selectedDomainName={ selectedDomainName }
-				source={ source }
-			/>
-
-			<GoogleWorkspaceCard
-				comparisonContext={ comparisonContext }
-				detailsExpanded={ detailsExpanded.google }
-				intervalLength={ selectedIntervalLength }
-				isDomainInCart={ isDomainInCart }
-				onExpandedChange={ changeExpandedState }
-				selectedDomainName={ selectedDomainName }
-				source={ source }
-			/>
+			<>
+				{ shouldPromoteGoogleWorkspace ? [ ...emailProviderCards ].reverse() : emailProviderCards }
+			</>
 
 			{ ! isDomainInCart && <EmailForwardingLink selectedDomainName={ selectedDomainName } /> }
 

--- a/client/my-sites/email/email-providers-stacked-comparison/index.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/index.tsx
@@ -1,3 +1,7 @@
+import {
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY,
+	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+} from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { stringify } from 'qs';
@@ -6,10 +10,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import Main from 'calypso/components/main';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
+import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-forwards-notice';
 import EmailExistingPaidServiceNotice from 'calypso/my-sites/email/email-existing-paid-service-notice';
@@ -20,6 +26,8 @@ import GoogleWorkspaceCard from 'calypso/my-sites/email/email-providers-stacked-
 import ProfessionalEmailCard from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card';
 import { emailManagementInDepthComparison } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsWithForwards } from 'calypso/state/selectors/get-email-forwards';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
@@ -48,7 +56,46 @@ const EmailProvidersStackedComparison = ( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
+	const currentRoute = useSelector( getCurrentRoute );
+
+	const selectedSite = useSelector( getSelectedSite );
+
+	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
+	const domain = getSelectedDomain( {
+		domains,
+		selectedDomainName: selectedDomainName,
+	} );
+	const domainsWithForwards = useSelector( ( state ) => getDomainsWithForwards( state, domains ) );
+
+	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
+
+	const gSuiteProduct = useSelector( ( state ) =>
+		getProductBySlug(
+			state,
+			selectedIntervalLength === IntervalLength.MONTHLY
+				? GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY
+				: GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+		)
+	);
+
 	const [ detailsExpanded, setDetailsExpanded ] = useState( () => {
+		const hasDiscountForGSuite = hasDiscount( gSuiteProduct );
+
+		const isGSuiteSupported =
+			domain && canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );
+
+		if (
+			isGSuiteSupported &&
+			source === 'google-sale' &&
+			hasDiscountForGSuite &&
+			! selectedEmailProviderSlug
+		) {
+			return {
+				google: true,
+				titan: false,
+			};
+		}
+
 		if ( selectedEmailProviderSlug === GOOGLE_WORKSPACE_PRODUCT_TYPE ) {
 			return {
 				titan: false,
@@ -61,17 +108,6 @@ const EmailProvidersStackedComparison = ( {
 			google: false,
 		};
 	} );
-
-	const currentRoute = useSelector( getCurrentRoute );
-
-	const selectedSite = useSelector( getSelectedSite );
-
-	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
-	const domain = getSelectedDomain( {
-		domains,
-		selectedDomainName: selectedDomainName,
-	} );
-	const domainsWithForwards = useSelector( ( state ) => getDomainsWithForwards( state, domains ) );
 
 	const changeExpandedState = ( providerKey: string, isCurrentlyExpanded: boolean ) => {
 		const expandedEntries = Object.entries( detailsExpanded ).map( ( entry ) => {
@@ -121,6 +157,7 @@ const EmailProvidersStackedComparison = ( {
 			recordTracksEvent( 'calypso_email_providers_compare_link_click', {
 				domain_name: selectedDomainName,
 				interval: selectedIntervalLength,
+				source,
 			} )
 		);
 	};
@@ -153,7 +190,7 @@ const EmailProvidersStackedComparison = ( {
 										selectedSite.slug,
 										selectedDomainName,
 										currentRoute,
-										null,
+										source,
 										selectedIntervalLength
 									) }
 									onClick={ handleCompareClick }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When accessing the Emails Providers Comparison page, through the domains sale banner:
![image](https://user-images.githubusercontent.com/5689927/168033581-fa489f00-616f-4843-b28a-2f77c21a142d.png)

The Google Workspace card is not expanded. This change request addresses it. It also sets the Google Workspace card in the first position when displaying it.

#### Testing instructions

1. Checkout locally the branch and run it as calypso localhost or use the calypso live link
2. Have a domain eligible to subscribe to a Google Workspace product
3. Go to Upgrades -> Domains and check that you see the previous banner shown
4. Click on the "Claim Now" button
5. Assert that the Google Workspace Card is expanded
6. Assert that navigating through the "See how they compare" and going back to Professional Email will indeed expand Professional Email

![image](https://user-images.githubusercontent.com/5689927/168101706-e77f65d7-c488-4c10-868a-5a7a24e4a2e4.png)

Related to {1200182182542585-as-1202260957707499}
