### PR TITLE
Marketplace: Remove search results from /manage pages

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -38,7 +38,6 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import NoPermissionsError from './no-permissions-error';
-import PluginsBrowser from './plugins-browser';
 import PluginsList from './plugins-list';
 
 import './style.scss';
@@ -288,11 +287,10 @@ export class PluginsMain extends Component {
 	}
 
 	renderPluginsContent() {
-		const { filter, search } = this.props;
+		const { search } = this.props;
 
 		const currentPlugins = this.getCurrentPlugins();
 		const showInstalledPluginList = ! isEmpty( currentPlugins ) || this.isFetchingPlugins();
-		const showSuggestedPluginsList = filter === 'all' || ( ! showInstalledPluginList && search );
 
 		if ( ! showInstalledPluginList && ! search ) {
 			const emptyContentData = this.getEmptyContentData();
@@ -317,41 +315,7 @@ export class PluginsMain extends Component {
 			/>
 		);
 
-		const morePluginsHeader = showInstalledPluginList && showSuggestedPluginsList && (
-			<h3 className="plugins__more-header">{ this.props.translate( 'More Plugins' ) }</h3>
-		);
-
-		let searchTitle;
-		if ( search ) {
-			searchTitle = this.props.translate( 'Suggested plugins for: {{b}}%(searchQuery)s{{/b}}', {
-				textOnly: true,
-				args: {
-					searchQuery: search,
-				},
-				components: {
-					b: <b />,
-				},
-			} );
-		}
-
-		const suggestedPluginsList = showSuggestedPluginsList && (
-			<PluginsBrowser
-				hideSearchForm
-				hideHeader
-				path={ this.props.context.path }
-				search={ search }
-				searchTitle={ searchTitle }
-				trackPageViews={ false }
-			/>
-		);
-
-		return (
-			<div>
-				{ installedPluginsList }
-				{ morePluginsHeader }
-				{ suggestedPluginsList }
-			</div>
-		);
+		return <div>{ installedPluginsList }</div>;
 	}
 
 	handleAddPluginButtonClick = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes PluginsBrowser usage from the /manage pages. After a lot of changes to the browser it doesn't look compatible with the old usage and leads to some artifacts around header / search / slowness. I don't think it actually makes sense to maintain search results here so lets just remove it instead.

#### Testing instructions

* Visit /plugins (no-site)
* Click Installed Plugins in the top right nav
* /plugins/manage should load but no search results below the manager should be rendered.

#### Screenshots

Before
![Screenshot 2022-05-16 at 15-25-30 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/168525645-cadaf2da-54c3-42b2-9f56-40f99cef5703.png)

After
![Screenshot 2022-05-16 at 15-31-00 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/168525641-d97ee091-3ba9-4b60-b41d-71232c08ab3b.png)



Fixes https://github.com/Automattic/wp-calypso/issues/63647
