### PR TITLE
Site setup flow: Redirect when user is logged out

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -7,7 +7,7 @@ import { useFSEStatus } from '../hooks/use-fse-status';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
-import { ONBOARD_STORE, SITE_STORE } from '../stores';
+import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { ProcessingResult } from './internals/steps-repository/processing-step';
 import type { StepPath } from './internals/steps-repository';
@@ -320,6 +320,12 @@ export const siteSetupFlow: Flow = {
 	useAssertConditions() {
 		const siteSlug = useSiteSlugParam();
 		const siteId = useSiteIdParam();
+		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+
+		if ( ! userIsLoggedIn ) {
+			redirect( '/start' );
+			throw new Error( 'site-setup requires a logged in user' );
+		}
 
 		if ( ! siteSlug && ! siteId ) {
 			throw new Error( 'site-setup did not provide the site slug or site id it is configured to.' );


### PR DESCRIPTION
This change should add a redirection to `/start` when the user is logged out.

#### Testing
1. Apply this PR.
2. While logged out navigate to a valid `site-setup` flow url, eg: `http://calypso.localhost:3000/setup/businessInfo?siteSlug=[YOUR_SITE]`.
3. Verify that you are redirected to `/start`.
4. Verify you can log in correctly.
5. While logged in, try to navigate to the URL in `2.` and verify it works as expected.

**NOTE** On incognito the `/start` login seems to be failing due to some local storage issues. I've tested with a logged out Firefox.

Closes https://github.com/Automattic/wp-calypso/issues/63686
Related https://github.com/Automattic/wp-calypso/issues/63674