### PR TITLE
`SelectDropdown`: refactor tests to `@testing-library`

### DIFF
--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -283,26 +283,26 @@ class SelectDropdown extends Component {
 	}
 
 	navigateItem = ( event ) => {
-		switch ( event.keyCode ) {
-			case 9: //tab
+		switch ( event.code ) {
+			case 'Tab':
 				this.navigateItemByTabKey( event );
 				break;
-			case 32: // space
-			case 13: // enter
+			case 'Space':
+			case 'Enter':
 				event.preventDefault();
 				this.activateItem();
 				break;
-			case 38: // up arrow
+			case 'ArrowUp':
 				event.preventDefault();
 				this.focusSibling( 'previous' );
 				this.openDropdown();
 				break;
-			case 40: // down arrow
+			case 'ArrowDown':
 				event.preventDefault();
 				this.focusSibling( 'next' );
 				this.openDropdown();
 				break;
-			case 27: // escape
+			case 'Escape':
 				event.preventDefault();
 				this.closeDropdown();
 				this.dropdownContainerRef.current.focus();

--- a/client/components/select-dropdown/separator.jsx
+++ b/client/components/select-dropdown/separator.jsx
@@ -1,7 +1,3 @@
-const stopPropagation = ( event ) => event.stopPropagation();
-
 export default function SelectDropdownSeparator() {
-	return (
-		<li onClick={ stopPropagation } role="presentation" className="select-dropdown__separator" />
-	);
+	return <li role="separator" className="select-dropdown__separator" />;
 }

--- a/client/components/select-dropdown/test/index.js
+++ b/client/components/select-dropdown/test/index.js
@@ -81,7 +81,7 @@ describe( 'selected items', () => {
 		expect( selected ).toHaveTextContent( 'Drafts' );
 
 		const btn = screen.getByRole( 'button' );
-		expect( btn.firstChild.textContent ).toBe( 'Drafts' );
+		expect( btn.firstChild ).toHaveTextContent( 'Drafts' );
 	} );
 
 	test( "should return `undefined`, when there aren't options", () => {
@@ -91,7 +91,7 @@ describe( 'selected items', () => {
 		expect( selected ).toBeNull();
 
 		const btn = screen.getByRole( 'button' );
-		expect( btn.firstChild.textContent ).toBe( '' );
+		expect( btn.firstChild ).toHaveTextContent( '' );
 	} );
 
 	test( "should return the first not-label option, when there isn't a preselected value", () => {
@@ -101,14 +101,14 @@ describe( 'selected items', () => {
 		expect( selected ).toHaveTextContent( 'Published' );
 
 		const btn = screen.getByRole( 'button' );
-		expect( btn.firstChild.textContent ).toBe( 'Published' );
+		expect( btn.firstChild ).toHaveTextContent( 'Published' );
 	} );
 
 	test( 'should return the initially selected text (if any)', () => {
 		renderDropdown( { selectedText: 'Drafts' } );
 
 		const btn = screen.getByRole( 'button' );
-		expect( btn.firstChild.textContent ).toEqual( 'Drafts' );
+		expect( btn.firstChild ).toHaveTextContent( 'Drafts' );
 	} );
 } );
 

--- a/client/components/select-dropdown/test/index.js
+++ b/client/components/select-dropdown/test/index.js
@@ -5,19 +5,17 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SelectDropdown from '../index';
 
-function getDropdownOptions() {
-	return [
-		{ value: 'status-options', label: 'Statuses', isLabel: true },
-		{ value: 'published', label: 'Published' },
-		{ value: 'scheduled', label: 'Scheduled' },
-		{ value: 'drafts', label: 'Drafts' },
-		null,
-		{ value: 'trashed', label: 'Trashed' },
-	];
-}
+const DROPDOWN_OPTIONS = [
+	{ value: 'status-options', label: 'Statuses', isLabel: true },
+	{ value: 'published', label: 'Published' },
+	{ value: 'scheduled', label: 'Scheduled' },
+	{ value: 'drafts', label: 'Drafts' },
+	null,
+	{ value: 'trashed', label: 'Trashed' },
+];
 
 function renderDropdown( props ) {
-	return render( <SelectDropdown options={ getDropdownOptions() } { ...props } /> );
+	return render( <SelectDropdown options={ DROPDOWN_OPTIONS } { ...props } /> );
 }
 
 describe( 'component rendering', () => {
@@ -115,19 +113,18 @@ describe( 'selected items', () => {
 describe( 'selectItem', () => {
 	test( 'should run the `onSelect` hook, and then update the state', async () => {
 		const onSelectSpy = jest.fn();
-		const options = getDropdownOptions();
 
-		render( <SelectDropdown options={ options } onSelect={ onSelectSpy } /> );
+		renderDropdown( { onSelect: onSelectSpy } );
 
-		const item = screen.getByRole( 'menuitem', { name: options[ 2 ].label } );
+		const item = screen.getByRole( 'menuitem', { name: DROPDOWN_OPTIONS[ 2 ].label } );
 
 		await userEvent.click( item );
 
 		const selected = screen.getByRole( 'menuitem', { current: true } );
-		expect( selected ).toHaveTextContent( options[ 2 ].label );
+		expect( selected ).toHaveTextContent( DROPDOWN_OPTIONS[ 2 ].label );
 
 		expect( onSelectSpy ).toHaveBeenCalledTimes( 1 );
-		expect( onSelectSpy ).toHaveBeenCalledWith( options[ 2 ] );
+		expect( onSelectSpy ).toHaveBeenCalledWith( DROPDOWN_OPTIONS[ 2 ] );
 	} );
 } );
 
@@ -146,8 +143,7 @@ describe( 'navigateItem', () => {
 
 	test( 'permits to select an option by pressing ENTER', async () => {
 		const onSelectSpy = jest.fn();
-		const options = getDropdownOptions();
-		renderDropdown( { options, onSelect: onSelectSpy } );
+		renderDropdown( { onSelect: onSelectSpy } );
 
 		const btn = screen.getByRole( 'button' );
 		await userEvent.click( btn );
@@ -155,13 +151,12 @@ describe( 'navigateItem', () => {
 		await userEvent.keyboard( '[Enter]' );
 
 		expect( onSelectSpy ).toHaveBeenCalledTimes( 1 );
-		expect( onSelectSpy ).toHaveBeenCalledWith( options[ 2 ] );
+		expect( onSelectSpy ).toHaveBeenCalledWith( DROPDOWN_OPTIONS[ 2 ] );
 	} );
 
 	test( 'permits to select an option by pressing SPACE', async () => {
 		const onSelectSpy = jest.fn();
-		const options = getDropdownOptions();
-		renderDropdown( { options, onSelect: onSelectSpy } );
+		renderDropdown( { onSelect: onSelectSpy } );
 
 		const btn = screen.getByRole( 'button' );
 		await userEvent.click( btn );
@@ -169,7 +164,7 @@ describe( 'navigateItem', () => {
 		await userEvent.keyboard( '[Space]' );
 
 		expect( onSelectSpy ).toHaveBeenCalledTimes( 1 );
-		expect( onSelectSpy ).toHaveBeenCalledWith( options[ 2 ] );
+		expect( onSelectSpy ).toHaveBeenCalledWith( DROPDOWN_OPTIONS[ 2 ] );
 	} );
 
 	test( 'permits to close the dropdown by pressing ESCAPE', async () => {

--- a/client/components/select-dropdown/test/item.js
+++ b/client/components/select-dropdown/test/item.js
@@ -17,7 +17,7 @@ describe( 'item', () => {
 			render( <SelectDropdownItem>Published</SelectDropdownItem> );
 			const item = screen.getByRole( 'listitem' );
 			const link = screen.getByRole( 'menuitem', { name: /published/i } );
-			expect( item.firstChild.textContent ).toBe( 'Published' );
+			expect( item.firstChild ).toHaveTextContent( 'Published' );
 			expect( item.firstChild ).toBe( link );
 		} );
 	} );

--- a/client/components/select-dropdown/test/item.js
+++ b/client/components/select-dropdown/test/item.js
@@ -1,47 +1,49 @@
 /**
  * @jest-environment jsdom
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import SelectDropdownItem from '../item';
 
 describe( 'item', () => {
 	describe( 'component rendering', () => {
 		test( 'should render a list entry', () => {
-			const dropdownItem = shallow( <SelectDropdownItem>Published</SelectDropdownItem> );
-			expect( dropdownItem.is( 'li.select-dropdown__option' ) ).toBe( true );
+			render( <SelectDropdownItem>Published</SelectDropdownItem> );
+			const item = screen.queryByRole( 'listitem' );
+			expect( item ).toBeInTheDocument();
 		} );
 
 		test( 'should contain a link', () => {
-			const dropdownItem = shallow( <SelectDropdownItem>Published</SelectDropdownItem> );
-			expect( dropdownItem.children( 'a.select-dropdown__item' ).length ).toEqual( 1 );
-			expect( dropdownItem.find( 'span.select-dropdown__item-text' ).text() ).toEqual(
-				'Published'
-			);
+			render( <SelectDropdownItem>Published</SelectDropdownItem> );
+			const item = screen.getByRole( 'listitem' );
+			const link = screen.getByRole( 'menuitem', { name: /published/i } );
+			expect( item.firstChild.textContent ).toBe( 'Published' );
+			expect( item.firstChild ).toBe( link );
 		} );
 	} );
 
 	describe( 'when the component is clicked', () => {
-		test( 'should do nothing when is disabled', () => {
+		test( 'should do nothing when is disabled', async () => {
 			const onClickSpy = jest.fn();
-			const dropdownItem = shallow(
+			render(
 				<SelectDropdownItem disabled={ true } onClick={ onClickSpy }>
 					Published
 				</SelectDropdownItem>
 			);
 
-			const link = dropdownItem.children( 'a.select-dropdown__item' );
-			expect( link.hasClass( 'is-disabled' ) ).toBe( true );
+			const link = screen.getByRole( 'menuitem', { name: /published/i } );
+			await userEvent.click( link );
 
-			link.simulate( 'click' );
 			expect( onClickSpy ).not.toHaveBeenCalled();
 		} );
 
-		test( 'should run the `onClick` hook', () => {
+		test( 'should run the `onClick` hook', async () => {
 			const onClickSpy = jest.fn();
-			const dropdownItem = shallow(
-				<SelectDropdownItem onClick={ onClickSpy }>Published</SelectDropdownItem>
-			);
-			dropdownItem.children( 'a.select-dropdown__item' ).simulate( 'click' );
+			render( <SelectDropdownItem onClick={ onClickSpy }>Published</SelectDropdownItem> );
+
+			const link = screen.getByRole( 'menuitem', { name: /published/i } );
+			await userEvent.click( link );
+
 			expect( onClickSpy ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `SelectDropdown`: refactor tests to `@testing-library`
* Refactor `SelectDropdown` in regards to keyboard navigation (using `event.code` rather than `event.keyCode`)

#### Testing instructions

* Verify unit tests still pass
* Go to `/devdocs/design/select-dropdown` and verify the component still works as expected

Related to #63409 
