### PR TITLE
Framework: Remove `reduxGetState` from `redux-bridge`

### DIFF
--- a/client/lib/redux-bridge/index.js
+++ b/client/lib/redux-bridge/index.js
@@ -5,18 +5,6 @@ export function setReduxStore( store ) {
 }
 
 /**
- * Get the state of the current redux store
- *
- * @returns {object} Redux state
- */
-export function reduxGetState() {
-	if ( ! reduxStore ) {
-		return;
-	}
-	return reduxStore.getState();
-}
-
-/**
  * Dispatch an action against the current redux store
  *
  * @returns {any} Result of the dispatch


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While we're in the process of removing the legacy `redux-bridge` from Calypso, this PR suggests removing the `reduxGetState()` function in order to avoid introducing new usages of it before we've removed the library completely. 

#### Testing instructions

Not needed, this removes unused code.