### PR TITLE
Reader: Disable blog stickers for non-a12s

### DIFF
--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -15,7 +15,7 @@ const BlogStickers = ( { blogId } ) => {
 
 	const { data: stickers } = useBlogStickersQuery( blogId );
 
-	if ( teams && ! isTeamMember ) {
+	if ( teams.length && ! isTeamMember ) {
 		return null;
 	}
 

--- a/client/blocks/blog-stickers/use-blog-stickers-query.js
+++ b/client/blocks/blog-stickers/use-blog-stickers-query.js
@@ -1,9 +1,20 @@
 import { useQuery } from 'react-query';
+import { useSelector } from 'react-redux';
 import wp from 'calypso/lib/wp';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
 
-export const useBlogStickersQuery = ( blogId, queryOptions = {} ) =>
-	useQuery( [ 'blog-stickers', blogId ], () => wp.req.get( `/sites/${ blogId }/blog-stickers` ), {
-		...queryOptions,
-		enabled: !! blogId,
-		staleTime: 1000 * 60 * 5, // 5 minutes
-	} );
+export const useBlogStickersQuery = ( blogId, queryOptions = {} ) => {
+	const teams = useSelector( getReaderTeams );
+	const isAutomattician = isAutomatticTeamMember( teams );
+
+	return useQuery(
+		[ 'blog-stickers', blogId ],
+		() => wp.req.get( `/sites/${ blogId }/blog-stickers` ),
+		{
+			...queryOptions,
+			enabled: !! blogId && isAutomattician,
+			staleTime: 1000 * 60 * 5, // 5 minutes
+		}
+	);
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to #63808 and disables the network request to fetch blog stickers for non-a12s.

#### Testing instructions

* Login as a non-a11n
* Go to `/read/feeds/25823`
* Verify that you no longer see a network request to `https://public-api.wordpress.com/rest/v1.1/sites/BLOG_ID/blog-stickers` (`BLOG_ID` is your blog ID).
* Login as an a11n
* Verify that you still see a request to fetch the blog stickers, and they appear well when you roll over the (i) icon.