### PR TITLE
Adds event to track the selected DIFM service

### DIFF
--- a/client/signup/steps/choose-service/index.tsx
+++ b/client/signup/steps/choose-service/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import {
@@ -90,6 +91,7 @@ export default function ChooseServiceStep( props: Props ): React.ReactNode {
 	}, [] );
 
 	const onSelect = ( value: ChoiceType ) => {
+		recordTracksEvent( 'calypso_signup_difm_service_selected', { service: value } );
 		if ( 'builtby' === value ) {
 			window.location.href = 'https://builtbywp.com/';
 			return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds an event `calypso_signup_difm_service_selected` which will be fired when any of the CTAs on the `choose-service` step are clicked.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/website-design-services/choose-service?siteSlug=<site slug>`
* Open the network inspector, and switch to the Images tab.
* Click on the "Get Started" button, and check the request to `http://pixel.wp.com`.
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/5436027/169973680-ee7b2eee-d7b7-4920-b1f1-499989863d7b.png">

* Go back, click on the "Learn More" button, and check the request to `http://pixel.wp.com`.
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/5436027/169973726-1a35420d-353c-4eb1-a609-fbf4d5b1aab5.png">

* Confirm that the event props are correct, especially the `service` prop.

