### PR TITLE
Site request: force wpcom if json-api module does not exist

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -135,8 +135,9 @@ export function requestSite( siteFragment ) {
 		const result = doRequest( false ).catch( ( error ) => {
 			// if there is Jetpack JSON API module error, retry with force: 'wpcom'
 			if (
-				error?.status === 403 &&
-				error?.message === 'API calls to this blog have been disabled.'
+				( error?.status === 403 &&
+					error?.message === 'API calls to this blog have been disabled.' ) ||
+				( error?.status === 400 && error?.name === 'ApiNotFoundError' )
 			) {
 				return doRequest( true );
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The PR propose an approach to handle an error where if `json-api` doesn't exist on site, then retry with `force=wpcom`.

#### Testing instructions
- Prepare a site with Boost and Search plugin active
- Connect site, but don't connect any user (You could do this by click start on Boost admin page)
- Start you local Calypso `yarn start`
- Open `http://calypso.localhost:3000/checkout/{slug}/jetpack_search?unlinked=1&redirect_to=https://{slug}/admin.php?` <- repalce the slug with the site domain
- Ensure you are redirected to Authorization page
- Ensure you could connect the site and checkout Jetpack Search product

Related to https://github.com/Automattic/jetpack/issues/23917 https://github.com/Automattic/jetpack/issues/23972
