### PR TITLE
Fix: Jetpack Search product should be added for Jetpack search standalone plugin sites

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -126,9 +126,8 @@ export default function CompositeCheckout( {
 		) ||
 		isJetpackCheckout ||
 		false;
-	const hasJetpackStandalonePlugins = useSelector(
-		( state ) => siteId && isJetpackProductSite( state, siteId )
-	);
+	const hasJetpackStandalonePlugins =
+		useSelector( ( state ) => siteId && isJetpackProductSite( state, siteId ) ) || false;
 	const usesJetpackProducts = isJetpackNotAtomic || hasJetpackStandalonePlugins;
 	const isPrivate = useSelector( ( state ) => siteId && isPrivateSite( state, siteId ) ) || false;
 	const isLoadingIntroOffers = useSelector( ( state ) =>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -29,7 +29,7 @@ import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
 import getIsIntroOfferRequesting from 'calypso/state/selectors/get-is-requesting-into-offers';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, isJetpackProductSite } from 'calypso/state/sites/selectors';
 import WPCheckout from './components/wp-checkout';
 import useActOnceOnStrings from './hooks/use-act-once-on-strings';
 import useAddProductsFromUrl from './hooks/use-add-products-from-url';
@@ -126,6 +126,10 @@ export default function CompositeCheckout( {
 		) ||
 		isJetpackCheckout ||
 		false;
+	const hasJetpackStandalonePlugins = useSelector(
+		( state ) => siteId && isJetpackProductSite( state, siteId )
+	);
+	const usesJetpackProducts = isJetpackNotAtomic || hasJetpackStandalonePlugins;
 	const isPrivate = useSelector( ( state ) => siteId && isPrivateSite( state, siteId ) ) || false;
 	const isLoadingIntroOffers = useSelector( ( state ) =>
 		getIsIntroOfferRequesting( state, siteId )
@@ -168,7 +172,7 @@ export default function CompositeCheckout( {
 		productAliasFromUrl,
 		purchaseId,
 		isInModal,
-		isJetpackNotAtomic,
+		usesJetpackProducts,
 		isPrivate,
 		siteSlug: updatedSiteSlug,
 		isLoggedOutCart,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -370,7 +370,7 @@ function useAddProductFromSlug( {
 		}
 		debug(
 			'preparing products that were requested in url',
-			{ productAliasFromUrl, isJetpackNotAtomic },
+			{ productAliasFromUrl, usesJetpackProducts },
 			cartProducts
 		);
 		dispatch( { type: 'PRODUCTS_ADD', products: cartProducts } );
@@ -378,7 +378,7 @@ function useAddProductFromSlug( {
 		addHandler,
 		translate,
 		isPrivate,
-		isJetpackNotAtomic,
+		usesJetpackProducts,
 		productAliasFromUrl,
 		validProducts,
 		isJetpackCheckout,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -36,7 +36,7 @@ export default function usePrepareProductsForCart( {
 	productAliasFromUrl,
 	purchaseId: originalPurchaseId,
 	isInModal,
-	isJetpackNotAtomic,
+	usesJetpackProducts,
 	isPrivate,
 	siteSlug,
 	isLoggedOutCart,
@@ -49,7 +49,7 @@ export default function usePrepareProductsForCart( {
 	productAliasFromUrl: string | null | undefined;
 	purchaseId: string | number | null | undefined;
 	isInModal?: boolean;
-	isJetpackNotAtomic: boolean;
+	usesJetpackProducts: boolean;
 	isPrivate: boolean;
 	siteSlug: string | undefined;
 	isLoggedOutCart?: boolean;
@@ -100,7 +100,7 @@ export default function usePrepareProductsForCart( {
 	useAddProductFromSlug( {
 		productAliasFromUrl,
 		dispatch,
-		isJetpackNotAtomic,
+		usesJetpackProducts,
 		isPrivate,
 		addHandler,
 		isJetpackCheckout,
@@ -294,7 +294,7 @@ function useAddRenewalItems( {
 function useAddProductFromSlug( {
 	productAliasFromUrl,
 	dispatch,
-	isJetpackNotAtomic,
+	usesJetpackProducts,
 	isPrivate,
 	addHandler,
 	isJetpackCheckout,
@@ -304,7 +304,7 @@ function useAddProductFromSlug( {
 }: {
 	productAliasFromUrl: string | undefined | null;
 	dispatch: ( action: PreparedProductsAction ) => void;
-	isJetpackNotAtomic: boolean;
+	usesJetpackProducts: boolean;
 	isPrivate: boolean;
 	addHandler: AddHandler;
 	isJetpackCheckout?: boolean;
@@ -322,7 +322,7 @@ function useAddProductFromSlug( {
 			productAliasFromUrl
 				?.split( ',' )
 				// Special treatment for Jetpack Search products
-				.map( ( productAlias ) => getJetpackSearchForSite( productAlias, isJetpackNotAtomic ) )
+				.map( ( productAlias ) => getJetpackSearchForSite( productAlias, usesJetpackProducts ) )
 				// Get the product information if it exists, and keep a reference to
 				// its product alias which we may need to get additional information like
 				// the domain name or theme (eg: 'theme:ovation').
@@ -330,7 +330,7 @@ function useAddProductFromSlug( {
 					const productSlug = getProductSlugFromAlias( productAlias );
 					return { productSlug, productAlias };
 				} ) ?? [],
-		[ isJetpackNotAtomic, productAliasFromUrl ]
+		[ usesJetpackProducts, productAliasFromUrl ]
 	);
 
 	useEffect( () => {
@@ -441,12 +441,12 @@ function createRenewalItemToAddToCart(
  * redirect to a valid checkout URL for a search purchase without worrying
  * about which type of site the user has.
  */
-function getJetpackSearchForSite( productAlias: string, isJetpackNotAtomic: boolean ): string {
+function getJetpackSearchForSite( productAlias: string, usesJetpackProducts: boolean ): string {
 	if (
 		productAlias &&
 		JETPACK_SEARCH_PRODUCTS.includes( productAlias as typeof JETPACK_SEARCH_PRODUCTS[ number ] )
 	) {
-		if ( isJetpackNotAtomic ) {
+		if ( usesJetpackProducts ) {
 			productAlias = productAlias.includes( 'monthly' )
 				? PRODUCT_JETPACK_SEARCH_MONTHLY
 				: PRODUCT_JETPACK_SEARCH;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The PR fixes the issue where WPCOM Search product (wpcom_search, wpcom_search_monthly)  is added to Jetpack Search standalone sites - Jetpack Search product  (jetpack_search, jetpack_search_monthly) should be added instead.

#### Testing instructions

- [Create a fresh JN site with Jetpack Beta Only - uncheck Jetpack please](https://jurassic.ninja/specialops/)
- Activate Search plugin on bleeding edge
- Start you local Calypso `yarn start`
- Open `/wp-admin/admin.php?page=jetpack-search`
- Click `Login` or `Get Jetpack Search`
- Replace `https://wordpress.com` with `http://calypso.localhost:3000/` then Authorize
- Ensure Search product is added to cart
- Ensure you could pay (with credits)