### PR TITLE
Draft: Fix Jetpack Search checkout variant dropdown prices

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -22,6 +22,7 @@ import { requestPlans } from 'calypso/state/plans/actions';
 import { requestProductsList } from 'calypso/state/products-list/actions';
 import { computeProductsWithPrices } from 'calypso/state/products-list/selectors';
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
+import { fetchSiteProducts } from 'calypso/state/sites/products/actions';
 import type { WPCOMProductVariant } from '../components/item-variation-picker';
 import type { Plan, Product } from '@automattic/calypso-products';
 
@@ -91,10 +92,12 @@ export function useGetProductVariants(
 		if ( shouldFetchProducts && ! haveFetchedProducts ) {
 			debug( 'dispatching request for product variant data' );
 			reduxDispatch( requestPlans() );
-			reduxDispatch( requestProductsList() );
+			siteId
+				? reduxDispatch( fetchSiteProducts( siteId ) )
+				: reduxDispatch( requestProductsList() );
 			setHaveFetchedProducts( true );
 		}
-	}, [ shouldFetchProducts, haveFetchedProducts, reduxDispatch ] );
+	}, [ shouldFetchProducts, haveFetchedProducts, reduxDispatch, siteId ] );
 
 	const getProductVariantFromAvailableVariant = useCallback(
 		( variant: AvailableProductVariantAndCompared ): WPCOMProductVariant => {

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -2,6 +2,11 @@ import { GROUP_WPCOM } from '@automattic/calypso-products';
 import { getPlanRawPrice } from 'calypso/state/plans/selectors';
 import getIntroOfferIsEligible from 'calypso/state/selectors/get-intro-offer-is-eligible';
 import getIntroOfferPrice from 'calypso/state/selectors/get-intro-offer-price';
+import {
+	getSiteAvailableProductCost,
+	getSiteAvailableProductSaleCouponCost,
+	getSiteAvailableProductSaleCouponDiscount,
+} from 'calypso/state/sites/products/selectors';
 import { getPlanPrice } from './get-plan-price';
 import { getProductCost } from './get-product-cost';
 import { getProductSaleCouponCost } from './get-product-sale-coupon-cost';
@@ -20,15 +25,17 @@ export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) 
 		return computePricesForWpComPlan( state, siteId, planObject );
 	}
 
-	const planOrProductPrice = ! getPlanPrice( state, siteId, planObject, false )
-		? getProductCost( state, planObject.getStoreSlug() )
-		: getPlanPrice( state, siteId, planObject, false );
+	const planOrProductPrice = getPlanOrProductPrice( state, siteId, planObject );
 	const introOfferIsEligible = getIntroOfferIsEligible( state, planObject.getProductId(), siteId );
-	const saleCouponDiscount = getProductSaleCouponDiscount( state, planObject.getStoreSlug() ) || 0;
+	const saleCouponDiscount = siteId
+		? getSiteAvailableProductSaleCouponDiscount( state, siteId, planObject.getStoreSlug() ) || 0
+		: getProductSaleCouponDiscount( state, planObject.getStoreSlug() ) || 0;
 	const introductoryOfferPrice = introOfferIsEligible
 		? getIntroOfferPrice( state, planObject.getProductId(), siteId )
 		: null;
-	const saleCouponCost = getProductSaleCouponCost( state, planObject.getStoreSlug() );
+	const saleCouponCost = siteId
+		? getSiteAvailableProductSaleCouponCost( state, siteId, planObject.getStoreSlug() )
+		: getProductSaleCouponCost( state, planObject.getStoreSlug() );
 
 	return {
 		priceFull: planOrProductPrice,
@@ -54,4 +61,28 @@ function computePricesForWpComPlan( state, siteId, planObject ) {
 		priceFinal: priceFull,
 		introductoryOfferPrice,
 	};
+}
+
+/**
+ * Returns the price of a product or plan.
+ * If a valid `siteId` is provided, prices are gathered from the site-specific products list,
+ * which contains the correct prices for tiered products, such as Jetpack Search (based on posts count),
+ * ie- (state.sites.products[siteId].data - public-api.wordpress.com/rest/v1.1/sites/:siteId/products).
+ * Otherwise, prices are gathered from state.productsList.items (public-api.wordpress.com/rest/v1.1/products)
+ *
+ * @param {object} state Current redux state
+ * @param {number} siteId Site ID to consider
+ * @param {object} planObject Plan object returned by getPlan() from @automattic/calypso-products
+ * @returns {number} The requested price
+ */
+function getPlanOrProductPrice( state, siteId, planObject ) {
+	const isProduct = ! getPlanPrice( state, siteId, planObject, false );
+	if ( siteId ) {
+		return isProduct
+			? getSiteAvailableProductCost( state, siteId, planObject.getStoreSlug() )
+			: getPlanPrice( state, siteId, planObject, false );
+	}
+	return isProduct
+		? getProductCost( state, planObject.getStoreSlug() )
+		: getPlanPrice( state, siteId, planObject, false );
 }

--- a/client/state/sites/products/selectors.js
+++ b/client/state/sites/products/selectors.js
@@ -21,6 +21,11 @@ export function isRequestingSiteProducts( state, siteId ) {
 	return products.isRequesting;
 }
 
+export function hasLoadedSiteProductsFromServer( state, siteId ) {
+	const products = getProductsBySiteId( state, siteId );
+	return products.hasLoadedFromServer;
+}
+
 export function getSiteAvailableProduct( state, siteId, productSlug ) {
 	const { data } = getAvailableProductsBySiteId( state, siteId );
 
@@ -31,4 +36,12 @@ export function getSiteAvailableProduct( state, siteId, productSlug ) {
 
 export function getSiteAvailableProductCost( state, siteId, productSlug ) {
 	return getSiteAvailableProduct( state, siteId, productSlug )?.cost;
+}
+
+export function getSiteAvailableProductSaleCouponDiscount( state, siteId, productSlug ) {
+	return getSiteAvailableProduct( state, siteId, productSlug )?.sale_coupon?.discount;
+}
+
+export function getSiteAvailableProductSaleCouponCost( state, siteId, productSlug ) {
+	return getSiteAvailableProduct( state, siteId, productSlug )?.sale_cost;
 }


### PR DESCRIPTION
Abandoning this PR, in favor of #63640 

#### Changes proposed in this Pull Request

The tiered prices for Jetpack Search are incorrectly displayed in checkout (in the term variant dropdown), for sites above the 1st tier, (sites with more than 100 records). This PR fixes the term variant dropdown prices for Jetpack Search tiered prices.

<img width="1211" alt="search-checkout-pricing" src="https://user-images.githubusercontent.com/11078128/168474186-7d9c97c3-204a-4dca-8c81-ec833c805cea.png">

Related to: 
- 1164141197617539-as-1201985749766679/f
- 1164141197617539-as-1202210164385929/f
- p1647507273547209-slack-CQXNTE9K9

Fixes: #63233 

#### Implementation notes:

- When the `siteId` is available in checkout, this PR forces the checkout term variant dropdown items to use the products list from the `/rest/v1.1/sites/:siteId/products` endpoint (which contains the correct tiered prices based on the site's post count), as opposed to the products list at `/rest/v1.1/products`. The `siteId` will always be available when checking out with Jetpack Search because Search requires/forces logged-in checkout.

#### Testing instructions

1. You'll need a Jetpack site with more than 100 posts. If you don't already own one, create a Jurassic Ninja site, connect Jetpack (Select Free plan), and then add & install the "Duplicate Posts" plugin. Duplicate a post 101+ times and publish, so that your site now has more than 100 posts.
2. Checkout this PR and spin up Calypso blue (`yarn start`).
3. Go to: http://calypso.localhost:3000/checkout/:SITE/jetpack_search (replace **:SITE** with the site-slug of your site).
4. You should now be in Checkout, with Jetpack search in your cart.
5. In the dropdown term variant items (for a site with 101 - 1000 records), verify the yearly price is correct at **$59.50** and the monthly price is at **$10**
6. Now load checkout with Jetpack Search, with a site with < 100 records. Verify the dropdown variant item prices are correct at **$29.97** (yearly) and **$5** (monthly).

#### Screenshots:

![Markup 2022-05-15 at 09 58 23](https://user-images.githubusercontent.com/11078128/168476721-97d68fc0-edbd-44ae-9850-e997cd02f9b9.png)

![Markup 2022-05-15 at 09 59 56](https://user-images.githubusercontent.com/11078128/168476729-fbc2a6af-9c2a-41ca-86f9-b41c096520c4.png)


