### PR TITLE
Add config import to "Set up the route" step

### DIFF
--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -102,7 +102,7 @@ You can read more about ES6 modules from Axel Rauschmayer's "[_ECMAScript 6 modu
 
 Now it's time to configure our section. Open `client/sections.js` and add the following code to the end of the `sections` array:
 
-```javascript
+```
 	{
 		name: 'hello-world',
 		paths: [ '/hello-world' ],

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -112,7 +112,7 @@ Now it's time to configure our section. Open `client/sections.js` and add the fo
 
 The array should look something like:
 
-```
+```javascript
 const sections = [
 	// All of the other sections are here
 	// ...

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -111,6 +111,7 @@ Now it's time to configure our section. Open `client/sections.js` and add the fo
 ```
 
 The array should look something like:
+
 ```
 const sections = [
 	// All of the other sections are here

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -71,6 +71,7 @@ touch client/my-sites/hello-world/index.js
 Here we'll import the `page` module, the My Sites controller and our own controller, and write our main route handler:
 
 ```javascript
+import config from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection } from 'calypso/my-sites/controller';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `config` import to top of `index.js` file

#### Testing instructions

* Follow the guide as is to create a new `hello-world` feature
* Confirm that there is an error under `config` as it is not being imported as-is
* Confirm the new feature page fails because of this
* Add `import config from '@automattic/calypso-config';` to the top of `calypso/client/my-sites/hello-world/index.js`
* Confirm the error goes away
* Confirm the new `hello-world` feature page loads