### PR TITLE
Add config feature-flag for pricing page update (Add Boost & Social).

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -106,6 +106,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	const showProductCategories = ! isDesktop;
 
 	const showAnnualPlansOnly = config.isEnabled( 'jetpack/pricing-page-annual-only' );
+	const showBoostAndSocial = config.isEnabled( 'jetpack/pricing-add-boost-social' );
 
 	const [ category, setCategory ] = useState< JetpackProductCategory >();
 	const onCategoryChange = useCallback( setCategory, [ setCategory ] );
@@ -280,9 +281,21 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 					<ul className="product-grid__product-grid">
 						{ filteredItems.map( getOtherItemsProductCard ) }
 						{ ( ! showProductCategories || category === JETPACK_GROWTH_CATEGORY ) && (
-							<li>
-								<JetpackCrmFreeCard siteId={ siteId } duration={ duration } />
-							</li>
+							<>
+								<li>
+									<JetpackCrmFreeCard siteId={ siteId } duration={ duration } />
+								</li>
+								{ showBoostAndSocial && (
+									<li>
+										{ /* Add Jetpack Social Free card here. */ }
+										JETPACK SOCIAL
+										<br />
+										FREE CARD
+										<br />
+										HERE
+									</li>
+								) }
+							</>
 						) }
 						{ showFreeCard && (
 							<li>

--- a/config/development.json
+++ b/config/development.json
@@ -86,6 +86,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/magic-link-signup": true,
+		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -50,6 +50,7 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/magic-link-signup": true,
+		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -50,7 +50,7 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/magic-link-signup": true,
-		"jetpack/pricing-add-boost-social": true,
+		"jetpack/pricing-add-boost-social": false,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -42,6 +42,7 @@
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,
+		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -36,6 +36,7 @@
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-page": true,
+		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -65,6 +65,7 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
+		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the `jetpack/pricing-add-boost-social` feature-flag for the Jetpack.com pricing page update (boost, social) project.
Project Thread: p1HpG7-g29-p2

The flag is enabled in development and horizon environments for now.  Then when the project is completed and ready for review/testing, we'll enable the flag for the `staging` environment, so stakeholders can easily view the changes. Once all is reviewed and looks good, we'll enable the flag for `production` environments.

Asana task: 1202316834912830-as-1202316834912847/f

#### Testing instructions

1. Checkout this PR and and spin up Calypso blue and Calypso green concurrently. (`yarn start` and also `yarn start-jetpack-cloud-p`).
2. Go to http://calypso.localhost:3000/jetpack/connect/store . Verify you can see the text, "JETPACK SOCIAL FREE CARD HERE", next to the Jetpack CRM product card. (See screenshot below)
3. Go to http://jetpack.cloud.localhost:3001/pricing . Verify you can see the text, "JETPACK SOCIAL FREE CARD HERE", next to the Jetpack CRM product card. (See screenshot below)
4. **Note:** This placeholder text will be replaced in a following PR when we add in the new Jetpack Social free product card.

#### Screenshots:

**Calypso Blue:** (http://calypso.localhost:3000/jetpack/connect/store)

![Markup 2022-05-24 at 10 42 16](https://user-images.githubusercontent.com/11078128/170069541-81d28ceb-6fe0-48d2-bf1e-a901e7528a36.png)

.
**Calypso Green:**

![Markup 2022-05-24 at 10 48 36](https://user-images.githubusercontent.com/11078128/170069634-03e4a039-9c3e-4208-9319-e7750b82e3d4.png)

