### PR TITLE
remove-purchase: Remove unused prop shouldRevertAtomicSite

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -29,10 +29,7 @@ import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { removePurchase } from 'calypso/state/purchases/actions';
-import {
-	getPurchasesError,
-	shouldRevertAtomicSiteBeforeDeactivation,
-} from 'calypso/state/purchases/selectors';
+import { getPurchasesError } from 'calypso/state/purchases/selectors';
 import isDomainOnly from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { receiveDeletedSite } from 'calypso/state/sites/actions';
@@ -449,7 +446,6 @@ export default connect(
 			isChatAvailable: isHappychatAvailable( state ),
 			isJetpack,
 			purchasesError: getPurchasesError( state ),
-			shouldRevertAtomicSite: shouldRevertAtomicSiteBeforeDeactivation( state, purchase.id ),
 			userId: getCurrentUserId( state ),
 		};
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In `client/me/purchases/remove-purchase/index.jsx`, remove the unused prop `shouldRevertAtomicSite` from its redux connect function call
  * The usage of the prop was removed in #57388, but the prop itself was not removed

#### Testing instructions

* Examine `client/me/purchases/remove-purchase/index.jsx` and verify the prop is not used anywhere, nor passed anywhere


