### PR TITLE
Stepper: Add hook to check for user capabilities for the site

### DIFF
--- a/client/landing/stepper/hooks/use-user-can-manage-options.ts
+++ b/client/landing/stepper/hooks/use-user-can-manage-options.ts
@@ -1,0 +1,20 @@
+import { useSelect } from '@wordpress/data';
+import { useSelector } from 'react-redux';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import isRequestingSites from 'calypso/state/sites/selectors/is-requesting-sites';
+import { SITE_STORE } from '../stores';
+import { useSiteSlugParam } from './use-site-slug-param';
+
+export function useCanUserManageOptions() {
+	const siteSlug = useSiteSlugParam();
+	const siteId = useSelect(
+		( select ) => siteSlug && select( SITE_STORE ).getSiteIdBySlug( siteSlug )
+	);
+	const isRequesting = useSelector( ( state ) => isRequestingSites( state ) );
+
+	const hasManageOptionsCap = useSelector( ( state ) =>
+		canCurrentUser( state, siteId as number, 'manage_options' )
+	);
+
+	return isRequesting ? 'requesting' : hasManageOptionsCap ?? false;
+}


### PR DESCRIPTION
Adds a hook to check for `manage_options` capability for current user.

#### Testing
1. Apply this PR. 
2. Go to `client/landing/stepper/declarative-flow/site-setup-flow.ts`.
3. Add this code to the bottom of the `useAssertConditions`:
```js
const canManageOptions = useCanUserManageOptions();
if ( ! canManageOptions ) {
	redirect( '/start' );
	throw new Error(
		'site-setup the user needs to have the manage_options capability to go through the flow.'
	);
}
```
4. Go to any step in the `setup` flow with a site you own.
6. Verify you see the step correctly.
7. Go to any step in the `setup` flow with a site you don't own.
8. Verify that you get redirected to `/start`.

Related to https://github.com/Automattic/wp-calypso/issues/63687
