### PR TITLE
Adjust position of homepage theme icon in Page List

### DIFF
--- a/client/my-sites/pages/page-card-info/style.scss
+++ b/client/my-sites/pages/page-card-info/style.scss
@@ -2,6 +2,13 @@
 	color: var( --color-text-subtle );
 	font-size: $font-body-extra-small;
 	vertical-align: middle;
+
+	.gridicon {
+    padding-right: 0.15rem;
+    position: relative;
+    top: 0.15rem;
+    
+}
 }
 
 .page-card-info__site-url {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjust the position and alignment of the Homepage theme icon so it looks visually correct.

#### Testing instructions

1. Switch from one Recommended them to another, and choose the option to use the new theme's homepage.
2. Switch to Pages > Drafts to see the icon shown next to the draft homepage from the old theme.

Related to #53085
