### PR TITLE
Jetpack Backups: Fix keys call on non-object

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -31,7 +31,7 @@ const BackupSuccessful = ( { backup, deltas, selectedDate } ) => {
 	} );
 
 	const warnings = getBackupWarnings( backup );
-	const hasWarnings = warnings ? Object.keys( warnings ).length !== 0 : false;
+	const hasWarnings = Object.keys( warnings ).length !== 0;
 
 	const moment = useLocalizedMoment();
 	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -31,7 +31,7 @@ const BackupSuccessful = ( { backup, deltas, selectedDate } ) => {
 	} );
 
 	const warnings = getBackupWarnings( backup );
-	const hasWarnings = Object.keys( warnings ).length !== 0;
+	const hasWarnings = warnings ? Object.keys( warnings ).length !== 0 : false;
 
 	const moment = useLocalizedMoment();
 	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );

--- a/client/lib/jetpack/backup-utils.js
+++ b/client/lib/jetpack/backup-utils.js
@@ -76,7 +76,7 @@ export const getBackupErrorCode = ( activity ) => {
  */
 export const getBackupWarnings = ( backup ) => {
 	if ( ! backup.activityWarnings ) {
-		return null;
+		return {};
 	}
 	const warnings = {};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Some sites were being affected by a bug that caused the backup screen to render blank
* Adds a check to the new warnings object

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check an affected site in the test container from the link below
