### PR TITLE
Add vertical_id to site setup api call

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -166,7 +166,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
 		setSelectedDesign( _selectedDesign );
 		if ( siteSlug && _selectedDesign ) {
-			setPendingAction( () => setDesignOnSite( siteSlug, _selectedDesign ) );
+			setPendingAction( () => setDesignOnSite( siteSlug, _selectedDesign, siteVerticalId ) );
 			recordTracksEvent( 'calypso_signup_select_design', getEventPropsByDesign( _selectedDesign ) );
 			const providedDependencies = {
 				selectedDesign: _selectedDesign,
@@ -195,7 +195,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 					return;
 				}
 
-				return setDesignOnSite( newSite.site_slug, _selectedDesign );
+				return setDesignOnSite( newSite.site_slug, _selectedDesign, siteVerticalId );
 			} );
 			submit?.();
 		}

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -242,7 +242,11 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		yield saveSiteSettings( siteId, { blogdescription } );
 	}
 
-	function* setDesignOnSite( siteSlug: string, selectedDesign: Design ) {
+	function* setDesignOnSite(
+		siteSlug: string,
+		selectedDesign: Design,
+		siteVerticalId: string | undefined
+	) {
 		const { theme, recipe } = selectedDesign;
 
 		yield wpcomRequest( {
@@ -261,7 +265,11 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup`,
 				apiNamespace: 'wpcom/v2',
-				body: { trim_content: true, pattern_ids: recipe?.patternIds },
+				body: {
+					trim_content: true,
+					pattern_ids: recipe?.patternIds,
+					vertical_id: siteVerticalId,
+				},
 				method: 'POST',
 			} );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Pass vertical_id in addition to pattern_ids to the theme-setup endpoint when selecting a verticalized design from the design picker.

#### Testing instructions

Apply D80605-code to your sandbox, this change depends on that diff

It appears the the new `/setup` verticalized design picker flow is not currently calling `setDesignOnSite` or headstarting the selected design at the moment? I haven't been able to test this end to end yet.

Test that the `/start/setup` site flow is not affected