### PR TITLE
P2 signup: log in users at the start of the flow

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1011,7 +1011,7 @@ export function excludeStepIfEmailVerified( stepName, defaultDependencies, nextP
 		return;
 	}
 
-	debug( 'User email is verified:  = %s', nextProps?.isEmailVerified );
+	debug( 'User email is verified: %s', nextProps?.isEmailVerified );
 	if ( ! nextProps.isEmailVerified ) {
 		return;
 	}
@@ -1033,10 +1033,10 @@ export function excludeStepIfProfileComplete( stepName, defaultDependencies, nex
 	}
 
 	const currentUser = getCurrentUser( state );
-
+	debug( 'Checking profile for current user', currentUser );
 	if ( currentUser?.display_name !== currentUser?.username ) {
+		debug( 'Skipping P2 complete profile step' );
 		nextProps.submitSignupStep( { stepName, wasSkipped: true } );
-
 		flows.excludeStep( stepName );
 	}
 }

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1007,13 +1007,16 @@ export function excludeStepIfEmailVerified( stepName, defaultDependencies, nextP
 	   we need to display it again when the user comes back to the flow
 	   after verification. */
 	if ( nextProps.flowName === 'p2' && nextProps?.progress[ stepName ]?.status === 'in-progress' ) {
+		debug( 'User email verification is in progress, do not skip this step' );
 		return;
 	}
 
+	debug( 'User email is verified:  = %s', nextProps?.isEmailVerified );
 	if ( ! nextProps.isEmailVerified ) {
 		return;
 	}
 
+	debug( 'Skipping P2 email confirmation step' );
 	nextProps.submitSignupStep( { stepName, wasSkipped: true } );
 	flows.excludeStep( stepName );
 }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -465,12 +465,12 @@ class Signup extends Component {
 		this.handleLogin( dependencies, destination );
 	};
 
-	handleLogin( dependencies, destination, clearSignupFlowController = true ) {
+	handleLogin( dependencies, destination, resetSignupFlowController = true ) {
 		const userIsLoggedIn = this.props.isLoggedIn;
 
 		debug( `Logging you in to "${ destination }"` );
 
-		if ( clearSignupFlowController ) {
+		if ( resetSignupFlowController ) {
 			this.signupFlowController.reset();
 
 			if ( ! this.state.controllerHasReset ) {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -184,10 +184,6 @@ class Signup extends Component {
 
 		this.updateShouldShowLoadingScreen();
 
-		// Only applies to the P2 signup flow (/start/p2) and only after logging in to
-		// a WP.com account during the signup flow.
-		this.completeP2FlowAfterLoggingIn();
-
 		if ( canResumeFlow( this.props.flowName, this.props.progress, this.props.isLoggedIn ) ) {
 			// Resume from the current window location
 			return;
@@ -278,6 +274,22 @@ class Signup extends Component {
 				sitePlanName,
 				sitePlanSlug
 			);
+		}
+
+		// Several steps in the P2 signup flow require a logged in user.
+		if ( isP2Flow( this.props.flowName ) && ! this.props.isLoggedIn && stepName !== 'user' ) {
+			debug( 'P2 signup: logging in user', this.props.signupDependencies );
+
+			// We want to be redirected to the next step.
+			const destinationStep = flows.getFlow( this.props.flowName, this.props.isLoggedIn )
+				.steps[ 1 ];
+			const stepUrl = getStepUrl(
+				this.props.flowName,
+				destinationStep,
+				undefined,
+				this.props.locale
+			);
+			this.handleLogin( this.props.signupDependencies, stepUrl, false );
 		}
 	}
 
@@ -453,15 +465,17 @@ class Signup extends Component {
 		this.handleLogin( dependencies, destination );
 	};
 
-	handleLogin( dependencies, destination ) {
+	handleLogin( dependencies, destination, clearSignupFlowController = true ) {
 		const userIsLoggedIn = this.props.isLoggedIn;
 
 		debug( `Logging you in to "${ destination }"` );
 
-		this.signupFlowController.reset();
+		if ( clearSignupFlowController ) {
+			this.signupFlowController.reset();
 
-		if ( ! this.state.controllerHasReset ) {
-			this.setState( { controllerHasReset: true } );
+			if ( ! this.state.controllerHasReset ) {
+				this.setState( { controllerHasReset: true } );
+			}
 		}
 
 		if ( userIsLoggedIn ) {
@@ -499,6 +513,7 @@ class Signup extends Component {
 			}
 
 			if ( this.state.bearerToken !== bearerToken && this.state.username !== username ) {
+				debug( 'Performing regular login' );
 				this.setState( {
 					bearerToken: dependencies.bearer_token,
 					username: dependencies.username,

--- a/client/signup/steps/p2-confirm-email/index.jsx
+++ b/client/signup/steps/p2-confirm-email/index.jsx
@@ -1,15 +1,17 @@
 import { Button } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { check } from '@wordpress/icons';
+import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
 import P2StepWrapper from 'calypso/signup/p2-step-wrapper';
-import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { saveSignupStep } from 'calypso/state/signup/progress/actions';
 import './style.scss';
+
+const debug = debugFactory( 'calypso:signup:p2-confirm-email' );
 
 function P2ConfirmEmail( {
 	flowName,
@@ -23,9 +25,7 @@ function P2ConfirmEmail( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const userEmail = useSelector( getCurrentUserEmail );
-	if ( ! userEmail ) {
-		dispatch( fetchCurrentUser() );
-	}
+	debug( 'User email: %s', userEmail );
 
 	const [ emailResendCount, setEmailResendCount ] = useState( 0 );
 	const EMAIL_RESEND_MAX = 3;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Background: The new P2 signup flow has several steps that need the user data to be present. For example, in the "Confirm email" step, we need to have the user's email address for displaying, and also to enable resending. In the "Complete Profile" step, we need the user's profile, etc.

Previously, we were issuing a `fetchUser()` in Step 2 (email confirmation step) if user data was absent. However, this caused `isUserLoggedIn()` to be `true`, even in cases that they are actually not, e.g. social login. The effect is that the `handleLogin()` called at the end of the flow skips social login users, thinking they are already logged in.

In this PR, we perform a proper login at the start of the P2 flow, if the user is logged out. We also remove the `fetchUser()` call in Step 2, as it is no longer needed after this.

Details:
* Add code that logs in logged out users at the start of the P2 signup flow (after signing up).
* Remove `fetchUser()` call in `p2-confirm-email`
* Add some debug lines to help in troubleshooting issues.
* Remove some old code from the old signup.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Open an incognito tab, and turn off third-party cookie blockers.
* Navigate to `calypso.localhost:3000/start/p2`. 
* Use a test address, or some 10-minute mail to sign up.
* Your new account should get the "Confirm Email" step. **Verify that your email address is properly displayed in the text, and that the resend feature is working.**
* Open the email confirmation link from the email, and change `wordpress.com` to `calypso.localhost:3000` after the redirect has happened.
* You should get the "Thank you for confirming your email address" step.
* Finish the flow. Everything should be as expected.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
