### PR TITLE
Marketplace: Add clear search filter link

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -316,17 +316,30 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 	);
 };
 
+const ClearSearch = () => {
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const translate = useTranslate();
+
+	return (
+		<a
+			className={ 'plugins-browser__clear-filters' }
+			href={ '/plugins' + ( siteSlug ? '/' + siteSlug : '' ) }
+		>
+			{ translate( 'Clear' ) }
+		</a>
+	);
+};
 const SearchListView = ( {
 	search: searchTerm,
 	pluginsPagination,
 	pluginsBySearchTerm,
 	fetchNextPage,
 	isFetchingPluginsBySearchTerm,
-	searchTitle: searchTitleTerm,
 	siteSlug,
 	siteId,
 	sites,
 	billingPeriod,
+	categoryName,
 } ) => {
 	const dispatch = useDispatch();
 
@@ -356,36 +369,54 @@ const SearchListView = ( {
 	}, [ searchTerm, pluginsPagination, dispatch, siteId ] );
 
 	if ( pluginsBySearchTerm.length > 0 || isFetchingPluginsBySearchTerm ) {
-		const searchTitle =
-			searchTitleTerm ||
-			( searchTerm &&
-				translate( 'Search results for {{b}}%(searchTerm)s{{/b}}', {
+		let title = translate( 'Search results for "%(searchTerm)"', {
+			textOnly: true,
+			args: { searchTerm },
+		} );
+
+		if ( pluginsPagination ) {
+			title = translate(
+				'Found %(total)s plugin for "%(searchTerm)s"',
+				'Found %(total)s plugins for "%(searchTerm)s"',
+				{
+					count: pluginsPagination.results,
 					textOnly: true,
 					args: {
+						total: pluginsPagination.results,
 						searchTerm,
 					},
-					components: {
-						b: <b />,
-					},
-				} ) );
+				}
+			);
 
-		const subtitle =
-			pluginsPagination &&
-			translate( '%(total)s plugin', '%(total)s plugins', {
-				count: pluginsPagination.results,
-				textOnly: true,
-				args: {
-					total: pluginsPagination.results,
-				},
-			} );
+			if ( categoryName ) {
+				title = translate(
+					'Found %(total)s plugin for "%(searchTerm)s" under "%(categoryName)s"',
+					'Found %(total)s plugins for "%(searchTerm)s" under "%(categoryName)s"',
+					{
+						count: pluginsPagination.results,
+						textOnly: true,
+						args: {
+							total: pluginsPagination.results,
+							searchTerm,
+							categoryName,
+						},
+					}
+				);
+			}
+		}
 
 		return (
 			<>
 				<PluginsBrowserList
 					plugins={ pluginsBySearchTerm.filter( isNotBlocked ) }
 					listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
-					title={ searchTitle }
-					subtitle={ subtitle }
+					subtitle={
+						<>
+							{ title }
+							<ClearSearch />
+						</>
+					}
+					showReset={ true }
 					site={ siteSlug }
 					showPlaceholders={ isFetchingPluginsBySearchTerm }
 					currentSites={ sites }

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -29,3 +29,9 @@
 		}
 	}
 }
+
+.plugins-browser__clear-filters, .plugins-browser__clear-filters:visited {
+	margin-left: 10px;
+	text-decoration: underline;
+	color: var( --studio-black );
+}

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -26,7 +26,8 @@ const selectors = {
 	searchIcon: '.search-component__open-icon',
 	searchInput: 'input.search-component__input',
 	searchResult: ( text: string ) => `.plugins-browser-item__title:text("${ text }")`,
-	searchResultTitle: ( text: string ) => `:text("Search results for ${ text }")`,
+	// eslint-disable-next-line no-useless-escape
+	searchResultTitle: ( text: string ) => `:text("Found /[0-9]+/ plugins for \"${ text }\"")`,
 
 	// Plugin view
 	pluginHamburgerMenu: `.plugin-site-jetpack__action`,

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -27,7 +27,7 @@ const selectors = {
 	searchInput: 'input.search-component__input',
 	searchResult: ( text: string ) => `.plugins-browser-item__title:text("${ text }")`,
 	// eslint-disable-next-line no-useless-escape
-	searchResultTitle: ( text: string ) => `:text("Found /[0-9]+/ plugins for \"${ text }\"")`,
+	searchResultTitle: ( text: string ) => `:text('plugins for "${ text }"')`,
 
 	// Plugin view
 	pluginHamburgerMenu: `.plugin-site-jetpack__action`,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a "Clear" link to the search result header
* Updates the search header to match figma (title > subtitle + merging texts)
* Adds support for categories once we have them

#### Testing instructions

* Search on `/plugins`
* Should se search result header change
* Clicking the clear link should take you back to `/plugins`

#### Screenshots

![Screenshot 2022-05-16 at 15-03-23 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/168523734-de7c089f-b40c-42bf-aacd-cd250dc74d5a.png)

By hardcoding a category name:
![Screenshot 2022-05-16 at 14-54-53 Plugins ‹ c3po - Atomic - Mapped — WordPress com](https://user-images.githubusercontent.com/811776/168523741-77d5170c-826b-42ec-adbe-9f0db8b4fc31.png)

Before shot
![Screenshot 2022-05-16 at 15-12-58 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/168523940-5b31c3d9-411e-449d-84ff-e3dbf671fe10.png)


Fixes https://github.com/Automattic/wp-calypso/issues/63461
