### PR TITLE
Framework: Remove much of the remaining `sinon`

### DIFF
--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -79,7 +79,7 @@ describe( 'DailyPostButton', () => {
 			);
 			dailyPostButton.simulate( 'click', { preventDefault: noop } );
 			expect( pageSpy ).toHaveBeenCalledWith(
-				expect.stringMatching( /post\/apps.wordpress.com?/ )
+				expect.stringContaining( 'post/apps.wordpress.com' )
 			);
 		} );
 

--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -13,7 +13,7 @@ jest.mock( 'calypso/reader/stats', () => ( {
 	recordGaEvent: () => {},
 	recordTrackForPost: () => {},
 } ) );
-jest.mock( 'page', () => require( 'sinon' ).spy() );
+jest.mock( 'page', () => jest.fn() );
 const markPostSeen = jest.fn();
 const noop = () => {};
 
@@ -78,7 +78,9 @@ describe( 'DailyPostButton', () => {
 				/>
 			);
 			dailyPostButton.simulate( 'click', { preventDefault: noop } );
-			expect( pageSpy.calledWithMatch( /post\/apps.wordpress.com?/ ) ).toBe( true );
+			expect( pageSpy ).toHaveBeenCalledWith(
+				expect.stringMatching( /post\/apps.wordpress.com?/ )
+			);
 		} );
 
 		// eslint-disable-next-line jest/expect-expect
@@ -115,7 +117,7 @@ describe( 'DailyPostButton', () => {
 				/>
 			);
 			prompt.instance().openEditorWithSite( 'apps.wordpress.com' );
-			const pageArgs = pageSpy.lastCall.args[ 0 ];
+			const pageArgs = pageSpy.mock.lastCall[ 0 ];
 			const query = parse( pageArgs.split( '?' )[ 1 ] );
 			const { title, URL } = dailyPromptPost;
 			expect( query ).toEqual( { title: `Daily Prompt: ${ title }`, url: URL } );

--- a/client/components/drop-zone/test/index.jsx
+++ b/client/components/drop-zone/test/index.jsx
@@ -4,7 +4,6 @@
 import { Component, createElement } from 'react';
 import ReactDom from 'react-dom';
 import TestUtils from 'react-dom/test-utils';
-import sinon from 'sinon';
 import { DropZone } from '../';
 
 class Wrapper extends Component {
@@ -15,7 +14,6 @@ class Wrapper extends Component {
 
 describe( 'index', () => {
 	let container;
-	let sandbox;
 	const requiredProps = {
 		hideDropZone: () => {},
 		showDropZone: () => {},
@@ -25,10 +23,10 @@ describe( 'index', () => {
 	beforeAll( function () {
 		container = document.createElement( 'div' );
 		container.id = 'container';
-		window.MutationObserver = sinon.stub().returns( {
-			observe: sinon.stub(),
-			disconnect: sinon.stub(),
-		} );
+		window.MutationObserver = jest.fn( () => ( {
+			observe: jest.fn(),
+			disconnect: jest.fn(),
+		} ) );
 	} );
 
 	afterAll( function () {
@@ -37,12 +35,7 @@ describe( 'index', () => {
 		}
 	} );
 
-	beforeEach( () => {
-		sandbox = sinon.createSandbox();
-	} );
-
 	afterEach( () => {
-		sandbox.restore();
 		ReactDom.unmountComponentAtNode( container );
 	} );
 
@@ -159,7 +152,7 @@ describe( 'index', () => {
 
 	test( 'should further highlight the drop zone when dragging over the element', () => {
 		const tree = ReactDom.render( createElement( DropZone, requiredProps ), container );
-		sandbox.stub( tree, 'isWithinZoneBounds' ).returns( true );
+		jest.spyOn( tree, 'isWithinZoneBounds' ).mockReturnValue( true );
 
 		const dragEnterEvent = new window.MouseEvent( 'dragenter' );
 		window.dispatchEvent( dragEnterEvent );
@@ -185,9 +178,9 @@ describe( 'index', () => {
 	} );
 
 	test( 'should call onDrop with the raw event data when a drop occurs', () => {
-		const spyDrop = sandbox.spy();
+		const spyDrop = jest.fn();
 
-		sandbox.stub( window.HTMLElement.prototype, 'contains' ).returns( true );
+		jest.spyOn( window.HTMLElement.prototype, 'contains' ).mockReturnValue( true );
 
 		ReactDom.render(
 			createElement( DropZone, {
@@ -200,14 +193,14 @@ describe( 'index', () => {
 		const dropEvent = new window.MouseEvent( 'drop' );
 		window.dispatchEvent( dropEvent );
 
-		expect( spyDrop.calledOnce ).toBeTruthy();
-		expect( spyDrop.getCall( 0 ).args[ 0 ] ).toBe( dropEvent );
+		expect( spyDrop ).toHaveBeenCalledTimes( 1 );
+		expect( spyDrop.mock.calls[ 0 ][ 0 ] ).toBe( dropEvent );
 	} );
 
 	test( 'should call onFilesDrop with the files array when a drop occurs', () => {
-		const spyDrop = sandbox.spy();
+		const spyDrop = jest.fn();
 
-		sandbox.stub( window.HTMLElement.prototype, 'contains' ).returns( true );
+		jest.spyOn( window.HTMLElement.prototype, 'contains' ).mockReturnValue( true );
 		ReactDom.render(
 			createElement( DropZone, {
 				...requiredProps,
@@ -220,12 +213,12 @@ describe( 'index', () => {
 		dropEvent.dataTransfer = { files: [ 1, 2, 3 ] };
 		window.dispatchEvent( dropEvent );
 
-		expect( spyDrop.calledOnce ).toBeTruthy();
-		expect( spyDrop.getCall( 0 ).args[ 0 ] ).toEqual( [ 1, 2, 3 ] );
+		expect( spyDrop ).toHaveBeenCalledTimes( 1 );
+		expect( spyDrop.mock.calls[ 0 ][ 0 ] ).toEqual( [ 1, 2, 3 ] );
 	} );
 
 	test( 'should not call onFilesDrop if onVerifyValidTransfer returns false', () => {
-		const spyDrop = sandbox.spy();
+		const spyDrop = jest.fn();
 		const dropEvent = new window.MouseEvent( 'drop' );
 
 		ReactDom.render(
@@ -243,7 +236,7 @@ describe( 'index', () => {
 		dropEvent.dataTransfer = { files: [ 1, 2, 3 ] };
 		window.dispatchEvent( dropEvent );
 
-		expect( spyDrop.called ).toBeFalsy();
+		expect( spyDrop ).not.toHaveBeenCalled();
 	} );
 
 	test( 'should allow more than one rendered DropZone on a page', () => {

--- a/client/components/search/test/index.jsx
+++ b/client/components/search/test/index.jsx
@@ -3,7 +3,6 @@
  */
 import { createElement } from 'react';
 import TestUtils from 'react-dom/test-utils';
-import sinon from 'sinon';
 import searchClass from '../';
 
 jest.mock( 'calypso/lib/analytics/ga', () => ( {} ) );
@@ -14,7 +13,7 @@ describe( 'Search', () => {
 		let rendered;
 
 		beforeEach( () => {
-			onSearch = sinon.stub();
+			onSearch = jest.fn();
 		} );
 
 		describe( 'with initialValue', () => {

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -55,7 +55,7 @@ exports[`Theme rendering with default display buttonContents should match snapsh
         options={
           Object {
             "dummyAction": Object {
-              "action": [Function],
+              "action": [MockFunction],
               "label": "Dummy action",
             },
           }

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -1,13 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-
 import { parse } from 'url';
 import { shallow } from 'enzyme';
 import { createElement } from 'react';
 import ReactDom from 'react-dom';
 import TestUtils from 'react-dom/test-utils';
-import sinon from 'sinon';
 import { Theme } from '../';
 
 jest.mock( 'calypso/components/popover-menu', () => 'components--popover--menu' );
@@ -25,7 +23,7 @@ describe( 'Theme', () => {
 				screenshot:
 					'https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?ssl=1',
 			},
-			buttonContents: { dummyAction: { label: 'Dummy action', action: sinon.spy() } }, // TODO: test if called when clicked
+			buttonContents: { dummyAction: { label: 'Dummy action', action: jest.fn() } }, // TODO: test if called when clicked
 			translate: ( string ) => string,
 			setThemesBookmark: () => {},
 		};
@@ -34,7 +32,7 @@ describe( 'Theme', () => {
 	describe( 'rendering', () => {
 		describe( 'with default display buttonContents', () => {
 			beforeEach( () => {
-				props.onScreenshotClick = sinon.spy();
+				props.onScreenshotClick = jest.fn();
 				const themeElement = TestUtils.renderIntoDocument( createElement( Theme, props ) );
 				themeNode = ReactDom.findDOMNode( themeElement );
 			} );
@@ -67,7 +65,7 @@ describe( 'Theme', () => {
 			test( 'should call onScreenshotClick() on click on screenshot', () => {
 				const imgNode = themeNode.getElementsByTagName( 'img' )[ 0 ];
 				TestUtils.Simulate.click( imgNode );
-				expect( props.onScreenshotClick.calledOnce ).toBe( true );
+				expect( props.onScreenshotClick ).toHaveBeenCalledTimes( 1 );
 			} );
 
 			test( 'should not show a price when there is none', () => {

--- a/client/lib/after-layout-flush/test/index.js
+++ b/client/lib/after-layout-flush/test/index.js
@@ -1,8 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
-import sinon from 'sinon';
 import afterLayoutFlush from '../';
 
 jest.useFakeTimers();
@@ -47,8 +45,8 @@ function setupPreserveThisTest() {
 describe( 'afterLayoutFlush', () => {
 	describe( 'in browsers that support requestAnimationFrame', () => {
 		beforeAll( () => {
-			sinon.stub( window, 'requestAnimationFrame' ).callsFake( requestAnimationFrameFake );
-			sinon.stub( window, 'cancelAnimationFrame' ).callsFake( cancelAnimationFrameFake );
+			jest.spyOn( window, 'requestAnimationFrame' ).mockImplementation( requestAnimationFrameFake );
+			jest.spyOn( window, 'cancelAnimationFrame' ).mockImplementation( cancelAnimationFrameFake );
 		} );
 
 		beforeEach( () => {
@@ -144,9 +142,14 @@ describe( 'afterLayoutFlush', () => {
 	} );
 
 	describe( 'in browsers that do not support requestAnimationFrame', () => {
+		let originalRequestAnimationFrame;
 		beforeAll( () => {
-			sinon.restore();
-			sinon.stub( window, 'requestAnimationFrame' ).value( undefined );
+			originalRequestAnimationFrame = window.requestAnimationFrame;
+			window.requestAnimationFrame = undefined;
+		} );
+
+		afterAll( () => {
+			window.requestAnimationFrame = originalRequestAnimationFrame;
 		} );
 
 		test( 'should execute after a timeout', () => {
@@ -217,6 +220,4 @@ describe( 'afterLayoutFlush', () => {
 			expect( ptt.callback ).toHaveBeenCalledWith( 'bar' );
 		} );
 	} );
-
-	afterAll( () => sinon.restore() );
 } );

--- a/client/lib/route/test/legacy-routes.js
+++ b/client/lib/route/test/legacy-routes.js
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import sinon from 'sinon';
 import { isLegacyRoute } from '../legacy-routes';
 
 let features = [];
@@ -7,13 +6,9 @@ let features = [];
 describe( 'legacy-routes', () => {
 	describe( '#isLegacyRoute()', () => {
 		beforeAll( () => {
-			sinon.stub( config, 'isEnabled' ).callsFake( ( flag ) => {
+			jest.spyOn( config, 'isEnabled' ).mockImplementation( ( flag ) => {
 				return features.indexOf( flag ) > -1;
 			} );
-		} );
-
-		afterAll( () => {
-			config.isEnabled.restore();
 		} );
 
 		test( 'should return false for /settings/general', () => {

--- a/client/lib/scroll-to/test/index.js
+++ b/client/lib/scroll-to/test/index.js
@@ -1,17 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-
-import sinon from 'sinon';
 import scrollTo from '../';
 
 describe( 'scroll-to', () => {
 	beforeAll( () => {
-		sinon.stub( window, 'scrollTo' );
-	} );
-
-	afterEach( () => {
-		window.scrollTo.resetHistory();
+		jest.spyOn( window, 'scrollTo' ).mockImplementation();
 	} );
 
 	test( 'window position x', () => {
@@ -21,8 +15,8 @@ describe( 'scroll-to', () => {
 				y: 300,
 				duration: 1,
 				onComplete: () => {
-					expect( window.scrollTo.lastCall.args[ 0 ] ).toEqual( 500 );
-					expect( window.scrollTo.lastCall.args[ 1 ] ).toEqual( 300 );
+					expect( window.scrollTo.mock.lastCall[ 0 ] ).toEqual( 500 );
+					expect( window.scrollTo.mock.lastCall[ 1 ] ).toEqual( 300 );
 					done();
 				},
 			} );
@@ -35,8 +29,8 @@ describe( 'scroll-to', () => {
 				y: 100,
 				duration: 1,
 				onComplete: () => {
-					expect( window.scrollTo.lastCall.args[ 0 ] ).toEqual( 0 );
-					expect( window.scrollTo.lastCall.args[ 1 ] ).toEqual( 100 );
+					expect( window.scrollTo.mock.lastCall[ 0 ] ).toEqual( 0 );
+					expect( window.scrollTo.mock.lastCall[ 1 ] ).toEqual( 100 );
 					done();
 				},
 			} );

--- a/client/lib/scroll-to/test/index.js
+++ b/client/lib/scroll-to/test/index.js
@@ -15,8 +15,7 @@ describe( 'scroll-to', () => {
 				y: 300,
 				duration: 1,
 				onComplete: () => {
-					expect( window.scrollTo.mock.lastCall[ 0 ] ).toEqual( 500 );
-					expect( window.scrollTo.mock.lastCall[ 1 ] ).toEqual( 300 );
+					expect( window.scrollTo ).toHaveBeenCalledWith( 500, 300 );
 					done();
 				},
 			} );
@@ -29,8 +28,7 @@ describe( 'scroll-to', () => {
 				y: 100,
 				duration: 1,
 				onComplete: () => {
-					expect( window.scrollTo.mock.lastCall[ 0 ] ).toEqual( 0 );
-					expect( window.scrollTo.mock.lastCall[ 1 ] ).toEqual( 100 );
+					expect( window.scrollTo ).toHaveBeenCalledWith( 0, 100 );
 					done();
 				},
 			} );

--- a/client/my-sites/media-library/test/index.jsx
+++ b/client/my-sites/media-library/test/index.jsx
@@ -21,7 +21,7 @@ jest.mock( 'calypso/my-sites/media-library/filter-bar', () =>
 	require( 'calypso/components/empty-component' )
 );
 jest.mock( 'calypso/state/sharing/keyring/actions', () => ( {
-	requestKeyringConnections: require( 'sinon' ).stub(),
+	requestKeyringConnections: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/sharing/keyring/selectors', () => ( {
 	getKeyringConnections: () => null,
@@ -46,44 +46,44 @@ describe( 'MediaLibrary', () => {
 		ID: 123,
 	};
 
-	beforeEach( () => {
-		requestStub.resetHistory();
-	} );
-
 	const getItem = ( source ) =>
 		mount( <MediaLibrary site={ site } store={ store } source={ source } /> );
 
 	describe( 'keyring request', () => {
+		afterEach( () => {
+			requestStub.mockReset();
+		} );
+
 		test( 'is issued when component mounted and viewing an external source', () => {
 			getItem( 'google_photos' );
 
-			expect( requestStub.callCount ).toEqual( 1 );
+			expect( requestStub ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		test( 'is not issued when component mounted and viewing wordpress', () => {
 			getItem( '' );
 
-			expect( requestStub.callCount ).toEqual( 0 );
+			expect( requestStub ).toHaveBeenCalledTimes( 0 );
 		} );
 
 		test( 'is issued when component source changes and now viewing an external source', () => {
 			const library = getItem( '' );
 
 			library.setProps( { source: 'google_photos' } );
-			expect( requestStub.callCount ).toEqual( 1 );
+			expect( requestStub ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		test( 'is not issued when component source changes and not viewing an external source', () => {
 			const library = getItem( '' );
 
 			library.setProps( { source: '' } );
-			expect( requestStub.callCount ).toEqual( 0 );
+			expect( requestStub ).toHaveBeenCalledTimes( 0 );
 		} );
 
 		test( 'is not issued when the external source does not need user connection', () => {
 			getItem( 'pexels' );
 
-			expect( requestStub.callCount ).toEqual( 0 );
+			expect( requestStub ).toHaveBeenCalledTimes( 0 );
 		} );
 	} );
 } );

--- a/client/my-sites/plugins/plugin-activate-toggle/test/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/index.jsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { mount } from 'enzyme';
-import { spy } from 'sinon';
 import { PluginActivateToggle } from 'calypso/my-sites/plugins/plugin-activate-toggle';
 import fixtures from './fixtures';
 
@@ -12,16 +11,12 @@ jest.mock( 'calypso/my-sites/plugins/plugin-action/plugin-action', () =>
 
 describe( 'PluginActivateToggle', () => {
 	const mockedProps = {
-		recordGoogleEvent: spy(),
-		recordTracksEvent: spy(),
-		removePluginStatuses: spy(),
-		togglePluginActivation: spy(),
-		translate: spy(),
+		recordGoogleEvent: jest.fn(),
+		recordTracksEvent: jest.fn(),
+		removePluginStatuses: jest.fn(),
+		togglePluginActivation: jest.fn(),
+		translate: jest.fn(),
 	};
-
-	afterEach( () => {
-		mockedProps.recordGoogleEvent.resetHistory();
-	} );
 
 	test( 'should render the component', () => {
 		const wrapper = mount( <PluginActivateToggle { ...mockedProps } { ...fixtures } /> );
@@ -34,8 +29,8 @@ describe( 'PluginActivateToggle', () => {
 
 		wrapper.simulate( 'click' );
 
-		expect( mockedProps.recordGoogleEvent.called ).toEqual( true );
-		expect( mockedProps.recordTracksEvent.called ).toEqual( true );
+		expect( mockedProps.recordGoogleEvent ).toHaveBeenCalled();
+		expect( mockedProps.recordTracksEvent ).toHaveBeenCalled();
 	} );
 
 	test( 'should call an action when the subcomponent action is executed', () => {
@@ -43,6 +38,6 @@ describe( 'PluginActivateToggle', () => {
 
 		wrapper.simulate( 'click' );
 
-		expect( mockedProps.togglePluginActivation.called ).toEqual( true );
+		expect( mockedProps.togglePluginActivation ).toHaveBeenCalled();
 	} );
 } );

--- a/client/my-sites/plugins/plugin-activate-toggle/test/mocks/actions.js
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/mocks/actions.js
@@ -1,3 +1,0 @@
-export default {
-	togglePluginActivation: jest.fn(),
-};

--- a/client/my-sites/plugins/plugin-activate-toggle/test/mocks/actions.js
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/mocks/actions.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 export default {
-	togglePluginActivation: sinon.spy(),
+	togglePluginActivation: jest.fn(),
 };

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/test/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/test/index.jsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { mount } from 'enzyme';
-import { spy } from 'sinon';
 import { PluginAutoUpdateToggle } from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 import fixtures from './fixtures';
 
@@ -13,17 +12,12 @@ jest.mock( 'query', () => require( 'component-query' ), { virtual: true } );
 
 describe( 'PluginAutoupdateToggle', () => {
 	const mockedProps = {
-		recordGoogleEvent: spy(),
-		recordTracksEvent: spy(),
-		removePluginStatuses: spy(),
-		translate: spy(),
-		togglePluginAutoUpdate: spy(),
+		recordGoogleEvent: jest.fn(),
+		recordTracksEvent: jest.fn(),
+		removePluginStatuses: jest.fn(),
+		translate: jest.fn(),
+		togglePluginAutoUpdate: jest.fn(),
 	};
-
-	afterEach( () => {
-		mockedProps.togglePluginAutoUpdate.resetHistory();
-		mockedProps.recordGoogleEvent.resetHistory();
-	} );
 
 	test( 'should render the component', () => {
 		const wrapper = mount( <PluginAutoUpdateToggle { ...mockedProps } { ...fixtures } /> );
@@ -36,8 +30,8 @@ describe( 'PluginAutoupdateToggle', () => {
 
 		wrapper.simulate( 'click' );
 
-		expect( mockedProps.recordGoogleEvent.called ).toEqual( true );
-		expect( mockedProps.recordTracksEvent.called ).toEqual( true );
+		expect( mockedProps.recordGoogleEvent ).toHaveBeenCalled();
+		expect( mockedProps.recordTracksEvent ).toHaveBeenCalled();
 	} );
 
 	test( 'should call an action when the subcomponent action is executed', () => {
@@ -45,6 +39,6 @@ describe( 'PluginAutoupdateToggle', () => {
 
 		wrapper.simulate( 'click' );
 
-		expect( mockedProps.togglePluginAutoUpdate.called ).toEqual( true );
+		expect( mockedProps.togglePluginAutoUpdate ).toHaveBeenCalled();
 	} );
 } );

--- a/client/package.json
+++ b/client/package.json
@@ -139,6 +139,7 @@
 		"jest": "^27.3.1",
 		"jest-fetch-mock": "^3.0.3",
 		"jest-mock-process": "^1.4.1",
+		"jest-when": "^3.5.1",
 		"lodash": "^4.17.21",
 		"lodash-es": "^4.17.21",
 		"lru": "^3.1.0",

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -1,44 +1,36 @@
 /**
  * @jest-environment jsdom
  */
-
-import assert from 'assert';
-import sinon from 'sinon';
 import flows from 'calypso/signup/config/flows';
 import mockedFlows from './fixtures/flows';
 
 describe( 'Signup Flows Configuration', () => {
 	describe( 'getFlow', () => {
 		beforeAll( () => {
-			sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
-		} );
-
-		afterAll( () => {
-			flows.getFlows.restore();
+			jest.spyOn( flows, 'getFlows' ).mockReturnValue( mockedFlows );
 		} );
 
 		test( 'should return the full flow when the user is not logged in', () => {
-			assert.deepEqual( flows.getFlow( 'main', false ).steps, [ 'user', 'site' ] );
+			expect( flows.getFlow( 'main', false ).steps ).toEqual( [ 'user', 'site' ] );
 		} );
 
 		test( 'should remove the user step from the flow when the user is logged in', () => {
-			assert.deepEqual( flows.getFlow( 'main', true ).steps, [ 'site' ] );
+			expect( flows.getFlow( 'main', true ).steps ).toEqual( [ 'site' ] );
 		} );
 	} );
 
 	describe( 'excludeSteps', () => {
 		beforeAll( () => {
-			sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
+			jest.spyOn( flows, 'getFlows' ).mockReturnValue( mockedFlows );
 		} );
 
 		afterAll( () => {
-			flows.getFlows.restore();
 			flows.excludeStep();
 		} );
 
 		test( 'should exclude site step from getFlow', () => {
 			flows.excludeStep( 'site' );
-			assert.deepEqual( flows.getFlow( 'main', false ).steps, [ 'user' ] );
+			expect( flows.getFlow( 'main', false ).steps ).toEqual( [ 'user' ] );
 		} );
 	} );
 } );

--- a/client/state/application/test/actions.js
+++ b/client/state/application/test/actions.js
@@ -1,4 +1,3 @@
-import { spy } from 'sinon';
 import {
 	CONNECTION_LOST,
 	CONNECTION_RESTORED,
@@ -9,58 +8,64 @@ import { connectionLost, connectionRestored } from '../actions';
 
 describe( 'state/application actions', () => {
 	describe( '#connectionLost()', () => {
-		const dispatch = spy();
+		const dispatch = jest.fn();
 		const exampleText = 'potato';
 
 		//( dispatch ) because it is a thunk action creator
 		connectionLost( exampleText )( dispatch );
 
 		test( 'should dispatch an action with CONNECTION_LOST type', () => {
-			expect( dispatch.calledWith( { type: CONNECTION_LOST } ) ).ok;
+			expect( dispatch ).toHaveBeenCalledWith( { type: CONNECTION_LOST } );
 		} );
 
 		test( 'should remove notice with connectionRestored information', () => {
-			expect( dispatch.calledWith( { type: NOTICE_REMOVE, noticeId: 'connectionRestored' } ) ).ok;
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: NOTICE_REMOVE,
+				noticeId: 'connectionRestored',
+			} );
 		} );
 
 		test( 'should dispatch a notice with connectionLost information', () => {
-			expect(
-				dispatch.calledWithMatch( {
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: NOTICE_CREATE,
-					notice: {
+					notice: expect.objectContaining( {
 						noticeId: 'connectionLost',
 						text: exampleText,
-					},
+					} ),
 				} )
-			).ok;
+			);
 		} );
 	} );
 
 	describe( '#connectionRestored()', () => {
-		const dispatch = spy();
+		const dispatch = jest.fn();
 		const exampleText = 'potato';
 
 		//( dispatch ) because it is a thunk action creator
 		connectionRestored( exampleText )( dispatch );
 
 		test( 'should dispatch an action with CONNECTION_RESTORED type', () => {
-			expect( dispatch.calledWith( { type: CONNECTION_RESTORED } ) ).ok;
+			expect( dispatch ).toHaveBeenCalledWith( { type: CONNECTION_RESTORED } );
 		} );
 
 		test( 'should remove notice with connectionLost information', () => {
-			expect( dispatch.calledWith( { type: NOTICE_REMOVE, noticeId: 'connectionLost' } ) ).ok;
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: NOTICE_REMOVE,
+				noticeId: 'connectionLost',
+			} );
 		} );
 
 		test( 'should dispatch a notice with connectionRestored information', () => {
-			expect(
-				dispatch.calledWithMatch( {
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: NOTICE_CREATE,
-					notice: {
+					notice: expect.objectContaining( {
 						noticeId: 'connectionRestored',
 						text: exampleText,
-					},
+					} ),
 				} )
-			).ok;
+			);
 		} );
 	} );
 } );

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -1,5 +1,4 @@
-import lodash from 'lodash';
-import sinon from 'sinon';
+import { cloneDeep } from 'lodash';
 import {
 	isRequestingInvitesForSite,
 	getPendingInvitesForSite,
@@ -192,14 +191,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getInviteForSite()', () => {
-		beforeAll( () => {
-			sinon.spy( lodash, 'find' );
-		} );
-
-		afterEach( () => {
-			lodash.find.resetHistory();
-		} );
-
 		test( 'should return invite', () => {
 			const state = {
 				invites: {
@@ -270,19 +261,14 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( lodash.find.callCount ).toEqual( 0 );
-
 			const call1 = getInviteForSite( state, 12345, '123456asdf789' );
-			expect( lodash.find.callCount ).toEqual( 2 );
-			expect( call1 ).toEqual( state.invites.items[ 12345 ].accepted[ 0 ] );
+			expect( call1 ).toBe( state.invites.items[ 12345 ].accepted[ 0 ] );
 
 			const call2 = getInviteForSite( state, 12345, '123456asdf789' );
-			expect( lodash.find.callCount ).toEqual( 2 );
-			expect( call1 ).toEqual( call2 );
+			expect( call1 ).toBe( call2 );
 
-			const newState = lodash.cloneDeep( state );
+			const newState = cloneDeep( state );
 			const call3 = getInviteForSite( newState, 12345, '123456asdf789' );
-			expect( lodash.find.callCount ).toEqual( 4 );
 			expect( call3 ).toEqual( newState.invites.items[ 12345 ].accepted[ 0 ] );
 			expect( call3 ).not.toBe( call2 );
 		} );

--- a/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
@@ -1,3 +1,4 @@
+import { when } from 'jest-when';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isMappedDomainSite from 'calypso/state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
@@ -5,44 +6,44 @@ import isVipSite from 'calypso/state/selectors/is-vip-site';
 import isEligibleForDomainToPaidPlanUpsell from '../is-eligible-for-domain-to-paid-plan-upsell';
 
 jest.mock( 'calypso/state/selectors/can-current-user', () => ( {
-	canCurrentUser: require( 'sinon' ).stub(),
+	canCurrentUser: jest.fn(),
 } ) );
-jest.mock( 'calypso/state/selectors/is-mapped-domain-site', () => require( 'sinon' ).stub() );
-jest.mock( 'calypso/state/selectors/is-site-on-free-plan', () => require( 'sinon' ).stub() );
-jest.mock( 'calypso/state/selectors/is-vip-site', () => require( 'sinon' ).stub() );
+jest.mock( 'calypso/state/selectors/is-mapped-domain-site', () => jest.fn() );
+jest.mock( 'calypso/state/selectors/is-site-on-free-plan', () => jest.fn() );
+jest.mock( 'calypso/state/selectors/is-vip-site', () => jest.fn() );
 
 describe( 'isEligibleForDomainToPaidPlanUpsell', () => {
 	const state = 'state';
 	const siteId = 'siteId';
 
 	const meetAllConditions = () => {
-		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( true );
-		isMappedDomainSite.withArgs( state, siteId ).returns( true );
-		isSiteOnFreePlan.withArgs( state, siteId ).returns( true );
-		isVipSite.withArgs( state, siteId ).returns( false );
+		when( canCurrentUser ).calledWith( state, siteId, 'manage_options' ).mockReturnValue( true );
+		when( isMappedDomainSite ).calledWith( state, siteId ).mockReturnValue( true );
+		when( isSiteOnFreePlan ).calledWith( state, siteId ).mockReturnValue( true );
+		when( isVipSite ).calledWith( state, siteId ).mockReturnValue( false );
 	};
 
 	test( 'should return false when user can not manage options', () => {
 		meetAllConditions();
-		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( false );
+		when( canCurrentUser ).calledWith( state, siteId, 'manage_options' ).mockReturnValue( false );
 		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site does not have mapped domain', () => {
 		meetAllConditions();
-		isMappedDomainSite.withArgs( state, siteId ).returns( false );
+		when( isMappedDomainSite ).calledWith( state, siteId ).mockReturnValue( false );
 		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site is not on a free plan', () => {
 		meetAllConditions();
-		isSiteOnFreePlan.withArgs( state, siteId ).returns( false );
+		when( isSiteOnFreePlan ).calledWith( state, siteId ).mockReturnValue( false );
 		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site is a vip site', () => {
 		meetAllConditions();
-		isVipSite.withArgs( state, siteId ).returns( true );
+		when( isVipSite ).calledWith( state, siteId ).mockReturnValue( true );
 		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).toBe( false );
 	} );
 

--- a/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
@@ -1,3 +1,4 @@
+import { when } from 'jest-when';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isMappedDomainSite from 'calypso/state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
@@ -6,54 +7,54 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isEligibleForFreeToPaidUpsell from '../is-eligible-for-free-to-paid-upsell';
 
 jest.mock( 'calypso/state/selectors/can-current-user', () => ( {
-	canCurrentUser: require( 'sinon' ).stub(),
+	canCurrentUser: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/sites/selectors', () => ( {
-	isJetpackSite: require( 'sinon' ).stub(),
+	isJetpackSite: jest.fn(),
 } ) );
-jest.mock( 'calypso/state/selectors/is-mapped-domain-site', () => require( 'sinon' ).stub() );
-jest.mock( 'calypso/state/selectors/is-site-on-free-plan', () => require( 'sinon' ).stub() );
-jest.mock( 'calypso/state/selectors/is-vip-site', () => require( 'sinon' ).stub() );
+jest.mock( 'calypso/state/selectors/is-mapped-domain-site', () => jest.fn() );
+jest.mock( 'calypso/state/selectors/is-site-on-free-plan', () => jest.fn() );
+jest.mock( 'calypso/state/selectors/is-vip-site', () => jest.fn() );
 
 describe( 'isEligibleForFreeToPaidUpsell', () => {
 	const state = 'state';
 	const siteId = 'siteId';
 
 	const meetAllConditions = () => {
-		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( true );
-		isJetpackSite.withArgs( state, siteId ).returns( false );
-		isMappedDomainSite.withArgs( state, siteId ).returns( false );
-		isSiteOnFreePlan.withArgs( state, siteId ).returns( true );
-		isVipSite.withArgs( state, siteId ).returns( false );
+		when( canCurrentUser ).calledWith( state, siteId, 'manage_options' ).mockReturnValue( true );
+		when( isJetpackSite ).calledWith( state, siteId ).mockReturnValue( false );
+		when( isMappedDomainSite ).calledWith( state, siteId ).mockReturnValue( false );
+		when( isSiteOnFreePlan ).calledWith( state, siteId ).mockReturnValue( true );
+		when( isVipSite ).calledWith( state, siteId ).mockReturnValue( false );
 	};
 
 	test( 'should return false when user can not manage options', () => {
 		meetAllConditions();
-		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( false );
+		when( canCurrentUser ).calledWith( state, siteId, 'manage_options' ).mockReturnValue( false );
 		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site is Jetpack', () => {
 		meetAllConditions();
-		isJetpackSite.withArgs( state, siteId ).returns( true );
+		when( isJetpackSite ).calledWith( state, siteId ).mockReturnValue( true );
 		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site has mapped domain', () => {
 		meetAllConditions();
-		isMappedDomainSite.withArgs( state, siteId ).returns( true );
+		when( isMappedDomainSite ).calledWith( state, siteId ).mockReturnValue( true );
 		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site is not on a free plan', () => {
 		meetAllConditions();
-		isSiteOnFreePlan.withArgs( state, siteId ).returns( false );
+		when( isSiteOnFreePlan ).calledWith( state, siteId ).mockReturnValue( false );
 		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).toBe( false );
 	} );
 
 	test( 'should return false when site is a vip site', () => {
 		meetAllConditions();
-		isVipSite.withArgs( state, siteId ).returns( true );
+		when( isVipSite ).calledWith( state, siteId ).mockReturnValue( true );
 		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).toBe( false );
 	} );
 

--- a/client/state/selectors/test/is-site-on-free-plan.js
+++ b/client/state/selectors/test/is-site-on-free-plan.js
@@ -3,29 +3,29 @@ import deepFreeze from 'deep-freeze';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import isSiteOnFreePlan from '../is-site-on-free-plan';
 jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
-	getCurrentPlan: require( 'sinon' ).stub(),
+	getCurrentPlan: jest.fn(),
 } ) );
 
 describe( 'isSiteOnFreePlan', () => {
 	const state = deepFreeze( {} );
 
 	test( 'should return false when plan is not known', () => {
-		getCurrentPlan.returns( null );
+		getCurrentPlan.mockReturnValue( null );
 		expect( isSiteOnFreePlan( state, 'site1' ) ).toBe( false );
 	} );
 
 	test( 'should return false when not on free plan', () => {
-		getCurrentPlan.returns( { productSlug: PLAN_BUSINESS } );
+		getCurrentPlan.mockReturnValue( { productSlug: PLAN_BUSINESS } );
 		expect( isSiteOnFreePlan( state, 'site1' ) ).toBe( false );
 	} );
 
 	test( 'should return true when on free plan', () => {
-		getCurrentPlan.returns( { productSlug: PLAN_FREE } );
+		getCurrentPlan.mockReturnValue( { productSlug: PLAN_FREE } );
 		expect( isSiteOnFreePlan( state, 'site1' ) ).toBe( true );
 	} );
 
 	test( 'should return true when on free Jetpack plan', () => {
-		getCurrentPlan.returns( { productSlug: PLAN_JETPACK_FREE } );
+		getCurrentPlan.mockReturnValue( { productSlug: PLAN_JETPACK_FREE } );
 		expect( isSiteOnFreePlan( state, 'site1' ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-site-on-paid-plan.js
+++ b/client/state/selectors/test/is-site-on-paid-plan.js
@@ -9,39 +9,39 @@ import deepFreeze from 'deep-freeze';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import isSiteOnPaidPlan from '../is-site-on-paid-plan';
 jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
-	getCurrentPlan: require( 'sinon' ).stub(),
+	getCurrentPlan: jest.fn(),
 } ) );
 
 describe( 'isSiteOnPaidPlan', () => {
 	const state = deepFreeze( {} );
 
 	test( 'should return false when plan is not known', () => {
-		getCurrentPlan.returns( null );
+		getCurrentPlan.mockReturnValue( null );
 		expect( isSiteOnPaidPlan( state, 'site1' ) ).toBe( false );
 	} );
 
 	test( 'should return false when on free plan', () => {
-		getCurrentPlan.returns( { productSlug: PLAN_FREE } );
+		getCurrentPlan.mockReturnValue( { productSlug: PLAN_FREE } );
 		expect( isSiteOnPaidPlan( state, 'site1' ) ).toBe( false );
 	} );
 
 	test( 'should return false when on free Jetpack plan', () => {
-		getCurrentPlan.returns( { productSlug: PLAN_JETPACK_FREE } );
+		getCurrentPlan.mockReturnValue( { productSlug: PLAN_JETPACK_FREE } );
 		expect( isSiteOnPaidPlan( state, 'site1' ) ).toBe( false );
 	} );
 
 	test( 'should return true when on paid plan', () => {
-		getCurrentPlan.returns( { productSlug: PLAN_BUSINESS } );
+		getCurrentPlan.mockReturnValue( { productSlug: PLAN_BUSINESS } );
 		expect( isSiteOnPaidPlan( state, 'site1' ) ).toBe( true );
 	} );
 
 	test( 'should return true when on eCommerce plan', () => {
-		getCurrentPlan.returns( { productSlug: PLAN_ECOMMERCE } );
+		getCurrentPlan.mockReturnValue( { productSlug: PLAN_ECOMMERCE } );
 		expect( isSiteOnPaidPlan( state, 'site1' ) ).toBe( true );
 	} );
 
 	test( 'should return true when on paid Jetpack plan', () => {
-		getCurrentPlan.returns( { productSlug: PLAN_JETPACK_BUSINESS } );
+		getCurrentPlan.mockReturnValue( { productSlug: PLAN_JETPACK_BUSINESS } );
 		expect( isSiteOnPaidPlan( state, 'site1' ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-user-registration-days-within-range.js
+++ b/client/state/selectors/test/is-user-registration-days-within-range.js
@@ -1,7 +1,8 @@
+import { when } from 'jest-when';
 import { getCurrentUserDate } from 'calypso/state/current-user/selectors';
 import isUserRegistrationDaysWithinRange from '../is-user-registration-days-within-range';
 jest.mock( 'calypso/state/current-user/selectors', () => ( {
-	getCurrentUserDate: require( 'sinon' ).stub(),
+	getCurrentUserDate: jest.fn(),
 } ) );
 
 describe( 'isUserRegistrationDaysWithinRange()', () => {
@@ -9,14 +10,14 @@ describe( 'isUserRegistrationDaysWithinRange()', () => {
 	const registrationDate = '2019-03-15';
 
 	test( 'should return null when there is no current user date', () => {
-		getCurrentUserDate.withArgs( state ).returns( null );
+		when( getCurrentUserDate ).calledWith( state ).mockReturnValue( null );
 		const refDate = registrationDate;
 		expect( isUserRegistrationDaysWithinRange( state, refDate, 5, 10 ) ).toBe( null );
 	} );
 
 	describe( 'when there is a current user date', () => {
 		beforeAll( () => {
-			getCurrentUserDate.withArgs( state ).returns( registrationDate );
+			when( getCurrentUserDate ).calledWith( state ).mockReturnValue( registrationDate );
 		} );
 
 		test( 'should return false when user has been registered for less than the lower bound', () => {

--- a/client/state/user-suggestions/test/actions.js
+++ b/client/state/user-suggestions/test/actions.js
@@ -1,6 +1,5 @@
 import deepFreeze from 'deep-freeze';
 import nock from 'nock';
-import sinon from 'sinon';
 import {
 	USER_SUGGESTIONS_RECEIVE,
 	USER_SUGGESTIONS_REQUEST,
@@ -11,12 +10,6 @@ import sampleSuccessResponse from './sample-response.json';
 const siteId = 123;
 
 describe( 'actions', () => {
-	const spy = sinon.spy();
-
-	beforeEach( () => {
-		spy.resetHistory();
-	} );
-
 	describe( '#receiveUserSuggestions()', () => {
 		test( 'should return an action object', () => {
 			const suggestions = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -12604,6 +12604,7 @@ __metadata:
     jest: ^27.3.1
     jest-fetch-mock: ^3.0.3
     jest-mock-process: ^1.4.1
+    jest-when: ^3.5.1
     lodash: ^4.17.21
     lodash-es: ^4.17.21
     lru: ^3.1.0
@@ -22239,6 +22240,15 @@ __metadata:
     jest-util: ^27.5.1
     string-length: ^4.0.1
   checksum: e42f5e38bc4da56bde6ccec4b13b7646460a3d6b567934e0ca96d72c2ce837223ffbb84a2f8428197da4323870c03f00969237f9b40f83a3072111a8cd66cc4b
+  languageName: node
+  linkType: hard
+
+"jest-when@npm:^3.5.1":
+  version: 3.5.1
+  resolution: "jest-when@npm:3.5.1"
+  peerDependencies:
+    jest: ">= 25"
+  checksum: 06719b89fc924a6c67c402366309099a0ec37f54851e9889f632fad88e7f9537504b63cdc805738e73425ff69ca883340f0977ac512bf7d931dbe1d6384a4d91
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes a bunch of the straightforward remaining `sinon` and replaces it with `jest`. 

We also introduce `jest-when` because that allows for easier and more native writing of mocks based on particular expected arguments.

After this PR, there are a few more `sinon` usages that we can address separately that seemed not that straightforward at the first look.

#### Testing instructions

Verify all tests pass.