### PR TITLE
State: Refactor AR tests away from `chai` and `sinon`

### DIFF
--- a/client/state/account-recovery/settings/test/actions.js
+++ b/client/state/account-recovery/settings/test/actions.js
@@ -1,5 +1,3 @@
-import { assert } from 'chai';
-import sinon from 'sinon';
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH,
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
@@ -17,7 +15,6 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS,
 	ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED,
 } from 'calypso/state/action-types';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	accountRecoverySettingsFetch,
 	accountRecoverySettingsFetchSuccess,
@@ -49,7 +46,9 @@ import { generateSuccessAndFailedTestsForThunk } from './utils';
 
 describe( 'account-recovery actions', () => {
 	let spy;
-	useSandbox( ( sandbox ) => ( spy = sandbox.spy() ) );
+	beforeEach( () => {
+		spy = jest.fn();
+	} );
 
 	const errorResponse = { status: 400, message: 'Something wrong!' };
 
@@ -62,23 +61,20 @@ describe( 'account-recovery actions', () => {
 			errorResponse: errorResponse,
 		},
 		thunk: () => accountRecoverySettingsFetch()( spy ),
-		preCondition: () => assert( spy.calledWith( { type: ACCOUNT_RECOVERY_SETTINGS_FETCH } ) ),
+		preCondition: () =>
+			expect( spy ).toHaveBeenCalledWith( { type: ACCOUNT_RECOVERY_SETTINGS_FETCH } ),
 		postConditionSuccess: () => {
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
-					settings: dummyData,
-				} )
-			);
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
+				settings: dummyData,
+			} );
 		},
 		postConditionFailed: () => {
-			assert(
-				spy.calledWith(
-					sinon.match( {
-						type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
-						error: errorResponse,
-					} )
-				)
+			expect( spy ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
+					error: expect.objectContaining( errorResponse ),
+				} )
 			);
 		},
 	} );
@@ -86,7 +82,7 @@ describe( 'account-recovery actions', () => {
 	describe( '#accountRecoverySettingsFetchSuccess()', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS', () => {
 			const action = accountRecoverySettingsFetchSuccess( dummyData );
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
 				settings: dummyData,
 			} );
@@ -97,9 +93,9 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED', () => {
 			const action = accountRecoverySettingsFetchFailed( errorResponse );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
-				error: errorResponse,
+				error: expect.objectContaining( errorResponse ),
 			} );
 		} );
 	} );
@@ -121,29 +117,23 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => updateAccountRecoveryPhone( newPhoneValue )( spy ),
 		preCondition: () =>
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_UPDATE,
-					target: 'phone',
-				} )
-			),
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE,
+				target: 'phone',
+			} ),
 		postConditionSuccess: () =>
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
-					target: 'phone',
-					value: newPhoneValue,
-				} )
-			),
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
+				target: 'phone',
+				value: newPhoneValue,
+			} ),
 		postConditionFailed: () =>
-			assert(
-				spy.calledWith(
-					sinon.match( {
-						type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
-						target: 'phone',
-						error: errorResponse,
-					} )
-				)
+			expect( spy ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
+					target: 'phone',
+					error: expect.objectContaining( errorResponse ),
+				} )
 			),
 	} );
 
@@ -152,7 +142,7 @@ describe( 'account-recovery actions', () => {
 			const phone = dummyData.phone;
 			const action = updateAccountRecoveryPhoneSuccess( phone );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 				target: 'phone',
 				value: phone,
@@ -164,10 +154,10 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED with target: phone', () => {
 			const action = updateAccountRecoveryPhoneFailed( errorResponse );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
 				target: 'phone',
-				error: errorResponse,
+				error: expect.objectContaining( errorResponse ),
 			} );
 		} );
 	} );
@@ -182,28 +172,22 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => deleteAccountRecoveryPhone()( spy ),
 		preCondition: () =>
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_DELETE,
-					target: 'phone',
-				} )
-			),
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_DELETE,
+				target: 'phone',
+			} ),
 		postConditionSuccess: () =>
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
-					target: 'phone',
-				} )
-			),
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
+				target: 'phone',
+			} ),
 		postConditionFailed: () =>
-			assert(
-				spy.calledWith(
-					sinon.match( {
-						type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
-						target: 'phone',
-						error: errorResponse,
-					} )
-				)
+			expect( spy ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
+					target: 'phone',
+					error: expect.objectContaining( errorResponse ),
+				} )
 			),
 	} );
 
@@ -211,7 +195,7 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS with target: phone', () => {
 			const action = deleteAccountRecoveryPhoneSuccess();
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
 				target: 'phone',
 			} );
@@ -222,10 +206,10 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED with target: phone', () => {
 			const action = deleteAccountRecoveryPhoneFailed( errorResponse );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 				target: 'phone',
-				error: errorResponse,
+				error: expect.objectContaining( errorResponse ),
 			} );
 		} );
 	} );
@@ -240,30 +224,24 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => updateAccountRecoveryEmail( dummyNewEmail )( spy ),
 		preCondition: () =>
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_UPDATE,
-					target: 'email',
-				} )
-			),
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE,
+				target: 'email',
+			} ),
 		postConditionSuccess: () => {
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
-					target: 'email',
-					value: dummyNewEmail,
-				} )
-			);
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
+				target: 'email',
+				value: dummyNewEmail,
+			} );
 		},
 		postConditionFailed: () => {
-			assert(
-				spy.calledWith(
-					sinon.match( {
-						type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
-						target: 'email',
-						error: errorResponse,
-					} )
-				)
+			expect( spy ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
+					target: 'email',
+					error: expect.objectContaining( errorResponse ),
+				} )
 			);
 		},
 	} );
@@ -272,7 +250,7 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS with target: email', () => {
 			const action = updateAccountRecoveryEmailSuccess( dummyData.email );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 				target: 'email',
 				value: dummyData.email,
@@ -284,10 +262,10 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_FAILED with target: email', () => {
 			const action = updateAccountRecoveryEmailFailed( errorResponse );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
 				target: 'email',
-				error: errorResponse,
+				error: expect.objectContaining( errorResponse ),
 			} );
 		} );
 	} );
@@ -302,28 +280,22 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => deleteAccountRecoveryEmail()( spy ),
 		preCondition: () =>
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_DELETE,
-					target: 'email',
-				} )
-			),
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_DELETE,
+				target: 'email',
+			} ),
 		postConditionSuccess: () =>
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
-					target: 'email',
-				} )
-			),
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
+				target: 'email',
+			} ),
 		postConditionFailed: () =>
-			assert(
-				spy.calledWith(
-					sinon.match( {
-						type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
-						target: 'email',
-						error: errorResponse,
-					} )
-				)
+			expect( spy ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
+					target: 'email',
+					error: expect.objectContaining( errorResponse ),
+				} )
 			),
 	} );
 
@@ -331,7 +303,7 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS with target: email', () => {
 			const action = deleteAccountRecoveryEmailSuccess();
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
 				target: 'email',
 			} );
@@ -342,10 +314,10 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED with target: email', () => {
 			const action = deleteAccountRecoveryEmailFailed( errorResponse );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 				target: 'email',
-				error: errorResponse,
+				error: expect.objectContaining( errorResponse ),
 			} );
 		} );
 	} );
@@ -353,7 +325,7 @@ describe( 'account-recovery actions', () => {
 	describe( '#resendAccountRecoveryEmailValidationSuccess', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS with target: email', () => {
 			const action = resendAccountRecoveryEmailValidationSuccess();
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS,
 				target: 'email',
 			} );
@@ -363,10 +335,10 @@ describe( 'account-recovery actions', () => {
 	describe( '#resendAccountRecoveryEmailValidationFailed', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED with target: email', () => {
 			const action = resendAccountRecoveryEmailValidationFailed( errorResponse );
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED,
 				target: 'email',
-				error: errorResponse,
+				error: expect.objectContaining( errorResponse ),
 			} );
 		} );
 	} );
@@ -381,35 +353,29 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => resendAccountRecoveryEmailValidation()( spy ),
 		preCondition: () =>
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION,
-					target: 'email',
-				} )
-			),
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION,
+				target: 'email',
+			} ),
 		postConditionSuccess: () =>
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS,
-					target: 'email',
-				} )
-			),
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS,
+				target: 'email',
+			} ),
 		postConditionFailed: () =>
-			assert(
-				spy.calledWith(
-					sinon.match( {
-						type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED,
-						target: 'email',
-						error: errorResponse,
-					} )
-				)
+			expect( spy ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED,
+					target: 'email',
+					error: expect.objectContaining( errorResponse ),
+				} )
 			),
 	} );
 
 	describe( '#resendAccountRecoveryPhoneValidationSuccess', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS with target: phone', () => {
 			const action = resendAccountRecoveryPhoneValidationSuccess();
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS,
 				target: 'phone',
 			} );
@@ -419,10 +385,10 @@ describe( 'account-recovery actions', () => {
 	describe( '#resendAccountRecoveryPhoneValidationFailed', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED with target: phone', () => {
 			const action = resendAccountRecoveryPhoneValidationFailed( errorResponse );
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED,
 				target: 'phone',
-				error: errorResponse,
+				error: expect.objectContaining( errorResponse ),
 			} );
 		} );
 	} );
@@ -437,35 +403,29 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => resendAccountRecoveryPhoneValidation()( spy ),
 		preCondition: () =>
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION,
-					target: 'phone',
-				} )
-			),
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION,
+				target: 'phone',
+			} ),
 		postConditionSuccess: () =>
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS,
-					target: 'phone',
-				} )
-			),
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS,
+				target: 'phone',
+			} ),
 		postConditionFailed: () =>
-			assert(
-				spy.calledWith(
-					sinon.match( {
-						type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED,
-						target: 'phone',
-						error: errorResponse,
-					} )
-				)
+			expect( spy ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED,
+					target: 'phone',
+					error: expect.objectContaining( errorResponse ),
+				} )
 			),
 	} );
 
 	describe( '#validateAccountRecoveryPhoneSuccess', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS', () => {
 			const action = validateAccountRecoveryPhoneSuccess();
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS,
 			} );
 		} );
@@ -474,9 +434,9 @@ describe( 'account-recovery actions', () => {
 	describe( '#validateAccountRecoveryPhoneFailed', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED', () => {
 			const action = validateAccountRecoveryPhoneFailed( errorResponse );
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED,
-				error: errorResponse,
+				error: expect.objectContaining( errorResponse ),
 			} );
 		} );
 	} );
@@ -491,25 +451,19 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => validateAccountRecoveryPhone( '' )( spy ),
 		preCondition: () =>
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE,
-				} )
-			),
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE,
+			} ),
 		postConditionSuccess: () =>
-			assert(
-				spy.calledWith( {
-					type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS,
-				} )
-			),
+			expect( spy ).toHaveBeenCalledWith( {
+				type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS,
+			} ),
 		postConditionFailed: () =>
-			assert(
-				spy.calledWith(
-					sinon.match( {
-						type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED,
-						error: errorResponse,
-					} )
-				)
+			expect( spy ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED,
+					error: expect.objectContaining( errorResponse ),
+				} )
 			),
 	} );
 } );

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -1,4 +1,3 @@
-import { assert } from 'chai';
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
 	ACCOUNT_RECOVERY_SETTINGS_UPDATE,
@@ -35,7 +34,7 @@ describe( '#account-recovery reducer fetch:', () => {
 			settings: dummyData,
 		} );
 
-		assert.deepEqual( initState.data, expectedState );
+		expect( initState.data ).toEqual( expectedState );
 	} );
 } );
 
@@ -63,7 +62,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			value: newPhoneValue,
 		} );
 
-		assert.deepEqual( state.data, {
+		expect( state.data ).toEqual( {
 			...initState.data,
 			phone: newPhoneValue,
 		} );
@@ -75,7 +74,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: 'phone',
 		} );
 
-		assert.isNull( state.data.phone );
+		expect( state.data.phone ).toBeNull();
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS action with email target should update the email field', () => {
@@ -85,7 +84,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			value: dummyNewEmail,
 		} );
 
-		assert.equal( state.data.email, dummyNewEmail );
+		expect( state.data.email ).toEqual( dummyNewEmail );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS action with email target should wipe the email field', () => {
@@ -94,7 +93,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: 'email',
 		} );
 
-		assert.equal( state.data.email, '' );
+		expect( state.data.email ).toEqual( '' );
 	} );
 
 	const arbitraryTargetName = 'whatever';
@@ -105,7 +104,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isTrue( state.isUpdating[ arbitraryTargetName ] );
+		expect( state.isUpdating[ arbitraryTargetName ] ).toBe( true );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS action should unset the isUpdating sub field', () => {
@@ -114,7 +113,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isFalse( state.isUpdating[ arbitraryTargetName ] );
+		expect( state.isUpdating[ arbitraryTargetName ] ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS action should set the hasSentValidation sub field', () => {
@@ -123,7 +122,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isTrue( state.hasSentValidation[ arbitraryTargetName ] );
+		expect( state.hasSentValidation[ arbitraryTargetName ] ).toBe( true );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED action should unset the isUpdating sub field', () => {
@@ -132,7 +131,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isFalse( state.isUpdating[ arbitraryTargetName ] );
+		expect( state.isUpdating[ arbitraryTargetName ] ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINS_DELETE action should set the isDeleting sub field', () => {
@@ -141,7 +140,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isTrue( state.isDeleting[ arbitraryTargetName ] );
+		expect( state.isDeleting[ arbitraryTargetName ] ).toBe( true );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS action should unset the isDeleting sub field', () => {
@@ -150,7 +149,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isFalse( state.isDeleting[ arbitraryTargetName ] );
+		expect( state.isDeleting[ arbitraryTargetName ] ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED action should unset the isDeleting sub field', () => {
@@ -159,7 +158,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isFalse( state.isDeleting[ arbitraryTargetName ] );
+		expect( state.isDeleting[ arbitraryTargetName ] ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION action should set hasSentValidation sub field', () => {
@@ -168,7 +167,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isTrue( state.hasSentValidation[ arbitraryTargetName ] );
+		expect( state.hasSentValidation[ arbitraryTargetName ] ).toBe( true );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS action should set phoneValidated as true', () => {
@@ -176,7 +175,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS,
 		} );
 
-		assert.isTrue( state.data.phoneValidated );
+		expect( state.data.phoneValidated ).toBe( true );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE action should set isValidatingPhone as true', () => {
@@ -184,7 +183,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE,
 		} );
 
-		assert.isTrue( state.isValidatingPhone );
+		expect( state.isValidatingPhone ).toBe( true );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS action should set isValidatingPhone as false', () => {
@@ -192,7 +191,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS,
 		} );
 
-		assert.isFalse( state.isValidatingPhone );
+		expect( state.isValidatingPhone ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE action should set isValidatingPhone as false', () => {
@@ -200,6 +199,6 @@ describe( '#account-recovery/settings reducer:', () => {
 			type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED,
 		} );
 
-		assert.isFalse( state.isValidatingPhone );
+		expect( state.isValidatingPhone ).toBe( false );
 	} );
 } );

--- a/client/state/account-recovery/settings/test/selectors.js
+++ b/client/state/account-recovery/settings/test/selectors.js
@@ -1,4 +1,3 @@
-import { assert } from 'chai';
 import {
 	isAccountRecoverySettingsReady,
 	isAccountRecoveryEmailValidated,
@@ -55,51 +54,51 @@ describe( '#account-recovery/settings/selectors', () => {
 
 	describe( '#isAccountRecoverySettingsReady', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isAccountRecoverySettingsReady( stateBeforeFetching ) );
+			expect( isAccountRecoverySettingsReady( stateBeforeFetching ) ).toBe( false );
 		} );
 
 		test( 'should return true if exists', () => {
-			assert.isTrue( isAccountRecoverySettingsReady( stateAfterFetching ) );
+			expect( isAccountRecoverySettingsReady( stateAfterFetching ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isAccountRecoveryEmailValidated:', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isAccountRecoveryEmailValidated( stateBeforeFetching ) );
+			expect( isAccountRecoveryEmailValidated( stateBeforeFetching ) ).toBe( false );
 		} );
 
 		test( 'should return the emailValidated field', () => {
-			assert.isTrue( isAccountRecoveryEmailValidated( stateAfterFetching ) );
+			expect( isAccountRecoveryEmailValidated( stateAfterFetching ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isAccountRecoveryPhoneValidated:', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isAccountRecoveryPhoneValidated( stateBeforeFetching ) );
+			expect( isAccountRecoveryPhoneValidated( stateBeforeFetching ) ).toBe( false );
 		} );
 
 		test( 'should return the phoneValidated field', () => {
-			assert.isTrue( isAccountRecoveryPhoneValidated( stateAfterFetching ) );
+			expect( isAccountRecoveryPhoneValidated( stateAfterFetching ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#getAccountRecoveryEmail:', () => {
 		test( 'should return a default value on absence', () => {
-			assert.equal( getAccountRecoveryEmail( stateBeforeFetching ), '' );
+			expect( getAccountRecoveryEmail( stateBeforeFetching ) ).toEqual( '' );
 		} );
 
 		test( 'should return the email field', () => {
-			assert.equal( getAccountRecoveryEmail( stateAfterFetching ), dummyNewEmail );
+			expect( getAccountRecoveryEmail( stateAfterFetching ) ).toEqual( dummyNewEmail );
 		} );
 	} );
 
 	describe( '#getAccountRecoveryPhone', () => {
 		test( 'should return a default value on absence', () => {
-			assert.isNull( getAccountRecoveryPhone( stateBeforeFetching ) );
+			expect( getAccountRecoveryPhone( stateBeforeFetching ) ).toBeNull();
 		} );
 
 		test( 'should return the phone field', () => {
-			assert.deepEqual( getAccountRecoveryPhone( stateAfterFetching ), {
+			expect( getAccountRecoveryPhone( stateAfterFetching ) ).toEqual( {
 				countryCode: dummyNewPhone.country_code,
 				countryNumericCode: dummyNewPhone.country_numeric_code,
 				number: dummyNewPhone.number,
@@ -129,21 +128,21 @@ describe( '#account-recovery/settings/selectors', () => {
 
 	describe( '#isUpdatingAccountRecoveryPhone', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isUpdatingAccountRecoveryPhone( stateBeforeUpdating ) );
+			expect( isUpdatingAccountRecoveryPhone( stateBeforeUpdating ) ).toBe( false );
 		} );
 
 		test( 'should return isUpdating.phone', () => {
-			assert.isTrue( isUpdatingAccountRecoveryPhone( stateDuringUpdating ) );
+			expect( isUpdatingAccountRecoveryPhone( stateDuringUpdating ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isUpdatingAccountRecoveryEmail', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isUpdatingAccountRecoveryEmail( stateBeforeUpdating ) );
+			expect( isUpdatingAccountRecoveryEmail( stateBeforeUpdating ) ).toBe( false );
 		} );
 
 		test( 'should return isUpdating.email', () => {
-			assert.isTrue( isUpdatingAccountRecoveryEmail( stateDuringUpdating ) );
+			expect( isUpdatingAccountRecoveryEmail( stateDuringUpdating ) ).toBe( true );
 		} );
 	} );
 
@@ -168,49 +167,49 @@ describe( '#account-recovery/settings/selectors', () => {
 
 	describe( '#isDeletingAccountRecoveryPhone', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isDeletingAccountRecoveryPhone( stateBeforeDeleting ) );
+			expect( isDeletingAccountRecoveryPhone( stateBeforeDeleting ) ).toBe( false );
 		} );
 
 		test( 'should return isDeleting.phone', () => {
-			assert.isTrue( isDeletingAccountRecoveryPhone( stateDuringDeleting ) );
+			expect( isDeletingAccountRecoveryPhone( stateDuringDeleting ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isDeletingAccountRecoveryEmail', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isDeletingAccountRecoveryEmail( stateBeforeDeleting ) );
+			expect( isDeletingAccountRecoveryEmail( stateBeforeDeleting ) ).toBe( false );
 		} );
 
 		test( 'should return isDeleting.email', () => {
-			assert.isTrue( isDeletingAccountRecoveryEmail( stateDuringDeleting ) );
+			expect( isDeletingAccountRecoveryEmail( stateDuringDeleting ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isAccountRecoveryEmailActionInProgress', () => {
 		test( 'should return true if the whole data is not in place yet', () => {
-			assert.isTrue( isAccountRecoveryEmailActionInProgress( stateBeforeFetching ) );
+			expect( isAccountRecoveryEmailActionInProgress( stateBeforeFetching ) ).toBe( true );
 		} );
 
 		test( 'should return true if isUpdating.email is set', () => {
-			assert.isTrue( isAccountRecoveryEmailActionInProgress( stateDuringUpdating ) );
+			expect( isAccountRecoveryEmailActionInProgress( stateDuringUpdating ) ).toBe( true );
 		} );
 
 		test( 'should return true if isDeleting.email is set', () => {
-			assert.isTrue( isAccountRecoveryEmailActionInProgress( stateDuringDeleting ) );
+			expect( isAccountRecoveryEmailActionInProgress( stateDuringDeleting ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isAccountRecoveryPhoneActionInProgress', () => {
 		test( 'should return true if the whole data is not in place yet', () => {
-			assert.isTrue( isAccountRecoveryPhoneActionInProgress( stateBeforeFetching ) );
+			expect( isAccountRecoveryPhoneActionInProgress( stateBeforeFetching ) ).toBe( true );
 		} );
 
 		test( 'should return true if isUpdating.email is set', () => {
-			assert.isTrue( isAccountRecoveryPhoneActionInProgress( stateDuringUpdating ) );
+			expect( isAccountRecoveryPhoneActionInProgress( stateDuringUpdating ) ).toBe( true );
 		} );
 
 		test( 'should return true if isDeleting.email is set', () => {
-			assert.isTrue( isAccountRecoveryPhoneActionInProgress( stateDuringDeleting ) );
+			expect( isAccountRecoveryPhoneActionInProgress( stateDuringDeleting ) ).toBe( true );
 		} );
 	} );
 
@@ -224,7 +223,7 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isFalse( hasSentAccountRecoveryEmailValidation( state ) );
+			expect( hasSentAccountRecoveryEmailValidation( state ) ).toBe( false );
 		} );
 
 		test( 'should return hasSentValidation.email', () => {
@@ -238,7 +237,7 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isTrue( hasSentAccountRecoveryEmailValidation( state ) );
+			expect( hasSentAccountRecoveryEmailValidation( state ) ).toBe( true );
 		} );
 	} );
 
@@ -252,7 +251,7 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isFalse( hasSentAccountRecoveryPhoneValidation( state ) );
+			expect( hasSentAccountRecoveryPhoneValidation( state ) ).toBe( false );
 		} );
 
 		test( 'should return hasSentValidation.phone', () => {
@@ -266,7 +265,7 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isTrue( hasSentAccountRecoveryPhoneValidation( state ) );
+			expect( hasSentAccountRecoveryPhoneValidation( state ) ).toBe( true );
 		} );
 	} );
 
@@ -280,7 +279,7 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isTrue( isValidatingAccountRecoveryPhone( state ) );
+			expect( isValidatingAccountRecoveryPhone( state ) ).toBe( true );
 		} );
 	} );
 
@@ -301,19 +300,25 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isTrue( shouldPromptAccountRecoveryEmailValidationNotice( state ) );
+			expect( shouldPromptAccountRecoveryEmailValidationNotice( state ) ).toBe( true );
 		} );
 
 		test( 'should not prompt if the settings data is not ready.', () => {
-			assert.isFalse( shouldPromptAccountRecoveryEmailValidationNotice( stateBeforeFetching ) );
+			expect( shouldPromptAccountRecoveryEmailValidationNotice( stateBeforeFetching ) ).toBe(
+				false
+			);
 		} );
 
 		test( 'should not prompt if isUpdating.email is set.', () => {
-			assert.isFalse( shouldPromptAccountRecoveryEmailValidationNotice( stateDuringUpdating ) );
+			expect( shouldPromptAccountRecoveryEmailValidationNotice( stateDuringUpdating ) ).toBe(
+				false
+			);
 		} );
 
 		test( 'should not prompt if isDeleting.email is set.', () => {
-			assert.isFalse( shouldPromptAccountRecoveryEmailValidationNotice( stateDuringDeleting ) );
+			expect( shouldPromptAccountRecoveryEmailValidationNotice( stateDuringDeleting ) ).toBe(
+				false
+			);
 		} );
 	} );
 
@@ -339,19 +344,25 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isTrue( shouldPromptAccountRecoveryPhoneValidationNotice( state ) );
+			expect( shouldPromptAccountRecoveryPhoneValidationNotice( state ) ).toBe( true );
 		} );
 
 		test( 'should not prompt if the settings data is not ready.', () => {
-			assert.isFalse( shouldPromptAccountRecoveryPhoneValidationNotice( stateBeforeFetching ) );
+			expect( shouldPromptAccountRecoveryPhoneValidationNotice( stateBeforeFetching ) ).toBe(
+				false
+			);
 		} );
 
 		test( 'should not prompt if isUpdating.phone is set.', () => {
-			assert.isFalse( shouldPromptAccountRecoveryPhoneValidationNotice( stateDuringUpdating ) );
+			expect( shouldPromptAccountRecoveryPhoneValidationNotice( stateDuringUpdating ) ).toBe(
+				false
+			);
 		} );
 
 		test( 'should not prompt if isDeleting.phone is set.', () => {
-			assert.isFalse( shouldPromptAccountRecoveryPhoneValidationNotice( stateDuringDeleting ) );
+			expect( shouldPromptAccountRecoveryPhoneValidationNotice( stateDuringDeleting ) ).toBe(
+				false
+			);
 		} );
 	} );
 } );

--- a/client/state/account-recovery/test/reducer.js
+++ b/client/state/account-recovery/test/reducer.js
@@ -1,4 +1,3 @@
-import { assert } from 'chai';
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH,
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
@@ -12,7 +11,7 @@ describe( '#account-recovery/isFetchingSettings reducer :', () => {
 			type: ACCOUNT_RECOVERY_SETTINGS_FETCH,
 		} );
 
-		assert.isTrue( state.isFetchingSettings );
+		expect( state.isFetchingSettings ).toBe( true );
 	} );
 
 	test( 'should unset isFetchingSettings flag on success.', () => {
@@ -26,7 +25,7 @@ describe( '#account-recovery/isFetchingSettings reducer :', () => {
 			},
 		} );
 
-		assert.isFalse( state.isFetchingSettings );
+		expect( state.isFetchingSettings ).toBe( false );
 	} );
 
 	test( 'should unset isFetchingSettings flag on failure.', () => {
@@ -34,6 +33,6 @@ describe( '#account-recovery/isFetchingSettings reducer :', () => {
 			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
 		} );
 
-		assert.isFalse( state.isFetchingSettings );
+		expect( state.isFetchingSettings ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As we've been moving towards canonically using `jest` as our primary unit testing platform, we're slowly moving away from `chai`. 

This PR refactors the account recovery state tests to use `jest` instead of `chai`.  We also use the opportunity to refactor away from `sinon` in favor of the built-in jest mocking functionality.

Some of the legwork here has been done with codemods, but I had to do a few more additional changes manually due to the added complexity of the test helpers.

#### Testing instructions

Verify all tests pass: `yarn run test-client client/state/account-recovery`