### PR TITLE
Components: Refactor `TimeMismatchWarning` to `@testing-library/react`

### DIFF
--- a/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
+++ b/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
@@ -1,12 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TimeMismatchWarning to render if GMT offsets do not match 1`] = `
-<Component
-  onDismissClick={[Function]}
-  status="is-warning"
->
-  This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.
-</Component>
+<div>
+  <div
+    aria-label="Notice"
+    class="notice is-warning is-dismissable"
+    role="status"
+  >
+    <span
+      class="notice__icon-wrapper"
+    >
+      <span
+        class="notice__icon-wrapper-drop"
+      />
+      <svg
+        class="gridicon gridicons-notice notice__icon"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="gridicons.svg#gridicons-notice"
+        />
+      </svg>
+    </span>
+    <span
+      class="notice__content"
+    >
+      <span
+        class="notice__text"
+      >
+        This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.
+      </span>
+    </span>
+    <button
+      aria-label="Dismiss"
+      class="notice__dismiss"
+    >
+      <svg
+        class="gridicon gridicons-cross"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="gridicons.svg#gridicons-cross"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
 `;
 
 exports[`TimeMismatchWarning to render the passed site settings URL 1`] = `

--- a/client/blocks/time-mismatch-warning/test/index.jsx
+++ b/client/blocks/time-mismatch-warning/test/index.jsx
@@ -1,6 +1,7 @@
-/* eslint-disable no-irregular-whitespace */
-
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import { getPreference } from 'calypso/state/preferences/selectors';
@@ -22,11 +23,6 @@ jest.mock( 'calypso/state/preferences/selectors', () => ( {
 	hasReceivedRemotePreferences: jest.fn( () => true ),
 	getPreference: jest.fn( () => false ),
 } ) );
-jest.mock( 'calypso/components/notice', () => ( { status, onDismissClick, children } ) => (
-	<button className={ status } onClick={ onDismissClick }>
-		{ children }
-	</button>
-) );
 
 describe( 'TimeMismatchWarning', () => {
 	beforeAll( () => {
@@ -38,64 +34,62 @@ describe( 'TimeMismatchWarning', () => {
 	} );
 
 	test( 'to render nothing if no site ID is provided', () => {
-		const wrapper = shallow( <TimeMismatchWarning settingsUrl="https://example.com" /> );
-		expect( wrapper.isEmptyRender() ).toBeTruthy();
+		const { container } = render( <TimeMismatchWarning settingsUrl="https://example.com" /> );
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	test( 'to render nothing if no settings URL is provided', () => {
-		const wrapper = shallow( <TimeMismatchWarning siteId={ 1 } /> );
-		expect( wrapper.isEmptyRender() ).toBeTruthy();
+		const { container } = render( <TimeMismatchWarning siteId={ 1 } /> );
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	test( 'to render nothing if times match', () => {
-		const wrapper = shallow(
+		const { container } = render(
 			<TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" />
 		);
-		expect( wrapper.isEmptyRender() ).toBeTruthy();
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	test( 'to render nothing if the user preference is dismissed', () => {
 		getSiteGmtOffset.mockReturnValueOnce( 10 );
 		getPreference.mockReturnValueOnce( () => true );
-		const wrapper = shallow(
+		const { container } = render(
 			<TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" />
 		);
-		expect( wrapper.isEmptyRender() ).toBeTruthy();
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	test( 'to render if GMT offsets do not match', () => {
 		getSiteGmtOffset.mockReturnValueOnce( 10 );
-		const wrapper = shallow(
+		const { container } = render(
 			<TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" />
 		);
-		expect( wrapper ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'to render the passed site settings URL', () => {
 		const translate = jest.fn( ( text ) => text );
 		getSiteGmtOffset.mockReturnValueOnce( 10 );
 		useTranslate.mockImplementationOnce( () => translate );
-		shallow( <TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" /> );
+		render( <TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" /> );
 		expect( translate ).toMatchSnapshot();
 	} );
 
 	test( 'to render the status if set', () => {
 		getSiteGmtOffset.mockReturnValueOnce( 10 );
-		const wrapper = shallow(
+		const { container } = render(
 			<TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" status="is-error" />
 		);
-		expect( wrapper.dive().prop( 'className' ) ).toEqual( 'is-error' );
+		expect( container.firstChild ).toHaveClass( 'is-error' );
 	} );
 
 	test( 'to dispatch user preference setting on dismiss click', () => {
 		const dispatch = jest.fn( () => null );
 		useDispatch.mockReturnValueOnce( dispatch );
 		getSiteGmtOffset.mockReturnValueOnce( 10 );
-		const wrapper = shallow(
-			<TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" />
-		);
-		const onDismissClick = wrapper.prop( 'onDismissClick' );
-		onDismissClick();
+		render( <TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" /> );
+		const dismissButton = screen.getByRole( 'button' );
+		fireEvent.click( dismissButton );
 		expect( dispatch ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `TimeMismatchWarning` component to use `@testing-library/react` instead of `enzyme`.

Part of #63409.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/blocks/time-mismatch-warning/test/index.jsx`