### PR TITLE
[ETK][TeamCity] Show full diff output in the ETK build process if there's a diff between builds

### DIFF
--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -177,7 +177,7 @@ open class WPComPluginBuild(
 						echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
 
 						echo "DIFF: Start"
-						diff -r ./editing-toolkit-plugin/ ./release-archive/
+						diff -r $archiveDir ./release-archive/
 						echo "DIFF: End"
 
 						tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`

--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -175,6 +175,11 @@ open class WPComPluginBuild(
 					# Note: we exclude asset changes because we only really care if the build files (JS/CSS) change. That file is basically just metadata.
 					if [ "%skip_release_diff%" = "true" ] || ! diff -rq --exclude="*.asset.php" --exclude="build_meta.json" --exclude="README.md" $archiveDir ./release-archive/ ; then
 						echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
+
+						echo "DIFF: Start"
+						diff -r ./editing-toolkit-plugin/ ./release-archive/
+						echo "DIFF: End"
+
 						tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`
 						echo -e "Build tagging status: ${'$'}tag_response\n"
 

--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -177,7 +177,7 @@ open class WPComPluginBuild(
 						echo "The build is different from the last release build. Therefore, this can be tagged as a release build."
 
 						echo "DIFF: Start"
-						diff -r $archiveDir ./release-archive/
+						diff -r $archiveDir ./release-archive/ || true
 						echo "DIFF: End"
 
 						tag_response=`curl -s -X POST -H "Content-Type: text/plain" --data "$releaseTag" -u "%system.teamcity.auth.userId%:%system.teamcity.auth.password%" %teamcity.serverUrl%/httpAuth/app/rest/builds/id:%teamcity.build.id%/tags/`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

### What

* If the current ETK build is different from the last release build, then we run the `diff` command again but without the `-q` in order to show the full diff output. 

### Why?

We've hit a strange scenario where the `diff` command has shown that a `.js.map` file was different between the current and the latest release builds (see p1652802107630609-slack-C02DQP0FP). The [related PR](https://github.com/Automattic/wp-calypso/pull/63688#issuecomment-1128058694) didn't change anything in ETK. We'd like to know why the diff detected it as different, and what the differences are. This might be a symptom of a bug and we need to get the full diff in order to diagnose it.

#### Testing instructions

New ETK plugin builds will show the full diff between the latest build and the current build.

Related to https://github.com/Automattic/wp-calypso/pull/63688 and https://github.com/Automattic/wp-calypso/pull/63724.