### PR TITLE
Jetpack Search: adjust text above button on product cards

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-card/product-above-button-text.ts
+++ b/client/my-sites/plans/jetpack-plans/product-card/product-above-button-text.ts
@@ -14,7 +14,7 @@ export default function productAboveButtonText(
 		siteProduct &&
 		( JETPACK_SEARCH_PRODUCTS as ReadonlyArray< string > ).includes( product.productSlug )
 	) {
-		return translate( '*estimated price based off of %(records)s records', {
+		return translate( '*estimated price based on %(records)s records', {
 			args: {
 				records: numberFormat( siteProduct.tierUsage, 0 ),
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On Jetpack Search product cards (for example, on https://cloud.jetpack.com/pricing/), we show extra text above the call-to-action button. Ours currently says:

`*estimated price based off of 2 records`

<img width="358" alt="Screen Shot 2022-05-16 at 17 04 11" src="https://user-images.githubusercontent.com/17325/168523661-3ba36c61-2f81-4de8-aa5d-e53238d0c7ce.png">

I think "based off of" may be more common in US English but doesn't sound right to me (UK/NZ). This PR switches to the shorter, and more widely used:

`*estimated price based on 2 records`

https://www.merriam-webster.com/words-at-play/based-on-vs-based-off

#### Testing instructions

1. Apply the changes locally and start the Jetpack Cloud dev environment with `CALYPSO_ENV=jetpack-cloud-development yarn start`.
2. Create a new jurassic.ninja site.
3. Navigate to http://jetpack.cloud.localhost:3000/pricing/<your-site-url>.

After:

<img width="342" alt="Screen Shot 2022-05-16 at 17 18 05" src="https://user-images.githubusercontent.com/17325/168524436-52859d37-7f8d-4a25-a04e-c96a1d220505.png">
