### PR TITLE
Help Center: only count recieved messages in unread count

### DIFF
--- a/apps/happychat/src/happychat.jsx
+++ b/apps/happychat/src/happychat.jsx
@@ -22,11 +22,11 @@ import isHappychatServerReachable from 'calypso/state/happychat/selectors/is-hap
 import { setCurrentMessage } from 'calypso/state/happychat/ui/actions';
 import './happychat.scss';
 
-function getMessagesOlderThan( timestamp, messages ) {
+function getReceivedMessagesOlderThan( timestamp, messages ) {
 	if ( ! timestamp ) {
 		return [];
 	}
-	return messages.filter( ( m ) => m.timestamp >= timestamp );
+	return messages.filter( ( m ) => m.timestamp >= timestamp && m.source !== 'customer' );
 }
 
 function ParentConnection( { chatStatus, timeline } ) {
@@ -142,7 +142,7 @@ function ParentConnection( { chatStatus, timeline } ) {
 	}, [] );
 
 	useEffect( () => {
-		const unreadMessageCount = getMessagesOlderThan( blurredAt, timeline ).length;
+		const unreadMessageCount = getReceivedMessagesOlderThan( blurredAt, timeline ).length;
 		( window.opener || window.parent )?.postMessage(
 			{
 				type: 'calypso-happy-chat-unread-messages',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR filters by message source in addition to the timestamp. 

#### Testing instructions

1. Start a chat.
2. Send a message. The unread count should remain zero.
3. Wait until you receive a message, the unread count should increase.
