### PR TITLE
Fix unlinked checkout flow - sites state is not current on a particular occasion

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -462,13 +462,10 @@ export function siteSelection( context, next ) {
 		return next();
 	}
 
-	// For unlinked checkout flow, we should always request fresh site information.
-	// Because sites might not be current.
-	const isUnlinkedCheckoutFlow =
-		'1' === context?.query?.unlinked && context?.path?.startsWith( '/checkout/' );
-
 	Promise.resolve( () => {
-		if ( ! isUnlinkedCheckoutFlow ) {
+		// For unlinked checkout flow, we should always request fresh site information.
+		// Because sites might not be current.
+		if ( '1' !== context?.query?.unlinked || ! context?.path?.startsWith( '/checkout/' ) ) {
 			return;
 		}
 		return dispatch( requestSites() );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -464,11 +464,11 @@ export function siteSelection( context, next ) {
 
 	// For unlinked checkout flow, we should always request fresh site information.
 	// Because sites might not be current.
-	const isUnlinkedFlow =
+	const isUnlinkedCheckoutFlow =
 		'1' === context?.query?.unlinked && context?.path?.startsWith( '/checkout/' );
 
 	Promise.resolve( () => {
-		if ( ! isUnlinkedFlow ) {
+		if ( ! isUnlinkedCheckoutFlow ) {
 			return;
 		}
 		return dispatch( requestSites() );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -463,7 +463,10 @@ export function siteSelection( context, next ) {
 	}
 
 	const siteId = getSiteId( getState(), siteFragment );
-	if ( siteId ) {
+	// For unlinked checkout flow, we should always request fresh site information.
+	const isUnlinkedFlow =
+		'1' === context?.query?.unlinked && context?.path?.startsWith( '/checkout/' );
+	if ( siteId && ! isUnlinkedFlow ) {
 		// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
 		// to wp-admin. In that case, don't continue handling the route.
 		dispatch( setSelectedSiteId( siteId ) );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -4,7 +4,6 @@ import i18n from 'i18n-calypso';
 import { some, startsWith } from 'lodash';
 import page from 'page';
 import { createElement } from 'react';
-import { requestAll } from 'calypso/client/components/data/query-sites';
 import EmptyContentComponent from 'calypso/components/empty-content';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import { makeLayout, render as clientRender, setSectionMiddleware } from 'calypso/controller';
@@ -60,7 +59,7 @@ import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import { requestSite } from 'calypso/state/sites/actions';
+import { requestSites, requestSite } from 'calypso/state/sites/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSite, getSiteId, getSiteSlug } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
@@ -468,7 +467,12 @@ export function siteSelection( context, next ) {
 	const isUnlinkedFlow =
 		'1' === context?.query?.unlinked && context?.path?.startsWith( '/checkout/' );
 
-	Promise.resolve( () => isUnlinkedFlow && dispatch( requestAll() ) )
+	Promise.resolve( () => {
+		if ( ! isUnlinkedFlow ) {
+			return;
+		}
+		return dispatch( requestSites() );
+	} )
 		.catch( () => null )
 		.then( () => {
 			const siteId = getSiteId( getState(), siteFragment );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When site is connected, Calypso is opened by user, and site disconnected in the meanwhile, the unlinked checkout would fail because the disconnected site is still considered user's site at the time.

The PR refreshes sites data for unlinked checkout flow.

#### Testing instructions

- Start Calypso locally `yarn start`
- Use your local site to test (with only Search plugin, disconnected)
- Change your local Jetpack

https://github.com/Automattic/jetpack/blob/39a6867e127d171baec568b66c7887ba04fc7761/projects/js-packages/components/tools/get-product-checkout-url/index.jsx#L16

Replace `https://wordpress.com` with `http://calypso.localhost:3000`, and build
- Connect the site using My Jetpack
- Open a local Calypso page (any page), and keeps it open
- Disconnect site from `/wp-admin/admin.php?page=my-jetpack`
- Open a new page of Search dashboard
- Click `Get Jetpack Search`
- Ensure you could purchase Jetpack Search product with/without errors

Note: 

1. Test with the steps to see the error on `trunk`
2. Test with the steps to see the  error gone on current branch

![image](https://user-images.githubusercontent.com/1425433/170381275-a0da0a59-b49d-46fc-967b-f9fe81320fd7.png)
