### PR TITLE
Fix tour-kit storybook `__i18n_text_domain__ is not defined` error

### DIFF
--- a/packages/tour-kit/.storybook/preview.js
+++ b/packages/tour-kit/.storybook/preview.js
@@ -1,3 +1,5 @@
 import '@automattic/calypso-color-schemes';
 import '@wordpress/components/build-style/style.css';
 import './styles.scss';
+
+window.__i18n_text_domain__ = 'default';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Declare `__i18n_text_domain__` in tour-kit `preview.js`  (The same approach that [Search component](https://github.com/Automattic/wp-calypso/blob/trunk/packages/search/.storybook/preview.js#L4) used)

before
![Screen Shot 2022-05-25 at 09 53 11](https://user-images.githubusercontent.com/4344253/170164333-27c3160a-332b-4d2c-ac5c-30733604ae1e.png)



after
![Screen Shot 2022-05-25 at 10 08 26](https://user-images.githubusercontent.com/4344253/170164340-418979dd-7385-4184-8bf9-c7bdeba36891.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start Storybook `yarn workspace @automattic/tour-kit run storybook`
* Go to `wpcom-tour-kit` stories
* Click `Start Tour` button
* Observe that Tour starts
 




<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


Related to https://github.com/Automattic/wp-calypso/issues/63991