### PR TITLE
Anchor: Move handling of query params into login step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
@@ -10,33 +10,23 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
 import getTextWidth from 'calypso/landing/gutenboarding/onboarding-block/acquire-intent/get-text-width';
-import { useAnchorFmParams } from 'calypso/landing/stepper/hooks/use-anchor-fm-params';
-import useDetectMatchingAnchorSite from 'calypso/landing/stepper/hooks/use-detect-matching-anchor-site';
 import usePodcastTitle from 'calypso/landing/stepper/hooks/use-podcast-title';
-import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { tip } from 'calypso/signup/icons';
 import type { Step } from '../../types';
 import './style.scss';
 
 const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
-	const { goBack, submit, goToStep } = navigation;
+	const { goBack, submit } = navigation;
 	const { __ } = useI18n();
-	const { isAnchorFmPodcastIdError } = useAnchorFmParams();
-	const { setSiteSetupError } = useDispatch( SITE_STORE );
-
-	//Check to see if there is a site with a matching anchor podcast ID
-	const isLookingUpMatchingAnchorSites = useDetectMatchingAnchorSite();
 
 	const PodcastTitleForm: React.FC = () => {
 		//Get the podcast title from the API
 		const podcastTitle = usePodcastTitle();
 		const { siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 		const hasSiteTitle = siteTitle.length > 0;
-		const { setSiteTitle, setAnchorPodcastId, setAnchorEpisodeId, setAnchorSpotifyUrl } =
-			useDispatch( ONBOARD_STORE );
-		const { anchorFmPodcastId, isAnchorFmPodcastIdError, anchorFmEpisodeId, anchorFmSpotifyUrl } =
-			useAnchorFmParams();
+		const { setSiteTitle } = useDispatch( ONBOARD_STORE );
 		const [ formTouched, setFormTouched ] = useState( false );
 
 		/*
@@ -56,14 +46,8 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 		const handleSubmit = ( siteTitle: string ) => {
 			const providedDependencies = {
 				siteTitle,
-				anchorFmPodcastId,
-				anchorFmEpisodeId,
-				anchorFmSpotifyUrl,
 			};
 			setSiteTitle( siteTitle );
-			setAnchorPodcastId( ! isAnchorFmPodcastIdError ? anchorFmPodcastId : null );
-			setAnchorEpisodeId( anchorFmEpisodeId );
-			setAnchorSpotifyUrl( anchorFmSpotifyUrl );
 			submit?.( providedDependencies );
 		};
 
@@ -71,11 +55,6 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 			setFormTouched( true );
 			setSiteTitle( event.currentTarget.value );
 		};
-
-		//If we're still checking for matching Anchor sites, don't show the form
-		if ( isLookingUpMatchingAnchorSites ) {
-			return <div />;
-		}
 
 		return (
 			<form
@@ -114,17 +93,6 @@ const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
 			</form>
 		);
 	};
-
-	useEffect( () => {
-		if ( isAnchorFmPodcastIdError ) {
-			const error = __( "We're sorry!" );
-			const message = __(
-				"We're unable to locate your podcast. Return to Anchor or continue with site creation."
-			);
-			setSiteSetupError( error, message );
-			return goToStep?.( 'error' );
-		}
-	}, [ isAnchorFmPodcastIdError ] );
 
 	return (
 		<StepContainer


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move logic for setting Anchor query params in the onboard store to the login step, separate from podcast title
* This cleans up the podcast title step so it only handles the title
* From here, we can either recreate a login form on this step, or redirect to `/start`. Either way, the query params will be available to us in the onboard store.

#### Testing instructions

* Apply D80216-code to your sandbox and sandbox the API
* Switch to this PR, navigate to `/setup?anchor_podcast=[your podcast id]`
* You should be redirected to the podcast title step with the anchor parameters in the onboard store:
<img width="815" alt="Screen Shot 2022-05-23 at 11 08 27 AM" src="https://user-images.githubusercontent.com/2124984/169850235-2bc738ee-76de-40e1-aa8f-357277c08bd0.png">

* If you're logged out when going through this flow, you'll remain on the login screen until you hit Continue.
* Hitting Continue from the login screen should store your anchor parameters in the onboard store.


Related to #63674
