### PR TITLE
Signup: Refactor `SitePickerSubmit` tests to `@testing-library/react`

### DIFF
--- a/client/signup/steps/site-picker/test/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/test/site-picker-submit.jsx
@@ -75,7 +75,7 @@ describe( 'SitePickerSubmit', () => {
 		props.goToStep.mockReset();
 	} );
 
-	test( 'Does not blow up', () => {
+	test( 'Submits the signup step on render', () => {
 		expect( props.goToStep ).toHaveBeenCalledTimes( 0 );
 		const { container } = render( <SitePickerSubmit { ...props } /> );
 		expect( container ).toBeEmptyDOMElement();

--- a/client/signup/steps/site-picker/test/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/test/site-picker-submit.jsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
@@ -23,7 +26,7 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from '@automattic/calypso-products';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import { siteHasPaidPlan, SitePickerSubmit } from '../site-picker-submit';
 
 const noop = () => {};
@@ -74,8 +77,8 @@ describe( 'SitePickerSubmit', () => {
 
 	test( 'Does not blow up', () => {
 		expect( props.goToStep ).toHaveBeenCalledTimes( 0 );
-		const comp = shallow( <SitePickerSubmit { ...props } /> );
-		expect( comp.find( '*' ).length ).toBe( 0 );
+		const { container } = render( <SitePickerSubmit { ...props } /> );
+		expect( container ).toBeEmptyDOMElement();
 		expect( props.goToStep ).toHaveBeenCalledTimes( 1 );
 	} );
 
@@ -100,9 +103,7 @@ describe( 'SitePickerSubmit', () => {
 	].forEach( ( plan ) => {
 		test( `Goes to step "user" when paid plan is passed (${ plan })`, () => {
 			expect( props.goToStep ).toHaveBeenCalledTimes( 0 );
-			shallow(
-				<SitePickerSubmit { ...props } selectedSite={ { plan: { product_slug: plan } } } />
-			);
+			render( <SitePickerSubmit { ...props } selectedSite={ { plan: { product_slug: plan } } } /> );
 			expect( props.goToStep ).toHaveBeenCalledWith( 'user' );
 		} );
 	} );
@@ -110,9 +111,7 @@ describe( 'SitePickerSubmit', () => {
 	[ PLAN_FREE, PLAN_JETPACK_FREE ].forEach( ( plan ) => {
 		test( `Goes to step "plans-site-selected" when a free plan is passed (${ plan })`, () => {
 			expect( props.goToStep ).toHaveBeenCalledTimes( 0 );
-			shallow(
-				<SitePickerSubmit { ...props } selectedSite={ { plan: { product_slug: plan } } } />
-			);
+			render( <SitePickerSubmit { ...props } selectedSite={ { plan: { product_slug: plan } } } /> );
 			expect( props.goToStep ).toHaveBeenCalledWith( 'plans-site-selected' );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `SitePickerSubmit` component to use `@testing-library/react` instead of `enzyme`.

Part of #63409.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/signup/steps/site-picker/test/site-picker-submit.jsx`