### PR TITLE
Purchases: Sort purchases within sites in getPurchasesBySite

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -48,7 +48,9 @@ function getPurchasesBySite( purchases, sites ) {
 		.reduce( ( result, currentValue ) => {
 			const site = find( result, { id: currentValue.siteId } );
 			if ( site ) {
-				site.purchases = site.purchases.concat( currentValue );
+				site.purchases = site.purchases
+					.concat( currentValue )
+					.sort( ( a, b ) => ( a.id > b.id ? 1 : -1 ) );
 			} else {
 				const siteObject = find( sites, { ID: currentValue.siteId } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sometimes the list of purchases on the account-level purchases page (`/me/purchases`) re-orders the purchases after the page has rendered. This is poor UX as they jump around.

There may be several reasons for this but one of them is [this line in getPurchasesBySite](https://github.com/Automattic/wp-calypso/blob/3339a9b09b73d6f977244e964d9214c6ff841b7d/client/lib/purchases/index.js#L51) which causes the purchases for a site to be reordered on every query based on the order of `getUserPurchases()` and the `state.purchases.data` array in Redux. Why the Redux data should change order, I do not know (possibly a problem with the endpoint), but `getPurchasesBySite()` can sort them (as it does with the sites themselves) which should help considerably.

This PR adds sorting for the purchases within a site.

Addresses 932-gh-Automattic/payments-shilling

A fix for a similar bug exists in https://github.com/Automattic/wp-calypso/pull/63734

#### Testing instructions

Visit `/me/purchases` and verify that the items do not re-order themselves. This is best done on an account with many purchases.