### PR TITLE
Data Layer: Cleanup `retryOnFailure` tests

### DIFF
--- a/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/test/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/test/index.js
@@ -84,29 +84,29 @@ describe( '#retryOnFailure', () => {
 		expect(
 			retryIt( { ...inbound, originalRequest: inbound.store.dispatch.mock.lastCall[ 0 ] } )
 		).toHaveProperty( 'shouldAbort', true );
-		expect( inbound.store.dispatch.mock.calls.length ).toEqual( 1 );
+		expect( inbound.store.dispatch ).toBeCalledTimes( 1 );
 
 		jest.advanceTimersByTime( 1337 );
-		expect( inbound.store.dispatch.mock.calls.length ).toEqual( 2 );
+		expect( inbound.store.dispatch ).toBeCalledTimes( 2 );
 		expect( inbound.store.dispatch ).toBeCalledWith( withRetries( 2 )( originalRequest ) );
 
 		// retry 3
 		expect(
 			retryIt( { ...inbound, originalRequest: inbound.store.dispatch.mock.lastCall[ 0 ] } )
 		).toHaveProperty( 'shouldAbort', true );
-		expect( inbound.store.dispatch.mock.calls.length ).toEqual( 2 );
+		expect( inbound.store.dispatch ).toBeCalledTimes( 2 );
 
 		jest.advanceTimersByTime( 1337 );
-		expect( inbound.store.dispatch.mock.calls.length ).toEqual( 3 );
+		expect( inbound.store.dispatch ).toBeCalledTimes( 3 );
 		expect( inbound.store.dispatch ).toBeCalledWith( withRetries( 3 )( originalRequest ) );
 
 		// retry 4
 		const finalRequest = { ...inbound, originalRequest: inbound.store.dispatch.mock.lastCall[ 0 ] };
 		expect( retryIt( finalRequest ) ).toEqual( finalRequest );
-		expect( inbound.store.dispatch.mock.calls.length ).toEqual( 3 );
+		expect( inbound.store.dispatch ).toBeCalledTimes( 3 );
 
 		jest.advanceTimersByTime( 1337 );
-		expect( inbound.store.dispatch.mock.calls.length ).toEqual( 3 );
+		expect( inbound.store.dispatch ).toBeCalledTimes( 3 );
 	} );
 
 	test( 'should handle `exponentialBackoff`', () => {

--- a/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/test/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/test/index.js
@@ -4,6 +4,8 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { retryOnFailure as rof } from '../';
 import { noRetry, exponentialBackoff } from '../policies';
 
+jest.useFakeTimers();
+
 const retryOnFailure = rof();
 const retryWithDelay = ( delay ) => rof( () => delay );
 
@@ -24,94 +26,87 @@ const withRetries = ( retryCount ) => ( actionOrInbound ) =>
 		  } )
 		: merge( actionOrInbound, { meta: { dataLayer: { retryCount } } } );
 
+const createMockStore = () => ( { dispatch: jest.fn() } );
+
 describe( '#retryOnFailure', () => {
-	let dispatch;
-	let store;
-
-	beforeEach( () => {
-		jest.useFakeTimers();
-		dispatch = jest.fn();
-		store = { dispatch };
-	} );
-
 	test( 'should pass through initially successful requests', () => {
-		const inbound = { nextData: 1, originalRequest: getSites, store };
+		const inbound = { nextData: 1, originalRequest: getSites, store: createMockStore() };
 
 		expect( retryOnFailure( inbound ) ).toEqual( inbound );
 
 		jest.advanceTimersByTime( 20000 );
-		expect( dispatch ).not.toBeCalled();
+		expect( inbound.store.dispatch ).not.toBeCalled();
 	} );
 
 	test( 'should pass through no-retry failed requests', () => {
 		const originalRequest = { ...getSites, options: { retryPolicy: noRetry() } };
-		const inbound = { nextError, originalRequest, store };
+		const inbound = { nextError, originalRequest, store: createMockStore() };
 
 		expect( retryOnFailure( inbound ) ).toEqual( inbound );
 
 		jest.advanceTimersByTime( 20000 );
-		expect( dispatch ).not.toBeCalled();
+		expect( inbound.store.dispatch ).not.toBeCalled();
 	} );
 
 	test( 'should pass through POST requests', () => {
 		const originalRequest = { ...getSites, method: 'POST' };
-		const inbound = { nextError, originalRequest, store };
+		const inbound = { nextError, originalRequest, store: createMockStore() };
 
 		expect( retryOnFailure( inbound ) ).toEqual( inbound );
 
 		jest.advanceTimersByTime( 20000 );
-		expect( dispatch ).not.toBeCalled();
+		expect( inbound.store.dispatch ).not.toBeCalled();
 	} );
 
 	test( 'should requeue a plain failed request', () => {
-		const inbound = { nextError, originalRequest: getSites, store };
+		const inbound = { nextError, originalRequest: getSites, store: createMockStore() };
 
 		expect( retryWithDelay( 1337 )( inbound ) ).toHaveProperty( 'shouldAbort', true );
-		expect( dispatch ).not.toBeCalled();
+		expect( inbound.store.dispatch ).not.toBeCalled();
 
 		jest.advanceTimersByTime( 1337 );
-		expect( dispatch ).toBeCalledWith( withRetries( 1 )( getSites ) );
+		expect( inbound.store.dispatch ).toBeCalledWith( withRetries( 1 )( getSites ) );
 	} );
 
 	test( 'should requeue only up to `maxAttempts`', () => {
 		const originalRequest = { ...getSites, options: { retryPolicy: { maxAttempts: 3 } } };
-		const inbound = { nextError, originalRequest, store };
+		const inbound = { nextError, originalRequest, store: createMockStore() };
 		const retryIt = retryWithDelay( 1337 );
 
 		// retry 1
 		expect( retryIt( inbound ) ).toHaveProperty( 'shouldAbort', true );
-		expect( dispatch ).not.toBeCalled();
+		expect( inbound.store.dispatch ).not.toBeCalled();
 
 		jest.advanceTimersByTime( 1337 );
-		expect( dispatch ).toBeCalledWith( withRetries( 1 )( originalRequest ) );
+		expect( inbound.store.dispatch ).toBeCalledWith( withRetries( 1 )( originalRequest ) );
 
 		// retry 2
 		expect(
-			retryIt( { ...inbound, originalRequest: dispatch.mock.lastCall[ 0 ] } )
+			retryIt( { ...inbound, originalRequest: inbound.store.dispatch.mock.lastCall[ 0 ] } )
 		).toHaveProperty( 'shouldAbort', true );
-		expect( dispatch.mock.calls.length ).toEqual( 1 );
+		expect( inbound.store.dispatch.mock.calls.length ).toEqual( 1 );
 
 		jest.advanceTimersByTime( 1337 );
-		expect( dispatch.mock.calls.length ).toEqual( 2 );
-		expect( dispatch ).toBeCalledWith( withRetries( 2 )( originalRequest ) );
+		expect( inbound.store.dispatch.mock.calls.length ).toEqual( 2 );
+		expect( inbound.store.dispatch ).toBeCalledWith( withRetries( 2 )( originalRequest ) );
 
 		// retry 3
 		expect(
-			retryIt( { ...inbound, originalRequest: dispatch.mock.lastCall[ 0 ] } )
+			retryIt( { ...inbound, originalRequest: inbound.store.dispatch.mock.lastCall[ 0 ] } )
 		).toHaveProperty( 'shouldAbort', true );
-		expect( dispatch.mock.calls.length ).toEqual( 2 );
+		expect( inbound.store.dispatch.mock.calls.length ).toEqual( 2 );
 
 		jest.advanceTimersByTime( 1337 );
-		expect( dispatch.mock.calls.length ).toEqual( 3 );
-		expect( dispatch ).toBeCalledWith( withRetries( 3 )( originalRequest ) );
+		expect( inbound.store.dispatch.mock.calls.length ).toEqual( 3 );
+		expect( inbound.store.dispatch ).toBeCalledWith( withRetries( 3 )( originalRequest ) );
 
 		// retry 4
-		const finalRequest = { ...inbound, originalRequest: dispatch.mock.lastCall[ 0 ] };
+		const finalRequest = { ...inbound, originalRequest: inbound.store.dispatch.mock.lastCall[ 0 ] };
 		expect( retryIt( finalRequest ) ).toEqual( finalRequest );
-		expect( dispatch.mock.calls.length ).toEqual( 3 );
+		expect( inbound.store.dispatch.mock.calls.length ).toEqual( 3 );
 
 		jest.advanceTimersByTime( 1337 );
-		expect( dispatch.mock.calls.length ).toEqual( 3 );
+		expect( inbound.store.dispatch.mock.calls.length ).toEqual( 3 );
 	} );
 
 	test( 'should handle `exponentialBackoff`', () => {
@@ -119,33 +114,33 @@ describe( '#retryOnFailure', () => {
 			...getSites,
 			options: { retryPolicy: exponentialBackoff( { delay: 1000, maxAttempts: 5 } ) },
 		};
-		const inbound = { nextError, originalRequest, store };
+		const inbound = { nextError, originalRequest, store: createMockStore() };
 
 		// retry 1
 		expect( retryOnFailure( inbound ) ).toHaveProperty( 'shouldAbort', true );
-		expect( dispatch ).not.toBeCalled();
+		expect( inbound.store.dispatch ).not.toBeCalled();
 
 		jest.advanceTimersByTime( 1000 + 3 * 1000 );
-		expect( dispatch ).toBeCalledTimes( 1 );
+		expect( inbound.store.dispatch ).toBeCalledTimes( 1 );
 
 		jest.advanceTimersByTime( 200000 );
-		expect( dispatch ).toBeCalledTimes( 1 );
+		expect( inbound.store.dispatch ).toBeCalledTimes( 1 );
 
 		// retry 4 (should have much longer delay)
 		expect( retryOnFailure( withRetries( 4 )( inbound ) ) ).toHaveProperty( 'shouldAbort', true );
-		expect( dispatch ).toBeCalledTimes( 1 );
+		expect( inbound.store.dispatch ).toBeCalledTimes( 1 );
 
 		jest.advanceTimersByTime( 1000 + 3 * 16000 );
-		expect( dispatch ).toBeCalledTimes( 2 );
+		expect( inbound.store.dispatch ).toBeCalledTimes( 2 );
 
 		jest.advanceTimersByTime( 200000 );
-		expect( dispatch ).toBeCalledTimes( 2 );
+		expect( inbound.store.dispatch ).toBeCalledTimes( 2 );
 
 		// retry 5 (should not retry)
 		expect( retryOnFailure( withRetries( 5 )( inbound ) ) ).toEqual( withRetries( 5 )( inbound ) );
-		expect( dispatch ).toBeCalledTimes( 2 );
+		expect( inbound.store.dispatch ).toBeCalledTimes( 2 );
 
 		jest.advanceTimersByTime( 200000 );
-		expect( dispatch ).toBeCalledTimes( 2 );
+		expect( inbound.store.dispatch ).toBeCalledTimes( 2 );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a follow-up cleanup to https://github.com/Automattic/wp-calypso/pull/63816#pullrequestreview-978621278

#### Testing instructions

Verify tests pass: `yarn run test-client client/state/data-layer/wpcom-http/pipeline/retry-on-failure/test/index.js`