### PR TITLE
Remove more Lodash after removing _.take

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -1,5 +1,5 @@
 import { Gridicon } from '@automattic/components';
-import { get, map, values } from 'lodash';
+import { get, values } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
@@ -80,10 +80,11 @@ class PostByline extends Component {
 		const streamUrl = getStreamUrl( feedId, siteId );
 		const siteIcon = get( site, 'icon.img' );
 		const feedIcon = get( feed, 'image' );
-		let tagsInOccurrenceOrder = values( post.tags );
+		const tagsInOccurrenceOrder = values( post.tags );
 		tagsInOccurrenceOrder.sort( ( a, b ) => b.post_count - a.post_count );
-		tagsInOccurrenceOrder = tagsInOccurrenceOrder.slice( 0, TAGS_TO_SHOW );
-		const tags = map( tagsInOccurrenceOrder, ( tag ) => <TagLink tag={ tag } key={ tag.slug } /> );
+		const tags = tagsInOccurrenceOrder
+			.slice( 0, TAGS_TO_SHOW )
+			.map( ( tag ) => <TagLink tag={ tag } key={ tag.slug } /> );
 
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -1,4 +1,3 @@
-import { map, filter } from 'lodash';
 import PropTypes from 'prop-types';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import AutoDirection from 'calypso/components/auto-direction';
@@ -16,13 +15,12 @@ function getGalleryWorthyImages( post ) {
 		images.splice( indexToRemove, 1 );
 	}
 
-	const worthyImages = filter( images, imageIsBigEnoughForGallery );
-	return worthyImages.slice( 0, numberOfImagesToDisplay );
+	return images.filter( imageIsBigEnoughForGallery ).slice( 0, numberOfImagesToDisplay );
 }
 
 const PostGallery = ( { post, children, isDiscover } ) => {
 	const imagesToDisplay = getGalleryWorthyImages( post );
-	const listItems = map( imagesToDisplay, ( image, index ) => {
+	const listItems = imagesToDisplay.map( ( image, index ) => {
 		const imageUrl = resizeImageUrl( image.src, {
 			w: READER_CONTENT_WIDTH / imagesToDisplay.length,
 		} );

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -1,17 +1,6 @@
 import classNames from 'classnames';
 import i18n from 'i18n-calypso';
-import {
-	has,
-	pick,
-	pickBy,
-	without,
-	isEmpty,
-	filter,
-	map,
-	sortBy,
-	partition,
-	includes,
-} from 'lodash';
+import { has, pick, pickBy, without, isEmpty, map, sortBy, partition, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { cosineSimilarity } from 'calypso/lib/trigram';
@@ -202,9 +191,9 @@ class KeyedSuggestions extends Component {
 		const filtered = {};
 
 		//If this is valid full taxonomy:filter we want to show alternatives instead of suggestions
-		if ( filterText !== undefined && includes( terms[ taxonomy ], filter ) ) {
+		if ( filterText !== undefined && includes( terms[ taxonomy ], filterText ) ) {
 			// remove what is already in input - so we can add it to the beggining of the list
-			const otherSuggestions = without( terms[ taxonomy ], filter );
+			const otherSuggestions = without( terms[ taxonomy ], filterText );
 			// add back at the beggining of the list so it will showup first.
 			otherSuggestions.unshift( filterText );
 			// limit or show all
@@ -283,14 +272,14 @@ class KeyedSuggestions extends Component {
 					return max_seen > SEARCH_THRESHOLD;
 				};
 
-				filtered[ key ] = filter(
-					map( terms[ key ], ( term, k ) =>
-						cleanFilterTerm === '' ||
-						matcher( term.name.toLowerCase(), cleanFilterTerm.toLowerCase() )
-							? k
-							: null
-					)
-				).slice( 0, limit );
+				filtered[ key ] = map( terms[ key ], ( term, k ) =>
+					cleanFilterTerm === '' ||
+					matcher( term.name.toLowerCase(), cleanFilterTerm.toLowerCase() )
+						? k
+						: null
+				)
+					.filter( Boolean )
+					.slice( 0, limit );
 			}
 		}
 		return this.removeEmptySuggestions( filtered );

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import debugFactory from 'debug';
-import { clone, difference, forEach, last, map, some } from 'lodash';
+import { difference } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import isSuggestionLabel from './helpers';
@@ -33,7 +33,7 @@ class TokenField extends PureComponent {
 				return new Error( 'Value prop is expected to be an array.' );
 			}
 
-			forEach( value, ( item ) => {
+			for ( const item of value ) {
 				if ( 'object' === typeof item ) {
 					if ( ! ( 'value' in item ) ) {
 						return new Error(
@@ -41,7 +41,7 @@ class TokenField extends PureComponent {
 						);
 					}
 				}
-			} );
+			}
 		},
 	};
 
@@ -129,7 +129,7 @@ class TokenField extends PureComponent {
 	}
 
 	_renderTokensAndInput = () => {
-		const components = map( this.props.value, this._renderToken );
+		const components = this.props.value.map( this._renderToken );
 
 		components.splice( this._getIndexOfInput(), 0, this._renderInput() );
 
@@ -243,7 +243,7 @@ class TokenField extends PureComponent {
 		}
 
 		this.setState( {
-			incompleteTokenValue: last( items ) || '',
+			incompleteTokenValue: items[ items.length - 1 ] || '',
 			selectedSuggestionIndex: -1,
 			selectedSuggestionScroll: false,
 		} );
@@ -493,8 +493,8 @@ class TokenField extends PureComponent {
 		debug( '_addNewTokens: tokensToAdd', tokensToAdd );
 
 		if ( tokensToAdd.length > 0 ) {
-			const newValue = clone( this.props.value );
-			newValue.splice.apply( newValue, [ this._getIndexOfInput(), 0 ].concat( tokensToAdd ) );
+			const newValue = [ ...this.props.value ];
+			newValue.splice( this._getIndexOfInput(), 0, ...tokensToAdd );
 			debug( '_addNewTokens: onChange', newValue );
 			this.props.onChange( newValue );
 		}
@@ -516,7 +516,7 @@ class TokenField extends PureComponent {
 	};
 
 	_valueContainsToken = ( token ) => {
-		return some( this.props.value, ( item ) => {
+		return this.props.value.some( ( item ) => {
 			return this._getTokenValue( token ) === this._getTokenValue( item );
 		} );
 	};


### PR DESCRIPTION
While reviewing #63176 I noticed a few other obvious Lodash removal opportunities, typically `map` or `filter` usages, in the affected files. This PR performs them.

In addition to the refactoring, I found and fixed one funny bug in the `<KeyedSuggestions>` component, introduced in #37629. String lookup was done with `includes( array, filter )` where `filter` was the Lodash function, not the string to find -- that's `filterText`.