### PR TITLE
Add phpcs installer to allow-plugins in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,10 @@
 	"require": {
 		"wp-phpunit/wp-phpunit": "^5.4",
 		"automattic/jetpack-codesniffer": "^2.1"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
When running `composer install`, it will ask you to enable permissions for the phpcs installer. According to the phpcs installer, this is now required in newer composer versions (https://github.com/PHPCSStandards/composer-installer#usage).

To fix the issue, we can add this entry to the composer.json file.

#### Testing instructions

CI should pass (particularly ETK)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
