### PR TITLE
Fix: Empty label on checkout screen when adding only a domain to an existing plan

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -178,6 +178,9 @@ function CheckoutSummaryFeaturesList( props: {
 	}
 	const refundText = getRefundText( refundDays, null, translate );
 
+	const hasOnlyStarterPlan =
+		plans.filter( ( plan ) => isStarterPlan( plan.product_slug ) ).length === plans.length;
+
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
 			{ hasDomainsInCart &&
@@ -190,10 +193,12 @@ function CheckoutSummaryFeaturesList( props: {
 					nextDomainIsFree={ nextDomainIsFree }
 				/>
 			) }
-			<CheckoutSummaryFeaturesListItem>
-				<WPCheckoutCheckIcon id="features-list-support-text" />
-				<SupportText plans={ plans } isJetpackNotAtomic={ isJetpackNotAtomic } />
-			</CheckoutSummaryFeaturesListItem>
+			{ hasOnlyStarterPlan && (
+				<CheckoutSummaryFeaturesListItem>
+					<WPCheckoutCheckIcon id="features-list-support-text" />
+					<SupportText plans={ plans } isJetpackNotAtomic={ isJetpackNotAtomic } />
+				</CheckoutSummaryFeaturesListItem>
+			) }
 
 			{ ! hasPlanInCart && <CheckoutSummaryChatIfAvailable siteId={ siteId } /> }
 
@@ -215,12 +220,6 @@ function SupportText( {
 	isJetpackNotAtomic?: boolean | null;
 } ) {
 	const translate = useTranslate();
-	const hasOnlyStarterPlan =
-		plans.filter( ( plan ) => isStarterPlan( plan.product_slug ) ).length === plans.length;
-
-	if ( hasOnlyStarterPlan ) {
-		return null;
-	}
 
 	if ( plans.length && ! isJetpackNotAtomic ) {
 		return <span>{ translate( 'Unlimited customer support via email' ) }</span>;

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -193,7 +193,7 @@ function CheckoutSummaryFeaturesList( props: {
 					nextDomainIsFree={ nextDomainIsFree }
 				/>
 			) }
-			{ hasOnlyStarterPlan && (
+			{ ! hasOnlyStarterPlan && (
 				<CheckoutSummaryFeaturesListItem>
 					<WPCheckoutCheckIcon id="features-list-support-text" />
 					<SupportText plans={ plans } isJetpackNotAtomic={ isJetpackNotAtomic } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes the empty feature item in the Checkout `Included with your purchase` section.

<img width="480" alt="Screenshot on 2022-05-19 at 15-04-26" src="https://user-images.githubusercontent.com/2749938/169289335-1f7d4d86-5bf7-4c86-a7e0-3faaadee0598.png">



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start/domain
* Select a domain and proceed to checkout
* There shouldn't be any empty feature items in the `Included with your purchase` section
<img width="480" alt="Screenshot on 2022-05-19 at 15-01-00" src="https://user-images.githubusercontent.com/2749938/169289223-ec7b8aa0-c1ae-4a8b-b2a2-d42f03f1dc1c.png">


* Go to /start/starter
* Proceed to checkout
* Make sure the `Unlimited support` item is not shown
<img width="480" alt="Screenshot on 2022-05-19 at 15-04-26" src="https://user-images.githubusercontent.com/2749938/169289202-ab149c5d-71e2-47a8-8c2e-47a0f9ed179b.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

