### PR TITLE
P2 signup: tweak CSS for "join workspaces" step

### DIFF
--- a/client/signup/steps/p2-join-workspace/style.scss
+++ b/client/signup/steps/p2-join-workspace/style.scss
@@ -1,8 +1,19 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .is-p-2-join-workspace .p2-step-wrapper {
 	max-width: 620px;
 
 	button.components-button.is-busy {
 		background-image: none;
+	}
+
+	.p2-step-wrapper__subheader-text {
+		padding: 0 2rem;
+
+		@include break-small {
+			padding: 0;
+		}
 	}
 }
 
@@ -14,8 +25,12 @@
 	display: grid;
 	grid-template-columns: min-content auto min-content;
 	grid-column-gap: 12px;
-	padding: 0.75rem 1.5rem;
+	padding: 0.75rem;
 	border-top: 1px solid var( --p2-color-border-light );
+
+	@include break-small {
+		padding: 0.75rem 1.5rem;
+	}
 
 	&:last-of-type {
 		border-bottom: 1px solid var( --p2-color-border-light );
@@ -30,14 +45,23 @@
 	font-size: 1.25rem;
 	height: 50px;
 	width: 50px;
-	display: flex;
-	justify-content: center;
-	align-items: center;
 	border-radius: 2px;
+	display: none;
+
+	@include break-small {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
 }
 
 .p2-join-workspace__workspace-name {
 	font-weight: 600;
+	grid-area: 1/1/span 1/span 2;
+
+	@include break-small {
+		grid-area: 1/2/span 1/span 1;
+	}
 
 	.p2-join-workspace__workspace-link {
 		color: var( --p2-color-text );
@@ -52,7 +76,11 @@
 	font-size: 0.75rem;
 	color: var( --p2-color-border-medium );
 	grid-area: 2 / 2;
-	line-height: 0.5;
+	grid-area: 2/1/span 1/span 2;
+
+	@include break-small {
+		grid-area: 2/2/span 1/span 1;
+	}
 	
 	> span::after {
 		content: '·';
@@ -87,25 +115,44 @@
 	background: var( --p2-color-background-light );
 	padding: 1.2rem;
 	display: grid;
-	grid-template-columns: auto auto;
-	grid-template-rows: auto auto;
 	border-radius: 2px; /* stylelint-disable-line scales/radii */
+
+	@include break-small {
+		grid-template-columns: auto auto;
+		grid-template-rows: auto auto;
+	}
 }
 
 .p2-join-workspace__create-workspace-header {
 	font-size: 0.875rem;
 	font-weight: 600;
+	text-align: center;
+
+	@include break-small {
+		text-align: left;
+	}
 }
 
 .p2-join-workspace__create-workspace-subheader {
 	font-size: 0.75rem;
+	text-align: center;
+
+	@include break-small {
+		text-align: left;
+	}
 }
 
 .p2-join-workspace__create-workspace-action {
-	grid-area: 1 / 2 / span 2;
 	align-items: center;
 	display: flex;
-	justify-content: right;
+	padding-top: 18px;
+	justify-content: center;
+
+	@include break-small {
+		grid-area: 1 / 2 / span 2;
+		justify-content: right;
+		padding-top: unset;
+	}
 	
 	button:not( :disabled ) {
 		background: var( --p2-color-link );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the "join workspaces" step UI for narrower viewports.

**BEFORE**
<img width="369" alt="Screen Shot 2022-05-12 at 12 11 56 PM" src="https://user-images.githubusercontent.com/730823/168047802-0ffd6ef9-0dcb-4b1a-8aa6-596195bf7642.png">



**AFTER**
<img width="369" alt="Screen Shot 2022-05-12 at 12 11 25 PM" src="https://user-images.githubusercontent.com/730823/168047821-a5cbb228-2cbe-4591-8783-bc39a78eb17f.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit http://calypso.localhost:3000/start/p2/p2-join-workspace or use the calypso.live address, preferably with your `automattic.com` account as there are workspaces already set up for that domain.
* Check that things look okay.
* Switch to mobile view using your browser's dev tools, and check that things look okay even with a narrower viewport.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
