### PR TITLE
Revert "Jetpack Cloud: Control DisplayPrice text direction with CSS"

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -55,19 +55,25 @@ const Paid: React.FC< OwnProps > = ( {
 		 */
 		return (
 			<>
-				<PlanPrice
-					original
-					className="display-price__original-price"
-					rawPrice={ originalPrice as number }
-					currencyCode={ currencyCode }
-				/>
-				<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
+				<span dir="ltr">
+					<PlanPrice
+						original
+						className="display-price__original-price"
+						rawPrice={ originalPrice as number }
+						currencyCode={ currencyCode }
+					/>
+				</span>
+				<span dir="ltr">
+					<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
+				</span>
 			</>
 		);
 	};
 
 	const renderNonDiscountedPrice = () => (
-		<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
+		<span dir="ltr">
+			<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
+		</span>
 	);
 
 	const renderPrice = () =>

--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -39,12 +39,6 @@
 
 	.plan-price {
 		display: inline-flex;
-
-		// inline-flex causes *everything* to flow right-to-left in right-to-left locales,
-		// so we override currency displays by setting the direction explicitly
-		/* rtl:ignore */
-		direction: ltr;
-
 		color: var( --studio-gray-100 );
 
 		&.display-price__original-price {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#63718.

For some reason, the RTL-CSS override/ignore directive isn't working in production 🤔 