### PR TITLE
SelectDropdown: use `uuid` to create unique instanceId

### DIFF
--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { filter, find, get } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Children, cloneElement, Component } from 'react';
+import { v4 as uuid } from 'uuid';
 import Count from 'calypso/components/count';
 import MaterialIcon from 'calypso/components/material-icon';
 import TranslatableString from 'calypso/components/translatable/proptype';
@@ -49,9 +50,7 @@ class SelectDropdown extends Component {
 		style: {},
 	};
 
-	static instances = 0;
-
-	instanceId = ++SelectDropdown.instances;
+	instanceId = uuid();
 
 	state = {
 		isOpen: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We merged #63966 with an open eslint warning which this PR attempts to fix. We seem to use `uuid` in other places too where we need a unique `instanceId`.

* SelectDropdown: use `uuid` to create unique instanceId

#### Testing instructions

* Go to `/devdocs/design/select-dropdown`
* Verify shown `SelectDropdown` components work as expected
* You should also be able to observe the different ids by looking at the source code

Follow up to #63966
