### PR TITLE
Install Themes: Make sure site is atomic before sending it there

### DIFF
--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -70,13 +70,15 @@ const InstallThemeButton = ( {
 
 const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
+	const atomicSite = isAtomicSite( state, selectedSiteId );
 	return {
 		siteSlug: getSelectedSiteSlug( state ),
 		isLoggedIn: isUserLoggedIn( state ),
 		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),
 		jetpackSite: isJetpackSite( state, selectedSiteId ),
-		siteCanInstallThemes: siteHasFeature( state, selectedSiteId, FEATURE_INSTALL_THEMES ),
-		atomicSite: isAtomicSite( state, selectedSiteId ),
+		siteCanInstallThemes:
+			siteHasFeature( state, selectedSiteId, FEATURE_INSTALL_THEMES ) && atomicSite,
+		atomicSite,
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Checks if a site is atomic before sending it to the wp-admin theme install screen.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /themes and select a site on a Business/Pro/eCommerce plan that is not on Atomic.
* Look for the Install Themes button in the top right corner of the screen.
* It should point to `/themes/upload/:site`.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See #63565
