### PR TITLE
Tourkit: Hack in support for iframes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -148,7 +148,7 @@ function WelcomeTour() {
 									const boundary = document.querySelector( '.edit-post-header' );
 
 									if ( ! boundary ) {
-										return;
+										return [ 0, 0 ];
 									}
 
 									const boundaryRect = boundary.getBoundingClientRect();

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -79,6 +79,9 @@ function getTourSteps(
 		},
 		{
 			slug: 'everything-is-a-block',
+			referenceElements: {
+				desktop: '.wp-block-site-title',
+			},
 			meta: {
 				heading: __( 'Everything is a block', 'full-site-editing' ),
 				descriptions: {

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -25,6 +25,18 @@ interface Props {
 	config: Config;
 }
 
+function getEditorElement( selector: string ): HTMLElement | null {
+	const iFrameEditor = document.querySelector(
+		'.edit-site-visual-editor__editor-canvas'
+	) as HTMLIFrameElement;
+
+	// We will need a better way to disambiguate that this is a selector inside the Editor
+	// Ideas: a flag in meta to say so, perhaps a token like `EDITOR` as a parent selector
+	return (
+		iFrameEditor?.contentDocument?.querySelector( selector ) || document.querySelector( selector )
+	);
+}
+
 const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 	const [ currentStepIndex, setCurrentStepIndex ] = useState( 0 );
 	const [ initialFocusedElement, setInitialFocusedElement ] = useState< HTMLElement | null >(
@@ -39,8 +51,9 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 	const lastStepIndex = config.steps.length - 1;
 	const referenceElementSelector =
 		config.steps[ currentStepIndex ].referenceElements?.[ isMobile ? 'mobile' : 'desktop' ] || null;
+
 	const referenceElement = referenceElementSelector
-		? document.querySelector< HTMLElement >( referenceElementSelector )
+		? getEditorElement( referenceElementSelector )
 		: null;
 
 	useEffect( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* basic editor iframe support for positioning in the site editor

#### Testing instructions

1. Sync `editing-toolkit` to your sandbox
2. View the Site Editor on a sandboxed site
4. Start the Welcome Guide (you can bring it back from the three dots menu)
5. Ensure you have a Site Title block somewhere (in view, this doesn't scroll into view yet)
6. Go to the 2nd step with the "Try it Out!" button
7. It should be positioned directly over the Site Title block (we can massage the positioning, but it's in the right place)
