### PR TITLE
Hosting: Use feature checks rather than plan checks

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,4 +1,4 @@
-import { PLAN_WPCOM_PRO, FEATURE_SFTP } from '@automattic/calypso-products';
+import { PLAN_WPCOM_PRO, FEATURE_SFTP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import wrapWithClickOutside from 'react-click-outside';
@@ -22,7 +22,7 @@ import {
 } from 'calypso/state/automated-transfer/selectors';
 import canSiteViewAtomicHosting from 'calypso/state/selectors/can-site-view-atomic-hosting';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import isSiteOnAtomicPlan from 'calypso/state/selectors/is-site-on-atomic-plan';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import MiscellaneousCard from './miscellaneous-card';
@@ -56,7 +56,7 @@ class Hosting extends Component {
 		const {
 			canViewAtomicHosting,
 			clickActivate,
-			isOnAtomicPlan,
+			hasAtomicFeature,
 			isDisabled,
 			isTransferring,
 			requestSiteById,
@@ -182,7 +182,7 @@ class Hosting extends Component {
 					) }
 					align="left"
 				/>
-				{ isOnAtomicPlan ? getAtomicActivationNotice() : getUpgradeBanner() }
+				{ hasAtomicFeature ? getAtomicActivationNotice() : getUpgradeBanner() }
 				{ getContent() }
 			</Main>
 		);
@@ -195,13 +195,13 @@ export const clickActivate = () =>
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
+		const hasAtomicFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC );
 
 		return {
 			transferState: getAutomatedTransferStatus( state, siteId ),
 			isTransferring: isAutomatedTransferActive( state, siteId ),
-			isDisabled:
-				! isSiteOnAtomicPlan( state, siteId ) || ! isSiteAutomatedTransfer( state, siteId ),
-			isOnAtomicPlan: isSiteOnAtomicPlan( state, siteId ),
+			isDisabled: ! hasAtomicFeature || ! isSiteAutomatedTransfer( state, siteId ),
+			hasAtomicFeature,
 			canViewAtomicHosting: canSiteViewAtomicHosting( state ),
 			siteSlug: getSelectedSiteSlug( state ),
 			siteId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replaces a plan checks for Atomic support with a feature check.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to https://container-silly-kowalevski.calypso.live/hosting-config and select a site
* On a site that is on simple you should see an upgrade banner (or transfer banner) and disabled hosting settings 
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/1398304/168123425-90c51a7d-9aa9-479b-a4d3-3ad3eb1e11a4.png">
* On a site on Atomic it should show hosting settings 
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/1398304/168123559-9cd047ad-1782-4791-bfa4-58b1c149e218.png">


Related to p4TIVU-a66-p2