### PR TITLE
Extract re-usable code for Jetpack landing pages

### DIFF
--- a/client/components/jetpack/jetpack-free-welcome/Step1.tsx
+++ b/client/components/jetpack/jetpack-free-welcome/Step1.tsx
@@ -1,0 +1,43 @@
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export const Step1 = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const jetpackInstallInstructionsLink =
+		'https://jetpack.com/support/getting-started-with-jetpack/';
+
+	return (
+		<>
+			<h2>{ translate( 'Install Jetpack' ) }</h2>
+			<p>
+				{ translate(
+					'Download Jetpack or install it directly from your site by following the {{a}}instructions we put together here{{/a}}.',
+					{
+						components: {
+							a: (
+								<a
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ () =>
+										dispatch(
+											recordTracksEvent(
+												'calypso_siteless_free_page_install_instructions_link_clicked',
+												{
+													product_slug: 'jetpack_free',
+												}
+											)
+										)
+									}
+									href={ jetpackInstallInstructionsLink }
+								/>
+							),
+						},
+					}
+				) }
+			</p>
+		</>
+	);
+};

--- a/client/components/jetpack/jetpack-free-welcome/Step2.tsx
+++ b/client/components/jetpack/jetpack-free-welcome/Step2.tsx
@@ -1,0 +1,86 @@
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export const Step2 = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const featureLink1 = 'https://jetpack.com/features/design/content-delivery-network/';
+	const featureLink2 = 'https://jetpack.com/features/security/downtime-monitoring/';
+	const featureLink3 = 'https://jetpack.com/features/growth/automatic-publishing/';
+	const featuresComparisonLink = 'https://jetpack.com/features/comparison/';
+
+	return (
+		<>
+			<h2>{ translate( 'Try our powerful free features' ) }</h2>
+
+			<ul className="jetpack-free-welcome__features">
+				<li>
+					{ translate( '{{a}}Speed up your site{{/a}} with our CDN.', {
+						components: {
+							a: (
+								<a
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ () =>
+										dispatch( recordTracksEvent( 'jetpack_free_welcome_cdn_link_clicked' ) )
+									}
+									href={ featureLink1 }
+								/>
+							),
+						},
+					} ) }
+				</li>
+				<li>
+					{ translate( '{{a}}Make sure your site is online{{/a}} with our Downtime Monitor.', {
+						components: {
+							a: (
+								<a
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ () =>
+										dispatch(
+											recordTracksEvent( 'jetpack_free_welcome_downtime_monitor_link_clicked' )
+										)
+									}
+									href={ featureLink2 }
+								/>
+							),
+						},
+					} ) }
+				</li>
+				<li>
+					{ translate( '{{a}}Grow your brand{{/a}} with our Social Media Tools.', {
+						components: {
+							a: (
+								<a
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ () =>
+										dispatch(
+											recordTracksEvent( 'jetpack_free_welcome_social_media_tools_link_clicked' )
+										)
+									}
+									href={ featureLink3 }
+								/>
+							),
+						},
+					} ) }
+				</li>
+			</ul>
+			<a
+				className="jetpack-free-welcome__feature-nav-button"
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={ () =>
+					dispatch( recordTracksEvent( 'jetpack_free_welcome_learn_products_link_clicked' ) )
+				}
+				href={ featuresComparisonLink }
+			>
+				<span>{ translate( 'Want to learn more about our products?' ) }</span>
+				<span>{ translate( 'See how Jetpack can help grow your business or hobby' ) }</span>
+			</a>
+		</>
+	);
+};

--- a/client/components/jetpack/jetpack-free-welcome/index.tsx
+++ b/client/components/jetpack/jetpack-free-welcome/index.tsx
@@ -1,18 +1,15 @@
-import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import { useDispatch } from 'react-redux';
-import JetpackLogo from 'calypso/components/jetpack-logo';
-import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { JetpackWelcomePage } from '../jetpack-welcome-page';
 
 import './style.scss';
 
 const JetpackFreeWelcome: FC = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-
 	const jetpackInstallInstructionsLink =
 		'https://jetpack.com/support/getting-started-with-jetpack/';
 	const featureLink1 = 'https://jetpack.com/features/design/content-delivery-network/';
@@ -21,67 +18,67 @@ const JetpackFreeWelcome: FC = () => {
 	const featuresComparisonLink = 'https://jetpack.com/features/comparison/';
 
 	return (
-		<Main wideLayout className="jetpack-free-welcome">
-			<PageViewTracker
-				path="/pricing/jetpack-free/welcome"
-				title="Pricing > Jetpack Free > Welcome to Jetpack"
-			/>
-			<Card className="jetpack-free-welcome__card">
-				<div className="jetpack-free-welcome__card-main">
-					<JetpackLogo size={ 45 } />
-					<h1 className="jetpack-free-welcome__main-message">
-						{ translate( 'Welcome{{br/}} to Jetpack!', {
-							components: {
-								br: <br />,
-							},
-						} ) }{ ' ' }
-						{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
-					</h1>
-					<p>{ translate( "Here's how to get started with Jetpack." ) }</p>
-					<div className="jetpack-free-welcome__step">
-						<div className="jetpack-free-welcome__step-number">1</div>
-						<div className="jetpack-free-welcome__step-content">
-							<h2>{ translate( 'Install Jetpack' ) }</h2>
-							<p>
-								{ translate(
-									'Download Jetpack or install it directly from your site by following the {{a}}instructions we put together here{{/a}}.',
-									{
-										components: {
-											a: (
-												<a
-													className="jetpack-free-welcome__link"
-													target="_blank"
-													rel="noopener noreferrer"
-													onClick={ () =>
-														dispatch(
-															recordTracksEvent(
-																'calypso_siteless_free_page_install_instructions_link_clicked',
-																{
-																	product_slug: 'jetpack_free',
-																}
-															)
+		<JetpackWelcomePage
+			description={ translate( "Here's how to get started with Jetpack." ) }
+			mainClassName="jetpack-free-welcome"
+			pageViewTracker={
+				<PageViewTracker
+					path="/pricing/jetpack-free/welcome"
+					title="Pricing > Jetpack Free > Welcome to Jetpack"
+				/>
+			}
+			title={
+				<>
+					{ translate( 'Welcome{{br/}} to Jetpack!', {
+						components: {
+							br: <br />,
+						},
+					} ) }{ ' ' }
+					{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
+				</>
+			}
+			steps={ [
+				{
+					title: translate( 'Install Jetpack' ),
+					content: (
+						<p>
+							{ translate(
+								'Download Jetpack or install it directly from your site by following the {{a}}instructions we put together here{{/a}}.',
+								{
+									components: {
+										a: (
+											<a
+												target="_blank"
+												rel="noopener noreferrer"
+												onClick={ () =>
+													dispatch(
+														recordTracksEvent(
+															'calypso_siteless_free_page_install_instructions_link_clicked',
+															{
+																product_slug: 'jetpack_free',
+															}
 														)
-													}
-													href={ jetpackInstallInstructionsLink }
-												/>
-											),
-										},
-									}
-								) }
-							</p>
-						</div>
-					</div>
-					<div className="jetpack-free-welcome__step">
-						<div className="jetpack-free-welcome__step-number">2</div>
-						<div className="jetpack-free-welcome__step-content">
-							<h2>{ translate( 'Try our powerful free features' ) }</h2>
+													)
+												}
+												href={ jetpackInstallInstructionsLink }
+											/>
+										),
+									},
+								}
+							) }
+						</p>
+					),
+				},
+				{
+					title: translate( 'Try our powerful free features' ),
+					content: (
+						<>
 							<ul className="jetpack-free-welcome__features">
 								<li>
 									{ translate( '{{a}}Speed up your site{{/a}} with our CDN.', {
 										components: {
 											a: (
 												<a
-													className="jetpack-free-welcome__feature-link"
 													target="_blank"
 													rel="noopener noreferrer"
 													onClick={ () =>
@@ -100,7 +97,6 @@ const JetpackFreeWelcome: FC = () => {
 											components: {
 												a: (
 													<a
-														className="jetpack-free-welcome__feature-link"
 														target="_blank"
 														rel="noopener noreferrer"
 														onClick={ () =>
@@ -122,7 +118,6 @@ const JetpackFreeWelcome: FC = () => {
 										components: {
 											a: (
 												<a
-													className="jetpack-free-welcome__feature-link"
 													target="_blank"
 													rel="noopener noreferrer"
 													onClick={ () =>
@@ -153,11 +148,11 @@ const JetpackFreeWelcome: FC = () => {
 								<span>{ translate( 'Want to learn more about our products?' ) }</span>
 								<span>{ translate( 'See how Jetpack can help grow your business or hobby' ) }</span>
 							</a>
-						</div>
-					</div>
-				</div>
-			</Card>
-		</Main>
+						</>
+					),
+				},
+			] }
+		/>
 	);
 };
 

--- a/client/components/jetpack/jetpack-free-welcome/index.tsx
+++ b/client/components/jetpack/jetpack-free-welcome/index.tsx
@@ -1,21 +1,16 @@
 import { useTranslate } from 'i18n-calypso';
-import { FC } from 'react';
-import { useDispatch } from 'react-redux';
+import { useMemo } from 'react';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { JetpackWelcomePage } from '../jetpack-welcome-page';
+import { Step1 } from './Step1';
+import { Step2 } from './Step2';
 
 import './style.scss';
 
-const JetpackFreeWelcome: FC = () => {
+const JetpackFreeWelcome: React.FC = () => {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
-	const jetpackInstallInstructionsLink =
-		'https://jetpack.com/support/getting-started-with-jetpack/';
-	const featureLink1 = 'https://jetpack.com/features/design/content-delivery-network/';
-	const featureLink2 = 'https://jetpack.com/features/security/downtime-monitoring/';
-	const featureLink3 = 'https://jetpack.com/features/growth/automatic-publishing/';
-	const featuresComparisonLink = 'https://jetpack.com/features/comparison/';
+
+	const steps = useMemo( () => [ <Step1 />, <Step2 /> ], [] );
 
 	return (
 		<JetpackWelcomePage
@@ -37,121 +32,7 @@ const JetpackFreeWelcome: FC = () => {
 					{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
 				</>
 			}
-			steps={ [
-				{
-					title: translate( 'Install Jetpack' ),
-					content: (
-						<p>
-							{ translate(
-								'Download Jetpack or install it directly from your site by following the {{a}}instructions we put together here{{/a}}.',
-								{
-									components: {
-										a: (
-											<a
-												target="_blank"
-												rel="noopener noreferrer"
-												onClick={ () =>
-													dispatch(
-														recordTracksEvent(
-															'calypso_siteless_free_page_install_instructions_link_clicked',
-															{
-																product_slug: 'jetpack_free',
-															}
-														)
-													)
-												}
-												href={ jetpackInstallInstructionsLink }
-											/>
-										),
-									},
-								}
-							) }
-						</p>
-					),
-				},
-				{
-					title: translate( 'Try our powerful free features' ),
-					content: (
-						<>
-							<ul className="jetpack-free-welcome__features">
-								<li>
-									{ translate( '{{a}}Speed up your site{{/a}} with our CDN.', {
-										components: {
-											a: (
-												<a
-													target="_blank"
-													rel="noopener noreferrer"
-													onClick={ () =>
-														dispatch( recordTracksEvent( 'jetpack_free_welcome_cdn_link_clicked' ) )
-													}
-													href={ featureLink1 }
-												/>
-											),
-										},
-									} ) }
-								</li>
-								<li>
-									{ translate(
-										'{{a}}Make sure your site is online{{/a}} with our Downtime Monitor.',
-										{
-											components: {
-												a: (
-													<a
-														target="_blank"
-														rel="noopener noreferrer"
-														onClick={ () =>
-															dispatch(
-																recordTracksEvent(
-																	'jetpack_free_welcome_downtime_monitor_link_clicked'
-																)
-															)
-														}
-														href={ featureLink2 }
-													/>
-												),
-											},
-										}
-									) }
-								</li>
-								<li>
-									{ translate( '{{a}}Grow your brand{{/a}} with our Social Media Tools.', {
-										components: {
-											a: (
-												<a
-													target="_blank"
-													rel="noopener noreferrer"
-													onClick={ () =>
-														dispatch(
-															recordTracksEvent(
-																'jetpack_free_welcome_social_media_tools_link_clicked'
-															)
-														)
-													}
-													href={ featureLink3 }
-												/>
-											),
-										},
-									} ) }
-								</li>
-							</ul>
-							<a
-								className="jetpack-free-welcome__feature-nav-button"
-								target="_blank"
-								rel="noopener noreferrer"
-								onClick={ () =>
-									dispatch(
-										recordTracksEvent( 'jetpack_free_welcome_learn_products_link_clicked' )
-									)
-								}
-								href={ featuresComparisonLink }
-							>
-								<span>{ translate( 'Want to learn more about our products?' ) }</span>
-								<span>{ translate( 'See how Jetpack can help grow your business or hobby' ) }</span>
-							</a>
-						</>
-					),
-				},
-			] }
+			steps={ steps }
 		/>
 	);
 };

--- a/client/components/jetpack/jetpack-free-welcome/style.scss
+++ b/client/components/jetpack/jetpack-free-welcome/style.scss
@@ -3,151 +3,56 @@
 @import '@wordpress/base-styles/variables';
 
 .jetpack-free-welcome {
-	&.main.is-wide-layout {
-		max-width: 744px;
+	.jetpack-free-welcome__features {
+		margin: 0 0 0 10px;
+		padding: 0 0 32px 5px;
+		@include break-mobile {
+			font-size: 18px; /* stylelint-disable-line */
+			line-height: 2rem;
+		}
 	}
-	.jetpack-free-welcome__card {
-		padding: 0;
-		box-shadow: 0 0 40px 0 #00000014;
 
-		width: 100%;
-		max-width: none;
+	.jetpack-free-welcome__feature-nav-button {
+		position: relative;
+		display: block;
+		padding: 16px 64px 16px 24px;
+		color: var( --color-studio-black );
+		border: 2px solid var( --studio-jetpack-green-40 );
+		border-radius: calc( 2px * 2 );
+		text-decoration: none;
 
-		> div.jetpack-free-welcome__card-main {
-			box-sizing: border-box;
-			padding: 26px;
-			@include break-mobile {
-				padding: 76px;
-			}
-		}
-
-		.jetpack-logo {
-			margin-bottom: 48px;
-		}
-
-		h1 {
-			line-height: 1;
-			@include break-mobile {
-				font-size: $font-headline-medium;
-			}
-			+ p {
-				font-size: 18px; /* stylelint-disable-line */
-				line-height: 1.5rem;
-				@include break-mobile {
-					font-size: $font-title-medium;
-					line-height: 2rem;
-				}
-			}
-		}
-		h2 {
-			font-size: $font-title-medium;
-			font-weight: 700;
-			line-height: 1.75rem;
-			padding-bottom: 16px;
-		}
-
-		a.jetpack-free-welcome__link,
-		a.jetpack-free-welcome__feature-link {
-			text-decoration: underline;
-			color: var( --color-studio-black );
-			&:hover {
-				text-decoration: none;
-			}
-		}
-
-		.jetpack-free-welcome__step {
-			display: flex;
-			align-items: flex-start;
-			padding-bottom: 40px;
+		span {
+			display: block;
 
 			&:last-of-type {
-				padding-bottom: 0;
-			}
-
-			.jetpack-free-welcome__step-number {
-				color: white;
-				background-color: var( --studio-jetpack-green-40 );
-				text-align: center;
-				border-radius: 50%; /* stylelint-disable-line */
-				font-size: $font-title-small;
 				font-weight: 600;
-				width: rem( 32px );
-				height: rem( 32px );
-			}
-			.jetpack-free-welcome__step-content {
-				flex: 1;
-				padding: 0 10px 0 16px;
-				p {
-					@include break-mobile {
-						font-size: 18px; /* stylelint-disable-line */
-						line-height: 1.75rem;
-					}
-					margin: 0;
-				}
 			}
 		}
 
-		.jetpack-free-welcome__main-message {
-			font-size: 2.25rem;
-			font-weight: 700;
-			margin-bottom: 24px;
+		&:hover,
+		&:focus {
+			//box-shadow: 0px 0px 40px rgba( 0, 0, 0, 0.08 );
 
-			@include break-mobile {
-				font-size: 3rem;
+			span:last-of-type {
+				text-decoration: underline;
+				text-decoration-thickness: 2px;
 			}
-		}
-
-		.jetpack-free-welcome__features {
-			margin: 0 0 0 10px;
-			padding: 0 0 32px 5px;
-			@include break-mobile {
-				font-size: 18px; /* stylelint-disable-line */
-				line-height: 2rem;
-			}
-		}
-
-		.jetpack-free-welcome__feature-nav-button {
-			position: relative;
-			display: block;
-			padding: 16px 64px 16px 24px;
-			color: var( --color-studio-black );
-			border: 2px solid var( --studio-jetpack-green-40 );
-			border-radius: calc( 2px * 2 );
-			text-decoration: none;
-
-			span {
-				display: block;
-
-				&:last-of-type {
-					font-weight: 600;
-				}
-			}
-
-			&:hover,
-				&:focus {
-					//box-shadow: 0px 0px 40px rgba( 0, 0, 0, 0.08 );
-
-					span:last-of-type {
-						text-decoration: underline;
-						text-decoration-thickness: 2px;
-					}
-
-					&::after {
-						transform: translateY( -50% ) translateX( 8px );
-					}
-				}
 
 			&::after {
-				content: '→';
-				position: absolute;
-				top: 50%;
-				right: 24px;
-				font-size: $font-title-medium;
-				font-weight: 600;
-				color: var( --studio-jetpack-green-40 );
-				transform: translateY( -50% );
-				transition: transform 0.15s ease-out;
+				transform: translateY( -50% ) translateX( 8px );
 			}
+		}
+
+		&::after {
+			content: '→';
+			position: absolute;
+			top: 50%;
+			right: 24px;
+			font-size: $font-title-medium;
+			font-weight: 600;
+			color: var( --studio-jetpack-green-40 );
+			transform: translateY( -50% );
+			transition: transform 0.15s ease-out;
 		}
 	}
 }

--- a/client/components/jetpack/jetpack-welcome-page/index.tsx
+++ b/client/components/jetpack/jetpack-welcome-page/index.tsx
@@ -5,13 +5,13 @@ import Main from 'calypso/components/main';
 
 import './style.scss';
 
-export type JetpackWelcomePageProps = {
+type JetpackWelcomePageProps = {
+	title: React.ReactNode;
 	description?: React.ReactNode;
 	footer?: React.ReactNode;
 	mainClassName?: string;
 	pageViewTracker?: React.ReactNode;
 	steps?: Array< React.ReactNode >;
-	title: React.ReactNode;
 };
 
 export const JetpackWelcomePage: React.FC< JetpackWelcomePageProps > = ( {

--- a/client/components/jetpack/jetpack-welcome-page/index.tsx
+++ b/client/components/jetpack/jetpack-welcome-page/index.tsx
@@ -5,18 +5,12 @@ import Main from 'calypso/components/main';
 
 import './style.scss';
 
-export type WelcomeStep = {
-	content?: React.ReactNode;
-	id?: string;
-	title?: React.ReactNode;
-};
-
 export type JetpackWelcomePageProps = {
 	description?: React.ReactNode;
 	footer?: React.ReactNode;
 	mainClassName?: string;
 	pageViewTracker?: React.ReactNode;
-	steps?: Array< WelcomeStep >;
+	steps?: Array< React.ReactNode >;
 	title: React.ReactNode;
 };
 
@@ -37,16 +31,11 @@ export const JetpackWelcomePage: React.FC< JetpackWelcomePageProps > = ( {
 					<h1 className="jetpack-welcome-page__title">{ title }</h1>
 					<p className="jetpack-welcome-page__description">{ description }</p>
 					<div className="jetpack-welcome-page__steps">
-						{ steps?.map( ( { content, id, title }, index ) => {
+						{ steps?.map( ( step, index ) => {
 							return (
-								<div className="jetpack-welcome-page__step" key={ id || index }>
+								<div className="jetpack-welcome-page__step" key={ index }>
 									<div className="jetpack-welcome-page__step--number">{ index + 1 }</div>
-									<div className="jetpack-welcome-page__step--body">
-										{ title ? (
-											<h2 className="jetpack-welcome-page__step--title">{ title }</h2>
-										) : null }
-										<div className="jetpack-welcome-page__step--content">{ content }</div>
-									</div>
+									<div className="jetpack-welcome-page__step--content">{ step }</div>
 								</div>
 							);
 						} ) }

--- a/client/components/jetpack/jetpack-welcome-page/index.tsx
+++ b/client/components/jetpack/jetpack-welcome-page/index.tsx
@@ -1,0 +1,61 @@
+import { Card } from '@automattic/components';
+import classnames from 'classnames';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import Main from 'calypso/components/main';
+
+import './style.scss';
+
+export type WelcomeStep = {
+	content?: React.ReactNode;
+	id?: string;
+	title?: React.ReactNode;
+};
+
+export type JetpackWelcomePageProps = {
+	description?: React.ReactNode;
+	footer?: React.ReactNode;
+	mainClassName?: string;
+	pageViewTracker?: React.ReactNode;
+	steps?: Array< WelcomeStep >;
+	title: React.ReactNode;
+};
+
+export const JetpackWelcomePage: React.FC< JetpackWelcomePageProps > = ( {
+	description,
+	footer,
+	mainClassName,
+	pageViewTracker,
+	steps,
+	title,
+} ) => {
+	return (
+		<Main wideLayout className={ classnames( 'jetpack-welcome-page', mainClassName ) }>
+			{ pageViewTracker }
+			<Card className="jetpack-welcome-page__card">
+				<div className="jetpack-welcome-page__card--main">
+					<JetpackLogo size={ 45 } />
+					<h1 className="jetpack-welcome-page__title">{ title }</h1>
+					<p className="jetpack-welcome-page__description">{ description }</p>
+					<div className="jetpack-welcome-page__steps">
+						{ steps?.map( ( { content, id, title }, index ) => {
+							return (
+								<div className="jetpack-welcome-page__step" key={ id || index }>
+									<div className="jetpack-welcome-page__step--number">{ index + 1 }</div>
+									<div className="jetpack-welcome-page__step--body">
+										{ title ? (
+											<h2 className="jetpack-welcome-page__step--title">{ title }</h2>
+										) : null }
+										<div className="jetpack-welcome-page__step--content">{ content }</div>
+									</div>
+								</div>
+							);
+						} ) }
+					</div>
+				</div>
+				{ footer ? <div className="jetpack-welcome-page__card--footer">{ footer }</div> : null }
+			</Card>
+		</Main>
+	);
+};
+
+export default JetpackWelcomePage;

--- a/client/components/jetpack/jetpack-welcome-page/style.scss
+++ b/client/components/jetpack/jetpack-welcome-page/style.scss
@@ -1,0 +1,106 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+
+.jetpack-welcome-page {
+	&.main.is-wide-layout {
+		max-width: 744px;
+	}
+	&__card {
+		padding: 0;
+		box-shadow: 0 0 40px 0 #00000014;
+
+		width: 100%;
+		max-width: none;
+
+		&--main, &--footer {
+			box-sizing: border-box;
+			padding: 26px;
+			@include break-mobile {
+				padding: 76px;
+			}
+		}
+		&--footer {
+			padding-top: 0;
+		}
+
+		.jetpack-logo {
+			margin-bottom: 48px;
+		}
+
+		a {
+			text-decoration: underline;
+			color: var( --color-studio-black );
+			&:hover {
+				text-decoration: none;
+			}
+		}
+
+		h1 {
+			line-height: 1;
+			@include break-mobile {
+				font-size: $font-headline-medium;
+			}
+			+ p {
+				font-size: 18px; /* stylelint-disable-line */
+				line-height: 1.5rem;
+				@include break-mobile {
+					font-size: $font-title-medium;
+					line-height: 2rem;
+				}
+			}
+		}
+		h2 {
+			font-size: $font-title-medium;
+			font-weight: 700;
+			line-height: 1.75rem;
+			padding-bottom: 16px;
+		}
+
+		.jetpack-welcome-page__step {
+			display: flex;
+			align-items: flex-start;
+			padding-bottom: 40px;
+
+			&:last-of-type {
+				padding-bottom: 0;
+			}
+
+			&--body {
+				flex: 1;
+				padding: 0 10px 0 16px;
+			}
+
+			&--number {
+				color: white;
+				background-color: var( --studio-jetpack-green-40 );
+				text-align: center;
+				border-radius: 50%; /* stylelint-disable-line */
+				font-size: $font-title-small;
+				font-weight: 600;
+				width: rem( 32px );
+				height: rem( 32px );
+			}
+			&--content {
+				flex: 1;
+				p {
+					@include break-mobile {
+						font-size: 18px; /* stylelint-disable-line */
+						line-height: 1.75rem;
+					}
+					margin: 0;
+				}
+			}
+		}
+
+		.jetpack-welcome-page__title {
+			font-size: 2.25rem;
+			font-weight: 700;
+			margin-bottom: 24px;
+
+			@include break-mobile {
+				font-size: 3rem;
+			}
+		}
+	}
+}

--- a/client/components/jetpack/jetpack-welcome-page/style.scss
+++ b/client/components/jetpack/jetpack-welcome-page/style.scss
@@ -66,11 +66,6 @@
 				padding-bottom: 0;
 			}
 
-			&--body {
-				flex: 1;
-				padding: 0 10px 0 16px;
-			}
-
 			&--number {
 				color: white;
 				background-color: var( --studio-jetpack-green-40 );
@@ -83,6 +78,7 @@
 			}
 			&--content {
 				flex: 1;
+				padding: 0 10px 0 16px;
 				p {
 					@include break-mobile {
 						font-size: 18px; /* stylelint-disable-line */


### PR DESCRIPTION
In order to create the landing pages for Jetpack Boost and Jetpack Social, we need to re-use as much of the existing code from [Jetpack Landing page](https://cloud.jetpack.com/pricing/jetpack-free/welcome) as possible to avoid duplication.

#### Changes proposed in this Pull Request

* Extract re-usable code from `JetpackFreeWelcome` to create `JetpackWelcomePage`

#### Testing instructions

- Checkout the PR and run `yarn start` and also `yarn start-jetpack-cloud-p`.
- Goto http://jetpack.cloud.localhost:3001/pricing/jetpack-free/welcome
- Compare it with existing landing page https://cloud.jetpack.com/pricing/jetpack-free/welcome
- Confirm that everything works and looks as before.


<img width="1556" alt="Screenshot 2022-05-25 at 2 19 50 PM" src="https://user-images.githubusercontent.com/18226415/170222266-66ac63d8-2add-4641-a65c-1ee290c2a83d.png">
