### PR TITLE
Signup: Refactor `ValidationFieldset` tests to `@testing-library/react`

### DIFF
--- a/client/components/forms/form-fieldset/index.jsx
+++ b/client/components/forms/form-fieldset/index.jsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import './style.scss';
 
 const FormFieldset = ( { className = '', children, ...otherProps } ) => (
-	<fieldset { ...otherProps } className={ classnames( className, 'form-fieldset' ) }>
+	<fieldset role="group" { ...otherProps } className={ classnames( className, 'form-fieldset' ) }>
 		{ children }
 	</fieldset>
 );

--- a/client/components/multiple-choice-question/test/__snapshots__/index.js.snap
+++ b/client/components/multiple-choice-question/test/__snapshots__/index.js.snap
@@ -3,6 +3,7 @@
 exports[`MultipleChoiceQuestion should render with the minimum required properties ( plus extra prop to guarantee order ) 1`] = `
 <fieldset
   className="multiple-choice-question form-fieldset"
+  role="group"
 >
   <legend
     className="form-legend"

--- a/client/signup/validation-fieldset/test/index.jsx
+++ b/client/signup/validation-fieldset/test/index.jsx
@@ -1,38 +1,42 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
 import ValidationFieldset from '..';
 
 describe( 'ValidationFieldset', () => {
 	test( 'should pass className prop to the child FormFieldset component.', () => {
-		const wrapper = shallow( <ValidationFieldset className="test__foo-bar" /> );
+		render( <ValidationFieldset className="test__foo-bar" /> );
 
-		expect( wrapper.find( 'FormFieldset' ) ).toHaveLength( 1 );
-		expect( wrapper.find( 'FormFieldset' ).hasClass( 'test__foo-bar' ) ).toBe( true );
+		const fieldset = screen.getByRole( 'group' );
+		expect( fieldset ).toBeVisible();
+		expect( fieldset ).toHaveClass( 'test__foo-bar' );
 	} );
 
 	test( 'should include a FormInputValidation only when errorMessages prop is set.', () => {
-		const wrapper = shallow( <ValidationFieldset /> );
+		const { rerender } = render( <ValidationFieldset /> );
 
-		expect( wrapper.find( 'FormInputValidation' ).exists() ).toBe( false );
+		expect( screen.queryByRole( 'alert' ) ).not.toBeInTheDocument();
 
-		wrapper.setProps( { errorMessages: [ 'error', 'message' ] } );
-		expect( wrapper.find( 'FormInputValidation' ) ).toHaveLength( 1 );
+		rerender( <ValidationFieldset errorMessages={ [ 'error', 'message' ] } /> );
 
-		expect( wrapper.find( 'FormInputValidation' ).prop( 'text' ) ).toEqual( 'error' );
-
-		expect( wrapper.find( '.validation-fieldset__validation-message' ).exists() ).toBe( true );
+		const validationError = screen.queryByRole( 'alert' );
+		expect( validationError ).toBeVisible();
+		expect( validationError ).toHaveTextContent( 'error' );
+		expect( validationError.parentNode ).toHaveClass( 'validation-fieldset__validation-message' );
 	} );
 
 	test( 'should render the children within a FormFieldset', () => {
-		const wrapper = shallow(
+		render(
 			<ValidationFieldset>
-				<p>Lorem ipsum dolor sit amet</p>
-				<p>consectetur adipiscing elit</p>
+				<p data-testid="paragraph-1">Lorem ipsum dolor sit amet</p>
+				<p data-testid="paragraph-2">consectetur adipiscing elit</p>
 			</ValidationFieldset>
 		);
 
-		expect( wrapper.find( 'FormFieldset > p' ) ).toHaveLength( 2 );
-		expect( wrapper.find( 'FormFieldset > p' ).first().text() ).toEqual(
-			'Lorem ipsum dolor sit amet'
-		);
+		const paragraph1 = screen.getByTestId( 'paragraph-1' );
+		expect( paragraph1 ).toBeVisible();
+		expect( paragraph1 ).toHaveTextContent( 'Lorem ipsum dolor sit amet' );
+		expect( screen.getByTestId( 'paragraph-2' ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `ValidationFieldset` component to use `@testing-library/react` instead of `enzyme`.

We use the opportunity to add a `role="group"` to the fieldset component. Ideally, it should also have an `aria-labelled-by`, but that's likely work for another PR, because of the way we currently handle labels of those fieldsets.

Part of #63409.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/signup/validation-fieldset/test/index.jsx`