### PR TITLE
Tests: Remove Contextual Results tests timeout

### DIFF
--- a/packages/help-center/test/contextual-help.tsx
+++ b/packages/help-center/test/contextual-help.tsx
@@ -15,8 +15,6 @@ jest.mock( '@automattic/calypso-config', () => ( {
 	},
 } ) );
 
-jest.setTimeout( 2000 );
-
 async function linkStatus( link: string ) {
 	const response = await fetch( link, { redirect: 'manual' } );
 	return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I added this timeout while writing the tests to reveal bugs quickly during development. I don't think it is useful in production. 
* It makes the tests flaky for no reason. Example [here](https://github.com/Automattic/wp-calypso/pull/63992). 

#### Testing instructions

Just wait for tests to pass ✅ 