### PR TITLE
Never fail webpack build from sentry

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -386,6 +386,10 @@ const webpackConfig = {
 				release: `calypso_${ process.env.COMMIT_SHA }`,
 				include: filePaths.path,
 				urlPrefix: `~${ filePaths.publicPath }`,
+				errorHandler: ( err, invokeErr, compilation ) => {
+					// Sentry should _never_ fail the webpack build, so only emit warnings here:
+					compilation.warnings.push( 'Sentry CLI Plugin: ' + err.message );
+				},
 			} ),
 	].filter( Boolean ),
 	externals: [ 'keytar' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Override the sentry error handler to only emit warnings. The default behavior is to fail the build. If anything goes wrong with sentry, we don't want to block our CD workflow on trunk, so we need to avoid treating Sentry problems like errors in Webpack.

The main goal is to avoid CD workflow blockers when Sentry has an outage.

#### Testing instructions
Build should pass with sentry enabled. 
