### PR TITLE
Backup Upsells: Use feature check for promo

### DIFF
--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -1,4 +1,4 @@
-import { isFreePlan } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_FULL_ACTIVITY_LOG } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
@@ -16,7 +16,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { preventWidows } from 'calypso/lib/formatting';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { getSitePlan } from 'calypso/state/sites/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -30,8 +30,9 @@ export default function WPCOMUpsellPage(): ReactElement {
 	const isAdmin = useSelector( ( state ) =>
 		canCurrentUser( state, siteId ?? 0, 'manage_options' )
 	);
-	const { product_slug: planSlug = '' } =
-		useSelector( ( state ) => getSitePlan( state, siteId ) ) ?? {};
+	const hasFullActivityLogFeature = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_FULL_ACTIVITY_LOG )
+	);
 	const translate = useTranslate();
 	const promos: PromoSectionProps = {
 		promos: [
@@ -90,7 +91,7 @@ export default function WPCOMUpsellPage(): ReactElement {
 				) }
 			</PromoCard>
 
-			{ isFreePlan( planSlug ) && (
+			{ ! hasFullActivityLogFeature && (
 				<>
 					<h2 className="backup__subheader">{ translate( 'Also included in the Pro Plan' ) }</h2>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replaces plan check with feature check.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to https://container-cranky-ptolemy.calypso.live/backup
* On a simple site with free plan, make sure it shows the activity log promo <img width="1510" alt="image" src="https://user-images.githubusercontent.com/1398304/168167138-dacbf804-d675-4dcb-a2ad-07d802b09e15.png">
* One a site with a paid plan it should not be shown.

Related to p4TIVU-a66-p2