### PR TITLE
Generated design picker: Tracks events

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -151,11 +151,13 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	}
 
 	const getEventPropsByDesign = ( design: Design ) => ( {
-		theme: design.recipe?.stylesheet,
+		slug: design?.slug,
+		theme: design?.recipe?.stylesheet,
 		template: design?.template,
+		flow,
+		intent,
 		is_premium: design?.is_premium,
-		flow: showGeneratedDesigns ? 'generated-design-step' : flow,
-		intent: intent,
+		is_generated: showGeneratedDesigns,
 		...( design?.recipe?.patternIds && { pattern_ids: design.recipe.patternIds.join( ',' ) } ),
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -228,9 +228,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	}
 
 	function viewMoreDesigns() {
-		recordTracksEvent( 'calypso_signup_design_view_more_select', {
-			flow: showGeneratedDesigns ? 'generated-design-step' : flow,
-		} );
+		recordTracksEvent( 'calypso_signup_design_view_more_select' );
 
 		setSelectedDesign( undefined );
 		setIsPreviewingDesign( false );
@@ -264,7 +262,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 			intent: intent,
 		};
 
-		if ( isForceStaticDesigns ) {
+		if ( ! isPreviewingDesign && isForceStaticDesigns ) {
 			recordTracksEvent( 'calypso_signup_back_to_generated_design_step' );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -102,6 +102,9 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		[ generatedDesigns ]
 	);
 
+	const selectedGeneratedDesign = ! isMobile
+		? selectedDesign || shuffledGeneratedDesigns[ 0 ]
+		: undefined;
 	const visibility = useNewSiteVisibility();
 
 	function headerText() {
@@ -149,10 +152,11 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	const getEventPropsByDesign = ( design: Design ) => ( {
 		theme: design.recipe?.stylesheet,
-		template: design.template,
+		template: design?.template,
 		is_premium: design?.is_premium,
-		flow,
+		flow: showGeneratedDesigns ? 'generated-design-step' : flow,
 		intent: intent,
+		...( design?.recipe?.patternIds && { pattern_ids: design.recipe.patternIds.join( ',' ) } ),
 	} );
 
 	const categorizationOptions = getCategorizationOptions(
@@ -163,11 +167,23 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) );
 
-	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
+	function pickDesign(
+		_selectedDesign: Design | undefined = selectedDesign,
+		buttonLocation?: string
+	) {
 		setSelectedDesign( _selectedDesign );
 		if ( siteSlug && _selectedDesign ) {
+			const positionIndex = showGeneratedDesigns
+				? shuffledGeneratedDesigns.findIndex( ( design ) => design.slug === _selectedDesign.slug )
+				: -1;
+
 			setPendingAction( () => setDesignOnSite( siteSlug, _selectedDesign, siteVerticalId ) );
-			recordTracksEvent( 'calypso_signup_select_design', getEventPropsByDesign( _selectedDesign ) );
+			recordTracksEvent( 'calypso_signup_select_design', {
+				...getEventPropsByDesign( _selectedDesign ),
+				...( buttonLocation && { button_location: buttonLocation } ),
+				...( showGeneratedDesigns && positionIndex >= 0 && { position_index: positionIndex } ),
+			} );
+
 			const providedDependencies = {
 				selectedDesign: _selectedDesign,
 				selectedSiteCategory: categorization.selection,
@@ -201,17 +217,21 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		}
 	}
 
-	function previewDesign( _selectedDesign: Design ) {
-		recordTracksEvent(
-			'calypso_signup_design_preview_select',
-			getEventPropsByDesign( _selectedDesign )
-		);
+	function previewDesign( _selectedDesign: Design, positionIndex?: number ) {
+		recordTracksEvent( 'calypso_signup_design_preview_select', {
+			...getEventPropsByDesign( _selectedDesign ),
+			...( positionIndex && { position_index: positionIndex } ),
+		} );
 
 		setSelectedDesign( _selectedDesign );
 		setIsPreviewingDesign( true );
 	}
 
 	function viewMoreDesigns() {
+		recordTracksEvent( 'calypso_signup_design_view_more_select', {
+			flow: showGeneratedDesigns ? 'generated-design-step' : flow,
+		} );
+
 		setSelectedDesign( undefined );
 		setIsPreviewingDesign( false );
 		setIsForceStaticDesigns( true );
@@ -236,6 +256,19 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 				siteSlug
 			) }/${ plan }?${ params.toString() }`;
 		}
+	}
+
+	function recordStepContainerTracksEvent( eventName: string ) {
+		const tracksProps = {
+			step: showGeneratedDesigns ? 'generated-design-step' : 'design-step',
+			intent: intent,
+		};
+
+		if ( isForceStaticDesigns ) {
+			recordTracksEvent( 'calypso_signup_back_to_generated_design_step' );
+		}
+
+		recordTracksEvent( eventName, tracksProps );
 	}
 
 	const handleBackClick = () => {
@@ -309,7 +342,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 						) : undefined }
 					</>
 				}
-				recordTracksEvent={ recordTracksEvent }
+				recordTracksEvent={ recordStepContainerTracksEvent }
 			/>
 		);
 	}
@@ -337,7 +370,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 				backLabelText={ 'Pick another' }
 				goBack={ handleBackClick }
 				goNext={ () => pickDesign() }
-				recordTracksEvent={ recordTracksEvent }
+				recordTracksEvent={ recordStepContainerTracksEvent }
 			/>
 		);
 	}
@@ -373,14 +406,18 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	const stepContent = showGeneratedDesigns ? (
 		<GeneratedDesignPicker
-			selectedDesign={ ! isMobile ? selectedDesign || shuffledGeneratedDesigns[ 0 ] : undefined }
+			selectedDesign={ selectedGeneratedDesign }
 			designs={ shuffledGeneratedDesigns }
 			verticalId={ siteVerticalId }
 			locale={ locale }
 			heading={
 				<div className={ classnames( 'step-container__header', 'design-setup__header' ) }>
 					{ heading }
-					<Button ref={ continueButtonRef } primary>
+					<Button
+						ref={ continueButtonRef }
+						primary
+						onClick={ () => pickDesign( selectedGeneratedDesign, 'top' ) }
+					>
 						{ translate( 'Continue' ) }
 					</Button>
 				</div>
@@ -391,7 +428,9 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 					targetRef={ continueButtonRef }
 				>
 					<div className={ 'design-setup__footer-inner' }>
-						<Button primary>{ translate( 'Continue' ) }</Button>
+						<Button primary onClick={ () => pickDesign( selectedGeneratedDesign, 'bottom' ) }>
+							{ translate( 'Continue' ) }
+						</Button>
 					</div>
 				</StickyFooter>
 			}
@@ -434,7 +473,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 			hideFormattedHeader
 			skipLabelText={ intent === 'write' ? translate( 'Skip and draft first post' ) : undefined }
 			stepContent={ stepContent }
-			recordTracksEvent={ recordTracksEvent }
+			recordTracksEvent={ recordStepContainerTracksEvent }
 			goNext={ () => submit?.() }
 			goBack={ handleBackClick }
 		/>

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -102,7 +102,7 @@ export interface GeneratedDesignPickerProps {
 	locale: string;
 	heading?: React.ReactElement;
 	footer?: React.ReactElement;
-	onPreview: ( design: Design ) => void;
+	onPreview: ( design: Design, positionIndex: number ) => void;
 	onViewMore: () => void;
 }
 
@@ -124,13 +124,13 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 			<div className="generated_design-picker__content">
 				<div className="generated-design-picker__thumbnails">
 					{ designs &&
-						designs.map( ( design ) => (
+						designs.map( ( design, index ) => (
 							<GeneratedDesignThumbnail
 								key={ design.slug }
 								slug={ design.slug }
 								thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
 								isSelected={ selectedDesign?.slug === design.slug }
-								onPreview={ () => onPreview( design ) }
+								onPreview={ () => onPreview( design, index ) }
 							/>
 						) ) }
 					<Button className="generated-design-picker__view-more" onClick={ onViewMore }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds and updates the following Tracks events:
* Added `calypso_signup_design_view_more_select`, for when users click on the "View more options" button.
* Added `calypso_signup_back_to_generated_design_step`, for when users go back from the existing design picker to the generated design picker (by clicking the Back button)
* Updated `calypso_signup_design_preview_select` to include:
  * `pattern_ids`. The selected design recipe's pattern IDs (only for generated designs).
  * `position_index`. The thumbnail ordering position index (only in the generated design picker).
* Updated  `calypso_signup_select_design` to include:
  * `pattern_ids`. The selected design recipe's pattern IDs (only for generated designs).
  * `position_index`. The thumbnail ordering position index (only in the generated design picker).
  * `button_location`. The location of the button from which the user selected the design (only in the generated design picker).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From the site intent screen `/setup/intent?siteSlug=${site_slug}`, click on the "Start building" button.
* Expect to land on the generated design picker.
* Open up the browser DevTools, and select the tab "Network".
* Test `calypso_signup_design_view_more_select`:
  * Click on the "View more options" button and check that the event has been fired with the correct properties.
* Test `calypso_signup_back_to_generated_design_step`:
  * Click on the "View more options" button so that the design picker changes to the existing one, then click on the "Back" button to switch back to the generated design picker.
* Test `calypso_signup_design_preview_select`:
  * Click on any of the thumbnails on the left side and check that the event has been fired with the correct properties.
* Test `calypso_signup_select_design`:
  * Click on any of the "Continue" button and check that the event has been fired with the correct properties. 
* Test that the Back button Tracks event has `stepName`:
  * `design-step` for traditional design picker.
  * `generated-design-step` for generated design picker.
* Test the same above, with the "Skip" button.
 
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62237
