### PR TITLE
State: Refactor selector tests from `chai` to `jest`

### DIFF
--- a/client/state/selectors/test/are-all-sites-single-user.js
+++ b/client/state/selectors/test/are-all-sites-single-user.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import areAllSitesSingleUser from 'calypso/state/selectors/are-all-sites-single-user';
 import { userState } from './fixtures/user-state';
 
@@ -12,7 +11,7 @@ describe( 'areAllSitesSingleUser()', () => {
 		};
 
 		const allAreSingleUser = areAllSitesSingleUser( state );
-		expect( allAreSingleUser ).to.be.false;
+		expect( allAreSingleUser ).toBe( false );
 	} );
 
 	test( "should return false if single_user_site isn't true for all sites", () => {
@@ -36,7 +35,7 @@ describe( 'areAllSitesSingleUser()', () => {
 		};
 
 		const allAreSingleUser = areAllSitesSingleUser( state );
-		expect( allAreSingleUser ).to.be.false;
+		expect( allAreSingleUser ).toBe( false );
 	} );
 
 	test( 'should return true if single_user_site is true for all sites', () => {
@@ -60,6 +59,6 @@ describe( 'areAllSitesSingleUser()', () => {
 		};
 
 		const allAreSingleUser = areAllSitesSingleUser( state );
-		expect( allAreSingleUser ).to.be.true;
+		expect( allAreSingleUser ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/can-current-user-edit-post.js
+++ b/client/state/selectors/test/can-current-user-edit-post.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { canCurrentUserEditPost } from 'calypso/state/posts/selectors/can-current-user-edit-post';
 
 describe( 'canCurrentUserEditPost()', () => {
@@ -17,7 +16,7 @@ describe( 'canCurrentUserEditPost()', () => {
 			fakeGlobalId
 		);
 
-		expect( canEdit ).to.be.null;
+		expect( canEdit ).toBeNull();
 	} );
 
 	test( 'should return null if the post capabilities are not known', () => {
@@ -45,7 +44,7 @@ describe( 'canCurrentUserEditPost()', () => {
 			fakeGlobalId
 		);
 
-		expect( canEdit ).to.be.null;
+		expect( canEdit ).toBeNull();
 	} );
 
 	test( 'should allow based on the post capabilities', () => {
@@ -76,7 +75,7 @@ describe( 'canCurrentUserEditPost()', () => {
 			fakeGlobalId
 		);
 
-		expect( canEdit ).to.be.true;
+		expect( canEdit ).toBe( true );
 	} );
 
 	test( 'should deny based on the post capabilities', () => {
@@ -107,6 +106,6 @@ describe( 'canCurrentUserEditPost()', () => {
 			fakeGlobalId
 		);
 
-		expect( canEdit ).to.be.false;
+		expect( canEdit ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/can-current-user-manage-plugins.js
+++ b/client/state/selectors/test/can-current-user-manage-plugins.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
 
 describe( 'canCurrentUserManagePlugins()', () => {
@@ -8,7 +7,7 @@ describe( 'canCurrentUserManagePlugins()', () => {
 				capabilities: {},
 			},
 		};
-		expect( canCurrentUserManagePlugins( state ) ).be.false;
+		expect( canCurrentUserManagePlugins( state ) ).toBe( false );
 	} );
 
 	test( 'should return false if one site capability exists without referring if the user can manage it or not', () => {
@@ -21,7 +20,7 @@ describe( 'canCurrentUserManagePlugins()', () => {
 				},
 			},
 		};
-		expect( canCurrentUserManagePlugins( state ) ).be.false;
+		expect( canCurrentUserManagePlugins( state ) ).toBe( false );
 	} );
 
 	test( 'should return false if several sites capabilities exists without referring if the user can manage it or not', () => {
@@ -38,7 +37,7 @@ describe( 'canCurrentUserManagePlugins()', () => {
 				},
 			},
 		};
-		expect( canCurrentUserManagePlugins( state ) ).be.false;
+		expect( canCurrentUserManagePlugins( state ) ).toBe( false );
 	} );
 
 	test( 'should return false if sites capabilities explicitly tell the user can not manage', () => {
@@ -59,7 +58,7 @@ describe( 'canCurrentUserManagePlugins()', () => {
 				},
 			},
 		};
-		expect( canCurrentUserManagePlugins( state ) ).be.false;
+		expect( canCurrentUserManagePlugins( state ) ).toBe( false );
 	} );
 
 	test( 'should return true if just one site capability exists and the user can manage it', () => {
@@ -72,7 +71,7 @@ describe( 'canCurrentUserManagePlugins()', () => {
 				},
 			},
 		};
-		expect( canCurrentUserManagePlugins( state ) ).be.true;
+		expect( canCurrentUserManagePlugins( state ) ).toBe( true );
 	} );
 
 	test( 'should return true if many sites capabilities exist and the user can manage in all of them', () => {
@@ -93,7 +92,7 @@ describe( 'canCurrentUserManagePlugins()', () => {
 				},
 			},
 		};
-		expect( canCurrentUserManagePlugins( state ) ).be.true;
+		expect( canCurrentUserManagePlugins( state ) ).toBe( true );
 	} );
 
 	test( 'should return true if many sites capabilities exist and the user can manage in just one', () => {
@@ -114,6 +113,6 @@ describe( 'canCurrentUserManagePlugins()', () => {
 				},
 			},
 		};
-		expect( canCurrentUserManagePlugins( state ) ).be.true;
+		expect( canCurrentUserManagePlugins( state ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/count-post-likes.js
+++ b/client/state/selectors/test/count-post-likes.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { countPostLikes } from 'calypso/state/posts/selectors/count-post-likes';
 
 describe( 'countPostLikes()', () => {
@@ -15,7 +14,7 @@ describe( 'countPostLikes()', () => {
 			50
 		);
 
-		expect( count ).to.be.null;
+		expect( count ).toBeNull();
 	} );
 
 	test( 'should return null if the post has never been fetched', () => {
@@ -35,7 +34,7 @@ describe( 'countPostLikes()', () => {
 			50
 		);
 
-		expect( count ).to.be.null;
+		expect( count ).toBeNull();
 	} );
 
 	test( 'should return the total of post likes', () => {
@@ -55,6 +54,6 @@ describe( 'countPostLikes()', () => {
 			50
 		);
 
-		expect( count ).to.eql( 42 );
+		expect( count ).toEqual( 42 );
 	} );
 } );

--- a/client/state/selectors/test/find-theme-filter-term.js
+++ b/client/state/selectors/test/find-theme-filter-term.js
@@ -1,16 +1,15 @@
-import { expect } from 'chai';
 import { findThemeFilterTerm } from 'calypso/state/themes/selectors';
 import { state } from './fixtures/theme-filters';
 
 describe( 'findThemeFilterTerm()', () => {
 	test( 'should return null for an inexistent term slug', () => {
 		const term = findThemeFilterTerm( state, 'blahg' );
-		expect( term ).to.be.null;
+		expect( term ).toBeNull();
 	} );
 
 	test( 'should return the filter term object for a given term slug', () => {
 		const term = findThemeFilterTerm( state, 'blog' );
-		expect( term ).to.deep.equal( {
+		expect( term ).toEqual( {
 			name: 'Blog',
 			description:
 				"Whether you're authoring a personal blog, professional blog, or a business blog — ...",
@@ -19,7 +18,7 @@ describe( 'findThemeFilterTerm()', () => {
 
 	test( 'should return the filter term object for a given tax:term slug', () => {
 		const term = findThemeFilterTerm( state, 'style:bright' );
-		expect( term ).to.deep.equal( {
+		expect( term ).toEqual( {
 			name: 'Bright',
 			description: '',
 		} );

--- a/client/state/selectors/test/get-blocked-sites.js
+++ b/client/state/selectors/test/get-blocked-sites.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getBlockedSites } from 'calypso/state/reader/site-blocks/selectors';
 
 describe( 'getBlockedSites()', () => {
@@ -14,6 +13,6 @@ describe( 'getBlockedSites()', () => {
 				},
 			},
 		};
-		expect( getBlockedSites( state ) ).to.deep.equal( [ 123, 125 ] );
+		expect( getBlockedSites( state ) ).toEqual( [ 123, 125 ] );
 	} );
 } );

--- a/client/state/selectors/test/get-comments-page.js
+++ b/client/state/selectors/test/get-comments-page.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getCommentsPage from 'calypso/state/selectors/get-comments-page';
 
 const SITE_ID = 12345678;
@@ -26,17 +25,17 @@ describe( 'getCommentsPage()', () => {
 
 	test( 'should return undefined if the state is not initialized for the requested filter', () => {
 		const commentsPage = getCommentsPage( state, SITE_ID, { page: 10, status: 'all' } );
-		expect( commentsPage ).to.be.undefined;
+		expect( commentsPage ).toBeUndefined();
 	} );
 
 	test( 'should return an empty array if the state is empty for the requested filters', () => {
 		const commentsPage = getCommentsPage( state, SITE_ID, { page: 1, status: 'trash' } );
-		expect( commentsPage ).to.eql( [] );
+		expect( commentsPage ).toEqual( [] );
 	} );
 
 	test( 'should return the first comments page of site view', () => {
 		const commentsPage = getCommentsPage( state, SITE_ID, {} );
-		expect( commentsPage ).to.eql( [ 1, 2, 3, 4, 5 ] );
+		expect( commentsPage ).toEqual( [ 1, 2, 3, 4, 5 ] );
 	} );
 
 	test( 'should return the first comments page of post view', () => {
@@ -45,7 +44,7 @@ describe( 'getCommentsPage()', () => {
 			postId: POST_ID,
 			status: 'all',
 		} );
-		expect( commentsPage ).to.eql( [ 6, 7, 8, 9, 10 ] );
+		expect( commentsPage ).toEqual( [ 6, 7, 8, 9, 10 ] );
 	} );
 
 	test( 'should return a comments page based on several filters', () => {
@@ -56,6 +55,6 @@ describe( 'getCommentsPage()', () => {
 			search: 'foo',
 			status: 'spam',
 		} );
-		expect( commentsPage ).to.eql( [ 11, 12, 13, 14, 15 ] );
+		expect( commentsPage ).toEqual( [ 11, 12, 13, 14, 15 ] );
 	} );
 } );

--- a/client/state/selectors/test/get-current-locale-variant.js
+++ b/client/state/selectors/test/get-current-locale-variant.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getCurrentLocaleVariant from 'calypso/state/selectors/get-current-locale-variant';
 
 describe( 'getCurrentLocaleVariant()', () => {
@@ -9,7 +8,7 @@ describe( 'getCurrentLocaleVariant()', () => {
 			},
 		};
 
-		expect( getCurrentLocaleVariant( state ) ).to.be.null;
+		expect( getCurrentLocaleVariant( state ) ).toBeNull();
 	} );
 
 	test( 'should return the locale variant slug stored', () => {
@@ -22,6 +21,6 @@ describe( 'getCurrentLocaleVariant()', () => {
 			},
 		};
 
-		expect( getCurrentLocaleVariant( state ) ).to.eql( localeVariant );
+		expect( getCurrentLocaleVariant( state ) ).toEqual( localeVariant );
 	} );
 } );

--- a/client/state/selectors/test/get-current-plan-purchase-id.js
+++ b/client/state/selectors/test/get-current-plan-purchase-id.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 
 describe( 'getCurrentPlanPurchaseId()', () => {
@@ -24,8 +23,8 @@ describe( 'getCurrentPlanPurchaseId()', () => {
 			},
 		};
 
-		expect( getCurrentPlanPurchaseId( state ) ).to.be.null;
-		expect( getCurrentPlanPurchaseId( state, 123 ) ).to.be.null;
+		expect( getCurrentPlanPurchaseId( state ) ).toBeNull();
+		expect( getCurrentPlanPurchaseId( state, 123 ) ).toBeNull();
 	} );
 
 	it( 'should return null if the current purchase ID is unknown', () => {
@@ -54,7 +53,7 @@ describe( 'getCurrentPlanPurchaseId()', () => {
 			},
 		};
 
-		expect( getCurrentPlanPurchaseId( state, siteId ) ).to.be.null;
+		expect( getCurrentPlanPurchaseId( state, siteId ) ).toBeNull();
 	} );
 
 	it( 'should return null if there is no plans data, but there is site plan data', () => {
@@ -77,7 +76,7 @@ describe( 'getCurrentPlanPurchaseId()', () => {
 			},
 		};
 
-		expect( getCurrentPlanPurchaseId( state, siteId ) ).to.be.null;
+		expect( getCurrentPlanPurchaseId( state, siteId ) ).toBeNull();
 	} );
 
 	it( 'should return the purchase ID for a site', () => {
@@ -106,6 +105,6 @@ describe( 'getCurrentPlanPurchaseId()', () => {
 			},
 		};
 
-		expect( getCurrentPlanPurchaseId( state, siteId ) ).to.equal( purchaseId );
+		expect( getCurrentPlanPurchaseId( state, siteId ) ).toEqual( purchaseId );
 	} );
 } );

--- a/client/state/selectors/test/get-current-route-parameterized.js
+++ b/client/state/selectors/test/get-current-route-parameterized.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 
 describe( 'getCurrentRouteParameterized()', () => {
@@ -18,7 +17,7 @@ describe( 'getCurrentRouteParameterized()', () => {
 			sites: sites,
 		};
 
-		expect( getCurrentRouteParameterized( state, 12345 ) ).to.be.null;
+		expect( getCurrentRouteParameterized( state, 12345 ) ).toBeNull();
 	} );
 
 	test( 'it returns null when state is missing the site', () => {
@@ -27,7 +26,7 @@ describe( 'getCurrentRouteParameterized()', () => {
 			sites: { items: {} },
 		};
 
-		expect( getCurrentRouteParameterized( state, 12345 ) ).to.be.null;
+		expect( getCurrentRouteParameterized( state, 12345 ) ).toBeNull();
 	} );
 
 	test( 'it replaces the site slug with :site', () => {
@@ -36,7 +35,7 @@ describe( 'getCurrentRouteParameterized()', () => {
 			sites,
 		};
 
-		expect( getCurrentRouteParameterized( state, 12345 ) ).to.equal( '/test/url/:site' );
+		expect( getCurrentRouteParameterized( state, 12345 ) ).toEqual( '/test/url/:site' );
 	} );
 
 	test( 'it replaces the site ID with :siteid', () => {
@@ -49,6 +48,6 @@ describe( 'getCurrentRouteParameterized()', () => {
 			sites: sites,
 		};
 
-		expect( getCurrentRouteParameterized( state, 12345 ) ).to.equal( '/test/url/:siteid' );
+		expect( getCurrentRouteParameterized( state, 12345 ) ).toEqual( '/test/url/:siteid' );
 	} );
 } );

--- a/client/state/selectors/test/get-google-my-business-stats-error.js
+++ b/client/state/selectors/test/get-google-my-business-stats-error.js
@@ -1,9 +1,8 @@
-import { expect } from 'chai';
 import getGoogleMyBusinessStatsError from 'calypso/state/selectors/get-google-my-business-stats-error';
 
 describe( 'getGoogleMyBusinessStatsError', () => {
 	test( 'should return null if no error available', () => {
-		expect( getGoogleMyBusinessStatsError( {}, 123, 'actions', 'month' ) ).to.be.null;
+		expect( getGoogleMyBusinessStatsError( {}, 123, 'actions', 'month' ) ).toBeNull();
 	} );
 
 	test( 'should return stats error', () => {
@@ -29,7 +28,7 @@ describe( 'getGoogleMyBusinessStatsError', () => {
 			},
 		};
 
-		expect( getGoogleMyBusinessStatsError( state, 123, 'actions', 'month', 'total' ) ).to.eql( {
+		expect( getGoogleMyBusinessStatsError( state, 123, 'actions', 'month', 'total' ) ).toEqual( {
 			interval: 'month',
 			statType: 'actions',
 			aggregation: 'total',

--- a/client/state/selectors/test/get-google-my-business-stats.js
+++ b/client/state/selectors/test/get-google-my-business-stats.js
@@ -1,9 +1,8 @@
-import { expect } from 'chai';
 import getGoogleMyBusinessStats from 'calypso/state/selectors/get-google-my-business-stats';
 
 describe( 'getGoogleMyBusinessStats', () => {
 	test( 'should return null if data not available', () => {
-		expect( getGoogleMyBusinessStats( {}, 123, 'actions', 'month' ) ).to.be.null;
+		expect( getGoogleMyBusinessStats( {}, 123, 'actions', 'month' ) ).toBeNull();
 	} );
 
 	test( 'should return stats data', () => {
@@ -29,7 +28,7 @@ describe( 'getGoogleMyBusinessStats', () => {
 			},
 		};
 
-		expect( getGoogleMyBusinessStats( state, 123, 'actions', 'month', 'total' ) ).to.eql( {
+		expect( getGoogleMyBusinessStats( state, 123, 'actions', 'month', 'total' ) ).toEqual( {
 			interval: 'month',
 			statType: 'actions',
 			aggregation: 'total',

--- a/client/state/selectors/test/get-image-editor-is-greater-than-minimum-dimensions.js
+++ b/client/state/selectors/test/get-image-editor-is-greater-than-minimum-dimensions.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getImageEditorIsGreaterThanMinimumDimensions from 'calypso/state/selectors/get-image-editor-is-greater-than-minimum-dimensions';
 
 describe( 'getImageEditorIsGreaterThanMinimumDimensions()', () => {
@@ -11,7 +10,7 @@ describe( 'getImageEditorIsGreaterThanMinimumDimensions()', () => {
 			},
 		} );
 
-		expect( isGreaterThanMinimumDimensions ).to.be.false;
+		expect( isGreaterThanMinimumDimensions ).toBe( false );
 	} );
 	test( 'should return false if the width value is not an integer', () => {
 		const isGreaterThanMinimumDimensions = getImageEditorIsGreaterThanMinimumDimensions(
@@ -26,7 +25,7 @@ describe( 'getImageEditorIsGreaterThanMinimumDimensions()', () => {
 			50
 		);
 
-		expect( isGreaterThanMinimumDimensions ).to.be.false;
+		expect( isGreaterThanMinimumDimensions ).toBe( false );
 	} );
 	test( 'should return false if the height value is not an integer', () => {
 		const isGreaterThanMinimumDimensions = getImageEditorIsGreaterThanMinimumDimensions(
@@ -41,7 +40,7 @@ describe( 'getImageEditorIsGreaterThanMinimumDimensions()', () => {
 			50
 		);
 
-		expect( isGreaterThanMinimumDimensions ).to.be.false;
+		expect( isGreaterThanMinimumDimensions ).toBe( false );
 	} );
 
 	test( 'should return false if the dimensions do not meet the supplied minimum dimensions', () => {
@@ -57,7 +56,7 @@ describe( 'getImageEditorIsGreaterThanMinimumDimensions()', () => {
 			50
 		);
 
-		expect( isGreaterThanMinimumDimensions ).to.be.false;
+		expect( isGreaterThanMinimumDimensions ).toBe( false );
 	} );
 
 	test( 'should return true if the dimensions meet the supplied minimum dimensions', () => {
@@ -73,6 +72,6 @@ describe( 'getImageEditorIsGreaterThanMinimumDimensions()', () => {
 			44
 		);
 
-		expect( isGreaterThanMinimumDimensions ).to.be.true;
+		expect( isGreaterThanMinimumDimensions ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/get-image-editor-original-aspect-ratio.js
+++ b/client/state/selectors/test/get-image-editor-original-aspect-ratio.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getImageEditorOriginalAspectRatio from 'calypso/state/selectors/get-image-editor-original-aspect-ratio';
 
 describe( 'getImageEditorOriginalAspectRatio()', () => {
@@ -11,7 +10,7 @@ describe( 'getImageEditorOriginalAspectRatio()', () => {
 			},
 		} );
 
-		expect( originalAspectRatio ).to.equal( null );
+		expect( originalAspectRatio ).toBeNull();
 	} );
 
 	test( 'should return the original aspect ratio', () => {
@@ -23,6 +22,6 @@ describe( 'getImageEditorOriginalAspectRatio()', () => {
 			},
 		} );
 
-		expect( originalAspectRatio ).to.eql( { width: 100, height: 200 } );
+		expect( originalAspectRatio ).toEqual( { width: 100, height: 200 } );
 	} );
 } );

--- a/client/state/selectors/test/get-jetpack-connection-status.js
+++ b/client/state/selectors/test/get-jetpack-connection-status.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getJetpackConnectionStatus from 'calypso/state/selectors/get-jetpack-connection-status';
 import { items as ITEMS_FIXTURE } from './fixtures/jetpack-connection';
 
@@ -13,7 +12,7 @@ describe( 'getJetpackConnectionStatus()', () => {
 		};
 		const siteId = 12345678;
 		const output = getJetpackConnectionStatus( stateIn, siteId );
-		expect( output ).to.eql( ITEMS_FIXTURE[ siteId ] );
+		expect( output ).toEqual( ITEMS_FIXTURE[ siteId ] );
 	} );
 
 	test( 'should return null for an unknown site', () => {
@@ -26,6 +25,6 @@ describe( 'getJetpackConnectionStatus()', () => {
 		};
 		const siteId = 88888888;
 		const output = getJetpackConnectionStatus( stateIn, siteId );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-jetpack-module.js
+++ b/client/state/selectors/test/get-jetpack-module.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getJetpackModule from 'calypso/state/selectors/get-jetpack-module';
 import { moduleData as MODULE_DATA_FIXTURE } from './fixtures/jetpack-modules';
 
@@ -15,7 +14,7 @@ describe( 'getJetpackModule()', () => {
 		};
 		const siteId = 123456;
 		const output = getJetpackModule( stateIn, siteId, 'module-a' );
-		expect( output ).to.eql( MODULE_DATA_FIXTURE[ 'module-a' ] );
+		expect( output ).toEqual( MODULE_DATA_FIXTURE[ 'module-a' ] );
 	} );
 
 	test( 'should return null for an unknown site', () => {
@@ -30,7 +29,7 @@ describe( 'getJetpackModule()', () => {
 		};
 		const siteId = 123456;
 		const output = getJetpackModule( stateIn, siteId, 'module-a' );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 
 	test( 'should return null for an unknown module', () => {
@@ -45,6 +44,6 @@ describe( 'getJetpackModule()', () => {
 		};
 		const siteId = 123456;
 		const output = getJetpackModule( stateIn, siteId, 'module-z' );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-jetpack-modules-requiring-connection.js
+++ b/client/state/selectors/test/get-jetpack-modules-requiring-connection.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getJetpackModulesRequiringConnection from 'calypso/state/selectors/get-jetpack-modules-requiring-connection';
 
 describe( 'getJetpackModulesRequiringConnection()', () => {
@@ -12,7 +11,7 @@ describe( 'getJetpackModulesRequiringConnection()', () => {
 		};
 
 		const modules = getJetpackModulesRequiringConnection( stateTree, 12345678 );
-		expect( modules ).to.be.null;
+		expect( modules ).toBeNull();
 	} );
 
 	test( 'should return the modules that require connection for a known site', () => {
@@ -39,6 +38,6 @@ describe( 'getJetpackModulesRequiringConnection()', () => {
 		};
 
 		const modules = getJetpackModulesRequiringConnection( stateTree, 12345678 );
-		expect( modules ).to.eql( [ 'module-a' ] );
+		expect( modules ).toEqual( [ 'module-a' ] );
 	} );
 } );

--- a/client/state/selectors/test/get-jetpack-modules.js
+++ b/client/state/selectors/test/get-jetpack-modules.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getJetpackModules from 'calypso/state/selectors/get-jetpack-modules';
 import { moduleData as MODULE_DATA_FIXTURE } from './fixtures/jetpack-modules';
 
@@ -15,7 +14,7 @@ describe( 'getJetpackModules()', () => {
 		};
 		const siteId = 123456;
 		const output = getJetpackModules( stateIn, siteId );
-		expect( output ).to.eql( MODULE_DATA_FIXTURE );
+		expect( output ).toEqual( MODULE_DATA_FIXTURE );
 	} );
 
 	test( 'should return null for an unknown site', () => {
@@ -30,6 +29,6 @@ describe( 'getJetpackModules()', () => {
 		};
 		const siteId = 123456;
 		const output = getJetpackModules( stateIn, siteId );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-jetpack-setting.js
+++ b/client/state/selectors/test/get-jetpack-setting.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getJetpackSetting from 'calypso/state/selectors/get-jetpack-setting';
 import { settings as SETTINGS_FIXTURE } from './fixtures/jetpack-settings';
 
@@ -12,7 +11,7 @@ describe( 'getJetpackSetting()', () => {
 		const siteId = 12345678;
 		const setting = 'setting_1';
 		const output = getJetpackSetting( stateIn, siteId, setting );
-		expect( output ).to.eql( SETTINGS_FIXTURE[ siteId ][ setting ] );
+		expect( output ).toEqual( SETTINGS_FIXTURE[ siteId ][ setting ] );
 	} );
 
 	test( 'should return null for an unknown site', () => {
@@ -26,7 +25,7 @@ describe( 'getJetpackSetting()', () => {
 		const siteId = 12345678;
 		const setting = 'setting_1';
 		const output = getJetpackSetting( stateIn, siteId, setting );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 
 	test( 'should return null for an unknown setting', () => {
@@ -40,6 +39,6 @@ describe( 'getJetpackSetting()', () => {
 		const siteId = 12345678;
 		const setting = 'unexisting_setting';
 		const output = getJetpackSetting( stateIn, siteId, setting );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-jetpack-settings-save-request-status.js
+++ b/client/state/selectors/test/get-jetpack-settings-save-request-status.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getRequestKey } from 'calypso/state/data-layer/wpcom-http/utils';
 import { saveJetpackSettings } from 'calypso/state/jetpack/settings/actions';
 import getJetpackSettingsSaveRequestStatus from 'calypso/state/selectors/get-jetpack-settings-save-request-status';
@@ -19,7 +18,7 @@ describe( 'getJetpackSettingsSaveRequestStatus()', () => {
 		};
 		const status = getJetpackSettingsSaveRequestStatus( state, 87654321, settings );
 
-		expect( status ).to.be.undefined;
+		expect( status ).toBeUndefined();
 	} );
 
 	test( 'should return success if the save request status is success', () => {
@@ -32,7 +31,7 @@ describe( 'getJetpackSettingsSaveRequestStatus()', () => {
 		};
 		const status = getJetpackSettingsSaveRequestStatus( state, 12345678, settings );
 
-		expect( status ).to.eql( 'success' );
+		expect( status ).toEqual( 'success' );
 	} );
 
 	test( 'should return error if the save request status is error', () => {
@@ -45,7 +44,7 @@ describe( 'getJetpackSettingsSaveRequestStatus()', () => {
 		};
 		const status = getJetpackSettingsSaveRequestStatus( state, 12345678, settings );
 
-		expect( status ).to.eql( 'error' );
+		expect( status ).toEqual( 'error' );
 	} );
 
 	test( 'should return pending if the save request status is pending', () => {
@@ -58,6 +57,6 @@ describe( 'getJetpackSettingsSaveRequestStatus()', () => {
 		};
 		const status = getJetpackSettingsSaveRequestStatus( state, 12345678, settings );
 
-		expect( status ).to.eql( 'pending' );
+		expect( status ).toEqual( 'pending' );
 	} );
 } );

--- a/client/state/selectors/test/get-jetpack-sites.js
+++ b/client/state/selectors/test/get-jetpack-sites.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getJetpackSites from 'calypso/state/selectors/get-jetpack-sites';
 import { userState } from './fixtures/user-state';
 
@@ -11,7 +10,7 @@ describe( 'getJetpackSites()', () => {
 			},
 		};
 		const sites = getJetpackSites( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 
 	test( 'should return an empty array if the sites existing are not Jetpack sites', () => {
@@ -25,7 +24,7 @@ describe( 'getJetpackSites()', () => {
 			},
 		};
 		const sites = getJetpackSites( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 
 	test( 'should return one Jetpack site if only one site exists and it is a Jetpack site', () => {
@@ -44,8 +43,8 @@ describe( 'getJetpackSites()', () => {
 			},
 		};
 		const sites = getJetpackSites( state );
-		expect( sites ).to.have.length( 1 );
-		expect( sites[ 0 ].ID ).to.eql( 2916289 );
+		expect( sites ).toHaveLength( 1 );
+		expect( sites[ 0 ].ID ).toEqual( 2916289 );
 	} );
 
 	test( 'should return all the sites in state if all of them are Jetpack sites', () => {
@@ -71,9 +70,9 @@ describe( 'getJetpackSites()', () => {
 			},
 		};
 		const sites = getJetpackSites( state );
-		expect( sites ).to.have.length( 2 );
-		expect( sites[ 0 ].ID ).to.eql( 2916288 );
-		expect( sites[ 1 ].ID ).to.eql( 2916289 );
+		expect( sites ).toHaveLength( 2 );
+		expect( sites[ 0 ].ID ).toEqual( 2916288 );
+		expect( sites[ 1 ].ID ).toEqual( 2916289 );
 	} );
 
 	test( 'should return only the Jetpack sites if the state contains Jetpack and non Jetpack sites', () => {
@@ -104,8 +103,8 @@ describe( 'getJetpackSites()', () => {
 			},
 		};
 		const sites = getJetpackSites( state );
-		expect( sites ).to.have.length( 2 );
-		expect( sites[ 0 ].ID ).to.eql( 2916288 );
-		expect( sites[ 1 ].ID ).to.eql( 2916289 );
+		expect( sites ).toHaveLength( 2 );
+		expect( sites[ 0 ].ID ).toEqual( 2916288 );
+		expect( sites[ 1 ].ID ).toEqual( 2916289 );
 	} );
 } );

--- a/client/state/selectors/test/get-jetpack-user-connection.js
+++ b/client/state/selectors/test/get-jetpack-user-connection.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getJetpackUserConnection from 'calypso/state/selectors/get-jetpack-user-connection';
 import { dataItems } from './fixtures/jetpack-connection';
 
@@ -13,7 +12,7 @@ describe( 'getJetpackUserConnection()', () => {
 		};
 		const siteId = 12345678;
 		const output = getJetpackUserConnection( stateIn, siteId );
-		expect( output ).to.eql( dataItems[ siteId ] );
+		expect( output ).toEqual( dataItems[ siteId ] );
 	} );
 
 	test( 'should return null for an unknown site', () => {
@@ -26,6 +25,6 @@ describe( 'getJetpackUserConnection()', () => {
 		};
 		const siteId = 88888888;
 		const output = getJetpackUserConnection( stateIn, siteId );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-magic-login-current-view.js
+++ b/client/state/selectors/test/get-magic-login-current-view.js
@@ -1,10 +1,9 @@
-import { expect } from 'chai';
 import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
 
 describe( 'getMagicLoginCurrentView()', () => {
 	test( 'should return null if there is no information yet', () => {
 		const isShowing = getMagicLoginCurrentView( undefined );
-		expect( isShowing ).to.be.null;
+		expect( isShowing ).toBeNull();
 	} );
 
 	test( 'should return the current view if set', () => {
@@ -15,6 +14,6 @@ describe( 'getMagicLoginCurrentView()', () => {
 				},
 			},
 		} );
-		expect( isShowing ).to.equal( 'some random view' );
+		expect( isShowing ).toEqual( 'some random view' );
 	} );
 } );

--- a/client/state/selectors/test/get-magic-login-request-auth-error.js
+++ b/client/state/selectors/test/get-magic-login-request-auth-error.js
@@ -1,10 +1,9 @@
-import { expect } from 'chai';
 import getMagicLoginRequestAuthError from 'calypso/state/selectors/get-magic-login-request-auth-error';
 
 describe( 'getMagicLoginRequestAuthError()', () => {
 	test( 'should return null if there is no information yet', () => {
 		const error = getMagicLoginRequestAuthError( undefined );
-		expect( error ).to.be.null;
+		expect( error ).toBeNull();
 	} );
 
 	test( 'should return the error if set', () => {
@@ -15,6 +14,6 @@ describe( 'getMagicLoginRequestAuthError()', () => {
 				},
 			},
 		} );
-		expect( error ).to.equal( 'to err is human' );
+		expect( error ).toEqual( 'to err is human' );
 	} );
 } );

--- a/client/state/selectors/test/get-magic-login-request-email-error.js
+++ b/client/state/selectors/test/get-magic-login-request-email-error.js
@@ -1,10 +1,9 @@
-import { expect } from 'chai';
 import getMagicLoginRequestEmailError from 'calypso/state/selectors/get-magic-login-request-email-error';
 
 describe( 'getMagicLoginRequestEmailError()', () => {
 	test( 'should return null if there is no information yet', () => {
 		const error = getMagicLoginRequestEmailError( undefined );
-		expect( error ).to.be.null;
+		expect( error ).toBeNull();
 	} );
 
 	test( 'should return the error if set', () => {
@@ -15,6 +14,6 @@ describe( 'getMagicLoginRequestEmailError()', () => {
 				},
 			},
 		} );
-		expect( error ).to.equal( 'to err is human' );
+		expect( error ).toEqual( 'to err is human' );
 	} );
 } );

--- a/client/state/selectors/test/get-magic-login-requested-auth-successfully.js
+++ b/client/state/selectors/test/get-magic-login-requested-auth-successfully.js
@@ -1,10 +1,9 @@
-import { expect } from 'chai';
 import getMagicLoginRequestedAuthSuccessfully from 'calypso/state/selectors/get-magic-login-requested-auth-successfully';
 
 describe( 'getMagicLoginRequestedAuthSuccessfully()', () => {
 	test( 'should return false if there is no information yet', () => {
 		const status = getMagicLoginRequestedAuthSuccessfully( undefined );
-		expect( status ).to.be.false;
+		expect( status ).toBe( false );
 	} );
 
 	test( 'should return true if requested auth succeeded', () => {
@@ -15,7 +14,7 @@ describe( 'getMagicLoginRequestedAuthSuccessfully()', () => {
 				},
 			},
 		} );
-		expect( status ).to.be.true;
+		expect( status ).toBe( true );
 	} );
 
 	test( 'should return false if requested auth failed', () => {
@@ -26,6 +25,6 @@ describe( 'getMagicLoginRequestedAuthSuccessfully()', () => {
 				},
 			},
 		} );
-		expect( status ).to.be.false;
+		expect( status ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/get-magic-login-requested-email-successfully.js
+++ b/client/state/selectors/test/get-magic-login-requested-email-successfully.js
@@ -1,10 +1,9 @@
-import { expect } from 'chai';
 import getMagicLoginRequestedEmailSuccessfully from 'calypso/state/selectors/get-magic-login-requested-email-successfully';
 
 describe( 'getMagicLoginRequestedEmailSuccessfully()', () => {
 	test( 'should return false if there is no information yet', () => {
 		const requested = getMagicLoginRequestedEmailSuccessfully( undefined );
-		expect( requested ).to.be.false;
+		expect( requested ).toBe( false );
 	} );
 
 	test( 'should return true if true', () => {
@@ -15,7 +14,7 @@ describe( 'getMagicLoginRequestedEmailSuccessfully()', () => {
 				},
 			},
 		} );
-		expect( requested ).to.be.true;
+		expect( requested ).toBe( true );
 	} );
 
 	test( 'should return false if false', () => {
@@ -26,6 +25,6 @@ describe( 'getMagicLoginRequestedEmailSuccessfully()', () => {
 				},
 			},
 		} );
-		expect( requested ).to.be.false;
+		expect( requested ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/get-media-item.js
+++ b/client/state/selectors/test/get-media-item.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import MediaQueryManager from 'calypso/lib/query-manager/media';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
 
@@ -23,15 +22,15 @@ describe( 'getMediaItem()', () => {
 	};
 
 	test( 'should return null if the site is not in state', () => {
-		expect( getMediaItem( state, 2916285, 42 ) ).to.be.null;
+		expect( getMediaItem( state, 2916285, 42 ) ).toBeNull();
 	} );
 
 	test( 'should return null if the media for the site is not in state', () => {
-		expect( getMediaItem( state, 2916284, 43 ) ).to.be.null;
+		expect( getMediaItem( state, 2916284, 43 ) ).toBeNull();
 	} );
 
 	test( 'should return the media item', () => {
-		expect( getMediaItem( state, 2916284, 42 ) ).to.eql( item );
+		expect( getMediaItem( state, 2916284, 42 ) ).toEqual( item );
 	} );
 
 	describe( 'transient media', () => {
@@ -74,19 +73,19 @@ describe( 'getMediaItem()', () => {
 		describe( 'before promotion', () => {
 			test( 'should return the transient media item', () => {
 				const result = getMediaItem( transientStatePreSave, siteId, transientItem.ID );
-				expect( result ).to.eql( transientItem );
+				expect( result ).toEqual( transientItem );
 			} );
 		} );
 
 		describe( 'after promotion', () => {
 			test( 'should return the actual media item when given the transient ID', () => {
 				const result = getMediaItem( transientStatePostSave, siteId, transientItem.ID );
-				expect( result ).to.eql( item );
+				expect( result ).toEqual( item );
 			} );
 
 			test( 'should return the actual media item when given the server ID', () => {
 				const result = getMediaItem( transientStatePostSave, siteId, item.ID );
-				expect( result ).to.eql( item );
+				expect( result ).toEqual( item );
 			} );
 		} );
 	} );

--- a/client/state/selectors/test/get-media-url.js
+++ b/client/state/selectors/test/get-media-url.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import MediaQueryManager from 'calypso/lib/query-manager/media';
 import getMediaUrl from 'calypso/state/selectors/get-media-url';
 
@@ -27,14 +26,14 @@ describe( 'getMediaUrl()', () => {
 	};
 
 	test( 'should return null if the item is not in state', () => {
-		expect( getMediaUrl( state, 2916285, 42 ) ).to.be.null;
+		expect( getMediaUrl( state, 2916285, 42 ) ).toBeNull();
 	} );
 
 	test( 'should return null if the media item URL is invalid', () => {
-		expect( getMediaUrl( state, 2916284, 43 ) ).to.be.null;
+		expect( getMediaUrl( state, 2916284, 43 ) ).toBeNull();
 	} );
 
 	test( 'should return a safe variation of the media URL', () => {
-		expect( getMediaUrl( state, 2916284, 42 ) ).to.be.equal( url );
+		expect( getMediaUrl( state, 2916284, 42 ) ).toEqual( url );
 	} );
 } );

--- a/client/state/selectors/test/get-media.js
+++ b/client/state/selectors/test/get-media.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import MediaQueryManager from 'calypso/lib/query-manager/media';
 import getMedia from 'calypso/state/selectors/get-media';
 
@@ -32,7 +31,7 @@ describe( 'getMedia()', () => {
 	test( 'should return null if the site is not in state', () => {
 		const media = getMedia( state, 2916285, query );
 
-		expect( media ).to.be.null;
+		expect( media ).toBeNull();
 	} );
 
 	test( 'should return null if the query is not in state', () => {
@@ -40,12 +39,12 @@ describe( 'getMedia()', () => {
 			search: 'flowers',
 		} );
 
-		expect( media ).to.be.null;
+		expect( media ).toBeNull();
 	} );
 
 	test( 'should return media', () => {
 		const media = getMedia( state, 2916284, query );
 
-		expect( media ).to.eql( [ item ] );
+		expect( media ).toEqual( [ item ] );
 	} );
 } );

--- a/client/state/selectors/test/get-network-sites.js
+++ b/client/state/selectors/test/get-network-sites.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getNetworkSites from 'calypso/state/selectors/get-network-sites';
 import { userState } from './fixtures/user-state';
 
@@ -10,7 +9,7 @@ describe( 'getNetworkSites()', () => {
 				items: {},
 			},
 		};
-		expect( getNetworkSites( state, 1 ) ).to.be.null;
+		expect( getNetworkSites( state, 1 ) ).toBeNull();
 	} );
 
 	test( 'should return null if main site is not found', () => {
@@ -30,7 +29,7 @@ describe( 'getNetworkSites()', () => {
 				},
 			},
 		};
-		expect( getNetworkSites( state, 2 ) ).to.be.null;
+		expect( getNetworkSites( state, 2 ) ).toBeNull();
 	} );
 
 	test( 'should return null if site is not a main site', () => {
@@ -47,7 +46,7 @@ describe( 'getNetworkSites()', () => {
 				},
 			},
 		};
-		expect( getNetworkSites( state, 1 ) ).to.be.null;
+		expect( getNetworkSites( state, 1 ) ).toBeNull();
 	} );
 
 	test( 'should return only the main site if no secondary sites exist', () => {
@@ -70,8 +69,9 @@ describe( 'getNetworkSites()', () => {
 			},
 		};
 		const networkSites = getNetworkSites( state, 1 );
-		expect( networkSites ).to.be.an( 'array' ).that.has.lengthOf( 1 );
-		expect( networkSites[ 0 ].ID ).to.eql( 1 );
+		expect( Array.isArray( networkSites ) ).toBe( true );
+		expect( networkSites ).toHaveLength( 1 );
+		expect( networkSites[ 0 ].ID ).toEqual( 1 );
 	} );
 
 	test( 'should return an array with secondary sites if they exist', () => {
@@ -110,9 +110,10 @@ describe( 'getNetworkSites()', () => {
 			},
 		};
 		const networkSites = getNetworkSites( state, 1 );
-		expect( networkSites ).to.be.an( 'array' ).that.has.lengthOf( 3 );
-		expect( networkSites[ 0 ].ID ).to.eql( 1 );
-		expect( networkSites[ 1 ].ID ).to.eql( 2 );
-		expect( networkSites[ 2 ].ID ).to.eql( 3 );
+		expect( Array.isArray( networkSites ) ).toBe( true );
+		expect( networkSites ).toHaveLength( 3 );
+		expect( networkSites[ 0 ].ID ).toEqual( 1 );
+		expect( networkSites[ 1 ].ID ).toEqual( 2 );
+		expect( networkSites[ 2 ].ID ).toEqual( 3 );
 	} );
 } );

--- a/client/state/selectors/test/get-original-user-setting.js
+++ b/client/state/selectors/test/get-original-user-setting.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getOriginalUserSetting from 'calypso/state/selectors/get-original-user-setting';
 
 describe( 'getOriginalUserSetting()', () => {
@@ -13,7 +12,7 @@ describe( 'getOriginalUserSetting()', () => {
 			'foo'
 		);
 
-		expect( setting ).to.be.null;
+		expect( setting ).toBeNull();
 	} );
 
 	test( 'should ignore the unsaved settings and always return the server value', () => {
@@ -27,6 +26,6 @@ describe( 'getOriginalUserSetting()', () => {
 			'foo'
 		);
 
-		expect( setting ).to.eql( 'bar' );
+		expect( setting ).toEqual( 'bar' );
 	} );
 } );

--- a/client/state/selectors/test/get-parent-comment.js
+++ b/client/state/selectors/test/get-parent-comment.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getParentComment } from 'calypso/state/comments/selectors';
 
 const state = {
@@ -20,21 +19,21 @@ const state = {
 
 describe( 'getParentComment()', () => {
 	test( 'should return the parent comment if available', () => {
-		expect( getParentComment( state, 123, 4, 2 ) ).to.eql( {
+		expect( getParentComment( state, 123, 4, 2 ) ).toEqual( {
 			ID: 1,
 			parent: { ID: 0 },
 		} );
 	} );
 	test( 'should return an empty object if the parent comment is not available', () => {
-		expect( getParentComment( state, 123, 4, 1 ) ).to.eql( {} );
+		expect( getParentComment( state, 123, 4, 1 ) ).toEqual( {} );
 	} );
 	test( 'should return an empty object if the site does not exist', () => {
-		expect( getParentComment( state, 456, 4, 2 ) ).to.eql( {} );
+		expect( getParentComment( state, 456, 4, 2 ) ).toEqual( {} );
 	} );
 	test( 'should return an empty object if the post does not exist', () => {
-		expect( getParentComment( state, 123, 5, 2 ) ).to.eql( {} );
+		expect( getParentComment( state, 123, 5, 2 ) ).toEqual( {} );
 	} );
 	test( 'should return an empty object if the comment does not exist', () => {
-		expect( getParentComment( state, 123, 4, 3 ) ).to.eql( {} );
+		expect( getParentComment( state, 123, 4, 3 ) ).toEqual( {} );
 	} );
 } );

--- a/client/state/selectors/test/get-past-billing-transactions.js
+++ b/client/state/selectors/test/get-past-billing-transactions.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getPastBillingTransactions from 'calypso/state/selectors/get-past-billing-transactions';
 
 describe( 'getPastBillingTransactions()', () => {
@@ -28,7 +27,7 @@ describe( 'getPastBillingTransactions()', () => {
 			return transaction;
 		} );
 		const output = getPastBillingTransactions( state );
-		expect( output ).to.eql( expected );
+		expect( output ).toEqual( expected );
 	} );
 
 	test( 'should return null if billing transactions have not been fetched yet', () => {
@@ -37,6 +36,6 @@ describe( 'getPastBillingTransactions()', () => {
 				items: {},
 			},
 		} );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-plugin-upload-error.js
+++ b/client/state/selectors/test/get-plugin-upload-error.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getPluginUploadError from 'calypso/state/selectors/get-plugin-upload-error';
 
 const siteId = 77203074;
@@ -16,7 +15,7 @@ describe( 'getPluginUploadError', () => {
 				},
 			},
 		};
-		expect( getPluginUploadError( state, siteId ) ).to.be.null;
+		expect( getPluginUploadError( state, siteId ) ).toBeNull();
 	} );
 
 	test( 'should return current value for site', () => {
@@ -29,6 +28,6 @@ describe( 'getPluginUploadError', () => {
 				},
 			},
 		};
-		expect( getPluginUploadError( state, siteId ) ).to.deep.equal( error );
+		expect( getPluginUploadError( state, siteId ) ).toEqual( error );
 	} );
 } );

--- a/client/state/selectors/test/get-plugin-upload-progress.js
+++ b/client/state/selectors/test/get-plugin-upload-progress.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getPluginUploadProgress from 'calypso/state/selectors/get-plugin-upload-progress';
 
 const siteId = 77203074;
@@ -12,7 +11,7 @@ describe( 'getPluginUploadProgress', () => {
 				},
 			},
 		};
-		expect( getPluginUploadProgress( state, siteId ) ).to.equal( 0 );
+		expect( getPluginUploadProgress( state, siteId ) ).toEqual( 0 );
 	} );
 
 	test( 'should return current value for site', () => {
@@ -25,6 +24,6 @@ describe( 'getPluginUploadProgress', () => {
 				},
 			},
 		};
-		expect( getPluginUploadProgress( state, siteId ) ).to.equal( 73 );
+		expect( getPluginUploadProgress( state, siteId ) ).toEqual( 73 );
 	} );
 } );

--- a/client/state/selectors/test/get-podcasting-category-id.js
+++ b/client/state/selectors/test/get-podcasting-category-id.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getPodcastingCategoryId from 'calypso/state/selectors/get-podcasting-category-id';
 
 describe( 'getPodcastingCategoryId', () => {
@@ -15,7 +14,7 @@ describe( 'getPodcastingCategoryId', () => {
 				},
 				1
 			)
-		).to.be.null;
+		).toBeNull();
 	} );
 
 	test( 'returns 0 if podcasting has not been configured', () => {
@@ -35,7 +34,7 @@ describe( 'getPodcastingCategoryId', () => {
 				},
 				1
 			)
-		).to.equal( 0 );
+		).toEqual( 0 );
 	} );
 
 	test( 'returns a category ID if podcasting has been configured', () => {
@@ -55,7 +54,7 @@ describe( 'getPodcastingCategoryId', () => {
 				},
 				1
 			)
-		).to.equal( 123 );
+		).toEqual( 123 );
 	} );
 
 	test( 'returns null for private sites', () => {
@@ -79,6 +78,6 @@ describe( 'getPodcastingCategoryId', () => {
 				},
 				1
 			)
-		).to.be.null;
+		).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-post-likes.js
+++ b/client/state/selectors/test/get-post-likes.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getPostLikes } from 'calypso/state/posts/selectors/get-post-likes';
 
 describe( 'getPostLikes()', () => {
@@ -15,7 +14,7 @@ describe( 'getPostLikes()', () => {
 			50
 		);
 
-		expect( postLikes ).to.be.null;
+		expect( postLikes ).toBeNull();
 	} );
 
 	test( 'should return null if the post has never been fetched', () => {
@@ -36,7 +35,7 @@ describe( 'getPostLikes()', () => {
 			50
 		);
 
-		expect( postLikes ).to.be.null;
+		expect( postLikes ).toBeNull();
 	} );
 
 	test( 'should return the post likes', () => {
@@ -57,6 +56,6 @@ describe( 'getPostLikes()', () => {
 			50
 		);
 
-		expect( postLikes ).to.eql( likes );
+		expect( postLikes ).toEqual( likes );
 	} );
 } );

--- a/client/state/selectors/test/get-post-revision.js
+++ b/client/state/selectors/test/get-post-revision.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getPostRevision } from 'calypso/state/posts/selectors/get-post-revision';
 
 describe( 'getPostRevision', () => {
@@ -22,7 +21,7 @@ describe( 'getPostRevision', () => {
 				10,
 				7979
 			)
-		).to.be.null;
+		).toBeNull();
 	} );
 
 	test( 'should return a post revision', () => {
@@ -51,7 +50,7 @@ describe( 'getPostRevision', () => {
 				10,
 				11
 			)
-		).to.eql( {
+		).toEqual( {
 			id: 11,
 			post_author: 9090,
 			post_title: 'Badman <img onerror= />',

--- a/client/state/selectors/test/get-post-revisions-authors-id.js
+++ b/client/state/selectors/test/get-post-revisions-authors-id.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getPostRevisionsAuthorsId } from 'calypso/state/posts/selectors/get-post-revisions-authors-id';
 
 describe( 'getPostRevisionsAuthorsId', () => {
@@ -21,7 +20,7 @@ describe( 'getPostRevisionsAuthorsId', () => {
 				12345678,
 				10
 			)
-		).to.eql( [] );
+		).toEqual( [] );
 	} );
 
 	test( 'should return an array of post revisions authors ID', () => {
@@ -47,6 +46,6 @@ describe( 'getPostRevisionsAuthorsId', () => {
 				12345678,
 				10
 			)
-		).to.eql( [ 123 ] );
+		).toEqual( [ 123 ] );
 	} );
 } );

--- a/client/state/selectors/test/get-post-revisions-comparisons.js
+++ b/client/state/selectors/test/get-post-revisions-comparisons.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getPostRevisionsComparisons } from 'calypso/state/posts/selectors/get-post-revisions-comparisons';
 
 describe( 'getPostRevisionsComparisons', () => {
@@ -19,7 +18,7 @@ describe( 'getPostRevisionsComparisons', () => {
 				12345678,
 				10
 			)
-		).to.eql( {} );
+		).toEqual( {} );
 	} );
 
 	test( 'should return a map of revision id to its valid (sequential) comparisons for `siteId, postId`', () => {
@@ -81,7 +80,7 @@ describe( 'getPostRevisionsComparisons', () => {
 			10
 		);
 
-		expect( selection ).to.eql( {
+		expect( selection ).toEqual( {
 			13: {
 				diff: {
 					post_content: [ { op: 'add', value: 'older content' } ],

--- a/client/state/selectors/test/get-post-revisions-diff-view.js
+++ b/client/state/selectors/test/get-post-revisions-diff-view.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getPostRevisionsDiffView } from 'calypso/state/posts/selectors/get-post-revisions-diff-view';
 
 describe( 'getPostRevisionsDiffView', () => {
@@ -13,7 +12,7 @@ describe( 'getPostRevisionsDiffView', () => {
 					},
 				},
 			} )
-		).to.eql( 'unified' );
+		).toEqual( 'unified' );
 	} );
 
 	test( 'should return "split" if the revisions UI diffView state is split', () => {
@@ -28,6 +27,6 @@ describe( 'getPostRevisionsDiffView', () => {
 					},
 				},
 			} )
-		).to.eql( 'split' );
+		).toEqual( 'split' );
 	} );
 } );

--- a/client/state/selectors/test/get-poster-upload-progress.js
+++ b/client/state/selectors/test/get-poster-upload-progress.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getPosterUploadProgress from 'calypso/state/selectors/get-poster-upload-progress';
 
 describe( 'getPosterUploadProgress()', () => {
@@ -12,6 +11,6 @@ describe( 'getPosterUploadProgress()', () => {
 			},
 		} );
 
-		expect( uploadProgress ).to.eql( percentage );
+		expect( uploadProgress ).toEqual( percentage );
 	} );
 } );

--- a/client/state/selectors/test/get-poster-url.js
+++ b/client/state/selectors/test/get-poster-url.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getPosterUrl from 'calypso/state/selectors/get-poster-url';
 
 describe( 'getPosterUrl()', () => {
@@ -12,6 +11,6 @@ describe( 'getPosterUrl()', () => {
 			},
 		} );
 
-		expect( poster ).to.eql( url );
+		expect( poster ).toEqual( url );
 	} );
 } );

--- a/client/state/selectors/test/get-previous-path.js
+++ b/client/state/selectors/test/get-previous-path.js
@@ -1,11 +1,10 @@
-import { expect } from 'chai';
 import getPreviousPath from 'calypso/state/selectors/get-previous-path';
 
 describe( 'getPreviousPath()', () => {
 	test( 'should return empty if the previous path is not set', () => {
 		const stateIn = {};
 		const output = getPreviousPath( stateIn );
-		expect( output ).to.eql( '' );
+		expect( output ).toEqual( '' );
 	} );
 
 	test( 'should return previous path if one is found', () => {
@@ -17,6 +16,6 @@ describe( 'getPreviousPath()', () => {
 			},
 		};
 		const output = getPreviousPath( stateIn );
-		expect( output ).to.eql( '/hello' );
+		expect( output ).toEqual( '/hello' );
 	} );
 } );

--- a/client/state/selectors/test/get-previous-query.js
+++ b/client/state/selectors/test/get-previous-query.js
@@ -1,11 +1,10 @@
-import { expect } from 'chai';
 import getPreviousQuery from 'calypso/state/selectors/get-previous-query';
 
 describe( 'getPreviousQuery()', () => {
 	test( 'should return empty if the previous Route is not set', () => {
 		const stateIn = {};
 		const output = getPreviousQuery( stateIn );
-		expect( output ).to.eql( '' );
+		expect( output ).toEqual( '' );
 	} );
 
 	test( 'should return previous query if one is found', () => {
@@ -17,6 +16,6 @@ describe( 'getPreviousQuery()', () => {
 			},
 		};
 		const output = getPreviousQuery( stateIn );
-		expect( output.filter ).to.eql( 'howdy' );
+		expect( output.filter ).toEqual( 'howdy' );
 	} );
 } );

--- a/client/state/selectors/test/get-previous-route.js
+++ b/client/state/selectors/test/get-previous-route.js
@@ -1,11 +1,10 @@
-import { expect } from 'chai';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 
 describe( 'getPreviousRoute()', () => {
 	test( 'should return empty if the previous Route is not set', () => {
 		const stateIn = {};
 		const output = getPreviousRoute( stateIn );
-		expect( output ).to.eql( '' );
+		expect( output ).toEqual( '' );
 	} );
 
 	test( 'should return previous route if one is found', () => {
@@ -22,6 +21,6 @@ describe( 'getPreviousRoute()', () => {
 			},
 		};
 		const output = getPreviousRoute( stateIn );
-		expect( output ).to.eql( '/hello?filter=hello' );
+		expect( output ).toEqual( '/hello?filter=hello' );
 	} );
 } );

--- a/client/state/selectors/test/get-public-sites.js
+++ b/client/state/selectors/test/get-public-sites.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getPublicSites from 'calypso/state/selectors/get-public-sites';
 import { userState } from './fixtures/user-state';
 
@@ -11,7 +10,7 @@ describe( 'getPublicSites()', () => {
 			},
 		};
 		const sites = getPublicSites( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 
 	test( 'should return the public sites in state', () => {
@@ -44,7 +43,7 @@ describe( 'getPublicSites()', () => {
 			},
 		};
 		const sites = getPublicSites( state );
-		expect( sites ).to.eql( [
+		expect( sites ).toEqual( [
 			{
 				ID: 2916284,
 				is_private: false,

--- a/client/state/selectors/test/get-raw-offsets.js
+++ b/client/state/selectors/test/get-raw-offsets.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getRawOffsets from 'calypso/state/selectors/get-raw-offsets';
 
 describe( 'getRawOffsets()', () => {
@@ -13,7 +12,7 @@ describe( 'getRawOffsets()', () => {
 
 		const manualUTCOffsets = getRawOffsets( state );
 
-		expect( manualUTCOffsets ).to.eql( {} );
+		expect( manualUTCOffsets ).toEqual( {} );
 	} );
 
 	test( 'should return raw offsets data', () => {
@@ -31,7 +30,7 @@ describe( 'getRawOffsets()', () => {
 
 		const offsets = getRawOffsets( state );
 
-		expect( offsets ).to.eql( {
+		expect( offsets ).toEqual( {
 			'UTC+0': 'UTC',
 			'UTC-12': 'UTC-12',
 			'UTC-11.5': 'UTC-11:30',

--- a/client/state/selectors/test/get-reader-aliased-follow-feed-url.js
+++ b/client/state/selectors/test/get-reader-aliased-follow-feed-url.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getReaderAliasedFollowFeedUrl } from 'calypso/state/reader/follows/selectors';
 
 const site1UrlKey = 'discover.wordpress.com';
@@ -29,20 +28,20 @@ describe( 'getReaderAliasedFollowFeedUrl()', () => {
 
 	test( 'should return passed in url if it cannot find anything', () => {
 		const feedUrl = getReaderAliasedFollowFeedUrl( state, 'http://croissant.happy' );
-		expect( feedUrl ).eql( 'http://croissant.happy' );
+		expect( feedUrl ).toEqual( 'http://croissant.happy' );
 	} );
 
 	test( 'should return exact match when it exists in state', () => {
 		const feedUrl = getReaderAliasedFollowFeedUrl( state, site1UrlKey );
-		expect( feedUrl ).eql( site1UrlKey );
+		expect( feedUrl ).toEqual( site1UrlKey );
 	} );
 
 	test( 'should utilize aliases within follow object to figure out a feed_url', () => {
 		const feedUrl1 = getReaderAliasedFollowFeedUrl( state, site1Aliases[ 0 ] );
-		expect( feedUrl1 ).eql( site1UrlKey );
+		expect( feedUrl1 ).toEqual( site1UrlKey );
 
 		const feedUrl2 = getReaderAliasedFollowFeedUrl( state, site1Aliases[ 1 ] );
-		expect( feedUrl2 ).eql( site1UrlKey );
+		expect( feedUrl2 ).toEqual( site1UrlKey );
 	} );
 
 	test( 'should try to guess basic rss/feed extensions', () => {
@@ -51,9 +50,9 @@ describe( 'getReaderAliasedFollowFeedUrl()', () => {
 		const feedUrlC = getReaderAliasedFollowFeedUrl( state, 'siteC' );
 		const feedUrlD = getReaderAliasedFollowFeedUrl( state, 'siteD' );
 
-		expect( feedUrlA ).eql( siteA );
-		expect( feedUrlB ).eql( siteB );
-		expect( feedUrlC ).eql( siteC );
-		expect( feedUrlD ).eql( siteD );
+		expect( feedUrlA ).toEqual( siteA );
+		expect( feedUrlB ).toEqual( siteB );
+		expect( feedUrlC ).toEqual( siteC );
+		expect( feedUrlD ).toEqual( siteD );
 	} );
 } );

--- a/client/state/selectors/test/get-reader-follows.js
+++ b/client/state/selectors/test/get-reader-follows.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import { userState } from './fixtures/user-state';
@@ -57,7 +56,7 @@ describe( 'getReaderFollows()', () => {
 
 	test( 'should not return follows with an error set and should fill in feed and site when available', () => {
 		const follows = getReaderFollows( state );
-		expect( follows ).to.eql( [
+		expect( follows ).toEqual( [
 			{
 				URL: 'http://discover.wordpress.com',
 				blog_ID: 1,

--- a/client/state/selectors/test/get-removable-connections.js
+++ b/client/state/selectors/test/get-removable-connections.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getRemovableConnections from 'calypso/state/selectors/get-removable-connections';
 
 describe( 'getRemovableConnections()', () => {
@@ -43,13 +42,13 @@ describe( 'getRemovableConnections()', () => {
 	test( 'should return an empty array for a service without connections', () => {
 		const connections = getRemovableConnections( state, 'path' );
 
-		expect( connections ).to.eql( [] );
+		expect( connections ).toEqual( [] );
 	} );
 
 	test( 'should return an array of connection objects that are removable by the current user without duplicates', () => {
 		const twitterConnections = getRemovableConnections( state, 'twitter' );
 
-		expect( twitterConnections ).to.eql( [
+		expect( twitterConnections ).toEqual( [
 			{ ID: 1, site_ID: 2916284, shared: true, service: 'twitter', user_ID: 0 },
 			{
 				ID: 2,
@@ -62,7 +61,7 @@ describe( 'getRemovableConnections()', () => {
 
 		const instagramConnections = getRemovableConnections( state, 'instagram-basic-display' );
 
-		expect( instagramConnections ).to.eql( [
+		expect( instagramConnections ).toEqual( [
 			{ ID: 4, type: 'other', service: 'instagram-basic-display', user_ID: 26957695 },
 		] );
 	} );

--- a/client/state/selectors/test/get-restore-progress.js
+++ b/client/state/selectors/test/get-restore-progress.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getRestoreProgress from 'calypso/state/selectors/get-restore-progress';
 
 const SITE_ID = 1234;
@@ -13,7 +12,7 @@ describe( 'getRestoreProgress()', () => {
 			},
 			SITE_ID
 		);
-		expect( result ).to.be.null;
+		expect( result ).toBeNull();
 	} );
 
 	test( 'should return existing progress for a site', () => {
@@ -32,6 +31,6 @@ describe( 'getRestoreProgress()', () => {
 			},
 			SITE_ID
 		);
-		expect( result ).to.deep.equal( progress );
+		expect( result ).toEqual( progress );
 	} );
 } );

--- a/client/state/selectors/test/get-selected-or-all-sites-jetpack-can-manage.js
+++ b/client/state/selectors/test/get-selected-or-all-sites-jetpack-can-manage.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
 import { userState } from './fixtures/user-state';
 
@@ -12,7 +11,7 @@ describe( 'getSelectedOrAllSitesJetpackCanManage()', () => {
 			ui: { selectedSiteId: 2916284 },
 		};
 		const sites = getSelectedOrAllSitesJetpackCanManage( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 
 	test( 'should return an empty array if the sites existing do not verify jetpack management conditions', () => {
@@ -29,7 +28,7 @@ describe( 'getSelectedOrAllSitesJetpackCanManage()', () => {
 			ui: {},
 		};
 		const sites = getSelectedOrAllSitesJetpackCanManage( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 
 	test( 'should return an array with one site if just one site exists and verifies jetpack management conditions', () => {
@@ -55,8 +54,8 @@ describe( 'getSelectedOrAllSitesJetpackCanManage()', () => {
 			ui: {},
 		};
 		const sites = getSelectedOrAllSitesJetpackCanManage( state );
-		expect( sites ).to.have.length( 1 );
-		expect( sites[ 0 ].ID ).to.eql( 2916288 );
+		expect( sites ).toHaveLength( 1 );
+		expect( sites[ 0 ].ID ).toEqual( 2916288 );
 	} );
 
 	test( 'should return an array with all the sites that verify jetpack management conditions', () => {
@@ -93,9 +92,9 @@ describe( 'getSelectedOrAllSitesJetpackCanManage()', () => {
 			ui: {},
 		};
 		const sites = getSelectedOrAllSitesJetpackCanManage( state );
-		expect( sites ).to.have.length( 2 );
-		expect( sites[ 0 ].ID ).to.eql( 2916286 );
-		expect( sites[ 1 ].ID ).to.eql( 2916289 );
+		expect( sites ).toHaveLength( 2 );
+		expect( sites[ 0 ].ID ).toEqual( 2916286 );
+		expect( sites[ 1 ].ID ).toEqual( 2916289 );
 	} );
 
 	test( 'should return an array with the selected site if it verifies jetpack management conditions', () => {
@@ -121,8 +120,8 @@ describe( 'getSelectedOrAllSitesJetpackCanManage()', () => {
 			ui: { selectedSiteId: 2916289 },
 		};
 		const sites = getSelectedOrAllSitesJetpackCanManage( state );
-		expect( sites ).to.have.length( 1 );
-		expect( sites[ 0 ].ID ).to.eql( 2916289 );
+		expect( sites ).toHaveLength( 1 );
+		expect( sites[ 0 ].ID ).toEqual( 2916289 );
 	} );
 
 	test( 'should return an empty array if the selected site can not be managed', () => {
@@ -147,6 +146,6 @@ describe( 'getSelectedOrAllSitesJetpackCanManage()', () => {
 			ui: { selectedSiteId: 2916287 },
 		};
 		const sites = getSelectedOrAllSitesJetpackCanManage( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 } );

--- a/client/state/selectors/test/get-selected-or-all-sites-with-plugins.js
+++ b/client/state/selectors/test/get-selected-or-all-sites-with-plugins.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import { userState } from './fixtures/user-state';
 
@@ -12,7 +11,7 @@ describe( 'getSelectedOrAllSitesWithPlugins()', () => {
 			ui: { selectedSiteId: 2916284 },
 		};
 		const sites = getSelectedOrAllSitesWithPlugins( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 
 	test( 'should return an empty array if the sites existing are not able to contain plugins', () => {
@@ -29,7 +28,7 @@ describe( 'getSelectedOrAllSitesWithPlugins()', () => {
 			ui: {},
 		};
 		const sites = getSelectedOrAllSitesWithPlugins( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 
 	test( 'should return an array with one site if just one site exists and the user is able to manage plugins there', () => {
@@ -55,8 +54,8 @@ describe( 'getSelectedOrAllSitesWithPlugins()', () => {
 			ui: {},
 		};
 		const sites = getSelectedOrAllSitesWithPlugins( state );
-		expect( sites ).to.have.length( 1 );
-		expect( sites[ 0 ].ID ).to.eql( 2916288 );
+		expect( sites ).toHaveLength( 1 );
+		expect( sites[ 0 ].ID ).toEqual( 2916288 );
 	} );
 
 	test( 'should return an array with all the sites able to have plugins', () => {
@@ -94,9 +93,9 @@ describe( 'getSelectedOrAllSitesWithPlugins()', () => {
 			ui: {},
 		};
 		const sites = getSelectedOrAllSitesWithPlugins( state );
-		expect( sites ).to.have.length( 2 );
-		expect( sites[ 0 ].ID ).to.eql( 2916286 );
-		expect( sites[ 1 ].ID ).to.eql( 2916289 );
+		expect( sites ).toHaveLength( 2 );
+		expect( sites[ 0 ].ID ).toEqual( 2916286 );
+		expect( sites[ 1 ].ID ).toEqual( 2916289 );
 	} );
 
 	test( 'should return an array with the selected site if it is able to have plugins', () => {
@@ -130,8 +129,8 @@ describe( 'getSelectedOrAllSitesWithPlugins()', () => {
 			ui: { selectedSiteId: 2916289 },
 		};
 		const sites = getSelectedOrAllSitesWithPlugins( state );
-		expect( sites ).to.have.length( 1 );
-		expect( sites[ 0 ].ID ).to.eql( 2916289 );
+		expect( sites ).toHaveLength( 1 );
+		expect( sites[ 0 ].ID ).toEqual( 2916289 );
 	} );
 
 	test( 'should return an empty array if the selected site is not able to have plugins', () => {
@@ -167,6 +166,6 @@ describe( 'getSelectedOrAllSitesWithPlugins()', () => {
 			ui: { selectedSiteId: 2916287 },
 		};
 		const sites = getSelectedOrAllSitesWithPlugins( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 } );

--- a/client/state/selectors/test/get-site-connection-status.js
+++ b/client/state/selectors/test/get-site-connection-status.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 
 describe( 'getSiteConnectionStatus()', () => {
@@ -15,7 +14,7 @@ describe( 'getSiteConnectionStatus()', () => {
 			},
 		};
 		const output = getSiteConnectionStatus( state, siteId );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return null for an unknown site', () => {
@@ -29,6 +28,6 @@ describe( 'getSiteConnectionStatus()', () => {
 			},
 		};
 		const output = getSiteConnectionStatus( state, siteId );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-site-features.js
+++ b/client/state/selectors/test/get-site-features.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 
 describe( 'selectors', () => {
@@ -44,7 +43,7 @@ describe( 'selectors', () => {
 			};
 
 			const features = getFeaturesBySiteId( state, 123001 ); // site (A).
-			expect( features ).to.eql( features_a );
+			expect( features ).toEqual( features_a );
 		} );
 	} );
 
@@ -84,6 +83,6 @@ describe( 'selectors', () => {
 		};
 
 		const features = getFeaturesBySiteId( state ); // site (A).
-		expect( features ).to.eql( null );
+		expect( features ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-site-gmt-offset.js
+++ b/client/state/selectors/test/get-site-gmt-offset.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 
 describe( 'getSiteGmtOffset()', () => {
@@ -10,7 +9,7 @@ describe( 'getSiteGmtOffset()', () => {
 		};
 
 		const offset = getSiteGmtOffset( stateTree, 2916284 );
-		expect( offset ).to.be.null;
+		expect( offset ).toBeNull();
 	} );
 
 	test( 'should return null if the site-settings has never been fetched', () => {
@@ -23,7 +22,7 @@ describe( 'getSiteGmtOffset()', () => {
 		};
 
 		const offset = getSiteGmtOffset( stateTree, 2916284 );
-		expect( offset ).to.be.null;
+		expect( offset ).toBeNull();
 	} );
 
 	test( 'should return the site-settings utc offset', () => {
@@ -38,6 +37,6 @@ describe( 'getSiteGmtOffset()', () => {
 		};
 
 		const offset = getSiteGmtOffset( stateTree, 2916284 );
-		expect( offset ).to.eql( 11 );
+		expect( offset ).toEqual( 11 );
 	} );
 } );

--- a/client/state/selectors/test/get-site-icon-id.js
+++ b/client/state/selectors/test/get-site-icon-id.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getSiteIconId from 'calypso/state/selectors/get-site-icon-id';
 
 describe( 'getSiteIconId()', () => {
@@ -15,7 +14,7 @@ describe( 'getSiteIconId()', () => {
 			2916284
 		);
 
-		expect( id ).to.be.null;
+		expect( id ).toBeNull();
 	} );
 
 	test( 'should prefer site state', () => {
@@ -43,7 +42,7 @@ describe( 'getSiteIconId()', () => {
 			2916284
 		);
 
-		expect( id ).to.equal( 42 );
+		expect( id ).toEqual( 42 );
 	} );
 
 	test( 'should prefer site state, even if unset', () => {
@@ -68,7 +67,7 @@ describe( 'getSiteIconId()', () => {
 			2916284
 		);
 
-		expect( id ).to.be.null;
+		expect( id ).toBeNull();
 	} );
 
 	test( 'should fall back to settings state', () => {
@@ -88,6 +87,6 @@ describe( 'getSiteIconId()', () => {
 			2916284
 		);
 
-		expect( id ).to.equal( 42 );
+		expect( id ).toEqual( 42 );
 	} );
 } );

--- a/client/state/selectors/test/get-site-icon-url.js
+++ b/client/state/selectors/test/get-site-icon-url.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import MediaQueryManager from 'calypso/lib/query-manager/media';
 import getSiteIconUrl from 'calypso/state/selectors/get-site-icon-url';
 
@@ -19,7 +18,7 @@ describe( 'getSiteIconUrl()', () => {
 			2916284
 		);
 
-		expect( iconUrl ).to.be.null;
+		expect( iconUrl ).toBeNull();
 	} );
 
 	test( 'should the site icon image as a fallback if the media is not known for the assigned icon ID', () => {
@@ -44,7 +43,7 @@ describe( 'getSiteIconUrl()', () => {
 			2916284
 		);
 
-		expect( iconUrl ).to.equal(
+		expect( iconUrl ).toEqual(
 			'https://secure.gravatar.com/blavatar/0d6c430459af115394a012d20b6711d6'
 		);
 	} );
@@ -80,6 +79,6 @@ describe( 'getSiteIconUrl()', () => {
 			2916284
 		);
 
-		expect( iconUrl ).to.equal( 'https://example.files.wordpress.com/2014/06/flower.gif' );
+		expect( iconUrl ).toEqual( 'https://example.files.wordpress.com/2014/06/flower.gif' );
 	} );
 } );

--- a/client/state/selectors/test/get-site-setting.js
+++ b/client/state/selectors/test/get-site-setting.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getSiteSetting from 'calypso/state/selectors/get-site-setting';
 
 describe( 'getSiteSettings()', () => {
@@ -13,12 +12,12 @@ describe( 'getSiteSettings()', () => {
 	test( 'should return null if the site is not tracked', () => {
 		const settings = getSiteSetting( state, 2916285 );
 
-		expect( settings ).to.be.null;
+		expect( settings ).toBeNull();
 	} );
 
 	test( 'should return the setting for a siteId', () => {
 		const settings = getSiteSetting( state, 2916284, 'default_category' );
 
-		expect( settings ).to.eql( 'chicken' );
+		expect( settings ).toEqual( 'chicken' );
 	} );
 } );

--- a/client/state/selectors/test/get-site-stats-query-date.js
+++ b/client/state/selectors/test/get-site-stats-query-date.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getSiteStatsQueryDate } from 'calypso/state/stats/lists/selectors';
 
 describe( 'getSiteStatsQueryDate()', () => {
@@ -16,7 +15,7 @@ describe( 'getSiteStatsQueryDate()', () => {
 			{}
 		);
 
-		expect( date ).to.be.undefined;
+		expect( date ).toBeUndefined();
 	} );
 
 	test( 'should return the query date properly', () => {
@@ -40,6 +39,6 @@ describe( 'getSiteStatsQueryDate()', () => {
 			{ startDate: '2015-06-01', endDate: '2016-06-01' }
 		);
 
-		expect( date ).to.eql( today );
+		expect( date ).toEqual( today );
 	} );
 } );

--- a/client/state/selectors/test/get-site-stats-view-summary.js
+++ b/client/state/selectors/test/get-site-stats-view-summary.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getSiteStatsViewSummary } from 'calypso/state/stats/lists/selectors';
 
 describe( 'getSiteStatsViewSummary()', () => {
@@ -18,7 +17,7 @@ describe( 'getSiteStatsViewSummary()', () => {
 			2916284
 		);
 
-		expect( data ).to.be.null;
+		expect( data ).toBeNull();
 	} );
 
 	test( 'should return an empty object if data is empty', () => {
@@ -43,7 +42,7 @@ describe( 'getSiteStatsViewSummary()', () => {
 			2916284
 		);
 
-		expect( data ).to.eql( {} );
+		expect( data ).toEqual( {} );
 	} );
 
 	test( 'should return a parsed object if data is present', () => {
@@ -74,7 +73,7 @@ describe( 'getSiteStatsViewSummary()', () => {
 			2916284
 		);
 
-		expect( data ).to.eql( {
+		expect( data ).toEqual( {
 			2014: {
 				0: {
 					total: 31,
@@ -128,7 +127,7 @@ describe( 'getSiteStatsViewSummary()', () => {
 			2916284
 		);
 
-		expect( data[ today.getFullYear() ][ today.getMonth() ] ).to.eql( {
+		expect( data[ today.getFullYear() ][ today.getMonth() ] ).toEqual( {
 			total: 96,
 			average: Math.round( 96 / daysSinceStartOfMonth ),
 			daysInMonth: daysSinceStartOfMonth,

--- a/client/state/selectors/test/get-site-timezone-value.js
+++ b/client/state/selectors/test/get-site-timezone-value.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 
 describe( 'getSiteTimezoneValue()', () => {
@@ -10,7 +9,7 @@ describe( 'getSiteTimezoneValue()', () => {
 		};
 
 		const timezone = getSiteTimezoneValue( stateTree, 2916284 );
-		expect( timezone ).to.be.null;
+		expect( timezone ).toBeNull();
 	} );
 
 	test( 'should return null if the site-settings has never been fetched', () => {
@@ -23,7 +22,7 @@ describe( 'getSiteTimezoneValue()', () => {
 		};
 
 		const timezone = getSiteTimezoneValue( stateTree, 2916284 );
-		expect( timezone ).to.be.null;
+		expect( timezone ).toBeNull();
 	} );
 
 	test( 'should return null if the timezone_string is an empty string', () => {
@@ -38,7 +37,7 @@ describe( 'getSiteTimezoneValue()', () => {
 		};
 
 		const timezone = getSiteTimezoneValue( stateTree, 2916284 );
-		expect( timezone ).to.be.null;
+		expect( timezone ).toBeNull();
 	} );
 
 	test( 'should return site-settings timezone', () => {
@@ -53,6 +52,6 @@ describe( 'getSiteTimezoneValue()', () => {
 		};
 
 		const timezone = getSiteTimezoneValue( stateTree, 2916284 );
-		expect( timezone ).to.eql( 'Europe/Skopje' );
+		expect( timezone ).toEqual( 'Europe/Skopje' );
 	} );
 } );

--- a/client/state/selectors/test/get-site-url.js
+++ b/client/state/selectors/test/get-site-url.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
 
 describe( 'getSiteUrl()', () => {
@@ -11,8 +10,8 @@ describe( 'getSiteUrl()', () => {
 			},
 		};
 
-		expect( getSiteUrl( state ) ).to.be.null;
-		expect( getSiteUrl( state, 123 ) ).to.be.null;
+		expect( getSiteUrl( state ) ).toBeNull();
+		expect( getSiteUrl( state, 123 ) ).toBeNull();
 	} );
 
 	test( 'should return null if the Url is unknown', () => {
@@ -24,7 +23,7 @@ describe( 'getSiteUrl()', () => {
 				},
 			},
 		};
-		expect( getSiteUrl( state, 123 ) ).to.be.null;
+		expect( getSiteUrl( state, 123 ) ).toBeNull();
 	} );
 
 	test( 'should return the Url for a site', () => {
@@ -42,6 +41,6 @@ describe( 'getSiteUrl()', () => {
 			123
 		);
 
-		expect( result ).to.equal( URL );
+		expect( result ).toEqual( URL );
 	} );
 } );

--- a/client/state/selectors/test/get-sites-items.js
+++ b/client/state/selectors/test/get-sites-items.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getSitesItems from 'calypso/state/selectors/get-sites-items';
 
 describe( 'getSitesItems()', () => {
@@ -8,7 +7,7 @@ describe( 'getSitesItems()', () => {
 				items: { 13434: { ID: 13434 } },
 			},
 		};
-		expect( getSitesItems( state ) ).to.eql( { 13434: { ID: 13434 } } );
+		expect( getSitesItems( state ) ).toEqual( { 13434: { ID: 13434 } } );
 	} );
 
 	test( 'should return empty object if site items are empty', () => {
@@ -17,7 +16,7 @@ describe( 'getSitesItems()', () => {
 				items: {},
 			},
 		};
-		expect( getSitesItems( state ) ).to.eql( {} );
+		expect( getSitesItems( state ) ).toEqual( {} );
 	} );
 
 	test( 'should return empty object if site items are null (not loaded)', () => {
@@ -26,6 +25,6 @@ describe( 'getSitesItems()', () => {
 				items: null,
 			},
 		};
-		expect( getSitesItems( state ) ).to.eql( {} );
+		expect( getSitesItems( state ) ).toEqual( {} );
 	} );
 } );

--- a/client/state/selectors/test/get-sites.js
+++ b/client/state/selectors/test/get-sites.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getSites from 'calypso/state/selectors/get-sites';
 
 const currentUser = {
@@ -18,7 +17,7 @@ describe( 'getSites()', () => {
 			},
 		};
 		const sites = getSites( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 
 	test( 'should return the primary site if the user has only one site', () => {
@@ -32,7 +31,7 @@ describe( 'getSites()', () => {
 		};
 
 		const sites = getSites( state );
-		expect( sites ).to.have.length( 1 );
+		expect( sites ).toHaveLength( 1 );
 	} );
 
 	test( 'should return the sites lists if the user has no primary site', () => {
@@ -47,7 +46,7 @@ describe( 'getSites()', () => {
 		};
 
 		const sites = getSites( state );
-		expect( sites ).to.have.length( 2 );
+		expect( sites ).toHaveLength( 2 );
 	} );
 
 	test( 'should return all the sites in state', () => {
@@ -64,9 +63,9 @@ describe( 'getSites()', () => {
 			},
 		};
 		const sites = getSites( state );
-		expect( sites ).to.have.length( 2 );
-		expect( sites[ 0 ] ).to.have.property( 'name', 'WordPress.com Example Blog' );
-		expect( sites[ 1 ] ).to.have.property( 'name', 'WordPress.com Way Better Example Blog' );
+		expect( sites ).toHaveLength( 2 );
+		expect( sites[ 0 ] ).toHaveProperty( 'name', 'WordPress.com Example Blog' );
+		expect( sites[ 1 ] ).toHaveProperty( 'name', 'WordPress.com Way Better Example Blog' );
 	} );
 
 	test( 'should return the primary site as the first element of the list', () => {
@@ -85,8 +84,8 @@ describe( 'getSites()', () => {
 		};
 		const sites = getSites( state );
 
-		expect( sites ).to.have.length( 3 );
-		expect( sites[ 0 ] ).to.have.property( 'ID', 2916288 );
+		expect( sites ).toHaveLength( 3 );
+		expect( sites[ 0 ] ).toHaveProperty( 'ID', 2916288 );
 	} );
 
 	test( 'should return sites in alphabetical order by name and url', () => {
@@ -119,15 +118,15 @@ describe( 'getSites()', () => {
 		};
 		const sites = getSites( state );
 
-		expect( sites ).to.have.length( 9 );
-		expect( sites[ 0 ] ).to.have.property( 'ID', 2916288 ); // WordPress.com Z Blog - Primary Site
-		expect( sites[ 1 ] ).to.have.property( 'ID', 2916293 ); // https://0-site-with-no-name.wordpress.com
-		expect( sites[ 2 ] ).to.have.property( 'ID', 2916292 ); // https://z-site-with-no-name.wordpress.com
-		expect( sites[ 3 ] ).to.have.property( 'ID', 2916291 ); // WordPress.com 0 Site
-		expect( sites[ 4 ] ).to.have.property( 'ID', 2916289 ); // WordPress.com A Site
-		expect( sites[ 5 ] ).to.have.property( 'ID', 2916287 ); // WordPress.com B Site
-		expect( sites[ 6 ] ).to.have.property( 'ID', 2916295 ); // WordPress.com B Site - https://site-with-same-name-1.wordpress.com
-		expect( sites[ 7 ] ).to.have.property( 'ID', 2916294 ); // WordPress.com B Site - https://site-with-same-name-2.wordpress.com
-		expect( sites[ 8 ] ).to.have.property( 'ID', 2916290 ); // WordPress.com C Site
+		expect( sites ).toHaveLength( 9 );
+		expect( sites[ 0 ] ).toHaveProperty( 'ID', 2916288 ); // WordPress.com Z Blog - Primary Site
+		expect( sites[ 1 ] ).toHaveProperty( 'ID', 2916293 ); // https://0-site-with-no-name.wordpress.com
+		expect( sites[ 2 ] ).toHaveProperty( 'ID', 2916292 ); // https://z-site-with-no-name.wordpress.com
+		expect( sites[ 3 ] ).toHaveProperty( 'ID', 2916291 ); // WordPress.com 0 Site
+		expect( sites[ 4 ] ).toHaveProperty( 'ID', 2916289 ); // WordPress.com A Site
+		expect( sites[ 5 ] ).toHaveProperty( 'ID', 2916287 ); // WordPress.com B Site
+		expect( sites[ 6 ] ).toHaveProperty( 'ID', 2916295 ); // WordPress.com B Site - https://site-with-same-name-1.wordpress.com
+		expect( sites[ 7 ] ).toHaveProperty( 'ID', 2916294 ); // WordPress.com B Site - https://site-with-same-name-2.wordpress.com
+		expect( sites[ 8 ] ).toHaveProperty( 'ID', 2916290 ); // WordPress.com C Site
 	} );
 } );

--- a/client/state/selectors/test/get-theme-filter-term-from-string.js
+++ b/client/state/selectors/test/get-theme-filter-term-from-string.js
@@ -1,15 +1,14 @@
-import { expect } from 'chai';
 import { getThemeFilterTermFromString } from 'calypso/state/themes/selectors';
 import { state } from './fixtures/theme-filters';
 
 describe( 'getThemeFilterTermFromString()', () => {
 	test( 'should drop taxonomy prefix from unambiguous filter term', () => {
 		const term = getThemeFilterTermFromString( state, 'subject:business' );
-		expect( term ).to.equal( 'business' );
+		expect( term ).toEqual( 'business' );
 	} );
 
 	test( 'should retain taxonomy prefix for ambiguous filter term', () => {
 		const term = getThemeFilterTermFromString( state, 'subject:video' );
-		expect( term ).to.equal( 'subject:video' );
+		expect( term ).toEqual( 'subject:video' );
 	} );
 } );

--- a/client/state/selectors/test/get-theme-filter-term.js
+++ b/client/state/selectors/test/get-theme-filter-term.js
@@ -1,21 +1,20 @@
-import { expect } from 'chai';
 import { getThemeFilterTerm } from 'calypso/state/themes/selectors';
 import { state } from './fixtures/theme-filters';
 
 describe( 'getThemeFilterTerm()', () => {
 	test( 'should return undefined for an inexistent filter slug', () => {
 		const term = getThemeFilterTerm( state, 'object', 'blog' );
-		expect( term ).to.be.undefined;
+		expect( term ).toBeUndefined();
 	} );
 
 	test( 'should return undefined for an inexistent term slug', () => {
 		const term = getThemeFilterTerm( state, 'subject', 'blahg' );
-		expect( term ).to.be.undefined;
+		expect( term ).toBeUndefined();
 	} );
 
 	test( 'should return the filter term object for a given filter and term slug', () => {
 		const term = getThemeFilterTerm( state, 'subject', 'blog' );
-		expect( term ).to.deep.equal( {
+		expect( term ).toEqual( {
 			name: 'Blog',
 			description:
 				"Whether you're authoring a personal blog, professional blog, or a business blog — ...",

--- a/client/state/selectors/test/get-theme-filter-terms-table.js
+++ b/client/state/selectors/test/get-theme-filter-terms-table.js
@@ -1,11 +1,10 @@
-import { expect } from 'chai';
 import { getThemeFilterTermsTable } from 'calypso/state/themes/selectors';
 import { state } from './fixtures/theme-filters';
 
 describe( 'getThemeFilterTermsTable()', () => {
 	test( 'should return a dictionary mapping terms to taxonomies', () => {
 		const table = getThemeFilterTermsTable( state );
-		expect( table ).to.deep.equal( {
+		expect( table ).toEqual( {
 			artwork: 'subject',
 			blog: 'subject',
 			business: 'subject',

--- a/client/state/selectors/test/get-theme-filter-terms.js
+++ b/client/state/selectors/test/get-theme-filter-terms.js
@@ -1,15 +1,14 @@
-import { expect } from 'chai';
 import { getThemeFilterTerms } from 'calypso/state/themes/selectors';
 import { state } from './fixtures/theme-filters';
 
 describe( 'getThemeFilterTerms()', () => {
 	test( 'should return undefined for an inexistent filter slug', () => {
 		const terms = getThemeFilterTerms( state, 'object' );
-		expect( terms ).to.be.undefined;
+		expect( terms ).toBeUndefined();
 	} );
 
 	test( 'should return the filter terms for a given filter slug', () => {
 		const terms = getThemeFilterTerms( state, 'subject' );
-		expect( terms ).to.deep.equal( state.themes.themeFilters.subject );
+		expect( terms ).toEqual( state.themes.themeFilters.subject );
 	} );
 } );

--- a/client/state/selectors/test/get-theme-filter-to-term-table.js
+++ b/client/state/selectors/test/get-theme-filter-to-term-table.js
@@ -1,11 +1,10 @@
-import { expect } from 'chai';
 import { getThemeFilterToTermTable } from 'calypso/state/themes/selectors';
 import { state } from './fixtures/theme-filters';
 
 describe( 'getThemeFilterToTermTable()', () => {
 	test( 'should return a dictionary mapping taxomomy-prefixed terms to unprefixed terms (except for ambiguous terms)', () => {
 		const table = getThemeFilterToTermTable( state );
-		expect( table ).to.deep.equal( {
+		expect( table ).toEqual( {
 			'subject:artwork': 'artwork',
 			'subject:blog': 'blog',
 			'subject:business': 'business',

--- a/client/state/selectors/test/get-theme-filters.js
+++ b/client/state/selectors/test/get-theme-filters.js
@@ -1,10 +1,9 @@
-import { expect } from 'chai';
 import { getThemeFilters } from 'calypso/state/themes/selectors';
 import { state } from './fixtures/theme-filters';
 
 describe( 'getThemeFilterTerms()', () => {
 	test( 'should return all available filters', () => {
 		const filters = getThemeFilters( state );
-		expect( filters ).to.deep.equal( state.themes.themeFilters );
+		expect( filters ).toEqual( state.themes.themeFilters );
 	} );
 } );

--- a/client/state/selectors/test/get-theme-showcase-description.js
+++ b/client/state/selectors/test/get-theme-showcase-description.js
@@ -1,25 +1,24 @@
-import { expect } from 'chai';
 import { getThemeShowcaseDescription } from 'calypso/state/themes/selectors';
 import { state } from './fixtures/theme-filters';
 
 describe( 'getThemeShowcaseDescription()', () => {
 	test( 'should return the vertical description for a known vertical', () => {
 		const description = getThemeShowcaseDescription( state, { vertical: 'blog' } );
-		expect( description ).to.equal(
+		expect( description ).toEqual(
 			"Whether you're authoring a personal blog, professional blog, or a business blog — ..."
 		);
 	} );
 
 	test( 'should return the filter description for a known filter', () => {
 		const description = getThemeShowcaseDescription( state, { filter: 'minimal' } );
-		expect( description ).to.equal(
+		expect( description ).toEqual(
 			"Whether you're minimalist at heart, like keeping things clean, or just want to focus — ..."
 		);
 	} );
 
 	test( 'should fall back to generic vertical description for an unknown vertical', () => {
 		const description = getThemeShowcaseDescription( state, { vertical: 'blahg', tier: 'free' } );
-		expect( description ).to.equal(
+		expect( description ).toEqual(
 			'Discover blahg WordPress Themes on the WordPress.com Showcase. ' +
 				'Here you can browse and find the best WordPress designs available on ' +
 				'WordPress.com to discover the one that is just right for you.'
@@ -28,7 +27,7 @@ describe( 'getThemeShowcaseDescription()', () => {
 
 	test( 'should return the generic Theme Showcase description if no additional args are provided', () => {
 		const description = getThemeShowcaseDescription( state );
-		expect( description ).to.equal(
+		expect( description ).toEqual(
 			'Beautiful, responsive, free and premium WordPress themes ' +
 				'for your photography site, portfolio, magazine, business website, or blog.'
 		);

--- a/client/state/selectors/test/get-theme-showcase-title.js
+++ b/client/state/selectors/test/get-theme-showcase-title.js
@@ -1,35 +1,34 @@
-import { expect } from 'chai';
 import { getThemeShowcaseTitle } from 'calypso/state/themes/selectors';
 import { state } from './fixtures/theme-filters';
 
 describe( 'getThemeShowcaseTitle()', () => {
 	test( 'should return the correct title for a known vertical', () => {
 		const title = getThemeShowcaseTitle( state, { vertical: 'business' } );
-		expect( title ).to.equal( 'Business WordPress Themes' );
+		expect( title ).toEqual( 'Business WordPress Themes' );
 	} );
 
 	test( 'should return the correct title for a known filter', () => {
 		const title = getThemeShowcaseTitle( state, { filter: 'minimal' } );
-		expect( title ).to.equal( 'Minimal WordPress Themes' );
+		expect( title ).toEqual( 'Minimal WordPress Themes' );
 	} );
 
 	test( 'should fall back to tier if multiple filters are specified', () => {
 		const title = getThemeShowcaseTitle( state, { filter: 'artwork+blog', tier: 'free' } );
-		expect( title ).to.equal( 'Free WordPress Themes' );
+		expect( title ).toEqual( 'Free WordPress Themes' );
 	} );
 
 	test( 'should return correct title if only premium tier is specified', () => {
 		const title = getThemeShowcaseTitle( state, { tier: 'premium' } );
-		expect( title ).to.equal( 'Premium WordPress Themes' );
+		expect( title ).toEqual( 'Premium WordPress Themes' );
 	} );
 
 	test( 'should return correct title if only free tier is specified', () => {
 		const title = getThemeShowcaseTitle( state, { tier: 'free' } );
-		expect( title ).to.equal( 'Free WordPress Themes' );
+		expect( title ).toEqual( 'Free WordPress Themes' );
 	} );
 
 	test( 'should return the generic Theme Showcase title if no additional args are provided', () => {
 		const title = getThemeShowcaseTitle( state );
-		expect( title ).to.equal( 'WordPress Themes' );
+		expect( title ).toEqual( 'WordPress Themes' );
 	} );
 } );

--- a/client/state/selectors/test/get-timezones-label.js
+++ b/client/state/selectors/test/get-timezones-label.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getTimezonesLabel from 'calypso/state/selectors/get-timezones-label';
 
 describe( 'getTimezonesLabel()', () => {
@@ -13,7 +12,7 @@ describe( 'getTimezonesLabel()', () => {
 
 		const label = getTimezonesLabel( state );
 
-		expect( label ).to.eql( null );
+		expect( label ).toBeNull();
 	} );
 
 	test( "should return null if `key` isn't defined", () => {
@@ -30,7 +29,7 @@ describe( 'getTimezonesLabel()', () => {
 		};
 
 		const label = getTimezonesLabel( state );
-		expect( label ).to.eql( null );
+		expect( label ).toBeNull();
 	} );
 
 	test( 'should return the label of the given key', () => {
@@ -47,6 +46,6 @@ describe( 'getTimezonesLabel()', () => {
 		};
 
 		const label = getTimezonesLabel( state, 'America/Boa_Vista' );
-		expect( label ).to.eql( 'Boa Vista' );
+		expect( label ).toEqual( 'Boa Vista' );
 	} );
 } );

--- a/client/state/selectors/test/get-timezones-labels.js
+++ b/client/state/selectors/test/get-timezones-labels.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getTimezonesLabels from 'calypso/state/selectors/get-timezones-labels';
 
 describe( 'getTimezonesLabels()', () => {
@@ -13,7 +12,7 @@ describe( 'getTimezonesLabels()', () => {
 
 		const timezonesLabels = getTimezonesLabels( state );
 
-		expect( timezonesLabels ).to.eql( {} );
+		expect( timezonesLabels ).toEqual( {} );
 	} );
 
 	test( 'should return timezones by contienent object data', () => {
@@ -31,7 +30,7 @@ describe( 'getTimezonesLabels()', () => {
 
 		const labels = getTimezonesLabels( state );
 
-		expect( labels ).to.eql( {
+		expect( labels ).toEqual( {
 			'Asia/Aqtobe': 'Aqtobe',
 			'America/Boa_Vista': 'Boa Vista',
 			'Indian/Comoro': 'Comoro',

--- a/client/state/selectors/test/get-timezones.js
+++ b/client/state/selectors/test/get-timezones.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getTimezones from 'calypso/state/selectors/get-timezones';
 
 describe( 'getTimezones()', () => {
@@ -12,7 +11,7 @@ describe( 'getTimezones()', () => {
 		};
 
 		const timezones = getTimezones( state, 'Atlantic' );
-		expect( timezones ).to.eql( [] );
+		expect( timezones ).toEqual( [] );
 	} );
 
 	test( 'should return timezones array data', () => {
@@ -34,7 +33,7 @@ describe( 'getTimezones()', () => {
 		};
 
 		const timezones = getTimezones( state );
-		expect( timezones ).to.eql( [
+		expect( timezones ).toEqual( [
 			[ 'Asia', [ [ 'Asia/Aqtobe', 'Aqtobe' ] ] ],
 
 			[

--- a/client/state/selectors/test/get-upcoming-billing-transactions.js
+++ b/client/state/selectors/test/get-upcoming-billing-transactions.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getUpcomingBillingTransactions from 'calypso/state/selectors/get-upcoming-billing-transactions';
 
 describe( 'getUpcomingBillingTransactions()', () => {
@@ -28,7 +27,7 @@ describe( 'getUpcomingBillingTransactions()', () => {
 			return transaction;
 		} );
 		const output = getUpcomingBillingTransactions( state );
-		expect( output ).to.eql( expected );
+		expect( output ).toEqual( expected );
 	} );
 
 	test( 'should return null if billing transactions have not been fetched yet', () => {
@@ -37,6 +36,6 @@ describe( 'getUpcomingBillingTransactions()', () => {
 				items: {},
 			},
 		} );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-uploaded-plugin-id.js
+++ b/client/state/selectors/test/get-uploaded-plugin-id.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id';
 
 const siteId = 77203074;
@@ -12,7 +11,7 @@ describe( 'getUploadedPluginId', () => {
 				},
 			},
 		};
-		expect( getUploadedPluginId( state, siteId ) ).to.be.null;
+		expect( getUploadedPluginId( state, siteId ) ).toBeNull();
 	} );
 
 	test( 'should return current value for site', () => {
@@ -25,6 +24,6 @@ describe( 'getUploadedPluginId', () => {
 				},
 			},
 		};
-		expect( getUploadedPluginId( state, siteId ) ).to.be.equal( 'hello-dolly' );
+		expect( getUploadedPluginId( state, siteId ) ).toEqual( 'hello-dolly' );
 	} );
 } );

--- a/client/state/selectors/test/get-user-devices.js
+++ b/client/state/selectors/test/get-user-devices.js
@@ -1,11 +1,10 @@
-import { expect } from 'chai';
 import getUserDevices from 'calypso/state/selectors/get-user-devices';
 
 describe( '#getUserDevices()', () => {
 	test( 'should return an empty array if there are no devices', () => {
 		const result = getUserDevices( {} );
 
-		expect( result ).to.be.empty;
+		expect( Object.keys( result ) ).toHaveLength( 0 );
 	} );
 	test( 'should return all available user devices', () => {
 		const userDevices = {
@@ -14,7 +13,7 @@ describe( '#getUserDevices()', () => {
 		};
 		const result = getUserDevices( { userDevices } );
 
-		expect( result ).to.deep.equal( [
+		expect( result ).toEqual( [
 			{ device_id: 1, device_name: 'Mobile Phone' },
 			{ device_id: 2, device_name: 'Tablet' },
 		] );

--- a/client/state/selectors/test/get-user-setting.js
+++ b/client/state/selectors/test/get-user-setting.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 
 describe( 'getUserSetting()', () => {
@@ -13,7 +12,7 @@ describe( 'getUserSetting()', () => {
 			'__unknown'
 		);
 
-		expect( setting ).to.be.null;
+		expect( setting ).toBeNull();
 	} );
 
 	test( 'should prefer an unsaved setting over the server one', () => {
@@ -27,7 +26,7 @@ describe( 'getUserSetting()', () => {
 			'foo'
 		);
 
-		expect( setting ).to.eql( 'unsavedBar' );
+		expect( setting ).toEqual( 'unsavedBar' );
 	} );
 
 	test( 'should ignore an unsaved setting if there is no server value for the same key', () => {
@@ -41,7 +40,7 @@ describe( 'getUserSetting()', () => {
 			'foo'
 		);
 
-		expect( setting ).to.be.null;
+		expect( setting ).toBeNull();
 	} );
 
 	test( 'should return a server value if there is no unsaved one', () => {
@@ -55,6 +54,6 @@ describe( 'getUserSetting()', () => {
 			'foo'
 		);
 
-		expect( setting ).to.eql( 'bar' );
+		expect( setting ).toEqual( 'bar' );
 	} );
 } );

--- a/client/state/selectors/test/get-visible-sites.js
+++ b/client/state/selectors/test/get-visible-sites.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import getVisibleSites from 'calypso/state/selectors/get-visible-sites';
 import { userState } from './fixtures/user-state';
 
@@ -10,7 +9,7 @@ describe( 'getVisibleSites()', () => {
 			},
 		};
 		const sites = getVisibleSites( state );
-		expect( sites ).to.eql( [] );
+		expect( sites ).toEqual( [] );
 	} );
 
 	test( 'should return the visibles sites in state', () => {
@@ -43,7 +42,7 @@ describe( 'getVisibleSites()', () => {
 			},
 		};
 		const sites = getVisibleSites( state );
-		expect( sites ).to.eql( [
+		expect( sites ).toEqual( [
 			{
 				ID: 2916284,
 				visible: true,

--- a/client/state/selectors/test/has-active-site-feature.js
+++ b/client/state/selectors/test/has-active-site-feature.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 
 describe( 'selectors', () => {
@@ -18,7 +17,7 @@ describe( 'selectors', () => {
 			};
 
 			const activeFeature = hasActiveSiteFeature( state );
-			expect( activeFeature ).to.eql( false );
+			expect( activeFeature ).toEqual( false );
 		} );
 
 		test( 'should return False when site does not exist', () => {
@@ -37,7 +36,7 @@ describe( 'selectors', () => {
 			};
 
 			const activeFeature = hasActiveSiteFeature( state, 'unknown' );
-			expect( activeFeature ).to.eql( false );
+			expect( activeFeature ).toEqual( false );
 		} );
 
 		test( 'should return False when feature param is not defined', () => {
@@ -56,7 +55,7 @@ describe( 'selectors', () => {
 			};
 
 			const activeFeature = hasActiveSiteFeature( state, 123001 );
-			expect( activeFeature ).to.eql( false );
+			expect( activeFeature ).toEqual( false );
 		} );
 
 		test( 'should return False when feature is not defined in the active array', () => {
@@ -75,7 +74,7 @@ describe( 'selectors', () => {
 			};
 
 			const activeFeature = hasActiveSiteFeature( state, 123001, 'unknown-feature' );
-			expect( activeFeature ).to.eql( false );
+			expect( activeFeature ).toEqual( false );
 		} );
 
 		test( 'should return True when feature is defined in the active array', () => {
@@ -94,7 +93,7 @@ describe( 'selectors', () => {
 			};
 
 			const activeFeature = hasActiveSiteFeature( state, 123001, 'feature_active_01' );
-			expect( activeFeature ).to.eql( true );
+			expect( activeFeature ).toEqual( true );
 		} );
 	} );
 } );

--- a/client/state/selectors/test/has-available-site-feature.js
+++ b/client/state/selectors/test/has-available-site-feature.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import hasAvailableSiteFeature from 'calypso/state/selectors/has-available-site-feature';
 
 describe( 'selectors', () => {
@@ -23,7 +22,7 @@ describe( 'selectors', () => {
 			};
 
 			const availableFeature = hasAvailableSiteFeature( state );
-			expect( availableFeature ).to.eql( false );
+			expect( availableFeature ).toEqual( false );
 		} );
 
 		test( 'should return False when site does not exist', () => {
@@ -46,7 +45,7 @@ describe( 'selectors', () => {
 			};
 
 			const availableFeature = hasAvailableSiteFeature( state, 'unknown' );
-			expect( availableFeature ).to.eql( false );
+			expect( availableFeature ).toEqual( false );
 		} );
 
 		test( 'should return False when feature is not populated', () => {
@@ -55,7 +54,7 @@ describe( 'selectors', () => {
 			};
 
 			const availableFeature = hasAvailableSiteFeature( state, 123001 );
-			expect( availableFeature ).to.eql( false );
+			expect( availableFeature ).toEqual( false );
 		} );
 
 		test( 'should return False when available feature is not populated', () => {
@@ -70,7 +69,7 @@ describe( 'selectors', () => {
 			};
 
 			const availableFeature = hasAvailableSiteFeature( state, 123001 );
-			expect( availableFeature ).to.eql( false );
+			expect( availableFeature ).toEqual( false );
 		} );
 
 		test( 'should return False when feature id is not defined', () => {
@@ -93,7 +92,7 @@ describe( 'selectors', () => {
 			};
 
 			const availableFeature = hasAvailableSiteFeature( state, 123001 );
-			expect( availableFeature ).to.eql( false );
+			expect( availableFeature ).toEqual( false );
 		} );
 
 		test( 'should return False when feature is not defined in the available object', () => {
@@ -116,7 +115,7 @@ describe( 'selectors', () => {
 			};
 
 			const availableFeature = hasAvailableSiteFeature( state, 123001, 'not-available-feature' );
-			expect( availableFeature ).to.eql( false );
+			expect( availableFeature ).toEqual( false );
 		} );
 
 		test( 'should return plans array when feature available', () => {
@@ -139,7 +138,7 @@ describe( 'selectors', () => {
 			};
 
 			const availableFeature = hasAvailableSiteFeature( state, 123001, 'feature-available-01' );
-			expect( availableFeature ).to.eql( [ 'plan-01', 'plan-02', 'plan-03' ] );
+			expect( availableFeature ).toEqual( [ 'plan-01', 'plan-02', 'plan-03' ] );
 		} );
 	} );
 } );

--- a/client/state/selectors/test/has-initialized-sites.js
+++ b/client/state/selectors/test/has-initialized-sites.js
@@ -1,11 +1,10 @@
-import { expect } from 'chai';
 import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
 
 describe( 'hasInitializedSites()', () => {
 	test( 'should return false if site selection has not occurred', () => {
-		expect( hasInitializedSites( { ui: { siteSelectionInitialized: false } } ) ).to.be.false;
+		expect( hasInitializedSites( { ui: { siteSelectionInitialized: false } } ) ).toBe( false );
 	} );
 	test( 'should return true if site selection has occurred', () => {
-		expect( hasInitializedSites( { ui: { siteSelectionInitialized: true } } ) ).to.be.true;
+		expect( hasInitializedSites( { ui: { siteSelectionInitialized: true } } ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/has-jetpack-sites.js
+++ b/client/state/selectors/test/has-jetpack-sites.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';
 
 describe( 'hasJetpackSites()', () => {
@@ -9,7 +8,7 @@ describe( 'hasJetpackSites()', () => {
 					items: {},
 				},
 			} )
-		).to.be.false;
+		).toBe( false );
 	} );
 
 	test( 'it should return false if one site exists and the site is not a Jetpack site', () => {
@@ -21,7 +20,7 @@ describe( 'hasJetpackSites()', () => {
 					},
 				},
 			} )
-		).to.be.false;
+		).toBe( false );
 	} );
 
 	test( 'it should return false if several sites exist and none of them is a Jetpack site', () => {
@@ -35,7 +34,7 @@ describe( 'hasJetpackSites()', () => {
 					},
 				},
 			} )
-		).to.be.false;
+		).toBe( false );
 	} );
 
 	test( 'it should return true if one site is a Jetpack site and the others are not', () => {
@@ -49,7 +48,7 @@ describe( 'hasJetpackSites()', () => {
 					},
 				},
 			} )
-		).to.be.true;
+		).toBe( true );
 	} );
 
 	test( 'it should return true if several sites exist and all of them are Jetpack sites', () => {
@@ -63,6 +62,6 @@ describe( 'hasJetpackSites()', () => {
 					},
 				},
 			} )
-		).to.be.true;
+		).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/has-loaded-sites.js
+++ b/client/state/selectors/test/has-loaded-sites.js
@@ -1,14 +1,13 @@
-import { expect } from 'chai';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 
 describe( 'hasLoadedSites()', () => {
 	it( 'should return false if site items are null', () => {
-		expect( hasLoadedSites( { sites: { items: null } } ) ).to.be.false;
+		expect( hasLoadedSites( { sites: { items: null } } ) ).toBe( false );
 	} );
 	it( 'should return true if site items are empty', () => {
-		expect( hasLoadedSites( { sites: { items: {} } } ) ).to.be.true;
+		expect( hasLoadedSites( { sites: { items: {} } } ) ).toBe( true );
 	} );
 	it( 'should return true if sites exist in state', () => {
-		expect( hasLoadedSites( { sites: { items: { 1: { ID: 1 } } } } ) ).to.be.true;
+		expect( hasLoadedSites( { sites: { items: { 1: { ID: 1 } } } } ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/has-navigated.js
+++ b/client/state/selectors/test/has-navigated.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { ROUTE_SET } from 'calypso/state/action-types';
 import hasNavigated from 'calypso/state/selectors/has-navigated';
 
@@ -6,7 +5,7 @@ describe( 'hasNavigated()', () => {
 	test( 'should return false if only one ROUTE_SET has occurred', () => {
 		const state = { ui: { actionLog: [ { type: ROUTE_SET, path: 'a' } ] } };
 
-		expect( hasNavigated( state ) ).to.be.false;
+		expect( hasNavigated( state ) ).toBe( false );
 	} );
 
 	test( 'should return true if more than one ROUTE_SET has occurred', () => {
@@ -19,6 +18,6 @@ describe( 'hasNavigated()', () => {
 			},
 		};
 
-		expect( hasNavigated( state ) ).to.be.true;
+		expect( hasNavigated( state ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/has-site-pending-automated-transfer.js
+++ b/client/state/selectors/test/has-site-pending-automated-transfer.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import hasSitePendingAutomatedTransfer from 'calypso/state/selectors/has-site-pending-automated-transfer';
 
 describe( 'hasSitePendingAutomatedTransfer()', () => {
@@ -9,7 +8,7 @@ describe( 'hasSitePendingAutomatedTransfer()', () => {
 			},
 		};
 
-		expect( hasSitePendingAutomatedTransfer( state, 12345 ) ).to.be.null;
+		expect( hasSitePendingAutomatedTransfer( state, 12345 ) ).toBeNull();
 	} );
 
 	test( 'should return false if site is an Atomic one', () => {
@@ -26,7 +25,7 @@ describe( 'hasSitePendingAutomatedTransfer()', () => {
 			},
 		};
 
-		expect( hasSitePendingAutomatedTransfer( state, 12345 ) ).to.be.false;
+		expect( hasSitePendingAutomatedTransfer( state, 12345 ) ).toBe( false );
 	} );
 
 	test( 'should return true if site has the has_pending_automated_transfer option set to true', () => {
@@ -42,7 +41,7 @@ describe( 'hasSitePendingAutomatedTransfer()', () => {
 			},
 		};
 
-		expect( hasSitePendingAutomatedTransfer( state, 12345 ) ).to.be.true;
+		expect( hasSitePendingAutomatedTransfer( state, 12345 ) ).toBe( true );
 	} );
 
 	test(
@@ -64,8 +63,8 @@ describe( 'hasSitePendingAutomatedTransfer()', () => {
 				},
 			};
 
-			expect( hasSitePendingAutomatedTransfer( state, 12345 ) ).to.be.false;
-			expect( hasSitePendingAutomatedTransfer( state, 12346 ) ).to.be.false;
+			expect( hasSitePendingAutomatedTransfer( state, 12345 ) ).toBe( false );
+			expect( hasSitePendingAutomatedTransfer( state, 12346 ) ).toBe( false );
 		}
 	);
 } );

--- a/client/state/selectors/test/is-activating-jetpack-module.js
+++ b/client/state/selectors/test/is-activating-jetpack-module.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
 import { requests as REQUESTS_FIXTURE } from './fixtures/jetpack-modules';
 
@@ -13,7 +12,7 @@ describe( 'isActivatingJetpackModule()', () => {
 		};
 		const siteId = 123456;
 		const output = isActivatingJetpackModule( stateIn, siteId, 'module-b' );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if module is currently not being activated', () => {
@@ -26,7 +25,7 @@ describe( 'isActivatingJetpackModule()', () => {
 		};
 		const siteId = 123456;
 		const output = isActivatingJetpackModule( stateIn, siteId, 'module-a' );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return null if that module is not known', () => {
@@ -39,6 +38,6 @@ describe( 'isActivatingJetpackModule()', () => {
 		};
 		const siteId = 123456;
 		const output = isActivatingJetpackModule( stateIn, siteId, 'module-z' );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/is-ambiguous-theme-filter-term.js
+++ b/client/state/selectors/test/is-ambiguous-theme-filter-term.js
@@ -1,13 +1,12 @@
-import { expect } from 'chai';
 import { isAmbiguousThemeFilterTerm } from 'calypso/state/themes/selectors';
 import { state } from './fixtures/theme-filters';
 
 describe( 'isAmbiguousThemeFilterTerm()', () => {
 	test( 'should return false for an unambiguous term', () => {
-		expect( isAmbiguousThemeFilterTerm( state, 'music' ) ).to.be.false;
+		expect( isAmbiguousThemeFilterTerm( state, 'music' ) ).toBe( false );
 	} );
 
 	test( 'should return true for an ambiguous term', () => {
-		expect( isAmbiguousThemeFilterTerm( state, 'video' ) ).to.be.true;
+		expect( isAmbiguousThemeFilterTerm( state, 'video' ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-authors-email-blocked.js
+++ b/client/state/selectors/test/is-authors-email-blocked.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isAuthorsEmailBlocked from 'calypso/state/selectors/is-authors-email-blocked';
 
 const email = 'foo@bar.baz';
@@ -23,21 +22,21 @@ const noSiteSettingsState = { siteSettings: {} };
 
 describe( 'isAuthorsEmailBlocked()', () => {
 	test( 'should return true if email is blocked', () => {
-		expect( isAuthorsEmailBlocked( state, 123, email ) ).to.be.true;
+		expect( isAuthorsEmailBlocked( state, 123, email ) ).toBe( true );
 	} );
 	test( 'should return false if email is not blocked', () => {
-		expect( isAuthorsEmailBlocked( state, 456, email ) ).to.be.false;
+		expect( isAuthorsEmailBlocked( state, 456, email ) ).toBe( false );
 	} );
 	test( 'should return false if blocklist is empty', () => {
-		expect( isAuthorsEmailBlocked( state, 789, email ) ).to.be.false;
+		expect( isAuthorsEmailBlocked( state, 789, email ) ).toBe( false );
 	} );
 	test( 'should return false if there are no site settings in state', () => {
-		expect( isAuthorsEmailBlocked( noSiteSettingsState, 123, email ) ).to.be.false;
+		expect( isAuthorsEmailBlocked( noSiteSettingsState, 123, email ) ).toBe( false );
 	} );
 	test( 'should return false if no email is provided', () => {
-		expect( isAuthorsEmailBlocked( state, 123 ) ).to.be.false;
+		expect( isAuthorsEmailBlocked( state, 123 ) ).toBe( false );
 	} );
 	test( 'should return false if email is empty', () => {
-		expect( isAuthorsEmailBlocked( state, 123, '' ) ).to.be.false;
+		expect( isAuthorsEmailBlocked( state, 123, '' ) ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-connected-secondary-network-site.js
+++ b/client/state/selectors/test/is-connected-secondary-network-site.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isConnectedSecondaryNetworkSite from 'calypso/state/selectors/is-connected-secondary-network-site';
 
 describe( 'isConnectedSecondaryNetworkSite()', () => {
@@ -8,7 +7,7 @@ describe( 'isConnectedSecondaryNetworkSite()', () => {
 				items: {},
 			},
 		};
-		expect( isConnectedSecondaryNetworkSite( state, 1 ) ).be.false;
+		expect( isConnectedSecondaryNetworkSite( state, 1 ) ).toBe( false );
 	} );
 
 	test( 'should return false if site with id equal to siteId is not found', () => {
@@ -27,7 +26,7 @@ describe( 'isConnectedSecondaryNetworkSite()', () => {
 				},
 			},
 		};
-		expect( isConnectedSecondaryNetworkSite( state, 2 ) ).be.false;
+		expect( isConnectedSecondaryNetworkSite( state, 2 ) ).toBe( false );
 	} );
 
 	test( 'should return false if some is not yet loaded and with the loaded ones no conclusion can be taken', () => {
@@ -47,7 +46,7 @@ describe( 'isConnectedSecondaryNetworkSite()', () => {
 				},
 			},
 		};
-		expect( isConnectedSecondaryNetworkSite( state, 2 ) ).be.false;
+		expect( isConnectedSecondaryNetworkSite( state, 2 ) ).toBe( false );
 	} );
 
 	test( 'should return false if site with id equal to siteId is a secondary site but the main site is not part of the state', () => {
@@ -66,7 +65,7 @@ describe( 'isConnectedSecondaryNetworkSite()', () => {
 				},
 			},
 		};
-		expect( isConnectedSecondaryNetworkSite( state, 2 ) ).be.false;
+		expect( isConnectedSecondaryNetworkSite( state, 2 ) ).toBe( false );
 	} );
 
 	test( 'should return false if site with id equal to siteId is not a secondary network site', () => {
@@ -85,7 +84,7 @@ describe( 'isConnectedSecondaryNetworkSite()', () => {
 				},
 			},
 		};
-		expect( isConnectedSecondaryNetworkSite( state, 1 ) ).be.false;
+		expect( isConnectedSecondaryNetworkSite( state, 1 ) ).toBe( false );
 	} );
 
 	test( 'should return true if site with id equal to siteId is a connected secondary network site', () => {
@@ -113,6 +112,6 @@ describe( 'isConnectedSecondaryNetworkSite()', () => {
 				},
 			},
 		};
-		expect( isConnectedSecondaryNetworkSite( state, 2 ) ).be.true;
+		expect( isConnectedSecondaryNetworkSite( state, 2 ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-deactivating-jetpack-module.js
+++ b/client/state/selectors/test/is-deactivating-jetpack-module.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isDeactivatingJetpackModule from 'calypso/state/selectors/is-deactivating-jetpack-module';
 import { requests as REQUESTS_FIXTURE } from './fixtures/jetpack-modules';
 
@@ -13,7 +12,7 @@ describe( 'isDeactivatingJetpackModule()', () => {
 		};
 		const siteId = 123456;
 		const output = isDeactivatingJetpackModule( stateIn, siteId, 'module-a' );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if module is currently not being deactivated', () => {
@@ -26,7 +25,7 @@ describe( 'isDeactivatingJetpackModule()', () => {
 		};
 		const siteId = 123456;
 		const output = isDeactivatingJetpackModule( stateIn, siteId, 'module-b' );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return null if that module is not known', () => {
@@ -39,6 +38,6 @@ describe( 'isDeactivatingJetpackModule()', () => {
 		};
 		const siteId = 123456;
 		const output = isDeactivatingJetpackModule( stateIn, siteId, 'module-z' );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/is-directly-failed.js
+++ b/client/state/selectors/test/is-directly-failed.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import {
 	STATUS_ERROR,
 	STATUS_INITIALIZING,
@@ -10,21 +9,21 @@ import isDirectlyFailed from 'calypso/state/selectors/is-directly-failed';
 describe( 'isDirectlyFailed()', () => {
 	test( 'should be false when uninitialized', () => {
 		const state = { help: { directly: { status: STATUS_UNINITIALIZED } } };
-		expect( isDirectlyFailed( state ) ).to.be.false;
+		expect( isDirectlyFailed( state ) ).toBe( false );
 	} );
 
 	test( 'should be false when initializing', () => {
 		const state = { help: { directly: { status: STATUS_INITIALIZING } } };
-		expect( isDirectlyFailed( state ) ).to.be.false;
+		expect( isDirectlyFailed( state ) ).toBe( false );
 	} );
 
 	test( 'should be false when ready', () => {
 		const state = { help: { directly: { status: STATUS_READY } } };
-		expect( isDirectlyFailed( state ) ).to.be.false;
+		expect( isDirectlyFailed( state ) ).toBe( false );
 	} );
 
 	test( 'should be true when failed', () => {
 		const state = { help: { directly: { status: STATUS_ERROR } } };
-		expect( isDirectlyFailed( state ) ).to.be.true;
+		expect( isDirectlyFailed( state ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-directly-ready.js
+++ b/client/state/selectors/test/is-directly-ready.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import {
 	STATUS_ERROR,
 	STATUS_INITIALIZING,
@@ -10,21 +9,21 @@ import isDirectlyReady from 'calypso/state/selectors/is-directly-ready';
 describe( 'isDirectlyReady()', () => {
 	test( 'should be false when uninitialized', () => {
 		const state = { help: { directly: { status: STATUS_UNINITIALIZED } } };
-		expect( isDirectlyReady( state ) ).to.be.false;
+		expect( isDirectlyReady( state ) ).toBe( false );
 	} );
 
 	test( 'should be false when initializing', () => {
 		const state = { help: { directly: { status: STATUS_INITIALIZING } } };
-		expect( isDirectlyReady( state ) ).to.be.false;
+		expect( isDirectlyReady( state ) ).toBe( false );
 	} );
 
 	test( 'should be true when ready', () => {
 		const state = { help: { directly: { status: STATUS_READY } } };
-		expect( isDirectlyReady( state ) ).to.be.true;
+		expect( isDirectlyReady( state ) ).toBe( true );
 	} );
 
 	test( 'should be false when failed', () => {
 		const state = { help: { directly: { status: STATUS_ERROR } } };
-		expect( isDirectlyReady( state ) ).to.be.false;
+		expect( isDirectlyReady( state ) ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-directly-uninitialized.js
+++ b/client/state/selectors/test/is-directly-uninitialized.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import {
 	STATUS_ERROR,
 	STATUS_INITIALIZING,
@@ -10,21 +9,21 @@ import isDirectlyUninitialized from 'calypso/state/selectors/is-directly-uniniti
 describe( 'isDirectlyUninitialized()', () => {
 	test( 'should be true when uninitialized', () => {
 		const state = { help: { directly: { status: STATUS_UNINITIALIZED } } };
-		expect( isDirectlyUninitialized( state ) ).to.be.true;
+		expect( isDirectlyUninitialized( state ) ).toBe( true );
 	} );
 
 	test( 'should be false when initializing', () => {
 		const state = { help: { directly: { status: STATUS_INITIALIZING } } };
-		expect( isDirectlyUninitialized( state ) ).to.be.false;
+		expect( isDirectlyUninitialized( state ) ).toBe( false );
 	} );
 
 	test( 'should be false when ready', () => {
 		const state = { help: { directly: { status: STATUS_READY } } };
-		expect( isDirectlyUninitialized( state ) ).to.be.false;
+		expect( isDirectlyUninitialized( state ) ).toBe( false );
 	} );
 
 	test( 'should be false when failed', () => {
 		const state = { help: { directly: { status: STATUS_ERROR } } };
-		expect( isDirectlyUninitialized( state ) ).to.be.false;
+		expect( isDirectlyUninitialized( state ) ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-domain-only-site.js
+++ b/client/state/selectors/test/is-domain-only-site.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 
 describe( '#isDomainOnlySite()', () => {
@@ -14,7 +13,7 @@ describe( '#isDomainOnlySite()', () => {
 			siteId
 		);
 
-		expect( result ).to.be.null;
+		expect( result ).toBeNull();
 	} );
 
 	test( 'it should return false if the site does not have the domain only option set to true', () => {
@@ -35,7 +34,7 @@ describe( '#isDomainOnlySite()', () => {
 			siteId
 		);
 
-		expect( result ).to.be.false;
+		expect( result ).toBe( false );
 	} );
 
 	test( 'it should return false if the site has the domain only option set to true', () => {
@@ -56,6 +55,6 @@ describe( '#isDomainOnlySite()', () => {
 			siteId
 		);
 
-		expect( result ).to.be.true;
+		expect( result ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isMappedDomainSite from 'calypso/state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
@@ -26,29 +25,29 @@ describe( 'isEligibleForDomainToPaidPlanUpsell', () => {
 	test( 'should return false when user can not manage options', () => {
 		meetAllConditions();
 		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( false );
-		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).to.be.false;
+		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site does not have mapped domain', () => {
 		meetAllConditions();
 		isMappedDomainSite.withArgs( state, siteId ).returns( false );
-		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).to.be.false;
+		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site is not on a free plan', () => {
 		meetAllConditions();
 		isSiteOnFreePlan.withArgs( state, siteId ).returns( false );
-		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).to.be.false;
+		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site is a vip site', () => {
 		meetAllConditions();
 		isVipSite.withArgs( state, siteId ).returns( true );
-		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).to.be.false;
+		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return true when all conditions are met', () => {
 		meetAllConditions();
-		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).to.be.true;
+		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isMappedDomainSite from 'calypso/state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
@@ -31,35 +30,35 @@ describe( 'isEligibleForFreeToPaidUpsell', () => {
 	test( 'should return false when user can not manage options', () => {
 		meetAllConditions();
 		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( false );
-		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
+		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site is Jetpack', () => {
 		meetAllConditions();
 		isJetpackSite.withArgs( state, siteId ).returns( true );
-		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
+		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site has mapped domain', () => {
 		meetAllConditions();
 		isMappedDomainSite.withArgs( state, siteId ).returns( true );
-		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
+		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site is not on a free plan', () => {
 		meetAllConditions();
 		isSiteOnFreePlan.withArgs( state, siteId ).returns( false );
-		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
+		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site is a vip site', () => {
 		meetAllConditions();
 		isVipSite.withArgs( state, siteId ).returns( true );
-		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
+		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return true when all conditions are met', () => {
 		meetAllConditions();
-		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.true;
+		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-fetching-jetpack-modules.js
+++ b/client/state/selectors/test/is-fetching-jetpack-modules.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isFetchingJetpackModules from 'calypso/state/selectors/is-fetching-jetpack-modules';
 import { requests as REQUESTS_FIXTURE } from './fixtures/jetpack-modules';
 
@@ -13,7 +12,7 @@ describe( 'isFetchingJetpackModules()', () => {
 		};
 		const siteId = 123456;
 		const output = isFetchingJetpackModules( stateIn, siteId );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if the list of modules is currently not being fetched', () => {
@@ -26,7 +25,7 @@ describe( 'isFetchingJetpackModules()', () => {
 		};
 		const siteId = 654321;
 		const output = isFetchingJetpackModules( stateIn, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return null if that site is not known', () => {
@@ -39,6 +38,6 @@ describe( 'isFetchingJetpackModules()', () => {
 		};
 		const siteId = 888888;
 		const output = isFetchingJetpackModules( stateIn, siteId );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/is-fetching-magic-login-auth.js
+++ b/client/state/selectors/test/is-fetching-magic-login-auth.js
@@ -1,10 +1,9 @@
-import { expect } from 'chai';
 import isFetchingMagicLoginAuth from 'calypso/state/selectors/is-fetching-magic-login-auth';
 
 describe( 'isFetchingMagicLoginAuth()', () => {
 	test( 'should return false if there is no fetching information yet', () => {
 		const isFetching = isFetchingMagicLoginAuth( undefined );
-		expect( isFetching ).to.be.false;
+		expect( isFetching ).toBe( false );
 	} );
 
 	test( 'should return true if client is requesting auth', () => {
@@ -15,7 +14,7 @@ describe( 'isFetchingMagicLoginAuth()', () => {
 				},
 			},
 		} );
-		expect( isFetching ).to.be.true;
+		expect( isFetching ).toBe( true );
 	} );
 
 	test( 'should return false when finished requesting auth', () => {
@@ -26,6 +25,6 @@ describe( 'isFetchingMagicLoginAuth()', () => {
 				},
 			},
 		} );
-		expect( isFetching ).to.be.false;
+		expect( isFetching ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-fetching-magic-login-email.js
+++ b/client/state/selectors/test/is-fetching-magic-login-email.js
@@ -1,10 +1,9 @@
-import { expect } from 'chai';
 import isFetchingMagicLoginEmail from 'calypso/state/selectors/is-fetching-magic-login-email';
 
 describe( 'isFetchingMagicLoginEmail()', () => {
 	test( 'should return false if there is no fetching information yet', () => {
 		const isFetching = isFetchingMagicLoginEmail( undefined );
-		expect( isFetching ).to.be.false;
+		expect( isFetching ).toBe( false );
 	} );
 
 	test( 'should return true if client is requesting an email', () => {
@@ -15,7 +14,7 @@ describe( 'isFetchingMagicLoginEmail()', () => {
 				},
 			},
 		} );
-		expect( isFetching ).to.be.true;
+		expect( isFetching ).toBe( true );
 	} );
 
 	test( 'should return false when finished requesting an email', () => {
@@ -26,6 +25,6 @@ describe( 'isFetchingMagicLoginEmail()', () => {
 				},
 			},
 		} );
-		expect( isFetching ).to.be.false;
+		expect( isFetching ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-hidden-site.js
+++ b/client/state/selectors/test/is-hidden-site.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isHiddenSite from 'calypso/state/selectors/is-hidden-site';
 
 describe( 'isHiddenSite()', () => {
@@ -16,7 +15,7 @@ describe( 'isHiddenSite()', () => {
 			2916285
 		);
 
-		expect( isHidden ).to.be.null;
+		expect( isHidden ).toBeNull();
 	} );
 
 	test( 'should return false for public sites', () => {
@@ -33,7 +32,7 @@ describe( 'isHiddenSite()', () => {
 			2916284
 		);
 
-		expect( isHidden ).to.be.false;
+		expect( isHidden ).toBe( false );
 	} );
 
 	test( 'should return true for hidden sites', () => {
@@ -50,6 +49,6 @@ describe( 'isHiddenSite()', () => {
 			2916284
 		);
 
-		expect( isHidden ).to.be.true;
+		expect( isHidden ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-jetpack-module-active.js
+++ b/client/state/selectors/test/is-jetpack-module-active.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { modules as MODULES_FIXTURE } from './fixtures/jetpack-modules';
 
@@ -13,7 +12,7 @@ describe( 'isJetpackModuleActive()', () => {
 		};
 		const siteId = 123456;
 		const output = isJetpackModuleActive( stateIn, siteId, 'module-b' );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if the module is currently not active', () => {
@@ -26,7 +25,7 @@ describe( 'isJetpackModuleActive()', () => {
 		};
 		const siteId = 123456;
 		const output = isJetpackModuleActive( stateIn, siteId, 'module-a' );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return null if that module is not known', () => {
@@ -39,6 +38,6 @@ describe( 'isJetpackModuleActive()', () => {
 		};
 		const siteId = 123456;
 		const output = isJetpackModuleActive( stateIn, siteId, 'module-z' );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/is-jetpack-module-unavailable-in-development-mode.js
+++ b/client/state/selectors/test/is-jetpack-module-unavailable-in-development-mode.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
 
 describe( 'isJetpackModuleUnavailableInDevelopmentMode()', () => {
@@ -16,7 +15,7 @@ describe( 'isJetpackModuleUnavailableInDevelopmentMode()', () => {
 			12345678,
 			'module-a'
 		);
-		expect( unavailable ).to.be.null;
+		expect( unavailable ).toBeNull();
 	} );
 
 	test( 'should return true for a module that requires connection', () => {
@@ -40,7 +39,7 @@ describe( 'isJetpackModuleUnavailableInDevelopmentMode()', () => {
 			12345678,
 			'module-a'
 		);
-		expect( unavailable ).to.be.true;
+		expect( unavailable ).toBe( true );
 	} );
 
 	test( 'should return false for a module that does not require connection', () => {
@@ -64,7 +63,7 @@ describe( 'isJetpackModuleUnavailableInDevelopmentMode()', () => {
 			12345678,
 			'module-a'
 		);
-		expect( unavailable ).to.be.false;
+		expect( unavailable ).toBe( false );
 	} );
 
 	test( 'should return false for a module that does not specify whether it requires connection', () => {
@@ -87,6 +86,6 @@ describe( 'isJetpackModuleUnavailableInDevelopmentMode()', () => {
 			12345678,
 			'module-a'
 		);
-		expect( unavailable ).to.be.false;
+		expect( unavailable ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-jetpack-settings-save-failure.js
+++ b/client/state/selectors/test/is-jetpack-settings-save-failure.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getRequestKey } from 'calypso/state/data-layer/wpcom-http/utils';
 import { saveJetpackSettings } from 'calypso/state/jetpack/settings/actions';
 import isJetpackSettingsSaveFailure from 'calypso/state/selectors/is-jetpack-settings-save-failure';
@@ -19,7 +18,7 @@ describe( 'isJetpackSettingsSaveFailure()', () => {
 		};
 		const isFailure = isJetpackSettingsSaveFailure( state, 87654321, settings );
 
-		expect( isFailure ).to.be.false;
+		expect( isFailure ).toBe( false );
 	} );
 
 	test( 'should return false if the save request status is success', () => {
@@ -32,7 +31,7 @@ describe( 'isJetpackSettingsSaveFailure()', () => {
 		};
 		const isFailure = isJetpackSettingsSaveFailure( state, 12345678, settings );
 
-		expect( isFailure ).to.be.false;
+		expect( isFailure ).toBe( false );
 	} );
 
 	test( 'should return true if the save request status is failure', () => {
@@ -45,6 +44,6 @@ describe( 'isJetpackSettingsSaveFailure()', () => {
 		};
 		const isFailure = isJetpackSettingsSaveFailure( state, 12345678, settings );
 
-		expect( isFailure ).to.be.true;
+		expect( isFailure ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-jetpack-site-connected.js
+++ b/client/state/selectors/test/is-jetpack-site-connected.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isJetpackSiteConnected from 'calypso/state/selectors/is-jetpack-site-connected';
 import { items as ITEMS_FIXTURE } from './fixtures/jetpack-connection';
 
@@ -13,7 +12,7 @@ describe( 'isJetpackSiteConnected()', () => {
 		};
 		const siteId = 87654321;
 		const output = isJetpackSiteConnected( stateIn, siteId );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if the site is not connected', () => {
@@ -26,7 +25,7 @@ describe( 'isJetpackSiteConnected()', () => {
 		};
 		const siteId = 12345678;
 		const output = isJetpackSiteConnected( stateIn, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return null if the site is not known yet', () => {
@@ -39,6 +38,6 @@ describe( 'isJetpackSiteConnected()', () => {
 		};
 		const siteId = 88888888;
 		const output = isJetpackSiteConnected( stateIn, siteId );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/is-jetpack-site-in-development-mode.js
+++ b/client/state/selectors/test/is-jetpack-site-in-development-mode.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
 import { items as ITEMS_FIXTURE } from './fixtures/jetpack-connection';
 
@@ -13,7 +12,7 @@ describe( 'isJetpackSiteInDevelopmentMode()', () => {
 		};
 		const siteId = 87654321;
 		const output = isJetpackSiteInDevelopmentMode( stateIn, siteId );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if the site is not in development mode', () => {
@@ -26,7 +25,7 @@ describe( 'isJetpackSiteInDevelopmentMode()', () => {
 		};
 		const siteId = 12345678;
 		const output = isJetpackSiteInDevelopmentMode( stateIn, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return false if the site is not in development mode with isActive: 0', () => {
@@ -39,7 +38,7 @@ describe( 'isJetpackSiteInDevelopmentMode()', () => {
 		};
 		const siteId = 987654321;
 		const output = isJetpackSiteInDevelopmentMode( stateIn, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return null if the site is not known yet', () => {
@@ -52,6 +51,6 @@ describe( 'isJetpackSiteInDevelopmentMode()', () => {
 		};
 		const siteId = 88888888;
 		const output = isJetpackSiteInDevelopmentMode( stateIn, siteId );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/is-jetpack-site-in-staging-mode.js
+++ b/client/state/selectors/test/is-jetpack-site-in-staging-mode.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isJetpackSiteInStagingMode from 'calypso/state/selectors/is-jetpack-site-in-staging-mode';
 import { items as ITEMS_FIXTURE } from './fixtures/jetpack-connection';
 
@@ -13,7 +12,7 @@ describe( 'isJetpackSiteInStagingMode()', () => {
 		};
 		const siteId = 87654321;
 		const output = isJetpackSiteInStagingMode( stateIn, siteId );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if the site is not in staging mode', () => {
@@ -26,7 +25,7 @@ describe( 'isJetpackSiteInStagingMode()', () => {
 		};
 		const siteId = 12345678;
 		const output = isJetpackSiteInStagingMode( stateIn, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return null if the site is not known yet', () => {
@@ -39,6 +38,6 @@ describe( 'isJetpackSiteInStagingMode()', () => {
 		};
 		const siteId = 88888888;
 		const output = isJetpackSiteInStagingMode( stateIn, siteId );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/is-jetpack-user-connection-owner.js
+++ b/client/state/selectors/test/is-jetpack-user-connection-owner.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isJetpackUserConnectionOwner from 'calypso/state/selectors/is-jetpack-user-connection-owner';
 import { dataItems } from './fixtures/jetpack-connection';
 
@@ -13,7 +12,7 @@ describe( 'isJetpackUserConnectionOwner()', () => {
 		};
 		const siteId = 12345678;
 		const output = isJetpackUserConnectionOwner( stateIn, siteId );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( "should return false if the user is not the owner of the site's connection", () => {
@@ -26,7 +25,7 @@ describe( 'isJetpackUserConnectionOwner()', () => {
 		};
 		const siteId = 87654321;
 		const output = isJetpackUserConnectionOwner( stateIn, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return null if the information is not known yet', () => {
@@ -39,6 +38,6 @@ describe( 'isJetpackUserConnectionOwner()', () => {
 		};
 		const siteId = 88888888;
 		const output = isJetpackUserConnectionOwner( stateIn, siteId );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/is-main-site-of.js
+++ b/client/state/selectors/test/is-main-site-of.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isMainSiteOf from 'calypso/state/selectors/is-main-site-of';
 
 describe( 'isMainSiteOf()', () => {
@@ -8,7 +7,7 @@ describe( 'isMainSiteOf()', () => {
 				items: {},
 			},
 		};
-		expect( isMainSiteOf( state, 1, 2 ) ).be.null;
+		expect( isMainSiteOf( state, 1, 2 ) ).toBeNull();
 	} );
 
 	test( 'should return null if no site with id equal to mainSiteId exists in state', () => {
@@ -27,7 +26,7 @@ describe( 'isMainSiteOf()', () => {
 				},
 			},
 		};
-		expect( isMainSiteOf( state, 1, 2 ) ).be.null;
+		expect( isMainSiteOf( state, 1, 2 ) ).toBeNull();
 	} );
 
 	test( 'should return null if no site with id equal to secondarySiteId exists in state', () => {
@@ -46,7 +45,7 @@ describe( 'isMainSiteOf()', () => {
 				},
 			},
 		};
-		expect( isMainSiteOf( state, 1, 2 ) ).be.null;
+		expect( isMainSiteOf( state, 1, 2 ) ).toBeNull();
 	} );
 
 	test( 'should return false if site mainSiteId is not a main site', () => {
@@ -74,7 +73,7 @@ describe( 'isMainSiteOf()', () => {
 				},
 			},
 		};
-		expect( isMainSiteOf( state, 1, 2 ) ).be.false;
+		expect( isMainSiteOf( state, 1, 2 ) ).toBe( false );
 	} );
 
 	test( 'should return false if site secondarySiteId is not a secondary site', () => {
@@ -102,7 +101,7 @@ describe( 'isMainSiteOf()', () => {
 				},
 			},
 		};
-		expect( isMainSiteOf( state, 1, 2 ) ).be.false;
+		expect( isMainSiteOf( state, 1, 2 ) ).toBe( false );
 	} );
 
 	test( 'should return false if site mainSiteId is not the main site of site secondarySiteId', () => {
@@ -130,7 +129,7 @@ describe( 'isMainSiteOf()', () => {
 				},
 			},
 		};
-		expect( isMainSiteOf( state, 1, 2 ) ).be.false;
+		expect( isMainSiteOf( state, 1, 2 ) ).toBe( false );
 	} );
 
 	test( 'should return true if site mainSiteId is the main site of site secondarySiteId', () => {
@@ -158,6 +157,6 @@ describe( 'isMainSiteOf()', () => {
 				},
 			},
 		};
-		expect( isMainSiteOf( state, 1, 2 ) ).be.true;
+		expect( isMainSiteOf( state, 1, 2 ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-mapped-domain-site.js
+++ b/client/state/selectors/test/is-mapped-domain-site.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isMappedDomainSite from 'calypso/state/selectors/is-mapped-domain-site';
 
 describe( '#isMappedDomainSite()', () => {
@@ -35,7 +34,7 @@ describe( '#isMappedDomainSite()', () => {
 			siteId
 		);
 
-		expect( result ).to.be.null;
+		expect( result ).toBeNull();
 	} );
 
 	test( 'should return null if no domain is found', () => {
@@ -51,7 +50,7 @@ describe( '#isMappedDomainSite()', () => {
 			siteId
 		);
 
-		expect( result ).to.be.null;
+		expect( result ).toBeNull();
 	} );
 
 	test( 'it should return false if the site does not have the mapped domain option set to true', () => {
@@ -73,7 +72,7 @@ describe( '#isMappedDomainSite()', () => {
 			siteId
 		);
 
-		expect( result ).to.be.false;
+		expect( result ).toBe( false );
 	} );
 
 	test( 'it should return false if the site has the mapped domain option set to true', () => {
@@ -95,6 +94,6 @@ describe( '#isMappedDomainSite()', () => {
 			siteId
 		);
 
-		expect( result ).to.be.true;
+		expect( result ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-notifications-open.js
+++ b/client/state/selectors/test/is-notifications-open.js
@@ -1,17 +1,16 @@
-import { expect } from 'chai';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 
 describe( 'isNotificationsOpen()', () => {
 	test( 'returns true if notifications are open', () => {
 		const isOpen = isNotificationsOpen( { ui: { isNotificationsOpen: true } } );
-		expect( isOpen ).to.equal( true );
+		expect( isOpen ).toEqual( true );
 	} );
 	test( 'returns false if notifications are closed', () => {
 		const isOpen = isNotificationsOpen( { ui: { isNotificationsOpen: false } } );
-		expect( isOpen ).to.equal( false );
+		expect( isOpen ).toEqual( false );
 	} );
 	test( 'defaults to false if no data is available', () => {
 		const isOpen = isNotificationsOpen( {} );
-		expect( isOpen ).to.equal( false );
+		expect( isOpen ).toEqual( false );
 	} );
 } );

--- a/client/state/selectors/test/is-plugin-active.js
+++ b/client/state/selectors/test/is-plugin-active.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import isPluginActive from 'calypso/state/selectors/is-plugin-active';
 
@@ -27,18 +26,18 @@ const state = deepFreeze( {
 
 describe( 'isPluginActive', () => {
 	test( 'should return false if the site cannot be found', () => {
-		expect( isPluginActive( state, 'some-unknown-id', 'my-slug' ) ).to.be.false;
+		expect( isPluginActive( state, 'some-unknown-id', 'my-slug' ) ).toBe( false );
 	} );
 
 	test( 'should return false if the plugin cannot be found', () => {
-		expect( isPluginActive( state, 'site.two', 'some-non-existant-slug' ) ).to.be.false;
+		expect( isPluginActive( state, 'site.two', 'some-non-existant-slug' ) ).toBe( false );
 	} );
 
 	test( 'should return false if the plugin is found, but not active', () => {
-		expect( isPluginActive( state, 'site.two', 'hello-dolly' ) ).to.be.false;
+		expect( isPluginActive( state, 'site.two', 'hello-dolly' ) ).toBe( false );
 	} );
 
 	test( 'should return true if the plugin is found and is active', () => {
-		expect( isPluginActive( state, 'site.two', 'jetpack' ) ).to.be.true;
+		expect( isPluginActive( state, 'site.two', 'jetpack' ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-plugin-upload-complete.js
+++ b/client/state/selectors/test/is-plugin-upload-complete.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-complete';
 
 const siteId = 77203074;
@@ -13,7 +12,7 @@ describe( 'isPluginUploadComplete', () => {
 				},
 			},
 		};
-		expect( isPluginUploadComplete( state, siteId ) ).to.be.false;
+		expect( isPluginUploadComplete( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false if no plugin id available', () => {
@@ -27,7 +26,7 @@ describe( 'isPluginUploadComplete', () => {
 				},
 			},
 		};
-		expect( isPluginUploadComplete( state, siteId ) ).to.be.false;
+		expect( isPluginUploadComplete( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false if upload still in progress', () => {
@@ -43,7 +42,7 @@ describe( 'isPluginUploadComplete', () => {
 				},
 			},
 		};
-		expect( isPluginUploadComplete( state, siteId ) ).to.be.false;
+		expect( isPluginUploadComplete( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return true if upload not in progress and plugin id present', () => {
@@ -59,6 +58,6 @@ describe( 'isPluginUploadComplete', () => {
 				},
 			},
 		};
-		expect( isPluginUploadComplete( state, siteId ) ).to.be.true;
+		expect( isPluginUploadComplete( state, siteId ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-plugin-upload-in-progress.js
+++ b/client/state/selectors/test/is-plugin-upload-in-progress.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isPluginUploadInProgress from 'calypso/state/selectors/is-plugin-upload-in-progress';
 
 const siteId = 77203074;
@@ -12,7 +11,7 @@ describe( 'isPluginUploadInProgress', () => {
 				},
 			},
 		};
-		expect( isPluginUploadInProgress( state, siteId ) ).to.be.false;
+		expect( isPluginUploadInProgress( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return current value for site', () => {
@@ -25,7 +24,7 @@ describe( 'isPluginUploadInProgress', () => {
 				},
 			},
 		};
-		expect( isPluginUploadInProgress( stateFalse, siteId ) ).to.be.false;
+		expect( isPluginUploadInProgress( stateFalse, siteId ) ).toBe( false );
 
 		const stateTrue = {
 			plugins: {
@@ -36,6 +35,6 @@ describe( 'isPluginUploadInProgress', () => {
 				},
 			},
 		};
-		expect( isPluginUploadInProgress( stateTrue, siteId ) ).to.be.true;
+		expect( isPluginUploadInProgress( stateTrue, siteId ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-private-site.js
+++ b/client/state/selectors/test/is-private-site.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 
 describe( 'isPrivateSite()', () => {
@@ -20,7 +19,7 @@ describe( 'isPrivateSite()', () => {
 			2916285
 		);
 
-		expect( isPrivate ).to.be.null;
+		expect( isPrivate ).toBeNull();
 	} );
 
 	test( 'should prefer site state', () => {
@@ -45,7 +44,7 @@ describe( 'isPrivateSite()', () => {
 			2916284
 		);
 
-		expect( isPrivate ).to.be.true;
+		expect( isPrivate ).toBe( true );
 	} );
 
 	test( 'should fall back to settings state', () => {
@@ -65,7 +64,7 @@ describe( 'isPrivateSite()', () => {
 			2916284
 		);
 
-		expect( isPrivate ).to.be.false;
+		expect( isPrivate ).toBe( false );
 	} );
 
 	test( 'should return false for public sites', () => {
@@ -90,7 +89,7 @@ describe( 'isPrivateSite()', () => {
 			2916284
 		);
 
-		expect( isPrivate ).to.be.false;
+		expect( isPrivate ).toBe( false );
 	} );
 
 	test( 'should return true for private sites', () => {
@@ -115,6 +114,6 @@ describe( 'isPrivateSite()', () => {
 			2916284
 		);
 
-		expect( isPrivate ).to.be.true;
+		expect( isPrivate ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-publicize-enabled.js
+++ b/client/state/selectors/test/is-publicize-enabled.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isPublicizeEnabled from 'calypso/state/selectors/is-publicize-enabled';
 
 describe( 'isPublicizeEnabled()', () => {
@@ -23,7 +22,7 @@ describe( 'isPublicizeEnabled()', () => {
 			postType
 		);
 
-		expect( result ).to.be.false;
+		expect( result ).toBe( false );
 	} );
 
 	test( 'should return false for jetpack site with Publicize disabled', () => {
@@ -45,7 +44,7 @@ describe( 'isPublicizeEnabled()', () => {
 			postType
 		);
 
-		expect( result ).to.be.false;
+		expect( result ).toBe( false );
 	} );
 
 	test( 'should return true for jetpack site with Publicize enabled', () => {
@@ -67,7 +66,7 @@ describe( 'isPublicizeEnabled()', () => {
 			postType
 		);
 
-		expect( result ).to.be.true;
+		expect( result ).toBe( true );
 	} );
 
 	test( 'should return true for regular site and post type', () => {
@@ -85,6 +84,6 @@ describe( 'isPublicizeEnabled()', () => {
 			postType
 		);
 
-		expect( result ).to.be.true;
+		expect( result ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-regenerating-jetpack-post-by-email.js
+++ b/client/state/selectors/test/is-regenerating-jetpack-post-by-email.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getRequestKey } from 'calypso/state/data-layer/wpcom-http/utils';
 import { regeneratePostByEmail } from 'calypso/state/jetpack/settings/actions';
 import isRegeneratingJetpackPostByEmail from 'calypso/state/selectors/is-regenerating-jetpack-post-by-email';
@@ -16,7 +15,7 @@ describe( 'isRegeneratingJetpackPostByEmail()', () => {
 		};
 
 		const output = isRegeneratingJetpackPostByEmail( state, siteId );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if post by email is currently not being regenerated', () => {
@@ -31,7 +30,7 @@ describe( 'isRegeneratingJetpackPostByEmail()', () => {
 		};
 
 		const output = isRegeneratingJetpackPostByEmail( state, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return false if that site is not known', () => {
@@ -46,6 +45,6 @@ describe( 'isRegeneratingJetpackPostByEmail()', () => {
 		};
 
 		const output = isRegeneratingJetpackPostByEmail( state, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-requesting-billing-transactions.js
+++ b/client/state/selectors/test/is-requesting-billing-transactions.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isRequestingBillingTransactions from 'calypso/state/selectors/is-requesting-billing-transactions';
 
 describe( 'isRequestingBillingTransactions()', () => {
@@ -9,7 +8,7 @@ describe( 'isRequestingBillingTransactions()', () => {
 			},
 		};
 		const output = isRequestingBillingTransactions( state );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if the billing transactions are currently not being fetched', () => {
@@ -19,11 +18,11 @@ describe( 'isRequestingBillingTransactions()', () => {
 			},
 		};
 		const output = isRequestingBillingTransactions( state );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return false if the billing transactions have never been requested', () => {
 		const output = isRequestingBillingTransactions( {} );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-requesting-jetpack-connection-status.js
+++ b/client/state/selectors/test/is-requesting-jetpack-connection-status.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isRequestingJetpackConnectionStatus from 'calypso/state/selectors/is-requesting-jetpack-connection-status';
 import { requests as REQUESTS_FIXTURE } from './fixtures/jetpack-connection';
 
@@ -13,7 +12,7 @@ describe( 'isRequestingJetpackConnectionStatus()', () => {
 		};
 		const siteId = 87654321;
 		const output = isRequestingJetpackConnectionStatus( stateIn, siteId );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if the connection status is not being fetched', () => {
@@ -26,7 +25,7 @@ describe( 'isRequestingJetpackConnectionStatus()', () => {
 		};
 		const siteId = 12345678;
 		const output = isRequestingJetpackConnectionStatus( stateIn, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return false if the site is not known yet', () => {
@@ -39,6 +38,6 @@ describe( 'isRequestingJetpackConnectionStatus()', () => {
 		};
 		const siteId = 88888888;
 		const output = isRequestingJetpackConnectionStatus( stateIn, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-requesting-jetpack-user-connection.js
+++ b/client/state/selectors/test/is-requesting-jetpack-user-connection.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isRequestingJetpackUserConnection from 'calypso/state/selectors/is-requesting-jetpack-user-connection';
 import { requests as REQUESTS_FIXTURE } from './fixtures/jetpack-connection';
 
@@ -13,7 +12,7 @@ describe( 'isRequestingJetpackUserConnection()', () => {
 		};
 		const siteId = 87654321;
 		const output = isRequestingJetpackUserConnection( stateIn, siteId );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if the user connection data is not being fetched', () => {
@@ -26,7 +25,7 @@ describe( 'isRequestingJetpackUserConnection()', () => {
 		};
 		const siteId = 12345678;
 		const output = isRequestingJetpackUserConnection( stateIn, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return false if the site is not known yet', () => {
@@ -39,6 +38,6 @@ describe( 'isRequestingJetpackUserConnection()', () => {
 		};
 		const siteId = 88888888;
 		const output = isRequestingJetpackUserConnection( stateIn, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-requesting-reader-teams.js
+++ b/client/state/selectors/test/is-requesting-reader-teams.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { isRequestingReaderTeams } from 'calypso/state/teams/selectors';
 
 describe( 'isRequestingReaderTeams()', () => {
@@ -9,7 +8,7 @@ describe( 'isRequestingReaderTeams()', () => {
 			},
 		} );
 
-		expect( isRequesting ).to.be.false;
+		expect( isRequesting ).toBe( false );
 	} );
 
 	test( 'should return true if requesting teams', () => {
@@ -19,6 +18,6 @@ describe( 'isRequestingReaderTeams()', () => {
 			},
 		} );
 
-		expect( isRequesting ).to.be.true;
+		expect( isRequesting ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-requesting-site-connection-status.js
+++ b/client/state/selectors/test/is-requesting-site-connection-status.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isRequestingSiteConnectionStatus from 'calypso/state/selectors/is-requesting-site-connection-status';
 
 describe( 'isRequestingSiteConnectionStatus()', () => {
@@ -15,7 +14,7 @@ describe( 'isRequestingSiteConnectionStatus()', () => {
 			},
 		};
 		const output = isRequestingSiteConnectionStatus( state, siteId );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if connection status is currently not being requested for that site', () => {
@@ -29,7 +28,7 @@ describe( 'isRequestingSiteConnectionStatus()', () => {
 			},
 		};
 		const output = isRequestingSiteConnectionStatus( state, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return false if connection status has never been requested for that site', () => {
@@ -43,6 +42,6 @@ describe( 'isRequestingSiteConnectionStatus()', () => {
 			},
 		};
 		const output = isRequestingSiteConnectionStatus( state, siteId );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-requesting-site-features.js
+++ b/client/state/selectors/test/is-requesting-site-features.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 
 describe( 'selectors', () => {
@@ -24,7 +23,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isRequestingSiteFeatures( state, 123001 ) ).to.equal( true );
+			expect( isRequestingSiteFeatures( state, 123001 ) ).toEqual( true );
 		} );
 
 		test( 'should return False if we are not fetching features', () => {
@@ -48,7 +47,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isRequestingSiteFeatures( state, 123002 ) ).to.equal( false );
+			expect( isRequestingSiteFeatures( state, 123002 ) ).toEqual( false );
 		} );
 
 		test( 'should return False when site has not been synced', () => {
@@ -72,7 +71,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isRequestingSiteFeatures( state, 'unknown' ) ).to.equal( false );
+			expect( isRequestingSiteFeatures( state, 'unknown' ) ).toEqual( false );
 		} );
 
 		test( 'should return False when no site id', () => {
@@ -96,7 +95,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isRequestingSiteFeatures( state ) ).to.equal( false );
+			expect( isRequestingSiteFeatures( state ) ).toEqual( false );
 		} );
 	} );
 } );

--- a/client/state/selectors/test/is-rewind-activating.js
+++ b/client/state/selectors/test/is-rewind-activating.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import isRewindActivating from 'calypso/state/selectors/is-rewind-activating';
 
@@ -11,7 +10,7 @@ describe( 'isRewindActivating()', () => {
 				activationRequesting: {},
 			},
 		} );
-		expect( isRewindActivating( stateNoSite, siteId ) ).to.be.false;
+		expect( isRewindActivating( stateNoSite, siteId ) ).toBe( false );
 
 		const stateNoValue = deepFreeze( {
 			activityLog: {
@@ -20,7 +19,7 @@ describe( 'isRewindActivating()', () => {
 				},
 			},
 		} );
-		expect( isRewindActivating( stateNoValue, siteId ) ).to.be.false;
+		expect( isRewindActivating( stateNoValue, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return the value for a site', () => {
@@ -31,7 +30,7 @@ describe( 'isRewindActivating()', () => {
 				},
 			},
 		} );
-		expect( isRewindActivating( stateTrue, siteId ) ).to.be.true;
+		expect( isRewindActivating( stateTrue, siteId ) ).toBe( true );
 
 		const stateFalse = deepFreeze( {
 			activityLog: {
@@ -41,6 +40,6 @@ describe( 'isRewindActivating()', () => {
 			},
 		} );
 
-		expect( isRewindActivating( stateFalse, siteId ) ).to.be.false;
+		expect( isRewindActivating( stateFalse, siteId ) ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-sending-billing-receipt-email.js
+++ b/client/state/selectors/test/is-sending-billing-receipt-email.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isSendingBillingReceiptEmail from 'calypso/state/selectors/is-sending-billing-receipt-email';
 
 describe( 'isSendingBillingReceiptEmail()', () => {
@@ -11,7 +10,7 @@ describe( 'isSendingBillingReceiptEmail()', () => {
 			},
 		};
 		const output = isSendingBillingReceiptEmail( stateIn, 12345678 );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if the receipt email is not being sent for that receiptId', () => {
@@ -23,7 +22,7 @@ describe( 'isSendingBillingReceiptEmail()', () => {
 			},
 		};
 		const output = isSendingBillingReceiptEmail( stateIn, 12345678 );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return null if receipt email for that receiptId is not known yet', () => {
@@ -35,6 +34,6 @@ describe( 'isSendingBillingReceiptEmail()', () => {
 			},
 		};
 		const output = isSendingBillingReceiptEmail( stateIn, 12345678 );
-		expect( output ).to.be.null;
+		expect( output ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/is-site-on-free-plan.js
+++ b/client/state/selectors/test/is-site-on-free-plan.js
@@ -1,5 +1,4 @@
 import { PLAN_BUSINESS, PLAN_FREE, PLAN_JETPACK_FREE } from '@automattic/calypso-products';
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import isSiteOnFreePlan from '../is-site-on-free-plan';
@@ -12,21 +11,21 @@ describe( 'isSiteOnFreePlan', () => {
 
 	test( 'should return false when plan is not known', () => {
 		getCurrentPlan.returns( null );
-		expect( isSiteOnFreePlan( state, 'site1' ) ).to.be.false;
+		expect( isSiteOnFreePlan( state, 'site1' ) ).toBe( false );
 	} );
 
 	test( 'should return false when not on free plan', () => {
 		getCurrentPlan.returns( { productSlug: PLAN_BUSINESS } );
-		expect( isSiteOnFreePlan( state, 'site1' ) ).to.be.false;
+		expect( isSiteOnFreePlan( state, 'site1' ) ).toBe( false );
 	} );
 
 	test( 'should return true when on free plan', () => {
 		getCurrentPlan.returns( { productSlug: PLAN_FREE } );
-		expect( isSiteOnFreePlan( state, 'site1' ) ).to.be.true;
+		expect( isSiteOnFreePlan( state, 'site1' ) ).toBe( true );
 	} );
 
 	test( 'should return true when on free Jetpack plan', () => {
 		getCurrentPlan.returns( { productSlug: PLAN_JETPACK_FREE } );
-		expect( isSiteOnFreePlan( state, 'site1' ) ).to.be.true;
+		expect( isSiteOnFreePlan( state, 'site1' ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-site-on-paid-plan.js
+++ b/client/state/selectors/test/is-site-on-paid-plan.js
@@ -5,7 +5,6 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_FREE,
 } from '@automattic/calypso-products';
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import isSiteOnPaidPlan from '../is-site-on-paid-plan';
@@ -18,31 +17,31 @@ describe( 'isSiteOnPaidPlan', () => {
 
 	test( 'should return false when plan is not known', () => {
 		getCurrentPlan.returns( null );
-		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.false;
+		expect( isSiteOnPaidPlan( state, 'site1' ) ).toBe( false );
 	} );
 
 	test( 'should return false when on free plan', () => {
 		getCurrentPlan.returns( { productSlug: PLAN_FREE } );
-		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.false;
+		expect( isSiteOnPaidPlan( state, 'site1' ) ).toBe( false );
 	} );
 
 	test( 'should return false when on free Jetpack plan', () => {
 		getCurrentPlan.returns( { productSlug: PLAN_JETPACK_FREE } );
-		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.false;
+		expect( isSiteOnPaidPlan( state, 'site1' ) ).toBe( false );
 	} );
 
 	test( 'should return true when on paid plan', () => {
 		getCurrentPlan.returns( { productSlug: PLAN_BUSINESS } );
-		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.true;
+		expect( isSiteOnPaidPlan( state, 'site1' ) ).toBe( true );
 	} );
 
 	test( 'should return true when on eCommerce plan', () => {
 		getCurrentPlan.returns( { productSlug: PLAN_ECOMMERCE } );
-		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.true;
+		expect( isSiteOnPaidPlan( state, 'site1' ) ).toBe( true );
 	} );
 
 	test( 'should return true when on paid Jetpack plan', () => {
 		getCurrentPlan.returns( { productSlug: PLAN_JETPACK_BUSINESS } );
-		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.true;
+		expect( isSiteOnPaidPlan( state, 'site1' ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-site-supporting-image-editor.js
+++ b/client/state/selectors/test/is-site-supporting-image-editor.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isSiteSupportingImageEditor from 'calypso/state/selectors/is-site-supporting-image-editor';
 
 describe( 'isSiteSupportingImageEditor()', () => {
@@ -15,7 +14,7 @@ describe( 'isSiteSupportingImageEditor()', () => {
 			2916284
 		);
 
-		expect( siteSupportsImageEditor ).to.be.true;
+		expect( siteSupportsImageEditor ).toBe( true );
 	} );
 
 	test( 'should return true if site is public and not jetpack site', () => {
@@ -35,7 +34,7 @@ describe( 'isSiteSupportingImageEditor()', () => {
 			2916284
 		);
 
-		expect( siteSupportsImageEditor ).to.be.true;
+		expect( siteSupportsImageEditor ).toBe( true );
 	} );
 
 	test( 'should return false if site is private', () => {
@@ -55,7 +54,7 @@ describe( 'isSiteSupportingImageEditor()', () => {
 			2916284
 		);
 
-		expect( siteSupportsImageEditor ).to.be.false;
+		expect( siteSupportsImageEditor ).toBe( false );
 	} );
 
 	test( 'should return true if site is public and jetpack and has photon enabled', () => {
@@ -78,7 +77,7 @@ describe( 'isSiteSupportingImageEditor()', () => {
 			2916284
 		);
 
-		expect( siteSupportsImageEditor ).to.be.true;
+		expect( siteSupportsImageEditor ).toBe( true );
 	} );
 
 	test( 'should return false if site is public and jetpack but has photon disabled', () => {
@@ -101,6 +100,6 @@ describe( 'isSiteSupportingImageEditor()', () => {
 			2916284
 		);
 
-		expect( siteSupportsImageEditor ).to.be.false;
+		expect( siteSupportsImageEditor ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-site-wpforteams.js
+++ b/client/state/selectors/test/is-site-wpforteams.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 
 describe( 'isSiteWPForTeams()', () => {
@@ -9,7 +8,7 @@ describe( 'isSiteWPForTeams()', () => {
 			},
 		};
 
-		expect( isSiteWPForTeams( state, 12345 ) ).to.be.null;
+		expect( isSiteWPForTeams( state, 12345 ) ).toBeNull();
 	} );
 
 	test( 'should return false if site is not a WP for Teams one', () => {
@@ -25,7 +24,7 @@ describe( 'isSiteWPForTeams()', () => {
 			},
 		};
 
-		expect( isSiteWPForTeams( state, 12345 ) ).to.be.false;
+		expect( isSiteWPForTeams( state, 12345 ) ).toBe( false );
 	} );
 
 	test( 'should return true if site is a WP for Teams one', () => {
@@ -41,6 +40,6 @@ describe( 'isSiteWPForTeams()', () => {
 			},
 		};
 
-		expect( isSiteWPForTeams( state, 12345 ) ).to.be.true;
+		expect( isSiteWPForTeams( state, 12345 ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-transient-media.js
+++ b/client/state/selectors/test/is-transient-media.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import MediaQueryManager from 'calypso/lib/query-manager/media';
 import isTransientMedia from 'calypso/state/selectors/is-transient-media';
 
@@ -14,7 +13,7 @@ describe( 'isTransientMedia()', () => {
 			42
 		);
 
-		expect( isTransient ).to.be.false;
+		expect( isTransient ).toBe( false );
 	} );
 
 	test( 'should return false if the media has no transient flag', () => {
@@ -34,7 +33,7 @@ describe( 'isTransientMedia()', () => {
 			42
 		);
 
-		expect( isTransient ).to.be.false;
+		expect( isTransient ).toBe( false );
 	} );
 
 	test( 'should return the true if truthy transient flag on media', () => {
@@ -59,6 +58,6 @@ describe( 'isTransientMedia()', () => {
 			42
 		);
 
-		expect( isTransient ).to.be.true;
+		expect( isTransient ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-updating-jetpack-settings.js
+++ b/client/state/selectors/test/is-updating-jetpack-settings.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getRequestKey } from 'calypso/state/data-layer/wpcom-http/utils';
 import { saveJetpackSettings } from 'calypso/state/jetpack/settings/actions';
 import isUpdatingJetpackSettings from 'calypso/state/selectors/is-updating-jetpack-settings';
@@ -18,11 +17,11 @@ describe( 'isUpdatingJetpackSettings()', () => {
 
 	test( 'should return true if settings are currently being updated', () => {
 		const output = isUpdatingJetpackSettings( state, siteId, settings );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if settings are currently not being updated', () => {
 		const output = isUpdatingJetpackSettings( state, 87654321, settings );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-valid-theme-filter-term.js
+++ b/client/state/selectors/test/is-valid-theme-filter-term.js
@@ -1,17 +1,16 @@
-import { expect } from 'chai';
 import { isValidThemeFilterTerm } from 'calypso/state/themes/selectors';
 import { state } from './fixtures/theme-filters';
 
 describe( 'isValidThemeFilterTerm()', () => {
 	test( 'should return true for a valid term string', () => {
-		expect( isValidThemeFilterTerm( state, 'music' ) ).to.be.true;
-		expect( isValidThemeFilterTerm( state, 'feature:video' ) ).to.be.true;
+		expect( isValidThemeFilterTerm( state, 'music' ) ).toBe( true );
+		expect( isValidThemeFilterTerm( state, 'feature:video' ) ).toBe( true );
 	} );
 
 	test( 'should return false for an invalid filter string', () => {
-		expect( isValidThemeFilterTerm( state, 'video' ) ).to.be.false;
-		expect( isValidThemeFilterTerm( state, '' ) ).to.be.false;
-		expect( isValidThemeFilterTerm( state, ':video' ) ).to.be.false;
-		expect( isValidThemeFilterTerm( state, ':' ) ).to.be.false;
+		expect( isValidThemeFilterTerm( state, 'video' ) ).toBe( false );
+		expect( isValidThemeFilterTerm( state, '' ) ).toBe( false );
+		expect( isValidThemeFilterTerm( state, ':video' ) ).toBe( false );
+		expect( isValidThemeFilterTerm( state, ':' ) ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-vip-site.js
+++ b/client/state/selectors/test/is-vip-site.js
@@ -1,24 +1,23 @@
-import { expect } from 'chai';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 
 describe( 'isVipSite()', () => {
 	test( 'returns null if site does not exist', () => {
 		const isVip = isVipSite( { sites: { items: { 5: { is_vip: true } } } }, 99999 );
-		expect( isVip ).to.be.null;
+		expect( isVip ).toBeNull();
 	} );
 
 	test( 'returns true if is_vip property of the site is true', () => {
 		const isVip = isVipSite( { sites: { items: { 5: { is_vip: true } } } }, 5 );
-		expect( isVip ).to.be.true;
+		expect( isVip ).toBe( true );
 	} );
 
 	test( 'returns false if is_vip property of the site is false', () => {
 		const isVip = isVipSite( { sites: { items: { 5: { is_vip: false } } } }, 5 );
-		expect( isVip ).to.be.false;
+		expect( isVip ).toBe( false );
 	} );
 
 	test( 'returns null if is_vip property of the site does not exist', () => {
 		const isVip = isVipSite( { sites: { items: { 5: {} } } }, 5 );
-		expect( isVip ).to.be.null;
+		expect( isVip ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/prepend-theme-filter-keys.js
+++ b/client/state/selectors/test/prepend-theme-filter-keys.js
@@ -1,16 +1,15 @@
-import { expect } from 'chai';
 import { prependThemeFilterKeys } from 'calypso/state/themes/selectors';
 import { state } from './fixtures/theme-filters';
 
 describe( 'getThemeFilterStringFromTerm', () => {
 	test( 'should handle invalid input', () => {
-		expect( prependThemeFilterKeys( state, '' ) ).to.equal( '' );
-		expect( prependThemeFilterKeys( state, '     ' ) ).to.equal( '' );
-		expect( prependThemeFilterKeys( state, ' tsr tsr .' ) ).to.equal( '' );
+		expect( prependThemeFilterKeys( state, '' ) ).toEqual( '' );
+		expect( prependThemeFilterKeys( state, '     ' ) ).toEqual( '' );
+		expect( prependThemeFilterKeys( state, ' tsr tsr .' ) ).toEqual( '' );
 	} );
 
 	test( 'should prepend keys for valid terms and leave a trailing space', () => {
 		const result = prependThemeFilterKeys( state, 'business subject:video blog clean' );
-		expect( result ).to.equal( 'subject:business subject:video subject:blog style:clean ' );
+		expect( result ).toEqual( 'subject:business subject:video subject:blog style:clean ' );
 	} );
 } );

--- a/client/state/selectors/test/should-display-app-banner.js
+++ b/client/state/selectors/test/should-display-app-banner.js
@@ -1,5 +1,4 @@
 import { isMobile } from '@automattic/viewport';
-import { expect } from 'chai';
 import { isE2ETest } from 'calypso/lib/e2e';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { shouldDisplayAppBanner } from 'calypso/state/selectors/should-display-app-banner';
@@ -31,7 +30,7 @@ describe( 'shouldDisplayAppBanner()', () => {
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
-		expect( output ).to.be.true;
+		expect( output ).toBe( true );
 	} );
 
 	test( 'should return false if ToS update banner is displayed', () => {
@@ -55,7 +54,7 @@ describe( 'shouldDisplayAppBanner()', () => {
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return false if the app banner is not enabled', () => {
@@ -74,7 +73,7 @@ describe( 'shouldDisplayAppBanner()', () => {
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return false if current layout focus is sidebar', () => {
@@ -93,7 +92,7 @@ describe( 'shouldDisplayAppBanner()', () => {
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return false if has not received remote preferences', () => {
@@ -112,7 +111,7 @@ describe( 'shouldDisplayAppBanner()', () => {
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return false if in section not allowed', () => {
@@ -131,7 +130,7 @@ describe( 'shouldDisplayAppBanner()', () => {
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return false if in e2e test', () => {
@@ -151,7 +150,7 @@ describe( 'shouldDisplayAppBanner()', () => {
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return false if not on mobile', () => {
@@ -171,7 +170,7 @@ describe( 'shouldDisplayAppBanner()', () => {
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 
 	test( 'should return false if in the app', () => {
@@ -191,6 +190,6 @@ describe( 'shouldDisplayAppBanner()', () => {
 			},
 		};
 		const output = shouldDisplayAppBanner( state );
-		expect( output ).to.be.false;
+		expect( output ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/should-show-video-editor-error.js
+++ b/client/state/selectors/test/should-show-video-editor-error.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import shouldShowVideoEditorError from 'calypso/state/selectors/should-show-video-editor-error';
 
 describe( 'shouldShowVideoEditorError()', () => {
@@ -11,6 +10,6 @@ describe( 'shouldShowVideoEditorError()', () => {
 			},
 		} );
 
-		expect( showError ).to.be.true;
+		expect( showError ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/should-sync-reader-follows.js
+++ b/client/state/selectors/test/should-sync-reader-follows.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import shouldSyncReaderFollows, {
 	MS_BETWEEN_SYNCS,
 } from 'calypso/state/selectors/should-sync-reader-follows';
@@ -13,7 +12,7 @@ describe( 'shouldSyncReaderFollows', () => {
 					},
 				},
 			} )
-		).to.be.true;
+		).toBe( true );
 	} );
 
 	test( 'should return true when last time is just over an hour ago', () => {
@@ -25,7 +24,7 @@ describe( 'shouldSyncReaderFollows', () => {
 					},
 				},
 			} )
-		).to.be.true;
+		).toBe( true );
 	} );
 
 	test( 'should return false when last sync date is now', () => {
@@ -37,7 +36,7 @@ describe( 'shouldSyncReaderFollows', () => {
 					},
 				},
 			} )
-		).to.be.false;
+		).toBe( false );
 	} );
 
 	test( 'should return false when last sync date is within an hour', () => {
@@ -49,6 +48,6 @@ describe( 'shouldSyncReaderFollows', () => {
 					},
 				},
 			} )
-		).to.be.false;
+		).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/site-has-feature.js
+++ b/client/state/selectors/test/site-has-feature.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 
 describe( 'selectors', () => {
@@ -18,7 +17,7 @@ describe( 'selectors', () => {
 			};
 
 			const activeFeature = siteHasFeature( state );
-			expect( activeFeature ).to.eql( false );
+			expect( activeFeature ).toEqual( false );
 		} );
 
 		test( 'should return False when site does not exist', () => {
@@ -37,7 +36,7 @@ describe( 'selectors', () => {
 			};
 
 			const activeFeature = siteHasFeature( state, 0 );
-			expect( activeFeature ).to.eql( false );
+			expect( activeFeature ).toEqual( false );
 		} );
 
 		test( 'should return False when feature param is not defined', () => {
@@ -56,7 +55,7 @@ describe( 'selectors', () => {
 			};
 
 			const activeFeature = siteHasFeature( state, 123001 );
-			expect( activeFeature ).to.eql( false );
+			expect( activeFeature ).toEqual( false );
 		} );
 
 		test( 'should return False when feature is not defined in the active array', () => {
@@ -75,7 +74,7 @@ describe( 'selectors', () => {
 			};
 
 			const activeFeature = siteHasFeature( state, 123001, 'unknown-feature' );
-			expect( activeFeature ).to.eql( false );
+			expect( activeFeature ).toEqual( false );
 		} );
 
 		test( 'should return True when feature is defined in the active array', () => {
@@ -94,7 +93,7 @@ describe( 'selectors', () => {
 			};
 
 			const activeFeature = siteHasFeature( state, 123001, 'feature_active_01' );
-			expect( activeFeature ).to.eql( true );
+			expect( activeFeature ).toEqual( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As we've been moving towards canonically using `jest` as our primary unit testing platform, we're slowly moving away from `chai`. 

This PR refactors the global selector tests to use `jest` instead of `chai`. 

I could address a larger part of the `state` tests, but I'm trying to keep the PR in a size that's reasonable to review.

Most of the legwork here has been done with codemods, and I slightly helped to fix some false positives and bad transformations.

#### Testing instructions

Verify all tests pass: `yarn run test-client client/state/selectors`