### PR TITLE
Help Center: make the site picker readonly for chat + email support

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -36,7 +36,12 @@ const fakeFaces = Array.from(
 );
 const randomTwoFaces = fakeFaces.sort( () => Math.random() - 0.5 ).slice( 0, 2 );
 
-const HelpCenterSitePicker: React.FC< SitePicker > = ( { onSelect, currentSite, siteId } ) => {
+const HelpCenterSitePicker: React.FC< SitePicker > = ( {
+	onSelect,
+	currentSite,
+	siteId,
+	enabled,
+} ) => {
 	const otherSite = {
 		name: __( 'Other site', __i18n_text_domain__ ),
 		ID: 0,
@@ -50,7 +55,14 @@ const HelpCenterSitePicker: React.FC< SitePicker > = ( { onSelect, currentSite, 
 
 	const options = [ currentSite, otherSite ];
 
-	return <SitePickerDropDown onPickSite={ pickSite } options={ options } siteId={ siteId } />;
+	return (
+		<SitePickerDropDown
+			enabled={ enabled }
+			onPickSite={ pickSite }
+			options={ options }
+			siteId={ siteId }
+		/>
+	);
 };
 
 const titles: {
@@ -311,6 +323,7 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 			) }
 			<section>
 				<HelpCenterSitePicker
+					enabled={ mode === 'FORUM' }
 					currentSite={ currentSite }
 					onSelect={ ( id: string | number ) => {
 						if ( id !== 0 ) {

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -30,6 +30,7 @@ export interface SitePicker {
 	currentSite: SiteDetails | undefined;
 	onSelect: ( siteId: number | string ) => void;
 	siteId: string | number | null | undefined;
+	enabled: boolean;
 }
 
 // ended means the user closed the popup

--- a/packages/site-picker/src/index.tsx
+++ b/packages/site-picker/src/index.tsx
@@ -20,6 +20,7 @@ type ItemProps = {
 	onKeyDown?: React.KeyboardEventHandler< HTMLButtonElement >;
 	logo: { id: string; sizes: string[]; url: string } | undefined;
 	id: string;
+	enabled?: boolean;
 };
 
 const SiteLogo: FC< { logo: ItemProps[ 'logo' ] } > = ( { logo } ) => {
@@ -38,10 +39,11 @@ const SitePickerItem: FC< ItemProps > = ( {
 	selected,
 	logo,
 	id,
+	enabled = true,
 }: ItemProps ) => {
 	return (
 		<button
-			className={ cx( 'site-picker__site-item', { 'main-item': mainItem, selected } ) }
+			className={ cx( 'site-picker__site-item', { 'main-item': mainItem, selected, enabled } ) }
 			onClick={ onClick }
 			// eslint-disable-next-line jsx-a11y/no-autofocus
 			autoFocus={ selected }
@@ -75,9 +77,15 @@ export type Props = {
 	siteId: string | number | undefined | null;
 	options: ( SitePickerSite | undefined )[];
 	onPickSite: ( siteId: number ) => void;
+	enabled: boolean;
 };
 
-export const SitePickerDropDown: FC< Props > = ( { siteId, options, onPickSite }: Props ) => {
+export const SitePickerDropDown: FC< Props > = ( {
+	siteId,
+	options,
+	onPickSite,
+	enabled,
+}: Props ) => {
 	const [ ref, setRef ] = useState< HTMLDivElement | null >( null );
 	const [ open, setOpen ] = useState( false );
 
@@ -93,22 +101,25 @@ export const SitePickerDropDown: FC< Props > = ( { siteId, options, onPickSite }
 				setOpen( false );
 			}
 		}
-		if ( open ) {
+		if ( open && enabled ) {
 			window.addEventListener( 'click', onClickOutside );
 			return () => {
 				window.removeEventListener( 'click', onClickOutside );
 			};
 		}
-	}, [ siteId, options, open, ref ] );
+	}, [ siteId, options, open, ref, enabled ] );
 
 	return (
 		<>
 			<label className="site-picker__label" htmlFor="site-picker-button">
-				{ __( 'Select a site', __i18n_text_domain__ ) }
+				{ enabled
+					? __( 'Select a site', __i18n_text_domain__ )
+					: __( 'Site', __i18n_text_domain__ ) }
 			</label>
 			<div className={ cx( 'site-picker__site-dropdown', { open } ) }>
 				<SitePickerItem
 					host={ selectedSite?.URL?.replace( 'https://', '' ) ?? '' }
+					enabled={ enabled }
 					name={
 						selectedSite?.name ??
 						// if site has no name, show URL
@@ -116,10 +127,19 @@ export const SitePickerDropDown: FC< Props > = ( { siteId, options, onPickSite }
 						__( 'Unknown site', __i18n_text_domain__ )
 					}
 					logo={ selectedSite?.logo }
-					mainItem
+					// mainItem implies showing the dropdown arrow, hide it when the picking feature is disabled
+					mainItem={ enabled }
 					open={ open }
-					onClick={ () => setOpen( ( o ) => ! o ) }
-					onKeyDown={ ( event ) => event.key === 'ArrowDown' && setOpen( true ) }
+					onClick={ () => {
+						if ( enabled ) {
+							setOpen( ( o ) => ! o );
+						}
+					} }
+					onKeyDown={ ( event ) => {
+						if ( event.key === 'ArrowDown' && enabled ) {
+							setOpen( true );
+						}
+					} }
 					id="site-picker-button"
 				/>
 				{ open && (

--- a/packages/site-picker/src/style.scss
+++ b/packages/site-picker/src/style.scss
@@ -43,16 +43,19 @@
 	background: transparent;
 	border: none;
 	width: 100%;
-	cursor: pointer;
 	border-radius: 4px;
 	align-items: center;
+
+	&.enabled {
+		cursor: pointer;
+	}
 
 	&.selected {
 		background: #f6f7f7;
 	}
 }
 
-.site-picker__site-item:not( .main-item ):hover {
+.site-picker__site-item.enabled:not( .main-item ):hover {
 	background-color: #f6f7f7;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Title is sufficient.

#### Testing instructions

* Using a user who has only a free site, you'll land in the `forum` mode, the site picker should work as it used to (you can pick this site or "other site").
* Using a user with a paid plan, the site picker should be locked to the current site.

