### PR TITLE
social-previews: Fix peer dependencies

### DIFF
--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Remove unnecessary peer dependencies on `@wordpress/data`, `reakit-utils`, and `redux`.
+- Add missing peer dependency on `react-dom`.
+
 ## v1.1.2 (2022-05-13)
 
 - Dependency updates and internal code cleanup.

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "1.1.2",
+	"version": "1.1.3-alpha",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
@@ -51,9 +51,7 @@
 		"react-dom": "^17.0.2"
 	},
 	"peerDependencies": {
-		"@wordpress/data": "^6.7.0",
 		"react": "^17.0.2",
-		"reakit-utils": "^0.15.1",
-		"redux": "^4.1.2"
+		"react-dom": "^17.0.2"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,10 +1263,8 @@ __metadata:
     react: ^17.0.2
     react-dom: ^17.0.2
   peerDependencies:
-    "@wordpress/data": ^6.7.0
     react: ^17.0.2
-    reakit-utils: ^0.15.1
-    redux: ^4.1.2
+    react-dom: ^17.0.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove unnecessary peer dependencies on `@wordpress/data` and
`reakit-utils`. These were added for `@wordpress/components` 13.0.3, but
`@wordpress/components` has since dropped those peer deps.

Remove unnecessary peer dependency on `redux`. That was added for
`@wordpress/data` 6.1.0, which has since dropped that dep and we're
dropping the dep on it anyway.

Add missing peer dependency on `react-dom`, needed by
`@wordpress/components`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Nothing should change. The removed deps shouldn't have been being used, and the added one was presumably already provided by things needing it.