### PR TITLE
Add Sentry error logging to checkout decider error boundary

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { logToLogstash } from 'calypso/lib/logstash';
+import { captureException } from 'calypso/lib/sentry';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import Recaptcha from 'calypso/signup/recaptcha';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
@@ -24,6 +25,7 @@ const logCheckoutError = ( error ) => {
 			message: error.message + '; Stack: ' + error.stack,
 		},
 	} );
+	captureException( error );
 };
 
 export default function CheckoutSystemDecider( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR modifies the `CheckoutSystemDecider` React Error Boundary (which sits at the top of checkout and catches errors not caught by the other Error Boundaries we use) so that it will send caught Errors to Sentry.

Requires https://github.com/Automattic/wp-calypso/pull/64306

#### Testing instructions

To test this properly we'll need to intentionally cause an error in the code.

<details><summary>Running calypso with this branch, try adding a line like this:</summary>

```diff
diff --git a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx b/client/my-sites/checkout/composite-checkout/components/wp-checko
ut.tsx
index c3c301170b..bb957dba90 100644
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -298,6 +298,8 @@ export default function WPCheckout( {

        const { transactionStatus } = useTransactionStatus();

+       throw new Error( 'this is a test error' );
+
        if ( transactionStatus === TransactionStatus.COMPLETE ) {
                debug( 'rendering post-checkout redirecting page' );
                return (
```
</details>

Next visit checkout and verify that you see an error message displayed by the error boundary on the page.

We need to somehow verify that the call to notify Sentry worked, but I'm not sure how to do that... suggestions are welcome!