### PR TITLE
Help Center: Allow forum ticket with no site

### DIFF
--- a/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
+++ b/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
@@ -8,6 +8,7 @@ type ForumTopic = {
 	subject: string;
 	locale: string;
 	hideInfo: boolean;
+	userDeclaredSiteUrl?: string;
 };
 
 type Response = {
@@ -15,37 +16,41 @@ type Response = {
 };
 
 export function useSubmitForumsMutation() {
-	return useMutation( ( { site, message, subject, locale, hideInfo }: ForumTopic ) => {
-		const blogHelpMessages = [];
+	return useMutation(
+		( { site, message, subject, locale, hideInfo, userDeclaredSiteUrl }: ForumTopic ) => {
+			const blogHelpMessages = [];
 
-		if ( site ) {
-			if ( site.jetpack ) {
-				blogHelpMessages.push( 'WP.com: Unknown' );
-				blogHelpMessages.push( 'Jetpack: Yes' );
-			} else {
-				blogHelpMessages.push( 'WP.com: Yes' );
+			if ( site ) {
+				if ( site.jetpack ) {
+					blogHelpMessages.push( 'WP.com: Unknown' );
+					blogHelpMessages.push( 'Jetpack: Yes' );
+				} else {
+					blogHelpMessages.push( 'WP.com: Yes' );
+				}
+
+				blogHelpMessages.push( 'Correct account: yes' );
+			} else if ( userDeclaredSiteUrl ) {
+				blogHelpMessages.push( `Self-declared URL: ${ userDeclaredSiteUrl }` );
 			}
 
-			blogHelpMessages.push( 'Correct account: yes' );
+			const forumMessage = message + '\n\n' + blogHelpMessages.join( '\n' );
+
+			const requestData = {
+				subject,
+				message: forumMessage,
+				locale,
+				client: 'help-center',
+				hide_blog_info: hideInfo,
+				blog_id: site?.ID,
+				blog_url: site?.URL,
+			};
+
+			return wpcomRequest< Response >( {
+				path: '/help/forums/support/topics/new',
+				apiVersion: '1.1',
+				method: 'POST',
+				body: requestData,
+			} );
 		}
-
-		const forumMessage = message + '\n\n' + blogHelpMessages.join( '\n' );
-
-		const requestData = {
-			subject,
-			message: forumMessage,
-			locale,
-			client: 'help-center',
-			hide_blog_info: hideInfo,
-			blog_id: site?.ID,
-			blog_url: site?.URL,
-		};
-
-		return wpcomRequest< Response >( {
-			path: '/help/forums/support/topics/new',
-			apiVersion: '1.1',
-			method: 'POST',
-			body: requestData,
-		} );
-	} );
+	);
 }

--- a/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
+++ b/packages/data-stores/src/support-queries/use-submit-forums-topic.ts
@@ -3,7 +3,7 @@ import wpcomRequest from 'wpcom-proxy-request';
 import { SiteDetails } from '../site';
 
 type ForumTopic = {
-	site: SiteDetails;
+	site?: SiteDetails;
 	message: string;
 	subject: string;
 	locale: string;
@@ -16,18 +16,20 @@ type Response = {
 
 export function useSubmitForumsMutation() {
 	return useMutation( ( { site, message, subject, locale, hideInfo }: ForumTopic ) => {
-		const blogHelpMessages = [ message ];
+		const blogHelpMessages = [];
 
-		if ( site.jetpack ) {
-			blogHelpMessages.push( 'WP.com: Unknown' );
-			blogHelpMessages.push( 'Jetpack: Yes' );
-		} else {
-			blogHelpMessages.push( 'WP.com: Yes' );
+		if ( site ) {
+			if ( site.jetpack ) {
+				blogHelpMessages.push( 'WP.com: Unknown' );
+				blogHelpMessages.push( 'Jetpack: Yes' );
+			} else {
+				blogHelpMessages.push( 'WP.com: Yes' );
+			}
+
+			blogHelpMessages.push( 'Correct account: yes' );
 		}
 
-		blogHelpMessages.push( 'Correct account: yes' );
-
-		const forumMessage = message + '\n\n' + 'Correct account: yes';
+		const forumMessage = message + '\n\n' + blogHelpMessages.join( '\n' );
 
 		const requestData = {
 			subject,
@@ -35,8 +37,8 @@ export function useSubmitForumsMutation() {
 			locale,
 			client: 'help-center',
 			hide_blog_info: hideInfo,
-			blog_id: site.ID,
-			blog_url: site.URL,
+			blog_id: site?.ID,
+			blog_url: site?.URL,
 		};
 
 		return wpcomRequest< Response >( {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -206,9 +206,9 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 	}
 
 	function handleCTA( event: React.MouseEvent< HTMLButtonElement > ) {
-		if ( supportSite ) {
-			switch ( mode ) {
-				case 'CHAT': {
+		switch ( mode ) {
+			case 'CHAT': {
+				if ( supportSite ) {
 					if ( hasCookies ) {
 						setOpenChat( true );
 						break;
@@ -216,11 +216,11 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 						const popup = openPopup( event );
 						setPopup( popup );
 					}
-					// in chat, we don't need to reset the store here, the Happychat communicator will take care of that
-					// this is to make sure we only reset the store after we communicated everything to Happychat.
-					break;
 				}
-				case 'EMAIL': {
+				break;
+			}
+			case 'EMAIL': {
+				if ( supportSite ) {
 					const ticketMeta = [
 						'Site I need help with: ' + supportSite?.URL,
 						'Plan: ' + supportSite?.plan?.product_slug,
@@ -238,21 +238,22 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 						setContactSuccess( true );
 						resetStore();
 					} );
-					break;
 				}
-				case 'FORUM': {
-					submitTopic( {
-						site: supportSite,
-						message: message ?? '',
-						subject: subject ?? '',
-						locale,
-						hideInfo: hideSiteInfo,
-					} ).then( ( response ) => {
-						setForumTopicUrl( response.topic_URL );
-						resetStore();
-					} );
-					break;
-				}
+				break;
+			}
+			case 'FORUM': {
+				submitTopic( {
+					site: supportSite,
+					message: message ?? '',
+					subject: subject ?? '',
+					locale,
+					hideInfo: hideSiteInfo,
+					userDeclaredSiteUrl,
+				} ).then( ( response ) => {
+					setForumTopicUrl( response.topic_URL );
+					resetStore();
+				} );
+				break;
 			}
 		}
 	}
@@ -375,7 +376,7 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 			) }
 			<section>
 				<Button
-					disabled={ isLoading || ! supportSite || ! message }
+					disabled={ isLoading || ( mode !== 'FORUM' && ! supportSite ) || ! message }
 					onClick={ handleCTA }
 					primary
 					className="help-center-contact-form__site-picker-cta"

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -293,6 +293,10 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 		);
 	};
 
+	const isCTADisabled = () => {
+		return isLoading || ( mode !== 'FORUM' && ! supportSite ) || ! message;
+	};
+
 	return (
 		<main className="help-center-contact-form">
 			<header>
@@ -376,7 +380,7 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 			) }
 			<section>
 				<Button
-					disabled={ isLoading || ( mode !== 'FORUM' && ! supportSite ) || ! message }
+					disabled={ isCTADisabled() }
 					onClick={ handleCTA }
 					primary
 					className="help-center-contact-form__site-picker-cta"


### PR DESCRIPTION
Submit forum ticket without site

#### Changes proposed in this Pull Request

Free users can create a forum ticket even without writing a valid wpcom site in Other sites => Site Address

Also changed the ticket message code, as it was not using the strings correctly

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* checkout
* `yarn dev --sync` from ETK
* open the help center as a free user
* try to submit a ticket without stating a site address or putting a not wpcom
* verify that the ticket is created
* remember to trash it

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63557
Fixes #63557