### PR TITLE
Plan Cancellation: replace plan check with plan has feature

### DIFF
--- a/client/state/purchases/selectors/will-atomic-site-revert-after-purchase-deactivation.js
+++ b/client/state/purchases/selectors/will-atomic-site-revert-after-purchase-deactivation.js
@@ -1,9 +1,4 @@
-import {
-	isWpComBusinessPlan,
-	isWpComEcommercePlan,
-	isWpComProPlan,
-} from '@automattic/calypso-products';
-import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
+import { planHasFeature, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getByPurchaseId } from './get-by-purchase-id';
 import { getSitePurchases } from './get-site-purchases';
@@ -28,10 +23,7 @@ export const willAtomicSiteRevertAfterPurchaseDeactivation = ( state, purchaseId
 	const purchase = getByPurchaseId( state, purchaseId );
 
 	const isAtomicSupportedProduct = ( productSlug ) =>
-		isWpComProPlan( productSlug ) ||
-		isWpComBusinessPlan( productSlug ) ||
-		isWpComEcommercePlan( productSlug ) ||
-		isMarketplaceProduct( state, productSlug );
+		planHasFeature( productSlug, WPCOM_FEATURES_ATOMIC );
 
 	if (
 		! purchase ||

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -199,6 +199,7 @@ import {
 	TYPE_STARTER,
 	FEATURE_TITAN_EMAIL,
 	FEATURE_SOCIAL_MEDIA_TOOLS,
+	WPCOM_FEATURES_ATOMIC,
 } from './constants';
 import type {
 	BillingTerm,
@@ -478,6 +479,7 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_UPLOAD_THEMES_PLUGINS,
 		FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
 		FEATURE_SEO_PREVIEW_TOOLS,
+		WPCOM_FEATURES_ATOMIC,
 	],
 	getInferiorFeatures: () => [],
 } );
@@ -668,6 +670,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_CLOUDFLARE_ANALYTICS,
 		FEATURE_EMAIL_FORWARDING_EXTENDED_LIMIT,
 		FEATURE_SEO_PREVIEW_TOOLS,
+		WPCOM_FEATURES_ATOMIC,
 	],
 	getInferiorFeatures: () => [],
 } );
@@ -1660,5 +1663,6 @@ PLANS_LIST[ PLAN_WPCOM_PRO ] = {
 		FEATURE_UPLOAD_PLUGINS,
 		FEATURE_UPLOAD_THEMES,
 		FEATURE_UPLOAD_THEMES_PLUGINS,
+		WPCOM_FEATURES_ATOMIC,
 	],
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR replaces plan to check with feature check by adding the Atomic feature constant to appropriate plan details so that product can offer the Atomic feature. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Please follow test instructions provided in [#63737](https://github.com/Automattic/wp-calypso/pull/63737)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Depends on: [#63737](https://github.com/Automattic/wp-calypso/pull/63737)
