### PR TITLE
Checkout: Remove useLineItems from payment methods

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.tsx
@@ -217,7 +217,7 @@ export default function CompositeCheckout( {
 		isInitialCartLoading,
 	} );
 
-	const { items, total, allowedPaymentMethods } = useMemo(
+	const { total, allowedPaymentMethods } = useMemo(
 		() => translateResponseCartToWPCOMCart( responseCart ),
 		[ responseCart ]
 	);
@@ -690,7 +690,6 @@ export default function CompositeCheckout( {
 				options={ { useJetpackGoogleAnalytics: isJetpackCheckout || isJetpackNotAtomic } }
 			/>
 			<CheckoutProvider
-				items={ items }
 				total={ total }
 				onPaymentComplete={ handlePaymentComplete }
 				onPaymentError={ handlePaymentError }

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -1,15 +1,13 @@
 import {
-	isPlan,
 	isGoogleWorkspaceExtraLicence,
 	isGSuiteOrGoogleWorkspaceProductSlug,
 } from '@automattic/calypso-products';
-import { isValueTruthy, getLabel, getTotalLineItemFromCart } from '@automattic/wpcom-checkout';
+import { isValueTruthy, getTotalLineItemFromCart } from '@automattic/wpcom-checkout';
 import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import {
 	readWPCOMPaymentMethodClass,
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
 } from './translate-payment-method-names';
-import type { LineItem } from '@automattic/composite-checkout';
 import type {
 	ResponseCart,
 	ResponseCartProduct,
@@ -33,7 +31,7 @@ import type {
  * @returns Cart object suitable for passing to the checkout component
  */
 export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WPCOMCart {
-	const { products, allowed_payment_methods } = serverCart;
+	const { allowed_payment_methods } = serverCart;
 
 	const totalItem = getTotalLineItemFromCart( serverCart );
 
@@ -45,30 +43,8 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		.map( translateWpcomPaymentMethodToCheckoutPaymentMethod );
 
 	return {
-		items: products.map( translateReponseCartProductToLineItem ),
 		total: totalItem,
 		allowedPaymentMethods,
-	};
-}
-
-// Convert a backend cart item to a checkout cart item
-function translateReponseCartProductToLineItem( serverCartItem: ResponseCartProduct ): LineItem {
-	const { product_slug, currency, item_subtotal_display, item_subtotal_integer, uuid } =
-		serverCartItem;
-
-	const label = getLabel( serverCartItem );
-
-	const type = isPlan( serverCartItem ) ? 'plan' : product_slug;
-
-	return {
-		id: uuid,
-		label,
-		type,
-		amount: {
-			currency: currency || '',
-			value: item_subtotal_integer || 0,
-			displayValue: item_subtotal_display || '',
-		},
 	};
 }
 

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -1,5 +1,5 @@
 import { useStripe } from '@automattic/calypso-stripe';
-import { Button, FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
 import { useElements, CardNumberElement } from '@stripe/react-stripe-js';
 import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
@@ -26,7 +26,7 @@ export default function CreditCardPayButton( {
 	activeButtonText?: string;
 } ) {
 	const { __ } = useI18n();
-	const [ , total ] = useLineItems();
+	const total = useTotal();
 	const { stripeConfiguration, stripe } = useStripe();
 	const fields = useSelect( ( select ) => select( 'wpcom-credit-card' ).getFields() );
 	const useForAllSubscriptions = useSelect( ( select ) =>

--- a/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/existing-credit-card/index.tsx
@@ -1,7 +1,7 @@
 import {
 	Button,
 	FormStatus,
-	useLineItems,
+	useTotal,
 	useFormStatus,
 	PaymentLogo,
 } from '@automattic/composite-checkout';
@@ -182,7 +182,7 @@ function ExistingCardPayButton( {
 	activeButtonText?: string;
 	isTaxInfoRequired?: boolean;
 } ) {
-	const [ items, total ] = useLineItems();
+	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const translate = useTranslate();
 
@@ -211,7 +211,6 @@ function ExistingCardPayButton( {
 					);
 				} else {
 					onClick( {
-						items,
 						name: cardholderName,
 						storedDetailsId,
 						paymentMethodToken,

--- a/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/free-purchase.tsx
@@ -1,4 +1,4 @@
-import { Button, useFormStatus, FormStatus, useLineItems } from '@automattic/composite-checkout';
+import { Button, useFormStatus, FormStatus } from '@automattic/composite-checkout';
 import { useI18n } from '@wordpress/react-i18n';
 import { Fragment } from 'react';
 import WordPressLogo from '../components/wordpress-logo';
@@ -22,7 +22,6 @@ function FreePurchaseSubmitButton( {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 } ) {
-	const [ items ] = useLineItems();
 	const { formStatus } = useFormStatus();
 
 	// This must be typed as optional because it's injected by cloning the
@@ -35,9 +34,7 @@ function FreePurchaseSubmitButton( {
 	}
 
 	const handleButtonPress = () => {
-		onClick( {
-			items,
-		} );
+		onClick( {} );
 	};
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/full-credits.tsx
@@ -1,4 +1,4 @@
-import { Button, FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -25,7 +25,6 @@ function FullCreditsSubmitButton( {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 } ) {
-	const [ items ] = useLineItems();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const { formStatus } = useFormStatus();
@@ -40,9 +39,7 @@ function FullCreditsSubmitButton( {
 	}
 
 	const handleButtonPress = () => {
-		onClick( {
-			items,
-		} );
+		onClick( {} );
 	};
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.tsx
@@ -1,4 +1,4 @@
-import { Button, FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
 import { Field } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
@@ -236,7 +236,7 @@ function NetBankingPayButton( {
 	store: NetBankingStore;
 } ) {
 	const { __ } = useI18n();
-	const [ , total ] = useLineItems();
+	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const customerName = useSelect( ( select ) => select( 'netbanking' ).getCustomerName() );
 	const fields = useSelect( ( select ) => select( 'netbanking' ).getFields() );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
@@ -2,7 +2,6 @@ import {
 	FormStatus,
 	TransactionStatus,
 	useTransactionStatus,
-	useLineItems,
 	useFormStatus,
 	Button,
 } from '@automattic/composite-checkout';
@@ -209,7 +208,6 @@ function PayPalSubmitButton( {
 } ) {
 	const { formStatus } = useFormStatus();
 	const { transactionStatus } = useTransactionStatus();
-	const [ items ] = useLineItems();
 	const postalCode = useSelect( ( select ) => select( storeKey )?.getPostalCode() );
 	const countryCode = useSelect( ( select ) => select( storeKey )?.getCountryCode() );
 
@@ -220,7 +218,6 @@ function PayPalSubmitButton( {
 			);
 		}
 		onClick( {
-			items,
 			postalCode: postalCode?.value,
 			countryCode: countryCode?.value,
 		} );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/wechat/index.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/wechat/index.js
@@ -1,7 +1,7 @@
 import {
 	Button,
 	FormStatus,
-	useLineItems,
+	useTotal,
 	useFormStatus,
 	useTransactionStatus,
 	PaymentProcessorResponseType,
@@ -132,7 +132,7 @@ const WeChatField = styled( Field )`
 `;
 
 function WeChatPayButton( { disabled, onClick, store, stripe, stripeConfiguration, siteSlug } ) {
-	const [ items, total ] = useLineItems();
+	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const { resetTransaction } = useTransactionStatus();
 	const customerName = useSelect( ( select ) => select( 'wechat' ).getCustomerName() );
@@ -166,8 +166,6 @@ function WeChatPayButton( { disabled, onClick, store, stripe, stripeConfiguratio
 					onClick( {
 						stripe,
 						name: customerName?.value,
-						items,
-						total,
 						stripeConfiguration,
 					} ).then( ( processorResponse ) => {
 						if ( processorResponse?.type === PaymentProcessorResponseType.MANUAL ) {

--- a/client/my-sites/checkout/composite-checkout/test/existing-credit-card.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/existing-credit-card.tsx
@@ -108,7 +108,6 @@ describe( 'Existing credit card payment methods', () => {
 		await userEvent.click( await screen.findByText( activePayButtonText ) );
 		await waitFor( () => {
 			expect( existingCardProcessor ).toHaveBeenCalledWith( {
-				items: [],
 				name: cardholderName,
 				storedDetailsId,
 				paymentMethodToken,
@@ -133,7 +132,6 @@ describe( 'Existing credit card payment methods', () => {
 		await userEvent.click( await screen.findByText( activePayButtonText ) );
 		await waitFor( () => {
 			expect( existingCardProcessor ).toHaveBeenCalledWith( {
-				items: [],
 				name: cardholderName,
 				storedDetailsId,
 				paymentMethodToken,

--- a/client/my-sites/checkout/composite-checkout/test/translate-cart.js
+++ b/client/my-sites/checkout/composite-checkout/test/translate-cart.js
@@ -83,35 +83,8 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 		it( 'has the expected total display value', function () {
 			expect( clientCart.total.amount.displayValue ).toBe( 'R$149' );
 		} );
-		it( 'has an array of items', function () {
-			expect( clientCart.items ).toBeDefined();
-		} );
-		it( 'has the expected number of line items', function () {
-			expect( clientCart.items.length ).toBe( 1 );
-		} );
 		it( 'has an array of allowed payment methods', function () {
 			expect( clientCart.allowedPaymentMethods ).toBeDefined();
-		} );
-
-		describe( 'first cart item (plan)', function () {
-			it( 'has an id', function () {
-				expect( clientCart.items[ 0 ].id ).toBeDefined();
-			} );
-			it( 'has the expected label', function () {
-				expect( clientCart.items[ 0 ].label ).toBe( 'WordPress.com Personal' );
-			} );
-			it( 'has the expected type', function () {
-				expect( clientCart.items[ 0 ].type ).toBe( 'plan' );
-			} );
-			it( 'has the expected currency', function () {
-				expect( clientCart.items[ 0 ].amount.currency ).toBe( 'BRL' );
-			} );
-			it( 'has the expected value', function () {
-				expect( clientCart.items[ 0 ].amount.value ).toBe( 14400 );
-			} );
-			it( 'has the expected display value', function () {
-				expect( clientCart.items[ 0 ].amount.displayValue ).toBe( 'R$144' );
-			} );
 		} );
 
 		describe( 'allowed payment methods', function () {
@@ -237,56 +210,8 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 		it( 'has the expected total display value', function () {
 			expect( clientCart.total.amount.displayValue ).toBe( 'R$149' );
 		} );
-		it( 'has a list of items', function () {
-			expect( clientCart.items ).toBeDefined();
-		} );
-		it( 'has the expected number of line items', function () {
-			expect( clientCart.items.length ).toBe( 2 );
-		} );
 		it( 'has an array of allowed payment methods', function () {
 			expect( clientCart.allowedPaymentMethods ).toBeDefined();
-		} );
-
-		describe( 'first cart item (plan)', function () {
-			it( 'has an id', function () {
-				expect( clientCart.items[ 0 ].id ).toBeDefined();
-			} );
-			it( 'has the expected label', function () {
-				expect( clientCart.items[ 0 ].label ).toBe( 'WordPress.com Personal' );
-			} );
-			it( 'has the expected type', function () {
-				expect( clientCart.items[ 0 ].type ).toBe( 'plan' );
-			} );
-			it( 'has the expected currency', function () {
-				expect( clientCart.items[ 0 ].amount.currency ).toBe( 'BRL' );
-			} );
-			it( 'has the expected value', function () {
-				expect( clientCart.items[ 0 ].amount.value ).toBe( 14400 );
-			} );
-			it( 'has the expected display value', function () {
-				expect( clientCart.items[ 0 ].amount.displayValue ).toBe( 'R$144' );
-			} );
-		} );
-
-		describe( 'second cart item (domain)', function () {
-			it( 'has an id', function () {
-				expect( clientCart.items[ 1 ].id ).toBeDefined();
-			} );
-			it( 'has the expected label (the domain name)', function () {
-				expect( clientCart.items[ 1 ].label ).toBe( 'foo.cash' );
-			} );
-			it( 'has the expected type', function () {
-				expect( clientCart.items[ 1 ].type ).toBe( 'dotcash_domain' );
-			} );
-			it( 'has the expected currency', function () {
-				expect( clientCart.items[ 1 ].amount.currency ).toBe( 'BRL' );
-			} );
-			it( 'has the expected value', function () {
-				expect( clientCart.items[ 1 ].amount.value ).toBe( 0 );
-			} );
-			it( 'has the expected display value', function () {
-				expect( clientCart.items[ 1 ].amount.displayValue ).toBe( 'R$0' );
-			} );
 		} );
 
 		describe( 'allowed payment methods', function () {
@@ -454,35 +379,8 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 		it( 'has the expected total display value', function () {
 			expect( clientCart.total.amount.displayValue ).toBe( '$221' );
 		} );
-		it( 'has a list of items', function () {
-			expect( clientCart.items ).toBeDefined();
-		} );
-		it( 'has the expected number of line items', function () {
-			expect( clientCart.items.length ).toBe( 3 );
-		} );
 		it( 'has an array of allowed payment methods', function () {
 			expect( clientCart.allowedPaymentMethods ).toBeDefined();
-		} );
-
-		describe( 'third cart item (GSuite)', function () {
-			it( 'has an id', function () {
-				expect( clientCart.items[ 2 ].id ).toBeDefined();
-			} );
-			it( 'has the expected label', function () {
-				expect( clientCart.items[ 2 ].label ).toBe( 'G Suite' );
-			} );
-			it( 'has the expected type', function () {
-				expect( clientCart.items[ 2 ].type ).toBe( 'gapps' );
-			} );
-			it( 'has the expected currency', function () {
-				expect( clientCart.items[ 2 ].amount.currency ).toBe( 'USD' );
-			} );
-			it( 'has the expected value', function () {
-				expect( clientCart.items[ 2 ].amount.value ).toBe( 7200 );
-			} );
-			it( 'has the expected display value', function () {
-				expect( clientCart.items[ 2 ].amount.displayValue ).toBe( '$72' );
-			} );
 		} );
 
 		describe( 'allowed payment methods', function () {
@@ -577,35 +475,8 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 		it( 'has the expected total display value', function () {
 			expect( clientCart.total.amount.displayValue ).toBe( '$132' );
 		} );
-		it( 'has an array of items', function () {
-			expect( clientCart.items ).toBeDefined();
-		} );
-		it( 'has the expected number of line items', function () {
-			expect( clientCart.items.length ).toBe( 1 );
-		} );
 		it( 'has an array of allowed payment methods', function () {
 			expect( clientCart.allowedPaymentMethods ).toBeDefined();
-		} );
-
-		describe( 'first cart item (plan)', function () {
-			it( 'has an id', function () {
-				expect( clientCart.items[ 0 ].id ).toBeDefined();
-			} );
-			it( 'has the expected label', function () {
-				expect( clientCart.items[ 0 ].label ).toBe( 'WordPress.com Personal' );
-			} );
-			it( 'has the expected type', function () {
-				expect( clientCart.items[ 0 ].type ).toBe( 'plan' );
-			} );
-			it( 'has the expected currency', function () {
-				expect( clientCart.items[ 0 ].amount.currency ).toBe( 'USD' );
-			} );
-			it( 'has the expected value', function () {
-				expect( clientCart.items[ 0 ].amount.value ).toBe( 12700 );
-			} );
-			it( 'has the expected display value', function () {
-				expect( clientCart.items[ 0 ].amount.displayValue ).toBe( '$127' );
-			} );
 		} );
 
 		describe( 'allowed payment methods', function () {

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -37,7 +37,6 @@ export function PurchaseModal( {
 }: PurchaseModalProps ) {
 	const [ step, setStep ] = useState( BEFORE_SUBMIT );
 	const submitTransaction = useSubmitTransaction( {
-		cart,
 		setStep,
 		storedCard: cards[ 0 ],
 		onClose,

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
@@ -2,10 +2,8 @@ import { useProcessPayment, PaymentProcessorResponseType } from '@automattic/com
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { translateResponseCartToWPCOMCart } from 'calypso/my-sites/checkout/composite-checkout/lib/translate-cart';
 import { errorNotice } from 'calypso/state/notices/actions';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
-import type { ResponseCart } from '@automattic/shopping-cart';
 import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
 
 export function extractStoredCardMetaValue( card: StoredCard, key: string ): string | undefined {
@@ -17,12 +15,10 @@ type OnClose = () => void;
 type SubmitTransactionFunction = () => void;
 
 export function useSubmitTransaction( {
-	cart,
 	storedCard,
 	setStep,
 	onClose,
 }: {
-	cart: ResponseCart;
 	storedCard: StoredCard | undefined;
 	setStep: SetStep;
 	onClose: OnClose;
@@ -34,10 +30,8 @@ export function useSubmitTransaction( {
 		if ( ! storedCard ) {
 			throw new Error( 'No saved card found' );
 		}
-		const wpcomCart = translateResponseCartToWPCOMCart( cart );
 		setStep( 'processing' );
 		callPaymentProcessor( {
-			items: wpcomCart.items,
 			name: storedCard.name,
 			storedDetailsId: storedCard.stored_details_id,
 			paymentMethodToken: storedCard.mp_ref,
@@ -64,7 +58,7 @@ export function useSubmitTransaction( {
 				reduxDispatch( errorNotice( error.message ) );
 				onClose();
 			} );
-	}, [ callPaymentProcessor, cart, storedCard, setStep, onClose, reduxDispatch ] );
+	}, [ callPaymentProcessor, storedCard, setStep, onClose, reduxDispatch ] );
 }
 
 export function formatDate( cardExpiry: string ): string {

--- a/packages/wpcom-checkout/src/payment-methods/alipay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/alipay.tsx
@@ -1,4 +1,4 @@
-import { Button, FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
@@ -138,7 +138,7 @@ function AlipayPayButton( {
 	onClick?: ProcessPayment;
 	store: AlipayStore;
 } ) {
-	const [ items, total ] = useLineItems();
+	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const customerName = useSelect( ( select ) => select( 'alipay' ).getCustomerName() );
 
@@ -159,8 +159,6 @@ function AlipayPayButton( {
 					debug( 'submitting alipay payment' );
 					onClick( {
 						name: customerName?.value,
-						items,
-						total,
 					} );
 				}
 			} }

--- a/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
@@ -1,4 +1,4 @@
-import { Button, FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
@@ -140,7 +140,7 @@ function BancontactPayButton( {
 	onClick?: ProcessPayment;
 	store: BancontactStore;
 } ) {
-	const [ , total ] = useLineItems();
+	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const customerName = useSelect( ( select ) => select( 'bancontact' ).getCustomerName() );
 	if ( ! onClick ) {

--- a/packages/wpcom-checkout/src/payment-methods/eps.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/eps.tsx
@@ -1,4 +1,4 @@
-import { Button, FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
@@ -139,7 +139,7 @@ function EpsPayButton( {
 	onClick?: ProcessPayment;
 	store: EpsStore;
 } ) {
-	const [ , total ] = useLineItems();
+	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const customerName = useSelect( ( select ) => select( 'eps' ).getCustomerName() );
 

--- a/packages/wpcom-checkout/src/payment-methods/giropay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/giropay.tsx
@@ -1,4 +1,4 @@
-import { Button, FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
@@ -141,7 +141,7 @@ function GiropayPayButton( {
 	onClick?: ProcessPayment;
 	store: GiropayStore;
 } ) {
-	const [ , total ] = useLineItems();
+	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const customerName = useSelect( ( select ) => select( 'giropay' ).getCustomerName() );
 

--- a/packages/wpcom-checkout/src/payment-methods/ideal.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/ideal.tsx
@@ -1,4 +1,4 @@
-import { Button, FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
@@ -269,7 +269,7 @@ function IdealPayButton( {
 	onClick?: ProcessPayment;
 	store: IdealStore;
 } ) {
-	const [ items, total ] = useLineItems();
+	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const customerName = useSelect( ( select ) => select( 'ideal' ).getCustomerName() );
 	const customerBank = useSelect( ( select ) => select( 'ideal' ).getCustomerBank() );
@@ -292,8 +292,6 @@ function IdealPayButton( {
 					onClick( {
 						name: customerName?.value,
 						idealBank: customerBank?.value,
-						items,
-						total,
 					} );
 				}
 			} }

--- a/packages/wpcom-checkout/src/payment-methods/p24.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/p24.tsx
@@ -1,4 +1,4 @@
-import { Button, FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
@@ -162,7 +162,7 @@ function P24PayButton( {
 	onClick?: ProcessPayment;
 	store: P24Store;
 } ) {
-	const [ , total ] = useLineItems();
+	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const customerName = useSelect( ( select ) => select( 'p24' ).getCustomerName() );
 	const customerEmail = useSelect( ( select ) => select( 'p24' ).getCustomerEmail() );

--- a/packages/wpcom-checkout/src/payment-methods/sofort.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/sofort.tsx
@@ -1,4 +1,4 @@
-import { Button, FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
@@ -140,7 +140,7 @@ function SofortPayButton( {
 	onClick?: ProcessPayment;
 	store: SofortStore;
 } ) {
-	const [ items, total ] = useLineItems();
+	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const customerName = useSelect( ( select ) => select( 'sofort' ).getCustomerName() );
 
@@ -161,8 +161,6 @@ function SofortPayButton( {
 					debug( 'submitting sofort payment' );
 					onClick( {
 						name: customerName?.value,
-						items,
-						total,
 					} );
 				}
 			} }

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -190,7 +190,6 @@ export type PayPalExpressEndpointRequestPayload = {
 export type PayPalExpressEndpointResponse = unknown;
 
 export interface WPCOMCart {
-	items: LineItem[];
 	total: LineItem;
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the `composite-checkout` package was originally developed, it included its own mechanism to store line items. These were passed to `CheckoutProvider` and could be retrieved using the `useLineItems` React hook. However, as the checkout redesign project evolved it became clear that we have too many specialized options for wpcom and Jetpack products, and the line item schema was both insufficient for capturing those as well as being redundant since the shopping cart already provided those items and had its own hook. To that end, a series of PRs was made which removed the use of `useLineItems` in most places. Now there are only a few places left that utilize it.

This PR removes the use of `useLineItems` in all checkout payment methods. In each of these places, the line items were unused. Mostly they were passed to the payment processor function of the shopping cart provider, but that usage has been long deprecated.

This then removes the unused `items` array passed to checkout's `CheckoutProvider`.

#### Testing instructions

- Verify that none of the payment processors use `items` or `total` (search in `client/my-sites/checkout/composite-checkout/lib/` and `client/me/purchases/manage-purchase/payment-method-selector/`).
- Verify that there are no other uses of `useLineItems` outside of `packages/composite-checkout`.