### PR TITLE
Update tour-kit build script to copy assets to ./dist

### DIFF
--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -24,7 +24,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch",
 		"storybook": "start-storybook"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Append `&& run -T  copy-assets` to `build` script.

> If it contains [assets](https://github.com/Automattic/wp-calypso/blob/d709f0e79ba29f2feb35690d275087179b18f632/packages/calypso-build/bin/copy-assets.js#L17-L25) (eg .scss) then after transpile append && copy-assets ie "build": "transpile && copy-assets". - https://github.com/Automattic/wp-calypso/blob/trunk/docs/monorepo.md

- using `run -T` to resolve `copy-assets` properly.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn workspace @automattic/tour-kit clean`
* Run `yarn workspace @automattic/tour-kit build`
* Run `ls packages/tour-kit/dist/esm`
* Observe that the `styles.scss` exists in the dist folder.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

