### PR TITLE
Storybook: update docs to reference the correct Storybook commands

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -41,4 +41,4 @@ in the root of the repository to get the required `devDependencies`.
 
 ### Using [Storybook](https://storybook.js.org/)
 
-`yarn run components:storybook:start`
+`yarn workspace @automattic/components run storybook`

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -21,7 +21,7 @@ in the root of the repository to get the required `devDependencies`.
 
 ### Using [Storybook](https://storybook.js.org/)
 
-`yarn run components:storybook:start`
+`yarn workspace @automattic/components run storybook`
 
 ### Search Modes
 

--- a/packages/tour-kit/README.md
+++ b/packages/tour-kit/README.md
@@ -104,7 +104,7 @@ function FooBar() {
 
 See it in action with some basic configurations (includes both the plain Tour Kit and the WPCOM Tour Kit variant):
 
-`yarn run tour-kit:storybook:start`
+`yarn workspace @automattic/tour-kit run storybook`
 
 ## Accessibility
 


### PR DESCRIPTION
The commands were updated in #59057 but not the documentation

#### Changes proposed in this Pull Request

* Update documentation to point to workspace'd storybook run commands

#### Testing instructions

The new commands work, the old one provide an error