### PR TITLE
Update the copy regarding the domain credit policy

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -10,9 +10,33 @@ class ReskinSideExplainer extends Component {
 	getStarterPlanOverrides( isEnLocale ) {
 		const { translate } = this.props;
 
-		const hasTitle =
+		const fallbackTitle = translate(
+			'Get a free one-year domain registration with any paid plan.'
+		);
+
+		const isPaidPlan = [ 'starter', 'pro' ].includes( this.props.flowName );
+		const hasFreeTitle =
+			i18n.hasTranslation(
+				'Get a {{b}}free{{/b}} one-year domain registration with any paid plan.'
+			) || isEnLocale;
+
+		const freeTitle = hasFreeTitle
+			? translate( 'Get a {{b}}free{{/b}} one-year domain registration with any paid plan.', {
+					components: { b: <strong /> },
+			  } )
+			: fallbackTitle;
+
+		const hasPaidTitle =
 			i18n.hasTranslation( 'Get a {{b}}free{{/b}} one-year domain registration with your plan.' ) ||
 			isEnLocale;
+
+		const paidTitle = hasPaidTitle
+			? translate( 'Get a {{b}}free{{/b}} one-year domain registration with your plan.', {
+					components: { b: <strong /> },
+			  } )
+			: fallbackTitle;
+
+		const title = isPaidPlan ? paidTitle : freeTitle;
 
 		const hasFreeSubtitle =
 			i18n.hasTranslation(
@@ -25,15 +49,9 @@ class ReskinSideExplainer extends Component {
 				'Use the search tool on this page to find a domain you love, then select a paid plan.'
 			);
 
-		const title = hasTitle
-			? translate( 'Get a {{b}}free{{/b}} one-year domain registration with your plan.', {
-					components: { b: <strong /> },
-			  } )
-			: translate( 'Get a free one-year domain registration with any paid plan.' );
+		const paidSubtitle = translate( 'Use the search tool on this page to find a domain you love.' );
 
-		let subtitle = [ 'starter', 'pro' ].includes( this.props.flowName )
-			? translate( 'Use the search tool on this page to find a domain you love.' )
-			: freeSubtitle;
+		let subtitle = isPaidPlan ? paidSubtitle : freeSubtitle;
 
 		let subtitle2 = translate(
 			'We’ll pay the first year’s domain registration fees for you, simple as that!'

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -1,12 +1,51 @@
 import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import { isStarterPlanEnabled } from 'calypso/my-sites/plans-comparison';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
 class ReskinSideExplainer extends Component {
+	getStarterPlanOverrides( isEnLocale ) {
+		const { translate } = this.props;
+
+		const hasTitle =
+			i18n.hasTranslation(
+				'Get a {{b}}free{{/b}} one-year domain registration with any paid plan.'
+			) || isEnLocale;
+
+		const hasFreeSubtitle =
+			i18n.hasTranslation(
+				'Use the search tool on this page to find a domain you love, then select a paid plan.'
+			) || isEnLocale;
+
+		const freeSubtitle =
+			hasFreeSubtitle &&
+			translate(
+				'Use the search tool on this page to find a domain you love, then select a paid plan.'
+			);
+
+		const title = hasTitle
+			? translate( 'Get a {{b}}free{{/b}} one-year domain registration with any paid plan.', {
+					components: { b: <strong /> },
+			  } )
+			: translate( 'Get a free one-year domain registration with any paid plan.' );
+
+		let subtitle = [ 'starter', 'pro' ].includes( this.props.flowName )
+			? translate( 'Use the search tool on this page to find a domain you love.' )
+			: freeSubtitle;
+
+		let subtitle2 = translate(
+			'We’ll pay the first year’s domain registration fees for you, simple as that!'
+		);
+
+		if ( ! subtitle ) {
+			subtitle = subtitle2;
+			subtitle2 = null;
+		}
+		return { title, subtitle, subtitle2, ctaText: false };
+	}
 	getStrings() {
 		const { type, translate } = this.props;
 
@@ -57,6 +96,16 @@ class ReskinSideExplainer extends Component {
 						'We’ll pay the first year’s domain registration fees for you, simple as that!'
 					);
 				ctaText = ! showNewSubtitle && translate( 'Choose my domain later' );
+
+				//todo: use only getStarterPlanOverrides() after Starter plan deploy
+				if ( isStarterPlanEnabled() ) {
+					const overrides = this.getStarterPlanOverrides( isEnLocale );
+					title = overrides.title;
+					subtitle = overrides.subtitle;
+					subtitle2 = overrides.subtitle2;
+					ctaText = overrides.ctaText;
+				}
+
 				break;
 
 			case 'use-your-domain':
@@ -117,6 +166,5 @@ export default connect( ( state ) => {
 
 	return {
 		selectedSiteId,
-		eligibleForProPlan: isEligibleForProPlan( state, selectedSiteId ),
 	};
 } )( localize( ReskinSideExplainer ) );

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -11,9 +11,8 @@ class ReskinSideExplainer extends Component {
 		const { translate } = this.props;
 
 		const hasTitle =
-			i18n.hasTranslation(
-				'Get a {{b}}free{{/b}} one-year domain registration with any paid plan.'
-			) || isEnLocale;
+			i18n.hasTranslation( 'Get a {{b}}free{{/b}} one-year domain registration with your plan.' ) ||
+			isEnLocale;
 
 		const hasFreeSubtitle =
 			i18n.hasTranslation(
@@ -27,7 +26,7 @@ class ReskinSideExplainer extends Component {
 			);
 
 		const title = hasTitle
-			? translate( 'Get a {{b}}free{{/b}} one-year domain registration with any paid plan.', {
+			? translate( 'Get a {{b}}free{{/b}} one-year domain registration with your plan.', {
 					components: { b: <strong /> },
 			  } )
 			: translate( 'Get a free one-year domain registration with any paid plan.' );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -880,7 +880,7 @@ export default connect(
 			sites: getSitesItems( state ),
 			isPlanSelectionAvailableLaterInFlow:
 				( ! isPlanStepSkipped && isPlanSelectionAvailableLaterInFlow( steps ) ) ||
-				( eligibleForProPlan && 'pro' === flowName ),
+				[ 'pro', 'starter' ].includes( flowName ),
 			userLoggedIn: isUserLoggedIn( state ),
 			eligibleForProPlan,
 		};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This replaces the WordPress Pro mention in the Domains credit policy with **any paid plan** because now there's also the Starter plan.

<img width="480" alt="168991485-0657c7aa-9bd5-485d-b070-d710c1d58dc3" src="https://user-images.githubusercontent.com/2749938/169110819-1090988b-4c54-4635-9d9e-8695f0cd0c9a.png">


#### Testing instructions

##### Onboarding flow
* Go to /start/plans in English locale
* The block should match the screenshot
<img width="240" alt="en-onboarding" src="https://user-images.githubusercontent.com/2749938/169112780-270a6de9-34a9-4107-821b-1b478e470d86.png">

* Non-English locales should look like this if strings are untranslated (ie. no subtitle and unbold Gratis)
<img width="240" alt="es-onboarding" src="https://user-images.githubusercontent.com/2749938/169113059-0fd98fe0-6ec2-43e6-8c0e-a4acfbd13065.png">
* Appending `?flags=-plans/starter-plan` should go back to the previous (WordPress Pro) version

##### Starter/Pro flow
* Go to /start/pro and/or /start/starter in English locale
* The block should match the screenshot
<img width="240" alt="en-paid-2" src="https://user-images.githubusercontent.com/2749938/169117558-e6eaed67-f05d-4cbf-8e80-f81cafb8b02e.png">


* Non-English locales should look like this if strings are untranslated (ie. unbold Gratis)
<img width="240" alt="es-paid" src="https://user-images.githubusercontent.com/2749938/169112974-ef449aa9-a266-4689-9aed-f5656db65d04.png">

* Appending `?flags=-plans/starter-plan` should go back to the previous (WordPress Pro) version


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
