### PR TITLE
State: Refactor themes tests away from `chai` and `sinon`

### DIFF
--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -1,5 +1,3 @@
-import { expect } from 'chai';
-import sinon from 'sinon';
 // Importing `jest-fetch-mock` adds a jest-friendly `fetch` polyfill to the global scope.
 import 'jest-fetch-mock';
 import ThemeQueryManager from 'calypso/lib/query-manager/theme';
@@ -55,20 +53,39 @@ import {
 	receiveRecommendedThemes,
 } from '../actions';
 
+expect.extend( {
+	toMatchFunction( received, fn ) {
+		if ( received.toString() === fn.toString() ) {
+			return {
+				message: () => 'Expected functions to match.',
+				pass: true,
+			};
+		}
+
+		return {
+			message: () => 'Expected functions to not match.',
+			pass: false,
+		};
+	},
+	toBeTruthy( received ) {
+		if ( received ) {
+			return {
+				message: () => 'Expected value to be truthy.',
+				pass: true,
+			};
+		}
+
+		return {
+			message: () => 'Expected value to not be truthy.',
+			pass: false,
+		};
+	},
+} );
+
 describe( 'actions', () => {
-	const spy = sinon.spy();
-
-	function isEqualFunction( f1, f2 ) {
-		// TODO: Also compare params!
-		return f1.toString() === f2.toString();
-	}
-
-	function matchFunction( fn ) {
-		return sinon.match( ( value ) => isEqualFunction( value, fn ) );
-	}
-
+	let spy;
 	beforeEach( () => {
-		spy.resetHistory();
+		spy = jest.fn();
 	} );
 
 	describe( '#receiveTheme()', () => {
@@ -87,7 +104,7 @@ describe( 'actions', () => {
 			const theme = { id: 'twentysixteen', name: 'Twenty Sixteen' };
 			receiveTheme( theme, 'wpcom' )( spy, getState );
 
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toBeCalledWith( {
 				type: THEMES_REQUEST_SUCCESS,
 				themes: [ { id: 'twentysixteen', name: 'Twenty Sixteen' } ],
 				siteId: 'wpcom',
@@ -123,7 +140,7 @@ describe( 'actions', () => {
 
 			test( 'should dispatch themes request success action', () => {
 				receiveThemes( themes, 'wpcom', query, 4 )( spy, getState );
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEMES_REQUEST_SUCCESS,
 					siteId: 'wpcom',
 					query,
@@ -141,7 +158,7 @@ describe( 'actions', () => {
 
 			test( 'should dispatch themes request success action', () => {
 				receiveThemes( themes, 77203074, {} )( spy, getState );
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEMES_REQUEST_SUCCESS,
 					siteId: 77203074,
 					query: {},
@@ -170,12 +187,12 @@ describe( 'actions', () => {
 			test( 'should dispatch fetch action when thunk triggered', () => {
 				requestThemes( 'wpcom' )( spy );
 
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEMES_REQUEST,
 					siteId: 'wpcom',
 					query: {},
 				} );
-				expect( nockScope.isDone() ).to.be.true;
+				expect( nockScope.isDone() ).toBe( true );
 			} );
 		} );
 
@@ -200,7 +217,7 @@ describe( 'actions', () => {
 			test( 'should dispatch fetch action when thunk triggered', () => {
 				requestThemes( 77203074 )( spy );
 
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEMES_REQUEST,
 					siteId: 77203074,
 					query: {},
@@ -209,11 +226,11 @@ describe( 'actions', () => {
 
 			test( 'should dispatch fail action when request fails', () => {
 				return requestThemes( 1916284 )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toBeCalledWith( {
 						type: THEMES_REQUEST_FAILURE,
 						siteId: 1916284,
 						query: {},
-						error: sinon.match( { message: 'User cannot access this private blog.' } ),
+						error: expect.objectContaining( { message: 'User cannot access this private blog.' } ),
 					} );
 				} );
 			} );
@@ -243,7 +260,7 @@ describe( 'actions', () => {
 			test( 'should dispatch fetch action when thunk triggered', () => {
 				requestThemes( 'wporg' )( spy );
 
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEMES_REQUEST,
 					siteId: 'wporg',
 					query: {},
@@ -269,7 +286,7 @@ describe( 'actions', () => {
 			test( 'should dispatch request action when thunk triggered', () => {
 				requestTheme( 'twentysixteen', 'wpcom' )( spy );
 
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEME_REQUEST,
 					siteId: 'wpcom',
 					themeId: 'twentysixteen',
@@ -281,7 +298,7 @@ describe( 'actions', () => {
 					'twentysixteen',
 					'wpcom'
 				)( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toBeCalledWith( {
 						type: THEME_REQUEST_SUCCESS,
 						siteId: 'wpcom',
 						themeId: 'twentysixteen',
@@ -294,11 +311,11 @@ describe( 'actions', () => {
 					'twentyumpteen',
 					'wpcom'
 				)( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toBeCalledWith( {
 						type: THEME_REQUEST_FAILURE,
 						siteId: 'wpcom',
 						themeId: 'twentyumpteen',
-						error: sinon.match( { message: 'Unknown theme' } ),
+						error: expect.objectContaining( { message: 'Unknown theme' } ),
 					} );
 				} );
 			} );
@@ -320,7 +337,7 @@ describe( 'actions', () => {
 			test( 'should dispatch request action when thunk triggered', () => {
 				requestTheme( 'twentyfifteen', 77203074 )( spy );
 
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEME_REQUEST,
 					siteId: 77203074,
 					themeId: 'twentyfifteen',
@@ -332,7 +349,7 @@ describe( 'actions', () => {
 					'twentyfifteen',
 					77203074
 				)( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toBeCalledWith( {
 						type: THEME_REQUEST_SUCCESS,
 						siteId: 77203074,
 						themeId: 'twentyfifteen',
@@ -345,11 +362,11 @@ describe( 'actions', () => {
 					'twentyumpteen',
 					77203074
 				)( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toBeCalledWith( {
 						type: THEME_REQUEST_FAILURE,
 						siteId: 77203074,
 						themeId: 'twentyumpteen',
-						error: sinon.match( { message: 'Unknown theme' } ),
+						error: expect.objectContaining( { message: 'Unknown theme' } ),
 					} );
 				} );
 			} );
@@ -377,7 +394,7 @@ describe( 'actions', () => {
 			test( 'should dispatch request action when thunk triggered', () => {
 				requestTheme( 'twentyseventeen', 'wporg' )( spy );
 
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEME_REQUEST,
 					siteId: 'wporg',
 					themeId: 'twentyseventeen',
@@ -389,7 +406,7 @@ describe( 'actions', () => {
 					'twentyseventeen',
 					'wporg'
 				)( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toBeCalledWith( {
 						type: THEME_REQUEST_SUCCESS,
 						siteId: 'wporg',
 						themeId: 'twentyseventeen',
@@ -402,11 +419,11 @@ describe( 'actions', () => {
 					'twentyumpteen',
 					'wporg'
 				)( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toBeCalledWith( {
 						type: THEME_REQUEST_FAILURE,
 						siteId: 'wporg',
 						themeId: 'twentyumpteen',
-						error: sinon.match( 'not found' ),
+						error: 'Theme not found',
 					} );
 				} );
 			} );
@@ -475,7 +492,7 @@ describe( 'actions', () => {
 		describe( 'when switching between any theme', () => {
 			test( 'should refresh the admin bar', () => {
 				themeActivated( 'pub/mayland-blocks', 2211667 )( spy, fakeGetState );
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: 'ADMIN_MENU_REQUEST',
 					siteId: 2211667,
 				} );
@@ -508,14 +525,14 @@ describe( 'actions', () => {
 				siteId: 2211667,
 			};
 			themeActivated( 'pub/twentysixteen', 2211667 )( spy, fakeGetState );
-			expect( spy ).to.have.been.calledWith( expectedActivationSuccess );
+			expect( spy ).toBeCalledWith( expectedActivationSuccess );
 		} );
 	} );
 
 	describe( '#clearActivated()', () => {
 		test( 'should return an action object', () => {
 			const action = clearActivated( 22116677 );
-			expect( action ).to.eql( {
+			expect( action ).toEqual( {
 				type: THEME_CLEAR_ACTIVATED,
 				siteId: 22116677,
 			} );
@@ -546,7 +563,7 @@ describe( 'actions', () => {
 		test( 'should dispatch request action when thunk is triggered', () => {
 			activateTheme( 'twentysixteen', 2211667 )( spy );
 
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toBeCalledWith( {
 				type: THEME_ACTIVATE,
 				siteId: 2211667,
 				themeId: 'twentysixteen',
@@ -559,13 +576,13 @@ describe( 'actions', () => {
 				2211667,
 				trackingData
 			)( spy ).then( () => {
-				expect( spy.secondCall.args[ 0 ].name ).to.equal( 'themeActivatedThunk' );
+				expect( spy.mock.calls[ 1 ][ 0 ].name ).toEqual( 'themeActivatedThunk' );
 			} );
 		} );
 
 		test( 'should dispatch theme activation failure action when request completes', () => {
 			const themeActivationFailure = {
-				error: sinon.match( { message: 'The specified theme was not found' } ),
+				error: expect.objectContaining( { message: 'The specified theme was not found' } ),
 				siteId: 2211667,
 				themeId: 'badTheme',
 				type: THEME_ACTIVATE_FAILURE,
@@ -576,14 +593,14 @@ describe( 'actions', () => {
 				2211667,
 				trackingData
 			)( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( themeActivationFailure );
+				expect( spy ).toBeCalledWith( themeActivationFailure );
 			} );
 		} );
 	} );
 
 	describe( '#installAndActivateTheme', () => {
-		const stub = sinon.stub();
-		stub.returns(
+		const stub = jest.fn();
+		stub.mockReturnValue(
 			new Promise( ( res ) => {
 				res();
 			} )
@@ -595,11 +612,11 @@ describe( 'actions', () => {
 					'karuna-wpcom',
 					2211667
 				)( stub ).then( () => {
-					expect( stub ).to.have.been.calledWith(
-						matchFunction( installTheme( 'karuna-wpcom', 2211667 ) )
+					expect( stub ).toBeCalledWith(
+						expect.toMatchFunction( installTheme( 'karuna-wpcom', 2211667 ) )
 					);
-					expect( stub ).to.have.been.calledWith(
-						matchFunction( activateTheme( 'karuna-wpcom', 2211667 ) )
+					expect( stub ).toBeCalledWith(
+						expect.toMatchFunction( activateTheme( 'karuna-wpcom', 2211667 ) )
 					);
 					done();
 				} );
@@ -608,15 +625,14 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#activate', () => {
-		const stub = sinon.stub();
-		stub.returns(
+		const stub = jest.fn();
+		stub.mockReturnValue(
 			new Promise( ( res ) => {
 				res();
 			} )
 		);
 
 		describe( 'on a WordPress.com site', () => {
-			stub.resetHistory();
 			const fakeGetState = () => ( {
 				sites: {
 					items: {
@@ -634,11 +650,11 @@ describe( 'actions', () => {
 			test( 'should dispatch (only) activateTheme() and pass the unsuffixed themeId', () => {
 				return new Promise( ( done ) => {
 					activate( 'karuna', 77203074 )( stub, fakeGetState ).then( () => {
-						expect( stub ).to.have.been.calledWith(
-							matchFunction( activateTheme( 'karuna', 77203074 ) )
+						expect( stub ).toBeCalledWith(
+							expect.toMatchFunction( activateTheme( 'karuna', 77203074 ) )
 						);
-						expect( stub ).to.not.have.been.calledWith(
-							matchFunction( installAndActivateTheme( 'karuna-wpcom', 77203074 ) )
+						expect( stub ).not.toBeCalledWith(
+							expect.toMatchFunction( installAndActivateTheme( 'karuna-wpcom', 77203074 ) )
 						);
 						done();
 					} );
@@ -657,7 +673,6 @@ describe( 'actions', () => {
 				},
 			};
 			describe( 'if the theme is already installed', () => {
-				stub.resetHistory();
 				const fakeGetState = () => ( {
 					...sitesState,
 					themes: {
@@ -671,11 +686,11 @@ describe( 'actions', () => {
 				test( 'should dispatch (only) activateTheme() and pass the unsuffixed themeId', () => {
 					return new Promise( ( done ) => {
 						activate( 'karuna', 2211667 )( stub, fakeGetState ).then( () => {
-							expect( stub ).to.have.been.calledWith(
-								matchFunction( activateTheme( 'karuna', 2211667 ) )
+							expect( stub ).toBeCalledWith(
+								expect.toMatchFunction( activateTheme( 'karuna', 2211667 ) )
 							);
-							expect( stub ).to.not.have.been.calledWith(
-								matchFunction( installAndActivateTheme( 'karuna-wpcom', 2211667 ) )
+							expect( stub ).not.toBeCalledWith(
+								expect.toMatchFunction( installAndActivateTheme( 'karuna-wpcom', 2211667 ) )
 							);
 							done();
 						} );
@@ -684,7 +699,6 @@ describe( 'actions', () => {
 			} );
 
 			describe( "if the theme isn't installed", () => {
-				stub.resetHistory();
 				const fakeGetState = () => ( {
 					...sitesState,
 					themes: {
@@ -694,11 +708,11 @@ describe( 'actions', () => {
 				test( 'should dispatch (only) installAndActivateTheme() and pass the suffixed themeId', () => {
 					return new Promise( ( done ) => {
 						activate( 'karuna', 2211667 )( stub, fakeGetState ).then( () => {
-							expect( stub ).to.not.have.been.calledWith(
-								matchFunction( activate( 'karuna', 2211667 ) )
+							expect( stub ).not.toBeCalledWith(
+								expect.toMatchFunction( activate( 'karuna', 2211667 ) )
 							);
-							expect( stub ).to.have.been.calledWith(
-								matchFunction( installAndActivateTheme( 'karuna-wpcom', 2211667 ) )
+							expect( stub ).toBeCalledWith(
+								expect.toMatchFunction( installAndActivateTheme( 'karuna-wpcom', 2211667 ) )
 							);
 							done();
 						} );
@@ -776,7 +790,7 @@ describe( 'actions', () => {
 		test( 'should dispatch active theme request action when triggered', () => {
 			requestActiveTheme( 2211667 )( spy );
 
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toBeCalledWith( {
 				type: ACTIVE_THEME_REQUEST,
 				siteId: 2211667,
 			} );
@@ -785,7 +799,7 @@ describe( 'actions', () => {
 		describe( 'when request completes successfully', () => {
 			test( 'should dispatch active theme request success action', () => {
 				return requestActiveTheme( 2211667 )( spy, fakeGetState ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toBeCalledWith( {
 						type: ACTIVE_THEME_REQUEST_SUCCESS,
 						siteId: 2211667,
 						theme: successResponse,
@@ -796,10 +810,10 @@ describe( 'actions', () => {
 
 		test( 'should dispatch active theme request failure action when request completes', () => {
 			return requestActiveTheme( 666 )( spy, fakeGetState ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: ACTIVE_THEME_REQUEST_FAILURE,
 					siteId: 666,
-					error: sinon.match( { message: 'Unknown blog' } ),
+					error: expect.objectContaining( { message: 'Unknown blog' } ),
 				} );
 			} );
 		} );
@@ -830,7 +844,7 @@ describe( 'actions', () => {
 				1,
 				'themes'
 			)( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEME_TRANSFER_STATUS_RECEIVE,
 					siteId,
 					transferId: 1,
@@ -849,7 +863,7 @@ describe( 'actions', () => {
 				10,
 				25
 			)( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEME_TRANSFER_STATUS_FAILURE,
 					siteId,
 					transferId: 2,
@@ -861,8 +875,8 @@ describe( 'actions', () => {
 		test( 'should dispatch status update', async () => {
 			await pollThemeTransferStatus( siteId, 3, 'themes', 20 )( spy );
 			// Two 'progress' then a 'complete'
-			expect( spy ).to.have.callCount( 4 );
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toBeCalledTimes( 4 );
+			expect( spy ).toBeCalledWith( {
 				type: THEME_TRANSFER_STATUS_RECEIVE,
 				siteId: siteId,
 				transferId: 3,
@@ -870,7 +884,7 @@ describe( 'actions', () => {
 				message: 'in progress',
 				themeId: undefined,
 			} );
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toBeCalledWith( {
 				type: THEME_TRANSFER_STATUS_RECEIVE,
 				siteId: siteId,
 				transferId: 3,
@@ -882,12 +896,14 @@ describe( 'actions', () => {
 
 		test( 'should dispatch failure on receipt of error', async () => {
 			await pollThemeTransferStatus( siteId, 4, 'themes' )( spy );
-			expect( spy ).to.have.been.calledWithMatch( {
-				type: THEME_TRANSFER_STATUS_FAILURE,
-				siteId,
-				transferId: 4,
-			} );
-			expect( spy ).to.have.been.calledWith( sinon.match.has( 'error', sinon.match.truthy ) );
+			expect( spy ).toBeCalledWith(
+				expect.objectContaining( {
+					type: THEME_TRANSFER_STATUS_FAILURE,
+					siteId,
+					transferId: 4,
+				} )
+			);
+			expect( spy ).toBeCalledWith( expect.objectContaining( { error: expect.toBeTruthy() } ) );
 		} );
 	} );
 
@@ -904,34 +920,40 @@ describe( 'actions', () => {
 
 		test( 'should dispatch success', () => {
 			return initiateThemeTransfer( siteId )( spy ).then( () => {
-				expect( spy ).to.have.been.calledThrice;
+				expect( spy ).toBeCalledTimes( 3 );
 
-				expect( spy ).to.have.been.calledWith( {
-					meta: sinon.match.object,
-					type: THEME_TRANSFER_INITIATE_REQUEST,
-					siteId,
-				} );
+				expect( spy ).toBeCalledWith(
+					expect.objectContaining( {
+						meta: expect.objectContaining( {} ),
+						type: THEME_TRANSFER_INITIATE_REQUEST,
+						siteId,
+					} )
+				);
 
-				expect( spy ).to.have.been.calledWith( {
-					meta: sinon.match.object,
-					type: THEME_TRANSFER_INITIATE_SUCCESS,
-					siteId,
-					transferId: 1,
-				} );
+				expect( spy ).toBeCalledWith(
+					expect.objectContaining( {
+						meta: expect.objectContaining( {} ),
+						type: THEME_TRANSFER_INITIATE_SUCCESS,
+						siteId,
+						transferId: 1,
+					} )
+				);
 
-				expect( spy ).to.have.been.calledWith( sinon.match.func );
+				expect( spy ).toBeCalledWith( expect.any( Function ) );
 			} );
 		} );
 		test( 'should dispatch failure on error', () => {
 			/* eslint-disable jest/no-conditional-expect */
 			return initiateThemeTransfer( siteId )( spy ).catch( () => {
-				expect( spy ).to.have.been.calledOnce;
+				expect( spy ).toBeCalledTimes( 1 );
 
-				expect( spy ).to.have.been.calledWithMatch( {
-					type: THEME_TRANSFER_INITIATE_FAILURE,
-					siteId,
-				} );
-				expect( spy ).to.have.been.calledWith( sinon.match.has( 'error', sinon.match.truthy ) );
+				expect( spy ).toBeCalledWith(
+					expect.objectContaining( {
+						type: THEME_TRANSFER_INITIATE_FAILURE,
+						siteId,
+					} )
+				);
+				expect( spy ).toBeCalledWith( expect.objectContaining( { error: expect.toBeTruthy() } ) );
 			} );
 			/* eslint-enable jest/no-conditional-expect */
 		} );
@@ -995,7 +1017,7 @@ describe( 'actions', () => {
 		test( 'should dispatch install theme request action when triggered', () => {
 			installTheme( 'karuna-wpcom', 2211667 )( spy, getState );
 
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toBeCalledWith( {
 				type: THEME_INSTALL,
 				siteId: 2211667,
 				themeId: 'karuna-wpcom',
@@ -1004,7 +1026,7 @@ describe( 'actions', () => {
 
 		test( 'should dispatch wpcom theme install request success action when request completes', () => {
 			return installTheme( 'karuna-wpcom', 2211667 )( spy, getState ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEME_INSTALL_SUCCESS,
 					siteId: 2211667,
 					themeId: 'karuna-wpcom',
@@ -1014,22 +1036,22 @@ describe( 'actions', () => {
 
 		test( 'should dispatch wpcom theme install request failure action when theme was not found', () => {
 			return installTheme( 'typist-wpcom', 2211667 )( spy, getState ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEME_INSTALL_FAILURE,
 					siteId: 2211667,
 					themeId: 'typist-wpcom',
-					error: sinon.match( { message: 'Problem downloading theme' } ),
+					error: expect.objectContaining( { message: 'Problem downloading theme' } ),
 				} );
 			} );
 		} );
 
 		test( 'should dispatch wpcom theme install request failure action when theme is already installed', () => {
 			return installTheme( 'pinboard-wpcom', 2211667 )( spy, getState ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEME_INSTALL_FAILURE,
 					siteId: 2211667,
 					themeId: 'pinboard-wpcom',
-					error: sinon.match( { message: 'The theme is already installed' } ),
+					error: expect.objectContaining( { message: 'The theme is already installed' } ),
 				} );
 			} );
 		} );
@@ -1049,7 +1071,7 @@ describe( 'actions', () => {
 				'karuna',
 				2211667
 			)( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: THEME_DELETE_SUCCESS,
 					siteId: 2211667,
 					themeId: 'karuna',
@@ -1063,19 +1085,21 @@ describe( 'actions', () => {
 				'blahblah',
 				2211667
 			)( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: THEME_DELETE_FAILURE,
-					siteId: 2211667,
-					themeId: 'blahblah',
-					error: sinon.match.truthy,
-				} );
+				expect( spy ).toBeCalledWith(
+					expect.objectContaining( {
+						type: THEME_DELETE_FAILURE,
+						siteId: 2211667,
+						themeId: 'blahblah',
+						error: expect.toBeTruthy(),
+					} )
+				);
 			} );
 		} );
 	} );
 
 	describe( '#installAndTryAndCustomizeTheme', () => {
-		const stub = sinon.stub();
-		stub.returns(
+		const stub = jest.fn();
+		stub.mockReturnValue(
 			new Promise( ( res ) => {
 				res();
 			} )
@@ -1087,11 +1111,11 @@ describe( 'actions', () => {
 					'karuna-wpcom',
 					2211667
 				)( stub ).then( () => {
-					expect( stub ).to.have.been.calledWith(
-						matchFunction( installTheme( 'karuna-wpcom', 2211667 ) )
+					expect( stub ).toBeCalledWith(
+						expect.toMatchFunction( installTheme( 'karuna-wpcom', 2211667 ) )
 					);
-					expect( stub ).to.have.been.calledWith(
-						matchFunction( tryAndCustomizeTheme( 'karuna-wpcom', 2211667 ) )
+					expect( stub ).toBeCalledWith(
+						expect.toMatchFunction( tryAndCustomizeTheme( 'karuna-wpcom', 2211667 ) )
 					);
 					done();
 				} );
@@ -1100,15 +1124,14 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#tryAndCustomize', () => {
-		const stub = sinon.stub();
-		stub.returns(
+		const stub = jest.fn();
+		stub.mockReturnValue(
 			new Promise( ( res ) => {
 				res();
 			} )
 		);
 
 		describe( 'on a WordPress.com site', () => {
-			stub.resetHistory();
 			const fakeGetState = () => ( {
 				sites: {
 					items: {
@@ -1121,11 +1144,11 @@ describe( 'actions', () => {
 			test( 'should dispatch (only) activateTheme() and pass the unsuffixed themeId', () => {
 				return new Promise( ( done ) => {
 					tryAndCustomize( 'karuna', 77203074 )( stub, fakeGetState ).then( () => {
-						expect( stub ).to.have.been.calledWith(
-							matchFunction( tryAndCustomizeTheme( 'karuna', 77203074 ) )
+						expect( stub ).toBeCalledWith(
+							expect.toMatchFunction( tryAndCustomizeTheme( 'karuna', 77203074 ) )
 						);
-						expect( stub ).to.not.have.been.calledWith(
-							matchFunction( installAndTryAndCustomizeTheme( 'karuna-wpcom', 77203074 ) )
+						expect( stub ).not.toBeCalledWith(
+							expect.toMatchFunction( installAndTryAndCustomizeTheme( 'karuna-wpcom', 77203074 ) )
 						);
 						done();
 					} );
@@ -1144,7 +1167,6 @@ describe( 'actions', () => {
 				},
 			};
 			describe( 'if the theme is already installed', () => {
-				stub.resetHistory();
 				const fakeGetState = () => ( {
 					...sitesState,
 					themes: {
@@ -1158,11 +1180,11 @@ describe( 'actions', () => {
 				test( 'should dispatch (only) tryAndCustomizeTheme() and pass the unsuffixed themeId', () => {
 					return new Promise( ( done ) => {
 						tryAndCustomize( 'karuna', 2211667 )( stub, fakeGetState ).then( () => {
-							expect( stub ).to.have.been.calledWith(
-								matchFunction( tryAndCustomizeTheme( 'karuna', 2211667 ) )
+							expect( stub ).toBeCalledWith(
+								expect.toMatchFunction( tryAndCustomizeTheme( 'karuna', 2211667 ) )
 							);
-							expect( stub ).to.not.have.been.calledWith(
-								matchFunction( installAndTryAndCustomizeTheme( 'karuna-wpcom', 2211667 ) )
+							expect( stub ).not.toBeCalledWith(
+								expect.toMatchFunction( installAndTryAndCustomizeTheme( 'karuna-wpcom', 2211667 ) )
 							);
 							done();
 						} );
@@ -1171,7 +1193,6 @@ describe( 'actions', () => {
 			} );
 
 			describe( "if the theme isn't installed", () => {
-				stub.resetHistory();
 				const fakeGetState = () => ( {
 					...sitesState,
 					themes: {
@@ -1181,11 +1202,11 @@ describe( 'actions', () => {
 				test( 'should dispatch (only) installAndTryAndCustomizeTheme() and pass the suffixed themeId', () => {
 					return new Promise( ( done ) => {
 						tryAndCustomize( 'karuna', 2211667 )( stub, fakeGetState ).then( () => {
-							expect( stub ).to.not.have.been.calledWith(
-								matchFunction( tryAndCustomize( 'karuna', 2211667 ) )
+							expect( stub ).not.toBeCalledWith(
+								expect.toMatchFunction( tryAndCustomize( 'karuna', 2211667 ) )
 							);
-							expect( stub ).to.have.been.calledWith(
-								matchFunction( installAndTryAndCustomizeTheme( 'karuna-wpcom', 2211667 ) )
+							expect( stub ).toBeCalledWith(
+								expect.toMatchFunction( installAndTryAndCustomizeTheme( 'karuna-wpcom', 2211667 ) )
 							);
 							done();
 						} );
@@ -1198,7 +1219,7 @@ describe( 'actions', () => {
 	describe( '#requestThemeFilters', () => {
 		test( 'should return THEME_FILTERS_REQUEST action', () => {
 			const action = requestThemeFilters();
-			expect( action ).to.deep.equal( { type: THEME_FILTERS_REQUEST, locale: null } );
+			expect( action ).toEqual( { type: THEME_FILTERS_REQUEST, locale: null } );
 		} );
 	} );
 
@@ -1206,7 +1227,7 @@ describe( 'actions', () => {
 		const filter = 'nonsense-test-filter';
 		test( 'should dispatch fetch action', () => {
 			getRecommendedThemes( filter )( spy );
-			expect( spy ).to.have.been.calledWith( { type: RECOMMENDED_THEMES_FETCH, filter } );
+			expect( spy ).toBeCalledWith( { type: RECOMMENDED_THEMES_FETCH, filter } );
 		} );
 	} );
 
@@ -1215,7 +1236,7 @@ describe( 'actions', () => {
 		const filter = 'test-filter-nonsense';
 		test( 'should dispatch success action with themes as payload', () => {
 			receiveRecommendedThemes( themes, filter )( spy );
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toBeCalledWith( {
 				type: RECOMMENDED_THEMES_SUCCESS,
 				payload: themes,
 				filter,

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -5,7 +5,6 @@ import {
 	PLAN_ECOMMERCE,
 	WPCOM_FEATURES_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
-import { expect } from 'chai';
 import ThemeQueryManager from 'calypso/lib/query-manager/theme';
 import {
 	getTheme,
@@ -111,7 +110,7 @@ describe( 'themes selectors', () => {
 				413
 			);
 
-			expect( theme ).to.be.null;
+			expect( theme ).toBeNull();
 		} );
 
 		test( 'should return the object for the site ID, theme ID pair', () => {
@@ -129,7 +128,7 @@ describe( 'themes selectors', () => {
 				'twentysixteen'
 			);
 
-			expect( theme ).to.equal( twentysixteen );
+			expect( theme ).toEqual( twentysixteen );
 		} );
 	} );
 
@@ -149,7 +148,7 @@ describe( 'themes selectors', () => {
 				'twentysixteen'
 			);
 
-			expect( theme ).to.deep.equal( twentysixteen );
+			expect( theme ).toEqual( twentysixteen );
 		} );
 
 		test( 'with a theme found on WP.org but not on WP.com, should return the object fetched from there', () => {
@@ -179,7 +178,7 @@ describe( 'themes selectors', () => {
 				'twentyseventeen'
 			);
 
-			expect( theme ).to.deep.equal( wporgTheme );
+			expect( theme ).toEqual( wporgTheme );
 		} );
 
 		test( 'with a theme not found on WP.com nor on WP.org, should return the theme object from the given siteId', () => {
@@ -203,7 +202,7 @@ describe( 'themes selectors', () => {
 				'twentyseventeen'
 			);
 
-			expect( theme ).to.deep.equal( jetpackTheme );
+			expect( theme ).toEqual( jetpackTheme );
 		} );
 	} );
 
@@ -219,7 +218,7 @@ describe( 'themes selectors', () => {
 				413
 			);
 
-			expect( error ).to.be.null;
+			expect( error ).toBeNull();
 		} );
 
 		test( 'should return the error object for the site ID, theme ID pair', () => {
@@ -237,7 +236,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( error ).to.equal( 'Request error' );
+			expect( error ).toEqual( 'Request error' );
 		} );
 	} );
 
@@ -253,7 +252,7 @@ describe( 'themes selectors', () => {
 				'twentyfifteen'
 			);
 
-			expect( isRequesting ).to.be.false;
+			expect( isRequesting ).toBe( false );
 		} );
 
 		test( 'should return false if there is no active request for theme for site', () => {
@@ -271,7 +270,7 @@ describe( 'themes selectors', () => {
 				'twentyfifteen'
 			);
 
-			expect( isRequesting ).to.be.false;
+			expect( isRequesting ).toBe( false );
 		} );
 
 		test( 'should return true if there is request ongoing for theme for site', () => {
@@ -289,7 +288,7 @@ describe( 'themes selectors', () => {
 				'twentysixteen'
 			);
 
-			expect( isRequesting ).to.be.true;
+			expect( isRequesting ).toBe( true );
 		} );
 	} );
 
@@ -305,7 +304,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Sixteen' }
 			);
 
-			expect( siteThemes ).to.be.null;
+			expect( siteThemes ).toBeNull();
 		} );
 
 		test( 'should return null if the query is not tracked to the query manager', () => {
@@ -324,7 +323,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Sixteen' }
 			);
 
-			expect( siteThemes ).to.be.null;
+			expect( siteThemes ).toBeNull();
 		} );
 
 		test( 'should return an array of normalized known queried themes', () => {
@@ -349,7 +348,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Sixteen' }
 			);
 
-			expect( siteThemes ).to.eql( [ twentysixteen ] );
+			expect( siteThemes ).toEqual( [ twentysixteen ] );
 		} );
 
 		test( "should return null if we know the number of found items but the requested set hasn't been received", () => {
@@ -375,7 +374,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Fifteen', number: 1, page: 2 }
 			);
 
-			expect( siteThemes ).to.be.null;
+			expect( siteThemes ).toBeNull();
 		} );
 	} );
 
@@ -387,7 +386,7 @@ describe( 'themes selectors', () => {
 				},
 			} );
 
-			expect( query ).to.deep.equal( {} );
+			expect( query ).toEqual( {} );
 		} );
 
 		test( 'given a site, should return last used query', () => {
@@ -402,7 +401,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( query ).to.deep.equal( {
+			expect( query ).toEqual( {
 				search: 'theme that has this thing and does not have the other one',
 			} );
 		} );
@@ -420,7 +419,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Sixteen' }
 			);
 
-			expect( isRequesting ).to.be.false;
+			expect( isRequesting ).toBe( false );
 		} );
 
 		test( 'should return false if the site has not been queried for the specific query', () => {
@@ -436,7 +435,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Sixteen' }
 			);
 
-			expect( isRequesting ).to.be.false;
+			expect( isRequesting ).toBe( false );
 		} );
 
 		test( 'should return true if the site has been queried for the specific query', () => {
@@ -452,7 +451,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Sixteen' }
 			);
 
-			expect( isRequesting ).to.be.true;
+			expect( isRequesting ).toBe( true );
 		} );
 
 		test( 'should return false if the site has previously, but is not currently, querying for the specified query', () => {
@@ -468,7 +467,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Sixteen' }
 			);
 
-			expect( isRequesting ).to.be.false;
+			expect( isRequesting ).toBe( false );
 		} );
 	} );
 
@@ -484,7 +483,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Sixteen' }
 			);
 
-			expect( found ).to.be.null;
+			expect( found ).toBeNull();
 		} );
 
 		test( 'should return the found items for a site query', () => {
@@ -510,7 +509,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Sixteen' }
 			);
 
-			expect( found ).to.equal( 1 );
+			expect( found ).toEqual( 1 );
 		} );
 
 		test( 'should return zero if in-fact there are zero items', () => {
@@ -534,7 +533,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Umpteen' }
 			);
 
-			expect( found ).to.equal( 0 );
+			expect( found ).toEqual( 0 );
 		} );
 	} );
 
@@ -553,7 +552,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Sixteen' }
 			);
 
-			expect( lastPage ).to.be.null;
+			expect( lastPage ).toBeNull();
 		} );
 
 		test( 'should return the last page value for a site query', () => {
@@ -582,7 +581,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Sixteen' }
 			);
 
-			expect( lastPage ).to.equal( 1 );
+			expect( lastPage ).toEqual( 1 );
 		} );
 
 		test( 'should return the last page value for a site query, even if including page param', () => {
@@ -611,7 +610,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Twenty', page: 3, number: 1 }
 			);
 
-			expect( lastPage ).to.equal( 7 );
+			expect( lastPage ).toEqual( 7 );
 		} );
 
 		test( 'should return 1 if there are no found themes', () => {
@@ -638,7 +637,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Umpteen' }
 			);
 
-			expect( lastPage ).to.equal( 1 );
+			expect( lastPage ).toEqual( 1 );
 		} );
 
 		test( 'should return 1 for a Jetpack site', () => {
@@ -673,7 +672,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Twenty' }
 			);
 
-			expect( lastPage ).to.equal( 1 );
+			expect( lastPage ).toEqual( 1 );
 		} );
 	} );
 
@@ -689,7 +688,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Umpteen' }
 			);
 
-			expect( isLastPage ).to.be.null;
+			expect( isLastPage ).toBeNull();
 		} );
 
 		test( 'should return false if the query explicit value is not the last page', () => {
@@ -718,7 +717,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Twenty', page: 6, number: 1 }
 			);
 
-			expect( isLastPage ).to.be.false;
+			expect( isLastPage ).toBe( false );
 		} );
 
 		test( 'should return true if the query explicit value is the last page', () => {
@@ -747,7 +746,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Twenty', page: 7, number: 1 }
 			);
 
-			expect( isLastPage ).to.be.true;
+			expect( isLastPage ).toBe( true );
 		} );
 
 		test( 'should return true if the query implicit value is the last page', () => {
@@ -776,7 +775,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Sixteen', number: 1 }
 			);
 
-			expect( isLastPage ).to.be.true;
+			expect( isLastPage ).toBe( true );
 		} );
 
 		test( 'should return true for a Jetpack site', () => {
@@ -811,7 +810,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Twenty' }
 			);
 
-			expect( isLastPage ).to.be.true;
+			expect( isLastPage ).toBe( true );
 		} );
 	} );
 
@@ -827,7 +826,7 @@ describe( 'themes selectors', () => {
 				{ search: '', number: 1 }
 			);
 
-			expect( themes ).to.be.null;
+			expect( themes ).toBeNull();
 		} );
 
 		test( 'should return null if the query manager has not received items for query', () => {
@@ -846,7 +845,7 @@ describe( 'themes selectors', () => {
 				{ search: '', number: 1 }
 			);
 
-			expect( themes ).to.be.null;
+			expect( themes ).toBeNull();
 		} );
 
 		test( 'should return a concatenated array of all site themes ignoring page', () => {
@@ -875,7 +874,7 @@ describe( 'themes selectors', () => {
 				{ search: '', number: 1 }
 			);
 
-			expect( themes ).to.eql( [ twentyfifteen, twentysixteen ] );
+			expect( themes ).toEqual( [ twentyfifteen, twentysixteen ] );
 		} );
 
 		test( 'should remove recommendedThemes with no filter and no search in query', () => {
@@ -903,7 +902,7 @@ describe( 'themes selectors', () => {
 				2916284,
 				{ search: '', number: 1 }
 			);
-			expect( themes ).to.eql( [ twentysixteen ] );
+			expect( themes ).toEqual( [ twentysixteen ] );
 		} );
 
 		test( "should omit found items for which the requested result hasn't been received", () => {
@@ -929,7 +928,7 @@ describe( 'themes selectors', () => {
 				{ search: 'Sixteen', number: 1 }
 			);
 
-			expect( themes ).to.eql( [ twentysixteen ] );
+			expect( themes ).toEqual( [ twentysixteen ] );
 		} );
 	} );
 
@@ -945,7 +944,7 @@ describe( 'themes selectors', () => {
 				{ search: 'twen' }
 			);
 
-			expect( isRequesting ).to.be.false;
+			expect( isRequesting ).toBe( false );
 		} );
 
 		test( 'should return true requesting for query at exact page', () => {
@@ -961,7 +960,7 @@ describe( 'themes selectors', () => {
 				{ search: 'twen', page: 4 }
 			);
 
-			expect( isRequesting ).to.be.true;
+			expect( isRequesting ).toBe( true );
 		} );
 
 		test( 'should return true requesting for query without page specified', () => {
@@ -977,7 +976,7 @@ describe( 'themes selectors', () => {
 				{ search: 'twen' }
 			);
 
-			expect( isRequesting ).to.be.true;
+			expect( isRequesting ).toBe( true );
 		} );
 	} );
 
@@ -996,7 +995,7 @@ describe( 'themes selectors', () => {
 				},
 				'twentysixteen'
 			);
-			expect( detailsUrl ).to.equal( '/theme/twentysixteen' );
+			expect( detailsUrl ).toEqual( '/theme/twentysixteen' );
 		} );
 
 		test( 'given a theme and wpcom site ID, should return the Calypso theme sheet URL', () => {
@@ -1014,7 +1013,7 @@ describe( 'themes selectors', () => {
 				'twentysixteen',
 				2916284
 			);
-			expect( detailsUrl ).to.equal( '/theme/twentysixteen/example.wordpress.com' );
+			expect( detailsUrl ).toEqual( '/theme/twentysixteen/example.wordpress.com' );
 		} );
 	} );
 
@@ -1041,7 +1040,7 @@ describe( 'themes selectors', () => {
 					},
 					'mood'
 				);
-				expect( supportUrl ).to.equal( '/theme/mood/setup' );
+				expect( supportUrl ).toEqual( '/theme/mood/setup' );
 			} );
 
 			test( 'given a wpcom site ID, should return the support URL', () => {
@@ -1066,7 +1065,7 @@ describe( 'themes selectors', () => {
 					'mood',
 					2916284
 				);
-				expect( supportUrl ).to.equal( '/theme/mood/setup/example.wordpress.com' );
+				expect( supportUrl ).toEqual( '/theme/mood/setup/example.wordpress.com' );
 			} );
 		} );
 
@@ -1092,7 +1091,7 @@ describe( 'themes selectors', () => {
 					},
 					'twentysixteen'
 				);
-				expect( supportUrl ).to.be.null;
+				expect( supportUrl ).toBeNull();
 			} );
 
 			test( 'given a wpcom site ID, should return null', () => {
@@ -1117,7 +1116,7 @@ describe( 'themes selectors', () => {
 					'twentysixteen',
 					2916284
 				);
-				expect( supportUrl ).to.be.null;
+				expect( supportUrl ).toBeNull();
 			} );
 
 			test( 'given a Jetpack site ID, should return null', () => {
@@ -1146,7 +1145,7 @@ describe( 'themes selectors', () => {
 					'twentysixteen',
 					77203074
 				);
-				expect( supportUrl ).to.be.null;
+				expect( supportUrl ).toBeNull();
 			} );
 		} );
 	} );
@@ -1166,7 +1165,7 @@ describe( 'themes selectors', () => {
 				},
 				'mood'
 			);
-			expect( helpUrl ).to.equal( '/theme/mood/support' );
+			expect( helpUrl ).toEqual( '/theme/mood/support' );
 		} );
 
 		test( 'given a theme and a wpcom site ID, should return the correct help URL', () => {
@@ -1191,7 +1190,7 @@ describe( 'themes selectors', () => {
 				'mood',
 				2916284
 			);
-			expect( helpUrl ).to.equal( '/theme/mood/support/example.wordpress.com' );
+			expect( helpUrl ).toEqual( '/theme/mood/support/example.wordpress.com' );
 		} );
 
 		test( 'given a theme and Jetpack site ID, should return the help url', () => {
@@ -1213,7 +1212,7 @@ describe( 'themes selectors', () => {
 				'twentysixteen',
 				77203074
 			);
-			expect( helpUrl ).to.be.equal( '/theme/twentysixteen/support/example.net' );
+			expect( helpUrl ).toEqual( '/theme/twentysixteen/support/example.net' );
 		} );
 	} );
 
@@ -1240,7 +1239,7 @@ describe( 'themes selectors', () => {
 				'twentysixteen',
 				2916284
 			);
-			expect( purchaseUrl ).to.be.null;
+			expect( purchaseUrl ).toBeNull();
 		} );
 
 		test( 'given a premium theme and a wpcom site ID, should return the purchase URL', () => {
@@ -1265,7 +1264,7 @@ describe( 'themes selectors', () => {
 				'mood',
 				2916284
 			);
-			expect( purchaseUrl ).to.equal( '/checkout/example.wordpress.com/theme:mood' );
+			expect( purchaseUrl ).toEqual( '/checkout/example.wordpress.com/theme:mood' );
 		} );
 	} );
 
@@ -1276,7 +1275,7 @@ describe( 'themes selectors', () => {
 					items: {},
 				},
 			} );
-			expect( customizeUrl ).to.equal( '/customize' );
+			expect( customizeUrl ).toEqual( '/customize' );
 		} );
 
 		test( 'given a theme and no site ID, should return the correct customize URL', () => {
@@ -1288,7 +1287,7 @@ describe( 'themes selectors', () => {
 				},
 				'twentysixteen'
 			);
-			expect( customizeUrl ).to.equal( '/customize' );
+			expect( customizeUrl ).toEqual( '/customize' );
 		} );
 
 		test( 'given a theme and wpcom site ID, should return the correct customize URL', () => {
@@ -1314,7 +1313,7 @@ describe( 'themes selectors', () => {
 				'twentysixteen',
 				2916284
 			);
-			expect( customizeUrl ).to.equal( '/customize/example.wordpress.com?theme=pub/twentysixteen' );
+			expect( customizeUrl ).toEqual( '/customize/example.wordpress.com?theme=pub/twentysixteen' );
 		} );
 
 		test( 'given a theme and wpcom site ID on which that theme is active, should return the correct customize URL', () => {
@@ -1342,7 +1341,7 @@ describe( 'themes selectors', () => {
 				'twentysixteen',
 				2916284
 			);
-			expect( customizeUrl ).to.equal( '/customize/example.wordpress.com' );
+			expect( customizeUrl ).toEqual( '/customize/example.wordpress.com' );
 		} );
 
 		describe( 'on a Jetpack site', () => {
@@ -1385,7 +1384,7 @@ describe( 'themes selectors', () => {
 
 					test( 'should return customizer URL with return arg and un-suffixed theme ID', () => {
 						const customizeUrl = getThemeCustomizeUrl( state, 'twentysixteen', 77203074 );
-						expect( customizeUrl ).to.equal(
+						expect( customizeUrl ).toEqual(
 							'https://example.net/wp-admin/customize.php?return=https%3A%2F%2Fwordpress.com&theme=twentysixteen'
 						);
 					} );
@@ -1394,7 +1393,7 @@ describe( 'themes selectors', () => {
 				describe( 'on the server', () => {
 					test( 'should return customizer URL with un-suffixed theme ID', () => {
 						const customizeUrl = getThemeCustomizeUrl( state, 'twentysixteen', 77203074 );
-						expect( customizeUrl ).to.equal(
+						expect( customizeUrl ).toEqual(
 							'https://example.net/wp-admin/customize.php?theme=twentysixteen'
 						);
 					} );
@@ -1440,7 +1439,7 @@ describe( 'themes selectors', () => {
 
 					test( 'should return customizer URL with return arg and unsuffixed theme ID', () => {
 						const customizeUrl = getThemeCustomizeUrl( state, 'twentysixteen', 77203074 );
-						expect( customizeUrl ).to.equal(
+						expect( customizeUrl ).toEqual(
 							'https://example.net/wp-admin/customize.php?return=https%3A%2F%2Fwordpress.com&theme=twentysixteen'
 						);
 					} );
@@ -1449,7 +1448,7 @@ describe( 'themes selectors', () => {
 				describe( 'on the server', () => {
 					test( 'should return customizer URL with unsuffixed theme ID', () => {
 						const customizeUrl = getThemeCustomizeUrl( state, 'twentysixteen', 77203074 );
-						expect( customizeUrl ).to.equal(
+						expect( customizeUrl ).toEqual(
 							'https://example.net/wp-admin/customize.php?theme=twentysixteen'
 						);
 					} );
@@ -1473,7 +1472,7 @@ describe( 'themes selectors', () => {
 				'twentysixteen'
 			);
 
-			expect( signupUrl ).to.equal( '/start/with-theme?ref=calypshowcase&theme=twentysixteen' );
+			expect( signupUrl ).toEqual( '/start/with-theme?ref=calypshowcase&theme=twentysixteen' );
 		} );
 
 		test( 'given a premium theme, should return the correct signup URL', () => {
@@ -1490,7 +1489,7 @@ describe( 'themes selectors', () => {
 				'mood'
 			);
 
-			expect( signupUrl ).to.equal( '/start/with-theme?ref=calypshowcase&theme=mood&premium=true' );
+			expect( signupUrl ).toEqual( '/start/with-theme?ref=calypshowcase&theme=mood&premium=true' );
 		} );
 	} );
 
@@ -1506,7 +1505,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( demoUrl ).to.be.undefined;
+			expect( demoUrl ).toBeUndefined();
 		} );
 
 		test( "with a theme found on WP.com, should return that object's demo_uri field", () => {
@@ -1524,7 +1523,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( demoUrl ).to.deep.equal( 'https://twentysixteendemo.wordpress.com/' );
+			expect( demoUrl ).toEqual( 'https://twentysixteendemo.wordpress.com/' );
 		} );
 
 		test( "with a theme found on WP.org but not on WP.com, should return that object's demo_uri field", () => {
@@ -1554,7 +1553,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( demoUrl ).to.deep.equal( 'https://wp-themes.com/twentyseventeen' );
+			expect( demoUrl ).toEqual( 'https://wp-themes.com/twentyseventeen' );
 		} );
 	} );
 
@@ -1577,7 +1576,7 @@ describe( 'themes selectors', () => {
 					'twentysixteen'
 				);
 
-				expect( forumUrl ).to.equal( '//en.forums.wordpress.com/forum/themes' );
+				expect( forumUrl ).toEqual( '//en.forums.wordpress.com/forum/themes' );
 			} );
 
 			test( 'given a premium theme, should return the general themes forum URL', () => {
@@ -1597,7 +1596,7 @@ describe( 'themes selectors', () => {
 					'mood'
 				);
 
-				expect( forumUrl ).to.equal( '//en.forums.wordpress.com/forum/themes' );
+				expect( forumUrl ).toEqual( '//en.forums.wordpress.com/forum/themes' );
 			} );
 		} );
 
@@ -1622,7 +1621,7 @@ describe( 'themes selectors', () => {
 					77203074
 				);
 
-				expect( forumUrl ).to.be.null;
+				expect( forumUrl ).toBeNull();
 			} );
 
 			test( "given a theme that's found on WP.com, should return the generic WP.com themes support forum URL", () => {
@@ -1649,7 +1648,7 @@ describe( 'themes selectors', () => {
 					77203074
 				);
 
-				expect( forumUrl ).to.equal( '//en.forums.wordpress.com/forum/themes' );
+				expect( forumUrl ).toEqual( '//en.forums.wordpress.com/forum/themes' );
 			} );
 
 			test( "given a theme that's found on WP.org, should return the correspoding WP.org theme forum URL", () => {
@@ -1694,7 +1693,7 @@ describe( 'themes selectors', () => {
 					77203074
 				);
 
-				expect( forumUrl ).to.equal( '//wordpress.org/support/theme/twentyseventeen' );
+				expect( forumUrl ).toEqual( '//wordpress.org/support/theme/twentyseventeen' );
 			} );
 		} );
 	} );
@@ -1707,7 +1706,7 @@ describe( 'themes selectors', () => {
 				},
 			} );
 
-			expect( activeTheme ).to.be.null;
+			expect( activeTheme ).toBeNull();
 		} );
 
 		test( 'given a site, should return its currently active theme', () => {
@@ -1722,7 +1721,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( activeTheme ).to.equal( 'twentysixteen' );
+			expect( activeTheme ).toEqual( 'twentysixteen' );
 		} );
 
 		test( 'given a site, should return its currently active theme without -wpcom suffix', () => {
@@ -1737,7 +1736,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( activeTheme ).to.equal( 'twentysixteen' );
+			expect( activeTheme ).toEqual( 'twentysixteen' );
 		} );
 	} );
 
@@ -1754,7 +1753,7 @@ describe( 'themes selectors', () => {
 				},
 			} );
 
-			expect( isActive ).to.be.false;
+			expect( isActive ).toBe( false );
 		} );
 
 		test( 'given a theme but no site, should return false', () => {
@@ -1772,7 +1771,7 @@ describe( 'themes selectors', () => {
 				'mood'
 			);
 
-			expect( isActive ).to.be.false;
+			expect( isActive ).toBe( false );
 		} );
 
 		test( "given a theme and a site on which it isn't active, should return false", () => {
@@ -1796,7 +1795,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( isActive ).to.be.false;
+			expect( isActive ).toBe( false );
 		} );
 
 		test( 'given a theme and a site on which it is active, should return true', () => {
@@ -1820,7 +1819,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( isActive ).to.be.true;
+			expect( isActive ).toBe( true );
 		} );
 
 		test( 'given a wpcom theme and a jetpack site on which it is active, should return true', () => {
@@ -1846,7 +1845,7 @@ describe( 'themes selectors', () => {
 				77203074
 			);
 
-			expect( isActive ).to.be.true;
+			expect( isActive ).toBe( true );
 		} );
 	} );
 
@@ -1858,7 +1857,7 @@ describe( 'themes selectors', () => {
 				},
 			} );
 
-			expect( activating ).to.be.false;
+			expect( activating ).toBe( false );
 		} );
 
 		test( 'given a site, should return true if theme is currently activated', () => {
@@ -1873,7 +1872,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( activating ).to.be.true;
+			expect( activating ).toBe( true );
 		} );
 	} );
 
@@ -1885,7 +1884,7 @@ describe( 'themes selectors', () => {
 				},
 			} );
 
-			expect( activated ).to.be.false;
+			expect( activated ).toBe( false );
 		} );
 
 		test( 'given a site, should return true if theme has been activated', () => {
@@ -1900,7 +1899,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( activated ).to.be.true;
+			expect( activated ).toBe( true );
 		} );
 	} );
 
@@ -1912,7 +1911,7 @@ describe( 'themes selectors', () => {
 				},
 			} );
 
-			expect( isRequesting ).to.be.false;
+			expect( isRequesting ).toBe( false );
 		} );
 
 		test( 'given no active request, should return false', () => {
@@ -1927,7 +1926,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( isRequesting ).to.be.false;
+			expect( isRequesting ).toBe( false );
 		} );
 
 		test( 'given pending action request, should return true', () => {
@@ -1942,7 +1941,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( isRequesting ).to.be.true;
+			expect( isRequesting ).toBe( true );
 		} );
 	} );
 
@@ -1954,7 +1953,7 @@ describe( 'themes selectors', () => {
 				},
 			} );
 
-			expect( installing ).to.be.false;
+			expect( installing ).toBe( false );
 		} );
 
 		test( 'given a site, should return true if theme is currently being installed', () => {
@@ -1980,7 +1979,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( installing ).to.be.true;
+			expect( installing ).toBe( true );
 		} );
 
 		test( 'given a jetpack site and wpcom theme, should return true if theme is currently being installed', () => {
@@ -2008,7 +2007,7 @@ describe( 'themes selectors', () => {
 				77203074
 			);
 
-			expect( installing ).to.be.true;
+			expect( installing ).toBe( true );
 		} );
 	} );
 
@@ -2023,7 +2022,7 @@ describe( 'themes selectors', () => {
 				'twentyseventeen'
 			);
 
-			expect( isWporg ).to.be.false;
+			expect( isWporg ).toBe( false );
 		} );
 
 		test( 'should return true if theme is found on WP.org', () => {
@@ -2052,7 +2051,7 @@ describe( 'themes selectors', () => {
 				'twentyseventeen'
 			);
 
-			expect( isWporg ).to.be.true;
+			expect( isWporg ).toBe( true );
 		} );
 	} );
 
@@ -2067,7 +2066,7 @@ describe( 'themes selectors', () => {
 				'twentysixteen'
 			);
 
-			expect( isWpcom ).to.be.false;
+			expect( isWpcom ).toBe( false );
 		} );
 
 		test( 'should return true if theme is found on WP.com', () => {
@@ -2084,7 +2083,7 @@ describe( 'themes selectors', () => {
 				'twentysixteen'
 			);
 
-			expect( isWpcom ).to.be.true;
+			expect( isWpcom ).toBe( true );
 		} );
 	} );
 
@@ -2095,7 +2094,7 @@ describe( 'themes selectors', () => {
 					queries: {},
 				},
 			} );
-			expect( premium ).to.be.false;
+			expect( premium ).toBe( false );
 		} );
 
 		test( "given the ID of a theme that doesn't exist, should return false", () => {
@@ -2111,7 +2110,7 @@ describe( 'themes selectors', () => {
 				},
 				'twentyumpteen'
 			);
-			expect( premium ).to.be.false;
+			expect( premium ).toBe( false );
 		} );
 
 		test( 'given the ID of a free theme, should return false', () => {
@@ -2127,7 +2126,7 @@ describe( 'themes selectors', () => {
 				},
 				'twentysixteen'
 			);
-			expect( premium ).to.be.false;
+			expect( premium ).toBe( false );
 		} );
 
 		test( 'given the ID of a premium theme, should return true', () => {
@@ -2143,7 +2142,7 @@ describe( 'themes selectors', () => {
 				},
 				'mood'
 			);
-			expect( premium ).to.be.true;
+			expect( premium ).toBe( true );
 		} );
 	} );
 
@@ -2162,7 +2161,7 @@ describe( 'themes selectors', () => {
 				},
 			} );
 
-			expect( isPurchased ).to.be.false;
+			expect( isPurchased ).toBe( false );
 		} );
 
 		test( 'given a theme but no site, should return false', () => {
@@ -2182,7 +2181,7 @@ describe( 'themes selectors', () => {
 				'mood'
 			);
 
-			expect( isPurchased ).to.be.false;
+			expect( isPurchased ).toBe( false );
 		} );
 
 		test( 'given a theme that has not been purchased on a given site, should return false', () => {
@@ -2203,7 +2202,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( isPurchased ).to.be.false;
+			expect( isPurchased ).toBe( false );
 		} );
 
 		test( 'given a theme that has been purchased on a given site, should return true', () => {
@@ -2224,7 +2223,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( isPurchased ).to.be.true;
+			expect( isPurchased ).toBe( true );
 		} );
 	} );
 
@@ -2246,7 +2245,7 @@ describe( 'themes selectors', () => {
 				},
 			} );
 
-			expect( isAvailable ).to.be.false;
+			expect( isAvailable ).toBe( false );
 		} );
 
 		test( 'given a theme but no site, should return false', () => {
@@ -2269,7 +2268,7 @@ describe( 'themes selectors', () => {
 				'espresso'
 			);
 
-			expect( isAvailable ).to.be.false;
+			expect( isAvailable ).toBe( false );
 		} );
 
 		test( 'given a theme that has not been purchased on a given site, should return false', () => {
@@ -2309,7 +2308,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( isAvailable ).to.be.false;
+			expect( isAvailable ).toBe( false );
 		} );
 
 		test( 'given a premium squared theme and a site without the premium upgrade, should return false', () => {
@@ -2345,7 +2344,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( isAvailable ).to.be.false;
+			expect( isAvailable ).toBe( false );
 		} );
 
 		test( 'given a premium squared theme and a site with the premium upgrade, should return true', () => {
@@ -2389,7 +2388,7 @@ describe( 'themes selectors', () => {
 				2916284
 			);
 
-			expect( isAvailable ).to.be.true;
+			expect( isAvailable ).toBe( true );
 		} );
 
 		test( 'given a site with the unlimited premium themes bundle, should return true', () => {
@@ -2434,7 +2433,7 @@ describe( 'themes selectors', () => {
 					2916284
 				);
 
-				expect( isAvailable ).to.be.true;
+				expect( isAvailable ).toBe( true );
 			} );
 		} );
 	} );
@@ -2449,7 +2448,7 @@ describe( 'themes selectors', () => {
 				},
 				'blah'
 			);
-			expect( parentId ).to.be.null;
+			expect( parentId ).toBeNull();
 		} );
 
 		test( 'should return null for theme with no parent', () => {
@@ -2465,7 +2464,7 @@ describe( 'themes selectors', () => {
 				},
 				'mood'
 			);
-			expect( parentId ).to.be.null;
+			expect( parentId ).toBeNull();
 		} );
 
 		test( 'should return parent id', () => {
@@ -2481,7 +2480,7 @@ describe( 'themes selectors', () => {
 				},
 				'sidekick'
 			);
-			expect( parentId ).to.equal( 'superhero' );
+			expect( parentId ).toEqual( 'superhero' );
 		} );
 	} );
 } );
@@ -2501,12 +2500,12 @@ describe( '#getRecommendedThemes', () => {
 	};
 	test( 'should return correct themes list for filter', () => {
 		const recommended = getRecommendedThemes( state, filter );
-		expect( recommended ).to.equal( themes );
+		expect( recommended ).toEqual( themes );
 	} );
 
 	test( 'should return empty themes list for unfetched filter', () => {
 		const recommended = getRecommendedThemes( state, 'bazbazbaz' );
-		expect( recommended ).to.be.empty;
+		expect( Object.keys( recommended ) ).toHaveLength( 0 );
 	} );
 } );
 
@@ -2522,15 +2521,15 @@ describe( '#areRecommendedThemesLoading', () => {
 		},
 	};
 	test( 'should return true when loading', () => {
-		expect( areRecommendedThemesLoading( state, filterForIsLoading ) ).to.be.true;
+		expect( areRecommendedThemesLoading( state, filterForIsLoading ) ).toBe( true );
 	} );
 
 	test( 'should return false when not loading', () => {
-		expect( areRecommendedThemesLoading( state, filterForNotLoading ) ).to.be.false;
+		expect( areRecommendedThemesLoading( state, filterForNotLoading ) ).toBe( false );
 	} );
 
 	test( 'should return false when filter request not initiated', () => {
-		expect( areRecommendedThemesLoading( state, 'lolol' ) ).to.be.false;
+		expect( areRecommendedThemesLoading( state, 'lolol' ) ).toBe( false );
 	} );
 } );
 
@@ -2550,7 +2549,7 @@ describe( '#getPremiumThemePrice', () => {
 			2916284
 		);
 
-		expect( themePrice ).to.equal( '' );
+		expect( themePrice ).toEqual( '' );
 	} );
 	test( 'should return an empty string when a theme is already available on a given site', () => {
 		const themePrice = getPremiumThemePrice(
@@ -2589,7 +2588,7 @@ describe( '#getPremiumThemePrice', () => {
 			2916284
 		);
 
-		expect( themePrice ).to.equal( '' );
+		expect( themePrice ).toEqual( '' );
 	} );
 
 	test( 'should return price as string when a theme is not available on a given site', () => {
@@ -2622,7 +2621,7 @@ describe( '#getPremiumThemePrice', () => {
 			2916284
 		);
 
-		expect( themePrice ).to.equal( '$20' );
+		expect( themePrice ).toEqual( '$20' );
 	} );
 
 	test( 'should return an "Upgrade" string for non-Atomic Jetpack sites', () => {
@@ -2657,7 +2656,7 @@ describe( '#getPremiumThemePrice', () => {
 			77203074
 		);
 
-		expect( themePrice ).to.equal( 'Upgrade' );
+		expect( themePrice ).toEqual( 'Upgrade' );
 	} );
 
 	test( 'should return price as a string for free Atomic sites', () => {
@@ -2700,7 +2699,7 @@ describe( '#getPremiumThemePrice', () => {
 			77203074
 		);
 
-		expect( themePrice ).to.equal( '$20' );
+		expect( themePrice ).toEqual( '$20' );
 	} );
 } );
 
@@ -2717,7 +2716,7 @@ describe( '#shouldShowTryAndCustomize', () => {
 			'quadrat',
 			2916284
 		);
-		expect( showTryAndCustomize ).to.be.false;
+		expect( showTryAndCustomize ).toBe( false );
 	} );
 
 	test( 'should not show Try & Customize when logged out', () => {
@@ -2734,7 +2733,7 @@ describe( '#shouldShowTryAndCustomize', () => {
 			'quadrat',
 			2916284
 		);
-		expect( showTryAndCustomize ).to.be.false;
+		expect( showTryAndCustomize ).toBe( false );
 	} );
 
 	test( 'should not show Try & Customize for the currently active theme', () => {
@@ -2758,7 +2757,7 @@ describe( '#shouldShowTryAndCustomize', () => {
 			'quadrat',
 			2916284
 		);
-		expect( showTryAndCustomize ).to.be.false;
+		expect( showTryAndCustomize ).toBe( false );
 	} );
 
 	//Block-based themes like Quadrat should not show the Try & Customize action
@@ -2785,7 +2784,7 @@ describe( '#shouldShowTryAndCustomize', () => {
 			'quadrat',
 			2916284
 		);
-		expect( showTryAndCustomize ).to.be.false;
+		expect( showTryAndCustomize ).toBe( false );
 	} );
 
 	//Customizer-based themes should still show Try & Customize
@@ -2812,7 +2811,7 @@ describe( '#shouldShowTryAndCustomize', () => {
 			'mood',
 			2916284
 		);
-		expect( showTryAndCustomize ).to.be.true;
+		expect( showTryAndCustomize ).toBe( true );
 	} );
 
 	test( 'should not show Try & Customize action for Jetpack multisite', () => {
@@ -2840,7 +2839,7 @@ describe( '#shouldShowTryAndCustomize', () => {
 			'twentynineteen',
 			77203074
 		);
-		expect( showTryAndCustomize ).to.be.false;
+		expect( showTryAndCustomize ).toBe( false );
 	} );
 
 	test( 'should not show Try & Customize action for premium theme unavailable to Jetpack site', () => {
@@ -2879,6 +2878,6 @@ describe( '#shouldShowTryAndCustomize', () => {
 			'mood',
 			77203074
 		);
-		expect( showTryAndCustomize ).to.be.false;
+		expect( showTryAndCustomize ).toBe( false );
 	} );
 } );

--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import {
 	isPremium,
 	normalizeJetpackTheme,
@@ -16,14 +15,14 @@ describe( 'utils', () => {
 	describe( '#isPremium()', () => {
 		test( 'given no theme object, should return false', () => {
 			const premium = isPremium();
-			expect( premium ).to.be.false;
+			expect( premium ).toBe( false );
 		} );
 
 		test( 'given a theme object with no stylesheet attr, should return false', () => {
 			const premium = isPremium( {
 				id: 'twentysixteen',
 			} );
-			expect( premium ).to.be.false;
+			expect( premium ).toBe( false );
 		} );
 
 		test( 'given a theme object with a stylesheet attr that doesn\'t start with "premium/", should return false', () => {
@@ -31,7 +30,7 @@ describe( 'utils', () => {
 				id: 'twentysixteen',
 				stylesheet: 'pub/twentysixteen',
 			} );
-			expect( premium ).to.be.false;
+			expect( premium ).toBe( false );
 		} );
 
 		test( 'given a theme object with a stylesheet attr that starts with "premium/", should return true', () => {
@@ -39,14 +38,14 @@ describe( 'utils', () => {
 				id: 'mood',
 				stylesheet: 'premium/mood',
 			} );
-			expect( premium ).to.be.true;
+			expect( premium ).toBe( true );
 		} );
 	} );
 
 	describe( '#normalizeJetpackTheme()', () => {
 		test( 'should return an empty object when given no argument', () => {
 			const normalizedTheme = normalizeJetpackTheme();
-			expect( normalizedTheme ).to.deep.equal( {} );
+			expect( normalizedTheme ).toEqual( {} );
 		} );
 		test( 'should rename some keys', () => {
 			const normalizedTheme = normalizeJetpackTheme( {
@@ -57,7 +56,7 @@ describe( 'utils', () => {
 				download: 'http://downloads.wordpress.org/theme/twentyfifteen.1.7.zip',
 				tags: [ 'custom-header', 'two-columns' ],
 			} );
-			expect( normalizedTheme ).to.deep.equal( {
+			expect( normalizedTheme ).toEqual( {
 				id: 'twentyfifteen',
 				name: 'Twenty Fifteen',
 				author: 'the WordPress team',
@@ -73,7 +72,7 @@ describe( 'utils', () => {
 	describe( '#normalizeWpcomTheme()', () => {
 		test( 'should return an empty object when given no argument', () => {
 			const normalizedTheme = normalizeWpcomTheme();
-			expect( normalizedTheme ).to.deep.equal( {} );
+			expect( normalizedTheme ).toEqual( {} );
 		} );
 		test( 'should rename some keys', () => {
 			const normalizedTheme = normalizeWpcomTheme( {
@@ -90,7 +89,7 @@ describe( 'utils', () => {
 				demo_uri: 'https://mooddemo.wordpress.com/',
 				author_uri: 'https://wordpress.com/themes/',
 			} );
-			expect( normalizedTheme ).to.deep.equal( {
+			expect( normalizedTheme ).toEqual( {
 				id: 'mood',
 				name: 'Mood',
 				author: 'Automattic',
@@ -110,7 +109,7 @@ describe( 'utils', () => {
 	describe( '#normalizeWporgTheme()', () => {
 		test( 'should return an empty object when given no argument', () => {
 			const normalizedTheme = normalizeWporgTheme();
-			expect( normalizedTheme ).to.deep.equal( {} );
+			expect( normalizedTheme ).toEqual( {} );
 		} );
 
 		test( 'should rename some keys', () => {
@@ -133,7 +132,7 @@ describe( 'utils', () => {
 					'two-columns': 'Two Columns',
 				},
 			} );
-			expect( normalizedTheme ).to.deep.equal( {
+			expect( normalizedTheme ).toEqual( {
 				id: 'twentyfifteen',
 				name: 'Twenty Fifteen',
 				author: 'WordPress.org',
@@ -154,17 +153,17 @@ describe( 'utils', () => {
 	describe( '#getThemeIdFromStylesheet()', () => {
 		test( 'should return undefined when given no argument', () => {
 			const themeId = getThemeIdFromStylesheet();
-			expect( themeId ).to.be.undefined;
+			expect( themeId ).toBeUndefined();
 		} );
 
 		test( "should return the argument if it doesn't contain a slash (/)", () => {
 			const themeId = getThemeIdFromStylesheet( 'twentysixteen' );
-			expect( themeId ).to.equal( 'twentysixteen' );
+			expect( themeId ).toEqual( 'twentysixteen' );
 		} );
 
 		test( "should return argument's part after the slash if it does contain a slash (/)", () => {
 			const themeId = getThemeIdFromStylesheet( 'pub/twentysixteen' );
-			expect( themeId ).to.equal( 'twentysixteen' );
+			expect( themeId ).toEqual( 'twentysixteen' );
 		} );
 	} );
 
@@ -175,7 +174,7 @@ describe( 'utils', () => {
 				number: 20,
 			} );
 
-			expect( query ).to.eql( {
+			expect( query ).toEqual( {
 				page: 4,
 			} );
 		} );
@@ -188,7 +187,7 @@ describe( 'utils', () => {
 				page: 1,
 			} );
 
-			expect( serializedQuery ).to.equal( '{"type":"page"}' );
+			expect( serializedQuery ).toEqual( '{"type":"page"}' );
 		} );
 
 		test( 'should prefix site ID if specified', () => {
@@ -199,7 +198,7 @@ describe( 'utils', () => {
 				2916284
 			);
 
-			expect( serializedQuery ).to.equal( '2916284:{"search":"Hello"}' );
+			expect( serializedQuery ).toEqual( '2916284:{"search":"Hello"}' );
 		} );
 	} );
 
@@ -207,7 +206,7 @@ describe( 'utils', () => {
 		test( 'should return undefined query and site if string does not contain JSON', () => {
 			const queryDetails = getDeserializedThemesQueryDetails( 'bad' );
 
-			expect( queryDetails ).to.eql( {
+			expect( queryDetails ).toEqual( {
 				siteId: undefined,
 				query: undefined,
 			} );
@@ -216,7 +215,7 @@ describe( 'utils', () => {
 		test( 'should return query but not site if string does not contain site prefix', () => {
 			const queryDetails = getDeserializedThemesQueryDetails( '{"search":"hello"}' );
 
-			expect( queryDetails ).to.eql( {
+			expect( queryDetails ).toEqual( {
 				siteId: undefined,
 				query: { search: 'hello' },
 			} );
@@ -225,7 +224,7 @@ describe( 'utils', () => {
 		test( 'should return query and site if string contains site prefix and JSON', () => {
 			const queryDetails = getDeserializedThemesQueryDetails( '2916284:{"search":"hello"}' );
 
-			expect( queryDetails ).to.eql( {
+			expect( queryDetails ).toEqual( {
 				siteId: 2916284,
 				query: { search: 'hello' },
 			} );
@@ -239,7 +238,7 @@ describe( 'utils', () => {
 				page: 2,
 			} );
 
-			expect( serializedQuery ).to.equal( '{"type":"page"}' );
+			expect( serializedQuery ).toEqual( '{"type":"page"}' );
 		} );
 
 		test( 'should prefix site ID if specified', () => {
@@ -251,7 +250,7 @@ describe( 'utils', () => {
 				2916284
 			);
 
-			expect( serializedQuery ).to.equal( '2916284:{"search":"Hello"}' );
+			expect( serializedQuery ).toEqual( '2916284:{"search":"Hello"}' );
 		} );
 	} );
 
@@ -313,7 +312,7 @@ describe( 'utils', () => {
 					DEFAULT_THEME
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true for a falsey search', () => {
@@ -324,7 +323,7 @@ describe( 'utils', () => {
 					DEFAULT_THEME
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true for a matching ID search', () => {
@@ -335,7 +334,7 @@ describe( 'utils', () => {
 					DEFAULT_THEME
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true for a matching title search', () => {
@@ -346,7 +345,7 @@ describe( 'utils', () => {
 					DEFAULT_THEME
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true for a matching content search', () => {
@@ -357,7 +356,7 @@ describe( 'utils', () => {
 					DEFAULT_THEME
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true for a matching author search', () => {
@@ -368,7 +367,7 @@ describe( 'utils', () => {
 					DEFAULT_THEME
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should return true for a matching filter search', () => {
@@ -379,7 +378,7 @@ describe( 'utils', () => {
 					DEFAULT_THEME
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should search case-insensitive', () => {
@@ -390,7 +389,7 @@ describe( 'utils', () => {
 					DEFAULT_THEME
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			test( 'should separately test title and content fields', () => {
@@ -401,7 +400,7 @@ describe( 'utils', () => {
 					DEFAULT_THEME
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 		} );
 
@@ -414,7 +413,7 @@ describe( 'utils', () => {
 					DEFAULT_THEME
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return false on a partial match', () => {
@@ -425,7 +424,7 @@ describe( 'utils', () => {
 					DEFAULT_THEME
 				);
 
-				expect( isMatch ).to.be.false;
+				expect( isMatch ).toBe( false );
 			} );
 
 			test( 'should return true if theme includes filter', () => {
@@ -436,7 +435,7 @@ describe( 'utils', () => {
 					DEFAULT_THEME
 				);
 
-				expect( isMatch ).to.be.true;
+				expect( isMatch ).toBe( true );
 			} );
 
 			describe( 'with multiple filters from a single taxonomy', () => {
@@ -448,7 +447,7 @@ describe( 'utils', () => {
 						DEFAULT_THEME
 					);
 
-					expect( isMatch ).to.be.false;
+					expect( isMatch ).toBe( false );
 				} );
 				test( 'should return true if theme matches all filters', () => {
 					const isMatch = isThemeMatchingQuery(
@@ -458,7 +457,7 @@ describe( 'utils', () => {
 						DEFAULT_THEME
 					);
 
-					expect( isMatch ).to.be.true;
+					expect( isMatch ).toBe( true );
 				} );
 			} );
 
@@ -471,7 +470,7 @@ describe( 'utils', () => {
 						DEFAULT_THEME
 					);
 
-					expect( isMatch ).to.be.false;
+					expect( isMatch ).toBe( false );
 				} );
 				test( 'should return true if theme matches all filters', () => {
 					const isMatch = isThemeMatchingQuery(
@@ -481,7 +480,7 @@ describe( 'utils', () => {
 						DEFAULT_THEME
 					);
 
-					expect( isMatch ).to.be.true;
+					expect( isMatch ).toBe( true );
 				} );
 			} );
 		} );

--- a/client/state/themes/upload-theme/test/reducer.js
+++ b/client/state/themes/upload-theme/test/reducer.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import {
 	THEME_UPLOAD_START,
 	THEME_UPLOAD_SUCCESS,
@@ -31,7 +30,7 @@ const siteId = 2916284;
 describe( 'uploadedThemeId', () => {
 	test( 'should default to an empty object', () => {
 		const state = uploadedThemeId( undefined, {} );
-		expect( state ).to.deep.equal( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should contain theme id after successful upload', () => {
@@ -43,7 +42,7 @@ describe( 'uploadedThemeId', () => {
 				themeId,
 			}
 		);
-		expect( state[ siteId ] ).to.deep.equal( themeId );
+		expect( state[ siteId ] ).toEqual( themeId );
 	} );
 
 	test( 'should be empty after failed upload', () => {
@@ -55,7 +54,7 @@ describe( 'uploadedThemeId', () => {
 				error,
 			}
 		);
-		expect( state[ siteId ] ).to.be.undefined;
+		expect( state[ siteId ] ).toBeUndefined();
 	} );
 
 	test( 'should be empty after clear', () => {
@@ -68,7 +67,7 @@ describe( 'uploadedThemeId', () => {
 				siteId,
 			}
 		);
-		expect( state[ siteId ] ).to.be.undefined;
+		expect( state[ siteId ] ).toBeUndefined();
 	} );
 
 	test( 'should contain theme id after successful transfer with theme', () => {
@@ -83,14 +82,14 @@ describe( 'uploadedThemeId', () => {
 				themeId,
 			}
 		);
-		expect( state[ siteId ] ).to.deep.equal( themeId );
+		expect( state[ siteId ] ).toEqual( themeId );
 	} );
 } );
 
 describe( 'uploadError', () => {
 	test( 'should default to an empty object', () => {
 		const state = uploadError( undefined, {} );
-		expect( state ).to.deep.equal( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should contain error after failed upload', () => {
@@ -102,7 +101,7 @@ describe( 'uploadError', () => {
 				error,
 			}
 		);
-		expect( state[ siteId ] ).to.deep.equal( error );
+		expect( state[ siteId ] ).toEqual( error );
 	} );
 
 	test( 'should be empty after successful upload', () => {
@@ -114,7 +113,7 @@ describe( 'uploadError', () => {
 				themeId,
 			}
 		);
-		expect( state[ siteId ] ).to.be.undefined;
+		expect( state[ siteId ] ).toBeUndefined();
 	} );
 
 	test( 'should be empty on clear', () => {
@@ -127,7 +126,7 @@ describe( 'uploadError', () => {
 				siteId,
 			}
 		);
-		expect( state[ siteId ] ).to.be.undefined;
+		expect( state[ siteId ] ).toBeUndefined();
 	} );
 
 	test( 'should contain error after failed transfer request', () => {
@@ -139,7 +138,7 @@ describe( 'uploadError', () => {
 				error,
 			}
 		);
-		expect( state[ siteId ] ).to.deep.equal( error );
+		expect( state[ siteId ] ).toEqual( error );
 	} );
 
 	test( 'should contain error after failed transfer status request', () => {
@@ -152,14 +151,14 @@ describe( 'uploadError', () => {
 				error,
 			}
 		);
-		expect( state[ siteId ] ).to.deep.equal( error );
+		expect( state[ siteId ] ).toEqual( error );
 	} );
 } );
 
 describe( 'progressLoaded', () => {
 	test( 'should default to an empty object', () => {
 		const state = progressLoaded( undefined, {} );
-		expect( state ).to.deep.equal( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should contain loaded amount after progress action', () => {
@@ -172,7 +171,7 @@ describe( 'progressLoaded', () => {
 				loaded: 50,
 			}
 		);
-		expect( state[ siteId ] ).to.equal( 50 );
+		expect( state[ siteId ] ).toEqual( 50 );
 	} );
 
 	test( 'should be empty on clear', () => {
@@ -185,7 +184,7 @@ describe( 'progressLoaded', () => {
 				siteId,
 			}
 		);
-		expect( state[ siteId ] ).to.be.undefined;
+		expect( state[ siteId ] ).toBeUndefined();
 	} );
 
 	test( 'should contain loaded amount after transfer progress action', () => {
@@ -198,14 +197,14 @@ describe( 'progressLoaded', () => {
 				loaded: 50,
 			}
 		);
-		expect( state[ siteId ] ).to.equal( 50 );
+		expect( state[ siteId ] ).toEqual( 50 );
 	} );
 } );
 
 describe( 'progressTotal', () => {
 	test( 'should default to an empty object', () => {
 		const state = progressLoaded( undefined, {} );
-		expect( state ).to.deep.equal( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should contain total amount after progress action', () => {
@@ -218,7 +217,7 @@ describe( 'progressTotal', () => {
 				loaded: 50,
 			}
 		);
-		expect( state[ siteId ] ).to.equal( 100 );
+		expect( state[ siteId ] ).toEqual( 100 );
 	} );
 
 	test( 'should be empty on clear', () => {
@@ -231,7 +230,7 @@ describe( 'progressTotal', () => {
 				siteId,
 			}
 		);
-		expect( state[ siteId ] ).to.be.undefined;
+		expect( state[ siteId ] ).toBeUndefined();
 	} );
 
 	test( 'should contain total amount after transfer progress action', () => {
@@ -244,14 +243,14 @@ describe( 'progressTotal', () => {
 				loaded: 50,
 			}
 		);
-		expect( state[ siteId ] ).to.equal( 100 );
+		expect( state[ siteId ] ).toEqual( 100 );
 	} );
 } );
 
 describe( 'inProgress', () => {
 	test( 'should default to an empty object', () => {
 		const state = inProgress( undefined, {} );
-		expect( state ).to.deep.equal( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should be true on upload start', () => {
@@ -262,7 +261,7 @@ describe( 'inProgress', () => {
 				siteId,
 			}
 		);
-		expect( state[ siteId ] ).to.be.true;
+		expect( state[ siteId ] ).toBe( true );
 	} );
 
 	test( 'should not be true on upload success', () => {
@@ -274,7 +273,7 @@ describe( 'inProgress', () => {
 				themeId,
 			}
 		);
-		expect( state[ siteId ] ).to.not.be.true;
+		expect( state[ siteId ] ).not.toBe( true );
 	} );
 
 	test( 'should not be true on upload failure', () => {
@@ -286,7 +285,7 @@ describe( 'inProgress', () => {
 				error,
 			}
 		);
-		expect( state[ siteId ] ).to.not.be.true;
+		expect( state[ siteId ] ).not.toBe( true );
 	} );
 
 	test( 'should not be true on clear', () => {
@@ -297,7 +296,7 @@ describe( 'inProgress', () => {
 				siteId,
 			}
 		);
-		expect( state[ siteId ] ).to.not.be.true;
+		expect( state[ siteId ] ).not.toBe( true );
 	} );
 
 	test( 'should be true on transfer initiate', () => {
@@ -308,7 +307,7 @@ describe( 'inProgress', () => {
 				siteId,
 			}
 		);
-		expect( state[ siteId ] ).to.be.true;
+		expect( state[ siteId ] ).toBe( true );
 	} );
 
 	test( 'should not be true on transfer status complete', () => {
@@ -321,7 +320,7 @@ describe( 'inProgress', () => {
 				status: 'complete',
 			}
 		);
-		expect( state[ siteId ] ).to.not.be.true;
+		expect( state[ siteId ] ).not.toBe( true );
 	} );
 
 	test( 'should be true on transfer status not-complete', () => {
@@ -334,7 +333,7 @@ describe( 'inProgress', () => {
 				status: 'uploading',
 			}
 		);
-		expect( state[ siteId ] ).to.be.true;
+		expect( state[ siteId ] ).toBe( true );
 	} );
 
 	test( 'should not be true on transfer status failure', () => {
@@ -346,6 +345,6 @@ describe( 'inProgress', () => {
 				error,
 			}
 		);
-		expect( state[ siteId ] ).to.not.be.true;
+		expect( state[ siteId ] ).not.toBe( true );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As we've been moving towards canonically using `jest` as our primary unit testing platform, we're slowly moving away from `chai`. 

This PR refactors the themes state tests to use `jest` instead of `chai`.  We also use the opportunity to refactor away from `sinon` in favor of the built-in jest mocking functionality.

Some of the legwork here has been done with codemods, but I had to do a few more additional changes manually due to the added complexity of the test helpers.

#### Testing instructions

Verify all tests pass: `yarn run test-client client/state/themes`