### PR TITLE
Clarifies expiration is for domain connection, and adds condition for auto-renew enabled subscriptions

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -125,13 +125,18 @@ export function resolveDomainStatus(
 					);
 				}
 
+				let status = translate( 'Active' );
+				if ( ! domain.autoRenewing ) {
+					status = domain.bundledPlanSubscriptionId
+						? translate( 'Expires with your plan' )
+						: translate( 'Expiring soon' );
+				}
+
 				if ( isExpiringSoon( domain, 7 ) ) {
 					return {
 						statusText: expiresMessage,
 						statusClass: `status-${ domain.autoRenewing ? 'success' : 'error' }`,
-						status: domain.autoRenewing
-							? translate( 'Active' )
-							: translate( 'Domain connection expiring soon' ),
+						status: status,
 						icon: 'info',
 						listStatusText: expiresMessage,
 						listStatusClass: domain.autoRenewing ? 'info' : 'alert',
@@ -142,10 +147,8 @@ export function resolveDomainStatus(
 
 				return {
 					statusText: expiresMessage,
-					statusClass: `status-${ domain.autoRenewing ? 'success' : 'error' }`,
-					status: domain.autoRenewing
-						? translate( 'Active' )
-						: translate( 'Domain connection expiring soon' ),
+					statusClass: 'status-warning',
+					status: status,
 					icon: 'info',
 					listStatusText: expiresMessage,
 					listStatusClass: 'warning',

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -129,7 +129,9 @@ export function resolveDomainStatus(
 					return {
 						statusText: expiresMessage,
 						statusClass: `status-${ domain.autoRenewing ? 'success' : 'error' }`,
-						status: domain.autoRenewing ? translate( 'Active' ) : translate( 'Expiring soon' ),
+						status: domain.autoRenewing
+							? translate( 'Active' )
+							: translate( 'Domain connection expiring soon' ),
 						icon: 'info',
 						listStatusText: expiresMessage,
 						listStatusClass: domain.autoRenewing ? 'info' : 'alert',
@@ -140,8 +142,10 @@ export function resolveDomainStatus(
 
 				return {
 					statusText: expiresMessage,
-					statusClass: 'status-warning',
-					status: translate( 'Expiring soon' ),
+					statusClass: `status-${ domain.autoRenewing ? 'success' : 'error' }`,
+					status: domain.autoRenewing
+						? translate( 'Active' )
+						: translate( 'Domain connection expiring soon' ),
 					icon: 'info',
 					listStatusText: expiresMessage,
 					listStatusClass: 'warning',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* adds a condition for mapped domain expiring within 30 days, to display status depending on whether or not auto-renew is enabled. Condition was already present for domains expiring within 7 days
* If auto-renew is enabled, status will show "Active"
* If auto-renew is disabled, status will show "Domain connection expiring soon"

#### Testing instructions

**BEFORE:** 

* add a domain connection to a plan that is set to expire within 30 days, but greater than 7 days
* Go to Upgrades > Domains
* Domain status displays "Expiring soon", whether auto-renew is enabled for plan or not
* "Expiring soon" has caused some confusion for both HEs and users, as it does not clarify if this is for the domain registration's expiration or the domain connection subscription

![image](https://user-images.githubusercontent.com/65082164/168690598-cba6e6b2-0441-430a-a0f0-80eda6dcc3b5.png)

**AFTER:**

* With fix in place, for domains expiring within 7 days or 30 days, if auto-renew is enabled, it displays "Active" in the status
* If auto-renew is disabled, the status clarifies that this is for the domain connection

![image](https://user-images.githubusercontent.com/65082164/168690797-13dd7a18-1d7c-4fa0-9cbc-b393fa427d9e.png)



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63633
