### PR TITLE
Stepper: Use CalypsoI18nProvider and i18n-calypso locale setup

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -3,12 +3,15 @@ import accessibleFocus from '@automattic/accessible-focus';
 import { initializeAnalytics } from '@automattic/calypso-analytics';
 import { CurrentUser } from '@automattic/calypso-analytics/dist/types/utils/current-user';
 import config from '@automattic/calypso-config';
+import defaultCalypsoI18n from 'i18n-calypso';
 import ReactDom from 'react-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { requestAllBlogsAccess } from 'wpcom-proxy-request';
+import { setupLocale } from 'calypso/boot/locale';
 import AsyncLoad from 'calypso/components/async-load';
+import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
 import { createReduxStore } from 'calypso/state';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
@@ -18,7 +21,6 @@ import { loadPersistedState } from 'calypso/state/persisted-state';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
 import { requestSites } from 'calypso/state/sites/actions';
-import { LocaleContext } from '../gutenboarding/components/locale-context';
 import { WindowLocaleEffectManager } from '../gutenboarding/components/window-locale-effect-manager';
 import { setupWpDataDebug } from '../gutenboarding/devtools';
 import { anchorFmFlow } from './declarative-flow/anchor-fm-flow';
@@ -86,10 +88,11 @@ window.AppBoot = async () => {
 	const initialState = getInitialState( initialReducer, userId );
 	const reduxStore = createReduxStore( initialState, initialReducer );
 	setStore( reduxStore, getStateFromCache( userId ) );
+	setupLocale( user, reduxStore );
 	user && setupHappyChat( reduxStore, user as CurrentUser );
 
 	ReactDom.render(
-		<LocaleContext>
+		<CalypsoI18nProvider i18n={ defaultCalypsoI18n }>
 			<Provider store={ reduxStore }>
 				<QueryClientProvider client={ queryClient }>
 					<WindowLocaleEffectManager />
@@ -99,7 +102,7 @@ window.AppBoot = async () => {
 					<AsyncLoad require="calypso/blocks/inline-help" placeholder={ null } />
 				</QueryClientProvider>
 			</Provider>
-		</LocaleContext>,
+		</CalypsoI18nProvider>,
 		document.getElementById( 'wpcom' )
 	);
 };


### PR DESCRIPTION
Stepper section doesn't load the translation data correctly, because it uses the `LocaleContext` from Gutenboarding section, which supports only `@wordpress/i18n` and `@wordpress/react-i18n`, whereas we use `translate` calls from `i18n-calypso` within the Stepper section.

#### Changes proposed in this Pull Request

* Remove `LocaleContext` from Gutenboarding
* Use `CalypsoI18nProvider` and the locale setup for `i18n-calypso`.

**Before:**
![CleanShot 2022-05-18 at 12 50 32](https://user-images.githubusercontent.com/2722412/169011526-e46f51d5-7aa9-43cf-8e68-eb6a5d151f52.png)

**After:**
![CleanShot 2022-05-18 at 12 50 19](https://user-images.githubusercontent.com/2722412/169011564-494da671-5950-477f-96e5-026499871b59.png)

#### Testing instructions

* Code review
* Change UI language to a Mag-16 language
* Go to `/start` and follow the steps for creating a new site (choose a domain, select free plan)
* Upon landing on the setup screen, confirm the strings are rendered in the selected language

Related to 436-gh-Automattic/i18n-issues
