### PR TITLE
Rename `shouldRevertAtomicSiteBeforeDeactivation` -> `willAtomicSiteRevertAfterPurchaseDeactivation`

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -118,11 +118,11 @@ class CancelPurchaseForm extends Component {
 	}
 
 	getAllSurveySteps() {
-		const { purchase, shouldRevertAtomicSite } = this.props;
+		const { purchase, willAtomicSiteRevert } = this.props;
 
 		if ( isPlan( purchase ) ) {
 			if ( this.shouldUseBlankCanvasLayout() ) {
-				if ( shouldRevertAtomicSite ) {
+				if ( willAtomicSiteRevert ) {
 					return [ FEEDBACK_STEP, ATOMIC_REVERT_STEP ];
 				}
 
@@ -1255,7 +1255,7 @@ export default connect(
 		downgradePlanPrice: getDowngradePlanRawPrice( state, purchase ),
 		supportVariation: getSupportVariation( state ),
 		site: getSite( state, purchase.siteId ),
-		shouldRevertAtomicSite: willAtomicSiteRevertAfterPurchaseDeactivation( state, purchase.id ),
+		willAtomicSiteRevert: willAtomicSiteRevertAfterPurchaseDeactivation( state, purchase.id ),
 		atomicTransfer: getAtomicTransfer( state, purchase.siteId ),
 	} ),
 	{

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -52,7 +52,7 @@ import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-act
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import {
 	getDowngradePlanRawPrice,
-	shouldRevertAtomicSiteBeforeDeactivation,
+	willAtomicSiteRevertAfterPurchaseDeactivation,
 } from 'calypso/state/purchases/selectors';
 import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import getSupportVariation, {
@@ -1255,7 +1255,7 @@ export default connect(
 		downgradePlanPrice: getDowngradePlanRawPrice( state, purchase ),
 		supportVariation: getSupportVariation( state ),
 		site: getSite( state, purchase.siteId ),
-		shouldRevertAtomicSite: shouldRevertAtomicSiteBeforeDeactivation( state, purchase.id ),
+		shouldRevertAtomicSite: willAtomicSiteRevertAfterPurchaseDeactivation( state, purchase.id ),
 		atomicTransfer: getAtomicTransfer( state, purchase.siteId ),
 	} ),
 	{

--- a/client/state/purchases/selectors/index.js
+++ b/client/state/purchases/selectors/index.js
@@ -16,7 +16,7 @@ export { getRenewableSitePurchases } from './get-renewable-site-purchases';
 export { getSitePurchases } from './get-site-purchases';
 export { getUserPurchases } from './get-user-purchases';
 export { isUserPaid } from './is-user-paid';
-export { shouldRevertAtomicSiteBeforeDeactivation } from './should-revert-atomic-site-before-deactivation';
+export { willAtomicSiteRevertAfterPurchaseDeactivation } from './will-atomic-site-revert-after-purchase-deactivation';
 export { siteHasBackupProductPurchase } from './site-has-backup-product-purchase';
 export { siteHasJetpackProductPurchase } from './site-has-jetpack-product-purchase';
 export { siteHasScanProductPurchase } from './site-has-scan-product-purchase';

--- a/client/state/purchases/selectors/will-atomic-site-revert-after-purchase-deactivation.js
+++ b/client/state/purchases/selectors/will-atomic-site-revert-after-purchase-deactivation.js
@@ -17,7 +17,7 @@ import 'calypso/state/purchases/init';
  * @param   {number} purchaseId  the purchase id
  * @returns {boolean} True if the Atomic revert is needed, false otherwise.
  */
-export const shouldRevertAtomicSiteBeforeDeactivation = ( state, purchaseId ) => {
+export const willAtomicSiteRevertAfterPurchaseDeactivation = ( state, purchaseId ) => {
 	if ( ! purchaseId ) {
 		return false;
 	}

--- a/client/state/purchases/selectors/will-atomic-site-revert-after-purchase-deactivation.js
+++ b/client/state/purchases/selectors/will-atomic-site-revert-after-purchase-deactivation.js
@@ -11,11 +11,14 @@ import { getSitePurchases } from './get-site-purchases';
 import 'calypso/state/purchases/init';
 
 /**
- * Whether a purchase needs to trigger an Atomic revert prior its cancellation/removal.
+ * Whether a purchase will trigger an Atomic revert when it is canceled or removed.
+ * The backend has the final say on if this actually happens, see:
+ * revert_atomic_site_on_subscription_removal() and deactivate_product().
+ * This is a helper for UI elements only, it does not control actual revert decisions.
  *
  * @param   {object} state       global state
  * @param   {number} purchaseId  the purchase id
- * @returns {boolean} True if the Atomic revert is needed, false otherwise.
+ * @returns {boolean} True if the Atomic revert will happen, false otherwise.
  */
 export const willAtomicSiteRevertAfterPurchaseDeactivation = ( state, purchaseId ) => {
 	if ( ! purchaseId ) {
@@ -40,7 +43,7 @@ export const willAtomicSiteRevertAfterPurchaseDeactivation = ( state, purchaseId
 
 	// Retrieves all Atomic supported purchases for the site.
 	// If there is at least one active subscription except the given one,
-	// the site needs to be kept in the Atomic infra.
+	// the site will be kept in the Atomic infra.
 	return ! getSitePurchases( state, purchase.siteId ).some(
 		( sitePurchase ) =>
 			sitePurchase.id !== purchaseId && isAtomicSupportedProduct( sitePurchase.productSlug )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename `shouldRevertAtomicSiteBeforeDeactivation` -> `willAtomicSiteRevertAfterPurchaseDeactivation`
  * The idea is to emphasize that calypso is not making revert decisions, it is simply trying to predict what will happen.
  * See p1652461537707349/1652459989.214949-slack-C02V49GM0PN
* No functional changes

#### Testing instructions

We will go through the steps for canceling a plan on an atomic and simple site, but you don't have to actually cancel it. Just be careful and don't click through the last step.
 
- **Choose an atomic site with an atomic plan**
- Sidebar (Upgrades -> Plans)
- Click the "My Plan" tab
- Click the "Manage Plan" button at the top

![2022-05-17_17-04](https://user-images.githubusercontent.com/937354/168918471-05042f59-928a-446c-ad11-eca77e9f5e2e.png)

- Click "Remove (Plan Name)" at the bottom

![2022-05-17_17-03](https://user-images.githubusercontent.com/937354/168918510-f5bf2fdd-ebec-42ff-9b85-43f76f131cec.png)

- You should see a survey, fill out some answers and click next

![2022-05-17_17-04_1](https://user-images.githubusercontent.com/937354/168918734-5c2303ff-d61b-49c9-837b-f82c7bffdb62.png)

- Now you will see the atomic specific step with two checkboxes about themes/plugins and being reverted

![2022-05-17_17-05](https://user-images.githubusercontent.com/937354/168918616-726e828c-f378-4a8a-b8b4-19d6185b71b1.png)


- Back out and **choose a simple site with a non-atomic plan** (Like personal or blogger if you have any of those)
- Repeat the steps
- This time, the survey will only have one step and no "next" button

![2022-05-17_17-06](https://user-images.githubusercontent.com/937354/168919063-cf0e5429-4e3e-4260-9252-96e408d42f27.png)

- The difference between step two displaying or not was determined with the `willAtomicSiteRevertAfterPurchaseDeactivation` selector ([Link](https://github.com/Automattic/wp-calypso/blob/ce52f762d80eccd36a55f10706073bd0f8ac6487/client/components/marketing-survey/cancel-purchase-form/index.jsx#L125-L127)), so that should prove that it's still working


