### PR TITLE
Help Center: Address minimized icon style

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -13,7 +13,7 @@ import { SitePickerDropDown } from '@automattic/site-picker';
 import { TextControl, CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { Icon, info, page as pageIcon } from '@wordpress/icons';
+import { Icon, info, commentContent } from '@wordpress/icons';
 import React, { useEffect, useState, useContext } from 'react';
 /**
  * Internal Dependencies
@@ -161,7 +161,7 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 				if ( openChat ) {
 					setHeaderText(
 						<>
-							<Icon icon={ pageIcon } />
+							<Icon icon={ commentContent } />
 							{ __( 'Live chat', 'full-site-editing' ) }
 						</>
 					);

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -50,8 +50,8 @@ const HelpCenterMobileHeader: React.FC< Header > = ( {
 	return (
 		<CardHeader className={ classNames }>
 			<Flex>
-				<p style={ { fontSize: 14, fontWeight: 500, display: 'flex', alignItems: 'center' } }>
-					{ headerText }
+				<p className="help-center-header__text">
+					<span className="help-center-header__icon">{ headerText }</span>
 					<span
 						className="help-center-header__a8c-only-badge"
 						title="The help center is only visible to Automatticians at this stage."

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -27,6 +27,24 @@ $head-foot-height: 50px;
 			transform: scale( 0.7, 1 );
 			transform-origin: right;
 		}
+
+		.help-center-header__text {
+			font-size: $font-body-small;
+			font-weight: 500;
+			display: flex;
+			align-items: center;
+
+			.help-center-header__icon {
+				display: flex;
+				align-items: center;
+				margin-right: 4px;
+
+				svg {
+					font-size: $font-title-small;
+					margin-right: 4px;
+				}
+			}
+		}
 	}
 
 	.help-center__container-content {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: https://github.com/Automattic/wp-calypso/pull/63464#issuecomment-1123793309

- make the icons smaller: 20px
- Add a bit of spacing between the icon and the title: 4px
- The chat page should have a "chat" (commentContent) icon.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* checkout
* `yarn dev --sync` from ETK
* open the help center
* verify that the minimized icon styles match
