### PR TITLE
Documentation: revise documentation on how to run tests locally

### DIFF
--- a/test/e2e/docs/setup.md
+++ b/test/e2e/docs/setup.md
@@ -66,7 +66,6 @@ arch -x86_64 npm install yarn
 arch -x86_64 yarn install --frozen-lockfile
 ```
 
-
 At any point, run `arch` to verify whether shell is running with Rosetta 2 emulation.
 
 ## Apple Silicon (arm64)

--- a/test/e2e/docs/tests_local.md
+++ b/test/e2e/docs/tests_local.md
@@ -79,11 +79,11 @@ By default, tests run against the `desktop` viewport size, approximately 1920x10
 
 To specify the viewport size:
 
-    a. set the viewport size to persist in the shell: `export VIEWPORT_NAME=<viewport>`
+a. set the viewport size to persist in the shell: `export VIEWPORT_NAME=<viewport>`
 
-    b. set the viewport size for the command only: `VIEWPORT_NAME=<viewport> yarn jest <test_path>`
+b. set the viewport size for the command only: `VIEWPORT_NAME=<viewport> yarn jest <test_path>`
 
-```
+```bash
 VIEWPORT_NAME=mobile yarn jest ...
 ```
 

--- a/test/e2e/docs/tests_local.md
+++ b/test/e2e/docs/tests_local.md
@@ -62,11 +62,11 @@ See the [list of groups](docs/overview.md#what-is-tested).
 
 ### Save authentication cookies
 
-Specified accounts will be pre-authenticated prior to the main test suite executions and its cookies saved to be re-used until expiry (typically 3 days).
+Specified accounts will be pre-authenticated prior to the main test suite executions and their cookies saved to be re-used until expiry (typically 3 days).
 
 Specify a list of user accounts found in [Secret Manager](packages/calypso-e2e/src/secrets/secrets-manager.ts), separated by commas:
 
-```
+```test/e2e/docs/tests_local.md
 export AUTHENTICATE_ACCOUNTS=simpleSitePersonalPlanUser,eCommerceUser,defaultUser
 ```
 

--- a/test/e2e/docs/tests_local.md
+++ b/test/e2e/docs/tests_local.md
@@ -9,16 +9,16 @@
 <!-- TOC -->
 
 - [Running tests on your machine](#running-tests-on-your-machine)
-    - [Prerequisites](#prerequisites)
-    - [Running tests](#running-tests)
-        - [Individual spec files](#individual-spec-files)
-        - [Test Group](#test-group)
-    - [Advanced techniques](#advanced-techniques)
-        - [Save authentication cookies](#save-authentication-cookies)
-        - [Use the mobile viewport](#use-the-mobile-viewport)
-        - [Target a different environment](#target-a-different-environment)
-        - [Debug mode](#debug-mode)
-            - [Notes on TypeScript](#notes-on-typescript)
+  - [Prerequisites](#prerequisites)
+  - [Running tests](#running-tests)
+    - [Individual spec files](#individual-spec-files)
+    - [Test Group](#test-group)
+  - [Advanced techniques](#advanced-techniques)
+    - [Save authentication cookies](#save-authentication-cookies)
+    - [Use the mobile viewport](#use-the-mobile-viewport)
+    - [Target a different environment](#target-a-different-environment)
+    - [Debug mode](#debug-mode)
+      - [Notes on TypeScript](#notes-on-typescript)
 
 <!-- /TOC -->
 
@@ -79,9 +79,9 @@ By default, tests run against the `desktop` viewport size, approximately 1920x10
 
 To specify the viewport size:
 
-	a. set the viewport size to persist in the shell: `export VIEWPORT_NAME=<viewport>`
+    a. set the viewport size to persist in the shell: `export VIEWPORT_NAME=<viewport>`
 
-	b. set the viewport size for the command only: `VIEWPORT_NAME=<viewport> yarn jest <test_path>`
+    b. set the viewport size for the command only: `VIEWPORT_NAME=<viewport> yarn jest <test_path>`
 
 ```
 VIEWPORT_NAME=mobile yarn jest ...
@@ -93,15 +93,15 @@ To target a webapp running in a different environment:
 
 1. determine the base URL to use for the appropriate environment.
 
-	- for local webapp: `http://calypso.localhost:3000`
-	- for staging webapp: `https://wordpress.com`
-	- for wpcalypso webapp: `https://wpcalypso.wordpress.com`
+   - for local webapp: `http://calypso.localhost:3000`
+   - for staging webapp: `https://wordpress.com`
+   - for wpcalypso webapp: `https://wpcalypso.wordpress.com`
 
 2. set the `CALYPSO_BASE_URL` environment variable:
 
-	a. set the variable to persist in the shell: `export CALYPSO_BASE_URL=<url>`
+   a. set the variable to persist in the shell: `export CALYPSO_BASE_URL=<url>`
 
-	b. set the variable for the command only: `CALYPSO_BASE_URL=<url> yarn jest <test_path>`
+   b. set the variable for the command only: `CALYPSO_BASE_URL=<url> yarn jest <test_path>`
 
 <img alt="Local Calypso Webapp" src="https://cldup.com/1WwDmUXWen.png" />
 <sup><center>Example: webapp running on localhost.</center></sup>

--- a/test/e2e/docs/tests_local.md
+++ b/test/e2e/docs/tests_local.md
@@ -9,16 +9,16 @@
 <!-- TOC -->
 
 - [Running tests on your machine](#running-tests-on-your-machine)
-  - [Prerequisites](#prerequisites)
-  - [Running tests](#running-tests)
-    - [Individual spec files](#individual-spec-files)
-    - [Test Group](#test-group)
-  - [Advanced techniques](#advanced-techniques)
-    - [Save authentication cookies](#save-authentication-cookies)
-    - [Use the mobile viewport](#use-the-mobile-viewport)
-    - [Target local webapp](#target-local-webapp)
-    - [Debug mode](#debug-mode)
-      - [Notes on TypeScript](#notes-on-typescript)
+    - [Prerequisites](#prerequisites)
+    - [Running tests](#running-tests)
+        - [Individual spec files](#individual-spec-files)
+        - [Test Group](#test-group)
+    - [Advanced techniques](#advanced-techniques)
+        - [Save authentication cookies](#save-authentication-cookies)
+        - [Use the mobile viewport](#use-the-mobile-viewport)
+        - [Target a different environment](#target-a-different-environment)
+        - [Debug mode](#debug-mode)
+            - [Notes on TypeScript](#notes-on-typescript)
 
 <!-- /TOC -->
 
@@ -62,9 +62,9 @@ See the [list of groups](docs/overview.md#what-is-tested).
 
 ### Save authentication cookies
 
-Specify accounts to be pre-authenticated by saving authentication cookies and reusing them for each test that is run against those accounts.
+Specified accounts will be pre-authenticated prior to the main test suite executions and its cookies saved to be re-used until expiry (typically 3 days).
 
-**Enable**
+Specify a list of user accounts found in [Secret Manager](packages/calypso-e2e/src/secrets/secrets-manager.ts), separated by commas:
 
 ```
 export AUTHENTICATE_ACCOUNTS=simpleSitePersonalPlanUser,eCommerceUser,defaultUser
@@ -77,34 +77,34 @@ By default, tests run against the `desktop` viewport size, approximately 1920x10
 - mobile
 - desktop
 
+To specify the viewport size:
+
+	a. set the viewport size to persist in the shell: `export VIEWPORT_NAME=<viewport>`
+
+	b. set the viewport size for the command only: `VIEWPORT_NAME=<viewport> yarn jest <test_path>`
+
 ```
 VIEWPORT_NAME=mobile yarn jest ...
 ```
 
-### Target local webapp
+### Target a different environment
 
-Local webapp refers to a locally served instance of the `wp-calypso` frontend.
+To target a webapp running in a different environment:
 
-1. override the `calypsoBaseURL` value to point to `http://calypso.localhost:3000` using one of the following methods:
+1. determine the base URL to use for the appropriate environment.
 
-   a. change the `calypsoBaseURL` value in `test/e2e/config/default.json`.
+	- for local webapp: `http://calypso.localhost:3000`
+	- for staging webapp: `https://wordpress.com`
+	- for wpcalypso webapp: `https://wpcalypso.wordpress.com`
 
-   b. create a new local configuration. See [Test Environment](./test_environment.md#local-configs).
+2. set the `CALYPSO_BASE_URL` environment variable:
 
-   c. export `calypsoBaseURL` override as part of environment variable: `export NODE_CONFIG="{\"calypsoBaseURL\":\"${'$'}{URL/}\"}"`
+	a. set the variable to persist in the shell: `export CALYPSO_BASE_URL=<url>`
 
-2. start the webapp:
-
-```shell
-yarn start
-```
-
-3. once webapp is started, open `http://calypso.localhost:3000` in your browser.
+	b. set the variable for the command only: `CALYPSO_BASE_URL=<url> yarn jest <test_path>`
 
 <img alt="Local Calypso Webapp" src="https://cldup.com/1WwDmUXWen.png" />
-<sup><center>Local webapp start page.</center></sup>
-
-The local environment is now ready for testing. When a test is run, it will hit the locally run webapp instead of the WordPress.com staging environment.
+<sup><center>Example: webapp running on localhost.</center></sup>
 
 ### Debug mode
 

--- a/test/e2e/docs/writing_tests.md
+++ b/test/e2e/docs/writing_tests.md
@@ -9,16 +9,16 @@
 <!-- TOC -->
 
 - [Writing Tests](#writing-tests)
-    - [Example test spec](#example-test-spec)
-    - [Quick start](#quick-start)
-    - [Child-level describe blocks](#child-level-describe-blocks)
-    - [Test step](#test-step)
-    - [Hooks](#hooks)
-    - [Viewports](#viewports)
-    - [Block Smoke Testing](#block-smoke-testing)
-        - [Overview](#overview)
-        - [How To](#how-to)
-        - [Examples](#examples)
+  - [Example test spec](#example-test-spec)
+  - [Quick start](#quick-start)
+  - [Child-level describe blocks](#child-level-describe-blocks)
+  - [Test step](#test-step)
+  - [Hooks](#hooks)
+  - [Viewports](#viewports)
+  - [Block Smoke Testing](#block-smoke-testing)
+    - [Overview](#overview)
+    - [How To](#how-to)
+    - [Examples](#examples)
 
 <!-- /TOC -->
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the `Running tests locally` section of the documentation.

Key changes:
- take into account the large Secrets overhaul that was done in https://github.com/Automattic/wp-calypso/pull/63183.
- generalize the section on targeting local webapp to be applicable to various targets.
- miscellaneous formatting change.

#### Testing instructions

1. Navigate to [DevDocs](https://container-xenodochial-blackburn.calypso.live/devdocs)
2. read the section under Testing > End-to-end Tests > [Running tests on your machine](https://container-xenodochial-blackburn.calypso.live/devdocs/test/e2e/docs/tests_local.md).

Related to https://github.com/Automattic/wp-calypso/issues/63726.
