### PR TITLE
Purchases: Do not remove/re-add purchases when updating in the reducer

### DIFF
--- a/client/state/purchases/test/reducer.js
+++ b/client/state/purchases/test/reducer.js
@@ -33,10 +33,11 @@ describe( 'reducer', () => {
 	} );
 
 	test( 'should return an object with the list of purchases when fetching completed', () => {
+		const siteId2 = '2828828282';
 		let state = reducer( undefined, {
 			type: PURCHASES_USER_FETCH_COMPLETED,
 			purchases: [
-				{ ID: '1', blog_id: siteId, user_id: userId },
+				{ ID: '1', blog_id: siteId2, user_id: userId },
 				{ ID: '2', blog_id: siteId, user_id: userId },
 			],
 		} );
@@ -44,16 +45,17 @@ describe( 'reducer', () => {
 		state = reducer( state, {
 			type: PURCHASES_SITE_FETCH_COMPLETED,
 			purchases: [
-				{ ID: '2', blog_id: siteId, user_id: userId },
+				{ ID: '2', blog_id: siteId, user_id: userId, other: true },
 				{ ID: '3', blog_id: siteId, user_id: userId },
 			],
+			siteId: Number( siteId ),
 		} );
 
 		expect( state ).toEqual( {
 			data: [
-				{ ID: '2', blog_id: siteId, user_id: userId },
+				{ ID: '1', blog_id: siteId2, user_id: userId },
+				{ ID: '2', blog_id: siteId, user_id: userId, other: true },
 				{ ID: '3', blog_id: siteId, user_id: userId },
-				{ ID: '1', blog_id: siteId, user_id: userId },
 			],
 			error: null,
 			isFetchingSitePurchases: false,


### PR DESCRIPTION
#### Problem

The purchases reducer in Redux state is updated by both requests for user-level and requests for site-level purchases. However, if both requests are triggered, they can cause unexpected results. If site-level purchases are added to the store after they've already been fetched by the user-level purchases, the order of those purchases will change. This happens because when updating purchases that already exist in the list, they are removed from the list and re-added at the end.

On the `/me/purchases` page, this happens and can cause the list of purchases to jump around after it loads. The order of operations on the page is:

1. The user level purchases are loaded by [the query component in the page](https://github.com/Automattic/wp-calypso/blob/4c80ffc6033c2e732547d7da98bc86e4b3f0af42/client/me/purchases/purchases-list/index.jsx#L169).
2. For each site the user has, [the ProductPlanOverlapNotices component queries the site level purchases](https://github.com/Automattic/wp-calypso/blob/4c80ffc6033c2e732547d7da98bc86e4b3f0af42/client/blocks/product-plan-overlap-notices/index.jsx#L141). 

#### Changes proposed in this Pull Request

In this PR we change the behavior of the purchases reducer so that if purchases are already loaded, they are updated in-place rather than being removed and re-added, preserving the existing order whenever possible.

Fixes 932-gh-Automattic/payments-shilling

A related change is #63728

#### Testing instructions

Automated tests are included.

Visit `/me/purchases` and verify that the items do not re-order themselves and that the same ones show up as in production. This is best done on an account with many purchases.