### PR TITLE
Framework: Refactor rest of `client` tests away from `chai`

### DIFF
--- a/client/blocks/daily-post-button/test/helper.js
+++ b/client/blocks/daily-post-button/test/helper.js
@@ -1,29 +1,28 @@
-import { assert } from 'chai';
 import * as helper from '../helper';
 import * as posts from './fixtures';
 
 describe( 'daily post helper', () => {
 	describe( 'isDailyPostChallengeOrPrompt', () => {
 		test( 'returns false if the post is not from daily post', () => {
-			assert.isFalse( helper.isDailyPostChallengeOrPrompt( posts.basicPost ) );
+			expect( helper.isDailyPostChallengeOrPrompt( posts.basicPost ) ).toBe( false );
 		} );
 
 		test( 'returns false if the post is from daily post but is not a challenge or prompt', () => {
-			assert.isFalse( helper.isDailyPostChallengeOrPrompt( posts.dailyPostSitePost ) );
+			expect( helper.isDailyPostChallengeOrPrompt( posts.dailyPostSitePost ) ).toBe( false );
 		} );
 	} );
 
 	describe( 'getDailyPostType', () => {
 		test( 'returns "prompt" if the post is a daily prompt', () => {
-			assert.equal( 'prompt', helper.getDailyPostType( posts.dailyPromptPost ) );
+			expect( 'prompt' ).toEqual( helper.getDailyPostType( posts.dailyPromptPost ) );
 		} );
 
 		test( 'returns "photo" if the post is a photo challenge', () => {
-			assert.equal( 'photo', helper.getDailyPostType( posts.photoChallengePost ) );
+			expect( 'photo' ).toEqual( helper.getDailyPostType( posts.photoChallengePost ) );
 		} );
 
 		test( 'returns "discover" if the post is a discover challenge', () => {
-			assert.equal( 'discover', helper.getDailyPostType( posts.discoverChallengePost ) );
+			expect( 'discover' ).toEqual( helper.getDailyPostType( posts.discoverChallengePost ) );
 		} );
 	} );
 } );

--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import pageSpy from 'page';
 import { parse } from 'qs';
@@ -34,7 +32,7 @@ describe( 'DailyPostButton', () => {
 					markPostSeen={ markPostSeen }
 				/>
 			);
-			assert.isNull( dailyPostPrompt.type() );
+			expect( dailyPostPrompt.type() ).toBeNull();
 		} );
 
 		test( 'renders as a span tag by default', () => {
@@ -48,7 +46,7 @@ describe( 'DailyPostButton', () => {
 					markPostSeen={ markPostSeen }
 				/>
 			);
-			assert.equal( 'span', renderAsSpan.type() );
+			expect( renderAsSpan.type() ).toEqual( 'span' );
 		} );
 
 		test( 'renders as the tag specified in props tagName', () => {
@@ -63,7 +61,7 @@ describe( 'DailyPostButton', () => {
 					markPostSeen={ markPostSeen }
 				/>
 			);
-			assert.equal( 'span', renderAsSpan.type() );
+			expect( renderAsSpan.type() ).toEqual( 'span' );
 		} );
 	} );
 
@@ -80,7 +78,7 @@ describe( 'DailyPostButton', () => {
 				/>
 			);
 			dailyPostButton.simulate( 'click', { preventDefault: noop } );
-			assert.isTrue( pageSpy.calledWithMatch( /post\/apps.wordpress.com?/ ) );
+			expect( pageSpy.calledWithMatch( /post\/apps.wordpress.com?/ ) ).toBe( true );
 		} );
 
 		// eslint-disable-next-line jest/expect-expect
@@ -120,7 +118,7 @@ describe( 'DailyPostButton', () => {
 			const pageArgs = pageSpy.lastCall.args[ 0 ];
 			const query = parse( pageArgs.split( '?' )[ 1 ] );
 			const { title, URL } = dailyPromptPost;
-			assert.deepEqual( query, { title: `Daily Prompt: ${ title }`, url: URL } );
+			expect( query ).toEqual( { title: `Daily Prompt: ${ title }`, url: URL } );
 		} );
 	} );
 } );

--- a/client/blocks/inline-help/test/admin-sections.js
+++ b/client/blocks/inline-help/test/admin-sections.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { filterListBySearchTerm } from 'calypso/blocks/inline-help/admin-sections';
 
 describe( 'filterListBySearchTerm()', () => {
@@ -21,17 +20,17 @@ describe( 'filterListBySearchTerm()', () => {
 
 	test( 'should ignore non-word characters and return an empty array', () => {
 		const result = filterListBySearchTerm( "<$(*&#\\\\\\'''''>", mockCollection );
-		expect( result ).to.deep.equal( [] );
+		expect( result ).toEqual( [] );
 	} );
 
 	test( 'should return an empty array for no matches', () => {
 		const result = filterListBySearchTerm( 'ciao', mockCollection );
-		expect( result ).to.deep.equal( [] );
+		expect( result ).toEqual( [] );
 	} );
 
 	test( 'should return a direct match', () => {
 		const result = filterListBySearchTerm( 'The best section', mockCollection );
-		expect( result ).to.deep.equal( [
+		expect( result ).toEqual( [
 			{
 				description: 'Better than that other section.',
 				icon: 'beta',
@@ -44,7 +43,7 @@ describe( 'filterListBySearchTerm()', () => {
 
 	test( 'should return a partial match', () => {
 		const result = filterListBySearchTerm( 'best section', mockCollection );
-		expect( result ).to.deep.equal( [
+		expect( result ).toEqual( [
 			{
 				description: 'Better than that other section.',
 				icon: 'beta',
@@ -57,7 +56,7 @@ describe( 'filterListBySearchTerm()', () => {
 
 	test( 'should return a synonym match', () => {
 		const result = filterListBySearchTerm( 'yolo', mockCollection );
-		expect( result ).to.deep.equal( [
+		expect( result ).toEqual( [
 			{
 				description: 'Better than that other section.',
 				icon: 'beta',

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import FormsButton from 'calypso/components/forms/form-button';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
@@ -22,9 +20,9 @@ describe( 'LoginForm', () => {
 			const wrapper = shallow(
 				<LoginForm translate={ noop } socialAccountLink={ { isLinking: false } } />
 			);
-			expect( wrapper.find( FormTextInput ).length ).to.equal( 1 );
-			expect( wrapper.find( FormPasswordInput ).length ).to.equal( 1 );
-			expect( wrapper.find( FormsButton ).length ).to.equal( 1 );
+			expect( wrapper.find( FormTextInput ).length ).toEqual( 1 );
+			expect( wrapper.find( FormPasswordInput ).length ).toEqual( 1 );
+			expect( wrapper.find( FormsButton ).length ).toEqual( 1 );
 		} );
 	} );
 } );

--- a/client/me/help/help-contact-form/test/utils.js
+++ b/client/me/help/help-contact-form/test/utils.js
@@ -1,21 +1,20 @@
-import { expect } from 'chai';
 import { generateSubjectFromMessage } from '../utils';
 
 describe( 'utils', () => {
 	describe( '#generateSubjectFromMessage', () => {
 		test( 'should return empty string for empty string', () => {
 			const str = generateSubjectFromMessage( '' );
-			expect( str ).to.equal( '' );
+			expect( str ).toEqual( '' );
 		} );
 		test( 'should return first 20 characters if input equals 20 characters', () => {
 			const str = generateSubjectFromMessage( '12345678901234567890' );
-			expect( str ).to.equal( '12345678901234567890' );
+			expect( str ).toEqual( '12345678901234567890' );
 		} );
 		test( 'should return first 40 characters in input has more than 40 characters', () => {
 			const str = generateSubjectFromMessage(
 				'12345678901234567890123456789012345678901234567890'
 			);
-			expect( str ).to.equal( '1234567890123456789012345678901234567890' );
+			expect( str ).toEqual( '1234567890123456789012345678901234567890' );
 		} );
 	} );
 } );

--- a/client/me/purchases/billing-history/test/utils.js
+++ b/client/me/purchases/billing-history/test/utils.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import { groupDomainProducts } from '../utils';
 
@@ -9,7 +8,7 @@ describe( 'utils', () => {
 		test( 'should return non-domain items unchanged', () => {
 			const items = deepFreeze( [ { foo: 'bar', product_slug: 'foobar' } ] );
 			const result = groupDomainProducts( items, ident );
-			expect( result ).to.eql( items );
+			expect( result ).toEqual( items );
 		} );
 
 		test( 'should return a domain item with a groupCount', () => {
@@ -27,7 +26,7 @@ describe( 'utils', () => {
 				},
 			];
 			const result = groupDomainProducts( items, ident );
-			expect( result ).to.eql( expected );
+			expect( result ).toEqual( expected );
 		} );
 
 		test( 'should not group domain items with different domains', () => {
@@ -64,8 +63,8 @@ describe( 'utils', () => {
 				},
 			];
 			const result = groupDomainProducts( items, ident );
-			expect( result ).to.eql( expected );
-			expect( result.length ).to.eql( 3 );
+			expect( result ).toEqual( expected );
+			expect( result.length ).toEqual( 3 );
 		} );
 
 		test( 'should only return one domain item of multiple with the same domain', () => {
@@ -85,7 +84,7 @@ describe( 'utils', () => {
 				},
 			] );
 			const result = groupDomainProducts( items, ident );
-			expect( result.length ).to.eql( 2 );
+			expect( result.length ).toEqual( 2 );
 		} );
 
 		test( 'should increment groupCount for multiple items with the same domain', () => {
@@ -105,7 +104,7 @@ describe( 'utils', () => {
 				},
 			] );
 			const result = groupDomainProducts( items, ident );
-			expect( result[ 1 ].groupCount ).to.eql( 2 );
+			expect( result[ 1 ].groupCount ).toEqual( 2 );
 		} );
 
 		test( 'should sum the raw_amount for multiple items with the same domain', () => {
@@ -141,8 +140,8 @@ describe( 'utils', () => {
 				},
 			] );
 			const result = groupDomainProducts( items, ident );
-			expect( result[ 1 ].raw_amount ).to.eql( 2 );
-			expect( result[ 2 ].raw_amount ).to.eql( 19 );
+			expect( result[ 1 ].raw_amount ).toEqual( 2 );
+			expect( result[ 2 ].raw_amount ).toEqual( 19 );
 		} );
 
 		test( 'should include the formatted, summed raw_amount as amount for multiple items with teh same domain', () => {
@@ -182,8 +181,8 @@ describe( 'utils', () => {
 				},
 			] );
 			const result = groupDomainProducts( items, ident );
-			expect( result[ 1 ].amount ).to.eql( '$2.00' );
-			expect( result[ 2 ].amount ).to.eql( '$19.00' );
+			expect( result[ 1 ].amount ).toEqual( '$2.00' );
+			expect( result[ 2 ].amount ).toEqual( '$19.00' );
 		} );
 	} );
 } );

--- a/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
@@ -1,5 +1,5 @@
+// eslint-disable-next-line import/default
 import productsValues from '@automattic/calypso-products';
-import { expect } from 'chai';
 import { isRefundable, getSubscriptionEndDate } from 'calypso/lib/purchases';
 import { cancellationEffectDetail, cancellationEffectHeadline } from '../cancellation-effect';
 
@@ -26,7 +26,7 @@ describe( 'cancellation-effect', () => {
 
 			test( 'should return translation of cancel and return', () => {
 				const headline = cancellationEffectHeadline( purchase, translate );
-				expect( headline.text ).to.equal(
+				expect( headline.text ).toEqual(
 					'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? '
 				);
 			} );
@@ -39,7 +39,7 @@ describe( 'cancellation-effect', () => {
 
 			test( 'should return translation of cancel', () => {
 				const headline = cancellationEffectHeadline( purchase, translate );
-				expect( headline.text ).to.equal(
+				expect( headline.text ).toEqual(
 					'Are you sure you want to cancel %(purchaseName)s for {{em}}%(domain)s{{/em}}? '
 				);
 			} );
@@ -55,7 +55,7 @@ describe( 'cancellation-effect', () => {
 			test( 'should return translation of theme message when product is a theme', () => {
 				productsValues.isTheme = () => true;
 				const headline = cancellationEffectDetail( purchase, translate );
-				expect( headline.text ).to.equal(
+				expect( headline.text ).toEqual(
 					"Your site's appearance will revert to its previously selected theme and you will be refunded %(cost)s."
 				);
 			} );
@@ -65,7 +65,7 @@ describe( 'cancellation-effect', () => {
 				productsValues.isGSuiteOrGoogleWorkspace = () => true;
 				productsValues.isGSuiteProductSlug = () => true;
 				const headline = cancellationEffectDetail( purchase, translate );
-				expect( headline.text ).to.equal(
+				expect( headline.text ).toEqual(
 					'You will be refunded %(cost)s, and your %(googleMailService)s account will continue working without interruption. You will be able to set up billing for your account directly with Google.'
 				);
 			} );
@@ -75,7 +75,7 @@ describe( 'cancellation-effect', () => {
 				productsValues.isGSuiteOrGoogleWorkspace = () => false;
 				productsValues.isJetpackPlan = () => true;
 				const headline = cancellationEffectDetail( purchase, translate );
-				expect( headline.text ).to.equal(
+				expect( headline.text ).toEqual(
 					'All plan features - spam filtering, backups, and security screening ' +
 						'- will be removed from your site and you will be refunded %(cost)s.'
 				);
@@ -87,7 +87,7 @@ describe( 'cancellation-effect', () => {
 				productsValues.isJetpackPlan = () => false;
 				productsValues.isDotComPlan = () => true;
 				const headline = cancellationEffectDetail( purchase, translate );
-				expect( headline.text ).to.equal(
+				expect( headline.text ).toEqual(
 					'All plan features and custom changes will be removed from your site and you will be refunded %(cost)s.'
 				);
 			} );
@@ -98,7 +98,7 @@ describe( 'cancellation-effect', () => {
 				productsValues.isJetpackPlan = () => false;
 				productsValues.isDotComPlan = () => false;
 				const headline = cancellationEffectDetail( purchase, translate );
-				expect( headline.text ).to.equal( 'You will be refunded %(cost)s.' );
+				expect( headline.text ).toEqual( 'You will be refunded %(cost)s.' );
 			} );
 		} );
 
@@ -111,7 +111,7 @@ describe( 'cancellation-effect', () => {
 			test( 'should return translation of g suite message when product is g suite', () => {
 				productsValues.isGSuiteOrGoogleWorkspace = () => true;
 				const headline = cancellationEffectDetail( purchase, translate );
-				expect( headline.text ).to.equal(
+				expect( headline.text ).toEqual(
 					'Your %(googleMailService)s account remains active until it expires on %(subscriptionEndDate)s.'
 				);
 			} );
@@ -120,7 +120,7 @@ describe( 'cancellation-effect', () => {
 				productsValues.isGSuiteOrGoogleWorkspace = () => false;
 				productsValues.isDomainMapping = () => true;
 				const headline = cancellationEffectDetail( purchase, translate );
-				expect( headline.text ).to.equal(
+				expect( headline.text ).toEqual(
 					'Your domain mapping remains active until it expires on %(subscriptionEndDate)s.'
 				);
 			} );
@@ -130,7 +130,7 @@ describe( 'cancellation-effect', () => {
 				productsValues.isDomainMapping = () => false;
 				productsValues.isPlan = () => true;
 				const headline = cancellationEffectDetail( purchase, translate );
-				expect( headline.text ).to.equal(
+				expect( headline.text ).toEqual(
 					"Your plan's features remain active until your subscription expires on %(subscriptionEndDate)s."
 				);
 			} );
@@ -140,7 +140,7 @@ describe( 'cancellation-effect', () => {
 				productsValues.isDomainMapping = () => false;
 				productsValues.isPlan = () => false;
 				const headline = cancellationEffectDetail( purchase, translate );
-				expect( headline ).to.equal( '' );
+				expect( headline ).toEqual( '' );
 			} );
 		} );
 	} );

--- a/client/my-sites/customize/test/panels.js
+++ b/client/my-sites/customize/test/panels.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getCustomizerFocus } from '../panels';
 
 describe( 'panels', () => {
@@ -6,19 +5,19 @@ describe( 'panels', () => {
 		test( 'should return null if passed a falsey value', () => {
 			const arg = getCustomizerFocus();
 
-			expect( arg ).to.be.null;
+			expect( arg ).toBeNull();
 		} );
 
 		test( 'should return null if panel is not recognized', () => {
 			const arg = getCustomizerFocus( '__UNKNOWN' );
 
-			expect( arg ).to.be.null;
+			expect( arg ).toBeNull();
 		} );
 
 		test( 'should return object of recognized wordpress focus argument', () => {
 			const arg = getCustomizerFocus( 'identity' );
 
-			expect( arg ).to.eql( { 'autofocus[section]': 'title_tagline' } );
+			expect( arg ).toEqual( { 'autofocus[section]': 'title_tagline' } );
 		} );
 	} );
 } );

--- a/client/my-sites/domains/map-domain/test/map-domain.js
+++ b/client/my-sites/domains/map-domain/test/map-domain.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import pageSpy from 'page';
 import MapDomainStep from 'calypso/components/domains/map-domain-step';
@@ -11,18 +10,12 @@ import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { MapDomain } from '..';
 
 jest.mock( 'page', () => {
-	const sinon = require( 'sinon' );
-	const spy = sinon.spy();
-	spy.redirect = sinon.spy();
-	return spy;
+	const pageMock = jest.fn();
+	pageMock.redirect = jest.fn();
+	return pageMock;
 } );
 
 describe( 'MapDomain component', () => {
-	beforeEach( () => {
-		pageSpy.resetHistory();
-		pageSpy.redirect.resetHistory();
-	} );
-
 	const defaultProps = {
 		cart: {},
 		productsList: {},
@@ -39,34 +32,34 @@ describe( 'MapDomain component', () => {
 
 	test( 'does not blow up with default props', () => {
 		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
-		expect( wrapper ).to.have.length( 1 );
+		expect( wrapper ).toHaveLength( 1 );
 	} );
 
 	test( 'redirects if site cannot be upgraded at mounting', () => {
 		shallow( <MapDomain { ...defaultProps } isSiteUpgradeable={ false } /> );
-		expect( pageSpy.redirect ).to.have.been.calledWith( '/domains/add/mapping' );
+		expect( pageSpy.redirect ).toBeCalledWith( '/domains/add/mapping' );
 	} );
 
 	test( 'redirects if site cannot be upgraded at new props', () => {
 		const wrapper = shallow( <MapDomain { ...defaultProps } isSiteUpgradeable={ true } /> );
 		wrapper.setProps( { selectedSiteId: 501, isSiteUpgradeable: false } );
-		expect( pageSpy.redirect ).to.have.been.calledWith( '/domains/add/mapping' );
+		expect( pageSpy.redirect ).toBeCalledWith( '/domains/add/mapping' );
 	} );
 
 	test( 'renders a MapDomainStep', () => {
 		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
-		expect( wrapper.find( MapDomainStep ) ).to.have.length( 1 );
+		expect( wrapper.find( MapDomainStep ) ).toHaveLength( 1 );
 	} );
 
 	test( "goes back when HeaderCake's onClick is fired", () => {
 		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
-		expect( wrapper.find( HeaderCake ).prop( 'onClick' ) ).to.equal( wrapper.instance().goBack );
+		expect( wrapper.find( HeaderCake ).prop( 'onClick' ) ).toEqual( wrapper.instance().goBack );
 	} );
 
 	test( 'goes back to /domains/add if no selected site', () => {
 		const wrapper = shallow( <MapDomain { ...defaultProps } selectedSite={ null } /> );
 		wrapper.instance().goBack();
-		expect( pageSpy ).to.have.been.calledWith( '/domains/add' );
+		expect( pageSpy ).toBeCalledWith( '/domains/add' );
 	} );
 
 	test( 'goes back to domain management for VIP sites', () => {
@@ -78,25 +71,25 @@ describe( 'MapDomain component', () => {
 			/>
 		);
 		wrapper.instance().goBack();
-		expect( pageSpy ).to.have.been.calledWith( domainManagementList( 'baba' ) );
+		expect( pageSpy ).toBeCalledWith( domainManagementList( 'baba' ) );
 	} );
 
 	test( 'goes back to domain add page if non-VIP site', () => {
 		const wrapper = shallow( <MapDomain { ...defaultProps } selectedSiteSlug="baba" /> );
 		wrapper.instance().goBack();
-		expect( pageSpy ).to.have.been.calledWith( '/domains/add/baba' );
+		expect( pageSpy ).toBeCalledWith( '/domains/add/baba' );
 	} );
 
 	test( 'does not render a notice by default', () => {
 		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
 		// we match the notice by props, because enzyme isn't matching the Notice type for some reason
-		expect( wrapper.find( { status: 'is-error' } ) ).to.have.length( 0 );
+		expect( wrapper.find( { status: 'is-error' } ) ).toHaveLength( 0 );
 	} );
 
 	test( 'render a notice by when there is an errorMessage in the state', () => {
 		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
 		// we match the notice by props, because enzyme isn't matching the Notice type for some reason
 		wrapper.setState( { errorMessage: 'baba' } );
-		expect( wrapper.find( { status: 'is-error' } ) ).to.have.length( 1 );
+		expect( wrapper.find( { status: 'is-error' } ) ).toHaveLength( 1 );
 	} );
 } );

--- a/client/my-sites/media-library/test/data-source.jsx
+++ b/client/my-sites/media-library/test/data-source.jsx
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { Provider as ReduxProvider } from 'react-redux';
 import MediaLibraryDataSource from 'calypso/my-sites/media-library/data-source';
@@ -38,8 +36,8 @@ describe( 'MediaLibraryDataSource', () => {
 					/>
 				</ReduxProvider>
 			);
-			expect( wrapper.find( 'button[data-source="google_photos"]' ) ).to.have.length( 1 );
-			expect( wrapper.find( 'button[data-source="pexels"]' ) ).to.have.length( 1 );
+			expect( wrapper.find( 'button[data-source="google_photos"]' ) ).toHaveLength( 1 );
+			expect( wrapper.find( 'button[data-source="pexels"]' ) ).toHaveLength( 1 );
 		} );
 
 		test( 'excludes data sources listed in disabledSources', () => {
@@ -55,8 +53,8 @@ describe( 'MediaLibraryDataSource', () => {
 					/>
 				</ReduxProvider>
 			);
-			expect( wrapper.find( 'button[data-source="google_photos"]' ) ).to.have.length( 1 );
-			expect( wrapper.find( 'button[data-source="pexels"]' ) ).to.have.length( 0 );
+			expect( wrapper.find( 'button[data-source="google_photos"]' ) ).toHaveLength( 1 );
+			expect( wrapper.find( 'button[data-source="pexels"]' ) ).toHaveLength( 0 );
 		} );
 	} );
 } );

--- a/client/my-sites/media-library/test/index.jsx
+++ b/client/my-sites/media-library/test/index.jsx
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { requestKeyringConnections as requestStub } from 'calypso/state/sharing/keyring/actions';
 import MediaLibrary from '..';
@@ -59,33 +57,33 @@ describe( 'MediaLibrary', () => {
 		test( 'is issued when component mounted and viewing an external source', () => {
 			getItem( 'google_photos' );
 
-			expect( requestStub.callCount ).to.equal( 1 );
+			expect( requestStub.callCount ).toEqual( 1 );
 		} );
 
 		test( 'is not issued when component mounted and viewing wordpress', () => {
 			getItem( '' );
 
-			expect( requestStub.callCount ).to.equal( 0 );
+			expect( requestStub.callCount ).toEqual( 0 );
 		} );
 
 		test( 'is issued when component source changes and now viewing an external source', () => {
 			const library = getItem( '' );
 
 			library.setProps( { source: 'google_photos' } );
-			expect( requestStub.callCount ).to.equal( 1 );
+			expect( requestStub.callCount ).toEqual( 1 );
 		} );
 
 		test( 'is not issued when component source changes and not viewing an external source', () => {
 			const library = getItem( '' );
 
 			library.setProps( { source: '' } );
-			expect( requestStub.callCount ).to.equal( 0 );
+			expect( requestStub.callCount ).toEqual( 0 );
 		} );
 
 		test( 'is not issued when the external source does not need user connection', () => {
 			getItem( 'pexels' );
 
-			expect( requestStub.callCount ).to.equal( 0 );
+			expect( requestStub.callCount ).toEqual( 0 );
 		} );
 	} );
 } );

--- a/client/my-sites/media-library/test/list-item-image.jsx
+++ b/client/my-sites/media-library/test/list-item-image.jsx
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import resize from 'calypso/lib/resize-image-url';
 import ListItemImage from 'calypso/my-sites/media-library/list-item-image';
@@ -35,24 +33,24 @@ describe( 'MediaLibraryListItem image', () => {
 		test( 'defaults to photon when no thumbnail parameter is passed', () => {
 			wrapper = shallow( getItem( 0 ) );
 
-			expect( wrapper.props().src ).to.be.equal( getResizedUrl() );
+			expect( wrapper.props().src ).toEqual( getResizedUrl() );
 		} );
 		test( 'returns a resized private thumbnail for type MEDIA_IMAGE_RESIZER', () => {
 			wrapper = shallow( getItem( 0, 'MEDIA_IMAGE_RESIZER' ) );
 
-			expect( wrapper.props().src ).to.be.equal( getResizedUrl() );
+			expect( wrapper.props().src ).toEqual( getResizedUrl() );
 		} );
 
 		test( 'returns existing medium thumbnail for type MEDIA_IMAGE_THUMBNAIL', () => {
 			wrapper = shallow( getItem( 0, 'MEDIA_IMAGE_THUMBNAIL' ) );
 
-			expect( wrapper.props().src ).to.be.equal( fixtures.media[ 0 ].thumbnails.medium );
+			expect( wrapper.props().src ).toEqual( fixtures.media[ 0 ].thumbnails.medium );
 		} );
 
 		test( 'returns resized thumbnail for type MEDIA_IMAGE_THUMBNAIL when no medium thumbnail', () => {
 			wrapper = shallow( getItem( 1, 'MEDIA_IMAGE_THUMBNAIL' ) );
 
-			expect( wrapper.props().src ).to.be.equal( getResizedUrl() );
+			expect( wrapper.props().src ).toEqual( getResizedUrl() );
 		} );
 	} );
 } );

--- a/client/my-sites/media-library/test/list-item.jsx
+++ b/client/my-sites/media-library/test/list-item.jsx
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import ListItem from 'calypso/my-sites/media-library/list-item';
 import fixtures from './fixtures';
@@ -22,14 +20,14 @@ describe( 'MediaLibraryListItem', () => {
 				<ListItem media={ fixtures.media[ 0 ] } scale={ 1 } selectedIndex={ 99 } />
 			);
 
-			expect( wrapper.props()[ 'data-selected-number' ] ).to.be.equal( '99+' );
+			expect( wrapper.props()[ 'data-selected-number' ] ).toEqual( '99+' );
 		} );
 		test( 'when selectedIndex is under 100 it is as shown', () => {
 			wrapper = shallow(
 				<ListItem media={ fixtures.media[ 0 ] } scale={ 1 } selectedIndex={ 98 } />
 			);
 
-			expect( wrapper.props()[ 'data-selected-number' ] ).to.be.equal( 99 );
+			expect( wrapper.props()[ 'data-selected-number' ] ).toEqual( 99 );
 		} );
 	} );
 } );

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -3,8 +3,6 @@
  */
 
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expectSelectedItems", "expect"] }] */
-
-import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { defer } from 'lodash';
 import moment from 'moment';
@@ -39,7 +37,7 @@ describe( 'MediaLibraryList item selection', () => {
 
 	function expectSelectedItems( ...args ) {
 		defer( function () {
-			expect( mockSelectedItems ).to.have.members(
+			expect( mockSelectedItems ).toContain(
 				args.map( function ( arg ) {
 					return fixtures.media[ arg ];
 				} )
@@ -202,12 +200,12 @@ describe( 'MediaLibraryList item selection', () => {
 
 		test( 'should have no group label for an ungrouped source', () => {
 			const grid = getList( fixtures.media, 'pexels' ).render();
-			expect( grid.props.getGroupLabel() ).to.equal( '' );
+			expect( grid.props.getGroupLabel() ).toEqual( '' );
 		} );
 
 		test( 'should use the source name as the item group for an ungrouped source', () => {
 			const grid = getList( fixtures.media, 'pexels' ).render();
-			expect( grid.props.getItemGroup() ).to.equal( 'pexels' );
+			expect( grid.props.getItemGroup() ).toEqual( 'pexels' );
 		} );
 	} );
 } );

--- a/client/my-sites/pages/test/helpers.js
+++ b/client/my-sites/pages/test/helpers.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { sortPagesHierarchically } from '../helpers';
 
 describe( 'helpers', () => {
@@ -25,7 +24,7 @@ describe( 'helpers', () => {
 
 			const sortedPages = sortPagesHierarchically( testData );
 
-			expect( sortedPages ).to.deep.equal( [
+			expect( sortedPages ).toEqual( [
 				{
 					ID: 2,
 					parent: false,
@@ -77,7 +76,7 @@ describe( 'helpers', () => {
 
 			const sortedPages = sortPagesHierarchically( testData );
 
-			expect( sortedPages ).to.deep.equal( [
+			expect( sortedPages ).toEqual( [
 				{
 					ID: 1,
 					menu_order: 0,
@@ -139,7 +138,7 @@ describe( 'helpers', () => {
 
 			const sortedPages = sortPagesHierarchically( testData );
 
-			expect( sortedPages ).to.deep.equal( [
+			expect( sortedPages ).toEqual( [
 				{
 					ID: 1,
 					menu_order: 1,
@@ -201,7 +200,7 @@ describe( 'helpers', () => {
 
 			const sortedPages = sortPagesHierarchically( testData, 4 );
 
-			expect( sortedPages ).to.deep.equal( [
+			expect( sortedPages ).toEqual( [
 				{
 					ID: 4,
 					menu_order: 6,
@@ -254,7 +253,7 @@ describe( 'helpers', () => {
 			const homepageId = 0;
 			const sortedPages = sortPagesHierarchically( testData, homepageId );
 
-			expect( sortedPages ).to.deep.equal( [
+			expect( sortedPages ).toEqual( [
 				{
 					ID: 2,
 					parent: false,

--- a/client/my-sites/plugins/plugin-action/test/index.jsx
+++ b/client/my-sites/plugins/plugin-action/test/index.jsx
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
 import PluginAction from '../plugin-action';
 
@@ -15,13 +13,13 @@ describe( 'PluginAction', () => {
 		test( 'should have plugin-action class', () => {
 			const wrapper = shallow( <PluginAction /> );
 
-			expect( wrapper.find( '.plugin-action' ) ).to.have.lengthOf( 1 );
+			expect( wrapper.find( '.plugin-action' ) ).toHaveLength( 1 );
 		} );
 
 		test( 'should render compact form toggle when no children passed', () => {
 			const wrapper = mount( <PluginAction /> );
 
-			expect( wrapper.find( 'input.components-form-toggle__input' ) ).to.have.lengthOf( 1 );
+			expect( wrapper.find( 'input.components-form-toggle__input' ) ).toHaveLength( 1 );
 		} );
 
 		test( 'should render a plugin action label', () => {
@@ -31,7 +29,7 @@ describe( 'PluginAction', () => {
 				</PluginAction>
 			);
 
-			expect( wrapper.find( '.plugin-action__label' ) ).to.have.lengthOf( 1 );
+			expect( wrapper.find( '.plugin-action__label' ) ).toHaveLength( 1 );
 		} );
 	} );
 
@@ -43,7 +41,7 @@ describe( 'PluginAction', () => {
 				</PluginAction>
 			);
 
-			expect( wrapper.find( '.components-form-toggle__input' ) ).to.have.lengthOf( 0 );
+			expect( wrapper.find( '.components-form-toggle__input' ) ).toHaveLength( 0 );
 		} );
 
 		test( 'should render child within plugin-action__children container', () => {
@@ -54,8 +52,8 @@ describe( 'PluginAction', () => {
 			);
 			const children = wrapper.find( '.plugin-action__children' );
 
-			expect( children.length ).to.equal( 1 );
-			expect( children.props().children[ 0 ].type ).to.equal( 'span' );
+			expect( children.length ).toEqual( 1 );
+			expect( children.props().children[ 0 ].type ).toEqual( 'span' );
 		} );
 
 		test( 'should render a plugin action label', () => {
@@ -65,7 +63,7 @@ describe( 'PluginAction', () => {
 				</PluginAction>
 			);
 
-			expect( wrapper.find( '.plugin-action__label' ) ).to.have.lengthOf( 1 );
+			expect( wrapper.find( '.plugin-action__label' ) ).toHaveLength( 1 );
 		} );
 	} );
 } );

--- a/client/my-sites/plugins/plugin-activate-toggle/test/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/index.jsx
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { spy } from 'sinon';
 import { PluginActivateToggle } from 'calypso/my-sites/plugins/plugin-activate-toggle';
@@ -28,7 +26,7 @@ describe( 'PluginActivateToggle', () => {
 	test( 'should render the component', () => {
 		const wrapper = mount( <PluginActivateToggle { ...mockedProps } { ...fixtures } /> );
 
-		expect( wrapper.find( '.plugin-action' ) ).to.have.lengthOf( 1 );
+		expect( wrapper.find( '.plugin-action' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should register an event when the subcomponent action is executed', () => {
@@ -36,8 +34,8 @@ describe( 'PluginActivateToggle', () => {
 
 		wrapper.simulate( 'click' );
 
-		expect( mockedProps.recordGoogleEvent.called ).to.equal( true );
-		expect( mockedProps.recordTracksEvent.called ).to.equal( true );
+		expect( mockedProps.recordGoogleEvent.called ).toEqual( true );
+		expect( mockedProps.recordTracksEvent.called ).toEqual( true );
 	} );
 
 	test( 'should call an action when the subcomponent action is executed', () => {
@@ -45,6 +43,6 @@ describe( 'PluginActivateToggle', () => {
 
 		wrapper.simulate( 'click' );
 
-		expect( mockedProps.togglePluginActivation.called ).to.equal( true );
+		expect( mockedProps.togglePluginActivation.called ).toEqual( true );
 	} );
 } );

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/test/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/test/index.jsx
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { spy } from 'sinon';
 import { PluginAutoUpdateToggle } from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
@@ -30,7 +28,7 @@ describe( 'PluginAutoupdateToggle', () => {
 	test( 'should render the component', () => {
 		const wrapper = mount( <PluginAutoUpdateToggle { ...mockedProps } { ...fixtures } /> );
 
-		expect( wrapper.find( '.plugin-action' ) ).to.have.lengthOf( 1 );
+		expect( wrapper.find( '.plugin-action' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should register an event when the subcomponent action is executed', () => {
@@ -38,8 +36,8 @@ describe( 'PluginAutoupdateToggle', () => {
 
 		wrapper.simulate( 'click' );
 
-		expect( mockedProps.recordGoogleEvent.called ).to.equal( true );
-		expect( mockedProps.recordTracksEvent.called ).to.equal( true );
+		expect( mockedProps.recordGoogleEvent.called ).toEqual( true );
+		expect( mockedProps.recordTracksEvent.called ).toEqual( true );
 	} );
 
 	test( 'should call an action when the subcomponent action is executed', () => {
@@ -47,6 +45,6 @@ describe( 'PluginAutoupdateToggle', () => {
 
 		wrapper.simulate( 'click' );
 
-		expect( mockedProps.togglePluginAutoUpdate.called ).to.equal( true );
+		expect( mockedProps.togglePluginAutoUpdate.called ).toEqual( true );
 	} );
 } );

--- a/client/my-sites/sidebar/test/index.js
+++ b/client/my-sites/sidebar/test/index.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { itemLinkMatches } from '../utils';
 
 describe( 'MySitesSidebar', () => {
@@ -9,7 +8,7 @@ describe( 'MySitesSidebar', () => {
 				'/posts/example.wordpress.com'
 			);
 
-			expect( isSelected ).to.be.false;
+			expect( isSelected ).toBe( false );
 		} );
 
 		test( "should return true if a path's first fragment does match the current path", () => {
@@ -18,7 +17,7 @@ describe( 'MySitesSidebar', () => {
 				'/pages/test/example.wordpress.com'
 			);
 
-			expect( isSelected ).to.be.true;
+			expect( isSelected ).toBe( true );
 		} );
 
 		test( 'should return true for jetpack types', () => {
@@ -27,13 +26,13 @@ describe( 'MySitesSidebar', () => {
 				'/types/jetpack-testimonial/test'
 			);
 
-			expect( isSelected ).to.be.true;
+			expect( isSelected ).toBe( true );
 		} );
 
 		test( 'should return true if one of the paths is a prefix of the current path and separated by search query', () => {
 			const isSelected = itemLinkMatches( '/posts', '/posts?s=search' );
 
-			expect( isSelected ).to.be.true;
+			expect( isSelected ).toBe( true );
 		} );
 
 		test( 'should return false if a fragment matches but not in position (1)', () => {
@@ -42,12 +41,12 @@ describe( 'MySitesSidebar', () => {
 				'/test/pages/example.wordpress.com'
 			);
 
-			expect( isSelected ).to.be.false;
+			expect( isSelected ).toBe( false );
 		} );
 		test( '#itemLinkMatches() compares 2 part path with 1 part path without error', () => {
 			const isSelected = itemLinkMatches( '/stats/day', '/plugins' );
 
-			expect( isSelected ).to.be.false;
+			expect( isSelected ).toBe( false );
 		} );
 	} );
 
@@ -58,7 +57,7 @@ describe( 'MySitesSidebar', () => {
 				'/settings/discussion/cpapfree.wordpress.com'
 			);
 
-			expect( isSelected ).to.be.false;
+			expect( isSelected ).toBe( false );
 		} );
 
 		test( 'clicking a marketing panel should activate the marketing/tools menu', () => {
@@ -67,7 +66,7 @@ describe( 'MySitesSidebar', () => {
 				'/marketing/traffic/cpapfree.wordpress.com'
 			);
 
-			expect( isSelected ).to.be.true;
+			expect( isSelected ).toBe( true );
 		} );
 	} );
 } );

--- a/client/my-sites/site-settings/date-time-format/test/index.js
+++ b/client/my-sites/site-settings/date-time-format/test/index.js
@@ -1,37 +1,26 @@
-import chai from 'chai';
 import moment from 'moment';
 import { phpToMomentDatetimeFormat } from '../utils';
 
 describe( 'phpToMomentDatetimeFormat', () => {
 	const testDate = moment();
 	test( 'should return the correct Moment date', () => {
-		chai.assert.equal(
-			phpToMomentDatetimeFormat( testDate, 'F j, Y' ),
+		expect( phpToMomentDatetimeFormat( testDate, 'F j, Y' ) ).toEqual(
 			testDate.format( 'MMMM D, YYYY' )
 		);
-		chai.assert.equal(
-			phpToMomentDatetimeFormat( testDate, 'Y-m-d' ),
+		expect( phpToMomentDatetimeFormat( testDate, 'Y-m-d' ) ).toEqual(
 			testDate.format( 'YYYY-MM-DD' )
 		);
-		chai.assert.equal(
-			phpToMomentDatetimeFormat( testDate, 'm/d/Y' ),
+		expect( phpToMomentDatetimeFormat( testDate, 'm/d/Y' ) ).toEqual(
 			testDate.format( 'MM/DD/YYYY' )
 		);
-		chai.assert.equal(
-			phpToMomentDatetimeFormat( testDate, 'd/m/Y' ),
+		expect( phpToMomentDatetimeFormat( testDate, 'd/m/Y' ) ).toEqual(
 			testDate.format( 'DD/MM/YYYY' )
 		);
 	} );
 
 	test( 'should return the correct Moment time', () => {
-		chai.assert.equal(
-			phpToMomentDatetimeFormat( testDate, 'g:i a' ),
-			testDate.format( 'h:mm a' )
-		);
-		chai.assert.equal(
-			phpToMomentDatetimeFormat( testDate, 'g:i A' ),
-			testDate.format( 'h:mm A' )
-		);
-		chai.assert.equal( phpToMomentDatetimeFormat( testDate, 'H:i' ), testDate.format( 'HH:mm' ) );
+		expect( phpToMomentDatetimeFormat( testDate, 'g:i a' ) ).toEqual( testDate.format( 'h:mm a' ) );
+		expect( phpToMomentDatetimeFormat( testDate, 'g:i A' ) ).toEqual( testDate.format( 'h:mm A' ) );
+		expect( phpToMomentDatetimeFormat( testDate, 'H:i' ) ).toEqual( testDate.format( 'HH:mm' ) );
 	} );
 } );

--- a/client/my-sites/store/app/store-stats/test/utils.js
+++ b/client/my-sites/store/app/store-stats/test/utils.js
@@ -1,4 +1,3 @@
-import { assert } from 'chai';
 import moment from 'moment';
 import { UNITS } from '../constants';
 import {
@@ -18,7 +17,7 @@ describe( 'getQueryDate', () => {
 			query: { startDate: '2017-06-12' },
 		};
 		const queryDate = getQueryDate( context );
-		assert.isString( queryDate );
+		expect( typeof queryDate ).toBe( 'string' );
 	} );
 
 	test( 'should return a value for today given an undefined startDate queryParameter', () => {
@@ -28,7 +27,7 @@ describe( 'getQueryDate', () => {
 		};
 		const today = moment().format( 'YYYY-MM-DD' );
 		const queryDate = getQueryDate( context );
-		assert.strictEqual( queryDate, today );
+		expect( queryDate ).toBe( today );
 	} );
 
 	test( 'should return a value for today given a startDate of less than the quantity', () => {
@@ -42,7 +41,7 @@ describe( 'getQueryDate', () => {
 		};
 		const queryDate = getQueryDate( context );
 		const today = moment().format( 'YYYY-MM-DD' );
-		assert.strictEqual( queryDate, today );
+		expect( queryDate ).toBe( today );
 	} );
 
 	test( 'should return a value going back only in multiples of the specified quantity', () => {
@@ -57,7 +56,7 @@ describe( 'getQueryDate', () => {
 		const todayShouldBe = moment()
 			.subtract( quantity * 2, 'days' )
 			.format( 'YYYY-MM-DD' );
-		assert.strictEqual( queryDate, todayShouldBe );
+		expect( queryDate ).toBe( todayShouldBe );
 	} );
 
 	test( 'should work in weeks as well', () => {
@@ -72,20 +71,20 @@ describe( 'getQueryDate', () => {
 		const todayShouldBe = moment()
 			.subtract( quantity * 2, 'weeks' )
 			.format( 'YYYY-MM-DD' );
-		assert.strictEqual( queryDate, todayShouldBe );
+		expect( queryDate ).toBe( todayShouldBe );
 	} );
 } );
 
 describe( 'getStartDate', () => {
 	test( 'should return a string', () => {
 		const queryDate = getStartDate( '2017-06-12', 'day' );
-		assert.isString( queryDate );
+		expect( typeof queryDate ).toBe( 'string' );
 	} );
 
 	test( 'should return a value for today given an undefined startDate queryParameter', () => {
 		const today = moment().format( 'YYYY-MM-DD' );
 		const queryDate = getStartDate( undefined, 'day' );
-		assert.strictEqual( queryDate, today );
+		expect( queryDate ).toBe( today );
 	} );
 
 	test( 'should return a value for today given a startDate of less than the quantity', () => {
@@ -95,7 +94,7 @@ describe( 'getStartDate', () => {
 			.format( 'YYYY-MM-DD' );
 		const queryDate = getStartDate( startDate, 'day' );
 		const today = moment().format( 'YYYY-MM-DD' );
-		assert.strictEqual( queryDate, today );
+		expect( queryDate ).toBe( today );
 	} );
 
 	test( 'should return a value going back only in multiples of the specified quantity', () => {
@@ -106,7 +105,7 @@ describe( 'getStartDate', () => {
 		const todayShouldBe = moment()
 			.subtract( quantity * 2, 'days' )
 			.format( 'YYYY-MM-DD' );
-		assert.strictEqual( queryDate, todayShouldBe );
+		expect( queryDate ).toBe( todayShouldBe );
 	} );
 
 	test( 'should calculate with weeks', () => {
@@ -117,7 +116,7 @@ describe( 'getStartDate', () => {
 		const todayShouldBe = moment()
 			.subtract( quantity * 2, 'weeks' )
 			.format( 'YYYY-MM-DD' );
-		assert.strictEqual( queryDate, todayShouldBe );
+		expect( queryDate ).toBe( todayShouldBe );
 	} );
 
 	test( 'should calculate with months', () => {
@@ -128,91 +127,91 @@ describe( 'getStartDate', () => {
 		const todayShouldBe = moment()
 			.subtract( quantity * 2, 'months' )
 			.format( 'YYYY-MM-DD' );
-		assert.strictEqual( queryDate, todayShouldBe );
+		expect( queryDate ).toBe( todayShouldBe );
 	} );
 } );
 
 describe( 'getUnitPeriod', () => {
 	test( 'should return a string', () => {
 		const queryDate = getUnitPeriod( '2017-07-05', 'week' );
-		assert.isString( queryDate );
+		expect( typeof queryDate ).toBe( 'string' );
 	} );
 	test( 'should return an isoWeek format for a week unit', () => {
 		const queryDate = getUnitPeriod( '2017-07-05', 'week' );
-		assert.strictEqual( queryDate, '2017-W27' );
+		expect( queryDate ).toBe( '2017-W27' );
 	} );
 	test( 'should return a well formatted period for a month unit', () => {
 		const queryDate = getUnitPeriod( '2017-07-05', 'month' );
-		assert.strictEqual( queryDate, '2017-07' );
+		expect( queryDate ).toBe( '2017-07' );
 	} );
 	test( 'should return a well formatted period for a year unit', () => {
 		const queryDate = getUnitPeriod( '2017-07-05', 'year' );
-		assert.strictEqual( queryDate, '2017' );
+		expect( queryDate ).toBe( '2017' );
 	} );
 	test( 'should return a well formatted period for a day unit', () => {
 		const queryDate = getUnitPeriod( '2017-07-05', 'day' );
-		assert.strictEqual( queryDate, '2017-07-05' );
+		expect( queryDate ).toBe( '2017-07-05' );
 	} );
 } );
 
 describe( 'getEndPeriod', () => {
 	test( 'should return a string', () => {
 		const queryDate = getEndPeriod( '2017-07-05', 'week' );
-		assert.isString( queryDate );
+		expect( typeof queryDate ).toBe( 'string' );
 	} );
 	test( 'should return an the date for the end of the week', () => {
 		const queryDate = getEndPeriod( '2017-07-05', 'week' );
-		assert.strictEqual( queryDate, '2017-07-09' );
+		expect( queryDate ).toBe( '2017-07-09' );
 	} );
 	test( 'should return an the date for the end of the month', () => {
 		const queryDate = getEndPeriod( '2017-07-05', 'month' );
-		assert.strictEqual( queryDate, '2017-07-31' );
+		expect( queryDate ).toBe( '2017-07-31' );
 	} );
 	test( 'should return an the date for the end of the year', () => {
 		const queryDate = getEndPeriod( '2017-07-05', 'year' );
-		assert.strictEqual( queryDate, '2017-12-31' );
+		expect( queryDate ).toBe( '2017-12-31' );
 	} );
 	test( 'should return an the date for the end of the day', () => {
 		const queryDate = getEndPeriod( '2017-07-05', 'day' );
-		assert.strictEqual( queryDate, '2017-07-05' );
+		expect( queryDate ).toBe( '2017-07-05' );
 	} );
 } );
 
 describe( 'formatValue', () => {
 	test( 'should return a correctly formatted currency for NZD', () => {
 		const response = formatValue( 12.34, 'currency', 'NZD' );
-		assert.isString( response );
-		assert.strictEqual( response, 'NZ$12.34' );
+		expect( typeof response ).toBe( 'string' );
+		expect( response ).toBe( 'NZ$12.34' );
 	} );
 	test( 'should return a correctly formatted currency for USD', () => {
 		const response = formatValue( 12.34, 'currency', 'USD' );
-		assert.isString( response );
-		assert.strictEqual( response, '$12.34' );
+		expect( typeof response ).toBe( 'string' );
+		expect( response ).toBe( '$12.34' );
 	} );
 	test( 'should return a correctly formatted currency for ZAR', () => {
 		const response = formatValue( 12.34, 'currency', 'ZAR' );
-		assert.isString( response );
-		assert.strictEqual( response, 'R12,34' );
+		expect( typeof response ).toBe( 'string' );
+		expect( response ).toBe( 'R12,34' );
 	} );
 	test( 'should return a correctly formatted USD currency for unknown code', () => {
 		const response = formatValue( 12.34, 'currency', 'XXX' );
-		assert.isString( response );
-		assert.strictEqual( response, '$12.34' );
+		expect( typeof response ).toBe( 'string' );
+		expect( response ).toBe( '$12.34' );
 	} );
 	test( 'should return a correctly formatted USD currency for missing code', () => {
 		const response = formatValue( 12.34, 'currency' );
-		assert.isString( response );
-		assert.strictEqual( response, '$12.34' );
+		expect( typeof response ).toBe( 'string' );
+		expect( response ).toBe( '$12.34' );
 	} );
 	test( 'should return a correctly formatted number to 2 decimals', () => {
 		const response = formatValue( 12.3456, 'number', null, 2 );
 		// assert.isNumber( response );
-		assert.strictEqual( response, '12.35' );
+		expect( response ).toBe( '12.35' );
 	} );
 	test( 'should return a correctly formatted string', () => {
 		const response = formatValue( 'string', 'text' );
-		assert.isString( response );
-		assert.strictEqual( response, 'string' );
+		expect( typeof response ).toBe( 'string' );
+		expect( response ).toBe( 'string' );
 	} );
 } );
 
@@ -243,33 +242,33 @@ const deltas = [
 describe( 'getDelta', () => {
 	test( 'should return an Object', () => {
 		const delta = getDelta( deltas, '2017-07-06', 'right' );
-		assert.isObject( delta );
+		expect( typeof delta ).toBe( 'object' );
 	} );
 	test( 'should return the correct delta', () => {
 		const delta = getDelta( deltas, '2017-07-06', 'right' );
-		assert.strictEqual( delta.right, true );
-		assert.strictEqual( delta.period, '2017-07-06' );
+		expect( delta.right ).toBe( true );
+		expect( delta.period ).toBe( '2017-07-06' );
 	} );
 } );
 
 describe( 'getWidgetPath', () => {
 	test( 'should return a string', () => {
 		const widgetPath = getWidgetPath( 'unit', 'slug', {} );
-		assert.isString( widgetPath );
+		expect( typeof widgetPath ).toBe( 'string' );
 	} );
 
 	test( 'should return a correct string', () => {
 		const widgetPath = getWidgetPath( 'unit', 'slug', {} );
-		assert.strictEqual( '/unit/slug', widgetPath );
+		expect( '/unit/slug' ).toBe( widgetPath );
 	} );
 
 	test( 'should return a correct string with one query param', () => {
 		const widgetPath = getWidgetPath( 'unit', 'slug', { param1: 1 } );
-		assert.strictEqual( '/unit/slug?param1=1', widgetPath );
+		expect( '/unit/slug?param1=1' ).toBe( widgetPath );
 	} );
 
 	test( 'should return a correct string with two query params', () => {
 		const widgetPath = getWidgetPath( 'unit', 'slug', { param1: 1, param2: 2 } );
-		assert.strictEqual( '/unit/slug?param1=1&param2=2', widgetPath );
+		expect( '/unit/slug?param1=1&param2=2' ).toBe( widgetPath );
 	} );
 } );

--- a/client/my-sites/store/components/d3/base/test/index.js
+++ b/client/my-sites/store/components/d3/base/test/index.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
 import D3Base from '../index';
 
@@ -13,12 +12,12 @@ describe( 'D3base', () => {
 
 	test( 'should have d3Base class', () => {
 		const base = shallowWithoutLifecycle( <D3Base drawChart={ noop } getParams={ noop } /> );
-		assert.lengthOf( base.find( '.d3-base' ), 1 );
+		expect( base.find( '.d3-base' ).length ).toBe( 1 );
 	} );
 
 	test( 'should render an svg', () => {
 		const base = mount( <D3Base drawChart={ noop } getParams={ noop } /> );
-		assert.lengthOf( base.render().find( 'svg' ), 1 );
+		expect( base.render().find( 'svg' ).length ).toBe( 1 );
 	} );
 
 	test( 'should render a result of the drawChart prop', () => {
@@ -26,7 +25,7 @@ describe( 'D3base', () => {
 			return svg.append( 'circle' );
 		};
 		const base = mount( <D3Base drawChart={ drawChart } getParams={ noop } /> );
-		assert.lengthOf( base.render().find( 'circle' ), 1 );
+		expect( base.render().find( 'circle' ).length ).toBe( 1 );
 	} );
 
 	test( 'should pass a property of getParams output to drawChart function', () => {
@@ -37,6 +36,6 @@ describe( 'D3base', () => {
 			return svg.append( params.tagName );
 		};
 		const base = mount( <D3Base drawChart={ drawChart } getParams={ getParams } /> );
-		assert.lengthOf( base.render().find( 'circle' ), 1 );
+		expect( base.render().find( 'circle' ).length ).toBe( 1 );
 	} );
 } );

--- a/client/my-sites/store/components/d3/sparkline/test/index.jsx
+++ b/client/my-sites/store/components/d3/sparkline/test/index.jsx
@@ -1,4 +1,3 @@
-import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import Sparkline from '../index';
 
@@ -7,61 +6,61 @@ describe( 'Sparkline', () => {
 
 	test( 'should allow data to be set.', () => {
 		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } />;
-		assert.deepEqual( [ 1, 2, 3, 4, 5 ], sparkline.props.data );
+		expect( sparkline.props.data ).toEqual( [ 1, 2, 3, 4, 5 ] );
 	} );
 
 	test( 'should have sparkline class', () => {
 		const sparkline = shallowWithoutLifecycle( <Sparkline data={ [ 1, 2, 3, 4, 5 ] } /> );
-		assert.lengthOf( sparkline.find( '.sparkline' ), 1 );
+		expect( sparkline.find( '.sparkline' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should have className if provided, as well as sparkline class', () => {
 		const sparkline = shallowWithoutLifecycle(
 			<Sparkline data={ [ 1, 2, 3, 4, 5 ] } className="test__foobar" />
 		);
-		assert.lengthOf( sparkline.find( '.test__foobar' ), 1 );
-		assert.lengthOf( sparkline.find( '.sparkline' ), 1 );
+		expect( sparkline.find( '.test__foobar' ) ).toHaveLength( 1 );
+		expect( sparkline.find( '.sparkline' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should have a default aspectRatio of 4.5', () => {
 		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } />;
-		assert.equal( '4.5', sparkline.props.aspectRatio );
+		expect( sparkline.props.aspectRatio ).toEqual( 4.5 );
 	} );
 
 	test( 'should have a defined aspectRatio if set', () => {
 		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } aspectRatio={ 10 } />;
-		assert.equal( '10', sparkline.props.aspectRatio );
+		expect( sparkline.props.aspectRatio ).toEqual( 10 );
 	} );
 
 	test( 'should have a default highlightRadius of 3.5', () => {
 		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } />;
-		assert.equal( '3.5', sparkline.props.highlightRadius );
+		expect( sparkline.props.highlightRadius ).toEqual( 3.5 );
 	} );
 
 	test( 'should have a defined highlightRadius if set', () => {
 		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } highlightRadius={ 10 } />;
-		assert.equal( '10', sparkline.props.highlightRadius );
+		expect( sparkline.props.highlightRadius ).toEqual( 10 );
 	} );
 
 	test( 'should have a default margin', () => {
 		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } />;
-		assert.deepEqual( { top: 4, right: 4, bottom: 4, left: 4 }, sparkline.props.margin );
+		expect( sparkline.props.margin ).toEqual( { top: 4, right: 4, bottom: 4, left: 4 } );
 	} );
 
 	test( 'should have a defined margin if set', () => {
 		const sparkline = (
 			<Sparkline data={ [ 1, 2, 3, 4, 5 ] } margin={ { top: 1, right: 1, bottom: 1, left: 1 } } />
 		);
-		assert.deepEqual( { top: 1, right: 1, bottom: 1, left: 1 }, sparkline.props.margin );
+		expect( sparkline.props.margin ).toEqual( { top: 1, right: 1, bottom: 1, left: 1 } );
 	} );
 
 	test( 'should allow maxHeight to be defined.', () => {
 		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } maxHeight={ 10 } />;
-		assert.equal( '10', sparkline.props.maxHeight );
+		expect( sparkline.props.maxHeight ).toEqual( 10 );
 	} );
 
 	test( 'should allow highlightIndex to be defined.', () => {
 		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } highlightIndex={ 10 } />;
-		assert.equal( '10', sparkline.props.highlightIndex );
+		expect( sparkline.props.highlightIndex ).toEqual( 10 );
 	} );
 } );

--- a/client/my-sites/store/lib/analytics/test/tracks-utils.js
+++ b/client/my-sites/store/lib/analytics/test/tracks-utils.js
@@ -1,25 +1,19 @@
-import { expect } from 'chai';
-import { spy } from 'sinon';
 import { recordTrack } from '../tracks-utils';
 
 const noop = () => {};
 
 describe( 'recordTrack', () => {
-	it( 'should be a function', () => {
-		expect( recordTrack ).to.be.a( 'function' );
-	} );
-
 	it( 'should curry the tracks object', () => {
 		const tracksSpy = {
-			recordTracksEvent: spy(),
+			recordTracksEvent: jest.fn(),
 		};
 
-		expect( recordTrack( tracksSpy, noop ) ).to.be.a( 'function' );
+		expect( recordTrack( tracksSpy, noop ) ).toBeInstanceOf( Function );
 	} );
 
 	it( 'should call tracks to record an event with properties', () => {
 		const tracksSpy = {
-			recordTracksEvent: spy(),
+			recordTracksEvent: jest.fn(),
 		};
 
 		const eventProps = {
@@ -30,14 +24,14 @@ describe( 'recordTrack', () => {
 
 		recordTrack( tracksSpy, noop )( 'calypso_woocommerce_tracks_utils_test', eventProps );
 
-		expect( tracksSpy.recordTracksEvent ).to.have.been.calledWith(
+		expect( tracksSpy.recordTracksEvent ).toBeCalledWith(
 			'calypso_woocommerce_tracks_utils_test',
 			eventProps
 		);
 	} );
 
 	it( 'should log tracks via debug', () => {
-		const debugSpy = spy();
+		const debugSpy = jest.fn();
 
 		const eventProps = { a: 1 };
 
@@ -46,7 +40,7 @@ describe( 'recordTrack', () => {
 			eventProps
 		);
 
-		expect( debugSpy ).to.have.been.calledWith(
+		expect( debugSpy ).toBeCalledWith(
 			"track 'calypso_woocommerce_tracks_utils_test': ",
 			eventProps
 		);
@@ -54,14 +48,14 @@ describe( 'recordTrack', () => {
 
 	it( 'should ignore and debug log tracks with an improper event name', () => {
 		const tracksSpy = {
-			recordTracksEvent: spy(),
+			recordTracksEvent: jest.fn(),
 		};
-		const debugSpy = spy();
+		const debugSpy = jest.fn();
 
 		recordTrack( tracksSpy, debugSpy )( 'calypso_somethingelse_invalid_name', { a: 1 } );
 
-		expect( tracksSpy.recordTracksEvent ).to.not.have.been.called;
-		expect( debugSpy ).to.have.been.calledWith(
+		expect( tracksSpy.recordTracksEvent ).not.toBeCalled();
+		expect( debugSpy ).toBeCalledWith(
 			"invalid store track name: 'calypso_somethingelse_invalid_name', must start with 'calypso_woocommerce_'"
 		);
 	} );

--- a/client/post-editor/media-modal/detail/test/index.jsx
+++ b/client/post-editor/media-modal/detail/test/index.jsx
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { EditorMediaModalDetailItem as DetailItem } from '../detail-item';
@@ -60,7 +58,7 @@ describe( 'EditorMediaModalDetailItem', () => {
 
 		const editButton = tree.find( '.editor-media-modal-detail__edit' );
 
-		expect( editButton ).to.have.length.at.least( 1 );
+		expect( editButton.length ).toBeGreaterThanOrEqual( 1 );
 	} );
 
 	test( 'should display at least one edit button for a VideoPress video on a private site', () => {
@@ -75,7 +73,7 @@ describe( 'EditorMediaModalDetailItem', () => {
 
 		const editButton = tree.find( '.editor-media-modal-detail__edit' );
 
-		expect( editButton ).to.have.length.at.least( 1 );
+		expect( editButton.length ).toBeGreaterThanOrEqual( 1 );
 	} );
 
 	test( 'should display at least one edit button for an image on a public site', () => {
@@ -83,7 +81,7 @@ describe( 'EditorMediaModalDetailItem', () => {
 
 		const editButton = tree.find( '.editor-media-modal-detail__edit' );
 
-		expect( editButton ).to.have.length.at.least( 1 );
+		expect( editButton.length ).toBeGreaterThanOrEqual( 1 );
 	} );
 
 	test( 'should not display edit button for an image on a private site', () => {
@@ -93,6 +91,6 @@ describe( 'EditorMediaModalDetailItem', () => {
 
 		const editButton = tree.find( '.editor-media-modal-detail__edit' );
 
-		expect( editButton ).to.have.length( 0 );
+		expect( editButton ).toHaveLength( 0 );
 	} );
 } );

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -1,13 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { translate } from 'i18n-calypso';
-import accept from 'calypso/lib/accept';
 import { ModalViews } from 'calypso/state/ui/media-modal/constants';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { EditorMediaModal } from '../';
 
 jest.mock( 'component-closest', () => {} );
@@ -61,12 +57,12 @@ describe( 'EditorMediaModal', () => {
 	let changeMediaSource;
 	let baseProps;
 
-	useSandbox( ( sandbox ) => {
-		spy = sandbox.spy();
-		deleteMedia = sandbox.stub();
-		onClose = sandbox.stub();
-		selectMediaItems = sandbox.stub();
-		changeMediaSource = sandbox.stub();
+	beforeEach( () => {
+		spy = jest.fn();
+		deleteMedia = jest.fn();
+		onClose = jest.fn();
+		selectMediaItems = jest.fn();
+		changeMediaSource = jest.fn();
 		baseProps = {
 			selectMediaItems,
 			site: DUMMY_SITE,
@@ -79,12 +75,12 @@ describe( 'EditorMediaModal', () => {
 	} );
 
 	afterEach( () => {
-		accept.resetHistory();
+		jest.clearAllMocks();
 	} );
 
 	test( 'When `single` selection screen chosen should initialise with no items selected', () => {
 		shallow( <EditorMediaModal { ...baseProps } single={ true } view={ null } /> ).instance();
-		expect( selectMediaItems ).to.have.been.calledWith( DUMMY_SITE.ID, [] );
+		expect( selectMediaItems ).toHaveBeenCalledWith( DUMMY_SITE.ID, [] );
 	} );
 
 	test( 'should prompt to delete a single item from the list view', () => {
@@ -95,14 +91,9 @@ describe( 'EditorMediaModal', () => {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith(
-			'Are you sure you want to delete this item? ' +
-				'Deleted media will no longer appear anywhere on your website, including all posts, pages, and widgets. ' +
-				'This cannot be undone.'
-		);
 		return new Promise( ( resolve ) => {
 			process.nextTick( function () {
-				expect( deleteMedia ).to.have.been.calledWith(
+				expect( deleteMedia ).toHaveBeenCalledWith(
 					DUMMY_SITE.ID,
 					media.map( ( { ID } ) => ID )
 				);
@@ -115,15 +106,9 @@ describe( 'EditorMediaModal', () => {
 		const tree = shallow( <EditorMediaModal { ...baseProps } /> ).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith(
-			'Are you sure you want to delete these items? ' +
-				'Deleted media will no longer appear anywhere on your website, including all posts, pages, and widgets. ' +
-				'This cannot be undone.'
-		);
-
 		return new Promise( ( resolve ) => {
 			process.nextTick( function () {
-				expect( deleteMedia ).to.have.been.calledWith(
+				expect( deleteMedia ).toHaveBeenCalledWith(
 					DUMMY_SITE.ID,
 					DUMMY_MEDIA.map( ( { ID } ) => ID )
 				);
@@ -144,7 +129,7 @@ describe( 'EditorMediaModal', () => {
 
 		const buttons = tree.getModalButtons();
 
-		expect( buttons ).to.be.undefined;
+		expect( buttons ).toBeUndefined();
 	} );
 
 	test( 'should show a Copy to media library button when viewing external media (no selection)', () => {
@@ -160,8 +145,8 @@ describe( 'EditorMediaModal', () => {
 		tree.setState( { source: 'external' } );
 		const buttons = tree.getModalButtons();
 
-		expect( buttons.length ).to.be.equals( 2 );
-		expect( buttons[ 1 ].label ).to.be.equals( 'Copy to media library' );
+		expect( buttons.length ).toEqual( 2 );
+		expect( buttons[ 1 ].label ).toEqual( 'Copy to media library' );
 	} );
 
 	test( 'should show a Copy to media library button when 1 external image is selected', () => {
@@ -177,8 +162,8 @@ describe( 'EditorMediaModal', () => {
 		tree.setState( { source: 'external' } );
 		const buttons = tree.getModalButtons();
 
-		expect( buttons.length ).to.be.equals( 2 );
-		expect( buttons[ 1 ].label ).to.be.equals( 'Copy to media library' );
+		expect( buttons.length ).toEqual( 2 );
+		expect( buttons[ 1 ].label ).toEqual( 'Copy to media library' );
 	} );
 
 	test( 'should show a copy button when 1 external video is selected', () => {
@@ -194,8 +179,8 @@ describe( 'EditorMediaModal', () => {
 		tree.setState( { source: 'external' } );
 		const buttons = tree.getModalButtons();
 
-		expect( buttons.length ).to.be.equals( 2 );
-		expect( buttons[ 1 ].label ).to.be.equals( 'Copy to media library' );
+		expect( buttons.length ).toEqual( 2 );
+		expect( buttons[ 1 ].label ).toEqual( 'Copy to media library' );
 	} );
 
 	test( 'should show a copy button when 2 or more external media are selected', () => {
@@ -206,8 +191,8 @@ describe( 'EditorMediaModal', () => {
 		tree.setState( { source: 'external' } );
 		const buttons = tree.getModalButtons();
 
-		expect( buttons.length ).to.be.equals( 2 );
-		expect( buttons[ 1 ].label ).to.be.equals( 'Copy to media library' );
+		expect( buttons.length ).toEqual( 2 );
+		expect( buttons[ 1 ].label ).toEqual( 'Copy to media library' );
 	} );
 
 	test( 'should show a continue button when multiple images are selected', () => {
@@ -217,7 +202,7 @@ describe( 'EditorMediaModal', () => {
 
 		const buttons = tree.getModalButtons();
 
-		expect( buttons[ 1 ].label ).to.be.equals( 'Continue' );
+		expect( buttons[ 1 ].label ).toEqual( 'Continue' );
 	} );
 
 	test( 'should show an insert button if none or one local items are selected', () => {
@@ -232,7 +217,7 @@ describe( 'EditorMediaModal', () => {
 
 		const buttons = tree.getModalButtons();
 
-		expect( buttons[ 1 ].label ).to.be.equals( 'Insert' );
+		expect( buttons[ 1 ].label ).toEqual( 'Insert' );
 	} );
 
 	test( 'should show an insert button if multiple images are selected when gallery view is disabled', () => {
@@ -247,7 +232,7 @@ describe( 'EditorMediaModal', () => {
 
 		const buttons = tree.getModalButtons();
 
-		expect( buttons[ 1 ].label ).to.be.equals( 'Insert' );
+		expect( buttons[ 1 ].label ).toEqual( 'Insert' );
 	} );
 
 	describe( '#confirmSelection()', () => {
@@ -260,7 +245,7 @@ describe( 'EditorMediaModal', () => {
 
 			return new Promise( ( resolve ) => {
 				process.nextTick( () => {
-					expect( onClose ).to.have.been.calledWith( {
+					expect( onClose ).toHaveBeenCalledWith( {
 						items: DUMMY_MEDIA,
 						settings: undefined,
 						type: 'media',
@@ -292,7 +277,7 @@ describe( 'EditorMediaModal', () => {
 
 			return new Promise( ( resolve ) => {
 				process.nextTick( () => {
-					expect( onClose ).to.have.been.calledWith( transientItems, 'external' );
+					expect( onClose ).toHaveBeenCalledWith( transientItems, 'external' );
 					resolve();
 				} );
 			} );
@@ -321,7 +306,7 @@ describe( 'EditorMediaModal', () => {
 			];
 			return new Promise( ( resolve ) => {
 				process.nextTick( () => {
-					expect( onClose ).to.have.been.calledWith( transientItems, 'external' );
+					expect( onClose ).toHaveBeenCalledWith( transientItems, 'external' );
 					resolve();
 				} );
 			} );

--- a/client/post-editor/media-modal/test/markup.js
+++ b/client/post-editor/media-modal/test/markup.js
@@ -2,40 +2,31 @@
  * @jest-environment jsdom
  */
 
-import { expect } from 'chai';
 import ReactDomServer from 'react-dom/server';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import markup from '../markup';
 
 describe( 'markup', () => {
-	let sandbox;
 	const site = {};
-
-	useSandbox( ( newSandbox ) => ( sandbox = newSandbox ) );
-
-	beforeEach( () => {
-		sandbox.restore();
-	} );
 
 	describe( '#get()', () => {
 		test( 'should return an empty string if not passed any arguments', () => {
 			const value = markup.get( site );
 
-			expect( value ).to.equal( '' );
+			expect( value ).toEqual( '' );
 		} );
 
 		test( 'should defer to a specific mime type handler if one exists', () => {
-			sandbox.stub( markup.mimeTypes, 'image' );
+			jest.spyOn( markup.mimeTypes, 'image' );
 			markup.get( site, { mime_type: 'image/png' } );
 
-			expect( markup.mimeTypes.image ).to.have.been.called;
+			expect( markup.mimeTypes.image ).toBeCalled();
 		} );
 
 		test( 'should return a link for a mime type prefix without a specific handler', () => {
-			sandbox.stub( markup, 'link' );
+			jest.spyOn( markup, 'link' );
 			markup.get( site, { mime_type: 'application/pdf' } );
 
-			expect( markup.link ).to.have.been.called;
+			expect( markup.link ).toBeCalled();
 		} );
 	} );
 
@@ -46,7 +37,7 @@ describe( 'markup', () => {
 				title: 'document',
 			} );
 
-			expect( value ).to.equal(
+			expect( value ).toEqual(
 				'<a href="http://example.com/wp-content/uploads/document.pdf" title="document">document</a>'
 			);
 		} );
@@ -63,8 +54,8 @@ describe( 'markup', () => {
 				width: 276,
 			} );
 
-			expect( value.type ).to.equal( 'dl' );
-			expect( ReactDomServer.renderToStaticMarkup( value ) ).to.equal(
+			expect( value.type ).toEqual( 'dl' );
+			expect( ReactDomServer.renderToStaticMarkup( value ) ).toEqual(
 				'<dl class="wp-caption" style="width:276px"><dt class="wp-caption-dt"><img src="https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png" alt="Automattic" width="276" class="alignnone size-full wp-image-1"/></dt><dd class="wp-caption-dd">Logo</dd></dl>'
 			);
 		} );
@@ -78,7 +69,7 @@ describe( 'markup', () => {
 				width: 276,
 			} );
 
-			expect( value ).to.be.null;
+			expect( value ).toBeNull();
 		} );
 
 		test( 'should accept a captioned string, returning a React element', () => {
@@ -87,8 +78,8 @@ describe( 'markup', () => {
 				'[caption id="attachment_1627" align="aligncenter" width="660"]<img class="size-full wp-image-1627" src="https://andrewmduthietest.files.wordpress.com/2015/01/img_0372.jpg" alt="Example" width="660" height="660" /> Ceramic[/caption]'
 			);
 
-			expect( value.type ).to.equal( 'dl' );
-			expect( ReactDomServer.renderToStaticMarkup( value ) ).to.equal(
+			expect( value.type ).toEqual( 'dl' );
+			expect( ReactDomServer.renderToStaticMarkup( value ) ).toEqual(
 				'<dl class="wp-caption aligncenter" style="width:660px"><dt class="wp-caption-dt"><img class="size-full wp-image-1627" src="https://andrewmduthietest.files.wordpress.com/2015/01/img_0372.jpg" alt="Example" width="660" height="660" /></dt><dd class="wp-caption-dd">Ceramic</dd></dl>'
 			);
 		} );
@@ -103,7 +94,7 @@ describe( 'markup', () => {
 					thumbnails: {},
 				} );
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'<img src="http%3A//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71" class="alignnone size-full wp-image-media-4"/>'
 				);
 			} );
@@ -117,7 +108,7 @@ describe( 'markup', () => {
 					width: 276,
 				} );
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'<img src="https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png" alt="Automattic" width="276" class="alignnone size-full wp-image-1"/>'
 				);
 			} );
@@ -142,7 +133,7 @@ describe( 'markup', () => {
 					{ size: 'large' }
 				);
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'<img src="http://example.wordpress.com/image.png?w=1024" width="1024" height="410" class="alignnone size-large wp-image-1"/>'
 				);
 			} );
@@ -167,7 +158,7 @@ describe( 'markup', () => {
 					{ size: 'large' }
 				);
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'<img src="http://example.wordpress.com/image.png?w=410" width="410" height="1024" class="alignnone size-large wp-image-1"/>'
 				);
 			} );
@@ -185,7 +176,7 @@ describe( 'markup', () => {
 					{ forceResize: true }
 				);
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'<img src="https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png?w=276" alt="Automattic" width="276" class="alignnone size-full wp-image-1"/>'
 				);
 			} );
@@ -198,7 +189,7 @@ describe( 'markup', () => {
 					width: 276,
 				} );
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'<img src="&quot;&quot;&gt;&lt;SCRIPT&gt;alert(&quot;XSS&quot;)&lt;/SCRIPT&gt;&quot;" width="276" class="alignnone size-full wp-image-1"/>'
 				);
 			} );
@@ -222,7 +213,7 @@ describe( 'markup', () => {
 					{ size: 'large' }
 				);
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'<img src="https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png?w=200" alt="Automattic" width="200" class="alignnone size-large wp-image-1"/>'
 				);
 			} );
@@ -244,7 +235,7 @@ describe( 'markup', () => {
 					{ size: 'large' }
 				);
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'<img src="http://example.com/wp-content/uploads/2015/05/logo11w-1024x1024.png" alt="WordPress" width="1024" class="alignnone size-large wp-image-1"/>'
 				);
 			} );
@@ -259,7 +250,7 @@ describe( 'markup', () => {
 					width: 276,
 				} );
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'[caption id="attachment_1" width="276"]<img src="https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png" alt="Automattic" width="276" class="alignnone size-full wp-image-1"/> Logo[/caption]'
 				);
 			} );
@@ -278,7 +269,7 @@ describe( 'markup', () => {
 					{ size: 'large' }
 				);
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'<img src="https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png?w=1024" alt="Automattic" width="1024" height="111" class="alignnone size-large wp-image-1"/>'
 				);
 			} );
@@ -294,7 +285,7 @@ describe( 'markup', () => {
 					transient: true,
 				} );
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'<img src="https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png" alt="Automattic" width="2760" height="300" class="alignnone size-full wp-image-1" data-istransient="istransient"/>'
 				);
 			} );
@@ -310,7 +301,7 @@ describe( 'markup', () => {
 					transient: false,
 				} );
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'<img src="https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png" alt="Automattic" width="2760" height="300" class="alignnone size-full wp-image-1"/>'
 				);
 			} );
@@ -322,7 +313,7 @@ describe( 'markup', () => {
 					URL: 'http://example.com/wp-content/uploads/2015/06/loop.mp3',
 				} );
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'[audio src="http://example.com/wp-content/uploads/2015/06/loop.mp3"][/audio]'
 				);
 			} );
@@ -334,7 +325,7 @@ describe( 'markup', () => {
 					videopress_guid: '11acMj3O',
 				} );
 
-				expect( value ).to.equal( '[wpvideo 11acMj3O]' );
+				expect( value ).toEqual( '[wpvideo 11acMj3O]' );
 			} );
 
 			test( 'should return a `video` shortcode for a video', () => {
@@ -344,7 +335,7 @@ describe( 'markup', () => {
 					width: 1436,
 				} );
 
-				expect( value ).to.equal(
+				expect( value ).toEqual(
 					'[video src="http://example.com/wp-content/uploads/2015/06/loop.mp4" height="454" width="1436"][/video]'
 				);
 			} );

--- a/client/post-editor/media-modal/test/preload-image.js
+++ b/client/post-editor/media-modal/test/preload-image.js
@@ -1,45 +1,43 @@
 /**
  * @jest-environment jsdom
  */
-
-import { expect } from 'chai';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import preloadImage from '../preload-image';
 
 describe( '#preloadImage()', () => {
-	let sandbox;
-	let Image;
+	let image;
 
-	useSandbox( ( newSandbox ) => {
-		sandbox = newSandbox;
-		Image = sandbox.stub( global.window, 'Image' );
+	beforeAll( () => {
+		image = jest.spyOn( global.window, 'Image' );
 	} );
 
 	beforeEach( () => {
 		preloadImage.cache.clear();
 	} );
 
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	test( 'should load an image', () => {
-		const src = 'example.jpg';
+		const src = 'https://wordpress.com/example.jpg';
 
 		preloadImage( src );
 
-		expect( Image ).to.have.been.calledOnce;
-		expect( Image ).to.have.been.calledWithNew;
-		expect( Image.returnValues[ 0 ].src ).to.equal( src );
+		expect( image ).toBeCalledTimes( 1 );
+		expect( image.mock.results[ 0 ].value.src ).toEqual( src );
 	} );
 
 	test( 'should only load an image once per `src`', () => {
-		preloadImage( 'example.jpg' );
-		preloadImage( 'example.jpg' );
+		preloadImage( 'https://wordpress.com/example.jpg' );
+		preloadImage( 'https://wordpress.com/example.jpg' );
 
-		expect( Image ).to.have.been.calledOnce;
+		expect( image ).toBeCalledTimes( 1 );
 	} );
 
 	test( 'should load an image per unique `src`', () => {
-		preloadImage( 'example1.jpg' );
-		preloadImage( 'example2.jpg' );
+		preloadImage( 'https://wordpress.com/example1.jpg' );
+		preloadImage( 'https://wordpress.com/example2.jpg' );
 
-		expect( Image ).to.have.been.calledTwice;
+		expect( image ).toBeCalledTimes( 2 );
 	} );
 } );

--- a/client/reader/discover/test/helper.js
+++ b/client/reader/discover/test/helper.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { assert } from 'chai';
 import { get, omit } from 'lodash';
 import * as helper from '../helper';
 import * as fixtures from './fixtures';
@@ -15,83 +14,83 @@ describe( 'helper', () => {
 
 	describe( 'isDiscoverPost', () => {
 		test( 'returns true if discover metadata is present', () => {
-			assert.isTrue( helper.isDiscoverPost( discoverPost ) );
+			expect( helper.isDiscoverPost( discoverPost ) ).toBe( true );
 		} );
 
 		test( 'returns true if the site id is discovery_blog_id', () => {
 			const withoutMetadata = omit( fixtures.discoverSiteFormat, 'discover_metadata' );
-			assert.isTrue( helper.isDiscoverPost( withoutMetadata ) );
+			expect( helper.isDiscoverPost( withoutMetadata ) ).toBe( true );
 		} );
 
 		test( 'returns false if the site is not disover or discover metadata is not present', () => {
-			assert.isFalse( helper.isDiscoverPost( fixtures.nonDiscoverPost ) );
+			expect( helper.isDiscoverPost( fixtures.nonDiscoverPost ) ).toBe( false );
 		} );
 
 		test( 'returns false if the post is undefined', () => {
-			assert.isFalse( helper.isDiscoverPost() );
+			expect( helper.isDiscoverPost() ).toBe( false );
 		} );
 	} );
 
 	describe( 'isDiscoverSitePick', () => {
 		test( 'returns true if the post is a site pick', () => {
-			assert.isTrue( helper.isDiscoverSitePick( fixtures.discoverSiteFormat ) );
+			expect( helper.isDiscoverSitePick( fixtures.discoverSiteFormat ) ).toBe( true );
 		} );
 
 		test( 'returns false if the post is not a site pick', () => {
-			assert.isFalse( helper.isDiscoverSitePick( discoverPost ) );
+			expect( helper.isDiscoverSitePick( discoverPost ) ).toBe( false );
 		} );
 
 		test( 'returns false if the post is undefined', () => {
-			assert.isFalse( helper.isDiscoverSitePick() );
+			expect( helper.isDiscoverSitePick() ).toBe( false );
 		} );
 	} );
 
 	describe( 'isInternalDiscoverPost', () => {
 		test( 'returns true if the post is internal to wpcom', () => {
-			assert.isTrue( helper.isInternalDiscoverPost( discoverPost ) );
+			expect( helper.isInternalDiscoverPost( discoverPost ) ).toBe( true );
 		} );
 
 		test( 'returns false if the post is not internal to wpcom', () => {
-			assert.isFalse( helper.isInternalDiscoverPost( fixtures.externalDiscoverPost ) );
+			expect( helper.isInternalDiscoverPost( fixtures.externalDiscoverPost ) ).toBe( false );
 		} );
 	} );
 
 	describe( 'getSiteUrl', () => {
 		test( 'returns a reader route if the post is internal', () => {
-			assert.match( helper.getSiteUrl( discoverPost ), /^\/read\/blogs/ );
+			expect( helper.getSiteUrl( discoverPost ) ).toMatch( /^\/read\/blogs/ );
 		} );
 
 		test( 'returns the permalink if the post is not internal', () => {
 			const permalink = get( fixtures.externalDiscoverPost, 'discover_metadata.permalink' );
-			assert.equal( permalink, helper.getSiteUrl( fixtures.externalDiscoverPost ) );
+			expect( permalink ).toEqual( helper.getSiteUrl( fixtures.externalDiscoverPost ) );
 		} );
 
 		test( 'returns undefined if the post is not a discover post', () => {
-			assert.isUndefined( helper.getSiteUrl( fixtures.nonDiscoverPost ) );
+			expect( helper.getSiteUrl( fixtures.nonDiscoverPost ) ).not.toBeDefined();
 		} );
 	} );
 
 	describe( 'hasSource', () => {
 		test( 'returns true if the post is not a site pick', () => {
-			assert.isTrue( helper.hasSource( discoverPost ) );
+			expect( helper.hasSource( discoverPost ) ).toBe( true );
 		} );
 
 		test( 'returns false if the post is a site pick', () => {
-			assert.isFalse( helper.hasSource( fixtures.discoverSiteFormat ) );
+			expect( helper.hasSource( fixtures.discoverSiteFormat ) ).toBe( false );
 		} );
 
 		test( 'returns false if the post is undefined', () => {
-			assert.isFalse( helper.hasSource() );
+			expect( helper.hasSource() ).toBe( false );
 		} );
 	} );
 
 	describe( 'getSourceData', () => {
 		test( 'returns empty object if the post is not a discover post', () => {
-			assert.deepEqual( {}, helper.getSourceData( fixtures.nonDiscoverPost ) );
+			expect( {} ).toEqual( helper.getSourceData( fixtures.nonDiscoverPost ) );
 		} );
 
 		test( 'returns empty object if the post is external', () => {
-			assert.deepEqual( {}, helper.getSourceData( fixtures.externalDiscoverPost ) );
+			expect( {} ).toEqual( helper.getSourceData( fixtures.externalDiscoverPost ) );
 		} );
 
 		test( 'returns blog id if the post is a discover site pick', () => {
@@ -102,7 +101,7 @@ describe( 'helper', () => {
 				),
 				postId: undefined,
 			};
-			assert.deepEqual( fixtureData, helper.getSourceData( fixtures.discoverSiteFormat ) );
+			expect( fixtureData ).toEqual( helper.getSourceData( fixtures.discoverSiteFormat ) );
 		} );
 
 		test( 'returns the post and blog id', () => {
@@ -110,31 +109,31 @@ describe( 'helper', () => {
 				blogId: get( discoverPost, 'discover_metadata.featured_post_wpcom_data.blog_id' ),
 				postId: get( discoverPost, 'discover_metadata.featured_post_wpcom_data.post_id' ),
 			};
-			assert.deepEqual( fixtureData, helper.getSourceData( discoverPost ) );
+			expect( fixtureData ).toEqual( helper.getSourceData( discoverPost ) );
 		} );
 	} );
 
 	describe( 'getLinkProps', () => {
 		test( 'returns empty props if the post is internal', () => {
 			const siteUrl = helper.getSiteUrl( discoverPost );
-			assert.deepEqual( helper.getLinkProps( siteUrl ), { rel: '', target: '' } );
+			expect( helper.getLinkProps( siteUrl ) ).toEqual( { rel: '', target: '' } );
 		} );
 
 		test( 'returns props for external posts', () => {
 			const siteUrl = helper.getSiteUrl( fixtures.externalDiscoverPost );
-			assert.deepEqual( helper.getLinkProps( siteUrl ), { rel: 'external', target: '_blank' } );
+			expect( helper.getLinkProps( siteUrl ) ).toEqual( { rel: 'external', target: '_blank' } );
 		} );
 	} );
 
 	describe( 'getSourceFollowUrl', () => {
 		test( 'returns the site url if its a discover pick to an internal site', () => {
 			const followUrl = helper.getSourceFollowUrl( discoverPost );
-			assert.equal( followUrl, get( discoverPost, 'discover_metadata.attribution.blog_url' ) );
+			expect( followUrl ).toEqual( get( discoverPost, 'discover_metadata.attribution.blog_url' ) );
 		} );
 
 		test( 'returns undefined if the post is not a discover pick', () => {
 			const followUrl = helper.getSourceFollowUrl( fixtures.nonDiscoverPost );
-			assert.isUndefined( followUrl );
+			expect( followUrl ).not.toBeDefined();
 		} );
 	} );
 } );

--- a/client/reader/lib/teams/test/index.js
+++ b/client/reader/lib/teams/test/index.js
@@ -1,13 +1,12 @@
-import { expect } from 'chai';
 import { isAutomatticTeamMember } from '../';
 
 describe( 'isAutomatticTeamMember', () => {
 	test( 'should return true if teams include a8c', () => {
-		expect( isAutomatticTeamMember( [ { slug: 'a8c' }, { slug: 'okapi' } ] ) ).to.be.true;
+		expect( isAutomatticTeamMember( [ { slug: 'a8c' }, { slug: 'okapi' } ] ) ).toBe( true );
 	} );
 
 	test( 'should return false if teams do include a8c', () => {
-		expect( isAutomatticTeamMember( [] ) ).to.be.false;
-		expect( isAutomatticTeamMember( [ { slug: 'okapi' } ] ) ).to.be.false;
+		expect( isAutomatticTeamMember( [] ) ).toBe( false );
+		expect( isAutomatticTeamMember( [ { slug: 'okapi' } ] ) ).toBe( false );
 	} );
 } );

--- a/client/reader/route/test/index.js
+++ b/client/reader/route/test/index.js
@@ -1,35 +1,34 @@
 import config from '@automattic/calypso-config';
-import { expect } from 'chai';
 import * as route from '../';
 
 describe( 'index', () => {
 	describe( 'getStreamUrlFromPost', () => {
 		test( 'should return url for post from feed', () => {
-			expect( route.getStreamUrlFromPost( { feed_ID: 1234 } ) ).to.equal( '/read/feeds/1234' );
+			expect( route.getStreamUrlFromPost( { feed_ID: 1234 } ) ).toEqual( '/read/feeds/1234' );
 		} );
 
 		test( 'should return url for post from site', () => {
-			expect( route.getStreamUrlFromPost( { site_ID: 1234 } ) ).to.equal( '/read/blogs/1234' );
+			expect( route.getStreamUrlFromPost( { site_ID: 1234 } ) ).toEqual( '/read/blogs/1234' );
 		} );
 	} );
 
 	describe( 'getSiteUrl', () => {
 		test( 'should return site URL', () => {
-			expect( route.getSiteUrl( 1234 ) ).to.equal( '/read/blogs/1234' );
+			expect( route.getSiteUrl( 1234 ) ).toEqual( '/read/blogs/1234' );
 		} );
 
 		test( 'should return pretty URL for discover', () => {
-			expect( route.getSiteUrl( config( 'discover_blog_id' ) ) ).to.equal( '/discover' );
+			expect( route.getSiteUrl( config( 'discover_blog_id' ) ) ).toEqual( '/discover' );
 		} );
 	} );
 
 	describe( 'getFeedUrl', () => {
 		test( 'should return site URL', () => {
-			expect( route.getFeedUrl( 1234 ) ).to.equal( '/read/feeds/1234' );
+			expect( route.getFeedUrl( 1234 ) ).toEqual( '/read/feeds/1234' );
 		} );
 
 		test( 'should return pretty URL for discover', () => {
-			expect( route.getFeedUrl( config( 'discover_feed_id' ) ) ).to.equal( '/discover' );
+			expect( route.getFeedUrl( config( 'discover_feed_id' ) ) ).toEqual( '/discover' );
 		} );
 	} );
 } );

--- a/client/reader/stream/test/utils.js
+++ b/client/reader/stream/test/utils.js
@@ -1,4 +1,3 @@
-import { expect, assert } from 'chai';
 import moment from 'moment';
 import { sameDay, sameSite, combine, combineCards, injectRecommendations } from '../utils';
 
@@ -30,13 +29,13 @@ describe( 'reader stream', () => {
 		const oneMonthAgoPostKey = datePostKey( moment( today ).subtract( 1, 'month' ).toDate() );
 
 		test( 'should return true when two days are the same day', () => {
-			assert( sameDay( todayPostKey, todayPostKey2 ) );
+			expect( sameDay( todayPostKey, todayPostKey2 ) ).toBe( true );
 		} );
 
 		test( 'should return false when two days are not the same day', () => {
-			assert( ! sameDay( todayPostKey, oneYearAgoPostKey ) );
-			assert( ! sameDay( todayPostKey, oneYearInTheFuturePostKey ) );
-			assert( ! sameDay( todayPostKey, oneMonthAgoPostKey ) );
+			expect( sameDay( todayPostKey, oneYearAgoPostKey ) ).toBe( false );
+			expect( sameDay( todayPostKey, oneYearInTheFuturePostKey ) ).toBe( false );
+			expect( sameDay( todayPostKey, oneMonthAgoPostKey ) ).toBe( false );
 		} );
 	} );
 
@@ -44,27 +43,27 @@ describe( 'reader stream', () => {
 		test( 'should return true when two postKeys represent the same site', () => {
 			const postId = 'postId';
 			const isSame = sameSite( { blogId: 'site1', postId }, { blogId: 'site1', postId } );
-			assert( isSame );
+			expect( isSame ).toBe( true );
 		} );
 
 		test( 'should return true when two postKeys represent the same feed', () => {
 			const isSame = sameSite( postKey1, postKey2 );
-			assert( isSame );
+			expect( isSame ).toBe( true );
 		} );
 
 		test( 'should return true when samesite and one item is a combinedCard', () => {
 			const isSame = sameSite( combinedCardPostKey1, combinedCardPostKey2 );
-			assert( isSame );
+			expect( isSame ).toBe( true );
 		} );
 
 		test( 'should return false when different site and one item is a combinedCard', () => {
 			const isSame = sameSite( { ...combinedCardPostKey1, feedId: 'feed3' }, combinedCardPostKey2 );
-			assert( ! isSame );
+			expect( isSame ).toBe( false );
 		} );
 
 		test( 'should work when both postKeys represent combinedCards', () => {
 			const isSame = sameSite( combinedCardPostKey1, combinedCardPostKey2 );
-			assert( isSame );
+			expect( isSame ).toBe( true );
 		} );
 
 		test( 'recs should never be marked as sameSite', () => {
@@ -72,14 +71,14 @@ describe( 'reader stream', () => {
 				{ ...postKey1, isRecommendationBlock: 'isRecommendationBlock' },
 				postKey1
 			);
-			assert.isNotTrue( isSame );
+			expect( isSame ).toBe( false );
 		} );
 	} );
 
 	describe( '#combine', () => {
 		test( 'should combine two regular postkeys', () => {
 			const combined = combine( postKey1, postKey2 );
-			expect( combined ).to.eql( {
+			expect( combined ).toEqual( {
 				feedId: postKey1.feedId,
 				postIds: [ postKey1.postId, postKey2.postId ],
 				isCombination: true,
@@ -89,12 +88,12 @@ describe( 'reader stream', () => {
 
 		test( 'should return null if either postKey is null', () => {
 			const combined = combine( postKey1, null );
-			assert.equal( combined, null );
+			expect( combined ).toBeNull();
 		} );
 
 		test( 'should combine a combined card with a regular postKey', () => {
 			const combined = combine( combinedCardPostKey1, postKey1 );
-			expect( combined ).to.eql( {
+			expect( combined ).toEqual( {
 				...combinedCardPostKey1,
 				postIds: combinedCardPostKey1.postIds.concat( postKey1.postId ),
 			} );
@@ -102,7 +101,7 @@ describe( 'reader stream', () => {
 
 		test( 'should combine two combined cards correctly', () => {
 			const combined = combine( combinedCardPostKey1, combinedCardPostKey2 );
-			expect( combined ).to.eql( {
+			expect( combined ).toEqual( {
 				...combinedCardPostKey1,
 				postIds: combinedCardPostKey1.postIds.concat( combinedCardPostKey2.postIds ),
 			} );
@@ -121,11 +120,11 @@ describe( 'reader stream', () => {
 		test( 'should combine series with 2 in a rows', () => {
 			const postKeysSet1 = [ site1Key1, site1Key2 ];
 			const combinedItems1 = combineCards( postKeysSet1 );
-			expect( combinedItems1 ).eql( [ combine( site1Key1, site1Key2 ) ] );
+			expect( combinedItems1 ).toEqual( [ combine( site1Key1, site1Key2 ) ] );
 
 			const postKeysSet2 = [ site4Key1, site1Key1, site1Key2, site3Key1 ];
 			const combinedItems2 = combineCards( postKeysSet2 );
-			expect( combinedItems2 ).eql( [ site4Key1, combine( site1Key1, site1Key2 ), site3Key1 ] );
+			expect( combinedItems2 ).toEqual( [ site4Key1, combine( site1Key1, site1Key2 ), site3Key1 ] );
 		} );
 
 		test( 'should combine cards with series of 3 in a row', () => {
@@ -133,17 +132,17 @@ describe( 'reader stream', () => {
 
 			const postKeys1 = [ site1Key1, site1Key2, site1Key3 ];
 			const combinedItems1 = combineCards( postKeys1 );
-			expect( combinedItems1 ).eql( [ combinedCard ] );
+			expect( combinedItems1 ).toEqual( [ combinedCard ] );
 
 			const postKeys2 = [ site4Key1, site1Key1, site1Key2, site1Key3, site3Key1 ];
 			const combinedItems2 = combineCards( postKeys2 );
-			expect( combinedItems2 ).eql( [ site4Key1, combinedCard, site3Key1 ] );
+			expect( combinedItems2 ).toEqual( [ site4Key1, combinedCard, site3Key1 ] );
 		} );
 
 		test( 'should not combine any cards when no series exist', () => {
 			const postKeys = [ site1Key1, site2Key2, site3Key1, site4Key1 ];
 			const combinedItems = combineCards( postKeys );
-			expect( combinedItems ).eql( postKeys );
+			expect( combinedItems ).toEqual( postKeys );
 		} );
 
 		test( 'should not combine discover cards', () => {
@@ -160,15 +159,15 @@ describe( 'reader stream', () => {
 			const combinedFeedItems = combineCards( discoverFeedPostKeys );
 			const combinedSiteItems = combineCards( discoverSitePostKeys );
 
-			expect( combinedFeedItems ).eql( discoverFeedPostKeys );
-			expect( combinedSiteItems ).eql( discoverSitePostKeys );
+			expect( combinedFeedItems ).toEqual( discoverFeedPostKeys );
+			expect( combinedSiteItems ).toEqual( discoverSitePostKeys );
 		} );
 
 		test( 'should not combine cards that are greater than a day apart', () => {
 			const theDistantPast = moment().year( -1 ).toDate();
 			const postKeys = [ site1Key1, { ...site1Key2, date: theDistantPast } ];
 			const combinedItems = combineCards( postKeys );
-			expect( combinedItems ).eql( postKeys );
+			expect( combinedItems ).toEqual( postKeys );
 		} );
 	} );
 
@@ -186,7 +185,7 @@ describe( 'reader stream', () => {
 			const items = [ {} ];
 			const injectedItems = injectRecommendations( items, [], 1 );
 
-			expect( injectedItems ).eql( items );
+			expect( injectedItems ).toEqual( items );
 		} );
 
 		test( 'should not modify items if cards per rec is greater than length of items', () => {
@@ -194,7 +193,7 @@ describe( 'reader stream', () => {
 			const items = [ {} ];
 			const injectedItems = injectRecommendations( items, recs, 1 );
 
-			expect( injectedItems ).eql( items );
+			expect( injectedItems ).toEqual( items );
 		} );
 
 		test( 'should inject 2 recs for each regular post when cards per rec = 1', () => {
@@ -202,7 +201,7 @@ describe( 'reader stream', () => {
 			const items = [ post(), post(), post(), post(), post() ];
 			const injectedItems = injectRecommendations( items, recs, 1 );
 
-			expect( injectedItems ).eql( [
+			expect( injectedItems ).toEqual( [
 				post(),
 				createRecBlock( [ rec(), rec() ], 0 ),
 				post(),
@@ -220,7 +219,7 @@ describe( 'reader stream', () => {
 			const items = [ post(), post(), post() ];
 			const injectedItems = injectRecommendations( items, recs, 1 );
 
-			expect( injectedItems ).eql( [
+			expect( injectedItems ).toEqual( [
 				post(),
 				createRecBlock( [ rec(), rec() ], 0 ),
 				post(),
@@ -233,7 +232,7 @@ describe( 'reader stream', () => {
 			const items = [ post(), post(), post(), post(), post() ];
 			const injectedItems = injectRecommendations( items, recs, 4 );
 
-			expect( injectedItems ).eql( [
+			expect( injectedItems ).toEqual( [
 				post(),
 				post(),
 				post(),

--- a/client/reader/test/get-helpers.js
+++ b/client/reader/test/get-helpers.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { getSiteUrl, getSiteName } from '../get-helpers';
 
 describe( '#getSiteUrl', () => {
@@ -9,25 +8,25 @@ describe( '#getSiteUrl', () => {
 
 	test( 'should favor site over feed if both exist', () => {
 		const siteUrl = getSiteUrl( { site: siteWithUrl, feed: feedWithUrl } );
-		expect( siteUrl ).eql( siteWithUrl.URL );
+		expect( siteUrl ).toEqual( siteWithUrl.URL );
 	} );
 
 	test( 'should get title from site if feed does not exist', () => {
 		const siteUrl = getSiteUrl( { site: siteWithUrl } );
-		expect( siteUrl ).eql( siteWithUrl.URL );
+		expect( siteUrl ).toEqual( siteWithUrl.URL );
 	} );
 
 	test( 'should get title from feed if site does not exist', () => {
 		const siteUrl = getSiteUrl( { feed: feedWithUrl } );
-		expect( siteUrl ).eql( feedWithUrl.URL );
+		expect( siteUrl ).toEqual( feedWithUrl.URL );
 
 		const siteUrl2 = getSiteUrl( { feed: feedWithFeedUrl } );
-		expect( siteUrl2 ).eql( 'feedwithFeedUrl.com' );
+		expect( siteUrl2 ).toEqual( 'feedwithFeedUrl.com' );
 	} );
 
 	test( 'should grab url from post if its there', () => {
 		const siteUrl = getSiteUrl( { post: postWithSiteUrl } );
-		expect( siteUrl ).eql( postWithSiteUrl.site_URL );
+		expect( siteUrl ).toEqual( postWithSiteUrl.site_URL );
 	} );
 
 	test( 'should return undefined if cannot find a reasonable url', () => {
@@ -59,35 +58,35 @@ describe( '#getSiteName', () => {
 	test( 'should favor site title over everything', () => {
 		allFeeds.forEach( ( feed ) => {
 			const siteName = getSiteName( { site: siteWithTitleAndDomain, feed } );
-			expect( siteName ).eql( siteWithTitleAndDomain.title );
+			expect( siteName ).toEqual( siteWithTitleAndDomain.title );
 		} );
 	} );
 
 	test( 'should fallback to feed if site title doesnt exist', () => {
 		const siteName = getSiteName( { site: {}, feed: feedWithName } );
-		expect( siteName ).eql( feedWithName.name );
+		expect( siteName ).toEqual( feedWithName.name );
 
 		const siteTitle = getSiteName( { site: {}, feed: feedWithTitle, post: {} } );
-		expect( siteTitle ).eql( feedWithTitle.title );
+		expect( siteTitle ).toEqual( feedWithTitle.title );
 	} );
 
 	test( 'should fallback to post if neither site or feed exist', () => {
-		expect( getSiteName( { site: {}, feed: {}, post: postWithSiteName } ) ).eql(
+		expect( getSiteName( { site: {}, feed: {}, post: postWithSiteName } ) ).toEqual(
 			postWithSiteName.site_name
 		);
 
-		expect( getSiteName( { post: postWithSiteName } ) ).eql( postWithSiteName.site_name );
+		expect( getSiteName( { post: postWithSiteName } ) ).toEqual( postWithSiteName.site_name );
 	} );
 
 	test( 'should fallback to domain name if cannot find title', () => {
-		expect( getSiteName( { site: siteWithDomain, post: {} } ) ).eql( siteWithDomain.domain );
+		expect( getSiteName( { site: siteWithDomain, post: {} } ) ).toEqual( siteWithDomain.domain );
 
-		expect( getSiteName( { feed: feedWithUrl } ) ).eql( 'feedwithurl.com' );
+		expect( getSiteName( { feed: feedWithUrl } ) ).toEqual( 'feedwithurl.com' );
 	} );
 
 	test( 'should return null if nothing was found', () => {
-		expect( getSiteName() ).eql( null );
+		expect( getSiteName() ).toBeNull();
 
-		expect( getSiteName( { feed: {}, site: {}, post: {} } ) ).eql( null );
+		expect( getSiteName( { feed: {}, site: {}, post: {} } ) ).toBeNull();
 	} );
 } );

--- a/client/reader/test/id-helpers.js
+++ b/client/reader/test/id-helpers.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { toValidId } from '../id-helpers';
 
 describe( 'toValidId', () => {
@@ -20,7 +19,7 @@ describe( 'toValidId', () => {
 	testCases.forEach( function ( testCase ) {
 		const [ provided, expected ] = testCase;
 		test( `'${ provided }' should yield '${ expected }'`, () => {
-			expect( toValidId( provided ) ).to.equal( expected );
+			expect( toValidId( provided ) ).toEqual( expected );
 		} );
 	} );
 } );

--- a/client/reader/test/utils.js
+++ b/client/reader/test/utils.js
@@ -2,12 +2,11 @@
  * @jest-environment jsdom
  */
 
-import { expect } from 'chai';
 import page from 'page';
 import { showSelectedPost } from '../utils';
 
 jest.mock( 'page', () => ( {
-	show: require( 'sinon' ).spy(),
+	show: jest.fn(),
 } ) );
 jest.mock( 'calypso/lib/redux-bridge', () => ( {
 	reduxGetState: function () {
@@ -17,23 +16,23 @@ jest.mock( 'calypso/lib/redux-bridge', () => ( {
 
 describe( 'reader utils', () => {
 	beforeEach( () => {
-		page.show.resetHistory();
+		page.show.mockReset();
 	} );
 
 	describe( '#showSelectedPost', () => {
 		test( 'does not do anything if postKey argument is missing', () => {
 			showSelectedPost( {} );
-			expect( page.show ).to.have.not.been.called;
+			expect( page.show ).not.toBeCalled();
 		} );
 
 		test( 'redirects if passed a post key', () => {
 			showSelectedPost( { postKey: { feedId: 1, postId: 5 } } );
-			expect( page.show ).to.have.been.calledOnce;
+			expect( page.show ).toBeCalledTimes( 1 );
 		} );
 
 		test( 'redirects to a #comments URL if we passed comments argument', () => {
 			showSelectedPost( { postKey: { feedId: 1, postId: 5 }, comments: true } );
-			expect( page.show ).to.have.been.calledWithMatch( '#comments' );
+			expect( page.show ).toBeCalledWith( '/read/feeds/1/posts/5#comments' );
 		} );
 	} );
 } );

--- a/client/server/pages/test/analytics.js
+++ b/client/server/pages/test/analytics.js
@@ -1,5 +1,4 @@
 import events from 'events';
-import sinon from 'sinon';
 import { logSectionResponse } from 'calypso/server/pages/analytics';
 import { useFakeTimers } from 'calypso/test-helpers/use-sinon';
 import analytics from '../../lib/analytics';
@@ -29,15 +28,15 @@ describe( 'index', () => {
 			useFakeTimers( ( newClock ) => ( clock = newClock ) );
 
 			beforeEach( () => {
-				sinon.stub( analytics.statsd, 'recordTiming' );
-				sinon.stub( analytics.statsd, 'recordCounting' );
+				jest.spyOn( analytics.statsd, 'recordTiming' );
+				jest.spyOn( analytics.statsd, 'recordCounting' );
 				request.context.sectionName = 'reader';
 				request.context.target = 'evergreen';
 			} );
 
 			afterEach( () => {
-				analytics.statsd.recordTiming.restore();
-				analytics.statsd.recordCounting.restore();
+				analytics.statsd.recordTiming.mockReset();
+				analytics.statsd.recordCounting.mockReset();
 			} );
 
 			test( 'logs response analytics', () => {
@@ -104,13 +103,13 @@ describe( 'index', () => {
 
 		describe( 'when not rendering a section', () => {
 			beforeEach( () => {
-				sinon.stub( analytics.statsd, 'recordTiming' );
-				sinon.stub( analytics.statsd, 'recordCounting' );
+				jest.spyOn( analytics.statsd, 'recordTiming' );
+				jest.spyOn( analytics.statsd, 'recordCounting' );
 			} );
 
 			afterEach( () => {
-				analytics.statsd.recordTiming.restore();
-				analytics.statsd.recordCounting.restore();
+				analytics.statsd.recordTiming.mockReset();
+				analytics.statsd.recordCounting.mockReset();
 			} );
 
 			test( 'does not log response time analytics', () => {

--- a/client/server/pages/test/analytics.js
+++ b/client/server/pages/test/analytics.js
@@ -1,5 +1,4 @@
 import events from 'events';
-import { expect } from 'chai';
 import sinon from 'sinon';
 import { logSectionResponse } from 'calypso/server/pages/analytics';
 import { useFakeTimers } from 'calypso/test-helpers/use-sinon';
@@ -51,16 +50,13 @@ describe( 'index', () => {
 				clock.tick( TWO_SECONDS );
 				response.emit( 'finish' );
 
-				expect( analytics.statsd.recordTiming ).to.have.been.calledWith(
+				expect( analytics.statsd.recordTiming ).toBeCalledWith(
 					'reader',
 					'response-time',
 					TWO_SECONDS
 				);
 
-				expect( analytics.statsd.recordCounting ).to.have.been.calledWith(
-					'reader',
-					'target.evergreen'
-				);
+				expect( analytics.statsd.recordCounting ).toBeCalledWith( 'reader', 'target.evergreen' );
 			} );
 
 			test( 'does not log build target if not defined', () => {
@@ -75,13 +71,13 @@ describe( 'index', () => {
 				clock.tick( TWO_SECONDS );
 				response.emit( 'finish' );
 
-				expect( analytics.statsd.recordTiming ).to.have.been.calledWith(
+				expect( analytics.statsd.recordTiming ).toBeCalledWith(
 					'reader',
 					'response-time',
 					TWO_SECONDS
 				);
 
-				expect( analytics.statsd.recordCounting ).not.to.have.been.called;
+				expect( analytics.statsd.recordCounting ).not.toBeCalled();
 			} );
 
 			test( 'throttles calls to log analytics', () => {
@@ -94,15 +90,15 @@ describe( 'index', () => {
 				response.emit( 'finish' );
 				response2.emit( 'finish' );
 
-				expect( analytics.statsd.recordTiming ).to.have.been.calledOnce;
-				expect( analytics.statsd.recordCounting ).to.have.been.calledOnce;
+				expect( analytics.statsd.recordTiming ).toBeCalledTimes( 1 );
+				expect( analytics.statsd.recordCounting ).toBeCalledTimes( 1 );
 
 				clock.tick( TWO_SECONDS );
 				response.emit( 'finish' );
 				response2.emit( 'finish' );
 
-				expect( analytics.statsd.recordTiming ).to.have.been.calledTwice;
-				expect( analytics.statsd.recordCounting ).to.have.been.calledTwice;
+				expect( analytics.statsd.recordTiming ).toBeCalledTimes( 2 );
+				expect( analytics.statsd.recordCounting ).toBeCalledTimes( 2 );
 			} );
 		} );
 
@@ -123,8 +119,8 @@ describe( 'index', () => {
 				// Mock the "finish" event
 				response.emit( 'finish' );
 
-				expect( analytics.statsd.recordTiming ).not.to.have.been.called;
-				expect( analytics.statsd.recordCounting ).not.to.have.been.called;
+				expect( analytics.statsd.recordTiming ).not.toBeCalled();
+				expect( analytics.statsd.recordCounting ).not.toBeCalled();
 			} );
 		} );
 	} );

--- a/client/signup/validation-fieldset/test/index.jsx
+++ b/client/signup/validation-fieldset/test/index.jsx
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import ValidationFieldset from '..';
 
@@ -6,27 +5,21 @@ describe( 'ValidationFieldset', () => {
 	test( 'should pass className prop to the child FormFieldset component.', () => {
 		const wrapper = shallow( <ValidationFieldset className="test__foo-bar" /> );
 
-		expect( wrapper.find( 'FormFieldset' ) ).to.have.length( 1 );
-		expect( wrapper.find( 'FormFieldset' ).hasClass( 'test__foo-bar' ) ).to.be.true;
+		expect( wrapper.find( 'FormFieldset' ) ).toHaveLength( 1 );
+		expect( wrapper.find( 'FormFieldset' ).hasClass( 'test__foo-bar' ) ).toBe( true );
 	} );
 
 	test( 'should include a FormInputValidation only when errorMessages prop is set.', () => {
 		const wrapper = shallow( <ValidationFieldset /> );
 
-		expect( wrapper.find( 'FormInputValidation' ).exists() ).to.be.false;
+		expect( wrapper.find( 'FormInputValidation' ).exists() ).toBe( false );
 
 		wrapper.setProps( { errorMessages: [ 'error', 'message' ] } );
-		expect( wrapper.find( 'FormInputValidation' ) ).to.have.length( 1 );
+		expect( wrapper.find( 'FormInputValidation' ) ).toHaveLength( 1 );
 
-		expect(
-			wrapper.find( 'FormInputValidation' ).prop( 'text' ),
-			"FormInputValidation's text prop"
-		).to.equal( 'error' );
+		expect( wrapper.find( 'FormInputValidation' ).prop( 'text' ) ).toEqual( 'error' );
 
-		expect(
-			wrapper.find( '.validation-fieldset__validation-message' ).exists(),
-			'Is the meesage container empty?'
-		).to.be.true;
+		expect( wrapper.find( '.validation-fieldset__validation-message' ).exists() ).toBe( true );
 	} );
 
 	test( 'should render the children within a FormFieldset', () => {
@@ -37,8 +30,8 @@ describe( 'ValidationFieldset', () => {
 			</ValidationFieldset>
 		);
 
-		expect( wrapper.find( 'FormFieldset > p' ) ).to.have.length( 2 );
-		expect( wrapper.find( 'FormFieldset > p' ).first().text() ).to.equal(
+		expect( wrapper.find( 'FormFieldset > p' ) ).toHaveLength( 2 );
+		expect( wrapper.find( 'FormFieldset > p' ).first().text() ).toEqual(
 			'Lorem ipsum dolor sit amet'
 		);
 	} );

--- a/client/signup/wpcom-login-form/test/index.jsx
+++ b/client/signup/wpcom-login-form/test/index.jsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import WpcomLoginForm from '..';
 jest.mock( '@automattic/calypso-config', () => jest.fn().mockReturnValueOnce( 'wordpress.com' ) );
@@ -17,24 +16,24 @@ describe( 'WpcomLoginForm', () => {
 
 		// should render root form element
 		const form = wrapper.find( 'form' );
-		expect( form ).to.have.length( 1 );
-		expect( form.prop( 'method' ) ).to.equal( 'post' );
-		expect( form.prop( 'action' ) ).to.equal( 'https://test.wordpress.com/wp-login.php' );
+		expect( form ).toHaveLength( 1 );
+		expect( form.prop( 'method' ) ).toEqual( 'post' );
+		expect( form.prop( 'action' ) ).toEqual( 'https://test.wordpress.com/wp-login.php' );
 
 		// form should include default hidden elements
-		expect( wrapper.find( 'form > input[type="hidden"]' ) ).to.have.length( 4 );
-		expect( wrapper.find( 'form > input[name="log"]' ).prop( 'value' ) ).to.equal( 'log_text' );
-		expect( wrapper.find( 'form > input[name="pwd"]' ).prop( 'value' ) ).to.equal( 'secret' );
-		expect( wrapper.find( 'form > input[name="authorization"]' ).prop( 'value' ) ).to.equal(
+		expect( wrapper.find( 'form > input[type="hidden"]' ) ).toHaveLength( 4 );
+		expect( wrapper.find( 'form > input[name="log"]' ).prop( 'value' ) ).toEqual( 'log_text' );
+		expect( wrapper.find( 'form > input[name="pwd"]' ).prop( 'value' ) ).toEqual( 'secret' );
+		expect( wrapper.find( 'form > input[name="authorization"]' ).prop( 'value' ) ).toEqual(
 			'authorization_token'
 		);
-		expect( wrapper.find( 'form > input[name="redirect_to"]' ).prop( 'value' ) ).to.equal(
+		expect( wrapper.find( 'form > input[name="redirect_to"]' ).prop( 'value' ) ).toEqual(
 			'https://test.wordpress.com'
 		);
 
 		// when update a prop
 		wrapper.setProps( { log: 'another_log' } );
-		expect( wrapper.find( 'form > input[name="log"]' ).prop( 'value' ) ).to.equal( 'another_log' );
+		expect( wrapper.find( 'form > input[name="log"]' ).prop( 'value' ) ).toEqual( 'another_log' );
 	} );
 
 	test( 'should render extra fields if extraFields prop is passed.', () => {
@@ -49,9 +48,9 @@ describe( 'WpcomLoginForm', () => {
 			{ disableLifecycleMethods: true }
 		);
 
-		expect( wrapper.find( 'input[type="hidden"]' ) ).to.have.length( 6 );
-		expect( wrapper.find( 'input[name="foo"]' ).prop( 'value' ) ).to.equal( 'bar' );
-		expect( wrapper.find( 'input[name="lorem"]' ).prop( 'value' ) ).to.equal( 'ipsum' );
+		expect( wrapper.find( 'input[type="hidden"]' ) ).toHaveLength( 6 );
+		expect( wrapper.find( 'input[name="foo"]' ).prop( 'value' ) ).toEqual( 'bar' );
+		expect( wrapper.find( 'input[name="lorem"]' ).prop( 'value' ) ).toEqual( 'ipsum' );
 	} );
 
 	test( 'its action should be under the wpcom subdomain that `redirectTo` prop contains.', () => {
@@ -60,12 +59,12 @@ describe( 'WpcomLoginForm', () => {
 			{ disableLifecycleMethods: true }
 		);
 
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal(
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
 			'https://foo.wordpress.com/wp-login.php'
 		);
 
 		wrapper.setProps( { redirectTo: 'https://bar.wordpress.com' } );
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal(
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
 			'https://bar.wordpress.com/wp-login.php'
 		);
 	} );
@@ -77,21 +76,21 @@ describe( 'WpcomLoginForm', () => {
 		);
 
 		// should has the same hostname with redirectTo prop.
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal(
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
 			'https://foo.wordpress.com/wp-login.php'
 		);
 
 		// should be default url
 		config.mockReturnValueOnce( 'wpcalypso.wordpress.com' );
 		wrapper.setProps( { log: 'wpcalpso' } ); // to update form action
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal(
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
 			'https://wordpress.com/wp-login.php'
 		);
 
 		// should has the same hostname with redirectTo prop.
 		config.mockReturnValueOnce( 'bar.wordpress.com' );
 		wrapper.setProps( { log: 'bar' } ); // to update form action
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal(
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
 			'https://foo.wordpress.com/wp-login.php'
 		);
 
@@ -99,7 +98,7 @@ describe( 'WpcomLoginForm', () => {
 		config.mockReturnValueOnce( 'horizon.wordpress.com' );
 		config.mockReturnValueOnce( 'horizon.wordpress.com' );
 		wrapper.setProps( { log: 'horizon' } ); // to update form action
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal(
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
 			'https://wordpress.com/wp-login.php'
 		);
 	} );
@@ -109,7 +108,7 @@ describe( 'WpcomLoginForm', () => {
 			disableLifecycleMethods: true,
 		} );
 
-		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal(
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).toEqual(
 			'https://wordpress.com/wp-login.php'
 		);
 	} );

--- a/client/test-helpers/use-nock/integration/index.js
+++ b/client/test-helpers/use-nock/integration/index.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { nock, useNock } from '../index.js';
 
 describe( 'useNock', () => {
@@ -13,7 +12,7 @@ describe( 'useNock', () => {
 
 	describe( 'Illustration Block', () => {
 		test( 'still sees the earlier persistent connection', () => {
-			expect( nock.isDone() ).to.be.false;
+			expect( nock.isDone() ).toBe( false );
 		} );
 
 		afterAll( () => nock.cleanAll() );
@@ -25,17 +24,17 @@ describe( 'useNock', () => {
 		test( 'sets up a persistent interceptor', () => {
 			nock( 'wordpress.com' ).persist().get( '/me' ).reply( 200, { id: 42 } );
 
-			expect( nock.isDone() ).to.be.false;
+			expect( nock.isDone() ).toBe( false );
 		} );
 
 		test( 'persists inside the same `describe` block', () => {
-			expect( nock.isDone() ).to.be.false;
+			expect( nock.isDone() ).toBe( false );
 		} );
 	} );
 
 	describe( 'Test Block', () => {
 		test( 'should have reset all remaining nocks', () => {
-			expect( nock.isDone() ).to.be.true;
+			expect( nock.isDone() ).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As we've been moving towards canonically using `jest` as our primary unit testing platform, we're slowly moving away from `chai`. 

This PR refactors all remaining `client` tests to use `jest` instead of `chai`. We also use the opportunity to refactor away from `sinon` in favor of the built-in jest mocking functionality where necessary.

Most of the legwork here has been done with codemods, but I had to do a few more additional changes manually due to the added complexity of the test helpers.

#### Testing instructions

Verify all tests pass: `yarn run test-client`