### PR TITLE
Themes: Use feature check instead of plan check

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -1,4 +1,4 @@
-import { FEATURE_PREMIUM_THEMES, planHasFeature } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { compact, property, snakeCase } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -9,7 +9,8 @@ import ThemesList from 'calypso/components/themes-list';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer.js';
-import { getSiteSlug, isJetpackSite, getSitePlanSlug } from 'calypso/state/sites/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
 import {
 	arePremiumThemesEnabled,
@@ -211,8 +212,11 @@ export const ConnectedThemesSelection = connect(
 		const isJetpack = isJetpackSite( state, siteId );
 		const isAtomic = isSiteAutomatedTransfer( state, siteId );
 		const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
-		const sitePlanSlug = getSitePlanSlug( state, siteId );
-		const hasUnlimitedPremiumThemes = planHasFeature( sitePlanSlug, FEATURE_PREMIUM_THEMES );
+		const hasUnlimitedPremiumThemes = siteHasFeature(
+			state,
+			siteId,
+			WPCOM_FEATURES_PREMIUM_THEMES
+		);
 
 		let sourceSiteId;
 		if ( source === 'wpcom' || source === 'wporg' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replaces unlimited theme plan check wit ha feature check.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the PR.
* Visit the "My Themes" tab on an Atomic business, Atomic eCommerce, and Jetpack site. It should display the correct themes, NOT all themes. (See pictures above.)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-a66-p2