### PR TITLE
Generated Design Picker: Pass siteSlug as the seed to the generated designs endpoint

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -96,7 +96,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	);
 
 	const { data: generatedDesigns = [], isLoading: isLoadingGeneratedDesigns } =
-		useStarterDesignsGeneratedQuery();
+		useStarterDesignsGeneratedQuery( { seed: siteSlug || undefined } );
 
 	const selectedGeneratedDesign = useMemo(
 		() => selectedDesign ?? ( ! isMobile ? generatedDesigns[ 0 ] : undefined ),

--- a/packages/data-stores/src/starter-designs-queries/types.ts
+++ b/packages/data-stores/src/starter-designs-queries/types.ts
@@ -1,5 +1,9 @@
 import type { DesignRecipe } from '@automattic/design-picker/src/types';
 
+export interface StarterDesignsGeneratedQueryParams {
+	seed?: string;
+}
+
 export interface StarterDesignsGenerated {
 	slug: string;
 	title: string;

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-generated-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-generated-query.ts
@@ -1,21 +1,31 @@
+import { stringify } from 'qs';
 import { useQuery, UseQueryResult } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
-import type { StarterDesignsGenerated } from './types';
+import type { StarterDesignsGenerated, StarterDesignsGeneratedQueryParams } from './types';
 import type { Design } from '@automattic/design-picker/src/types';
 
-export function useStarterDesignsGeneratedQuery(): UseQueryResult< Design[] > {
-	return useQuery( [ 'starter-designs-generated' ], () => fetchStarterDesignsGenerated(), {
-		select: ( response ) => response.map( apiStarterDesignsGeneratedToDesign ),
-		enabled: true,
-		refetchOnMount: 'always',
-		staleTime: Infinity,
-	} );
+export function useStarterDesignsGeneratedQuery(
+	queryParams: StarterDesignsGeneratedQueryParams
+): UseQueryResult< Design[] > {
+	return useQuery(
+		[ 'starter-designs-generated' ],
+		() => fetchStarterDesignsGenerated( queryParams ),
+		{
+			select: ( response ) => response.map( apiStarterDesignsGeneratedToDesign ),
+			enabled: true,
+			refetchOnMount: 'always',
+			staleTime: Infinity,
+		}
+	);
 }
 
-function fetchStarterDesignsGenerated(): Promise< StarterDesignsGenerated[] > {
+function fetchStarterDesignsGenerated(
+	queryParams: StarterDesignsGeneratedQueryParams
+): Promise< StarterDesignsGenerated[] > {
 	return wpcomRequest< StarterDesignsGenerated[] >( {
 		apiNamespace: 'wpcom/v2',
 		path: '/starter-designs/generated',
+		query: stringify( queryParams ),
 	} );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR passes the current site slug as the randomization seed to the `/wpcom/v2/starter-designs/generated` endpoint. This results in the generated design picker to show only one random design per segment (as per D81487-code).

I pick the site slug as the seed for the sake of simplicity of the implementation.

#### Testing instructions

1. Apply D81487-code to your sandbox.
2. Open `http://calypso.localhost:3000/setup/vertical?siteSlug=<your site slug>`.
3. Select a vertical.
4. Select Build intent.
5. Verify that the Design Picker shows generated designs, one design per segment, in random order.
6. Refresh your browser. Verify that you see the same exact list of designs.
7. Repeat steps 2-6 with a several other site slugs. Verify that you (very likely) see a different list of designs.

Related to 16-gh-Automattic/ganon-issues