### PR TITLE
Create routes for Boost & Social landing pages

### DIFF
--- a/client/components/jetpack/jetpack-boost-welcome/index.tsx
+++ b/client/components/jetpack/jetpack-boost-welcome/index.tsx
@@ -1,0 +1,34 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+const JetpackBoostWelcome: React.FC = () => {
+	const translate = useTranslate();
+
+	return (
+		<Main wideLayout className="jetpack-boost-welcome">
+			<PageViewTracker
+				path="/pricing/jetpack-boost/welcome"
+				title="Pricing > Jetpack Boost > Welcome to Jetpack Boost"
+			/>
+			<Card className="jetpack-boost-welcome__card">
+				<div className="jetpack-boost-welcome__card-main">
+					<JetpackLogo size={ 45 } />
+					<h1 className="jetpack-boost-welcome__main-message">
+						{ translate( 'Welcome{{br/}} to Jetpack Boost!', {
+							components: {
+								br: <br />,
+							},
+						} ) }
+						&nbsp;
+						{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
+					</h1>
+				</div>
+			</Card>
+		</Main>
+	);
+};
+
+export default JetpackBoostWelcome;

--- a/client/components/jetpack/jetpack-social-welcome/index.tsx
+++ b/client/components/jetpack/jetpack-social-welcome/index.tsx
@@ -1,0 +1,34 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+const JetpackSocialWelcome: React.FC = () => {
+	const translate = useTranslate();
+
+	return (
+		<Main wideLayout className="jetpack-social-welcome">
+			<PageViewTracker
+				path="/pricing/jetpack-social/welcome"
+				title="Pricing > Jetpack Boost > Welcome to Jetpack Boost"
+			/>
+			<Card className="jetpack-social-welcome__card">
+				<div className="jetpack-social-welcome__card-main">
+					<JetpackLogo size={ 45 } />
+					<h1 className="jetpack-social-welcome__main-message">
+						{ translate( 'Welcome{{br/}} to Jetpack Social!', {
+							components: {
+								br: <br />,
+							},
+						} ) }
+						&nbsp;
+						{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
+					</h1>
+				</div>
+			</Card>
+		</Main>
+	);
+};
+
+export default JetpackSocialWelcome;

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -1,5 +1,7 @@
 import { TERM_MONTHLY, TERM_ANNUALLY } from '@automattic/calypso-products';
+import JetpackBoostWelcomePage from 'calypso/components/jetpack/jetpack-boost-welcome';
 import JetpackFreeWelcomePage from 'calypso/components/jetpack/jetpack-free-welcome';
+import JetpackSocialWelcomePage from 'calypso/components/jetpack/jetpack-social-welcome';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -85,6 +87,16 @@ export const productSelect =
 
 export function jetpackFreeWelcome( context: PageJS.Context, next: () => void ): void {
 	context.primary = <JetpackFreeWelcomePage />;
+	next();
+}
+
+export function jetpackBoostWelcome( context: PageJS.Context, next: () => void ): void {
+	context.primary = <JetpackBoostWelcomePage />;
+	next();
+}
+
+export function jetpackSocialWelcome( context: PageJS.Context, next: () => void ): void {
+	context.primary = <JetpackSocialWelcomePage />;
 	next();
 }
 

--- a/client/my-sites/plans/jetpack-plans/index.ts
+++ b/client/my-sites/plans/jetpack-plans/index.ts
@@ -9,11 +9,11 @@ import {
 } from './controller';
 
 export default function ( rootUrl: string, ...rest: PageJS.Callback[] ): void {
-	const addBoostAndSocialRouts = config.isEnabled( 'jetpack/pricing-add-boost-social' );
+	const addBoostAndSocialRoutes = config.isEnabled( 'jetpack/pricing-add-boost-social' );
 
 	page( `${ rootUrl }/jetpack-free/welcome`, jetpackFreeWelcome, makeLayout, clientRender );
 
-	if ( addBoostAndSocialRouts ) {
+	if ( addBoostAndSocialRoutes ) {
 		page( `${ rootUrl }/jetpack-boost/welcome`, jetpackBoostWelcome, makeLayout, clientRender );
 		page( `${ rootUrl }/jetpack-social/welcome`, jetpackSocialWelcome, makeLayout, clientRender );
 	}

--- a/client/my-sites/plans/jetpack-plans/index.ts
+++ b/client/my-sites/plans/jetpack-plans/index.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
 import {
@@ -8,9 +9,14 @@ import {
 } from './controller';
 
 export default function ( rootUrl: string, ...rest: PageJS.Callback[] ): void {
+	const addBoostAndSocialRouts = config.isEnabled( 'jetpack/pricing-add-boost-social' );
+
 	page( `${ rootUrl }/jetpack-free/welcome`, jetpackFreeWelcome, makeLayout, clientRender );
-	page( `${ rootUrl }/jetpack-boost/welcome`, jetpackBoostWelcome, makeLayout, clientRender );
-	page( `${ rootUrl }/jetpack-social/welcome`, jetpackSocialWelcome, makeLayout, clientRender );
+
+	if ( addBoostAndSocialRouts ) {
+		page( `${ rootUrl }/jetpack-boost/welcome`, jetpackBoostWelcome, makeLayout, clientRender );
+		page( `${ rootUrl }/jetpack-social/welcome`, jetpackSocialWelcome, makeLayout, clientRender );
+	}
 
 	page(
 		`${ rootUrl }/:duration?/:site?`,

--- a/client/my-sites/plans/jetpack-plans/index.ts
+++ b/client/my-sites/plans/jetpack-plans/index.ts
@@ -1,9 +1,16 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
-import { jetpackFreeWelcome, productSelect } from './controller';
+import {
+	jetpackBoostWelcome,
+	jetpackFreeWelcome,
+	jetpackSocialWelcome,
+	productSelect,
+} from './controller';
 
 export default function ( rootUrl: string, ...rest: PageJS.Callback[] ): void {
 	page( `${ rootUrl }/jetpack-free/welcome`, jetpackFreeWelcome, makeLayout, clientRender );
+	page( `${ rootUrl }/jetpack-boost/welcome`, jetpackBoostWelcome, makeLayout, clientRender );
+	page( `${ rootUrl }/jetpack-social/welcome`, jetpackSocialWelcome, makeLayout, clientRender );
 
 	page(
 		`${ rootUrl }/:duration?/:site?`,


### PR DESCRIPTION
Completes 1202316834912830-as-1202316835174108/f

#### Changes proposed in this Pull Request

* Add routes for new Jetpack Boost and Jetpack Social landing pages

#### Testing instructions

This PR needs #63969 to be merged

* Checkout the PR and run `yarn start` and also `yarn start-jetpack-cloud-p`.
* Goto http://jetpack.cloud.localhost:3001/pricing/jetpack-boost/welcome and http://jetpack.cloud.localhost:3001/pricing/jetpack-social/welcome
* Confirm that the routes exist and they show a simple welcome text as in below screenshots


<img width="1464" alt="Screenshot 2022-05-25 at 12 16 43 PM" src="https://user-images.githubusercontent.com/18226415/170197905-523fa946-c88a-43ce-8241-bcc698369e07.png">

<img width="1464" alt="Screenshot 2022-05-25 at 12 16 53 PM" src="https://user-images.githubusercontent.com/18226415/170197889-b82640a5-e624-4e4d-83f3-32a8de2cf8ec.png">
