### PR TITLE
SupportInfo: refactor tests to `@testing-library/react`

### DIFF
--- a/client/components/support-info/index.jsx
+++ b/client/components/support-info/index.jsx
@@ -1,4 +1,4 @@
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import ExternalLink from 'calypso/components/external-link';
 import InfoPopover from 'calypso/components/info-popover';
@@ -17,7 +17,8 @@ function makePrivacyLink( privacyLink, link ) {
 	return null;
 }
 
-function SupportInfo( { text, link, position, translate, privacyLink } ) {
+function SupportInfo( { text, link, position, privacyLink } ) {
+	const translate = useTranslate();
 	const filteredPrivacyLink = makePrivacyLink( privacyLink, link );
 
 	return (
@@ -56,4 +57,4 @@ SupportInfo.propTypes = {
 	privacyLink: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 };
 
-export default localize( SupportInfo );
+export default SupportInfo;

--- a/client/components/support-info/test/index.js
+++ b/client/components/support-info/test/index.js
@@ -2,8 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { fireEvent, render, screen } from '@testing-library/react';
 import SupportInfo from '../';
 
 describe( 'SupportInfo', () => {
@@ -13,15 +12,25 @@ describe( 'SupportInfo', () => {
 		privacyLink: 'https://foo.com/privacy/',
 	};
 
-	const wrapper = shallow( <SupportInfo { ...testProps } /> ).dive();
+	test( 'should have a proper "Learn more" link', () => {
+		render( <SupportInfo { ...testProps } /> );
 
-	it( 'should have a proper "Learn more" link', () => {
-		expect( wrapper.find( 'ExternalLink' ).get( 0 ).props.href ).to.be.equal( 'https://foo.com/' );
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		const link = screen.getByRole( 'link', { name: /learn more/i } );
+
+		expect( link ).toBeInTheDocument();
+		expect( link ).toHaveAttribute( 'href', testProps.link );
 	} );
 
 	it( 'should have a proper "Privacy Information" link', () => {
-		expect( wrapper.find( 'ExternalLink' ).get( 1 ).props.href ).to.be.equal(
-			'https://foo.com/privacy/'
-		);
+		render( <SupportInfo { ...testProps } /> );
+
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		const link = screen.getByRole( 'link', { name: /privacy information/i } );
+
+		expect( link ).toBeInTheDocument();
+		expect( link ).toHaveAttribute( 'href', testProps.privacyLink );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* SupportInfo: refactor tests to `@testing-library/react`

#### Testing instructions

* Make sure unit tests pass

Related to #63409 
