### PR TITLE
Disable "Add new mailbox" button when awaiting Google ToS

### DIFF
--- a/client/components/vertical-nav/item/index.jsx
+++ b/client/components/vertical-nav/item/index.jsx
@@ -53,7 +53,7 @@ class VerticalNavItem extends Component {
 			return this.renderPlaceholder();
 		}
 
-		const compactCardClassNames = classNames( 'vertical-nav-item', className );
+		const compactCardClassNames = classNames( 'vertical-nav-item', className, { disabled } );
 
 		const linkProps = external ? { target: '_blank', rel: 'noreferrer' } : {};
 

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -15,6 +15,7 @@ import {
 	getGoogleAdminUrl,
 	getGoogleMailServiceFamily,
 	getGSuiteProductSlug,
+	getGSuiteSubscriptionStatus,
 	getProductType,
 	hasGSuiteWithUs,
 } from 'calypso/lib/gsuite';
@@ -266,14 +267,11 @@ const EmailPlan = ( props ) => {
 				);
 			}
 
-			if ( canAddMailboxes ) {
-				return (
-					<VerticalNavItem { ...getAddMailboxProps() }>
-						{ translate( 'Add new mailboxes' ) }
-					</VerticalNavItem>
-				);
-			}
-			return null;
+			return (
+				<VerticalNavItem { ...getAddMailboxProps() } disabled={ ! canAddMailboxes }>
+					{ translate( 'Add new mailboxes' ) }
+				</VerticalNavItem>
+			);
 		}
 
 		return (
@@ -357,8 +355,8 @@ EmailPlan.propType = {
 export default connect( ( state, ownProps ) => {
 	return {
 		canAddMailboxes:
-			Boolean( getGSuiteProductSlug( ownProps.domain ) ) ||
-			Boolean( getTitanProductSlug( ownProps.domain ) ),
+			( getGSuiteProductSlug( ownProps.domain ) || getTitanProductSlug( ownProps.domain ) ) &&
+			getGSuiteSubscriptionStatus( ownProps.domain ) !== 'suspended',
 		currentRoute: getCurrentRoute( state ),
 		emailForwards: getEmailForwards( state, ownProps.domain.name ),
 		isLoadingEmailForwards: isRequestingEmailForwards( state, ownProps.domain.name ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- When a user has purchased a Google Workspace license but hasn't yet logged in to accept Google's ToS, we want to prevent them from adding additional mailboxes. This PR disables the "Add new mailbox" button until the user has taken that action.
- Apply the CSS class `disabled` to `VerticalNavItem` when the `disabled` prop is present. This activates existing styling that more clearly distinguishes between active and disabled states.
- The "Add new mailbox" button is now disabled during mailbox provisioning as well (implemented in #62556). It doesn't look like there was consensus around which approach we should use between disabling/hiding, but I figured it could make sense to use the same approach in this case.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have an account without any email accounts
2. Purchase a Google Workspace license
3. Go to /email/{domainName}/manage/{siteSlug}
4. Notice that there is a warning at the top of the page that says "You need to log in to the Google Admin console to accept the Terms of Service before you can access your mailboxes."
5. The "Add new mailbox" button should be greyed out and should not be clickable.

![lorem](https://user-images.githubusercontent.com/1101677/169530423-56083e43-a0fe-4716-85a3-bb793440393e.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62556
