### PR TITLE
Design Picker: Responsive thumbnails

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -433,7 +433,6 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		flex-direction: column;
 		flex-grow: 1;
 		margin-bottom: 98px;
-		row-gap: 24px;
 
 		@include break-small {
 			flex: 0 154px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -498,7 +498,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		line-height: 1.25rem;
 		margin: 8px 0;
 		width: 100%;
-		overflow: visible;
+		flex-shrink: 0;
     	margin-bottom: 48px;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -433,6 +433,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		flex-direction: column;
 		flex-grow: 1;
 		margin-bottom: 98px;
+		row-gap: 24px;
 
 		@include break-small {
 			flex: 0 154px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -498,6 +498,8 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		line-height: 1.25rem;
 		margin: 8px 0;
 		width: 100%;
+		overflow: visible;
+    	margin-bottom: 48px;
 	}
 
 	.step-container__content {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -496,10 +496,9 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		border-radius: 4px;
 		font-weight: 500;
 		line-height: 1.25rem;
-		margin: 8px 0;
+		margin: 8px 0 48px;
 		width: 100%;
 		flex-shrink: 0;
-    	margin-bottom: 48px;
 	}
 
 	.step-container__content {

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -5,6 +5,7 @@ import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
+import { useEffect, useRef } from 'react';
 import { getDesignPreviewUrl, getMShotOptions } from '../utils';
 import type { Design } from '../types';
 import './style.scss';
@@ -77,24 +78,55 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 } ) => {
 	const { __ } = useI18n();
 
+	/* eslint-disable @typescript-eslint/no-unused-vars */
+	const wrapperRef = useRef< HTMLDivElement >( null );
+
+	useEffect( () => {
+		const onResize = () => {
+			const { current: thumnbnailWrapper } = wrapperRef;
+			if ( ! thumnbnailWrapper ) {
+				return;
+			}
+
+			const viewportHeight = Math.max(
+				document.documentElement.clientHeight,
+				window.innerHeight || 0
+			);
+			const wrapperMaxHeight =
+				viewportHeight - ( thumnbnailWrapper.getClientRects()[ 0 ].y + window.scrollY );
+		};
+
+		window.addEventListener( 'resize', onResize );
+		onResize();
+
+		return () => {
+			window.removeEventListener( 'resize', onResize );
+		};
+	}, [] );
+	/* eslint-enable @typescript-eslint/no-unused-vars */
+
 	return (
 		<div className="generated-design-picker">
 			{ heading }
 			<div className="generated_design-picker__content">
 				<div className="generated-design-picker__thumbnails">
-					{ designs &&
-						designs.map( ( design, index ) => (
-							<GeneratedDesignThumbnail
-								key={ design.slug }
-								slug={ design.slug }
-								thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
-								isSelected={ selectedDesign?.slug === design.slug }
-								onPreview={ () => onPreview( design, index ) }
-							/>
-						) ) }
-					<Button className="generated-design-picker__view-more" onClick={ onViewMore }>
-						{ __( 'View more options' ) }
-					</Button>
+					<div className="generated-design-picker__thumbnails-wrapper" ref={ wrapperRef }>
+						{ designs &&
+							designs.map( ( design, index ) => (
+								<GeneratedDesignThumbnail
+									key={ design.slug }
+									slug={ design.slug }
+									thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
+									isSelected={ selectedDesign?.slug === design.slug }
+									onPreview={ () => onPreview( design, index ) }
+								/>
+							) ) }
+					</div>
+					<div className="generated-design-picker__view-more-wrapper">
+						<Button className="generated-design-picker__view-more" onClick={ onViewMore }>
+							{ __( 'View more options' ) }
+						</Button>
+					</div>
 				</div>
 				<div className="generated-design-picker__previews">{ previews }</div>
 			</div>

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -80,14 +80,11 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 
 	/* eslint-disable @typescript-eslint/no-unused-vars */
 	const wrapperRef = useRef< HTMLDivElement >( null );
-	const viewmoreRef = useRef< HTMLDivElement >( null );
-	const propertyForThumbnailHeight = '--thumbnail-design-height';
 
 	useEffect( () => {
 		const onResize = () => {
 			const { current: thumnbnailWrapper } = wrapperRef;
-			const { current: viewmoreWrapper } = viewmoreRef;
-			if ( ! thumnbnailWrapper || ! viewmoreWrapper ) {
+			if ( ! thumnbnailWrapper ) {
 				return;
 			}
 
@@ -96,16 +93,9 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 				window.innerHeight || 0
 			);
 			const wrapperMaxHeight =
-				viewportHeight -
-				( thumnbnailWrapper.getClientRects()[ 0 ].y + window.scrollY ) -
-				viewmoreWrapper.getClientRects()[ 0 ].height;
-			const thumbnailHeight = wrapperMaxHeight / 3;
-			const thumbnailActualHeight = Math.min( 300, Math.max( 100, thumbnailHeight ) );
+				viewportHeight - ( thumnbnailWrapper.getClientRects()[ 0 ].y + window.scrollY );
 
-			thumnbnailWrapper.style.setProperty(
-				propertyForThumbnailHeight,
-				`${ thumbnailActualHeight }px`
-			);
+			thumnbnailWrapper.style.height = `${ wrapperMaxHeight }px`;
 		};
 
 		window.addEventListener( 'resize', onResize );
@@ -121,26 +111,22 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 		<div className="generated-design-picker">
 			{ heading }
 			<div className="generated_design-picker__content">
-				<div className="generated-design-picker__thumbnails">
-					<div className="generated-design-picker__thumbnails-wrapper" ref={ wrapperRef }>
-						{ designs &&
-							designs
-								.slice( 0, 3 )
-								.map( ( design, index ) => (
-									<GeneratedDesignThumbnail
-										key={ design.slug }
-										slug={ design.slug }
-										thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
-										isSelected={ selectedDesign?.slug === design.slug }
-										onPreview={ () => onPreview( design, index ) }
-									/>
-								) ) }
-					</div>
-					<div className="generated-design-picker__view-more-wrapper" ref={ viewmoreRef }>
-						<Button className="generated-design-picker__view-more" onClick={ onViewMore }>
-							{ __( 'View more options' ) }
-						</Button>
-					</div>
+				<div className="generated-design-picker__thumbnails" ref={ wrapperRef }>
+					{ designs &&
+						designs
+							.slice( 0, 3 )
+							.map( ( design, index ) => (
+								<GeneratedDesignThumbnail
+									key={ design.slug }
+									slug={ design.slug }
+									thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
+									isSelected={ selectedDesign?.slug === design.slug }
+									onPreview={ () => onPreview( design, index ) }
+								/>
+							) ) }
+					<Button className="generated-design-picker__view-more" onClick={ onViewMore }>
+						{ __( 'View more options' ) }
+					</Button>
 				</div>
 				<div className="generated-design-picker__previews">{ previews }</div>
 			</div>

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -80,12 +80,14 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 
 	/* eslint-disable @typescript-eslint/no-unused-vars */
 	const wrapperRef = useRef< HTMLDivElement >( null );
+	const viewmoreRef = useRef< HTMLDivElement >( null );
 	const propertyForThumbnailHeight = '--thumbnail-design-height';
 
 	useEffect( () => {
 		const onResize = () => {
 			const { current: thumnbnailWrapper } = wrapperRef;
-			if ( ! thumnbnailWrapper ) {
+			const { current: viewmoreWrapper } = viewmoreRef;
+			if ( ! thumnbnailWrapper || ! viewmoreWrapper ) {
 				return;
 			}
 
@@ -94,7 +96,9 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 				window.innerHeight || 0
 			);
 			const wrapperMaxHeight =
-				viewportHeight - ( thumnbnailWrapper.getClientRects()[ 0 ].y + window.scrollY );
+				viewportHeight -
+				( thumnbnailWrapper.getClientRects()[ 0 ].y + window.scrollY ) -
+				viewmoreWrapper.getClientRects()[ 0 ].height;
 			const thumbnailHeight = wrapperMaxHeight / 3;
 			const thumbnailActualHeight = Math.min( 300, Math.max( 100, thumbnailHeight ) );
 
@@ -120,17 +124,19 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 				<div className="generated-design-picker__thumbnails">
 					<div className="generated-design-picker__thumbnails-wrapper" ref={ wrapperRef }>
 						{ designs &&
-							designs.map( ( design, index ) => (
-								<GeneratedDesignThumbnail
-									key={ design.slug }
-									slug={ design.slug }
-									thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
-									isSelected={ selectedDesign?.slug === design.slug }
-									onPreview={ () => onPreview( design, index ) }
-								/>
-							) ) }
+							designs
+								.slice( 0, 3 )
+								.map( ( design, index ) => (
+									<GeneratedDesignThumbnail
+										key={ design.slug }
+										slug={ design.slug }
+										thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
+										isSelected={ selectedDesign?.slug === design.slug }
+										onPreview={ () => onPreview( design, index ) }
+									/>
+								) ) }
 					</div>
-					<div className="generated-design-picker__view-more-wrapper">
+					<div className="generated-design-picker__view-more-wrapper" ref={ viewmoreRef }>
 						<Button className="generated-design-picker__view-more" onClick={ onViewMore }>
 							{ __( 'View more options' ) }
 						</Button>

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -80,6 +80,7 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 
 	/* eslint-disable @typescript-eslint/no-unused-vars */
 	const wrapperRef = useRef< HTMLDivElement >( null );
+	const propertyForThumbnailHeight = '--thumbnail-design-height';
 
 	useEffect( () => {
 		const onResize = () => {
@@ -94,6 +95,13 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 			);
 			const wrapperMaxHeight =
 				viewportHeight - ( thumnbnailWrapper.getClientRects()[ 0 ].y + window.scrollY );
+			const thumbnailHeight = wrapperMaxHeight / 3;
+			const thumbnailActualHeight = Math.min( 300, Math.max( 100, thumbnailHeight ) );
+
+			thumnbnailWrapper.style.setProperty(
+				propertyForThumbnailHeight,
+				`${ thumbnailActualHeight }px`
+			);
 		};
 
 		window.addEventListener( 'resize', onResize );

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -78,7 +78,6 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 } ) => {
 	const { __ } = useI18n();
 
-	/* eslint-disable @typescript-eslint/no-unused-vars */
 	const wrapperRef = useRef< HTMLDivElement >( null );
 
 	useEffect( () => {
@@ -88,14 +87,7 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 				return;
 			}
 
-			const viewportHeight = Math.max(
-				document.documentElement.clientHeight,
-				window.innerHeight || 0
-			);
-			const wrapperMaxHeight =
-				viewportHeight - ( thumnbnailWrapper.getClientRects()[ 0 ].y + window.scrollY );
-
-			thumnbnailWrapper.style.height = `${ wrapperMaxHeight }px`;
+			thumnbnailWrapper.style.height = `calc( 100vh - ${ thumnbnailWrapper.offsetTop }px`;
 		};
 
 		window.addEventListener( 'resize', onResize );
@@ -105,7 +97,6 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 			window.removeEventListener( 'resize', onResize );
 		};
 	}, [] );
-	/* eslint-enable @typescript-eslint/no-unused-vars */
 
 	return (
 		<div className="generated-design-picker">
@@ -113,17 +104,15 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 			<div className="generated_design-picker__content">
 				<div className="generated-design-picker__thumbnails" ref={ wrapperRef }>
 					{ designs &&
-						designs
-							.slice( 0, 3 )
-							.map( ( design, index ) => (
-								<GeneratedDesignThumbnail
-									key={ design.slug }
-									slug={ design.slug }
-									thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
-									isSelected={ selectedDesign?.slug === design.slug }
-									onPreview={ () => onPreview( design, index ) }
-								/>
-							) ) }
+						designs.map( ( design, index ) => (
+							<GeneratedDesignThumbnail
+								key={ design.slug }
+								slug={ design.slug }
+								thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
+								isSelected={ selectedDesign?.slug === design.slug }
+								onPreview={ () => onPreview( design, index ) }
+							/>
+						) ) }
 					<Button className="generated-design-picker__view-more" onClick={ onViewMore }>
 						{ __( 'View more options' ) }
 					</Button>

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -465,8 +465,9 @@
 	@include break-small {
 		border-radius: 2px;
 		height: 170px;
-		height: calc( var( --thumbnail-design-height ) - 24px );
-		margin-bottom: 24px;
+		min-height: 100px;
+		max-height: 300px;
+		flex-basis: 100%;
 		padding: 8px;
 
 		.generated-design-thumbnail__header {

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -465,6 +465,8 @@
 	@include break-small {
 		border-radius: 2px;
 		height: 170px;
+		height: calc( var( --thumbnail-design-height ) - 24px );
+		margin-bottom: 24px;
 		padding: 8px;
 
 		.generated-design-thumbnail__header {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the design thumbnails height to be responsive
* Thumbnails has min height as 100px and max height as 300px
* The "view more options" to be stayed visible in the viewport


https://user-images.githubusercontent.com/13596067/170967754-5d7e90e9-d388-44dd-8221-171c12da916c.mov

#### Testing instructions

* Go to Generated Design Picker: `/setup/designSetup?siteSlug=<your_site`
* Adjust the screen size, the thumbnails should be responsive

Related to #63588 
