### PR TITLE
Marketplace: Category selector - mobile breakpoint

### DIFF
--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -4,7 +4,7 @@ import Breadcrumb, { Item as TBreadcrumbItem } from 'calypso/components/breadcru
 
 const Header = styled.header`
 	position: fixed;
-	z-index: 1;
+	z-index: 10;
 	top: var( --masterbar-height );
 	left: calc( var( --sidebar-width-max ) + 1px ); // 1px is the sidebar border.
 	width: calc( 100% - var( --sidebar-width-max ) - 1px ); // 1px is the sidebar border.

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -5,6 +5,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ResponsiveToolbarGroup from './responsive-toolbar-group';
+import SwipeMenu from './swipe-menu';
 import { useCategories } from './use-categories';
 import './style.scss';
 
@@ -46,7 +47,6 @@ const Categories = ( { selected }: { selected?: string } ) => {
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 
 	const categories = Object.values( useCategories( ALLOWED_CATEGORIES ) );
-
 	const onClick = ( index: number ) => {
 		const category = categories[ index ];
 
@@ -73,8 +73,17 @@ const Categories = ( { selected }: { selected?: string } ) => {
 	const current = selected ? categories.findIndex( ( { slug } ) => slug === selected ) : 0;
 
 	if ( isSwippeable ) {
-		//return mobile view
-		return <div></div>;
+		return (
+			<SwipeMenu
+				className="categories__swipe-menu"
+				initialActiveIndex={ current }
+				onClick={ onClick }
+			>
+				{ categories.map( ( category ) => (
+					<span key={ `category-${ category.slug }` }>{ category.name }</span>
+				) ) }
+			</SwipeMenu>
+		);
 	}
 
 	return (

--- a/client/my-sites/plugins/categories/style.scss
+++ b/client/my-sites/plugins/categories/style.scss
@@ -17,3 +17,45 @@
 		}
 	}
 };
+
+.categories__swipe-menu {
+	width: 100%;
+
+	.categories__swipe-menu-list {
+		padding: 0 44px;
+		display: flex;
+		flex-wrap: nowrap;
+		overflow-x: scroll;
+		overflow-y: hidden;
+
+		border: none;
+
+		.categories__swipe-menu-scroll {
+			position: absolute;
+			z-index: 2;
+			&.scroll-left {
+				left: 0;
+				background: linear-gradient( to left, transparent, white 30% );
+			}
+
+			&.scroll-right {
+				right: 0;
+				background: linear-gradient( to right, transparent, white 30% );
+			}
+		}
+
+		.categories__swipe-menu-item {
+			font-size: 0.875rem;
+		}
+
+		// Core override - prevent buttons from wordwrapping content
+		> div {
+			flex-shrink: 0;
+		}
+	}
+
+	.components-toolbar .components-button::before {
+		box-shadow: none;
+	}
+
+}

--- a/client/my-sites/plugins/categories/swipe-menu.tsx
+++ b/client/my-sites/plugins/categories/swipe-menu.tsx
@@ -1,0 +1,62 @@
+import { Gridicon } from '@automattic/components';
+import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import classnames from 'classnames';
+import { ReactChild, useRef, useState } from 'react';
+
+import './style.scss';
+
+export default function SwipeMenu( {
+	children,
+	className = '',
+	onClick = () => null,
+	initialActiveIndex = -1,
+}: {
+	children: ReactChild[];
+	className?: string;
+	onClick?: ( index: number ) => void;
+	initialActiveIndex?: number;
+} ) {
+	const classes = classnames( 'categories__swipe-menu', className );
+
+	const toolbarRef = useRef< HTMLDivElement | null >( null );
+
+	const [ activeIndex, setActiveIndex ] = useState< number >( initialActiveIndex );
+
+	function scrollRef( ref: typeof toolbarRef, distance: number ) {
+		if ( ref?.current ) {
+			ref.current.children[ 0 ].scrollLeft += distance;
+		}
+	}
+
+	return (
+		<div className={ classes } ref={ toolbarRef }>
+			<ToolbarGroup className="categories__swipe-menu-list">
+				<ToolbarButton
+					className="categories__swipe-menu-scroll scroll-left"
+					onClick={ () => scrollRef( toolbarRef, -100 ) }
+				>
+					<Gridicon icon="chevron-left" />
+				</ToolbarButton>
+				{ children.map( ( child, index ) => (
+					<ToolbarButton
+						key={ `button-item-${ index }` }
+						isActive={ activeIndex === index }
+						onClick={ () => {
+							setActiveIndex( index );
+							onClick( index );
+						} }
+						className="categories__swipe-menu-item"
+					>
+						{ child }
+					</ToolbarButton>
+				) ) }
+				<ToolbarButton
+					className="categories__swipe-menu-scroll scroll-right"
+					onClick={ () => scrollRef( toolbarRef, 100 ) }
+				>
+					<Gridicon icon="chevron-right" />
+				</ToolbarButton>
+			</ToolbarGroup>
+		</div>
+	);
+}

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -48,7 +48,7 @@ export function useCategories(
 	}
 
 	const categories = {
-		discover: { name: __( 'Discover' ), slug: 'discover', tags: [] },
+		discover: { name: __( 'All' ), slug: 'discover', tags: [] },
 		paid: { name: __( 'Top paid plugins' ), slug: 'paid', tags: [] },
 		popular: { name: __( 'Top free plugins' ), slug: 'popular', tags: [] },
 		featured: { name: __( 'Editor’s pick' ), slug: 'featured', tags: [] },

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -103,7 +103,7 @@
 		@media ( min-width: 783px ) {
 			margin-top: 0;
 			position: fixed;
-			z-index: 2;
+			z-index: 20;
 			top: var( --masterbar-height );
 			left: calc( var( --sidebar-width-max ) + 1px );
 			width: calc( 100% - var( --sidebar-width-max ) - 1px );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds mobile only handling for the category selector to replace dropdown with a swipe / scroll selector in its place

#### Testing instructions

* On mobile breakpoints < 660px, you should see the swipe-friendly category selector and be able to change category.
* At non mobile breakpoints the new selector from [this parent branch / pr](https://github.com/Automattic/wp-calypso/pull/63592) should render in its place.

https://user-images.githubusercontent.com/811776/168952850-9817b330-f6f7-4709-893d-ea0b3fa4966b.mp4

Related to https://github.com/Automattic/wp-calypso/issues/62891
