### PR TITLE
Masterbar: enable `My sites` link on theme section

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -206,7 +206,6 @@ class Layout extends Component {
 		return (
 			<MasterbarComponent
 				section={ this.props.sectionGroup }
-				sectionName={ this.props.sectionName }
 				isCheckout={ this.props.sectionName === 'checkout' }
 				isCheckoutPending={ this.props.sectionName === 'checkout-pending' }
 			/>

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -206,6 +206,7 @@ class Layout extends Component {
 		return (
 			<MasterbarComponent
 				section={ this.props.sectionGroup }
+				sectionName={ this.props.sectionName }
 				isCheckout={ this.props.sectionName === 'checkout' }
 				isCheckoutPending={ this.props.sectionName === 'checkout-pending' }
 			/>

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -46,6 +46,8 @@ const MENU_POPOVER_PREFERENCE_KEY = 'dismissible-card-masterbar-collapsable-menu
 
 const MOBILE_BREAKPOINT = '<480px';
 
+const FULL_WIDTH_SECTIONS = [ 'theme' ];
+
 class MasterbarLoggedIn extends Component {
 	state = {
 		isActionSearchVisible: false,
@@ -59,6 +61,7 @@ class MasterbarLoggedIn extends Component {
 		user: PropTypes.object.isRequired,
 		domainOnlySite: PropTypes.bool,
 		section: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+		sectionName: PropTypes.string,
 		setNextLayoutFocus: PropTypes.func.isRequired,
 		currentLayoutFocus: PropTypes.string,
 		siteSlug: PropTypes.string,
@@ -213,7 +216,8 @@ class MasterbarLoggedIn extends Component {
 			: getStatsPathForTab( 'day', siteSlug );
 
 		let mySitesUrl = domainOnlySite ? domainManagementList( siteSlug ) : homeUrl;
-		if ( 'sites' === section ) {
+		const isMainFullWidth = FULL_WIDTH_SECTIONS.includes( this.props.sectionName );
+		if ( 'sites' === section && ! isMainFullWidth ) {
 			mySitesUrl = '';
 		}
 		const icon =

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -45,14 +45,14 @@ const NEW_MASTERBAR_SHIPPING_DATE = new Date( 2022, 3, 14 ).getTime();
 const MENU_POPOVER_PREFERENCE_KEY = 'dismissible-card-masterbar-collapsable-menu-popover';
 
 const MOBILE_BREAKPOINT = '<480px';
-
-const FULL_WIDTH_SECTIONS = [ 'theme' ];
+const IS_RESPONSIVE_MENU_BREAKPOINT = '<782px';
 
 class MasterbarLoggedIn extends Component {
 	state = {
 		isActionSearchVisible: false,
 		isMenuOpen: false,
 		isMobile: isWithinBreakpoint( MOBILE_BREAKPOINT ),
+		isResponsiveMenu: isWithinBreakpoint( IS_RESPONSIVE_MENU_BREAKPOINT ),
 		// making the ref a state triggers a re-render when it changes (needed for popover)
 		menuBtnRef: null,
 	};
@@ -61,7 +61,6 @@ class MasterbarLoggedIn extends Component {
 		user: PropTypes.object.isRequired,
 		domainOnlySite: PropTypes.bool,
 		section: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
-		sectionName: PropTypes.string,
 		setNextLayoutFocus: PropTypes.func.isRequired,
 		currentLayoutFocus: PropTypes.string,
 		siteSlug: PropTypes.string,
@@ -77,6 +76,10 @@ class MasterbarLoggedIn extends Component {
 		this.unsubscribeToViewPortChanges = subscribeIsWithinBreakpoint(
 			MOBILE_BREAKPOINT,
 			( isMobile ) => this.setState( { isMobile } )
+		);
+		this.unsubscribeResponsiveMenuViewPortChanges = subscribeIsWithinBreakpoint(
+			IS_RESPONSIVE_MENU_BREAKPOINT,
+			( isResponsiveMenu ) => this.setState( { isResponsiveMenu } )
 		);
 	}
 	handleLayoutFocus = ( currentSection ) => {
@@ -109,6 +112,7 @@ class MasterbarLoggedIn extends Component {
 	componentWillUnmount() {
 		document.removeEventListener( 'keydown', this.actionSearchShortCutListener );
 		this.unsubscribeToViewPortChanges?.();
+		this.unsubscribeResponsiveMenuViewPortChanges?.();
 	}
 
 	clickMySites = () => {
@@ -209,15 +213,14 @@ class MasterbarLoggedIn extends Component {
 			isCustomerHomeEnabled,
 			section,
 		} = this.props;
-		const { isMenuOpen } = this.state;
+		const { isMenuOpen, isResponsiveMenu } = this.state;
 
 		const homeUrl = isCustomerHomeEnabled
 			? `/home/${ siteSlug }`
 			: getStatsPathForTab( 'day', siteSlug );
 
 		let mySitesUrl = domainOnlySite ? domainManagementList( siteSlug ) : homeUrl;
-		const isMainFullWidth = FULL_WIDTH_SECTIONS.includes( this.props.sectionName );
-		if ( 'sites' === section && ! isMainFullWidth ) {
+		if ( 'sites' === section && isResponsiveMenu ) {
 			mySitesUrl = '';
 		}
 		const icon =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`My sites` button is clickable when the user is in a different Group Section, like `Reader`.
- Now, the `My sites` is clickable in any case for the desktop version. And it is a link to `My Home`.
- For the tablet/mobile version, we keep the same current behavior that toggles the visibility of the menu.

#### Screencast


https://user-images.githubusercontent.com/779993/169977546-9bf3230d-5903-4b2b-ac67-dec4855dacb3.mp4





#### Testing instructions

**Test theme section**
- On any site.
- Go to **Appearance** > **Themes** , and select any theme.
- Observe the menu on the left is hidden.
- Click on `My Sites`.
- Observe you have navigated to `My home` in your current selected site.
- This behavior is similar to going to `Reader` or your Profile and then clicking to `My Sites`.

**Test any page**
- Click on any other page of the menu, for example, Posts.
- Click on `My Sites`.
- Observe you have navigated to `My home` in your current selected site.

Closes #49847
