### PR TITLE
Add GitHub workflow file for Sentry git integration

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -1,19 +1,19 @@
 name: Create Sentry Release
-
 on:
   push:
     branches:
       - 'trunk'
-
 jobs:
-  build:
-  - uses: actions/checkout@v2
-  - name: Create Sentry release
-    uses: getsentry/action-release@v1
-    env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: a8c
-      SENTRY_PROJECT: calypso
-    with:
-      finalize: false
-      version_prefix: calypso_
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: a8c
+          SENTRY_PROJECT: calypso
+        with:
+          finalize: false
+          version_prefix: calypso_

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -1,0 +1,19 @@
+name: Create Sentry Release
+
+on:
+  push:
+    branches:
+      - 'trunk'
+
+jobs:
+  build:
+  - uses: actions/checkout@v2
+  - name: Create Sentry release
+    uses: getsentry/action-release@v1
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: a8c
+      SENTRY_PROJECT: calypso
+    with:
+      finalize: false
+      version_prefix: calypso_


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Note: this attempt two for #63313. The first attempt did not work because the auth token did not have the correct permissions, so the build failed. We'll get a new token and try again.

I outlined why it's very complex to do this as part of our TeamCity webpack build over here: #63309. Of course, it wouldn't be _that_ hard to create a TeamCity step _outside_ of webpack... but Sentry does already maintain a GitHub action which makes this super straightforward. 

The main goal of this integration is basically sending the VCS info over to Sentry, which enables features like "X commit caused Y problem." Since we aren't finalizing the releases, it should be possible to upload sourcemaps later, during the webpack build.

Docs here: https://github.com/marketplace/actions/sentry-release

This can't really be tested before merging.
