### PR TITLE
Fix typo to remove extra 'hours' in SSL Cert Pending notice

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
@@ -23,7 +23,7 @@ const DomainSecurityDetails = ( { domain }: DetailsCardProps ): JSX.Element | nu
 				return null;
 			case sslStatuses.SSL_PENDING:
 				return translate(
-					'It may take up to a few hours hours to add an SSL certificate to your site. If you are not seeing it yet, give it some time to take effect.',
+					'It may take up to a few hours to add an SSL certificate to your site. If you are not seeing it yet, give it some time to take effect.',
 					{ textOnly: true }
 				);
 			case sslStatuses.SSL_DISABLED:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove additional 'hours' text in text string about SSL certificates

Before

`It may take up to a few hours hours to add an SSL certificate to your site.`

After

`It may take up to a few hours to add an SSL certificate to your site.`

#### Testing

This would require adding a new domain, and viewing the Domains settings regarding SSL soon afterwards

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63467 63467
