### PR TITLE
Add landing pages for Jetpack Boost and Social

### DIFF
--- a/client/components/jetpack/jetpack-boost-welcome/Step1.tsx
+++ b/client/components/jetpack/jetpack-boost-welcome/Step1.tsx
@@ -1,0 +1,54 @@
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export const Step1 = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const downloadLink = 'https://wordpress.org/plugins/jetpack-boost/';
+	const instructionsLink = 'https://jetpack.com/support/performance/jetpack-boost/';
+
+	return (
+		<p>
+			{ translate(
+				'{{downloadLink}}Download Boost{{/downloadLink}} or install it directly from your site by following these {{instructions}}instructions{{/instructions}}.',
+				{
+					components: {
+						downloadLink: (
+							<a
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () =>
+									dispatch(
+										recordTracksEvent( 'calypso_siteless_free_page_install_download_link_clicked', {
+											product_slug: 'jetpack_boost',
+										} )
+									)
+								}
+								href={ downloadLink }
+							/>
+						),
+						instructions: (
+							<a
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () =>
+									dispatch(
+										recordTracksEvent(
+											'calypso_siteless_free_page_install_instructions_link_clicked',
+											{
+												product_slug: 'jetpack_boost',
+											}
+										)
+									)
+								}
+								href={ instructionsLink }
+							/>
+						),
+					},
+				}
+			) }
+		</p>
+	);
+};

--- a/client/components/jetpack/jetpack-boost-welcome/Step2.tsx
+++ b/client/components/jetpack/jetpack-boost-welcome/Step2.tsx
@@ -1,0 +1,7 @@
+import { useTranslate } from 'i18n-calypso';
+
+export const Step2 = () => {
+	const translate = useTranslate();
+
+	return <p>{ translate( 'That’s it! Boost will automatically begin optimizing your site.' ) }</p>;
+};

--- a/client/components/jetpack/jetpack-boost-welcome/index.tsx
+++ b/client/components/jetpack/jetpack-boost-welcome/index.tsx
@@ -1,33 +1,45 @@
-import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import JetpackLogo from 'calypso/components/jetpack-logo';
-import Main from 'calypso/components/main';
+import { useMemo } from 'react';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { JETPACK_CONTACT_SUPPORT } from 'calypso/lib/url/support';
+import { JetpackWelcomePage } from '../jetpack-welcome-page';
+import { Step1 } from './Step1';
+import { Step2 } from './Step2';
+
+import './style.scss';
 
 const JetpackBoostWelcome: React.FC = () => {
 	const translate = useTranslate();
 
+	const steps = useMemo( () => [ <Step1 />, <Step2 /> ], [] );
+
 	return (
-		<Main wideLayout className="jetpack-boost-welcome">
-			<PageViewTracker
-				path="/pricing/jetpack-boost/welcome"
-				title="Pricing > Jetpack Boost > Welcome to Jetpack Boost"
-			/>
-			<Card className="jetpack-boost-welcome__card">
-				<div className="jetpack-boost-welcome__card-main">
-					<JetpackLogo size={ 45 } />
-					<h1 className="jetpack-boost-welcome__main-message">
-						{ translate( 'Welcome{{br/}} to Jetpack Boost!', {
-							components: {
-								br: <br />,
-							},
-						} ) }
-						&nbsp;
-						{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
-					</h1>
-				</div>
-			</Card>
-		</Main>
+		<JetpackWelcomePage
+			description={ translate( "Here's how to get started" ) }
+			footer={ translate( 'Need help? {{a}}Contact us{{/a}}.', {
+				components: {
+					a: <a target="_blank" rel="noopener noreferrer" href={ JETPACK_CONTACT_SUPPORT } />,
+				},
+			} ) }
+			mainClassName="jetpack-boost-welcome"
+			pageViewTracker={
+				<PageViewTracker
+					path="/pricing/jetpack-boost/welcome"
+					title="Pricing > Jetpack Boost > Welcome to Jetpack Boost"
+				/>
+			}
+			title={
+				<>
+					{ translate( 'Welcome to{{br/}} Jetpack Boost!', {
+						components: {
+							br: <br />,
+						},
+					} ) }{ ' ' }
+					{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
+				</>
+			}
+			steps={ steps }
+		/>
 	);
 };
 

--- a/client/components/jetpack/jetpack-boost-welcome/style.scss
+++ b/client/components/jetpack/jetpack-boost-welcome/style.scss
@@ -1,0 +1,5 @@
+.jetpack-boost-welcome {
+	.jetpack-welcome-page__card--footer {
+		color: var( --studio-gray-50 );
+	}
+}

--- a/client/components/jetpack/jetpack-social-welcome/Step1.tsx
+++ b/client/components/jetpack/jetpack-social-welcome/Step1.tsx
@@ -1,0 +1,55 @@
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export const Step1 = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	// TODO update the correct links when available
+	const downloadLink = 'https://wordpress.org/plugins/jetpack-social/';
+	const instructionsLink = 'https://jetpack.com/support/publicize/';
+
+	return (
+		<p>
+			{ translate(
+				'{{downloadLink}}Download Social{{/downloadLink}} or install it directly from your site by following these {{instructions}}instructions{{/instructions}}.',
+				{
+					components: {
+						downloadLink: (
+							<a
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () =>
+									dispatch(
+										recordTracksEvent( 'calypso_siteless_free_page_install_download_link_clicked', {
+											product_slug: 'jetpack_social',
+										} )
+									)
+								}
+								href={ downloadLink }
+							/>
+						),
+						instructions: (
+							<a
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () =>
+									dispatch(
+										recordTracksEvent(
+											'calypso_siteless_free_page_install_instructions_link_clicked',
+											{
+												product_slug: 'jetpack_social',
+											}
+										)
+									)
+								}
+								href={ instructionsLink }
+							/>
+						),
+					},
+				}
+			) }
+		</p>
+	);
+};

--- a/client/components/jetpack/jetpack-social-welcome/Step2.tsx
+++ b/client/components/jetpack/jetpack-social-welcome/Step2.tsx
@@ -1,0 +1,7 @@
+import { useTranslate } from 'i18n-calypso';
+
+export const Step2 = () => {
+	const translate = useTranslate();
+
+	return <p>{ translate( 'Connect your desired social media accounts.' ) }</p>;
+};

--- a/client/components/jetpack/jetpack-social-welcome/index.tsx
+++ b/client/components/jetpack/jetpack-social-welcome/index.tsx
@@ -1,34 +1,46 @@
-import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import JetpackLogo from 'calypso/components/jetpack-logo';
-import Main from 'calypso/components/main';
+import { useMemo } from 'react';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { JETPACK_CONTACT_SUPPORT } from 'calypso/lib/url/support';
+import { JetpackWelcomePage } from '../jetpack-welcome-page';
+import { Step1 } from './Step1';
+import { Step2 } from './Step2';
 
-const JetpackSocialWelcome: React.FC = () => {
+import './style.scss';
+
+const JetpackBoostWelcome: React.FC = () => {
 	const translate = useTranslate();
 
+	const steps = useMemo( () => [ <Step1 />, <Step2 /> ], [] );
+
 	return (
-		<Main wideLayout className="jetpack-social-welcome">
-			<PageViewTracker
-				path="/pricing/jetpack-social/welcome"
-				title="Pricing > Jetpack Boost > Welcome to Jetpack Boost"
-			/>
-			<Card className="jetpack-social-welcome__card">
-				<div className="jetpack-social-welcome__card-main">
-					<JetpackLogo size={ 45 } />
-					<h1 className="jetpack-social-welcome__main-message">
-						{ translate( 'Welcome{{br/}} to Jetpack Social!', {
-							components: {
-								br: <br />,
-							},
-						} ) }
-						&nbsp;
-						{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
-					</h1>
-				</div>
-			</Card>
-		</Main>
+		<JetpackWelcomePage
+			description={ translate( "Here's how to get started" ) }
+			footer={ translate( 'Need help? {{a}}Contact us{{/a}}.', {
+				components: {
+					a: <a target="_blank" rel="noopener noreferrer" href={ JETPACK_CONTACT_SUPPORT } />,
+				},
+			} ) }
+			mainClassName="jetpack-social-welcome"
+			pageViewTracker={
+				<PageViewTracker
+					path="/pricing/jetpack-social/welcome"
+					title="Pricing > Jetpack Social > Welcome to Jetpack Social"
+				/>
+			}
+			title={
+				<>
+					{ translate( 'Welcome to{{br/}} Jetpack Social!', {
+						components: {
+							br: <br />,
+						},
+					} ) }{ ' ' }
+					{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
+				</>
+			}
+			steps={ steps }
+		/>
 	);
 };
 
-export default JetpackSocialWelcome;
+export default JetpackBoostWelcome;

--- a/client/components/jetpack/jetpack-social-welcome/style.scss
+++ b/client/components/jetpack/jetpack-social-welcome/style.scss
@@ -1,0 +1,5 @@
+.jetpack-social-welcome {
+	.jetpack-welcome-page__card--footer {
+		color: var( --studio-gray-50 );
+	}
+}

--- a/client/components/jetpack/jetpack-welcome-page/style.scss
+++ b/client/components/jetpack/jetpack-welcome-page/style.scss
@@ -13,7 +13,8 @@
 		width: 100%;
 		max-width: none;
 
-		&--main, &--footer {
+		&--main,
+		&--footer {
 			box-sizing: border-box;
 			padding: 26px;
 			@include break-mobile {


### PR DESCRIPTION
Completes 1202316834912830-as-1202316835174110/f and 1202316834912830-as-1202316835174112/f

#### Changes proposed in this Pull Request

* Add landing pages for Jetpack Boost and Jetpack Social

#### Testing instructions

* Checkout the PR and run `yarn start` and also `yarn start-jetpack-cloud-p`.
* Goto http://jetpack.cloud.localhost:3001/pricing/jetpack-boost/welcome and http://jetpack.cloud.localhost:3001/pricing/jetpack-social/welcome
* Confirm that the routes exist and the page design matches the [figma design](https://www.figma.com/file/lJK0hlU19QOhqub0uhlIWp/(WCEU)-Pricing-page-update?node-id=2381%3A11371).
* You may see some differences from Figma design, those are only to make the landing page look consistent as other landing pages like https://cloud.jetpack.com/pricing/jetpack-free/welcome


<img width="1463" alt="Screenshot 2022-05-25 at 3 34 47 PM" src="https://user-images.githubusercontent.com/18226415/170237529-65d2bc6a-b84c-4a1d-9461-da4a6d06b1a5.png">

<img width="1542" alt="Screenshot 2022-05-25 at 6 37 43 PM" src="https://user-images.githubusercontent.com/18226415/170269267-c0446805-1b64-48aa-9fe8-051b11678c50.png">
