### PR TITLE
Jetpack Cloud: Control DisplayPrice text direction with CSS

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -55,25 +55,19 @@ const Paid: React.FC< OwnProps > = ( {
 		 */
 		return (
 			<>
-				<span dir="ltr">
-					<PlanPrice
-						original
-						className="display-price__original-price"
-						rawPrice={ originalPrice as number }
-						currencyCode={ currencyCode }
-					/>
-				</span>
-				<span dir="ltr">
-					<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
-				</span>
+				<PlanPrice
+					original
+					className="display-price__original-price"
+					rawPrice={ originalPrice as number }
+					currencyCode={ currencyCode }
+				/>
+				<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
 			</>
 		);
 	};
 
 	const renderNonDiscountedPrice = () => (
-		<span dir="ltr">
-			<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
-		</span>
+		<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
 	);
 
 	const renderPrice = () =>

--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -41,9 +41,13 @@
 		display: inline-flex;
 
 		// inline-flex causes *everything* to flow right-to-left in right-to-left locales,
-		// so we override currency displays by setting the direction explicitly;
-		// the special comment syntax is important so the SASS compiler doesn't remove it
-		// too early in the build process
+		// so we override currency displays by setting the direction explicitly.
+		//
+		// NOTE: We set a comment directive here to inform the RTL CSS plugin
+		// not to override our text direction rule for right-to-left locales.
+		// We add the comment using string interpolation so that the SCSS compiler
+		// adds it during compilation instead of deleting the comment completely
+		// in the name of optimization.
 		direction: ltr #{'/* rtl:ignore */'};
 
 		color: var( --studio-gray-100 );

--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -39,6 +39,12 @@
 
 	.plan-price {
 		display: inline-flex;
+
+		// inline-flex causes *everything* to flow right-to-left in right-to-left locales,
+		// so we override currency displays by setting the direction explicitly
+		/* rtl:ignore */
+		direction: ltr;
+
 		color: var( --studio-gray-100 );
 
 		&.display-price__original-price {

--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -41,9 +41,10 @@
 		display: inline-flex;
 
 		// inline-flex causes *everything* to flow right-to-left in right-to-left locales,
-		// so we override currency displays by setting the direction explicitly
-		/* rtl:ignore */
-		direction: ltr;
+		// so we override currency displays by setting the direction explicitly;
+		// the special comment syntax is important so the SASS compiler doesn't remove it
+		// too early in the build process
+		direction: ltr #{'/* rtl:ignore */'};
 
 		color: var( --studio-gray-100 );
 


### PR DESCRIPTION
Relates to #63718, #29810.
Resolves `1164141197617539-as-1200899033701474`.

#### Changes proposed in this Pull Request

* All changes in #63718, plus:
* Protect the `/* rtl:ignore */` comment directive from being deleted by the SCSS compiler, by using [interpolation](https://sass-lang.com/documentation/interpolation#quoted-strings) to add the comment during the compilation itself.

#### Testing instructions

Same instructions as #63718; **HOWEVER**, please test with Calypso Live (links in comment below), to ensure changes also work beyond local development environments. Alternatively, see the test instructions in #29810 to test locally but in production mode.

***Regression testing:** All pages should render exactly as they do in production currently.*

* Visit the pricing page on:
  * Calypso Blue (`/plans/:site`);
  * Calypso Green (`/pricing`); and
  * Jetpack Connect (`/jetpack/connect/store`).
* Test how the prices on these pages render for locales that use right-to-left text flow (e.g., `he`, `ar`).
  * You may need to temporarily change your user locale in your WordPress.com account settings.
  * TIP: For Jetpack Cloud, you can do this by adding the locale to the beginning of the URL path (e.g., `/he/pricing`).
* Test how prices render in other currencies, like INR or ILS. (Automatticians can do this by changing their WordPress.com account's default currency via the Store Admin.)

#### Reference screenshots

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/670067/168848697-1ddc139a-8589-49fd-a144-0b83acf2058f.png">
<img width="985" alt="image" src="https://user-images.githubusercontent.com/670067/168849112-9c1f73f5-b009-48f0-b1da-008496153c0b.png">
<img width="1056" alt="image" src="https://user-images.githubusercontent.com/670067/168848486-f77acc44-dc63-4563-b84d-950ab897f576.png">