### PR TITLE
Plans overhaul: General tweaks to plans grid (reorder, title, etc.)

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -228,6 +228,42 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 	},
 	{
 		get title() {
+			return translate( 'Google Analytics integration' );
+		},
+		get description() {
+			return translate(
+				"Track your site's stats with Google Analytics for a deeper understanding of your visitors and customers."
+			);
+		},
+		features: [ FEATURE_GOOGLE_ANALYTICS ],
+		getCellText: ( feature, isMobile = false ) => {
+			if ( ! isMobile ) {
+				if ( feature ) {
+					return (
+						<>
+							<Gridicon icon="checkmark" />
+							{ translate( 'Included' ) }
+						</>
+					);
+				}
+
+				return (
+					<>
+						<Gridicon icon="cross" />
+						{ translate( 'Not included' ) }
+					</>
+				);
+			}
+
+			return feature
+				? translate( 'Google Analytics integration' )
+				: translate( 'Google Analytics integration is {{strong}}not{{/strong}} included', {
+						components: { strong: <strong /> },
+				  } );
+		},
+	},
+	{
+		get title() {
 			return translate( 'WordPress plugins' );
 		},
 		get subtitle() {
@@ -314,6 +350,29 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 	},
 	{
 		get title() {
+			return translate( 'Advanced social media tools' );
+		},
+		get description() {
+			return translate( 'Amplify your voice with our built-in social tools.' );
+		},
+		features: [ FEATURE_SOCIAL_MEDIA_TOOLS ],
+		getCellText: ( feature, isMobile = false ) => {
+			let cellText = defaultGetCellText( translate( 'Built in social media tools' ) )(
+				feature,
+				isMobile
+			);
+			if ( isMobile ) {
+				cellText = feature
+					? translate( 'Built in social media tools are included' )
+					: translate( 'Built in social media tools are {{strong}}not{{/strong}} included', {
+							components: { strong: <strong /> },
+					  } );
+			}
+			return cellText;
+		},
+	},
+	{
+		get title() {
 			return translate( 'Sell products with WooCommerce' );
 		},
 		get description() {
@@ -369,42 +428,6 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			return feature
 				? translate( 'Professional Email is free for 3 months' )
 				: translate( 'Professional Email is {{strong}}not{{/strong}} included', {
-						components: { strong: <strong /> },
-				  } );
-		},
-	},
-	{
-		get title() {
-			return translate( 'Google Analytics integration' );
-		},
-		get description() {
-			return translate(
-				"Track your site's stats with Google Analytics for a deeper understanding of your visitors and customers."
-			);
-		},
-		features: [ FEATURE_GOOGLE_ANALYTICS ],
-		getCellText: ( feature, isMobile = false ) => {
-			if ( ! isMobile ) {
-				if ( feature ) {
-					return (
-						<>
-							<Gridicon icon="checkmark" />
-							{ translate( 'Included' ) }
-						</>
-					);
-				}
-
-				return (
-					<>
-						<Gridicon icon="cross" />
-						{ translate( 'Not included' ) }
-					</>
-				);
-			}
-
-			return feature
-				? translate( 'Google Analytics integration' )
-				: translate( 'Google Analytics integration is {{strong}}not{{/strong}} included', {
 						components: { strong: <strong /> },
 				  } );
 		},
@@ -540,29 +563,6 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 					args: { adminCount: numberFormat( adminCount, 0 ) },
 				}
 			);
-		},
-	},
-	{
-		get title() {
-			return translate( 'Advanced social media tools' );
-		},
-		get description() {
-			return translate( 'Amplify your voice with our built-in social tools.' );
-		},
-		features: [ FEATURE_SOCIAL_MEDIA_TOOLS ],
-		getCellText: ( feature, isMobile = false ) => {
-			let cellText = defaultGetCellText( translate( 'Built in social media tools' ) )(
-				feature,
-				isMobile
-			);
-			if ( isMobile ) {
-				cellText = feature
-					? translate( 'Built in social media tools are included' )
-					: translate( 'Built in social media tools are {{strong}}not{{/strong}} included', {
-							components: { strong: <strong /> },
-					  } );
-			}
-			return cellText;
 		},
 	},
 	{

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -206,24 +206,34 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			}
 
 			if ( isLegacySiteWithHigherLimits && legacyStorageSize > storageSize ) {
-				return translate(
-					'{{del}}%(originalStorage)sGB{{/del}} %(modifiedStorage)sGB on this site',
-					{
-						components: {
-							del: <del />,
-						},
-						args: {
-							originalStorage: storageSize,
-							modifiedStorage: legacyStorageSize,
-						},
-					}
+				return (
+					<>
+						<Gridicon icon="checkmark" />
+						{ translate(
+							'{{del}}%(originalStorage)sGB{{/del}} %(modifiedStorage)sGB on this site',
+							{
+								components: {
+									del: <del />,
+								},
+								args: {
+									originalStorage: storageSize,
+									modifiedStorage: legacyStorageSize,
+								},
+							}
+						) }
+					</>
 				);
 			}
 
-			return translate( '%sGB', {
-				args: [ storageSize ],
-				comment: '%s is a number of gigabytes.',
-			} );
+			return (
+				<>
+					<Gridicon icon="checkmark" />
+					{ translate( '%sGB', {
+						args: [ storageSize ],
+						comment: '%s is a number of gigabytes.',
+					} ) }
+				</>
+			);
 		},
 	},
 	{

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -360,6 +360,28 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 	},
 	{
 		get title() {
+			return translate( 'Sell products with WooCommerce' );
+		},
+		get description() {
+			return translate(
+				'Includes one-click payments, premium store designs and personalized expert support.'
+			);
+		},
+		features: [ FEATURE_WOOCOMMERCE ],
+		getCellText: ( feature, isMobile = false ) => {
+			let cellText = defaultGetCellText( translate( 'WooCommerce' ) )( feature, isMobile );
+			if ( isMobile ) {
+				cellText = feature
+					? translate( 'WooCommerce is included' )
+					: translate( 'WooCommerce is {{strong}}not{{/strong}} included', {
+							components: { strong: <strong /> },
+					  } );
+			}
+			return cellText;
+		},
+	},
+	{
+		get title() {
 			return translate( 'Advanced social media tools' );
 		},
 		get description() {
@@ -375,28 +397,6 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 				cellText = feature
 					? translate( 'Built in social media tools are included' )
 					: translate( 'Built in social media tools are {{strong}}not{{/strong}} included', {
-							components: { strong: <strong /> },
-					  } );
-			}
-			return cellText;
-		},
-	},
-	{
-		get title() {
-			return translate( 'Sell products with WooCommerce' );
-		},
-		get description() {
-			return translate(
-				'Includes one-click payments, premium store designs and personalized expert support.'
-			);
-		},
-		features: [ FEATURE_WOOCOMMERCE ],
-		getCellText: ( feature, isMobile = false ) => {
-			let cellText = defaultGetCellText( translate( 'WooCommerce' ) )( feature, isMobile );
-			if ( isMobile ) {
-				cellText = feature
-					? translate( 'WooCommerce is included' )
-					: translate( 'WooCommerce is {{strong}}not{{/strong}} included', {
 							components: { strong: <strong /> },
 					  } );
 			}

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -497,7 +497,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 					</tr>
 				</THead>
 				<PlansComparisonRows>
-					{ planComparisonFeatures.slice( 0, 7 ).map( ( feature ) => (
+					{ planComparisonFeatures.slice( 0, 8 ).map( ( feature ) => (
 						<PlansComparisonRow
 							feature={ feature }
 							plans={ plans }
@@ -507,7 +507,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 					) ) }
 				</PlansComparisonRows>
 				<PlansComparisonCollapsibleRows collapsed={ showCollapsibleRows }>
-					{ planComparisonFeatures.slice( 7 ).map( ( feature ) => (
+					{ planComparisonFeatures.slice( 8 ).map( ( feature ) => (
 						<PlansComparisonRow
 							feature={ feature }
 							plans={ plans }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -226,8 +226,8 @@ export class PlansStep extends Component {
 		const { headerText, translate, eligibleForProPlan, locale } = this.props;
 
 		if ( eligibleForProPlan ) {
-			return 'en' === locale || i18n.hasTranslation( 'Choose your hosting plan' )
-				? translate( 'Choose your hosting plan' )
+			return 'en' === locale || i18n.hasTranslation( 'Choose the right plan for you' )
+				? translate( 'Choose the right plan for you' )
 				: translate( 'Choose the plan that’s right for you' );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

General updates to the plans grid:
- Rename heading
- increase features visible to 8 in default list
- reorder items per design

#### Media

**Design/mock**

![design](https://user-images.githubusercontent.com/1705499/170268985-4ed69b25-88cb-4a09-ba0b-b4ad9f2ca1ea.png)

**Default list**

<img width="500" alt="Screenshot 2022-05-25 at 4 08 03 PM" src="https://user-images.githubusercontent.com/1705499/170269470-f40b8f86-a270-4a96-958f-ab7e62ec77a3.png">

**Expanded list**

<img width="342" alt="Screenshot 2022-05-25 at 4 08 26 PM" src="https://user-images.githubusercontent.com/1705499/170269522-657a4ff5-2e2e-48bb-ad9f-f8a209c20e5a.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/start/plans`
    - confirm the plans grid & title as in media above
2. Go to `/plans/[SITE_ON_FREE_OR_STARTER]`
    - confirm the plans grid as in media above

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
