### PR TITLE
jetpackBenefits: migrate tests to `@testing-library`

### DIFF
--- a/client/blocks/jetpack-benefits/benefit-card.tsx
+++ b/client/blocks/jetpack-benefits/benefit-card.tsx
@@ -15,6 +15,7 @@ export const JetpackBenefitsCard: React.FC< Props > = ( {
 	headline,
 	description,
 	placeholder,
+	jestMarker,
 } ) => {
 	const getStat = () => {
 		if ( stat ) {
@@ -28,7 +29,7 @@ export const JetpackBenefitsCard: React.FC< Props > = ( {
 	} );
 
 	return (
-		<div className="jetpack-benefits__card card">
+		<div className="jetpack-benefits__card card" data-testid={ jestMarker }>
 			<div className="jetpack-benefits__card-content">
 				<p className="jetpack-benefits__card-headline">{ headline }</p>
 				<div className={ statBlockClassNames }>

--- a/client/blocks/jetpack-benefits/benefit-card.tsx
+++ b/client/blocks/jetpack-benefits/benefit-card.tsx
@@ -15,7 +15,6 @@ export const JetpackBenefitsCard: React.FC< Props > = ( {
 	headline,
 	description,
 	placeholder,
-	jestMarker,
 } ) => {
 	const getStat = () => {
 		if ( stat ) {
@@ -29,7 +28,7 @@ export const JetpackBenefitsCard: React.FC< Props > = ( {
 	} );
 
 	return (
-		<div className="jetpack-benefits__card card" data-testid={ jestMarker }>
+		<div className="jetpack-benefits__card card">
 			<div className="jetpack-benefits__card-content">
 				<p className="jetpack-benefits__card-headline">{ headline }</p>
 				<div className={ statBlockClassNames }>

--- a/client/blocks/jetpack-benefits/scan-history.tsx
+++ b/client/blocks/jetpack-benefits/scan-history.tsx
@@ -39,7 +39,6 @@ const JetpackBenefitsScanHistory: React.FC< Props > = ( { siteId, isStandalone }
 	if ( scanState === 'scanning' ) {
 		return (
 			<JetpackBenefitsCard
-				jestMarker="scanning"
 				headline={ translate( 'Site Scan' ) }
 				description={
 					<ProgressBar value={ siteScanProgress ?? 0 } total={ 100 } color="#069E08" />
@@ -53,7 +52,6 @@ const JetpackBenefitsScanHistory: React.FC< Props > = ( { siteId, isStandalone }
 	if ( scanState === 'provisioning' ) {
 		return (
 			<JetpackBenefitsCard
-				jestMarker="provisioning"
 				headline={ translate( 'Site Scan' ) }
 				description={ translate( 'Jetpack is preparing to scan your site.' ) }
 				stat="Preparing"
@@ -65,7 +63,6 @@ const JetpackBenefitsScanHistory: React.FC< Props > = ( { siteId, isStandalone }
 	if ( requestingScanState ) {
 		return (
 			<JetpackBenefitsCard
-				jestMarker="loading"
 				headline={ translate( 'Site Scan' ) }
 				description={ translate( 'Waiting for scan status' ) }
 				stat={ translate( 'Loading' ) }
@@ -78,7 +75,6 @@ const JetpackBenefitsScanHistory: React.FC< Props > = ( { siteId, isStandalone }
 	if ( ! scanState ) {
 		return (
 			<JetpackBenefitsCard
-				jestMarker="error"
 				headline={ translate( 'Site Scan' ) }
 				description={ translate( 'Jetpack is having trouble scanning your site.' ) }
 			/>
@@ -91,7 +87,6 @@ const JetpackBenefitsScanHistory: React.FC< Props > = ( { siteId, isStandalone }
 	if ( ! mostRecent ) {
 		return (
 			<JetpackBenefitsCard
-				jestMarker="scheduled"
 				headline={ translate( 'Site Scan' ) }
 				description={ translate( 'Jetpack will scan your site for threats soon.' ) }
 				stat="Scheduled"
@@ -144,7 +139,6 @@ const JetpackBenefitsScanHistory: React.FC< Props > = ( { siteId, isStandalone }
 
 	return (
 		<JetpackBenefitsCard
-			jestMarker="default"
 			headline={ translate( 'Site Scan' ) }
 			description={ cardDescription }
 			stat={ cardStat }

--- a/client/blocks/jetpack-benefits/site-backups.tsx
+++ b/client/blocks/jetpack-benefits/site-backups.tsx
@@ -68,7 +68,6 @@ const JetpackBenefitsSiteBackups: React.FC< Props > = ( { siteId, isStandalone }
 		return (
 			<React.Fragment>
 				<JetpackBenefitsCard
-					jestMarker="loading-backups" // for test suite
 					headline={ translate( 'Site Backups' ) }
 					description={ translate( 'Loading backup data' ) }
 					stat={ translate( 'Placeholder' ) }
@@ -106,7 +105,6 @@ const JetpackBenefitsSiteBackups: React.FC< Props > = ( { siteId, isStandalone }
 	if ( ! mostRecentBackup ) {
 		return (
 			<JetpackBenefitsCard
-				jestMarker="no-backups" // for test suite
 				headline={ translate( 'Site Backups' ) }
 				description={ translate( 'Jetpack will back up your site soon.' ) }
 			/>
@@ -117,7 +115,6 @@ const JetpackBenefitsSiteBackups: React.FC< Props > = ( { siteId, isStandalone }
 	if ( mostRecentBackup.status !== 'finished' && mostRecentBackup.status !== 'started' ) {
 		return (
 			<JetpackBenefitsCard
-				jestMarker="recent-backup-error" // for test suite
 				headline={ translate( 'Site Backups' ) }
 				description={ translate(
 					"Jetpack's last attempt to back up your site was not successful. Please contact Jetpack support."
@@ -156,7 +153,6 @@ const JetpackBenefitsSiteBackups: React.FC< Props > = ( { siteId, isStandalone }
 
 	return (
 		<JetpackBenefitsCard
-			jestMarker="default-backup-output" // for test suite
 			headline={ translate( 'Site Backups' ) }
 			description={ translate( 'Your latest site backup.' ) }
 			stat={ lastBackupTimeAgo }

--- a/client/blocks/jetpack-benefits/test/__snapshots__/scan-history.jsx.snap
+++ b/client/blocks/jetpack-benefits/test/__snapshots__/scan-history.jsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scan History Jetpack Benefit Block If product is standalone scan, the expanded standalone card is rendered 1`] = `
+<div>
+  <div
+    class="jetpack-benefits__card jetpack-benefits__card--standalone card"
+  >
+    <p
+      class="jetpack-benefits__card-headline"
+    >
+      Site Scan
+    </p>
+    <div
+      class="jetpack-benefits__card-content"
+    >
+      <div
+        class="jetpack-benefits__standalone-summary"
+      >
+        <span
+          class="jetpack-benefits__stat-title"
+        >
+          Last Scan
+        </span>
+        <p
+          class="jetpack-benefits__card-stat"
+        >
+          Invalid date
+        </p>
+      </div>
+      <ul
+        class="jetpack-benefits__standalone-stats"
+      >
+        <li>
+          <span
+            class="jetpack-benefits__stat-title"
+          >
+            Malware Threats Found
+          </span>
+          <p
+            class="jetpack-benefits__card-stat"
+          >
+            ...
+          </p>
+        </li>
+        <li>
+          <span
+            class="jetpack-benefits__stat-title"
+          >
+            Threats Fixed (Lifetime)
+          </span>
+          <p
+            class="jetpack-benefits__card-stat"
+          >
+            0
+          </p>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;

--- a/client/blocks/jetpack-benefits/test/scan-history.jsx
+++ b/client/blocks/jetpack-benefits/test/scan-history.jsx
@@ -1,6 +1,7 @@
-import { shallow } from 'enzyme';
-import { JetpackBenefitsCard } from 'calypso/blocks/jetpack-benefits/benefit-card';
-import { JetpackBenefitsStandaloneCard } from 'calypso/blocks/jetpack-benefits/standalone-benefit-card';
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
 import getSiteScanState from 'calypso/state/selectors/get-site-scan-state';
 import isRequestingJetpackScan from 'calypso/state/selectors/is-requesting-jetpack-scan';
 import JetpackBenefitsScanHistory from '../scan-history';
@@ -17,11 +18,6 @@ jest.mock( 'calypso/state/selectors/is-requesting-jetpack-scan-threat-counts' );
 jest.mock( 'calypso/state/selectors/get-site-scan-progress' );
 
 describe( 'Scan History Jetpack Benefit Block', () => {
-	const getBenefitsCard = () => {
-		const element = shallow( <JetpackBenefitsScanHistory /> );
-		return element.find( 'JetpackBenefitsScanHistory' ).dive().find( JetpackBenefitsCard );
-	};
-
 	beforeEach( () => {
 		getSiteScanState.mockReset();
 		isRequestingJetpackScan.mockReset();
@@ -30,43 +26,59 @@ describe( 'Scan History Jetpack Benefit Block', () => {
 	test( 'When the scan state is actively scanning, show a scanning message', () => {
 		const scanState = { state: 'scanning' };
 		getSiteScanState.mockReturnValue( scanState );
-		expect( getBenefitsCard().props() ).toHaveProperty( 'jestMarker', 'scanning' );
+
+		render( <JetpackBenefitsScanHistory /> );
+		const card = screen.getByTestId( 'scanning' );
+
+		expect( card ).toBeInTheDocument();
 	} );
 
 	test( 'When the scan state is provisioning, show a preparing message', () => {
 		const scanState = { state: 'provisioning' };
 		getSiteScanState.mockReturnValue( scanState );
-		expect( getBenefitsCard().props() ).toHaveProperty( 'jestMarker', 'provisioning' );
+
+		render( <JetpackBenefitsScanHistory /> );
+		const card = screen.getByTestId( 'provisioning' );
+
+		expect( card ).toBeInTheDocument();
 	} );
 
 	test( 'When the scan state is still loading, show a loading placeholder', () => {
 		getSiteScanState.mockReturnValue( null );
 		isRequestingJetpackScan.mockReturnValue( true );
-		expect( getBenefitsCard().props() ).toHaveProperty( 'jestMarker', 'loading' );
+
+		render( <JetpackBenefitsScanHistory /> );
+		const card = screen.getByTestId( 'loading' );
+
+		expect( card ).toBeInTheDocument();
 	} );
 
 	test( 'When the scan state is not present and not loading, show an error', () => {
 		getSiteScanState.mockReturnValue( null );
 		isRequestingJetpackScan.mockReturnValue( false );
-		expect( getBenefitsCard().props() ).toHaveProperty( 'jestMarker', 'error' );
+
+		render( <JetpackBenefitsScanHistory /> );
+		const card = screen.getByTestId( 'error' );
+
+		expect( card ).toBeInTheDocument();
 	} );
 
 	test( 'When the scan state is idle, but there is not a recent scan, indicate that a scan is scheduled', () => {
 		const scanState = { state: 'idle' };
 		getSiteScanState.mockReturnValue( scanState );
 		isRequestingJetpackScan.mockReturnValue( false );
-		expect( getBenefitsCard().props() ).toHaveProperty( 'jestMarker', 'scheduled' );
+
+		render( <JetpackBenefitsScanHistory /> );
+		const card = screen.getByTestId( 'scheduled' );
+
+		expect( card ).toBeInTheDocument();
 	} );
 
 	test( 'If product is standalone scan, the expanded standalone card is rendered', () => {
 		getSiteScanState.mockReturnValue( { state: 'idle', mostRecent: { timestamp: '' } } );
 		isRequestingJetpackScan.mockReturnValue( false );
 
-		const standaloneCard = shallow( <JetpackBenefitsScanHistory isStandalone={ true } /> )
-			.find( 'JetpackBenefitsScanHistory' )
-			.dive()
-			.find( JetpackBenefitsStandaloneCard );
-
-		expect( standaloneCard ).toHaveLength( 1 );
+		const { container } = render( <JetpackBenefitsScanHistory isStandalone={ true } /> );
+		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/client/blocks/jetpack-benefits/test/scan-history.jsx
+++ b/client/blocks/jetpack-benefits/test/scan-history.jsx
@@ -24,54 +24,41 @@ describe( 'Scan History Jetpack Benefit Block', () => {
 	} );
 
 	test( 'When the scan state is actively scanning, show a scanning message', () => {
-		const scanState = { state: 'scanning' };
-		getSiteScanState.mockReturnValue( scanState );
-
+		getSiteScanState.mockReturnValue( { state: 'scanning' } );
 		render( <JetpackBenefitsScanHistory /> );
-		const card = screen.getByTestId( 'scanning' );
 
-		expect( card ).toBeInTheDocument();
+		expect( screen.getByText( /in progress$/i ) ).toBeInTheDocument();
 	} );
 
 	test( 'When the scan state is provisioning, show a preparing message', () => {
-		const scanState = { state: 'provisioning' };
-		getSiteScanState.mockReturnValue( scanState );
-
+		getSiteScanState.mockReturnValue( { state: 'provisioning' } );
 		render( <JetpackBenefitsScanHistory /> );
-		const card = screen.getByTestId( 'provisioning' );
 
-		expect( card ).toBeInTheDocument();
+		expect( screen.getByText( /preparing$/i ) ).toBeInTheDocument();
 	} );
 
 	test( 'When the scan state is still loading, show a loading placeholder', () => {
 		getSiteScanState.mockReturnValue( null );
 		isRequestingJetpackScan.mockReturnValue( true );
-
 		render( <JetpackBenefitsScanHistory /> );
-		const card = screen.getByTestId( 'loading' );
 
-		expect( card ).toBeInTheDocument();
+		expect( screen.getByText( /loading/i ) ).toBeInTheDocument();
 	} );
 
 	test( 'When the scan state is not present and not loading, show an error', () => {
 		getSiteScanState.mockReturnValue( null );
 		isRequestingJetpackScan.mockReturnValue( false );
-
 		render( <JetpackBenefitsScanHistory /> );
-		const card = screen.getByTestId( 'error' );
 
-		expect( card ).toBeInTheDocument();
+		expect( screen.getByText( /trouble scanning your site/i ) ).toBeInTheDocument();
 	} );
 
 	test( 'When the scan state is idle, but there is not a recent scan, indicate that a scan is scheduled', () => {
-		const scanState = { state: 'idle' };
-		getSiteScanState.mockReturnValue( scanState );
+		getSiteScanState.mockReturnValue( { state: 'idle' } );
 		isRequestingJetpackScan.mockReturnValue( false );
-
 		render( <JetpackBenefitsScanHistory /> );
-		const card = screen.getByTestId( 'scheduled' );
 
-		expect( card ).toBeInTheDocument();
+		expect( screen.getByText( /scheduled/i ) ).toBeInTheDocument();
 	} );
 
 	test( 'If product is standalone scan, the expanded standalone card is rendered', () => {

--- a/client/blocks/jetpack-benefits/test/site-backups.jsx
+++ b/client/blocks/jetpack-benefits/test/site-backups.jsx
@@ -1,4 +1,7 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
 import getRewindBackups from 'calypso/state/selectors/get-rewind-backups';
 import JetpackBenefitsSiteBackups from '../site-backups';
 
@@ -11,11 +14,6 @@ jest.mock( 'react-redux', () => ( {
 jest.mock( 'calypso/state/selectors/get-rewind-backups' );
 
 describe( 'Jetpack Benefits site backups card', () => {
-	const getBenefitsCard = () => {
-		const element = shallow( <JetpackBenefitsSiteBackups /> );
-		return element.find( 'JetpackBenefitsSiteBackups' ).dive().find( 'JetpackBenefitsCard' );
-	};
-
 	beforeEach( () => {
 		getRewindBackups.mockReset();
 	} );
@@ -23,24 +21,36 @@ describe( 'Jetpack Benefits site backups card', () => {
 	test( 'If backups are still loading, show a placeholder output', () => {
 		const backupsReceived = null;
 		getRewindBackups.mockReturnValue( backupsReceived );
-		expect( getBenefitsCard().props() ).toHaveProperty( 'jestMarker', 'loading-backups' );
+
+		render( <JetpackBenefitsSiteBackups /> );
+		const card = screen.getByTestId( 'loading-backups' );
+		expect( card ).toBeInTheDocument();
 	} );
 
 	test( 'If no backups are found, show a no-backups output', () => {
 		const backupsReceived = [];
 		getRewindBackups.mockReturnValue( backupsReceived );
-		expect( getBenefitsCard().props() ).toHaveProperty( 'jestMarker', 'no-backups' );
+
+		render( <JetpackBenefitsSiteBackups /> );
+		const card = screen.getByTestId( 'no-backups' );
+		expect( card ).toBeInTheDocument();
 	} );
 
 	test( 'If last backup was an error, show an error message', () => {
 		const backupsReceived = [ { status: 'error-will-retry' } ];
 		getRewindBackups.mockReturnValue( backupsReceived );
-		expect( getBenefitsCard().props() ).toHaveProperty( 'jestMarker', 'recent-backup-error' );
+
+		render( <JetpackBenefitsSiteBackups /> );
+		const card = screen.getByTestId( 'recent-backup-error' );
+		expect( card ).toBeInTheDocument();
 	} );
 
 	test( 'If last backup is good, show default backup card output', () => {
 		const backupsReceived = [ { status: 'finished' } ];
 		getRewindBackups.mockReturnValue( backupsReceived );
-		expect( getBenefitsCard().props() ).toHaveProperty( 'jestMarker', 'default-backup-output' );
+
+		render( <JetpackBenefitsSiteBackups /> );
+		const card = screen.getByTestId( 'default-backup-output' );
+		expect( card ).toBeInTheDocument();
 	} );
 } );

--- a/client/blocks/jetpack-benefits/test/site-backups.jsx
+++ b/client/blocks/jetpack-benefits/test/site-backups.jsx
@@ -19,38 +19,30 @@ describe( 'Jetpack Benefits site backups card', () => {
 	} );
 
 	test( 'If backups are still loading, show a placeholder output', () => {
-		const backupsReceived = null;
-		getRewindBackups.mockReturnValue( backupsReceived );
-
+		getRewindBackups.mockReturnValue( null );
 		render( <JetpackBenefitsSiteBackups /> );
-		const card = screen.getByTestId( 'loading-backups' );
-		expect( card ).toBeInTheDocument();
+
+		expect( screen.getByText( /loading backup data/i ) ).toBeInTheDocument();
 	} );
 
 	test( 'If no backups are found, show a no-backups output', () => {
-		const backupsReceived = [];
-		getRewindBackups.mockReturnValue( backupsReceived );
-
+		getRewindBackups.mockReturnValue( [] );
 		render( <JetpackBenefitsSiteBackups /> );
-		const card = screen.getByTestId( 'no-backups' );
-		expect( card ).toBeInTheDocument();
+
+		expect( screen.getByText( /will back up your site soon/i ) ).toBeInTheDocument();
 	} );
 
 	test( 'If last backup was an error, show an error message', () => {
-		const backupsReceived = [ { status: 'error-will-retry' } ];
-		getRewindBackups.mockReturnValue( backupsReceived );
-
+		getRewindBackups.mockReturnValue( [ { status: 'error-will-retry' } ] );
 		render( <JetpackBenefitsSiteBackups /> );
-		const card = screen.getByTestId( 'recent-backup-error' );
-		expect( card ).toBeInTheDocument();
+
+		expect( screen.getByText( /error/i ) ).toBeInTheDocument();
 	} );
 
 	test( 'If last backup is good, show default backup card output', () => {
-		const backupsReceived = [ { status: 'finished' } ];
-		getRewindBackups.mockReturnValue( backupsReceived );
-
+		getRewindBackups.mockReturnValue( [ { status: 'finished' } ] );
 		render( <JetpackBenefitsSiteBackups /> );
-		const card = screen.getByTestId( 'default-backup-output' );
-		expect( card ).toBeInTheDocument();
+
+		expect( screen.getByText( /your latest site backup/i ) ).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate the following test files to `@testing-library`:

- client/blocks/jetpack-benefits/test/site-backups.jsx 
- client/blocks/jetpack-benefits/test/scan-history.jsx 

#### Testing instructions


* Verify unit tests pass


Related to #63409 
