### PR TITLE
Components: Replace Enzyme with react-testing-library in the `DateRange` component test

### DIFF
--- a/client/components/date-range/header.tsx
+++ b/client/components/date-range/header.tsx
@@ -20,24 +20,27 @@ const DateRangeHeader: FunctionComponent< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 
+	const cancelText = cancelButtonText || translate( 'Cancel' );
+	const applyText = applyButtonText || translate( 'Apply' );
+
 	return (
 		<div className="date-range__popover-header">
 			<Button
 				className="date-range__cancel-btn"
 				onClick={ onCancelClick }
 				compact
-				aria-label="Cancel"
+				aria-label={ cancelText }
 			>
-				{ cancelButtonText || translate( 'Cancel' ) }
+				{ cancelText }
 			</Button>
 			<Button
 				className="date-range__apply-btn"
 				onClick={ onApplyClick }
 				primary
 				compact
-				aria-label="Apply"
+				aria-label={ applyText }
 			>
-				{ applyButtonText || translate( 'Apply' ) }
+				{ applyText }
 			</Button>
 		</div>
 	);

--- a/client/components/date-range/header.tsx
+++ b/client/components/date-range/header.tsx
@@ -22,10 +22,21 @@ const DateRangeHeader: FunctionComponent< Props > = ( {
 
 	return (
 		<div className="date-range__popover-header">
-			<Button className="date-range__cancel-btn" onClick={ onCancelClick } compact>
+			<Button
+				className="date-range__cancel-btn"
+				onClick={ onCancelClick }
+				compact
+				aria-label="Cancel"
+			>
 				{ cancelButtonText || translate( 'Cancel' ) }
 			</Button>
-			<Button className="date-range__apply-btn" onClick={ onApplyClick } primary compact>
+			<Button
+				className="date-range__apply-btn"
+				onClick={ onApplyClick }
+				primary
+				compact
+				aria-label="Apply"
+			>
 				{ applyButtonText || translate( 'Apply' ) }
 			</Button>
 		</div>

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -1,12 +1,12 @@
-import { Button, Popover, Gridicon } from '@automattic/components';
+import {Button, Popover, Gridicon} from '@automattic/components';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
+import {localize} from 'i18n-calypso';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { createRef, Component } from 'react';
-import { DateUtils } from 'react-day-picker';
+import {createRef, Component} from 'react';
+import {DateUtils} from 'react-day-picker';
 import DatePicker from 'calypso/components/date-picker';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import {withLocalizedMoment} from 'calypso/components/localized-moment';
 import DateRangeHeader from './header';
 import DateRangeInputs from './inputs';
 import DateRangeTrigger from './trigger';
@@ -17,28 +17,28 @@ import './style.scss';
  * Module variables
  */
 const NO_DATE_SELECTED_VALUE = null;
-const noop = () => {};
+const noop = () => { };
 
 export class DateRange extends Component {
 	static propTypes = {
-		selectedStartDate: PropTypes.oneOfType( [
-			PropTypes.instanceOf( Date ),
-			PropTypes.instanceOf( moment ),
-		] ),
-		selectedEndDate: PropTypes.oneOfType( [
-			PropTypes.instanceOf( Date ),
-			PropTypes.instanceOf( moment ),
-		] ),
+		selectedStartDate: PropTypes.oneOfType([
+			PropTypes.instanceOf(Date),
+			PropTypes.instanceOf(moment),
+		]),
+		selectedEndDate: PropTypes.oneOfType([
+			PropTypes.instanceOf(Date),
+			PropTypes.instanceOf(moment),
+		]),
 		onDateSelect: PropTypes.func,
 		onDateCommit: PropTypes.func,
-		firstSelectableDate: PropTypes.oneOfType( [
-			PropTypes.instanceOf( Date ),
-			PropTypes.instanceOf( moment ),
-		] ),
-		lastSelectableDate: PropTypes.oneOfType( [
-			PropTypes.instanceOf( Date ),
-			PropTypes.instanceOf( moment ),
-		] ),
+		firstSelectableDate: PropTypes.oneOfType([
+			PropTypes.instanceOf(Date),
+			PropTypes.instanceOf(moment),
+		]),
+		lastSelectableDate: PropTypes.oneOfType([
+			PropTypes.instanceOf(Date),
+			PropTypes.instanceOf(moment),
+		]),
 		triggerText: PropTypes.func,
 		isCompact: PropTypes.bool,
 		showTriggerClear: PropTypes.bool,
@@ -53,41 +53,42 @@ export class DateRange extends Component {
 		isCompact: false,
 		focusedMonth: null,
 		showTriggerClear: true,
-		renderTrigger: ( props ) => <DateRangeTrigger { ...props } />,
-		renderHeader: ( props ) => <DateRangeHeader { ...props } />,
-		renderInputs: ( props ) => <DateRangeInputs { ...props } />,
+		renderTrigger: (props) => <DateRangeTrigger {...props} />,
+		renderHeader: (props) => <DateRangeHeader {...props} />,
+		renderInputs: (props) => <DateRangeInputs {...props} />,
 	};
 
-	constructor( props ) {
-		super( props );
+	constructor(props) {
+		super(props);
 
 		// Define the date range that is selectable (ie: not disabled)
 		const firstSelectableDate =
-			this.props.firstSelectableDate && this.props.moment( this.props.firstSelectableDate );
+			this.props.firstSelectableDate && this.props.moment(this.props.firstSelectableDate);
 		const lastSelectableDate =
-			this.props.lastSelectableDate && this.props.moment( this.props.lastSelectableDate );
+			this.props.lastSelectableDate && this.props.moment(this.props.lastSelectableDate);
 
+		debugger;
 		// Clamp start/end dates to ranges (if specified)
 		let startDate =
 			this.props.selectedStartDate == null
 				? NO_DATE_SELECTED_VALUE
-				: this.clampDateToRange( this.props.moment( this.props.selectedStartDate ), {
-						dateFrom: firstSelectableDate,
-						dateTo: lastSelectableDate,
-				  } );
+				: this.clampDateToRange(this.props.moment(this.props.selectedStartDate), {
+					dateFrom: firstSelectableDate,
+					dateTo: lastSelectableDate,
+				});
 
 		let endDate =
 			this.props.selectedEndDate == null
 				? NO_DATE_SELECTED_VALUE
-				: this.clampDateToRange( this.props.moment( this.props.selectedEndDate ), {
-						dateFrom: firstSelectableDate,
-						dateTo: lastSelectableDate,
-				  } );
+				: this.clampDateToRange(this.props.moment(this.props.selectedEndDate), {
+					dateFrom: firstSelectableDate,
+					dateTo: lastSelectableDate,
+				});
 
 		// Ensure start is before end otherwise flip the values
-		if ( startDate && endDate && endDate.isBefore( startDate ) ) {
+		if (startDate && endDate && endDate.isBefore(startDate)) {
 			// flip values via array destructuring (think about it...)
-			[ startDate, endDate ] = [ endDate, startDate ];
+			[startDate, endDate] = [endDate, startDate];
 		}
 
 		// Build initial state
@@ -100,8 +101,8 @@ export class DateRange extends Component {
 			staleDatesSaved: false,
 			// this needs to be independent from startDate because we must independently validate them
 			// before updating the central source of truth (ie: startDate)
-			textInputStartDate: this.toDateString( startDate ),
-			textInputEndDate: this.toDateString( endDate ),
+			textInputStartDate: this.toDateString(startDate),
+			textInputEndDate: this.toDateString(endDate),
 			initialStartDate: startDate, // cache values in case we need to reset to them
 			initialEndDate: endDate, // cache values in case we need to reset to them
 			focusedMonth: this.props.focusedMonth,
@@ -116,9 +117,9 @@ export class DateRange extends Component {
 	 * Note this does not commit the current date state
 	 */
 	openPopover = () => {
-		this.setState( {
+		this.setState({
 			popoverVisible: true,
-		} );
+		});
 	};
 
 	/**
@@ -126,9 +127,9 @@ export class DateRange extends Component {
 	 * Note this does not commit the current date state
 	 */
 	closePopover = () => {
-		this.setState( {
+		this.setState({
 			popoverVisible: false,
-		} );
+		});
 	};
 
 	/**
@@ -136,7 +137,7 @@ export class DateRange extends Component {
 	 * Note this does not commit the current date state
 	 */
 	togglePopover = () => {
-		if ( this.state.popoverVisible ) {
+		if (this.state.popoverVisible) {
 			this.closePopover();
 		} else {
 			this.openPopover();
@@ -160,10 +161,10 @@ export class DateRange extends Component {
 	 * @param  {string} val        the value of the input
 	 * @param  {string} startOrEnd either "Start" or "End"
 	 */
-	handleInputChange = ( val, startOrEnd ) => {
-		this.setState( {
-			[ `textInput${ startOrEnd }Date` ]: val,
-		} );
+	handleInputChange = (val, startOrEnd) => {
+		this.setState({
+			[`textInput${startOrEnd}Date`]: val,
+		});
 	};
 
 	/**
@@ -173,27 +174,27 @@ export class DateRange extends Component {
 	 * @param  {moment}  date MomentJS date object
 	 * @returns {boolean}      whether date is considered valid or not
 	 */
-	isValidDate( date ) {
-		const { firstSelectableDate, lastSelectableDate } = this.props;
+	isValidDate(date) {
+		const {firstSelectableDate, lastSelectableDate} = this.props;
 
-		const epoch = this.props.moment( '01/01/1970', this.getLocaleDateFormat() );
+		const epoch = this.props.moment('01/01/1970', this.getLocaleDateFormat());
 
 		// By default check
 		// 1. Looks like a valid date
 		// 2. after 01/01/1970 (avoids bugs when really stale dates are treated as valid)
-		if ( ! date.isValid() || ! date.isSameOrAfter( epoch ) ) {
+		if (!date.isValid() || !date.isSameOrAfter(epoch)) {
 			return false;
 		}
 
 		// Check not before the first selectable date
 		// https://momentjs.com/docs/#/query/is-same-or-before/
-		if ( firstSelectableDate && date.isBefore( firstSelectableDate ) ) {
+		if (firstSelectableDate && date.isBefore(firstSelectableDate)) {
 			return false;
 		}
 
 		// Check not before the last selectable date
 		// https://momentjs.com/docs/#/query/is-same-or-before/
-		if ( lastSelectableDate && date.isAfter( lastSelectableDate ) ) {
+		if (lastSelectableDate && date.isAfter(lastSelectableDate)) {
 			return false;
 		}
 
@@ -206,27 +207,27 @@ export class DateRange extends Component {
 	 * @param  {string} val        the value of the input
 	 * @param  {string} startOrEnd either "Start" or "End"
 	 */
-	handleInputBlur = ( val, startOrEnd ) => {
-		if ( val === '' ) {
+	handleInputBlur = (val, startOrEnd) => {
+		if (val === '') {
 			return;
 		}
-		const date = this.props.moment( val, this.getLocaleDateFormat() );
+		const date = this.props.moment(val, this.getLocaleDateFormat());
 
-		if ( ! date.isValid() ) {
+		if (!date.isValid()) {
 			return; // bail out
 		}
 
 		// Either `startDate` or `endDate`
-		const stateKey = `${ startOrEnd.toLowerCase() }Date`;
+		const stateKey = `${startOrEnd.toLowerCase()}Date`;
 
 		const isSameDate =
-			this.state[ stateKey ] !== null ? this.state[ stateKey ].isSame( date, 'day' ) : false;
+			this.state[stateKey] !== null ? this.state[stateKey].isSame(date, 'day') : false;
 
-		if ( isSameDate ) {
+		if (isSameDate) {
 			return;
 		}
 
-		this.onSelectDate( date );
+		this.onSelectDate(date);
 	};
 
 	/**
@@ -237,14 +238,14 @@ export class DateRange extends Component {
 	 * @param  {string} val        the value of the input
 	 * @param  {string} startOrEnd either "Start" or "End"
 	 */
-	handleInputFocus = ( val, startOrEnd ) => {
-		if ( val === '' ) {
+	handleInputFocus = (val, startOrEnd) => {
+		if (val === '') {
 			return;
 		}
 
-		const date = this.props.moment( val, this.getLocaleDateFormat() );
+		const date = this.props.moment(val, this.getLocaleDateFormat());
 
-		if ( ! date.isValid() ) {
+		if (!date.isValid()) {
 			return; // bail out
 		}
 
@@ -252,15 +253,15 @@ export class DateRange extends Component {
 
 		// If we focused the endDate and we're showing more than 1 month
 		// then the picker should focus the month before
-		if ( startOrEnd === 'End' && numMonthsShowing > 1 ) {
+		if (startOrEnd === 'End' && numMonthsShowing > 1) {
 			// moment isn't immutable so this modifies
 			// the existing moment instance
-			date.subtract( 1, 'months' );
+			date.subtract(1, 'months');
 		}
 
-		this.setState( {
+		this.setState({
 			focusedMonth: date.toDate(),
-		} );
+		});
 	};
 
 	/**
@@ -271,10 +272,10 @@ export class DateRange extends Component {
 	 * @param  {import('moment').Moment} endDate   the end date for the range
 	 * @returns {object}           the date range object
 	 */
-	toDateRange( startDate, endDate ) {
+	toDateRange(startDate, endDate) {
 		return {
-			from: this.momentDateToJsDate( startDate ),
-			to: this.momentDateToJsDate( endDate ),
+			from: this.momentDateToJsDate(startDate),
+			to: this.momentDateToJsDate(endDate),
 		};
 	}
 
@@ -288,43 +289,44 @@ export class DateRange extends Component {
 	 *
 	 * @param  {import('moment').Moment} date the newly selected date object
 	 */
-	onSelectDate = ( date ) => {
-		if ( ! this.isValidDate( date ) ) {
+	onSelectDate = (date) => {
+		debugger;
+		if (!this.isValidDate(date)) {
 			return;
 		}
 
 		// DateUtils requires a range object with this shape
-		const range = this.toDateRange( this.state.startDate, this.state.endDate );
+		const range = this.toDateRange(this.state.startDate, this.state.endDate);
 
-		const rawDay = this.momentDateToJsDate( date );
+		const rawDay = this.momentDateToJsDate(date);
 
 		// Calculate the new Date range
-		const newRange = DateUtils.addDayToRange( rawDay, range );
+		const newRange = DateUtils.addDayToRange(rawDay, range);
 
 		// Update state to reflect new date range for
 		// calendar and text inputs
 		this.setState(
-			( previousState ) => {
+			(previousState) => {
 				// Update to date or `null` which means "not date"
 				const newStartDate =
 					newRange.from === null
 						? NO_DATE_SELECTED_VALUE
-						: this.nativeDateToMoment( newRange.from );
+						: this.nativeDateToMoment(newRange.from);
 				const newEndDate =
-					newRange.to === null ? NO_DATE_SELECTED_VALUE : this.nativeDateToMoment( newRange.to );
+					newRange.to === null ? NO_DATE_SELECTED_VALUE : this.nativeDateToMoment(newRange.to);
 
 				// Update start/end state values
 				let newState = {
 					startDate: newStartDate,
 					endDate: newEndDate,
-					textInputStartDate: this.toDateString( newStartDate ),
-					textInputEndDate: this.toDateString( newEndDate ),
+					textInputStartDate: this.toDateString(newStartDate),
+					textInputEndDate: this.toDateString(newEndDate),
 				};
 
 				// For first date selection only: "cache" previous dates
 				// just in case user doesn't "Apply" and we need to revert
 				// to the original dates
-				if ( ! previousState.staleDatesSaved ) {
+				if (!previousState.staleDatesSaved) {
 					newState = {
 						...newState,
 						staleStartDate: previousState.startDate,
@@ -338,7 +340,7 @@ export class DateRange extends Component {
 			() => {
 				// Trigger callback prop to allow parent components to consume
 				// this components state
-				this.props.onDateSelect( this.state.startDate, this.state.endDate );
+				this.props.onDateSelect(this.state.startDate, this.state.endDate);
 			}
 		);
 	};
@@ -350,13 +352,13 @@ export class DateRange extends Component {
 	 */
 	commitDates = () => {
 		this.setState(
-			( previousState ) => ( {
+			(previousState) => ({
 				staleStartDate: previousState.startDate, // update cached stale dates
 				staleEndDate: previousState.endDate, // update cached stale dates
 				staleDatesSaved: false,
-			} ),
+			}),
 			() => {
-				this.props.onDateCommit( this.state.startDate, this.state.endDate );
+				this.props.onDateCommit(this.state.startDate, this.state.endDate);
 				this.closePopover();
 			}
 		);
@@ -368,7 +370,7 @@ export class DateRange extends Component {
 	 * the DateRange without clicking "Apply"
 	 */
 	revertDates = () => {
-		this.setState( ( previousState ) => {
+		this.setState((previousState) => {
 			const startDate = previousState.staleStartDate;
 			const endDate = previousState.staleEndDate;
 
@@ -376,12 +378,12 @@ export class DateRange extends Component {
 				staleDatesSaved: false,
 				startDate: startDate,
 				endDate: endDate,
-				textInputStartDate: this.toDateString( startDate ),
-				textInputEndDate: this.toDateString( endDate ),
+				textInputStartDate: this.toDateString(startDate),
+				textInputEndDate: this.toDateString(endDate),
 			};
 
 			return newState;
-		} );
+		});
 	};
 
 	/**
@@ -393,7 +395,7 @@ export class DateRange extends Component {
 	 * without selecting any dates
 	 */
 	resetDates = () => {
-		this.setState( ( previousState ) => {
+		this.setState((previousState) => {
 			const startDate = previousState.initialStartDate;
 			const endDate = previousState.initialEndDate;
 
@@ -401,12 +403,12 @@ export class DateRange extends Component {
 				staleDatesSaved: false,
 				startDate: startDate,
 				endDate: endDate,
-				textInputStartDate: this.toDateString( startDate ),
-				textInputEndDate: this.toDateString( endDate ),
+				textInputStartDate: this.toDateString(startDate),
+				textInputEndDate: this.toDateString(endDate),
 			};
 
 			return newState;
-		} );
+		});
 	};
 
 	/**
@@ -425,7 +427,7 @@ export class DateRange extends Component {
 			},
 			() => {
 				// Fired to ensure date change is propagated upwards
-				this.props.onDateCommit( this.state.startDate, this.state.endDate );
+				this.props.onDateCommit(this.state.startDate, this.state.endDate);
 			}
 		);
 	};
@@ -436,8 +438,8 @@ export class DateRange extends Component {
 	 * @param  {import('moment').Moment} momentDate a momentjs date object to convert
 	 * @returns {Date}            the converted JS Date object
 	 */
-	momentDateToJsDate( momentDate ) {
-		return this.props.moment.isMoment( momentDate ) ? momentDate.toDate() : momentDate;
+	momentDateToJsDate(momentDate) {
+		return this.props.moment.isMoment(momentDate) ? momentDate.toDate() : momentDate;
 	}
 
 	/**
@@ -446,8 +448,8 @@ export class DateRange extends Component {
 	 * @param  {Date} nativeDate date to be converted
 	 * @returns {import('moment').Moment}            the converted Date
 	 */
-	nativeDateToMoment( nativeDate ) {
-		return this.props.moment( nativeDate );
+	nativeDateToMoment(nativeDate) {
+		return this.props.moment(nativeDate);
 	}
 
 	/**
@@ -457,8 +459,8 @@ export class DateRange extends Component {
 	 * @param  {import('moment').Moment | Date} date the date to be converted
 	 * @returns {string}      the date as a formatted locale string
 	 */
-	formatDateToLocale( date ) {
-		return this.props.moment( date ).format( 'L' );
+	formatDateToLocale(date) {
+		return this.props.moment(date).format('L');
 	}
 
 	/**
@@ -467,7 +469,7 @@ export class DateRange extends Component {
 	 * @returns {string} date format as a string
 	 */
 	getLocaleDateFormat() {
-		return this.props.moment.localeData().longDateFormat( 'L' );
+		return this.props.moment.localeData().longDateFormat('L');
 	}
 
 	/**
@@ -480,13 +482,13 @@ export class DateRange extends Component {
 	 * @param  {import('moment').Moment | Date}  options.dateTo   the end of the date range
 	 * @returns {import('moment').Moment}                  the date clamped to be within the range
 	 */
-	clampDateToRange( date, { dateFrom, dateTo } ) {
+	clampDateToRange(date, {dateFrom, dateTo}) {
 		// Ensure endDate is within bounds of firstSelectableDate
-		if ( dateFrom && date.isBefore( dateFrom ) ) {
+		if (dateFrom && date.isBefore(dateFrom)) {
 			date = dateFrom;
 		}
 
-		if ( dateTo && date.isAfter( dateTo ) ) {
+		if (dateTo && date.isAfter(dateTo)) {
 			date = dateTo;
 		}
 
@@ -502,9 +504,9 @@ export class DateRange extends Component {
 	 * @returns {string}      the date expressed as a locale appropriate string or if null
 	 *                       then returns the locale format (eg: MM/DD/YYYY)
 	 */
-	toDateString( date ) {
-		if ( this.props.moment.isMoment( date ) || this.props.moment.isDate( date ) ) {
-			return this.formatDateToLocale( this.props.moment( date ) );
+	toDateString(date) {
+		if (this.props.moment.isMoment(date) || this.props.moment.isDate(date)) {
+			return this.formatDateToLocale(this.props.moment(date));
 		}
 
 		return this.getLocaleDateFormat(); // "MM/DD/YYY" or locale equivalent
@@ -522,54 +524,54 @@ export class DateRange extends Component {
 	 * @returns {Array} configuration to be passed to DatePicker as disabledDays prop
 	 */
 	getDisabledDaysConfig() {
-		const { firstSelectableDate, lastSelectableDate } = this.props;
+		const {firstSelectableDate, lastSelectableDate} = this.props;
 
 		const config = {};
 
-		if ( firstSelectableDate ) {
-			config.before = this.momentDateToJsDate( firstSelectableDate ); // disable all days before today
+		if (firstSelectableDate) {
+			config.before = this.momentDateToJsDate(firstSelectableDate); // disable all days before today
 		}
 
-		if ( lastSelectableDate ) {
-			config.after = this.momentDateToJsDate( lastSelectableDate ); // disable all days before today
+		if (lastSelectableDate) {
+			config.after = this.momentDateToJsDate(lastSelectableDate); // disable all days before today
 		}
 
 		// Requires a wrapping Array
-		return [ config ];
+		return [config];
 	}
 
 	getNumberOfMonths() {
-		return window.matchMedia( '(min-width: 480px)' ).matches ? 2 : 1;
+		return window.matchMedia('(min-width: 480px)').matches ? 2 : 1;
 	}
 
 	renderDateHelp() {
-		const { startDate, endDate } = this.state;
+		const {startDate, endDate} = this.state;
 
 		return (
 			<div className="date-range__info" role="status" aria-live="polite">
-				{ ! startDate &&
-					! endDate &&
-					this.props.translate( '{{icon/}} Please select the {{em}}first{{/em}} day.', {
+				{!startDate &&
+					!endDate &&
+					this.props.translate('{{icon/}} Please select the {{em}}first{{/em}} day.', {
 						components: {
 							icon: <Gridicon aria-hidden="true" icon="info" />,
 							em: <em />,
 						},
-					} ) }
-				{ startDate &&
-					! endDate &&
-					this.props.translate( '{{icon/}} Please select the {{em}}last{{/em}} day.', {
+					})}
+				{startDate &&
+					!endDate &&
+					this.props.translate('{{icon/}} Please select the {{em}}last{{/em}} day.', {
 						components: {
 							icon: <Gridicon aria-hidden="true" icon="info" />,
 							em: <em />,
 						},
-					} ) }
-				{ startDate && endDate && (
-					<Button className="date-range__info-btn" borderless compact onClick={ this.resetDates }>
-						{ this.props.translate( '{{icon/}} reset selected dates', {
-							components: { icon: <Gridicon aria-hidden="true" icon="cross-small" /> },
-						} ) }
+					})}
+				{startDate && endDate && (
+					<Button className="date-range__info-btn" borderless compact onClick={this.resetDates} aria-label="Reset selected dates">
+						{this.props.translate('{{icon/}} reset selected dates', {
+							components: {icon: <Gridicon aria-hidden="true" icon="cross-small" />},
+						})}
 					</Button>
-				) }
+				)}
 			</div>
 		);
 	}
@@ -596,18 +598,18 @@ export class DateRange extends Component {
 		return (
 			<Popover
 				className="date-range__popover"
-				isVisible={ this.state.popoverVisible }
-				context={ this.triggerButtonRef.current }
+				isVisible={this.state.popoverVisible}
+				context={this.triggerButtonRef.current}
 				position="bottom"
-				onClose={ this.closePopoverAndCommit }
+				onClose={this.closePopoverAndCommit}
 			>
 				<div className="date-range__popover-inner">
 					<div className="date-range__controls">
-						{ this.props.renderHeader( headerProps ) }
-						{ this.renderDateHelp() }
+						{this.props.renderHeader(headerProps)}
+						{this.renderDateHelp()}
 					</div>
-					{ this.props.renderInputs( inputsProps ) }
-					{ this.renderDatePicker() }
+					{this.props.renderInputs(inputsProps)}
+					{this.renderDatePicker()}
 				</div>
 			</Popover>
 		);
@@ -619,8 +621,8 @@ export class DateRange extends Component {
 	 * @returns {import('react').Element} the DatePicker component
 	 */
 	renderDatePicker() {
-		const fromDate = this.momentDateToJsDate( this.state.startDate );
-		const toDate = this.momentDateToJsDate( this.state.endDate );
+		const fromDate = this.momentDateToJsDate(this.state.startDate);
+		const toDate = this.momentDateToJsDate(this.state.endDate);
 
 		// Add "Range" modifier classes to Day component
 		// within Date Picker to aid "range" styling
@@ -649,18 +651,24 @@ export class DateRange extends Component {
 			'date-range__picker': true,
 		};
 
+		const calendarInitialDate = this.props.firstSelectableDate
+			|| this.props.firstSelectableDate
+			|| (this.props.lastSelectableDate && moment(this.props.lastSelectableDate).subtract(1, 'month'))
+			|| this.state.startDate;
+
 		return (
 			<DatePicker
-				calendarViewDate={ this.state.focusedMonth }
-				rootClassNames={ rootClassNames }
-				modifiers={ modifiers }
-				showOutsideDays={ false }
-				fromMonth={ this.momentDateToJsDate( this.props.firstSelectableDate ) }
-				toMonth={ this.momentDateToJsDate( this.props.lastSelectableDate ) }
-				onSelectDay={ this.onSelectDate }
-				selectedDays={ selected }
-				numberOfMonths={ this.getNumberOfMonths() }
-				disabledDays={ this.getDisabledDaysConfig() }
+				calendarViewDate={this.state.focusedMonth}
+				calendarInitialDate={this.momentDateToJsDate(calendarInitialDate)}
+				rootClassNames={rootClassNames}
+				modifiers={modifiers}
+				showOutsideDays={false}
+				fromMonth={this.momentDateToJsDate(this.props.firstSelectableDate)}
+				toMonth={this.momentDateToJsDate(this.props.lastSelectableDate)}
+				onSelectDay={this.onSelectDate}
+				selectedDays={selected}
+				numberOfMonths={this.getNumberOfMonths()}
+				disabledDays={this.getDisabledDaysConfig()}
 			/>
 		);
 	}
@@ -671,16 +679,16 @@ export class DateRange extends Component {
 	 * @returns {import('react').Element} the DateRange component
 	 */
 	render() {
-		const rootClassNames = classNames( {
+		const rootClassNames = classNames({
 			'date-range': true,
 			'toggle-visible': this.state.popoverVisible,
-		} );
+		});
 
 		const triggerProps = {
 			startDate: this.state.startDate,
 			endDate: this.state.endDate,
-			startDateText: this.toDateString( this.state.startDate ),
-			endDateText: this.toDateString( this.state.endDate ),
+			startDateText: this.toDateString(this.state.startDate),
+			endDateText: this.toDateString(this.state.endDate),
 			buttonRef: this.triggerButtonRef,
 			onTriggerClick: this.togglePopover,
 			onClearClick: this.clearDates,
@@ -690,12 +698,12 @@ export class DateRange extends Component {
 		};
 
 		return (
-			<div className={ rootClassNames }>
-				{ this.props.renderTrigger( triggerProps ) }
-				{ this.renderPopover() }
+			<div className={rootClassNames}>
+				{this.props.renderTrigger(triggerProps)}
+				{this.renderPopover()}
 			</div>
 		);
 	}
 }
 
-export default localize( withLocalizedMoment( DateRange ) );
+export default localize(withLocalizedMoment(DateRange));

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -1,12 +1,12 @@
-import {Button, Popover, Gridicon} from '@automattic/components';
+import { Button, Popover, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
-import {localize} from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import {createRef, Component} from 'react';
-import {DateUtils} from 'react-day-picker';
+import { createRef, Component } from 'react';
+import { DateUtils } from 'react-day-picker';
 import DatePicker from 'calypso/components/date-picker';
-import {withLocalizedMoment} from 'calypso/components/localized-moment';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import DateRangeHeader from './header';
 import DateRangeInputs from './inputs';
 import DateRangeTrigger from './trigger';
@@ -17,28 +17,28 @@ import './style.scss';
  * Module variables
  */
 const NO_DATE_SELECTED_VALUE = null;
-const noop = () => { };
+const noop = () => {};
 
 export class DateRange extends Component {
 	static propTypes = {
-		selectedStartDate: PropTypes.oneOfType([
-			PropTypes.instanceOf(Date),
-			PropTypes.instanceOf(moment),
-		]),
-		selectedEndDate: PropTypes.oneOfType([
-			PropTypes.instanceOf(Date),
-			PropTypes.instanceOf(moment),
-		]),
+		selectedStartDate: PropTypes.oneOfType( [
+			PropTypes.instanceOf( Date ),
+			PropTypes.instanceOf( moment ),
+		] ),
+		selectedEndDate: PropTypes.oneOfType( [
+			PropTypes.instanceOf( Date ),
+			PropTypes.instanceOf( moment ),
+		] ),
 		onDateSelect: PropTypes.func,
 		onDateCommit: PropTypes.func,
-		firstSelectableDate: PropTypes.oneOfType([
-			PropTypes.instanceOf(Date),
-			PropTypes.instanceOf(moment),
-		]),
-		lastSelectableDate: PropTypes.oneOfType([
-			PropTypes.instanceOf(Date),
-			PropTypes.instanceOf(moment),
-		]),
+		firstSelectableDate: PropTypes.oneOfType( [
+			PropTypes.instanceOf( Date ),
+			PropTypes.instanceOf( moment ),
+		] ),
+		lastSelectableDate: PropTypes.oneOfType( [
+			PropTypes.instanceOf( Date ),
+			PropTypes.instanceOf( moment ),
+		] ),
 		triggerText: PropTypes.func,
 		isCompact: PropTypes.bool,
 		showTriggerClear: PropTypes.bool,
@@ -53,42 +53,41 @@ export class DateRange extends Component {
 		isCompact: false,
 		focusedMonth: null,
 		showTriggerClear: true,
-		renderTrigger: (props) => <DateRangeTrigger {...props} />,
-		renderHeader: (props) => <DateRangeHeader {...props} />,
-		renderInputs: (props) => <DateRangeInputs {...props} />,
+		renderTrigger: ( props ) => <DateRangeTrigger { ...props } />,
+		renderHeader: ( props ) => <DateRangeHeader { ...props } />,
+		renderInputs: ( props ) => <DateRangeInputs { ...props } />,
 	};
 
-	constructor(props) {
-		super(props);
+	constructor( props ) {
+		super( props );
 
 		// Define the date range that is selectable (ie: not disabled)
 		const firstSelectableDate =
-			this.props.firstSelectableDate && this.props.moment(this.props.firstSelectableDate);
+			this.props.firstSelectableDate && this.props.moment( this.props.firstSelectableDate );
 		const lastSelectableDate =
-			this.props.lastSelectableDate && this.props.moment(this.props.lastSelectableDate);
+			this.props.lastSelectableDate && this.props.moment( this.props.lastSelectableDate );
 
-		debugger;
 		// Clamp start/end dates to ranges (if specified)
 		let startDate =
 			this.props.selectedStartDate == null
 				? NO_DATE_SELECTED_VALUE
-				: this.clampDateToRange(this.props.moment(this.props.selectedStartDate), {
-					dateFrom: firstSelectableDate,
-					dateTo: lastSelectableDate,
-				});
+				: this.clampDateToRange( this.props.moment( this.props.selectedStartDate ), {
+						dateFrom: firstSelectableDate,
+						dateTo: lastSelectableDate,
+				  } );
 
 		let endDate =
 			this.props.selectedEndDate == null
 				? NO_DATE_SELECTED_VALUE
-				: this.clampDateToRange(this.props.moment(this.props.selectedEndDate), {
-					dateFrom: firstSelectableDate,
-					dateTo: lastSelectableDate,
-				});
+				: this.clampDateToRange( this.props.moment( this.props.selectedEndDate ), {
+						dateFrom: firstSelectableDate,
+						dateTo: lastSelectableDate,
+				  } );
 
 		// Ensure start is before end otherwise flip the values
-		if (startDate && endDate && endDate.isBefore(startDate)) {
+		if ( startDate && endDate && endDate.isBefore( startDate ) ) {
 			// flip values via array destructuring (think about it...)
-			[startDate, endDate] = [endDate, startDate];
+			[ startDate, endDate ] = [ endDate, startDate ];
 		}
 
 		// Build initial state
@@ -101,8 +100,8 @@ export class DateRange extends Component {
 			staleDatesSaved: false,
 			// this needs to be independent from startDate because we must independently validate them
 			// before updating the central source of truth (ie: startDate)
-			textInputStartDate: this.toDateString(startDate),
-			textInputEndDate: this.toDateString(endDate),
+			textInputStartDate: this.toDateString( startDate ),
+			textInputEndDate: this.toDateString( endDate ),
 			initialStartDate: startDate, // cache values in case we need to reset to them
 			initialEndDate: endDate, // cache values in case we need to reset to them
 			focusedMonth: this.props.focusedMonth,
@@ -117,9 +116,9 @@ export class DateRange extends Component {
 	 * Note this does not commit the current date state
 	 */
 	openPopover = () => {
-		this.setState({
+		this.setState( {
 			popoverVisible: true,
-		});
+		} );
 	};
 
 	/**
@@ -127,9 +126,9 @@ export class DateRange extends Component {
 	 * Note this does not commit the current date state
 	 */
 	closePopover = () => {
-		this.setState({
+		this.setState( {
 			popoverVisible: false,
-		});
+		} );
 	};
 
 	/**
@@ -137,7 +136,7 @@ export class DateRange extends Component {
 	 * Note this does not commit the current date state
 	 */
 	togglePopover = () => {
-		if (this.state.popoverVisible) {
+		if ( this.state.popoverVisible ) {
 			this.closePopover();
 		} else {
 			this.openPopover();
@@ -161,10 +160,10 @@ export class DateRange extends Component {
 	 * @param  {string} val        the value of the input
 	 * @param  {string} startOrEnd either "Start" or "End"
 	 */
-	handleInputChange = (val, startOrEnd) => {
-		this.setState({
-			[`textInput${startOrEnd}Date`]: val,
-		});
+	handleInputChange = ( val, startOrEnd ) => {
+		this.setState( {
+			[ `textInput${ startOrEnd }Date` ]: val,
+		} );
 	};
 
 	/**
@@ -174,27 +173,27 @@ export class DateRange extends Component {
 	 * @param  {moment}  date MomentJS date object
 	 * @returns {boolean}      whether date is considered valid or not
 	 */
-	isValidDate(date) {
-		const {firstSelectableDate, lastSelectableDate} = this.props;
+	isValidDate( date ) {
+		const { firstSelectableDate, lastSelectableDate } = this.props;
 
-		const epoch = this.props.moment('01/01/1970', this.getLocaleDateFormat());
+		const epoch = this.props.moment( '01/01/1970', this.getLocaleDateFormat() );
 
 		// By default check
 		// 1. Looks like a valid date
 		// 2. after 01/01/1970 (avoids bugs when really stale dates are treated as valid)
-		if (!date.isValid() || !date.isSameOrAfter(epoch)) {
+		if ( ! date.isValid() || ! date.isSameOrAfter( epoch ) ) {
 			return false;
 		}
 
 		// Check not before the first selectable date
 		// https://momentjs.com/docs/#/query/is-same-or-before/
-		if (firstSelectableDate && date.isBefore(firstSelectableDate)) {
+		if ( firstSelectableDate && date.isBefore( firstSelectableDate ) ) {
 			return false;
 		}
 
 		// Check not before the last selectable date
 		// https://momentjs.com/docs/#/query/is-same-or-before/
-		if (lastSelectableDate && date.isAfter(lastSelectableDate)) {
+		if ( lastSelectableDate && date.isAfter( lastSelectableDate ) ) {
 			return false;
 		}
 
@@ -207,27 +206,27 @@ export class DateRange extends Component {
 	 * @param  {string} val        the value of the input
 	 * @param  {string} startOrEnd either "Start" or "End"
 	 */
-	handleInputBlur = (val, startOrEnd) => {
-		if (val === '') {
+	handleInputBlur = ( val, startOrEnd ) => {
+		if ( val === '' ) {
 			return;
 		}
-		const date = this.props.moment(val, this.getLocaleDateFormat());
+		const date = this.props.moment( val, this.getLocaleDateFormat() );
 
-		if (!date.isValid()) {
+		if ( ! date.isValid() ) {
 			return; // bail out
 		}
 
 		// Either `startDate` or `endDate`
-		const stateKey = `${startOrEnd.toLowerCase()}Date`;
+		const stateKey = `${ startOrEnd.toLowerCase() }Date`;
 
 		const isSameDate =
-			this.state[stateKey] !== null ? this.state[stateKey].isSame(date, 'day') : false;
+			this.state[ stateKey ] !== null ? this.state[ stateKey ].isSame( date, 'day' ) : false;
 
-		if (isSameDate) {
+		if ( isSameDate ) {
 			return;
 		}
 
-		this.onSelectDate(date);
+		this.onSelectDate( date );
 	};
 
 	/**
@@ -238,14 +237,14 @@ export class DateRange extends Component {
 	 * @param  {string} val        the value of the input
 	 * @param  {string} startOrEnd either "Start" or "End"
 	 */
-	handleInputFocus = (val, startOrEnd) => {
-		if (val === '') {
+	handleInputFocus = ( val, startOrEnd ) => {
+		if ( val === '' ) {
 			return;
 		}
 
-		const date = this.props.moment(val, this.getLocaleDateFormat());
+		const date = this.props.moment( val, this.getLocaleDateFormat() );
 
-		if (!date.isValid()) {
+		if ( ! date.isValid() ) {
 			return; // bail out
 		}
 
@@ -253,15 +252,15 @@ export class DateRange extends Component {
 
 		// If we focused the endDate and we're showing more than 1 month
 		// then the picker should focus the month before
-		if (startOrEnd === 'End' && numMonthsShowing > 1) {
+		if ( startOrEnd === 'End' && numMonthsShowing > 1 ) {
 			// moment isn't immutable so this modifies
 			// the existing moment instance
-			date.subtract(1, 'months');
+			date.subtract( 1, 'months' );
 		}
 
-		this.setState({
+		this.setState( {
 			focusedMonth: date.toDate(),
-		});
+		} );
 	};
 
 	/**
@@ -272,10 +271,10 @@ export class DateRange extends Component {
 	 * @param  {import('moment').Moment} endDate   the end date for the range
 	 * @returns {object}           the date range object
 	 */
-	toDateRange(startDate, endDate) {
+	toDateRange( startDate, endDate ) {
 		return {
-			from: this.momentDateToJsDate(startDate),
-			to: this.momentDateToJsDate(endDate),
+			from: this.momentDateToJsDate( startDate ),
+			to: this.momentDateToJsDate( endDate ),
 		};
 	}
 
@@ -289,44 +288,43 @@ export class DateRange extends Component {
 	 *
 	 * @param  {import('moment').Moment} date the newly selected date object
 	 */
-	onSelectDate = (date) => {
-		debugger;
-		if (!this.isValidDate(date)) {
+	onSelectDate = ( date ) => {
+		if ( ! this.isValidDate( date ) ) {
 			return;
 		}
 
 		// DateUtils requires a range object with this shape
-		const range = this.toDateRange(this.state.startDate, this.state.endDate);
+		const range = this.toDateRange( this.state.startDate, this.state.endDate );
 
-		const rawDay = this.momentDateToJsDate(date);
+		const rawDay = this.momentDateToJsDate( date );
 
 		// Calculate the new Date range
-		const newRange = DateUtils.addDayToRange(rawDay, range);
+		const newRange = DateUtils.addDayToRange( rawDay, range );
 
 		// Update state to reflect new date range for
 		// calendar and text inputs
 		this.setState(
-			(previousState) => {
+			( previousState ) => {
 				// Update to date or `null` which means "not date"
 				const newStartDate =
 					newRange.from === null
 						? NO_DATE_SELECTED_VALUE
-						: this.nativeDateToMoment(newRange.from);
+						: this.nativeDateToMoment( newRange.from );
 				const newEndDate =
-					newRange.to === null ? NO_DATE_SELECTED_VALUE : this.nativeDateToMoment(newRange.to);
+					newRange.to === null ? NO_DATE_SELECTED_VALUE : this.nativeDateToMoment( newRange.to );
 
 				// Update start/end state values
 				let newState = {
 					startDate: newStartDate,
 					endDate: newEndDate,
-					textInputStartDate: this.toDateString(newStartDate),
-					textInputEndDate: this.toDateString(newEndDate),
+					textInputStartDate: this.toDateString( newStartDate ),
+					textInputEndDate: this.toDateString( newEndDate ),
 				};
 
 				// For first date selection only: "cache" previous dates
 				// just in case user doesn't "Apply" and we need to revert
 				// to the original dates
-				if (!previousState.staleDatesSaved) {
+				if ( ! previousState.staleDatesSaved ) {
 					newState = {
 						...newState,
 						staleStartDate: previousState.startDate,
@@ -340,7 +338,7 @@ export class DateRange extends Component {
 			() => {
 				// Trigger callback prop to allow parent components to consume
 				// this components state
-				this.props.onDateSelect(this.state.startDate, this.state.endDate);
+				this.props.onDateSelect( this.state.startDate, this.state.endDate );
 			}
 		);
 	};
@@ -352,13 +350,13 @@ export class DateRange extends Component {
 	 */
 	commitDates = () => {
 		this.setState(
-			(previousState) => ({
+			( previousState ) => ( {
 				staleStartDate: previousState.startDate, // update cached stale dates
 				staleEndDate: previousState.endDate, // update cached stale dates
 				staleDatesSaved: false,
-			}),
+			} ),
 			() => {
-				this.props.onDateCommit(this.state.startDate, this.state.endDate);
+				this.props.onDateCommit( this.state.startDate, this.state.endDate );
 				this.closePopover();
 			}
 		);
@@ -370,7 +368,7 @@ export class DateRange extends Component {
 	 * the DateRange without clicking "Apply"
 	 */
 	revertDates = () => {
-		this.setState((previousState) => {
+		this.setState( ( previousState ) => {
 			const startDate = previousState.staleStartDate;
 			const endDate = previousState.staleEndDate;
 
@@ -378,12 +376,12 @@ export class DateRange extends Component {
 				staleDatesSaved: false,
 				startDate: startDate,
 				endDate: endDate,
-				textInputStartDate: this.toDateString(startDate),
-				textInputEndDate: this.toDateString(endDate),
+				textInputStartDate: this.toDateString( startDate ),
+				textInputEndDate: this.toDateString( endDate ),
 			};
 
 			return newState;
-		});
+		} );
 	};
 
 	/**
@@ -395,7 +393,7 @@ export class DateRange extends Component {
 	 * without selecting any dates
 	 */
 	resetDates = () => {
-		this.setState((previousState) => {
+		this.setState( ( previousState ) => {
 			const startDate = previousState.initialStartDate;
 			const endDate = previousState.initialEndDate;
 
@@ -403,12 +401,12 @@ export class DateRange extends Component {
 				staleDatesSaved: false,
 				startDate: startDate,
 				endDate: endDate,
-				textInputStartDate: this.toDateString(startDate),
-				textInputEndDate: this.toDateString(endDate),
+				textInputStartDate: this.toDateString( startDate ),
+				textInputEndDate: this.toDateString( endDate ),
 			};
 
 			return newState;
-		});
+		} );
 	};
 
 	/**
@@ -427,7 +425,7 @@ export class DateRange extends Component {
 			},
 			() => {
 				// Fired to ensure date change is propagated upwards
-				this.props.onDateCommit(this.state.startDate, this.state.endDate);
+				this.props.onDateCommit( this.state.startDate, this.state.endDate );
 			}
 		);
 	};
@@ -438,8 +436,8 @@ export class DateRange extends Component {
 	 * @param  {import('moment').Moment} momentDate a momentjs date object to convert
 	 * @returns {Date}            the converted JS Date object
 	 */
-	momentDateToJsDate(momentDate) {
-		return this.props.moment.isMoment(momentDate) ? momentDate.toDate() : momentDate;
+	momentDateToJsDate( momentDate ) {
+		return this.props.moment.isMoment( momentDate ) ? momentDate.toDate() : momentDate;
 	}
 
 	/**
@@ -448,8 +446,8 @@ export class DateRange extends Component {
 	 * @param  {Date} nativeDate date to be converted
 	 * @returns {import('moment').Moment}            the converted Date
 	 */
-	nativeDateToMoment(nativeDate) {
-		return this.props.moment(nativeDate);
+	nativeDateToMoment( nativeDate ) {
+		return this.props.moment( nativeDate );
 	}
 
 	/**
@@ -459,8 +457,8 @@ export class DateRange extends Component {
 	 * @param  {import('moment').Moment | Date} date the date to be converted
 	 * @returns {string}      the date as a formatted locale string
 	 */
-	formatDateToLocale(date) {
-		return this.props.moment(date).format('L');
+	formatDateToLocale( date ) {
+		return this.props.moment( date ).format( 'L' );
 	}
 
 	/**
@@ -469,7 +467,7 @@ export class DateRange extends Component {
 	 * @returns {string} date format as a string
 	 */
 	getLocaleDateFormat() {
-		return this.props.moment.localeData().longDateFormat('L');
+		return this.props.moment.localeData().longDateFormat( 'L' );
 	}
 
 	/**
@@ -482,13 +480,13 @@ export class DateRange extends Component {
 	 * @param  {import('moment').Moment | Date}  options.dateTo   the end of the date range
 	 * @returns {import('moment').Moment}                  the date clamped to be within the range
 	 */
-	clampDateToRange(date, {dateFrom, dateTo}) {
+	clampDateToRange( date, { dateFrom, dateTo } ) {
 		// Ensure endDate is within bounds of firstSelectableDate
-		if (dateFrom && date.isBefore(dateFrom)) {
+		if ( dateFrom && date.isBefore( dateFrom ) ) {
 			date = dateFrom;
 		}
 
-		if (dateTo && date.isAfter(dateTo)) {
+		if ( dateTo && date.isAfter( dateTo ) ) {
 			date = dateTo;
 		}
 
@@ -504,9 +502,9 @@ export class DateRange extends Component {
 	 * @returns {string}      the date expressed as a locale appropriate string or if null
 	 *                       then returns the locale format (eg: MM/DD/YYYY)
 	 */
-	toDateString(date) {
-		if (this.props.moment.isMoment(date) || this.props.moment.isDate(date)) {
-			return this.formatDateToLocale(this.props.moment(date));
+	toDateString( date ) {
+		if ( this.props.moment.isMoment( date ) || this.props.moment.isDate( date ) ) {
+			return this.formatDateToLocale( this.props.moment( date ) );
 		}
 
 		return this.getLocaleDateFormat(); // "MM/DD/YYY" or locale equivalent
@@ -524,54 +522,60 @@ export class DateRange extends Component {
 	 * @returns {Array} configuration to be passed to DatePicker as disabledDays prop
 	 */
 	getDisabledDaysConfig() {
-		const {firstSelectableDate, lastSelectableDate} = this.props;
+		const { firstSelectableDate, lastSelectableDate } = this.props;
 
 		const config = {};
 
-		if (firstSelectableDate) {
-			config.before = this.momentDateToJsDate(firstSelectableDate); // disable all days before today
+		if ( firstSelectableDate ) {
+			config.before = this.momentDateToJsDate( firstSelectableDate ); // disable all days before today
 		}
 
-		if (lastSelectableDate) {
-			config.after = this.momentDateToJsDate(lastSelectableDate); // disable all days before today
+		if ( lastSelectableDate ) {
+			config.after = this.momentDateToJsDate( lastSelectableDate ); // disable all days before today
 		}
 
 		// Requires a wrapping Array
-		return [config];
+		return [ config ];
 	}
 
 	getNumberOfMonths() {
-		return window.matchMedia('(min-width: 480px)').matches ? 2 : 1;
+		return window.matchMedia( '(min-width: 480px)' ).matches ? 2 : 1;
 	}
 
 	renderDateHelp() {
-		const {startDate, endDate} = this.state;
+		const { startDate, endDate } = this.state;
 
 		return (
 			<div className="date-range__info" role="status" aria-live="polite">
-				{!startDate &&
-					!endDate &&
-					this.props.translate('{{icon/}} Please select the {{em}}first{{/em}} day.', {
+				{ ! startDate &&
+					! endDate &&
+					this.props.translate( '{{icon/}} Please select the {{em}}first{{/em}} day.', {
 						components: {
 							icon: <Gridicon aria-hidden="true" icon="info" />,
 							em: <em />,
 						},
-					})}
-				{startDate &&
-					!endDate &&
-					this.props.translate('{{icon/}} Please select the {{em}}last{{/em}} day.', {
+					} ) }
+				{ startDate &&
+					! endDate &&
+					this.props.translate( '{{icon/}} Please select the {{em}}last{{/em}} day.', {
 						components: {
 							icon: <Gridicon aria-hidden="true" icon="info" />,
 							em: <em />,
 						},
-					})}
-				{startDate && endDate && (
-					<Button className="date-range__info-btn" borderless compact onClick={this.resetDates} aria-label="Reset selected dates">
-						{this.props.translate('{{icon/}} reset selected dates', {
-							components: {icon: <Gridicon aria-hidden="true" icon="cross-small" />},
-						})}
+					} ) }
+				{ startDate && endDate && (
+					<Button
+						className="date-range__info-btn"
+						borderless
+						compact
+						onClick={ this.resetDates }
+						aria-label="Reset selected dates"
+					>
+						{ this.props.translate( '{{icon/}} reset selected dates', {
+							components: { icon: <Gridicon aria-hidden="true" icon="cross-small" /> },
+						} ) }
 					</Button>
-				)}
+				) }
 			</div>
 		);
 	}
@@ -598,18 +602,18 @@ export class DateRange extends Component {
 		return (
 			<Popover
 				className="date-range__popover"
-				isVisible={this.state.popoverVisible}
-				context={this.triggerButtonRef.current}
+				isVisible={ this.state.popoverVisible }
+				context={ this.triggerButtonRef.current }
 				position="bottom"
-				onClose={this.closePopoverAndCommit}
+				onClose={ this.closePopoverAndCommit }
 			>
 				<div className="date-range__popover-inner">
 					<div className="date-range__controls">
-						{this.props.renderHeader(headerProps)}
-						{this.renderDateHelp()}
+						{ this.props.renderHeader( headerProps ) }
+						{ this.renderDateHelp() }
 					</div>
-					{this.props.renderInputs(inputsProps)}
-					{this.renderDatePicker()}
+					{ this.props.renderInputs( inputsProps ) }
+					{ this.renderDatePicker() }
 				</div>
 			</Popover>
 		);
@@ -621,8 +625,8 @@ export class DateRange extends Component {
 	 * @returns {import('react').Element} the DatePicker component
 	 */
 	renderDatePicker() {
-		const fromDate = this.momentDateToJsDate(this.state.startDate);
-		const toDate = this.momentDateToJsDate(this.state.endDate);
+		const fromDate = this.momentDateToJsDate( this.state.startDate );
+		const toDate = this.momentDateToJsDate( this.state.endDate );
 
 		// Add "Range" modifier classes to Day component
 		// within Date Picker to aid "range" styling
@@ -651,24 +655,26 @@ export class DateRange extends Component {
 			'date-range__picker': true,
 		};
 
-		const calendarInitialDate = this.props.firstSelectableDate
-			|| this.props.firstSelectableDate
-			|| (this.props.lastSelectableDate && moment(this.props.lastSelectableDate).subtract(1, 'month'))
-			|| this.state.startDate;
+		const calendarInitialDate =
+			this.props.firstSelectableDate ||
+			this.props.firstSelectableDate ||
+			( this.props.lastSelectableDate &&
+				moment( this.props.lastSelectableDate ).subtract( 1, 'month' ) ) ||
+			this.state.startDate;
 
 		return (
 			<DatePicker
-				calendarViewDate={this.state.focusedMonth}
-				calendarInitialDate={this.momentDateToJsDate(calendarInitialDate)}
-				rootClassNames={rootClassNames}
-				modifiers={modifiers}
-				showOutsideDays={false}
-				fromMonth={this.momentDateToJsDate(this.props.firstSelectableDate)}
-				toMonth={this.momentDateToJsDate(this.props.lastSelectableDate)}
-				onSelectDay={this.onSelectDate}
-				selectedDays={selected}
-				numberOfMonths={this.getNumberOfMonths()}
-				disabledDays={this.getDisabledDaysConfig()}
+				calendarViewDate={ this.state.focusedMonth }
+				calendarInitialDate={ this.momentDateToJsDate( calendarInitialDate ) }
+				rootClassNames={ rootClassNames }
+				modifiers={ modifiers }
+				showOutsideDays={ false }
+				fromMonth={ this.momentDateToJsDate( this.props.firstSelectableDate ) }
+				toMonth={ this.momentDateToJsDate( this.props.lastSelectableDate ) }
+				onSelectDay={ this.onSelectDate }
+				selectedDays={ selected }
+				numberOfMonths={ this.getNumberOfMonths() }
+				disabledDays={ this.getDisabledDaysConfig() }
 			/>
 		);
 	}
@@ -679,16 +685,16 @@ export class DateRange extends Component {
 	 * @returns {import('react').Element} the DateRange component
 	 */
 	render() {
-		const rootClassNames = classNames({
+		const rootClassNames = classNames( {
 			'date-range': true,
 			'toggle-visible': this.state.popoverVisible,
-		});
+		} );
 
 		const triggerProps = {
 			startDate: this.state.startDate,
 			endDate: this.state.endDate,
-			startDateText: this.toDateString(this.state.startDate),
-			endDateText: this.toDateString(this.state.endDate),
+			startDateText: this.toDateString( this.state.startDate ),
+			endDateText: this.toDateString( this.state.endDate ),
 			buttonRef: this.triggerButtonRef,
 			onTriggerClick: this.togglePopover,
 			onClearClick: this.clearDates,
@@ -698,12 +704,12 @@ export class DateRange extends Component {
 		};
 
 		return (
-			<div className={rootClassNames}>
-				{this.props.renderTrigger(triggerProps)}
-				{this.renderPopover()}
+			<div className={ rootClassNames }>
+				{ this.props.renderTrigger( triggerProps ) }
+				{ this.renderPopover() }
 			</div>
 		);
 	}
 }
 
-export default localize(withLocalizedMoment(DateRange));
+export default localize( withLocalizedMoment( DateRange ) );

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -569,7 +569,7 @@ export class DateRange extends Component {
 						borderless
 						compact
 						onClick={ this.resetDates }
-						aria-label="Reset selected dates"
+						aria-label={ this.props.translate( 'Reset selected dates' ) }
 					>
 						{ this.props.translate( '{{icon/}} reset selected dates', {
 							components: { icon: <Gridicon aria-hidden="true" icon="cross-small" /> },

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -657,7 +657,6 @@ export class DateRange extends Component {
 
 		const calendarInitialDate =
 			this.props.firstSelectableDate ||
-			this.props.firstSelectableDate ||
 			( this.props.lastSelectableDate &&
 				moment( this.props.lastSelectableDate ).subtract( 1, 'month' ) ) ||
 			this.state.startDate;

--- a/client/components/date-range/test/__snapshots__/index.js.snap
+++ b/client/components/date-range/test/__snapshots__/index.js.snap
@@ -6,9 +6,11 @@ exports[`DateRange should render 1`] = `
 >
   <span
     class="button-group date-range__trigger"
+    role="group"
   >
     <button
       aria-haspopup="true"
+      aria-label="Select date range"
       class="button date-range__trigger-btn"
       type="button"
     >

--- a/client/components/date-range/test/__snapshots__/index.js.snap
+++ b/client/components/date-range/test/__snapshots__/index.js.snap
@@ -33,6 +33,7 @@ exports[`DateRange should render 1`] = `
       </span>
     </button>
     <button
+      aria-label="Clear date selection"
       class="button date-range__clear-btn"
       disabled=""
       title="Clear date selection"

--- a/client/components/date-range/test/__snapshots__/index.js.snap
+++ b/client/components/date-range/test/__snapshots__/index.js.snap
@@ -27,6 +27,7 @@ exports[`DateRange should render 1`] = `
         />
       </svg>
       <span
+        aria-label="Date range"
         class="date-range__trigger-btn-text"
       >
         MM/DD/YYYY - MM/DD/YYYY

--- a/client/components/date-range/test/__snapshots__/index.js.snap
+++ b/client/components/date-range/test/__snapshots__/index.js.snap
@@ -2,101 +2,58 @@
 
 exports[`DateRange should render 1`] = `
 <div
-  className="date-range"
+  class="date-range"
 >
-  <DateRangeTrigger
-    buttonRef={
-      Object {
-        "current": null,
-      }
-    }
-    endDate={null}
-    endDateText="MM/DD/YYYY"
-    isCompact={false}
-    onClearClick={[Function]}
-    onTriggerClick={[Function]}
-    showClearBtn={true}
-    startDate={null}
-    startDateText="MM/DD/YYYY"
-  />
-  <Popover
-    className="date-range__popover"
-    context={null}
-    isVisible={false}
-    onClose={[Function]}
-    position="bottom"
+  <span
+    class="button-group date-range__trigger"
   >
-    <div
-      className="date-range__popover-inner"
+    <button
+      aria-haspopup="true"
+      class="button date-range__trigger-btn"
+      type="button"
     >
-      <div
-        className="date-range__controls"
+      <svg
+        aria-hidden="true"
+        class="gridicon gridicons-calendar date-range__trigger-btn-icon"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <DateRangeHeader
-          onApplyClick={[Function]}
-          onCancelClick={[Function]}
+        <use
+          xlink:href="gridicons.svg#gridicons-calendar"
         />
-        <div
-          aria-live="polite"
-          className="date-range__info"
-          role="status"
-        >
-          <Gridicon
-            aria-hidden="true"
-            icon="info"
-          />
-           Please select the 
-          <em>
-            first
-          </em>
-           day.
-        </div>
-      </div>
-      <DateRangeInputs
-        endDateValue="MM/DD/YYYY"
-        onInputBlur={[Function]}
-        onInputChange={[Function]}
-        onInputFocus={[Function]}
-        startDateValue="MM/DD/YYYY"
-      />
-      <Localized(WithLocalizedMoment(DatePicker))
-        calendarViewDate={null}
-        disabledDays={
-          Array [
-            Object {},
-          ]
-        }
-        modifiers={
-          Object {
-            "end": null,
-            "range": Object {
-              "from": null,
-              "to": null,
-            },
-            "range-end": null,
-            "range-start": null,
-            "start": null,
-          }
-        }
-        numberOfMonths={2}
-        onSelectDay={[Function]}
-        rootClassNames={
-          Object {
-            "date-range__picker": true,
-          }
-        }
-        selectedDays={
-          Array [
-            null,
-            Object {
-              "from": null,
-              "to": null,
-            },
-          ]
-        }
-        showOutsideDays={false}
-      />
-    </div>
-  </Popover>
+      </svg>
+      <span
+        class="date-range__trigger-btn-text"
+      >
+        MM/DD/YYYY - MM/DD/YYYY
+      </span>
+    </button>
+    <button
+      class="button date-range__clear-btn"
+      disabled=""
+      title="Clear date selection"
+      type="button"
+    >
+      <span
+        class="screen-reader-text"
+      >
+        Clear date selection
+      </span>
+      <svg
+        aria-hidden="true"
+        class="gridicon gridicons-cross"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="gridicons.svg#gridicons-cross"
+        />
+      </svg>
+    </button>
+  </span>
 </div>
 `;

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -171,7 +171,7 @@ describe( 'DateRange', () => {
 			const applyBtnEl = screen.getByText( 'Apply' );
 			await userEvent.click( applyBtnEl );
 
-			expect( popoverEl ).not.toBeVisible();
+			expect( popoverEl ).not.toBeInTheDocument();
 		} );
 
 		test( 'should reset Dates on trigger clear btn click', async () => {
@@ -258,7 +258,7 @@ describe( 'DateRange', () => {
 			const endMonthEl = screen.queryByText( 'November 2018' );
 
 			expect( startMonthEl ).toBeVisible();
-			expect( endMonthEl ).toBeNull();
+			expect( endMonthEl ).not.toBeInTheDocument();
 		} );
 
 		test( 'should disable dates before firstSelectableDate when set', async () => {
@@ -341,7 +341,7 @@ describe( 'DateRange', () => {
 			const previousMonthBtnEl = screen.queryByLabelText( /Previous month/ );
 			const nextMonthBtnEl = screen.getByLabelText( 'Next month (December 2018)' );
 
-			expect( previousMonthBtnEl ).toBeNull();
+			expect( previousMonthBtnEl ).not.toBeInTheDocument();
 			expect( nextMonthBtnEl ).toBeVisible();
 		} );
 
@@ -362,7 +362,7 @@ describe( 'DateRange', () => {
 			const nextMonthBtnEl = screen.queryByLabelText( /Next month/ );
 
 			expect( previousMonthBtnEl ).toBeVisible();
-			expect( nextMonthBtnEl ).toBeNull();
+			expect( nextMonthBtnEl ).not.toBeInTheDocument();
 		} );
 	} );
 
@@ -640,7 +640,7 @@ describe( 'DateRange', () => {
 
 			const resetBtn = screen.getByLabelText( 'Reset selected dates' );
 
-			expect( resetBtn ).toBeTruthy();
+			expect( resetBtn ).toBeVisible();
 		} );
 
 		test( 'Should reset selection when reset UI clicked', async () => {

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -153,7 +153,7 @@ describe( 'DateRange', () => {
 
 			await userEvent.click( applyBtnEl );
 
-			const rangeText = screen.getByLabelText( 'Data range' ).textContent;
+			const rangeText = screen.getByLabelText( 'Date range' ).textContent;
 
 			expect( rangeText ).toEqual( '04/01/2018 - 04/29/2018' );
 		} );
@@ -567,7 +567,7 @@ describe( 'DateRange', () => {
 		test( 'should persist date selection when user clicks the "Apply" button', async () => {
 			render( <DateRange translate={ translate } moment={ moment } /> );
 
-			const originalRangeText = screen.getByLabelText( 'Data range' ).textContent;
+			const originalRangeText = screen.getByLabelText( 'Date range' ).textContent;
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 			await userEvent.click( screen.getByLabelText( 'From' ) );

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -667,8 +667,8 @@ describe( 'DateRange', () => {
 			await userEvent.click( toInputEl );
 			await userEvent.clear( toInputEl );
 			await userEvent.keyboard( '05/13/2018' );
-			// force a blur out of `toEl`
-			await userEvent.click( fromInputEl );
+			// Blurs out of `toInputEl`
+			await userEvent.tab();
 
 			expect( screen.getByLabelText( 'Fri, Apr 13, 2018 12:00 PM' ) ).toHaveAttribute(
 				'aria-selected',

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -46,7 +46,6 @@ describe( 'DateRange', () => {
 	describe( 'Date range clamping', () => {
 		test( 'should ensure the end date is not before the start date', () => {
 			const selectedEndDate = moment( '06-01-2018', 'MM-DD-YYYY' );
-
 			const selectedStartDate = moment( selectedEndDate ).add( 1, 'months' );
 
 			render(
@@ -106,7 +105,6 @@ describe( 'DateRange', () => {
 
 		test( 'should clamp selected dates to respect lastSelectableDate prop', () => {
 			const lastSelectableDate = moment( '06-01-2018', 'MM-DD-YYYY' );
-
 			const startDateInFuture = moment( lastSelectableDate ).add( 1, 'months' );
 			const endDateInFuture = moment( lastSelectableDate ).add( 2, 'months' );
 
@@ -142,9 +140,11 @@ describe( 'DateRange', () => {
 		test( 'should render trigger with appropriate placeholders if no dates provided or selected', () => {
 			render( <DateRange translate={ translate } moment={ moment } /> );
 
-			const range = screen.getByLabelText( 'Select date range' ).querySelector( 'span' ).innerHTML;
+			const rangeText = screen
+				.getByLabelText( 'Select date range' )
+				.querySelector( 'span' ).innerHTML;
 
-			expect( range ).toEqual( 'MM/DD/YYYY - MM/DD/YYYY' );
+			expect( rangeText ).toEqual( 'MM/DD/YYYY - MM/DD/YYYY' );
 		} );
 
 		test( 'should update trigger props to match currently selected dates', async () => {
@@ -152,18 +152,20 @@ describe( 'DateRange', () => {
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 
-			const from = screen.getByLabelText( 'From' );
-			const to = screen.getByLabelText( 'To' );
-			const applyBtn = screen.getByText( 'Apply' );
+			const fromInputEl = screen.getByLabelText( 'From' );
+			const toInputEl = screen.getByLabelText( 'To' );
+			const applyBtnEl = screen.getByText( 'Apply' );
 
-			await userEvent.type( from, '04-01-2018' );
-			await userEvent.type( to, '04-29-2018' );
+			await userEvent.type( fromInputEl, '04/01/2018' );
+			await userEvent.type( toInputEl, '04/29/2018' );
 
-			await userEvent.click( applyBtn );
+			await userEvent.click( applyBtnEl );
 
-			const range = screen.getByLabelText( 'Select date range' ).querySelector( 'span' ).innerHTML;
+			const rangeText = screen
+				.getByLabelText( 'Select date range' )
+				.querySelector( 'span' ).innerHTML;
 
-			expect( range ).toEqual( '04/01/2018 - 04/29/2018' );
+			expect( rangeText ).toEqual( '04/01/2018 - 04/29/2018' );
 		} );
 
 		test( 'should toggle popover on trigger click', async () => {
@@ -171,16 +173,15 @@ describe( 'DateRange', () => {
 
 			// Open
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
+			const popoverEl = screen.getByRole( 'tooltip' );
 
-			const popover = screen.getByRole( 'tooltip' );
-
-			expect( popover ).toBeVisible();
+			expect( popoverEl ).toBeVisible();
 
 			// Close
-			const applyBtn = screen.getByText( 'Apply' );
-			await userEvent.click( applyBtn );
+			const applyBtnEl = screen.getByText( 'Apply' );
+			await userEvent.click( applyBtnEl );
 
-			expect( popover ).not.toBeVisible();
+			expect( popoverEl ).not.toBeVisible();
 		} );
 
 		test( 'should reset Dates on trigger clear btn click', async () => {
@@ -196,11 +197,14 @@ describe( 'DateRange', () => {
 				/>
 			);
 
-			const clearBtn = screen.getByTitle( 'Clear date selection' );
-			await userEvent.click( clearBtn );
+			const clearBtnEl = screen.getByTitle( 'Clear date selection' );
+			await userEvent.click( clearBtnEl );
 
-			const range = screen.getByLabelText( 'Select date range' ).querySelector( 'span' ).innerHTML;
-			expect( range ).toEqual( 'MM/DD/YYYY - MM/DD/YYYY' );
+			const rangeText = screen
+				.getByLabelText( 'Select date range' )
+				.querySelector( 'span' ).innerHTML;
+
+			expect( rangeText ).toEqual( 'MM/DD/YYYY - MM/DD/YYYY' );
 		} );
 	} );
 
@@ -233,12 +237,11 @@ describe( 'DateRange', () => {
 			);
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
+			const startMonthEl = screen.getByText( 'October 2018' );
+			const endMonthEl = screen.getByText( 'November 2018' );
 
-			const startMonth = screen.getByText( 'October 2018' );
-			const endMonth = screen.getByText( 'November 2018' );
-
-			expect( startMonth ).toBeVisible();
-			expect( endMonth ).toBeVisible();
+			expect( startMonthEl ).toBeVisible();
+			expect( endMonthEl ).toBeVisible();
 		} );
 
 		test( 'should set 1 month calendar view on screens <480px by default', async () => {
@@ -263,12 +266,11 @@ describe( 'DateRange', () => {
 			);
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
+			const startMonthEl = screen.getByText( 'October 2018' );
+			const endMonthEl = screen.queryByText( 'November 2018' );
 
-			const startMonth = screen.getByText( 'October 2018' );
-			const endMonth = screen.queryByText( 'November 2018' );
-
-			expect( startMonth ).toBeVisible();
-			expect( endMonth ).toBeNull();
+			expect( startMonthEl ).toBeVisible();
+			expect( endMonthEl ).toBeNull();
 		} );
 
 		test( 'should disable dates before firstSelectableDate when set', async () => {
@@ -287,18 +289,18 @@ describe( 'DateRange', () => {
 			// We assume that dates before the `firstSelectableDate` date and on/after
 			// it are disabled/enabled respectively. We test two of each for good
 			// measure. Testing all enabled/disabled dates wouldn't be feasible.
-			const someDisabledDates = [ 'Mon, Oct 1, 2018 12:00 PM', 'Tue, Oct 2, 2018 12:00 PM' ];
-			const someEnabledDates = [ 'Wed, Oct 3, 2018 12:00 PM', 'Thu, Oct 4, 2018 12:00 PM' ];
+			const someDisabledDatesStrings = [ 'Mon, Oct 1, 2018 12:00 PM', 'Tue, Oct 2, 2018 12:00 PM' ];
+			const someEnabledDatesStrings = [ 'Wed, Oct 3, 2018 12:00 PM', 'Thu, Oct 4, 2018 12:00 PM' ];
 
 			// Dates before `10-03-2018`
-			someDisabledDates.forEach( ( timestamp ) => {
-				const el = screen.getByLabelText( timestamp );
+			someDisabledDatesStrings.forEach( ( dateString ) => {
+				const el = screen.getByLabelText( dateString );
 				expect( el ).toHaveAttribute( 'aria-disabled', 'true' );
 			} );
 
 			// Dates on/after `10-03-2018`
-			someEnabledDates.forEach( ( timestamp ) => {
-				const el = screen.getByLabelText( timestamp );
+			someEnabledDatesStrings.forEach( ( dateString ) => {
+				const el = screen.getByLabelText( dateString );
 				expect( el ).toHaveAttribute( 'aria-disabled', 'false' );
 			} );
 		} );
@@ -319,18 +321,18 @@ describe( 'DateRange', () => {
 			// We assume that dates on/before the `lastSelectableDate` date and after
 			// it are enabled/disabled respectively. We test two of each for good
 			// measure. Testing all enabled/disabled dates wouldn't be feasible.
-			const someEnabledDates = [ 'Tue, Oct 2, 2018 12:00 PM', 'Wed, Oct 3, 2018 12:00 PM' ];
-			const someDisabledDates = [ 'Thu, Oct 4, 2018 12:00 PM', 'Fri, Oct 5, 2018 12:00 PM' ];
+			const someEnabledDatesStrings = [ 'Tue, Oct 2, 2018 12:00 PM', 'Wed, Oct 3, 2018 12:00 PM' ];
+			const someDisabledDatesStrings = [ 'Thu, Oct 4, 2018 12:00 PM', 'Fri, Oct 5, 2018 12:00 PM' ];
 
 			// Dates on/before `10-03-2018`
-			someEnabledDates.forEach( ( timestamp ) => {
-				const el = screen.getByLabelText( timestamp );
+			someEnabledDatesStrings.forEach( ( dateString ) => {
+				const el = screen.getByLabelText( dateString );
 				expect( el ).toHaveAttribute( 'aria-disabled', 'false' );
 			} );
 
 			// Dates after `10-03-2018`
-			someDisabledDates.forEach( ( timestamp ) => {
-				const el = screen.getByLabelText( timestamp );
+			someDisabledDatesStrings.forEach( ( dateString ) => {
+				const el = screen.getByLabelText( dateString );
 				expect( el ).toHaveAttribute( 'aria-disabled', 'true' );
 			} );
 		} );
@@ -348,11 +350,11 @@ describe( 'DateRange', () => {
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 
-			const previousMonthBtn = screen.queryByLabelText( /Previous month/ );
-			const nextMonthBtn = screen.getByLabelText( 'Next month (December 2018)' );
+			const previousMonthBtnEl = screen.queryByLabelText( /Previous month/ );
+			const nextMonthBtnEl = screen.getByLabelText( 'Next month (December 2018)' );
 
-			expect( previousMonthBtn ).toBeNull();
-			expect( nextMonthBtn ).toBeVisible();
+			expect( previousMonthBtnEl ).toBeNull();
+			expect( nextMonthBtnEl ).toBeVisible();
 		} );
 
 		test( 'should *not* show the navigation button for the month afer to the one for `lastSelectableDate`', async () => {
@@ -368,11 +370,11 @@ describe( 'DateRange', () => {
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 
-			const previousMonthBtn = screen.getByLabelText( 'Previous month (August 2018)' );
-			const nextMonthBtn = screen.queryByLabelText( /Next month/ );
+			const previousMonthBtnEl = screen.getByLabelText( 'Previous month (August 2018)' );
+			const nextMonthBtnEl = screen.queryByLabelText( /Next month/ );
 
-			expect( previousMonthBtn ).toBeVisible();
-			expect( nextMonthBtn ).toBeNull();
+			expect( previousMonthBtnEl ).toBeVisible();
+			expect( nextMonthBtnEl ).toBeNull();
 		} );
 	} );
 
@@ -380,8 +382,8 @@ describe( 'DateRange', () => {
 		test( 'should see inputs reflect date picker selection', async () => {
 			const firstSelectableDate = moment( '04-03-2018', 'MM-DD-YYYY' );
 
-			const startDate = 'Tue, Apr 3, 2018 12:00 PM';
-			const endDate = 'Tue, May 29, 2018 12:00 PM';
+			const startDateString = 'Tue, Apr 3, 2018 12:00 PM';
+			const endDateString = 'Tue, May 29, 2018 12:00 PM';
 
 			render(
 				<DateRange
@@ -392,14 +394,14 @@ describe( 'DateRange', () => {
 			);
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
-			await userEvent.click( screen.getByLabelText( startDate ) );
-			await userEvent.click( screen.getByLabelText( endDate ) );
+			await userEvent.click( screen.getByLabelText( startDateString ) );
+			await userEvent.click( screen.getByLabelText( endDateString ) );
 
-			const fromInput = screen.queryByDisplayValue( '04/03/2018' );
-			const toInput = screen.getByDisplayValue( '05/29/2018' );
+			const fromInputEl = screen.queryByDisplayValue( '04/03/2018' );
+			const toInputEl = screen.getByDisplayValue( '05/29/2018' );
 
-			expect( fromInput ).toBeVisible();
-			expect( toInput ).toBeVisible();
+			expect( fromInputEl ).toBeVisible();
+			expect( toInputEl ).toBeVisible();
 		} );
 
 		test( 'should update start date selection on start date input blur', async () => {
@@ -459,14 +461,14 @@ describe( 'DateRange', () => {
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 
-			const fromEl = screen.getByLabelText( 'From' );
-			const toEl = screen.getByLabelText( 'To' );
+			const fromInputEl = screen.getByLabelText( 'From' );
+			const toInputEl = screen.getByLabelText( 'To' );
 
-			await userEvent.clear( fromEl );
-			await userEvent.click( fromEl );
+			await userEvent.clear( fromInputEl );
+			await userEvent.click( fromInputEl );
 			await userEvent.keyboard( invalidDateString );
-			await userEvent.clear( toEl );
-			await userEvent.click( toEl );
+			await userEvent.clear( toInputEl );
+			await userEvent.click( toInputEl );
 			await userEvent.keyboard( invalidDateString );
 
 			const startDateEl = screen.getByLabelText( 'Wed, May 30, 2018 12:00 PM' );
@@ -577,7 +579,7 @@ describe( 'DateRange', () => {
 		test( 'should persist date selection when user clicks the "Apply" button', async () => {
 			render( <DateRange translate={ translate } moment={ moment } /> );
 
-			const originalRange = screen
+			const originalRangeText = screen
 				.getByLabelText( 'Select date range' )
 				.querySelector( 'span' ).innerHTML;
 
@@ -588,18 +590,18 @@ describe( 'DateRange', () => {
 			await userEvent.keyboard( '04/29/2018' );
 			await userEvent.click( screen.getByLabelText( 'Apply' ) );
 
-			const newRange = screen
+			const newRangeText = screen
 				.getByLabelText( 'Select date range' )
 				.querySelector( 'span' ).innerHTML;
 
-			expect( originalRange ).toEqual( 'MM/DD/YYYY - MM/DD/YYYY' );
-			expect( newRange ).toEqual( '04/01/2018 - 04/29/2018' );
+			expect( originalRangeText ).toEqual( 'MM/DD/YYYY - MM/DD/YYYY' );
+			expect( newRangeText ).toEqual( '04/01/2018 - 04/29/2018' );
 		} );
 
 		test( 'should discard date selection when user clicks the "Cancel" button', async () => {
 			render( <DateRange translate={ translate } moment={ moment } /> );
 
-			const originalRange = screen
+			const originalRangeText = screen
 				.getByLabelText( 'Select date range' )
 				.querySelector( 'span' ).innerHTML;
 
@@ -610,11 +612,11 @@ describe( 'DateRange', () => {
 			await userEvent.keyboard( '04/29/2018' );
 			await userEvent.click( screen.getByLabelText( 'Cancel' ) );
 
-			const newRange = screen
+			const newRangeText = screen
 				.getByLabelText( 'Select date range' )
 				.querySelector( 'span' ).innerHTML;
 
-			expect( originalRange ).toEqual( newRange );
+			expect( originalRangeText ).toEqual( newRangeText );
 		} );
 
 		test( 'Should display prompt to select first date when no start date selected', async () => {
@@ -676,17 +678,17 @@ describe( 'DateRange', () => {
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 
-			const fromEl = screen.getByLabelText( 'From' );
-			const toEl = screen.getByLabelText( 'To' );
+			const fromInputEl = screen.getByLabelText( 'From' );
+			const toInputEl = screen.getByLabelText( 'To' );
 
-			await userEvent.click( fromEl );
-			await userEvent.clear( fromEl );
+			await userEvent.click( fromInputEl );
+			await userEvent.clear( fromInputEl );
 			await userEvent.keyboard( '04/13/2018' );
-			await userEvent.click( toEl );
-			await userEvent.clear( toEl );
+			await userEvent.click( toInputEl );
+			await userEvent.clear( toInputEl );
 			await userEvent.keyboard( '05/13/2018' );
 			// force a blur out of `toEl`
-			await userEvent.click( fromEl );
+			await userEvent.click( fromInputEl );
 
 			expect( screen.getByLabelText( 'Fri, Apr 13, 2018 12:00 PM' ) ).toHaveAttribute(
 				'aria-selected',
@@ -700,8 +702,8 @@ describe( 'DateRange', () => {
 			const resetBtn = screen.getByLabelText( 'Reset selected dates' );
 			await userEvent.click( resetBtn );
 
-			expect( fromEl.value ).toEqual( '04/28/2018' );
-			expect( toEl.value ).toEqual( '05/28/2018' );
+			expect( fromInputEl.value ).toEqual( '04/28/2018' );
+			expect( toInputEl.value ).toEqual( '05/28/2018' );
 			expect( screen.getByLabelText( 'Sat, Apr 28, 2018 12:00 PM' ) ).toHaveAttribute(
 				'aria-selected',
 				'true'

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -134,9 +134,9 @@ describe( 'DateRange', () => {
 		test( 'should render trigger with appropriate placeholders if no dates provided or selected', () => {
 			render( <DateRange translate={ translate } moment={ moment } /> );
 
-			const rangeText = screen.getByLabelText( 'Date range' ).textContent;
-
-			expect( rangeText ).toEqual( 'MM/DD/YYYY - MM/DD/YYYY' );
+			expect( screen.getByLabelText( 'Date range' ) ).toHaveTextContent(
+				'MM/DD/YYYY - MM/DD/YYYY'
+			);
 		} );
 
 		test( 'should update trigger props to match currently selected dates', async () => {
@@ -153,9 +153,9 @@ describe( 'DateRange', () => {
 
 			await userEvent.click( applyBtnEl );
 
-			const rangeText = screen.getByLabelText( 'Date range' ).textContent;
-
-			expect( rangeText ).toEqual( '04/01/2018 - 04/29/2018' );
+			expect( screen.getByLabelText( 'Date range' ) ).toHaveTextContent(
+				'04/01/2018 - 04/29/2018'
+			);
 		} );
 
 		test( 'should toggle popover on trigger click', async () => {
@@ -190,9 +190,9 @@ describe( 'DateRange', () => {
 			const clearBtnEl = screen.getByTitle( 'Clear date selection' );
 			await userEvent.click( clearBtnEl );
 
-			const rangeText = screen.getByLabelText( 'Date range' ).textContent;
-
-			expect( rangeText ).toEqual( 'MM/DD/YYYY - MM/DD/YYYY' );
+			expect( screen.getByLabelText( 'Date range' ) ).toHaveTextContent(
+				'MM/DD/YYYY - MM/DD/YYYY'
+			);
 		} );
 	} );
 
@@ -567,7 +567,9 @@ describe( 'DateRange', () => {
 		test( 'should persist date selection when user clicks the "Apply" button', async () => {
 			render( <DateRange translate={ translate } moment={ moment } /> );
 
-			const originalRangeText = screen.getByLabelText( 'Date range' ).textContent;
+			expect( screen.getByLabelText( 'Date range' ) ).toHaveTextContent(
+				'MM/DD/YYYY - MM/DD/YYYY'
+			);
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 			await userEvent.click( screen.getByLabelText( 'From' ) );
@@ -576,16 +578,17 @@ describe( 'DateRange', () => {
 			await userEvent.keyboard( '04/29/2018' );
 			await userEvent.click( screen.getByLabelText( 'Apply' ) );
 
-			const newRangeText = screen.getByLabelText( 'Date range' ).textContent;
-
-			expect( originalRangeText ).toEqual( 'MM/DD/YYYY - MM/DD/YYYY' );
-			expect( newRangeText ).toEqual( '04/01/2018 - 04/29/2018' );
+			expect( screen.getByLabelText( 'Date range' ) ).toHaveTextContent(
+				'04/01/2018 - 04/29/2018'
+			);
 		} );
 
 		test( 'should discard date selection when user clicks the "Cancel" button', async () => {
 			render( <DateRange translate={ translate } moment={ moment } /> );
 
-			const originalRangeText = screen.getByLabelText( 'Date range' ).textContent;
+			expect( screen.getByLabelText( 'Date range' ) ).toHaveTextContent(
+				'MM/DD/YYYY - MM/DD/YYYY'
+			);
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 			await userEvent.click( screen.getByLabelText( 'From' ) );
@@ -594,9 +597,9 @@ describe( 'DateRange', () => {
 			await userEvent.keyboard( '04/29/2018' );
 			await userEvent.click( screen.getByLabelText( 'Cancel' ) );
 
-			const newRangeText = screen.getByLabelText( 'Date range' ).textContent;
-
-			expect( originalRangeText ).toEqual( newRangeText );
+			expect( screen.getByLabelText( 'Date range' ) ).toHaveTextContent(
+				'MM/DD/YYYY - MM/DD/YYYY'
+			);
 		} );
 
 		test( 'Should display prompt to select first date when no start date selected', async () => {
@@ -604,9 +607,7 @@ describe( 'DateRange', () => {
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 
-			const infoText = screen.getByRole( 'status' ).textContent;
-
-			expect( infoText ).toEqual( expect.stringContaining( 'Please select the first day' ) );
+			expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Please select the first day' );
 		} );
 
 		test( 'Should display prompt to select last date when no end date selected', async () => {
@@ -618,9 +619,7 @@ describe( 'DateRange', () => {
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 
-			const infoText = screen.getByRole( 'status' ).textContent;
-
-			expect( infoText ).toEqual( expect.stringContaining( 'Please select the last day' ) );
+			expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Please select the last day' );
 		} );
 
 		test( 'Should display reset button when both dates are selected', async () => {
@@ -682,8 +681,8 @@ describe( 'DateRange', () => {
 			const resetBtn = screen.getByLabelText( 'Reset selected dates' );
 			await userEvent.click( resetBtn );
 
-			expect( fromInputEl.value ).toEqual( '04/28/2018' );
-			expect( toInputEl.value ).toEqual( '05/28/2018' );
+			expect( fromInputEl ).toHaveValue( '04/28/2018' );
+			expect( toInputEl ).toHaveValue( '05/28/2018' );
 			expect( screen.getByLabelText( 'Sat, Apr 28, 2018 12:00 PM' ) ).toHaveAttribute(
 				'aria-selected',
 				'true'

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -44,6 +44,12 @@ describe( 'DateRange', () => {
 	} );
 
 	describe( 'Date range clamping', () => {
+		const splitFromDateRangeText = () =>
+			screen
+				.getByLabelText( 'Date range' )
+				.textContent.split( '-' )
+				.map( ( s ) => s.trim() );
+
 		test( 'should ensure the end date is not before the start date', () => {
 			const selectedEndDate = moment( '06-01-2018', 'MM-DD-YYYY' );
 			const selectedStartDate = moment( selectedEndDate ).add( 1, 'months' );
@@ -57,10 +63,7 @@ describe( 'DateRange', () => {
 				/>
 			);
 
-			const [ actualStartDate, actualEndDate ] = screen
-				.getByLabelText( 'Date range' )
-				.textContent.split( '-' )
-				.map( ( s ) => s.trim() );
+			const [ actualStartDate, actualEndDate ] = splitFromDateRangeText();
 
 			const isStartBeforeEnd = moment( actualStartDate, 'MM-DD-YYYY' ).isBefore(
 				moment( actualEndDate, 'MM-DD-YYYY' )
@@ -88,10 +91,7 @@ describe( 'DateRange', () => {
 			const expectedStartDate = dateToLocaleString( firstSelectableDate );
 			const expectedEndDate = dateToLocaleString( firstSelectableDate );
 
-			let [ actualStartDate, actualEndDate ] = screen
-				.getByLabelText( 'Date range' )
-				.textContent.split( '-' )
-				.map( ( s ) => s.trim() );
+			let [ actualStartDate, actualEndDate ] = splitFromDateRangeText();
 
 			actualStartDate = dateToLocaleString( moment( actualStartDate, 'MM-DD-YYYY' ) );
 			actualEndDate = dateToLocaleString( moment( actualEndDate, 'MM-DD-YYYY' ) );
@@ -116,10 +116,7 @@ describe( 'DateRange', () => {
 				/>
 			);
 
-			let [ actualStartDate, actualEndDate ] = screen
-				.getByLabelText( 'Date range' )
-				.textContent.split( '-' )
-				.map( ( s ) => s.trim() );
+			let [ actualStartDate, actualEndDate ] = splitFromDateRangeText();
 
 			const expectedStartDate = dateToLocaleString( lastSelectableDate );
 			const expectedEndDate = dateToLocaleString( lastSelectableDate );

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -414,8 +414,8 @@ describe( 'DateRange', () => {
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 			await userEvent.click( screen.getByLabelText( 'From' ) );
 			await userEvent.keyboard( '05/30/2018' );
-			// This causes a blur on the `From` input, which is enough for our test case
-			await userEvent.click( screen.getByLabelText( 'To' ) );
+			// This causes a blur on the `From` input
+			await userEvent.tab();
 
 			const startDateEl = screen.getByLabelText( 'Wed, May 30, 2018 12:00 PM' );
 
@@ -428,8 +428,8 @@ describe( 'DateRange', () => {
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 			await userEvent.click( screen.getByLabelText( 'To' ) );
 			await userEvent.keyboard( '06/30/2018' );
-			// This causes a blur on the `From` input, which is enough for our test case
-			await userEvent.click( screen.getByLabelText( 'From' ) );
+			// This causes a blur on the `To`
+			await userEvent.tab();
 
 			const endDateEl = screen.getByLabelText( 'Sat, Jun 30, 2018 12:00 PM' );
 

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -32,7 +32,7 @@ describe( 'DateRange', () => {
 		} );
 
 		// Set the clock for our test assertions so that new Date()
-		// will return to a known deterministic date. This important
+		// will return a known deterministic date. This important
 		// for the component to render the expected calendars when
 		// an initial date is not passed to it in a test.
 		MockDate.set( moment.utc( '2018-06-01' ) );

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -134,9 +134,7 @@ describe( 'DateRange', () => {
 		test( 'should render trigger with appropriate placeholders if no dates provided or selected', () => {
 			render( <DateRange translate={ translate } moment={ moment } /> );
 
-			const rangeText = screen
-				.getByLabelText( 'Select date range' )
-				.querySelector( 'span' ).innerHTML;
+			const rangeText = screen.getByLabelText( 'Date range' ).textContent;
 
 			expect( rangeText ).toEqual( 'MM/DD/YYYY - MM/DD/YYYY' );
 		} );
@@ -155,9 +153,7 @@ describe( 'DateRange', () => {
 
 			await userEvent.click( applyBtnEl );
 
-			const rangeText = screen
-				.getByLabelText( 'Select date range' )
-				.querySelector( 'span' ).innerHTML;
+			const rangeText = screen.getByLabelText( 'Data range' ).textContent;
 
 			expect( rangeText ).toEqual( '04/01/2018 - 04/29/2018' );
 		} );
@@ -194,9 +190,7 @@ describe( 'DateRange', () => {
 			const clearBtnEl = screen.getByTitle( 'Clear date selection' );
 			await userEvent.click( clearBtnEl );
 
-			const rangeText = screen
-				.getByLabelText( 'Select date range' )
-				.querySelector( 'span' ).innerHTML;
+			const rangeText = screen.getByLabelText( 'Date range' ).textContent;
 
 			expect( rangeText ).toEqual( 'MM/DD/YYYY - MM/DD/YYYY' );
 		} );
@@ -573,9 +567,7 @@ describe( 'DateRange', () => {
 		test( 'should persist date selection when user clicks the "Apply" button', async () => {
 			render( <DateRange translate={ translate } moment={ moment } /> );
 
-			const originalRangeText = screen
-				.getByLabelText( 'Select date range' )
-				.querySelector( 'span' ).innerHTML;
+			const originalRangeText = screen.getByLabelText( 'Data range' ).textContent;
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 			await userEvent.click( screen.getByLabelText( 'From' ) );
@@ -584,9 +576,7 @@ describe( 'DateRange', () => {
 			await userEvent.keyboard( '04/29/2018' );
 			await userEvent.click( screen.getByLabelText( 'Apply' ) );
 
-			const newRangeText = screen
-				.getByLabelText( 'Select date range' )
-				.querySelector( 'span' ).innerHTML;
+			const newRangeText = screen.getByLabelText( 'Date range' ).textContent;
 
 			expect( originalRangeText ).toEqual( 'MM/DD/YYYY - MM/DD/YYYY' );
 			expect( newRangeText ).toEqual( '04/01/2018 - 04/29/2018' );
@@ -595,9 +585,7 @@ describe( 'DateRange', () => {
 		test( 'should discard date selection when user clicks the "Cancel" button', async () => {
 			render( <DateRange translate={ translate } moment={ moment } /> );
 
-			const originalRangeText = screen
-				.getByLabelText( 'Select date range' )
-				.querySelector( 'span' ).innerHTML;
+			const originalRangeText = screen.getByLabelText( 'Date range' ).textContent;
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 			await userEvent.click( screen.getByLabelText( 'From' ) );
@@ -606,9 +594,7 @@ describe( 'DateRange', () => {
 			await userEvent.keyboard( '04/29/2018' );
 			await userEvent.click( screen.getByLabelText( 'Cancel' ) );
 
-			const newRangeText = screen
-				.getByLabelText( 'Select date range' )
-				.querySelector( 'span' ).innerHTML;
+			const newRangeText = screen.getByLabelText( 'Date range' ).textContent;
 
 			expect( originalRangeText ).toEqual( newRangeText );
 		} );

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -407,11 +407,11 @@ describe( 'DateRange', () => {
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 			await userEvent.click( screen.getByLabelText( 'From' ) );
-			await userEvent.keyboard( '05/30/2018' );
+			await userEvent.keyboard( '06/30/2018' );
 			// This causes a blur on the `From` input
 			await userEvent.tab();
 
-			const startDateEl = screen.getByLabelText( 'Wed, May 30, 2018 12:00 PM' );
+			const startDateEl = screen.getByLabelText( 'Sat, Jun 30, 2018 12:00 PM' );
 
 			expect( startDateEl ).toHaveAttribute( 'aria-selected', 'true' );
 		} );
@@ -422,7 +422,7 @@ describe( 'DateRange', () => {
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 			await userEvent.click( screen.getByLabelText( 'To' ) );
 			await userEvent.keyboard( '06/30/2018' );
-			// This causes a blur on the `To`
+			// This causes a blur on the `To` input
 			await userEvent.tab();
 
 			const endDateEl = screen.getByLabelText( 'Sat, Jun 30, 2018 12:00 PM' );
@@ -712,9 +712,6 @@ describe( 'DateRange', () => {
 			);
 		} );
 	} );
-
-	// TODO Other tests?
-	// - Navigate to next/prev months
 
 	afterEach( () => {
 		MockDate.reset();

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -416,7 +416,6 @@ describe( 'DateRange', () => {
 			await userEvent.keyboard( '05/30/2018' );
 			// This causes a blur on the `From` input, which is enough for our test case
 			await userEvent.click( screen.getByLabelText( 'To' ) );
-			await userEvent.keyboard( '06/30/2018' );
 
 			const startDateEl = screen.getByLabelText( 'Wed, May 30, 2018 12:00 PM' );
 
@@ -431,7 +430,6 @@ describe( 'DateRange', () => {
 			await userEvent.keyboard( '06/30/2018' );
 			// This causes a blur on the `From` input, which is enough for our test case
 			await userEvent.click( screen.getByLabelText( 'From' ) );
-			await userEvent.keyboard( '05/30/2018' );
 
 			const endDateEl = screen.getByLabelText( 'Sat, Jun 30, 2018 12:00 PM' );
 

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -19,8 +19,6 @@ function dateToLocaleString( date ) {
 }
 
 describe( 'DateRange', () => {
-	let fixedEndDate;
-
 	beforeEach( () => {
 		// Mock matchMedia
 		window.matchMedia = jest.fn().mockImplementation( ( query ) => {
@@ -33,15 +31,11 @@ describe( 'DateRange', () => {
 			};
 		} );
 
-		// Forces the date to be UTC format which avoids offset woes
-		// in the tests
-		fixedEndDate = moment.utc( '2018-06-01' );
-
 		// Set the clock for our test assertions so that new Date()
-		// will return the known `fixedEndDate` set above. This helps
-		// us control the non-determenism that comes from usage of
-		// JS `Date` within the component
-		MockDate.set( fixedEndDate );
+		// will return to a known deterministic date. This important
+		// for the component to render the expected calendars when
+		// an initial date is not passed to it in a test.
+		MockDate.set( moment.utc( '2018-06-01' ) );
 	} );
 
 	test( 'should render', () => {

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -58,9 +58,8 @@ describe( 'DateRange', () => {
 			);
 
 			const [ actualStartDate, actualEndDate ] = screen
-				.getByLabelText( 'Select date range' )
-				.querySelector( 'span' )
-				.innerHTML.split( '-' )
+				.getByLabelText( 'Date range' )
+				.textContent.split( '-' )
 				.map( ( s ) => s.trim() );
 
 			const isStartBeforeEnd = moment( actualStartDate, 'MM-DD-YYYY' ).isBefore(
@@ -90,9 +89,8 @@ describe( 'DateRange', () => {
 			const expectedEndDate = dateToLocaleString( firstSelectableDate );
 
 			let [ actualStartDate, actualEndDate ] = screen
-				.getByLabelText( 'Select date range' )
-				.querySelector( 'span' )
-				.innerHTML.split( '-' )
+				.getByLabelText( 'Date range' )
+				.textContent.split( '-' )
 				.map( ( s ) => s.trim() );
 
 			actualStartDate = dateToLocaleString( moment( actualStartDate, 'MM-DD-YYYY' ) );
@@ -119,9 +117,8 @@ describe( 'DateRange', () => {
 			);
 
 			let [ actualStartDate, actualEndDate ] = screen
-				.getByLabelText( 'Select date range' )
-				.querySelector( 'span' )
-				.innerHTML.split( '-' )
+				.getByLabelText( 'Date range' )
+				.textContent.split( '-' )
 				.map( ( s ) => s.trim() );
 
 			const expectedStartDate = dateToLocaleString( lastSelectableDate );

--- a/client/components/date-range/trigger.tsx
+++ b/client/components/date-range/trigger.tsx
@@ -57,6 +57,7 @@ const DateRangeTrigger: FunctionComponent< Props > = ( {
 				onClick={ onTriggerClick }
 				compact={ isCompact }
 				aria-haspopup={ true }
+				aria-label="Select date range"
 			>
 				<Gridicon className="date-range__trigger-btn-icon" icon="calendar" aria-hidden="true" />
 				<span className="date-range__trigger-btn-text">{ dateRangeText }</span>

--- a/client/components/date-range/trigger.tsx
+++ b/client/components/date-range/trigger.tsx
@@ -62,7 +62,9 @@ const DateRangeTrigger: FunctionComponent< Props > = ( {
 				aria-label={ translate( 'Select date range' ) }
 			>
 				<Gridicon className="date-range__trigger-btn-icon" icon="calendar" aria-hidden="true" />
-				<span className="date-range__trigger-btn-text">{ dateRangeText }</span>
+				<span className="date-range__trigger-btn-text" aria-label={ translate( 'Date range' ) }>
+					{ dateRangeText }
+				</span>
 				{ ! showClearBtn && <Gridicon aria-hidden="true" icon="chevron-down" /> }
 			</Button>
 			{ showClearBtn && (

--- a/client/components/date-range/trigger.tsx
+++ b/client/components/date-range/trigger.tsx
@@ -49,6 +49,8 @@ const DateRangeTrigger: FunctionComponent< Props > = ( {
 		} );
 	}
 
+	const clearDateSelectionText = translate( 'Clear date selection' );
+
 	return (
 		<ButtonGroup className="date-range__trigger">
 			<Button
@@ -57,7 +59,7 @@ const DateRangeTrigger: FunctionComponent< Props > = ( {
 				onClick={ onTriggerClick }
 				compact={ isCompact }
 				aria-haspopup={ true }
-				aria-label="Select date range"
+				aria-label={ translate( 'Select date range' ) }
 			>
 				<Gridicon className="date-range__trigger-btn-icon" icon="calendar" aria-hidden="true" />
 				<span className="date-range__trigger-btn-text">{ dateRangeText }</span>
@@ -69,7 +71,8 @@ const DateRangeTrigger: FunctionComponent< Props > = ( {
 					compact={ isCompact }
 					onClick={ onClearClick }
 					disabled={ ! canReset }
-					title="Clear date selection"
+					aria-label={ clearDateSelectionText }
+					title={ clearDateSelectionText }
 				>
 					<ScreenReaderText>{ translate( 'Clear date selection' ) }</ScreenReaderText>
 					<Gridicon aria-hidden="true" icon="cross" />

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -75,6 +75,7 @@ export type EventListener = ( ...payload: any ) => any;
 
 export interface I18N {
 	translate( options: DeprecatedTranslateOptions ): React.ReactChild;
+	translate( original: string ): string;
 	translate( original: string ): React.ReactChild;
 	translate( original: string, options: TranslateOptions ): React.ReactChild;
 	translate( original: string, options: TranslateOptionsText ): string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace Enzyme with react-testing-library in the `DateRange` component test

#### Testing instructions

- Run the test via `yarn test-client yarn test-client client/components/date-range/test/index.js` and it should pass.
- All unit tests should pass
- All E2E tests should pass

Follow up:
* [ ] Add case to test navigation between months (prev/next)

#### For translators (see https://github.com/Automattic/wp-calypso/pull/63879#issuecomment-1167711118):

##### `Reset selected dates`  

This is present in the UI (see screenshot below) and also as an `aria-label`. Refer to the diff in this  PR.

![reset-selected-dates](https://user-images.githubusercontent.com/81248/176036136-3c5faefb-921c-49e9-905c-b3d56c58db80.png)


##### `Select date range`

This is only present as an `aria-label` and not visible in the UI. Refer to the diff in this PR.

##### `Date range`

I think this string is already fully translated? Either way, this is also only present as an `aria-label`. Refer to the diff in this PR.

Related to https://github.com/Automattic/wp-calypso/issues/63409.