### PR TITLE
P2 signup flow: better progress marker for confirm email step

### DIFF
--- a/client/signup/steps/p2-confirm-email/index.jsx
+++ b/client/signup/steps/p2-confirm-email/index.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { check } from '@wordpress/icons';
@@ -49,6 +50,9 @@ function P2ConfirmEmail( {
 			dispatch(
 				saveSignupStep( { stepName, ...( refParameter && { storedRefParameter: refParameter } ) } )
 			);
+
+			debug( 'Email confirmation step loaded for %s', userEmail );
+			recordTracksEvent( 'calypso_signup_p2_confirm_email_load', { userEmail, isEmailVerified } );
 		}
 	}, [ dispatch, stepName, refParameter ] );
 
@@ -76,6 +80,9 @@ function P2ConfirmEmail( {
 	};
 
 	const handleNextStepClick = () => {
+		debug( 'Email confirmation step completed for %s', userEmail );
+		recordTracksEvent( 'calypso_signup_p2_confirm_email_complete', { userEmail, isEmailVerified } );
+
 		submitSignupStep( { stepName } );
 
 		goToNextStep();

--- a/client/signup/steps/p2-confirm-email/index.jsx
+++ b/client/signup/steps/p2-confirm-email/index.jsx
@@ -45,9 +45,11 @@ function P2ConfirmEmail( {
 	// We also need to store the original refParameter, as the redirect on email verification
 	// loses it.
 	useEffect( () => {
-		dispatch(
-			saveSignupStep( { stepName, ...( refParameter && { storedRefParameter: refParameter } ) } )
-		);
+		if ( userEmail ) {
+			dispatch(
+				saveSignupStep( { stepName, ...( refParameter && { storedRefParameter: refParameter } ) } )
+			);
+		}
 	}, [ dispatch, stepName, refParameter ] );
 
 	const handleResendEmailClick = () => {

--- a/client/signup/steps/p2-confirm-email/index.jsx
+++ b/client/signup/steps/p2-confirm-email/index.jsx
@@ -1,4 +1,3 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { check } from '@wordpress/icons';
@@ -52,7 +51,6 @@ function P2ConfirmEmail( {
 			);
 
 			debug( 'Email confirmation step loaded for %s', userEmail );
-			recordTracksEvent( 'calypso_signup_p2_confirm_email_load', { userEmail, isEmailVerified } );
 		}
 	}, [ dispatch, stepName, refParameter ] );
 
@@ -81,7 +79,6 @@ function P2ConfirmEmail( {
 
 	const handleNextStepClick = () => {
 		debug( 'Email confirmation step completed for %s', userEmail );
-		recordTracksEvent( 'calypso_signup_p2_confirm_email_complete', { userEmail, isEmailVerified } );
 
 		submitSignupStep( { stepName } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Only save the step (mark it as in-progress) when the userEmail is already loaded. This will hopefully prevent marking someone as going through email confirmation while their information is still loading.
* Add some debug

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `calypso.localhost:3000/start/p2` (or `<calypso.live URL>/start/p2`) and go through the flow as a verified user. The confirm email step should be skipped for you. You will either get the Complete Profile, or the Welcome to P2 step.
* Go through the flow as a new, unverified user. You should get the email verification step after creating the account.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->