### PR TITLE
Scroll the active index into view on load

### DIFF
--- a/client/my-sites/plugins/categories/responsive-toolbar-group/swipe-group.tsx
+++ b/client/my-sites/plugins/categories/responsive-toolbar-group/swipe-group.tsx
@@ -1,6 +1,6 @@
 import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
 import classnames from 'classnames';
-import { ReactChild, useState } from 'react';
+import { ReactChild, useState, useRef, useEffect } from 'react';
 
 import './style.scss';
 
@@ -19,6 +19,22 @@ export default function SwipeGroup( {
 
 	const [ activeIndex, setActiveIndex ] = useState< number >( initialActiveIndex );
 
+	const ref = useRef< HTMLButtonElement | null >( null );
+
+	// Scroll to category on load
+	useEffect( () => {
+		if ( ref.current ) {
+			ref.current.scrollIntoView( { block: 'end', inline: 'center' } );
+		}
+	}, [] );
+
+	// Scroll to the beginning when activeIndex changes to 0. This indicates a state reset.
+	useEffect( () => {
+		if ( ref.current && activeIndex === 0 ) {
+			ref.current.scrollIntoView( { block: 'end', inline: 'center' } );
+		}
+	}, [ activeIndex ] );
+
 	return (
 		<div className={ classes }>
 			<ToolbarGroup className="responsive-toolbar-group__swipe-list">
@@ -27,6 +43,7 @@ export default function SwipeGroup( {
 						key={ `button-item-${ index }` }
 						id={ `button-item-${ index }` }
 						isActive={ activeIndex === index }
+						ref={ activeIndex === index ? ref : null }
 						onClick={ () => {
 							setActiveIndex( index );
 							onClick( index );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Mobile: Scrolls selected category into view on load

#### Testing instructions

* Ensure the category scrolls into view when loading or refreshing the page


https://user-images.githubusercontent.com/811776/169438576-e98efbaf-62b6-47b8-aefd-1f963b122814.mp4



Fixes https://github.com/Automattic/wp-calypso/issues/63788
