### PR TITLE
Earn: Extend use of feature checks

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -41,7 +41,6 @@ import './style.scss';
 interface ConnectedProps {
 	siteId: number;
 	selectedSiteSlug: SiteSlug | null;
-	isFreePlan: boolean;
 	isNonAtomicJetpack: boolean;
 	isLoading: boolean;
 	hasSimplePayments: boolean;
@@ -61,7 +60,6 @@ interface ConnectedProps {
 const Home: FunctionComponent< ConnectedProps > = ( {
 	siteId,
 	selectedSiteSlug,
-	isFreePlan,
 	isNonAtomicJetpack,
 	isUserAdmin,
 	isLoading,
@@ -199,12 +197,12 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 				{ translate(
 					'Accept one-time and recurring credit card payments for physical products, services, memberships, subscriptions, and donations.'
 				) }
-				{ isFreePlan && <em>{ getAnyPlanNames() }</em> }
+				{ ! hasRecurringPayments && <em>{ getAnyPlanNames() }</em> }
 			</>
 		);
 		const body = hasConnectedAccount ? hasConnectionBody : noConnectionBody;
 
-		const learnMoreLink = isFreePlan
+		const learnMoreLink = ! hasRecurringPayments
 			? {
 					url: 'https://wordpress.com/support/recurring-payments/',
 					onClick: () => trackLearnLink( 'recurring-payments' ),
@@ -249,7 +247,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 				{ translate(
 					'Collect donations, tips, and contributions for your creative pursuits, organization, or whatever your website is about.'
 				) }
-				{ isFreePlan && <em>{ getAnyPlanNames() }</em> }
+				{ ! hasDonations && <em>{ getAnyPlanNames() }</em> }
 			</>
 		);
 
@@ -316,10 +314,10 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 				{ translate(
 					'Create paid subscription options to share premium content like text, images, video, and any other content on your website.'
 				) }
-				{ isFreePlan && <em>{ getAnyPlanNames() }</em> }
+				{ ! hasPremiumContent && <em>{ getAnyPlanNames() }</em> }
 			</>
 		);
-		const learnMoreLink = isFreePlan
+		const learnMoreLink = ! hasPremiumContent
 			? {
 					url: 'https://wordpress.com/support/wordpress-editor/blocks/premium-content-block/',
 					onClick: () => trackLearnLink( 'premium-content' ),
@@ -365,7 +363,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					},
 			  };
 		const title = translate( 'Send paid email newsletters' );
-		const body = isFreePlan ? (
+		const body = ! hasPremiumContent ? (
 			<>
 				{ ' ' }
 				{ translate(
@@ -561,17 +559,16 @@ export default connect(
 		const siteId = getSelectedSiteId( state ) ?? 0;
 		const selectedSiteSlug = getSelectedSiteSlug( state );
 		const site = getSiteBySlug( state, selectedSiteSlug );
-		const isFreePlan = ! isCurrentPlanPaid( state, siteId );
 
 		const hasConnectedAccount =
 			state?.memberships?.settings?.[ siteId ]?.connectedAccountId ?? null;
 		const sitePlanSlug = getSitePlanSlug( state, siteId );
-		const isLoading = ( hasConnectedAccount === null && ! isFreePlan ) || sitePlanSlug === null;
+		const hasPaidPlan = isCurrentPlanPaid( state, siteId );
+		const isLoading = ( hasConnectedAccount === null && hasPaidPlan ) || sitePlanSlug === null;
 
 		return {
 			siteId,
 			selectedSiteSlug,
-			isFreePlan,
 			isNonAtomicJetpack: Boolean(
 				isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
 			),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replaces free-plan checks with feature checks that were introduced in #63395.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to Tools > Earn on any WP.com site: /earn
* On sites with a free plan, make sure that all cards have an "Unlock this feature" action button. <img width="524" alt="image" src="https://user-images.githubusercontent.com/1398304/167219462-a9a608d4-a76e-47d2-b34b-0feb24849f49.png">

* On sites with a plan that unlocks these features, make sure the action buttons are unlocked. <img width="526" alt="image" src="https://user-images.githubusercontent.com/1398304/167219483-f6a880f1-b436-4e95-a97a-1281c87ea37b.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-a66-p2