### PR TITLE
Marketplace: check for preinstalled plugins by slug.

### DIFF
--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -1,0 +1,9 @@
+export const PREINSTALLED_PLUGINS = [
+	'jetpack',
+	'akismet',
+	'vaultpress',
+	'gutenberg',
+	'full-site-editing',
+	'layout-grid',
+	'page-optimize',
+];

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -26,6 +26,7 @@ import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-featur
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { PREINSTALLED_PLUGINS } from '../constants';
 import { PluginCustomDomainDialog } from '../plugin-custom-domain-dialog';
 import { PluginPrice, getPeriodVariationValue } from '../plugin-price';
 import USPS from './usps';
@@ -115,6 +116,18 @@ const PluginDetailsCTA = ( {
 	if ( isPluginInstalledOnsite ) {
 		// Check if already instlaled on the site
 		return null;
+	}
+
+	// If we cannot retrieve plugin status through jetpack ( ! isJetpack ) and plugin is preinstalled.
+	if ( ! isJetpack && PREINSTALLED_PLUGINS.includes( plugin.slug ) ) {
+		return (
+			<div className="plugin-details-CTA__container">
+				<div className="plugin-details-CTA__price">{ translate( 'Free' ) }</div>
+				<span className="plugin-details-CTA__preinstalled">
+					{ plugin.name + translate( ' is automatically managed for you.' ) }
+				</span>
+			</div>
+		);
 	}
 
 	return (

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -52,6 +52,11 @@
 	color: var( --studio-gray-50 );
 }
 
+.plugin-details-CTA__preinstalled {
+	width: 100%;
+	margin-bottom: 20px;
+}
+
 .plugin-details-CTA__install {
 	margin-bottom: 20px;
 

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -21,11 +21,10 @@ import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/st
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { PREINSTALLED_PLUGINS } from '../constants';
 import { PluginsBrowserElementVariant } from './types';
 
 import './style.scss';
-
-const PREINSTALLED_PLUGINS = [ 'jetpack', 'akismet', 'vaultpress' ];
 
 const PluginsBrowserListElement = ( props ) => {
 	const {

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -25,7 +25,7 @@ import { PluginsBrowserElementVariant } from './types';
 
 import './style.scss';
 
-const PREINSTALLED_PLUGINS = [ 'Jetpack by WordPress.com', 'Akismet', 'VaultPress' ];
+const PREINSTALLED_PLUGINS = [ 'jetpack', 'akismet', 'vaultpress' ];
 
 const PluginsBrowserListElement = ( props ) => {
 	const {
@@ -89,7 +89,7 @@ const PluginsBrowserListElement = ( props ) => {
 			return false;
 		}
 
-		return ! isJetpack && PREINSTALLED_PLUGINS.includes( plugin.name );
+		return ! isJetpack && PREINSTALLED_PLUGINS.includes( plugin.slug );
 	}, [ isJetpack, site, plugin ] );
 
 	const isUntestedVersion = useMemo( () => {

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -1,3 +1,4 @@
+import { FEATURE_INSTALL_PLUGINS } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -18,6 +19,7 @@ import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import { getSitesWithPlugin, getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
+import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -215,19 +217,23 @@ const InstalledInOrPricing = ( {
 	const isPluginAtive = useSelector( ( state ) =>
 		getPluginOnSites( state, [ selectedSiteId ], plugin.slug )
 	)?.active;
+	const pluginInstallationNotAllowed = useSelector(
+		( state ) => ! hasActiveSiteFeature( state, selectedSiteId, FEATURE_INSTALL_PLUGINS )
+	);
+	const active = ( pluginInstallationNotAllowed && isWpcomPreinstalled ) || isPluginAtive;
 
 	let checkmarkColorClass = 'checkmark--active';
 
 	if ( ( sitesWithPlugin && sitesWithPlugin.length > 0 ) || isWpcomPreinstalled ) {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		if ( selectedSiteId ) {
-			checkmarkColorClass = isPluginAtive ? 'checkmark--active' : 'checkmark--inactive';
+			checkmarkColorClass = active ? 'checkmark--active' : 'checkmark--inactive';
 		}
 		return (
 			<div className="plugins-browser-item__installed-and-active-container">
 				<div className="plugins-browser-item__installed ">
 					<Gridicon icon="checkmark" className={ checkmarkColorClass } size={ 14 } />
-					{ isWpcomPreinstalled || currentSites?.length === 1
+					{ ( pluginInstallationNotAllowed && isWpcomPreinstalled ) || currentSites?.length === 1
 						? translate( 'Installed' )
 						: translate( 'Installed on %d site', 'Installed on %d sites', {
 								args: [ sitesWithPlugin.length ],
@@ -236,8 +242,8 @@ const InstalledInOrPricing = ( {
 				</div>
 				{ selectedSiteId && (
 					<div className="plugins-browser-item__active">
-						<Badge type={ isPluginAtive ? 'success' : 'info' }>
-							{ isPluginAtive ? translate( 'Active' ) : translate( 'Inactive' ) }
+						<Badge type={ active ? 'success' : 'info' }>
+							{ active ? translate( 'Active' ) : translate( 'Inactive' ) }
 						</Badge>
 					</div>
 				) }

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -1,4 +1,3 @@
-import { FEATURE_INSTALL_PLUGINS } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -19,7 +18,6 @@ import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import { getSitesWithPlugin, getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
 import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
-import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -217,10 +215,7 @@ const InstalledInOrPricing = ( {
 	const isPluginAtive = useSelector( ( state ) =>
 		getPluginOnSites( state, [ selectedSiteId ], plugin.slug )
 	)?.active;
-	const pluginInstallationNotAllowed = useSelector(
-		( state ) => ! hasActiveSiteFeature( state, selectedSiteId, FEATURE_INSTALL_PLUGINS )
-	);
-	const active = ( pluginInstallationNotAllowed && isWpcomPreinstalled ) || isPluginAtive;
+	const active = isWpcomPreinstalled || isPluginAtive;
 
 	let checkmarkColorClass = 'checkmark--active';
 
@@ -233,7 +228,7 @@ const InstalledInOrPricing = ( {
 			<div className="plugins-browser-item__installed-and-active-container">
 				<div className="plugins-browser-item__installed ">
 					<Gridicon icon="checkmark" className={ checkmarkColorClass } size={ 14 } />
-					{ ( pluginInstallationNotAllowed && isWpcomPreinstalled ) || currentSites?.length === 1
+					{ isWpcomPreinstalled || currentSites?.length === 1
 						? translate( 'Installed' )
 						: translate( 'Installed on %d site', 'Installed on %d sites', {
 								args: [ sitesWithPlugin.length ],


### PR DESCRIPTION
- [x] move array with `slug` constants to a more central file
- [x] reuse these constants in plugin details page
- [x] make sure to show these plugins as installed and active. We might also need to check for the ~~current plan~~ site features active.

#### Changes proposed in this Pull Request

* check preinstalled plugins by `slug`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* search for `'jetpack','akismet','vaultpress','gutenberg','full-site-editing','layout-grid','page-optimize'`
* make sure that these plugins appear as installed and active in plugin browser list and plugin details page

|Before | After|
|-------|------|
|![CleanShot 2022-05-13 at 17 04 21@2x](https://user-images.githubusercontent.com/12430020/168300954-4ddace55-a9ef-4d37-b2b9-1f14d6ae50ef.png)|![CleanShot 2022-05-13 at 17 05 09@2x](https://user-images.githubusercontent.com/12430020/168301118-2a220378-6e02-4695-8f43-2fab442fc594.png)|
|<img width="1084" alt="CleanShot 2022-05-18 at 16 20 23@2x" src="https://user-images.githubusercontent.com/12430020/169048392-230894c3-a44f-4422-a18c-8bc3c2b679ee.png">|<img width="1124" alt="CleanShot 2022-05-18 at 16 20 35@2x" src="https://user-images.githubusercontent.com/12430020/169048438-d1bc2da7-92e6-45ab-93c4-1b39deafb75c.png">|

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1652448293562329-slack-C029JEQRVRT