### PR TITLE
Generated design picker: Use iframes for large previews

### DIFF
--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -55,6 +55,8 @@ export class WebPreviewModal extends Component {
 		frontPageMetaDescription: PropTypes.string,
 		// A post object used to override the selected post in the SEO preview
 		overridePost: PropTypes.object,
+		// Set height based on page content. This requires the page to post it's dimensions as message.
+		autoHeight: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -71,6 +73,7 @@ export class WebPreviewModal extends Component {
 		onEdit: noop,
 		hasSidebar: false,
 		overridePost: null,
+		autoHeight: false,
 	};
 
 	constructor( props ) {

--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -75,7 +75,6 @@ export class WebPreviewModal extends Component {
 		onEdit: noop,
 		hasSidebar: false,
 		overridePost: null,
-		fetchPriority: null,
 		autoHeight: false,
 	};
 

--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -55,6 +55,8 @@ export class WebPreviewModal extends Component {
 		frontPageMetaDescription: PropTypes.string,
 		// A post object used to override the selected post in the SEO preview
 		overridePost: PropTypes.object,
+		// iframe's fetchPriority.
+		fetchPriority: PropTypes.string,
 		// Set height based on page content. This requires the page to post it's dimensions as message.
 		autoHeight: PropTypes.bool,
 	};
@@ -73,6 +75,7 @@ export class WebPreviewModal extends Component {
 		onEdit: noop,
 		hasSidebar: false,
 		overridePost: null,
+		fetchPriority: null,
 		autoHeight: false,
 	};
 

--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -55,8 +55,6 @@ export class WebPreviewModal extends Component {
 		frontPageMetaDescription: PropTypes.string,
 		// A post object used to override the selected post in the SEO preview
 		overridePost: PropTypes.object,
-		// iframe's fetchPriority.
-		fetchPriority: PropTypes.string,
 		// Set height based on page content. This requires the page to post it's dimensions as message.
 		autoHeight: PropTypes.bool,
 	};
@@ -75,7 +73,6 @@ export class WebPreviewModal extends Component {
 		onEdit: noop,
 		hasSidebar: false,
 		overridePost: null,
-		fetchPriority: null,
 		autoHeight: false,
 	};
 

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -261,7 +261,7 @@ export default class WebPreviewContent extends Component {
 	}
 
 	render() {
-		const { translate, toolbarComponent: ToolbarComponent, fetchPriority, autoHeight } = this.props;
+		const { translate, toolbarComponent: ToolbarComponent, autoHeight } = this.props;
 		const isLoaded =
 			this.state.loaded && ( ! autoHeight || ( autoHeight && this.state.viewport !== null ) );
 
@@ -318,7 +318,6 @@ export default class WebPreviewContent extends Component {
 								src="about:blank"
 								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
 								title={ this.props.iframeTitle || translate( 'Preview' ) }
-								fetchpriority={ fetchPriority ? fetchPriority : undefined }
 								scrolling={ autoHeight ? 'no' : undefined }
 							/>
 						</div>
@@ -393,8 +392,6 @@ WebPreviewContent.propTypes = {
 	overridePost: PropTypes.object,
 	// A customized Toolbar element
 	toolbarComponent: PropTypes.elementType,
-	// iframe's fetchPriority.
-	fetchPriority: PropTypes.string,
 	// Set height based on page content. This requires the page to post it's dimensions as message.
 	autoHeight: PropTypes.bool,
 };
@@ -419,6 +416,5 @@ WebPreviewContent.defaultProps = {
 	isModalWindow: false,
 	overridePost: null,
 	toolbarComponent: Toolbar,
-	fetchPriority: null,
 	autoHeight: false,
 };

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -22,6 +22,7 @@ export default class WebPreviewContent extends Component {
 	state = {
 		iframeUrl: null,
 		device: this.props.defaultViewportDevice || 'computer',
+		viewport: null,
 		loaded: false,
 		isLoadingSubpage: false,
 	};
@@ -103,6 +104,11 @@ export default class WebPreviewContent extends Component {
 				return;
 			case 'loading':
 				this.setState( { isLoadingSubpage: true } );
+				return;
+			case 'page-dimensions-on-load':
+				if ( this.props.autoHeight ) {
+					this.setState( { viewport: data.payload } );
+				}
 				return;
 		}
 	};
@@ -289,7 +295,10 @@ export default class WebPreviewContent extends Component {
 				/>
 				{ this.props.belowToolbar }
 				{ ( ! this.state.loaded || this.state.isLoadingSubpage ) && <SpinnerLine /> }
-				<div className="web-preview__placeholder">
+				<div
+					className="web-preview__placeholder"
+					style={ this.state.viewport ? { minHeight: this.state.viewport.height } : null }
+				>
 					{ showLoadingMessage && (
 						<div className="web-preview__loading-message-wrapper">
 							<span className="web-preview__loading-message">{ this.props.loadingMessage }</span>
@@ -307,6 +316,7 @@ export default class WebPreviewContent extends Component {
 								src="about:blank"
 								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
 								title={ this.props.iframeTitle || translate( 'Preview' ) }
+								scrolling={ this.props.autoHeight ? 'no' : undefined }
 							/>
 						</div>
 					) }
@@ -380,6 +390,8 @@ WebPreviewContent.propTypes = {
 	overridePost: PropTypes.object,
 	// A customized Toolbar element
 	toolbarComponent: PropTypes.elementType,
+	// Set height based on page content. This requires the page to post it's dimensions as message.
+	autoHeight: PropTypes.bool,
 };
 
 WebPreviewContent.defaultProps = {
@@ -402,4 +414,5 @@ WebPreviewContent.defaultProps = {
 	isModalWindow: false,
 	overridePost: null,
 	toolbarComponent: Toolbar,
+	autoHeight: false,
 };

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -261,7 +261,7 @@ export default class WebPreviewContent extends Component {
 	}
 
 	render() {
-		const { translate, toolbarComponent: ToolbarComponent, autoHeight } = this.props;
+		const { translate, toolbarComponent: ToolbarComponent, fetchPriority, autoHeight } = this.props;
 		const isLoaded =
 			this.state.loaded && ( ! autoHeight || ( autoHeight && this.state.viewport !== null ) );
 
@@ -318,6 +318,7 @@ export default class WebPreviewContent extends Component {
 								src="about:blank"
 								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
 								title={ this.props.iframeTitle || translate( 'Preview' ) }
+								fetchpriority={ fetchPriority ? fetchPriority : undefined }
 								scrolling={ autoHeight ? 'no' : undefined }
 							/>
 						</div>
@@ -392,6 +393,8 @@ WebPreviewContent.propTypes = {
 	overridePost: PropTypes.object,
 	// A customized Toolbar element
 	toolbarComponent: PropTypes.elementType,
+	// iframe's fetchPriority.
+	fetchPriority: PropTypes.string,
 	// Set height based on page content. This requires the page to post it's dimensions as message.
 	autoHeight: PropTypes.bool,
 };
@@ -416,5 +419,6 @@ WebPreviewContent.defaultProps = {
 	isModalWindow: false,
 	overridePost: null,
 	toolbarComponent: Toolbar,
+	fetchPriority: null,
 	autoHeight: false,
 };

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -261,7 +261,9 @@ export default class WebPreviewContent extends Component {
 	}
 
 	render() {
-		const { translate, toolbarComponent: ToolbarComponent } = this.props;
+		const { translate, toolbarComponent: ToolbarComponent, fetchPriority, autoHeight } = this.props;
+		const isLoaded =
+			this.state.loaded && ( ! autoHeight || ( autoHeight && this.state.viewport !== null ) );
 
 		const className = classNames( this.props.className, 'web-preview__inner', {
 			'is-touch': hasTouch(),
@@ -271,11 +273,11 @@ export default class WebPreviewContent extends Component {
 			'is-tablet': this.state.device === 'tablet',
 			'is-phone': this.state.device === 'phone',
 			'is-seo': this.state.device === 'seo',
-			'is-loaded': this.state.loaded,
+			'is-loaded': isLoaded,
 		} );
 
 		const showLoadingMessage =
-			! this.state.loaded &&
+			! isLoaded &&
 			this.props.loadingMessage &&
 			( this.props.showPreview || ! this.props.isModalWindow ) &&
 			this.state.device !== 'seo';
@@ -294,7 +296,7 @@ export default class WebPreviewContent extends Component {
 					isLoading={ this.state.isLoadingSubpage }
 				/>
 				{ this.props.belowToolbar }
-				{ ( ! this.state.loaded || this.state.isLoadingSubpage ) && <SpinnerLine /> }
+				{ ( ! isLoaded || this.state.isLoadingSubpage ) && <SpinnerLine /> }
 				<div
 					className="web-preview__placeholder"
 					style={ this.state.viewport ? { minHeight: this.state.viewport.height } : null }
@@ -316,7 +318,8 @@ export default class WebPreviewContent extends Component {
 								src="about:blank"
 								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
 								title={ this.props.iframeTitle || translate( 'Preview' ) }
-								scrolling={ this.props.autoHeight ? 'no' : undefined }
+								fetchpriority={ fetchPriority ? fetchPriority : undefined }
+								scrolling={ autoHeight ? 'no' : undefined }
 							/>
 						</div>
 					) }
@@ -390,6 +393,8 @@ WebPreviewContent.propTypes = {
 	overridePost: PropTypes.object,
 	// A customized Toolbar element
 	toolbarComponent: PropTypes.elementType,
+	// iframe's fetchPriority.
+	fetchPriority: PropTypes.string,
 	// Set height based on page content. This requires the page to post it's dimensions as message.
 	autoHeight: PropTypes.bool,
 };
@@ -414,5 +419,6 @@ WebPreviewContent.defaultProps = {
 	isModalWindow: false,
 	overridePost: null,
 	toolbarComponent: Toolbar,
+	fetchPriority: null,
 	autoHeight: false,
 };

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -262,8 +262,7 @@ export default class WebPreviewContent extends Component {
 
 	render() {
 		const { translate, toolbarComponent: ToolbarComponent, fetchPriority, autoHeight } = this.props;
-		const isLoaded =
-			this.state.loaded && ( ! autoHeight || ( autoHeight && this.state.viewport !== null ) );
+		const isLoaded = this.state.loaded && ( ! autoHeight || this.state.viewport !== null );
 
 		const className = classNames( this.props.className, 'web-preview__inner', {
 			'is-touch': hasTouch(),
@@ -419,6 +418,5 @@ WebPreviewContent.defaultProps = {
 	isModalWindow: false,
 	overridePost: null,
 	toolbarComponent: Toolbar,
-	fetchPriority: null,
 	autoHeight: false,
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -1,0 +1,61 @@
+import { getDesignPreviewUrl } from '@automattic/design-picker';
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import WebPreview from 'calypso/components/web-preview/content';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import PreviewToolbar from './preview-toolbar';
+import type { Design } from '@automattic/design-picker';
+
+interface Site {
+	ID: string;
+	URL: string;
+}
+
+interface GeneratedDesignPickerWebPreview {
+	site?: Site;
+	design: Design;
+	locale: string;
+	verticalId: string;
+	isSelected: boolean;
+	isPrivateAtomic: boolean;
+	translate: ReturnType< typeof useTranslate >;
+	recordTracksEvent: typeof recordTracksEvent;
+}
+
+const GeneratedDesignPickerWebPreview: ReactFC< GeneratedDesignWebPreviewProps > = ( {
+	site,
+	design,
+	locale,
+	verticalId,
+	isSelected,
+	isPrivateAtomic,
+	translate,
+	recordTracksEvent,
+} ) => {
+	return (
+		<WebPreview
+			className={ classnames( { 'is-selected': isSelected } ) }
+			showPreview
+			showClose={ false }
+			showEdit={ false }
+			showDeviceSwitcher={ false }
+			previewUrl={ getDesignPreviewUrl( design, {
+				language: locale,
+				verticalId,
+			} ) }
+			loadingMessage={ translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
+				components: { strong: <strong /> },
+			} ) }
+			toolbarComponent={ PreviewToolbar }
+			fetchPriority={ isSelected ? 'high' : 'low' }
+			autoHeight
+			siteId={ site?.ID }
+			url={ site?.URL }
+			isPrivateAtomic={ isPrivateAtomic }
+			translate={ translate }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default GeneratedDesignPickerWebPreview;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -13,7 +13,6 @@ interface GeneratedDesignPickerWebPreviewProps {
 	verticalId: string;
 	isSelected: boolean;
 	isPrivateAtomic: boolean;
-	translate: ReturnType< typeof useTranslate >;
 	recordTracksEvent: ( eventName: string, eventProperties: object ) => void;
 }
 
@@ -24,9 +23,10 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 	verticalId,
 	isSelected,
 	isPrivateAtomic,
-	translate,
 	recordTracksEvent,
 } ) => {
+	const translate = useTranslate();
+
 	return (
 		<WebPreview
 			className={ classnames( { 'is-selected': isSelected } ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -2,24 +2,19 @@ import { getDesignPreviewUrl } from '@automattic/design-picker';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import WebPreview from 'calypso/components/web-preview/content';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import PreviewToolbar from './preview-toolbar';
+import type { SiteDetails } from '@automattic/data-stores';
 import type { Design } from '@automattic/design-picker';
 
-interface Site {
-	ID: string;
-	URL: string;
-}
-
 interface GeneratedDesignPickerWebPreviewProps {
-	site?: Site;
+	site?: SiteDetails | null;
 	design: Design;
 	locale: string;
 	verticalId: string;
 	isSelected: boolean;
 	isPrivateAtomic: boolean;
 	translate: ReturnType< typeof useTranslate >;
-	recordTracksEvent: typeof recordTracksEvent;
+	recordTracksEvent: ( eventName: string, eventProperties: object ) => void;
 }
 
 const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreviewProps > = ( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -11,7 +11,7 @@ interface Site {
 	URL: string;
 }
 
-interface GeneratedDesignPickerWebPreview {
+interface GeneratedDesignPickerWebPreviewProps {
 	site?: Site;
 	design: Design;
 	locale: string;
@@ -22,7 +22,7 @@ interface GeneratedDesignPickerWebPreview {
 	recordTracksEvent: typeof recordTracksEvent;
 }
 
-const GeneratedDesignPickerWebPreview: ReactFC< GeneratedDesignWebPreviewProps > = ( {
+const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreviewProps > = ( {
 	site,
 	design,
 	locale,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -104,7 +104,12 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	const selectedGeneratedDesign = ! isMobile
 		? selectedDesign || shuffledGeneratedDesigns[ 0 ]
 		: undefined;
+
 	const visibility = useNewSiteVisibility();
+	const previewLoadingMessage = translate(
+		'{{strong}}One moment, please…{{/strong}} loading your site.',
+		{ components: { strong: <strong /> } }
+	);
 
 	function headerText() {
 		if ( showGeneratedDesigns ) {
@@ -303,9 +308,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 				externalUrl={ siteSlug }
 				showExternal={ true }
 				previewUrl={ previewUrl }
-				loadingMessage={ translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
-					components: { strong: <strong /> },
-				} ) }
+				loadingMessage={ previewLoadingMessage }
 				toolbarComponent={ PreviewToolbar }
 				siteId={ site?.ID }
 				isPrivateAtomic={ isPrivateAtomic }
@@ -358,9 +361,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 					language: locale,
 					verticalId: siteVerticalId,
 				} ) }
-				loadingMessage={ translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
-					components: { strong: <strong /> },
-				} ) }
+				loadingMessage={ previewLoadingMessage }
 				toolbarComponent={ PreviewToolbar }
 				autoHeight
 				siteId={ site?.ID }
@@ -422,35 +423,32 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 			designs={ shuffledGeneratedDesigns }
 			verticalId={ siteVerticalId }
 			locale={ locale }
-			previews={ shuffledGeneratedDesigns.map( ( design ) => (
-				<WebPreview
-					key={ design.slug }
-					className={ classnames( {
-						'is-selected': design.slug === selectedGeneratedDesign?.slug,
-					} ) }
-					showPreview
-					showClose={ false }
-					showEdit={ false }
-					showDeviceSwitcher={ false }
-					previewUrl={ getDesignPreviewUrl( design, {
-						language: locale,
-						verticalId: siteVerticalId,
-					} ) }
-					loadingMessage={ translate(
-						'{{strong}}One moment, please…{{/strong}} loading your site.',
-						{
-							components: { strong: <strong /> },
-						}
-					) }
-					toolbarComponent={ PreviewToolbar }
-					autoHeight
-					siteId={ site?.ID }
-					url={ site?.URL }
-					isPrivateAtomic={ isPrivateAtomic }
-					translate={ translate }
-					recordTracksEvent={ recordTracksEvent }
-				/>
-			) ) }
+			previews={ shuffledGeneratedDesigns.map( ( design ) => {
+				const isSelected = design.slug === selectedGeneratedDesign?.slug;
+				return (
+					<WebPreview
+						key={ design.slug }
+						className={ classnames( { 'is-selected': isSelected } ) }
+						showPreview
+						showClose={ false }
+						showEdit={ false }
+						showDeviceSwitcher={ false }
+						previewUrl={ getDesignPreviewUrl( design, {
+							language: locale,
+							verticalId: siteVerticalId,
+						} ) }
+						loadingMessage={ previewLoadingMessage }
+						fetchPriority={ isSelected ? 'high' : 'low' }
+						toolbarComponent={ PreviewToolbar }
+						autoHeight
+						siteId={ site?.ID }
+						url={ site?.URL }
+						isPrivateAtomic={ isPrivateAtomic }
+						translate={ translate }
+						recordTracksEvent={ recordTracksEvent }
+					/>
+				);
+			} ) }
 			heading={
 				<div className={ classnames( 'step-container__header', 'design-setup__header' ) }>
 					{ heading }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -4,7 +4,6 @@ import { Button } from '@automattic/components';
 import { useVerticalImagesQuery } from '@automattic/data-stores';
 import DesignPicker, {
 	GeneratedDesignPicker,
-	GeneratedDesignPreview,
 	PremiumBadge,
 	useCategorization,
 	isBlankCanvasDesign,
@@ -349,13 +348,26 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	function previewGeneratedDesign( design: Design ) {
 		const stepContent = (
-			<GeneratedDesignPreview
-				slug={ design.slug }
+			<WebPreview
+				key={ design.slug }
+				showPreview
+				showClose={ false }
+				showEdit={ false }
+				showDeviceSwitcher={ false }
 				previewUrl={ getDesignPreviewUrl( design, {
 					language: locale,
 					verticalId: siteVerticalId,
 				} ) }
-				isSelected
+				loadingMessage={ translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
+					components: { strong: <strong /> },
+				} ) }
+				toolbarComponent={ PreviewToolbar }
+				autoHeight
+				siteId={ site?.ID }
+				url={ site?.URL }
+				isPrivateAtomic={ isPrivateAtomic }
+				translate={ translate }
+				recordTracksEvent={ recordTracksEvent }
 			/>
 		);
 
@@ -410,6 +422,35 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 			designs={ shuffledGeneratedDesigns }
 			verticalId={ siteVerticalId }
 			locale={ locale }
+			previews={ shuffledGeneratedDesigns.map( ( design ) => (
+				<WebPreview
+					key={ design.slug }
+					className={ classnames( {
+						'is-selected': design.slug === selectedGeneratedDesign?.slug,
+					} ) }
+					showPreview
+					showClose={ false }
+					showEdit={ false }
+					showDeviceSwitcher={ false }
+					previewUrl={ getDesignPreviewUrl( design, {
+						language: locale,
+						verticalId: siteVerticalId,
+					} ) }
+					loadingMessage={ translate(
+						'{{strong}}One moment, please…{{/strong}} loading your site.',
+						{
+							components: { strong: <strong /> },
+						}
+					) }
+					toolbarComponent={ PreviewToolbar }
+					autoHeight
+					siteId={ site?.ID }
+					url={ site?.URL }
+					isPrivateAtomic={ isPrivateAtomic }
+					translate={ translate }
+					recordTracksEvent={ recordTracksEvent }
+				/>
+			) ) }
 			heading={
 				<div className={ classnames( 'step-container__header', 'design-setup__header' ) }>
 					{ heading }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -99,7 +99,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		useGeneratedDesignsQuery();
 
 	const shuffledGeneratedDesigns = useMemo(
-		() => shuffle( generatedDesigns ).slice( 0, 3 ),
+		() => shuffle( generatedDesigns ),
 		[ generatedDesigns ]
 	);
 
@@ -387,7 +387,6 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 					verticalId={ siteVerticalId }
 					isSelected={ design.slug === selectedGeneratedDesign?.slug }
 					isPrivateAtomic={ isPrivateAtomic }
-					translate={ translate }
 					recordTracksEvent={ recordTracksEvent }
 				/>
 			) ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -96,6 +96,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	const { data: generatedDesigns = [], isLoading: isLoadingGeneratedDesigns } =
 		useGeneratedDesignsQuery();
+
 	const shuffledGeneratedDesigns = useMemo(
 		() => shuffle( generatedDesigns ),
 		[ generatedDesigns ]
@@ -108,8 +109,8 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	const isPreviewingGeneratedDesign =
 		isMobile && showGeneratedDesigns && selectedDesign && isPreviewingDesign;
-	const visibility = useNewSiteVisibility();
 
+	const visibility = useNewSiteVisibility();
 	const previewLoadingMessage = translate(
 		'{{strong}}One moment, please…{{/strong}} loading your site.',
 		{ components: { strong: <strong /> } }
@@ -393,7 +394,6 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 							verticalId: siteVerticalId,
 						} ) }
 						loadingMessage={ previewLoadingMessage }
-						fetchPriority={ isSelected ? 'high' : 'low' }
 						toolbarComponent={ PreviewToolbar }
 						autoHeight
 						siteId={ site?.ID }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -28,6 +28,7 @@ import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../../../../stores';
 import { ANCHOR_FM_THEMES } from './anchor-fm-themes';
 import { getCategorizationOptions } from './categories';
+import GeneratedDesignPickerWebPreview from './generated-design-picker-web-preview';
 import PreviewToolbar from './preview-toolbar';
 import StickyFooter from './sticky-footer';
 import type { Step } from '../../types';
@@ -379,31 +380,19 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 			designs={ shuffledGeneratedDesigns }
 			verticalId={ siteVerticalId }
 			locale={ locale }
-			previews={ shuffledGeneratedDesigns.map( ( design ) => {
-				const isSelected = design.slug === selectedGeneratedDesign?.slug;
-				return (
-					<WebPreview
-						key={ design.slug }
-						className={ classnames( { 'is-selected': isSelected } ) }
-						showPreview
-						showClose={ false }
-						showEdit={ false }
-						showDeviceSwitcher={ false }
-						previewUrl={ getDesignPreviewUrl( design, {
-							language: locale,
-							verticalId: siteVerticalId,
-						} ) }
-						loadingMessage={ previewLoadingMessage }
-						toolbarComponent={ PreviewToolbar }
-						autoHeight
-						siteId={ site?.ID }
-						url={ site?.URL }
-						isPrivateAtomic={ isPrivateAtomic }
-						translate={ translate }
-						recordTracksEvent={ recordTracksEvent }
-					/>
-				);
-			} ) }
+			previews={ shuffledGeneratedDesigns.map( ( design ) => (
+				<GeneratedDesignPickerWebPreview
+					key={ design.slug }
+					site={ site }
+					design={ design }
+					locale={ locale }
+					verticalId={ siteVerticalId }
+					isSelected={ design.slug === selectedGeneratedDesign?.slug }
+					isPrivateAtomic={ isPrivateAtomic }
+					translate={ translate }
+					recordTracksEvent={ recordTracksEvent }
+				/>
+			) ) }
 			heading={
 				<div className={ classnames( 'step-container__header', 'design-setup__header' ) }>
 					{ heading }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -99,7 +99,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		useGeneratedDesignsQuery();
 
 	const shuffledGeneratedDesigns = useMemo(
-		() => shuffle( generatedDesigns ),
+		() => shuffle( generatedDesigns ).slice( 0, 3 ),
 		[ generatedDesigns ]
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -112,10 +112,6 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		isMobile && showGeneratedDesigns && selectedDesign && isPreviewingDesign;
 
 	const visibility = useNewSiteVisibility();
-	const previewLoadingMessage = translate(
-		'{{strong}}One moment, please…{{/strong}} loading your site.',
-		{ components: { strong: <strong /> } }
-	);
 
 	function headerText() {
 		if ( showGeneratedDesigns ) {
@@ -314,7 +310,9 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 				externalUrl={ siteSlug }
 				showExternal={ true }
 				previewUrl={ previewUrl }
-				loadingMessage={ previewLoadingMessage }
+				loadingMessage={ translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
+					components: { strong: <strong /> },
+				} ) }
 				toolbarComponent={ PreviewToolbar }
 				siteId={ site?.ID }
 				isPrivateAtomic={ isPrivateAtomic }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -447,6 +447,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 				opacity: 1;
 				pointer-events: auto;
 				position: relative;
+				z-index: 1;
 			}
 
 			.preview-toolbar__browser-header {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -301,21 +301,39 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 			margin: 0;
 		}
 
-		.design-setup__content {
-			height: calc( 100vh - 157px );
-			margin-top: 48px;
+		.step-container__content {
+			height: calc( 100vh - 172px );
+			margin-top: 32px;
 			overflow: scroll;
 			padding: 0 24px;
+
+			.web-preview__inner {
+				transform: none;
+			}
 		}
 
-		.generated-design-preview__frame {
-			max-height: none;
-			margin-bottom: 24px;
+		.web-preview__inner {
+			.preview-toolbar__browser-header {
+				height: 23px;
 
-			.mshots-image__container {
-				object-fit: cover;
-				object-position: top;
-				width: 100%;
+				svg {
+					height: 6px;
+					left: 12px;
+
+					rect {
+						height: 6px;
+						rx: 3px;
+						width: 6px;
+
+						&:nth-child( 2 ) {
+							x: 12px;
+						}
+
+						&:nth-child( 3 ) {
+							x: 24px;
+						}
+					}
+				}
 			}
 		}
 	}
@@ -413,9 +431,31 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 	.generated-design-picker__previews {
 		display: none;
+		position: relative;
 
-		.mshots-image__container {
-			width: 100%;
+		.web-preview__inner {
+			opacity: 0;
+			left: 0;
+			overflow: hidden;
+			pointer-events: none;
+			position: absolute;
+			right: 0;
+			top: 0;
+			transition: opacity 0.15s ease-in-out;
+
+			&.is-selected {
+				opacity: 1;
+				pointer-events: auto;
+				position: relative;
+			}
+
+			.preview-toolbar__browser-header {
+				height: 34px;
+
+				svg {
+					left: 12px;
+				}
+			}
 		}
 
 		@include break-small {
@@ -433,5 +473,27 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		line-height: 1.25rem;
 		margin: 8px 0;
 		width: 100%;
+	}
+
+	.step-container__content {
+		.web-preview__inner {
+			.web-preview__placeholder {
+				border: 1px solid rgba( 0, 0, 0, 0.12 );
+				/* stylelint-disable-next-line scales/radii */
+				border-radius: 0 0 6px 6px;
+				border-width: 0 1px 1px;
+				box-sizing: border-box;
+				overflow: hidden;
+			}
+
+			.web-preview__frame {
+				border: 0;
+				overflow: hidden;
+			}
+
+			.spinner-line {
+				display: none;
+			}
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -294,6 +294,22 @@ $design-button-primary-color: rgb( 17, 122, 201 );
  * Generated Design Picker
  */
 .design-picker__is-generated {
+	&.design-picker__is-generated-previewing {
+		.design-setup__header,
+		.generated-design-picker__thumbnails {
+			display: none;
+
+			@include break-small {
+				display: flex;
+			}
+		}
+
+		.generated-design-picker__previews {
+			height: auto;
+			min-height: calc( 100vh - 172px );
+		}
+	}
+
 	&.design-setup__preview {
 		padding: 0;
 
@@ -397,6 +413,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 			&.is-visible {
 				opacity: 1;
 				transform: translateY( 0 );
+				z-index: 1;
 
 				.design-setup__footer-inner {
 					pointer-events: auto;
@@ -430,7 +447,12 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 	}
 
 	.generated-design-picker__previews {
-		display: none;
+		display: flex;
+		height: 0;
+		flex: 1;
+		flex-direction: column;
+		row-gap: 24px;
+		margin-bottom: 44px;
 		position: relative;
 
 		.web-preview__inner {
@@ -460,11 +482,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		}
 
 		@include break-small {
-			display: flex;
-			flex: 1;
-			flex-direction: column;
-			row-gap: 24px;
-			margin-bottom: 44px;
+			height: auto;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -307,6 +307,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		.generated-design-picker__previews {
 			height: auto;
 			min-height: calc( 100vh - 172px );
+			margin-bottom: 84px;
 		}
 	}
 
@@ -478,6 +479,11 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 				svg {
 					left: 12px;
 				}
+			}
+
+			.web-preview__placeholder {
+				flex: 0;
+				min-height: 80vh;
 			}
 		}
 

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -7,15 +7,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { getDesignPreviewUrl, getMShotOptions } from '../utils';
 import type { Design } from '../types';
-import type { MShotsOptions } from '@automattic/onboarding';
 import './style.scss';
-
-const previewImageOptions: MShotsOptions = {
-	vpw: 1600,
-	vph: 1040,
-	w: 2399,
-	screen_height: 3600,
-};
 
 interface GeneratedDesignThumbnailProps {
 	slug: string;
@@ -60,44 +52,10 @@ const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
 	);
 };
 
-interface GeneratedDesignPreviewProps {
-	slug: string;
-	previewUrl: string;
-	isSelected: boolean;
-}
-
-const GeneratedDesignPreview: React.FC< GeneratedDesignPreviewProps > = ( {
-	slug,
-	previewUrl,
-	isSelected,
-} ) => {
-	return (
-		<div className={ classnames( 'generated-design-preview', { 'is-selected': isSelected } ) }>
-			<div className="generated-design-preview__header">
-				<svg width="36" height="8">
-					<g>
-						<rect width="8" height="8" rx="4" />
-						<rect x="14" width="8" height="8" rx="4" />
-						<rect x="28" width="8" height="8" rx="4" />
-					</g>
-				</svg>
-			</div>
-			<div className="generated-design-preview__frame">
-				<MShotsImage
-					url={ previewUrl }
-					alt=""
-					aria-labelledby={ `generated-design-preview__image__${ slug }` }
-					options={ previewImageOptions }
-					scrollable={ false }
-				/>
-			</div>
-		</div>
-	);
-};
-
 export interface GeneratedDesignPickerProps {
 	selectedDesign?: Design;
 	designs: Design[];
+	previews: React.ReactElement[];
 	verticalId: string;
 	locale: string;
 	heading?: React.ReactElement;
@@ -109,6 +67,7 @@ export interface GeneratedDesignPickerProps {
 const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 	selectedDesign,
 	designs,
+	previews,
 	verticalId,
 	locale,
 	heading,
@@ -137,21 +96,11 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 						{ __( 'View more options' ) }
 					</Button>
 				</div>
-				<div className="generated-design-picker__previews">
-					{ designs &&
-						designs.map( ( design ) => (
-							<GeneratedDesignPreview
-								key={ design.slug }
-								slug={ design.slug }
-								isSelected={ selectedDesign?.slug === design.slug }
-								previewUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
-							/>
-						) ) }
-				</div>
+				<div className="generated-design-picker__previews">{ previews }</div>
 			</div>
 			{ footer }
 		</div>
 	);
 };
 
-export { GeneratedDesignPicker as default, GeneratedDesignPreview };
+export default GeneratedDesignPicker;

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -1,5 +1,5 @@
 export { default } from './components';
-export { default } from './components/generated-design-picker';
+export { default as GeneratedDesignPicker } from './components/generated-design-picker';
 export { default as FeaturedPicksButtons } from './components/featured-picks-buttons';
 export { default as PremiumBadge } from './components/premium-badge';
 export {

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -1,9 +1,5 @@
 export { default } from './components';
-export {
-	default as GeneratedDesignPicker,
-	GeneratedDesignPreview,
-} from './components/generated-design-picker';
-
+export { default } from './components/generated-design-picker';
 export { default as FeaturedPicksButtons } from './components/featured-picks-buttons';
 export { default as PremiumBadge } from './components/premium-badge';
 export {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR replaces mShots with iframes for large design previews. As part of the design spec, we want to show the full design by scrolling the page, and not the iframe itself. To accomplish this, we added a message event handler which receives the page dimensions from the embedded site and resize the iframe's height using this payload.

Another thing we set out to do is to try to load as much of the iframes as early as possible, so that users can switch designs without needing to wait for the iframe to load each time. As an optimization, we load every iframe on page initialization and prioritize loading on the iframe users will see first.

Figma file for reference: 42PgVsdlQ1v2wpk6lmmrnq-fi-1601%3A59509
Loom recording for reference: https://www.loom.com/share/d2353287b0c646cf9d028796cf13d195 

CAVEAT: Currently there are a lot of designs, which means a lot of iframes loading in parallel. Once we only have three designs, I expect the iframe load time to improve.

![Screen Shot 2022-05-19 at 5 04 28 PM](https://user-images.githubusercontent.com/797888/169256652-61d15c0a-3f96-4a42-99ae-c02689136bfe.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/vertical?siteSlug=${site_slug}` and make sure your site has a vertical set (I recommend Arts & Entertainment)
* Head to `/setup/intent?siteSlug=${site_slug}` and click on the "Start building" button.
* You should now land on the generated design picker screen.
* The design previews should now load in iframes.
  * Before done loading, they will show a loading message. 
  * After done loading, they will resize to the design's height.
* Also test that it works as per design in the mobile view.
* Also test switching to the traditional design picker and confirm it's working as before.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->