### PR TITLE
purchases: refactor tests to `@testing-library`

### DIFF
--- a/client/me/purchases/billing-history/test/tax.js
+++ b/client/me/purchases/billing-history/test/tax.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { renderTransactionAmount, transactionIncludesTax } from '../utils';
 
 const translate = ( x ) => x;
@@ -75,8 +75,8 @@ test( 'tax shown if available', () => {
 		],
 	};
 
-	const wrapper = mount( renderTransactionAmount( transaction, { translate } ) );
-	expect( wrapper.last().text() ).toContain( 'tax' );
+	render( renderTransactionAmount( transaction, { translate } ) );
+	expect( screen.getByText( /tax/ ) ).toBeInTheDocument();
 } );
 
 test( 'tax includes', () => {
@@ -91,8 +91,8 @@ test( 'tax includes', () => {
 		],
 	};
 
-	const wrapper = mount( renderTransactionAmount( transaction, { translate, addingTax: false } ) );
-	expect( wrapper.last().text() ).toEqual( '(includes %(taxAmount)s tax)' );
+	render( renderTransactionAmount( transaction, { translate, addingTax: false } ) );
+	expect( screen.getByText( '(includes %(taxAmount)s tax)' ) ).toBeInTheDocument();
 } );
 
 test( 'tax adding', () => {
@@ -107,8 +107,8 @@ test( 'tax adding', () => {
 		],
 	};
 
-	const wrapper = mount( renderTransactionAmount( transaction, { translate, addingTax: true } ) );
-	expect( wrapper.last().text() ).toEqual( '(+%(taxAmount)s tax)' );
+	render( renderTransactionAmount( transaction, { translate, addingTax: true } ) );
+	expect( screen.getByText( '(+%(taxAmount)s tax)' ) ).toBeInTheDocument();
 } );
 
 test( 'tax hidden if not available', () => {

--- a/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
@@ -1,4 +1,7 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import page from 'page';
@@ -6,7 +9,7 @@ import { PlanBillingPeriod } from '../billing-period';
 
 const props = {
 	purchase: {
-		// Including only the properties that are used by this component
+		// Including the properties that are used by this component
 		id: 123,
 		siteId: 123,
 		productName: 'Jetpack Personal',
@@ -35,28 +38,25 @@ jest.mock( 'page', () => jest.fn() );
 
 describe( 'PlanBillingPeriod', () => {
 	describe( 'a monthly plan', () => {
-		it( 'should display the current period', () => {
-			const wrapper = shallow( <PlanBillingPeriod { ...props } /> );
-			expect( wrapper.find( 'FormSettingExplanation' ).shallow().text() ).toContain(
-				'Billed monthly'
-			);
+		test( 'should display the current period', () => {
+			render( <PlanBillingPeriod { ...props } /> );
+			expect( screen.getByText( /billed monthly/i ) ).toBeInTheDocument();
 		} );
 
-		it( 'should upgrade to a yearly plan when the button is clicked', () => {
-			const wrapper = shallow( <PlanBillingPeriod { ...props } /> );
-			wrapper.find( 'ForwardRef(Button)' ).simulate( 'click' );
+		test( 'should upgrade to a yearly plan when the button is clicked', () => {
+			render( <PlanBillingPeriod { ...props } /> );
+			const btn = screen.getByRole( 'button', { name: /upgrade/i } );
+			fireEvent.click( btn );
 			expect( page ).toHaveBeenCalledWith( '/checkout/site.com/jetpack_premium' );
 		} );
 
-		describe( 'a disconnected site', () => {
-			test( 'should display a message instead of the upgrade button', () => {
-				const site = null;
-				const wrapper = shallow( <PlanBillingPeriod { ...props } site={ site } /> );
-				expect( wrapper.find( 'ForwardRef(Button)' ) ).toHaveLength( 0 );
-				expect( wrapper.find( 'FormSettingExplanation' ).last().shallow().text() ).toContain(
-					'To manage your plan, please reconnect your site.'
-				);
-			} );
+		test( 'should display a message instead of the upgrade button for a disconnected site', () => {
+			render( <PlanBillingPeriod { ...props } site={ null } /> );
+
+			expect( screen.queryAllByRole( 'button', { name: /upgrade/i } ) ).toHaveLength( 0 );
+			expect( screen.getByText( /to manage your plan/i ) ).toHaveTextContent(
+				'To manage your plan, please reconnect your site'
+			);
 		} );
 	} );
 
@@ -71,15 +71,13 @@ describe( 'PlanBillingPeriod', () => {
 			},
 		};
 
-		it( 'should display the current period', () => {
-			const wrapper = shallow( <PlanBillingPeriod { ...annualPlanProps } /> );
-			expect( wrapper.find( 'FormSettingExplanation' ).shallow().text() ).toEqual(
-				'Billed yearly'
-			);
+		test( 'should display the current period', () => {
+			render( <PlanBillingPeriod { ...annualPlanProps } /> );
+			expect( screen.getByText( /billed yearly/i ) ).toBeInTheDocument();
 		} );
 
 		describe( 'when credit card is expiring', () => {
-			it( 'should display a warning to the user', () => {
+			test( 'should display a warning to the user', () => {
 				const planExpiryDate = moment().add( 3, 'months' ).format();
 				const cardExpiryDate = moment().add( 1, 'months' ).format( 'MM/YY' );
 				const purchase = {
@@ -92,54 +90,49 @@ describe( 'PlanBillingPeriod', () => {
 						},
 					},
 				};
-				const wrapper = shallow(
-					<PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } />
-				);
-				expect( wrapper.find( 'FormSettingExplanation' ).shallow().text() ).toEqual(
+				render( <PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } /> );
+				expect( screen.getByText( /billed yearly/i ) ).toHaveTextContent(
 					'Billed yearly, credit card expiring soon'
 				);
 			} );
 		} );
+
 		describe( 'when plan is renewing', () => {
-			it( 'should display a warning to the user', () => {
+			test( 'should display a warning to the user', () => {
 				const purchase = {
 					...annualPlanProps.purchase,
 					renewDate: moment( '2020-01-01' ).format(),
 				};
-				const wrapper = shallow(
-					<PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } />
-				);
-				expect( wrapper.find( 'FormSettingExplanation' ).shallow().text() ).toEqual(
+				render( <PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } /> );
+				expect( screen.getByText( /billed yearly/i ) ).toHaveTextContent(
 					'Billed yearly, renews on January 1, 2020'
 				);
 			} );
 		} );
+
 		describe( 'when plan is expiring', () => {
-			it( 'should display a warning to the user', () => {
+			test( 'should display a warning to the user', () => {
 				const purchase = {
 					...annualPlanProps.purchase,
 					expiryDate: moment( '2020-01-01' ).format(),
 					expiryStatus: 'expiring',
 				};
-				const wrapper = shallow(
-					<PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } />
-				);
-				expect( wrapper.find( 'FormSettingExplanation' ).shallow().text() ).toEqual(
+				render( <PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } /> );
+				expect( screen.getByText( /billed yearly/i ) ).toHaveTextContent(
 					'Billed yearly, expires on January 1, 2020'
 				);
 			} );
 		} );
+
 		describe( 'when plan is expired', () => {
-			it( 'should display a warning to the user', () => {
+			test( 'should display a warning to the user', () => {
 				const purchase = {
 					...annualPlanProps.purchase,
 					expiryDate: moment().subtract( 1, 'month' ).format(),
 					expiryStatus: 'expired',
 				};
-				const wrapper = shallow(
-					<PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } />
-				);
-				expect( wrapper.find( 'FormSettingExplanation' ).shallow().text() ).toEqual(
+				render( <PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } /> );
+				expect( screen.getByText( /billed yearly/i ) ).toHaveTextContent(
 					'Billed yearly, expired a month ago'
 				);
 			} );

--- a/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
@@ -38,19 +38,19 @@ jest.mock( 'page', () => jest.fn() );
 
 describe( 'PlanBillingPeriod', () => {
 	describe( 'a monthly plan', () => {
-		test( 'should display the current period', () => {
+		it( 'should display the current period', () => {
 			render( <PlanBillingPeriod { ...props } /> );
 			expect( screen.getByText( /billed monthly/i ) ).toBeInTheDocument();
 		} );
 
-		test( 'should upgrade to a yearly plan when the button is clicked', () => {
+		it( 'should upgrade to a yearly plan when the button is clicked', () => {
 			render( <PlanBillingPeriod { ...props } /> );
 			const btn = screen.getByRole( 'button', { name: /upgrade/i } );
 			fireEvent.click( btn );
 			expect( page ).toHaveBeenCalledWith( '/checkout/site.com/jetpack_premium' );
 		} );
 
-		test( 'should display a message instead of the upgrade button for a disconnected site', () => {
+		it( 'should display a message instead of the upgrade button for a disconnected site', () => {
 			render( <PlanBillingPeriod { ...props } site={ null } /> );
 
 			expect( screen.queryAllByRole( 'button', { name: /upgrade/i } ) ).toHaveLength( 0 );
@@ -71,13 +71,13 @@ describe( 'PlanBillingPeriod', () => {
 			},
 		};
 
-		test( 'should display the current period', () => {
+		it( 'should display the current period', () => {
 			render( <PlanBillingPeriod { ...annualPlanProps } /> );
 			expect( screen.getByText( /billed yearly/i ) ).toBeInTheDocument();
 		} );
 
 		describe( 'when credit card is expiring', () => {
-			test( 'should display a warning to the user', () => {
+			it( 'should display a warning to the user', () => {
 				const planExpiryDate = moment().add( 3, 'months' ).format();
 				const cardExpiryDate = moment().add( 1, 'months' ).format( 'MM/YY' );
 				const purchase = {
@@ -98,7 +98,7 @@ describe( 'PlanBillingPeriod', () => {
 		} );
 
 		describe( 'when plan is renewing', () => {
-			test( 'should display a warning to the user', () => {
+			it( 'should display a warning to the user', () => {
 				const purchase = {
 					...annualPlanProps.purchase,
 					renewDate: moment( '2020-01-01' ).format(),
@@ -111,7 +111,7 @@ describe( 'PlanBillingPeriod', () => {
 		} );
 
 		describe( 'when plan is expiring', () => {
-			test( 'should display a warning to the user', () => {
+			it( 'should display a warning to the user', () => {
 				const purchase = {
 					...annualPlanProps.purchase,
 					expiryDate: moment( '2020-01-01' ).format(),
@@ -125,7 +125,7 @@ describe( 'PlanBillingPeriod', () => {
 		} );
 
 		describe( 'when plan is expired', () => {
-			test( 'should display a warning to the user', () => {
+			it( 'should display a warning to the user', () => {
 				const purchase = {
 					...annualPlanProps.purchase,
 					expiryDate: moment().subtract( 1, 'month' ).format(),

--- a/client/me/purchases/purchase-item/test/index.js
+++ b/client/me/purchases/purchase-item/test/index.js
@@ -1,8 +1,10 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
 import i18n from 'i18n-calypso';
 import moment from 'moment';
-import { Provider } from 'react-redux';
-import { createStore } from 'redux';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import PurchaseItem from '../';
 
 describe( 'PurchaseItem', () => {
@@ -13,21 +15,19 @@ describe( 'PurchaseItem', () => {
 			expiryDate: moment().subtract( 10, 'hours' ).format(),
 		};
 
-		const store = createStore( () => {}, {} );
-		const wrapper = shallow(
-			<Provider store={ store }>
-				<PurchaseItem purchase={ purchase } />
-			</Provider>
-		);
-
 		test( 'should be described as "Expired today"', () => {
-			expect( wrapper.html() ).toContain( 'Expired today' );
+			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
+
+			expect( screen.getByText( /expired today/i ) ).toBeInTheDocument();
 		} );
 
 		test( 'should be described with a translated label', () => {
 			const translation = 'Vandaag verlopen';
 			i18n.addTranslations( { 'Expired today': [ translation ] } );
-			expect( wrapper.html() ).toContain( translation );
+
+			renderWithProvider( <PurchaseItem purchase={ purchase } /> );
+
+			expect( screen.getByText( translation ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/me/purchases/track-purchase-page-view/test/index.js
+++ b/client/me/purchases/track-purchase-page-view/test/index.js
@@ -1,5 +1,8 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
 import deepFreeze from 'deep-freeze';
-import { shallow } from 'enzyme';
 import { TrackPurchasePageView } from '..';
 
 const baseProps = deepFreeze( {
@@ -15,12 +18,12 @@ beforeEach( jest.clearAllMocks );
 
 describe( 'TrackPurchasePageView', () => {
 	test( 'should render nothing', () => {
-		const wrapper = shallow( <TrackPurchasePageView { ...baseProps } /> );
-		expect( wrapper.type() ).toBeNull();
+		const { container } = render( <TrackPurchasePageView { ...baseProps } /> );
+		expect( container.innerHTML ).toEqual( '' );
 	} );
 
 	test( 'should track on mount if data is loaded', () => {
-		shallow( <TrackPurchasePageView { ...baseProps } /> );
+		render( <TrackPurchasePageView { ...baseProps } /> );
 		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 1 );
 		expect( baseProps.recordTracksEvent ).toHaveBeenCalledWith( baseProps.eventName, {
 			product_slug: baseProps.productSlug,
@@ -28,15 +31,15 @@ describe( 'TrackPurchasePageView', () => {
 	} );
 
 	test( 'should not track if productSlug is absent (data not loaded)', () => {
-		shallow( <TrackPurchasePageView { ...baseProps } productSlug={ null } /> );
+		render( <TrackPurchasePageView { ...baseProps } productSlug={ null } /> );
 		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 0 );
 	} );
 
 	test( 'should track when productSlug is provided (data loads)', () => {
-		const wrapper = shallow( <TrackPurchasePageView { ...baseProps } productSlug={ null } /> );
+		const { rerender } = render( <TrackPurchasePageView { ...baseProps } productSlug={ null } /> );
 		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 0 );
 
-		wrapper.setProps( { productSlug: baseProps.productSlug } );
+		rerender( <TrackPurchasePageView { ...baseProps } /> );
 		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 1 );
 		expect( baseProps.recordTracksEvent ).toHaveBeenCalledWith( baseProps.eventName, {
 			product_slug: baseProps.productSlug,
@@ -44,15 +47,14 @@ describe( 'TrackPurchasePageView', () => {
 	} );
 
 	test( 'should only track once if relevant props are unchanged', () => {
-		const wrapper = shallow( <TrackPurchasePageView { ...baseProps } /> );
-		wrapper.update();
-		wrapper.update();
-		wrapper.update();
+		const { rerender } = render( <TrackPurchasePageView { ...baseProps } /> );
+		rerender( <TrackPurchasePageView { ...baseProps } /> );
+		rerender( <TrackPurchasePageView { ...baseProps } /> );
 		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	test( 'should track when relevant props update', () => {
-		const wrapper = shallow( <TrackPurchasePageView { ...baseProps } /> );
+		const { rerender } = render( <TrackPurchasePageView { ...baseProps } /> );
 
 		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 1 );
 		expect( baseProps.recordTracksEvent ).toHaveBeenCalledWith( baseProps.eventName, {
@@ -61,7 +63,7 @@ describe( 'TrackPurchasePageView', () => {
 
 		const productSlug = 'new-product-slug';
 
-		wrapper.setProps( { productSlug } );
+		rerender( <TrackPurchasePageView { ...baseProps } productSlug={ productSlug } /> );
 		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 2 );
 		expect( baseProps.recordTracksEvent ).toHaveBeenLastCalledWith( baseProps.eventName, {
 			product_slug: productSlug,
@@ -69,7 +71,9 @@ describe( 'TrackPurchasePageView', () => {
 
 		const eventName = 'new-tracking-slug';
 
-		wrapper.setProps( { eventName } );
+		rerender(
+			<TrackPurchasePageView { ...baseProps } productSlug={ productSlug } eventName={ eventName } />
+		);
 		expect( baseProps.recordTracksEvent ).toHaveBeenCalledTimes( 3 );
 		expect( baseProps.recordTracksEvent ).toHaveBeenLastCalledWith( eventName, {
 			product_slug: productSlug,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate the following test files to `@testing-library`

- client/me/purchases/billing-history/test/tax.js 
- client/me/purchases/purchase-item/test/index.jsx 
- client/me/purchases/track-purchase-page-view/test/index.js 
- client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure unit tests pass

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63409
