### PR TITLE
Replace hasAvailableSiteFeature with getPlansForFeature

### DIFF
--- a/client/state/selectors/get-plans-for-feature.js
+++ b/client/state/selectors/get-plans-for-feature.js
@@ -1,14 +1,16 @@
 import getSiteFeatures from 'calypso/state/selectors/get-site-features';
 
 /**
- * Check if the feature is available for the site.
+ * Gets the list of plans that contain the passed feature.
+ *
+ * Used to determine which plan to upgrade to, in order for a site to gain access to a feature.
  *
  * @param  {object}  state      Global state tree
  * @param  {number}  siteId     The ID of the site we're querying
  * @param  {string}  featureId  The dotcom feature to check.
- * @returns {false|string[]}    Plasns array if the feature is available. Otherwise, False.
+ * @returns {false|string[]}    Plans array if the feature is available. Otherwise, False.
  */
-export default function hasAvailableSiteFeature( state, siteId, featureId ) {
+export default function getPlansForFeature( state, siteId, featureId ) {
 	const siteFeatures = getSiteFeatures( state, siteId );
 
 	if ( ! siteFeatures?.available ) {

--- a/client/state/selectors/test/has-available-site-feature.js
+++ b/client/state/selectors/test/has-available-site-feature.js
@@ -1,7 +1,7 @@
-import hasAvailableSiteFeature from 'calypso/state/selectors/has-available-site-feature';
+import getPlansForFeature from 'calypso/state/selectors/get-plans-for-feature';
 
 describe( 'selectors', () => {
-	describe( '#hasAvailableSiteFeature()', () => {
+	describe( '#getPlansForFeature()', () => {
 		test( 'should return False when no site id', () => {
 			const available = {
 				'feature-available-01': [ 'plan-01', 'plan-02', 'plan-03' ],
@@ -21,7 +21,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			const availableFeature = hasAvailableSiteFeature( state );
+			const availableFeature = getPlansForFeature( state );
 			expect( availableFeature ).toEqual( false );
 		} );
 
@@ -44,7 +44,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			const availableFeature = hasAvailableSiteFeature( state, 'unknown' );
+			const availableFeature = getPlansForFeature( state, 'unknown' );
 			expect( availableFeature ).toEqual( false );
 		} );
 
@@ -53,7 +53,7 @@ describe( 'selectors', () => {
 				sites: {},
 			};
 
-			const availableFeature = hasAvailableSiteFeature( state, 123001 );
+			const availableFeature = getPlansForFeature( state, 123001 );
 			expect( availableFeature ).toEqual( false );
 		} );
 
@@ -68,7 +68,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			const availableFeature = hasAvailableSiteFeature( state, 123001 );
+			const availableFeature = getPlansForFeature( state, 123001 );
 			expect( availableFeature ).toEqual( false );
 		} );
 
@@ -91,7 +91,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			const availableFeature = hasAvailableSiteFeature( state, 123001 );
+			const availableFeature = getPlansForFeature( state, 123001 );
 			expect( availableFeature ).toEqual( false );
 		} );
 
@@ -114,7 +114,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			const availableFeature = hasAvailableSiteFeature( state, 123001, 'not-available-feature' );
+			const availableFeature = getPlansForFeature( state, 123001, 'not-available-feature' );
 			expect( availableFeature ).toEqual( false );
 		} );
 
@@ -137,7 +137,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			const availableFeature = hasAvailableSiteFeature( state, 123001, 'feature-available-01' );
+			const availableFeature = getPlansForFeature( state, 123001, 'feature-available-01' );
 			expect( availableFeature ).toEqual( [ 'plan-01', 'plan-02', 'plan-03' ] );
 		} );
 	} );

--- a/client/state/sites/hooks/test/use-selected-site-selector.js
+++ b/client/state/sites/hooks/test/use-selected-site-selector.js
@@ -1,6 +1,6 @@
 import { FEATURE_WP_SUBDOMAIN } from '@automattic/calypso-products';
 import * as redux from 'react-redux';
-import hasAvailableSiteFeature from 'calypso/state/selectors/has-available-site-feature';
+import getPlansForFeature from 'calypso/state/selectors/get-plans-for-feature';
 import { useSelectedSiteSelector } from '../';
 import { isJetpackSite } from '../../selectors';
 
@@ -42,8 +42,6 @@ describe( 'useSelectedSiteSelector()', () => {
 			},
 		};
 		useSelector.mockImplementation( ( selector ) => selector( state ) );
-		expect( useSelectedSiteSelector( hasAvailableSiteFeature, FEATURE_WP_SUBDOMAIN ) ).toEqual(
-			true
-		);
+		expect( useSelectedSiteSelector( getPlansForFeature, FEATURE_WP_SUBDOMAIN ) ).toEqual( true );
 	} );
 } );

--- a/client/state/sites/hooks/use-selected-site-selector.ts
+++ b/client/state/sites/hooks/use-selected-site-selector.ts
@@ -14,7 +14,7 @@ export type SelectedSiteSelector< Params extends any[], Result > = (
  * Usage:
  *
  *   useSelectedSiteSelector( isJetpackSite );
- *   useSelectedSiteSelector( hasAvailableSiteFeature, FEATURE_WP_SUBDOMAIN );
+ *   useSelectedSiteSelector( getPlansForFeature, FEATURE_WP_SUBDOMAIN );
  *
  * @param selector A selector that takes state, a site id and any additional params.
  * @returns The result of the selector applied to application state.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replaces `hasAvailableSiteFeature` with `getPlansForFeature`
* Updates woop hook

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /woocommerce-installation with a simple site.
* Go through the onboarding steps.
* With a site that supports Woop (Business & above), make sure you see the domain change notification in step 3. <img width="1511" alt="Screen Shot 2022-05-18 at 9 08 33 AM" src="https://user-images.githubusercontent.com/1398304/169090314-c9f00080-1547-4bd1-9d64-718bd1921262.png">
* With a site on a plan that doesn't support Woop,  make sure you see the plan upgrade notification in step 3. <img width="1511" alt="image" src="https://user-images.githubusercontent.com/1398304/169090435-e92edc24-d12a-4d25-8f1a-44a8ec62e59b.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status]

 Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-a66-p2