### PR TITLE
Editing Toolkit: Prevent what's new plugin from being loaded on atomic sites.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -350,6 +350,9 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_coming_soon' );
  * What's New section of the Tools menu.
  */
 function load_whats_new() {
+	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+		return;
+	}
 	require_once __DIR__ . '/whats-new/class-whats-new.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_whats_new' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Do not load the what's new plugin on atomic sites.


#### Testing instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and navigate to `apps/apps/editing-toolkit/editing-toolkit-plugin`
* Run `yarn dev --sync`  to sync to your sandbox
* Verify that what's new feature works on Simple Sites.

For atomic sites
* Download the TeamCity Artifact editing-toolkit.zip (See [here](https://teamcity.a8c.com/viewLog.html?buildId=7942253&buildTypeId=calypso_WPComPlugins_EditorToolKit&tab=artifacts)) - _Make sure to click the editing-toolkit.zip filename and not the Download All link._
* Go to `wordpress.com/plugins/upload/{atomic_site_slug}` and drag n drop the editing-toolkit.zip file.
* After the plugin is installed ensure you are using the correct version.
* View a post and verify that the what's new feature is not loaded.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #56797

Before:
![Screenshot 2022-06-15 at 4 01 45 PM](https://user-images.githubusercontent.com/47489215/173929172-336a44b9-d77c-4b57-afa6-9600b5c929ae.png)

After:
![Screenshot 2022-06-15 at 4 00 40 PM](https://user-images.githubusercontent.com/47489215/173928984-487006ab-414c-484e-b418-a353718ce81b.png)

