### PR TITLE
Filter out installed plugins from the Plugins landing page

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -514,6 +514,11 @@ const PluginSingleListView = ( {
 	if ( domain ) {
 		listLink = '/plugins/' + category + '/' + domain;
 	}
+
+	if ( ! isFetching && plugins.length === 0 ) {
+		return null;
+	}
+
 	return (
 		<PluginsBrowserList
 			plugins={ plugins.slice( 0, SHORT_LIST_LENGTH ) }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -43,7 +43,7 @@ import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
-import { getPlugins, getPluginsOnSites } from 'calypso/state/plugins/installed/selectors';
+import { getPlugins } from 'calypso/state/plugins/installed/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
@@ -487,9 +487,6 @@ const PluginSingleListView = ( {
 	const installedPlugins = useSelector( ( state ) =>
 		getPlugins( state, siteObjectsToSiteIds( sites ) )
 	);
-	const aggregatedInstalledPlugins = useSelector( ( state ) =>
-		getPluginsOnSites( state, installedPlugins )
-	);
 
 	let plugins;
 	let isFetching;
@@ -508,7 +505,7 @@ const PluginSingleListView = ( {
 
 	plugins = plugins
 		.filter( isNotBlocked )
-		.filter( ( plugin ) => isNotInstalled( plugin, aggregatedInstalledPlugins ) );
+		.filter( ( plugin ) => isNotInstalled( plugin, installedPlugins ) );
 
 	let listLink = '/plugins/' + category;
 	if ( domain ) {
@@ -692,7 +689,7 @@ function isNotBlocked( plugin ) {
  * @returns Boolean weather a plugin is not installed on not
  */
 function isNotInstalled( plugin, installedPlugins ) {
-	return ! installedPlugins[ plugin.slug ];
+	return ! installedPlugins.find( ( item ) => item.slug === plugin.slug );
 }
 
 export default PluginsBrowser;

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -43,7 +43,7 @@ import { updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
-import { getPlugins } from 'calypso/state/plugins/installed/selectors';
+import { getPlugins, isEqualSlugOrId } from 'calypso/state/plugins/installed/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
@@ -689,7 +689,9 @@ function isNotBlocked( plugin ) {
  * @returns Boolean weather a plugin is not installed on not
  */
 function isNotInstalled( plugin, installedPlugins ) {
-	return ! installedPlugins.find( ( item ) => item.slug === plugin.slug );
+	return ! installedPlugins.find( ( installedPlugin ) =>
+		isEqualSlugOrId( plugin.slug, installedPlugin )
+	);
 }
 
 export default PluginsBrowser;


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Filter out installed plugins from the main Browser Plugins page
* Hide the entire section when there is no plugin to show

## Testing instructions
* Go to `/plugins` page
* Check if you have installed plugins (if don't, install some)
* You shouldn't see the installed plugins on the plugins lists.
* They should be hidden.
* Try install all plugins of a given section (editor's pick will be the easiest one)
*  Go to the landing page again
* The entire section should be hidden


| Old version (production) | Filtering out installed plugins|
| ------------- |------------- |
|<img width="982" alt="Screen Shot 2022-05-16 at 12 45 21" src="https://user-images.githubusercontent.com/5039531/168675893-b2d9c653-ee8d-46b2-91b3-0f3ea2f775b1.png">|<img width="982" alt="Screen Shot 2022-05-16 at 12 41 57" src="https://user-images.githubusercontent.com/5039531/168676037-e4217cf5-a616-4744-8ab1-8ddbf634ea38.png">|

---

Fixes #62205
