### PR TITLE
composite-checkout: Allow calling step isCompleteCallback from inside steps

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -447,7 +447,7 @@ export default function WPCheckout( {
 			/>
 			{ contactDetailsType !== 'none' && (
 				<CheckoutStep
-					stepId={ 'contact-form' }
+					stepId="contact-form"
 					isCompleteCallback={ async () => {
 						setShouldShowContactDetailsValidationErrors( true );
 						// Touch the fields so they display validation errors

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -1,10 +1,8 @@
-import { useShoppingCart } from '@automattic/shopping-cart';
 import { getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
 import { useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useEffect, useRef } from 'react';
 import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
-import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { requestContactDetailsCache } from 'calypso/state/domains/management/actions';
 import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-cache';
 import useCountryList from './use-country-list';
@@ -14,20 +12,6 @@ import type {
 } from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-cached-domain-contact-details' );
-
-function areTaxFieldsDifferent(
-	previousTaxFields: PossiblyCompleteDomainContactDetails | undefined,
-	nextTaxFields: PossiblyCompleteDomainContactDetails | undefined
-): boolean {
-	if (
-		nextTaxFields?.countryCode === previousTaxFields?.countryCode &&
-		nextTaxFields?.postalCode === previousTaxFields?.postalCode &&
-		nextTaxFields?.state === previousTaxFields?.state
-	) {
-		return false;
-	}
-	return true;
-}
 
 function useCachedContactDetails(): PossiblyCompleteDomainContactDetails | null {
 	const reduxDispatch = useReduxDispatch();
@@ -100,61 +84,6 @@ function useCachedContactDetailsForCheckoutForm(
 	] );
 }
 
-function useCachedContactDetailsForCart(
-	cachedContactDetails: PossiblyCompleteDomainContactDetails | null,
-	overrideCountryList?: CountryListItem[]
-): void {
-	const countriesList = useCountryList( overrideCountryList );
-	const previousDetailsForCart = useRef< PossiblyCompleteDomainContactDetails >();
-	const cartKey = useCartKey();
-	const {
-		updateLocation: updateCartLocation,
-		isLoading: isLoadingCart,
-		loadingError: cartLoadingError,
-	} = useShoppingCart( cartKey );
-
-	const arePostalCodesSupported =
-		countriesList.length && cachedContactDetails?.countryCode
-			? getCountryPostalCodeSupport( countriesList, cachedContactDetails.countryCode )
-			: true;
-
-	// When we have fetched or loaded contact details, send them to the
-	// to the shopping cart for calculating taxes.
-	useEffect( () => {
-		// Do nothing if the cart is loading, the contact details are loading, or the countries are loading.
-		if ( isLoadingCart || cartLoadingError || ! cachedContactDetails || ! countriesList.length ) {
-			return;
-		}
-		if (
-			! cachedContactDetails.countryCode &&
-			! cachedContactDetails.postalCode &&
-			! cachedContactDetails.state
-		) {
-			return;
-		}
-		// Do nothing if the cached data has not changed since the last time we
-		// sent the data to the cart endpoint (this typically will only ever need
-		// to be activated once).
-		if ( ! areTaxFieldsDifferent( previousDetailsForCart.current, cachedContactDetails ) ) {
-			return;
-		}
-		previousDetailsForCart.current = cachedContactDetails;
-		debug( 'updating cart tax details with cached contact details', cachedContactDetails );
-		updateCartLocation( {
-			countryCode: cachedContactDetails.countryCode ?? '',
-			postalCode: arePostalCodesSupported ? cachedContactDetails.postalCode ?? '' : '',
-			subdivisionCode: cachedContactDetails.state ?? '',
-		} );
-	}, [
-		cartLoadingError,
-		isLoadingCart,
-		cachedContactDetails,
-		updateCartLocation,
-		arePostalCodesSupported,
-		countriesList,
-	] );
-}
-
 /**
  * Load cached contact details from the server and use them to populate the
  * checkout contact form and the shopping cart tax location.
@@ -164,5 +93,4 @@ export default function useCachedDomainContactDetails(
 ): void {
 	const cachedContactDetails = useCachedContactDetails();
 	useCachedContactDetailsForCheckoutForm( cachedContactDetails, overrideCountryList );
-	useCachedContactDetailsForCart( cachedContactDetails, overrideCountryList );
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-skip-to-last-step-if-form-complete.js
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-skip-to-last-step-if-form-complete.js
@@ -20,7 +20,7 @@ export default function useSkipToLastStepIfFormComplete( isCachedContactFormVali
 			// If the details are already populated and valid, jump to payment method step
 			if ( isCachedContactFormValid ) {
 				debug( 'Contact details are already populated; skipping to payment method step' );
-				setStepCompleteStatus( 1 ); // TODO: can we do this dynamically somehow in case the step numbers change?
+				setStepCompleteStatus( 'contact-form' );
 
 				reduxDispatch( recordTracksEvent( 'calypso_checkout_skip_to_last_step' ) );
 			}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-skip-to-last-step-if-form-complete.js
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-skip-to-last-step-if-form-complete.js
@@ -21,7 +21,7 @@ export default function useSkipToLastStepIfFormComplete( isCachedContactFormVali
 			if ( isCachedContactFormValid ) {
 				debug( 'Contact details are already populated; skipping to payment method step' );
 				saveStepNumberToUrl( 2 ); // TODO: can we do this dynamically somehow in case the step numbers change?
-				setStepCompleteStatus( 1, true ); // TODO: can we do this dynamically somehow in case the step numbers change?
+				setStepCompleteStatus( 1 ); // TODO: can we do this dynamically somehow in case the step numbers change?
 
 				reduxDispatch( recordTracksEvent( 'calypso_checkout_skip_to_last_step' ) );
 			}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-skip-to-last-step-if-form-complete.js
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-skip-to-last-step-if-form-complete.js
@@ -20,51 +20,10 @@ export default function useSkipToLastStepIfFormComplete( isCachedContactFormVali
 			// If the details are already populated and valid, jump to payment method step
 			if ( isCachedContactFormValid ) {
 				debug( 'Contact details are already populated; skipping to payment method step' );
-				saveStepNumberToUrl( 2 ); // TODO: can we do this dynamically somehow in case the step numbers change?
 				setStepCompleteStatus( 1 ); // TODO: can we do this dynamically somehow in case the step numbers change?
 
 				reduxDispatch( recordTracksEvent( 'calypso_checkout_skip_to_last_step' ) );
 			}
 		}
 	}, [ isCachedContactFormValid, setStepCompleteStatus, reduxDispatch ] );
-}
-
-function saveStepNumberToUrl( stepNumber ) {
-	if ( ! window?.history || ! window?.location ) {
-		return;
-	}
-	const newHash = stepNumber > 1 ? `#step${ stepNumber }` : '';
-	if ( window.location.hash === newHash ) {
-		return;
-	}
-	const newUrl = window.location.hash
-		? window.location.href.replace( window.location.hash, newHash )
-		: window.location.href + newHash;
-	debug( 'updating url to', newUrl );
-	// We've seen this call to replaceState fail sometimes when the current URL
-	// is somehow different ("A history state object with URL
-	// 'https://wordpress.com/checkout/example.com#step2' cannot be created
-	// in a document with origin 'https://wordpress.com' and URL
-	// 'https://www.username@wordpress.com/checkout/example.com'.") so we
-	// wrap this in try/catch. It's not critical that the step number is saved to
-	// the URL.
-	try {
-		window.history.replaceState( null, '', newUrl );
-	} catch ( error ) {
-		debug( 'changing the url failed' );
-		return;
-	}
-	// Modifying history does not trigger a hashchange event which is what
-	// composite-checkout uses to change its current step, so we must fire one
-	// manually. (HashChangeEvent is part of the web API so I'm not sure why
-	// eslint reports this as undefined.)
-	//
-	// We use try/catch because we support IE11 and that browser does not include
-	// HashChange.
-	try {
-		const event = new HashChangeEvent( 'hashchange' );
-		window.dispatchEvent( event );
-	} catch ( error ) {
-		debug( 'hashchange firing failed' );
-	}
 }

--- a/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
@@ -7,7 +7,7 @@ import {
 	createShoppingCartManagerClient,
 	getEmptyResponseCart,
 } from '@automattic/shopping-cart';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
 import { useState } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -86,75 +86,6 @@ function MyTestContent( { countries }: { countries: CountryListItem[] } ) {
 }
 
 describe( 'useCachedDomainContactDetails', () => {
-	it( 'sends the postal code and country from the contact details endpoint to the cart for country with postal code', async () => {
-		const countryCode = 'US';
-		const postalCode = '10001';
-		mockCachedContactDetailsEndpoint( {
-			country_code: countryCode,
-			postal_code: postalCode,
-		} );
-		render( <MyTestWrapper countries={ countryList } /> );
-		await waitFor( () => {
-			expect( screen.queryByText( `Tax Country: ${ countryCode }` ) ).toBeInTheDocument();
-			expect( screen.queryByText( `Tax Postal: ${ postalCode }` ) ).toBeInTheDocument();
-		} );
-	} );
-
-	it( 'sends the country from the contact details endpoint to the cart for country without postal code', async () => {
-		mockCachedContactDetailsEndpoint( {
-			country_code: 'CW',
-			postal_code: '10001',
-		} );
-		render( <MyTestWrapper countries={ countryList } /> );
-		await waitFor( () => {
-			expect( screen.queryByText( `Tax Country: CW` ) ).toBeInTheDocument();
-			expect( screen.queryByText( `Tax Postal: 10001` ) ).not.toBeInTheDocument();
-		} );
-	} );
-
-	it( 'does not send the country from the contact details endpoint to the cart if countries have not loaded', async () => {
-		mockCachedContactDetailsEndpoint( {
-			country_code: 'US',
-			postal_code: '10001',
-		} );
-		render( <MyTestWrapper countries={ [] } /> );
-		await expect( screen.findByText( 'Tax Country: US' ) ).toNeverAppear();
-		await expect( screen.findByText( 'Tax Postal: 10001' ) ).toNeverAppear();
-	} );
-
-	it( 'does not send the country from the contact details endpoint to the cart if the cart reloads after they have already been sent', async () => {
-		mockCachedContactDetailsEndpoint( {
-			country_code: 'US',
-			postal_code: '10001',
-		} );
-		render( <MyTestWrapper countries={ countryList } /> );
-		// Wait for the cart info to be populated by the hook.
-		await waitFor( () => {
-			expect( screen.queryByText( 'Tax Country: US' ) ).toBeInTheDocument();
-			expect( screen.queryByText( 'Tax Postal: 10001' ) ).toBeInTheDocument();
-		} );
-
-		// Change the cart info to something else.
-		fireEvent.change( screen.getByLabelText( 'Country' ), {
-			target: { value: 'US' },
-		} );
-		fireEvent.change( screen.getByLabelText( 'Postal' ), {
-			target: { value: '90210' },
-		} );
-		fireEvent.click( await screen.findByText( 'Click to set cart tax location' ) );
-		await waitFor( () => {
-			expect( screen.queryByText( 'Tax Country: US' ) ).toBeInTheDocument();
-			expect( screen.queryByText( 'Tax Postal: 90210' ) ).toBeInTheDocument();
-		} );
-
-		// Reload the cart and verify that the hook does not revert the cart info.
-		fireEvent.click( await screen.findByText( 'Click to reload cart' ) );
-		await expect( screen.findByText( 'Tax Postal: 10001' ) ).toNeverAppear();
-		await waitFor( () => {
-			expect( screen.queryByText( 'Tax Postal: 90210' ) ).toBeInTheDocument();
-		} );
-	} );
-
 	it( 'sends the postal code and country from the contact details endpoint to the checkout data store for country with postal code', async () => {
 		const countryCode = 'US';
 		const postalCode = '10001';

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -408,7 +408,7 @@ A React Hook that will return the `onClick` function passed to each [payment met
 
 ### useSetStepComplete
 
-A React Hook that will return a function to set a step to "complete". Only works within a step but it does not have to be the targeted step. The returned function looks like `( stepNumber: number ) => Promise< void >;`. Calling this function is similar to pressing the "Continue" button on the specified step; it will call the `isCompleteCallback` prop of the step and only succeed if the callback succeeds. In addition, all previous incomplete steps will be marked as complete in the same way, and the process will fail and stop at the first step whose `isCompleteCallback` fails.
+A React Hook that will return a function to set a step to "complete". Only works within a step but it does not have to be the targeted step. The returned function looks like `( stepId: string ) => Promise< void >;`. Calling this function is similar to pressing the "Continue" button on the specified step; it will call the `isCompleteCallback` prop of the step and only succeed if the callback succeeds. In addition, all previous incomplete steps will be marked as complete in the same way, and the process will fail and stop at the first step whose `isCompleteCallback` fails.
 
 ### useTotal
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -408,7 +408,7 @@ A React Hook that will return the `onClick` function passed to each [payment met
 
 ### useSetStepComplete
 
-A React Hook that will return a function to set a step to "complete". Only works within a step. The function looks like `( stepNumber: number, isComplete: boolean ) => void;`.
+A React Hook that will return a function to set a step to "complete". Only works within a step but it does not have to be the targeted step. The returned function looks like `( stepNumber: number ) => Promise< void >;`. Calling this function is similar to pressing the "Continue" button on the specified step; it will call the `isCompleteCallback` prop of the step and only succeed if the callback succeeds. In addition, all previous incomplete steps will be marked as complete in the same way, and the process will fail and stop at the first step whose `isCompleteCallback` fails.
 
 ### useTotal
 

--- a/packages/composite-checkout/demo/index.tsx
+++ b/packages/composite-checkout/demo/index.tsx
@@ -191,7 +191,6 @@ function usePrefilledCountry( preFilledCountry?: string ) {
 			// we have to wait for a render to occur. Therefore we use setTimeout to
 			// defer the calls to setStepComplete.
 			setTimeout( () => {
-				setStepComplete( 1 );
 				setStepComplete( 2 );
 			} );
 		}

--- a/packages/composite-checkout/demo/index.tsx
+++ b/packages/composite-checkout/demo/index.tsx
@@ -191,7 +191,7 @@ function usePrefilledCountry( preFilledCountry?: string ) {
 			// we have to wait for a render to occur. Therefore we use setTimeout to
 			// defer the calls to setStepComplete.
 			setTimeout( () => {
-				setStepComplete( 2 );
+				setStepComplete( 'contact-form' );
 			} );
 		}
 	}, [ preFilledCountry, setStepComplete ] );

--- a/packages/composite-checkout/demo/index.tsx
+++ b/packages/composite-checkout/demo/index.tsx
@@ -84,7 +84,7 @@ const Form = styled.div`
 `;
 
 const contactStore = {
-	subscibers: [],
+	subscribers: [],
 	data: {
 		country: {
 			value: '',
@@ -95,11 +95,15 @@ const contactStore = {
 		return contactStore.data;
 	},
 	subscribe( callback: () => void ): () => void {
-		contactStore.subscibers.push( callback );
-		return () => void contactStore.subscibers.filter( ( client ) => client !== callback );
+		contactStore.subscribers.push( callback );
+		return () => {
+			contactStore.subscribers = contactStore.subscribers.filter(
+				( client ) => client !== callback
+			);
+		};
 	},
 	notify() {
-		setTimeout( () => contactStore.subscibers.forEach( ( callback ) => callback() ) );
+		setTimeout( () => contactStore.subscribers.forEach( ( callback ) => callback() ) );
 	},
 };
 
@@ -114,7 +118,7 @@ function setCountryError( error: string ) {
 }
 
 function useCountry() {
-	const [ state, setState ] = useState( { value: '', error: '' } );
+	const [ state, setState ] = useState( contactStore.getData().country );
 	useEffect( () => {
 		return contactStore.subscribe( () => {
 			const { value, error } = contactStore.getData().country;
@@ -164,9 +168,15 @@ const contactFormStep = {
 	completeStepContent: <ContactFormSummary />,
 };
 
-export function CheckoutDemo() {
+function CheckoutDemo( { preFilledCountry }: { preFilledCountry?: string } ) {
 	const [ items ] = useState( initialItems );
 	const total = useMemo( () => getTotal( items ), [ items ] );
+
+	useEffect( () => {
+		if ( preFilledCountry ) {
+			setCountry( preFilledCountry );
+		}
+	}, [ preFilledCountry ] );
 
 	const [ isLoading, setIsLoading ] = useState( true );
 	useEffect( () => {
@@ -248,3 +258,6 @@ export default {
 	title: 'composite-checkout',
 	component: CheckoutDemo,
 };
+
+export const Basic = () => <CheckoutDemo />;
+export const Prefilled = () => <CheckoutDemo preFilledCountry="Canada" />;

--- a/packages/composite-checkout/demo/index.tsx
+++ b/packages/composite-checkout/demo/index.tsx
@@ -248,7 +248,7 @@ function MyCheckoutBody( { preFilledCountry }: { preFilledCountry?: string } ) {
 					new Promise( ( resolve ) =>
 						// Simulate async validation
 						setTimeout( () => {
-							if ( value.length === 0 ) {
+							if ( value.trim() === '' || value.trim().toLowerCase() === 'unknown' ) {
 								setCountryError( 'Invalid country' );
 								resolve( false );
 								return;
@@ -288,3 +288,4 @@ export default {
 
 export const Basic = () => <CheckoutDemo />;
 export const Prefilled = () => <CheckoutDemo preFilledCountry="Canada" />;
+export const PrefilledFailure = () => <CheckoutDemo preFilledCountry="Unknown" />;

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -300,8 +300,14 @@ export const CheckoutStep = ( {
 		setStepCompleteStatus( { ...stepCompleteStatus, [ stepNumber ]: newStatus } );
 	const goToThisStep = () => setActiveStepNumber( stepNumber );
 	const activePaymentMethod = usePaymentMethod();
-	const finishIsCompleteCallback = ( completeResult: boolean ) => {
-		setThisStepCompleteStatus( !! completeResult );
+
+	// This is the callback called when you press "Continue" on a step.
+	const goToNextStep = async () => {
+		setFormValidating();
+		// Wrapping isCompleteCallback in Promise.resolve allows it to return a Promise or boolean.
+		const completeResult = Boolean( await Promise.resolve( isCompleteCallback() ) );
+		debug( `isCompleteCallback for step ${ stepNumber } finished with`, completeResult );
+		setThisStepCompleteStatus( completeResult );
 		if ( completeResult ) {
 			onStepChanged?.( {
 				stepNumber: nextStepNumber,
@@ -314,14 +320,6 @@ export const CheckoutStep = ( {
 			}
 		}
 		setFormReady();
-	};
-	const goToNextStep = async () => {
-		// Wrapping this in Promise.resolve allows it to be a Promise or boolean
-		const completeResult = Promise.resolve( isCompleteCallback() );
-		setFormValidating();
-		const delayedCompleteResult = await completeResult;
-		debug( `isCompleteCallback for step ${ stepNumber } finished with`, delayedCompleteResult );
-		finishIsCompleteCallback( delayedCompleteResult );
 	};
 
 	const classNames = [

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -40,7 +40,7 @@ interface StepCompleteCallbackState {
 	[ key: string ]: () => void;
 }
 
-interface CheckoutStepDataContext {
+interface CheckoutStepDataContextType {
 	activeStepNumber: number;
 	stepCompleteStatus: StepCompleteStatus;
 	totalSteps: number;
@@ -60,7 +60,7 @@ interface CheckoutSingleStepDataContext {
 }
 
 const noop = () => {}; // eslint-disable-line @typescript-eslint/no-empty-function
-const CheckoutStepDataContext = createContext< CheckoutStepDataContext >( {
+const CheckoutStepDataContext = createContext< CheckoutStepDataContextType >( {
 	activeStepNumber: 0,
 	stepCompleteStatus: {},
 	totalSteps: 0,

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -743,18 +743,15 @@ export function useIsStepComplete(): boolean {
 
 export function useSetStepComplete(): ( stepNumber: number ) => Promise< void > {
 	const { getStepCompleteCallback, stepCompleteStatus } = useContext( CheckoutStepDataContext );
-	return useCallback(
-		async ( stepNumber: number ) => {
-			// To try to complete a step, we must try to complete all previous steps
-			// first, ignoring steps that are already complete.
-			for ( let step = 1; step <= stepNumber; step++ ) {
-				if ( ! stepCompleteStatus[ step ] ) {
-					await getStepCompleteCallback( step )();
-				}
+	return useEvent( async ( stepNumber: number ) => {
+		// To try to complete a step, we must try to complete all previous steps
+		// first, ignoring steps that are already complete.
+		for ( let step = 1; step <= stepNumber; step++ ) {
+			if ( ! stepCompleteStatus[ step ] ) {
+				await getStepCompleteCallback( step )();
 			}
-		},
-		[ getStepCompleteCallback, stepCompleteStatus ]
-	);
+		}
+	} );
 }
 
 const StepTitle = styled.span< StepTitleProps & HTMLAttributes< HTMLSpanElement > >`

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -748,7 +748,10 @@ export function useSetStepComplete(): ( stepNumber: number ) => Promise< void > 
 		// first, ignoring steps that are already complete.
 		for ( let step = 1; step <= stepNumber; step++ ) {
 			if ( ! stepCompleteStatus[ step ] ) {
-				await getStepCompleteCallback( step )();
+				const didStepComplete = await getStepCompleteCallback( step )();
+				if ( ! didStepComplete ) {
+					break;
+				}
 			}
 		}
 	} );

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -1000,7 +1000,7 @@ function getStepNumberForegroundColor( {
 }
 
 function saveStepNumberToUrl( stepNumber: number ) {
-	if ( ! window.history?.pushState ) {
+	if ( ! window?.history || ! window?.location ) {
 		return;
 	}
 	const newHash = stepNumber > 1 ? `#step${ stepNumber }` : '';
@@ -1011,7 +1011,31 @@ function saveStepNumberToUrl( stepNumber: number ) {
 		? window.location.href.replace( window.location.hash, newHash )
 		: window.location.href + newHash;
 	debug( 'updating url to', newUrl );
-	window.history.pushState( null, '', newUrl );
+	// We've seen this call to replaceState fail sometimes when the current URL
+	// is somehow different ("A history state object with URL
+	// 'https://wordpress.com/checkout/example.com#step2' cannot be created
+	// in a document with origin 'https://wordpress.com' and URL
+	// 'https://www.username@wordpress.com/checkout/example.com'.") so we
+	// wrap this in try/catch. It's not critical that the step number is saved to
+	// the URL.
+	try {
+		window.history.replaceState( null, '', newUrl );
+	} catch ( error ) {
+		debug( 'changing the url failed' );
+		return;
+	}
+	// Modifying history does not trigger a hashchange event which is what
+	// composite-checkout uses to change its current step, so we must fire one
+	// manually.
+	//
+	// We use try/catch because we support IE11 and that browser does not include
+	// HashChange.
+	try {
+		const event = new HashChangeEvent( 'hashchange' );
+		window.dispatchEvent( event );
+	} catch ( error ) {
+		debug( 'hashchange firing failed' );
+	}
 }
 
 function getStepNumberFromUrl() {

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -25,7 +25,7 @@ export interface CheckoutStepProps {
 
 export type IsCompleteCallback = () => boolean | Promise< boolean >;
 
-export type StepCompleteCallback = () => Promise< void >;
+export type StepCompleteCallback = () => Promise< boolean >;
 
 export interface OrderSummaryData {
 	className: string;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -25,6 +25,8 @@ export interface CheckoutStepProps {
 
 export type IsCompleteCallback = () => boolean | Promise< boolean >;
 
+export type StepCompleteCallback = () => Promise< void >;
+
 export interface OrderSummaryData {
 	className: string;
 	summaryContent: React.ReactNode;


### PR DESCRIPTION
#### Background

The `@automattic/composite-checkout` package includes the `CheckoutStep` component which can be used to create a series of form steps. Each step has a `isCompleteCallback` prop that can be used to validate a step's content when the user presses the step's "Continue" button.

Sometimes, it's desirable to complete steps programmatically without relying on user input. This can be done by using the function returned by the `useSetStepComplete()` React hook. However, setting the complete status in this way is very heavy-handed, changing the complete status directly and ignoring the `isCompleteCallback` function. This can result in needing to duplicate step validation behavior and other subtle bugs.

#### Changes proposed in this Pull Request

In this PR we modify `useSetStepComplete()` so that its returned function now calls the `isCompleteCallback` prop of the requested step directly as if the user had clicked the "Continue" button. If the callback fails, the step remains incomplete. (Previously it was also possible to use this function to set a step to incomplete, but that functionality has been removed.) In addition, before a step's callback is called, all previous incomplete steps must pass their callbacks as well.

Secondly, as long as we're changing its API, this PR changes the function returned by `useSetStepComplete()` to use the step's `stepId` prop instead of its number. This is a much better argument because steps are numbered automatically but the `stepId` is provided by the developer on the step. If the step numbers were to change, this would allow the function to still target the correct step.

Because the `isCompleteCallback` of the contact/billing step in checkout will now be called by `useSkipToLastStepIfFormComplete()`, and that callback saves the form data to the cart, this PR also removes the redundant `useCachedContactDetailsForCart()`.

#### Testing instructions

**To test basic behavior in demo:**

Run `yarn workspace @automattic/composite-checkout run storybook` and try the prefilled demo content to be sure it works as expected.

**To test calypso checkout:**

Add a product to your cart and visit checkout. Verify that if you have cached contact details, the contact/billing step is automatically completed (and that tax info accurately matches the chosen location). Verify that clicking "Continue" on each step moves to the next step if appropriate. 