### PR TITLE
HelpCenter: more styling changes

### DIFF
--- a/client/blocks/inline-help/inline-help-center-content.jsx
+++ b/client/blocks/inline-help/inline-help-center-content.jsx
@@ -50,7 +50,7 @@ const InlineHelpCenterContent = ( { setContactFormOpen, openInContactPage } ) =>
 		} else if ( activeSecondaryView === VIEW_RICH_RESULT ) {
 			setHeaderText(
 				<div className="inline-help__rich-result-header">
-					<Icon icon={ pageIcon } />
+					<Icon size="20" icon={ pageIcon } />
 					{ selectedArticle?.title }
 				</div>
 			);

--- a/client/blocks/inline-help/inline-help-center-content.scss
+++ b/client/blocks/inline-help/inline-help-center-content.scss
@@ -20,7 +20,7 @@
 		}
 
 		h3 {
-			font-size: $font-body-small !important;
+			font-size: $font-body-small;
 			font-weight: 500;
 			color: var( --studio-gray-100 );
 		}
@@ -212,6 +212,11 @@
 	.inline-help__contact-page {
 		.inline-help__contact-content {
 			margin-bottom: 40px;
+
+			h3 {
+				font-size: $font-body;
+				font-weight: 500;
+			}
 		}
 
 		.inline-help__contact-boxes {
@@ -450,6 +455,7 @@
 			.wp-block-separator {
 				margin: auto;
 				border-bottom: 1px solid var( --color-neutral-10 );
+				border-top: 0;
 				width: 100%;
 			}
 

--- a/client/blocks/inline-help/inline-help-center-content.scss
+++ b/client/blocks/inline-help/inline-help-center-content.scss
@@ -283,7 +283,8 @@
 					}
 
 					h2 {
-						font-weight: 400;
+						font-weight: 500;
+						font-size: $font-body;
 					}
 				}
 
@@ -398,6 +399,8 @@
 		}
 
 		li {
+			margin-bottom: 0;
+
 			a {
 				font-size: $font-body-small;
 			}
@@ -406,6 +409,11 @@
 				margin-left: 2em;
 			}
 		}
+	}
+
+	.inline-help__external-button {
+		display: flex;
+		align-items: center;
 	}
 
 	p {
@@ -426,6 +434,10 @@
 
 	.support-article-dialog__story {
 		padding: 0;
+
+		.support-article-dialog__header {
+			margin-bottom: 0;
+		}
 
 		.support-article-dialog__story-content {
 			.wp-block-quote {
@@ -470,7 +482,7 @@
 				border-radius: 2px;
 				color: var( --color-text-inverted );
 				font-size: $font-body-small;
-				padding: 8px 14px;
+				padding: 4px 14px;
 				width: 100%;
 			}
 
@@ -482,16 +494,13 @@
 				}
 			}
 
-			.support-article-dialog__header {
-				margin-bottom: 0;
-			}
-
 			.wp-block-image figure figcaption {
 				display: block;
 			}
 		}
 	}
 }
+
 /**
 * FOOTER - high specificity to overwrite base styling
 */
@@ -503,10 +512,7 @@
 		width: 100%;
 
 		&:hover {
-			border-color: var( --studio-gray-50 );
-		}
-
-		&:hover {
+			border-color: var( --color-neutral-20 );
 			box-shadow: none;
 			outline: none;
 		}

--- a/client/blocks/inline-help/inline-help-embed-result.tsx
+++ b/client/blocks/inline-help/inline-help-embed-result.tsx
@@ -36,15 +36,24 @@ const InlineHelpEmbedResult: React.FC< Props > = ( { result, handleBackButton, s
 
 	return (
 		<div className="inline-help__embed-result">
-			<Flex justify="space-between">
+			<Flex justify="space-between" className="inline-help__embed-navigation">
 				<FlexItem>
-					<Button borderless={ true } onClick={ handleBackButton }>
+					<Button
+						borderless={ true }
+						onClick={ handleBackButton }
+						className="inline-help__back-button"
+					>
 						<Icon icon={ chevronLeft } size={ 20 } />
 						{ __( 'Back' ) }
 					</Button>
 				</FlexItem>
 				<FlexItem>
-					<Button borderless={ true } href={ link } target="_blank">
+					<Button
+						borderless={ true }
+						href={ link }
+						target="_blank"
+						className="inline-help__external-button"
+					>
 						<Icon icon={ external } size={ 20 } />
 					</Button>
 				</FlexItem>

--- a/client/blocks/support-article-dialog/style.scss
+++ b/client/blocks/support-article-dialog/style.scss
@@ -51,18 +51,16 @@
 	-moz-osx-font-smoothing: grayscale;
 	font-size: $font-title-medium;
 	font-weight: 600;
-	line-height: 34px;
+	line-height: 32px;
 	margin: 56px 0 0;
 	max-width: 750px;
 
 	@include breakpoint-deprecated( '>960px' ) {
 		font-size: $font-headline-small;
-		line-height: 46px;
 	}
 
 	@include breakpoint-deprecated( '480px-960px' ) {
 		font-size: $font-title-large;
-		line-height: 40px;
 	}
 
 	@include breakpoint-deprecated( '<660px' ) {

--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -72,6 +72,12 @@
 	border-color: var( --color-accent );
 	color: var( --color-text-inverted );
 
+	&:hover {
+		color: var( --color-text-inverted );
+		background-color: var( --color-accent-60 );
+		border-color: var( --color-accent-60 );
+	}
+
 	&:disabled {
 		background-color: var( --color-surface ) !important;
 		border-color: var( --color-neutral-5 ) !important;
@@ -167,10 +173,12 @@ span.help-center-header__title {
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
+	display: flex;
 }
 
 .is-minimized .help-center-header__title .inline-help__rich-result-header {
 	padding-left: 24px;
+	display: inline;
 
 	svg {
 		position: absolute;

--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -51,6 +51,10 @@
 			}
 		}
 	}
+
+	.site-picker__site-item {
+		padding: 12px 8px;
+	}
 }
 
 .help-center-contact-form__message, .help-center-contact-form__subject input.components-text-control__input {
@@ -173,7 +177,6 @@ span.help-center-header__title {
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
-	display: flex;
 }
 
 .is-minimized .help-center-header__title .inline-help__rich-result-header {
@@ -184,5 +187,6 @@ span.help-center-header__title {
 		position: absolute;
 		left: 12px;
 		top: 12px;
+		margin-right: 4px;
 	}
 }

--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -53,18 +53,18 @@
 	}
 }
 
-.help-center-contact-form__message {
+.help-center-contact-form__message, .help-center-contact-form__subject input.components-text-control__input {
 	padding: 15.5px;
 	border: 1px solid var( --studio-gray-10 );
 	border-radius: 4px;
 	width: 100%;
 	display: block;
-}
 
-.help-center-contact-form__message:focus {
-	box-shadow: none;
-	outline: none;
-	border-color: var( --studio-gray-10 );
+	&:focus {
+		box-shadow: none;
+		outline: none;
+		border-color: var( --studio-gray-10 );
+	}
 }
 
 .button.help-center-contact-form__site-picker-cta.is-primary {
@@ -79,7 +79,7 @@
 	}
 }
 
-.site-picker__site-item-site-logo svg {
+.help-center .help-center-contact-form .site-picker__site-item-site-logo svg {
 	fill: var( --studio-gray-30 );
 }
 

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -309,18 +309,22 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 					{ formTitles.formDisclaimer }
 				</p>
 			) }
-			<section>
-				<HelpCenterSitePicker
-					currentSite={ currentSite }
-					onSelect={ ( id: string | number ) => {
-						if ( id !== 0 ) {
-							setSite( currentSite );
-						}
-						setSitePickerChoice( id === 0 ? 'OTHER_SITE' : 'CURRENT_SITE' );
-					} }
-					siteId={ sitePickerChoice === 'CURRENT_SITE' ? currentSite?.ID : 0 }
-				/>
-			</section>
+
+			{ mode === 'FORUM' && (
+				<section>
+					<HelpCenterSitePicker
+						currentSite={ currentSite }
+						onSelect={ ( id: string | number ) => {
+							if ( id !== 0 ) {
+								setSite( currentSite );
+							}
+							setSitePickerChoice( id === 0 ? 'OTHER_SITE' : 'CURRENT_SITE' );
+						} }
+						siteId={ sitePickerChoice === 'CURRENT_SITE' ? currentSite?.ID : 0 }
+					/>
+				</section>
+			) }
+
 			{ sitePickerChoice === 'OTHER_SITE' && (
 				<>
 					<section>
@@ -343,6 +347,7 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 			{ [ 'FORUM', 'EMAIL' ].includes( mode ) && (
 				<section>
 					<TextControl
+						className="help-center-contact-form__subject"
 						label={ __( 'Subject', __i18n_text_domain__ ) }
 						value={ subject ?? '' }
 						onChange={ setSubject }

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -310,20 +310,18 @@ const ContactForm: React.FC< ContactFormProps > = ( { mode, onBackClick, onGoHom
 				</p>
 			) }
 
-			{ mode === 'FORUM' && (
-				<section>
-					<HelpCenterSitePicker
-						currentSite={ currentSite }
-						onSelect={ ( id: string | number ) => {
-							if ( id !== 0 ) {
-								setSite( currentSite );
-							}
-							setSitePickerChoice( id === 0 ? 'OTHER_SITE' : 'CURRENT_SITE' );
-						} }
-						siteId={ sitePickerChoice === 'CURRENT_SITE' ? currentSite?.ID : 0 }
-					/>
-				</section>
-			) }
+			<section>
+				<HelpCenterSitePicker
+					currentSite={ currentSite }
+					onSelect={ ( id: string | number ) => {
+						if ( id !== 0 ) {
+							setSite( currentSite );
+						}
+						setSitePickerChoice( id === 0 ? 'OTHER_SITE' : 'CURRENT_SITE' );
+					} }
+					siteId={ sitePickerChoice === 'CURRENT_SITE' ? currentSite?.ID : 0 }
+				/>
+			</section>
 
 			{ sitePickerChoice === 'OTHER_SITE' && (
 				<>

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -16,6 +16,10 @@ $head-foot-height: 50px;
 		font-size: $font-title-small;
 	}
 
+	.button {
+		font-size: $font-body-small;
+	}
+
 	& > div {
 		display: flex;
 		flex-direction: column;

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -12,6 +12,10 @@ $head-foot-height: 50px;
 	z-index: 9999;
 	cursor: default;
 
+	button.button-primary, button.button-secondary {
+		font-size: $font-title-small;
+	}
+
 	& > div {
 		display: flex;
 		flex-direction: column;
@@ -150,6 +154,7 @@ $head-foot-height: 50px;
 
 .ticket-success-screen__help-center {
 	text-align: center;
+
 	.ticket-success-screen__help-center-heading {
 		font-size: $font-title-small;
 		color: $studio-gray-100;


### PR DESCRIPTION
## Changes proposed in this Pull Request

- [x] “Still need help” button**: the hover color for the button is too dark. [Let’s make it like the standard Calypso buttons](https://wpcalypso.wordpress.com/devdocs/design/button)
- [ ] **All buttons**: I see we have a styling for “.wp-core-ui .button, .wp-core-ui .button-primary, .wp-core-ui .button-secondary” of font-size: 13px. Let’s remove this.
- [x] **Header**: The “minimize” button should be centered vertically
- [x] **Article page**: table of contents: remove the margin-bottom of 6px from “li” elements.
- [x] **Article page**: set bottom margin of `.support-article-dialog__header` to 0px. 
- [ ] (*not sure about this one*) **Article page**: h1: change line-height to 32px
- [x] **Article page**: change the `.button-primary` top & bottom padding to 4px.
- [x] **Contact form page - email**: remove “focus state” styling from “subject”.
- [ ] **Contact form page**: remove the “other site” option from all forms except the “Public forms” contact form.
- [ ] **Contact us page**: the title “Contact our WordPress.com experts” should be the same as the title on the contact forms “Start live chat” etc. They should all be $font-body, font-weight: 500.
- [x] **Contact us page**: “.site-picker__site-item-site-logo svg” fill should be “var( --studio-gray-30 );”.
- [x] **Chat**: There is some misalignment with the title of the minimized view.
- [ ] **Contact form page:** let’s make “.site-picker__site-item” padding: 12px 8px;
- [ ] **Minimized view with long article name**: add ellipses to the end of the truncated text.

## Testing instructions

1. Login to sandbox, pull branch, and `yarn dev --sync` from apps/editing-toolkit
2. Go to the editor and open the HelpCenter
3. Observe the style and make sure nothing looks borked

Related to #63275
Fixes #63275