### PR TITLE
track-element-size: Refactor tests to @testing-library

### DIFF
--- a/client/lib/track-element-size/test/index.js
+++ b/client/lib/track-element-size/test/index.js
@@ -1,20 +1,15 @@
 /**
  * @jest-environment jsdom
  */
-
+import { fireEvent, render } from '@testing-library/react';
 import { useCallback } from 'react';
-import ReactDOM from 'react-dom';
-import { act } from 'react-dom/test-utils';
-import { useFakeTimers } from 'sinon';
 import { useWindowResizeCallback, useWindowResizeRect, THROTTLE_RATE } from '..';
 
 const initialRect = { width: 10, height: 10 };
 
 describe( 'useWindowResizeCallback', () => {
-	let container;
 	let lastRect;
 	let callback;
-	let clock;
 
 	// Auxiliary function to create a test component.
 	function createTestComponent( cb, mock ) {
@@ -33,9 +28,7 @@ describe( 'useWindowResizeCallback', () => {
 	}
 
 	beforeEach( () => {
-		clock = useFakeTimers();
-		container = document.createElement( 'div' );
-		document.body.appendChild( container );
+		jest.useFakeTimers();
 
 		callback = jest.fn( ( boundingClientRect ) => {
 			lastRect = boundingClientRect;
@@ -43,10 +36,8 @@ describe( 'useWindowResizeCallback', () => {
 	} );
 
 	afterEach( () => {
-		clock.restore();
-		document.body.removeChild( container );
-		ReactDOM.unmountComponentAtNode( container );
-		container = null;
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
 	} );
 
 	// eslint-disable-next-line jest/expect-expect
@@ -56,18 +47,14 @@ describe( 'useWindowResizeCallback', () => {
 			return <div ref={ ref } />;
 		};
 
-		act( () => {
-			ReactDOM.render( <TestComponent />, container );
-		} );
+		render( <TestComponent /> );
 	} );
 
 	it( 'triggers an initial callback', () => {
 		const getBoundingClientRectMock = jest.fn().mockReturnValueOnce( initialRect );
 		const TestComponent = createTestComponent( callback, getBoundingClientRectMock );
 
-		act( () => {
-			ReactDOM.render( <TestComponent />, container );
-		} );
+		render( <TestComponent /> );
 
 		expect( lastRect ).toBe( initialRect );
 		expect( callback ).toHaveBeenCalledTimes( 1 );
@@ -82,21 +69,15 @@ describe( 'useWindowResizeCallback', () => {
 
 		const TestComponent = createTestComponent( callback, getBoundingClientRectMock );
 
-		act( () => {
-			ReactDOM.render( <TestComponent />, container );
-		} );
+		render( <TestComponent /> );
 
 		expect( lastRect ).toBe( initialRect );
 
 		// Fire resize event.
-		act( () => {
-			global.dispatchEvent( new Event( 'resize' ) );
-		} );
+		fireEvent.resize( window );
 
 		// Flush timer queue to trigger callbacks.
-		act( () => {
-			clock.tick( THROTTLE_RATE );
-		} );
+		jest.advanceTimersByTime( THROTTLE_RATE );
 
 		expect( lastRect ).toBe( secondRect );
 		expect( callback ).toHaveBeenCalledTimes( 2 );
@@ -111,21 +92,15 @@ describe( 'useWindowResizeCallback', () => {
 
 		const TestComponent = createTestComponent( callback, getBoundingClientRectMock );
 
-		act( () => {
-			ReactDOM.render( <TestComponent />, container );
-		} );
+		render( <TestComponent /> );
 
 		expect( lastRect ).toBe( initialRect );
 
 		// Fire resize event.
-		act( () => {
-			global.dispatchEvent( new Event( 'resize' ) );
-		} );
+		fireEvent.resize( window );
 
 		// Flush timer queue to trigger callbacks.
-		act( () => {
-			clock.tick( THROTTLE_RATE );
-		} );
+		jest.advanceTimersByTime( THROTTLE_RATE );
 
 		expect( lastRect ).toBe( initialRect );
 		expect( callback ).toHaveBeenCalledTimes( 1 );
@@ -133,8 +108,6 @@ describe( 'useWindowResizeCallback', () => {
 } );
 
 describe( 'useWindowResizeRect', () => {
-	let clock;
-	let container;
 	let lastRect;
 	let renderTracker;
 
@@ -159,18 +132,13 @@ describe( 'useWindowResizeRect', () => {
 	}
 
 	beforeEach( () => {
-		clock = useFakeTimers();
-		container = document.createElement( 'div' );
-		document.body.appendChild( container );
-
+		jest.useFakeTimers();
 		renderTracker = jest.fn();
 	} );
 
 	afterEach( () => {
-		clock.restore();
-		document.body.removeChild( container );
-		ReactDOM.unmountComponentAtNode( container );
-		container = null;
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
 	} );
 
 	it( 'returns the initial rect', () => {
@@ -181,9 +149,7 @@ describe( 'useWindowResizeRect', () => {
 
 		const TestComponent = createTestComponent( getBoundingClientRectMock );
 
-		act( () => {
-			ReactDOM.render( <TestComponent />, container );
-		} );
+		const { container } = render( <TestComponent /> );
 
 		expect( container ).toHaveTextContent( initialRect.width.toString() );
 		expect( lastRect ).toBe( initialRect );
@@ -205,22 +171,16 @@ describe( 'useWindowResizeRect', () => {
 
 		const TestComponent = createTestComponent( getBoundingClientRectMock );
 
-		act( () => {
-			ReactDOM.render( <TestComponent />, container );
-		} );
+		const { container } = render( <TestComponent /> );
 
 		expect( container ).toHaveTextContent( initialRect.width.toString() );
 		expect( lastRect ).toBe( initialRect );
 
 		// Fire resize event.
-		act( () => {
-			global.dispatchEvent( new Event( 'resize' ) );
-		} );
+		fireEvent.resize( window );
 
 		// Flush timer queue to trigger callbacks.
-		act( () => {
-			clock.tick( THROTTLE_RATE );
-		} );
+		jest.advanceTimersByTime( THROTTLE_RATE );
 
 		expect( container ).toHaveTextContent( secondRect.width.toString() );
 		expect( lastRect ).toBe( secondRect );
@@ -242,22 +202,16 @@ describe( 'useWindowResizeRect', () => {
 
 		const TestComponent = createTestComponent( getBoundingClientRectMock );
 
-		act( () => {
-			ReactDOM.render( <TestComponent />, container );
-		} );
+		const { container } = render( <TestComponent /> );
 
 		expect( container ).toHaveTextContent( initialRect.width.toString() );
 		expect( lastRect ).toBe( initialRect );
 
 		// Fire resize event.
-		act( () => {
-			global.dispatchEvent( new Event( 'resize' ) );
-		} );
+		fireEvent.resize( window );
 
 		// Flush timer queue to trigger callbacks.
-		act( () => {
-			clock.tick( THROTTLE_RATE );
-		} );
+		jest.advanceTimersByTime( THROTTLE_RATE );
 
 		expect( container ).toHaveTextContent( initialRect.width.toString() );
 		expect( lastRect ).toBe( initialRect );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `track-element-size` tests to use `@testing-library/react`. This allows us to make a solid cleanup of the tests:

* No longer necessary to implicitly use `react-dom/test-utils`'s `act()` as the `@testing-library/react` is taking care of that.
* No longer necessary to use `ReactDOM` to manage the container element.
* Not necessary to use `sinon`'s fake timers, when we can use the `jest` ones.
* We're also using the `@testing-library/react` built-in event firing instead of firing native events.

This conveniently also fixes a bunch of `testing-library/no-unnecessary-act` ESLint errors. This ESLint error isn't enabled yet, but we'll [soon be enabling it](https://github.com/Automattic/wp-calypso/pull/63537) once we fix the rest of the errors.

#### Testing instructions

Verify tests pass: `yarn run test-client client/lib/track-element-size/test/index.js`
