### PR TITLE
Plugin Install: Replace plan check with siteHasFeature check

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -124,7 +124,7 @@ const MarketplacePluginInstall = ( {
 	);
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
 
-	const supportsAtomicUpgrade = useSelector( ( state ) =>
+	const hasAtomicFeature = useSelector( ( state ) =>
 		siteHasFeature( state, selectedSite?.ID ?? null, WPCOM_FEATURES_ATOMIC )
 	);
 
@@ -138,9 +138,9 @@ const MarketplacePluginInstall = ( {
 	// Check if the user plan is enough for installation or it is a self-hosted jetpack site
 	// if not, check again in 2s and show an error message
 	useEffect( () => {
-		if ( ! supportsAtomicUpgrade && ! isJetpackSelfHosted ) {
+		if ( ! hasAtomicFeature && ! isJetpackSelfHosted ) {
 			waitFor( 2 ).then( () => {
-				if ( ! supportsAtomicUpgrade && ! isJetpackSelfHosted ) {
+				if ( ! hasAtomicFeature && ! isJetpackSelfHosted ) {
 					setNonInstallablePlanError( true );
 				}
 			} );
@@ -185,7 +185,7 @@ const MarketplacePluginInstall = ( {
 				dispatch( installPlugin( siteId, wporgPlugin, false ) );
 
 				triggerInstallFlow();
-			} else if ( supportsAtomicUpgrade ) {
+			} else if ( hasAtomicFeature ) {
 				// initialize atomic flow
 				setAtomicFlow( true );
 				dispatch( initiateTransfer( siteId, null, productSlug ) );
@@ -203,7 +203,7 @@ const MarketplacePluginInstall = ( {
 		wporgPlugin,
 		productSlug,
 		dispatch,
-		supportsAtomicUpgrade,
+		hasAtomicFeature,
 	] );
 
 	// Validate completition of atomic transfer flow

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -1,9 +1,9 @@
-import { isBusiness, isEcommerce, isEnterprise, isPro } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { ThemeProvider } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector, useDispatch, DefaultRootState } from 'react-redux';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -34,6 +34,7 @@ import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id'
 import isPluginActive from 'calypso/state/selectors/is-plugin-active';
 import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-complete';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { initiateThemeTransfer as initiateTransfer } from 'calypso/state/themes/actions';
 import {
@@ -123,15 +124,9 @@ const MarketplacePluginInstall = ( {
 	);
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
 
-	const supportsAtomicUpgrade = useRef< boolean >();
-	useEffect( () => {
-		supportsAtomicUpgrade.current =
-			selectedSite?.plan &&
-			( isPro( selectedSite.plan ) ||
-				isBusiness( selectedSite.plan ) ||
-				isEnterprise( selectedSite.plan ) ||
-				isEcommerce( selectedSite.plan ) );
-	}, [ selectedSite ] );
+	const supportsAtomicUpgrade = useSelector( ( state ) =>
+		siteHasFeature( state, selectedSite?.ID ?? null, WPCOM_FEATURES_ATOMIC )
+	);
 
 	// retrieve plugin data if not available
 	useEffect( () => {
@@ -143,9 +138,9 @@ const MarketplacePluginInstall = ( {
 	// Check if the user plan is enough for installation or it is a self-hosted jetpack site
 	// if not, check again in 2s and show an error message
 	useEffect( () => {
-		if ( ! supportsAtomicUpgrade.current && ! isJetpackSelfHosted ) {
+		if ( ! supportsAtomicUpgrade && ! isJetpackSelfHosted ) {
 			waitFor( 2 ).then( () => {
-				if ( ! supportsAtomicUpgrade.current && ! isJetpackSelfHosted ) {
+				if ( ! supportsAtomicUpgrade && ! isJetpackSelfHosted ) {
 					setNonInstallablePlanError( true );
 				}
 			} );
@@ -190,7 +185,7 @@ const MarketplacePluginInstall = ( {
 				dispatch( installPlugin( siteId, wporgPlugin, false ) );
 
 				triggerInstallFlow();
-			} else if ( supportsAtomicUpgrade.current ) {
+			} else if ( supportsAtomicUpgrade ) {
 				// initialize atomic flow
 				setAtomicFlow( true );
 				dispatch( initiateTransfer( siteId, null, productSlug ) );
@@ -208,6 +203,7 @@ const MarketplacePluginInstall = ( {
 		wporgPlugin,
 		productSlug,
 		dispatch,
+		supportsAtomicUpgrade,
 	] );
 
 	// Validate completition of atomic transfer flow


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR replaces the plan to check with the siteHasFeature check-in Marketplace plugin installation thank you page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to the plugin install URL with a free or premium website: [http://calypso.localhost:3000/marketplace/wordpress-seo/install/[free_site]](http://calypso.localhost:3000/marketplace/wordpress-seo/install/%5Bfree_site%5D)


After around 2 seconds you should see the following error:
<img width="591" alt="Screenshot 2022-05-18 at 9 11 00 AM" src="https://user-images.githubusercontent.com/86406124/168952563-fb13d106-e29f-4b94-9298-c692650b5e89.png">

Try to go to the same URL with a business or e-commerce site: [http://calypso.localhost:3000/marketplace/wordpress-seo/install/[business_site]](http://calypso.localhost:3000/marketplace/wordpress-seo/install/%5Bbusiness_site%5D)

The plugin installation should proceed as expected and you should see a thank you page.