### PR TITLE
Pricing page: Add Jetpack Social and Boost Free product cards

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -223,7 +223,8 @@
 	margin: 0.75rem 0;
 }
 
-.jetpack-product-card__discount-label {
+.jetpack-product-card__discount-label,
+.jetpack-product-card__new-label {
 	display: inline-block;
 
 	padding: 0.125rem 0.5rem;
@@ -241,6 +242,9 @@
 
 		font-size: 0.75em;
 	}
+}
+.jetpack-product-card__new-label {
+	background-color: var( --studio-jetpack-green-10 );
 }
 
 .jetpack-product-card {

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -42,6 +42,7 @@ type OwnProps = {
 	aboveButtonText?: TranslateResult | ReactNode;
 	featuredLabel?: TranslateResult;
 	hideSavingLabel?: boolean;
+	showNewLabel?: boolean;
 	showAbovePriceText?: boolean;
 	scrollCardIntoView?: ScrollCardIntoViewCallback;
 	collapseFeaturesOnMobile?: boolean;
@@ -81,6 +82,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 	tooltipText,
 	featuredLabel,
 	hideSavingLabel,
+	showNewLabel,
 	showAbovePriceText,
 	aboveButtonText = null,
 	scrollCardIntoView,
@@ -143,6 +145,9 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 					<Header level={ headerLevel } className="jetpack-product-card__product-name">
 						{ item.displayName }
 					</Header>
+					{ showNewLabel && (
+						<span className="jetpack-product-card__new-label">{ translate( 'New' ) }</span>
+					) }
 					{ discountElt && (
 						<span className="jetpack-product-card__discount-label">{ discountElt }</span>
 					) }

--- a/client/my-sites/plans/jetpack-plans/jetpack-boost-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-boost-free-card/index.tsx
@@ -1,0 +1,81 @@
+import { TERM_ANNUALLY } from '@automattic/calypso-products';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { ITEM_TYPE_PRODUCT } from 'calypso/my-sites/plans/jetpack-plans/constants';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import type { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+const BOOST_FREE_URL = isJetpackCloud()
+	? '/pricing/jetpack-boost/welcome'
+	: 'https://wordpress.org/plugins/jetpack-boost/';
+
+const useBoostFreeItem = (): SelectorProduct => {
+	const translate = useTranslate();
+
+	return useMemo(
+		() => ( {
+			productSlug: 'jetpack-boost-free',
+			isFree: true,
+			displayName: translate( 'Boost' ),
+			features: {
+				items: [
+					{ slug: 'not used', text: translate( 'Defer Non-Essential Javascript' ) },
+					{ slug: 'not used', text: translate( 'Optimize CSS Structure' ) },
+					{ slug: 'not used', text: translate( 'Lazy Image Loading' ) },
+				],
+			},
+			type: ITEM_TYPE_PRODUCT, // not used
+			term: TERM_ANNUALLY, // not used
+			iconSlug: 'not used',
+			shortName: 'not used',
+			tagline: 'not used',
+			description: 'not used',
+		} ),
+		[ translate ]
+	);
+};
+
+export type CardWithPriceProps = {
+	siteId: number | null;
+};
+
+const CardWithPrice: React.FC< CardWithPriceProps > = ( { siteId } ) => {
+	const translate = useTranslate();
+	const boostFreeProduct = useBoostFreeItem();
+
+	const dispatch = useDispatch();
+	const onButtonClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_product_jpboostfree_click', {
+				site_id: siteId ?? undefined,
+			} )
+		);
+	}, [ dispatch, siteId ] );
+
+	return (
+		<JetpackProductCard
+			className={ classNames( 'jetpack-boost-free-card', {
+				'is-jetpack-cloud': isJetpackCloud(),
+			} ) }
+			hideSavingLabel
+			showNewLabel
+			showAbovePriceText
+			buttonPrimary
+			item={ boostFreeProduct }
+			headerLevel={ 3 }
+			description={ translate(
+				"Boost gives your site the same performance advantages as the world's leading websites."
+			) }
+			buttonLabel={ translate( 'Get Boost' ) }
+			buttonURL={ BOOST_FREE_URL }
+			onButtonClick={ onButtonClick }
+			collapseFeaturesOnMobile
+		/>
+	);
+};
+
+export default CardWithPrice;

--- a/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/index.tsx
@@ -10,7 +10,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { QueryArgs, SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 
 const SOCIAL_FREE_URL = isJetpackCloud()
-	? 'https://cloud.jetpack.com/pricing/jetpack-social/welcome'
+	? '/pricing/jetpack-social/welcome'
 	: 'https://wordpress.org/plugins/jetpack-social/'; // This may need to be updated (page doesn't exist yet).
 
 const useSocialFreeItem = (): SelectorProduct => {

--- a/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/index.tsx
@@ -7,7 +7,7 @@ import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { ITEM_TYPE_PRODUCT } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import type { QueryArgs, SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+import type { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 
 const SOCIAL_FREE_URL = isJetpackCloud()
 	? '/pricing/jetpack-social/welcome'
@@ -41,10 +41,9 @@ const useSocialFreeItem = (): SelectorProduct => {
 
 export type CardWithPriceProps = {
 	siteId: number | null;
-	urlQueryArgs: QueryArgs;
 };
 
-const CardWithPrice: React.FC< CardWithPriceProps > = ( { siteId, urlQueryArgs } ) => {
+const CardWithPrice: React.FC< CardWithPriceProps > = ( { siteId } ) => {
 	const translate = useTranslate();
 	const socialFreeProduct = useSocialFreeItem();
 

--- a/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/index.tsx
@@ -1,4 +1,3 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { TERM_ANNUALLY } from '@automattic/calypso-products';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -7,6 +6,7 @@ import { useDispatch } from 'react-redux';
 import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { ITEM_TYPE_PRODUCT } from 'calypso/my-sites/plans/jetpack-plans/constants';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { QueryArgs, SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 
 const SOCIAL_FREE_URL = isJetpackCloud()
@@ -49,19 +49,13 @@ const CardWithPrice: React.FC< CardWithPriceProps > = ( { siteId, urlQueryArgs }
 	const socialFreeProduct = useSocialFreeItem();
 
 	const dispatch = useDispatch();
-	const trackCallback = useCallback(
-		() =>
-			dispatch(
-				recordTracksEvent( 'calypso_product_jpsocialfree_click', {
-					site_id: siteId ?? undefined,
-				} )
-			),
-		[ dispatch, siteId ]
-	);
-
 	const onButtonClick = useCallback( () => {
-		trackCallback();
-	}, [ trackCallback ] );
+		dispatch(
+			recordTracksEvent( 'calypso_product_jpsocialfree_click', {
+				site_id: siteId ?? undefined,
+			} )
+		);
+	}, [ dispatch, siteId ] );
 
 	return (
 		<JetpackProductCard

--- a/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/index.tsx
@@ -1,0 +1,88 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { TERM_ANNUALLY } from '@automattic/calypso-products';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { ITEM_TYPE_PRODUCT } from 'calypso/my-sites/plans/jetpack-plans/constants';
+import type { QueryArgs, SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+const SOCIAL_FREE_URL = isJetpackCloud()
+	? 'https://cloud.jetpack.com/pricing/jetpack-social/welcome'
+	: 'https://wordpress.org/plugins/jetpack-social/'; // This may need to be updated (page doesn't exist yet).
+
+const useSocialFreeItem = (): SelectorProduct => {
+	const translate = useTranslate();
+
+	return useMemo(
+		() => ( {
+			productSlug: 'jetpack-social-free',
+			isFree: true,
+			displayName: translate( 'Social' ),
+			features: {
+				items: [
+					{ slug: 'not used', text: translate( 'Schedule or share instantly' ) },
+					{ slug: 'not used', text: translate( 'Connect to leading social platforms' ) },
+					{ slug: 'not used', text: translate( 'Manage everything from Publishing Hub' ) },
+				],
+			},
+			type: ITEM_TYPE_PRODUCT, // not used
+			term: TERM_ANNUALLY, // not used
+			iconSlug: 'not used',
+			shortName: 'not used',
+			tagline: 'not used',
+			description: 'not used',
+		} ),
+		[ translate ]
+	);
+};
+
+export type CardWithPriceProps = {
+	siteId: number | null;
+	urlQueryArgs: QueryArgs;
+};
+
+const CardWithPrice: React.FC< CardWithPriceProps > = ( { siteId, urlQueryArgs } ) => {
+	const translate = useTranslate();
+	const socialFreeProduct = useSocialFreeItem();
+
+	const dispatch = useDispatch();
+	const trackCallback = useCallback(
+		() =>
+			dispatch(
+				recordTracksEvent( 'calypso_product_jpsocialfree_click', {
+					site_id: siteId ?? undefined,
+				} )
+			),
+		[ dispatch, siteId ]
+	);
+
+	const onButtonClick = useCallback( () => {
+		trackCallback();
+	}, [ trackCallback ] );
+
+	return (
+		<JetpackProductCard
+			className={ classNames( 'jetpack-social-free-card', {
+				'is-jetpack-cloud': isJetpackCloud(),
+			} ) }
+			hideSavingLabel
+			showNewLabel
+			showAbovePriceText
+			buttonPrimary
+			item={ socialFreeProduct }
+			headerLevel={ 3 }
+			description={ translate(
+				'Grow your audience effortlessly by automating posting on social media.'
+			) }
+			buttonLabel={ translate( 'Get Social' ) }
+			buttonURL={ SOCIAL_FREE_URL }
+			onButtonClick={ onButtonClick }
+			collapseFeaturesOnMobile
+		/>
+	);
+};
+
+export default CardWithPrice;

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -285,7 +285,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 							<>
 								{ showBoostAndSocialFree && (
 									<li>
-										<JetpackSocialFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
+										<JetpackSocialFreeCard siteId={ siteId } />
 									</li>
 								) }
 								<li>

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -21,6 +21,7 @@ import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import CategoryFilter from '../category-filter';
 import JetpackCrmFreeCard from '../jetpack-crm-free-card';
 import JetpackFreeCard from '../jetpack-free-card';
+import JetpackSocialFreeCard from '../jetpack-social-free-card';
 import MoreInfoBox from '../more-info-box';
 import PlanUpgradeSection from '../plan-upgrade';
 import PlansFilterBar from '../plans-filter-bar';
@@ -106,7 +107,7 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	const showProductCategories = ! isDesktop;
 
 	const showAnnualPlansOnly = config.isEnabled( 'jetpack/pricing-page-annual-only' );
-	const showBoostAndSocial = config.isEnabled( 'jetpack/pricing-add-boost-social' );
+	const showBoostAndSocialFree = config.isEnabled( 'jetpack/pricing-add-boost-social' );
 
 	const [ category, setCategory ] = useState< JetpackProductCategory >();
 	const onCategoryChange = useCallback( setCategory, [ setCategory ] );
@@ -285,14 +286,9 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 								<li>
 									<JetpackCrmFreeCard siteId={ siteId } duration={ duration } />
 								</li>
-								{ showBoostAndSocial && (
+								{ showBoostAndSocialFree && (
 									<li>
-										{ /* Add Jetpack Social Free card here. */ }
-										JETPACK SOCIAL
-										<br />
-										FREE CARD
-										<br />
-										HERE
+										<JetpackSocialFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
 									</li>
 								) }
 							</>

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -283,14 +283,14 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 						{ filteredItems.map( getOtherItemsProductCard ) }
 						{ ( ! showProductCategories || category === JETPACK_GROWTH_CATEGORY ) && (
 							<>
-								<li>
-									<JetpackCrmFreeCard siteId={ siteId } duration={ duration } />
-								</li>
 								{ showBoostAndSocialFree && (
 									<li>
 										<JetpackSocialFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
 									</li>
 								) }
+								<li>
+									<JetpackCrmFreeCard siteId={ siteId } duration={ duration } />
+								</li>
 							</>
 						) }
 						{ showFreeCard && (

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -4,6 +4,8 @@ import {
 	PLAN_JETPACK_SECURITY_T1_MONTHLY,
 	PLAN_JETPACK_SECURITY_T2_YEARLY,
 	PLAN_JETPACK_SECURITY_T2_MONTHLY,
+	JETPACK_BOOST_PRODUCTS,
+	JETPACK_PERFORMANCE_CATEGORY,
 	JETPACK_SECURITY_CATEGORY,
 	JETPACK_GROWTH_CATEGORY,
 } from '@automattic/calypso-products';
@@ -19,6 +21,7 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selector
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import CategoryFilter from '../category-filter';
+import JetpackBoostFreeCard from '../jetpack-boost-free-card';
 import JetpackCrmFreeCard from '../jetpack-crm-free-card';
 import JetpackFreeCard from '../jetpack-free-card';
 import JetpackSocialFreeCard from '../jetpack-social-free-card';
@@ -139,6 +142,9 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	const { shouldWrap: shouldWrapGrid, gridRef } = useWrapGridForSmallScreens( 3 );
 	const { availableProducts, purchasedProducts, includedInPlanProducts } =
 		useGetPlansGridProducts( siteId );
+	const siteHasBoostPremium = purchasedProducts.some( ( product ) =>
+		( JETPACK_BOOST_PRODUCTS as ReadonlyArray< string > ).includes( product.productSlug )
+	);
 	const [ popularItems, otherItems ] = useMemo( () => {
 		const allItems = sortByGridPosition( [
 			...getProductsToDisplay( {
@@ -281,6 +287,13 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 					) }
 					<ul className="product-grid__product-grid">
 						{ filteredItems.map( getOtherItemsProductCard ) }
+						{ ( ! showProductCategories || category === JETPACK_PERFORMANCE_CATEGORY ) &&
+							showBoostAndSocialFree &&
+							! siteHasBoostPremium && (
+								<li>
+									<JetpackBoostFreeCard siteId={ siteId } />
+								</li>
+							) }
 						{ ( ! showProductCategories || category === JETPACK_GROWTH_CATEGORY ) && (
 							<>
 								{ showBoostAndSocialFree && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the Jetpack Social Free product card into the pricing page grid.

Project Thread: p1HpG7-g29-p2
Asana task: 1202316834912830-as-1202316834912849/f

#### Testing instructions

1. Checkout this PR and spin up Calypso blue and Calypso green concurrently (`yarn start`) and also (`yarn start-jetpack-cloud-p`).
2. If #63969 is not merged yet, you'll need to open up file `client/my-sites/plans/jetpack-plans/product-grid/index.tsx` in your editor and manually set `line 110`, `showBoostAndSocialFree` to equal `true`. Otherwise, skip this step.
3. Go to http://jetpack.cloud.localhost:3001/pricing and verify that the "Social" free product card is displaying right after the VideoPress card.
4. Verify the Social card _design_ and _copy_ match the Figma mockup: https://www.figma.com/file/lJK0hlU19QOhqub0uhlIWp/(WCEU)-Pricing-page-update?node-id=2381%3A8262
5. Verify the CTA points to: `/pricing/jetpack-social/welcome` (this route is not created yet).
6. In mobile view, verify the Social product is displayed when viewing the "Growth" filter.
7. Also check the Social card in Calypso blue at http://calypso.localhost:3000/plans/:site and http://calypso.localhost:3000/jetpack/connect/store. Verify the CTA points to the WordPress plugin repository (https://wordpress.org/plugins/jetpack-social/) although the repository page is not created yet.

**Additional note:** I think we'll need to integrate the product/plugin state into the card. ie.- like show/hide the card (or show as owned) based on if the plugin is installed/active on the site. I'll address this in an upcoming PR.

#### Screenshots:

**Calypso Green:**

![Markup 2022-05-24 at 18 55 59](https://user-images.githubusercontent.com/11078128/170145144-66aa5666-f58a-46d1-bdad-ce2db23a662e.png)


![Markup 2022-05-24 at 18 58 36](https://user-images.githubusercontent.com/11078128/170145382-853823c8-889c-4b79-9365-019ba4f1959a.png)

.
**Calypso Blue:**

![Markup 2022-05-24 at 19 04 24](https://user-images.githubusercontent.com/11078128/170146160-d2cbc5a5-ba13-410d-9540-39cea3a90345.png)


![Markup 2022-05-24 at 19 06 31](https://user-images.githubusercontent.com/11078128/170146185-67c9890e-c567-42e2-807d-824a42ac4d2a.png)