### PR TITLE
Jetpack Cloud: only show server credentials settings if user has Backup or Scan

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
+++ b/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
@@ -1,11 +1,15 @@
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
+import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import { settingsPath, purchasesPath, purchasesBasePath } from 'calypso/lib/jetpack/paths';
 import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import { isSectionNameEnabled } from 'calypso/sections-filter';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { siteHasScanProductPurchase } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import isRewindActive from 'calypso/state/selectors/is-rewind-active';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import JetpackIcons from './jetpack-icons';
@@ -16,6 +20,8 @@ export default ( { path } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const hasScanProduct = useSelector( ( state ) => siteHasScanProductPurchase( state, siteId ) );
+	const hasActiveRewind = useSelector( ( state ) => isRewindActive( state, siteId ) );
 
 	const onNavigate = () => {
 		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_settings_clicked' ) );
@@ -24,9 +30,9 @@ export default ( { path } ) => {
 		window.scrollTo( 0, 0 );
 	};
 
-	const shouldShowSettings = useSelector( ( state ) =>
-		canCurrentUser( state, siteId, 'manage_options' )
-	);
+	const shouldShowSettings =
+		useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) ) &&
+		( hasActiveRewind || hasScanProduct );
 
 	const shouldShowPurchases =
 		isSectionNameEnabled( 'site-purchases' ) &&
@@ -34,6 +40,8 @@ export default ( { path } ) => {
 
 	return (
 		<>
+			<QueryRewindState siteId={ siteId } />
+			<QuerySitePurchases siteId={ siteId } />
 			<JetpackSidebarMenuItems
 				path={ path }
 				showIcons={ true }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In a Jetpack call for testing (p1HpG7-fTB-p2#comment-54355), @bobmatyas noted:

> When I only have a Jetpack Search plan, I can add credentials via Jetpack Cloud. I don’t have a Backup or scan plan though.

Remove server credentials are only relevant to Backup and Scan so the section shouldn't be shown for a user who just purchases Search, for example.

This PR ensures that the Settings link is only displayed if it's relevant to the user - i.e. they have a current Scan purchase or Rewind is enabled.

<img width="285" alt="Screen Shot 2022-05-16 at 14 59 26" src="https://user-images.githubusercontent.com/17325/168512640-554dac3a-9522-493e-a137-4873a63c1657.png">

<img width="731" alt="Screen Shot 2022-05-16 at 15 06 45" src="https://user-images.githubusercontent.com/17325/168513276-8cffac54-52e4-4fa8-8e94-4ebb1000cfb6.png">



#### Testing instructions

Set up a new jurassic.ninja site, connect to Jetpack and subscribe to Jetpack Search.

Navigate to Jetpack Cloud and ensure the Settings menu item is hidden.

Now purchase either Backup or Scan, return to Jetpack Cloud and ensure the Settings menu item is shown.
