### PR TITLE
Marketplace: Don't attempt to render empty plugin data

### DIFF
--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -34,6 +34,10 @@ const PluginsBrowserList = ( {
 
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {
+			// Needs a beter fix but something is leaking empty objects into this list.
+			if ( ! plugin?.slug ) {
+				return null;
+			}
 			return (
 				<PluginBrowserItem
 					site={ site }


### PR DESCRIPTION
Something is leaking empty plugins into this list, timeboxed a better fix but couldn't find the source, this will have to do for now.

#### Changes proposed in this Pull Request

* Don't render empty plugins

#### Testing instructions

* Enable infinite scroll on plugin search `infinite: true` to `usePlugins` in the plugins browser
* Search for "seo"
* Scroll to "LuckyWP"
* The next plugin should be rendered and not an empty card

#### Screenshots

Before
![Screenshot 2022-05-23 at 13-14-19 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/169736349-d6d06212-3b90-41fe-9606-1653f2432d3b.png)


After
![Screenshot 2022-05-23 at 13-11-34 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/169736318-a320545c-291e-4c03-bb4d-8ece4b3c871a.png)


Fixes https://github.com/Automattic/wp-calypso/issues/63587
