### PR TITLE
Marketplace: Replace external link with clickable span

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -5,7 +5,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
-import ExternalLink from 'calypso/components/external-link';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
@@ -120,6 +119,13 @@ const PluginsBrowserListElement = ( props ) => {
 	const classNames = classnames( 'plugins-browser-item', variant, {
 		incompatible: isPluginIncompatible,
 	} );
+
+	const onClick = ( e ) => {
+		e.preventDefault();
+		e.stopPropagation();
+		window.location.href = 'https://wordpress.com/support/incompatible-plugins/';
+	};
+
 	return (
 		<li className={ classNames }>
 			<a
@@ -160,9 +166,15 @@ const PluginsBrowserListElement = ( props ) => {
 					</div>
 				) }
 				{ isPluginIncompatible && (
-					<ExternalLink icon={ false } href="https://wordpress.com/support/incompatible-plugins/">
+					<span
+						role="link"
+						tabIndex="-1"
+						onClick={ onClick }
+						onKeyPress={ onClick }
+						className="plugins-browser-item__incompatible"
+					>
 						{ translate( 'Why is this plugin not compatible with WordPress.com?' ) }
-					</ExternalLink>
+					</span>
 				) }
 				<div className="plugins-browser-item__footer">
 					{ variant === PluginsBrowserElementVariant.Extended && (

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -60,16 +60,21 @@
 
 	&.incompatible {
 		.plugins-browser-item__link {
-			.external-link {
+			.plugins-browser-item__incompatible {
 				margin-bottom: 16px;
 				font-size: $font-body-small;
+				color: $studio-blue-40;
 			}
 
-			*:not( .external-link ) {
+			*:not( .plugins-browser-item__incompatible ) {
 				opacity: 0.6;
 			}
+
 		}
+
 	}
+
+
 }
 
 .plugins-browser-item__info {

--- a/client/my-sites/plugins/plugins-browser-item/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/test/index.jsx
@@ -27,7 +27,9 @@ describe( 'PluginsBrowserItem Incompatible Plugins Message', () => {
 		};
 
 		const comp = shallow( <PluginsBrowserListElement { ...props } /> );
-		expect( comp.find( 'ExternalLink' ).length ).toBe( 1 );
+		expect( comp.text().includes( 'Why is this plugin not compatible with WordPress.com?' ) ).toBe(
+			true
+		);
 	} );
 
 	test( 'should render the incompatible plugin message on Atomic Sites', () => {
@@ -39,7 +41,9 @@ describe( 'PluginsBrowserItem Incompatible Plugins Message', () => {
 		};
 
 		const comp = shallow( <PluginsBrowserListElement { ...props } /> );
-		expect( comp.find( 'ExternalLink' ).length ).toBe( 1 );
+		expect( comp.text().includes( 'Why is this plugin not compatible with WordPress.com?' ) ).toBe(
+			true
+		);
 	} );
 
 	test( 'should NOT render the incompatible plugin message on JetpackSite non Atomic sites', () => {
@@ -51,7 +55,9 @@ describe( 'PluginsBrowserItem Incompatible Plugins Message', () => {
 		};
 
 		const comp = shallow( <PluginsBrowserListElement { ...props } /> );
-		expect( comp.find( 'ExternalLink' ).length ).toBe( 0 );
+		expect( comp.text().includes( 'Why is this plugin not compatible with WordPress.com?' ) ).toBe(
+			false
+		);
 	} );
 
 	test( 'should NOT render the incompatible plugin message if it is not in the list', () => {
@@ -63,6 +69,8 @@ describe( 'PluginsBrowserItem Incompatible Plugins Message', () => {
 		};
 
 		const comp = shallow( <PluginsBrowserListElement { ...props } /> );
-		expect( comp.find( 'ExternalLink' ).length ).toBe( 0 );
+		expect( comp.text().includes( 'Why is this plugin not compatible with WordPress.com?' ) ).toBe(
+			false
+		);
 	} );
 } );


### PR DESCRIPTION
This isn't a great fix but it gets rid of the console warning.

@SaxonF the card underneath this link is still clickable (we're nesting link `<a />` tags in html and its giving a react error), should we just replace the whole card's link to the support doc or should we implement some kind of full overlay? At the moment we're rendering the link in the middle of the card to make space for it, imo we should do something different maybe make the card not clickable and only have the middle link or move the card link to the card title and have two.

#### Changes proposed in this Pull Request

* Replace ExternalLink with clickable span

#### Testing instructions

* Search for something that displays an incompatible plugin, e.g. seo http://calypso.localhost:3000/plugins/?s=seo
* Observe no nested `<a />` warnings in the console.

Fixes https://github.com/Automattic/wp-calypso/issues/63586
