### PR TITLE
Help Center: Tracking events

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useHasSeenWhatsNewModalQuery } from '@automattic/data-stores';
 import HelpCenter, { HelpIcon } from '@automattic/help-center';
 import { Button } from '@wordpress/components';
@@ -24,11 +25,20 @@ function HelpCenterContent() {
 		}
 	}, [ data, isLoading ] );
 
+	const handleToggleHelpCenter = () => {
+		if ( show ) {
+			recordTracksEvent( 'calypso_inlinehelp_close', { location: 'help-center-desktop' } );
+		} else {
+			recordTracksEvent( 'calypso_inlinehelp_show', { location: 'help-center-desktop' } );
+		}
+		setShowHelpCenter( ! show );
+	};
+
 	const content = (
 		<span className="etk-help-center">
 			<Button
 				className={ cx( 'entry-point-button', { 'is-active': show } ) }
-				onClick={ () => setShowHelpCenter( ! show ) }
+				onClick={ handleToggleHelpCenter }
 				icon={ <HelpIcon newItems={ showHelpIconDot } /> }
 			></Button>
 		</span>

--- a/client/blocks/inline-help/inline-help-contact-view.jsx
+++ b/client/blocks/inline-help/inline-help-contact-view.jsx
@@ -1,3 +1,4 @@
+import { SUPPORT_FORUM } from '@automattic/help-center';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import InlineHelpForumView from 'calypso/blocks/inline-help/inline-help-forum-view';
@@ -5,9 +6,7 @@ import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-supp
 import PlaceholderLines from 'calypso/blocks/inline-help/placeholder-lines';
 import HelpContact from 'calypso/me/help/help-contact';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import getInlineHelpSupportVariation, {
-	SUPPORT_FORUM,
-} from 'calypso/state/selectors/get-inline-help-support-variation';
+import getInlineHelpSupportVariation from 'calypso/state/selectors/get-inline-help-support-variation';
 import isSupportVariationDetermined from 'calypso/state/selectors/is-support-variation-determined';
 
 function InlineHelpContactViewLoaded() {

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -14,6 +14,7 @@ import {
 } from '@automattic/calypso-products';
 import { Dialog, Button } from '@automattic/components';
 import { getCurrencyDefaults } from '@automattic/format-currency';
+import { SUPPORT_HAPPYCHAT } from '@automattic/help-center';
 import {
 	Button as GutenbergButton,
 	CheckboxControl,
@@ -55,9 +56,7 @@ import {
 	willAtomicSiteRevertAfterPurchaseDeactivation,
 } from 'calypso/state/purchases/selectors';
 import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
-import getSupportVariation, {
-	SUPPORT_HAPPYCHAT,
-} from 'calypso/state/selectors/get-inline-help-support-variation';
+import getSupportVariation from 'calypso/state/selectors/get-inline-help-support-variation';
 import getSiteImportEngine from 'calypso/state/selectors/get-site-import-engine';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import getSite from 'calypso/state/sites/selectors/get-site';

--- a/client/layout/masterbar/masterbar-help-center.jsx
+++ b/client/layout/masterbar/masterbar-help-center.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useHasSeenWhatsNewModalQuery } from '@automattic/data-stores';
 import { HelpIcon } from '@automattic/help-center';
 import classnames from 'classnames';
@@ -13,9 +14,19 @@ const MasterbarHelpCenter = ( { siteId } ) => {
 
 	const helpCenterVisible = useSelector( isHelpCenterVisible );
 	const dispatch = useDispatch();
+
+	const handleToggleHelpCenter = () => {
+		if ( helpCenterVisible ) {
+			recordTracksEvent( 'calypso_inlinehelp_close', { location: 'help-center-mobile' } );
+		} else {
+			recordTracksEvent( 'calypso_inlinehelp_show', { location: 'help-center-mobile' } );
+		}
+		dispatch( setHelpCenterVisible( ! helpCenterVisible ) );
+	};
+
 	return (
 		<Item
-			onClick={ () => dispatch( setHelpCenterVisible( ! helpCenterVisible ) ) }
+			onClick={ handleToggleHelpCenter }
 			className={ classnames( 'masterbar__item-help', {
 				'is-active': helpCenterVisible,
 			} ) }

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -1,6 +1,14 @@
 import config from '@automattic/calypso-config';
 import { getPlanTermLabel } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
+import {
+	SUPPORT_CHAT_OVERFLOW,
+	SUPPORT_DIRECTLY,
+	SUPPORT_FORUM,
+	SUPPORT_HAPPYCHAT,
+	SUPPORT_TICKET,
+	SUPPORT_UPWORK_TICKET,
+} from '@automattic/help-center';
 import { isDefaultLocale, localizeUrl } from '@automattic/i18n-utils';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
@@ -48,14 +56,7 @@ import {
 	getTicketSupportRequestError,
 } from 'calypso/state/help/ticket/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
-import getInlineHelpSupportVariation, {
-	SUPPORT_CHAT_OVERFLOW,
-	SUPPORT_DIRECTLY,
-	SUPPORT_FORUM,
-	SUPPORT_HAPPYCHAT,
-	SUPPORT_TICKET,
-	SUPPORT_UPWORK_TICKET,
-} from 'calypso/state/selectors/get-inline-help-support-variation';
+import getInlineHelpSupportVariation from 'calypso/state/selectors/get-inline-help-support-variation';
 import getLocalizedLanguageNames from 'calypso/state/selectors/get-localized-language-names';
 import hasUserAskedADirectlyQuestion from 'calypso/state/selectors/has-user-asked-a-directly-question';
 import isDirectlyFailed from 'calypso/state/selectors/is-directly-failed';

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -6,6 +6,7 @@ import {
 	isPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
+import { SUPPORT_HAPPYCHAT, SUPPORT_FORUM, SUPPORT_DIRECTLY } from '@automattic/help-center';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -19,11 +20,7 @@ import getSupportLevel from 'calypso/state/happychat/selectors/get-support-level
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import isPresalesChatAvailable from 'calypso/state/happychat/selectors/is-presales-chat-available';
 import { showInlineHelpPopover } from 'calypso/state/inline-help/actions';
-import getSupportVariation, {
-	SUPPORT_HAPPYCHAT,
-	SUPPORT_FORUM,
-	SUPPORT_DIRECTLY,
-} from 'calypso/state/selectors/get-inline-help-support-variation';
+import getSupportVariation from 'calypso/state/selectors/get-inline-help-support-variation';
 import isSupportVariationDetermined from 'calypso/state/selectors/is-support-variation-determined';
 import type { Theme } from '@automattic/composite-checkout';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';

--- a/client/state/selectors/get-inline-help-support-variation.js
+++ b/client/state/selectors/get-inline-help-support-variation.js
@@ -1,17 +1,18 @@
 import config from '@automattic/calypso-config';
+import {
+	SUPPORT_CHAT_OVERFLOW,
+	SUPPORT_DIRECTLY,
+	SUPPORT_FORUM,
+	SUPPORT_HAPPYCHAT,
+	SUPPORT_TICKET,
+	SUPPORT_UPWORK_TICKET,
+} from '@automattic/help-center';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
 import { isTicketSupportEligible } from 'calypso/state/help/ticket/selectors';
 import isDirectlyReady from 'calypso/state/selectors/is-directly-ready';
 import isEligibleForUpworkSupport from 'calypso/state/selectors/is-eligible-for-upwork-support';
-
-export const SUPPORT_CHAT_OVERFLOW = 'SUPPORT_CHAT_OVERFLOW';
-export const SUPPORT_DIRECTLY = 'SUPPORT_DIRECTLY';
-export const SUPPORT_FORUM = 'SUPPORT_FORUM';
-export const SUPPORT_HAPPYCHAT = 'SUPPORT_HAPPYCHAT';
-export const SUPPORT_TICKET = 'SUPPORT_TICKET';
-export const SUPPORT_UPWORK_TICKET = 'SUPPORT_UPWORK_TICKET';
 
 /**
  * @param {object} state Global state tree

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -23,6 +23,7 @@ declare const window: undefined | ( Window & { BUILD_TIMESTAMP?: number } );
 const TRACKS_SPECIAL_PROPS_NAMES = [ 'geo', 'message', 'request', 'geocity', 'ip' ];
 const EVENT_NAME_EXCEPTIONS = [
 	'a8c_cookie_banner_ok',
+	'helpcenter_page_open',
 	// WooCommerce Onboarding / Connection Flow.
 	'wcadmin_storeprofiler_create_jetpack_account',
 	'wcadmin_storeprofiler_connect_store',

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, FormInputValidation, Popover } from '@automattic/components';
 import {
 	useSubmitTicketMutation,
@@ -189,6 +190,14 @@ export const HelpCenterContactForm = () => {
 		switch ( mode ) {
 			case 'CHAT': {
 				if ( supportSite ) {
+					recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
+						support_variation: 'happychat',
+					} );
+
+					recordTracksEvent( 'calypso_help_live_chat_begin', {
+						site_plan_product_id: supportSite ? supportSite.plan?.product_id : null,
+						is_automated_transfer: supportSite ? supportSite.options.is_automated_transfer : null,
+					} );
 					history.push( '/inline-chat' );
 					break;
 				}
@@ -212,6 +221,14 @@ export const HelpCenterContactForm = () => {
 						is_chat_overflow: false,
 					} )
 						.then( () => {
+							recordTracksEvent( 'calypso_help_contact_submit', {
+								ticket_type: 'kayako',
+								support_variation: 'SUPPORT_TICKET',
+								site_plan_product_id: supportSite ? supportSite.plan?.product_id : null,
+								is_automated_transfer: supportSite
+									? supportSite.options.is_automated_transfer
+									: null,
+							} );
 							history.push( '/success' );
 							resetStore();
 						} )
@@ -232,6 +249,7 @@ export const HelpCenterContactForm = () => {
 					userDeclaredSiteUrl,
 				} )
 					.then( ( response ) => {
+						recordTracksEvent( 'calypso_help_contact_submit', { ticket_type: 'forum' } );
 						history.push( `/success?forumTopic=${ encodeURIComponent( response.topic_URL ) }` );
 						resetStore();
 					} )

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -221,13 +221,8 @@ export const HelpCenterContactForm = () => {
 						is_chat_overflow: false,
 					} )
 						.then( () => {
-							recordTracksEvent( 'calypso_help_contact_submit', {
-								ticket_type: 'kayako',
-								support_variation: 'SUPPORT_TICKET',
-								site_plan_product_id: supportSite ? supportSite.plan?.product_id : null,
-								is_automated_transfer: supportSite
-									? supportSite.options.is_automated_transfer
-									: null,
+							recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
+								support_variation: 'kayako',
 							} );
 							history.push( '/success' );
 							resetStore();
@@ -249,7 +244,9 @@ export const HelpCenterContactForm = () => {
 					userDeclaredSiteUrl,
 				} )
 					.then( ( response ) => {
-						recordTracksEvent( 'calypso_help_contact_submit', { ticket_type: 'forum' } );
+						recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
+							support_variation: 'forums',
+						} );
 						history.push( `/success?forumTopic=${ encodeURIComponent( response.topic_URL ) }` );
 						resetStore();
 					} )

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -265,6 +265,9 @@ export const HelpCenterContactForm = () => {
 			}
 			case 'DIRECTLY': {
 				askDirectlyQuestion( message ?? '', userData?.display_name ?? '', userData?.email ?? '' );
+				recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
+					support_variation: 'directly',
+				} );
 				setShowHelpCenter( false );
 				break;
 			}

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -21,6 +21,7 @@ import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { askDirectlyQuestion, execute } from '../directly';
 import { STORE_KEY, USER_KEY } from '../store';
+import { getSupportVariationFromMode } from '../support-variations';
 import { SitePicker } from '../types';
 import { BackButton } from './back-button';
 import { HelpCenterOwnershipNotice } from './help-center-notice';
@@ -154,6 +155,13 @@ export const HelpCenterContactForm = () => {
 		isLoading: isAnalysisLoading,
 		site: userDeclaredSite,
 	} = useSiteAnalysis( userDeclaredSiteUrl );
+
+	useEffect( () => {
+		const supportVariation = getSupportVariationFromMode( mode );
+		recordTracksEvent( 'calypso_inlinehelp_contact_view', {
+			support_variation: supportVariation,
+		} );
+	}, [ mode ] );
 
 	// record the resolved site
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Icon, comment } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -87,8 +88,18 @@ export const HelpCenterContactButton: React.FC = () => {
 	const { __ } = useI18n();
 	const url = useStillNeedHelpURL();
 
+	const trackContactButtonClicked = () => {
+		recordTracksEvent( 'calypso_inlinehelp_morehelp_click', {
+			location: 'help-center-still-need-help',
+		} );
+	};
+
 	return (
-		<Link to={ url } className="button help-center-contact-page__button">
+		<Link
+			to={ url }
+			onClick={ trackContactButtonClicked }
+			className="button help-center-contact-page__button"
+		>
 			<Icon icon={ comment } />
 			<span>{ __( 'Still need help?' ) }</span>
 		</Link>

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -1,6 +1,8 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CardBody } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
 import classnames from 'classnames';
-import { Route } from 'react-router-dom';
+import { Route, useLocation } from 'react-router-dom';
 import { Content } from '../types';
 import { HelpCenterContactForm } from './help-center-contact-form';
 import { HelpCenterContactPage } from './help-center-contact-page';
@@ -10,7 +12,16 @@ import { HelpCenterSearch } from './help-center-search';
 import { SuccessScreen } from './ticket-success-screen';
 
 const HelpCenterContent: React.FC< Content > = ( { isMinimized } ) => {
+	const location = useLocation();
 	const className = classnames( 'help-center__container-content' );
+
+	useEffect( () => {
+		recordTracksEvent( 'helpcenter_page_open', {
+			pathname: location.pathname,
+			search: location.search,
+		} );
+	}, [ location ] );
+
 	return (
 		<CardBody hidden={ isMinimized } className={ className }>
 			<Route exact path="/">

--- a/packages/help-center/src/components/ticket-success-screen.tsx
+++ b/packages/help-center/src/components/ticket-success-screen.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
@@ -9,6 +10,11 @@ export const SuccessScreen: React.FC = () => {
 	const { search } = useLocation();
 	const params = new URLSearchParams( search );
 	const forumTopicUrl = params.get( 'forumTopic' );
+
+	const trackForumOpen = () =>
+		recordTracksEvent( 'calypso_inlinehelp_forums_open', {
+			location: 'help-center',
+		} );
 
 	return (
 		<div>
@@ -25,7 +31,12 @@ export const SuccessScreen: React.FC = () => {
 							__i18n_text_domain__
 						) }
 						&nbsp;
-						<a target="_blank" rel="noopener noreferrer" href={ forumTopicUrl }>
+						<a
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={ trackForumOpen }
+							href={ forumTopicUrl }
+						>
 							{ __( 'View the forums topic here.', __i18n_text_domain__ ) }
 						</a>
 					</p>

--- a/packages/help-center/src/index.ts
+++ b/packages/help-center/src/index.ts
@@ -8,3 +8,4 @@ export { useHCWindowCommunicator } from './happychat-window-communicator';
 export { execute, checkAPIThenInitializeDirectly, askDirectlyQuestion } from './directly';
 export { default as Mail } from './icons/mail';
 export { default as NewReleases } from './icons/new-releases';
+export * from './support-variations';

--- a/packages/help-center/src/support-variations.ts
+++ b/packages/help-center/src/support-variations.ts
@@ -1,0 +1,21 @@
+export const SUPPORT_CHAT_OVERFLOW = 'SUPPORT_CHAT_OVERFLOW';
+export const SUPPORT_DIRECTLY = 'SUPPORT_DIRECTLY';
+export const SUPPORT_FORUM = 'SUPPORT_FORUM';
+export const SUPPORT_HAPPYCHAT = 'SUPPORT_HAPPYCHAT';
+export const SUPPORT_TICKET = 'SUPPORT_TICKET';
+export const SUPPORT_UPWORK_TICKET = 'SUPPORT_UPWORK_TICKET';
+
+/**
+ * @param {string} mode Help Center contact form mode
+ * @returns {string} One of the exported support variation constants listed above
+ */
+export const getSupportVariationFromMode = ( mode: 'CHAT' | 'EMAIL' | 'FORUM' ) => {
+	switch ( mode ) {
+		case 'CHAT':
+			return SUPPORT_HAPPYCHAT;
+		case 'EMAIL':
+			return SUPPORT_TICKET;
+		case 'FORUM':
+			return SUPPORT_FORUM;
+	}
+};

--- a/packages/help-center/src/support-variations.ts
+++ b/packages/help-center/src/support-variations.ts
@@ -9,7 +9,9 @@ export const SUPPORT_UPWORK_TICKET = 'SUPPORT_UPWORK_TICKET';
  * @param {string} mode Help Center contact form mode
  * @returns {string} One of the exported support variation constants listed above
  */
-export const getSupportVariationFromMode = ( mode: 'CHAT' | 'EMAIL' | 'FORUM' ) => {
+export const getSupportVariationFromMode = (
+	mode: 'CHAT' | 'EMAIL' | 'FORUM' | 'DIRECTLY' | 'UPWORK'
+) => {
 	switch ( mode ) {
 		case 'CHAT':
 			return SUPPORT_HAPPYCHAT;
@@ -17,5 +19,9 @@ export const getSupportVariationFromMode = ( mode: 'CHAT' | 'EMAIL' | 'FORUM' ) 
 			return SUPPORT_TICKET;
 		case 'FORUM':
 			return SUPPORT_FORUM;
+		case 'DIRECTLY':
+			return SUPPORT_DIRECTLY;
+		case 'UPWORK':
+			return SUPPORT_UPWORK_TICKET;
 	}
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Already there:
- `calypso_inlinehelp_richresult_show` / `calypso_inlinehelp_richresult_hide`: When opening/closing an article.
- `calypso_inlinehelp_contact_show`: / `calypso_inlinehelp_contact_hide`: When opening/closing the contact page.
- `calypso_inlinehelp_article_open`: When viewing an article.
- `calypso_inlinehelp_tour_open`: When viewing a tour.
- `calypso_inlinehelp_video_open`: When viewing a video.
- `calypso_inlinehelp_search`: When searching.
- `calypso_inlinehelp_admin_section_visit`: When clicking on an admin link.
- `calypso_help_courses_click`: When clicking on courses.

Trackings added to the help center:
- `calypso_inlinehelp_contact_submit`, with `support_variation: kayako` when submitting an email
- `calypso_inlinehelp_contact_submit`, with `support_variation: forums` when posting to the forums
- `calypso_inlinehelp_contact_submit` with `support_variation: happychat` when starting happychat.
- `calypso_inlinehelp_forums_open` if a customer click on the new forum ticket and goes to the forums
- `calypso_inlinehelp_show` with location `help-center-desktop` or `help-center-mobile` when the customer opens the help center. **This could be changed to not reflect desktop or mobile.**
- `calypso_inlinehelp_close` with location `help-center-desktop` or `help-center-mobile` when the customer closes the help center. **This could be changed to not reflect desktop or mobile.**
- `calypso_inlinehelp_contact_view` with `support_variation:` `SUPPORT_HAPPYCHAT`, `SUPPORT_FORUM` or `SUPPORT_TICKET`, when viewing chat, forum or email contact form
- `calypso_inlinehelp_morehelp_click` when clicking on `Still need help?`

New tracking events:

- `helpcenter_page_open ` triggered when viewing a page in the help center
 

