### PR TITLE
social-previews: Add missing dep on `@emotion/react`

### DIFF
--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.4 (2022-05-25)
+
+- Add missing dependency on `@emotion/react`.
+
 ## v1.1.3 (2022-05-16)
 
 - Remove unnecessary peer dependencies on `@wordpress/data`, `reakit-utils`, and `redux`.

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
@@ -37,6 +37,7 @@
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"dependencies": {
+		"@emotion/react": "^11.4.1",
 		"@wordpress/components": "^19.9.0",
 		"@wordpress/i18n": "^4.7.0",
 		"classnames": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,6 +1251,7 @@ __metadata:
   resolution: "@automattic/social-previews@workspace:packages/social-previews"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@emotion/react": ^11.4.1
     "@wordpress/components": ^19.9.0
     "@wordpress/i18n": ^4.7.0
     classnames: ^2.3.1


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There's no direct reference to `@emotion/react` in the source of the
package, but calypso-babel-config sets up `@babel/preset-react` to use
that rather than normal React so the built code winds up depending on
it.

Following the lead of `@wordpress/components`, this is added as a
dependency rather than a peer dep.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try making use of the package with Yarn's p'n'p or pnpm.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->