### PR TITLE
Help Center: Height respects viewport

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -61,7 +61,7 @@ $head-foot-height: 50px;
 		top: calc( $header-height + 16px );
 		right: 16px;
 		width: 410px;
-		height: 800px;
+		height: 80vh;
 		box-shadow: 0 0 3px 0 rgba( 0, 0, 0, 0.25 );
 		overflow: auto;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Height of the help center now respects the viewport, showing the `Still need help` even on smaller screens.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* checkout the branch
* `yarn dev --sync` from ETK
* verify that it works with different screen sizes
* regression test that it still works on mobile

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63547
Fixes #63547
