### PR TITLE
composite-checkout: Change error logging callbacks to keep Error

### DIFF
--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -38,7 +38,7 @@ function useLogPurchasesError( message ) {
 				extra: {
 					env: config( 'env_id' ),
 					type: 'account_level_purchases',
-					message: String( error ),
+					message: error.message + '; Stack: ' + error.stack,
 				},
 			} );
 		},

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -21,7 +21,7 @@ const logCheckoutError = ( error ) => {
 		extra: {
 			env: config( 'env_id' ),
 			type: 'checkout_system_decider',
-			message: String( error ),
+			message: error.message + '; Stack: ' + error.stack,
 		},
 	} );
 };

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -267,16 +267,16 @@ export default function WPCheckout( {
 	useUpdateCartLocationWhenPaymentMethodChanges( activePaymentMethod, updateCartContactDetails );
 
 	const onReviewError = useCallback(
-		( error ) =>
-			onPageLoadError( 'step_load', String( error ), {
+		( error: Error ) =>
+			onPageLoadError( 'step_load', error, {
 				step_id: 'review',
 			} ),
 		[ onPageLoadError ]
 	);
 
 	const onSummaryError = useCallback(
-		( error ) =>
-			onPageLoadError( 'step_load', String( error ), {
+		( error: Error ) =>
+			onPageLoadError( 'step_load', error, {
 				step_id: 'summary',
 			} ),
 		[ onPageLoadError ]

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -523,8 +523,8 @@ export default function CompositeCheckout( {
 	} );
 
 	const onPageLoadError: CheckoutPageErrorCallback = useCallback(
-		( errorType, errorMessage, errorData ) => {
-			logStashLoadErrorEvent( errorType, errorMessage, errorData );
+		( errorType, error, errorData ) => {
+			logStashLoadErrorEvent( errorType, error, errorData );
 			function errorTypeToTracksEventName( type: string ): string {
 				switch ( type ) {
 					case 'page_load':
@@ -543,7 +543,7 @@ export default function CompositeCheckout( {
 			}
 			reduxDispatch(
 				recordTracksEvent( errorTypeToTracksEventName( errorType ), {
-					error_message: errorMessage,
+					error_message: error.message + '; Stack: ' + error.stack,
 					...errorData,
 				} )
 			);

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -155,7 +155,7 @@ export default function useCreatePaymentCompleteCallback( {
 				console.error( err );
 				reduxDispatch(
 					recordCompositeCheckoutErrorDuringAnalytics( {
-						errorObject: err,
+						errorObject: err as Error,
 						failureDescription: 'useCreatePaymentCompleteCallback',
 					} )
 				);

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -33,7 +33,7 @@ import './style.scss';
 
 function useLogBillingHistoryError( message: string ) {
 	return useCallback(
-		( error ) => {
+		( error: Error ) => {
 			logToLogstash( {
 				feature: 'calypso_client',
 				message,
@@ -41,7 +41,7 @@ function useLogBillingHistoryError( message: string ) {
 				extra: {
 					env: config( 'env_id' ),
 					type: 'site_level_billing_history',
-					message: String( error ),
+					message: error.message + '; Stack: ' + error.stack,
 				},
 			} );
 		},

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -30,7 +30,7 @@ import { getChangeOrAddPaymentMethodUrlFor } from './utils';
 
 function useLogPurchasesError( message: string ) {
 	return useCallback(
-		( error ) => {
+		( error: Error ) => {
 			logToLogstash( {
 				feature: 'calypso_client',
 				message,
@@ -38,7 +38,7 @@ function useLogPurchasesError( message: string ) {
 				extra: {
 					env: config( 'env_id' ),
 					type: 'site_level_purchases',
-					message: String( error ),
+					message: error.message + '; Stack: ' + error.stack,
 				},
 			} );
 		},

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -36,7 +36,7 @@ import { getAddNewPaymentMethodUrlFor, getPaymentMethodsUrlFor } from '../paths'
 
 function useLogPaymentMethodsError( message: string ) {
 	return useCallback(
-		( error ) => {
+		( error: Error ) => {
 			logToLogstash( {
 				feature: 'calypso_client',
 				message,
@@ -44,7 +44,7 @@ function useLogPaymentMethodsError( message: string ) {
 				extra: {
 					env: config( 'env_id' ),
 					type: 'site_level_payment_methods',
-					message: String( error ),
+					message: error.message + '; Stack: ' + error.stack,
 				},
 			} );
 		},

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -191,7 +191,7 @@ This component's props are:
 - `stepNumber: number`. The step number to display for the step.
 - `totalSteps: number`. The total number of steps in the current connected group of steps.
 - `errorMessage?: string`. The error message to display in the React error boundary if there is an error thrown by any component in this step.
-- `onError?: (string) => void`. A callback to be called from the React error boundary if there is an error thrown by any component in this step.
+- `onError?: (error: Error) => void`. A callback to be called from the React error boundary if there is an error thrown by any component in this step.
 - `editButtonText?: string`. The text to display instead of "Edit" for the edit step button.
 - `editButtonAriaLabel?: string`. The text to display for `aria-label` instead of "Edit" for the edit step button.
 - `nextStepButtonText?: string`. Like `editButtonText` but for the "Continue" button.

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -108,7 +108,7 @@ Requires an `id` prop, which is a string that is used to construct the SVG `id`.
 A [React error boundary](https://reactjs.org/docs/error-boundaries.html) that can be used to wrap any components you like. There are several layers of these already built-in to `CheckoutProvider` and its children, but you may use this to manually wrap components. It has the following props.
 
 - `errorMessage: React.ReactNode`. The error message to display to the user if there is a problem; typically a string but can also be a component.
-- `onError?: (string) => void`. A function to be called when there is an error. Can be used for logging.
+- `onError?: (error: Error) => void`. A function to be called when there is an error. Can be used for logging.
 
 ### CheckoutProvider
 

--- a/packages/composite-checkout/src/components/checkout-error-boundary.tsx
+++ b/packages/composite-checkout/src/components/checkout-error-boundary.tsx
@@ -1,16 +1,13 @@
 import styled from '@emotion/styled';
-import debugFactory from 'debug';
-import { ErrorInfo } from 'react';
-import * as React from 'react';
-
-const debug = debugFactory( 'composite-checkout:checkout-error-boundary' );
+import { Component } from 'react';
+import type { ReactNode } from 'react';
 
 const ErrorContainer = styled.div`
 	margin: 2em;
 	text-align: center;
 `;
 
-export default class CheckoutErrorBoundary extends React.Component< CheckoutErrorBoundaryProps > {
+export default class CheckoutErrorBoundary extends Component< CheckoutErrorBoundaryProps > {
 	constructor( props: CheckoutErrorBoundaryProps ) {
 		super( props );
 	}
@@ -21,15 +18,13 @@ export default class CheckoutErrorBoundary extends React.Component< CheckoutErro
 		return { hasError: true };
 	}
 
-	componentDidCatch( error: Error, errorInfo: ErrorInfo ): void {
+	componentDidCatch( error: Error ): void {
 		if ( this.props.onError ) {
-			const errorMessage = `${ error.message }; Stack: ${ error.stack }; Component Stack: ${ errorInfo.componentStack }`;
-			debug( 'reporting the error', errorMessage );
-			this.props.onError( errorMessage );
+			this.props.onError( error );
 		}
 	}
 
-	render(): React.ReactNode {
+	render(): ReactNode {
 		if ( this.state.hasError ) {
 			return <ErrorFallback errorMessage={ this.props.errorMessage } />;
 		}
@@ -38,11 +33,11 @@ export default class CheckoutErrorBoundary extends React.Component< CheckoutErro
 }
 
 interface CheckoutErrorBoundaryProps {
-	errorMessage: React.ReactNode;
-	onError?: ( message: string ) => void | undefined;
-	children?: React.ReactNode;
+	errorMessage: ReactNode;
+	onError?: ( error: Error ) => void;
+	children?: ReactNode;
 }
 
-function ErrorFallback( { errorMessage }: { errorMessage: React.ReactNode } ) {
+function ErrorFallback( { errorMessage }: { errorMessage: ReactNode } ) {
 	return <ErrorContainer>{ errorMessage }</ErrorContainer>;
 }

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -37,7 +37,7 @@ export default function CheckoutPaymentMethods( {
 	const { __ } = useI18n();
 	const { onPageLoadError, onPaymentMethodChanged } = useContext( CheckoutContext );
 	const onError = useCallback(
-		( error ) => onPageLoadError?.( 'payment_method_load', error ),
+		( error: Error ) => onPageLoadError?.( 'payment_method_load', error ),
 		[ onPageLoadError ]
 	);
 

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -136,8 +136,8 @@ export function CheckoutProvider( {
 	const { __ } = useI18n();
 	const errorMessage = __( 'Sorry, there was an error loading this page.' );
 	const onLoadError = useCallback(
-		( errorMessage ) => {
-			onPageLoadError?.( 'page_load', errorMessage );
+		( error: Error ) => {
+			onPageLoadError?.( 'page_load', error );
 		},
 		[ onPageLoadError ]
 	);

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -332,7 +332,7 @@ export const CheckoutStep = ( {
 	];
 
 	const onError = useCallback(
-		( error ) => onPageLoadError?.( 'step_load', error, { step_id: stepId } ),
+		( error: Error ) => onPageLoadError?.( 'step_load', error, { step_id: stepId } ),
 		[ onPageLoadError, stepId ]
 	);
 
@@ -633,7 +633,7 @@ export function CheckoutStepBody( {
 
 interface CheckoutStepBodyProps {
 	errorMessage?: string;
-	onError?: ( message: string ) => void;
+	onError?: ( error: Error ) => void;
 	editButtonAriaLabel?: string;
 	editButtonText?: string;
 	nextStepButtonText?: string;

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -11,7 +11,7 @@ export default function CheckoutSubmitButton( {
 }: {
 	className?: string;
 	disabled?: boolean;
-	onLoadError?: ( error: string ) => void;
+	onLoadError?: ( error: Error ) => void;
 } ): JSX.Element | null {
 	const { formStatus } = useFormStatus();
 	const { __ } = useI18n();

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -133,7 +133,7 @@ export type PaymentErrorCallback = ( args: {
 } ) => void;
 export type CheckoutPageErrorCallback = (
 	errorType: string,
-	errorMessage: string,
+	error: Error,
 	errorData?: Record< string, string | number | undefined >
 ) => void;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In checkout and related sections, we use React Error Boundaries to guard against and log fatal errors. To do this we use custom components and error handler functions which collect and record an error message string. However, this pattern is not very flexible because we lose any additional data that would be available in the `Error` itself (like the raw stack trace).

In this PR we modify all the classes and handlers used for these Error Boundaries to pass the raw `Error` object instead of a string.

This is required in order to use Sentry to track these errors in https://github.com/Automattic/wp-calypso/pull/63634

#### Testing instructions

To test this properly we'll need to intentionally cause an error in the code and verify that the Error Boundary correctly logs the error message.

<details><summary>Running calypso with this branch, try adding a line like this:</summary>

```diff
diff --git a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx b/client/my-sites/checkout/composite-checkout/components/wp-checko
ut.tsx
index c3c301170b..353700b0eb 100644
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -74,6 +74,7 @@ const ContactFormTitle = (): JSX.Element => {
        const cartKey = useCartKey();
        const { responseCart } = useShoppingCart( cartKey );
        const contactDetailsType = getContactDetailsType( responseCart );
+       throw new Error( 'this is a test' );

        if ( contactDetailsType === 'domain' ) {
                return (
```
</details>

Open calypso in your browser and then open the browser's devtools. Type `localStorage.setItem('debug', 'calypso:analytics')` in the devtools console and reload calypso. This will show logstash events in the console.

Next visit checkout and verify that you see an error message displayed by the error boundary on the page, and verify that you see a logstash entry in the console with the error message that was thrown. Sometimes the error logging won't show up in the console, in which case you can check the browser's network devtools panel to look for a call to the `logstash` endpoint.

<img width="582" alt="Screen Shot 2022-05-16 at 12 09 29 PM" src="https://user-images.githubusercontent.com/2036909/168636868-cda248c1-8d4a-42e1-a9da-5fc8156329c3.png">

<img width="573" alt="Screen Shot 2022-05-16 at 12 09 42 PM" src="https://user-images.githubusercontent.com/2036909/168636881-c6def261-3ac5-4072-8e0a-d0146334cfb9.png">

You can also try putting a `throw` in other places within checkout code to make sure they also work. 
