### PR TITLE
Prepare some packages for release

### DIFF
--- a/packages/eslint-plugin-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-plugin-wpcalypso/CHANGELOG.md
@@ -1,6 +1,6 @@
 #### Unreleased
 
-#### trunk
+#### v6.0.0 (2022-05-13)
 
 - Breaking: Migrated from `babel-eslint` to `@babel/eslint-parser`. This requires `@babel/core` to be
   installed (added as a `peerDependency` to this package) and a valid Babel configuration file to exist.

--- a/packages/eslint-plugin-wpcalypso/package.json
+++ b/packages/eslint-plugin-wpcalypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-plugin-wpcalypso",
-	"version": "5.1.0",
+	"version": "6.0.0",
 	"description": "Custom ESLint rules for the WordPress.com Calypso project.",
 	"repository": {
 		"type": "git",

--- a/packages/popup-monitor/CHANGELOG.md
+++ b/packages/popup-monitor/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 1.0.1 - 2022-05-13
 
 ### Added
 

--- a/packages/popup-monitor/package.json
+++ b/packages/popup-monitor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/popup-monitor",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Utility to facilitate the monitoring of a popup window close action.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.2 (2022-05-13)
+
+- Dependency updates and internal code cleanup.
+
 ## v1.1.1 (2021-04-05)
 
 - Ensure that lengthy text doesn't overflow in the Twitter preview.

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/webpack-rtl-plugin/CHANGELOG.md
+++ b/packages/webpack-rtl-plugin/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 6.0.0 - 2022-05-13
 
 ### Removed
 

--- a/packages/webpack-rtl-plugin/package.json
+++ b/packages/webpack-rtl-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/webpack-rtl-plugin",
-	"version": "5.1.0",
+	"version": "6.0.0",
 	"description": "Webpack plugin to produce a rtl css bundle.",
 	"main": "src/index.js",
 	"author": "Automattic Inc.",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `@automattic/eslint-plugin-wpcalypso` 6.0.0
* `@automattic/popup-monitor` 1.0.1
* `@automattic/social-previews` 1.1.2
* `@automattic/webpack-rtl-plugin` 6.0.0

We use the last three in Jetpack and want to pick up the dependency updates.
Releasing `@automattic/eslint-plugin-wpcalypso` will allow us to switch to that in place of `@automattic/eslint-config-wpcalypso` which you seem to have discontinued a while back.

We could also use `@automattic/components` to pick up #58271, but that one depends on some other of your packages too and I didn't want to go down that rabbit hole.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Nothing should change, this just bumps some versions and finalizes changelogs.
* Check that the new versions are correct per semver.