### PR TITLE
Design Picker:  Increase mobile thumbnail height and adjust some styles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -18,13 +18,14 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState, useEffect } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview/content';
 import { useNewSiteVisibility } from 'calypso/landing/gutenboarding/hooks/use-selected-plan';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
+import useTrackScrollPageFromTop from '../../../../hooks/use-track-scroll-page-from-top';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../../../../stores';
 import { ANCHOR_FM_THEMES } from './anchor-fm-themes';
 import { getCategorizationOptions } from './categories';
@@ -34,6 +35,8 @@ import StickyFooter from './sticky-footer';
 import type { Step } from '../../types';
 import './style.scss';
 import type { Design } from '@automattic/design-picker';
+
+const STEP_NAME = 'design-setup';
 
 /**
  * The design picker step
@@ -292,6 +295,16 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		goBack();
 	};
 
+	// Track scroll event to make sure people are scrolling on mobile.
+	useTrackScrollPageFromTop( isMobile && ! isPreviewingDesign, flow || '', STEP_NAME, {
+		is_generated_designs: showGeneratedDesigns,
+	} );
+
+	// Make sure people is at the top when switching between generated designs and static designs
+	useEffect( () => {
+		window.scrollTo( { top: 0 } );
+	}, [ isForceStaticDesigns ] );
+
 	if ( selectedDesign && isPreviewingDesign && ! showGeneratedDesigns ) {
 		const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
 		const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
@@ -324,7 +337,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 		return (
 			<StepContainer
-				stepName={ 'design-setup' }
+				stepName={ STEP_NAME }
 				stepContent={ stepContent }
 				hideSkip
 				hideNext={ shouldUpgrade }
@@ -442,7 +455,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	return (
 		<StepContainer
-			stepName={ 'design-step' }
+			stepName={ STEP_NAME }
 			className={ classnames( {
 				'design-picker__is-generated': showGeneratedDesigns,
 				'design-picker__is-generated-previewing': isPreviewingGeneratedDesign,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -9,13 +9,9 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 .design-setup {
 	.step-container {
-		padding-left: 24px;
-		padding-right: 24px;
+		padding-left: 20px;
+		padding-right: 20px;
 		max-width: 1440px;
-
-		.step-container__navigation.action-buttons {
-			border: none;
-		}
 
 		.step-container__content {
 			margin-top: 32px;
@@ -40,8 +36,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 			}
 
 			.formatted-header__subtitle {
-				// Overrides some very specific selectors in /client/signup/style.scss
-				margin: 12px 0 48px !important;
+				margin: 12px 0 48px;
 			}
 		}
 
@@ -87,12 +82,8 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 				text-align: left;
 				color: $gray-60;
 				font-size: 1rem;
-				margin: 8px 0 0;
+				margin: 12px 0 32px;
 				line-height: 24px;
-
-				@include breakpoint-deprecated('<660px') {
-					margin-top: 16px;
-				}
 			}
 		}
 
@@ -373,6 +364,14 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		margin: 48px 0;
 		row-gap: 1.5rem;
 		flex-wrap: wrap;
+
+		.button {
+			display: none;
+
+			@include break-small {
+				display: inherit;
+			}
+		}
 	}
 
 	.design-setup__footer {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -296,7 +296,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		}
 
 		.generated-design-picker__previews {
-			height: auto;
+			flex: 1;
 			min-height: calc( 100vh - 172px );
 			margin-bottom: 84px;
 		}
@@ -448,8 +448,6 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 	.generated-design-picker__previews {
 		display: flex;
-		height: 0;
-		flex: 1;
 		flex-direction: column;
 		row-gap: 24px;
 		margin-bottom: 44px;
@@ -487,7 +485,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		}
 
 		@include break-small {
-			height: auto;
+			flex: 1;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -297,6 +297,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 		.generated-design-picker__previews {
 			flex: 1;
+			height: auto;
 			min-height: calc( 100vh - 172px );
 			margin-bottom: 84px;
 		}
@@ -448,6 +449,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 	.generated-design-picker__previews {
 		display: flex;
+		height: 0;
 		flex-direction: column;
 		row-gap: 24px;
 		margin-bottom: 44px;
@@ -486,6 +488,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 		@include break-small {
 			flex: 1;
+			height: auto;
 		}
 	}
 

--- a/client/landing/stepper/hooks/use-track-scroll-page-from-top.ts
+++ b/client/landing/stepper/hooks/use-track-scroll-page-from-top.ts
@@ -1,0 +1,56 @@
+import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
+import { useEffect, useRef } from 'react';
+import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+
+type OptionalProps = {
+	[ key: string ]: unknown;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
+const useTrackScrollPageFromTop = (
+	enabled: boolean,
+	flow: string,
+	step: string,
+	optionalProps?: OptionalProps
+) => {
+	const prevScrollY = useRef( window.scrollY );
+
+	useEffect( () => {
+		if ( ! enabled ) {
+			return noop;
+		}
+
+		const trackScroll = () => {
+			const eventProps = {
+				flow,
+				step,
+				device: resolveDeviceTypeByViewPort(),
+				...optionalProps,
+			};
+
+			recordTracksEvent( 'calypso_signup_scroll_page', eventProps );
+			recordFullStoryEvent( 'calypso_signup_scroll_page', eventProps );
+		};
+
+		const onScroll = () => {
+			if ( prevScrollY.current === 0 && window.scrollY > 0 ) {
+				trackScroll();
+				// Only trigger this event once
+				window.removeEventListener( 'scroll', onScroll );
+			}
+
+			prevScrollY.current = window.scrollY;
+		};
+
+		window.addEventListener( 'scroll', onScroll );
+
+		return () => {
+			window.removeEventListener( 'scroll', onScroll );
+		};
+	}, [ enabled, flow, step, optionalProps ] );
+};
+
+export default useTrackScrollPageFromTop;

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -88,7 +88,7 @@ $design-picker-category-filter-text-color-active: var( --studio-gray-100 );
 	border-radius: 4px; // stylelint-disable-line scales/radii
 	border: 1px solid #c3c4c7;
 	padding: 0 35px 0 10px;
-	margin-bottom: 24px;
+	margin-bottom: 32px;
 	min-height: 44px;
 	height: 44px;
 	width: 100%;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -152,7 +152,11 @@
 	// padding-top to set the size of the element and then reposition content
 	// over the padding
 	.design-picker__image-frame-landscape {
-		padding-top: 65%; // Aspect ratio for the picker
+		padding-top: 100%; // Aspect ratio for the picker
+
+		@include break-small {
+			padding-top: 65%;
+		}
 	}
 
 	.design-picker__image-frame-portrait {
@@ -397,7 +401,6 @@
 	cursor: pointer;
 	display: flex;
 	flex-direction: column;
-	height: 355px;
 	padding: 0;
 	overflow: hidden;
 	transition: border-color 0.15s ease-in-out;
@@ -430,13 +433,32 @@
     }
 
 	.generated-design-thumbnail__image {
-		flex: 1;
+		position: relative;
+		width: 100%;
+		height: 0;
+		padding-top: 100%;
 		overflow: hidden;
+
+		.mshots-image__container {
+			position: absolute;
+			left: 0;
+			top: 0;
+
+			@include break-small {
+				position: relative;
+			}
+		}
 
 		.mshots-image-visible {
 			object-fit: cover;
 			object-position: top;
 			width: 100%;
+		}
+
+		@include break-small {
+			height: auto;
+			padding-top: 0;
+			flex: 1;
 		}
 	}
 

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -140,7 +140,6 @@
 	 *	Navigation
 	 */
 	.step-container__navigation.action-buttons {
-		border-top: 1px solid var( --studio-gray-100 );
 		background-color: $white;
 		height: 60px;
 		align-items: center;
@@ -154,6 +153,8 @@
 		bottom: 0;
 		padding: 0 20px;
 		margin: 0;
+		border-top: none;
+		box-shadow: inset 0 1px 0 #e2e4e7;
 
 		&:empty {
 			display: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the mShot of the Generated Design Picker/Design Picker on mobile square
* Reduce the padding of the page to make the mShot larger
* Adjust the margin of the subtitle and categories selector to fit the design
* Fix the box-shadow of the navigation buttons on mobile
* Hide the “Continue” button on mobile

| Generated Design Picker | Static Design Picker |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/168574209-982dce7b-2ed4-43c4-8180-25d415b74b23.png) | ![image](https://user-images.githubusercontent.com/13596067/168569583-e09780bc-8271-4ff1-a984-a6075ce84243.png) |

Also, we need to monitor the scroll event to make sure people are scrolling on mobile. See https://github.com/Automattic/wp-calypso/issues/63031#issuecomment-1134181296

![image](https://user-images.githubusercontent.com/13596067/169760304-9845bdf7-5807-4e61-ab03-baa29b4f6e6b.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Design Picker: /setup/designSetup?siteSlug=<your_site>
* Switch to mobile view
* The mShot should be square
* Open the DevTool and switch to the Network panel
* When you're scrolling from the top on mobile, you will see the `calypso_signup_scroll_page` event

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/63031
