### PR TITLE
Add page title and subtitle for agency dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,11 +1,19 @@
+import { useTranslate } from 'i18n-calypso';
 import SiteContent from './site-content';
 import type { ReactElement } from 'react';
 
 import './style.scss';
 
 export default function SitesOverview(): ReactElement {
+	const translate = useTranslate();
 	return (
 		<div className="sites-overview">
+			<div className="sites-overview__page-title-container">
+				<h2 className="sites-overview__page-title">{ translate( 'Dashboard' ) }</h2>
+				<div className="sites-overview__page-subtitle">
+					{ translate( 'Manage all your Jetpack sites from one location' ) }
+				</div>
+			</div>
 			<SiteContent />
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -8,8 +8,24 @@
 		padding: 0;
 	}
 	@include break-wide() {
-		padding: 16px;
+		padding: 6px 16px;
 	}
+}
+.sites-overview__page-title-container {
+	display: none;
+	@include break-large() {
+		display: block;
+	}
+}
+.sites-overview__page-title {
+	color: var( --studio-gray-80 );
+	font-weight: 400;
+
+}
+.sites-overview__page-subtitle {
+	font-size: 0.875rem;
+	color: var( --studio-gray-60 );
+	margin-bottom: 1.5rem;
 }
 .sites-overview__status-add-new {
 	display: inline-flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds title and subtitle to the agency dashboard page

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb

**Instructions**

1. Run `git checkout add/page-title-and-subtitle-for-agency-dashboard` and `yarn start-jetpack-cloud`
2. Apply D79008-code for the mock API to work.
3. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard
4. Verify that the page title and subtitle are being shown as shown in the screenshot below only on devices with width >960, this section should be hidden for devices <960


**Screenshots**

Large screen(>960)

<img width="1920" alt="Screenshot 2022-05-17 at 3 52 20 PM" src="https://user-images.githubusercontent.com/10586875/168792758-68ad6e70-674e-48f2-ae07-fcfb20dc4125.png">

Small screen(<960)

<img width="383" alt="Screenshot 2022-05-17 at 3 52 31 PM" src="https://user-images.githubusercontent.com/10586875/168792776-2c82ed1b-c87b-4564-a5be-05bc3bde3151.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202076982646589-as-1202265885291352