### PR TITLE
Avoid diffing *.js.map files in plugin builds

### DIFF
--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -173,7 +173,7 @@ open class WPComPluginBuild(
 
 					# 3. Check if the current build has changed, and if so, tag it for release.
 					# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
-					if [ "%skip_release_diff%" = "true" ] || ! diff -rq --exclude="*.asset.php" --exclude="build_meta.json" --exclude="README.md" $archiveDir ./release-archive/ ; then
+					if [ "%skip_release_diff%" = "true" ] || ! diff -rq --exclude="*.js.map" --exclude="*.asset.php" --exclude="build_meta.json" --exclude="README.md" $archiveDir ./release-archive/ ; then
 						echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
 
 						echo "DIFF: Start"


### PR DESCRIPTION
### Changes proposed in this Pull Request
In this [TeamCity build](https://teamcity.a8c.com/buildConfiguration/calypso_WPComPlugins_EditorToolKit/7916567?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&showLog=7916567_2036_101.1765.1916&logView=flowAware), I noticed that the only changed file is a .map file. While this is surprising, we should mitigate it now to avoid notifying people they need to deploy when they don't really need to.

I don't think we need to encourage ETK deployment for _only_ .map files when no other code changes, as map files are only useful internally. This PR avoids notifying developers when only .map files change.

### Testing instructions
TC should pass.
