### PR TITLE
webpack-rtl-plugin: Remove diffOnly option

### DIFF
--- a/packages/webpack-rtl-plugin/CHANGELOG.md
+++ b/packages/webpack-rtl-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Removed
+
+- BREAKING: Removed the `diffOnly` option.
+
 ## 5.1.0 - 2021-11-02
 
 ### Added

--- a/packages/webpack-rtl-plugin/README.md
+++ b/packages/webpack-rtl-plugin/README.md
@@ -62,11 +62,9 @@ This will create the normal `style.css` and an additionnal `style.rtl.css`.
 new WebpackRTLPlugin({
   options: {},
   plugins: [],
-  diffOnly: false,
 })
 ```
 
 - `test` a RegExp (object or string) that must match asset filename.
 - `options` Options given to `rtlcss`. See the [rtlcss documentation for available options](http://rtlcss.com/learn/usage-guide/options/).
 - `plugins` RTLCSS plugins given to `rtlcss`. See the [rtlcss documentation for writing plugins](http://rtlcss.com/learn/extending-rtlcss/writing-a-plugin/). Default to `[]`.
-- `diffOnly` If set to `true`, the stylesheet created will only contain the css that differs from the source stylesheet. Default to `false`.

--- a/packages/webpack-rtl-plugin/package.json
+++ b/packages/webpack-rtl-plugin/package.json
@@ -33,7 +33,6 @@
 		"webpack": "^5.68.0"
 	},
 	"dependencies": {
-		"@romainberger/css-diff": "^1.0.3",
 		"rtlcss": "^3.1.2"
 	}
 }

--- a/packages/webpack-rtl-plugin/src/index.js
+++ b/packages/webpack-rtl-plugin/src/index.js
@@ -1,4 +1,3 @@
-const cssDiff = require( '@romainberger/css-diff' );
 const rtlcss = require( 'rtlcss' );
 const { ConcatSource } = require( 'webpack' ).sources;
 
@@ -45,14 +44,11 @@ class WebpackRTLPlugin {
 									assets[ filename ] = cachedRTL;
 								} else {
 									const baseSource = assetInstance.source();
-									let rtlSource = rtlcss.process(
+									const rtlSource = rtlcss.process(
 										baseSource,
 										this.options.options,
 										this.options.plugins
 									);
-									if ( this.options.diffOnly ) {
-										rtlSource = cssDiff( baseSource, rtlSource );
-									}
 									// Save the asset
 									assets[ filename ] = new ConcatSource( rtlSource );
 									this.cache.set( assetInstance, assets[ filename ] );

--- a/packages/webpack-rtl-plugin/test/index.js
+++ b/packages/webpack-rtl-plugin/test/index.js
@@ -286,50 +286,6 @@ describe( 'Webpack RTL Plugin', () => {
 		} );
 	} );
 
-	describe( 'Diff', () => {
-		const rtlCssBundlePath = path.join( __dirname, 'dist-diff/style.rtl.css' );
-
-		beforeAll( () => {
-			return new Promise( function ( done ) {
-				const config = {
-					...baseConfig,
-					output: {
-						path: path.resolve( __dirname, 'dist-diff' ),
-						filename: 'bundle.js',
-					},
-					plugins: [
-						new MiniCssExtractPlugin( {
-							filename: 'style.css',
-						} ),
-						new WebpackRTLPlugin( {
-							diffOnly: true,
-						} ),
-					],
-				};
-
-				webpack( config, ( err, stats ) => {
-					if ( err ) {
-						return done( err );
-					}
-
-					if ( stats.hasErrors() ) {
-						return done( new Error( stats.toString() ) );
-					}
-
-					done();
-				} );
-			} );
-		} );
-
-		it( 'should only contain the diff between the source and the rtl version', () => {
-			const contentRrlCss = fs.readFileSync( rtlCssBundlePath, 'utf-8' ).replace( /\r/g, '' );
-			const expected = fs
-				.readFileSync( path.join( __dirname, 'rtl-diff-result.css' ), 'utf-8' )
-				.replace( /\r/g, '' );
-			expect( contentRrlCss ).toBe( expected );
-		} );
-	} );
-
 	describe( 'Asset with query string', () => {
 		const config = {
 			...baseConfig,

--- a/packages/webpack-rtl-plugin/test/rtl-diff-result.css
+++ b/packages/webpack-rtl-plugin/test/rtl-diff-result.css
@@ -1,6 +1,0 @@
-.foo {
-  padding-right: 10px;
-}
-.bar {
-  left: 100px;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1399,7 +1399,6 @@ __metadata:
   resolution: "@automattic/webpack-rtl-plugin@workspace:packages/webpack-rtl-plugin"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@romainberger/css-diff": ^1.0.3
     css-loader: ^6.5.1
     mini-css-extract-plugin: ^1.6.2
     rtlcss: ^3.1.2
@@ -4826,16 +4825,6 @@ __metadata:
   peerDependencies:
     rollup: ^1.20.0||^2.0.0
   checksum: 7151753160d15ba2b259461a6c25b3932150994ea52dba8fd3144f634c7647c2e56733d986e2c15de67c4d96a9ee7d6278efa6d2e626a7169898fd64adc0f90c
-  languageName: node
-  linkType: hard
-
-"@romainberger/css-diff@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "@romainberger/css-diff@npm:1.0.3"
-  dependencies:
-    lodash.merge: ^4.4.0
-    postcss: ^5.0.21
-  checksum: 6d7891d5c46060e0735f0d09ebddd7c3228834f0c8150795d7c4c6a64c0c205009cfa06b1db04e234fe143054078157ba459abd5f26206b37ea470565fd60fec
   languageName: node
   linkType: hard
 
@@ -19386,13 +19375,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-flag@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "has-flag@npm:1.0.0"
-  checksum: d0ad4bebbbc005edccfa1e2c0600c89375be5663d23f49a129e0f817187405748b0b515abfc5b3c209c92692e39bb0481c83c0ee4df69433d6ffd0242183100b
-  languageName: node
-  linkType: hard
-
 "has-flag@npm:^3.0.0":
   version: 3.0.0
   resolution: "has-flag@npm:3.0.0"
@@ -22420,7 +22402,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-base64@npm:^2.1.9, js-base64@npm:^2.6.1":
+"js-base64@npm:^2.6.1":
   version: 2.6.4
   resolution: "js-base64@npm:2.6.4"
   checksum: 95d93c4eca0bbe0f2d5ffe8682d9acd23051e5c0ad71873ff5a48dd46a5f19025de9f7b36e63fa3f02f342ae4a8ca4c56e7b590d7300ebb6639ce09675e0fd02
@@ -28015,18 +27997,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^5.0.21":
-  version: 5.2.18
-  resolution: "postcss@npm:5.2.18"
-  dependencies:
-    chalk: ^1.1.3
-    js-base64: ^2.1.9
-    source-map: ^0.5.6
-    supports-color: ^3.2.3
-  checksum: 1f9f6673dd24d52f1ed33b800248e6ef752d6b6a092fe268021e398df0d7e0956f00fb961781647264d659240c3d67f5bfd3df9bf1b7af985aa996be619d30b1
-  languageName: node
-  linkType: hard
-
 "postcss@npm:^6.0.23":
   version: 6.0.23
   resolution: "postcss@npm:6.0.23"
@@ -33453,15 +33423,6 @@ resolve@^2.0.0-next.3:
   version: 2.0.0
   resolution: "supports-color@npm:2.0.0"
   checksum: 570e0b63be36cccdd25186350a6cb2eaad332a95ff162fa06d9499982315f2fe4217e69dd98e862fbcd9c81eaff300a825a1fe7bf5cc752e5b84dfed042b0dda
-  languageName: node
-  linkType: hard
-
-"supports-color@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "supports-color@npm:3.2.3"
-  dependencies:
-    has-flag: ^1.0.0
-  checksum: d39a57dbd75c3b5740654f8ec16aaf7203b8d12b8a51314507bed590c9081120805f105b4ce741db13105e6f842ac09700e4bd665b9ffc46eb0b34ba54720bd3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

It doesn't seem to be used anywhere and has various issues, plus it
depends on a dead upstream project with outdated dependencies.

Per discussion on #63383

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This option isn't used anywhere, so this change shouldn't have an effect on anything.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
