### PR TITLE
tests: migrate `fireEvents` to `userEvent` where applicable

### DIFF
--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import page from 'page';
 import { ReactChild } from 'react';
 import { Provider } from 'react-redux';
@@ -144,7 +145,7 @@ describe( '<EligibilityWarnings>', () => {
 		expect( container.querySelectorAll( '.notice.is-warning' ) ).toHaveLength( 0 );
 	} );
 
-	it( 'goes to checkout when clicking "Upgrade and continue"', () => {
+	it( 'goes to checkout when clicking "Upgrade and continue"', async () => {
 		const state = createState( {
 			holds: [ 'NO_BUSINESS_PLAN' ],
 			siteUrl: 'https://example.wordpress.com',
@@ -161,7 +162,7 @@ describe( '<EligibilityWarnings>', () => {
 		expect( upgradeAndContinue ).toBeVisible();
 		expect( upgradeAndContinue ).not.toBeDisabled();
 
-		fireEvent.click( upgradeAndContinue );
+		await userEvent.click( upgradeAndContinue );
 
 		expect( handleProceed ).not.toHaveBeenCalled();
 		expect( page.redirect ).toHaveBeenCalledTimes( 1 );
@@ -170,7 +171,7 @@ describe( '<EligibilityWarnings>', () => {
 		);
 	} );
 
-	it( `disables the "Continue" button if holds can't be handled automatically`, () => {
+	it( `disables the "Continue" button if holds can't be handled automatically`, async () => {
 		const state = createState( {
 			holds: [ 'NON_ADMIN_USER', 'SITE_PRIVATE' ],
 		} );
@@ -186,7 +187,7 @@ describe( '<EligibilityWarnings>', () => {
 
 		expect( continueButton ).toBeDisabled();
 
-		fireEvent.click( continueButton );
+		userEvent.click( continueButton );
 		expect( handleProceed ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -187,7 +187,7 @@ describe( '<EligibilityWarnings>', () => {
 
 		expect( continueButton ).toBeDisabled();
 
-		userEvent.click( continueButton );
+		await userEvent.click( continueButton );
 		expect( handleProceed ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/blocks/image-editor/test/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/test/image-editor-toolbar.jsx
@@ -1,7 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ImageEditorToolbar } from '../image-editor-toolbar';
 
 describe( 'ImageEditorToolbar', () => {
@@ -37,12 +38,14 @@ describe( 'ImageEditorToolbar', () => {
 	test(
 		'should not trigger the method `onShowNotice` ' +
 			'when image width and height meet the minimum dimensions',
-		() => {
+		async () => {
 			const { container } = render(
 				<ImageEditorToolbar { ...defaultProps } isAspectRatioDisabled={ false } />
 			);
 
-			fireEvent.click( container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ] );
+			await userEvent.click(
+				container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ]
+			);
 
 			expect( defaultProps.onShowNotice ).not.toHaveBeenCalled();
 		}
@@ -51,11 +54,13 @@ describe( 'ImageEditorToolbar', () => {
 	test(
 		'should trigger the method `onShowNotice` with correct translation string ' +
 			'when the user clicks on a disabled aspect ratio toolbar button',
-		() => {
+		async () => {
 			const { container } = render(
 				<ImageEditorToolbar { ...defaultProps } isAspectRatioDisabled />
 			);
-			fireEvent.click( container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ] );
+			await userEvent.click(
+				container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ]
+			);
 
 			expect( defaultProps.onShowNotice ).toHaveBeenCalledWith(
 				'To change the aspect ratio, the height and width must be bigger than {{strong}}%(width)dpx{{/strong}}.'
@@ -66,11 +71,13 @@ describe( 'ImageEditorToolbar', () => {
 	test(
 		'should show aspect ratio popover display ' +
 			'when image width and height meet the minimum dimensions',
-		() => {
+		async () => {
 			const { container } = render(
 				<ImageEditorToolbar { ...defaultProps } isAspectRatioDisabled={ false } />
 			);
-			fireEvent.click( container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ] );
+			await userEvent.click(
+				container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ]
+			);
 
 			expect( screen.queryByRole( 'tooltip' ) ).toBeDefined();
 		}
@@ -79,11 +86,13 @@ describe( 'ImageEditorToolbar', () => {
 	test(
 		'should prevent aspect ratio popover display' +
 			'when image width and height do not meet the minimum dimensions',
-		() => {
+		async () => {
 			const { container } = render(
 				<ImageEditorToolbar { ...defaultProps } isAspectRatioDisabled />
 			);
-			fireEvent.click( container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ] );
+			await userEvent.click(
+				container.getElementsByClassName( 'image-editor__toolbar-button' )[ 1 ]
+			);
 
 			expect( screen.queryByRole( 'tooltip' ) ).toBeNull();
 		}

--- a/client/components/bulk-select/test/index.js
+++ b/client/components/bulk-select/test/index.js
@@ -1,7 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { BulkSelect } from '../index';
 
 const noop = () => {};
@@ -99,7 +100,7 @@ describe( 'index', () => {
 		expect( container.querySelectorAll( 'input' )[ 0 ] ).not.toHaveAttribute( 'readonly' );
 	} );
 
-	test( 'should be call onToggle when clicked', () => {
+	test( 'should be call onToggle when clicked', async () => {
 		const handleToggle = jest.fn();
 
 		const { container } = render(
@@ -110,61 +111,52 @@ describe( 'index', () => {
 				onToggle={ handleToggle }
 			/>
 		);
-		fireEvent.click( container.querySelectorAll( 'input' )[ 0 ] );
+		await userEvent.click( container.querySelectorAll( 'input' )[ 0 ] );
 		expect( handleToggle ).toHaveBeenCalled();
 	} );
 
-	test( 'should be call onToggle with the new state when there are no selected elements', () => {
-		return new Promise( ( done ) => {
-			const callback = function ( newState ) {
-				expect( newState ).toBe( true );
-				done();
-			};
-			const { container } = render(
-				<BulkSelect
-					translate={ translate }
-					selectedElements={ 0 }
-					totalElements={ 3 }
-					onToggle={ callback }
-				/>
-			);
-			fireEvent.click( container.querySelectorAll( 'input' )[ 0 ] );
-		} );
+	test( 'should be call onToggle with the new state when there are no selected elements', async () => {
+		const onToggle = jest.fn();
+		const { container } = render(
+			<BulkSelect
+				translate={ translate }
+				selectedElements={ 0 }
+				totalElements={ 3 }
+				onToggle={ onToggle }
+			/>
+		);
+		await userEvent.click( container.querySelectorAll( 'input' )[ 0 ] );
+		expect( onToggle ).toHaveBeenCalledTimes( 1 );
+		expect( onToggle ).toHaveBeenCalledWith( true );
 	} );
 
-	test( 'should be call onToggle with the new state when there are some selected elements', () => {
-		return new Promise( ( done ) => {
-			const callback = function ( newState ) {
-				expect( newState ).toBe( false );
-				done();
-			};
-			const { container } = render(
-				<BulkSelect
-					translate={ translate }
-					selectedElements={ 1 }
-					totalElements={ 3 }
-					onToggle={ callback }
-				/>
-			);
-			fireEvent.click( container.querySelectorAll( 'input' )[ 0 ] );
-		} );
+	test( 'should be call onToggle with the new state when there are some selected elements', async () => {
+		const onToggle = jest.fn();
+		const { container } = render(
+			<BulkSelect
+				translate={ translate }
+				selectedElements={ 1 }
+				totalElements={ 3 }
+				onToggle={ onToggle }
+			/>
+		);
+		await userEvent.click( container.querySelectorAll( 'input' )[ 0 ] );
+		expect( onToggle ).toHaveBeenCalledTimes( 1 );
+		expect( onToggle ).toHaveBeenCalledWith( false );
 	} );
 
-	test( 'should be call onToggle with the new state when there all elements are selected', () => {
-		return new Promise( ( done ) => {
-			const callback = function ( newState ) {
-				expect( newState ).toBe( false );
-				done();
-			};
-			const { container } = render(
-				<BulkSelect
-					translate={ translate }
-					selectedElements={ 3 }
-					totalElements={ 3 }
-					onToggle={ callback }
-				/>
-			);
-			fireEvent.click( container.querySelectorAll( 'input' )[ 0 ] );
-		} );
+	test( 'should be call onToggle with the new state when there all elements are selected', async () => {
+		const onToggle = jest.fn();
+		const { container } = render(
+			<BulkSelect
+				translate={ translate }
+				selectedElements={ 3 }
+				totalElements={ 3 }
+				onToggle={ onToggle }
+			/>
+		);
+		await userEvent.click( container.querySelectorAll( 'input' )[ 0 ] );
+		expect( onToggle ).toHaveBeenCalledTimes( 1 );
+		expect( onToggle ).toHaveBeenCalledWith( false );
 	} );
 } );

--- a/client/components/forms/form-phone-input/test/index.jsx
+++ b/client/components/forms/form-phone-input/test/index.jsx
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { FormPhoneInput } from '../';
 
 const countriesList = [
@@ -46,7 +47,7 @@ describe( 'FormPhoneInput', () => {
 			expect( option.textContent ).toBe( countriesList[ 0 ].name );
 		} );
 
-		test( 'should update country on change', () => {
+		test( 'should update country on change', async () => {
 			const onChange = jest.fn();
 			const { container } = render(
 				<FormPhoneInput
@@ -58,7 +59,7 @@ describe( 'FormPhoneInput', () => {
 
 			const [ select ] = container.getElementsByClassName( 'form-country-select' );
 
-			fireEvent.change( select, { target: { value: countriesList[ 1 ].code } } );
+			await userEvent.selectOptions( select, countriesList[ 1 ].code );
 
 			expect( onChange ).toHaveBeenCalledWith(
 				expect.objectContaining( { countryData: countriesList[ 1 ] } )

--- a/client/components/jetpack/with-server-credentials-form/test/index.js
+++ b/client/components/jetpack/with-server-credentials-form/test/index.js
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { render, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import withServerCredentialsForm from 'calypso/components/jetpack/with-server-credentials-form';
@@ -124,21 +125,34 @@ describe( 'useWithServerCredentials HOC', () => {
 		const { utils } = setup( {} );
 		const submitButton = utils.getByText( 'Submit' );
 		const errorMessagesContainer = utils.getByTestId( 'error-messages' );
-		fireEvent.click( submitButton );
+		await userEvent.click( submitButton );
 		expect( errorMessagesContainer.innerHTML ).toContain( 'Please enter your server password.' );
 		expect( actions.updateCredentials ).not.toBeCalled();
 	} );
 
 	it( 'should update credentials (should not display error messages)', async () => {
+		const user = userEvent.setup();
 		const { utils } = setup();
 		const submitButton = utils.getByText( 'Submit' );
-		const errorMessagesContainer = utils.getByTestId( 'error-messages' );
-		[ 'user', 'pass', 'host' ].forEach( ( inputName ) => {
-			const input = utils.getByTestId( inputName );
-			fireEvent.change( input, { target: { value: inputName } } );
-			expect( input.value ).toBe( inputName );
-		} );
-		fireEvent.click( submitButton );
+		const errorMessagesContainer = screen.getByTestId( 'error-messages' );
+
+		const userInput = utils.getByTestId( 'user' );
+		await user.clear( userInput );
+		await user.type( userInput, 'user' );
+		expect( userInput.value ).toBe( 'user' );
+
+		const passwordInput = utils.getByTestId( 'pass' );
+		await user.clear( passwordInput );
+		await user.type( passwordInput, 'pass' );
+		expect( passwordInput.value ).toBe( 'pass' );
+
+		const hostInput = utils.getByTestId( 'host' );
+		await user.clear( hostInput );
+		await user.type( hostInput, 'host' );
+		expect( hostInput.value ).toBe( 'host' );
+
+		await user.click( submitButton );
+
 		expect( errorMessagesContainer ).toBeEmptyDOMElement();
 		expect( actions.updateCredentials ).toHaveBeenCalledTimes( 1 );
 		expect( actions.updateCredentials ).toBeCalledWith(
@@ -160,7 +174,7 @@ describe( 'useWithServerCredentials HOC', () => {
 	it( 'should delete credentials', async () => {
 		const { utils } = setup();
 		const deleteButton = utils.getByText( 'Delete' );
-		fireEvent.click( deleteButton );
+		await userEvent.click( deleteButton );
 		expect( actions.deleteCredentials ).toHaveBeenCalledTimes( 1 );
 		expect( actions.deleteCredentials ).toBeCalledWith( 9999, 'main' );
 	} );
@@ -171,7 +185,7 @@ describe( 'useWithServerCredentials HOC', () => {
 		expect( advancedSection.innerHTML ).toContain( '' );
 
 		const toggleButton = utils.getByText( 'Advanced Section' );
-		fireEvent.click( toggleButton );
+		await userEvent.click( toggleButton );
 		expect( advancedSection.innerHTML ).toContain( 'Hidden content!' );
 	} );
 
@@ -187,7 +201,7 @@ describe( 'useWithServerCredentials HOC', () => {
 		expect( formDataContainer.innerHTML ).toContain( '33' );
 		expect( formDataContainer.innerHTML ).toContain( '/jetpack/path' );
 
-		fireEvent.click( submitButton );
+		await userEvent.click( submitButton );
 		expect( errorMessagesContainer.innerHTML ).not.toContain(
 			'Please enter your server username.'
 		);

--- a/client/components/screen-options-tab/test/index.js
+++ b/client/components/screen-options-tab/test/index.js
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import jetpack from 'calypso/state/jetpack/reducer';
 import { reducer as ui } from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
@@ -105,20 +106,21 @@ describe( 'ScreenOptionsTab', () => {
 		expect( screen.queryByTestId( 'screen-options-tab' ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'it toggles dropdown when clicked', () => {
+	test( 'it toggles dropdown when clicked', async () => {
+		const user = userEvent.setup();
 		render( <ScreenOptionsTab wpAdminPath="index.php" />, { initialState } );
 
 		// We expect the dropdown to not be shown by default.
 		expect( screen.queryByTestId( 'screen-options-dropdown' ) ).not.toBeInTheDocument();
 
 		// Click the button.
-		fireEvent.click( screen.getAllByRole( 'button' )[ 0 ] );
+		await user.click( screen.getAllByRole( 'button' )[ 0 ] );
 
 		// Dropdown should exist now it has been toggled.
 		expect( screen.queryByTestId( 'screen-options-dropdown' ) ).toBeInTheDocument();
 
 		// Click the button again.
-		fireEvent.click( screen.getAllByRole( 'button' )[ 0 ] );
+		await user.click( screen.getAllByRole( 'button' )[ 0 ] );
 
 		// Dropdown should not be shown again after toggling it off.
 		expect( screen.queryByTestId( 'screen-options-dropdown' ) ).not.toBeInTheDocument();

--- a/client/components/support-info/test/index.js
+++ b/client/components/support-info/test/index.js
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import SupportInfo from '../';
 
 describe( 'SupportInfo', () => {
@@ -12,10 +13,10 @@ describe( 'SupportInfo', () => {
 		privacyLink: 'https://foo.com/privacy/',
 	};
 
-	test( 'should have a proper "Learn more" link', () => {
+	test( 'should have a proper "Learn more" link', async () => {
 		render( <SupportInfo { ...testProps } /> );
 
-		fireEvent.click( screen.getByRole( 'button' ) );
+		await userEvent.click( screen.getByRole( 'button' ) );
 
 		const link = screen.getByRole( 'link', { name: /learn more/i } );
 
@@ -23,10 +24,10 @@ describe( 'SupportInfo', () => {
 		expect( link ).toHaveAttribute( 'href', testProps.link );
 	} );
 
-	it( 'should have a proper "Privacy Information" link', () => {
+	it( 'should have a proper "Privacy Information" link', async () => {
 		render( <SupportInfo { ...testProps } /> );
 
-		fireEvent.click( screen.getByRole( 'button' ) );
+		await userEvent.click( screen.getByRole( 'button' ) );
 
 		const link = screen.getByRole( 'link', { name: /privacy information/i } );
 

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/test/credit-card-submit-button.jsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/test/credit-card-submit-button.jsx
@@ -5,7 +5,8 @@
 import { useFormStatus } from '@automattic/composite-checkout';
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useSelect } from '@wordpress/data';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -125,7 +126,7 @@ describe( '<CreditCardSubmitButton>', () => {
 
 		const [ button ] = container.getElementsByTagName( 'button' );
 
-		fireEvent.click( button );
+		await userEvent.click( button );
 
 		expect( props.onClick ).toHaveBeenCalled();
 	} );

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/test/set-as-primary-payment-method.jsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/test/set-as-primary-payment-method.jsx
@@ -1,13 +1,14 @@
 /**
  * @jest-environment jsdom
  */
-import { render, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import SetAsPrimaryPaymentMethod from '../set-as-primary-payment-method';
 
 describe( '<SetAsPrimaryPaymentMethod>', () => {
-	test( 'should render correctly, and fire change event correctly', () => {
+	test( 'should render correctly, and fire change event correctly', async () => {
 		const initialState = {};
 		const mockStore = configureStore();
 		const store = mockStore( initialState );
@@ -18,18 +19,19 @@ describe( '<SetAsPrimaryPaymentMethod>', () => {
 			onChange: jest.fn(),
 		};
 
-		const { container } = render(
+		render(
 			<Provider store={ store }>
 				<SetAsPrimaryPaymentMethod { ...props } />
 			</Provider>
 		);
 
-		const [ input ] = container.getElementsByTagName( 'input' );
+		const input = screen.getByRole( 'checkbox' );
 
 		expect( input ).toBeChecked();
 
-		fireEvent.change( input, { target: { checked: false } } );
+		await userEvent.click( input );
 
-		expect( input ).not.toBeChecked();
+		expect( props.onChange ).toHaveBeenCalledTimes( 1 );
+		expect( props.onChange ).toHaveBeenCalledWith( false );
 	} );
 } );

--- a/client/me/purchases/upcoming-renewals/test/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/test/upcoming-renewals-dialog.tsx
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import moment from 'moment';
 import { unmountComponentAtNode } from 'react-dom';
 import Modal from 'react-modal';
@@ -112,7 +113,7 @@ describe( '<UpcomingRenewalsDialog>', () => {
 		).toHaveTextContent( /autorenewing-domain\.liveDotLive Domain Registration: renews in 5 days/ );
 	} );
 
-	test( 'selects all purchases by default', () => {
+	test( 'selects all purchases by default', async () => {
 		const onConfirm = jest.fn();
 		const purchases = mockPurchases();
 		render(
@@ -125,12 +126,13 @@ describe( '<UpcomingRenewalsDialog>', () => {
 			/>
 		);
 
-		fireEvent.click( screen.getByText( 'Renew now' ) );
+		await userEvent.click( screen.getByText( 'Renew now' ) );
 
 		expect( onConfirm ).toHaveBeenCalledWith( purchases );
 	} );
 
-	test( 'submits only the selected purchases', () => {
+	test( 'submits only the selected purchases', async () => {
+		const user = userEvent.setup();
 		const onConfirm = jest.fn();
 		const purchases = mockPurchases();
 		render(
@@ -143,13 +145,14 @@ describe( '<UpcomingRenewalsDialog>', () => {
 			/>
 		);
 
-		fireEvent.click( document.body.querySelector( 'input[name=personal-bundle-1]' ) );
-		fireEvent.click( screen.getByText( 'Renew now' ) );
+		await user.click( document.body.querySelector( 'input[name=personal-bundle-1]' ) );
+		await user.click( screen.getByText( 'Renew now' ) );
 
 		expect( onConfirm ).toHaveBeenCalledWith( [ purchases[ 1 ] ] );
 	} );
 
-	test( 'disables the submit button if no purchases are selected', () => {
+	test( 'disables the submit button if no purchases are selected', async () => {
+		const user = userEvent.setup();
 		render(
 			<UpcomingRenewalsDialog
 				isVisible={ true }
@@ -160,9 +163,8 @@ describe( '<UpcomingRenewalsDialog>', () => {
 			/>
 		);
 
-		fireEvent.click( document.body.querySelector( 'input[name=dotlive_domain-2]' ) );
-
-		fireEvent.click( document.body.querySelector( 'input[name=personal-bundle-1]' ) );
+		await user.click( document.body.querySelector( 'input[name=dotlive_domain-2]' ) );
+		await user.click( document.body.querySelector( 'input[name=personal-bundle-1]' ) );
 
 		expect( screen.getByText( 'Renew now' ) ).toHaveProperty( 'disabled', true );
 	} );

--- a/client/my-sites/checkout/composite-checkout/components/test/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/test/secondary-cart-promotions.tsx
@@ -5,7 +5,8 @@
 import config from '@automattic/calypso-config';
 import { checkoutTheme } from '@automattic/composite-checkout';
 import { ThemeProvider } from '@emotion/react';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
@@ -59,7 +60,7 @@ describe( 'SecondaryCartPromotions', () => {
 				expect( container ).toHaveTextContent( '' );
 			} );
 
-			test( 'adds the items to the cart when "Renew all" is clicked', () => {
+			test( 'adds the items to the cart when "Renew all" is clicked', async () => {
 				const mockAddItemToCart = jest.fn();
 				const { queryByText } = render(
 					<ReduxProvider store={ store }>
@@ -71,7 +72,7 @@ describe( 'SecondaryCartPromotions', () => {
 						</ThemeProvider>
 					</ReduxProvider>
 				);
-				fireEvent.click( queryByText( 'Renew all' ) );
+				await userEvent.click( queryByText( 'Renew all' ) );
 				expect( mockAddItemToCart ).toHaveBeenCalledTimes( 2 );
 				expect( mockAddItemToCart ).toHaveBeenCalledWith(
 					expect.objectContaining( {
@@ -122,7 +123,7 @@ describe( 'SecondaryCartPromotions', () => {
 				expect( queryByText( 'Add to Cart' ) ).toBeTruthy();
 			} );
 
-			test( 'adds the plan to the cart when "Add to Cart" is clicked', () => {
+			test( 'adds the plan to the cart when "Add to Cart" is clicked', async () => {
 				const mockAddItemToCart = jest.fn();
 				const { queryByText } = render(
 					<ReduxProvider store={ store }>
@@ -134,7 +135,7 @@ describe( 'SecondaryCartPromotions', () => {
 						</ThemeProvider>
 					</ReduxProvider>
 				);
-				fireEvent.click( queryByText( 'Add to Cart' ) );
+				await userEvent.click( queryByText( 'Add to Cart' ) );
 				expect( mockAddItemToCart ).toHaveBeenCalledTimes( 1 );
 				expect( mockAddItemToCart ).toHaveBeenCalledWith( {
 					product_slug: 'personal-bundle',

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -3,7 +3,8 @@
  */
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
-import { render, fireEvent, screen, within, waitFor } from '@testing-library/react';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -152,7 +153,7 @@ describe( 'CompositeCheckout with a variant picker', () => {
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
 			const editOrderButton = await screen.findByLabelText( 'Edit your order' );
-			fireEvent.click( editOrderButton );
+			await userEvent.click( editOrderButton );
 
 			expect( screen.getByText( getVariantItemTextForInterval( expectedVariant ) ) ).toBeVisible();
 		}
@@ -258,7 +259,7 @@ describe( 'CompositeCheckout with a variant picker', () => {
 		const cartChanges = { products: [ domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
-		fireEvent.click( editOrderButton );
+		await userEvent.click( editOrderButton );
 
 		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'One year' ) ).not.toBeInTheDocument();
@@ -288,7 +289,7 @@ describe( 'CompositeCheckout with a variant picker', () => {
 		const cartChanges = { products: [ currentPlanRenewal ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 		const editOrderButton = await screen.findByLabelText( 'Edit your order' );
-		fireEvent.click( editOrderButton );
+		await userEvent.click( editOrderButton );
 
 		expect( screen.queryByText( 'One month' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'One year' ) ).not.toBeInTheDocument();

--- a/client/my-sites/checkout/composite-checkout/test/existing-credit-card.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/existing-credit-card.tsx
@@ -8,7 +8,8 @@ import {
 	makeSuccessResponse,
 	CheckoutFormSubmit,
 } from '@automattic/composite-checkout';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -104,7 +105,7 @@ describe( 'Existing credit card payment methods', () => {
 			></TestWrapper>
 		);
 		await waitFor( () => expect( screen.getByText( activePayButtonText ) ).not.toBeDisabled() );
-		fireEvent.click( await screen.findByText( activePayButtonText ) );
+		await userEvent.click( await screen.findByText( activePayButtonText ) );
 		await waitFor( () => {
 			expect( existingCardProcessor ).toHaveBeenCalledWith( {
 				items: [],
@@ -129,7 +130,7 @@ describe( 'Existing credit card payment methods', () => {
 			></TestWrapper>
 		);
 		await waitFor( () => expect( screen.getByText( activePayButtonText ) ).not.toBeDisabled() );
-		fireEvent.click( await screen.findByText( activePayButtonText ) );
+		await userEvent.click( await screen.findByText( activePayButtonText ) );
 		await waitFor( () => {
 			expect( existingCardProcessor ).toHaveBeenCalledWith( {
 				items: [],
@@ -154,7 +155,7 @@ describe( 'Existing credit card payment methods', () => {
 			></TestWrapper>
 		);
 		await waitFor( () => expect( screen.getByText( activePayButtonText ) ).not.toBeDisabled() );
-		fireEvent.click( await screen.findByText( activePayButtonText ) );
+		await userEvent.click( await screen.findByText( activePayButtonText ) );
 		await waitFor( () => {
 			expect( existingCardProcessor ).not.toHaveBeenCalled();
 		} );

--- a/client/my-sites/checkout/composite-checkout/test/netbanking.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/netbanking.tsx
@@ -8,7 +8,8 @@ import {
 	makeSuccessResponse,
 	CheckoutFormSubmit,
 } from '@automattic/composite-checkout';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import {
@@ -73,6 +74,7 @@ describe( 'Netbanking payment method', () => {
 	} );
 
 	it( 'submits the data to the processor when the submit button is pressed', async () => {
+		const user = userEvent.setup();
 		const paymentMethod = getPaymentMethod();
 		const processorFunction = jest.fn( () => Promise.resolve( makeSuccessResponse( {} ) ) );
 		render(
@@ -83,32 +85,16 @@ describe( 'Netbanking payment method', () => {
 		);
 		await waitFor( () => expect( screen.getByText( activePayButtonText ) ).not.toBeDisabled() );
 
-		fireEvent.change( screen.getByLabelText( /Your name/i ), {
-			target: { value: customerName },
-		} );
-		fireEvent.change( screen.getByLabelText( /GSTIN/i ), {
-			target: { value: gstin },
-		} );
-		fireEvent.change( screen.getAllByLabelText( /PAN Number/i )[ 1 ], {
-			target: { value: pan },
-		} );
-		fireEvent.change( screen.getByLabelText( /Address/i ), {
-			target: { value: customerAddress },
-		} );
-		fireEvent.change( screen.getByLabelText( /Street Number/i ), {
-			target: { value: customerStreet },
-		} );
-		fireEvent.change( screen.getByLabelText( /City/i ), {
-			target: { value: customerCity },
-		} );
-		fireEvent.change( screen.getByLabelText( /State/i ), {
-			target: { value: customerState },
-		} );
-		fireEvent.change( screen.getByLabelText( /Postal code/i ), {
-			target: { value: customerPostalCode },
-		} );
+		await user.type( screen.getByLabelText( /Your name/i ), customerName );
+		await user.type( screen.getByLabelText( /GSTIN/i ), gstin );
+		await user.type( screen.getAllByLabelText( /PAN Number/i )[ 1 ], pan );
+		await user.type( screen.getByLabelText( /Address/i ), customerAddress );
+		await user.type( screen.getByLabelText( /Street Number/i ), customerStreet );
+		await user.type( screen.getByLabelText( /City/i ), customerCity );
+		await user.type( screen.getByLabelText( /State/i ), customerState );
+		await user.type( screen.getByLabelText( /Postal code/i ), customerPostalCode );
 
-		fireEvent.click( await screen.findByText( activePayButtonText ) );
+		await userEvent.click( await screen.findByText( activePayButtonText ) );
 		await waitFor( () => {
 			expect( processorFunction ).toHaveBeenCalledWith( {
 				name: customerName,
@@ -134,7 +120,7 @@ describe( 'Netbanking payment method', () => {
 			></TestWrapper>
 		);
 		await waitFor( () => expect( screen.getByText( activePayButtonText ) ).not.toBeDisabled() );
-		fireEvent.click( await screen.findByText( activePayButtonText ) );
+		await userEvent.click( await screen.findByText( activePayButtonText ) );
 		await waitFor( () => {
 			expect( processorFunction ).not.toHaveBeenCalled();
 		} );

--- a/client/my-sites/domains/components/form/test/hidden-input.js
+++ b/client/my-sites/domains/components/form/test/hidden-input.js
@@ -1,7 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { HiddenInput } from '../hidden-input';
 
 describe( 'HiddenInput', () => {
@@ -34,10 +35,10 @@ describe( 'HiddenInput', () => {
 		expect( screen.queryByPlaceholderText( 'Your name' ) ).toHaveValue( fieldValue );
 	} );
 
-	test( 'it should toggle input field when the toggle link is clicked', () => {
+	test( 'it should toggle input field when the toggle link is clicked', async () => {
 		const { container } = render( <HiddenInput { ...defaultProps } /> );
 		expect( screen.queryByText( 'Love cannot be hidden.' ) ).toBeVisible();
-		fireEvent.click( container.getElementsByTagName( 'a' )[ 0 ] );
+		await userEvent.click( container.getElementsByTagName( 'a' )[ 0 ] );
 		expect( screen.queryByText( 'Love cannot be hidden.' ) ).not.toBeInTheDocument();
 		expect( screen.queryByPlaceholderText( 'Your name' ) ).toBeVisible();
 	} );

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -21,7 +21,8 @@ import {
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_WPCOM_PRO,
 } from '@automattic/calypso-products';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import moment from 'moment';
 import editorReducer from 'calypso/state/editor/reducer';
 import mediaReducer from 'calypso/state/media/reducer';
@@ -150,7 +151,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 			expect( container.querySelectorAll( '[name="blog_public"]' ).length ).toBe( 4 );
 		} );
 
-		test( `Selecting Hidden should switch radio to Public`, () => {
+		test( `Selecting Hidden should switch radio to Public`, async () => {
 			testProps.fields.blog_public = -1;
 			const { getByLabelText } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
 
@@ -162,7 +163,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 			const publicRadio = getByLabelText( 'Public' );
 			expect( publicRadio ).not.toBeChecked();
 
-			fireEvent.click( hiddenCheckbox );
+			await userEvent.click( hiddenCheckbox );
 			expect( testProps.updateFields ).toBeCalledWith( {
 				blog_public: 0,
 				wpcom_coming_soon: 0,
@@ -170,7 +171,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 			} );
 		} );
 
-		test( `Hidden checkbox should be possible to unselect`, () => {
+		test( `Hidden checkbox should be possible to unselect`, async () => {
 			testProps.fields.blog_public = 0;
 			const { getByLabelText } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
 
@@ -182,7 +183,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 			const publicRadio = getByLabelText( 'Public' );
 			expect( publicRadio ).toBeChecked();
 
-			fireEvent.click( hiddenCheckbox );
+			await userEvent.click( hiddenCheckbox );
 			expect( testProps.updateFields ).toBeCalledWith( {
 				blog_public: 1,
 				wpcom_coming_soon: 0,
@@ -217,7 +218,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 					{ blog_public: -1, wpcom_coming_soon: 0, wpcom_public_coming_soon: 0 },
 				],
 			].forEach( ( [ name, text, initialBlogPublic, updatedFields ] ) => {
-				test( `${ name } option should be selectable`, () => {
+				test( `${ name } option should be selectable`, async () => {
 					testProps.fields.blog_public = initialBlogPublic;
 					const { getByLabelText } = renderWithRedux(
 						<SiteSettingsFormGeneral { ...testProps } />
@@ -225,7 +226,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 
 					const radioButton = getByLabelText( text, { exact: false } );
 					expect( radioButton ).not.toBeChecked();
-					fireEvent.click( radioButton );
+					await userEvent.click( radioButton );
 					expect( testProps.updateFields ).toBeCalledWith( updatedFields );
 				} );
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate `fireEvent` usages to `@testing-library/user-event` where applicable

#### Testing instructions


* Verify unit tests still pass

Related to #63409 
