### PR TITLE
Stepper: Fix inline help position

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -119,3 +119,11 @@ button {
 		--color-accent-60: #0e64a5;
 	}
 }
+
+@media ( max-width: 660px ) {
+	body.is-section-stepper .wpcom-site {
+		.inline-help {
+			bottom: 74px;
+		}
+	}
+}


### PR DESCRIPTION
Fixes inline help position on mobile.

| Before  | After |
| ------------- | ------------- |
| <img width="413" alt="image" src="https://user-images.githubusercontent.com/375980/169315984-03c0479f-8894-433d-92a4-dd98d055fd56.png">  | <img width="414" alt="image" src="https://user-images.githubusercontent.com/375980/169316027-67e57775-7cc9-442b-98b2-c6d3233238ad.png">  |

#### Testing
1. Apply this PR.
2. Go to any step on `/setup` on mobile.
3. Verify the position of the inline help icon is correct and does not overlay the footer.

Closes https://github.com/Automattic/wp-calypso/issues/63811