### PR TITLE
Update Plans (legacy) page to use productDisplayPrice

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -450,6 +450,7 @@ export class PlanFeaturesHeader extends Component {
 			plansWithScroll,
 			isInVerticalScrollingPlansExperiment,
 			isLoggedInMonthlyPricing,
+			productDisplayPrice,
 		} = this.props;
 		const displayFlatPrice =
 			isInSignup && ! plansWithScroll && ! isInVerticalScrollingPlansExperiment;
@@ -464,6 +465,7 @@ export class PlanFeaturesHeader extends Component {
 							displayFlatPrice={ displayFlatPrice }
 							displayPerMonthNotation={ true }
 							original
+							productDisplayPrice={ productDisplayPrice }
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
@@ -471,6 +473,7 @@ export class PlanFeaturesHeader extends Component {
 							displayFlatPrice={ displayFlatPrice }
 							displayPerMonthNotation={ true }
 							discounted
+							productDisplayPrice={ productDisplayPrice }
 						/>
 					</div>
 					{ plansWithScroll ? null : this.renderCreditLabel() }
@@ -484,6 +487,7 @@ export class PlanFeaturesHeader extends Component {
 				rawPrice={ fullPrice }
 				displayFlatPrice={ displayFlatPrice }
 				displayPerMonthNotation={ isInSignup || isLoggedInMonthlyPricing }
+				productDisplayPrice={ productDisplayPrice }
 			/>
 		);
 	}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -364,6 +364,7 @@ export class PlanFeatures extends Component {
 				bestValue,
 				relatedMonthlyPlan,
 				primaryUpgrade,
+				productDisplayPrice,
 				isPlaceholder,
 				hideMonthly,
 			} = properties;
@@ -384,6 +385,7 @@ export class PlanFeatures extends Component {
 						title={ planConstantObj.getTitle() }
 						planType={ planName }
 						rawPrice={ rawPrice }
+						productDisplayPrice={ productDisplayPrice }
 						discountPrice={ discountPrice }
 						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
 						hideMonthly={ hideMonthly }
@@ -466,6 +468,7 @@ export class PlanFeatures extends Component {
 				isPlaceholder,
 				hideMonthly,
 				rawPrice,
+				productDisplayPrice,
 				isMonthlyPlan,
 			} = properties;
 			let { discountPrice } = properties;
@@ -514,6 +517,7 @@ export class PlanFeatures extends Component {
 						planType={ planName }
 						popular={ popular }
 						rawPrice={ rawPrice }
+						productDisplayPrice={ productDisplayPrice }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 						selectedPlan={ selectedPlan }
 						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
@@ -900,6 +904,7 @@ const ConnectedPlanFeatures = connect(
 				const isLoadingSitePlans = selectedSiteId && ! sitePlans.hasLoadedFromServer;
 				const isMonthlyPlan = isMonthly( plan );
 				const showMonthly = ! isMonthlyPlan;
+				const productDisplayPrice = planObject.product_display_price;
 				const availableForPurchase = isInSignup
 					? true
 					: canUpgradeToPlan( state, selectedSiteId, plan ) && canPurchase;
@@ -990,6 +995,7 @@ const ConnectedPlanFeatures = connect(
 					planName: plan,
 					planObject: planObject,
 					popular,
+					productDisplayPrice,
 					productSlug: get( planObject, 'product_slug' ),
 					newPlan: newPlan,
 					bestValue: bestValue,

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -62,7 +62,7 @@
 }
 
 .plan-price__integer abbr {
-	font-size: 1.25rem;
+	font-size: 1rem;
 	vertical-align: text-top;
 }
 .plan-price__fraction {

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -61,6 +61,10 @@
 	font-weight: 400;
 }
 
+.plan-price__integer abbr {
+	font-size: 1.25rem;
+	vertical-align: text-top;
+}
 .plan-price__fraction {
 	font-weight: 600;
 }

--- a/client/state/plans/schema.js
+++ b/client/state/plans/schema.js
@@ -32,6 +32,7 @@ export const itemsSchema = {
 			product_name: { type: 'string' },
 			product_name_en: { type: 'string' },
 			product_name_short: { type: [ 'string', 'null' ] },
+			product_display_price: { type: 'string' },
 			product_slug: { type: 'string' },
 			product_type: { type: 'string' },
 			raw_price: { type: 'number' },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

These changes add a `productDisplayPrice` prop to PlanPrice which will replace the existing price with a geo-ided value provided from the backend. 

Also, a bit of styling was added to ensure the currency symbol HTML is properly sized.

#### Testing instructions

- Ensure you have a legacy plan on a site, go to this site > Plans
- Check that the plan prices have the abbr html element wrapping the currency, and that the currency title works as expected
- Check that right aligned currencies actual appear to the right (try PLN)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #50064
