### PR TITLE
Stepper: Add login step shell

### DIFF
--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -55,6 +55,8 @@ export const anchorFmFlow: Flow = {
 			const siteSlug = siteSlugParam || getNewSite()?.site_slug;
 
 			switch ( currentStep ) {
+				case 'login':
+					return navigate( 'podcastTitle' );
 				case 'podcastTitle':
 					return navigate( 'designSetup' );
 				case 'designSetup':

--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -1,8 +1,8 @@
 import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
-import { SITE_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
@@ -19,7 +19,7 @@ export const anchorFmFlow: Flow = {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 		}, [] );
 
-		return [ 'podcastTitle', 'designSetup', 'processing', 'error' ] as StepPath[];
+		return [ 'login', 'podcastTitle', 'designSetup', 'processing', 'error' ] as StepPath[];
 	},
 
 	useStepNavigation( currentStep, navigate ) {
@@ -31,6 +31,8 @@ export const anchorFmFlow: Flow = {
 			const siteSlug = siteSlugParam || getNewSite()?.site_slug;
 
 			switch ( currentStep ) {
+				case 'login':
+					return navigate( 'podcastTitle' );
 				case 'podcastTitle':
 					return navigate( 'designSetup' );
 				case 'designSetup':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -1,6 +1,7 @@
 export { default as courses } from './courses';
 export { default as intent } from './intent-step';
 export { default as podcastTitle } from './podcast-title';
+export { default as login } from './login';
 export { default as options } from './site-options';
 export { default as bloggerStartingPoint } from './blogger-starting-point';
 export { default as storeFeatures } from './store-features';
@@ -47,6 +48,7 @@ export type StepPath =
 	| 'businessInfo'
 	| 'storeAddress'
 	| 'processing'
+	| 'login'
 	| 'vertical'
 	| 'wooTransfer'
 	| 'wooInstallPlugins'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/login/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/login/index.tsx
@@ -1,0 +1,55 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { Button } from '@automattic/components';
+import { StepContainer } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
+import { USER_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+import '../style.scss';
+
+const LoginStep: Step = function LoginStep( { navigation } ) {
+	const { submit, goNext } = navigation;
+	const { __ } = useI18n();
+	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
+
+	const LoginForm: React.FC = () => {
+		const handleSubmit = () => {
+			submit?.();
+		};
+
+		return (
+			<form
+				className="login__form"
+				onSubmit={ () => {
+					handleSubmit?.();
+				} }
+			>
+				<Button className="login__submit-button" type="submit" primary>
+					{ __( 'Continue' ) }
+				</Button>
+			</form>
+		);
+	};
+
+	//If we have a current user, proceed to the next step; no need to log in.
+	useEffect( () => {
+		if ( currentUser ) {
+			goNext?.();
+		}
+	}, [ currentUser ] );
+
+	return (
+		<StepContainer
+			stepName={ 'login-step' }
+			hideBack
+			hideSkip
+			hideNext
+			stepContent={ <LoginForm /> }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default LoginStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/login/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/login/index.tsx
@@ -13,6 +13,7 @@ const LoginStep: Step = function LoginStep( { navigation } ) {
 	const { submit, goNext } = navigation;
 	const { __ } = useI18n();
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
+	const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
 
 	const LoginForm: React.FC = () => {
 		const handleSubmit = () => {
@@ -33,12 +34,15 @@ const LoginStep: Step = function LoginStep( { navigation } ) {
 		);
 	};
 
-	//If we have a current user, proceed to the next step; no need to log in.
+	/*
+	 * If we have a current user and they're logged in,
+	 * proceed to the next step; no need to log in.
+	 */
 	useEffect( () => {
-		if ( currentUser ) {
+		if ( currentUser && userIsLoggedIn ) {
 			goNext?.();
 		}
-	}, [ currentUser ] );
+	}, [ currentUser, userIsLoggedIn ] );
 
 	return (
 		<StepContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/login/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/login/style.scss
@@ -1,0 +1,14 @@
+.login__submit-button {
+    background: $design-button-primary-color;
+    border-color: $design-button-primary-color;
+    padding: 9px 48px;
+    border-radius: 4px;
+    font-weight: 500;
+    box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;
+
+    &:hover,
+    &:focus {
+        background: $design-button-primary-hover-color;
+        border-color: $design-button-primary-hover-color;
+    }
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Begin adding a login step to the Anchor flow
* There are no actual working inputs yet, just the step itself and some logic to check whether the user exists/is logged in before proceeding to the next step.

#### Testing instructions

* Switch to this PR and navigate to `/setup/?anchor_podcast=[your podcast ID]`
* You should be redirected to `/setup/login/?anchor_podcast...`
* If you are logged in, you should be forwarded to `/setup/podcastTitle/?anchor_podcast...`
* If you are logged out, you should just see a Continue button. Clicking on that should bring you to `/setup/podcastTitle/?anchor_podcast...`

Related to #63674
