### PR TITLE
State: Refactor tests from `use-sinon` to `jest`

### DIFF
--- a/client/state/active-promotions/test/reducer.js
+++ b/client/state/active-promotions/test/reducer.js
@@ -14,7 +14,7 @@ import activePromotionsReducer, {
 import { WPCOM_RESPONSE } from './fixture';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should export expected reducer keys', () => {
 		expect( Object.keys( activePromotionsReducer( undefined, {} ) ) ).toEqual(

--- a/client/state/active-promotions/test/reducer.js
+++ b/client/state/active-promotions/test/reducer.js
@@ -1,6 +1,5 @@
 import deepFreeze from 'deep-freeze';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	activePromotionsReceiveAction,
 	activePromotionsRequestSuccessAction,
@@ -15,13 +14,7 @@ import activePromotionsReducer, {
 import { WPCOM_RESPONSE } from './fixture';
 
 describe( 'reducer', () => {
-	let sandbox;
-
-	useSandbox( ( newSandbox ) => {
-		sandbox = newSandbox;
-		// mute off console warn
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should export expected reducer keys', () => {
 		expect( Object.keys( activePromotionsReducer( undefined, {} ) ) ).toEqual(

--- a/client/state/billing-transactions/test/reducer.js
+++ b/client/state/billing-transactions/test/reducer.js
@@ -9,13 +9,10 @@ import {
 	BILLING_TRANSACTIONS_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { requesting, items, sendingReceiptEmail } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/billing-transactions/test/reducer.js
+++ b/client/state/billing-transactions/test/reducer.js
@@ -12,7 +12,7 @@ import { serialize, deserialize } from 'calypso/state/utils';
 import reducer, { requesting, items, sendingReceiptEmail } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/country-states/test/reducer.js
+++ b/client/state/country-states/test/reducer.js
@@ -22,7 +22,7 @@ const originalCountryStates = [
 ];
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/country-states/test/reducer.js
+++ b/client/state/country-states/test/reducer.js
@@ -6,7 +6,6 @@ import {
 	COUNTRY_STATES_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { items, isFetching } from '../reducer';
 
 const originalCountryStates = [
@@ -23,7 +22,7 @@ const originalCountryStates = [
 ];
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => sandbox.stub( console, 'warn' ) );
+	console.warn = jest.fn();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/current-user/test/reducer.js
+++ b/client/state/current-user/test/reducer.js
@@ -1,13 +1,10 @@
 import deepFreeze from 'deep-freeze';
 import { CURRENT_USER_RECEIVE, SITE_RECEIVE, SITES_RECEIVE } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { id, capabilities } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/current-user/test/reducer.js
+++ b/client/state/current-user/test/reducer.js
@@ -4,7 +4,7 @@ import { serialize, deserialize } from 'calypso/state/utils';
 import reducer, { id, capabilities } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/test/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/test/index.js
@@ -34,11 +34,6 @@ describe( '#retryOnFailure', () => {
 		store = { dispatch };
 	} );
 
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
-	} );
-
 	test( 'should pass through initially successful requests', () => {
 		const inbound = { nextData: 1, originalRequest: getSites, store };
 

--- a/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/test/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/test/index.js
@@ -1,7 +1,6 @@
 import deepFreeze from 'deep-freeze';
 import { merge } from 'lodash';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
-import { useFakeTimers } from 'calypso/test-helpers/use-sinon';
 import { retryOnFailure as rof } from '../';
 import { noRetry, exponentialBackoff } from '../policies';
 
@@ -26,15 +25,18 @@ const withRetries = ( retryCount ) => ( actionOrInbound ) =>
 		: merge( actionOrInbound, { meta: { dataLayer: { retryCount } } } );
 
 describe( '#retryOnFailure', () => {
-	let clock;
 	let dispatch;
 	let store;
 
-	useFakeTimers( ( fakeClock ) => ( clock = fakeClock ) );
-
 	beforeEach( () => {
+		jest.useFakeTimers();
 		dispatch = jest.fn();
 		store = { dispatch };
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
 	} );
 
 	test( 'should pass through initially successful requests', () => {
@@ -42,7 +44,7 @@ describe( '#retryOnFailure', () => {
 
 		expect( retryOnFailure( inbound ) ).toEqual( inbound );
 
-		clock.tick( 20000 );
+		jest.advanceTimersByTime( 20000 );
 		expect( dispatch ).not.toBeCalled();
 	} );
 
@@ -52,7 +54,7 @@ describe( '#retryOnFailure', () => {
 
 		expect( retryOnFailure( inbound ) ).toEqual( inbound );
 
-		clock.tick( 20000 );
+		jest.advanceTimersByTime( 20000 );
 		expect( dispatch ).not.toBeCalled();
 	} );
 
@@ -62,7 +64,7 @@ describe( '#retryOnFailure', () => {
 
 		expect( retryOnFailure( inbound ) ).toEqual( inbound );
 
-		clock.tick( 20000 );
+		jest.advanceTimersByTime( 20000 );
 		expect( dispatch ).not.toBeCalled();
 	} );
 
@@ -72,7 +74,7 @@ describe( '#retryOnFailure', () => {
 		expect( retryWithDelay( 1337 )( inbound ) ).toHaveProperty( 'shouldAbort', true );
 		expect( dispatch ).not.toBeCalled();
 
-		clock.tick( 1337 );
+		jest.advanceTimersByTime( 1337 );
 		expect( dispatch ).toBeCalledWith( withRetries( 1 )( getSites ) );
 	} );
 
@@ -85,7 +87,7 @@ describe( '#retryOnFailure', () => {
 		expect( retryIt( inbound ) ).toHaveProperty( 'shouldAbort', true );
 		expect( dispatch ).not.toBeCalled();
 
-		clock.tick( 1337 );
+		jest.advanceTimersByTime( 1337 );
 		expect( dispatch ).toBeCalledWith( withRetries( 1 )( originalRequest ) );
 
 		// retry 2
@@ -94,7 +96,7 @@ describe( '#retryOnFailure', () => {
 		).toHaveProperty( 'shouldAbort', true );
 		expect( dispatch.mock.calls.length ).toEqual( 1 );
 
-		clock.tick( 1337 );
+		jest.advanceTimersByTime( 1337 );
 		expect( dispatch.mock.calls.length ).toEqual( 2 );
 		expect( dispatch ).toBeCalledWith( withRetries( 2 )( originalRequest ) );
 
@@ -104,7 +106,7 @@ describe( '#retryOnFailure', () => {
 		).toHaveProperty( 'shouldAbort', true );
 		expect( dispatch.mock.calls.length ).toEqual( 2 );
 
-		clock.tick( 1337 );
+		jest.advanceTimersByTime( 1337 );
 		expect( dispatch.mock.calls.length ).toEqual( 3 );
 		expect( dispatch ).toBeCalledWith( withRetries( 3 )( originalRequest ) );
 
@@ -113,7 +115,7 @@ describe( '#retryOnFailure', () => {
 		expect( retryIt( finalRequest ) ).toEqual( finalRequest );
 		expect( dispatch.mock.calls.length ).toEqual( 3 );
 
-		clock.tick( 1337 );
+		jest.advanceTimersByTime( 1337 );
 		expect( dispatch.mock.calls.length ).toEqual( 3 );
 	} );
 
@@ -128,27 +130,27 @@ describe( '#retryOnFailure', () => {
 		expect( retryOnFailure( inbound ) ).toHaveProperty( 'shouldAbort', true );
 		expect( dispatch ).not.toBeCalled();
 
-		clock.tick( 1000 + 3 * 1000 );
+		jest.advanceTimersByTime( 1000 + 3 * 1000 );
 		expect( dispatch ).toBeCalledTimes( 1 );
 
-		clock.tick( 200000 );
+		jest.advanceTimersByTime( 200000 );
 		expect( dispatch ).toBeCalledTimes( 1 );
 
 		// retry 4 (should have much longer delay)
 		expect( retryOnFailure( withRetries( 4 )( inbound ) ) ).toHaveProperty( 'shouldAbort', true );
 		expect( dispatch ).toBeCalledTimes( 1 );
 
-		clock.tick( 1000 + 3 * 16000 );
+		jest.advanceTimersByTime( 1000 + 3 * 16000 );
 		expect( dispatch ).toBeCalledTimes( 2 );
 
-		clock.tick( 200000 );
+		jest.advanceTimersByTime( 200000 );
 		expect( dispatch ).toBeCalledTimes( 2 );
 
 		// retry 5 (should not retry)
 		expect( retryOnFailure( withRetries( 5 )( inbound ) ) ).toEqual( withRetries( 5 )( inbound ) );
 		expect( dispatch ).toBeCalledTimes( 2 );
 
-		clock.tick( 200000 );
+		jest.advanceTimersByTime( 200000 );
 		expect( dispatch ).toBeCalledTimes( 2 );
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -4,7 +4,6 @@ import {
 	setAutomatedTransferStatus,
 } from 'calypso/state/automated-transfer/actions';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
-import { useFakeTimers } from 'calypso/test-helpers/use-sinon';
 import { requestStatus, receiveStatus } from '../';
 
 const siteId = 1916284;
@@ -38,8 +37,14 @@ describe( 'requestStatus', () => {
 } );
 
 describe( 'receiveStatus', () => {
-	let clock;
-	useFakeTimers( ( fakeClock ) => ( clock = fakeClock ) );
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
 
 	test( 'should dispatch set status action', () => {
 		const dispatch = jest.fn();
@@ -66,7 +71,7 @@ describe( 'receiveStatus', () => {
 	test( 'should request status again if not complete', () => {
 		const dispatch = jest.fn();
 		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
-		clock.tick( 4000 );
+		jest.advanceTimersByTime( 4000 );
 
 		expect( dispatch ).toBeCalledTimes( 2 );
 		expect( dispatch ).toBeCalledWith( fetchAutomatedTransferStatus( siteId ) );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -41,11 +41,6 @@ describe( 'receiveStatus', () => {
 		jest.useFakeTimers();
 	} );
 
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
-	} );
-
 	test( 'should dispatch set status action', () => {
 		const dispatch = jest.fn();
 		receiveStatus( { siteId }, COMPLETE_RESPONSE )( dispatch );
@@ -69,9 +64,10 @@ describe( 'receiveStatus', () => {
 	} );
 
 	test( 'should request status again if not complete', () => {
+		jest.useFakeTimers();
 		const dispatch = jest.fn();
 		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
-		jest.advanceTimersByTime( 4000 );
+		jest.runAllTimers();
 
 		expect( dispatch ).toBeCalledTimes( 2 );
 		expect( dispatch ).toBeCalledWith( fetchAutomatedTransferStatus( siteId ) );

--- a/client/state/data-layer/wpcom/sites/test/utils.js
+++ b/client/state/data-layer/wpcom/sites/test/utils.js
@@ -14,13 +14,7 @@ import {
 
 describe( 'utility functions', () => {
 	beforeAll( () => {
-		jest.useFakeTimers();
-		jest.setSystemTime( 0 );
-	} );
-
-	afterAll( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
+		jest.useFakeTimers().setSystemTime( 0 );
 	} );
 
 	describe( '#createPlaceholderComment()', () => {

--- a/client/state/data-layer/wpcom/sites/test/utils.js
+++ b/client/state/data-layer/wpcom/sites/test/utils.js
@@ -5,7 +5,6 @@ import {
 	NOTICE_CREATE,
 } from 'calypso/state/action-types';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
-import { useFakeTimers } from 'calypso/test-helpers/use-sinon';
 import {
 	createPlaceholderComment,
 	dispatchNewCommentRequest,
@@ -14,7 +13,15 @@ import {
 } from '../utils';
 
 describe( 'utility functions', () => {
-	useFakeTimers();
+	beforeAll( () => {
+		jest.useFakeTimers();
+		jest.setSystemTime( 0 );
+	} );
+
+	afterAll( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
 
 	describe( '#createPlaceholderComment()', () => {
 		test( 'should return a comment placeholder', () => {

--- a/client/state/domains/suggestions/test/reducer.js
+++ b/client/state/domains/suggestions/test/reducer.js
@@ -9,7 +9,7 @@ import { serialize, deserialize } from 'calypso/state/utils';
 import reducer, { items, requesting, errors } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should export expected reducer keys', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/domains/suggestions/test/reducer.js
+++ b/client/state/domains/suggestions/test/reducer.js
@@ -6,16 +6,10 @@ import {
 	DOMAINS_SUGGESTIONS_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { items, requesting, errors } from '../reducer';
 
 describe( 'reducer', () => {
-	let sandbox;
-
-	useSandbox( ( newSandbox ) => {
-		sandbox = newSandbox;
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should export expected reducer keys', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/help/ticket/test/actions.js
+++ b/client/state/help/ticket/test/actions.js
@@ -1,11 +1,9 @@
-import sinon from 'sinon';
 import {
 	HELP_TICKET_CONFIGURATION_REQUEST,
 	HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS,
 	HELP_TICKET_CONFIGURATION_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
 import { useNock } from 'calypso/test-helpers/use-nock';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	ticketSupportConfigurationRequest,
 	ticketSupportConfigurationRequestSuccess,
@@ -14,9 +12,6 @@ import {
 import { dummyConfiguration, dummyError } from './test-data';
 
 describe( 'ticket-support/configuration actions', () => {
-	let spy;
-	useSandbox( ( sandbox ) => ( spy = sandbox.spy() ) );
-
 	describe( '#ticketSupportConfigurationRequestSuccess', () => {
 		test( 'should return HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS', () => {
 			const action = ticketSupportConfigurationRequestSuccess( dummyConfiguration );
@@ -43,6 +38,8 @@ describe( 'ticket-support/configuration actions', () => {
 	const endpoint = '/rest/v1.1/help/tickets/kayako/mine';
 
 	describe( '#ticketSupportConfigurationRequest success', () => {
+		const spy = jest.fn();
+
 		useNock( ( nock ) => {
 			nock( apiUrl ).get( endpoint ).reply( 200, dummyConfiguration );
 		} );
@@ -50,22 +47,22 @@ describe( 'ticket-support/configuration actions', () => {
 		test( 'should be successful.', () => {
 			const action = ticketSupportConfigurationRequest()( spy );
 
-			expect(
-				spy.calledWith( sinon.match( { type: HELP_TICKET_CONFIGURATION_REQUEST } ) )
-			).toBeTruthy();
+			expect( spy ).toHaveBeenCalledWith(
+				expect.objectContaining( { type: HELP_TICKET_CONFIGURATION_REQUEST } )
+			);
 
 			return action.then( () => {
-				expect(
-					spy.calledWith( {
-						type: HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS,
-						configuration: dummyConfiguration,
-					} )
-				).toBeTruthy();
+				expect( spy ).toHaveBeenCalledWith( {
+					type: HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS,
+					configuration: dummyConfiguration,
+				} );
 			} );
 		} );
 	} );
 
 	describe( '#ticketSupportConfigurationRequest failed', () => {
+		const spy = jest.fn();
+
 		useNock( ( nock ) => {
 			nock( apiUrl ).get( endpoint ).reply( dummyError.status, dummyError );
 		} );
@@ -73,19 +70,17 @@ describe( 'ticket-support/configuration actions', () => {
 		test( 'should be failed.', () => {
 			const action = ticketSupportConfigurationRequest()( spy );
 
-			expect(
-				spy.calledWith( sinon.match( { type: HELP_TICKET_CONFIGURATION_REQUEST } ) )
-			).toBeTruthy();
+			expect( spy ).toHaveBeenCalledWith(
+				expect.objectContaining( { type: HELP_TICKET_CONFIGURATION_REQUEST } )
+			);
 
 			return action.then( () => {
-				expect(
-					spy.calledWith(
-						sinon.match( {
-							type: HELP_TICKET_CONFIGURATION_REQUEST_FAILURE,
-							error: dummyError,
-						} )
-					)
-				).toBeTruthy();
+				expect( spy ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						type: HELP_TICKET_CONFIGURATION_REQUEST_FAILURE,
+						error: expect.objectContaining( dummyError ),
+					} )
+				);
 			} );
 		} );
 	} );

--- a/client/state/hosting/test/reducer.js
+++ b/client/state/hosting/test/reducer.js
@@ -3,7 +3,7 @@ import { HOSTING_SFTP_USERS_SET, HOSTING_SFTP_USER_UPDATE } from 'calypso/state/
 import reducer, { sftpUsers } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	describe( '#sftpUsers()', () => {
 		test( 'should default to an empty object', () => {

--- a/client/state/hosting/test/reducer.js
+++ b/client/state/hosting/test/reducer.js
@@ -1,12 +1,9 @@
 import deepFreeze from 'deep-freeze';
 import { HOSTING_SFTP_USERS_SET, HOSTING_SFTP_USER_UPDATE } from 'calypso/state/action-types';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { sftpUsers } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	describe( '#sftpUsers()', () => {
 		test( 'should default to an empty object', () => {

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -10,7 +10,6 @@ import {
 	INVITES_DELETE_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { requesting, items, counts, requestingResend, deleting } from '../reducer';
 
 describe( 'reducer', () => {
@@ -454,9 +453,7 @@ describe( 'reducer', () => {
 		} );
 
 		describe( 'invalid state tests', () => {
-			useSandbox( ( sandbox ) => {
-				sandbox.stub( console, 'warn' );
-			} );
+			console.warn = jest.fn();
 
 			test( 'should not load invalid persisted state (1)', () => {
 				const original = deepFreeze( {

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -453,7 +453,7 @@ describe( 'reducer', () => {
 		} );
 
 		describe( 'invalid state tests', () => {
-			console.warn = jest.fn();
+			jest.spyOn( console, 'warn' ).mockImplementation();
 
 			test( 'should not load invalid persisted state (1)', () => {
 				const original = deepFreeze( {

--- a/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
@@ -8,13 +8,10 @@ import {
 	JETPACK_CONNECT_QUERY_SET,
 } from 'calypso/state/jetpack-connect/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import jetpackConnectAuthorize from '../jetpack-connect-authorize.js';
 
 describe( '#jetpackConnectAuthorize()', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should default to an empty object', () => {
 		const state = jetpackConnectAuthorize( undefined, {} );

--- a/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
@@ -11,7 +11,7 @@ import { serialize, deserialize } from 'calypso/state/utils';
 import jetpackConnectAuthorize from '../jetpack-connect-authorize.js';
 
 describe( '#jetpackConnectAuthorize()', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should default to an empty object', () => {
 		const state = jetpackConnectAuthorize( undefined, {} );

--- a/client/state/jetpack/settings/test/reducer.js
+++ b/client/state/jetpack/settings/test/reducer.js
@@ -10,7 +10,7 @@ import { serialize, deserialize } from 'calypso/state/utils';
 import reducer, { settingsReducer } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should export expected reducer keys', () => {
 		const state = reducer( undefined, {} );

--- a/client/state/jetpack/settings/test/reducer.js
+++ b/client/state/jetpack/settings/test/reducer.js
@@ -7,13 +7,10 @@ import {
 	JETPACK_SETTINGS_UPDATE,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { settingsReducer } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should export expected reducer keys', () => {
 		const state = reducer( undefined, {} );

--- a/client/state/plans/test/reducer.js
+++ b/client/state/plans/test/reducer.js
@@ -14,7 +14,7 @@ import plansReducer, {
 import { WPCOM_RESPONSE } from './fixture';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should export expected reducer keys', () => {
 		expect( Object.keys( plansReducer( undefined, {} ) ) ).toEqual(

--- a/client/state/plans/test/reducer.js
+++ b/client/state/plans/test/reducer.js
@@ -1,6 +1,5 @@
 import deepFreeze from 'deep-freeze';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import {
 	plansReceiveAction,
 	plansRequestSuccessAction,
@@ -15,13 +14,7 @@ import plansReducer, {
 import { WPCOM_RESPONSE } from './fixture';
 
 describe( 'reducer', () => {
-	let sandbox;
-
-	useSandbox( ( newSandbox ) => {
-		sandbox = newSandbox;
-		// mute off console warn
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should export expected reducer keys', () => {
 		expect( Object.keys( plansReducer( undefined, {} ) ) ).toEqual(

--- a/client/state/post-types/taxonomies/test/reducer.js
+++ b/client/state/post-types/taxonomies/test/reducer.js
@@ -6,14 +6,11 @@ import {
 	POST_TYPES_TAXONOMIES_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { receivePostTypeTaxonomies } from '../actions';
 import reducer, { requesting, items } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/post-types/taxonomies/test/reducer.js
+++ b/client/state/post-types/taxonomies/test/reducer.js
@@ -10,7 +10,7 @@ import { receivePostTypeTaxonomies } from '../actions';
 import reducer, { requesting, items } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/post-types/test/reducer.js
+++ b/client/state/post-types/test/reducer.js
@@ -4,7 +4,7 @@ import { serialize, deserialize } from 'calypso/state/utils';
 import reducer, { items } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/post-types/test/reducer.js
+++ b/client/state/post-types/test/reducer.js
@@ -1,13 +1,10 @@
 import deepFreeze from 'deep-freeze';
 import { POST_TYPES_RECEIVE } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { items } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/posts/counts/test/reducer.js
+++ b/client/state/posts/counts/test/reducer.js
@@ -14,7 +14,7 @@ import { serialize, deserialize } from 'calypso/state/utils';
 import reducer, { requesting, counts } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/posts/counts/test/reducer.js
+++ b/client/state/posts/counts/test/reducer.js
@@ -11,13 +11,10 @@ import {
 	POSTS_RECEIVE,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { requesting, counts } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -5,7 +5,7 @@ import { addLiker, removeLiker, like, unlike } from '../actions';
 import reducer, { items, itemReducer } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	const FAKE_NOW = 1000;
 

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -1,18 +1,23 @@
 import deepFreeze from 'deep-freeze';
 import { POST_LIKES_RECEIVE } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useFakeTimers, useSandbox } from 'calypso/test-helpers/use-sinon';
 import { addLiker, removeLiker, like, unlike } from '../actions';
 import reducer, { items, itemReducer } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	const FAKE_NOW = 1000;
 
-	useFakeTimers( FAKE_NOW );
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.setSystemTime( FAKE_NOW );
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual( [ 'items' ] );

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -10,13 +10,7 @@ describe( 'reducer', () => {
 	const FAKE_NOW = 1000;
 
 	beforeEach( () => {
-		jest.useFakeTimers();
-		jest.setSystemTime( FAKE_NOW );
-	} );
-
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
+		jest.useFakeTimers().setSystemTime( FAKE_NOW );
 	} );
 
 	test( 'should include expected keys in return value', () => {

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -30,7 +30,7 @@ import reducer, {
 } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -20,7 +20,6 @@ import {
 	POSTS_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, {
 	items,
 	queryRequests,
@@ -31,9 +30,7 @@ import reducer, {
 } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/products-list/test/reducer.js
+++ b/client/state/products-list/test/reducer.js
@@ -5,13 +5,10 @@ import {
 	PRODUCTS_LIST_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { items, isFetching, type } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/products-list/test/reducer.js
+++ b/client/state/products-list/test/reducer.js
@@ -8,7 +8,7 @@ import { serialize, deserialize } from 'calypso/state/utils';
 import reducer, { items, isFetching, type } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/rewind/backups/test/reducer.js
+++ b/client/state/rewind/backups/test/reducer.js
@@ -3,7 +3,7 @@ import { REWIND_BACKUPS_SET } from 'calypso/state/action-types';
 import reducer from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should default to an empty object', () => {
 		const state = reducer( undefined, {} );

--- a/client/state/rewind/backups/test/reducer.js
+++ b/client/state/rewind/backups/test/reducer.js
@@ -1,12 +1,9 @@
 import deepFreeze from 'deep-freeze';
 import { REWIND_BACKUPS_SET } from 'calypso/state/action-types';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should default to an empty object', () => {
 		const state = reducer( undefined, {} );

--- a/client/state/sharing/keyring/test/reducer.js
+++ b/client/state/sharing/keyring/test/reducer.js
@@ -142,7 +142,7 @@ describe( 'reducers', () => {
 		} );
 
 		describe( 'persistence', () => {
-			console.warn = jest.fn();
+			jest.spyOn( console, 'warn' ).mockImplementation();
 
 			test( 'should persist data', () => {
 				const state = deepFreeze( {

--- a/client/state/sharing/keyring/test/reducer.js
+++ b/client/state/sharing/keyring/test/reducer.js
@@ -9,7 +9,6 @@ import {
 	PUBLICIZE_CONNECTION_DELETE,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { isFetching, items } from '../reducer';
 
 describe( 'reducers', () => {
@@ -143,7 +142,7 @@ describe( 'reducers', () => {
 		} );
 
 		describe( 'persistence', () => {
-			useSandbox( ( sandbox ) => sandbox.stub( console, 'warn' ) );
+			console.warn = jest.fn();
 
 			test( 'should persist data', () => {
 				const state = deepFreeze( {

--- a/client/state/sharing/publicize/test/reducer.js
+++ b/client/state/sharing/publicize/test/reducer.js
@@ -254,7 +254,7 @@ describe( 'reducer', () => {
 		} );
 
 		describe( 'persistence', () => {
-			console.warn = jest.fn();
+			jest.spyOn( console, 'warn' ).mockImplementation();
 
 			test( 'should persist data', () => {
 				const state = deepFreeze( {

--- a/client/state/sharing/publicize/test/reducer.js
+++ b/client/state/sharing/publicize/test/reducer.js
@@ -9,7 +9,6 @@ import {
 	PUBLICIZE_CONNECTIONS_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { fetchingConnections, connections } from '../reducer';
 
 describe( 'reducer', () => {
@@ -255,7 +254,7 @@ describe( 'reducer', () => {
 		} );
 
 		describe( 'persistence', () => {
-			useSandbox( ( sandbox ) => sandbox.stub( console, 'warn' ) );
+			console.warn = jest.fn();
 
 			test( 'should persist data', () => {
 				const state = deepFreeze( {

--- a/client/state/sharing/services/test/reducer.js
+++ b/client/state/sharing/services/test/reducer.js
@@ -6,7 +6,6 @@ import {
 	KEYRING_SERVICES_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { items, isFetching } from '../reducer';
 
 const originalKeyringServices = {
@@ -45,7 +44,7 @@ const originalKeyringServices = {
 };
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => sandbox.stub( console, 'warn' ) );
+	console.warn = jest.fn();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/sharing/services/test/reducer.js
+++ b/client/state/sharing/services/test/reducer.js
@@ -44,7 +44,7 @@ const originalKeyringServices = {
 };
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/site-settings/test/reducer.js
+++ b/client/state/site-settings/test/reducer.js
@@ -11,13 +11,10 @@ import {
 	SITE_SETTINGS_UPDATE,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { items, requesting, saveRequests } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	describe( 'requesting()', () => {
 		test( 'should default to an empty object', () => {

--- a/client/state/site-settings/test/reducer.js
+++ b/client/state/site-settings/test/reducer.js
@@ -14,7 +14,7 @@ import { serialize, deserialize } from 'calypso/state/utils';
 import { items, requesting, saveRequests } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	describe( 'requesting()', () => {
 		test( 'should default to an empty object', () => {

--- a/client/state/stats/lists/test/reducer.js
+++ b/client/state/stats/lists/test/reducer.js
@@ -28,7 +28,7 @@ const streakQuery = { startDate: '2015-06-01', endDate: '2016-06-01' };
 const streakQueryDos = { startDate: '2014-06-01', endDate: '2015-06-01' };
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/stats/lists/test/reducer.js
+++ b/client/state/stats/lists/test/reducer.js
@@ -5,7 +5,6 @@ import {
 	SITE_STATS_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { items, requests } from '../reducer';
 
 /**
@@ -29,9 +28,7 @@ const streakQuery = { startDate: '2015-06-01', endDate: '2016-06-01' };
 const streakQueryDos = { startDate: '2014-06-01', endDate: '2015-06-01' };
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/stats/posts/test/reducer.js
+++ b/client/state/stats/posts/test/reducer.js
@@ -6,13 +6,10 @@ import {
 	POST_STATS_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { requesting, items } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	describe( '#requesting()', () => {
 		test( 'should default to an empty object', () => {

--- a/client/state/stats/posts/test/reducer.js
+++ b/client/state/stats/posts/test/reducer.js
@@ -9,7 +9,7 @@ import { serialize, deserialize } from 'calypso/state/utils';
 import { requesting, items } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	describe( '#requesting()', () => {
 		test( 'should default to an empty object', () => {

--- a/client/state/stored-cards/test/reducer.js
+++ b/client/state/stored-cards/test/reducer.js
@@ -10,14 +10,11 @@ import {
 	STORED_CARDS_UPDATE_IS_BACKUP_COMPLETED,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { items } from '../reducer';
 import { STORED_CARDS_FROM_API, SELECTED_STORED_CARDS } from './fixture';
 
 describe( 'items', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should return an object with the initial state', () => {
 		expect( reducer( undefined, { type: 'UNRELATED' } ) ).toEqual( {

--- a/client/state/stored-cards/test/reducer.js
+++ b/client/state/stored-cards/test/reducer.js
@@ -14,7 +14,7 @@ import reducer, { items } from '../reducer';
 import { STORED_CARDS_FROM_API, SELECTED_STORED_CARDS } from './fixture';
 
 describe( 'items', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should return an object with the initial state', () => {
 		expect( reducer( undefined, { type: 'UNRELATED' } ) ).toEqual( {

--- a/client/state/teams/test/reducer.js
+++ b/client/state/teams/test/reducer.js
@@ -1,7 +1,6 @@
 import deepfreeze from 'deep-freeze';
 import { TEAMS_REQUEST, TEAMS_RECEIVE } from 'calypso/state/teams/action-types';
 import { deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { items, isRequesting } from '../reducer';
 
 const TEAM1 = { slug: 'team one slug', title: 'team one title' };
@@ -10,12 +9,7 @@ const validState = [ TEAM1, TEAM2 ];
 const invalidState = [ { slug: 1, title: 'foo bar' } ];
 
 describe( 'reducer', () => {
-	let sandbox;
-
-	useSandbox( ( newSandbox ) => {
-		sandbox = newSandbox;
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	describe( 'items', () => {
 		test( 'should return an empty list by default', () => {

--- a/client/state/teams/test/reducer.js
+++ b/client/state/teams/test/reducer.js
@@ -9,7 +9,7 @@ const validState = [ TEAM1, TEAM2 ];
 const invalidState = [ { slug: 1, title: 'foo bar' } ];
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	describe( 'items', () => {
 		test( 'should return an empty list by default', () => {

--- a/client/state/terms/test/reducer.js
+++ b/client/state/terms/test/reducer.js
@@ -8,7 +8,6 @@ import {
 	TERMS_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import reducer, { queries, queryRequests } from '../reducer';
 
 /**
@@ -34,9 +33,7 @@ const testTerms = [
 ];
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/terms/test/reducer.js
+++ b/client/state/terms/test/reducer.js
@@ -33,7 +33,7 @@ const testTerms = [
 ];
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should include expected keys in return value', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(

--- a/client/state/timezones/test/reducer.js
+++ b/client/state/timezones/test/reducer.js
@@ -4,7 +4,7 @@ import { timezonesReceive } from '../actions';
 import timezonesReducer, { byContinents, labels, rawOffsets } from '../reducer';
 
 describe( 'reducer', () => {
-	console.warn = jest.fn();
+	jest.spyOn( console, 'warn' ).mockImplementation();
 
 	test( 'should export expected reducer keys', () => {
 		expect( Object.keys( timezonesReducer( undefined, {} ) ) ).toEqual(

--- a/client/state/timezones/test/reducer.js
+++ b/client/state/timezones/test/reducer.js
@@ -1,16 +1,10 @@
 import deepFreeze from 'deep-freeze';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { useSandbox } from 'calypso/test-helpers/use-sinon';
 import { timezonesReceive } from '../actions';
 import timezonesReducer, { byContinents, labels, rawOffsets } from '../reducer';
 
 describe( 'reducer', () => {
-	let sandbox;
-
-	useSandbox( ( newSandbox ) => {
-		sandbox = newSandbox;
-		sandbox.stub( console, 'warn' );
-	} );
+	console.warn = jest.fn();
 
 	test( 'should export expected reducer keys', () => {
 		expect( Object.keys( timezonesReducer( undefined, {} ) ) ).toEqual(

--- a/client/state/ui/action-log/test/reducer.js
+++ b/client/state/ui/action-log/test/reducer.js
@@ -1,9 +1,16 @@
 import { ROUTE_SET, COMMENTS_LIKE } from 'calypso/state/action-types';
-import { useFakeTimers } from 'calypso/test-helpers/use-sinon';
 import reducer from '../reducer';
 
 describe( 'reducer', () => {
-	useFakeTimers( 1337 );
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.setSystemTime( 1337 );
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
 
 	test( 'should default to an empty list', () => {
 		const state = reducer( undefined, {} );

--- a/client/state/ui/action-log/test/reducer.js
+++ b/client/state/ui/action-log/test/reducer.js
@@ -7,11 +7,6 @@ describe( 'reducer', () => {
 		jest.setSystemTime( 1337 );
 	} );
 
-	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
-	} );
-
 	test( 'should default to an empty list', () => {
 		const state = reducer( undefined, {} );
 

--- a/client/state/wordads/settings/test/reducer.js
+++ b/client/state/wordads/settings/test/reducer.js
@@ -13,7 +13,7 @@ describe( 'reducer', () => {
 	const originalConsoleWarn = global.console.warn;
 
 	beforeAll( () => {
-		global.console.warn = jest.fn();
+		jest.spyOn( console, 'warn' ).mockImplementation();
 	} );
 
 	afterAll( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors all state tests that use our custom `use-sinon` implementation to use `jest`. Usages are straightforward:

* `useSandbox()` - replaced with regular mocking.
* `useFakeTimers()` - replaced with the Jest fake timers.

The long-term goal of this PR is to get rid of `sinon` completely in favor of `jest`.

#### Testing instructions

Verify all tests pass: `yarn run test-client client/state`