### PR TITLE
Jetpack Cloud: Control DisplayPrice text direction with CSS

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -55,25 +55,19 @@ const Paid: React.FC< OwnProps > = ( {
 		 */
 		return (
 			<>
-				<span dir="ltr">
-					<PlanPrice
-						original
-						className="display-price__original-price"
-						rawPrice={ originalPrice as number }
-						currencyCode={ currencyCode }
-					/>
-				</span>
-				<span dir="ltr">
-					<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
-				</span>
+				<PlanPrice
+					original
+					className="display-price__original-price"
+					rawPrice={ originalPrice as number }
+					currencyCode={ currencyCode }
+				/>
+				<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
 			</>
 		);
 	};
 
 	const renderNonDiscountedPrice = () => (
-		<span dir="ltr">
-			<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
-		</span>
+		<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
 	);
 
 	const renderPrice = () =>

--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -39,6 +39,12 @@
 
 	.plan-price {
 		display: inline-flex;
+
+		// inline-flex causes *everything* to flow right-to-left in right-to-left locales,
+		// so we override currency displays by setting the direction explicitly
+		/* rtl:ignore */
+		direction: ltr;
+
 		color: var( --studio-gray-100 );
 
 		&.display-price__original-price {


### PR DESCRIPTION
Resolves `1164141197617539-as-1200899033701474`.

#### Changes proposed in this Pull Request

* Remove the explicit `dir="ltr"` attribute from spans in the `PlanPrice` component, as they are not necessary in most cases.
* Add a CSS rule to the `.plan-price` class when rendered as part of a `JetpackProductCard` component, to force left-to-right flow of elements that make up a price. This is necessary because the `.plan-price` class is rendered with `display: inline-flex`, which overrides the browser's default page flow. For more info, see the following CodePen: https://codepen.io/mattgawarecki/pen/WNMRYZV

#### Testing instructions

***Regression testing:** All pages should render exactly as they do in production currently.*

* Visit the pricing page on:
  * Calypso Blue (`/plans/:site`);
  * Calypso Green (`/pricing`); and
  * Jetpack Connect (`/connect/jetpack/store`).
* Test how the prices on these pages render for locales that use right-to-left text flow (e.g., `he`, `ar`).
  * You may need to temporarily change your user locale in your WordPress.com account settings.
  * TIP: For Jetpack Cloud, you can do this by adding the locale to the beginning of the URL path (e.g., `/he/pricing`).
* Test how prices render in other currencies, like INR or ILS. (Automatticians can do this by changing their WordPress.com account's default currency via the Store Admin.)

#### Reference screenshots

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/670067/168848697-1ddc139a-8589-49fd-a144-0b83acf2058f.png">
<img width="985" alt="image" src="https://user-images.githubusercontent.com/670067/168849112-9c1f73f5-b009-48f0-b1da-008496153c0b.png">
<img width="1056" alt="image" src="https://user-images.githubusercontent.com/670067/168848486-f77acc44-dc63-4563-b84d-950ab897f576.png">