### PR TITLE
Checkout: Show live chat button based on eligibility on post-checkout page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -19,7 +19,6 @@ import {
 	isTheme,
 	isStarter,
 	isTitanMail,
-	isJetpackBusinessPlan,
 	shouldFetchSitePlans,
 	isDIFMProduct,
 	isPro,
@@ -58,6 +57,7 @@ import {
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
 import { recordStartTransferClickInThankYou } from 'calypso/state/domains/actions';
+import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
 import { isProductsListFetching } from 'calypso/state/products-list/selectors';
 import { fetchReceipt } from 'calypso/state/receipts/actions';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
@@ -65,7 +65,7 @@ import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import getCheckoutUpgradeIntent from 'calypso/state/selectors/get-checkout-upgrade-intent';
 import getCustomizeOrEditFrontPageUrl from 'calypso/state/selectors/get-customize-or-edit-front-page-url';
 import { fetchSitePlans, refreshSitePlans } from 'calypso/state/sites/plans/actions';
-import { getPlansBySite, getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
+import { getPlansBySite } from 'calypso/state/sites/plans/selectors';
 import { getSiteHomeUrl, getSiteSlug, getSite } from 'calypso/state/sites/selectors';
 import { requestThenActivate } from 'calypso/state/themes/actions';
 import { getActiveTheme } from 'calypso/state/themes/selectors';
@@ -326,10 +326,6 @@ export class CheckoutThankYou extends Component {
 		return page( this.props.siteHomeUrl );
 	};
 
-	isEligibleForLiveChat = () => {
-		return isJetpackBusinessPlan( this.props.planSlug );
-	};
-
 	getAnalyticsProperties = () => {
 		const { gsuiteReceiptId, receiptId, selectedFeature: feature, selectedSite } = this.props;
 		const site = get( selectedSite, 'slug' );
@@ -374,7 +370,7 @@ export class CheckoutThankYou extends Component {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { translate, isHappychatEligible } = this.props;
 		let purchases = [];
 		let failedPurchases = [];
 		let wasJetpackPlanPurchased = false;
@@ -515,7 +511,7 @@ export class CheckoutThankYou extends Component {
 						<HappinessSupport
 							isJetpack={ wasJetpackPlanPurchased }
 							liveChatButtonEventName="calypso_plans_autoconfig_chat_initiated"
-							showLiveChatButton={ this.isEligibleForLiveChat() }
+							showLiveChatButton={ isHappychatEligible }
 						/>
 					</Card>
 				) }
@@ -707,12 +703,11 @@ export class CheckoutThankYou extends Component {
 export default connect(
 	( state, props ) => {
 		const siteId = getSelectedSiteId( state );
-		const planSlug = getSitePlanSlug( state, siteId );
 		const activeTheme = getActiveTheme( state, siteId );
 
 		return {
 			isProductsListFetching: isProductsListFetching( state ),
-			planSlug,
+			isHappychatEligible: isHappychatUserEligible( state ),
 			receipt: getReceiptById( state, props.receiptId ),
 			gsuiteReceipt: props.gsuiteReceiptId ? getReceiptById( state, props.gsuiteReceiptId ) : null,
 			sitePlans: getPlansBySite( state, props.selectedSite ),

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -3,23 +3,9 @@
  */
 
 import {
-	PLAN_FREE,
 	PLAN_ECOMMERCE,
-	PLAN_ECOMMERCE_2_YEARS,
 	PLAN_BUSINESS,
-	PLAN_BUSINESS_2_YEARS,
 	PLAN_PREMIUM,
-	PLAN_PREMIUM_2_YEARS,
-	PLAN_PERSONAL,
-	PLAN_PERSONAL_2_YEARS,
-	PLAN_BLOGGER,
-	PLAN_BLOGGER_2_YEARS,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
 	isDotComPlan,
 	WPCOM_DIFM_LITE,
 	isDIFMProduct,
@@ -211,38 +197,6 @@ describe( 'CheckoutThankYou', () => {
 				/>
 			);
 			expect( comp.find( DIFMLiteThankYou ) ).toHaveLength( 0 );
-		} );
-	} );
-
-	describe( 'isEligibleForLiveChat', () => {
-		[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ].forEach( ( planSlug ) => {
-			test( `Should return true for Jetpack business plans (${ planSlug })`, () => {
-				const instance = new CheckoutThankYou( { planSlug } );
-				expect( instance.isEligibleForLiveChat() ).toBe( true );
-			} );
-		} );
-
-		[
-			PLAN_FREE,
-			PLAN_BLOGGER,
-			PLAN_BLOGGER_2_YEARS,
-			PLAN_PERSONAL,
-			PLAN_PERSONAL_2_YEARS,
-			PLAN_JETPACK_PERSONAL,
-			PLAN_JETPACK_PERSONAL_MONTHLY,
-			PLAN_PREMIUM,
-			PLAN_PREMIUM_2_YEARS,
-			PLAN_JETPACK_PREMIUM,
-			PLAN_JETPACK_PREMIUM_MONTHLY,
-			PLAN_BUSINESS,
-			PLAN_BUSINESS_2_YEARS,
-			PLAN_ECOMMERCE,
-			PLAN_ECOMMERCE_2_YEARS,
-		].forEach( ( planSlug ) => {
-			test( `Should return false for all other plans (${ planSlug })`, () => {
-				const instance = new CheckoutThankYou( { planSlug } );
-				expect( instance.isEligibleForLiveChat() ).toBe( false );
-			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Looks at happychat eligibility to determine whether to show the HappyChat button.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Upgrade a free site to a Pro plan
* On the Thank You page scroll all the way down to see the support message
* Note: The Button will not open happychat because it seems to be unavailable everywhere but in production.

<img width="742" alt="image" src="https://user-images.githubusercontent.com/1398304/169873000-4d9da05a-3887-42c7-be84-f6ce33e5b272.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-a66-p2