### PR TITLE
Fix Jetpack Search checkout variant dropdown prices

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -667,10 +667,10 @@ export default function CompositeCheckout( {
 
 	const cartHasSearchProduct = useMemo(
 		() =>
-			items.some( ( { type } ) =>
-				JETPACK_SEARCH_PRODUCTS.includes( type as typeof JETPACK_SEARCH_PRODUCTS[ number ] )
+			responseCart.products.some( ( { product_slug } ) =>
+				JETPACK_SEARCH_PRODUCTS.includes( product_slug as typeof JETPACK_SEARCH_PRODUCTS[ number ] )
 			),
-		[ items ]
+		[ responseCart.products ]
 	);
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -1,3 +1,4 @@
+import { JETPACK_SEARCH_PRODUCTS } from '@automattic/calypso-products';
 import { useStripe } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
 import { CheckoutProvider, checkoutTheme } from '@automattic/composite-checkout';
@@ -12,6 +13,7 @@ import QueryContactDetailsCache from 'calypso/components/data/query-contact-deta
 import QueryIntroOffers from 'calypso/components/data/query-intro-offers';
 import QueryJetpackSaleCoupon from 'calypso/components/data/query-jetpack-sale-coupon';
 import QueryPlans from 'calypso/components/data/query-plans';
+import QueryPostCounts from 'calypso/components/data/query-post-counts';
 import QueryProducts from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
@@ -663,6 +665,14 @@ export default function CompositeCheckout( {
 		reduxDispatch( infoNotice( translate( 'Redirecting to payment partner…' ) ) );
 	}, [ reduxDispatch, translate ] );
 
+	const cartHasSearchProduct = useMemo(
+		() =>
+			items.some( ( { type } ) =>
+				JETPACK_SEARCH_PRODUCTS.includes( type as typeof JETPACK_SEARCH_PRODUCTS[ number ] )
+			),
+		[ items ]
+	);
+
 	return (
 		<Fragment>
 			<QueryIntroOffers siteId={ updatedSiteId } />
@@ -672,6 +682,7 @@ export default function CompositeCheckout( {
 			<QueryPlans />
 			<QueryProducts />
 			<QueryContactDetailsCache />
+			{ cartHasSearchProduct && <QueryPostCounts siteId={ updatedSiteId || -1 } type={ 'post' } /> }
 			<PageViewTracker
 				path={ analyticsPath }
 				title="Checkout"

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.js
@@ -1,9 +1,11 @@
-import { GROUP_WPCOM } from '@automattic/calypso-products';
+import { GROUP_WPCOM, JETPACK_SEARCH_PRODUCTS } from '@automattic/calypso-products';
 import { getPlanRawPrice } from 'calypso/state/plans/selectors';
+import { getAllPostCounts } from 'calypso/state/posts/counts/selectors';
 import getIntroOfferIsEligible from 'calypso/state/selectors/get-intro-offer-is-eligible';
 import getIntroOfferPrice from 'calypso/state/selectors/get-intro-offer-price';
 import { getPlanPrice } from './get-plan-price';
 import { getProductCost } from './get-product-cost';
+import { getProductPriceTierList } from './get-product-price-tiers';
 import { getProductSaleCouponCost } from './get-product-sale-coupon-cost';
 import { getProductSaleCouponDiscount } from './get-product-sale-coupon-discount';
 
@@ -20,15 +22,22 @@ export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) 
 		return computePricesForWpComPlan( state, siteId, planObject );
 	}
 
+	const isJetpackSearchProduct = JETPACK_SEARCH_PRODUCTS.includes( planObject.getStoreSlug() );
+
+	// eslint-disable-next-line no-nested-ternary
 	const planOrProductPrice = ! getPlanPrice( state, siteId, planObject, false )
-		? getProductCost( state, planObject.getStoreSlug() )
+		? isJetpackSearchProduct
+			? getSearchProductTierPrice( state, siteId, planObject.getStoreSlug() )
+			: getProductCost( state, planObject.getStoreSlug() )
 		: getPlanPrice( state, siteId, planObject, false );
 	const introOfferIsEligible = getIntroOfferIsEligible( state, planObject.getProductId(), siteId );
 	const saleCouponDiscount = getProductSaleCouponDiscount( state, planObject.getStoreSlug() ) || 0;
 	const introductoryOfferPrice = introOfferIsEligible
 		? getIntroOfferPrice( state, planObject.getProductId(), siteId )
 		: null;
-	const saleCouponCost = getProductSaleCouponCost( state, planObject.getStoreSlug() );
+	const saleCouponCost = isJetpackSearchProduct
+		? Math.floor( planOrProductPrice * ( 1 - saleCouponDiscount ) * 100 ) / 100
+		: getProductSaleCouponCost( state, planObject.getStoreSlug() );
 
 	return {
 		priceFull: planOrProductPrice,
@@ -54,4 +63,28 @@ function computePricesForWpComPlan( state, siteId, planObject ) {
 		priceFinal: priceFull,
 		introductoryOfferPrice,
 	};
+}
+
+/**
+ * Compute the Jetpack Search product tiered price based on the site's number of posts.
+ *
+ * @param {object} state Current redux state
+ * @param {number} siteId Site ID to consider
+ * @param {object} productSlug The product slug
+ * @returns {number} The tiered price (given the site's number of published posts)
+ */
+function getSearchProductTierPrice( state, siteId, productSlug ) {
+	const postsCounts = getAllPostCounts( state, siteId, 'post' );
+	const postsCount = postsCounts?.publish || 0;
+	const priceTierList = getProductPriceTierList( state, productSlug );
+	const tier = priceTierList.filter(
+		( tierItem ) => postsCount >= tierItem.minimum_units && postsCount <= tierItem.maximum_units
+	);
+	const minPrice = tier[ 0 ].minimum_price.toString(); // is missing decimal, ie- $9.95 is returned as 995
+	return (
+		// Inject decimal point into 100ths position.
+		Number(
+			minPrice.substring( 0, minPrice.length - 2 ) + '.' + minPrice.substring( minPrice.length - 2 )
+		)
+	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The tiered prices for Jetpack Search are incorrectly displayed in checkout (in the term variant dropdown), for sites above the 1st tier, (sites with more than 100 records). This PR fixes the term variant dropdown prices for Jetpack Search tiered prices.

<img width="1211" alt="search-checkout-pricing" src="https://user-images.githubusercontent.com/11078128/168474186-7d9c97c3-204a-4dca-8c81-ec833c805cea.png">

Related to: 
- 1164141197617539-as-1201985749766679/f
- 1164141197617539-as-1202210164385929/f
- p1647507273547209-slack-CQXNTE9K9

Fixes: #63233 

#### Testing instructions

1. You'll need a Jetpack site with more than 100 posts. If you don't already own one, create a Jurassic Ninja site, connect Jetpack (Select Free plan), and then add & install the "Duplicate Posts" plugin. Duplicate a post 101+ times and publish, so that your site now has more than 100 posts.
2. Checkout this PR and spin up Calypso blue (`yarn start`).
3. Go to: http://calypso.localhost:3000/checkout/:SITE/jetpack_search (replace **:SITE** with the site-slug of your site).
4. You should now be in Checkout, with Jetpack search in your cart.
5. In the dropdown term variant items (for a site with 101 - 1000 records), verify the yearly price is correct at **$59.50** and the monthly price is at **$10**
6. Now load checkout with Jetpack Search, with a site with < 100 records. Verify the dropdown variant item prices are correct at **$29.97** (yearly) and **$5** (monthly).

- You'll notice that the full price (that is striked-through with a line) in the variant dropdown displays as **$120**, when it should be **$119**.  (See screenshot below). This is not an issue with the code, it is because the _monthly_ price for Search is not set correctly in the _product pricing table_.  The monthly price for Search is set to **$10** (tier 2), but the monthly price should actually be set to: **$9.92**. This will need to be addressed in a follow-up PR.
![Markup 2022-05-15 at 21 28 08](https://user-images.githubusercontent.com/11078128/168504814-3c313162-20f8-4bd2-848c-c6a409b63323.png)


#### Screenshots:

![Markup 2022-05-17 at 09 22 15](https://user-images.githubusercontent.com/11078128/168821400-ef2216a6-678d-4904-8a10-8cbe918e5f93.png)

![Markup 2022-05-17 at 09 23 52](https://user-images.githubusercontent.com/11078128/168821426-16ea8b19-9a34-4bae-99e4-e546169be00a.png)



