### PR TITLE
tests(themes): clear query cache after each test ran

### DIFF
--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -24,8 +24,10 @@ const themeData = {
 	demo_uri: 'https://twentysixteendemo.wordpress.com/',
 };
 
+let queryClient;
+
 const TestComponent = ( { themeId, store } ) => {
-	const queryClient = new QueryClient();
+	queryClient = new QueryClient();
 	return (
 		<ReduxProvider store={ store }>
 			<QueryClientProvider client={ queryClient }>
@@ -36,6 +38,10 @@ const TestComponent = ( { themeId, store } ) => {
 };
 
 describe( 'main', () => {
+	afterEach( () => {
+		queryClient.clear();
+	} );
+
 	test( "doesn't throw an exception without theme data", () => {
 		const store = createReduxStore();
 		setStore( store );


### PR DESCRIPTION
This PR fixes a warning which appears after running unit tests. It says

> Jest did not exit one second after the test run has completed.
> This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.

#### Changes proposed in this Pull Request

* Add `queryClient.clear()` calls after each test for `client/my-sites/theme/test/main.jsx`

#### Testing instructions

* Verify you don't see the warning mentioned above after running tests with `yarn test-client`
