### PR TITLE
Add track events for the agency dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,6 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useState } from 'react';
+import { ReactElement, useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import SiteContent from './site-content';
 import SiteSearch from './site-search';
 import SiteWelcomeBanner from './site-welcome-banner';
@@ -17,6 +19,11 @@ export default function SitesOverview(): ReactElement {
 	const handleSearch = ( query: string | null ) => {
 		setSearchQuery( query );
 	};
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_visit' ) );
+	}, [ dispatch ] );
 
 	return (
 		<div className="sites-overview">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from 'react-redux';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getActionEventNames } from '../utils';
+import { getActionEventName } from '../utils';
 import type { SiteNode, AllowedActionTypes } from '../types';
 import type { ReactElement } from 'react';
 
@@ -43,7 +43,7 @@ export default function SiteActions( {
 	const siteId = site?.value?.blog_id;
 
 	const handleClickMenuItem = ( actionType: AllowedActionTypes ) => {
-		const eventName = getActionEventNames( actionType, isLargeScreen );
+		const eventName = getActionEventName( actionType, isLargeScreen );
 		dispatch( recordTracksEvent( eventName ) );
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -2,9 +2,12 @@ import { Gridicon, Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
+import { useDispatch } from 'react-redux';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import type { SiteNode } from '../types';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getActionEventNames } from '../utils';
+import type { SiteNode, AllowedActionTypes } from '../types';
 import type { ReactElement } from 'react';
 
 import './style.scss';
@@ -15,8 +18,13 @@ interface Props {
 	siteError: boolean;
 }
 
-export default function SiteActions( { isLargeScreen, site, siteError }: Props ): ReactElement {
+export default function SiteActions( {
+	isLargeScreen = false,
+	site,
+	siteError,
+}: Props ): ReactElement {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const [ isOpen, setIsOpen ] = useState( false );
 
@@ -34,8 +42,9 @@ export default function SiteActions( { isLargeScreen, site, siteError }: Props )
 	const siteUrlWithScheme = site?.value?.url_with_scheme;
 	const siteId = site?.value?.blog_id;
 
-	const handleClickMenuItem = () => {
-		// Handle track event here
+	const handleClickMenuItem = ( actionType: AllowedActionTypes ) => {
+		const eventName = getActionEventNames( actionType, isLargeScreen );
+		dispatch( recordTracksEvent( eventName ) );
 	};
 
 	return (
@@ -62,7 +71,7 @@ export default function SiteActions( { isLargeScreen, site, siteError }: Props )
 				{ ! siteError && (
 					<>
 						<PopoverMenuItem
-							onClick={ handleClickMenuItem }
+							onClick={ () => handleClickMenuItem( 'issue_license' ) }
 							href={ `/partner-portal/issue-license/?site_id=${ siteId }` }
 							className="site-actions__menu-item"
 							icon="chevron-right"
@@ -70,7 +79,7 @@ export default function SiteActions( { isLargeScreen, site, siteError }: Props )
 							{ translate( 'Issue new license' ) }
 						</PopoverMenuItem>
 						<PopoverMenuItem
-							onClick={ handleClickMenuItem }
+							onClick={ () => handleClickMenuItem( 'view_activity' ) }
 							href={ `/activity-log/${ siteUrl }` }
 							className="site-actions__menu-item"
 							icon="chevron-right"
@@ -81,7 +90,7 @@ export default function SiteActions( { isLargeScreen, site, siteError }: Props )
 				) }
 				<PopoverMenuItem
 					isExternalLink
-					onClick={ handleClickMenuItem }
+					onClick={ () => handleClickMenuItem( 'view_site' ) }
 					href={ siteUrlWithScheme }
 					className="site-actions__menu-item"
 				>
@@ -89,7 +98,7 @@ export default function SiteActions( { isLargeScreen, site, siteError }: Props )
 				</PopoverMenuItem>
 				<PopoverMenuItem
 					isExternalLink
-					onClick={ handleClickMenuItem }
+					onClick={ () => handleClickMenuItem( 'visit_wp_admin' ) }
 					href={ `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack#/dashboard` }
 					className="site-actions__menu-item"
 				>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -21,11 +21,11 @@ export default function SiteCard( { rows, columns }: Props ): ReactElement {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 
 	const toggleIsExpanded = () => {
-		setIsExpanded( ( prevValue ) => {
-			if ( ! prevValue ) {
+		setIsExpanded( ( expanded ) => {
+			if ( ! expanded ) {
 				dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_card_expand' ) );
 			}
-			return ! prevValue;
+			return ! expanded;
 		} );
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -1,6 +1,8 @@
 import { Card, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useState, ReactElement } from 'react';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import SiteActions from '../site-actions';
 import SiteErrorContent from '../site-error-content';
 import SiteStatusContent from '../site-status-content';
@@ -14,10 +16,17 @@ interface Props {
 }
 
 export default function SiteCard( { rows, columns }: Props ): ReactElement {
+	const dispatch = useDispatch();
+
 	const [ isExpanded, setIsExpanded ] = useState( false );
 
 	const toggleIsExpanded = () => {
-		setIsExpanded( ( prevValue ) => ! prevValue );
+		setIsExpanded( ( prevValue ) => {
+			if ( ! prevValue ) {
+				dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_card_expand' ) );
+			}
+			return ! prevValue;
+		} );
 	};
 
 	const toggleContent = isExpanded ? (
@@ -50,7 +59,7 @@ export default function SiteCard( { rows, columns }: Props ): ReactElement {
 
 			{ isExpanded && (
 				<div className="site-card__expanded-content">
-					{ siteError && <SiteErrorContent siteUrl={ siteUrl } /> }
+					{ site.error && <SiteErrorContent siteUrl={ siteUrl } /> }
 					{ columns
 						.filter( ( column ) => column.key !== 'site' )
 						.map( ( column, index ) => {
@@ -60,7 +69,7 @@ export default function SiteCard( { rows, columns }: Props ): ReactElement {
 									<div
 										className={ classNames(
 											'site-card__expanded-content-list',
-											! siteError && 'site-card__content-list-no-error'
+											! site.error && 'site-card__content-list-no-error'
 										) }
 										key={ index }
 									>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-error-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-error-content.tsx
@@ -1,12 +1,15 @@
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { ReactElement } from 'react';
 
 export default function SiteErrorContent( { siteUrl }: { siteUrl: string } ): ReactElement {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const handleClickFixNow = () => {
-		// Handle track event here
+		dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_fix_connection_click' ) );
 	};
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -12,7 +12,7 @@ import type { AllowedTypes, SiteData } from './types';
 interface Props {
 	rows: SiteData;
 	type: AllowedTypes;
-	isLargeScreen: boolean;
+	isLargeScreen?: boolean;
 }
 
 export default function SiteStatusContent( {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -2,17 +2,26 @@ import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { ReactElement, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import Tooltip from 'calypso/components/tooltip';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getRowMetaData } from './utils';
 import type { AllowedTypes, SiteData } from './types';
 
 interface Props {
 	rows: SiteData;
 	type: AllowedTypes;
+	isLargeScreen: boolean;
 }
 
-export default function SiteStatusContent( { rows, type }: Props ): ReactElement {
+export default function SiteStatusContent( {
+	rows,
+	type,
+	isLargeScreen = false,
+}: Props ): ReactElement {
+	const dispatch = useDispatch();
+
 	const {
 		link,
 		isExternalLink,
@@ -21,7 +30,8 @@ export default function SiteStatusContent( { rows, type }: Props ): ReactElement
 		tooltip,
 		tooltipId,
 		siteDown,
-	} = getRowMetaData( rows, type );
+		eventName,
+	} = getRowMetaData( rows, type, isLargeScreen );
 
 	// Disable clicks/hover when there is a site error &
 	// when the row it is not monitor and monitor status is down
@@ -39,7 +49,7 @@ export default function SiteStatusContent( { rows, type }: Props ): ReactElement
 	};
 
 	const handleClickRowAction = () => {
-		// Handle track event here
+		dispatch( recordTracksEvent( eventName ) );
 	};
 
 	if ( type === 'site' ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -53,7 +53,7 @@ export default function SiteTable( { isFetching, columns, items }: Props ): Reac
 													className={ classNames( site.error && 'site-table__td-with-error' ) }
 													key={ `table-data-${ row.type }-${ blogId }` }
 												>
-													<SiteStatusContent rows={ item } type={ row.type } />
+													<SiteStatusContent rows={ item } type={ row.type } isLargeScreen />
 												</td>
 											);
 										}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
@@ -3,6 +3,7 @@ import { ReactElement, useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import tipIcon from 'calypso/assets/images/jetpack/tip-icon.svg';
 import Banner from 'calypso/components/banner';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE,
 	JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE_HOME_PAGE as homePagePreferenceName,
@@ -36,19 +37,40 @@ export default function SiteWelcomeBanner( {
 		[ dispatch, preference, preferenceName ]
 	);
 
+	const handleTrackEvents = useCallback(
+		( eventName: string ) => {
+			dispatch( recordTracksEvent( eventName ) );
+		},
+		[ dispatch ]
+	);
+
 	const isDismissed = preference?.dismiss;
 	const hideBanner = ! isDashboardView && homePagePreference?.view;
 
 	useEffect( () => {
 		if ( ! isDismissed && ! hideBanner ) {
 			savePreferenceType( 'view' );
+			handleTrackEvents(
+				isDashboardView
+					? 'calypso_jetpack_agency_dashboard_home_page_banner_view'
+					: 'calypso_jetpack_agency_dashboard_other_page_banner_view'
+			);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
+	const trackViewEvent = () => {
+		handleTrackEvents( 'calypso_jetpack_agency_dashboard_other_page_banner_view_dashboard_click' );
+	};
+
 	const dismissBanner = useCallback( () => {
 		savePreferenceType( 'dismiss' );
-	}, [ savePreferenceType ] );
+		handleTrackEvents(
+			isDashboardView
+				? 'calypso_jetpack_agency_dashboard_home_page_banner_dismiss_click'
+				: 'calypso_jetpack_agency_dashboard_other_page_banner_dismiss_click'
+		);
+	}, [ handleTrackEvents, isDashboardView, savePreferenceType ] );
 
 	// Hide the banner if the banner is already viewed
 	// on the dashboard page or the banner is dismissed
@@ -73,7 +95,7 @@ export default function SiteWelcomeBanner( {
 			iconPath={ tipIcon }
 			callToAction={ isDashboardView ? translate( 'Got it' ) : translate( 'View' ) }
 			href={ isDashboardView ? '' : '/dashboard' }
-			onClick={ isDashboardView && dismissBanner }
+			onClick={ isDashboardView ? dismissBanner : trackViewEvent }
 			dismissTemporary={ ! isDashboardView }
 			onDismiss={ dismissBanner }
 			dismissPreferenceName={ isDashboardView ? '' : preferenceName }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -33,3 +33,15 @@ export type FormattedRowObj = {
 	threats?: number;
 	error?: boolean;
 };
+
+export type AllowedStatusTypes = 'inactive' | 'progress' | 'failed' | 'warning' | 'success';
+
+export type StatusEventNames = {
+	[ key in AllowedStatusTypes | string ]: { small_screen: string; large_screen: string };
+};
+
+export type AllowedActionTypes = 'issue_license' | 'view_activity' | 'view_site' | 'visit_wp_admin';
+
+export type ActionEventNames = {
+	[ key in AllowedActionTypes ]: { small_screen: string; large_screen: string };
+};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -180,6 +180,7 @@ const getLinks = (
 		case 'plugin': {
 			if ( status === 'warning' ) {
 				link = `https://wordpress.com/plugins/updates/${ siteUrl }`;
+				isExternalLink = true;
 			}
 			break;
 		}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -1,6 +1,129 @@
 import { translate } from 'i18n-calypso';
-import type { AllowedTypes, SiteData, FormattedRowObj } from './types';
+import type {
+	AllowedTypes,
+	SiteData,
+	FormattedRowObj,
+	StatusEventNames,
+	ActionEventNames,
+	AllowedStatusTypes,
+	AllowedActionTypes,
+} from './types';
 import type { ReactChild } from 'react';
+
+// Event names for all actions for large screen(>960px) and small screen(<960px)
+export const actionEventNames: ActionEventNames = {
+	issue_license: {
+		large_screen: 'calypso_jetpack_agency_dashboard_issue_license_large_screen',
+		small_screen: 'calypso_jetpack_agency_dashboard_issue_license_small_screen',
+	},
+	view_activity: {
+		large_screen: 'calypso_jetpack_agency_dashboard_view_activity_large_screen',
+		small_screen: 'calypso_jetpack_agency_dashboard_view_activity_small_screen',
+	},
+	view_site: {
+		large_screen: 'calypso_jetpack_agency_dashboard_view_site_large_screen',
+		small_screen: 'calypso_jetpack_agency_dashboard_view_site_small_screen',
+	},
+	visit_wp_admin: {
+		large_screen: 'calypso_jetpack_agency_dashboard_visit_wp_admin_large_screen',
+		small_screen: 'calypso_jetpack_agency_dashboard_visit_wp_admin_small_screen',
+	},
+};
+
+// Returns event name based on the action type
+export const getActionEventNames = ( actionType: AllowedActionTypes, isLargeScreen: boolean ) => {
+	const deviceKey = isLargeScreen ? 'large_screen' : 'small_screen';
+	return actionEventNames?.[ actionType ]?.[ deviceKey ];
+};
+
+// Backup feature status event names for large screen(>960px) and small screen(<960px)
+const backupEventNames: StatusEventNames = {
+	inactive: {
+		small_screen: 'calypso_jetpack_agency_dashboard_add_backup_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_add_backup_click_large_screen',
+	},
+	progress: {
+		small_screen: 'calypso_jetpack_agency_dashboard_backup_progress_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_backup_progress_click_large_screen',
+	},
+	failed: {
+		small_screen: 'calypso_jetpack_agency_dashboard_backup_failed_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_backup_failed_click_large_screen',
+	},
+	warning: {
+		small_screen: 'calypso_jetpack_agency_dashboard_backup_warning_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_backup_warning_click_large_screen',
+	},
+	success: {
+		small_screen: 'calypso_jetpack_agency_dashboard_backup_success_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_backup_success_click_large_screen',
+	},
+};
+
+// Scan feature status event names for large screen(>960px) and small screen(<960px)
+const scanEventNames: StatusEventNames = {
+	inactive: {
+		small_screen: 'calypso_jetpack_agency_dashboard_add_scan_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_add_scan_click_large_screen',
+	},
+	progress: {
+		small_screen: 'calypso_jetpack_agency_dashboard_scan_progress_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_scan_progress_click_large_screen',
+	},
+	failed: {
+		small_screen: 'calypso_jetpack_agency_dashboard_scan_threats_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_scan_threats_click_large_screen',
+	},
+	success: {
+		small_screen: 'calypso_jetpack_agency_dashboard_scan_success_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_scan_success_click_large_screen',
+	},
+};
+
+// Montitor feature status event names for large screen(>960px) and small screen(<960px)
+const monitorEventNames: StatusEventNames = {
+	failed: {
+		small_screen: 'calypso_jetpack_agency_dashboard_monitor_site_down_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_monitor_site_down_click_large_screen',
+	},
+};
+
+// Plugin updates status event names for large screen(>960px) and small screen(<960px)
+const pluginEventNames: StatusEventNames = {
+	warning: {
+		small_screen: 'calypso_jetpack_agency_dashboard_update_plugins_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_update_plugins_click_large_screen',
+	},
+};
+
+// Returns event name needed for all the feature state clicks on the agency dashboard
+const getRowEventName = (
+	type: AllowedTypes,
+	status: AllowedStatusTypes,
+	isLargeScreen: boolean
+) => {
+	let eventName = '';
+	const deviceKey = isLargeScreen ? 'large_screen' : 'small_screen';
+	switch ( type ) {
+		case 'backup': {
+			eventName = backupEventNames?.[ status ]?.[ deviceKey ];
+			break;
+		}
+		case 'scan': {
+			eventName = scanEventNames?.[ status ]?.[ deviceKey ];
+			break;
+		}
+		case 'monitor': {
+			eventName = monitorEventNames?.[ status ]?.[ deviceKey ];
+			break;
+		}
+		case 'plugin': {
+			eventName = pluginEventNames?.[ status ]?.[ deviceKey ];
+			break;
+		}
+	}
+	return eventName;
+};
 
 /**
  * Returns link and tooltip for each feature based on status
@@ -13,7 +136,11 @@ const getLinks = (
 	status: string,
 	siteUrl: string,
 	siteId: number
-): { tooltip: ReactChild | undefined; link: string; isExternalLink: boolean } => {
+): {
+	tooltip: ReactChild | undefined;
+	link: string;
+	isExternalLink: boolean;
+} => {
 	let link = '';
 	let isExternalLink = false;
 	let tooltip;
@@ -66,7 +193,8 @@ const getLinks = (
  */
 export const getRowMetaData = (
 	rows: SiteData,
-	type: AllowedTypes
+	type: AllowedTypes,
+	isLargeScreen: boolean
 ): {
 	row: { value: { url: string }; status: string; error: string };
 	link: string;
@@ -75,12 +203,14 @@ export const getRowMetaData = (
 	tooltip: ReactChild | undefined;
 	tooltipId: string;
 	siteDown: boolean;
+	eventName: string | null;
 } => {
 	const row = rows[ type ];
 	const siteUrl = rows.site?.value?.url;
 	const siteError = rows.site.error;
 	const siteId = rows.site?.value?.blog_id;
 	const { link, tooltip, isExternalLink } = getLinks( type, row.status, siteUrl, siteId );
+	const eventName = getRowEventName( type, row.status, isLargeScreen );
 	return {
 		row,
 		link,
@@ -89,6 +219,7 @@ export const getRowMetaData = (
 		tooltip,
 		tooltipId: `${ siteId }-${ type }`,
 		siteDown: rows.monitor.error,
+		eventName,
 	};
 };
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -31,7 +31,7 @@ export const actionEventNames: ActionEventNames = {
 };
 
 // Returns event name based on the action type
-export const getActionEventNames = ( actionType: AllowedActionTypes, isLargeScreen: boolean ) => {
+export const getActionEventName = ( actionType: AllowedActionTypes, isLargeScreen: boolean ) => {
 	const deviceKey = isLargeScreen ? 'large_screen' : 'small_screen';
 	return actionEventNames?.[ actionType ]?.[ deviceKey ];
 };
@@ -102,27 +102,21 @@ const getRowEventName = (
 	status: AllowedStatusTypes,
 	isLargeScreen: boolean
 ) => {
-	let eventName = '';
 	const deviceKey = isLargeScreen ? 'large_screen' : 'small_screen';
 	switch ( type ) {
 		case 'backup': {
-			eventName = backupEventNames?.[ status ]?.[ deviceKey ];
-			break;
+			return backupEventNames?.[ status ]?.[ deviceKey ];
 		}
 		case 'scan': {
-			eventName = scanEventNames?.[ status ]?.[ deviceKey ];
-			break;
+			return scanEventNames?.[ status ]?.[ deviceKey ];
 		}
 		case 'monitor': {
-			eventName = monitorEventNames?.[ status ]?.[ deviceKey ];
-			break;
+			return monitorEventNames?.[ status ]?.[ deviceKey ];
 		}
 		case 'plugin': {
-			eventName = pluginEventNames?.[ status ]?.[ deviceKey ];
-			break;
+			return pluginEventNames?.[ status ]?.[ deviceKey ];
 		}
 	}
-	return eventName;
 };
 
 /**
@@ -204,7 +198,7 @@ export const getRowMetaData = (
 	tooltip: ReactChild | undefined;
 	tooltipId: string;
 	siteDown: boolean;
-	eventName: string | null;
+	eventName: string | undefined;
 } => {
 	const row = rows[ type ];
 	const siteUrl = rows.site?.value?.url;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds track events for the agency dashboard changes.
* Makes plugin update row links open in a new tab

#### Testing instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb

**Instructions**

1. Run `git checkout add/track-events-for-agency-dashboard` and `yarn start-jetpack-cloud`
3. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard
5. Since we cannot test all track events added here, I'll note down the scenarios which can be tested and make sure everything works as expected.
6. Open the dev(inspect) tool -> Go to the Network tab -> Apply the filter `agency_dashboard` to filter only the event tracking network calls.
7. Refresh the dashboard page and verify that the API call is being made to track dashboard visit with event name - `calypso_jetpack_agency_dashboard_visit`
9. Click on `2 Available` in the Plugin Updates column, last row(3rd item) and verify that the API call is being made with event name - `calypso_jetpack_agency_dashboard_update_plugins_click_large_screen`. Also, verify the link opens in a new tab. It's ok if you don't have any updates for plugins, just click on any other Feature States(Backup, Scan, Monitor) and verify the API calls are being made for the click.
10.  Click on `...` -> `View site` and verify that the API call is being made with event name - `calypso_jetpack_agency_dashboard_view_site_large_screen`
11. Switch to the small screen(<960px) using the `toggle device toolbar` ->  Refresh the page -> Expand any card -> Verify the API calls is being made with event name - `calypso_jetpack_agency_dashboard_card_expand`
12. Expand the 3rd card -> Click on `2 Available` in the Plugin Updates column and verify that the API call is being made with event name - `calypso_jetpack_agency_dashboard_update_plugins_click_small_screen`
13. Click on `...` -> `View site` and verify that the API call is being made with event name - `calypso_jetpack_agency_dashboard_view_site_small_screen`

<img width="1595" alt="Screenshot 2022-05-25 at 4 53 37 PM" src="https://user-images.githubusercontent.com/10586875/170251152-b04e457d-c867-49c4-9b3a-a5a679b97687.png">


Related to 1202076982646589-as-1202257963437765