### PR TITLE
Marketplace: Add margin to no-results on mobile viewports

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -431,12 +431,14 @@ const SearchListView = ( {
 	}
 
 	return (
-		<NoResults
-			text={ translate( 'No plugins match your search for {{searchTerm/}}.', {
-				textOnly: true,
-				components: { searchTerm: <em>{ searchTerm }</em> },
-			} ) }
-		/>
+		<div className="plugins-browser__no-results">
+			<NoResults
+				text={ translate( 'No plugins match your search for {{searchTerm/}}.', {
+					textOnly: true,
+					components: { searchTerm: <em>{ searchTerm }</em> },
+				} ) }
+			/>
+		</div>
 	);
 };
 

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -35,3 +35,9 @@
 	text-decoration: underline;
 	color: var( --studio-black );
 }
+
+.plugins-browser__no-results {
+	@include breakpoint-deprecated('<660px') {
+		margin: 0 16px;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add margin to mobile no results

#### Testing instructions

* Search for something with no results: http://calypso.localhost:3000/plugins?s=2348+2734+89074
* Should see margin around the no results text

Before
![Screenshot 2022-05-23 at 14-41-13 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/169744831-0f3d241a-343a-4181-aac4-cc4965cb865b.png)

After
![Screenshot 2022-05-23 at 14-40-56 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/169744839-54d93036-9269-40d6-9707-e1d251a0c448.png)


Fixes https://github.com/Automattic/wp-calypso/issues/63439
