### PR TITLE
Help Center: Help center in widgets editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -40,6 +40,7 @@ function HelpCenterContent() {
 				<>
 					<PinnedItems scope="core/edit-post">{ content }</PinnedItems>
 					<PinnedItems scope="core/edit-site">{ content }</PinnedItems>
+					<PinnedItems scope="core/edit-widgets">{ content }</PinnedItems>
 				</>
 			) }
 			{ show && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Added the help center to the widget editor

![image](https://user-images.githubusercontent.com/52076348/168648467-43ddc263-4380-4aed-bb37-fcae1c3f5dfe.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* checkout the branch
* `yarn dev --sync` from `apps/editing-toolkit`
* visit `wp-admin/widgets.php`
* verify that the help center is there

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63572
Fixes #63572
