### PR TITLE
Backup: adding tracking analytics to upgrade storage link

### DIFF
--- a/client/components/backup-storage-space/hooks.tsx
+++ b/client/components/backup-storage-space/hooks.tsx
@@ -1,6 +1,7 @@
 import { useTranslate, TranslateResult } from 'i18n-calypso';
-import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useCallback, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import getJetpackStorageUpgradeUrl from 'calypso/state/plans/selectors/get-jetpack-storage-upgrade-url';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 
@@ -24,11 +25,21 @@ export const useStorageUsageText = (
 	bytesAvailable: number | undefined
 ): TranslateResult | null => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const storageUpgradeUrl = useSelector( ( state ) =>
 		getJetpackStorageUpgradeUrl( state, siteSlug )
 	);
+
+	const onClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_storage_usage_upgrade_click', {
+				bytes_used: bytesUsed,
+				bytes_available: bytesAvailable,
+			} )
+		);
+	}, [ dispatch, bytesUsed, bytesAvailable ] );
 
 	return useMemo( () => {
 		if ( bytesUsed === undefined ) {
@@ -59,7 +70,7 @@ export const useStorageUsageText = (
 					comment:
 						'Must use unit abbreviation; describes used vs available storage amounts (e.g., 20.0GB of 30GB used, 0.5GB of 20GB used)',
 					components: {
-						a: <a href={ storageUpgradeUrl } />,
+						a: <a onClick={ onClick } href={ storageUpgradeUrl } />,
 					},
 				}
 			);
@@ -75,5 +86,5 @@ export const useStorageUsageText = (
 					'Must use unit abbreviation; describes used vs available storage amounts (e.g., 20.0GB of 1TB used, 0.5GB of 2TB used)',
 			}
 		);
-	}, [ translate, storageUpgradeUrl, bytesUsed, bytesAvailable ] );
+	}, [ translate, storageUpgradeUrl, bytesUsed, bytesAvailable, onClick ] );
 };

--- a/client/components/backup-storage-space/test/hooks.js
+++ b/client/components/backup-storage-space/test/hooks.js
@@ -8,16 +8,19 @@ const EXAMPLE_SITE_SLUG = 'mysite.example';
 jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
 	useSelector: jest.fn().mockImplementation( ( selector ) => selector() ),
+	useDispatch: jest.fn().mockImplementation( () => () => {} ),
 } ) );
 jest.mock( 'calypso/state/ui/selectors/get-selected-site-slug', () =>
 	jest.fn().mockImplementation( () => EXAMPLE_SITE_SLUG )
 );
 jest.mock( 'calypso/lib/jetpack/is-jetpack-cloud' );
+jest.mock( 'calypso/state/analytics/actions/record' );
 
 import { render } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { useStorageUsageText } from 'calypso/components/backup-storage-space/hooks';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 
 const GIGABYTE = 2 ** 30;
 const TERABYTE = 2 ** 40;
@@ -97,6 +100,22 @@ describe( 'useStorageUsageText', () => {
 		const link = text.querySelector( 'a' );
 		expect( link ).toBeInTheDocument();
 		expect( link ).toHaveAttribute( 'href', `/pricing/storage/${ EXAMPLE_SITE_SLUG }` );
+	} );
+
+	test( 'fires the correct Tracks event when the Upgrade link is clicked', () => {
+		const text = renderText( GIGABYTE, GIGABYTE * 10 );
+
+		// Simulate clicking the Upgrade link
+		const link = text.querySelector( 'a' );
+		expect( link ).toBeInTheDocument();
+		link.click();
+
+		expect( recordTracksEvent ).toHaveBeenCalled();
+		const [ eventName, storageInfo ] = recordTracksEvent.mock.calls[ 0 ];
+
+		expect( eventName ).toEqual( 'calypso_jetpack_backup_storage_usage_upgrade_click' );
+		expect( storageInfo.bytes_used ).toEqual( GIGABYTE );
+		expect( storageInfo.bytes_available ).toEqual( GIGABYTE * 10 );
 	} );
 
 	// NOTE: Technically this should only happen for plans with the highest


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds analytics tracking to the "Upgrade" link next to the storage usage text below the progress bar on the Backup page.
* This will allow us to track how many people are entering the upgrade flow for storage. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR using Calypso or Jetpack Cloud
* Select a self-hosted Jetpack site that has a Jetpack Backup (10GB) subscription
* Copy and paste this into the your browser console:  `localStorage.setItem( 'debug', 'calypso:analytics*' );`  (this will log the tracks event)
* Visit `/backup/:site`
* Click on the "Upgrade" link just underneath the "Storage space" progress bar
* Check that the event `calypso_jetpack_backup_storage_usage_upgrade_click` was triggered

<img width="1413" alt="Screen Shot on 2022-05-15 at 14-39-43" src="https://user-images.githubusercontent.com/10015451/168488730-9d82598b-ebbc-434c-8cff-ef19a3096c47.png">



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62736 and 1164141197617539-as-1202079046529162/f