### PR TITLE
site-settings/search: Use siteHasFeature to detect search capability

### DIFF
--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -108,7 +108,7 @@ class Search extends Component {
 	}
 
 	renderUpgradeNotice() {
-		const { siteIsJetpack, siteSlug, translate, isJetpackClassicSearchIncluded } = this.props;
+		const { siteIsJetpack, siteSlug, translate, hasClassicSearch } = this.props;
 
 		const href = siteIsJetpack
 			? `/checkout/${ siteSlug }/${ PRODUCT_JETPACK_SEARCH_MONTHLY }`
@@ -118,7 +118,7 @@ class Search extends Component {
 			<Fragment>
 				<UpsellNudge
 					title={
-						isJetpackClassicSearchIncluded
+						hasClassicSearch
 							? translate( 'Upgrade your Jetpack Search and get the instant search experience' )
 							: translate( 'Upgrade to Jetpack Search and get the instant search experience' )
 					}
@@ -335,12 +335,8 @@ class Search extends Component {
 export default connect( ( state, { isRequestingSettings } ) => {
 	const siteId = getSelectedSiteId( state );
 	const hasInstantSearch = siteHasFeature( state, siteId, WPCOM_FEATURES_INSTANT_SEARCH );
-	const isJetpackClassicSearchIncluded = siteHasFeature(
-		state,
-		siteId,
-		WPCOM_FEATURES_CLASSIC_SEARCH
-	); // hasClassicSearch
-	const isSearchEligible = isJetpackClassicSearchIncluded || hasInstantSearch;
+	const hasClassicSearch = siteHasFeature( state, siteId, WPCOM_FEATURES_CLASSIC_SEARCH ); // hasClassicSearch
+	const isSearchEligible = hasClassicSearch || hasInstantSearch;
 	const upgradeLink =
 		'/checkout/' +
 		getSelectedSiteSlug( state ) +
@@ -363,6 +359,6 @@ export default connect( ( state, { isRequestingSettings } ) => {
 		upgradeLink,
 		isSearchModuleActive:
 			( isSearchModuleActive && ! deactivating ) || ( ! isSearchModuleActive && activating ),
-		isJetpackClassicSearchIncluded,
+		hasClassicSearch,
 	};
 } )( localize( Search ) );

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -1,11 +1,8 @@
 import {
-	isJetpackSearch,
-	isP2Plus,
-	planHasJetpackSearch,
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
 	PRODUCT_WPCOM_SEARCH_MONTHLY,
+	WPCOM_FEATURES_CLASSIC_SEARCH,
 	WPCOM_FEATURES_INSTANT_SEARCH,
-	planHasJetpackClassicSearch,
 } from '@automattic/calypso-products';
 import { CompactCard } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
@@ -22,10 +19,11 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import { getSitePurchases, isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
+import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
 import isDeactivatingJetpackModule from 'calypso/state/selectors/is-deactivating-jetpack-module';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite, getJetpackSearchCustomizeUrl } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
@@ -334,15 +332,14 @@ class Search extends Component {
 	}
 }
 
-const checkForSearchProduct = ( purchase ) =>
-	purchase.active && ( isJetpackSearch( purchase ) || isP2Plus( purchase ) );
 export default connect( ( state, { isRequestingSettings } ) => {
-	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
-	const hasSearchProduct =
-		getSitePurchases( state, siteId ).find( checkForSearchProduct ) ||
-		planHasJetpackSearch( site.plan?.product_slug );
-	const isJetpackClassicSearchIncluded = planHasJetpackClassicSearch( site?.plan );
+	const hasSearchProduct = siteHasFeature( state, siteId, WPCOM_FEATURES_INSTANT_SEARCH ); // hasInstantSearch
+	const isJetpackClassicSearchIncluded = siteHasFeature(
+		state,
+		siteId,
+		WPCOM_FEATURES_CLASSIC_SEARCH
+	); // hasClassicSearch
 	const isSearchEligible = isJetpackClassicSearchIncluded || !! hasSearchProduct;
 	const upgradeLink =
 		'/checkout/' +

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -148,7 +148,7 @@ class Search extends Component {
 			isLoading,
 			trackEvent,
 			activateModule,
-			hasSearchProduct,
+			hasInstantSearch,
 		} = this.props;
 
 		/**
@@ -157,7 +157,7 @@ class Search extends Component {
 		 * @param {boolean} jetpackSearchEnabled Whether Jetpack Search is enabled
 		 */
 		const handleJetpackSearchToggle = ( jetpackSearchEnabled ) => {
-			if ( hasSearchProduct ) {
+			if ( hasInstantSearch ) {
 				trackEvent( 'Toggled instant_search_enabled' );
 				saveJetpackSettings( siteId, {
 					instant_search_enabled: jetpackSearchEnabled,
@@ -190,15 +190,15 @@ class Search extends Component {
 					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ handleJetpackSearchToggle }
 				/>
-				{ this.props.hasSearchProduct && (
+				{ this.props.hasInstantSearch && (
 					<div className="site-settings__jetpack-instant-search-toggle">
 						<ToggleControl
 							checked={
 								isSearchModuleActive &&
-								this.props.hasSearchProduct &&
+								this.props.hasInstantSearch &&
 								!! fields.instant_search_enabled
 							}
-							disabled={ ! hasSearchProduct || isRequestingSettings || isSavingSettings }
+							disabled={ ! hasInstantSearch || isRequestingSettings || isSavingSettings }
 							onChange={ handleInstantSearchToggle }
 							label={ translate( 'Enable instant search experience (recommended)' ) }
 						></ToggleControl>
@@ -222,7 +222,7 @@ class Search extends Component {
 			trackEvent,
 			activatingSearchModule,
 			isLoading,
-			hasSearchProduct,
+			hasInstantSearch,
 		} = this.props;
 
 		/**
@@ -236,7 +236,7 @@ class Search extends Component {
 			const jetpackFieldsToUpdate = {
 				jetpack_search_enabled: jetpackSearchEnabled,
 			};
-			if ( hasSearchProduct ) {
+			if ( hasInstantSearch ) {
 				trackEvent( 'Toggled jetpack_search_enabled' );
 				jetpackFieldsToUpdate.instant_search_enabled = jetpackSearchEnabled;
 			}
@@ -264,11 +264,11 @@ class Search extends Component {
 					label={ translate( 'Enable Jetpack Search' ) }
 				></ToggleControl>
 				{ /** Business plan could be simple sites too, unless user triggers certain actions  */ }
-				{ this.props.hasSearchProduct && (
+				{ this.props.hasInstantSearch && (
 					<div className="site-settings__jetpack-instant-search-toggle">
 						<ToggleControl
 							checked={ !! fields.jetpack_search_enabled && !! fields.instant_search_enabled }
-							disabled={ isRequestingSettings || isSavingSettings || ! hasSearchProduct }
+							disabled={ isRequestingSettings || isSavingSettings || ! hasInstantSearch }
 							onChange={ handleInstantSearchToggle }
 							label={ translate( 'Enable instant search experience (recommended)' ) }
 						></ToggleControl>
@@ -282,7 +282,7 @@ class Search extends Component {
 	}
 
 	renderSettingsCard() {
-		const { fields, translate, siteIsJetpack, hasSearchProduct } = this.props;
+		const { fields, translate, siteIsJetpack, hasInstantSearch } = this.props;
 
 		return (
 			<Fragment>
@@ -294,7 +294,7 @@ class Search extends Component {
 							: this.renderSearchTogglesForSimpleSites() }
 					</FormFieldset>
 				</CompactCard>
-				{ hasSearchProduct && fields.instant_search_enabled && (
+				{ hasInstantSearch && fields.instant_search_enabled && (
 					<CompactCard
 						href={ this.props.jetpackSearchCustomizeUrl }
 						target={ siteIsJetpack ? 'external' : null }
@@ -313,7 +313,7 @@ class Search extends Component {
 				{ this.props.siteId && <QuerySitePurchases siteId={ this.props.siteId } /> }
 				<SettingsSectionHeader title={ this.props.translate( 'Jetpack Search' ) }>
 					{ this.renderInfoLink(
-						this.props.hasSearchProduct
+						this.props.hasInstantSearch
 							? 'https://jetpack.com/support/search/'
 							: this.props.upgradeLink
 					) }
@@ -322,9 +322,9 @@ class Search extends Component {
 					this.renderLoadingPlaceholder()
 				) : (
 					<>
-						{ ( this.props.hasSearchProduct || this.props.isSearchEligible ) &&
+						{ ( this.props.hasInstantSearch || this.props.isSearchEligible ) &&
 							this.renderSettingsCard() }
-						{ ! this.props.hasSearchProduct && this.renderUpgradeNotice() }
+						{ ! this.props.hasInstantSearch && this.renderUpgradeNotice() }
 					</>
 				) }
 			</div>
@@ -334,13 +334,13 @@ class Search extends Component {
 
 export default connect( ( state, { isRequestingSettings } ) => {
 	const siteId = getSelectedSiteId( state );
-	const hasSearchProduct = siteHasFeature( state, siteId, WPCOM_FEATURES_INSTANT_SEARCH ); // hasInstantSearch
+	const hasInstantSearch = siteHasFeature( state, siteId, WPCOM_FEATURES_INSTANT_SEARCH );
 	const isJetpackClassicSearchIncluded = siteHasFeature(
 		state,
 		siteId,
 		WPCOM_FEATURES_CLASSIC_SEARCH
 	); // hasClassicSearch
-	const isSearchEligible = isJetpackClassicSearchIncluded || !! hasSearchProduct;
+	const isSearchEligible = isJetpackClassicSearchIncluded || hasInstantSearch;
 	const upgradeLink =
 		'/checkout/' +
 		getSelectedSiteSlug( state ) +
@@ -352,7 +352,7 @@ export default connect( ( state, { isRequestingSettings } ) => {
 
 	return {
 		activatingSearchModule: activating || deactivating,
-		hasSearchProduct,
+		hasInstantSearch,
 		isSearchEligible,
 		isLoading: isRequestingSettings || isFetchingSitePurchases( state ),
 		jetpackSearchCustomizeUrl: getJetpackSearchCustomizeUrl( state, siteId ),

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -335,7 +335,7 @@ class Search extends Component {
 export default connect( ( state, { isRequestingSettings } ) => {
 	const siteId = getSelectedSiteId( state );
 	const hasInstantSearch = siteHasFeature( state, siteId, WPCOM_FEATURES_INSTANT_SEARCH );
-	const hasClassicSearch = siteHasFeature( state, siteId, WPCOM_FEATURES_CLASSIC_SEARCH ); // hasClassicSearch
+	const hasClassicSearch = siteHasFeature( state, siteId, WPCOM_FEATURES_CLASSIC_SEARCH );
 	const isSearchEligible = hasClassicSearch || hasInstantSearch;
 	const upgradeLink =
 		'/checkout/' +

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -217,6 +217,7 @@ export const WPCOM_FEATURES_AKISMET = 'akismet';
 export const WPCOM_FEATURES_ANTISPAM = 'antispam';
 export const WPCOM_FEATURES_ATOMIC = 'atomic';
 export const WPCOM_FEATURES_BACKUPS = 'backups';
+export const WPCOM_FEATURES_CLASSIC_SEARCH = 'search';
 export const WPCOM_FEATURES_FULL_ACTIVITY_LOG = 'full-activity-log';
 export const WPCOM_FEATURES_INSTANT_SEARCH = 'instant-search';
 export const WPCOM_FEATURES_LIVE_SUPPORT = 'live_support';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* site-settings/search: Use siteHasFeature to detect search capability

#### Testing instructions

* Visit `/settings/performance/<site>` across a variety of site types and purchases
  * The search section should be the same before and after the PR; honoring the `CLASSIC_SEARCH` and `INSTANT_SEARCH` definitions on wpcom

Some examples:

![2022-05-13_13-45](https://user-images.githubusercontent.com/937354/168363635-7a2c6686-a950-43fd-886a-17028e82cef5.png)
![2022-05-13_13-47](https://user-images.githubusercontent.com/937354/168363760-fba9f7ec-6e2f-45bf-b9fb-13cc36df0c07.png)
![2022-05-13_13-48](https://user-images.githubusercontent.com/937354/168363882-c5450cb1-8b80-4227-afaf-fe6a74b546b9.png)
![2022-05-13_13-50](https://user-images.githubusercontent.com/937354/168363990-2e1ef677-f2a4-404f-9e47-a8cda88fc160.png)
![2022-05-13_13-51](https://user-images.githubusercontent.com/937354/168364094-18dfc634-1039-456e-95a0-4f61b00efe4d.png)


Related to p4TIVU-a66-p2
