### PR TITLE
Stepper: Redirects when a logged out user hits the Site setup flow.

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -7,7 +7,7 @@ import { useFSEStatus } from '../hooks/use-fse-status';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
-import { ONBOARD_STORE, SITE_STORE } from '../stores';
+import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { ProcessingResult } from './internals/steps-repository/processing-step';
 import type { StepPath } from './internals/steps-repository';
@@ -344,6 +344,12 @@ export const siteSetupFlow: Flow = {
 	useAssertConditions() {
 		const siteSlug = useSiteSlugParam();
 		const siteId = useSiteIdParam();
+		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+
+		if ( ! userIsLoggedIn ) {
+			redirect( '/start' );
+			throw new Error( 'site-setup requires a logged in user' );
+		}
 
 		if ( ! siteSlug && ! siteId ) {
 			throw new Error( 'site-setup did not provide the site slug or site id it is configured to.' );

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -3,6 +3,8 @@ import accessibleFocus from '@automattic/accessible-focus';
 import { initializeAnalytics } from '@automattic/calypso-analytics';
 import { CurrentUser } from '@automattic/calypso-analytics/dist/types/utils/current-user';
 import config from '@automattic/calypso-config';
+import { User as UserStore } from '@automattic/data-stores';
+import { useDispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
 import ReactDom from 'react-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -28,6 +30,7 @@ import { FlowRenderer } from './declarative-flow/internals';
 import { siteSetupFlow } from './declarative-flow/site-setup-flow';
 import 'calypso/components/environment-badge/style.scss';
 import { useAnchorFmParams } from './hooks/use-anchor-fm-params';
+import { USER_STORE } from './stores';
 
 function generateGetSuperProps() {
 	return () => ( {
@@ -44,13 +47,16 @@ function setupHappyChat( reduxStore: any, user: CurrentUser ) {
 	reduxStore.dispatch( requestSites() );
 }
 
-const FlowWrapper: React.FC = () => {
+const FlowWrapper: React.FC< { user: UserStore.CurrentUser | undefined } > = ( { user } ) => {
 	const { anchorFmPodcastId } = useAnchorFmParams();
 	let flow = siteSetupFlow;
 
 	if ( anchorFmPodcastId && config.isEnabled( 'signup/anchor-fm' ) ) {
 		flow = anchorFmFlow;
 	}
+
+	const { receiveCurrentUser } = useDispatch( USER_STORE );
+	user && receiveCurrentUser( user as UserStore.CurrentUser );
 
 	return <FlowRenderer flow={ flow } />;
 };
@@ -89,6 +95,7 @@ window.AppBoot = async () => {
 	const reduxStore = createReduxStore( initialState, initialReducer );
 	setStore( reduxStore, getStateFromCache( userId ) );
 	setupLocale( user, reduxStore );
+
 	user && setupHappyChat( reduxStore, user as CurrentUser );
 
 	ReactDom.render(
@@ -97,7 +104,7 @@ window.AppBoot = async () => {
 				<QueryClientProvider client={ queryClient }>
 					<WindowLocaleEffectManager />
 					<BrowserRouter basename="setup">
-						<FlowWrapper />
+						<FlowWrapper user={ user as UserStore.CurrentUser } />
 					</BrowserRouter>
 					<AsyncLoad require="calypso/blocks/inline-help" placeholder={ null } />
 				</QueryClientProvider>


### PR DESCRIPTION
Redirects when a logged out user hits the Site setup flow. [This change](https://github.com/Automattic/wp-calypso/pull/63727) needed to be reverted because of failing pre-release tests.

The reason tests where failing was that [this PR](https://github.com/Automattic/wp-calypso/pull/63753) was merged after the CI passed. That change replaced `LocaleContext` by `CalypsoI18nProvider`, which is good. Sadly, the `LocaleContext` component was initializing the `User` data-store with the current user, so when it was replaced that stopped happening.

This PRs adds the original `/start` redirection from [this PR](https://github.com/Automattic/wp-calypso/pull/63727) and also fixes the initialization issue.

#### Testing
1. Apply this PR.
2. While logged out navigate to a valid `site-setup` flow url, eg: `http://calypso.localhost:3000/setup/businessInfo?siteSlug=[YOUR_SITE]`.
3. Verify that you are redirected to `/start`.
4. Verify you can log in correctly.
5. While logged in, try to navigate to the URL in `2.` and verify it works as expected.
6. **Verify that Pre-release tests pass.**
7. Verify that the steps are correctly translated for languages other than English.

**NOTE** On incognito the `/start` login seems to be failing due to some local storage issues. I've tested with a logged out Firefox.