### PR TITLE
Display transfer lock opt out for eligible domains only

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -145,18 +145,22 @@ class EditContactInfoFormCard extends Component {
 
 	renderTransferLockOptOut() {
 		const { domainRegistrationAgreementUrl, translate } = this.props;
-		return (
-			<>
-				<TransferLockOptOutForm
-					disabled={ this.state.formSubmitting }
-					onChange={ this.onTransferLockOptOutChange }
-				/>
-				<DesignatedAgentNotice
-					domainRegistrationAgreementUrl={ domainRegistrationAgreementUrl }
-					saveButtonLabel={ translate( 'Save contact info' ) }
-				/>
-			</>
-		);
+		const transferLockExpiration = this.props.selectedDomain.transferAwayEligibleAt;
+
+		if ( ! transferLockExpiration ) {
+			return (
+				<>
+					<TransferLockOptOutForm
+						disabled={ this.state.formSubmitting }
+						onChange={ this.onTransferLockOptOutChange }
+					/>
+					<DesignatedAgentNotice
+						domainRegistrationAgreementUrl={ domainRegistrationAgreementUrl }
+						saveButtonLabel={ translate( 'Save contact info' ) }
+					/>
+				</>
+			);
+		}
 	}
 
 	renderBackupEmail() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a condition to only render `TransferLockOptOutForm` & `DesignatedAgentNotice` if domain is eligible to opt out of transfer lock when updating contact information for a domain. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**BEFORE**

* Previously, this would display on all domains, even for domains that are not eligible to opt out of transfer lock, when updating contact information:
![image](https://user-images.githubusercontent.com/65082164/169170378-b3eb9e8e-571a-4b0c-936d-435cff542f09.png)

**AFTER**

• Now domains that are ineligible to opt out of transfer lock will only display the following, when updating contact information:

![image](https://user-images.githubusercontent.com/65082164/169170471-eed5c5d1-31dc-4d57-ad3b-207a43c18930.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


