### PR TITLE
Woo on Stepper: Fixes final redirect

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/business-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/business-info/index.tsx
@@ -97,10 +97,14 @@ const BusinessInfo: Step = function ( props ): ReactElement | null {
 	const onSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
 		if ( siteId ) {
+			const changes = {
+				...profileChanges,
+				[ 'completed' ]: true,
+			};
 			saveSiteSettings( siteId, {
 				woocommerce_onboarding_profile: {
 					...onboardingProfile,
-					...profileChanges,
+					...changes,
 				},
 			} );
 		}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -138,7 +138,7 @@ export const siteSetupFlow: Flow = {
 					if ( storeType === 'power' ) {
 						dispatch( recordTracksEvent( 'calypso_woocommerce_dashboard_redirect' ) );
 
-						return exitFlow( `${ adminUrl }/wp-admin/admin.php?page=wc-admin` );
+						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
 					}
 
 					if ( FSEActive && intent !== 'write' ) {


### PR DESCRIPTION
This PR fixes 2 things when finishing successfully the WooCommerce flow:
* Corrects the url, the user was being redirect to something like: `https://wooend3.wpcomstaging.com/wp-admin//wp-admin/admin.php?page=wc-admin`
* Sets the `completed` WC site setting to indicate that the wizard was completed successfully.

#### Testing
1. Apply this PR.
2. Go through the `More power` flow.
3. Verify the final redirect URL is correct, something like: `https://[YOUR_SITE]/wp-admin/admin.php?page=wc-admin`
4. Verify that WC does not expect the user to complete another Wizard. This is the screen that you see:
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/375980/170057967-7234ae39-9895-4507-840f-48842286de15.png">

Closes https://github.com/Automattic/wp-calypso/issues/63830
