### PR TITLE
Woo on Stepper: Enable WooCommerce flow in Stepper

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -96,7 +96,7 @@
 		"signup/site-vertical-step": false,
 		"signup/stepper-flow": true,
 		"site-indicator": true,
-		"stepper-woocommerce-poc": false,
+		"stepper-woocommerce-poc": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -110,7 +110,7 @@
 		"signup/site-vertical-step": false,
 		"signup/stepper-flow": true,
 		"site-indicator": true,
-		"stepper-woocommerce-poc": false,
+		"stepper-woocommerce-poc": true,
 		"ssr/sample-log-cache-misses": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -110,7 +110,7 @@
 		"signup/site-vertical-step": false,
 		"signup/stepper-flow": true,
 		"site-indicator": true,
-		"stepper-woocommerce-poc": false,
+		"stepper-woocommerce-poc": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/test.json
+++ b/config/test.json
@@ -78,7 +78,7 @@
 		"signup/social": true,
 		"signup/stepper-flow": true,
 		"site-indicator": true,
-		"stepper-woocommerce-poc": false,
+		"stepper-woocommerce-poc": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,7 +119,7 @@
 		"signup/site-vertical-step": false,
 		"signup/stepper-flow": true,
 		"site-indicator": true,
-		"stepper-woocommerce-poc": false,
+		"stepper-woocommerce-poc": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,


### PR DESCRIPTION
This change enables the Woo flow on Stepper. This is meant to be merged once all the pending work is completed.

#### Testing
1. Go to the calypso.live link in the comments.
2. Verify that when going through the Woo flow the Stepper code is being used.

