### PR TITLE
Fixes DIFM flow for new sites

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -691,7 +691,7 @@ export function generateSteps( {
 
 		'choose-service': {
 			stepName: 'choose-service',
-			providesDependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'siteSlug', 'newOrExistingSiteChoice' ],
 		},
 
 		'new-or-existing-site': {
@@ -714,6 +714,7 @@ export function generateSteps( {
 			stepName: 'difm-design-setup-site',
 			apiRequestFunction: setDIFMLiteDesign,
 			delayApiRequestUntilComplete: true,
+			dependencies: [ 'newOrExistingSiteChoice' ],
 			providesDependencies: [
 				'isFSEActive',
 				'selectedDesign',

--- a/client/signup/steps/choose-service/index.tsx
+++ b/client/signup/steps/choose-service/index.tsx
@@ -20,7 +20,6 @@ import './style.scss';
 interface Props {
 	existingSiteCount: number;
 	goToNextStep: () => void;
-	submitSignupStep: ( { stepName, wasSkipped }: { stepName: string; wasSkipped: boolean } ) => void;
 	goToStep: ( stepName: string ) => void;
 	stepName: string;
 	queryObject: {
@@ -99,6 +98,7 @@ export default function ChooseServiceStep( props: Props ): React.ReactNode {
 				{ stepName: props.stepName },
 				{
 					siteSlug: props.queryObject.siteSlug || props.queryObject.siteId,
+					newOrExistingSiteChoice: 'existing-site',
 				}
 			)
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Bug Report: p1653405018156199-slack-C02KVCAL7GX

The `newOrExistingSiteChoice` dependency was inadvertently removed from the `difm-design-setup-site` in #63316. New sites were not created since the `newOrExistingSiteChoice` key did not exist in `dependencies` and the check below evaluated to `false`:
https://github.com/Automattic/wp-calypso/blob/776472cc94c7e091c067df0d291e37837fd24fc4/client/lib/signup/step-actions/index.js#L366-L371

This change adds the dependency back to the `difm-design-setup-site` step. I've also modified the `choose-service` step so that submitting the step explicitly submits the `newOrExistingSiteChoice` dependency as `existing-site`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`, choose "New Site", go through the flow steps and reach the checkout page. Confirm that there is no error.
* Go to `/start/do-it-for-me`, choose "Existing Site", go through the flow steps and reach the checkout page. Confirm that there is no error.
* Go to `/setup/intent?siteSlug=<site slug>`, choose "Let our experts create your dream site", go through the flow steps and reach the checkout page. Confirm that there is no error.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

