### PR TITLE
CI: install `noto` font package for ci-e2e image.

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -86,6 +86,7 @@ ENV DISPLAY=:99
 RUN apt update \
 	&& apt-get install -y \
 		fonts-liberation \
+		fonts-noto \
 		git-restore-mtime \
 		gtk2-engines-pixbuf \
 		libappindicator3-1 \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -103,7 +103,6 @@ RUN apt update \
 		libxss1 \
 		libxss1 \
 		libxtst6 \
-		ttf-ubuntu-font-family \
 		xdg-utils \
 		xfonts-100dpi \
 		xfonts-75dpi \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -103,6 +103,7 @@ RUN apt update \
 		libxss1 \
 		libxss1 \
 		libxtst6 \
+		ttf-ubuntu-font-family \
 		xdg-utils \
 		xfonts-100dpi \
 		xfonts-75dpi \
@@ -110,13 +111,6 @@ RUN apt update \
 		xfonts-cyrillic \
 		xfonts-scalable \
 		xvfb
-
-WORKDIR /usr/share/fonts/opentype/noto
-RUN wget -O noto.zip "https://github.com/googlei18n/noto-cjk/blob/master/NotoSansCJK.ttc.zip?raw=true" \
-    && apt-get install -y unzip \
-    && unzip noto.zip \
-    && rm noto.zip \
-    && fc-cache -f -v
 
 RUN wget --no-verbose https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
 	&& apt-get install -y ./google-chrome-stable_current_amd64.deb \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -111,6 +111,13 @@ RUN apt update \
 		xfonts-scalable \
 		xvfb
 
+WORKDIR /usr/share/fonts/opentype/noto
+RUN wget -O noto.zip "https://github.com/googlei18n/noto-cjk/blob/master/NotoSansCJK.ttc.zip?raw=true" \
+    && apt-get install -y unzip \
+    && unzip noto.zip \
+    && rm noto.zip \
+    && fc-cache -f -v
+
 RUN wget --no-verbose https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
 	&& apt-get install -y ./google-chrome-stable_current_amd64.deb \
 	&& rm ./google-chrome-stable_current_amd64.deb


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR installs the `noto` font package to support CJK languages in CI tasks that use the `ci-e2e` image.

Context: https://github.com/Automattic/wp-calypso/issues/63771 and https://github.com/microsoft/playwright/issues/14187#issuecomment-1129494194.

#### Testing instructions

Closes https://github.com/Automattic/wp-calypso/issues/63771.
