### PR TITLE
Design step: Use right selector

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -83,7 +83,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	const isPremiumThemeAvailable = Boolean(
 		useSelect(
 			( select ) =>
-				site && select( SITE_STORE ).hasActiveSiteFeature( site.ID, WPCOM_FEATURES_PREMIUM_THEMES )
+				site && select( SITE_STORE ).siteHasFeature( site.ID, WPCOM_FEATURES_PREMIUM_THEMES )
 		)
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates selector to account for #63516.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to http://calypso.localhost:3000/setup/designSetup?siteSlug=YOUR_SITE

1. Pick a premium theme, you should be redirected to checkout
2. Buy the plan. You should be redirected back to design picker after checkout.
4. You should be able to pick a premium theme now. This means `isPremiumThemeAvailable` works now.


