### PR TITLE
Reader: Remove `redux-bridge` usage from utils - take 2

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -353,13 +353,13 @@ export class FullPostView extends Component {
 
 	goToNextPost = () => {
 		if ( this.props.nextPost ) {
-			showSelectedPost( { postKey: this.props.nextPost } );
+			this.props.showSelectedPost( { postKey: this.props.nextPost } );
 		}
 	};
 
 	goToPreviousPost = () => {
 		if ( this.props.previousPost ) {
-			showSelectedPost( { postKey: this.props.previousPost } );
+			this.props.showSelectedPost( { postKey: this.props.previousPost } );
 		}
 	};
 
@@ -689,5 +689,6 @@ export default connect(
 		requestMarkAsUnseen,
 		requestMarkAsSeenBlog,
 		requestMarkAsUnseenBlog,
+		showSelectedPost,
 	}
 )( FullPostView );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -205,7 +205,7 @@ class ReaderStream extends Component {
 	};
 
 	handleOpenSelection = () => {
-		showSelectedPost( {
+		this.props.showSelectedPost( {
 			store: this.props.streamKey,
 			postKey: this.props.selectedPostKey,
 		} );
@@ -382,7 +382,7 @@ class ReaderStream extends Component {
 
 		const itemKey = this.getPostRef( postKey );
 		const showPost = ( args ) =>
-			showSelectedPost( {
+			this.props.showSelectedPost( {
 				...args,
 				postKey: postKey.isCombination ? keyForPost( args ) : postKey,
 				streamKey,
@@ -503,6 +503,7 @@ export default connect(
 		selectItem,
 		selectNextItem,
 		selectPrevItem,
+		showSelectedPost,
 		showUpdates,
 		viewStream,
 	}

--- a/client/reader/test/utils.js
+++ b/client/reader/test/utils.js
@@ -5,9 +5,7 @@
 import page from 'page';
 import { showSelectedPost } from '../utils';
 
-jest.mock( 'page', () => ( {
-	show: jest.fn(),
-} ) );
+jest.mock( 'page', () => jest.fn() );
 
 describe( 'reader utils', () => {
 	const dispatch = jest.fn();
@@ -20,18 +18,18 @@ describe( 'reader utils', () => {
 	} );
 
 	beforeEach( () => {
-		page.show.mockReset();
+		page.mockReset();
 	} );
 
 	describe( '#showSelectedPost', () => {
 		test( 'does not do anything if postKey argument is missing', () => {
 			showSelectedPost( {} )( dispatch, getState );
-			expect( page.show ).not.toBeCalled();
+			expect( page ).not.toBeCalled();
 		} );
 
 		test( 'redirects if passed a post key', () => {
 			showSelectedPost( { postKey: { feedId: 1, postId: 5 } } )( dispatch, getState );
-			expect( page.show ).toBeCalledTimes( 1 );
+			expect( page ).toBeCalledTimes( 1 );
 		} );
 
 		test( 'redirects to a #comments URL if we passed comments argument', () => {
@@ -39,7 +37,7 @@ describe( 'reader utils', () => {
 				dispatch,
 				getState
 			);
-			expect( page.show ).toBeCalledWith( '/read/feeds/1/posts/5#comments' );
+			expect( page ).toBeCalledWith( '/read/feeds/1/posts/5#comments' );
 		} );
 	} );
 } );

--- a/client/reader/test/utils.js
+++ b/client/reader/test/utils.js
@@ -8,30 +8,37 @@ import { showSelectedPost } from '../utils';
 jest.mock( 'page', () => ( {
 	show: jest.fn(),
 } ) );
-jest.mock( 'calypso/lib/redux-bridge', () => ( {
-	reduxGetState: function () {
-		return { reader: { posts: { items: {} } } };
-	},
-} ) );
 
 describe( 'reader utils', () => {
+	const dispatch = jest.fn();
+	const getState = () => ( {
+		reader: {
+			posts: {
+				items: {},
+			},
+		},
+	} );
+
 	beforeEach( () => {
 		page.show.mockReset();
 	} );
 
 	describe( '#showSelectedPost', () => {
 		test( 'does not do anything if postKey argument is missing', () => {
-			showSelectedPost( {} );
+			showSelectedPost( {} )( dispatch, getState );
 			expect( page.show ).not.toBeCalled();
 		} );
 
 		test( 'redirects if passed a post key', () => {
-			showSelectedPost( { postKey: { feedId: 1, postId: 5 } } );
+			showSelectedPost( { postKey: { feedId: 1, postId: 5 } } )( dispatch, getState );
 			expect( page.show ).toBeCalledTimes( 1 );
 		} );
 
 		test( 'redirects to a #comments URL if we passed comments argument', () => {
-			showSelectedPost( { postKey: { feedId: 1, postId: 5 }, comments: true } );
+			showSelectedPost( { postKey: { feedId: 1, postId: 5 }, comments: true } )(
+				dispatch,
+				getState
+			);
 			expect( page.show ).toBeCalledWith( '/read/feeds/1/posts/5#comments' );
 		} );
 	} );

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -1,5 +1,4 @@
 import page from 'page';
-import { reduxGetState } from 'calypso/lib/redux-bridge';
 import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 
@@ -16,40 +15,42 @@ export function isPostNotFound( post ) {
 }
 
 export function showSelectedPost( { replaceHistory, postKey, comments } ) {
-	if ( ! postKey ) {
-		return;
-	}
+	return ( dispatch, getState ) => {
+		if ( ! postKey ) {
+			return;
+		}
 
-	// rec block
-	if ( postKey.isRecommendationBlock ) {
-		return;
-	}
+		// rec block
+		if ( postKey.isRecommendationBlock ) {
+			return;
+		}
 
-	const post = getPostByKey( reduxGetState(), postKey );
+		const post = getPostByKey( getState(), postKey );
 
-	if ( isXPost( post ) && ! replaceHistory ) {
-		return showFullXPost( XPostHelper.getXPostMetadata( post ) );
-	}
+		if ( isXPost( post ) && ! replaceHistory ) {
+			return showFullXPost( XPostHelper.getXPostMetadata( post ) );
+		}
 
-	// normal
-	let mappedPost;
-	if ( postKey.feedId ) {
-		mappedPost = {
-			feed_ID: postKey.feedId,
-			feed_item_ID: postKey.postId,
-		};
-	} else {
-		mappedPost = {
-			site_ID: postKey.blogId,
-			ID: postKey.postId,
-		};
-	}
+		// normal
+		let mappedPost;
+		if ( postKey.feedId ) {
+			mappedPost = {
+				feed_ID: postKey.feedId,
+				feed_item_ID: postKey.postId,
+			};
+		} else {
+			mappedPost = {
+				site_ID: postKey.blogId,
+				ID: postKey.postId,
+			};
+		}
 
-	showFullPost( {
-		post: mappedPost,
-		replaceHistory,
-		comments,
-	} );
+		showFullPost( {
+			post: mappedPost,
+			replaceHistory,
+			comments,
+		} );
+	};
 }
 
 export function showFullXPost( xMetadata ) {

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -14,7 +14,7 @@ export function isPostNotFound( post ) {
 	return post.statusCode === 404;
 }
 
-export function showSelectedPost( { replaceHistory, postKey, comments } ) {
+export function showSelectedPost( { postKey, comments } ) {
 	return ( dispatch, getState ) => {
 		if ( ! postKey ) {
 			return;
@@ -27,7 +27,7 @@ export function showSelectedPost( { replaceHistory, postKey, comments } ) {
 
 		const post = getPostByKey( getState(), postKey );
 
-		if ( isXPost( post ) && ! replaceHistory ) {
+		if ( isXPost( post ) ) {
 			return showFullXPost( XPostHelper.getXPostMetadata( post ) );
 		}
 
@@ -47,7 +47,6 @@ export function showSelectedPost( { replaceHistory, postKey, comments } ) {
 
 		showFullPost( {
 			post: mappedPost,
-			replaceHistory,
 			comments,
 		} );
 	};
@@ -68,7 +67,7 @@ export function showFullXPost( xMetadata ) {
 	}
 }
 
-export function showFullPost( { post, replaceHistory, comments } ) {
+export function showFullPost( { post, comments } ) {
 	const hashtag = comments ? '#comments' : '';
 	let query = '';
 	if ( post.referral ) {
@@ -76,13 +75,10 @@ export function showFullPost( { post, replaceHistory, comments } ) {
 		query += `ref_blog=${ blogId }&ref_post=${ postId }`;
 	}
 
-	const method = replaceHistory ? 'replace' : 'show';
 	if ( post.feed_ID && post.feed_item_ID ) {
-		page[ method ](
-			`/read/feeds/${ post.feed_ID }/posts/${ post.feed_item_ID }${ hashtag }${ query }`
-		);
+		page( `/read/feeds/${ post.feed_ID }/posts/${ post.feed_item_ID }${ hashtag }${ query }` );
 	} else {
-		page[ method ]( `/read/blogs/${ post.site_ID }/posts/${ post.ID }${ hashtag }${ query }` );
+		page( `/read/blogs/${ post.site_ID }/posts/${ post.ID }${ hashtag }${ query }` );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes one of the last remaining instances of `redux-bridge` in the Reader. 

It was necessary to retrieve the post to show in `showSelectedPost()`, but now we'll dispatch it as an action, and that way grant it access go `getState()` directly.

Alternative to #60800. Closes #60800.

#### Testing instructions

* Smoke test Reader, particularly opening of various types of posts in all kinds of feeds you have.
* Go to `/read/a8c` and open a regular post, verify it opens correctly.
* Go to `/read/a8c` and open an x-post post, verify it opens correctly.
* Verify all tests pass.