### PR TITLE
Disable site actions when the monitor status is down

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -12,9 +12,10 @@ import './style.scss';
 interface Props {
 	isLargeScreen?: boolean;
 	site: SiteNode;
+	siteError: boolean;
 }
 
-export default function SiteActions( { isLargeScreen, site }: Props ): ReactElement {
+export default function SiteActions( { isLargeScreen, site, siteError }: Props ): ReactElement {
 	const translate = useTranslate();
 
 	const [ isOpen, setIsOpen ] = useState( false );
@@ -31,7 +32,6 @@ export default function SiteActions( { isLargeScreen, site }: Props ): ReactElem
 
 	const siteUrl = site?.value?.url;
 	const siteUrlWithScheme = site?.value?.url_with_scheme;
-	const siteError = site?.error;
 	const siteId = site?.value?.blog_id;
 
 	const handleClickMenuItem = () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -29,7 +29,7 @@ export default function SiteCard( { rows, columns }: Props ): ReactElement {
 	const headerItem = rows[ 'site' ];
 
 	const site = rows.site;
-	const siteError = site.error;
+	const siteError = site.error || rows.monitor.error;
 	const siteUrl = site.value.url;
 
 	return (
@@ -45,7 +45,7 @@ export default function SiteCard( { rows, columns }: Props ): ReactElement {
 					{ toggleContent }
 					<SiteStatusContent rows={ rows } type={ headerItem.type } />
 				</span>
-				<SiteActions site={ site } />
+				<SiteActions site={ site } siteError={ siteError } />
 			</div>
 
 			{ isExpanded && (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -15,6 +15,7 @@ interface Props {
 export default function SiteStatusContent( { rows, type }: Props ): ReactElement {
 	const {
 		link,
+		isExternalLink,
 		row: { value, status, error },
 		siteError,
 		tooltip,
@@ -116,8 +117,14 @@ export default function SiteStatusContent( { rows, type }: Props ): ReactElement
 	let updatedContent = content;
 
 	if ( link ) {
+		let target = '_self';
+		let rel;
+		if ( isExternalLink ) {
+			target = '_blank';
+			rel = 'noreferrer';
+		}
 		updatedContent = (
-			<a onClick={ handleClickRowAction } href={ link }>
+			<a target={ target } rel={ rel } onClick={ handleClickRowAction } href={ link }>
 				{ content }
 			</a>
 		);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -19,7 +19,13 @@ export default function SiteStatusContent( { rows, type }: Props ): ReactElement
 		siteError,
 		tooltip,
 		tooltipId,
+		siteDown,
 	} = getRowMetaData( rows, type );
+
+	// Disable clicks/hover when there is a site error &
+	// when the row it is not monitor and monitor status is down
+	// since monitor is clickable when site is down.
+	const disabledStatus = siteError || ( type !== 'monitor' && siteDown );
 
 	const statusContentRef = useRef< HTMLSpanElement | null >( null );
 	const [ showTooltip, setShowTooltip ] = useState( false );
@@ -36,7 +42,8 @@ export default function SiteStatusContent( { rows, type }: Props ): ReactElement
 	};
 
 	if ( type === 'site' ) {
-		const siteIssues = rows.scan.threats || rows.plugin.updates;
+		// Site issues is the sum of scan threats and plugin updates
+		const siteIssues = rows.scan.threats + rows.plugin.updates;
 		let errorContent;
 		if ( error ) {
 			errorContent = (
@@ -116,13 +123,13 @@ export default function SiteStatusContent( { rows, type }: Props ): ReactElement
 		);
 	}
 
-	if ( siteError ) {
+	if ( disabledStatus ) {
 		updatedContent = <span className="sites-overview__disabled">{ content } </span>;
 	}
 
 	return (
 		<>
-			{ tooltip && ! siteError ? (
+			{ tooltip && ! disabledStatus ? (
 				<>
 					<span
 						ref={ statusContentRef }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -41,6 +41,7 @@ export default function SiteTable( { isFetching, columns, items }: Props ): Reac
 					items.map( ( item ) => {
 						const site = item.site;
 						const blogId = site.value.blog_id;
+						const siteError = site.error || item.monitor.error;
 						return (
 							<Fragment key={ `table-row-${ blogId }` }>
 								<tr className="site-table__table-row">
@@ -63,7 +64,7 @@ export default function SiteTable( { isFetching, columns, items }: Props ): Reac
 											'site-table__actions'
 										) }
 									>
-										<SiteActions isLargeScreen site={ site } />
+										<SiteActions isLargeScreen site={ site } siteError={ siteError } />
 									</td>
 								</tr>
 								{ site.error ? (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -13,8 +13,9 @@ const getLinks = (
 	status: string,
 	siteUrl: string,
 	siteId: number
-): { tooltip: ReactChild | undefined; link: string } => {
+): { tooltip: ReactChild | undefined; link: string; isExternalLink: boolean } => {
 	let link = '';
+	let isExternalLink = false;
 	let tooltip;
 	switch ( type ) {
 		case 'backup': {
@@ -42,6 +43,7 @@ const getLinks = (
 		case 'monitor': {
 			if ( status === 'failed' ) {
 				link = `https://jptools.wordpress.com/debug/?url=${ siteUrl }`;
+				isExternalLink = true;
 			}
 			if ( status === 'success' ) {
 				tooltip = translate( 'Monitor is on and your site is online' );
@@ -55,7 +57,7 @@ const getLinks = (
 			break;
 		}
 	}
-	return { link, tooltip };
+	return { link, isExternalLink, tooltip };
 };
 
 /**
@@ -68,6 +70,7 @@ export const getRowMetaData = (
 ): {
 	row: { value: { url: string }; status: string; error: string };
 	link: string;
+	isExternalLink: boolean;
 	siteError: string;
 	tooltip: ReactChild | undefined;
 	tooltipId: string;
@@ -77,10 +80,11 @@ export const getRowMetaData = (
 	const siteUrl = rows.site?.value?.url;
 	const siteError = rows.site.error;
 	const siteId = rows.site?.value?.blog_id;
-	const { link, tooltip } = getLinks( type, row.status, siteUrl, siteId );
+	const { link, tooltip, isExternalLink } = getLinks( type, row.status, siteUrl, siteId );
 	return {
 		row,
 		link,
+		isExternalLink,
 		siteError,
 		tooltip,
 		tooltipId: `${ siteId }-${ type }`,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -71,10 +71,11 @@ export const getRowMetaData = (
 	siteError: string;
 	tooltip: ReactChild | undefined;
 	tooltipId: string;
+	siteDown: boolean;
 } => {
 	const row = rows[ type ];
 	const siteUrl = rows.site?.value?.url;
-	const siteError = rows.site?.error;
+	const siteError = rows.site.error;
 	const siteId = rows.site?.value?.blog_id;
 	const { link, tooltip } = getLinks( type, row.status, siteUrl, siteId );
 	return {
@@ -83,6 +84,7 @@ export const getRowMetaData = (
 		siteError,
 		tooltip,
 		tooltipId: `${ siteId }-${ type }`,
+		siteDown: rows.monitor.error,
 	};
 };
 
@@ -110,15 +112,11 @@ export const formatSites = ( data: { items: Array< any > } ): Array< any > => {
 				}
 			);
 		}
-		let error;
-		if (
+		const error =
 			! site.is_connection_healthy ||
 			! site.access_xmlrpc ||
 			! site.valid_xmlrpc ||
-			! site.authenticated_xmlrpc
-		) {
-			error = translate( 'FIX CONNECTION' );
-		}
+			! site.authenticated_xmlrpc;
 		return {
 			site: {
 				value: site,
@@ -141,6 +139,7 @@ export const formatSites = ( data: { items: Array< any > } ): Array< any > => {
 				value: 'failed' === site.monitor_status ? translate( 'Site Down' ) : '',
 				status: site.monitor_status === 'accessible' ? 'success' : site.monitor_status,
 				type: 'monitor',
+				error: 'failed' === site.monitor_status,
 			},
 			plugin: {
 				value: `${ pluginUpdates.length } ${ translate( 'Available' ) }`,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR has changes that disable the row status actions except for monitor status when it is down(failed).

#### Testing instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb

**Instructions**

1. Run `git checkout update/disable-site-actions-when-site-is-down` and `yarn start-jetpack-cloud`
2. Apply D79008-code to your sandbox for the mock API to work.
3. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard
4. Verify that all the row statuses are disabled except Monitor which should take the user to JP debugger when clicked when the monitor shows `Site Down`.
5. When the site status is failed(down) and it shows `Jetpack is unable to connect to {site}` all the row actions including the monitor should be disabled. 
6. Verify that only 2 actions - `View site` & `Visit WP Admin` are shown in more actions(`...`) when the monitor shows `Site Down`.
7. Switch to mobile view(<960), the count on each card should show the sum of site issues - #Threats, Plugin Updates, etc

**Screenshots**

<img width="1625" alt="Screenshot 2022-05-19 at 3 03 26 PM" src="https://user-images.githubusercontent.com/10586875/169263232-d3573c0e-e99d-4100-916f-ec9cbf6bb276.png">
<img width="781" alt="Screenshot 2022-05-19 at 3 03 31 PM" src="https://user-images.githubusercontent.com/10586875/169263249-80f19af6-3b78-4d4f-855e-e81fd8de300b.png">

Mobile view showing count as the sum of site issues 

3 Threats and 2 Updates = 5

<img width="360" alt="Screenshot 2022-05-19 at 3 12 12 PM" src="https://user-images.githubusercontent.com/10586875/169264331-38351698-0041-464f-a6d2-4f9853f88de3.png">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202076982646589-as-1202304599668063