### PR TITLE
Show Stripe Account in Dashboard

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -35,6 +35,7 @@ import { getEarningsWithDefaultsForSiteId } from 'calypso/state/memberships/earn
 import { requestDisconnectStripeAccount } from 'calypso/state/memberships/settings/actions';
 import {
 	getConnectedAccountIdForSiteId,
+	getConnectedAccountDescriptionForSiteId,
 	getConnectUrlForSiteId,
 } from 'calypso/state/memberships/settings/selectors';
 import {
@@ -340,8 +341,19 @@ class MembershipsSection extends Component {
 						<div className="memberships__module-plans-icon">
 							<Gridicon size={ 24 } icon={ 'link-break' } />
 						</div>
-						<div className="memberships__module-settings-title">
-							{ this.props.translate( 'Disconnect Stripe Account' ) }
+						<div>
+							<div className="memberships__module-settings-title">
+								{ this.props.translate( 'Disconnect Stripe Account' ) }
+							</div>
+							{ this.props.connectedAccountDescription ? (
+								<div className="memberships__module-settings-description">
+									{ this.props.translate( 'Connected to %(connectedAccountDescription)s', {
+										args: {
+											connectedAccountDescription: this.props.connectedAccountDescription,
+										},
+									} ) }
+								</div>
+							) : null }
 						</div>
 					</div>
 				</Card>
@@ -497,7 +509,7 @@ class MembershipsSection extends Component {
 		);
 	}
 
-	renderOnboarding( cta ) {
+	renderOnboarding( cta, intro ) {
 		const { translate } = this.props;
 
 		return (
@@ -528,6 +540,7 @@ class MembershipsSection extends Component {
 								)
 							) }
 						</p>
+						{ intro ? <p className="memberships__onboarding-paragraph">{ intro }</p> : null }
 						<p className="memberships__onboarding-paragraph">{ cta }</p>
 						<p className="memberships__onboarding-paragraph memberships__onboarding-paragraph-disclaimer">
 							<em>
@@ -596,7 +609,17 @@ class MembershipsSection extends Component {
 					>
 						{ this.props.translate( 'Connect Stripe to Get Started' ) }{ ' ' }
 						<Gridicon size={ 18 } icon={ 'external' } />
-					</Button>
+					</Button>,
+					this.props.connectedAccountDescription
+						? this.props.translate(
+								'Previously connected to Stripe account %(connectedAccountDescription)s',
+								{
+									args: {
+										connectedAccountDescription: this.props.connectedAccountDescription,
+									},
+								}
+						  )
+						: null
 				) }
 			</div>
 		);
@@ -656,6 +679,7 @@ const mapStateToProps = ( state ) => {
 		totalSubscribers: getTotalSubscribersForSiteId( state, siteId ),
 		subscribers: getOwnershipsForSiteId( state, siteId ),
 		connectedAccountId: getConnectedAccountIdForSiteId( state, siteId ),
+		connectedAccountDescription: getConnectedAccountDescriptionForSiteId( state, siteId ),
 		connectUrl: getConnectUrlForSiteId( state, siteId ),
 		hasStripeFeature:
 			hasActiveSiteFeature( state, siteId, FEATURE_PREMIUM_CONTENT_CONTAINER ) ||

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -244,6 +244,11 @@
 	align-items: center;
 }
 
+.memberships__module-settings-description {
+	color: var( --color-neutral-100 );
+	font-size: $font-body-small;
+}
+
 .memberships__module-plans-description {
 	color: var( --color-neutral-100 );
 	font-size: $font-body-small;

--- a/client/state/memberships/settings/reducer.js
+++ b/client/state/memberships/settings/reducer.js
@@ -9,6 +9,7 @@ export default ( state = {}, action ) => {
 
 				[ action.siteId ]: {
 					connectedAccountId: get( action, 'data.connected_account_id', null ),
+					connectedAccountDescription: get( action, 'data.connected_account_description', null ),
 					connectUrl: get( action, 'data.connect_url', null ),
 				},
 			};

--- a/client/state/memberships/settings/selectors.js
+++ b/client/state/memberships/settings/selectors.js
@@ -6,6 +6,10 @@ export function getConnectedAccountIdForSiteId( state, siteId ) {
 	return get( state, [ 'memberships', 'settings', siteId, 'connectedAccountId' ], null );
 }
 
+export function getConnectedAccountDescriptionForSiteId( state, siteId ) {
+	return get( state, [ 'memberships', 'settings', siteId, 'connectedAccountDescription' ], null );
+}
+
 export function getConnectUrlForSiteId( state, siteId ) {
 	return get( state, [ 'memberships', 'settings', siteId, 'connectUrl' ], '' );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `connected_account_description` from `memberships/status` to the store
* Show the currently connected account below the Disconnect action
* Show the previously connected account above the Connect action

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D80890-code to add the new API field
* Visit the Collect payments area of the Earn tools
* For a connected account, verify that it appears in the Disconnect row
* For a disconnected account that had created a plan, verify that it appears above the Connect button

<img width="948" alt="image" src="https://user-images.githubusercontent.com/38750/169601375-3c877f4d-3ff8-43ac-a14f-4e17cb033d44.png">
<img width="953" alt="image" src="https://user-images.githubusercontent.com/38750/169601734-41ff71e6-2fa3-46e4-bf01-6cbcc245b960.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #46551 
