### PR TITLE
Add basic commit status and notifications to Calypso docker build

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -236,6 +236,31 @@ object BuildDockerImage : BuildType({
 				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
 			}
 		}
+
+		commitStatusPublisher {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			publisher = github {
+				githubUrl = "https://api.github.com"
+				authType = personalToken {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+			}
+		}
+		notifications {
+			notifierSettings = slackNotifier {
+				connection = "PROJECT_EXT_11"
+				sendTo = "#team-calypso-bot"
+				messageFormat = simpleMessageFormat()
+			}
+			branchFilter = """
+				+:trunk
+			""".trimIndent()
+			buildFailedToStart = true
+			buildFailed = true
+			buildFinishedSuccessfully = true
+			firstSuccessAfterFailure = true
+			buildProbablyHanging = true
+		}
 	}
 })
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
On Monday, the main Calypso build/deploy pipeline broke when Sentry had an outage. This was resolved by #63930, but the odd thing is that there was no indication on trunk that the build failed, making it more difficult to troubleshoot:

![image](https://user-images.githubusercontent.com/6265975/170137879-75fe547d-acaa-4eb1-9596-7d47236b2455.png)

The only indication something went wrong was a link to a webhook that got added somewhere in GitHub. This PR will add two things:
1. The commit status check for the "build docker image" portion of the pipeline.
2. A notification to calypso bots when this build fails on trunk. (Any time this build fails on trunk, the deployment process can't be completed so it needs to be resolved ASAP)

Why wasn't this the case already? Firstly, the docker image is not have any of its own triggers. It is instead triggered by other builds. For example, it is triggered on a PR when e2e tests get triggered which indicate they need a build of Calypso. It's triggered on trunk (I believe) by a webhook from MC so that it's tied in with the internal deploy system. As a result, in PRs, we rely on those _subsequent_ builds failing to indicate a problem with the build. So when all the e2e tests fail on a PR and you click in, it will say the dependency on the docker build failed, which means we've had a way to troubleshoot it very easily. But the docker build never published its _own_ status to the PR. On trunk, where those e2e suites are not run, there is no indication that any builds failed. So adding the status publisher for this specific build should solve that problem.

### Testing instructions
- Verify my changes match other builds which use these two features. 
- Verify a status check shows up on this PR for "build docker image". Edit: this doesn't seem to show up, which probably means we need to merge to test it


Edit: after merging, we can see the commit status appearing here:
![image](https://user-images.githubusercontent.com/6265975/170139922-806262f0-1063-4e5f-b87c-5ddec48af7fd.png)

