### PR TITLE
Jetpack Cloud: Update site admin link to include Social

### DIFF
--- a/client/state/sites/selectors/get-site-admin-page.js
+++ b/client/state/sites/selectors/get-site-admin-page.js
@@ -8,19 +8,9 @@ import getSiteOption from './get-site-option';
  * @returns {string}        Jetpack or standalone plugin page name
  */
 export default function getSiteAdminPage( state, siteId ) {
-	const activeConnectedPlugins = getSiteOption(
-		state,
-		siteId,
-		'jetpack_connection_active_plugins'
-	);
+	const activeConnectedPlugins =
+		getSiteOption( state, siteId, 'jetpack_connection_active_plugins' ) ?? [];
+	const plugins = [ 'jetpack', 'jetpack-backup', 'jetpack-search', 'jetpack-social' ];
 
-	let pluginPage = 'jetpack';
-	if ( Array.isArray( activeConnectedPlugins ) && ! activeConnectedPlugins.includes( 'jetpack' ) ) {
-		if ( activeConnectedPlugins.includes( 'jetpack-backup' ) ) {
-			pluginPage = 'jetpack-backup';
-		} else if ( activeConnectedPlugins.includes( 'jetpack-search' ) ) {
-			pluginPage = 'jetpack-search';
-		}
-	}
-	return pluginPage;
+	return plugins.find( ( plugin ) => activeConnectedPlugins.includes( plugin ) ) ?? 'jetpack';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a refactor of `getSiteAdminPage`. It will now also include the
appropriate link if Jetpack social is installed.

Future plugins can be added to the array in precedence order, but we may
also want to default to My Jetpack.

#### Testing instructions

- Connect a site with Jetpack Social installed
- Using the live branch for Jetpack Cloud click on the WP-Admin link in the sidebar for that site.
- You should be taken to the Jetpack Social admin page.
- It would also be worth checking that you are taken to the appropriate admin page still for the Search and Backup plugins


