### PR TITLE
Design Step: Use feature check for premium themes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { planHasFeature, FEATURE_PREMIUM_THEMES } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useVerticalImagesQuery } from '@automattic/data-stores';
 import DesignPicker, {
@@ -59,7 +59,6 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	const siteSlug = useSiteSlugParam();
 	const siteTitle = site?.name;
 	const isReskinned = true;
-	const sitePlanSlug = site?.plan?.product_slug;
 	const siteVerticalId = useSelect(
 		( select ) => ( site && select( SITE_STORE ).getSiteVerticalId( site.ID ) ) || undefined
 	);
@@ -82,9 +81,9 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	const showDesignPickerCategoriesAllFilter = isEnabled( 'signup/design-picker-categories' );
 
 	const isPremiumThemeAvailable = Boolean(
-		useMemo(
-			() => sitePlanSlug && planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES ),
-			[ sitePlanSlug ]
+		useSelect(
+			( select ) =>
+				site && select( SITE_STORE ).hasActiveSiteFeature( site.ID, WPCOM_FEATURES_PREMIUM_THEMES )
 		)
 	);
 
@@ -413,7 +412,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 			isGridMinimal={ isAnchorSite }
 			highResThumbnails
 			hideFullScreenPreview={ isAnchorSite }
-			premiumBadge={ <PremiumBadge isPremiumThemeAvailable={ !! isPremiumThemeAvailable } /> }
+			premiumBadge={ <PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } /> }
 			categorization={ showDesignPickerCategories ? categorization : undefined }
 			recommendedCategorySlug={ categorizationOptions.defaultSelection }
 			categoriesHeading={ heading }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates premium themes check to use a feature check and the new feature constant.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to http://calypso.localhost:3000/setup/designSetup?siteSlug=YOUR_SITE

1. Pick a premium theme, you should be redirected to checkout
2. Buy the plan. You should be redirected back to design picker after checkout.
4. You should be able to pick a premium theme now. This means `isPremiumThemeAvailable` works now.


Related to p4TIVU-a66-p2