### PR TITLE
Reorder the installed plugins to the end of each list on the main Browser Plugins page.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -43,6 +43,7 @@ import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
+import { getPlugins, getPluginsOnSites } from 'calypso/state/plugins/installed/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
@@ -452,6 +453,13 @@ const PluginSingleListView = ( {
 	const categories = useCategories();
 	const categoryName = categories[ category ]?.name || translate( 'Plugins' );
 
+	const installedPlugins = useSelector( ( state ) =>
+		getPlugins( state, siteObjectsToSiteIds( sites ) )
+	);
+	const aggregatedInstalledPlugins = useSelector( ( state ) =>
+		getPluginsOnSites( state, installedPlugins )
+	);
+
 	let plugins;
 	let isFetching;
 	if ( category === 'popular' ) {
@@ -468,6 +476,7 @@ const PluginSingleListView = ( {
 	}
 
 	plugins = plugins.filter( isNotBlocked );
+	plugins = reorganizeInstalledPlugins( plugins, aggregatedInstalledPlugins );
 
 	let listLink = '/plugins/' + category;
 	if ( domain ) {
@@ -636,6 +645,28 @@ const PLUGIN_SLUGS_BLOCKLIST = [];
 
 function isNotBlocked( plugin ) {
 	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;
+}
+
+function reorganizeInstalledPlugins( plugins, installedPlugins ) {
+	const nonInstalledList = plugins.filter( ( plugin ) =>
+		isNotInstalled( plugin, installedPlugins )
+	);
+	const installedList = plugins.filter(
+		( plugin ) => ! isNotInstalled( plugin, installedPlugins )
+	);
+
+	return nonInstalledList.concat( installedList );
+}
+
+/**
+ * Returns a boolean indicating if a plugin is already installed or not
+ *
+ * @param plugin plugin object to be tested
+ * @param installedPlugins list of installed plugins aggregated by plugin slug
+ * @returns Boolean weather a plugin is not installed on not
+ */
+function isNotInstalled( plugin, installedPlugins ) {
+	return ! installedPlugins[ plugin.slug ];
 }
 
 export default PluginsBrowser;


### PR DESCRIPTION

## Description


In order to make the Plugin's landing page looks fresh, the installed plugins are being de-prioritized. In this PR they are being sent to the end of the list to hide them, but if there are less than the minimum limit of plugins (currently 6), the installed plugins will be shown at the end of the list.

There is also a version where the filter is done, it can be found on the branch  [update/filter-installed-plugins](https://github.com/Automattic/wp-calypso/tree/update/filter-installed-plugins).

| Old version (production) | Reordering installed plugins (current branch) | Filtering out installed plugins ([update/filter-installed-plugins](https://github.com/Automattic/wp-calypso/tree/update/filter-installed-plugins))|
| ------------- | ------------- |------------- |
|<img width="982" alt="Screen Shot 2022-05-16 at 12 45 21" src="https://user-images.githubusercontent.com/5039531/168675893-b2d9c653-ee8d-46b2-91b3-0f3ea2f775b1.png">|<img width="982" alt="Screen Shot 2022-05-16 at 14 11 53" src="https://user-images.githubusercontent.com/5039531/168675766-a1482db7-74d6-40cb-8f10-4a70a3324814.png">|<img width="982" alt="Screen Shot 2022-05-16 at 12 41 57" src="https://user-images.githubusercontent.com/5039531/168676037-e4217cf5-a616-4744-8ab1-8ddbf634ea38.png">|

PS: It is important to note the difference will be mostly seen in the editors' pick section as there are only 6 plugins there currently. On the other sections (as paid plugins) you should see only non-installed plugins.


## Changes proposed in this Pull Request

 Reorder the installed plugins to the end of each list on the main Browser Plugins page.

## Testing instructions
* Go to `/plugins` page
* Check if you have installed plugins (if don't, install some)
* You shouldn't see the installed plugins on the first positions of the plugins lists.
* They should be hidden or on the later positions.

---

Fixes #62205
