### PR TITLE
Store: Refactor `D3Base` away from `UNSAFE_` methods

### DIFF
--- a/client/my-sites/store/components/d3/base/index.js
+++ b/client/my-sites/store/components/d3/base/index.js
@@ -10,21 +10,8 @@ export default class D3Base extends Component {
 		getParams: PropTypes.func.isRequired,
 	};
 
-	constructor( props ) {
-		super( props );
-		this.updateParams = this.updateParams.bind( this );
-	}
-
-	state = {};
-
 	componentDidMount() {
-		window.addEventListener( 'resize', this.updateParams );
-		this.updateParams();
-	}
-
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		this.updateParams( nextProps );
+		window.addEventListener( 'resize', this.draw );
 	}
 
 	componentDidUpdate() {
@@ -32,22 +19,19 @@ export default class D3Base extends Component {
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'resize', this.updateParams );
+		window.removeEventListener( 'resize', this.draw );
 		delete this.node;
 	}
 
-	updateParams( nextProps ) {
-		const getParams = ( nextProps && nextProps.getParams ) || this.props.getParams;
-		this.setState( getParams( this.node ), this.draw );
-	}
-
 	draw() {
-		this.props.drawChart( this.createNewContext(), this.state );
+		if ( this.node ) {
+			this.props.drawChart( this.createNewContext(), this.props.getParams( this.node ) );
+		}
 	}
 
 	createNewContext() {
 		const { className } = this.props;
-		const { width, height } = this.state;
+		const { width, height } = this.props.getParams( this.node );
 
 		d3Select( this.node ).selectAll( 'svg' ).remove();
 		const newNode = d3Select( this.node )

--- a/client/my-sites/store/components/d3/base/test/index.js
+++ b/client/my-sites/store/components/d3/base/test/index.js
@@ -1,41 +1,43 @@
 /**
  * @jest-environment jsdom
  */
-
-import { shallow, mount } from 'enzyme';
+import { render, screen, waitFor } from '@testing-library/react';
 import D3Base from '../index';
 
 const noop = () => {};
+const drawChart = ( svg ) => {
+	const circle = document.createElement( 'circle' );
+	circle.setAttribute( 'data-testid', 'test-circle' );
+	return svg.append( circle );
+};
 
 describe( 'D3base', () => {
-	const shallowWithoutLifecycle = ( arg ) => shallow( arg, { disableLifecycleMethods: true } );
-
 	test( 'should have d3Base class', () => {
-		const base = shallowWithoutLifecycle( <D3Base drawChart={ noop } getParams={ noop } /> );
-		expect( base.find( '.d3-base' ).length ).toBe( 1 );
+		const { container } = render( <D3Base drawChart={ noop } getParams={ noop } /> );
+		expect( container.firstChild ).toHaveClass( 'd3-base' );
 	} );
 
 	test( 'should render an svg', () => {
-		const base = mount( <D3Base drawChart={ noop } getParams={ noop } /> );
-		expect( base.render().find( 'svg' ).length ).toBe( 1 );
+		const { container } = render( <D3Base drawChart={ noop } getParams={ noop } /> );
+		waitFor( async () => {
+			await expect( container.getElementsByTagName( 'svg' ) ).toHaveLength( 1 );
+		} );
 	} );
 
 	test( 'should render a result of the drawChart prop', () => {
-		const drawChart = ( svg ) => {
-			return svg.append( 'circle' );
-		};
-		const base = mount( <D3Base drawChart={ drawChart } getParams={ noop } /> );
-		expect( base.render().find( 'circle' ).length ).toBe( 1 );
+		render( <D3Base drawChart={ drawChart } getParams={ noop } /> );
+		waitFor( async () => {
+			expect( screen.getByTestId( 'test-circle' ) ).toBeInTheDocument();
+		} );
 	} );
 
 	test( 'should pass a property of getParams output to drawChart function', () => {
 		const getParams = () => ( {
 			tagName: 'circle',
 		} );
-		const drawChart = ( svg, params ) => {
-			return svg.append( params.tagName );
-		};
-		const base = mount( <D3Base drawChart={ drawChart } getParams={ getParams } /> );
-		expect( base.render().find( 'circle' ).length ).toBe( 1 );
+		render( <D3Base drawChart={ drawChart } getParams={ getParams } /> );
+		waitFor( async () => {
+			expect( screen.getByTestId( 'test-circle' ) ).toBeInTheDocument();
+		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `D3Base` component away from the `UNSAFE_` deprecated React component methods.

I've also used the opportunity to refactor the component tests to use `@testing-library/react` and `jest`.

Part of #58453 and #63409.

#### Testing instructions
* Pick one of your WooCommerce store sites that has some store stats.
* Go to Stats and click Store (or go to `/store/stats/orders/year/:site`).
* Verify that the sparklines in the "Stats for 2022" section still work.
* Verify that as you toggle between periods, sparklines are properly updated.
* Verify that as you resize your window, sparklines are properly resized.