### PR TITLE
Implement welcome banner for agency dashboard

### DIFF
--- a/client/assets/images/jetpack/tip-icon.svg
+++ b/client/assets/images/jetpack/tip-icon.svg
@@ -1,0 +1,1 @@
+<svg width="12" height="17" viewBox="0 0 12 17" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="6" cy="6" r="5" stroke="#1E1E1E" stroke-width="1.42857"/><line x1="3" y1="13.8816" x2="9" y2="13.8816" stroke="#1E1E1E" stroke-width="1.5"/><line x1="4" y1="16.25" x2="8" y2="16.25" stroke="#1E1E1E" stroke-width="1.5"/></svg>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import SiteContent from './site-content';
+import SiteWelcomeBanner from './site-welcome-banner';
 import type { ReactElement } from 'react';
 
 import './style.scss';
@@ -8,6 +9,7 @@ export default function SitesOverview(): ReactElement {
 	const translate = useTranslate();
 	return (
 		<div className="sites-overview">
+			<SiteWelcomeBanner isDashboardView />
 			<div className="sites-overview__page-title-container">
 				<h2 className="sites-overview__page-title">{ translate( 'Dashboard' ) }</h2>
 				<div className="sites-overview__page-subtitle">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
@@ -9,7 +9,7 @@ import {
 	getJetpackDashboardWelcomeBannerPreference as getPreference,
 } from 'calypso/state/partner-portal/agency-dashboard/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
-import type { Preference, PreferenceType } from '../types';
+import type { PreferenceType } from '../types';
 
 export default function SiteWelcomeBanner( {
 	isDashboardView,
@@ -24,8 +24,8 @@ export default function SiteWelcomeBanner( {
 	const preferenceName = isDashboardView
 		? homePagePreferenceName
 		: `${ JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE }-${ bannerKey }`;
-	const preference: Preference = useSelector( ( state ) => getPreference( state, preferenceName ) );
-	const homePagePreference: Preference = useSelector( ( state ) =>
+	const preference = useSelector( ( state ) => getPreference( state, preferenceName ) );
+	const homePagePreference = useSelector( ( state ) =>
 		getPreference( state, homePagePreferenceName )
 	);
 
@@ -77,6 +77,6 @@ export default function SiteWelcomeBanner( {
 			dismissTemporary={ ! isDashboardView }
 			onDismiss={ dismissBanner }
 			dismissPreferenceName={ isDashboardView ? '' : preferenceName }
-		></Banner>
+		/>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
@@ -1,0 +1,82 @@
+import { useTranslate } from 'i18n-calypso';
+import { ReactElement, useCallback, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import tipIcon from 'calypso/assets/images/jetpack/tip-icon.svg';
+import Banner from 'calypso/components/banner';
+import {
+	JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE,
+	JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE_HOME_PAGE as homePagePreferenceName,
+	getJetpackDashboardWelcomeBannerPreference as getPreference,
+} from 'calypso/state/partner-portal/agency-dashboard/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
+import type { Preference, PreferenceType } from '../types';
+
+export default function SiteWelcomeBanner( {
+	isDashboardView,
+	bannerKey,
+}: {
+	isDashboardView?: boolean;
+	bannerKey?: string;
+} ): ReactElement | null {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const preferenceName = isDashboardView
+		? homePagePreferenceName
+		: `${ JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE }-${ bannerKey }`;
+	const preference: Preference = useSelector( ( state ) => getPreference( state, preferenceName ) );
+	const homePagePreference: Preference = useSelector( ( state ) =>
+		getPreference( state, homePagePreferenceName )
+	);
+
+	const savePreferenceType = useCallback(
+		( type: PreferenceType ) => {
+			dispatch( savePreference( preferenceName, { ...preference, [ type ]: true } ) );
+		},
+		[ dispatch, preference, preferenceName ]
+	);
+
+	const isDismissed = preference?.dismiss;
+	const hideBanner = ! isDashboardView && homePagePreference?.view;
+
+	useEffect( () => {
+		if ( ! isDismissed && ! hideBanner ) {
+			savePreferenceType( 'view' );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	const dismissBanner = useCallback( () => {
+		savePreferenceType( 'dismiss' );
+	}, [ savePreferenceType ] );
+
+	// Hide the banner if the banner is already viewed
+	// on the dashboard page or the banner is dismissed
+	if ( isDismissed || hideBanner ) {
+		return null;
+	}
+
+	return (
+		<Banner
+			title={ translate( 'A new way to manage all your Jetpack sites in one spot' ) }
+			description={
+				isDashboardView
+					? translate(
+							'Manage features and discover issues with any of your sites, which are automatically added when Jetpack is connected.'
+					  )
+					: translate(
+							'Manage features and discover issues with any of your sites within your new dashboard.'
+					  )
+			}
+			disableCircle
+			horizontal
+			iconPath={ tipIcon }
+			callToAction={ isDashboardView ? translate( 'Got it' ) : translate( 'View' ) }
+			href={ isDashboardView ? '' : '/dashboard' }
+			onClick={ isDashboardView && dismissBanner }
+			dismissTemporary={ ! isDashboardView }
+			onDismiss={ dismissBanner }
+			dismissPreferenceName={ isDashboardView ? '' : preferenceName }
+		></Banner>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -18,3 +18,10 @@ export interface SiteData {
 	plugin: { updates: number };
 	[ key: string ]: any;
 }
+
+export type PreferenceType = 'dismiss' | 'view';
+
+export type Preference = {
+	dismiss?: boolean;
+	view?: boolean;
+};

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -1,10 +1,11 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+import SiteWelcomeBanner from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner';
 import LicenseList from 'calypso/jetpack-cloud/sections/partner-portal/license-list';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 import LicenseStateFilter from 'calypso/jetpack-cloud/sections/partner-portal/license-state-filter';
@@ -16,6 +17,7 @@ import {
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { showAgencyDashboard } from 'calypso/state/partner-portal/partner/selectors';
 import './style.scss';
 
 interface Props {
@@ -35,6 +37,7 @@ export default function Licenses( {
 }: Props ): ReactElement {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const isAgencyUser = useSelector( showAgencyDashboard );
 
 	const context = {
 		filter,
@@ -52,7 +55,7 @@ export default function Licenses( {
 		<Main wideLayout className="licenses">
 			<DocumentHead title={ translate( 'Licenses' ) } />
 			<SidebarNavigation />
-
+			{ isAgencyUser && <SiteWelcomeBanner bannerKey="licenses-page" /> }
 			<div className="licenses__header">
 				<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
 

--- a/client/state/partner-portal/agency-dashboard/selectors.ts
+++ b/client/state/partner-portal/agency-dashboard/selectors.ts
@@ -1,0 +1,21 @@
+import { DefaultRootState } from 'react-redux';
+import { Preference } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import { getPreference } from 'calypso/state/preferences/selectors';
+
+export const JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE =
+	'jetpack-dashboard-welcome-banner-preference';
+
+export const JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE_HOME_PAGE =
+	'jetpack-dashboard-welcome-banner-preference-home-page';
+
+/**
+ * Returns preference associated with the welcome banner.
+ *
+ */
+export function getJetpackDashboardWelcomeBannerPreference(
+	state: DefaultRootState,
+	key: string
+): Preference {
+	const preference = getPreference( state, key );
+	return preference;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds banners to highlight the agency dashboard on the dashboard page and licenses page.

#### Testing instructions

**Prerequisites**

Make sure you are not an agency partner, if yes set it back to internal -  2c49b-pb

**Instructions**

1. Run `git checkout add/welcome-banner-to-agency-dashboard` and `yarn start-jetpack-cloud`
2. Apply D79008-code to your sandbox for the mock API to work.
3. Visit http://jetpack.cloud.localhost:3000/partner-portal/licenses directly without visiting the dashboard page or http://jetpack.cloud.localhost:3000/ and verify that no banner is shown since you are not an agency user.
4. Now, set yourself(partner) as an agency - 2c49b-pb
5. Refresh the licenses page without visiting the dashboard page, and verify that the banner is shown now.
6. Click on the `View` button on the banner on the licenses page, it should take you to the dashboard page(`/dashboard`)
7. Verify that the banner is shown on the dashboard page as shown in the screenshot below
8. Go back to the licenses page again, now the banner should be hidden(since you have visited the dashboard page)
9. Got back to the dashboard page, you should still see the banner. 
10. Click on the `Got it` button, the banner should be hidden now.
11. Refresh the page to make sure the banner is not appearing again.

**Screenshots**

Licenses Page

<img width="1084" alt="Screenshot 2022-05-24 at 1 15 02 PM" src="https://user-images.githubusercontent.com/10586875/169980111-aa1c5afb-8741-4e63-988e-edc6c40b1d69.png">

Dashboard Page

<img width="1076" alt="Screenshot 2022-05-24 at 1 14 44 PM" src="https://user-images.githubusercontent.com/10586875/169980080-29bc9afe-0285-47c5-8c9d-ff0c922f607f.png">

Related to 1202076982646589-as-1202228745081082