### PR TITLE
Only save modified fields on site settings page

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -167,7 +167,8 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 		};
 
 		submitForm = () => {
-			const { fields, jetpackFieldsToUpdate, settingsFields, siteId, siteIsJetpack } = this.props;
+			const { dirtyFields, fields, jetpackFieldsToUpdate, settingsFields, siteId, siteIsJetpack } =
+				this.props;
 			this.props.removeNotice( 'site-settings-save' );
 			debug( 'submitForm', { fields, settingsFields } );
 
@@ -180,7 +181,9 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 			}
 
 			const siteFields = pick( fields, settingsFields.site );
-			this.props.saveSiteSettings( siteId, siteFields );
+			const modifiedFields = pick( siteFields, dirtyFields );
+
+			this.props.saveSiteSettings( siteId, modifiedFields );
 		};
 
 		handleRadio = ( event ) => {


### PR DESCRIPTION
Currently when saving the site settings page we will save all fields as they were loaded on the page, even if the user has not modified them. This includes the three site visibility fields, "wpcom_public_coming_soon" and "blog_public". This is despite us already having a list of "dirty" fields which we currently only use for tracks events.

#### Coming soon bug case investigation
I've been investigating an issue with sites being launched but then remaining in "coming soon" mode https://github.com/Automattic/wp-calypso/issues/53626
I investigated this case in detail 29365431-hc
Digging into the nginx logs  2c7d9-pb relating to one of the sites, It appears that the user
1. (20 minutes earlier) Upgraded their site and purchased a domain name
2. Appeared to load another page in calypso, likely the site home page ( `GET` to `/checklist` endpoint)
3. Appeared to load the settings page in calypso (`GET` to `/settings` endpoint)
4. Launched the site from within calypso, likely from the checklist on the site home page (POST to `/launch` endpoint)
5. Saved the settings page (POST to the `/settings` endpoint)

#### Reproducing the issue
The homepage checklist has multiple steps, "Name your site" takes user to the settings page, and "Launch your site" immediately `/launch`es the site. My theory is that the user:
 1. Opened the "Name your site" (settings page) in one tab
 2. In a different tab, went back to the homepage and launched their site
 3. Then, went to the (now out of date) settings page tab, changed their site name, and hit save.

When the out of date settings page is saved, we send { "wpcom_public_coming_soon": 1, "blog_public": 0 } putting the site back into coming soon mode.

Following these steps, I was able to set my site back into "coming soon" mode despite having launched it!

https://user-images.githubusercontent.com/22446385/169949145-ec522755-1878-4cec-b774-776045f2c0aa.mov

#### Testing instructions
Save each element on the settings page, ensure that saving is successful.
Repeat the test scenario outlined above, and ensure that the site is no longer put into "coming soon" mode

(hopefully) fixes https://github.com/Automattic/wp-calypso/issues/53626