### PR TITLE
Invite: redirect to 'My Home' after accepting an invite

### DIFF
--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -155,6 +155,7 @@ export function getRedirectAfterAccept( invite ) {
 
 	const readerPath = '/read';
 	const postsListPath = '/posts/' + invite.site.ID;
+	const myHomePath = '/home/' + invite.site.domain;
 	const getDestinationUrl = ( redirect ) => {
 		const remoteLoginHost = `https://${ invite.site.domain }`;
 		const remoteLoginBackUrl = ( destinationPath ) => `https://wordpress.com${ destinationPath }`;
@@ -180,6 +181,6 @@ export function getRedirectAfterAccept( invite ) {
 			return getDestinationUrl( readerPath );
 
 		default:
-			return getDestinationUrl( postsListPath );
+			return getDestinationUrl( myHomePath );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Redirect users to `My Home` instead of `Posts` after accepting an invite.
* VIP websites will redirect to `wp-admin` if possible and `My Home` as a fallback.

#### Screencast


https://user-images.githubusercontent.com/779993/170039831-d85d8a3e-dde2-4b99-a37a-2a7f616090a1.mov



#### Testing instructions

- You will need two WordPress accounts. One to send the invite, another to test the redirection.
- In a simple site, go to **Users** > **Invites** > ➕ **Invite**.
- Write the username of your second account.
- Select a role with write access, such as Administrator.
- Click on Send Invite.
- On your second account: click on the **bell** > **Accept Invitation** (You can follow the steps described in the screencast).
   - The same link is also received as an email.
- Replace the `wordpress.com` URL to `calypso.localhost:3000` (or the corresponding live link).
- Accept the invitation.
- Observe you are redirected to `My home` page.

---

- Fixes #62053
