### PR TITLE
Playwright: Update site styles dimensions options selector for GB 13.2.0

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-dimensions-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-dimensions-component.ts
@@ -3,8 +3,7 @@ import { EditorPopoverMenuComponent } from './editor-popover-menu-component';
 
 const selectors = {
 	paddingInput: 'input[aria-label="Padding"]',
-	optionsButton:
-		'.components-tools-panel-header:has-text("Dimensions") button[aria-label="View options"]',
+	optionsButton: 'button[aria-label="Dimensions options"]',
 };
 
 export interface DimensionsSettings {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

GB 13.2.0 changed the `aria-label` on the options button in the dimensions component from "View options" to "Dimensions options".

This updates the Playwright selectors/tests accordingly!

#### Testing instructions

Once GB 13.2. is merged...

- [x] GB tests should pass!

Related to #
