### PR TITLE
Added the scan now button to view of results that include threats

### DIFF
--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -248,10 +248,7 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 							>
 								{ translate( 'Auto fix all' ) }
 							</Button>
-							<Button
-								className="scan-threats__button scan__retry-bottom"
-								onClick={ dispatchScanRun }
-							>
+							<Button className="scan-threats__retry-bottom" onClick={ dispatchScanRun }>
 								{ translate( 'Scan now' ) }
 							</Button>
 						</div>

--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -248,7 +248,7 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 							>
 								{ translate( 'Auto fix all' ) }
 							</Button>
-							<Button className="scan-threats__retry-bottom" onClick={ dispatchScanRun }>
+							<Button className="scan-threats__scan-secondary-button" onClick={ dispatchScanRun }>
 								{ translate( 'Scan now' ) }
 							</Button>
 						</div>

--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -248,8 +248,19 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 							>
 								{ translate( 'Auto fix all' ) }
 							</Button>
+							<Button
+								className="scan-threats__button scan__retry-bottom"
+								onClick={ dispatchScanRun }
+							>
+								{ translate( 'Scan now' ) }
+							</Button>
 						</div>
 					</>
+				) }
+				{ ! hasFixableThreats && (
+					<Button primary className="scan-threats__button" onClick={ dispatchScanRun }>
+						{ translate( 'Scan now' ) }
+					</Button>
 				) }
 			</Card>
 			<ThreatListHeader />

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -142,7 +142,6 @@
 			text-align: left;
 			flex-grow: 1;
 			margin: 0 !important;
-			padding-bottom: 10px;
 			// line-height: 24px;
 
 			@include breakpoint-deprecated( '<960px' ) {
@@ -150,6 +149,7 @@
 				font-weight: normal;
 				width: 100%;
 				text-align: center;
+				padding-bottom: 10px;
 			}
 		}
 	}

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -138,19 +138,18 @@
 
 		> p {
 			font-size: $font-body;
-			font-weight: normal;
-			width: 100%;
-			text-align: center;
+			width: auto;
+			text-align: left;
+			flex-grow: 1;
+			margin: 0 !important;
+			padding-bottom: 10px;
 			// line-height: 24px;
 
-			@include breakpoint-deprecated( '>660px' ) {
-				width: auto;
-				text-align: left;
-			}
-
-			@include breakpoint-deprecated( '>660px' ) {
-				flex-grow: 1;
-				margin: 0 !important;
+			@include breakpoint-deprecated( '<960px' ) {
+				font-size: $font-body;
+				font-weight: normal;
+				width: 100%;
+				text-align: center;
 			}
 		}
 	}
@@ -160,14 +159,14 @@
 		height: 40px;
 		border-radius: 2px;
 		font-weight: 600;
-		@include breakpoint-deprecated( '<800px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			flex-grow: 1;
 		}
 	}
 
 	&__scan-secondary-button {
 		margin-left: 10px;
-		@include breakpoint-deprecated( '<800px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			flex-grow: 1;
 		}
 	}

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -160,7 +160,7 @@
 		height: 40px;
 		border-radius: 2px;
 		font-weight: 600;
-		@include breakpoint-deprecated( '<800px' ) {
+		@include breakpoint-deprecated( '<900px' ) {
 			flex-grow: 1;
 		}
 	}
@@ -169,5 +169,13 @@
 		flex: 0 0 50px;
 		padding: 10px 0;
 		margin-left: 16px;
+	}
+
+	&__retry-bottom {
+		margin: 10px 16px;
+	
+		@include breakpoint-deprecated( '<900px' ) {
+			flex-grow: 1;
+		}
 	}
 }

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -148,7 +148,7 @@
 				text-align: left;
 			}
 
-			@include breakpoint-deprecated( '>800px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				flex-grow: 1;
 				margin: 0 !important;
 			}
@@ -160,7 +160,14 @@
 		height: 40px;
 		border-radius: 2px;
 		font-weight: 600;
-		@include breakpoint-deprecated( '<900px' ) {
+		@include breakpoint-deprecated( '<800px' ) {
+			flex-grow: 1;
+		}
+	}
+
+	&__scan-secondary-button {
+		margin-left: 10px;
+		@include breakpoint-deprecated( '<800px' ) {
 			flex-grow: 1;
 		}
 	}
@@ -169,13 +176,5 @@
 		flex: 0 0 50px;
 		padding: 10px 0;
 		margin-left: 16px;
-	}
-
-	&__retry-bottom {
-		margin: 10px 16px;
-	
-		@include breakpoint-deprecated( '<900px' ) {
-			flex-grow: 1;
-		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a manual "Scan now" button to the views where threat results are found.

Fixable Before             |  Fixable After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/8845655/168682508-4a4f29d3-ca7c-414f-b646-eec9cb2b61b5.png)  |  ![](https://user-images.githubusercontent.com/8845655/168682611-9220103d-56f9-4590-b8ca-97b61cbe6312.png)

Non-Fixable Before             |  Non-Fixable After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/8845655/168683019-91f69e85-0797-4aac-be2e-e663c795d83d.png)  |  ![](https://user-images.githubusercontent.com/8845655/168683056-a2981fd6-1728-466b-8c7d-0ca3aefb97dd.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a non-fixable threat such as an EICAR to random file in contents to a test site (I recommend the [Threat Tester](https://github.com/Automattic/jetpack-threat-tester) on a Jurassic Ninja site)
* Run a scan from Calypso 
* Notice the missing "Scan now" button
* Add a fixable threat such as modified core file threat
* Run a new scan, notice that the "Scan now" button is still missing
* Switch to this branch
* Run steps 1-4 again, but now notice the present Scan buttons
* Try the scan buttons to ensure they operate as expected

