### PR TITLE
Checkout: Make coupon failure message more generic

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/coupon.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/coupon.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/composite-checkout';
 import { Field, styled, joinClasses } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
-import i18n, { useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
 import type { CouponStatus } from '@automattic/shopping-cart';
@@ -126,10 +126,15 @@ function getCouponErrorMessageFromStatus(
 	isFreshOrEdited: boolean
 ): string | undefined {
 	if ( status === 'rejected' && ! isFreshOrEdited ) {
-		return String(
+		if (
+			getLocaleSlug() === 'en' ||
+			getLocaleSlug() === 'en-gb' ||
 			i18n.hasTranslation( 'There was a problem applying this coupon.' )
-				? translate( 'There was a problem applying this coupon.' )
-				: translate( "We couldn't find your coupon. Please check your coupon code and try again." )
+		) {
+			return translate( 'There was a problem applying this coupon.', { textOnly: true } );
+		}
+		return String(
+			translate( "We couldn't find your coupon. Please check your coupon code and try again." )
 		);
 	}
 	return undefined;

--- a/client/my-sites/checkout/composite-checkout/components/coupon.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/coupon.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/composite-checkout';
 import { Field, styled, joinClasses } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
 import type { CouponStatus } from '@automattic/shopping-cart';
@@ -127,7 +127,9 @@ function getCouponErrorMessageFromStatus(
 ): string | undefined {
 	if ( status === 'rejected' && ! isFreshOrEdited ) {
 		return String(
-			translate( "We couldn't find your coupon. Please check your coupon code and try again." )
+			i18n.hasTranslation( 'There was a problem applying this coupon.' )
+				? translate( 'There was a problem applying this coupon.' )
+				: translate( "We couldn't find your coupon. Please check your coupon code and try again." )
 		);
 	}
 	return undefined;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When we try to apply a coupon to the cart and it fails, the shopping cart returns an error message that explains why. Often this is because the coupon code cannot be found, but there are other possible reasons. The message is displayed as a global notice over checkout. At the same time, the coupon field displays its own error message just below the field. This message is always the same and reads `We couldn't find your coupon. Please check your coupon code and try again.`. This can be misleading if the actual cause of the coupon failure is something else.

In this PR we change the text displayed by the field to be more generic: `There was a problem applying this coupon.` The specific message will still be displayed by the global notice.

Before:

<img width="647" alt="Screen Shot 2022-05-24 at 3 16 32 PM" src="https://user-images.githubusercontent.com/2036909/170116194-3eae48ba-4530-4c84-81f9-ff437b6ed553.png">

After:

<img width="647" alt="Screen Shot 2022-05-24 at 3 24 52 PM" src="https://user-images.githubusercontent.com/2036909/170116212-46c2f0f6-d65f-4609-925d-658e07f58926.png">


#### Testing instructions

Add an invalid coupon to a cart and verify that it displays the updated message underneath the field.