### PR TITLE
Search: remove special redirection behaviour

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1,9 +1,7 @@
 import config from '@automattic/calypso-config';
 import {
 	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
-	PRODUCT_JETPACK_SEARCH,
 	WPCOM_FEATURES_BACKUPS,
-	WPCOM_FEATURES_INSTANT_SEARCH,
 } from '@automattic/calypso-products';
 import { Button, Card, Gridicon } from '@automattic/components';
 import debugModule from 'debug';
@@ -223,7 +221,7 @@ export class JetpackAuthorize extends Component {
 	}
 
 	redirect() {
-		const { isMobileAppFlow, mobileAppRedirect, siteHasBackups, siteHasInstantSearch } = this.props;
+		const { isMobileAppFlow, mobileAppRedirect, siteHasBackups } = this.props;
 		const { from, homeUrl, redirectAfterAuth, scope, closeWindowAfterAuthorize } =
 			this.props.authQuery;
 		const { isRedirecting } = this.state;
@@ -271,7 +269,8 @@ export class JetpackAuthorize extends Component {
 			this.isJetpackUpgradeFlow() ||
 			this.isFromJetpackConnectionManager() ||
 			this.isFromJetpackSocialPlugin() ||
-			this.isFromMyJetpack()
+			this.isFromMyJetpack() ||
+			this.isFromJetpackSearchPlugin()
 		) {
 			debug(
 				'Going back to WP Admin.',
@@ -284,9 +283,6 @@ export class JetpackAuthorize extends Component {
 		} else if ( this.isFromJetpackBackupPlugin() && ! siteHasBackups ) {
 			debug( `Redirecting directly to cart with ${ PRODUCT_JETPACK_BACKUP_T1_YEARLY } in cart.` );
 			navigate( `/checkout/${ urlToSlug( homeUrl ) }/${ PRODUCT_JETPACK_BACKUP_T1_YEARLY }` );
-		} else if ( this.isFromJetpackSearchPlugin() && ! siteHasInstantSearch ) {
-			debug( `Redirecting directly to cart with ${ PRODUCT_JETPACK_SEARCH } in cart.` );
-			navigate( `/checkout/${ urlToSlug( homeUrl ) }/${ PRODUCT_JETPACK_SEARCH }` );
 		} else {
 			const redirectionTarget = this.getRedirectionTarget();
 			debug( `Redirecting to: ${ redirectionTarget }` );
@@ -938,11 +934,6 @@ const connectComponent = connect(
 			selectedPlanSlug,
 			siteHasJetpackPaidProduct: siteHasJetpackProductPurchase( state, authQuery.clientId ),
 			siteHasBackups: siteHasFeature( state, authQuery.clientId, WPCOM_FEATURES_BACKUPS ),
-			siteHasInstantSearch: siteHasFeature(
-				state,
-				authQuery.clientId,
-				WPCOM_FEATURES_INSTANT_SEARCH
-			),
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),
 		};

--- a/client/state/sites/selectors/get-jetpack-checkout-redirect-url.js
+++ b/client/state/sites/selectors/get-jetpack-checkout-redirect-url.js
@@ -17,14 +17,12 @@ export default function getJetpackCheckoutRedirectUrl( state, siteId ) {
 	const redirectMap = {
 		jetpack: 'admin.php?page=jetpack#/recommendations',
 		'jetpack-backup': 'admin.php?page=jetpack-backup',
-		'jetpack-search': 'admin.php?page=jetpack-search',
 	};
 
 	// Higher values are prioritized
 	const priority = {
 		jetpack: 1,
 		'jetpack-backup': 0,
-		'jetpack-search': 0,
 	};
 
 	let bestMatchingPlugin = null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The PR removes the special behaviour where Search users are sent to checkout search product after the authorization process introduced in #62199.

The PR also fixes the Complete plan redirection issue for https://github.com/Automattic/jetpack/pull/24403.

#### Testing instructions
<strike>Please follow the instructions in https://github.com/Automattic/jetpack/pull/24403</strike>
- Run Calypso locally `yarn start`
- Prepare a site with only Search plugin, unconnected and without search subscription
- Open `/wp-admin/admin.php?page=jetpack-search`
- Click `Get Jetpack Search`
- Replace `https://wordpress.com` with `http://calypso.localhost:3000`, reload
- Click `Approve`
- Ensure you are only logged in but not redirected to checkout page

Related: [#23171](https://github.com/Automattic/jetpack/issues/23171) [#23917](https://github.com/Automattic/jetpack/issues/23917)
