### PR TITLE
Onboarding import improvement: Replace mShot preview with an iframe

### DIFF
--- a/client/signup/steps/import/ready/preview.tsx
+++ b/client/signup/steps/import/ready/preview.tsx
@@ -1,7 +1,4 @@
-import { memo, useState } from 'react';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
-import { MShotParams } from '../types';
-import useWindowDimensions from '../windowDimensions.effect';
+import { memo } from 'react';
 import type { FunctionComponent } from 'react';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -13,53 +10,7 @@ interface Props {
 const protocolRgx = /(?<protocol>https?:\/\/)?(?<address>.*)/i;
 
 const ImportPreview: FunctionComponent< Props > = ( { website } ) => {
-	const [ mShotUrl, setMShotUrl ] = useState( '' );
-	const { width } = useWindowDimensions();
-	const mShotParams: MShotParams = {
-		scale: 2,
-		vpw: width <= 640 ? 640 : undefined,
-	};
 	const websiteMatch = website.match( protocolRgx );
-
-	const checkScreenshot = ( screenShotUrl: string ) => {
-		const http = new XMLHttpRequest();
-		http.open( 'GET', screenShotUrl );
-		http.onreadystatechange = () => {
-			if ( http.readyState !== http.HEADERS_RECEIVED ) {
-				return;
-			}
-
-			if ( http.getResponseHeader( 'Content-Type' ) !== 'image/jpeg' ) {
-				setTimeout( () => {
-					checkScreenshot( screenShotUrl );
-				}, 5000 );
-			} else {
-				setMShotUrl( screenShotUrl );
-			}
-		};
-		http.send();
-	};
-
-	checkScreenshot(
-		`https://s0.wp.com/mshots/v1/${ website }?${ Object.entries( mShotParams )
-			.filter( ( entry ) => !! entry[ 1 ] )
-			.map( ( [ key, val ] ) => key + '=' + val )
-			.join( '&' ) }`
-	);
-
-	const Screenshot = () => {
-		if ( mShotUrl !== '' ) {
-			return (
-				<img src={ mShotUrl } alt="Website screenshot preview" className={ 'import__screenshot' } />
-			);
-		}
-
-		return (
-			<div className="import__screenshot-loading">
-				<LoadingEllipsis />
-			</div>
-		);
-	};
 
 	return (
 		<div className={ `import__preview` }>
@@ -79,7 +30,9 @@ const ImportPreview: FunctionComponent< Props > = ( { website } ) => {
 						) }
 					</div>
 				}
-				<Screenshot />
+				{ /* iframe-mask is a transparent cover it disallows the user to navigate inside iframed website */ }
+				<div className="import__preview-iframe-mask" />
+				<iframe title={ 'Preview' } className="import__preview-iframe" src={ website } />
 			</div>
 		</div>
 	);

--- a/client/signup/steps/import/ready/preview.tsx
+++ b/client/signup/steps/import/ready/preview.tsx
@@ -32,7 +32,12 @@ const ImportPreview: FunctionComponent< Props > = ( { website } ) => {
 				}
 				{ /* iframe-mask is a transparent cover it disallows the user to navigate inside iframed website */ }
 				<div className="import__preview-iframe-mask" />
-				<iframe title={ 'Preview' } className="import__preview-iframe" src={ website } />
+				<iframe
+					title={ 'Preview' }
+					className="import__preview-iframe"
+					src={ website }
+					loading="eager"
+				/>
 			</div>
 		</div>
 	);

--- a/client/signup/steps/import/ready/style.scss
+++ b/client/signup/steps/import/ready/style.scss
@@ -115,6 +115,30 @@
 			}
 		}
 	}
+
+	.import__preview-iframe {
+		overflow: hidden;
+		width: 100%;
+		height: 100vh;
+		border: none;
+		margin-top: 15px;
+
+		@include break-small {
+			margin-top: 30px;
+		}
+	}
+
+	.import__preview-iframe-mask {
+		position: absolute;
+		width: 100%;
+		top: 15px;
+		height: calc( 100% - 15px );
+
+		@include break-small {
+			top: 35px;
+			height: calc( 100% - 35px );
+		}
+	}
 }
 
 .import__details-modal.components-modal__frame {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace mShot with an iframe to improve the speed of showing the website preview.
* Now there is no situation when taking screenshots last too long

#### Testing instructions

* Go to `/setup/import?siteSlug={SLUG}`
* Check if the preview works

Related to #63121
