### PR TITLE
Flatten use of isDomainInCart prop

### DIFF
--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-list.tsx
@@ -13,7 +13,6 @@ import './style.scss';
 const ComparisonList = ( {
 	emailProviders,
 	intervalLength,
-	isDomainInCart,
 	onSelectEmailProvider,
 	selectedDomainName,
 }: ComparisonListOrTableProps ): ReactElement => {
@@ -62,7 +61,6 @@ const ComparisonList = ( {
 							className="email-providers-in-depth-comparison-list__button"
 							emailProviderSlug={ emailProviderFeatures.slug }
 							intervalLength={ intervalLength }
-							isDomainInCart={ isDomainInCart }
 							onSelectEmailProvider={ onSelectEmailProvider }
 							selectedDomainName={ selectedDomainName }
 						/>

--- a/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/comparison-table.tsx
@@ -12,7 +12,6 @@ import './style.scss';
 const ComparisonTable = ( {
 	emailProviders,
 	intervalLength,
-	isDomainInCart,
 	onSelectEmailProvider,
 	selectedDomainName,
 }: ComparisonListOrTableProps ): ReactElement => {
@@ -137,7 +136,6 @@ const ComparisonTable = ( {
 									className="email-providers-in-depth-comparison-table__button"
 									emailProviderSlug={ emailProviderFeatures.slug }
 									intervalLength={ intervalLength }
-									isDomainInCart={ isDomainInCart }
 									onSelectEmailProvider={ onSelectEmailProvider }
 									selectedDomainName={ selectedDomainName }
 								/>

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-import { useShoppingCart } from '@automattic/shopping-cart';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -9,8 +8,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { hasDomainInCart } from 'calypso/lib/cart-values/cart-items';
-import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
 import EmailForwardingLink from 'calypso/my-sites/email/email-providers-comparison/email-forwarding-link';
 import ComparisonList from 'calypso/my-sites/email/email-providers-comparison/in-depth/comparison-list';
@@ -38,9 +35,6 @@ const EmailProvidersInDepthComparison = ( {
 	const isMobile = useMobileBreakpoint();
 
 	const selectedSite = useSelector( getSelectedSite );
-	const cartKey = useCartKey();
-	const shoppingCartManager = useShoppingCart( cartKey );
-	const isDomainInCart = hasDomainInCart( shoppingCartManager.responseCart, selectedDomainName );
 
 	const changeIntervalLength = ( newIntervalLength: IntervalLength ) => {
 		if ( selectedSite === null ) {
@@ -111,7 +105,6 @@ const EmailProvidersInDepthComparison = ( {
 			<ComparisonComponent
 				emailProviders={ [ professionalEmailFeatures, googleWorkspaceFeatures ] }
 				intervalLength={ selectedIntervalLength }
-				isDomainInCart={ isDomainInCart }
 				onSelectEmailProvider={ selectEmailProvider }
 				selectedDomainName={ selectedDomainName }
 			/>

--- a/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/select-button.tsx
@@ -1,9 +1,12 @@
 import { Button } from '@automattic/components';
+import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import { hasDomainInCart } from 'calypso/lib/cart-values/cart-items';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
@@ -45,11 +48,14 @@ const SelectButton = ( {
 	className,
 	emailProviderSlug,
 	intervalLength,
-	isDomainInCart,
 	onSelectEmailProvider,
 	selectedDomainName,
 }: SelectButtonProps ): ReactElement => {
 	const translate = useTranslate();
+
+	const cartKey = useCartKey();
+	const shoppingCartManager = useShoppingCart( cartKey );
+	const isDomainInCart = hasDomainInCart( shoppingCartManager.responseCart, selectedDomainName );
 
 	const isPlanAvailable = usePlanAvailable(
 		emailProviderSlug,

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -5,7 +5,6 @@ import type { ReactNode } from 'react';
 export type ComparisonListOrTableProps = {
 	emailProviders: EmailProviderFeatures[];
 	intervalLength: IntervalLength;
-	isDomainInCart: boolean;
 	onSelectEmailProvider: ( emailProviderSlug: string ) => void;
 	selectedDomainName: string;
 };
@@ -51,7 +50,6 @@ export type SelectButtonProps = {
 	className: string;
 	emailProviderSlug: string;
 	intervalLength: IntervalLength;
-	isDomainInCart: boolean;
 	onSelectEmailProvider: ( emailProviderSlug: string ) => void;
 	selectedDomainName: string;
 };


### PR DESCRIPTION
A minor reshuffling of the prop structure in the email comparison table. More precisely, we now calculate the value of the `isDomainInCart` prop within the `SelectButton` component. This results in a little bit less boilerplate logic further up in the component tree.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This PR should have no visible effects in Calypso, but since the changes deal with the `SelectButton` component, I recommend to test there.

1. Have a plan, have a domain purchased through WP.com, do not have email
2. Open `/email/{domain}`
3. Click the "See how they compare" link under the "Pick an email solution" heading
4. Observe that both "Select" buttons work (at least under the same conditions as before)

![email comparison](https://user-images.githubusercontent.com/1101677/168102586-0aed533b-83a6-4c1b-af6e-49424ad164b4.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/62297#discussion_r837358202