### PR TITLE
Ignore browser extension errors in Sentry

### DIFF
--- a/client/lib/sentry/index.ts
+++ b/client/lib/sentry/index.ts
@@ -11,6 +11,11 @@ const SENTRY_CONFIG: SentryApi.BrowserOptions = {
 	dsn: 'https://61275d63a504465ab315245f1a379dab@o248881.ingest.sentry.io/6313676',
 	// Determine the sample of errors collected where 1.0 is 100% of errors.
 	sampleRate: 1.0, // We're disabling it for 90% of requests, so we should track 100% of errors for the remaining 10% of requests.
+	// Don't track errors on these URLs.
+	denyUrls: [
+		// Matches browser extension URLs, like "moz-extension://..." or "safari-web-extension://..."
+		/^[a-z]+(-[a-z]+)?-extension:\/\//i,
+	],
 };
 
 type SupportedMethods =


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Errors from browser extensions can show up in sentry, like this: https://sentry.io/share/issue/a1d93dce5e184f478e912d1ca6a2c652/

This should ignore any event coming from a browser extension. From what I can tell, this regex should match everything that got added to Sentry already, though we'll have to delete them after this is live.

