### PR TITLE
Always show price switcher unless on top free plugins screen

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -340,6 +340,8 @@ const SearchListView = ( {
 	siteId,
 	sites,
 	billingPeriod,
+	setBillingPeriod,
+	category,
 	categoryName,
 } ) => {
 	const dispatch = useDispatch();
@@ -424,6 +426,7 @@ const SearchListView = ( {
 					variant={ PluginsBrowserListVariant.Paginated }
 					extended
 					billingPeriod={ billingPeriod }
+					setBillingPeriod={ category !== 'popular' && setBillingPeriod }
 				/>
 				<InfiniteScroll nextPageMethod={ fetchNextPage } />
 			</>
@@ -441,7 +444,6 @@ const SearchListView = ( {
 };
 
 const FullListView = ( { category, siteSlug, sites, billingPeriod, setBillingPeriod } ) => {
-	const isPaidCategory = category === 'paid';
 	const { plugins, isFetching, fetchNextPage } = usePlugins( { category, infinite: true } );
 
 	const categories = useCategories();
@@ -460,7 +462,7 @@ const FullListView = ( { category, siteSlug, sites, billingPeriod, setBillingPer
 				currentSites={ sites }
 				variant={ PluginsBrowserListVariant.InfiniteScroll }
 				billingPeriod={ billingPeriod }
-				setBillingPeriod={ isPaidCategory && setBillingPeriod }
+				setBillingPeriod={ category !== 'popular' && setBillingPeriod }
 				extended
 			/>
 
@@ -534,7 +536,7 @@ const PluginSingleListView = ( {
 			currentSites={ sites }
 			variant={ PluginsBrowserListVariant.Fixed }
 			billingPeriod={ billingPeriod }
-			setBillingPeriod={ category === 'paid' && setBillingPeriod }
+			setBillingPeriod={ category !== 'popular' && setBillingPeriod }
 			extended
 		/>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Always show price toggle

#### Testing instructions

Test each page type, all except "Top Free" should show this - top free is only.

* http://calypso.localhost:3000/plugins/popular (free) - no toggle
* http://calypso.localhost:3000/plugins?s=booking - toggle on search
* http://calypso.localhost:3000/plugins/booking - toggle on category
* http://calypso.localhost:3000/plugins - toggle on non top free sections

Before
![Screenshot 2022-05-23 at 15-05-54 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/169747447-48b208ae-7b0e-4b7a-834d-9ef4788c1a2a.png)


After
![Screenshot 2022-05-23 at 15-07-09 Plugins — WordPress com](https://user-images.githubusercontent.com/811776/169747437-6d8625b4-9cc4-4cbd-8d3c-900cfa610310.png)


Fixes https://github.com/Automattic/wp-calypso/issues/63790
