### PR TITLE
Stepper: Remove inline-help until further notice

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -12,10 +12,12 @@ import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { setupLocale } from 'calypso/boot/locale';
+import AsyncLoad from 'calypso/components/async-load';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
 import { createReduxStore } from 'calypso/state';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
+import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
 import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
 import { loadPersistedState } from 'calypso/state/persisted-state';
 import initialReducer from 'calypso/state/reducer';
@@ -40,8 +42,7 @@ function generateGetSuperProps() {
 }
 
 function initializeCalypsoUserStore( reduxStore: any, user: CurrentUser ) {
-	// This should be re-enabled if we bring back the inline-help component.
-	// reduxStore.dispatch( requestHappychatEligibility() );
+	config.isEnabled( 'signup/inline-help' ) && reduxStore.dispatch( requestHappychatEligibility() );
 	reduxStore.dispatch( setCurrentUser( user ) );
 	reduxStore.dispatch( requestSites() );
 }
@@ -105,6 +106,9 @@ window.AppBoot = async () => {
 					<BrowserRouter basename="setup">
 						<FlowWrapper user={ user as UserStore.CurrentUser } />
 					</BrowserRouter>
+					{ config.isEnabled( 'signup/inline-help' ) && (
+						<AsyncLoad require="calypso/blocks/inline-help" placeholder={ null } />
+					) }
 				</QueryClientProvider>
 			</Provider>
 		</CalypsoI18nProvider>,

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -12,12 +12,10 @@ import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { setupLocale } from 'calypso/boot/locale';
-import AsyncLoad from 'calypso/components/async-load';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
 import { createReduxStore } from 'calypso/state';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
-import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
 import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
 import { loadPersistedState } from 'calypso/state/persisted-state';
 import initialReducer from 'calypso/state/reducer';
@@ -41,8 +39,9 @@ function generateGetSuperProps() {
 	} );
 }
 
-function setupHappyChat( reduxStore: any, user: CurrentUser ) {
-	reduxStore.dispatch( requestHappychatEligibility() );
+function initializeCalypsoUserStore( reduxStore: any, user: CurrentUser ) {
+	// This should be re-enabled if we bring back the inline-help component.
+	// reduxStore.dispatch( requestHappychatEligibility() );
 	reduxStore.dispatch( setCurrentUser( user ) );
 	reduxStore.dispatch( requestSites() );
 }
@@ -96,7 +95,7 @@ window.AppBoot = async () => {
 	setStore( reduxStore, getStateFromCache( userId ) );
 	setupLocale( user, reduxStore );
 
-	user && setupHappyChat( reduxStore, user as CurrentUser );
+	user && initializeCalypsoUserStore( reduxStore, user as CurrentUser );
 
 	ReactDom.render(
 		<CalypsoI18nProvider i18n={ defaultCalypsoI18n }>
@@ -106,7 +105,6 @@ window.AppBoot = async () => {
 					<BrowserRouter basename="setup">
 						<FlowWrapper user={ user as UserStore.CurrentUser } />
 					</BrowserRouter>
-					<AsyncLoad require="calypso/blocks/inline-help" placeholder={ null } />
 				</QueryClientProvider>
 			</Provider>
 		</CalypsoI18nProvider>,

--- a/config/development.json
+++ b/config/development.json
@@ -141,6 +141,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
+		"signup/inline-help": false,
 		"signup/hero-flow-non-en": true,
 		"signup/site-vertical-step": true,
 		"signup/starting-point-courses": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -90,6 +90,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": false,
+		"signup/inline-help": false,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,

--- a/config/production.json
+++ b/config/production.json
@@ -103,6 +103,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": false,
+		"signup/inline-help": false,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -103,6 +103,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": false,
+		"signup/inline-help": false,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,

--- a/config/test.json
+++ b/config/test.json
@@ -74,6 +74,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"signup/anchor-fm": false,
+		"signup/inline-help": false,
 		"signup/social": true,
 		"signup/stepper-flow": true,
 		"site-indicator": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -112,6 +112,7 @@
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": false,
+		"signup/inline-help": false,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,


### PR DESCRIPTION
Following this slack discussion: p1652951847775919-slack-C02T4NVL4JJ we agreed that it would be best to remove the inline-help component from the Stepper until we get some design input about it.

#### Testing
1. Apply this PR.
2. Go through any/all the Stepper flow/s.
3. Verify you don't see a blue inline-help component in the bottom right of the window. 
4. Set the `config/inline-help` to true in `config/development.json`. (You'll probably need to restart Calypso after doing this).
5. Verify the inline-help component appears.