### PR TITLE
Set max-width of agency dashboard content

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -4,6 +4,8 @@
 .sites-overview {
 	height: 100vh;
 	padding: 16px;
+	max-width: 1500px;
+	margin: auto;
 	@include break-large() {
 		padding: 0;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR sets a max-width to the agency dashboard content which majorly affects the large screens(4k)

#### Testing instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb

**Instructions**

1. Run `git checkout update/set-max-width-agency-dashboard-content` and `yarn start-jetpack-cloud`
2. Apply D79008-code to your sandbox for the mock API to work.
3. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard
4. Switch to 4K screen view(2560px) using the dev tool(inspect).
5. Verify that the dashboard page content doesn't exceed 1500px(excluding padding - 32px)

**Screenshots**

Before

<img width="1818" alt="Screenshot 2022-05-24 at 2 32 53 PM" src="https://user-images.githubusercontent.com/10586875/169994018-b084e0ba-5a7b-4e76-850d-d6702ac0a665.png">

After

<img width="1807" alt="Screenshot 2022-05-24 at 2 30 58 PM" src="https://user-images.githubusercontent.com/10586875/169994084-928a9957-5eb0-4051-b9b6-06697ebd6d69.png">

Related to 1202076982646589-as-1202304599668075