### PR TITLE
Reader: Make blog stickers error silent

### DIFF
--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -1,31 +1,19 @@
-import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import BlogStickersList from 'calypso/blocks/blog-stickers/list';
 import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
 import InfoPopover from 'calypso/components/info-popover';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
-import { errorNotice } from 'calypso/state/notices/actions';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { useBlogStickersQuery } from './use-blog-stickers-query';
 
 import './style.scss';
 
 const BlogStickers = ( { blogId } ) => {
-	const dispatch = useDispatch();
-	const translate = useTranslate();
 	const teams = useSelector( getReaderTeams );
 	const isTeamMember = isAutomatticTeamMember( teams );
 
-	const { data: stickers } = useBlogStickersQuery( blogId, {
-		onError() {
-			dispatch(
-				errorNotice(
-					translate( 'Sorry, we had a problem retrieving blog stickers. Please try again.' )
-				)
-			);
-		},
-	} );
+	const { data: stickers } = useBlogStickersQuery( blogId );
 
 	if ( teams && ! isTeamMember ) {
 		return null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The blog stickers endpoint is a11n-only and since #63454 we've been displaying error messages to users because the endpoint response is always failing for non-a12s. Reported in https://github.com/Automattic/wp-calypso/pull/63454#issuecomment-1131455869

This PR makes the error silent as a quick fix. Ideally, a follow-up should enable the query only for a12s (cc @flootr).

#### Testing instructions

* Login as a non-a11n
* Go to `/read/feeds/25823`
* Verify that you no longer see an error notice after a few seconds.
* Login as an a11n
* Verify that the (i) icon with the blog sticker still works and loads the stickers well.