### PR TITLE
Performance Settings: Use feature checks

### DIFF
--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -1,18 +1,11 @@
 import {
-	isJetpackVideoPress,
-	planHasFeature,
-	FEATURE_VIDEO_UPLOADS,
-	FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
-	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
-	PLAN_JETPACK_SECURITY_DAILY,
-	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 	PRODUCT_JETPACK_VIDEOPRESS,
 	WPCOM_FEATURES_VIDEOPRESS,
+	WPCOM_FEATURES_VIDEOPRESS_UNLIMITED_STORAGE,
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import filesize from 'filesize';
 import { localize } from 'i18n-calypso';
-import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -23,11 +16,9 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import SupportInfo from 'calypso/components/support-info';
 import withMediaStorage from 'calypso/data/media-storage/with-media-storage';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSitePlanSlug, getSiteSlug } from 'calypso/state/sites/selectors';
 
 class MediaSettingsPerformance extends Component {
 	static propTypes = {
@@ -41,7 +32,7 @@ class MediaSettingsPerformance extends Component {
 
 		// Connected props
 		isVideoPressActive: PropTypes.bool,
-		isVideoPressAvailable: PropTypes.bool,
+		hasVideoPress: PropTypes.bool,
 		mediaStorageLimit: PropTypes.number,
 		mediaStorageUsed: PropTypes.number,
 		sitePlanSlug: PropTypes.string,
@@ -49,43 +40,34 @@ class MediaSettingsPerformance extends Component {
 	};
 
 	renderVideoSettings() {
-		const {
-			isRequestingSettings,
-			isSavingSettings,
-			isVideoPressAvailable,
-			siteIsAtomic,
-			siteId,
-			translate,
-		} = this.props;
+		const { isRequestingSettings, isSavingSettings, siteIsAtomic, siteId, translate } = this.props;
 		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
 
 		return (
-			isVideoPressAvailable && (
-				<FormFieldset className="site-settings__formfieldset jetpack-video-hosting-settings">
-					<SupportInfo
-						text={ translate( 'Hosts your video files on the global WordPress.com servers.' ) }
-						link={
-							siteIsAtomic
-								? 'https://wordpress.com/support/videopress/'
-								: 'https://jetpack.com/support/videopress/'
-						}
-						privacyLink={ ! siteIsAtomic }
-					/>
-					<JetpackModuleToggle
-						siteId={ siteId }
-						moduleSlug="videopress"
-						label={ translate( 'Enable fast, ad-free video hosting' ) }
-						disabled={ isRequestingOrSaving }
-					/>
-					{ this.props.isVideoPressActive && this.renderVideoStorageIndicator() }
-				</FormFieldset>
-			)
+			<FormFieldset className="site-settings__formfieldset jetpack-video-hosting-settings">
+				<SupportInfo
+					text={ translate( 'Hosts your video files on the global WordPress.com servers.' ) }
+					link={
+						siteIsAtomic
+							? 'https://wordpress.com/support/videopress/'
+							: 'https://jetpack.com/support/videopress/'
+					}
+					privacyLink={ ! siteIsAtomic }
+				/>
+				<JetpackModuleToggle
+					siteId={ siteId }
+					moduleSlug="videopress"
+					label={ translate( 'Enable fast, ad-free video hosting' ) }
+					disabled={ isRequestingOrSaving }
+				/>
+				{ this.props.isVideoPressActive && this.renderVideoStorageIndicator() }
+			</FormFieldset>
 		);
 	}
 
 	renderVideoStorageIndicator() {
 		const {
-			isVideoPressFreeTier,
+			hasVideoPress,
 			mediaStorageLimit,
 			mediaStorageUsed,
 			sitePlanSlug,
@@ -100,7 +82,7 @@ class MediaSettingsPerformance extends Component {
 
 		const renderedStorageInfo =
 			isStorageDataValid &&
-			! isVideoPressFreeTier &&
+			hasVideoPress &&
 			( isStorageUnlimited ? (
 				<FormSettingExplanation className="site-settings__videopress-storage-used">
 					{ translate( '%(size)s uploaded, unlimited storage available', {
@@ -124,7 +106,7 @@ class MediaSettingsPerformance extends Component {
 	}
 
 	renderVideoUpgradeNudge() {
-		const { isVideoPressFreeTier, mediaStorageUsed, siteSlug, translate } = this.props;
+		const { hasVideoPress, mediaStorageUsed, siteSlug, translate } = this.props;
 
 		const upsellMessage =
 			0 === mediaStorageUsed
@@ -135,7 +117,7 @@ class MediaSettingsPerformance extends Component {
 						'You have used your free video. Upgrade now to unlock more videos and 1TB of storage.'
 				  );
 		return (
-			isVideoPressFreeTier && (
+			! hasVideoPress && (
 				<UpsellNudge
 					title={ upsellMessage }
 					event={ 'jetpack_video_settings' }
@@ -148,66 +130,26 @@ class MediaSettingsPerformance extends Component {
 	}
 
 	render() {
-		const { isVideoPressAvailable, sitePlanSlug } = this.props;
-
-		if ( ! sitePlanSlug ) {
-			return null;
-		}
-
 		return (
 			<div className="site-settings__module-settings site-settings__media-settings">
-				{ isVideoPressAvailable && <Card>{ this.renderVideoSettings() }</Card> }
+				<Card>{ this.renderVideoSettings() }</Card>
 				{ this.renderVideoUpgradeNudge() }
 			</div>
 		);
 	}
 }
-const checkForJetpackVideoPressProduct = ( purchase ) =>
-	purchase.active && isJetpackVideoPress( purchase );
-
-/**
- * Security Daily plan no longer includes VideoPress as of end of day Oct 6 2021 UTC.
- * This check enforces the upsell appears only for customers that purchased Security Daily after that date.
- *
- * @param {*} purchase
- * @returns bool
- */
-const checkForLegacySecurityDailyPlan = ( purchase ) =>
-	purchase.active &&
-	( PLAN_JETPACK_SECURITY_DAILY_MONTHLY === purchase.productSlug ||
-		PLAN_JETPACK_SECURITY_DAILY === purchase.productSlug ) &&
-	moment( purchase.subscribedDate ).isBefore( moment.utc( '2021-10-07' ) );
-
-const checkForActiveJetpackVideoPressPurchases = ( purchase ) =>
-	checkForJetpackVideoPressProduct( purchase ) || checkForLegacySecurityDailyPlan( purchase );
 
 export default withMediaStorage(
-	connect( ( state, { mediaStorage } ) => {
-		const selectedSiteId = getSelectedSiteId( state );
-		const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
-		const isVideoPressAvailable =
-			isJetpackSite( state, selectedSiteId ) ||
-			planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS ) ||
-			planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM ) ||
-			planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PRO );
-
+	connect( ( state, { mediaStorage, siteId } ) => {
 		return {
-			isVideoPressActive: isJetpackModuleActive( state, selectedSiteId, 'videopress' ),
-			isVideoPressAvailable,
-			isVideoPressFreeTier:
-				isJetpackSite( state, selectedSiteId ) &&
-				! isSiteAutomatedTransfer( state, selectedSiteId ) &&
-				! getSitePurchases( state, selectedSiteId ).find(
-					checkForActiveJetpackVideoPressPurchases
-				) &&
-				// These features are used in current plans that include VP
-				! planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS ) &&
-				! planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM ) &&
-				! planHasFeature( sitePlanSlug, FEATURE_VIDEO_UPLOADS_JETPACK_PRO ),
+			isVideoPressActive: isJetpackModuleActive( state, siteId, 'videopress' ),
+			hasVideoPress:
+				siteHasFeature( state, siteId, WPCOM_FEATURES_VIDEOPRESS ) ||
+				siteHasFeature( state, siteId, WPCOM_FEATURES_VIDEOPRESS_UNLIMITED_STORAGE ),
 			mediaStorageLimit: mediaStorage?.max_storage_bytes ?? null,
 			mediaStorageUsed: mediaStorage?.storage_used_bytes ?? null,
-			sitePlanSlug,
-			siteSlug: getSiteSlug( state, selectedSiteId ),
+			sitePlanSlug: getSitePlanSlug( state, siteId ),
+			siteSlug: getSiteSlug( state, siteId ),
 		};
 	} )( localize( MediaSettingsPerformance ) )
 );

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -232,4 +232,5 @@ export const WPCOM_FEATURES_UPLOAD_AUDIO_FILES = 'upload-audio-files';
 export const WPCOM_FEATURES_UPLOAD_VIDEO_FILES = 'upload-video-files';
 export const WPCOM_FEATURES_VAULTPRESS_BACKUPS = 'vaultpress-backups';
 export const WPCOM_FEATURES_VIDEOPRESS = 'videopress';
+export const WPCOM_FEATURES_VIDEOPRESS_UNLIMITED_STORAGE = 'videopress-unlimited-storage';
 export const WPCOM_FEATURES_WORDADS = 'wordads';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes `isVideoPressAvailable` prop since it's always true (this component only gets loaded for Jetpack sites, incl. WoA)
* Checks support for unlimited videopress storage to capture sites on legacy Security Daily plans.
* Uses `siteId` prop passed to the component to avoid a `selectedSiteId` lookup.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /settings/performance with a Jetpack or WoA site.
* If it's a Jetpack site on a free plan, make sure it shows the upgrade banner: <img width="1510" alt="image" src="https://user-images.githubusercontent.com/1398304/170138513-5d58279c-e65f-432f-ba10-bf254d740316.png">
* Jetpack Sites with a VideoPress plan should show the space upload bar with 1 TB:<img width="1510" alt="image" src="https://user-images.githubusercontent.com/1398304/170138754-07dfd08b-0ac2-40e1-b658-859ef75c0c3e.png">
* A WoA site should show the space upload bar with 200 GB: <img width="1510" alt="image" src="https://user-images.githubusercontent.com/1398304/170138670-77bd6c8e-bab8-40f4-8157-4110394b2a16.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-a66-p2