### PR TITLE
Code Style: Fix some `jest-dom` ESLint errors

### DIFF
--- a/client/components/badge/test/index.js
+++ b/client/components/badge/test/index.js
@@ -47,6 +47,6 @@ describe( 'Badge', () => {
 				<div>arbitrary-text-content</div>
 			</Badge>
 		);
-		expect( screen.getByText( 'arbitrary-text-content' ) ).toBeDefined();
+		expect( screen.getByText( 'arbitrary-text-content' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/components/bulk-select/test/index.js
+++ b/client/components/bulk-select/test/index.js
@@ -80,7 +80,8 @@ describe( 'index', () => {
 				ariaLabel="Select All"
 			/>
 		);
-		expect( container.querySelectorAll( 'input' )[ 0 ].getAttribute( 'aria-label' ) ).toBe(
+		expect( container.querySelectorAll( 'input' )[ 0 ] ).toHaveAttribute(
+			'aria-label',
 			'Select All'
 		);
 	} );
@@ -95,7 +96,7 @@ describe( 'index', () => {
 			/>
 		);
 		// There is no prop readOnly, so this is null
-		expect( container.querySelectorAll( 'input' )[ 0 ].getAttribute( 'readonly' ) ).toBeNull();
+		expect( container.querySelectorAll( 'input' )[ 0 ] ).not.toHaveAttribute( 'readonly' );
 	} );
 
 	test( 'should be call onToggle when clicked', () => {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
@@ -28,18 +28,18 @@ describe( 'EU Address Fieldset', () => {
 
 	test( 'should render expected input components', () => {
 		render( <EuAddressFieldset { ...defaultProps } /> );
-		expect( screen.queryByLabelText( 'City' ) ).toBeDefined();
-		expect( screen.queryByLabelText( 'Postal Code' ) ).toBeDefined();
+		expect( screen.queryByLabelText( 'City' ) ).toBeInTheDocument();
+		expect( screen.queryByLabelText( 'Postal Code' ) ).toBeInTheDocument();
 	} );
 
 	test( 'should not render a state select components', () => {
 		render( <EuAddressFieldset { ...defaultProps } /> );
-		expect( screen.queryByLabelText( 'State' ) ).toBeNull();
+		expect( screen.queryByLabelText( 'State' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'should render all expected input components but postal code', () => {
 		render( <EuAddressFieldset { ...propsWithoutPostalCode } /> );
-		expect( screen.queryByLabelText( 'City' ) ).toBeDefined();
-		expect( screen.queryByLabelText( 'Postal Code' ) ).toBeNull();
+		expect( screen.queryByLabelText( 'City' ) ).toBeInTheDocument();
+		expect( screen.queryByLabelText( 'Postal Code' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
@@ -37,8 +37,8 @@ describe( 'Region Address Fieldsets', () => {
 	test( 'should render `<UsAddressFieldset />` with default props', () => {
 		const { container } = renderWithProvider( <RegionAddressFieldsets { ...defaultProps } /> );
 		expect( container.getElementsByClassName( 'us-address-fieldset' ) ).toHaveLength( 1 );
-		expect( screen.queryByLabelText( 'Address' ) ).toBeDefined();
-		expect( screen.queryByText( '+ Add Address Line 2' ) ).toBeDefined();
+		expect( screen.queryByLabelText( 'Address' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '+ Add Address Line 2' ) ).toBeInTheDocument();
 	} );
 
 	test( 'should render `<UkAddressFieldset />` with a UK region countryCode', () => {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
@@ -28,18 +28,18 @@ describe( 'UK Address Fieldset', () => {
 
 	test( 'should render expected input components', () => {
 		render( <UkAddressFieldset { ...defaultProps } /> );
-		expect( screen.queryByLabelText( 'City' ) ).toBeDefined();
-		expect( screen.queryByLabelText( 'Postal Code' ) ).toBeDefined();
+		expect( screen.queryByLabelText( 'City' ) ).toBeInTheDocument();
+		expect( screen.queryByLabelText( 'Postal Code' ) ).toBeInTheDocument();
 	} );
 
 	test( 'should not render a state select components', () => {
 		render( <UkAddressFieldset { ...defaultProps } /> );
-		expect( screen.queryByLabelText( 'State' ) ).toBeNull();
+		expect( screen.queryByLabelText( 'State' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'should render all expected input components but postal code', () => {
 		render( <UkAddressFieldset { ...propsWithoutPostalCode } /> );
-		expect( screen.queryByLabelText( 'City' ) ).toBeDefined();
-		expect( screen.queryByLabelText( 'Postal Code' ) ).toBeNull();
+		expect( screen.queryByLabelText( 'City' ) ).toBeInTheDocument();
+		expect( screen.queryByLabelText( 'Postal Code' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
@@ -30,15 +30,15 @@ describe( 'US Address Fieldset', () => {
 
 	test( 'should render expected input components', () => {
 		renderWithProvider( <UsAddressFieldset { ...defaultProps } /> );
-		expect( screen.queryByLabelText( 'City' ) ).toBeDefined();
-		expect( screen.queryByLabelText( 'State' ) ).toBeDefined();
-		expect( screen.queryByLabelText( 'ZIP code' ) ).toBeDefined();
+		expect( screen.queryByLabelText( 'City' ) ).toBeInTheDocument();
+		expect( screen.queryByLabelText( 'State' ) ).toBeInTheDocument();
+		expect( screen.queryByLabelText( 'ZIP code' ) ).toBeInTheDocument();
 	} );
 
 	test( 'should render all expected input components but postal code', () => {
 		renderWithProvider( <UsAddressFieldset { ...propsWithoutPostalCode } /> );
-		expect( screen.queryByLabelText( 'City' ) ).toBeDefined();
-		expect( screen.queryByLabelText( 'State' ) ).toBeDefined();
-		expect( screen.queryByLabelText( 'Postal Code' ) ).toBeNull();
+		expect( screen.queryByLabelText( 'City' ) ).toBeInTheDocument();
+		expect( screen.queryByLabelText( 'State' ) ).toBeInTheDocument();
+		expect( screen.queryByLabelText( 'Postal Code' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/components/external-link/test/index.js
+++ b/client/components/external-link/test/index.js
@@ -17,7 +17,8 @@ describe( 'External Link', () => {
 
 	test( 'should have href if provided', () => {
 		const { container } = render( <ExternalLink href="http://foobar.bang" /> );
-		expect( container.getElementsByTagName( 'a' )[ 0 ].getAttribute( 'href' ) ).toEqual(
+		expect( container.getElementsByTagName( 'a' )[ 0 ] ).toHaveAttribute(
+			'href',
 			'http://foobar.bang'
 		);
 	} );
@@ -29,9 +30,7 @@ describe( 'External Link', () => {
 
 	test( 'should have a target if given one', () => {
 		const { container } = render( <ExternalLink target="_blank" /> );
-		expect( container.getElementsByTagName( 'a' )[ 0 ].getAttribute( 'target' ) ).toEqual(
-			'_blank'
-		);
+		expect( container.getElementsByTagName( 'a' )[ 0 ] ).toHaveAttribute( 'target', '_blank' );
 	} );
 
 	test( 'should have an icon className if specified', () => {
@@ -42,15 +41,15 @@ describe( 'External Link', () => {
 	test( 'should have an icon default size of 18', () => {
 		const { container } = render( <ExternalLink icon={ true } iconClassName="foo" /> );
 		const gridicon = container.getElementsByTagName( 'svg' )[ 0 ];
-		expect( gridicon.getAttribute( 'width' ) ).toEqual( '18' );
-		expect( gridicon.getAttribute( 'height' ) ).toEqual( '18' );
+		expect( gridicon ).toHaveAttribute( 'width', '18' );
+		expect( gridicon ).toHaveAttribute( 'height', '18' );
 	} );
 
 	test( 'should have an icon size that is provided', () => {
 		const { container } = render( <ExternalLink icon={ true } iconSize={ 20 } /> );
 		const gridicon = container.getElementsByTagName( 'svg' )[ 0 ];
-		expect( gridicon.getAttribute( 'width' ) ).toEqual( '20' );
-		expect( gridicon.getAttribute( 'height' ) ).toEqual( '20' );
+		expect( gridicon ).toHaveAttribute( 'width', '20' );
+		expect( gridicon ).toHaveAttribute( 'height', '20' );
 	} );
 
 	test( 'should have icon first if specified', () => {

--- a/client/components/jetpack/with-server-credentials-form/test/index.js
+++ b/client/components/jetpack/with-server-credentials-form/test/index.js
@@ -139,7 +139,7 @@ describe( 'useWithServerCredentials HOC', () => {
 			expect( input.value ).toBe( inputName );
 		} );
 		fireEvent.click( submitButton );
-		expect( errorMessagesContainer.innerHTML ).toBe( '' );
+		expect( errorMessagesContainer ).toBeEmptyDOMElement();
 		expect( actions.updateCredentials ).toHaveBeenCalledTimes( 1 );
 		expect( actions.updateCredentials ).toBeCalledWith(
 			9999,

--- a/client/components/product-expiration/test/index.js
+++ b/client/components/product-expiration/test/index.js
@@ -17,7 +17,7 @@ describe( 'ProductExpiration', () => {
 		const { container } = render(
 			<ProductExpiration purchaseDateMoment={ date } translate={ translate } isRefundable />
 		);
-		expect( container.textContent ).toEqual( 'Purchased on November 10, 2009' );
+		expect( container ).toHaveTextContent( 'Purchased on November 10, 2009' );
 	} );
 
 	it( 'should return the expiry date in past tense when date is in past', () => {
@@ -25,7 +25,7 @@ describe( 'ProductExpiration', () => {
 		const { container } = render(
 			<ProductExpiration expiryDateMoment={ date } translate={ translate } />
 		);
-		expect( container.textContent ).toEqual( 'Expired on November 10, 2009' );
+		expect( container ).toHaveTextContent( 'Expired on November 10, 2009' );
 	} );
 
 	it( 'should return the expiry date in future tense when date is in future', () => {
@@ -33,7 +33,7 @@ describe( 'ProductExpiration', () => {
 		const { container } = render(
 			<ProductExpiration expiryDateMoment={ date } translate={ translate } />
 		);
-		expect( container.textContent ).toEqual( 'Expires on November 10, 2100' );
+		expect( container ).toHaveTextContent( 'Expires on November 10, 2100' );
 	} );
 
 	it( 'should return the renewal date (same as the expiry date) in when the date is in the future', () => {
@@ -45,7 +45,7 @@ describe( 'ProductExpiration', () => {
 				translate={ translate }
 			/>
 		);
-		expect( container.textContent ).toEqual( 'Renews on November 10, 2100' );
+		expect( container ).toHaveTextContent( 'Renews on November 10, 2100' );
 	} );
 
 	it( 'should return the renewal date in when the date is in the future', () => {
@@ -58,7 +58,7 @@ describe( 'ProductExpiration', () => {
 				translate={ translate }
 			/>
 		);
-		expect( container.textContent ).toEqual( 'Renews on November 10, 2100' );
+		expect( container ).toHaveTextContent( 'Renews on November 10, 2100' );
 	} );
 
 	it( 'should return null when provided an invalid expiry date', () => {

--- a/client/components/product-expiration/test/index.js
+++ b/client/components/product-expiration/test/index.js
@@ -9,7 +9,7 @@ import { ProductExpiration } from '../index';
 describe( 'ProductExpiration', () => {
 	it( 'should return null if not provided dates', () => {
 		const { container } = render( <ProductExpiration translate={ translate } /> );
-		expect( container.firstChild ).toBeNull();
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	it( 'should return the purchase date when refundable', () => {
@@ -66,7 +66,7 @@ describe( 'ProductExpiration', () => {
 		const { container } = render(
 			<ProductExpiration expiryDateMoment={ date } translate={ translate } />
 		);
-		expect( container.firstChild ).toBeNull();
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	it( 'should return null when provided an invalid purchase date and no expiry date', () => {
@@ -74,6 +74,6 @@ describe( 'ProductExpiration', () => {
 		const { container } = render(
 			<ProductExpiration purchaseDateMoment={ date } translate={ translate } />
 		);
-		expect( container.firstChild ).toBeNull();
+		expect( container ).toBeEmptyDOMElement();
 	} );
 } );

--- a/client/components/rating/test/index.js
+++ b/client/components/rating/test/index.js
@@ -10,7 +10,7 @@ describe( '<Rating />', () => {
 			const { container } = render( <Rating /> );
 
 			const component = container.getElementsByClassName( 'rating' )[ 0 ];
-			expect( component.style.width ).toEqual( '90px' ); // 18 * 5 = 120;
+			expect( component ).toHaveStyle( { width: '90px' } ); // 18 * 5 = 120;
 		} );
 
 		test( 'should use size if passed', () => {

--- a/client/components/screen-options-tab/test/index.js
+++ b/client/components/screen-options-tab/test/index.js
@@ -39,7 +39,7 @@ describe( 'ScreenOptionsTab', () => {
 	test( 'it renders correctly', () => {
 		render( <ScreenOptionsTab wpAdminPath="index.php" />, { initialState } );
 
-		expect( screen.queryByTestId( 'screen-options-tab' ) ).toBeTruthy();
+		expect( screen.queryByTestId( 'screen-options-tab' ) ).toBeInTheDocument();
 	} );
 
 	test( 'does not render on all-sites screens', () => {
@@ -50,7 +50,7 @@ describe( 'ScreenOptionsTab', () => {
 			},
 		} );
 
-		expect( screen.queryByTestId( 'screen-options-tab' ) ).toBeNull();
+		expect( screen.queryByTestId( 'screen-options-tab' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'does not render on Jetpack sites', () => {
@@ -65,7 +65,7 @@ describe( 'ScreenOptionsTab', () => {
 			},
 		} );
 
-		expect( screen.queryByTestId( 'screen-options-tab' ) ).toBeNull();
+		expect( screen.queryByTestId( 'screen-options-tab' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'does render on Atomic sites', () => {
@@ -80,7 +80,7 @@ describe( 'ScreenOptionsTab', () => {
 			},
 		} );
 
-		expect( screen.queryByTestId( 'screen-options-tab' ) ).toBeTruthy();
+		expect( screen.queryByTestId( 'screen-options-tab' ) ).toBeInTheDocument();
 	} );
 
 	test( 'does not render when the SSO module is disabled', () => {
@@ -102,25 +102,25 @@ describe( 'ScreenOptionsTab', () => {
 			},
 		} );
 
-		expect( screen.queryByTestId( 'screen-options-tab' ) ).toBeNull();
+		expect( screen.queryByTestId( 'screen-options-tab' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'it toggles dropdown when clicked', () => {
 		render( <ScreenOptionsTab wpAdminPath="index.php" />, { initialState } );
 
 		// We expect the dropdown to not be shown by default.
-		expect( screen.queryByTestId( 'screen-options-dropdown' ) ).toBeNull();
+		expect( screen.queryByTestId( 'screen-options-dropdown' ) ).not.toBeInTheDocument();
 
 		// Click the button.
 		fireEvent.click( screen.getAllByRole( 'button' )[ 0 ] );
 
 		// Dropdown should exist now it has been toggled.
-		expect( screen.queryByTestId( 'screen-options-dropdown' ) ).toBeTruthy();
+		expect( screen.queryByTestId( 'screen-options-dropdown' ) ).toBeInTheDocument();
 
 		// Click the button again.
 		fireEvent.click( screen.getAllByRole( 'button' )[ 0 ] );
 
 		// Dropdown should not be shown again after toggling it off.
-		expect( screen.queryByTestId( 'screen-options-dropdown' ) ).toBeNull();
+		expect( screen.queryByTestId( 'screen-options-dropdown' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/lib/accept/test/index.js
+++ b/client/lib/accept/test/index.js
@@ -17,7 +17,7 @@ describe( '#accept()', () => {
 
 		const dialog = document.querySelector( '.accept__dialog' );
 		expect( dialog ).toBeInstanceOf( window.Element );
-		expect( dialog.textContent ).toEqual( message );
+		expect( dialog ).toHaveTextContent( message );
 	} );
 
 	test( 'should trigger the callback with an accepted prompt', () => {

--- a/client/lib/plugins/test/sanitize-section-content.js
+++ b/client/lib/plugins/test/sanitize-section-content.js
@@ -46,25 +46,23 @@ test( 'should strip out disallowed attributes', () =>
 
 test( 'should allow http(s) links', () => {
 	const img = cleanNode( '<img src="http://example.com/images/1f39.png?v=25">' );
-	expect( img.getAttribute( 'src' ) ).toBe( 'http://example.com/images/1f39.png?v=25' );
+	expect( img ).toHaveAttribute( 'src', 'http://example.com/images/1f39.png?v=25' );
 
 	const link = cleanNode( '<a id="test" href="https://github.com/README.md">docs</a>' );
-	expect( link.getAttribute( 'href' ) ).toBe(
-		'https://github.com/README.md?referrer=wordpress.com'
-	);
+	expect( link ).toHaveAttribute( 'href', 'https://github.com/README.md?referrer=wordpress.com' );
 } );
 
 test( 'should omit non http(s) links', () => {
-	expect( cleanNode( '<a href="file:///etc/passwd">a</a>' ).getAttribute( 'href' ) ).toBeNull();
-	expect( cleanNode( '<a href="javascript:alert(o)">a</a>' ).getAttribute( 'href' ) ).toBeNull();
-	expect( cleanNode( '<a href="ssh://bankvault">a</a>' ).getAttribute( 'href' ) ).toBeNull();
-	expect( cleanNode( '<a href="deep+link">a</a>' ).getAttribute( 'href' ) ).toBeNull();
+	expect( cleanNode( '<a href="file:///etc/passwd">a</a>' ) ).not.toHaveAttribute( 'href' );
+	expect( cleanNode( '<a href="javascript:alert(o)">a</a>' ) ).not.toHaveAttribute( 'href' );
+	expect( cleanNode( '<a href="ssh://bankvault">a</a>' ) ).not.toHaveAttribute( 'href' );
+	expect( cleanNode( '<a href="deep+link">a</a>' ) ).not.toHaveAttribute( 'href' );
 } );
 
 test( 'should set link params', () => {
 	const link = cleanNode( '<a href="https://example.com">' );
 
-	expect( link.getAttribute( 'target' ) ).toBe( '_blank' );
+	expect( link ).toHaveAttribute( 'target', '_blank' );
 
 	const rel = link.getAttribute( 'rel' ).split( ' ' );
 	expect( rel ).toContain( 'external' );
@@ -75,7 +73,8 @@ test( 'should set link params', () => {
 test( 'should add referrer query parameter', () => {
 	const link = cleanNode( '<a href="https://example.com?other-query">' );
 
-	expect( link.getAttribute( 'href' ) ).toBe(
+	expect( link ).toHaveAttribute(
+		'href',
 		'https://example.com?other-query=&referrer=wordpress.com'
 	);
 } );
@@ -89,7 +88,7 @@ test( 'should secure Youtube sources', () => {
 		'<iframe type="text/html" class="youtube-player" src="http://youtube.com/123456" />'
 	);
 
-	expect( embed.getAttribute( 'src' ) ).toBe( 'https://youtube.com/123456' );
+	expect( embed ).toHaveAttribute( 'src', 'https://youtube.com/123456' );
 } );
 
 test( 'should bump up header levels', () => {
@@ -159,10 +158,8 @@ test( 'should prevent known XSS attacks', () => {
 	).toBe( '' );
 
 	expect(
-		cleanNode(
-			'<A HREF="javascript:document.location=\'http://www.google.com/\'">XSS</A>'
-		).getAttribute( 'href' )
-	).toBeNull();
+		cleanNode( '<A HREF="javascript:document.location=\'http://www.google.com/\'">XSS</A>' )
+	).not.toHaveAttribute( 'href' );
 } );
 
 test( 'should prevent backspace-based XSS attacks', () => {
@@ -170,5 +167,5 @@ test( 'should prevent backspace-based XSS attacks', () => {
 		'<a href="http://example.com">' + '\u0008'.repeat( 71 ) + 'javascript:alert(1)\u0022>xss</a>'
 	);
 
-	expect( link.getAttribute( 'href' ) ).toBe( 'http://example.com?referrer=wordpress.com' );
+	expect( link ).toHaveAttribute( 'href', 'http://example.com?referrer=wordpress.com' );
 } );

--- a/client/lib/track-element-size/test/index.js
+++ b/client/lib/track-element-size/test/index.js
@@ -185,7 +185,7 @@ describe( 'useWindowResizeRect', () => {
 			ReactDOM.render( <TestComponent />, container );
 		} );
 
-		expect( container.textContent ).toBe( initialRect.width.toString() );
+		expect( container ).toHaveTextContent( initialRect.width.toString() );
 		expect( lastRect ).toBe( initialRect );
 
 		// We expect 2 renders:
@@ -209,7 +209,7 @@ describe( 'useWindowResizeRect', () => {
 			ReactDOM.render( <TestComponent />, container );
 		} );
 
-		expect( container.textContent ).toBe( initialRect.width.toString() );
+		expect( container ).toHaveTextContent( initialRect.width.toString() );
 		expect( lastRect ).toBe( initialRect );
 
 		// Fire resize event.
@@ -222,7 +222,7 @@ describe( 'useWindowResizeRect', () => {
 			clock.tick( THROTTLE_RATE );
 		} );
 
-		expect( container.textContent ).toBe( secondRect.width.toString() );
+		expect( container ).toHaveTextContent( secondRect.width.toString() );
 		expect( lastRect ).toBe( secondRect );
 
 		// We expect 3 renders:
@@ -246,7 +246,7 @@ describe( 'useWindowResizeRect', () => {
 			ReactDOM.render( <TestComponent />, container );
 		} );
 
-		expect( container.textContent ).toBe( initialRect.width.toString() );
+		expect( container ).toHaveTextContent( initialRect.width.toString() );
 		expect( lastRect ).toBe( initialRect );
 
 		// Fire resize event.
@@ -259,7 +259,7 @@ describe( 'useWindowResizeRect', () => {
 			clock.tick( THROTTLE_RATE );
 		} );
 
-		expect( container.textContent ).toBe( initialRect.width.toString() );
+		expect( container ).toHaveTextContent( initialRect.width.toString() );
 		expect( lastRect ).toBe( initialRect );
 
 		// We expect 2 renders:

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -586,7 +586,7 @@ describe( 'CompositeCheckout', () => {
 		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
 		fireEvent.click( confirmButton );
 		await waitFor( () => {
-			expect( screen.queryAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 0 );
+			expect( screen.queryByLabelText( 'WordPress.com Personal' ) ).not.toBeInTheDocument();
 		} );
 	} );
 
@@ -603,7 +603,7 @@ describe( 'CompositeCheckout', () => {
 		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
 		fireEvent.click( confirmButton );
 		await waitFor( async () => {
-			expect( screen.queryAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 0 );
+			expect( screen.queryByLabelText( 'WordPress.com Personal' ) ).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -45,8 +45,8 @@ describe( 'index', () => {
 
 			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
 
-			expect( ReactDom.findDOMNode( component ).textContent ).toContain(
-				'If you are unable to access your site at {{strong}}%(domainName)s{{/strong}}'
+			expect( ReactDom.findDOMNode( component ) ).toHaveTextContent(
+				/If you are unable to access your site at \{\{strong\}\}%\(domainName\)s\{\{\/strong\}\}/
 			);
 		} );
 	} );
@@ -67,8 +67,8 @@ describe( 'index', () => {
 
 			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
 
-			expect( ReactDom.findDOMNode( component ).textContent ).toContain(
-				'We are setting up {{strong}}%(domainName)s{{/strong}} for you'
+			expect( ReactDom.findDOMNode( component ) ).toHaveTextContent(
+				/We are setting up \{\{strong\}\}%\(domainName\)s\{\{\/strong\}\} for you/
 			);
 		} );
 
@@ -95,8 +95,8 @@ describe( 'index', () => {
 
 			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
 
-			expect( ReactDom.findDOMNode( component ).textContent ).toContain(
-				'We are setting up your new domains for you'
+			expect( ReactDom.findDOMNode( component ) ).toHaveTextContent(
+				/We are setting up your new domains for you/
 			);
 		} );
 	} );

--- a/client/my-sites/domains/components/form/test/hidden-input.js
+++ b/client/my-sites/domains/components/form/test/hidden-input.js
@@ -31,7 +31,7 @@ describe( 'HiddenInput', () => {
 		const fieldValue = 'Not empty';
 		render( <HiddenInput { ...defaultProps } value={ fieldValue } /> );
 		expect( screen.queryByText( 'Love cannot be hidden.' ) ).not.toBeInTheDocument();
-		expect( screen.queryByPlaceholderText( 'Your name' ) ).toHaveAttribute( 'value', fieldValue );
+		expect( screen.queryByPlaceholderText( 'Your name' ) ).toHaveValue( fieldValue );
 	} );
 
 	test( 'it should toggle input field when the toggle link is clicked', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR improves the code style of our `@testing-library` tests by using the `jest-dom` matches that are recommended by the library. Those correspond to the following ESLint rules that we'll introduce in #63537:

* `jest-dom/prefer-in-document`
* `jest-dom/prefer-to-have-attribute`
* `jest-dom/prefer-to-have-text-content`
* `jest-dom/prefer-empty`
* `jest-dom/prefer-to-have-style`
* `jest-dom/prefer-to-have-value`

This PR addresses all of them in preparation for #63537.

#### Testing instructions

Verify all client test still pass.