### PR TITLE
State: Refactor sites tests away from `chai` and `sinon`

### DIFF
--- a/client/state/sites/connection/test/actions.js
+++ b/client/state/sites/connection/test/actions.js
@@ -1,5 +1,3 @@
-import { expect } from 'chai';
-import { match } from 'sinon';
 import {
 	SITE_CONNECTION_STATUS_RECEIVE,
 	SITE_CONNECTION_STATUS_REQUEST,
@@ -7,12 +5,14 @@ import {
 	SITE_CONNECTION_STATUS_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import useNock from 'calypso/test-helpers/use-nock';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { requestConnectionStatus } from '../actions';
 
 describe( 'actions', () => {
 	let spy;
-	useSandbox( ( sandbox ) => ( spy = sandbox.spy() ) );
+
+	beforeEach( () => {
+		spy = jest.fn();
+	} );
 
 	const siteId = 12345678;
 
@@ -31,7 +31,7 @@ describe( 'actions', () => {
 			test( 'should dispatch a connection status request action when thunk triggered', () => {
 				requestConnectionStatus( siteId )( spy );
 
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toBeCalledWith( {
 					type: SITE_CONNECTION_STATUS_REQUEST,
 					siteId,
 				} );
@@ -39,13 +39,13 @@ describe( 'actions', () => {
 
 			test( 'should dispatch connection status request success and receive actions upon success', () => {
 				return requestConnectionStatus( siteId )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toBeCalledWith( {
 						type: SITE_CONNECTION_STATUS_RECEIVE,
 						siteId,
 						status: true,
 					} );
 
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toBeCalledWith( {
 						type: SITE_CONNECTION_STATUS_REQUEST_SUCCESS,
 						siteId,
 					} );
@@ -67,10 +67,10 @@ describe( 'actions', () => {
 
 			test( 'should dispatch connection status request failure action upon error', () => {
 				return requestConnectionStatus( siteId )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toBeCalledWith( {
 						type: SITE_CONNECTION_STATUS_REQUEST_FAILURE,
 						siteId,
-						error: match( { message: errorMessage } ),
+						error: expect.objectContaining( { message: errorMessage } ),
 					} );
 				} );
 			} );

--- a/client/state/sites/connection/test/reducer.js
+++ b/client/state/sites/connection/test/reducer.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import {
 	SITE_CONNECTION_STATUS_RECEIVE,
@@ -6,23 +5,28 @@ import {
 	SITE_CONNECTION_STATUS_REQUEST_FAILURE,
 	SITE_CONNECTION_STATUS_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { items, requesting } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
+	beforeAll( () => {
+		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+	} );
+
+	afterAll( () => {
+		jest.clearAllMocks();
 	} );
 
 	test( 'should export expected reducer keys', () => {
-		expect( reducer( undefined, {} ) ).to.have.keys( [ 'items', 'requesting' ] );
+		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(
+			expect.arrayContaining( [ 'items', 'requesting' ] )
+		);
 	} );
 
 	describe( '#items()', () => {
 		test( 'should default to an empty object', () => {
 			const state = items( undefined, {} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should store connection status when received', () => {
@@ -32,7 +36,7 @@ describe( 'reducer', () => {
 				status: true,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: true,
 			} );
 		} );
@@ -47,7 +51,7 @@ describe( 'reducer', () => {
 				status: false,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: true,
 				77203074: false,
 			} );
@@ -64,7 +68,7 @@ describe( 'reducer', () => {
 				status: false,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: false,
 				77203074: false,
 			} );
@@ -75,7 +79,7 @@ describe( 'reducer', () => {
 		test( 'should default to an empty object', () => {
 			const state = requesting( undefined, {} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should track connection status request when started', () => {
@@ -84,7 +88,7 @@ describe( 'reducer', () => {
 				siteId: 2916284,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: true,
 			} );
 		} );
@@ -98,7 +102,7 @@ describe( 'reducer', () => {
 				siteId: 77203074,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: true,
 				77203074: true,
 			} );
@@ -114,7 +118,7 @@ describe( 'reducer', () => {
 				siteId: 2916284,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: false,
 				77203074: true,
 			} );
@@ -130,7 +134,7 @@ describe( 'reducer', () => {
 				siteId: 77203074,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: false,
 				77203074: false,
 			} );

--- a/client/state/sites/domains/test/actions.js
+++ b/client/state/sites/domains/test/actions.js
@@ -1,6 +1,4 @@
-import { expect } from 'chai';
 import useNock from 'calypso/test-helpers/use-nock';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	domainsReceiveAction,
 	domainsRequestAction,
@@ -20,34 +18,32 @@ import {
 } from './fixture';
 
 describe( 'actions', () => {
-	let sandbox;
 	let spy;
 
-	useSandbox( ( newSandbox ) => {
-		sandbox = newSandbox;
-		spy = sandbox.spy();
+	beforeEach( () => {
+		spy = jest.fn();
 	} );
 
 	describe( 'Actions creators', () => {
 		test( '#domainsReceiveAction()', () => {
 			const { domains } = wpcomResponse;
 			const action = domainsReceiveAction( siteId, domains );
-			expect( action ).to.eql( ACTION_SITE_DOMAIN_RECEIVE );
+			expect( action ).toEqual( ACTION_SITE_DOMAIN_RECEIVE );
 		} );
 
 		test( '#domainsRequestAction()', () => {
 			const action = domainsRequestAction( siteId );
-			expect( action ).to.eql( ACTION_SITE_DOMAIN_REQUEST );
+			expect( action ).toEqual( ACTION_SITE_DOMAIN_REQUEST );
 		} );
 
 		test( '#domainsRequestSuccessAction()', () => {
 			const action = domainsRequestSuccessAction( siteId );
-			expect( action ).to.eql( ACTION_SITE_DOMAIN_REQUEST_SUCCESS );
+			expect( action ).toEqual( ACTION_SITE_DOMAIN_REQUEST_SUCCESS );
 		} );
 
 		test( '#domainsRequestFailureAction()', () => {
 			const action = domainsRequestFailureAction( siteId, errorResponse );
-			expect( action ).to.eql( ACTION_SITE_DOMAIN_REQUEST_FAILURE );
+			expect( action ).toEqual( ACTION_SITE_DOMAIN_REQUEST_FAILURE );
 		} );
 	} );
 
@@ -62,7 +58,7 @@ describe( 'actions', () => {
 		test( 'should dispatch REQUEST action when thunk triggered', () => {
 			const action = domainsRequestAction( siteId );
 			fetchSiteDomains( siteId )( spy );
-			expect( spy ).to.have.been.calledWith( action );
+			expect( spy ).toBeCalledWith( action );
 		} );
 
 		test( 'should dispatch RECEIVE action when request completes', () => {
@@ -70,7 +66,7 @@ describe( 'actions', () => {
 			const action = domainsReceiveAction( siteId, domains );
 
 			return fetchSiteDomains( siteId )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( action );
+				expect( spy ).toBeCalledWith( action );
 			} );
 		} );
 	} );
@@ -89,10 +85,10 @@ describe( 'actions', () => {
 			const failureAction = domainsRequestFailureAction( siteId, message );
 
 			const promise = fetchSiteDomains( siteId )( spy );
-			expect( spy ).to.have.been.calledWith( requestAction );
+			expect( spy ).toBeCalledWith( requestAction );
 
 			return promise.then( () => {
-				expect( spy ).to.have.been.calledWith( failureAction );
+				expect( spy ).toBeCalledWith( failureAction );
 			} );
 		} );
 	} );

--- a/client/state/sites/domains/test/reducer.js
+++ b/client/state/sites/domains/test/reducer.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import {
 	DOMAIN_PRIVACY_ENABLE_SUCCESS,
@@ -9,7 +8,6 @@ import {
 	SITE_DOMAINS_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	domainsRequestAction,
 	domainsRequestSuccessAction,
@@ -31,25 +29,23 @@ import {
 } from './fixture';
 
 describe( 'reducer', () => {
-	let sandbox;
+	beforeAll( () => {
+		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+	} );
 
-	useSandbox( ( newSandbox ) => {
-		sandbox = newSandbox;
-		sandbox.stub( console, 'warn' );
+	afterAll( () => {
+		jest.clearAllMocks();
 	} );
 
 	test( 'should export expected reducer keys', () => {
-		expect( domainsReducer( undefined, {} ) ).to.have.keys( [
-			'items',
-			'requesting',
-			'errors',
-			'updatingPrivacy',
-		] );
+		expect( Object.keys( domainsReducer( undefined, {} ) ) ).toEqual(
+			expect.arrayContaining( [ 'items', 'requesting', 'errors', 'updatingPrivacy' ] )
+		);
 	} );
 
 	describe( '#items()', () => {
 		test( 'should default to an empty object', () => {
-			expect( itemsReducer( undefined, {} ) ).to.eql( {} );
+			expect( itemsReducer( undefined, {} ) ).toEqual( {} );
 		} );
 
 		test( 'should index items state by site ID', () => {
@@ -65,7 +61,7 @@ describe( 'reducer', () => {
 
 			deepFreeze( action );
 
-			expect( itemsReducer( newState, action ) ).to.eql( expectedState );
+			expect( itemsReducer( newState, action ) ).toEqual( expectedState );
 		} );
 
 		test( 'should override domains for same site', () => {
@@ -84,7 +80,7 @@ describe( 'reducer', () => {
 			deepFreeze( newState );
 			deepFreeze( action );
 
-			expect( itemsReducer( newState, action ) ).to.eql( expectedState );
+			expect( itemsReducer( newState, action ) ).toEqual( expectedState );
 		} );
 
 		test( 'should enable privacy for given site and domain', () => {
@@ -107,7 +103,7 @@ describe( 'reducer', () => {
 			deepFreeze( state );
 			deepFreeze( action );
 
-			expect( itemsReducer( state, action ) ).to.eql( expectedState );
+			expect( itemsReducer( state, action ) ).toEqual( expectedState );
 		} );
 
 		test( 'should disable privacy for given site and domain', () => {
@@ -130,7 +126,7 @@ describe( 'reducer', () => {
 			deepFreeze( state );
 			deepFreeze( action );
 
-			expect( itemsReducer( state, action ) ).to.eql( expectedState );
+			expect( itemsReducer( state, action ) ).toEqual( expectedState );
 		} );
 
 		test( 'should accumulate domains for different sites', () => {
@@ -150,7 +146,7 @@ describe( 'reducer', () => {
 			deepFreeze( newState );
 			deepFreeze( action );
 
-			expect( itemsReducer( newState, action ) ).to.eql( expectedState );
+			expect( itemsReducer( newState, action ) ).toEqual( expectedState );
 		} );
 
 		test( 'should persist state', () => {
@@ -158,7 +154,7 @@ describe( 'reducer', () => {
 				[ firstSiteId ]: [ firstDomain ],
 				[ secondSiteId ]: [ secondDomain ],
 			} );
-			expect( serialize( itemsReducer, state ) ).to.eql( state );
+			expect( serialize( itemsReducer, state ) ).toEqual( state );
 		} );
 
 		test( 'should load persisted state', () => {
@@ -166,20 +162,20 @@ describe( 'reducer', () => {
 				[ firstSiteId ]: [ firstDomain ],
 				[ secondSiteId ]: [ secondDomain ],
 			} );
-			expect( deserialize( itemsReducer, state ) ).to.eql( state );
+			expect( deserialize( itemsReducer, state ) ).toEqual( state );
 		} );
 
 		test( 'should not load invalid persisted state', () => {
 			const state = deepFreeze( {
 				[ 77203074 ]: [ { domain: 1234 } ],
 			} );
-			expect( deserialize( itemsReducer, state ) ).to.eql( {} );
+			expect( deserialize( itemsReducer, state ) ).toEqual( {} );
 		} );
 	} );
 
 	describe( '#requesting()', () => {
 		test( 'should default to an empty object', () => {
-			expect( requestReducer( undefined, {} ) ).to.eql( {} );
+			expect( requestReducer( undefined, {} ) ).toEqual( {} );
 		} );
 
 		test( 'should index `requesting` state by site ID', () => {
@@ -194,7 +190,7 @@ describe( 'reducer', () => {
 
 			deepFreeze( action );
 
-			expect( requestReducer( newState, action ) ).to.eql( expectedState );
+			expect( requestReducer( newState, action ) ).toEqual( expectedState );
 		} );
 
 		test( 'should update `requesting` state by site ID on SUCCESS', () => {
@@ -213,7 +209,7 @@ describe( 'reducer', () => {
 			deepFreeze( newState );
 			deepFreeze( action );
 
-			expect( requestReducer( newState, action ) ).to.eql( expectedState );
+			expect( requestReducer( newState, action ) ).toEqual( expectedState );
 		} );
 
 		test( 'should update `requesting` state by site ID on FAILURE', () => {
@@ -232,13 +228,13 @@ describe( 'reducer', () => {
 			deepFreeze( newState );
 			deepFreeze( action );
 
-			expect( requestReducer( newState, action ) ).to.eql( expectedState );
+			expect( requestReducer( newState, action ) ).toEqual( expectedState );
 		} );
 	} );
 
 	describe( '#errors()', () => {
 		test( 'should default to an empty object', () => {
-			expect( errorsReducer( undefined, {} ) ).to.eql( {} );
+			expect( errorsReducer( undefined, {} ) ).toEqual( {} );
 		} );
 
 		test( 'should clean `errors` state by site ID on REQUEST', () => {
@@ -253,7 +249,7 @@ describe( 'reducer', () => {
 			deepFreeze( newState );
 			deepFreeze( action );
 
-			expect( errorsReducer( newState, action ) ).to.eql( expectedState );
+			expect( errorsReducer( newState, action ) ).toEqual( expectedState );
 		} );
 
 		test( 'should clean `errors` state by site ID on SUCCESS', () => {
@@ -268,7 +264,7 @@ describe( 'reducer', () => {
 			deepFreeze( newState );
 			deepFreeze( action );
 
-			expect( errorsReducer( newState, action ) ).to.eql( expectedState );
+			expect( errorsReducer( newState, action ) ).toEqual( expectedState );
 		} );
 
 		test( 'should index `errors` state by site ID on FAILURE', () => {
@@ -280,7 +276,7 @@ describe( 'reducer', () => {
 
 			deepFreeze( action );
 
-			expect( errorsReducer( newState, action ) ).to.eql( expectedState );
+			expect( errorsReducer( newState, action ) ).toEqual( expectedState );
 		} );
 	} );
 } );

--- a/client/state/sites/domains/test/selectors.js
+++ b/client/state/sites/domains/test/selectors.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getDomainsBySite, getDomainsBySiteId, isRequestingSiteDomains } from '../selectors';
 import {
 	SITE_ID_FIRST as firstSiteId,
@@ -15,11 +14,11 @@ describe( 'selectors', () => {
 
 			const firstDomains = getDomainsBySite( state, { ID: firstSiteId } );
 
-			expect( firstDomains ).to.eql( [ DOMAIN_PRIMARY ] );
+			expect( firstDomains ).toEqual( [ DOMAIN_PRIMARY ] );
 
 			const secondDomains = getDomainsBySite( state, { ID: secondSiteId } );
 
-			expect( secondDomains ).to.eql( [ DOMAIN_NOT_PRIMARY ] );
+			expect( secondDomains ).toEqual( [ DOMAIN_NOT_PRIMARY ] );
 		} );
 	} );
 
@@ -27,7 +26,7 @@ describe( 'selectors', () => {
 		test( 'should return domains by site id', () => {
 			const state = getStateInstance();
 			const domains = getDomainsBySiteId( state, firstSiteId );
-			expect( domains ).to.eql( [ DOMAIN_PRIMARY ] );
+			expect( domains ).toEqual( [ DOMAIN_PRIMARY ] );
 		} );
 	} );
 
@@ -35,9 +34,9 @@ describe( 'selectors', () => {
 		test( 'should return true if we are fetching domains', () => {
 			const state = getStateInstance();
 
-			expect( isRequestingSiteDomains( state, firstSiteId ) ).to.equal( false );
-			expect( isRequestingSiteDomains( state, secondSiteId ) ).to.equal( true );
-			expect( isRequestingSiteDomains( state, 'unknown' ) ).to.equal( false );
+			expect( isRequestingSiteDomains( state, firstSiteId ) ).toEqual( false );
+			expect( isRequestingSiteDomains( state, secondSiteId ) ).toEqual( true );
+			expect( isRequestingSiteDomains( state, 'unknown' ) ).toEqual( false );
 		} );
 	} );
 } );

--- a/client/state/sites/features/test/reducer.js
+++ b/client/state/sites/features/test/reducer.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import {
 	SITE_FEATURES_FETCH,
 	SITE_FEATURES_FETCH_COMPLETED,
@@ -10,14 +9,14 @@ describe( 'reducer', () => {
 	describe( '#features()', () => {
 		test( 'should return an empty state when original state is undefined and action is empty', () => {
 			const state = features( undefined, {} );
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should return an empty state when original state and action are empty', () => {
 			const original = Object.freeze( {} );
 			const state = features( original, {} );
 
-			expect( state ).to.eql( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return an empty state when original state is undefined and action is unknown', () => {
@@ -26,7 +25,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should return the original state when action is unknown', () => {
@@ -43,7 +42,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return the initial state with requesting enabled when fetching is triggered', () => {
@@ -52,7 +51,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: null,
 					error: null,
@@ -77,7 +76,7 @@ describe( 'reducer', () => {
 				error: 'Unable to fetch site features',
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: {},
 					error: 'Unable to fetch site features',
@@ -101,7 +100,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: {
 						active: [ 'active-01', 'active-03', 'active-03' ],
@@ -140,7 +139,7 @@ describe( 'reducer', () => {
 				siteId: 55555555,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: {
 						active: [ 'feature_active_a_01', 'feature_active_a_02', 'feature_active_a_03' ],
@@ -184,7 +183,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: {
 						active: [ 'feature_active_a_01', 'feature_active_a_02', 'feature_active_a_03' ],

--- a/client/state/sites/intro-offers/test/reducer.ts
+++ b/client/state/sites/intro-offers/test/reducer.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { SITE_INTRO_OFFER_RECEIVE } from 'calypso/state/action-types';
 import { items, IntroOfferReceiveAction } from '../reducer';
 
@@ -8,7 +7,7 @@ describe( 'reducer', () => {
 			test( 'should return an empty state when original state is undefined and action is empty', () => {
 				const state = items( undefined, { type: undefined } );
 
-				expect( state ).to.eql( {} );
+				expect( state ).toEqual( {} );
 			} );
 
 			test( 'should return the transformed introductory offer with no siteId', () => {
@@ -28,7 +27,7 @@ describe( 'reducer', () => {
 					],
 				} as IntroOfferReceiveAction );
 
-				expect( state ).to.eql( {
+				expect( state ).toEqual( {
 					none: {
 						2010: {
 							productId: 2010,
@@ -60,7 +59,7 @@ describe( 'reducer', () => {
 					],
 				} as IntroOfferReceiveAction );
 
-				expect( state ).to.eql( {
+				expect( state ).toEqual( {
 					12345: {
 						2010: {
 							productId: 2010,

--- a/client/state/sites/plans/test/reducer.js
+++ b/client/state/sites/plans/test/reducer.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import {
 	SITE_PLANS_FETCH,
 	SITE_PLANS_FETCH_COMPLETED,
@@ -12,14 +11,14 @@ describe( 'reducer', () => {
 		test( 'should return an empty state when original state is undefined and action is empty', () => {
 			const state = plans( undefined, {} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should return an empty state when original state and action are empty', () => {
 			const original = Object.freeze( {} );
 			const state = plans( original, {} );
 
-			expect( state ).to.eql( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return an empty state when original state is undefined and action is unknown', () => {
@@ -28,7 +27,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should return the original state when action is unknown', () => {
@@ -45,7 +44,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return the initial state with requesting enabled when fetching is triggered', () => {
@@ -54,7 +53,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: null,
 					error: null,
@@ -79,7 +78,7 @@ describe( 'reducer', () => {
 				error: 'Unable to fetch site plans',
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: [],
 					error: 'Unable to fetch site plans',
@@ -96,7 +95,7 @@ describe( 'reducer', () => {
 				plans: [],
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: [],
 					error: null,
@@ -120,7 +119,7 @@ describe( 'reducer', () => {
 				siteId: 55555555,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: [],
 					error: null,
@@ -150,7 +149,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: null,
 					error: null,
@@ -166,7 +165,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should return the original state when removal is triggered for an unknown site', () => {
@@ -183,7 +182,7 @@ describe( 'reducer', () => {
 				siteId: 22222222,
 			} );
 
-			expect( state ).to.eql( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should remove plans for a given site when removal is triggered', () => {
@@ -206,7 +205,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				22222222: {
 					data: [],
 					error: null,

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -6,7 +6,6 @@ import {
 	FEATURE_ADVANCED_DESIGN,
 	FEATURE_UPLOAD_PLUGINS,
 } from '@automattic/calypso-products';
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import { userState } from 'calypso/state/selectors/test/fixtures/user-state';
 import {
@@ -44,7 +43,7 @@ describe( 'selectors', () => {
 			};
 			const plans = getPlansBySite( state, { ID: 77203074 } );
 
-			expect( plans ).to.eql( plans2 );
+			expect( plans ).toEqual( plans2 );
 		} );
 	} );
 	describe( '#getPlansBySiteId()', () => {
@@ -65,7 +64,7 @@ describe( 'selectors', () => {
 			};
 			const plans = getPlansBySiteId( state, 2916284 );
 
-			expect( plans ).to.eql( plans1 );
+			expect( plans ).toEqual( plans1 );
 		} );
 	} );
 	describe( '#getCurrentPlan()', () => {
@@ -82,7 +81,7 @@ describe( 'selectors', () => {
 
 			test( 'returns null', () => {
 				const plan = getCurrentPlan( state, siteId );
-				expect( plan ).to.eql( null );
+				expect( plan ).toBeNull();
 			} );
 		} );
 
@@ -108,7 +107,7 @@ describe( 'selectors', () => {
 
 				test( 'returns the currentPlan', () => {
 					const plan = getCurrentPlan( state, siteId );
-					expect( plan ).to.eql( plan1 );
+					expect( plan ).toEqual( plan1 );
 				} );
 			} );
 
@@ -136,7 +135,7 @@ describe( 'selectors', () => {
 
 				test( 'returns a new sitePlanObject', () => {
 					const plan = getCurrentPlan( state, siteId );
-					expect( plan ).to.eql( {} );
+					expect( plan ).toEqual( {} );
 				} );
 			} );
 		} );
@@ -179,7 +178,7 @@ describe( 'selectors', () => {
 				},
 			};
 			const plan = getSitePlan( state, 77203074, 'gold' );
-			expect( plan ).to.eql( { currentPlan: true, productSlug: 'gold' } );
+			expect( plan ).toEqual( { currentPlan: true, productSlug: 'gold' } );
 		} );
 		test( 'should return falsey when plan is not found', () => {
 			const plans1 = {
@@ -223,7 +222,7 @@ describe( 'selectors', () => {
 				},
 			};
 			const plan = getSitePlan( state, 77203074, 'circle' );
-			expect( plan ).to.eql( undefined );
+			expect( plan ).toBeUndefined();
 		} );
 		test( 'should return falsey when siteId is not found', () => {
 			const plans1 = {
@@ -250,7 +249,7 @@ describe( 'selectors', () => {
 				},
 			};
 			const plan = getSitePlan( state, 77203074, 'gold' );
-			expect( plan ).to.eql( null );
+			expect( plan ).toBeNull();
 		} );
 	} );
 	describe( '#getPlanRawPrice()', () => {
@@ -297,29 +296,29 @@ describe( 'selectors', () => {
 		};
 		test( 'should return a plan price', () => {
 			const rawPrice = getSitePlanRawPrice( state, 77203074, 'personal-bundle' );
-			expect( rawPrice ).to.equal( 199 );
+			expect( rawPrice ).toEqual( 199 );
 		} );
 		test( 'should return a monthly price - annual term', () => {
 			const rawPrice = getSitePlanRawPrice( state, 77203074, 'personal-bundle', {
 				isMonthly: true,
 			} );
-			expect( rawPrice ).to.equal( 16.58 );
+			expect( rawPrice ).toEqual( 16.58 );
 		} );
 		test( 'should return a monthly price - biennial term', () => {
 			const rawPrice = getSitePlanRawPrice( state, 77203074, 'value_bundle-2y', {
 				isMonthly: true,
 			} );
-			expect( rawPrice ).to.equal( 11 );
+			expect( rawPrice ).toEqual( 11 );
 		} );
 		test( 'should return a monthly price - monthly term', () => {
 			const rawPrice = getSitePlanRawPrice( state, 77203074, 'jetpack_premium_monthly', {
 				isMonthly: true,
 			} );
-			expect( rawPrice ).to.equal( 40 );
+			expect( rawPrice ).toEqual( 40 );
 		} );
 		test( 'should return raw price, if no discount is available', () => {
 			const rawPrice = getSitePlanRawPrice( state, 77203074, 'value_bundle', { isMonthly: false } );
-			expect( rawPrice ).to.equal( 199 );
+			expect( rawPrice ).toEqual( 199 );
 		} );
 	} );
 	describe( '#getPlanDiscountedRawPrice()', () => {
@@ -373,37 +372,37 @@ describe( 'selectors', () => {
 
 		test( 'should return a discount price', () => {
 			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'personal-bundle' );
-			expect( discountPrice ).to.equal( 99 );
+			expect( discountPrice ).toEqual( 99 );
 		} );
 		test( 'should return a monthly discount price - annual term', () => {
 			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'personal-bundle', {
 				isMonthly: true,
 			} );
-			expect( discountPrice ).to.equal( 8.25 );
+			expect( discountPrice ).toEqual( 8.25 );
 		} );
 		test( 'should return a monthly discount price - biennial term', () => {
 			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'value_bundle-2y', {
 				isMonthly: true,
 			} );
-			expect( discountPrice ).to.equal( 10 );
+			expect( discountPrice ).toEqual( 10 );
 		} );
 		test( 'should return a monthly discount price - monthly term (isMonthly: true)', () => {
 			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'jetpack_premium_monthly', {
 				isMonthly: true,
 			} );
-			expect( discountPrice ).to.equal( 30 );
+			expect( discountPrice ).toEqual( 30 );
 		} );
 		test( 'should return a monthly discount price - monthly term (isMonthly: false)', () => {
 			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'jetpack_premium_monthly', {
 				isMonthly: false,
 			} );
-			expect( discountPrice ).to.equal( 30 );
+			expect( discountPrice ).toEqual( 30 );
 		} );
 		test( 'should return null, if no discount is available', () => {
 			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'value_bundle', {
 				isMonthly: true,
 			} );
-			expect( discountPrice ).to.equal( null );
+			expect( discountPrice ).toBeNull();
 		} );
 	} );
 
@@ -452,35 +451,35 @@ describe( 'selectors', () => {
 		};
 		test( 'should return a raw discount', () => {
 			const planRawDiscount = getPlanRawDiscount( state, 77203074, 'personal-bundle' );
-			expect( planRawDiscount ).to.equal( 100 );
+			expect( planRawDiscount ).toEqual( 100 );
 		} );
 
 		test( 'should return a monthly raw discount - annual term', () => {
 			const planRawDiscount = getPlanRawDiscount( state, 77203074, 'personal-bundle', {
 				isMonthly: true,
 			} );
-			expect( planRawDiscount ).to.equal( 8.33 );
+			expect( planRawDiscount ).toEqual( 8.33 );
 		} );
 
 		test( 'should return a monthly raw discount - biennial term', () => {
 			const planRawDiscount = getPlanRawDiscount( state, 77203074, 'value_bundle-2y', {
 				isMonthly: true,
 			} );
-			expect( planRawDiscount ).to.equal( 10 );
+			expect( planRawDiscount ).toEqual( 10 );
 		} );
 
 		test( 'should return a monthly raw discount - monthly term', () => {
 			const planRawDiscount = getPlanRawDiscount( state, 77203074, 'jetpack_premium_monthly', {
 				isMonthly: true,
 			} );
-			expect( planRawDiscount ).to.equal( 240 );
+			expect( planRawDiscount ).toEqual( 240 );
 		} );
 
 		test( 'should return null, if no raw discount is available', () => {
 			const planRawDiscount = getPlanRawDiscount( state, 77203074, 'value_bundle', {
 				isMonthly: true,
 			} );
-			expect( planRawDiscount ).to.equal( null );
+			expect( planRawDiscount ).toBeNull();
 		} );
 	} );
 
@@ -507,8 +506,8 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( hasDomainCredit( state, 77203074 ) ).to.equal( true );
-			expect( hasDomainCredit( state, 2916284 ) ).to.equal( false );
+			expect( hasDomainCredit( state, 77203074 ) ).toEqual( true );
+			expect( hasDomainCredit( state, 2916284 ) ).toEqual( false );
 		} );
 	} );
 	describe( '#isRequestingSitePlans()', () => {
@@ -532,9 +531,9 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isRequestingSitePlans( state, 2916284 ) ).to.equal( true );
-			expect( isRequestingSitePlans( state, 77203074 ) ).to.equal( false );
-			expect( isRequestingSitePlans( state, 'unknown' ) ).to.equal( false );
+			expect( isRequestingSitePlans( state, 2916284 ) ).toEqual( true );
+			expect( isRequestingSitePlans( state, 77203074 ) ).toEqual( false );
+			expect( isRequestingSitePlans( state, 'unknown' ) ).toEqual( false );
 		} );
 	} );
 	describe( '#isPlanDiscounted', () => {
@@ -569,7 +568,7 @@ describe( 'selectors', () => {
 				},
 			};
 			const discountPrice = isSitePlanDiscounted( state, 77203074, 'silver' );
-			expect( discountPrice ).to.equal( false );
+			expect( discountPrice ).toEqual( false );
 		} );
 		test( 'should return true, if discount is available', () => {
 			const plans = {
@@ -602,7 +601,7 @@ describe( 'selectors', () => {
 				},
 			};
 			const isDiscounted = isSitePlanDiscounted( state, 77203074, 'bronze' );
-			expect( isDiscounted ).to.equal( true );
+			expect( isDiscounted ).toEqual( true );
 		} );
 		test( 'should return null, if plan is unknown', () => {
 			const plans = {
@@ -635,7 +634,7 @@ describe( 'selectors', () => {
 				},
 			};
 			const isDiscounted = isSitePlanDiscounted( state, 77203074, 'diamond' );
-			expect( isDiscounted ).to.equal( null );
+			expect( isDiscounted ).toBeNull();
 		} );
 	} );
 
@@ -658,11 +657,11 @@ describe( 'selectors', () => {
 		};
 
 		test( 'should return false if user is not a plan owner', () => {
-			expect( isCurrentUserCurrentPlanOwner( state, 2916284 ) ).to.be.false;
+			expect( isCurrentUserCurrentPlanOwner( state, 2916284 ) ).toBe( false );
 		} );
 
 		test( 'should return true if user is a plan owner', () => {
-			expect( isCurrentUserCurrentPlanOwner( state, 77203074 ) ).to.be.true;
+			expect( isCurrentUserCurrentPlanOwner( state, 77203074 ) ).toBe( true );
 		} );
 	} );
 
@@ -679,7 +678,7 @@ describe( 'selectors', () => {
 					},
 					2916284
 				)
-			).to.be.null;
+			).toBeNull();
 		} );
 
 		test( "should return the given site's current plan's product slug", () => {
@@ -701,7 +700,7 @@ describe( 'selectors', () => {
 					},
 					2916284
 				)
-			).to.equal( PLAN_PREMIUM );
+			).toEqual( PLAN_PREMIUM );
 		} );
 	} );
 
@@ -726,7 +725,7 @@ describe( 'selectors', () => {
 					null,
 					FEATURE_ADVANCED_DESIGN
 				)
-			).to.be.false;
+			).toBe( false );
 		} );
 
 		test( 'should return false if no feature is given', () => {
@@ -748,7 +747,7 @@ describe( 'selectors', () => {
 					},
 					2916284
 				)
-			).to.be.false;
+			).toBe( false );
 		} );
 
 		test( 'should return false if no plan data is found for the given siteId', () => {
@@ -764,7 +763,7 @@ describe( 'selectors', () => {
 					2916284,
 					FEATURE_ADVANCED_DESIGN
 				)
-			).to.be.false;
+			).toBe( false );
 		} );
 
 		test( "should return false if the site's current plan doesn't include the specified feature", () => {
@@ -787,7 +786,7 @@ describe( 'selectors', () => {
 					2916284,
 					FEATURE_UPLOAD_PLUGINS
 				)
-			).to.be.false;
+			).toBe( false );
 		} );
 
 		test( "should return true if the site's current plan includes the specified feature", () => {
@@ -810,7 +809,7 @@ describe( 'selectors', () => {
 					2916284,
 					FEATURE_ADVANCED_DESIGN
 				)
-			).to.be.true;
+			).toBe( true );
 		} );
 
 		test( "should return true if the site's current plan includes a hidden feature", () => {
@@ -833,7 +832,7 @@ describe( 'selectors', () => {
 					2916284,
 					FEATURE_AUDIO_UPLOADS
 				)
-			).to.be.true;
+			).toBe( true );
 		} );
 	} );
 } );

--- a/client/state/sites/products/test/reducer.js
+++ b/client/state/sites/products/test/reducer.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import {
 	SITE_PRODUCTS_FETCH,
 	SITE_PRODUCTS_FETCH_COMPLETED,
@@ -11,14 +10,14 @@ describe( 'reducer', () => {
 		test( 'should return an empty state when original state is undefined and action is empty', () => {
 			const state = products( undefined, {} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should return an empty state when original state and action are empty', () => {
 			const original = Object.freeze( {} );
 			const state = products( original, {} );
 
-			expect( state ).to.eql( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return an empty state when original state is undefined and action is unknown', () => {
@@ -27,7 +26,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should return the original state when action is unknown', () => {
@@ -44,7 +43,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return the initial state with requesting enabled when fetching is triggered', () => {
@@ -53,7 +52,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: null,
 					error: null,
@@ -78,7 +77,7 @@ describe( 'reducer', () => {
 				error: 'Unable to fetch site products',
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: {},
 					error: 'Unable to fetch site products',
@@ -95,7 +94,7 @@ describe( 'reducer', () => {
 				products: {},
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: {},
 					error: null,
@@ -119,7 +118,7 @@ describe( 'reducer', () => {
 				siteId: 55555555,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: {},
 					error: null,
@@ -149,7 +148,7 @@ describe( 'reducer', () => {
 				siteId: 11111111,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				11111111: {
 					data: null,
 					error: null,

--- a/client/state/sites/products/test/selectors.js
+++ b/client/state/sites/products/test/selectors.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import {
 	getAvailableProductsBySiteId,
 	getProductsBySiteId,
@@ -24,7 +23,7 @@ describe( 'selectors', () => {
 			};
 			const products = getProductsBySiteId( state, 2916284 );
 
-			expect( products ).to.eql( products1 );
+			expect( products ).toEqual( products1 );
 		} );
 	} );
 
@@ -46,7 +45,7 @@ describe( 'selectors', () => {
 			};
 			const products = getAvailableProductsBySiteId( state, 2916284 );
 
-			expect( products ).to.eql( {
+			expect( products ).toEqual( {
 				data: { first_product: { available: true }, third_product: { available: true } },
 			} );
 		} );
@@ -73,9 +72,9 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isRequestingSiteProducts( state, 2916284 ) ).to.equal( true );
-			expect( isRequestingSiteProducts( state, 77203074 ) ).to.equal( false );
-			expect( isRequestingSiteProducts( state, 'unknown' ) ).to.equal( false );
+			expect( isRequestingSiteProducts( state, 2916284 ) ).toEqual( true );
+			expect( isRequestingSiteProducts( state, 77203074 ) ).toEqual( false );
+			expect( isRequestingSiteProducts( state, 'unknown' ) ).toEqual( false );
 		} );
 	} );
 } );

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import {
 	MEDIA_DELETE,
@@ -19,34 +18,39 @@ import {
 } from 'calypso/state/action-types';
 import { THEME_ACTIVATE_SUCCESS } from 'calypso/state/themes/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { items, requestingAll, requesting, hasAllSitesList } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
+	beforeAll( () => {
+		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+	} );
+
+	afterAll( () => {
+		jest.clearAllMocks();
 	} );
 
 	test( 'should export expected reducer keys', () => {
-		expect( reducer( undefined, {} ) ).to.have.keys( [
-			'connection',
-			'domains',
-			'requestingAll',
-			'items',
-			'plans',
-			'products',
-			'requesting',
-			'hasAllSitesList',
-			'features',
-			'introOffers',
-		] );
+		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(
+			expect.arrayContaining( [
+				'connection',
+				'domains',
+				'requestingAll',
+				'items',
+				'plans',
+				'products',
+				'requesting',
+				'hasAllSitesList',
+				'features',
+				'introOffers',
+			] )
+		);
 	} );
 
 	describe( 'requestingAll()', () => {
 		test( 'should default false', () => {
 			const state = requestingAll( undefined, {} );
 
-			expect( state ).to.be.false;
+			expect( state ).toBe( false );
 		} );
 
 		test( 'should update fetching state on fetch', () => {
@@ -54,7 +58,7 @@ describe( 'reducer', () => {
 				type: SITES_REQUEST,
 			} );
 
-			expect( state ).to.be.true;
+			expect( state ).toBe( true );
 		} );
 
 		test( 'should update fetching state on success', () => {
@@ -62,7 +66,7 @@ describe( 'reducer', () => {
 				type: SITES_REQUEST_SUCCESS,
 			} );
 
-			expect( state ).to.be.false;
+			expect( state ).toBe( false );
 		} );
 
 		test( 'should update fetching state on failure', () => {
@@ -70,7 +74,7 @@ describe( 'reducer', () => {
 				type: SITES_REQUEST_FAILURE,
 			} );
 
-			expect( state ).to.be.false;
+			expect( state ).toBe( false );
 		} );
 	} );
 
@@ -78,7 +82,7 @@ describe( 'reducer', () => {
 		test( 'should default to null', () => {
 			const state = items( undefined, {} );
 
-			expect( state ).to.be.null;
+			expect( state ).toBeNull();
 		} );
 
 		test( 'can receive all sites', () => {
@@ -89,7 +93,7 @@ describe( 'reducer', () => {
 					{ ID: 77203074, name: 'Another test site' },
 				],
 			} );
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
 				77203074: { ID: 77203074, name: 'Another test site' },
 			} );
@@ -104,7 +108,7 @@ describe( 'reducer', () => {
 				type: SITES_RECEIVE,
 				sites: [ { ID: 77203074, name: 'A Bowl of Pho' } ],
 			} );
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				77203074: { ID: 77203074, name: 'A Bowl of Pho' },
 			} );
 		} );
@@ -118,7 +122,7 @@ describe( 'reducer', () => {
 				sites: [ { ID: 2916284, name: 'WordPress.com Example Blog' } ],
 			} );
 
-			expect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should index sites by ID', () => {
@@ -127,7 +131,7 @@ describe( 'reducer', () => {
 				site: { ID: 2916284, name: 'WordPress.com Example Blog' },
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
 			} );
 		} );
@@ -141,7 +145,7 @@ describe( 'reducer', () => {
 				site: { ID: 77203074, name: 'Just You Wait' },
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
 				77203074: { ID: 77203074, name: 'Just You Wait' },
 			} );
@@ -158,7 +162,7 @@ describe( 'reducer', () => {
 				siteId: 2916284,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				77203074: { ID: 77203074, name: 'Just You Wait' },
 			} );
 		} );
@@ -175,7 +179,7 @@ describe( 'reducer', () => {
 				status: {},
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				77203074: { ID: 77203074, name: 'Just You Wait' },
 			} );
 		} );
@@ -191,7 +195,7 @@ describe( 'reducer', () => {
 				siteId: 1337,
 			} );
 
-			expect( state ).to.eql( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should override previous site of same ID', () => {
@@ -203,7 +207,7 @@ describe( 'reducer', () => {
 				site: { ID: 2916284, name: 'Just You Wait' },
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: { ID: 2916284, name: 'Just You Wait' },
 			} );
 		} );
@@ -217,7 +221,7 @@ describe( 'reducer', () => {
 				siteId: 2916284,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
@@ -235,7 +239,7 @@ describe( 'reducer', () => {
 				siteId: 77203074,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
 			} );
 		} );
@@ -256,7 +260,7 @@ describe( 'reducer', () => {
 				themeStylesheet: 'pub/twentysixteen',
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
@@ -275,7 +279,7 @@ describe( 'reducer', () => {
 				settings: {},
 			} );
 
-			expect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return same state when site settings received with icon for untracked site', () => {
@@ -288,7 +292,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return same state if received icon setting and matches current value', () => {
@@ -309,7 +313,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return same state if received privacy setting and matches current value', () => {
@@ -328,7 +332,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return same state if received null icon setting and already unset', () => {
@@ -346,7 +350,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return site having blavatar with unset icon property if received null icon setting', () => {
@@ -368,7 +372,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
@@ -394,7 +398,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
@@ -417,7 +421,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
@@ -444,7 +448,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
@@ -469,7 +473,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
@@ -497,7 +501,7 @@ describe( 'reducer', () => {
 				mediaIds: [ 36 ],
 			} );
 
-			expect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return site with unset icon property if media deleted includes icon setting', () => {
@@ -516,7 +520,7 @@ describe( 'reducer', () => {
 				mediaIds: [ 42 ],
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
@@ -533,7 +537,7 @@ describe( 'reducer', () => {
 			} );
 			const state = serialize( items, original );
 
-			expect( state ).to.eql( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should load valid persisted state', () => {
@@ -545,7 +549,7 @@ describe( 'reducer', () => {
 			} );
 			const state = deserialize( items, original );
 
-			expect( state ).to.eql( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return initial state when state is invalid', () => {
@@ -554,7 +558,7 @@ describe( 'reducer', () => {
 			} );
 			const state = deserialize( items, original );
 
-			expect( state ).to.be.null;
+			expect( state ).toBeNull();
 		} );
 	} );
 
@@ -562,7 +566,7 @@ describe( 'reducer', () => {
 		test( 'should default to an empty object', () => {
 			const state = requesting( undefined, {} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should track site request started', () => {
@@ -571,7 +575,7 @@ describe( 'reducer', () => {
 				siteId: 2916284,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: true,
 			} );
 		} );
@@ -585,7 +589,7 @@ describe( 'reducer', () => {
 				siteId: 77203074,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: true,
 				77203074: true,
 			} );
@@ -601,7 +605,7 @@ describe( 'reducer', () => {
 				siteId: 2916284,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: false,
 				77203074: true,
 			} );
@@ -617,7 +621,7 @@ describe( 'reducer', () => {
 				siteId: 77203074,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: false,
 				77203074: false,
 			} );
@@ -628,7 +632,7 @@ describe( 'reducer', () => {
 		test( 'should default false', () => {
 			const state = hasAllSitesList( undefined, {} );
 
-			expect( state ).to.be.false;
+			expect( state ).toBe( false );
 		} );
 
 		test( 'should update on receiving all sites', () => {
@@ -636,7 +640,7 @@ describe( 'reducer', () => {
 				type: SITES_RECEIVE,
 			} );
 
-			expect( state ).to.be.true;
+			expect( state ).toBe( true );
 		} );
 
 		test( 'should not update on receiving a single site', () => {
@@ -644,7 +648,7 @@ describe( 'reducer', () => {
 				type: SITE_RECEIVE,
 			} );
 
-			expect( state ).to.be.false;
+			expect( state ).toBe( false );
 		} );
 	} );
 
@@ -678,7 +682,7 @@ describe( 'reducer', () => {
 				siteId: 2916284,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				2916284: {
 					updates: {
 						plugins: 0,
@@ -704,7 +708,7 @@ describe( 'reducer', () => {
 			} );
 
 			const state = deserialize( items, original );
-			expect( state ).to.eql( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return initial state when persisted state has invalid updates', () => {
@@ -717,7 +721,7 @@ describe( 'reducer', () => {
 			} );
 
 			const state = deserialize( items, original );
-			expect( state ).to.be.null;
+			expect( state ).toBeNull();
 		} );
 	} );
 } );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -5,7 +5,6 @@ import {
 	PLAN_FREE,
 	WPCOM_FEATURES_WORDADS,
 } from '@automattic/calypso-products';
-import { expect as chaiExpect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import { userState } from 'calypso/state/selectors/test/fixtures/user-state';
 import {
@@ -96,7 +95,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( site ).to.be.null;
+			expect( site ).toBeNull();
 		} );
 
 		test( 'should return a normalized site with computed attributes', () => {
@@ -144,13 +143,13 @@ describe( 'selectors', () => {
 
 			// Verify that getting by slug returns the object memoized when previously getting by ID
 			const memoizedSlugSite = getSite( state, 'example.com' );
-			chaiExpect( memoizedSlugSite ).to.equal( site );
+			expect( memoizedSlugSite ).toEqual( site );
 
 			// Clear the memo cache and verify computed attributes are computed when getting by slug
 			getSite.clearCache();
 			const nonMemoizedSlugSite = getSite( state, 'example.com' );
-			chaiExpect( nonMemoizedSlugSite ).to.not.equal( memoizedSlugSite );
-			chaiExpect( nonMemoizedSlugSite ).to.eql( expectedSite );
+			expect( nonMemoizedSlugSite ).not.toBe( memoizedSlugSite );
+			expect( nonMemoizedSlugSite ).toEqual( expectedSite );
 		} );
 
 		test( 'should return a normalized site with correct slug when sites with collisions are passed in attributes', () => {
@@ -186,7 +185,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( site ).to.eql( {
+			expect( site ).toEqual( {
 				ID: 2916284,
 				name: 'WordPress.com Example Blog',
 				URL: 'https://example.wordpress.com',
@@ -218,9 +217,9 @@ describe( 'selectors', () => {
 			// Calling the selector two times on the same state should return identical value
 			const firstSite = getSite( state, 123 );
 			const secondSite = getSite( state, 123 );
-			chaiExpect( firstSite ).to.be.ok;
-			chaiExpect( secondSite ).to.be.ok;
-			chaiExpect( firstSite ).to.equal( secondSite );
+			expect( firstSite ).toBeTruthy();
+			expect( secondSite ).toBeTruthy();
+			expect( firstSite ).toEqual( secondSite );
 
 			// Construct an updated state with new items, but the first site object itself is unmodified
 			const altSite = {
@@ -239,11 +238,11 @@ describe( 'selectors', () => {
 			};
 			// Check that the new site is returned
 			const altGotSite = getSite( updatedState, 456 );
-			chaiExpect( altGotSite ).to.have.property( 'ID', 456 );
+			expect( altGotSite ).toHaveProperty( 'ID', 456 );
 
 			// And that the old one was memoized and identical site object is returned
 			const thirdSite = getSite( updatedState, 123 );
-			chaiExpect( thirdSite ).to.equal( firstSite );
+			expect( thirdSite ).toEqual( firstSite );
 		} );
 	} );
 
@@ -258,7 +257,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			chaiExpect( collisions ).to.eql( [] );
+			expect( collisions ).toEqual( [] );
 		} );
 
 		test( 'should return an array of conflicting site IDs', () => {
@@ -271,7 +270,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			chaiExpect( collisions ).to.eql( [ 77203199 ] );
+			expect( collisions ).toEqual( [ 77203199 ] );
 		} );
 
 		test( 'should ignore URL protocol in considering conflict', () => {
@@ -284,7 +283,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			chaiExpect( collisions ).to.eql( [ 77203199 ] );
+			expect( collisions ).toEqual( [ 77203199 ] );
 		} );
 	} );
 
@@ -302,7 +301,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( isConflicting ).to.be.false;
+			expect( isConflicting ).toBe( false );
 		} );
 
 		test( 'should return true if the specified site ID is included in the conflicting set', () => {
@@ -318,7 +317,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( isConflicting ).to.be.true;
+			expect( isConflicting ).toBe( true );
 		} );
 	} );
 
@@ -334,7 +333,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( singleUserSite ).to.be.null;
+			expect( singleUserSite ).toBeNull();
 		} );
 
 		test( 'it should return true if the site is a single user site', () => {
@@ -357,7 +356,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( singleUserSite ).to.be.true;
+			expect( singleUserSite ).toBe( true );
 		} );
 
 		test( 'it should return false if the site is not a single user site', () => {
@@ -380,7 +379,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( singleUserSite ).to.be.false;
+			expect( singleUserSite ).toBe( false );
 		} );
 	} );
 
@@ -395,7 +394,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( jetpackSite ).to.be.null;
+			expect( jetpackSite ).toBeNull();
 		} );
 
 		test( 'it should return true if the site is a jetpack site', () => {
@@ -410,7 +409,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( jetpackSite ).to.be.true;
+			expect( jetpackSite ).toBe( true );
 		} );
 
 		test( 'it should return false if the site is not a jetpack site', () => {
@@ -425,7 +424,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( jetpackSite ).to.be.false;
+			expect( jetpackSite ).toBe( false );
 		} );
 	} );
 
@@ -441,7 +440,7 @@ describe( 'selectors', () => {
 				'custom-content-types'
 			);
 
-			chaiExpect( isActive ).to.be.null;
+			expect( isActive ).toBeNull();
 		} );
 
 		test( 'should return null if the site is known and not a Jetpack site', () => {
@@ -462,7 +461,7 @@ describe( 'selectors', () => {
 				'custom-content-types'
 			);
 
-			chaiExpect( isActive ).to.be.null;
+			expect( isActive ).toBeNull();
 		} );
 
 		test( 'should return false if the site is a Jetpack site without the module active', () => {
@@ -485,7 +484,7 @@ describe( 'selectors', () => {
 				'custom-content-types'
 			);
 
-			chaiExpect( isActive ).to.be.false;
+			expect( isActive ).toBe( false );
 		} );
 
 		test( 'should return true if the site is a Jetpack site and the module is active', () => {
@@ -508,7 +507,7 @@ describe( 'selectors', () => {
 				'custom-content-types'
 			);
 
-			chaiExpect( isActive ).to.be.true;
+			expect( isActive ).toBe( true );
 		} );
 	} );
 
@@ -524,7 +523,7 @@ describe( 'selectors', () => {
 				'4.1.0'
 			);
 
-			chaiExpect( isMeetingMinimum ).to.be.null;
+			expect( isMeetingMinimum ).toBeNull();
 		} );
 
 		test( 'should return null if the site is not a Jetpack site', () => {
@@ -544,7 +543,7 @@ describe( 'selectors', () => {
 				'4.1.0'
 			);
 
-			chaiExpect( isMeetingMinimum ).to.be.null;
+			expect( isMeetingMinimum ).toBeNull();
 		} );
 
 		test( 'should return null if the site option is not known', () => {
@@ -564,7 +563,7 @@ describe( 'selectors', () => {
 				'4.1.0'
 			);
 
-			chaiExpect( isMeetingMinimum ).to.be.null;
+			expect( isMeetingMinimum ).toBeNull();
 		} );
 
 		test( 'should return true if meeting the minimum version', () => {
@@ -587,7 +586,7 @@ describe( 'selectors', () => {
 				'4.1.0'
 			);
 
-			chaiExpect( isMeetingMinimum ).to.be.true;
+			expect( isMeetingMinimum ).toBe( true );
 		} );
 
 		test( 'should return false if not meeting the minimum version', () => {
@@ -610,7 +609,7 @@ describe( 'selectors', () => {
 				'4.1.0'
 			);
 
-			chaiExpect( isMeetingMinimum ).to.be.false;
+			expect( isMeetingMinimum ).toBe( false );
 		} );
 	} );
 
@@ -625,7 +624,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( slug ).to.be.null;
+			expect( slug ).toBeNull();
 		} );
 
 		test( 'should return the unmapped hostname for a redirect site', () => {
@@ -647,7 +646,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( slug ).to.equal( 'example.wordpress.com' );
+			expect( slug ).toEqual( 'example.wordpress.com' );
 		} );
 
 		test( 'should return the unmapped hostname for a conflicting site', () => {
@@ -671,7 +670,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( slug ).to.equal( 'testtwosites2014.wordpress.com' );
+			expect( slug ).toEqual( 'testtwosites2014.wordpress.com' );
 		} );
 
 		test( 'should return the URL with scheme removed and paths separated', () => {
@@ -689,7 +688,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( slug ).to.equal( 'testtwosites2014.wordpress.com::path::to::site' );
+			expect( slug ).toEqual( 'testtwosites2014.wordpress.com::path::to::site' );
 		} );
 	} );
 
@@ -704,7 +703,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( domain ).to.be.null;
+			expect( domain ).toBeNull();
 		} );
 
 		test( 'should strip the protocol off', () => {
@@ -722,7 +721,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( domain ).to.equal( 'example.com' );
+			expect( domain ).toEqual( 'example.com' );
 		} );
 
 		test( 'should return the unmapped slug for a redirect site', () => {
@@ -744,7 +743,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( domain ).to.equal( 'example.wordpress.com' );
+			expect( domain ).toEqual( 'example.wordpress.com' );
 		} );
 
 		test( 'should return the site slug for a conflicting site', () => {
@@ -768,7 +767,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( domain ).to.equal( 'testtwosites2014.wordpress.com' );
+			expect( domain ).toEqual( 'testtwosites2014.wordpress.com' );
 		} );
 	} );
 
@@ -783,7 +782,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( title ).to.be.null;
+			expect( title ).toBeNull();
 		} );
 
 		test( 'should return the trimmed name of the site', () => {
@@ -802,7 +801,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( title ).to.equal( 'Example Site' );
+			expect( title ).toEqual( 'Example Site' );
 		} );
 
 		test( 'should fall back to the domain if the site name is empty', () => {
@@ -821,7 +820,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( title ).to.equal( 'example.com' );
+			expect( title ).toEqual( 'example.com' );
 		} );
 	} );
 
@@ -836,7 +835,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( isPreviewable ).to.be.null;
+			expect( isPreviewable ).toBeNull();
 		} );
 
 		test( 'should return false if the site is VIP', () => {
@@ -858,7 +857,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( isPreviewable ).to.be.false;
+			expect( isPreviewable ).toBe( false );
 		} );
 
 		test( 'should return false if the site unmapped URL is unknown', () => {
@@ -876,7 +875,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( isPreviewable ).to.be.false;
+			expect( isPreviewable ).toBe( false );
 		} );
 
 		test( 'should return false if the site unmapped URL is non-HTTPS', () => {
@@ -897,7 +896,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( isPreviewable ).to.be.false;
+			expect( isPreviewable ).toBe( false );
 		} );
 
 		test( 'should return true if the site unmapped URL is HTTPS', () => {
@@ -918,7 +917,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( isPreviewable ).to.be.true;
+			expect( isPreviewable ).toBe( true );
 		} );
 	} );
 
@@ -934,7 +933,7 @@ describe( 'selectors', () => {
 				'example_option'
 			);
 
-			chaiExpect( siteOption ).to.be.null;
+			expect( siteOption ).toBeNull();
 		} );
 
 		test( 'should return null if the options are not known for that site', () => {
@@ -953,7 +952,7 @@ describe( 'selectors', () => {
 				'example_option'
 			);
 
-			chaiExpect( siteOption ).to.be.null;
+			expect( siteOption ).toBeNull();
 		} );
 
 		test( 'should return null if the option is not known for that site', () => {
@@ -975,7 +974,7 @@ describe( 'selectors', () => {
 				'example_option'
 			);
 
-			chaiExpect( siteOption ).to.be.null;
+			expect( siteOption ).toBeNull();
 		} );
 
 		test( 'should return the option value if the option is known for that site', () => {
@@ -997,7 +996,7 @@ describe( 'selectors', () => {
 				'example_option'
 			);
 
-			chaiExpect( siteOption ).to.eql( 'example value' );
+			expect( siteOption ).toEqual( 'example value' );
 		} );
 	} );
 
@@ -1009,7 +1008,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			chaiExpect( isRequesting ).to.be.false;
+			expect( isRequesting ).toBe( false );
 		} );
 
 		test( 'should return true if a request is in progress', () => {
@@ -1019,7 +1018,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			chaiExpect( isRequesting ).to.be.true;
+			expect( isRequesting ).toBe( true );
 		} );
 	} );
 
@@ -1034,7 +1033,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( isRequesting ).to.be.false;
+			expect( isRequesting ).toBe( false );
 		} );
 
 		test( 'should return true if a request is in progress', () => {
@@ -1049,7 +1048,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( isRequesting ).to.be.true;
+			expect( isRequesting ).toBe( true );
 		} );
 
 		test( 'should return false after a request has completed', () => {
@@ -1064,7 +1063,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( isRequesting ).to.be.false;
+			expect( isRequesting ).toBe( false );
 		} );
 	} );
 
@@ -1079,7 +1078,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( seoTitleFormats ).to.eql( {} );
+			expect( seoTitleFormats ).toEqual( {} );
 		} );
 
 		test( 'should return an empty object when unavailable for a known site', () => {
@@ -1100,7 +1099,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( seoTitleFormats ).to.eql( {} );
+			expect( seoTitleFormats ).toEqual( {} );
 		} );
 
 		test( 'should return seo title formats by type if available', () => {
@@ -1132,7 +1131,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( seoTitleFormats ).to.eql( {
+			expect( seoTitleFormats ).toEqual( {
 				archives: [],
 				frontPage: [
 					{
@@ -1159,7 +1158,7 @@ describe( 'selectors', () => {
 				{}
 			);
 
-			chaiExpect( seoTitle ).to.eql( '' );
+			expect( seoTitle ).toEqual( '' );
 		} );
 
 		test( 'should convert site name and tagline for front page title type', () => {
@@ -1200,7 +1199,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql( 'Site Title | Site Tagline' );
+			expect( seoTitle ).toEqual( 'Site Title | Site Tagline' );
 		} );
 
 		test( 'should default to site name for front page title type if no other title is set', () => {
@@ -1230,7 +1229,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql( 'Site Title' );
+			expect( seoTitle ).toEqual( 'Site Title' );
 		} );
 
 		test( 'should convert site name, tagline and post title for posts title type', () => {
@@ -1281,7 +1280,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql( 'Site Title | Site Tagline > Post Title' );
+			expect( seoTitle ).toEqual( 'Site Title | Site Tagline > Post Title' );
 		} );
 
 		test( 'should default to post title for posts title type if no other title is set', () => {
@@ -1314,7 +1313,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql( 'Post Title' );
+			expect( seoTitle ).toEqual( 'Post Title' );
 		} );
 
 		test( 'should return empty string as post title for posts title type if post title is missing', () => {
@@ -1345,7 +1344,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql( '' );
+			expect( seoTitle ).toEqual( '' );
 		} );
 
 		test( 'should convert site name, tagline and page title for pages title type', () => {
@@ -1396,7 +1395,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql( 'Site Title | Site Tagline > Page Title' );
+			expect( seoTitle ).toEqual( 'Site Title | Site Tagline > Page Title' );
 		} );
 
 		test( 'should default to empty string for pages title type if no other title is set', () => {
@@ -1429,7 +1428,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql( '' );
+			expect( seoTitle ).toEqual( '' );
 		} );
 
 		test( 'should return empty string as page title for pages title type if page title is missing', () => {
@@ -1460,7 +1459,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql( '' );
+			expect( seoTitle ).toEqual( '' );
 		} );
 
 		test( 'should convert site name, tagline and group name for groups title type', () => {
@@ -1509,7 +1508,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql( 'Site Title | Site Tagline > Tag Name' );
+			expect( seoTitle ).toEqual( 'Site Title | Site Tagline > Tag Name' );
 		} );
 
 		test( 'should default to empty string for groups title type if no other title is set', () => {
@@ -1539,7 +1538,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql( '' );
+			expect( seoTitle ).toEqual( '' );
 		} );
 
 		test( 'should convert site name, tagline, date, and archive title for archives title type', () => {
@@ -1596,7 +1595,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql(
+			expect( seoTitle ).toEqual(
 				'Site Title | Site Tagline > Example Archive Title/Date | Example Archive Title/Date'
 			);
 		} );
@@ -1628,7 +1627,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql( '' );
+			expect( seoTitle ).toEqual( '' );
 		} );
 
 		test( 'should default to post title for a misc title type', () => {
@@ -1659,7 +1658,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql( 'Post Title' );
+			expect( seoTitle ).toEqual( 'Post Title' );
 		} );
 
 		test( 'should default to site name for a misc title type if post title is missing', () => {
@@ -1687,7 +1686,7 @@ describe( 'selectors', () => {
 				}
 			);
 
-			chaiExpect( seoTitle ).to.eql( 'Site Title' );
+			expect( seoTitle ).toEqual( 'Site Title' );
 		} );
 	} );
 
@@ -1702,7 +1701,7 @@ describe( 'selectors', () => {
 				'testtwosites2014.wordpress.com'
 			);
 
-			chaiExpect( site ).to.be.null;
+			expect( site ).toBeNull();
 		} );
 
 		test( 'should return a matched site', () => {
@@ -1718,7 +1717,7 @@ describe( 'selectors', () => {
 			};
 			const site = getSiteBySlug( state, 'testtwosites2014.wordpress.com' );
 
-			chaiExpect( site ).to.equal( state.sites.items[ 77203199 ] );
+			expect( site ).toEqual( state.sites.items[ 77203199 ] );
 		} );
 
 		test( 'should return a matched site with nested path', () => {
@@ -1735,7 +1734,7 @@ describe( 'selectors', () => {
 			};
 			const site = getSiteBySlug( state, 'testtwosites2014.wordpress.com::path::to::site' );
 
-			chaiExpect( site ).to.equal( state.sites.items[ 77203199 ] );
+			expect( site ).toEqual( state.sites.items[ 77203199 ] );
 		} );
 
 		test( 'should return a matched site jetpack site when the sites conflict', () => {
@@ -1760,7 +1759,7 @@ describe( 'selectors', () => {
 				},
 			};
 			const site = getSiteBySlug( state, 'example.com' );
-			chaiExpect( site ).to.equal( state.sites.items[ 2 ] );
+			expect( site ).toEqual( state.sites.items[ 2 ] );
 		} );
 	} );
 
@@ -1775,7 +1774,7 @@ describe( 'selectors', () => {
 				'https://testtwosites2014.wordpress.com'
 			);
 
-			chaiExpect( site ).to.be.null;
+			expect( site ).toBeNull();
 		} );
 
 		test( 'should return a matched site', () => {
@@ -1791,7 +1790,7 @@ describe( 'selectors', () => {
 			};
 			const site = getSiteByUrl( state, 'https://testtwosites2014.wordpress.com' );
 
-			chaiExpect( site ).to.equal( state.sites.items[ 77203199 ] );
+			expect( site ).toEqual( state.sites.items[ 77203199 ] );
 		} );
 
 		test( 'should return a matched site with nested path', () => {
@@ -1807,7 +1806,7 @@ describe( 'selectors', () => {
 			};
 			const site = getSiteByUrl( state, 'https://testtwosites2014.wordpress.com/path/to/site' );
 
-			chaiExpect( site ).to.equal( state.sites.items[ 77203199 ] );
+			expect( site ).toEqual( state.sites.items[ 77203199 ] );
 		} );
 	} );
 
@@ -1822,7 +1821,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( sitePlan ).to.be.null;
+			expect( sitePlan ).toBeNull();
 		} );
 
 		test( "it should return site's plan object.", () => {
@@ -1845,7 +1844,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( sitePlan ).to.eql( {
+			expect( sitePlan ).toEqual( {
 				product_id: 1008,
 				product_slug: 'business-bundle',
 				product_name_short: 'Business',
@@ -1874,7 +1873,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( sitePlan ).to.eql( {
+			expect( sitePlan ).toEqual( {
 				product_id: 1,
 				product_slug: 'free_plan',
 				product_name_short: 'Free',
@@ -1906,7 +1905,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( sitePlan ).to.eql( {
+			expect( sitePlan ).toEqual( {
 				product_id: 1,
 				product_slug: 'free_plan',
 				product_name_short: 'Free',
@@ -1938,7 +1937,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( sitePlan ).to.eql( {
+			expect( sitePlan ).toEqual( {
 				product_id: 2002,
 				product_slug: 'jetpack_free',
 				product_name_short: 'Free',
@@ -1959,7 +1958,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( planSlug ).to.be.null;
+			expect( planSlug ).toBeNull();
 		} );
 
 		test( 'should return the plan slug if it is known', () => {
@@ -1980,7 +1979,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( planSlug ).to.eql( 'fake-plan' );
+			expect( planSlug ).toEqual( 'fake-plan' );
 		} );
 	} );
 
@@ -1996,7 +1995,7 @@ describe( 'selectors', () => {
 				1008
 			);
 
-			chaiExpect( isCurrent ).to.be.null;
+			expect( isCurrent ).toBeNull();
 		} );
 
 		test( 'should return null if the planProductId is not supplied', () => {
@@ -2016,7 +2015,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( isCurrent ).to.be.null;
+			expect( isCurrent ).toBeNull();
 		} );
 
 		test( "it should return true if the site's plan matches supplied planProductId", () => {
@@ -2037,7 +2036,7 @@ describe( 'selectors', () => {
 				1008
 			);
 
-			chaiExpect( isCurrent ).to.be.true;
+			expect( isCurrent ).toBe( true );
 		} );
 
 		test( "it should return false if the site's plan doesn't match supplied planProductId", () => {
@@ -2058,7 +2057,7 @@ describe( 'selectors', () => {
 				1003
 			);
 
-			chaiExpect( isCurrent ).to.be.false;
+			expect( isCurrent ).toBe( false );
 		} );
 	} );
 
@@ -2081,7 +2080,7 @@ describe( 'selectors', () => {
 				1003
 			);
 
-			chaiExpect( isPaid ).to.equal( true );
+			expect( isPaid ).toEqual( true );
 		} );
 		test( 'it should return false if free plan', () => {
 			const isPaid = isCurrentPlanPaid(
@@ -2101,7 +2100,7 @@ describe( 'selectors', () => {
 				1003
 			);
 
-			chaiExpect( isPaid ).to.equal( false );
+			expect( isPaid ).toEqual( false );
 		} );
 
 		test( 'it should return null if plan is missing', () => {
@@ -2119,7 +2118,7 @@ describe( 'selectors', () => {
 				1003
 			);
 
-			chaiExpect( isPaid ).to.equal( null );
+			expect( isPaid ).toEqual( null );
 		} );
 	} );
 
@@ -2134,7 +2133,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( showcasePath ).to.be.null;
+			expect( showcasePath ).toBeNull();
 		} );
 
 		test( 'it should return null if site is jetpack', () => {
@@ -2150,7 +2149,7 @@ describe( 'selectors', () => {
 				1003
 			);
 
-			chaiExpect( showcasePath ).to.be.null;
+			expect( showcasePath ).toBeNull();
 		} );
 
 		test( 'it should return null if theme_slug is not pub or premium', () => {
@@ -2172,7 +2171,7 @@ describe( 'selectors', () => {
 				1003
 			);
 
-			chaiExpect( showcasePath ).to.be.null;
+			expect( showcasePath ).toBeNull();
 		} );
 
 		test( 'it should return the theme showcase path on non-premium themes', () => {
@@ -2194,7 +2193,7 @@ describe( 'selectors', () => {
 				1003
 			);
 
-			chaiExpect( showcasePath ).to.eql( '/theme/motif/testonesite2014.wordpress.com' );
+			expect( showcasePath ).toEqual( '/theme/motif/testonesite2014.wordpress.com' );
 		} );
 
 		test( 'it should return the theme setup path on premium themes', () => {
@@ -2216,9 +2215,7 @@ describe( 'selectors', () => {
 				1003
 			);
 
-			chaiExpect( showcasePath ).to.eql(
-				'/theme/journalistic/setup/testonesite2014.wordpress.com'
-			);
+			expect( showcasePath ).toEqual( '/theme/journalistic/setup/testonesite2014.wordpress.com' );
 		} );
 	} );
 
@@ -2240,7 +2237,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( frontPage ).to.be.not.ok;
+			expect( frontPage ).toBeFalsy();
 		} );
 
 		test( 'should return falsey if the site is not known', () => {
@@ -2253,7 +2250,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( frontPage ).to.be.not.ok;
+			expect( frontPage ).toBeFalsy();
 		} );
 
 		test( 'should return the page ID if the site has a static page set as the front page', () => {
@@ -2273,7 +2270,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( frontPage ).to.eql( 1 );
+			expect( frontPage ).toEqual( 1 );
 		} );
 	} );
 
@@ -2295,7 +2292,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( hasFrontPage ).to.eql( false );
+			expect( hasFrontPage ).toEqual( false );
 		} );
 
 		test( 'should return false if the site does not have a `page_on_front` value', () => {
@@ -2314,7 +2311,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( hasFrontPage ).to.eql( false );
+			expect( hasFrontPage ).toEqual( false );
 		} );
 
 		test( 'should return false if the site is not known', () => {
@@ -2327,7 +2324,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( hasFrontPage ).to.eql( false );
+			expect( hasFrontPage ).toEqual( false );
 		} );
 
 		test( 'should return true if the site has a static page set as the front page', () => {
@@ -2347,7 +2344,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( hasFrontPage ).to.eql( true );
+			expect( hasFrontPage ).toEqual( true );
 		} );
 	} );
 
@@ -2370,7 +2367,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( postsPage ).to.be.not.ok;
+			expect( postsPage ).toBeFalsy();
 		} );
 
 		test( 'should return falsey if the site is not known', () => {
@@ -2383,7 +2380,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( postsPage ).to.be.not.ok;
+			expect( postsPage ).toBeFalsy();
 		} );
 
 		test( 'should return the page ID if the site has a static page set as the posts page', () => {
@@ -2404,7 +2401,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( postsPage ).to.eql( 2 );
+			expect( postsPage ).toEqual( 2 );
 		} );
 	} );
 
@@ -2419,7 +2416,7 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( frontPageType ).to.be.not.ok;
+			expect( frontPageType ).toBeFalsy();
 		} );
 
 		test( "should return the site's front page type", () => {
@@ -2440,14 +2437,14 @@ describe( 'selectors', () => {
 				77203074
 			);
 
-			chaiExpect( frontPageType ).to.eql( 'page' );
+			expect( frontPageType ).toEqual( 'page' );
 		} );
 	} );
 
 	describe( '#canJetpackSiteUpdateFiles()', () => {
 		test( 'should return `null` for a non-existing site', () => {
 			const canUpdateFiles = canJetpackSiteUpdateFiles( stateWithNoItems, nonExistingSiteId );
-			chaiExpect( canUpdateFiles ).to.equal( null );
+			expect( canUpdateFiles ).toEqual( null );
 		} );
 
 		test( 'it should return `false` for a non jetpack site', () => {
@@ -2459,7 +2456,7 @@ describe( 'selectors', () => {
 			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
-			chaiExpect( canUpdateFiles ).to.equal( null );
+			expect( canUpdateFiles ).toEqual( null );
 		} );
 
 		test( 'it should return `false` if is a multi-network site', () => {
@@ -2476,7 +2473,7 @@ describe( 'selectors', () => {
 			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
-			chaiExpect( canUpdateFiles ).to.equal( false );
+			expect( canUpdateFiles ).toEqual( false );
 		} );
 
 		test( "it should return `false` if is not a main network site (urls don't match)", () => {
@@ -2496,7 +2493,7 @@ describe( 'selectors', () => {
 			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
-			chaiExpect( canUpdateFiles ).to.equal( false );
+			expect( canUpdateFiles ).toEqual( false );
 		} );
 
 		test( 'it should return `false` if `disallow_file_mods` is disabled', () => {
@@ -2517,7 +2514,7 @@ describe( 'selectors', () => {
 			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
-			chaiExpect( canUpdateFiles ).to.equal( false );
+			expect( canUpdateFiles ).toEqual( false );
 		} );
 
 		test( 'it should return `false` if `has_no_file_system_write_access` is disabled', () => {
@@ -2538,7 +2535,7 @@ describe( 'selectors', () => {
 			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
-			chaiExpect( canUpdateFiles ).to.equal( false );
+			expect( canUpdateFiles ).toEqual( false );
 		} );
 
 		test( 'it should return `true` for the site right configurations', () => {
@@ -2559,7 +2556,7 @@ describe( 'selectors', () => {
 			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
-			chaiExpect( canUpdateFiles ).to.equal( true );
+			expect( canUpdateFiles ).toEqual( true );
 		} );
 	} );
 
@@ -2579,7 +2576,7 @@ describe( 'selectors', () => {
 			} );
 
 			const canAutoUpdateFiles = canJetpackSiteAutoUpdateFiles( state, siteId );
-			chaiExpect( canAutoUpdateFiles ).to.equal( true );
+			expect( canAutoUpdateFiles ).toEqual( true );
 		} );
 
 		test( 'it should return `false` if the `file_mod_disabled` option contains `automatic_updater_disabled`', () => {
@@ -2597,7 +2594,7 @@ describe( 'selectors', () => {
 			} );
 
 			const canAutoUpdateFiles = canJetpackSiteAutoUpdateFiles( state, siteId );
-			chaiExpect( canAutoUpdateFiles ).to.equal( false );
+			expect( canAutoUpdateFiles ).toEqual( false );
 		} );
 	} );
 
@@ -2617,7 +2614,7 @@ describe( 'selectors', () => {
 			} );
 
 			const canAutoUpdateCore = canJetpackSiteAutoUpdateCore( state, siteId );
-			chaiExpect( canAutoUpdateCore ).to.equal( true );
+			expect( canAutoUpdateCore ).toEqual( true );
 		} );
 
 		test( 'it should return `false` if the `file_mod_disabled` option contains `automatic_updater_disabled`', () => {
@@ -2635,7 +2632,7 @@ describe( 'selectors', () => {
 			} );
 
 			const canAutoUpdateCore = canJetpackSiteAutoUpdateCore( state, siteId );
-			chaiExpect( canAutoUpdateCore ).to.equal( false );
+			expect( canAutoUpdateCore ).toEqual( false );
 		} );
 	} );
 
@@ -2740,7 +2737,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( isMultisite ).to.be.null;
+			expect( isMultisite ).toBeNull();
 		} );
 
 		test( 'should return null if the site is not a Jetpack site', () => {
@@ -2759,7 +2756,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( isMultisite ).to.be.null;
+			expect( isMultisite ).toBeNull();
 		} );
 
 		test( 'should return true if the site is a Jetpack multisite', () => {
@@ -2778,7 +2775,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( isMultisite ).to.be.true;
+			expect( isMultisite ).toBe( true );
 		} );
 
 		test( 'should return false if the site is a Jetpack single site', () => {
@@ -2797,14 +2794,14 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( isMultisite ).to.be.false;
+			expect( isMultisite ).toBe( false );
 		} );
 	} );
 
 	describe( '#isJetpackSiteSecondaryNetworkSite()', () => {
 		test( 'should return `null` for a non-existing site', () => {
 			const isSecondary = isJetpackSiteSecondaryNetworkSite( stateWithNoItems, nonExistingSiteId );
-			chaiExpect( isSecondary ).to.equal( null );
+			expect( isSecondary ).toEqual( null );
 		} );
 
 		test( 'it should return `false` for non multisite site', () => {
@@ -2818,7 +2815,7 @@ describe( 'selectors', () => {
 			} );
 
 			const isSecondary = isJetpackSiteSecondaryNetworkSite( state, siteId );
-			chaiExpect( isSecondary ).to.equal( false );
+			expect( isSecondary ).toEqual( false );
 		} );
 
 		test( 'it should return `false` for non-multisite/non-multinetwork sites', () => {
@@ -2834,7 +2831,7 @@ describe( 'selectors', () => {
 			} );
 
 			const isSecondary = isJetpackSiteSecondaryNetworkSite( state, siteId );
-			chaiExpect( isSecondary ).to.equal( false );
+			expect( isSecondary ).toEqual( false );
 		} );
 
 		test( 'it should return `false` for multisite sites without unmapped url', () => {
@@ -2852,7 +2849,7 @@ describe( 'selectors', () => {
 			} );
 
 			const isSecondary = isJetpackSiteSecondaryNetworkSite( state, siteId );
-			chaiExpect( isSecondary ).to.equal( false );
+			expect( isSecondary ).toEqual( false );
 		} );
 
 		test( 'it should return `false` for multisite sites without main_network_site', () => {
@@ -2870,7 +2867,7 @@ describe( 'selectors', () => {
 			} );
 
 			const isSecondary = isJetpackSiteSecondaryNetworkSite( state, siteId );
-			chaiExpect( isSecondary ).to.equal( false );
+			expect( isSecondary ).toEqual( false );
 		} );
 
 		test( 'it should return `true` for multisite sites which unmapped_url does not match their main_network_site', () => {
@@ -2888,7 +2885,7 @@ describe( 'selectors', () => {
 			} );
 
 			const isSecondary = isJetpackSiteSecondaryNetworkSite( state, siteId );
-			chaiExpect( isSecondary ).to.equal( true );
+			expect( isSecondary ).toEqual( true );
 		} );
 	} );
 
@@ -2897,7 +2894,7 @@ describe( 'selectors', () => {
 			const modulesActive = verifyJetpackModulesActive( stateWithNoItems, nonExistingSiteId, [
 				'manage',
 			] );
-			chaiExpect( modulesActive ).to.equal( null );
+			expect( modulesActive ).toEqual( null );
 		} );
 
 		test( 'it should return `null` for a non jetpack site', () => {
@@ -2910,7 +2907,7 @@ describe( 'selectors', () => {
 			} );
 
 			const modulesActive = verifyJetpackModulesActive( state, siteId, [ 'manage' ] );
-			chaiExpect( modulesActive ).to.equal( null );
+			expect( modulesActive ).toEqual( null );
 		} );
 
 		test( 'it should return `true` if all given modules are active for a site', () => {
@@ -2930,7 +2927,7 @@ describe( 'selectors', () => {
 				'sso',
 				'photon',
 			] );
-			chaiExpect( modulesActive ).to.equal( true );
+			expect( modulesActive ).toEqual( true );
 		} );
 
 		test( 'it should return `false` if not all given modules are active for a site', () => {
@@ -2949,14 +2946,14 @@ describe( 'selectors', () => {
 				'contact-form',
 				'manage',
 			] );
-			chaiExpect( modulesActive ).to.equal( false );
+			expect( modulesActive ).toEqual( false );
 		} );
 	} );
 
 	describe( '#hasJetpackSiteCustomDomain()', () => {
 		test( 'should return `null` for a non-existing site', () => {
 			const hasCustomDomain = hasJetpackSiteCustomDomain( stateWithNoItems, nonExistingSiteId );
-			chaiExpect( hasCustomDomain ).to.equal( null );
+			expect( hasCustomDomain ).toEqual( null );
 		} );
 
 		test( 'it should return `true` if `URL` and `unmapped_url` have different domains', () => {
@@ -2972,7 +2969,7 @@ describe( 'selectors', () => {
 			} );
 
 			const hasCustomDomain = hasJetpackSiteCustomDomain( state, siteId );
-			chaiExpect( hasCustomDomain ).to.equal( true );
+			expect( hasCustomDomain ).toEqual( true );
 		} );
 
 		test( 'it should return `false` if `URL` and `unmapped_url` have the same domain', () => {
@@ -2988,14 +2985,14 @@ describe( 'selectors', () => {
 			} );
 
 			const hasCustomDomain = hasJetpackSiteCustomDomain( state, siteId );
-			chaiExpect( hasCustomDomain ).to.equal( false );
+			expect( hasCustomDomain ).toEqual( false );
 		} );
 	} );
 
 	describe( '#isJetpackSiteMainNetworkSite()', () => {
 		test( 'should return `null` for a non-existing site', () => {
 			const isMainNetwork = isJetpackSiteMainNetworkSite( stateWithNoItems, nonExistingSiteId );
-			chaiExpect( isMainNetwork ).to.equal( null );
+			expect( isMainNetwork ).toEqual( null );
 		} );
 
 		test( 'it should return `false` for non multisite site', () => {
@@ -3009,7 +3006,7 @@ describe( 'selectors', () => {
 			} );
 
 			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
-			chaiExpect( isMainNetwork ).to.equal( false );
+			expect( isMainNetwork ).toEqual( false );
 		} );
 
 		test( 'it should return `false` for multisite sites without unmapped url', () => {
@@ -3027,7 +3024,7 @@ describe( 'selectors', () => {
 			} );
 
 			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
-			chaiExpect( isMainNetwork ).to.equal( false );
+			expect( isMainNetwork ).toEqual( false );
 		} );
 
 		test( 'it should return `false` for multisite sites without main_network_site', () => {
@@ -3045,7 +3042,7 @@ describe( 'selectors', () => {
 			} );
 
 			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
-			chaiExpect( isMainNetwork ).to.equal( false );
+			expect( isMainNetwork ).toEqual( false );
 		} );
 
 		test( 'it should return `true` for multisite sites and unmapped_url matches with main_network_site', () => {
@@ -3064,7 +3061,7 @@ describe( 'selectors', () => {
 			} );
 
 			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
-			chaiExpect( isMainNetwork ).to.equal( true );
+			expect( isMainNetwork ).toEqual( true );
 		} );
 	} );
 
@@ -3079,7 +3076,7 @@ describe( 'selectors', () => {
 				2916284
 			);
 
-			chaiExpect( adminUrl ).to.be.null;
+			expect( adminUrl ).toBeNull();
 		} );
 
 		test( 'should return the root admin url if no path specified', () => {
@@ -3100,7 +3097,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( adminUrl ).to.equal( 'https://example.wordpress.com/wp-admin/' );
+			expect( adminUrl ).toEqual( 'https://example.wordpress.com/wp-admin/' );
 		} );
 
 		test( 'should return the admin url concatenated with path', () => {
@@ -3122,7 +3119,7 @@ describe( 'selectors', () => {
 				'customize.php'
 			);
 
-			chaiExpect( adminUrl ).to.equal( 'https://example.wordpress.com/wp-admin/customize.php' );
+			expect( adminUrl ).toEqual( 'https://example.wordpress.com/wp-admin/customize.php' );
 		} );
 
 		test( 'should return the admin url with path left slash trimmed automatically', () => {
@@ -3144,7 +3141,7 @@ describe( 'selectors', () => {
 				'/customize.php'
 			);
 
-			chaiExpect( adminUrl ).to.equal( 'https://example.wordpress.com/wp-admin/customize.php' );
+			expect( adminUrl ).toEqual( 'https://example.wordpress.com/wp-admin/customize.php' );
 		} );
 	} );
 
@@ -3159,7 +3156,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( customizerUrl ).to.equal( '/customize' );
+			expect( customizerUrl ).toEqual( '/customize' );
 		} );
 
 		test( 'should return customizer URL for WordPress.com site', () => {
@@ -3178,7 +3175,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( customizerUrl ).to.equal( '/customize/example.com' );
+			expect( customizerUrl ).toEqual( '/customize/example.com' );
 		} );
 
 		test( 'should return customizer URL with return query for WordPress.com site', () => {
@@ -3199,7 +3196,7 @@ describe( 'selectors', () => {
 				'https://wordpress.com/things/are/going?to=be&okay=true'
 			);
 
-			chaiExpect( customizerUrl ).to.equal(
+			expect( customizerUrl ).toEqual(
 				`/customize/example.com?return=${ encodeURIComponent(
 					'https://wordpress.com/things/are/going?to=be&okay=true'
 				) }`
@@ -3222,7 +3219,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( customizerUrl ).to.be.null;
+			expect( customizerUrl ).toBeNull();
 		} );
 
 		test( 'should return customizer URL for Jetpack site', () => {
@@ -3244,7 +3241,7 @@ describe( 'selectors', () => {
 				77203199
 			);
 
-			chaiExpect( customizerUrl ).to.equal( 'https://example.com/wp-admin/customize.php' );
+			expect( customizerUrl ).toEqual( 'https://example.com/wp-admin/customize.php' );
 		} );
 
 		test( 'should prepend panel path parameter for WordPress.com site', () => {
@@ -3264,7 +3261,7 @@ describe( 'selectors', () => {
 				'identity'
 			);
 
-			chaiExpect( customizerUrl ).to.equal( '/customize/identity/example.com' );
+			expect( customizerUrl ).toEqual( '/customize/identity/example.com' );
 		} );
 
 		test( 'should prepend panel path parameter for Jetpack site', () => {
@@ -3287,7 +3284,7 @@ describe( 'selectors', () => {
 				'identity'
 			);
 
-			chaiExpect( customizerUrl ).to.equal(
+			expect( customizerUrl ).toEqual(
 				'https://example.com/wp-admin/customize.php?autofocus%5Bsection%5D=title_tagline'
 			);
 		} );
@@ -3311,7 +3308,7 @@ describe( 'selectors', () => {
 				'test-guide'
 			);
 
-			chaiExpect( customizerUrl ).to.equal( '/customize/identity/example.com?guide=test-guide' );
+			expect( customizerUrl ).toEqual( '/customize/identity/example.com?guide=test-guide' );
 		} );
 
 		test( 'should prepend guide parameter for Jetpack site', () => {
@@ -3336,7 +3333,7 @@ describe( 'selectors', () => {
 				'test-guide'
 			);
 
-			chaiExpect( customizerUrl ).to.equal(
+			expect( customizerUrl ).toEqual(
 				'https://example.com/wp-admin/customize.php?autofocus%5Bsection%5D=title_tagline&guide=test-guide'
 			);
 		} );
@@ -3373,7 +3370,7 @@ describe( 'selectors', () => {
 					77203199
 				);
 
-				chaiExpect( customizerUrl ).to.equal(
+				expect( customizerUrl ).toEqual(
 					'https://example.com/wp-admin/customize.php?return=https%3A%2F%2Fwordpress.com'
 				);
 			} );
@@ -3399,7 +3396,7 @@ describe( 'selectors', () => {
 					77203199
 				);
 
-				chaiExpect( customizerUrl ).to.equal( 'https://example.com/wp-admin/customize.php' );
+				expect( customizerUrl ).toEqual( 'https://example.com/wp-admin/customize.php' );
 			} );
 		} );
 	} );
@@ -3426,10 +3423,10 @@ describe( 'selectors', () => {
 			};
 
 			const noNewAttributes = getJetpackComputedAttributes( state, 77203074 );
-			chaiExpect( noNewAttributes.canAutoupdateFiles ).to.equal( undefined );
-			chaiExpect( noNewAttributes.canUpdateFiles ).to.equal( undefined );
-			chaiExpect( noNewAttributes.isMainNetworkSite ).to.equal( undefined );
-			chaiExpect( noNewAttributes.isSecondaryNetworkSite ).to.equal( undefined );
+			expect( noNewAttributes.canAutoupdateFiles ).toEqual( undefined );
+			expect( noNewAttributes.canUpdateFiles ).toEqual( undefined );
+			expect( noNewAttributes.isMainNetworkSite ).toEqual( undefined );
+			expect( noNewAttributes.isSecondaryNetworkSite ).toEqual( undefined );
 		} );
 
 		test( 'should return exists for attributes if a site is Jetpack', () => {
@@ -3452,10 +3449,10 @@ describe( 'selectors', () => {
 				},
 			};
 			const noNewAttributes = getJetpackComputedAttributes( state, 77203074 );
-			chaiExpect( noNewAttributes.canAutoupdateFiles ).to.have.property;
-			chaiExpect( noNewAttributes.canUpdateFiles ).to.have.property;
-			chaiExpect( noNewAttributes.isMainNetworkSite ).to.have.property;
-			chaiExpect( noNewAttributes.isSecondaryNetworkSite ).to.have.property;
+			expect( noNewAttributes ).toHaveProperty( 'canAutoupdateFiles' );
+			expect( noNewAttributes ).toHaveProperty( 'canUpdateFiles' );
+			expect( noNewAttributes ).toHaveProperty( 'isMainNetworkSite' );
+			expect( noNewAttributes ).toHaveProperty( 'isSecondaryNetworkSite' );
 		} );
 	} );
 	describe( 'getSiteComputedAttributes()', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As we've been moving towards canonically using `jest` as our primary unit testing platform, we're slowly moving away from `chai`. 

This PR refactors the sites state tests to use `jest` instead of `chai`.  We also use the opportunity to refactor away from `sinon` in favor of the built-in jest mocking functionality.

Some of the legwork here has been done with codemods, but I had to do a few more additional changes manually due to the added complexity of the test helpers.

#### Testing instructions

Verify all tests pass: `yarn run test-client client/state/sites`