### PR TITLE
Marketing: Gate Facebook plugin with installed check

### DIFF
--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -135,7 +135,7 @@ export const MarketingTools: FunctionComponent = () => {
 					>
 						<Button
 							onClick={ handleFacebookClick }
-							href={ `https://wordpress.com/plugins/official-facebook-pixel/${ selectedSiteSlug }` }
+							href={ `/plugins/official-facebook-pixel/${ selectedSiteSlug }` }
 						>
 							{ translate( 'Add Facebook for WordPress.com' ) }
 						</Button>

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -13,7 +13,6 @@ import sendinblueLogo from 'calypso/assets/images/illustrations/sendinblue-logo.
 import simpletextLogo from 'calypso/assets/images/illustrations/simpletext-logo.png';
 import verblioLogo from 'calypso/assets/images/illustrations/verblio-logo.png';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { marketingConnections, pluginsPath } from 'calypso/my-sites/marketing/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
@@ -87,7 +86,6 @@ export const MarketingTools: FunctionComponent = () => {
 
 	return (
 		<Fragment>
-			<QueryUserPurchases />
 			<QueryJetpackPlugins siteIds={ [ siteId ] } />
 			<PageViewTracker path="/marketing/tools/:site" title="Marketing > Tools" />
 

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -12,12 +12,12 @@ import facebookLogo from 'calypso/assets/images/illustrations/facebook-logo.png'
 import sendinblueLogo from 'calypso/assets/images/illustrations/sendinblue-logo.svg';
 import simpletextLogo from 'calypso/assets/images/illustrations/simpletext-logo.png';
 import verblioLogo from 'calypso/assets/images/illustrations/verblio-logo.png';
-import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { marketingConnections, pluginsPath } from 'calypso/my-sites/marketing/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
-import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
+import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import * as T from 'calypso/types';
 import MarketingToolsFeature from './feature';
@@ -32,9 +32,9 @@ export const MarketingTools: FunctionComponent = () => {
 
 	const selectedSiteSlug: T.SiteSlug | null = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId ) || 0;
-	const sitePlan = useSelector( ( state ) => getSitePlanSlug( state, siteId ) ) || '';
-	const showFacebookUpsell = [ 'value_bundle', 'personal-bundle', 'free_plan' ].includes(
-		sitePlan
+
+	const facebookPluginInstalled = useSelector( ( state ) =>
+		getPluginOnSite( state, siteId, 'official-facebook-pixel' )
 	);
 
 	const handleBusinessToolsClick = () => {
@@ -88,7 +88,7 @@ export const MarketingTools: FunctionComponent = () => {
 	return (
 		<Fragment>
 			<QueryUserPurchases />
-			{ ! sitePlan && <QuerySitePlans siteId={ siteId } /> }
+			<QueryJetpackPlugins siteIds={ [ siteId ] } />
 			<PageViewTracker path="/marketing/tools/:site" title="Marketing > Tools" />
 
 			<MarketingToolsHeader handleButtonClick={ handleBusinessToolsClick } />
@@ -122,7 +122,7 @@ export const MarketingTools: FunctionComponent = () => {
 					</Button>
 				</MarketingToolsFeature>
 
-				{ getLocaleSlug() === 'en' && (
+				{ ! facebookPluginInstalled && (
 					<MarketingToolsFeature
 						title={ translate( 'Want to connect with your audience on Facebook and Instagram?' ) }
 						description={ translate(
@@ -135,23 +135,12 @@ export const MarketingTools: FunctionComponent = () => {
 						) }
 						imagePath={ facebookLogo }
 					>
-						{ ! showFacebookUpsell && (
-							<Button
-								onClick={ handleFacebookClick }
-								href="https://wordpress.com/plugins/official-facebook-pixel"
-								target="_blank"
-							>
-								{ translate( 'Add Facebook for WordPress.com' ) }
-							</Button>
-						) }
-						{ showFacebookUpsell && (
-							<Button
-								onClick={ handleFacebookClick }
-								href={ `/plans/${ selectedSiteSlug }?customerType=business` }
-							>
-								{ translate( 'Unlock this feature' ) }
-							</Button>
-						) }
+						<Button
+							onClick={ handleFacebookClick }
+							href={ `https://wordpress.com/plugins/official-facebook-pixel/${ selectedSiteSlug }` }
+						>
+							{ translate( 'Add Facebook for WordPress.com' ) }
+						</Button>
 					</MarketingToolsFeature>
 				) }
 


### PR DESCRIPTION
Removes a plan check in favor of a plugin installed check.
The Marketplace now displays an "Upgrade and install" button when a site can't install plugins, so this change will let the Marketplace handle upgrade scenarios.

#### Changes proposed in this Pull Request

* Shows Facebook Upsell based on whether the plugin is installed or not.
* Removes restriction for English language users since all strings are translated now.
* Removed unused Purchases query. Usage removed in https://github.com/Automattic/wp-calypso/pull/63541.
* Opens plugin page in the same tab and without page reload.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /marketing/tools
* Click on "Add Facebook for WordPress.com"
* Either upgrade and install or install the plugin.
* Navigate back to /marketing/tools and make sure the upsell disappears.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-a66-p2