### PR TITLE
Generated design picker: Re-fit iframe height on resize

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -106,6 +106,7 @@ export default class WebPreviewContent extends Component {
 				this.setState( { isLoadingSubpage: true } );
 				return;
 			case 'page-dimensions-on-load':
+			case 'page-dimensions-on-resize':
 				if ( this.props.autoHeight ) {
 					this.setState( { viewport: data.payload } );
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR readjusts the iframe (used for large design previews) height when resized. This is achieved by handling the message `page-dimensions-on-resize` which is sent from the embedded page, and contains the page dimensions as payload.

This PR depends on D81458-code.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the generated design picker.
* In desktop view, resize the browser window so that the iframe would be resized as well.
* Expect the iframe height to readjust according to its embedded page's height.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
