### PR TITLE
E2E: add WordPress.com Pro plan specs.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -41,8 +41,11 @@ const selectors = {
 	submitBillingInformationButton:
 		'[data-testid="contact-form--visible"] button.checkout-button.is-status-primary',
 
+	// Payment method cards
+	existingCreditCard: ( cardHolderName: string ) =>
+		`label[for*="existingCard"]:has-text("${ cardHolderName }")`,
+
 	// Payment field
-	paymentMethod: '[data-testid="payment-method-step--visible"]',
 	cardholderName: `input[id="cardholder-name"]`,
 	cardNumberFrame: 'iframe[title="Secure card number input frame"]',
 	cardNumberInput: 'input[data-elements-stable-field-name="cardNumber"]',
@@ -66,7 +69,7 @@ const selectors = {
 };
 
 /**
- * Page representing the cart checkout page for purchases made in Upgrades.
+ * Page representing the Secure Checkout page.
  */
 export class CartCheckoutPage {
 	private page: Page;
@@ -227,11 +230,33 @@ export class CartCheckoutPage {
 	}
 
 	/**
+	 * Selects a saved card payment method.
+	 *
+	 * @param {string} cardHolderName Name of the card holder associated with the payment method.
+	 */
+	async selectSavedCard( cardHolderName: string ): Promise< void > {
+		const selector = this.page.locator( selectors.existingCreditCard( cardHolderName ) ).first();
+
+		await selector.click();
+	}
+
+	/**
 	 * Enter payment details.
+	 *
+	 * Note that this method will always choose to create
+	 * a new card entry even if the intended payment
+	 * details have already been saved.
 	 *
 	 * @param {PaymentDetails} paymentDetails Object implementing the PaymentDetails interface.
 	 */
 	async enterPaymentDetails( paymentDetails: PaymentDetails ): Promise< void > {
+		// Click on the Credit or debit card input in order
+		// to expand the fields.
+		const cardInputLocator = this.page.locator( `span:has-text("Credit or debit card")` );
+		await cardInputLocator.click();
+
+		// Begin filling in the card details from
+		// top to bottom.
 		await this.page.fill( selectors.cardholderName, paymentDetails.cardHolder );
 
 		const cardNumberFrameHandle = await this.page.waitForSelector( selectors.cardNumberFrame );

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -59,14 +59,18 @@ export class MediaPage {
 	 * Checks whether the storage capacity for Media files is
 	 * as expected.
 	 *
-	 * @param {number} capacity Expected capacity in GB (gigabytess).
+	 * @param {number} capacity Expected capacity in GB (gigabytes).
 	 */
 	async hasStorageCapacity( capacity: number ): Promise< boolean > {
 		const locator = this.page.locator(
 			`.plan-storage__storage-label:has-text("${ capacity.toString() }")`
 		);
-		const count = await locator.count();
-		return count > 0 ? true : false;
+		try {
+			await locator.waitFor( { timeout: 15 * 1000 } );
+			return true;
+		} catch {
+			return false;
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -61,7 +61,7 @@ export class MediaPage {
 	 *
 	 * @param {number} capacity Expected capacity in GB (gigabytess).
 	 */
-	async validateStorageCapacity( capacity: number ): Promise< boolean > {
+	async hasStorageCapacity( capacity: number ): Promise< boolean > {
 		const locator = this.page.locator(
 			`.plan-storage__storage-label:has-text("${ capacity.toString() }")`
 		);

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -65,7 +65,8 @@ export class MediaPage {
 		const locator = this.page.locator(
 			`.plan-storage__storage-label:has-text("${ capacity.toString() }")`
 		);
-		return Boolean( await locator.count() );
+		const count = await locator.count();
+		return count > 0 ? true : false;
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -56,6 +56,19 @@ export class MediaPage {
 	}
 
 	/**
+	 * Checks whether the storage capacity for Media files is
+	 * as expected.
+	 *
+	 * @param {number} capacity Expected capacity in GB (gigabytess).
+	 */
+	async validateStorageCapacity( capacity: number ): Promise< boolean > {
+		const locator = this.page.locator(
+			`.plan-storage__storage-label:has-text("${ capacity.toString() }")`
+		);
+		return Boolean( await locator.count() );
+	}
+
+	/**
 	 * Given a 1-indexed number `n`, click and select the nth item in the media gallery.
 	 *
 	 * Note that if the media gallery has been filtered (eg. Images only), this method

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -40,7 +40,7 @@ const selectors = {
 
 	// My Plans view
 	myPlanTitle: ( planName: LegacyPlans | Plans ) =>
-		`.my-plan-card__title:has-text("WordPress ${ planName }")`,
+		`.my-plan-card__title:has-text("${ planName }")`,
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/pages/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup-pick-plan-page.ts
@@ -38,7 +38,7 @@ export class SignupPickPlanPage {
 			throw new Error( 'Failed to create new site when selecting a plan at signup.' );
 		}
 
-		const responseBody: NewSiteResponse = JSON.parse( ( await response.body() ).toString() );
+		const responseBody: NewSiteResponse = await response.json();
 
 		return {
 			id: responseBody.body.blog_details.blogid,

--- a/packages/calypso-e2e/src/lib/pages/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup-pick-plan-page.ts
@@ -1,12 +1,7 @@
 import { Page } from 'playwright';
 import { NewSiteResponse } from '../../rest-api-client';
 import { PlansPage, Plans } from './plans-page';
-
-interface NewSiteDetails {
-	id: string;
-	url: string;
-	name: string;
-}
+import type { SiteDetails } from '../../rest-api-client';
 
 /**
  * Represents the Signup > Pick a Plan page.
@@ -31,18 +26,20 @@ export class SignupPickPlanPage {
 	 * Selects a WordPress.com plan matching the name, triggering site creation.
 	 *
 	 * @param {Plans} name Name of the plan.
+	 * @returns {Promise<SiteDetails>} Details of the newly created site.
 	 */
-	async selectPlan( name: Plans ): Promise< NewSiteDetails > {
+	async selectPlan( name: Plans ): Promise< SiteDetails > {
 		const [ response ] = await Promise.all( [
 			this.page.waitForResponse( /.*sites\/new\?.*/ ),
 			this.plansPage.selectPlan( name ),
 		] );
 
 		if ( ! response ) {
-			throw new Error( 'Failed to create new site at Signup.' );
+			throw new Error( 'Failed to create new site when selecting a plan at signup.' );
 		}
 
 		const responseBody: NewSiteResponse = JSON.parse( ( await response.body() ).toString() );
+
 		return {
 			id: responseBody.body.blog_details.blogid,
 			url: responseBody.body.blog_details.url,

--- a/packages/calypso-e2e/src/lib/pages/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/user-signup-page.ts
@@ -79,7 +79,8 @@ export class UserSignupPage {
 			throw new Error( 'Failed to create new user at signup.' );
 		}
 
-		const responseBody: NewUserResponse = JSON.parse( ( await response.body() ).toString() );
+		const responseBody: NewUserResponse = await response.json();
+
 		return { ID: responseBody.body.user_id, bearer_token: responseBody.body.bearer_token };
 	}
 

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -7,7 +7,7 @@ interface AccountClosureDetails {
 	username: string;
 	email: string;
 }
-interface SiteClosureDetails {
+export interface SiteDetails {
 	url: string;
 	id: string;
 	name: string;
@@ -212,12 +212,10 @@ export class RestAPIClient {
 	 * Otherwise the active subscription must be first cancelled
 	 * otherwise the REST API will throw a HTTP 403 status.
 	 *
-	 * @param {SiteClosureDetails} expectedSiteDetails Expected details for the site to be deleted.
+	 * @param {SiteDetails} expectedSiteDetails Expected details for the site to be deleted.
 	 * @returns {SiteDeletionResponse | null} Null if deletion was unsuccessful or not performed. SiteDeletionResponse otherwise.
 	 */
-	async deleteSite(
-		expectedSiteDetails: SiteClosureDetails
-	): Promise< SiteDeletionResponse | null > {
+	async deleteSite( expectedSiteDetails: SiteDetails ): Promise< SiteDeletionResponse | null > {
 		if ( ! expectedSiteDetails.url.includes( 'e2e' ) ) {
 			console.warn( `Aborting site deletion: target is not a test site.` );
 			return null;

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -162,8 +162,13 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ), function 
 		} );
 
 		it( 'Keep free plan', async function () {
-			const signupPickPlanPage = new SignupPickPlanPage( page );
-			await signupPickPlanPage.selectPlan( 'Free' );
+			try {
+				const signupPickPlanPage = new SignupPickPlanPage( page );
+				await signupPickPlanPage.selectPlan( 'Free' );
+			} catch {
+				// noop - see p1654033059549799-slack-C031TFM2NKC
+				// or https://github.com/Automattic/wp-calypso/issues/64248.
+			}
 		} );
 
 		it( 'Confirm site is launched', async function () {

--- a/test/e2e/specs/plans/plans__add-upgrade-cart.ts
+++ b/test/e2e/specs/plans/plans__add-upgrade-cart.ts
@@ -52,7 +52,7 @@ describe( DataHelper.createSuiteTitle( 'Plans: Add Upgrade to Cart' ), function 
 		} );
 
 		it( 'Automatically navigated back to Plans page', async function () {
-			await plansPage.validateActiveNavigationTab( 'Plans' );
+			await plansPage.validateActiveTab( 'Plans' );
 		} );
 	} );
 } );

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -16,7 +16,6 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () {
 	const planTier = 'Personal';
-	const planName = `WordPress.com ${ planTier }`;
 	let page: Page;
 	let plansPage: PlansPage;
 	let individualPurchasesPage: IndividualPurchasePage;
@@ -40,7 +39,7 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 			await plansPage.clickTab( 'My Plan' );
 		} );
 
-		it( `${ planName } is the active plan`, async function () {
+		it( `${ planTier } is the active plan`, async function () {
 			await plansPage.validateActivePlan( planTier );
 		} );
 
@@ -50,7 +49,7 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 	} );
 
 	describe( 'Renew Plan', function () {
-		it( `Manage ${ planName } plan`, async function () {
+		it( `Manage ${ planTier } plan`, async function () {
 			// This navigation also validates that we correctly identify the active plan in the Plans table.
 			// The button text won't be correct if Premium isn't the active plan.
 			await plansPage.clickPlanActionButton( { plan: planTier, buttonText: 'Manage plan' } );
@@ -58,25 +57,25 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 
 		it( `Details of purchased plan ${ planTier } are shown`, async function () {
 			individualPurchasesPage = new IndividualPurchasePage( page );
-			await individualPurchasesPage.validatePurchaseTitle( planName );
+			await individualPurchasesPage.validatePurchaseTitle( planTier );
 		} );
 
 		it( 'Renew plan', async function () {
 			await individualPurchasesPage.clickRenewNowCardButton();
 		} );
 
-		it( `${ planName } is added to cart`, async function () {
+		it( `${ planTier } is added to cart`, async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
-			await cartCheckoutPage.validateCartItem( planName );
+			await cartCheckoutPage.validateCartItem( planTier );
 		} );
 
-		it( `Remove ${ planName } from cart`, async function () {
-			await cartCheckoutPage.removeCartItem( planName );
+		it( `Remove ${ planTier } from cart`, async function () {
+			await cartCheckoutPage.removeCartItem( planTier );
 		} );
 
 		it( 'Automatically return to purchase page', async function () {
 			individualPurchasesPage = new IndividualPurchasePage( page );
-			await individualPurchasesPage.validatePurchaseTitle( planName );
+			await individualPurchasesPage.validatePurchaseTitle( planTier );
 		} );
 	} );
 } );

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -41,7 +41,7 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 		} );
 
 		it( `${ planName } is the active plan`, async function () {
-			await plansPage.validateActivePlanInMyPlanTab( planTier );
+			await plansPage.validateActivePlan( planTier );
 		} );
 
 		it( 'Click on the Plans tab', async function () {

--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -16,6 +16,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () {
 	const planTier = 'Personal';
+	const planName = `WordPress.com ${ planTier }`;
 	let page: Page;
 	let plansPage: PlansPage;
 	let individualPurchasesPage: IndividualPurchasePage;
@@ -39,7 +40,7 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 			await plansPage.clickTab( 'My Plan' );
 		} );
 
-		it( `${ planTier } is the active plan`, async function () {
+		it( `${ planName } is the active plan`, async function () {
 			await plansPage.validateActivePlan( planTier );
 		} );
 
@@ -49,7 +50,7 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 	} );
 
 	describe( 'Renew Plan', function () {
-		it( `Manage ${ planTier } plan`, async function () {
+		it( `Manage ${ planName } plan`, async function () {
 			// This navigation also validates that we correctly identify the active plan in the Plans table.
 			// The button text won't be correct if Premium isn't the active plan.
 			await plansPage.clickPlanActionButton( { plan: planTier, buttonText: 'Manage plan' } );
@@ -57,25 +58,25 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 
 		it( `Details of purchased plan ${ planTier } are shown`, async function () {
 			individualPurchasesPage = new IndividualPurchasePage( page );
-			await individualPurchasesPage.validatePurchaseTitle( planTier );
+			await individualPurchasesPage.validatePurchaseTitle( planName );
 		} );
 
 		it( 'Renew plan', async function () {
 			await individualPurchasesPage.clickRenewNowCardButton();
 		} );
 
-		it( `${ planTier } is added to cart`, async function () {
+		it( `${ planName } is added to cart`, async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
-			await cartCheckoutPage.validateCartItem( planTier );
+			await cartCheckoutPage.validateCartItem( planName );
 		} );
 
-		it( `Remove ${ planTier } from cart`, async function () {
-			await cartCheckoutPage.removeCartItem( planTier );
+		it( `Remove ${ planName } from cart`, async function () {
+			await cartCheckoutPage.removeCartItem( planName );
 		} );
 
 		it( 'Automatically return to purchase page', async function () {
 			individualPurchasesPage = new IndividualPurchasePage( page );
-			await individualPurchasesPage.validatePurchaseTitle( planTier );
+			await individualPurchasesPage.validatePurchaseTitle( planName );
 		} );
 	} );
 } );

--- a/test/e2e/specs/plans/plans__legacy-upgrade.ts
+++ b/test/e2e/specs/plans/plans__legacy-upgrade.ts
@@ -51,7 +51,7 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Upgrade' ), function () 
 		} );
 
 		it( 'Automatically return to Plans page', async function () {
-			await plansPage.validateActiveNavigationTab( 'Plans' );
+			await plansPage.validateActiveTab( 'Plans' );
 		} );
 	} );
 } );

--- a/test/e2e/specs/plans/plans__signup-pro.ts
+++ b/test/e2e/specs/plans/plans__signup-pro.ts
@@ -1,0 +1,141 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	BrowserManager,
+	SignupPickPlanPage,
+	StartSiteFlow,
+	SidebarComponent,
+	PlansPage,
+	RestAPIClient,
+	CartCheckoutPage,
+	TestAccount,
+	DomainSearchComponent,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe(
+	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Pro site as exising user' ),
+	function () {
+		const blogName = DataHelper.getBlogName();
+
+		let testAccount: TestAccount;
+		let page: Page;
+		let siteCreatedFlag = false;
+		let siteID: string;
+		let siteURL: string;
+		let siteName: string;
+
+		beforeAll( async () => {
+			page = await browser.newPage();
+
+			testAccount = new TestAccount( 'calypsoPreReleaseUser' );
+			await testAccount.authenticate( page );
+		} );
+
+		describe( 'Create new site', function () {
+			let cartCheckoutPage: CartCheckoutPage;
+
+			it( 'Navigate to /start', async function () {
+				await page.goto( DataHelper.getCalypsoURL( 'start' ) );
+			} );
+
+			it( 'Set store cookie', async function () {
+				await BrowserManager.setStoreCookie( page );
+			} );
+
+			it( 'Select a .wordpres.com domain name', async function () {
+				const domainSearchComponent = new DomainSearchComponent( page );
+				await domainSearchComponent.search( blogName );
+				await domainSearchComponent.selectDomain( '.wordpress.com' );
+			} );
+
+			it( 'Select WordPress.com Pro plan', async function () {
+				const signupPickPlanPage = new SignupPickPlanPage( page );
+				const details = await signupPickPlanPage.selectPlan( 'Pro' );
+
+				siteID = details.id;
+				siteURL = details.url;
+				siteName = details.name;
+
+				siteCreatedFlag = true;
+			} );
+
+			it( 'See secure checkout', async function () {
+				cartCheckoutPage = new CartCheckoutPage( page );
+				await cartCheckoutPage.validateCartItem( 'WordPress.com Pro' );
+			} );
+
+			it( 'Enter payment details', async function () {
+				await cartCheckoutPage.selectSavedCard( 'End to End Testing' );
+			} );
+
+			it( 'Make purchase', async function () {
+				await cartCheckoutPage.purchase();
+			} );
+
+			it( 'Skip to dashboard', async function () {
+				const startSiteFlow = new StartSiteFlow( page );
+				await Promise.all( [
+					page.waitForNavigation( { url: /.*\/home\/.*/ } ),
+					startSiteFlow.clickButton( 'Skip to dashboard' ),
+				] );
+			} );
+		} );
+
+		describe( 'Validate WordPress.com Pro functionality', function () {
+			let sidebarComponent: SidebarComponent;
+
+			it( 'Sidebar states user is on WordPress.com Pro plan', async function () {
+				sidebarComponent = new SidebarComponent( page );
+				const plan = await sidebarComponent.getCurrentPlanName();
+				expect( plan ).toBe( 'Pro' );
+			} );
+
+			it( 'Navigate to Upgrades > Plans', async function () {
+				sidebarComponent = new SidebarComponent( page );
+				await sidebarComponent.navigate( 'Upgrades', 'Plans' );
+			} );
+
+			it( 'Plans page states user is on WordPress.com Pro plan', async function () {
+				const plansPage = new PlansPage( page, 'current' );
+				await plansPage.validateActivePlan( 'Pro' );
+			} );
+		} );
+
+		afterAll( async function () {
+			if ( ! siteCreatedFlag ) {
+				return;
+			}
+
+			const restAPIClient = new RestAPIClient( {
+				username: testAccount.credentials.username,
+				password: testAccount.credentials.password,
+			} );
+
+			const response = await restAPIClient.deleteSite( {
+				url: siteURL,
+				id: siteID,
+				name: siteName,
+			} );
+
+			// If the response is `null` then no action has been
+			// performed.
+			if ( response ) {
+				// The only correct response is the string
+				// "deleted".
+				if ( response.status !== 'deleted' ) {
+					console.warn(
+						`Failed to delete siteID ${ siteID }.\nExpected: "deleted", Got: ${ response.status }`
+					);
+				} else {
+					console.log( `Successfully deleted siteID ${ siteID }.` );
+				}
+			}
+		} );
+	}
+);

--- a/test/e2e/specs/plans/plans__signup-pro.ts
+++ b/test/e2e/specs/plans/plans__signup-pro.ts
@@ -105,7 +105,7 @@ describe(
 			it( 'Validate storage capacity', async function () {
 				await sidebarComponent.navigate( 'Media' );
 				const mediaPage = new MediaPage( page );
-				await mediaPage.hasStorageCapacity( 50 );
+				expect( await mediaPage.hasStorageCapacity( 50 ) ).toBe( true );
 			} );
 		} );
 

--- a/test/e2e/specs/plans/plans__signup-pro.ts
+++ b/test/e2e/specs/plans/plans__signup-pro.ts
@@ -105,7 +105,7 @@ describe(
 			it( 'Validate storage capacity', async function () {
 				await sidebarComponent.navigate( 'Media' );
 				const mediaPage = new MediaPage( page );
-				await mediaPage.validateStorageCapacity( 50 );
+				await mediaPage.hasStorageCapacity( 50 );
 			} );
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR introduces a new spec that covers the WordPress.com Pro plan feature in the context of the onboarding flow.

Key changes:
- new spec file which creates a new WordPress.com Pro plan site with an existing user.
- change signature of SignupPickPlanPage.selectPlan to return details of the new site it creates.
- addition of new calls in RestAPIClient to delete a site.

Other housekeeping changes:
- renaming of methods in PlansPage to be less verbose.
- changes to CartCheckoutPage in order to select saved payment method.

#### Testing instructions

- trigger the Pre-Release Tests against this branch.
  - ensure that no failures are reported.
- in TeamCity, navigate to the **Tests** tab and ensure the test suite and/or steps from the new spec has been run.

Related to https://github.com/Automattic/wp-calypso/issues/62492