### PR TITLE
Creating a My Home card featuring the Starter plan.

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -16,6 +16,7 @@ export const NOTICE_CELEBRATE_SITE_CREATION = 'home-notice-celebrate-site-creati
 export const NOTICE_CELEBRATE_SITE_LAUNCH = 'home-notice-celebrate-site-launch';
 export const NOTICE_CELEBRATE_SITE_MIGRATION = 'home-notice-celebrate-site-migration';
 export const NOTICE_CELEBRATE_SITE_SETUP_COMPLETE = 'home-notice-celebrate-site-setup-complete';
+export const NOTICE_PLAN_ANNOUNCEMENT = 'home-notice-plan-announcement';
 export const SECTION_LEARN_GROW = 'home-section-learn-grow';
 export const SECTION_MANAGE_SITE = 'home-section-manage-site';
 export const TASK_CONNECT_ACCOUNTS = 'home-task-connect-accounts';

--- a/client/my-sites/customer-home/cards/notices/plan-announcement/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/plan-announcement/index.jsx
@@ -1,0 +1,25 @@
+import { useTranslate } from 'i18n-calypso';
+import sellerIllustration from 'calypso/assets/images/customer-home/illustration--seller.svg';
+import { NOTICE_PLAN_ANNOUNCEMENT } from 'calypso/my-sites/customer-home/cards/constants';
+import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
+
+const PlanAnnouncement = () => {
+	const translate = useTranslate();
+
+	return (
+		<Task
+			title={ translate( 'Announcing a new plan: WordPress.com Starter' ) }
+			description={ translate(
+				'Every site starts with an idea. WordPress Starter is a new, beautifully pared-back plan designed to put that idea center stage. For just $5/month.'
+			) }
+			actionText={ translate( 'Learn more' ) }
+			actionUrl={ `LINKTOANNOUNCEMENT` }
+			actionTarget="_blank"
+			completeOnStart={ false }
+			illustration={ sellerIllustration }
+			taskId={ NOTICE_PLAN_ANNOUNCEMENT }
+		/>
+	);
+};
+
+export default PlanAnnouncement;

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -9,6 +9,7 @@ import {
 	NOTICE_CELEBRATE_SITE_LAUNCH,
 	NOTICE_CELEBRATE_SITE_MIGRATION,
 	NOTICE_CELEBRATE_SITE_SETUP_COMPLETE,
+	NOTICE_PLAN_ANNOUNCEMENT,
 	TASK_CLOUDFLARE,
 	TASK_CONNECT_ACCOUNTS,
 	TASK_EARN_FEATURES,
@@ -29,6 +30,7 @@ import CelebrateSiteCreation from 'calypso/my-sites/customer-home/cards/notices/
 import CelebrateSiteLaunch from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-launch';
 import CelebrateSiteMigration from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-migration';
 import CelebrateSiteSetupComplete from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-setup-complete';
+import PlanAnnouncement from 'calypso/my-sites/customer-home/cards/notices/plan-announcement';
 import SiteLaunchSellerUpsell from 'calypso/my-sites/customer-home/cards/notices/site-launch-seller-upsell';
 import Cloudflare from 'calypso/my-sites/customer-home/cards/tasks/cloudflare';
 import ConnectAccounts from 'calypso/my-sites/customer-home/cards/tasks/connect-accounts';
@@ -51,6 +53,7 @@ const cardComponents = {
 	[ NOTICE_CELEBRATE_SITE_LAUNCH ]: CelebrateSiteLaunch,
 	[ NOTICE_CELEBRATE_SITE_MIGRATION ]: CelebrateSiteMigration,
 	[ NOTICE_CELEBRATE_SITE_SETUP_COMPLETE ]: CelebrateSiteSetupComplete,
+	[ NOTICE_PLAN_ANNOUNCEMENT ]: PlanAnnouncement,
 	[ TASK_CLOUDFLARE ]: Cloudflare,
 	[ TASK_CONNECT_ACCOUNTS ]: ConnectAccounts,
 	[ TASK_EARN_FEATURES ]: EarnFeatures,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a card to My Home featuring the Starter plan.
* The card will link to the /blog announcement
* Copy and illustration will be updated.
* Companion diff is D80664-code.

Screenshot:

<img width="1241" alt="CleanShot 2022-05-12 at 10 04 02@2x" src="https://user-images.githubusercontent.com/35781181/168094926-c28d828e-28b2-4af3-a78e-9ba798c1c31d.png">

#### Testing instruction

* Apply D80664-code to your sandbox.
* Sandbox public-api
* Checkout this PR and start Calypso locally.
* Navigate to My Home on your local Calypso.
* Ensure the card displays correctly, as shown in the PR.
* Ensure that the card does not show for non-EN folks.
* Ensure that the card does not show for people on paid plan.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
