### PR TITLE
Implement the no-ads add-on upsell for the Free plan and the Starter plan

### DIFF
--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -16,7 +16,6 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -24,7 +23,6 @@ import './style.scss';
 
 export const Sharing = ( {
 	contentComponent,
-	currentPlanSlug,
 	pathname,
 	showButtons,
 	showConnections,
@@ -157,7 +155,7 @@ export const Sharing = ( {
 					</NavTabs>
 				</SectionNav>
 			) }
-			{ ! isVip && ! isJetpack && currentPlanSlug && (
+			{ ! isVip && ! isJetpack && (
 				<UpsellNudge
 					event="sharing_no_ads"
 					feature={ WPCOM_FEATURES_NO_ADVERTS }
@@ -176,7 +174,6 @@ export const Sharing = ( {
 Sharing.propTypes = {
 	canManageOptions: PropTypes.bool,
 	contentComponent: PropTypes.node,
-	currentPlanSlug: PropTypes.string,
 	isVipSite: PropTypes.bool,
 	path: PropTypes.string,
 	showButtons: PropTypes.bool,
@@ -192,10 +189,8 @@ export default connect( ( state ) => {
 	const isJetpack = isJetpackSite( state, siteId );
 	const isAtomic = isSiteWpcomAtomic( state, siteId );
 	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
-	const currentPlanSlug = getCurrentPlan( state, siteId )?.productSlug;
 
 	return {
-		currentPlanSlug,
 		isP2Hub: isSiteP2Hub( state, siteId ),
 		showButtons: siteId && canManageOptions,
 		showConnections: !! siteId,

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -1,4 +1,4 @@
-import { WPCOM_FEATURES_NO_ADVERTS, isFreePlan, isStarterPlan } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_NO_ADVERTS } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
@@ -12,7 +12,6 @@ import Main from 'calypso/components/main';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import { isStarterPlanEnabled } from 'calypso/my-sites/plans-comparison';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
@@ -126,21 +125,8 @@ export const Sharing = ( {
 		titleHeader = translate( 'Integrations' );
 	}
 
-	// Determine the right type of upsell according to the plan.
-	// For the Free plan and the Starter plan, we want to upsell the no-ads add-on.
-	// Otherwise, it upsells the Pro plan.
-	let upsellNudgeTitle = translate( 'No ads with WordPress.com Pro' );
-	let upsellNudgeDesc = translate( 'Prevent ads from showing on your site.' );
-	let upsellNudgeHref;
-
-	if (
-		isStarterPlanEnabled() &&
-		( isFreePlan( currentPlanSlug ) || isStarterPlan( currentPlanSlug ) )
-	) {
-		upsellNudgeTitle = translate( 'Remove ads from your site with the No-Ads add-on' );
-		upsellNudgeDesc = translate( 'Click here to add to cart and continue.' );
-		upsellNudgeHref = `/checkout/${ siteSlug }/no-ads`;
-	}
+	const upsellNudgeTitle = translate( 'Remove ads from your site with the No Ads add-on' );
+	const upsellNudgeHref = `/checkout/${ siteSlug }/no-ads`;
 
 	const selected = find( filters, { route: pathname } );
 	return (
@@ -176,7 +162,6 @@ export const Sharing = ( {
 					event="sharing_no_ads"
 					feature={ WPCOM_FEATURES_NO_ADVERTS }
 					href={ upsellNudgeHref }
-					description={ upsellNudgeDesc }
 					title={ upsellNudgeTitle }
 					tracksImpressionName="calypso_upgrade_nudge_impression"
 					tracksClickName="calypso_upgrade_nudge_cta_click"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the upsell banner in the marketing tool page as:

* For the Free plan and the Starter plan, it upsells the no-ads add-on.
* Otherwise, it's the Pro plan upsell as it used to be.

Here is the new upsell:
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/1842898/169528329-10e44edf-c3d7-4e71-88ec-495be60d68b5.png">

TODO: Change the `href` prop to the right checkout URL once the product is ready.

#### Testing instructions

1. Accessing /marketing/tools from a Free site with `plans/starter-plan` enabled, the no-ads banner should show.
2. Accessing /marketing/tools from a Starter site with `plans/starter-plan` enabled, the no-ads banner should show.
3. Accessing /marketing/tools from a Free site with `plans/starter-plan` disabled, the Pro banner should show. 
4. Accessing /marketing/tools from a Personal/Premium/Business/eCommerce/Pro site, there shouldn't be a banner.