### PR TITLE
Experiment: Upsell screen in Jetpack purchase flow

### DIFF
--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -3,7 +3,9 @@ import { setLocaleMiddleware } from 'calypso/controller/shared';
 import { loggedInSiteSelection } from 'calypso/my-sites/controller';
 import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 import { jetpackStoragePlans } from 'calypso/my-sites/plans/jetpack-plans/jetpack-storage-plans';
+import { jetpackUpsell } from 'calypso/my-sites/plans/jetpack-plans/jetpack-upsell';
 import { jetpackPricingContext } from './controller';
+
 import './style.scss';
 
 export default function (): void {
@@ -13,6 +15,12 @@ export default function (): void {
 	);
 	page( '/plans/storage/:site', ( { params } ) =>
 		page.redirect( `/pricing/storage/${ params.site }` )
+	);
+	page( '/:locale/plans/upsell/:site/:product', ( { params } ) =>
+		page.redirect( `/${ params.locale }/pricing/upsell/${ params.site }/${ params.product }` )
+	);
+	page( '/plans/upsell/:site/:product', ( { params } ) =>
+		page.redirect( `/pricing/upsell/${ params.site }/${ params.product }` )
 	);
 	page( '/:locale/plans', ( { params } ) => page.redirect( `/${ params.locale }/pricing` ) );
 	page( '/plans/:site', ( { params } ) => page.redirect( `/pricing/${ params.site }` ) );
@@ -25,6 +33,13 @@ export default function (): void {
 		jetpackPricingContext
 	);
 	jetpackStoragePlans( '/pricing', loggedInSiteSelection, jetpackPricingContext );
+	jetpackUpsell(
+		`/:lang/pricing`,
+		setLocaleMiddleware(),
+		loggedInSiteSelection,
+		jetpackPricingContext
+	);
+	jetpackUpsell( '/pricing', loggedInSiteSelection, jetpackPricingContext );
 	jetpackPlans( `/:lang/pricing`, setLocaleMiddleware(), jetpackPricingContext );
 	jetpackPlans( '/pricing', loggedInSiteSelection, jetpackPricingContext );
 }

--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -16,11 +16,11 @@ export default function (): void {
 	page( '/plans/storage/:site', ( { params } ) =>
 		page.redirect( `/pricing/storage/${ params.site }` )
 	);
-	page( '/:locale/plans/upsell/:site/:product', ( { params } ) =>
-		page.redirect( `/${ params.locale }/pricing/upsell/${ params.site }/${ params.product }` )
+	page( '/:locale/plans/upsell/:product/:site?', ( { params } ) =>
+		page.redirect( `/${ params.locale }/pricing/upsell/${ params.product }/${ params.site }` )
 	);
-	page( '/plans/upsell/:site/:product', ( { params } ) =>
-		page.redirect( `/pricing/upsell/${ params.site }/${ params.product }` )
+	page( '/plans/upsell/:product/:site?', ( { params } ) =>
+		page.redirect( `/pricing/upsell/${ params.product }/${ params.site }` )
 	);
 	page( '/:locale/plans', ( { params } ) => page.redirect( `/${ params.locale }/pricing` ) );
 	page( '/plans/:site', ( { params } ) => page.redirect( `/pricing/${ params.site }` ) );

--- a/client/jetpack-cloud/sections/pricing/index.ts
+++ b/client/jetpack-cloud/sections/pricing/index.ts
@@ -17,10 +17,10 @@ export default function (): void {
 		page.redirect( `/pricing/storage/${ params.site }` )
 	);
 	page( '/:locale/plans/upsell/:product/:site?', ( { params } ) =>
-		page.redirect( `/${ params.locale }/pricing/upsell/${ params.product }/${ params.site }` )
+		page.redirect( `/${ params.locale }/pricing/upsell/${ params.product }/${ params.site || '' }` )
 	);
 	page( '/plans/upsell/:product/:site?', ( { params } ) =>
-		page.redirect( `/pricing/upsell/${ params.product }/${ params.site }` )
+		page.redirect( `/pricing/upsell/${ params.product }/${ params.site || '' }` )
 	);
 	page( '/:locale/plans', ( { params } ) => page.redirect( `/${ params.locale }/pricing` ) );
 	page( '/plans/:site', ( { params } ) => page.redirect( `/pricing/${ params.site }` ) );

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -73,8 +73,8 @@ export default function () {
 		clientRender
 	);
 
-	jetpackPlans( `/jetpack/connect/store`, controller.offerResetContext );
 	jetpackUpsell( `/jetpack/connect/store`, controller.offerResetContext );
+	jetpackPlans( `/jetpack/connect/store`, controller.offerResetContext );
 
 	page(
 		'/jetpack/connect/:_(akismet|plans|vaultpress)/:interval(yearly|monthly)?',

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -6,6 +6,7 @@ import { OFFER_RESET_FLOW_TYPES } from 'calypso/jetpack-connect/flow-types';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { siteSelection } from 'calypso/my-sites/controller';
 import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
+import { jetpackUpsell } from 'calypso/my-sites/plans/jetpack-plans/jetpack-upsell';
 import * as controller from './controller';
 
 import './style.scss';
@@ -73,6 +74,7 @@ export default function () {
 	);
 
 	jetpackPlans( `/jetpack/connect/store`, controller.offerResetContext );
+	jetpackUpsell( `/jetpack/connect/store`, controller.offerResetContext );
 
 	page(
 		'/jetpack/connect/:_(akismet|plans|vaultpress)/:interval(yearly|monthly)?',
@@ -81,6 +83,14 @@ export default function () {
 	);
 
 	jetpackPlans(
+		`/jetpack/connect/plans`,
+		controller.redirectToLoginIfLoggedOut,
+		siteSelection,
+		controller.partnerCouponRedirects,
+		controller.offerResetRedirects,
+		controller.offerResetContext
+	);
+	jetpackUpsell(
 		`/jetpack/connect/plans`,
 		controller.redirectToLoginIfLoggedOut,
 		siteSelection,

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -9,6 +9,7 @@ import {
 } from 'calypso/my-sites/controller';
 import jetpackPlans from 'calypso/my-sites/plans/jetpack-plans';
 import { jetpackStoragePlans } from 'calypso/my-sites/plans/jetpack-plans/jetpack-storage-plans';
+import { jetpackUpsell } from 'calypso/my-sites/plans/jetpack-plans/jetpack-upsell';
 import {
 	features,
 	plans,
@@ -92,6 +93,15 @@ export default function () {
 	// It needs to be defined before the other plans pages so that /plans/storage/:site
 	// will take precedence over /plans/:intervalType?/:site.
 	jetpackStoragePlans(
+		'/plans',
+		siteSelection,
+		wpForTeamsP2PlusNotSupportedRedirect,
+		redirectToPlansIfNotJetpack,
+		navigation
+	);
+
+	// Upsell page between pricing and checkout pages when purchasing some Jetpack products.
+	jetpackUpsell(
 		'/plans',
 		siteSelection,
 		wpForTeamsP2PlusNotSupportedRedirect,

--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -32,13 +32,14 @@ import {
 	PRODUCT_JETPACK_CRM_FREE_MONTHLY,
 	PRODUCT_JETPACK_SCAN,
 	PRODUCT_JETPACK_SCAN_MONTHLY,
+	PRODUCT_JETPACK_ANTI_SPAM,
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
 } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import buildCardFeaturesFromItem from './build-card-features-from-item';
 import type { SelectorProduct } from './types';
-import type { JetpackPlanSlug } from '@automattic/calypso-products';
+import type { JetpackPlanSlug, JetpackPurchasableItemSlug } from '@automattic/calypso-products';
 
 export const PLAN_COMPARISON_PAGE = 'https://jetpack.com/features/comparison/';
 export const INTRO_PRICING_DISCOUNT_PERCENTAGE = 50;
@@ -177,6 +178,15 @@ export const PRODUCT_UPSELLS_BY_FEATURE: Record< string, JetpackPlanSlug > = {
 	[ FEATURE_VIDEO_UPLOADS_JETPACK_PRO ]: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 	[ FEATURE_ADVANCED_SEO ]: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 	[ FEATURE_ACTIVITY_LOG ]: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+};
+
+/**
+ * Matrix of products upsold in the purchase flow, in between the pricing and checkout pages.
+ */
+export const PURCHASE_FLOW_UPSELLS_MATRIX: Record< string, JetpackPurchasableItemSlug > = {
+	[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: PLAN_JETPACK_SECURITY_T1_YEARLY,
+	[ PRODUCT_JETPACK_SCAN ]: PLAN_JETPACK_SECURITY_T1_YEARLY,
+	[ PRODUCT_JETPACK_ANTI_SPAM ]: PLAN_JETPACK_SECURITY_T1_YEARLY,
 };
 
 /**

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -120,17 +120,20 @@ export const jetpackStoragePricing = ( context: PageJS.Context, next: () => void
 	next();
 };
 
-export const jetpackProductUpsell = ( context: PageJS.Context, next: () => void ) => {
-	const { site, product } = context.params;
-	const urlQueryArgs = context.query;
+export const jetpackProductUpsell =
+	( rootUrl: string ): PageJS.Callback =>
+	( context: PageJS.Context, next: () => void ) => {
+		const { site, product } = context.params;
+		const urlQueryArgs = context.query;
 
-	context.primary = (
-		<JetpackUpsellPage
-			siteSlug={ site || urlQueryArgs.site }
-			productSlug={ product }
-			urlQueryArgs={ urlQueryArgs }
-		/>
-	);
+		context.primary = (
+			<JetpackUpsellPage
+				rootUrl={ rootUrl }
+				siteSlug={ site || urlQueryArgs.site }
+				productSlug={ product }
+				urlQueryArgs={ urlQueryArgs }
+			/>
+		);
 
-	next();
-};
+		next();
+	};

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -11,6 +11,7 @@ import { getPlanRecommendationFromContext } from './plan-upgrade/utils';
 import SelectorPage from './selector';
 import { StoragePricing } from './storage-pricing';
 import { StoragePricingHeader } from './storage-pricing-header';
+import JetpackUpsellPage from './upsell';
 import type { Duration, QueryArgs } from './types';
 
 function stringToDuration( duration?: string ): Duration | undefined {
@@ -116,5 +117,20 @@ export const jetpackStoragePricing = ( context: PageJS.Context, next: () => void
 			locale={ lang }
 		/>
 	);
+	next();
+};
+
+export const jetpackProductUpsell = ( context: PageJS.Context, next: () => void ) => {
+	const { site, product } = context.params;
+	const urlQueryArgs = context.query;
+
+	context.primary = (
+		<JetpackUpsellPage
+			siteSlug={ site || urlQueryArgs.site }
+			productSlug={ product }
+			urlQueryArgs={ urlQueryArgs }
+		/>
+	);
+
 	next();
 };

--- a/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
+++ b/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
@@ -56,6 +56,24 @@ export function buildCheckoutURL(
 			? 'http://calypso.localhost:3000'
 			: 'https://wordpress.com';
 
+	// Link to upsell page if upsell feature enabled
+	if ( showUpsellPage && rootUrl ) {
+		// Upsell page only supports one product
+		const product = productsArray[ 0 ];
+
+		// If upsell exists
+		if ( product in PURCHASE_FLOW_UPSELLS_MATRIX ) {
+			if ( ! urlQueryArgs.checkoutBackUrl ) {
+				urlQueryArgs.checkoutBackUrl = window.location.href;
+			}
+
+			return addQueryArgs(
+				urlQueryArgs,
+				`${ rootUrl.replace( /\/$/, '' ) }/upsell/${ product }/${ siteSlug }`
+			);
+		}
+	}
+
 	// siteless checkout
 	if (
 		! siteSlug &&
@@ -73,23 +91,6 @@ export function buildCheckoutURL(
 			urlQueryArgs,
 			host + `/checkout/jetpack/${ siteSlug }/${ productsString }`
 		);
-	}
-
-	if ( showUpsellPage && rootUrl && siteSlug ) {
-		// Upsell page only supports one product
-		const product = productsArray[ 0 ];
-
-		// If upsell exists
-		if ( product in PURCHASE_FLOW_UPSELLS_MATRIX ) {
-			if ( ! urlQueryArgs.checkoutBackUrl ) {
-				urlQueryArgs.checkoutBackUrl = window.location.href;
-			}
-
-			return addQueryArgs(
-				urlQueryArgs,
-				`${ rootUrl.replace( /\/$/, '' ) }/upsell/${ siteSlug }/${ product }`
-			);
-		}
 	}
 
 	// If there is not siteSlug, we need to redirect the user to the site selection

--- a/client/my-sites/plans/jetpack-plans/jetpack-upsell.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-upsell.ts
@@ -1,0 +1,13 @@
+import page from 'page';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { jetpackProductUpsell } from './controller';
+
+export const jetpackUpsell = ( rootUrl: string, ...rest: PageJS.Callback[] ) => {
+	page(
+		`${ rootUrl }/upsell/:site/:product`,
+		...rest,
+		jetpackProductUpsell,
+		makeLayout,
+		clientRender
+	);
+};

--- a/client/my-sites/plans/jetpack-plans/jetpack-upsell.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-upsell.ts
@@ -4,7 +4,7 @@ import { jetpackProductUpsell } from './controller';
 
 export const jetpackUpsell = ( rootUrl: string, ...rest: PageJS.Callback[] ) => {
 	page(
-		`${ rootUrl }/upsell/:site/:product`,
+		`${ rootUrl }/upsell/:product/:site?`,
 		...rest,
 		jetpackProductUpsell,
 		makeLayout,

--- a/client/my-sites/plans/jetpack-plans/jetpack-upsell.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-upsell.ts
@@ -6,7 +6,7 @@ export const jetpackUpsell = ( rootUrl: string, ...rest: PageJS.Callback[] ) => 
 	page(
 		`${ rootUrl }/upsell/:product/:site?`,
 		...rest,
-		jetpackProductUpsell,
+		jetpackProductUpsell( rootUrl ),
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -52,6 +52,7 @@ interface ProductCardProps {
 	hideSavingLabel?: boolean;
 	scrollCardIntoView?: ScrollCardIntoViewCallback;
 	collapseFeaturesOnMobile?: boolean;
+	isLoadingUpsellPageExperiment?: boolean;
 }
 
 const ProductCard: React.FC< ProductCardProps > = ( {
@@ -67,6 +68,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 	hideSavingLabel,
 	scrollCardIntoView,
 	collapseFeaturesOnMobile,
+	isLoadingUpsellPageExperiment,
 } ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
@@ -222,7 +224,7 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			buttonURL={
 				createButtonURL ? createButtonURL( item, isUpgradeableToYearly, purchase ) : undefined
 			}
-			buttonDisabled={ isDisabled || buttonDisabled }
+			buttonDisabled={ isDisabled || buttonDisabled || isLoadingUpsellPageExperiment }
 			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
 			isFeatured={ isFeatured }
 			isOwned={ isOwned }

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -105,6 +105,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	onDurationChange,
 	scrollCardIntoView,
 	createButtonURL,
+	isLoadingUpsellPageExperiment,
 } ) => {
 	const translate = useTranslate();
 	const isDesktop = useDesktopBreakpoint();
@@ -212,6 +213,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 				scrollCardIntoView={ scrollCardIntoView }
 				createButtonURL={ createButtonURL }
 				collapseFeaturesOnMobile
+				isLoadingUpsellPageExperiment={ isLoadingUpsellPageExperiment }
 			/>
 		</li>
 	);
@@ -268,6 +270,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 									isFeatured={ isFeatured }
 									scrollCardIntoView={ scrollCardIntoView }
 									createButtonURL={ createButtonURL }
+									isLoadingUpsellPageExperiment={ isLoadingUpsellPageExperiment }
 								/>
 							</li>
 						);

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -59,7 +59,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	const legacyPlan = planRecommendation ? planRecommendation[ 0 ] : null;
 
 	const [ isLoadingUpsellPageExperiment, experimentAssignment ] = useExperiment(
-		'jetpack_upsell_page_2022_05'
+		'calypso_jetpack_upsell_page_2022_06'
 	);
 	const showUpsellPage = experimentAssignment?.variationName === 'treatment';
 

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -1,6 +1,6 @@
 import { TERM_ANNUALLY } from '@automattic/calypso-products';
 import classNames from 'classnames';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useMemo } from 'react';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryIntroOffers from 'calypso/components/data/query-intro-offers';
@@ -16,6 +16,7 @@ import LicensingPromptDialog from 'calypso/components/jetpack/licensing-prompt-d
 import Main from 'calypso/components/main';
 import { MAIN_CONTENT_ID } from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useExperiment } from 'calypso/lib/explat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { EXTERNAL_PRODUCTS_LIST } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
@@ -56,6 +57,11 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 	const viewTrackerPath = getViewTrackerPath( rootUrl, siteSlugProp );
 	const viewTrackerProps = siteId ? { site: siteSlug } : {};
 	const legacyPlan = planRecommendation ? planRecommendation[ 0 ] : null;
+
+	const [ isLoadingUpsellPageExperiment, experimentAssignment ] = useExperiment(
+		'jetpack_upsell_page_2022_05'
+	);
+	const showUpsellPage = experimentAssignment?.variationName === 'treatment';
 
 	useEffect( () => {
 		dispatch(
@@ -122,7 +128,10 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 		[]
 	);
 
-	const createProductURL = getPurchaseURLCallback( siteSlug, urlQueryArgs, locale );
+	const createProductURL = useMemo(
+		() => getPurchaseURLCallback( siteSlug, urlQueryArgs, locale, rootUrl, showUpsellPage ),
+		[ siteSlug, urlQueryArgs, locale, rootUrl, showUpsellPage ]
+	);
 
 	// Sends a user to a page based on whether there are subtypes.
 	const selectProduct: PurchaseCallback = (
@@ -216,6 +225,7 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 					onDurationChange={ trackDurationChange }
 					scrollCardIntoView={ scrollCardIntoView }
 					createButtonURL={ createProductURL }
+					isLoadingUpsellPageExperiment={ isLoadingUpsellPageExperiment }
 				/>
 
 				<QueryProductsList type="jetpack" />

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -51,6 +51,7 @@ export interface ProductsGridProps {
 	onDurationChange?: DurationChangeCallback;
 	scrollCardIntoView: ScrollCardIntoViewCallback;
 	createButtonURL?: PurchaseURLCallback;
+	isLoadingUpsellPageExperiment?: boolean;
 }
 
 export type PlanGridProducts = {

--- a/client/my-sites/plans/jetpack-plans/upsell/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/upsell/index.tsx
@@ -1,0 +1,175 @@
+import {
+	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+	PRODUCT_JETPACK_SCAN,
+	PRODUCT_JETPACK_ANTI_SPAM,
+	PLAN_JETPACK_SECURITY_T1_YEARLY,
+	getJetpackProductsDisplayNames,
+} from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
+import { translate } from 'i18n-calypso';
+import { useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import QueryIntroOffers from 'calypso/components/data/query-intro-offers';
+import QuerySiteProducts from 'calypso/components/data/query-site-products';
+import Main from 'calypso/components/main';
+import { useExperiment } from 'calypso/lib/explat';
+import PlanPrice from 'calypso/my-sites/plan-price';
+import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
+import useItemPrice from 'calypso/my-sites/plans/jetpack-plans/use-item-price';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import { getSitePurchases, isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { PURCHASE_FLOW_UPSELLS_MATRIX } from '../constants';
+import slugToSelectorProduct from '../slug-to-selector-product';
+import type { QueryArgs } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+import './style.scss';
+
+interface Props {
+	siteSlug: string;
+	productSlug: string;
+	urlQueryArgs: QueryArgs;
+}
+
+const JetpackUpsellPage: React.FC< Props > = ( { siteSlug, productSlug, urlQueryArgs } ) => {
+	const upsellSlug = PURCHASE_FLOW_UPSELLS_MATRIX[ productSlug ];
+	const productNames = getJetpackProductsDisplayNames();
+
+	const [ isLoadingUpsellPageExperiment, experimentAssignment ] = useExperiment(
+		'jetpack_upsell_page_2022_05'
+	);
+
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const isFetchingPurchases = useSelector( isFetchingSitePurchases );
+	const purchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
+
+	const productItem = useMemo( () => slugToSelectorProduct( productSlug ), [ productSlug ] );
+	const upsellItem = useMemo(
+		() => ( upsellSlug ? slugToSelectorProduct( upsellSlug ) : null ),
+		[ upsellSlug ]
+	);
+	const productCheckoutURL = useMemo(
+		() => buildCheckoutURL( siteSlug, productSlug, urlQueryArgs ),
+		[ siteSlug, productSlug, urlQueryArgs ]
+	);
+	const upsellCheckoutURL = useMemo(
+		() => ( upsellSlug ? buildCheckoutURL( siteSlug, upsellSlug, urlQueryArgs ) : '' ),
+		[ siteSlug, upsellSlug, urlQueryArgs ]
+	);
+	const isUpsellOwned = useMemo(
+		() =>
+			isFetchingPurchases ? false : !! purchases?.find( ( p ) => p.productSlug === upsellSlug ),
+		[ upsellSlug, purchases, isFetchingPurchases ]
+	);
+	const { intro, description, cta, features } = useMemo( () => {
+		if ( PLAN_JETPACK_SECURITY_T1_YEARLY === upsellSlug ) {
+			return {
+				intro: translate( 'Here’s a popular bundle for comprehensive site security:' ),
+				description: translate( 'Save money with all Jetpack security products in one bundle:' ),
+				cta: translate( 'Upgrade your site security for only an additional:' ),
+				features: [
+					{
+						slug: PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+						text: translate( 'Real-time cloud backups and one-click restores' ),
+					},
+					{
+						slug: PRODUCT_JETPACK_SCAN,
+						text: translate( 'Malware scanning and one-click fixes' ),
+					},
+					{
+						slug: PRODUCT_JETPACK_ANTI_SPAM,
+						text: translate( 'Block spam in comments and forms' ),
+					},
+				],
+			};
+		}
+
+		return {};
+	}, [ upsellSlug ] );
+
+	const productName = productItem?.displayName;
+	const upsellName = upsellItem?.displayName;
+
+	const productPriceObj = useItemPrice( siteId, productItem );
+	const upsellPriceObj = useItemPrice( siteId, upsellItem );
+	const priceDelta =
+		( upsellPriceObj?.discountedPrice || upsellPriceObj?.originalPrice ) -
+		( productPriceObj?.discountedPrice || productPriceObj?.originalPrice );
+	const isLoadingPrice = productPriceObj?.isFetching || upsellPriceObj?.isFetching;
+
+	useEffect( () => {
+		const dontShowUpsell =
+			! isLoadingUpsellPageExperiment && experimentAssignment?.variationName !== 'treatment';
+
+		if ( ( ! upsellSlug || isUpsellOwned || dontShowUpsell ) && productCheckoutURL ) {
+			page.redirect( productCheckoutURL );
+		}
+	}, [
+		upsellSlug,
+		isUpsellOwned,
+		productCheckoutURL,
+		isLoadingUpsellPageExperiment,
+		experimentAssignment,
+	] );
+
+	if ( ! upsellSlug || isFetchingPurchases || isUpsellOwned ) {
+		return null;
+	}
+
+	return (
+		<>
+			{ siteId && <QuerySiteProducts siteId={ siteId } /> }
+			{ siteId && <QueryIntroOffers siteId={ siteId } /> }
+
+			<Main wideLayout>
+				<h1>
+					{ translate( 'Nice choice, we added %(productName)s to your cart.', {
+						args: {
+							productName,
+						},
+					} ) }{ ' ' }
+					{ intro }
+				</h1>
+				<p>{ translate( 'Best value' ) }</p>
+				<h2>{ upsellName }</h2>
+				{ description && <p>{ description }</p> }
+				{ features?.length && (
+					<ul>
+						{ features.map( ( { slug, text } ) => (
+							<li key={ slug }>
+								{ productNames[ slug ] || slug } -{ ' ' }
+								{ slug === productSlug ? translate( 'Already in your cart' ) : text }
+							</li>
+						) ) }
+					</ul>
+				) }
+				{ ! isLoadingPrice && priceDelta > 0 && (
+					<>
+						{ cta && <p>{ cta }</p> }
+						<PlanPrice rawPrice={ priceDelta } currency={ currencyCode } displayPerMonthNotation />
+						<br />
+					</>
+				) }
+				<Button href={ upsellCheckoutURL } primary>
+					{ translate( 'Upgrade to %(productName)s', {
+						args: {
+							productName: upsellName,
+						},
+					} ) }
+				</Button>
+				<br />
+				<br />
+				<Button href={ productCheckoutURL }>
+					{ translate( 'No thanks, proceed with %(productName)s', {
+						args: {
+							productName,
+						},
+					} ) }
+				</Button>
+			</Main>
+		</>
+	);
+};
+
+export default JetpackUpsellPage;

--- a/client/my-sites/plans/jetpack-plans/upsell/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/upsell/index.tsx
@@ -43,7 +43,7 @@ const JetpackUpsellPage: React.FC< Props > = ( {
 	const productNames = getJetpackProductsDisplayNames();
 
 	const [ isLoadingUpsellPageExperiment, experimentAssignment ] = useExperiment(
-		'jetpack_upsell_page_2022_05'
+		'calypso_jetpack_upsell_page_2022_06'
 	);
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );

--- a/client/my-sites/plans/jetpack-plans/upsell/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/upsell/index.tsx
@@ -27,12 +27,18 @@ import type { QueryArgs } from 'calypso/my-sites/plans/jetpack-plans/types';
 import './style.scss';
 
 interface Props {
+	rootUrl: string;
 	siteSlug: string;
 	productSlug: string;
 	urlQueryArgs: QueryArgs;
 }
 
-const JetpackUpsellPage: React.FC< Props > = ( { siteSlug, productSlug, urlQueryArgs } ) => {
+const JetpackUpsellPage: React.FC< Props > = ( {
+	rootUrl,
+	siteSlug,
+	productSlug,
+	urlQueryArgs,
+} ) => {
 	const upsellSlug = PURCHASE_FLOW_UPSELLS_MATRIX[ productSlug ];
 	const productNames = getJetpackProductsDisplayNames();
 
@@ -100,10 +106,11 @@ const JetpackUpsellPage: React.FC< Props > = ( { siteSlug, productSlug, urlQuery
 	const isLoadingPrice = productPriceObj?.isFetching || upsellPriceObj?.isFetching;
 
 	useEffect( () => {
-		const dontShowUpsell =
-			! isLoadingUpsellPageExperiment && experimentAssignment?.variationName !== 'treatment';
+		if ( ! isLoadingUpsellPageExperiment && experimentAssignment?.variationName !== 'treatment' ) {
+			page.redirect( `${ rootUrl }/${ siteSlug }` );
+		}
 
-		if ( ( ! upsellSlug || isUpsellOwned || dontShowUpsell ) && productCheckoutURL ) {
+		if ( ( ! upsellSlug || isUpsellOwned ) && productCheckoutURL ) {
 			page.redirect( productCheckoutURL );
 		}
 	}, [
@@ -112,9 +119,11 @@ const JetpackUpsellPage: React.FC< Props > = ( { siteSlug, productSlug, urlQuery
 		productCheckoutURL,
 		isLoadingUpsellPageExperiment,
 		experimentAssignment,
+		rootUrl,
+		siteSlug,
 	] );
 
-	if ( ! upsellSlug || isFetchingPurchases || isUpsellOwned ) {
+	if ( isLoadingUpsellPageExperiment || ! upsellSlug || isFetchingPurchases || isUpsellOwned ) {
 		return null;
 	}
 

--- a/client/my-sites/plans/jetpack-plans/upsell/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/upsell/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
+import page from 'page';
 import { useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import QueryIntroOffers from 'calypso/components/data/query-intro-offers';

--- a/client/my-sites/plans/jetpack-plans/upsell/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/upsell/index.tsx
@@ -130,7 +130,7 @@ const JetpackUpsellPage: React.FC< Props > = ( {
 	return (
 		<>
 			{ siteId && <QuerySiteProducts siteId={ siteId } /> }
-			{ siteId && <QueryIntroOffers siteId={ siteId } /> }
+			<QueryIntroOffers siteId={ siteId ?? 'none' } />
 
 			<Main wideLayout>
 				<h1>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR implements a new screen to upsell Jetpack products, as an A/B test. This new screen will appear:
- Between the pricing page and the checkout page
- Only if a user selects Backup, Scan, or Antispam (the upsold product is Security)

Context: pbNhbs-2pq-p2

This PR implements all the logic for this experiment and new page. The design of the page is handled in #64329.

### Implementation notes

- This new page has a dedicated URL, depending on where the user is seeing the landing page from:
  - `cloud.jetpack.com/pricing/upsell/:product/:site?`
  - `wordpress.com/pricing/upsell/:product/:site?`
  - `wordpress.com/jetpack/connect/store/upsell/:product`
  - `wordpress.com/jetpack/connect/plans/upsell/:product/:site`
- Name of the experiment: `calypso_jetpack_upsell_page_2022_06 `

### Testing instructions

_Note: clicking the close button in the checkout page should redirect you to the pricing page (passed in the `checkoutBackUrl` query param). This doesn't work as expected, and should be addressed in a separate PR._

#### Prerequisites

- Make sure you have a site connected to Jetpack with no subscriptions
- Check for JS errors in the console

#### Regression testing

- If you've tested this PR before, make sure to delete the `explat-experiment--jetpack_upsell_page_2022_05` key in your local storage, or assign yourself to the control variation in the experiment tool.
- In Calypso blue, visit `/plans/:site`
- Select a product, and make sure you're directed to the checkout page with the product in the cart
- Repeat the same operation with a couple more products
- Visit `/plans/upsell/jetpack_backup_t1_yearly/:site`: you should be redirected to the pricing page (you might briefly see the upsell page flash, but that's acceptable since we'll eventually keep or get rid of the page definitively)

#### Upsell screen

- Assign yourself to the treatment variation
- Calypso pricing page: 
  - Visit `/plans/:site`
  - Check that selecting Backup, Scan, or Anti-spam in the pricing page leads you to the upsell page
  - In the upsell page:
    - Check that the copy makes sense
    - Check that the price difference is accurate
    - Check that both links do what they advertise
    - Refresh the page, and verify that you see the same information
  - Check that selecting another product (than the 3 mentioned above) in the pricing page leads you directly to the checkout page
  - Visit `/plans/upsell/jetpack_complete/:site`, and check that you're redirected to the checkout page
- Calypso connect page: 
  - Visit `/jetpack/connect/store`
  - Repeat the aforementioned steps
  - Visit `/jetpack/connect/plans/:site`
  - Repeat the same steps
- Cloud pricing page:
  - Visit `/pricing`
  - Repeat the aforementioned steps
  - Visit `/pricing/:site`
  - Repeat the same steps
