### PR TITLE
seo-settings/form: Use siteHasFeature check for showAdvancedSeo

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -32,13 +32,12 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import { getPlugins } from 'calypso/state/plugins/installed/selectors';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
-import getJetpackModules from 'calypso/state/selectors/get-jetpack-modules';
-import hasActiveSiteFeature from 'calypso/state/selectors/has-active-site-feature';
 import isHiddenSite from 'calypso/state/selectors/is-hidden-site';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSiteSettings, saveSiteSettings } from 'calypso/state/site-settings/actions';
 import {
 	isSiteSettingsSaveSuccessful,
@@ -437,12 +436,6 @@ const mapStateToProps = ( state ) => {
 	const selectedSite = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
-	// SEO Tools are available with Business plan on WordPress.com, and
-	// will soon be available on all Jetpack sites, so we're checking
-	// the availability of the module.
-	const isAdvancedSeoEligible =
-		hasActiveSiteFeature( state, siteId, FEATURE_ADVANCED_SEO ) &&
-		( ! siteIsJetpack || get( getJetpackModules( state, siteId ), 'seo-tools.available', false ) );
 
 	const activePlugins = getPlugins( state, [ siteId ], 'active' );
 	const conflictedSeoPlugin = siteIsJetpack
@@ -455,7 +448,7 @@ const mapStateToProps = ( state ) => {
 		siteIsJetpack,
 		selectedSite,
 		storedTitleFormats: getSeoTitleFormatsForSite( getSelectedSite( state ) ),
-		showAdvancedSeo: isAdvancedSeoEligible,
+		showAdvancedSeo: siteHasFeature( state, siteId, FEATURE_ADVANCED_SEO ),
 		isAtomic: isAtomicSite( state, siteId ),
 		showWebsiteMeta: !! get( selectedSite, 'options.advanced_seo_front_page_description', '' ),
 		isSeoToolsActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In seo-settings/form.tsx, change `showAdvancedSeo` to be driven from a `siteHasFeature` check
  * It used to be a combination of `hasActiveSiteFeature` and `getJetpackModules`
    * `hasActiveSiteFeature` is deprecated by the newer `siteHasFeature` and will eventually be removed
    * I believe our work in integrating Jetpack sites with feature checks means the `getJetpackModules` check is no longer needed.

#### Testing instructions

* Visit `/marketing/traffic/<site>` on Pro simple, Free simple, Jetpack (any), and Atomic (any)
  * Results should be the same before and after the PR
  * Advanced SEO should be available on Pro plans, Business or higher, and all jetpack sites.

Here's what it looks like in various states

**Advanced SEO off:**
![2022-05-13_11-31](https://user-images.githubusercontent.com/937354/168328266-2a7d5ad5-0e61-41f0-adb8-f570a46cc55a.png)

**Advanced SEO on:**
![2022-05-13_11-32](https://user-images.githubusercontent.com/937354/168328281-7b9c9ec9-780e-4d3d-8594-cc3556c1d8d6.png)

**Advanced SEO on (jetpack/atomic):**
![2022-05-13_11-32_1](https://user-images.githubusercontent.com/937354/168328315-e76dd002-39a8-4b06-996d-dc0db5081e9e.png)



Related to p4TIVU-a66-p2
