### PR TITLE
Help Center: Reset HC store when support is done

### DIFF
--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -47,10 +47,16 @@ export const setUserDeclaredSite = ( site: SiteDetails | undefined ) =>
 		site,
 	} as const );
 
+export const resetStore = () =>
+	( {
+		type: 'HELP_CENTER_RESET_STORE',
+	} as const );
+
 export type HelpCenterAction = ReturnType<
 	| typeof setShowHelpCenter
 	| typeof setSite
 	| typeof setSubject
+	| typeof resetStore
 	| typeof setMessage
 	| typeof setUserDeclaredSite
 	| typeof setUserDeclaredSiteUrl

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -12,28 +12,36 @@ const showHelpCenter: Reducer< boolean | undefined, HelpCenterAction > = ( state
 };
 
 const site: Reducer< SiteDetails | undefined, HelpCenterAction > = ( state, action ) => {
-	if ( action.type === 'HELP_CENTER_SET_SITE' ) {
+	if ( action.type === 'HELP_CENTER_RESET_STORE' ) {
+		return undefined;
+	} else if ( action.type === 'HELP_CENTER_SET_SITE' ) {
 		return action.site;
 	}
 	return state;
 };
 
 const subject: Reducer< string | undefined, HelpCenterAction > = ( state, action ) => {
-	if ( action.type === 'HELP_CENTER_SET_SUBJECT' ) {
+	if ( action.type === 'HELP_CENTER_RESET_STORE' ) {
+		return undefined;
+	} else if ( action.type === 'HELP_CENTER_SET_SUBJECT' ) {
 		return action.subject;
 	}
 	return state;
 };
 
 const message: Reducer< string | undefined, HelpCenterAction > = ( state, action ) => {
-	if ( action.type === 'HELP_CENTER_SET_MESSAGE' ) {
+	if ( action.type === 'HELP_CENTER_RESET_STORE' ) {
+		return undefined;
+	} else if ( action.type === 'HELP_CENTER_SET_MESSAGE' ) {
 		return action.message;
 	}
 	return state;
 };
 
 const userDeclaredSiteUrl: Reducer< string | undefined, HelpCenterAction > = ( state, action ) => {
-	if ( action.type === 'HELP_CENTER_SET_USER_DECLARED_SITE_URL' ) {
+	if ( action.type === 'HELP_CENTER_RESET_STORE' ) {
+		return undefined;
+	} else if ( action.type === 'HELP_CENTER_SET_USER_DECLARED_SITE_URL' ) {
 		return action.url;
 	}
 	return state;
@@ -42,7 +50,9 @@ const userDeclaredSite: Reducer< SiteDetails | undefined, HelpCenterAction > = (
 	state,
 	action
 ) => {
-	if ( action.type === 'HELP_CENTER_SET_USER_DECLARED_SITE' ) {
+	if ( action.type === 'HELP_CENTER_RESET_STORE' ) {
+		return undefined;
+	} else if ( action.type === 'HELP_CENTER_SET_USER_DECLARED_SITE' ) {
 		return action.site;
 	}
 	return state;
@@ -51,7 +61,10 @@ const userDeclaredSite: Reducer< SiteDetails | undefined, HelpCenterAction > = (
 const popup: Reducer< Window | undefined, HelpCenterAction > = ( state, action ) => {
 	if ( action.type === 'HELP_CENTER_SET_POPUP' ) {
 		return action.popup;
-	} else if ( action.type === 'HELP_CENTER_RESET_POPUP' ) {
+	} else if (
+		action.type === 'HELP_CENTER_RESET_POPUP' ||
+		action.type === 'HELP_CENTER_RESET_STORE'
+	) {
 		return undefined;
 	}
 	return state;

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -139,8 +139,15 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 		};
 	} );
 
-	const { setSite, setUserDeclaredSiteUrl, setUserDeclaredSite, setSubject, setMessage, setPopup } =
-		useDispatch( STORE_KEY );
+	const {
+		setSite,
+		resetStore,
+		setUserDeclaredSiteUrl,
+		setUserDeclaredSite,
+		setSubject,
+		setMessage,
+		setPopup,
+	} = useDispatch( STORE_KEY );
 
 	const {
 		result: ownershipResult,
@@ -209,6 +216,8 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 						const popup = openPopup( event );
 						setPopup( popup );
 					}
+					// wait 10s then reset the store, to make sure the info is sent to the chat
+					setTimeout( resetStore, 10000 );
 					break;
 				}
 				case 'EMAIL': {
@@ -225,7 +234,10 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 						locale,
 						client: 'browser:help-center',
 						is_chat_overflow: false,
-					} ).then( () => setContactSuccess( true ) );
+					} ).then( () => {
+						setContactSuccess( true );
+						resetStore();
+					} );
 					break;
 				}
 				case 'FORUM': {
@@ -235,7 +247,10 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 						subject: subject ?? '',
 						locale,
 						hideInfo: hideSiteInfo,
-					} ).then( ( response ) => setForumTopicUrl( response.topic_URL ) );
+					} ).then( ( response ) => {
+						setForumTopicUrl( response.topic_URL );
+						resetStore();
+					} );
 					break;
 				}
 			}

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -216,8 +216,8 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 						const popup = openPopup( event );
 						setPopup( popup );
 					}
-					// wait 10s then reset the store, to make sure the info is sent to the chat
-					setTimeout( resetStore, 10000 );
+					// in chat, we don't need to reset the store here, the Happychat communicator will take care of that
+					// this is to make sure we only reset the store after we communicated everything to Happychat.
 					break;
 				}
 				case 'EMAIL': {

--- a/packages/help-center/src/happychat-window-communicator.ts
+++ b/packages/help-center/src/happychat-window-communicator.ts
@@ -17,7 +17,7 @@ export function useHCWindowCommunicator(
 	} );
 
 	const supportSite = selectedSite || userDeclaredSite;
-	const { resetPopup } = useDispatch( STORE_KEY );
+	const { resetPopup, resetStore } = useDispatch( STORE_KEY );
 
 	useEffect( () => {
 		const messageHandler = ( event: MessageEvent ) => {
@@ -47,6 +47,8 @@ export function useHCWindowCommunicator(
 							},
 							{ targetOrigin: event.origin }
 						);
+						// now clear the store, since we sent everything
+						resetStore();
 						break;
 					}
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a way to reset the store after the contact form is submitted/chat has started. This is important not prevent multiple submissions, and it makes more sense to empty the form after submitting.
 
#### Testing instructions

1. Run ETK.
2. In the HC, send a ticket, when you see the success screen, click "Back". Try contacting again, the form will be empty.
3. Repeat with a forum topic. 
4. Start a chat, once the chat starts, the form should be cleared.

Related to #63561
Fixes #63561