### PR TITLE
Marketplace: Revert #63161 /plugins (nosite) routes

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -494,9 +494,6 @@ export function siteSelection( context, next ) {
 					}
 				} else if ( shouldRedirectToJetpackAuthorize( context, site ) ) {
 					navigate( getJetpackAuthorizeURL( context, site ) );
-				} else if ( 'plugins' === context.path.split( '?' )[ 0 ].split( '/' )[ 1 ] ) {
-					// When path start with /plugins, redirect won't use site as query param. In plugins the param could be a site, plugin or category.
-					page.redirect( sectionify( context.path, siteFragment ) );
 				} else {
 					// If the site has loaded but siteId is still invalid then redirect to allSitesPath.
 					const allSitesPath = addQueryArgs(

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -1,11 +1,6 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import {
-	navigation,
-	siteSelection,
-	sites,
-	selectSiteIfLoggedIn,
-} from 'calypso/my-sites/controller';
+import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
 	browsePlugins,
 	browsePluginsOrPlugin,
@@ -48,7 +43,7 @@ export default function () {
 
 	page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
 	page(
-		'/plugins/upload/:site',
+		'/plugins/upload/:site_id',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -57,10 +52,8 @@ export default function () {
 		clientRender
 	);
 
-	page( '/plugins', selectSiteIfLoggedIn, navigation, makeLayout, clientRender );
-
 	page(
-		'/plugins/:site',
+		'/plugins',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -70,7 +63,7 @@ export default function () {
 	);
 
 	page(
-		'/plugins/manage/:site',
+		'/plugins/manage/:site?',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -80,7 +73,7 @@ export default function () {
 	);
 
 	page(
-		'/plugins/:pluginFilter(active|inactive|updates)/:site',
+		'/plugins/:pluginFilter(active|inactive|updates)/:site_id?',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -91,7 +84,7 @@ export default function () {
 	);
 
 	page(
-		'/plugins/:plugin/:site',
+		'/plugins/:plugin/:site_id?',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
@@ -101,7 +94,7 @@ export default function () {
 	);
 
 	page(
-		'/plugins/:plugin/eligibility/:site',
+		'/plugins/:plugin/eligibility/:site_id',
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,

--- a/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
+++ b/test/e2e/specs/plugins/plugins__browse-calypso-user.ts
@@ -24,13 +24,6 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			pluginsPage = new PluginsPage( page );
 			await pluginsPage.visit();
 		} );
-	} );
-
-	describe( 'Plugins page /plugins/:wpcom-site', function () {
-		it( 'Visit plugins page', async function () {
-			pluginsPage = new PluginsPage( page );
-			await pluginsPage.visit( siteUrl );
-		} );
 
 		it.each( [ 'Top paid plugins', 'Editor’s pick', 'Top free plugins' ] )(
 			'Plugins page loads %s section',
@@ -63,5 +56,19 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 		] )( 'Featured Plugins section should show the %s plugin', async function ( plugin: string ) {
 			await pluginsPage.validateHasPluginOnSection( 'featured', plugin );
 		} );
+	} );
+
+	describe( 'Plugins page /plugins/:wpcom-site', function () {
+		it( 'Visit plugins page', async function () {
+			pluginsPage = new PluginsPage( page );
+			await pluginsPage.visit( siteUrl );
+		} );
+
+		it.each( [ 'Top paid plugins', 'Editor’s pick', 'Top free plugins' ] )(
+			'Plugins page loads %s section',
+			async function ( section: string ) {
+				await pluginsPage.validateHasSection( section );
+			}
+		);
 	} );
 } );

--- a/test/e2e/specs/plugins/plugins__pricing.ts
+++ b/test/e2e/specs/plugins/plugins__pricing.ts
@@ -10,18 +10,16 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Plugins page pricing toggle' ), function () {
 	let page: Page;
 	let pluginsPage: PluginsPage;
-	let siteUrl: string;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
-		siteUrl = testAccount.getSiteURL( { protocol: false } );
 	} );
 
 	it( 'Visit plugins page', async function () {
 		pluginsPage = new PluginsPage( page );
-		await pluginsPage.visit( siteUrl );
+		await pluginsPage.visit();
 		await pluginsPage.validateIsMonthlyPricing();
 	} );
 

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -10,18 +10,16 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 	let page: Page;
 	let pluginsPage: PluginsPage;
-	let siteUrl: string;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		const testAccount = new TestAccount( 'defaultUser' );
 		await testAccount.authenticate( page );
-		siteUrl = testAccount.getSiteURL( { protocol: false } );
 	} );
 
 	it( 'Visit plugins page', async function () {
 		pluginsPage = new PluginsPage( page );
-		await pluginsPage.visit( siteUrl );
+		await pluginsPage.visit();
 	} );
 
 	it( 'Search for ecommerce', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reverts https://github.com/Automattic/wp-calypso/pull/63161

#### Testing instructions

* /plugins (no-site) routes should be available again, should no longer see the site selector.

Related to https://github.com/Automattic/wp-calypso/issues/62912
