### PR TITLE
i18n-utils: Add another way for useLocale to guess the locale

### DIFF
--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -76,7 +76,7 @@ export function useLocale(): string {
 		} );
 	}, [ providerHasLocale ] );
 
-	return fromProvider || fromWpI18n || 'en';
+	return fromProvider || fromWpI18n || window?._currentUserLocale || 'en';
 }
 
 /**

--- a/packages/i18n-utils/src/types.d.ts
+++ b/packages/i18n-utils/src/types.d.ts
@@ -1,0 +1,5 @@
+export declare global {
+	interface Window {
+		_currentUserLocale?: string;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds another way for `useLocale` to guess the locale. It's just a bandage to fix `What's New` translation in ETK. But [the translation issue in ETK in general](https://github.com/Automattic/wp-calypso/issues/63611) is expected to remain broken.

#### Testing instructions

1. Run ETK. 
2. Sandbox a site.
3. Switch your language to something else in Calypso. 
4. Visit the editor in said site. 
5. Open Help Center.
6. Open What's new. 
7. Should be in the language you picked. 