### PR TITLE
Checkout: Respect redirect_to query value for Jetpack product purchases

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -184,6 +184,7 @@ export default function getThankYouPageUrl( {
 		isJetpackNotAtomic: Boolean( isJetpackNotAtomic ),
 		productAliasFromUrl,
 		adminPageRedirect,
+		redirectTo,
 	} );
 	debug( 'fallbackUrl is', fallbackUrl );
 
@@ -305,6 +306,7 @@ function getFallbackDestination( {
 	isJetpackNotAtomic,
 	productAliasFromUrl,
 	adminPageRedirect,
+	redirectTo,
 }: {
 	pendingOrReceiptId: string;
 	siteSlug: string | undefined;
@@ -314,6 +316,7 @@ function getFallbackDestination( {
 	isJetpackNotAtomic: boolean;
 	productAliasFromUrl: string | undefined;
 	adminPageRedirect?: string;
+	redirectTo?: string;
 } ): string {
 	const isCartEmpty = cart ? getAllCartItems( cart ).length === 0 : true;
 	const isReceiptEmpty = ':receiptId' === pendingOrReceiptId;
@@ -346,7 +349,8 @@ function getFallbackDestination( {
 		if ( isJetpackNotAtomic && purchasedProduct ) {
 			debug( 'the site is jetpack and bought a jetpack product', siteSlug, purchasedProduct );
 
-			const adminPath = adminPageRedirect || 'admin.php?page=jetpack#/recommendations';
+			const adminPath =
+				redirectTo || adminPageRedirect || 'admin.php?page=jetpack#/recommendations';
 
 			// Jetpack Cloud will either redirect to wp-admin (if JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN
 			// flag is set), or otherwise will redirect to a Jetpack Redirect API url (source=jetpack-checkout-thankyou)

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -266,6 +266,23 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( `https://my.site/wp-admin/admin.php?page=jetpack-backup` );
 	} );
 
+	it( 'redirects to the sites wp-admin if checkout is on Jetpack Cloud and if redirectCheckoutToWpAdmin() flag is true and there is a non-atomic jetpack product and redirectTo is defined', () => {
+		isJetpackCloud.mockImplementation( () => true );
+		redirectCheckoutToWpAdmin.mockImplementation( () => true );
+		const adminUrl = 'https://my.site/wp-admin/';
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			isJetpackNotAtomic: true,
+			cart: {
+				products: [ { product_slug: 'jetpack_complete' } ],
+			},
+			adminUrl,
+			redirectTo: 'admin.php?page=some-page',
+		} );
+		expect( url ).toBe( `https://my.site/wp-admin/admin.php?page=some-page` );
+	} );
+
 	it( 'redirects to the plans page with thank-you query string if there is a non-atomic jetpack product', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For Jetpack product purchases, use `redirect_to` query value before considering `adminPageRedirect` value or falling back to `admin.php?page=jetpack#/recommendations`

#### Testing instructions

* Use Jurassic Ninja to spin up a site **without** the Jetpack plugin but **with** the Jetpack Beta plugin. Be sure to specify the `try/get-plan-before-connection` branch for the Jetpack Search plugin.
* Navigate to `/wp-admin/admin.php?page=jetpack-search` and click "Get Jetpack Search".
* Ensure you're redirected to `https://wordpress.com/jetpack/connect/authorize?[...]`. Replace the host with your test environment host (e.g. `http://calypso.localhost:3000`).
* Authorize the site connection and ensure you're redirected to the checkout flow. Replace the host here again. Note the `redirect_to` query value.
* Complete the purchase for a Jetpack Search subscription.
* Ensure that you're redirected to `/wp-admin/admin.php?page=jetpack-search` on your Jurassic Ninja site. 
It **should not redirect you to `wp-admin/admin.php?page=jetpack#/recommendations`**.
