### PR TITLE
Agencies: Add an empty signup route in the development env

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/controller.tsx
@@ -1,0 +1,22 @@
+import page from 'page';
+import AgencySignUp from 'calypso/jetpack-cloud/sections/agency-signup/primary/agency-signup';
+import { partnerPortalBasePath } from 'calypso/lib/jetpack/paths';
+import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
+
+export function requireNoPartnerRecordContext( context: PageJS.Context, next: () => void ): void {
+	const state = context.store.getState();
+	const partner = getCurrentPartner( state );
+
+	// Users who already have a partner record should be redirected away from the signup form.
+	if ( partner ) {
+		page.redirect( partnerPortalBasePath() );
+		return;
+	}
+
+	next();
+}
+
+export function signUpContext( context: PageJS.Context, next: () => void ): void {
+	context.primary = <AgencySignUp />;
+	next();
+}

--- a/client/jetpack-cloud/sections/agency-signup/index.ts
+++ b/client/jetpack-cloud/sections/agency-signup/index.ts
@@ -1,0 +1,14 @@
+import page from 'page';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { agencySignupBasePath } from 'calypso/lib/jetpack/paths';
+import * as controller from './controller';
+
+export default function () {
+	page(
+		agencySignupBasePath(),
+		controller.requireNoPartnerRecordContext,
+		controller.signUpContext,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/jetpack-cloud/sections/agency-signup/primary/agency-signup/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/primary/agency-signup/index.tsx
@@ -1,0 +1,22 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import CardHeading from 'calypso/components/card-heading';
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
+import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
+import type { ReactElement } from 'react';
+
+export default function AgencySignup(): ReactElement {
+	const translate = useTranslate();
+
+	return (
+		<Main wideLayout className="agency-signup">
+			<DocumentHead title={ translate( 'Sign up as an Agency' ) } />
+			<SidebarNavigation />
+
+			<Card>
+				<CardHeading>{ translate( 'Sign up as an Agency' ) }</CardHeading>
+			</Card>
+		</Main>
+	);
+}

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -29,3 +29,7 @@ export const purchasesPath = ( siteSlug: string | null ): string =>
 export const socialBasePath = () => '/jetpack-social';
 export const socialPath = ( siteSlug?: string ): string =>
 	siteSlug ? `${ socialBasePath() }/${ siteSlug }` : socialBasePath();
+
+export const partnerPortalBasePath = () => '/partner-portal';
+
+export const agencySignupBasePath = () => '/agency/signup';

--- a/client/sections.js
+++ b/client/sections.js
@@ -499,6 +499,12 @@ const sections = [
 		group: 'jetpack-cloud',
 	},
 	{
+		name: 'jetpack-cloud-agency-signup',
+		paths: [ '/agency/signup' ],
+		module: 'calypso/jetpack-cloud/sections/agency-signup',
+		group: 'jetpack-cloud',
+	},
+	{
 		name: 'jetpack-social',
 		paths: [ '/jetpack-social' ],
 		module: 'calypso/jetpack-cloud/sections/jetpack-social',

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -158,6 +158,7 @@
 	"sections": {
 		"jetpack-cloud": false,
 		"jetpack-cloud-agency-dashboard": false,
+		"jetpack-cloud-agency-signup": false,
 		"jetpack-cloud-auth": false,
 		"jetpack-cloud-partner-portal": false,
 		"jetpack-cloud-pricing": false,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -64,6 +64,7 @@
 		"backup": true,
 		"jetpack-cloud": true,
 		"jetpack-cloud-agency-dashboard": true,
+		"jetpack-cloud-agency-signup": true,
 		"jetpack-cloud-auth": true,
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud-pricing": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add an empty /agency/signup route in the development env

#### Testing instructions

* Checkout PR and run Jetpack Cloud.
* When logged out, visit http://jetpack.cloud.localhost:3000/agency/signup and confirm you are redirected to log in.
* When logged in, visit http://jetpack.cloud.localhost:3000/agency/signup and confirm you are presented with an almost blank page.

![jetpack cloud localhost_3000_agency_signup(iPad Mini)](https://user-images.githubusercontent.com/22746396/168287778-0c947bc0-de59-4129-b050-71546ec9a34a.png)