### PR TITLE
Adding feature flags for Embedded Mailbox

### DIFF
--- a/client/lib/titan/get-titan-urls.js
+++ b/client/lib/titan/get-titan-urls.js
@@ -30,12 +30,17 @@ function getTitanUrl(
 	titanAppsUrlPrefix,
 	email,
 	app = TITAN_APPS.EMAIL,
-	clearPreviousSessions = false
+	clearPreviousSessions = false,
+	redirectUrl = null
 ) {
 	const titanAppUrl = new URL( `${ titanAppsUrlPrefix }/${ app }/` );
 
 	if ( email?.includes( '@' ) ) {
 		titanAppUrl.searchParams.append( 'email_account', email );
+	}
+
+	if ( redirectUrl ) {
+		titanAppUrl.searchParams.append( 'topbar.redirect_url', redirectUrl );
 	}
 
 	if ( clearPreviousSessions ) {
@@ -53,6 +58,17 @@ export function getTitanContactsUrl( titanAppsUrlPrefix, email ) {
 	return getTitanUrl( titanAppsUrlPrefix, email, TITAN_APPS.CONTACTS );
 }
 
-export function getTitanEmailUrl( titanAppsUrlPrefix, email, clearPreviousSessions = false ) {
-	return getTitanUrl( titanAppsUrlPrefix, email, TITAN_APPS.EMAIL, clearPreviousSessions );
+export function getTitanEmailUrl(
+	titanAppsUrlPrefix,
+	email,
+	clearPreviousSessions = false,
+	redirectUrl = null
+) {
+	return getTitanUrl(
+		titanAppsUrlPrefix,
+		email,
+		TITAN_APPS.EMAIL,
+		clearPreviousSessions,
+		redirectUrl
+	);
 }

--- a/client/lib/titan/get-titan-urls.js
+++ b/client/lib/titan/get-titan-urls.js
@@ -58,6 +58,15 @@ export function getTitanContactsUrl( titanAppsUrlPrefix, email ) {
 	return getTitanUrl( titanAppsUrlPrefix, email, TITAN_APPS.CONTACTS );
 }
 
+/**
+ * Gets the Web client URL for Professional Email
+ *
+ * @param { string } titanAppsUrlPrefix URL prefix to build the final URL based on the next parameters
+ * @param { string | undefined } email Email account is going to be used
+ * @param { boolean } clearPreviousSessions Flag to clear session in the Web Client
+ * @param { string } redirectUrl URL to go back from the Web Client
+ * @returns { string } Path to be used to send the user to the Web Client
+ */
 export function getTitanEmailUrl(
 	titanAppsUrlPrefix,
 	email,

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -90,7 +90,7 @@ const getTitanMenuItems = ( {
 	const isEmbeddedInboxTestingEnabled = isEnabled( 'emails/embedded-inbox-testing' );
 
 	const mailboxPrefixUrl = isEmbeddedInboxTestingEnabled
-		? 'https://webmail-qa.riva.co/0.2361'
+		? 'https://webmail-qa.riva.co/0.2377'
 		: titanAppsUrlPrefix;
 
 	return [

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -102,6 +102,7 @@ const getTitanMenuItems = ( {
 				comment: 'View the Email application (i.e. the webmail) for Titan',
 			} ),
 			onClick: getTitanClickHandler( 'webmail' ),
+			isInternalLink: isEmbeddedInboxTestingEnabled,
 		},
 		{
 			href: getTitanCalendarUrl( titanAppsUrlPrefix, email ),

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -87,13 +87,15 @@ const getTitanMenuItems = ( {
 	translate,
 } ) => {
 	const email = getEmailAddress( mailbox );
-	const embeddedMailbox = isEnabled( 'emails/embedded-inbox-testing' );
+	const isEmbeddedMailboxEnabled = isEnabled( 'emails/embedded-inbox-testing' );
 
-	const emeddedMailbox = embeddedMailbox ? 'https://webmail-qa.riva.co/0.2361' : titanAppsUrlPrefix;
+	const mailboxUrl = isEmbeddedMailboxEnabled
+		? 'https://webmail-qa.riva.co/0.2361'
+		: titanAppsUrlPrefix;
 
 	return [
 		{
-			href: getTitanEmailUrl( emeddedMailbox, email, false, window.location.href ),
+			href: getTitanEmailUrl( mailboxUrl, email, false, window.location.href ),
 			image: titanMailIcon,
 			imageAltText: translate( 'Titan Mail icon' ),
 			title: translate( 'View Mail', {

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -87,15 +87,15 @@ const getTitanMenuItems = ( {
 	translate,
 } ) => {
 	const email = getEmailAddress( mailbox );
-	const isEmbeddedMailboxEnabled = isEnabled( 'emails/embedded-inbox-testing' );
+	const isEmbeddedInboxTestingEnabled = isEnabled( 'emails/embedded-inbox-testing' );
 
-	const mailboxUrl = isEmbeddedMailboxEnabled
+	const mailboxPrefixUrl = isEmbeddedInboxTestingEnabled
 		? 'https://webmail-qa.riva.co/0.2361'
 		: titanAppsUrlPrefix;
 
 	return [
 		{
-			href: getTitanEmailUrl( mailboxUrl, email, false, window.location.href ),
+			href: getTitanEmailUrl( mailboxPrefixUrl, email, false, window.location.href ),
 			image: titanMailIcon,
 			imageAltText: translate( 'Titan Mail icon' ),
 			title: translate( 'View Mail', {

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -90,7 +90,7 @@ const getTitanMenuItems = ( {
 	const isEmbeddedInboxTestingEnabled = isEnabled( 'emails/embedded-inbox-testing' );
 
 	const mailboxPrefixUrl = isEmbeddedInboxTestingEnabled
-		? 'https://webmail-qa.riva.co/0.2377'
+		? 'https://webmail-alpha.riva.co'
 		: titanAppsUrlPrefix;
 
 	return [
@@ -98,25 +98,27 @@ const getTitanMenuItems = ( {
 			href: getTitanEmailUrl( mailboxPrefixUrl, email, false, window.location.href ),
 			image: titanMailIcon,
 			imageAltText: translate( 'Titan Mail icon' ),
+			isInternalLink: isEmbeddedInboxTestingEnabled,
 			title: translate( 'View Mail', {
 				comment: 'View the Email application (i.e. the webmail) for Titan',
 			} ),
 			onClick: getTitanClickHandler( 'webmail' ),
-			isInternalLink: isEmbeddedInboxTestingEnabled,
 		},
 		{
-			href: getTitanCalendarUrl( titanAppsUrlPrefix, email ),
+			href: getTitanCalendarUrl( mailboxPrefixUrl, email ),
 			image: titanCalendarIcon,
 			imageAltText: translate( 'Titan Calendar icon' ),
+			isInternalLink: isEmbeddedInboxTestingEnabled,
 			title: translate( 'View Calendar', {
 				comment: 'View the Calendar application for Titan',
 			} ),
 			onClick: getTitanClickHandler( 'calendar' ),
 		},
 		{
-			href: getTitanContactsUrl( titanAppsUrlPrefix, email ),
+			href: getTitanContactsUrl( mailboxPrefixUrl, email ),
 			image: titanContactsIcon,
 			imageAltText: translate( 'Titan Contacts icon' ),
+			isInternalLink: isEmbeddedInboxTestingEnabled,
 			title: translate( 'View Contacts', {
 				comment: 'View the Contacts application for Titan',
 			} ),

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import { Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -86,10 +87,13 @@ const getTitanMenuItems = ( {
 	translate,
 } ) => {
 	const email = getEmailAddress( mailbox );
+	const embeddedMailbox = isEnabled( 'emails/embedded-inbox-testing' );
+
+	const emeddedMailbox = embeddedMailbox ? 'https://webmail-qa.riva.co/0.2361' : titanAppsUrlPrefix;
 
 	return [
 		{
-			href: getTitanEmailUrl( titanAppsUrlPrefix, email ),
+			href: getTitanEmailUrl( emeddedMailbox, email, false, window.location.href ),
 			image: titanMailIcon,
 			imageAltText: translate( 'Titan Mail icon' ),
 			title: translate( 'View Mail', {

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -41,15 +41,15 @@ import './style.scss';
 
 const getExternalUrl = ( mailbox, titanAppsUrlPrefix ) => {
 	if ( isTitanMailAccount( mailbox ) ) {
-		const isEmbeddedMailboxEnabled = isEnabled( 'emails/embedded-inbox-testing' );
+		const isEmbeddedInboxTestingEnabled = isEnabled( 'emails/embedded-inbox-testing' );
 
-		const mailboxUrl = isEmbeddedMailboxEnabled
+		const mailboxPrefixUrl = isEmbeddedInboxTestingEnabled
 			? 'https://webmail-qa.riva.co/0.2361'
 			: titanAppsUrlPrefix;
 		return getTitanEmailUrl(
-			mailboxUrl,
+			mailboxPrefixUrl,
 			getEmailAddress( mailbox ),
-			! mailboxUrl,
+			! mailboxPrefixUrl,
 			window.location.href
 		);
 	}

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -44,7 +44,7 @@ const getExternalUrl = ( mailbox, titanAppsUrlPrefix ) => {
 		const isEmbeddedInboxTestingEnabled = isEnabled( 'emails/embedded-inbox-testing' );
 
 		const mailboxPrefixUrl = isEmbeddedInboxTestingEnabled
-			? 'https://webmail-qa.riva.co/0.2361'
+			? 'https://webmail-qa.riva.co/0.2377'
 			: titanAppsUrlPrefix;
 		return getTitanEmailUrl(
 			mailboxPrefixUrl,

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Card, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -40,7 +41,15 @@ import './style.scss';
 
 const getExternalUrl = ( mailbox, titanAppsUrlPrefix ) => {
 	if ( isTitanMailAccount( mailbox ) ) {
-		return getTitanEmailUrl( titanAppsUrlPrefix, getEmailAddress( mailbox ), true );
+		const embeddedMailbox = isEnabled( 'emails/embedded-inbox-testing' );
+
+		const titanAppsUrl = embeddedMailbox ? 'https://webmail-qa.riva.co/0.2361' : titanAppsUrlPrefix;
+		return getTitanEmailUrl(
+			titanAppsUrl,
+			getEmailAddress( mailbox ),
+			! embeddedMailbox,
+			window.location.href
+		);
 	}
 
 	if ( isGoogleEmailAccount( mailbox ) ) {

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -44,7 +44,7 @@ const getExternalUrl = ( mailbox, titanAppsUrlPrefix ) => {
 		const isEmbeddedInboxTestingEnabled = isEnabled( 'emails/embedded-inbox-testing' );
 
 		const mailboxPrefixUrl = isEmbeddedInboxTestingEnabled
-			? 'https://webmail-qa.riva.co/0.2377'
+			? 'https://webmail-alpha.riva.co'
 			: titanAppsUrlPrefix;
 		return getTitanEmailUrl(
 			mailboxPrefixUrl,

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -120,7 +120,7 @@ const MailboxItem = ( { mailbox } ) => {
 			}
 			className="mailbox-selection-list__item"
 			href={ getExternalUrl( mailbox, titanAppsUrlPrefix ) }
-			target="external"
+			target={ isTitanMailAccount( mailbox ) ? null : 'external' }
 		>
 			<span className="mailbox-selection-list__icon">
 				<MailboxItemIcon mailbox={ mailbox } />

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -41,13 +41,15 @@ import './style.scss';
 
 const getExternalUrl = ( mailbox, titanAppsUrlPrefix ) => {
 	if ( isTitanMailAccount( mailbox ) ) {
-		const embeddedMailbox = isEnabled( 'emails/embedded-inbox-testing' );
+		const isEmbeddedMailboxEnabled = isEnabled( 'emails/embedded-inbox-testing' );
 
-		const titanAppsUrl = embeddedMailbox ? 'https://webmail-qa.riva.co/0.2361' : titanAppsUrlPrefix;
+		const mailboxUrl = isEmbeddedMailboxEnabled
+			? 'https://webmail-qa.riva.co/0.2361'
+			: titanAppsUrlPrefix;
 		return getTitanEmailUrl(
-			titanAppsUrl,
+			mailboxUrl,
 			getEmailAddress( mailbox ),
-			! embeddedMailbox,
+			! mailboxUrl,
 			window.location.href
 		);
 	}

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -41,6 +42,12 @@ const TitanSetUpThankYou = ( {
 	const titanAppsUrlPrefix = useTitanAppsUrlPrefix();
 	const translate = useTranslate();
 
+	const isEmbeddedInboxTestingEnabled = isEnabled( 'emails/embedded-inbox-testing' );
+
+	const mailboxPrefixUrl = isEmbeddedInboxTestingEnabled
+		? 'https://webmail-alpha.riva.co'
+		: titanAppsUrlPrefix;
+
 	const emailManagementPath = emailManagement( selectedSiteSlug, domainName, currentRoute );
 
 	const thankYouImage = {
@@ -67,9 +74,13 @@ const TitanSetUpThankYou = ( {
 				stepDescription: translate( 'Access your email from anywhere with our webmail.' ),
 				stepCta: (
 					<FullWidthButton
-						href={ getTitanEmailUrl( titanAppsUrlPrefix, emailAddress, true ) }
+						href={ getTitanEmailUrl(
+							mailboxPrefixUrl,
+							emailAddress,
+							true,
+							`${ window.location.protocol }//${ window.location.host }/${ emailManagementPath }`
+						) }
 						primary
-						target="_blank"
 						onClick={ () => {
 							recordEmailAppLaunchEvent( {
 								provider: 'titan',
@@ -79,7 +90,6 @@ const TitanSetUpThankYou = ( {
 						} }
 					>
 						{ translate( 'Go to Inbox' ) }
-						<Gridicon className="titan-set-up-thank-you__icon-external" icon="external" />
 					</FullWidthButton>
 				),
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add URL for the test staging environment for embedded inbox.

#### Testing instructions

We should have Titan Mailboxes created in the Titan staging environment, for that case you need to sandbox WordPress, buy a domain (if you don't have one) and buy a Professional Email while sandboxed.

1. Sandbox WordPress.com
2. Use the [Calypso Live](https://github.com/Automattic/wp-calypso/pull/63668#issuecomment-1127805793) link (the very first comment after this pull request description).
3. You are going to be redirected to a test environment with these changes applied.
4. Once you are in the WordPress dashboard, navigate to Inbox. From that screen add to the URL the following suffix: `?flags=emails/embedded-inbox-testing `and navigate to it.
5. Now the links to the Titan mailboxes should have changed to reflect the test environment in Titan.
6. Assert also that the links have changed in the following place `Upgrades -> Emails -> (A Professional Email subscription) -> Three dots to expand the menu -> View Mail`

For an E2E test, you need sandbox access. Please contact Letero team through Flock/Slack or the corresponding P2