### PR TITLE
Design Picker: show mobile mShots in Design Picker on mobile

### DIFF
--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -2,19 +2,13 @@
 
 import { Button } from '@automattic/components';
 import { MShotsImage } from '@automattic/onboarding';
+import { useViewportMatch } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { getDesignPreviewUrl } from '../utils';
+import { getDesignPreviewUrl, getMShotOptions } from '../utils';
 import type { Design } from '../types';
 import type { MShotsOptions } from '@automattic/onboarding';
 import './style.scss';
-
-const thumbnailImageOptions: MShotsOptions = {
-	vpw: 1600,
-	vph: 1040,
-	w: 600,
-	screen_height: 3600,
-};
 
 const previewImageOptions: MShotsOptions = {
 	vpw: 1600,
@@ -36,6 +30,8 @@ const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
 	isSelected,
 	onPreview,
 } ) => {
+	const isMobile = useViewportMatch( 'small', '<' );
+
 	return (
 		<button
 			type="button"
@@ -56,7 +52,7 @@ const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
 					url={ thumbnailUrl }
 					alt=""
 					aria-labelledby={ `generated-design-thumbnail__image__${ slug }` }
-					options={ thumbnailImageOptions }
+					options={ getMShotOptions( { isMobile } ) }
 					scrollable={ false }
 				/>
 			</span>

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -10,7 +10,7 @@ import { useMemo } from 'react';
 import {
 	getAvailableDesigns,
 	getDesignPreviewUrl,
-	mShotOptions,
+	getMShotOptions,
 	isBlankCanvasDesign,
 	filterDesignsByCategory,
 	sortDesigns,
@@ -29,15 +29,20 @@ interface DesignPreviewImageProps {
 	highRes: boolean;
 }
 
-const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( { design, locale, highRes } ) => (
-	<MShotsImage
-		url={ getDesignPreviewUrl( design, { language: locale } ) }
-		aria-labelledby={ makeOptionId( design ) }
-		alt=""
-		options={ mShotOptions( design, highRes ) }
-		scrollable={ design.preview !== 'static' }
-	/>
-);
+const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( { design, locale, highRes } ) => {
+	const scrollable = design.preview !== 'static';
+	const isMobile = useViewportMatch( 'small', '<' );
+
+	return (
+		<MShotsImage
+			url={ getDesignPreviewUrl( design, { language: locale } ) }
+			aria-labelledby={ makeOptionId( design ) }
+			alt=""
+			options={ getMShotOptions( { scrollable, highRes, isMobile } ) }
+			scrollable={ scrollable }
+		/>
+	);
+};
 
 interface DesignButtonProps {
 	design: Design;

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -51,3 +51,9 @@ export const ANCHORFM_FONT_PAIRINGS = [
 		base: 'Cabin',
 	},
 ] as const;
+
+/**
+ * mShot options
+ */
+export const DEFAULT_VIEWPORT_WIDTH = 1600;
+export const MOBILE_VIEWPORT_WIDTH = 599;

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -13,7 +13,7 @@ export {
 	getDesignUrl,
 	getDesignPreviewUrl,
 	isBlankCanvasDesign,
-	mShotOptions,
+	getMShotOptions,
 } from './utils';
 export { FONT_PAIRINGS, ANCHORFM_FONT_PAIRINGS } from './constants';
 export type { FontPair, Design, Category } from './types';

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { shuffle } from '@automattic/js-utils';
 import { addQueryArgs } from '@wordpress/url';
+import { DEFAULT_VIEWPORT_WIDTH, MOBILE_VIEWPORT_WIDTH } from '../constants';
 import { availableDesignsConfig } from './available-designs-config';
 import type { Design, DesignUrlOptions } from '../types';
 import type { AvailableDesigns } from './available-designs-config';
@@ -41,12 +42,22 @@ export const getDesignUrl = (
 	return url;
 };
 
+type MShotInputOptions = {
+	scrollable?: boolean;
+	highRes?: boolean;
+	isMobile?: boolean;
+};
+
 // Used for both prefetching and loading design screenshots
-export const mShotOptions = ( { preview }: Design, highRes: boolean ): MShotsOptions => {
+export const getMShotOptions = ( {
+	scrollable,
+	highRes,
+	isMobile,
+}: MShotInputOptions = {} ): MShotsOptions => {
 	// Take care changing these values, as the design-picker CSS animations are written for these values (see the *__landscape and *__portrait classes)
 	return {
-		vpw: 1600,
-		vph: preview === 'static' ? 1040 : 1600,
+		vpw: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
+		vph: scrollable ? 1600 : 1040,
 		// When `w` was 1200 it created a visual glitch on one thumbnail. #57261
 		w: highRes ? 1199 : 600,
 		screen_height: 3600,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the viewport width of the mShot to 599 if the user is on mobile.

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/168267313-75b508fe-a3d0-46f0-b43b-914f654eae9c.png) | ![image](https://user-images.githubusercontent.com/13596067/168267271-570136a0-33ef-4620-861c-bec6b6972a8d.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Design Picker: `/setup/designSetup?siteSlug=<your_site>`
* Switch to mobile view
* The mShot will show the mobile design

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/63031
