### PR TITLE
Implement search for agency dashboard - mobile only

### DIFF
--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -4,16 +4,19 @@ import { useDispatch } from 'react-redux';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
 
-const useFetchDashboardSites = () => {
+const useFetchDashboardSites = ( searchQuery: string | null ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	return useQuery(
-		[ 'jetpack-cloud', 'agency-dashboard', 'sites' ],
+		[ 'jetpack-cloud', 'agency-dashboard', 'sites', searchQuery ],
 		() =>
-			wpcomJpl.req.get( {
-				path: '/jetpack-agency/sites',
-				apiNamespace: 'wpcom/v2',
-			} ),
+			wpcomJpl.req.get(
+				{
+					path: '/jetpack-agency/sites',
+					apiNamespace: 'wpcom/v2',
+				},
+				{ ...( searchQuery && { query: searchQuery } ) }
+			),
 		{
 			select: ( data ) => ( data.sites ? Object.values( data.sites ) : [] ),
 			refetchOnWindowFocus: false,

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.js
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.js
@@ -25,7 +25,7 @@ export default function DashboardOverview() {
 		}
 	}, [ hasFetched, isAgency, isAgencyEnabled ] );
 
-	if ( hasFetched && isAgency ) {
+	if ( isAgencyEnabled && hasFetched && isAgency ) {
 		return <SitesOverview />;
 	}
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,12 +1,23 @@
 import { useTranslate } from 'i18n-calypso';
+import { ReactElement, useState } from 'react';
+import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import SiteContent from './site-content';
+import SiteSearch from './site-search';
 import SiteWelcomeBanner from './site-welcome-banner';
-import type { ReactElement } from 'react';
 
 import './style.scss';
 
 export default function SitesOverview(): ReactElement {
 	const translate = useTranslate();
+	const searchParam = new URLSearchParams( window.location.search ).get( 's' );
+
+	const [ searchQuery, setSearchQuery ] = useState( searchParam );
+	const { data, isError, isFetching } = useFetchDashboardSites( searchQuery );
+
+	const handleSearch = ( query: string | null ) => {
+		setSearchQuery( query );
+	};
+
 	return (
 		<div className="sites-overview">
 			<SiteWelcomeBanner isDashboardView />
@@ -16,7 +27,10 @@ export default function SitesOverview(): ReactElement {
 					{ translate( 'Manage all your Jetpack sites from one location' ) }
 				</div>
 			</div>
-			<SiteContent />
+			<div className="sites-overview__search">
+				<SiteSearch searchQuery={ searchQuery } handleSearch={ handleSearch } />
+			</div>
+			<SiteContent data={ data } isError={ isError } isFetching={ isFetching } />
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -1,6 +1,6 @@
+import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import JetpackLogo from 'calypso/components/jetpack-logo';
-import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
+import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import SiteCard from '../site-card';
 import SiteTable from '../site-table';
 import { formatSites } from '../utils';
@@ -8,10 +8,14 @@ import type { ReactElement } from 'react';
 
 import './style.scss';
 
-export default function SiteContent(): ReactElement {
-	const translate = useTranslate();
+interface Props {
+	data: Array< any > | undefined;
+	isError: boolean;
+	isFetching: boolean;
+}
 
-	const { data, error, isLoading } = useFetchDashboardSites();
+export default function SiteContent( { data, isError, isFetching }: Props ): ReactElement {
+	const translate = useTranslate();
 
 	const sites = formatSites( data );
 
@@ -38,17 +42,19 @@ export default function SiteContent(): ReactElement {
 		},
 	];
 
-	if ( ! isLoading && ! error && ! sites.length ) {
+	if ( ! isFetching && ! isError && ! sites.length ) {
 		return <div className="site-content__no-sites">{ translate( 'No active sites' ) }</div>;
 	}
 
 	return (
 		<>
-			<SiteTable isFetching={ isLoading } columns={ columns } items={ sites } />
+			<SiteTable isFetching={ isFetching } columns={ columns } items={ sites } />
 			<div className="site-content__mobile-view">
 				<>
-					{ isLoading || error ? (
-						<JetpackLogo size={ 72 } className="site-content__logo" />
+					{ isFetching ? (
+						<Card>
+							<TextPlaceholder />
+						</Card>
 					) : (
 						<>
 							{ sites.length > 0 &&

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -10,6 +10,3 @@
 		display: none;
 	}
 }
-.site-content__card.is-compact {
-	padding: 0;
-}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
 import Search from 'calypso/components/search';
 import { setQueryArgs } from 'calypso/lib/query-args';
+import type { ReactElement } from 'react';
 
 export default function SiteSearch( {
 	searchQuery,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search/index.tsx
@@ -1,0 +1,31 @@
+import { useTranslate } from 'i18n-calypso';
+import { ReactElement } from 'react';
+import Search from 'calypso/components/search';
+import useUrlSearch from 'calypso/lib/url-search/use-url-search';
+
+export default function SiteSearch( {
+	searchQuery,
+	handleSearch,
+}: {
+	searchQuery: string | null;
+	handleSearch: ( query: string ) => void;
+} ): ReactElement {
+	const translate = useTranslate();
+	const { doSearch } = useUrlSearch();
+
+	const handleSearchSites = ( query: string ) => {
+		doSearch( query );
+		handleSearch( query );
+	};
+
+	return (
+		<Search
+			isOpen
+			hideClose={ ! searchQuery }
+			initialValue={ searchQuery }
+			onSearch={ handleSearchSites }
+			placeholder={ translate( 'Search sites' ) }
+			delaySearch={ true }
+		/>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
 import Search from 'calypso/components/search';
-import useUrlSearch from 'calypso/lib/url-search/use-url-search';
+import { setQueryArgs } from 'calypso/lib/query-args';
 
 export default function SiteSearch( {
 	searchQuery,
@@ -11,10 +11,9 @@ export default function SiteSearch( {
 	handleSearch: ( query: string ) => void;
 } ): ReactElement {
 	const translate = useTranslate();
-	const { doSearch } = useUrlSearch();
 
 	const handleSearchSites = ( query: string ) => {
-		doSearch( query );
+		setQueryArgs( '' !== query ? { s: query } : {} );
 		handleSearch( query );
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -13,6 +13,11 @@
 		padding: 6px 16px;
 	}
 }
+.sites-overview__search {
+	@include break-large() {
+		display: none;
+	}
+}
 .sites-overview__page-title-container {
 	display: none;
 	@include break-large() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds search to the agency dashboard only in the small screen view(<960px) along with fetching animation of cards while searching.
* This also adds a condition that makes sure the root component(`<SiteOverview />`) is not rendered if the agency dashboard feature flag is not enabled. This will guarantee that no API calls are made when a user hits `/dashboard` manually and the feature is not enabled.

#### Testing instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb

**Instructions**

1. Run `git checkout add/implement-search-for-agency-dashboard` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard
4. Switch to small screen view(<960px) using the dev tool(inspect).
5. Verify that search is visible only on small screens(<960px) and hidden on large screens(>960px) 
6. Try entering some text in the search box and verify the results are appearing as expected.
7. Verify that the URL is appended with `?s={searchterm)` and the API call is being made(Since we have a delay(debounce with 300ms) in search, there won't be an API call on every key entered unless there is a delay between them) with params `?q=${searchterm}`

**Screenshots**

<img width="359" alt="Screenshot 2022-05-19 at 6 39 50 PM" src="https://user-images.githubusercontent.com/10586875/169463188-2a544f28-cd69-4d13-8c76-578007780b38.png">

<img width="348" alt="Screenshot 2022-05-19 at 6 40 14 PM" src="https://user-images.githubusercontent.com/10586875/169463189-9e70d6c9-7b1d-404e-b7fd-0cebfb7fd64a.png">

<img width="349" alt="Screenshot 2022-05-19 at 6 40 22 PM" src="https://user-images.githubusercontent.com/10586875/169463191-7447d880-c847-4cea-a384-b22b86d6e4a0.png">

Large screen view(no search shown)

<img width="1920" alt="Screenshot 2022-05-20 at 11 32 33 AM" src="https://user-images.githubusercontent.com/10586875/169463167-8bb494d2-f0ea-4a54-8440-ad00f7aad402.png">

Related to 1202076982646589-as-1202122273254236