### PR TITLE
Plans overhaul: fix e2e pre-release tests to execute/stay within expected env

### DIFF
--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -60,7 +60,7 @@ const defaultEnvVariables: SupportedEnvVariables = {
 	ARTIFACTS_PATH: path.join( process.cwd(), 'results' ),
 	TEST_ON_ATOMIC: false,
 	TEST_ON_JETPACK: false,
-	CALYPSO_BASE_URL: 'http://calypso.localhost:3000',
+	CALYPSO_BASE_URL: 'https://wordpress.com',
 };
 
 const castKnownEnvVariable = ( name: string, value: string ): EnvVariableValue => {

--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -60,7 +60,7 @@ const defaultEnvVariables: SupportedEnvVariables = {
 	ARTIFACTS_PATH: path.join( process.cwd(), 'results' ),
 	TEST_ON_ATOMIC: false,
 	TEST_ON_JETPACK: false,
-	CALYPSO_BASE_URL: 'https://wordpress.com',
+	CALYPSO_BASE_URL: 'http://calypso.localhost:3000',
 };
 
 const castKnownEnvVariable = ( name: string, value: string ): EnvVariableValue => {

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -8,7 +8,7 @@ type PlansGridVersion = 'current' | 'legacy';
 type PlansComparisonAction = 'show' | 'hide';
 
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
-export type Plans = 'start with a free site' | 'start with free' | 'Pro';
+export type Plans = 'start with a free site' | 'Pro';
 export type LegacyPlans = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
 export type PlansPageTab = 'My Plan' | 'Plans';
 export type PlanActionButton = 'Manage plan' | 'Upgrade';

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -124,6 +124,7 @@ skipDescribeIf( isStagingOrProd )(
 		describe( 'Validate site metadata', function () {
 			it( 'Return to Calypso dashboard', async function () {
 				editorPage = new EditorPage( page );
+				// Force the flow back into the configured environment for the test suite e.g. wpcalypso or calypso.localhost
 				editorPage.visit();
 				await editorPage.exitEditor();
 			} );
@@ -172,7 +173,7 @@ skipDescribeIf( isStagingOrProd )(
 
 			it( 'Keep free plan', async function () {
 				const signupPickPlanPage = new SignupPickPlanPage( page );
-				await signupPickPlanPage.selectPlan( 'start with free' );
+				await signupPickPlanPage.selectPlan( 'start with a free site' );
 			} );
 
 			it( 'Confirm site is launched', async function () {

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -22,9 +22,11 @@ import { skipDescribeIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
-const isStagingOrProd = DataHelper.getCalypsoURL()
-	.toLowerCase()
-	.includes( 'https://wordpress.com' );
+// const isStagingOrProd = DataHelper.getCalypsoURL()
+// 	.toLowerCase()
+// 	.includes( 'https://wordpress.com' );
+
+const isStagingOrProd = false;
 
 // Skipping while new onboarding flows are in transition and we map the new tests
 skipDescribeIf( isStagingOrProd )(
@@ -122,6 +124,7 @@ skipDescribeIf( isStagingOrProd )(
 		describe( 'Validate site metadata', function () {
 			it( 'Return to Calypso dashboard', async function () {
 				editorPage = new EditorPage( page );
+				editorPage.visit();
 				await editorPage.exitEditor();
 			} );
 

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -22,11 +22,9 @@ import { skipDescribeIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
-// const isStagingOrProd = DataHelper.getCalypsoURL()
-// 	.toLowerCase()
-// 	.includes( 'https://wordpress.com' );
-
-const isStagingOrProd = false;
+const isStagingOrProd = DataHelper.getCalypsoURL()
+	.toLowerCase()
+	.includes( 'https://wordpress.com' );
 
 // Skipping while new onboarding flows are in transition and we map the new tests
 skipDescribeIf( isStagingOrProd )(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While testing the e2e tests locally, we noticed that a redirect happens in one of the pre-release tests that forces the flow into production/staging (wordpress.com) despite being meant to execute within wpcalypso (or the local calypso instance). It appears the "redirection" happens when clicking on "Start writing" [in the onboarding-flow specs](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/specs/onboarding/signup__free.ts#L118).

If the understanding is correct, then it is ambiguous to have a test suite run in multiple environments (also contrary to expectation i.e. if some test suites are even blocked from executing in production/staging), and also impossible to run the tests locally without more complex network setup.

#### Media

Originally (with redirection):

![Kapture 2022-05-17 at 16 39 39](https://user-images.githubusercontent.com/1705499/168827569-693a1130-27a0-461a-9bb6-c2bc7c903886.gif)

^ Basically everything passed the redirect to wpcom executes on wpcom (not included in GIF)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* start Calyspo as normal
* follow [e2e setup guide](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e#quick-start) (steps 9 and forward)
* change [CALYPSO_BASE_URL](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/env-variables.ts#L63) to point to local calypso instance (`http://calypso.localhost:3000`)
* force [isStagingOrProd](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/specs/onboarding/signup__free.ts#L25) to be `false`
* execute the specs. from `test/e2e`:
    * may need to build the package: `yarn workspace @automattic/calypso-e2e build`
    * execute test suite: `yarn jest test/e2e/specs/onboarding/signup__free.ts`
* confirm that specs pass
* confirm that testing remains within `http://calypso.localhost:300`
    * there will be some redirection to wordpress.com (e.g. to confirm a site is launched), but it should always return to carry on against the local linstance

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
