### PR TITLE
Users: add invite button to empty viewers page

### DIFF
--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-import { Card, Button, Gridicon } from '@automattic/components';
+import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
@@ -14,6 +14,7 @@ import NoResults from 'calypso/my-sites/no-results';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import PeopleListSectionHeader from 'calypso/my-sites/people/people-list-section-header';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import InviteButton from '../invite-button';
 
 class Followers extends Component {
 	infiniteList = createRef();
@@ -91,14 +92,9 @@ class Followers extends Component {
 	}
 
 	renderInviteFollowersAction( isPrimary = true ) {
-		const { site, translate } = this.props;
+		const { site } = this.props;
 
-		return (
-			<Button primary={ isPrimary } href={ `/people/new/${ site.slug }` }>
-				<Gridicon icon="user-add" />
-				<span>{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }</span>
-			</Button>
-		);
+		return <InviteButton primary={ isPrimary } siteSlug={ site.slug } />;
 	}
 
 	render() {

--- a/client/my-sites/people/invite-button.jsx
+++ b/client/my-sites/people/invite-button.jsx
@@ -1,7 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 
-const InviteButton = ( { siteSlug } ) => {
+const InviteButton = ( { isPrimary = true, siteSlug } ) => {
 	const translate = useTranslate();
 
 	if ( ! siteSlug ) {
@@ -9,7 +9,7 @@ const InviteButton = ( { siteSlug } ) => {
 	}
 
 	return (
-		<Button primary href={ `/people/new/${ siteSlug }` }>
+		<Button primary={ isPrimary } href={ `/people/new/${ siteSlug }` }>
 			<Gridicon icon="user-add" />
 			<span>{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }</span>
 		</Button>

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -1,4 +1,4 @@
-import { Card, Button, Dialog, Gridicon } from '@automattic/components';
+import { Card, Button, Dialog } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 import PropTypes from 'prop-types';
@@ -25,6 +25,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import InviteButton from '../invite-button';
 import InvitesListEnd from './invites-list-end';
 
 import './style.scss';
@@ -214,14 +215,9 @@ class PeopleInvites extends PureComponent {
 	}
 
 	renderInviteUsersAction( isPrimary = true ) {
-		const { site, translate } = this.props;
+		const { site } = this.props;
 
-		return (
-			<Button primary={ isPrimary } href={ `/people/new/${ site.slug }` }>
-				<Gridicon icon="user-add" />
-				<span>{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }</span>
-			</Button>
-		);
+		return <InviteButton primary={ isPrimary } siteSlug={ site.slug } />;
 	}
 
 	renderPlaceholder() {

--- a/client/my-sites/people/viewers-list/invite-button.jsx
+++ b/client/my-sites/people/viewers-list/invite-button.jsx
@@ -3,6 +3,11 @@ import { useTranslate } from 'i18n-calypso';
 
 const InviteButton = ( { siteSlug } ) => {
 	const translate = useTranslate();
+
+	if ( ! siteSlug ) {
+		return null;
+	}
+
 	return (
 		<Button primary href={ `/people/new/${ siteSlug }` }>
 			<Gridicon icon="user-add" />

--- a/client/my-sites/people/viewers-list/invite-button.jsx
+++ b/client/my-sites/people/viewers-list/invite-button.jsx
@@ -1,7 +1,8 @@
 import { Button, Gridicon } from '@automattic/components';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
-const InviteButton = ( { siteSlug, translate } ) => {
+const InviteButton = ( { siteSlug } ) => {
+	const translate = useTranslate();
 	return (
 		<Button primary href={ `/people/new/${ siteSlug }` }>
 			<Gridicon icon="user-add" />
@@ -10,4 +11,4 @@ const InviteButton = ( { siteSlug, translate } ) => {
 	);
 };
 
-export default localize( InviteButton );
+export default InviteButton;

--- a/client/my-sites/people/viewers-list/invite-button.jsx
+++ b/client/my-sites/people/viewers-list/invite-button.jsx
@@ -3,7 +3,7 @@ import { localize } from 'i18n-calypso';
 
 const InviteButton = ( { siteSlug, translate } ) => {
 	return (
-		<Button primary={ true } href={ `/people/new/${ siteSlug }` }>
+		<Button primary href={ `/people/new/${ siteSlug }` }>
 			<Gridicon icon="user-add" />
 			<span>{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }</span>
 		</Button>

--- a/client/my-sites/people/viewers-list/invite-button.jsx
+++ b/client/my-sites/people/viewers-list/invite-button.jsx
@@ -1,0 +1,13 @@
+import { Button, Gridicon } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+
+const InviteButton = ( { siteSlug, translate } ) => {
+	return (
+		<Button primary={ true } href={ `/people/new/${ siteSlug }` }>
+			<Gridicon icon="user-add" />
+			<span>{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }</span>
+		</Button>
+	);
+};
+
+export default localize( InviteButton );

--- a/client/my-sites/people/viewers-list/viewers.jsx
+++ b/client/my-sites/people/viewers-list/viewers.jsx
@@ -85,7 +85,10 @@ class Viewers extends Component {
 		};
 
 		if ( this.props.site && ! this.props.site.jetpack ) {
-			emptyContentArgs.action = <InviteButton siteSlug={ this.props.site.slug } />;
+			emptyContentArgs = {
+				...emptyContentArgs, 
+				action: <InviteButton siteSlug={ this.props.site.slug } />
+			};
 		}
 
 		if ( ! this.props.viewers.length && ! this.props.isFetching ) {

--- a/client/my-sites/people/viewers-list/viewers.jsx
+++ b/client/my-sites/people/viewers-list/viewers.jsx
@@ -11,6 +11,7 @@ import accept from 'calypso/lib/accept';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import PeopleListSectionHeader from 'calypso/my-sites/people/people-list-section-header';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import InviteButton from './invite-button';
 
 class Viewers extends Component {
 	infiniteList = createRef();
@@ -82,6 +83,10 @@ class Viewers extends Component {
 					? this.props.translate( "Oops, Jetpack sites don't support viewers." )
 					: this.props.translate( "You don't have any viewers yet." ),
 		};
+
+		if ( this.props.site && ! this.props.site.jetpack ) {
+			emptyContentArgs.action = <InviteButton siteSlug={ this.props.site.slug } />;
+		}
 
 		if ( ! this.props.viewers.length && ! this.props.isFetching ) {
 			if ( this.props.site && ! this.props.site.jetpack && ! this.props.site.is_private ) {

--- a/client/my-sites/people/viewers-list/viewers.jsx
+++ b/client/my-sites/people/viewers-list/viewers.jsx
@@ -76,23 +76,23 @@ class Viewers extends Component {
 	getViewerRef = ( viewer ) => 'viewer-' + viewer.ID;
 
 	render() {
+		const isJetpackSite = this.props.site?.jetpack;
 		let viewers;
 		let emptyContentArgs = {
-			title:
-				this.props.site && this.props.site.jetpack
-					? this.props.translate( "Oops, Jetpack sites don't support viewers." )
-					: this.props.translate( "You don't have any viewers yet." ),
+			title: isJetpackSite
+				? this.props.translate( "Oops, Jetpack sites don't support viewers." )
+				: this.props.translate( "You don't have any viewers yet." ),
 		};
 
-		if ( this.props.site && ! this.props.site.jetpack ) {
+		if ( ! isJetpackSite ) {
 			emptyContentArgs = {
-				...emptyContentArgs, 
-				action: <InviteButton siteSlug={ this.props.site.slug } />
+				...emptyContentArgs,
+				action: <InviteButton siteSlug={ this.props.site?.slug } />,
 			};
 		}
 
 		if ( ! this.props.viewers.length && ! this.props.isFetching ) {
-			if ( this.props.site && ! this.props.site.jetpack && ! this.props.site.is_private ) {
+			if ( this.props.site && ! isJetpackSite && ! this.props.site.is_private ) {
 				emptyContentArgs = Object.assign( emptyContentArgs, {
 					line: this.props.translate(
 						'Only private sites can have viewers. You can make your site private by ' +

--- a/client/my-sites/people/viewers-list/viewers.jsx
+++ b/client/my-sites/people/viewers-list/viewers.jsx
@@ -11,7 +11,7 @@ import accept from 'calypso/lib/accept';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import PeopleListSectionHeader from 'calypso/my-sites/people/people-list-section-header';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import InviteButton from './invite-button';
+import InviteButton from '../invite-button';
 
 class Viewers extends Component {
 	infiniteList = createRef();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On the 'Email followers' tab in the Users section, there is an Invite button displayed when a site has no email followers. I noticed that an empty 'Viewers' section on a private site does not have an Invite button, which seemed inconsistent.

This PR adds an 'Invite' button to the empty Viewers page.

Before: 

<img width="774" alt="Screen Shot 2022-05-18 at 12 43 11" src="https://user-images.githubusercontent.com/17325/168934700-28730e70-4a92-4a8b-adae-556a464185c6.png">

After:

<img width="775" alt="Screen Shot 2022-05-18 at 12 43 16" src="https://user-images.githubusercontent.com/17325/168934710-11bf4261-9e44-4f30-8758-79d651203e71.png">

#### Testing instructions

1. Create a new private site.
2. Navigate to http://calypso.localhost:3000/people/viewers/<your site url>
3. Ensure that the 'Invite' button is displayed and that it takes you to the Invite form.
4. Check each of the sections under Users behave the same way - this PR modifies the invite button component used across all sections.

