### PR TITLE
Replace Pro plan mentions in Domain Transfer copy

### DIFF
--- a/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
@@ -21,7 +21,7 @@ export function getMappingFreeText( {
 	) {
 		mappingFreeText = __( 'No additional charge with your plan' );
 	} else if ( primaryWithPlansOnly || isSignupStep ) {
-		mappingFreeText = __( 'Included in Pro plan' );
+		mappingFreeText = __( 'Included in paid plans' );
 	}
 
 	return mappingFreeText;

--- a/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
@@ -4,6 +4,7 @@ import {
 	isDomainMappingFree,
 	isNextDomainFree,
 } from 'calypso/lib/cart-values/cart-items';
+import { isStarterPlanEnabled } from 'calypso/my-sites/plans-comparison';
 
 export function getMappingFreeText( {
 	cart,
@@ -21,7 +22,9 @@ export function getMappingFreeText( {
 	) {
 		mappingFreeText = __( 'No additional charge with your plan' );
 	} else if ( primaryWithPlansOnly || isSignupStep ) {
-		mappingFreeText = __( 'Included in paid plans' );
+		mappingFreeText = isStarterPlanEnabled()
+			? __( 'Included in paid plans' )
+			: __( 'Included in Pro plan' );
 	}
 
 	return mappingFreeText;

--- a/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { isDomainBundledWithPlan, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
+import { isStarterPlanEnabled } from 'calypso/my-sites/plans-comparison';
 
 export function getTransferFreeText( { cart, domain, isSignupStep, siteIsOnPaidPlan } ) {
 	const siteHasNoPaidPlan = ! siteIsOnPaidPlan || isSignupStep;
@@ -9,7 +10,9 @@ export function getTransferFreeText( { cart, domain, isSignupStep, siteIsOnPaidP
 	if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, domain ) ) {
 		domainProductFreeText = __( 'Free transfer with your plan' );
 	} else if ( siteHasNoPaidPlan ) {
-		domainProductFreeText = __( 'Included in paid plans' );
+		domainProductFreeText = isStarterPlanEnabled()
+			? __( 'Included in paid plans' )
+			: __( 'Included in Pro plan' );
 	}
 
 	return domainProductFreeText;

--- a/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
@@ -9,7 +9,7 @@ export function getTransferFreeText( { cart, domain, isSignupStep, siteIsOnPaidP
 	if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, domain ) ) {
 		domainProductFreeText = __( 'Free transfer with your plan' );
 	} else if ( siteHasNoPaidPlan ) {
-		domainProductFreeText = __( 'Included in Pro plan' );
+		domainProductFreeText = __( 'Included in paid plans' );
 	}
 
 	return domainProductFreeText;

--- a/client/components/domains/use-my-domain/utilities/get-transfer-price-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-price-text.js
@@ -1,12 +1,13 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { isDomainBundledWithPlan, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
 import { getDomainPrice, getDomainProductSlug } from 'calypso/lib/domains';
+import { isStarterPlanEnabled } from 'calypso/my-sites/plans-comparison';
 
 export function getTransferPriceText( { cart, currencyCode, domain, productsList } ) {
 	const productSlug = getDomainProductSlug( domain );
 	const domainProductPrice = getDomainPrice( productSlug, productsList, currencyCode );
 
-	if ( ! domainProductPrice ) {
+	if ( ! domainProductPrice || isStarterPlanEnabled() ) {
 		return;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This replaces the mentioned Pro plan with paid plans in Domain Transfer copy.

<img width="320" src="https://user-images.githubusercontent.com/2749938/169515665-a17bd90e-651f-4dfd-902d-d980a626d2e2.jpg" />

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/domains/use-your-domain`
* Submit a valid domain 
* The bottom paragraphs should mention `Included in paid plans`
* The pricing beneath should also be removed
<img width="320" alt="Screenshot on 2022-05-20 at 15-49-37" src="https://user-images.githubusercontent.com/2749938/169531616-07cadb74-6872-4dc3-9cb1-a3e3408b6b87.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

