### PR TITLE
Add/intro rate disclaimer to checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -559,16 +559,20 @@ const CheckoutSummaryTitleLink = styled.button`
 	justify-content: space-between;
 	padding: 20px 23px 20px 14px;
 	width: 100%;
+
 	.rtl & {
 		padding: 20px 14px 20px 23px;
 	}
+
 	.is-visible & {
 		border-bottom: none;
 	}
+
 	@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 		border-bottom: none 0;
 	}
+
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		display: none;
 	}
@@ -580,6 +584,7 @@ const CheckoutSummaryTitle = styled.span`
 
 const CheckoutSummaryTitleIcon = styled( Gridicon )`
 	margin-right: 4px;
+
 	.rtl & {
 		margin-right: 0;
 		margin-left: 4px;
@@ -593,10 +598,12 @@ const CheckoutSummaryTitleToggle = styled( MaterialIcon )`
 	width: 18px;
 	height: 18px;
 	vertical-align: bottom;
+
 	.rtl & {
 		margin-right: 0;
 		margin-left: 4px;
 	}
+
 	.is-visible & {
 		transform: rotate( 180deg );
 	}
@@ -611,12 +618,15 @@ const CheckoutSummaryTitlePrice = styled.span`
 const CheckoutSummaryBody = styled.div`
 	border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	display: none;
+
 	.is-visible & {
 		display: block;
 	}
+
 	@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
 		border-bottom: none;
 	}
+
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		display: block;
 		max-width: 328px;
@@ -706,12 +716,17 @@ const SubmitButtonFooterWrapper = styled.div< React.HTMLAttributes< HTMLDivEleme
 	justify-content: center;
 	align-items: flex-start;
 	flex-wrap: wrap;
+
 	margin-top: 1.25rem;
+
 	color: ${ ( props ) => props.theme.colors.textColor };
+
 	font-weight: 500;
+
 	img {
 		margin-right: 0.5rem;
 	}
+
 	span {
 		padding-top: 3px;
 	}
@@ -723,18 +738,22 @@ const SubmitButtonHeaderWrapper = styled.div`
 	margin-top: -5px;
 	margin-bottom: 10px;
 	text-align: center;
+
 	.checkout__step-wrapper--last-step & {
 		display: block;
+
 		@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 			display: none;
 		}
 	}
+
 	button {
 		color: ${ ( props ) => props.theme.colors.highlight };
 		display: inline;
 		font-size: 13px;
 		text-decoration: underline;
 		width: auto;
+
 		&:hover {
 			color: ${ ( props ) => props.theme.colors.highlightOver };
 		}
@@ -743,6 +762,7 @@ const SubmitButtonHeaderWrapper = styled.div`
 
 const NonCheckoutContentWrapper = styled.div`
 	display: flex;
+
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		align-items: flex-start;
 		flex-direction: row;
@@ -754,11 +774,13 @@ const NonCheckoutContentWrapper = styled.div`
 const NonCheckoutContentInnerWrapper = styled.div`
 	background: ${ ( props ) => props.theme.colors.surface };
 	width: 100%;
+
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 		max-width: 556px;
 		margin: 0 auto;
 	}
+
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		margin: 0;
 	}

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -24,7 +24,7 @@ import { styled, getCountryPostalCodeSupport } from '@automattic/wpcom-checkout'
 import { useSelect, useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback, HTMLAttributes } from 'react';
+import { useState, useCallback } from 'react';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import MaterialIcon from 'calypso/components/material-icon';
 import {
@@ -61,6 +61,7 @@ import type { OnChangeItemVariant } from './item-variation-picker';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type { RemoveProductFromCart, MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { CountryListItem, ManagedContactDetails } from '@automattic/wpcom-checkout';
+import type { HTMLAttributes } from 'react';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -24,7 +24,7 @@ import { styled, getCountryPostalCodeSupport } from '@automattic/wpcom-checkout'
 import { useSelect, useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import React, { useState, useCallback } from 'react';
+import { useState, useCallback, HTMLAttributes } from 'react';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import MaterialIcon from 'calypso/components/material-icon';
 import {
@@ -705,13 +705,13 @@ const SubmitButtonFooter = () => {
 	);
 };
 
-const SubmitButtonFooterDisclaimer = styled.span< React.HTMLAttributes< HTMLSpanElement > >`
+const SubmitButtonFooterDisclaimer = styled.span< HTMLAttributes< HTMLSpanElement > >`
 	flex-basis: 100%;
 	text-align: center;
 	font-size: 9px;
 `;
 
-const SubmitButtonFooterWrapper = styled.div< React.HTMLAttributes< HTMLDivElement > >`
+const SubmitButtonFooterWrapper = styled.div< HTMLAttributes< HTMLDivElement > >`
 	display: flex;
 	justify-content: center;
 	align-items: flex-start;

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -684,7 +684,10 @@ const SubmitButtonFooter = () => {
 	const disclaimerContent = responseCart?.products?.some( ( product ) => {
 		return !! product?.introductory_offer_terms?.enabled;
 	} )
-		? translate( '* All discounts are for the first term only, renewals are at full price.' )
+		? translate( '* All discounts are for the first term only, renewals are at full price.', {
+				comment:
+					'*, the asterisk, is used to refer to a comment at the bottom of the page that relates to the text before it',
+		  } )
 		: null;
 
 	let imgSrc = badgeGenericSrc;

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -686,7 +686,7 @@ const SubmitButtonFooter = () => {
 	} )
 		? translate( '* All discounts are for the first term only, renewals are at full price.', {
 				comment:
-					'*, the asterisk, is used to refer to a comment at the bottom of the page that relates to the text before it',
+					'*, the asterisk, is used to indicate it refers to any text with an asterisk after it previously on the page',
 		  } )
 		: null;
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -24,7 +24,7 @@ import { styled, getCountryPostalCodeSupport } from '@automattic/wpcom-checkout'
 import { useSelect, useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import MaterialIcon from 'calypso/components/material-icon';
 import {
@@ -559,20 +559,16 @@ const CheckoutSummaryTitleLink = styled.button`
 	justify-content: space-between;
 	padding: 20px 23px 20px 14px;
 	width: 100%;
-
 	.rtl & {
 		padding: 20px 14px 20px 23px;
 	}
-
 	.is-visible & {
 		border-bottom: none;
 	}
-
 	@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 		border-bottom: none 0;
 	}
-
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		display: none;
 	}
@@ -584,7 +580,6 @@ const CheckoutSummaryTitle = styled.span`
 
 const CheckoutSummaryTitleIcon = styled( Gridicon )`
 	margin-right: 4px;
-
 	.rtl & {
 		margin-right: 0;
 		margin-left: 4px;
@@ -598,12 +593,10 @@ const CheckoutSummaryTitleToggle = styled( MaterialIcon )`
 	width: 18px;
 	height: 18px;
 	vertical-align: bottom;
-
 	.rtl & {
 		margin-right: 0;
 		margin-left: 4px;
 	}
-
 	.is-visible & {
 		transform: rotate( 180deg );
 	}
@@ -618,15 +611,12 @@ const CheckoutSummaryTitlePrice = styled.span`
 const CheckoutSummaryBody = styled.div`
 	border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	display: none;
-
 	.is-visible & {
 		display: block;
 	}
-
 	@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
 		border-bottom: none;
 	}
-
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		display: block;
 		max-width: 328px;
@@ -666,7 +656,7 @@ const SubmitButtonFooter = () => {
 
 	const show7DayGuarantee = responseCart?.products?.every( isMonthlyProduct );
 	const show14DayGuarantee = responseCart?.products?.every( isYearly );
-	const content =
+	const guaranteeContent =
 		show7DayGuarantee || show14DayGuarantee ? (
 			translate( '%(dayCount)s day money back guarantee', {
 				args: {
@@ -680,6 +670,13 @@ const SubmitButtonFooter = () => {
 				{ translate( '7 day money back guarantee on monthly subscriptions' ) }
 			</>
 		);
+
+	const disclaimerContent = responseCart?.products?.some( ( product ) => {
+		return !! product?.introductory_offer_terms?.enabled;
+	} )
+		? translate( '* All discounts are for the first term only, renewals are at full price.' )
+		: null;
+
 	let imgSrc = badgeGenericSrc;
 
 	if ( show7DayGuarantee ) {
@@ -691,26 +688,30 @@ const SubmitButtonFooter = () => {
 	return (
 		<SubmitButtonFooterWrapper>
 			<img src={ imgSrc } alt="" />
-			<span>{ content }</span>
+			<span>{ guaranteeContent }</span>
+
+			<SubmitButtonFooterDisclaimer>{ disclaimerContent }</SubmitButtonFooterDisclaimer>
 		</SubmitButtonFooterWrapper>
 	);
 };
+
+const SubmitButtonFooterDisclaimer = styled.span< React.HTMLAttributes< HTMLSpanElement > >`
+	flex-basis: 100%;
+	text-align: center;
+	font-size: 9px;
+`;
 
 const SubmitButtonFooterWrapper = styled.div< React.HTMLAttributes< HTMLDivElement > >`
 	display: flex;
 	justify-content: center;
 	align-items: flex-start;
-
+	flex-wrap: wrap;
 	margin-top: 1.25rem;
-
 	color: ${ ( props ) => props.theme.colors.textColor };
-
 	font-weight: 500;
-
 	img {
 		margin-right: 0.5rem;
 	}
-
 	span {
 		padding-top: 3px;
 	}
@@ -722,22 +723,18 @@ const SubmitButtonHeaderWrapper = styled.div`
 	margin-top: -5px;
 	margin-bottom: 10px;
 	text-align: center;
-
 	.checkout__step-wrapper--last-step & {
 		display: block;
-
 		@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 			display: none;
 		}
 	}
-
 	button {
 		color: ${ ( props ) => props.theme.colors.highlight };
 		display: inline;
 		font-size: 13px;
 		text-decoration: underline;
 		width: auto;
-
 		&:hover {
 			color: ${ ( props ) => props.theme.colors.highlightOver };
 		}
@@ -746,7 +743,6 @@ const SubmitButtonHeaderWrapper = styled.div`
 
 const NonCheckoutContentWrapper = styled.div`
 	display: flex;
-
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		align-items: flex-start;
 		flex-direction: row;
@@ -758,13 +754,11 @@ const NonCheckoutContentWrapper = styled.div`
 const NonCheckoutContentInnerWrapper = styled.div`
 	background: ${ ( props ) => props.theme.colors.surface };
 	width: 100%;
-
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 		max-width: 556px;
 		margin: 0 auto;
 	}
-
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		margin: 0;
 	}

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -57,7 +57,6 @@ export const NonProductLineItem = styled( WPNonProductLineItem )< {
 	border-bottom: ${ ( { theme, total } ) =>
 		total ? 0 : '1px solid ' + theme.colors.borderColorLight };
 	position: relative;
-
 	.checkout-line-item__price {
 		position: relative;
 	}
@@ -75,7 +74,6 @@ export const LineItem = styled( WPLineItem )< {
 	padding: 20px 0;
 	border-bottom: ${ ( { theme } ) => '1px solid ' + theme.colors.borderColorLight };
 	position: relative;
-
 	.checkout-line-item__price {
 		position: relative;
 	}
@@ -85,15 +83,12 @@ export const CouponLineItem = styled( WPCouponLineItem )< {
 	theme?: Theme;
 } >`
 	border-bottom: ${ ( { theme } ) => '1px solid ' + theme.colors.borderColorLight };
-
 	&[data-partner-coupon='true'] ${ NonProductLineItem } {
 		border-bottom: none;
 	}
-
 	&:last-child {
 		border-bottom: none;
 	}
-
 	.jetpack-partner-logo {
 		padding-bottom: 20px;
 	}
@@ -130,7 +125,6 @@ const LineItemTitle = styled.div< { theme?: Theme; isSummary?: boolean } >`
 const LineItemPriceWrapper = styled.span< { theme?: Theme; isSummary?: boolean } >`
 	margin-left: 12px;
 	font-size: 16px;
-
 	.rtl & {
 		margin-right: 12px;
 		margin-left: 0;
@@ -709,15 +703,15 @@ function FirstTermDiscountCallout( {
 	}
 
 	if ( isMonthlyProduct( product ) ) {
-		return <DiscountCallout>{ translate( 'Discount for first month' ) }</DiscountCallout>;
+		return <DiscountCallout>{ translate( 'Discount for first month *' ) }</DiscountCallout>;
 	}
 
 	if ( isYearly( product ) ) {
-		return <DiscountCallout>{ translate( 'Discount for first year' ) }</DiscountCallout>;
+		return <DiscountCallout>{ translate( 'Discount for first year *' ) }</DiscountCallout>;
 	}
 
 	if ( isBiennially( product ) ) {
-		return <DiscountCallout>{ translate( 'Discount for first term' ) }</DiscountCallout>;
+		return <DiscountCallout>{ translate( 'Discount for first term *' ) }</DiscountCallout>;
 	}
 
 	return null;
@@ -775,7 +769,7 @@ function DomainDiscountCallout( {
 
 	const isFreeBundledDomainRegistration = product.is_bundled && product.item_subtotal_integer === 0;
 	if ( isFreeBundledDomainRegistration ) {
-		return <DiscountCallout>{ translate( 'Discount for first year' ) }</DiscountCallout>;
+		return <DiscountCallout>{ translate( 'Discount for first year *' ) }</DiscountCallout>;
 	}
 
 	const isFreeDomainMapping =
@@ -813,7 +807,7 @@ function GSuiteDiscountCallout( {
 		product.item_original_subtotal_integer < product.item_original_subtotal_integer &&
 		product.is_sale_coupon_applied
 	) {
-		return <DiscountCallout>{ translate( 'Discount for first year' ) }</DiscountCallout>;
+		return <DiscountCallout>{ translate( 'Discount for first year *' ) }</DiscountCallout>;
 	}
 	return null;
 }

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -709,15 +709,36 @@ function FirstTermDiscountCallout( {
 	}
 
 	if ( isMonthlyProduct( product ) ) {
-		return <DiscountCallout>{ translate( 'Discount for first month *' ) }</DiscountCallout>;
+		return (
+			<DiscountCallout>
+				{ translate( 'Discount for first month *', {
+					comment:
+						'*, the asterisk, is used to refer to a comment at the bottom of the page that relates to the text before it',
+				} ) }
+			</DiscountCallout>
+		);
 	}
 
 	if ( isYearly( product ) ) {
-		return <DiscountCallout>{ translate( 'Discount for first year *' ) }</DiscountCallout>;
+		return (
+			<DiscountCallout>
+				{ translate( 'Discount for first year *', {
+					comment:
+						'*, the asterisk, is used to refer to a comment at the bottom of the page that relates to the text before it',
+				} ) }
+			</DiscountCallout>
+		);
 	}
 
 	if ( isBiennially( product ) ) {
-		return <DiscountCallout>{ translate( 'Discount for first term *' ) }</DiscountCallout>;
+		return (
+			<DiscountCallout>
+				{ translate( 'Discount for first term *', {
+					comment:
+						'*, the asterisk, is used to refer to a comment at the bottom of the page that relates to the text before it',
+				} ) }
+			</DiscountCallout>
+		);
 	}
 
 	return null;
@@ -775,7 +796,14 @@ function DomainDiscountCallout( {
 
 	const isFreeBundledDomainRegistration = product.is_bundled && product.item_subtotal_integer === 0;
 	if ( isFreeBundledDomainRegistration ) {
-		return <DiscountCallout>{ translate( 'Discount for first year *' ) }</DiscountCallout>;
+		return (
+			<DiscountCallout>
+				{ translate( 'Discount for first year *', {
+					comment:
+						'*, the asterisk, is used to refer to a comment at the bottom of the page that relates to the text before it',
+				} ) }
+			</DiscountCallout>
+		);
 	}
 
 	const isFreeDomainMapping =
@@ -813,7 +841,14 @@ function GSuiteDiscountCallout( {
 		product.item_original_subtotal_integer < product.item_original_subtotal_integer &&
 		product.is_sale_coupon_applied
 	) {
-		return <DiscountCallout>{ translate( 'Discount for first year *' ) }</DiscountCallout>;
+		return (
+			<DiscountCallout>
+				{ translate( 'Discount for first year *', {
+					comment:
+						'*, the asterisk, is used to refer to a comment at the bottom of the page that relates to the text before it',
+				} ) }
+			</DiscountCallout>
+		);
 	}
 	return null;
 }

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -57,6 +57,7 @@ export const NonProductLineItem = styled( WPNonProductLineItem )< {
 	border-bottom: ${ ( { theme, total } ) =>
 		total ? 0 : '1px solid ' + theme.colors.borderColorLight };
 	position: relative;
+
 	.checkout-line-item__price {
 		position: relative;
 	}
@@ -74,6 +75,7 @@ export const LineItem = styled( WPLineItem )< {
 	padding: 20px 0;
 	border-bottom: ${ ( { theme } ) => '1px solid ' + theme.colors.borderColorLight };
 	position: relative;
+
 	.checkout-line-item__price {
 		position: relative;
 	}
@@ -83,12 +85,15 @@ export const CouponLineItem = styled( WPCouponLineItem )< {
 	theme?: Theme;
 } >`
 	border-bottom: ${ ( { theme } ) => '1px solid ' + theme.colors.borderColorLight };
+
 	&[data-partner-coupon='true'] ${ NonProductLineItem } {
 		border-bottom: none;
 	}
+
 	&:last-child {
 		border-bottom: none;
 	}
+
 	.jetpack-partner-logo {
 		padding-bottom: 20px;
 	}
@@ -125,6 +130,7 @@ const LineItemTitle = styled.div< { theme?: Theme; isSummary?: boolean } >`
 const LineItemPriceWrapper = styled.span< { theme?: Theme; isSummary?: boolean } >`
 	margin-left: 12px;
 	font-size: 16px;
+
 	.rtl & {
 		margin-right: 12px;
 		margin-left: 0;

--- a/packages/wpcom-checkout/src/get-introductory-offer-interval-display.ts
+++ b/packages/wpcom-checkout/src/get-introductory-offer-interval-display.ts
@@ -8,7 +8,12 @@ export function getIntroductoryOfferIntervalDisplay(
 	context: string,
 	remainingRenewalsUsingOffer = 0
 ): string {
-	let text = String( translate( 'Discount for first period *' ) );
+	let text = String(
+		translate( 'Discount for first period *', {
+			comment:
+				'*, the asterisk, is used to refer to a comment at the bottom of the page that relates to the text before it',
+		} )
+	);
 	if ( isFreeTrial ) {
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
@@ -39,26 +44,40 @@ export function getIntroductoryOfferIntervalDisplay(
 	} else {
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
-				text = String( translate( 'Discount for first month *' ) );
+				text = String(
+					translate( 'Discount for first month *', {
+						comment:
+							'*, the asterisk, is used to refer to a comment at the bottom of the page that relates to the text before it',
+					} )
+				);
 			} else {
 				text = String(
 					translate( 'Discount for first %(numberOfMonths)d months *', {
 						args: {
 							numberOfMonths: intervalCount,
 						},
+						comment:
+							'*, the asterisk, is used to refer to a comment at the bottom of the page that relates to the text before it',
 					} )
 				);
 			}
 		}
 		if ( intervalUnit === 'year' ) {
 			if ( intervalCount === 1 ) {
-				text = String( translate( 'Discount for first year *' ) );
+				text = String(
+					translate( 'Discount for first year *', {
+						comment:
+							'*, the asterisk, is used to refer to a comment at the bottom of the page that relates to the text before it',
+					} )
+				);
 			} else {
 				text = String(
 					translate( 'Discount for first %(numberOfYears)d years *', {
 						args: {
 							numberOfYears: intervalCount,
 						},
+						comment:
+							'*, the asterisk, is used to refer to a comment at the bottom of the page that relates to the text before it',
 					} )
 				);
 			}

--- a/packages/wpcom-checkout/src/get-introductory-offer-interval-display.ts
+++ b/packages/wpcom-checkout/src/get-introductory-offer-interval-display.ts
@@ -8,7 +8,7 @@ export function getIntroductoryOfferIntervalDisplay(
 	context: string,
 	remainingRenewalsUsingOffer = 0
 ): string {
-	let text = String( translate( 'Discount for first period' ) );
+	let text = String( translate( 'Discount for first period *' ) );
 	if ( isFreeTrial ) {
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
@@ -39,10 +39,10 @@ export function getIntroductoryOfferIntervalDisplay(
 	} else {
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
-				text = String( translate( 'Discount for first month' ) );
+				text = String( translate( 'Discount for first month *' ) );
 			} else {
 				text = String(
-					translate( 'Discount for first %(numberOfMonths)d months', {
+					translate( 'Discount for first %(numberOfMonths)d months *', {
 						args: {
 							numberOfMonths: intervalCount,
 						},
@@ -52,10 +52,10 @@ export function getIntroductoryOfferIntervalDisplay(
 		}
 		if ( intervalUnit === 'year' ) {
 			if ( intervalCount === 1 ) {
-				text = String( translate( 'Discount for first year' ) );
+				text = String( translate( 'Discount for first year *' ) );
 			} else {
 				text = String(
-					translate( 'Discount for first %(numberOfYears)d years', {
+					translate( 'Discount for first %(numberOfYears)d years *', {
 						args: {
 							numberOfYears: intervalCount,
 						},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add "* All discounts are for the first term only, renewals are at full price." to the bottom of the checkout if all items in the cart are Jetpack products and at least one product has an introductory discount applied

#### Testing instructions

1. Make sure you have a site or jurassic.ninja site that has Jetpack products available to buy (i.e. that doesn't already have all of them)
2. With this branch checked out, run `yarn start` 
3. Add a Jetpack product with an intro discount and one without one. I added Jetpack Security Daily (w/out intro discount by buying this, removing it, and adding it to the cart again) and Jetpack Backup ( 10GB ) with the intro discount
4. You should see an asterisk by the `Discount for first year` text 
![image](https://user-images.githubusercontent.com/65001528/169360006-79e63722-a29e-4e0f-a036-ebcb2706898b.png)
5. You should also see the text `* All discounts are for the first term only, renewals are at full price.` below the 7/14 day guarantee 
![image](https://user-images.githubusercontent.com/65001528/169360143-e84df815-d251-4e94-86cf-b857da418ef3.png)
6. If you remove the product with the intro discount (in this case, Jetpack Backup ( 10GB ), you should no longer see the footnote at the bottom
![image](https://user-images.githubusercontent.com/65001528/169360293-70c80981-5b49-48aa-a2cb-705922e700b0.png)
![image](https://user-images.githubusercontent.com/65001528/169360324-da3bf6a8-d450-4082-bef2-b55144d4be42.png)

