### PR TITLE
Complete the feature list of the Starter plan on the checkout page

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -10,6 +10,7 @@ import {
 	isWpComBusinessPlan,
 	isWpComEcommercePlan,
 	isWpComPremiumPlan,
+	isStarterPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import {
@@ -158,7 +159,10 @@ function CheckoutSummaryFeaturesList( props: {
 	const domains = responseCart.products.filter(
 		( product ) => isDomainProduct( product ) || isDomainTransfer( product )
 	);
-	const hasPlanInCart = responseCart.products.some( ( product ) => isPlan( product ) );
+
+	const plans = responseCart.products.filter( ( product ) => isPlan( product ) );
+	const hasPlanInCart = plans.length > 0;
+
 	const translate = useTranslate();
 	const isJetpackNotAtomic = useSelector( ( state ) =>
 		siteId ? isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) : undefined
@@ -188,7 +192,7 @@ function CheckoutSummaryFeaturesList( props: {
 			) }
 			<CheckoutSummaryFeaturesListItem>
 				<WPCheckoutCheckIcon id="features-list-support-text" />
-				<SupportText hasPlanInCart={ hasPlanInCart } isJetpackNotAtomic={ isJetpackNotAtomic } />
+				<SupportText plans={ plans } isJetpackNotAtomic={ isJetpackNotAtomic } />
 			</CheckoutSummaryFeaturesListItem>
 
 			{ ! hasPlanInCart && <CheckoutSummaryChatIfAvailable siteId={ siteId } /> }
@@ -204,15 +208,21 @@ function CheckoutSummaryFeaturesList( props: {
 }
 
 function SupportText( {
-	hasPlanInCart,
+	plans,
 	isJetpackNotAtomic,
 }: {
-	hasPlanInCart?: boolean;
+	plans: Array< ResponseCartProduct >;
 	isJetpackNotAtomic?: boolean | null;
 } ) {
 	const translate = useTranslate();
+	const hasOnlyStarterPlan =
+		plans.filter( ( plan ) => isStarterPlan( plan.product_slug ) ).length === plans.length;
 
-	if ( hasPlanInCart && ! isJetpackNotAtomic ) {
+	if ( hasOnlyStarterPlan ) {
+		return null;
+	}
+
+	if ( plans.length && ! isJetpackNotAtomic ) {
 		return <span>{ translate( 'Unlimited customer support via email' ) }</span>;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-plan-features.ts
@@ -6,6 +6,7 @@ import {
 	isWpComEcommercePlan,
 	isWpComPersonalPlan,
 	isWpComPremiumPlan,
+	isStarterPlan,
 } from '@automattic/calypso-products';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
@@ -37,6 +38,15 @@ export default function getPlanFeatures(
 			! isMonthlyPlan && freeOneYearDomain,
 			String( translate( 'Best-in-class hosting' ) ),
 			String( translate( 'Dozens of Free Themes' ) ),
+		].filter( isValueTruthy );
+	}
+
+	if ( isStarterPlan( productSlug ) ) {
+		return [
+			freeOneYearDomain,
+			String( translate( 'Best-in-class hosting' ) ),
+			String( translate( 'Dozens of Free Themes' ) ),
+			String( translate( 'Track your stats with Google Analytics' ) ),
 		].filter( isValueTruthy );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the included features on the Starter Plan checkout by:
- bringing in the Personal features
- replacing `Unlimited customer support via email` with `Track your stats with Google Analytics`

#### Testing instructions

* Go to /start/starter and proceed through to the checkout page
* The `Included with your purchase` section should show the Starter plan features

* Go to /start/personal and proceed through to the checkout page
* Make sure that the `Unlimited customer support via email` is still mentioned

<img width="480" src="https://user-images.githubusercontent.com/2749938/169003448-74c7b4ac-0a66-404e-a929-d1c49349e1c6.png"/>