### PR TITLE
Expand button in EmailProviderCard always sets expanded state to true

### DIFF
--- a/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
+++ b/client/my-sites/email/email-providers-comparison/email-provider-card.jsx
@@ -35,10 +35,10 @@ function EmailProviderCard( {
 
 	const showFeaturesToggleButton = detailsExpanded && isViewportSizeLowerThan1040px;
 
-	const toggleVisibility = ( event ) => {
+	const expandCard = ( event ) => {
 		event.preventDefault();
 
-		onExpandedChange( providerKey, ! detailsExpanded );
+		onExpandedChange( providerKey, true );
 	};
 
 	const labelForExpandButton = expandButtonLabel ? expandButtonLabel : buttonLabel;
@@ -59,7 +59,7 @@ function EmailProviderCard( {
 				{ showExpandButton && (
 					<Button
 						primary={ false }
-						onClick={ toggleVisibility }
+						onClick={ expandCard }
 						className="email-providers-comparison__provider-expand-cta"
 					>
 						{ labelForExpandButton }

--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -191,8 +191,9 @@ class EmailProvidersComparison extends Component {
 		return ! hasCartDomain && hasEmailForwards( domain );
 	};
 
-	onTitanMailboxesChange = ( updatedMailboxes ) =>
+	onTitanMailboxesChange = ( updatedMailboxes ) => {
 		this.setState( { titanMailboxes: updatedMailboxes } );
+	};
 
 	onTitanFormReturnKeyPress = ( event ) => {
 		// Simulate form submission


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the interest of avoiding to set new state based on old state (see [React's `setState` docs](https://reactjs.org/docs/react-component.html#setstate) for context), I've updated the logic for changing the `expanded` state in the `EmailProviderCard` component.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add a new domain to your cart.
2. You should be taken to `/domains/add/{domain}/email/{store}`, where you are presented with a comparison of Titan and Google Workspace.
3. Click "Add professional email" to expand the Titan email card.
4. The Titan card should expand and the Google Workspace card should be minimized.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


