### PR TITLE
E2E: add coverage for user upgrade from Free to Pro plan.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/checkout-thank-you-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/checkout-thank-you-page.ts
@@ -1,0 +1,31 @@
+import { Page } from 'playwright';
+
+/**
+ * Represents the page that is shown post-checkout.
+ *
+ * This screen is only shown when a user checks out an upgrade
+ * on an existing site *outside* of the onboarding flow.
+ */
+export class CheckoutThankYouPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Clicks on a button that has matching string.
+	 *
+	 * @param {string} text Text to match on.
+	 */
+	async clickButton( text: string ): Promise< void > {
+		const locator = this.page.locator( `a:has-text("${ text }"), button:has-text("${ text }")` );
+
+		await locator.click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -28,5 +28,6 @@ export * from './plugins-page';
 export * from './writing-settings-page';
 export * from './shared-types';
 export * from './full-site-editor-page';
+export * from './checkout-thank-you-page';
 
 export * from './me';

--- a/packages/calypso-e2e/src/lib/pages/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup-pick-plan-page.ts
@@ -1,6 +1,6 @@
 import { Page } from 'playwright';
 import { PlansPage, Plans } from './plans-page';
-import type { SiteDetails, NewSiteResponse } from '../../types/rest-api-client.types';
+import type { SiteDetails } from '../../types/rest-api-client.types';
 
 /**
  * Represents the Signup > Pick a Plan page.
@@ -37,12 +37,12 @@ export class SignupPickPlanPage {
 			throw new Error( 'Failed to create new site when selecting a plan at signup.' );
 		}
 
-		const responseBody: NewSiteResponse = await response.json();
+		const responseJSON = await response.json();
 
 		return {
-			id: responseBody.body.blog_details.blogid,
-			url: responseBody.body.blog_details.url,
-			name: responseBody.body.blog_details.blogname,
+			id: responseJSON[ 'body' ].blog_details.blogid,
+			url: responseJSON[ 'body' ].blog_details.url,
+			name: responseJSON[ 'body' ].blog_details.blogname,
 		};
 	}
 }

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -106,7 +106,8 @@ export class RestAPIClient {
 	 */
 	private async getAuthorizationHeader( scheme: 'bearer' ): Promise< string > {
 		if ( scheme === 'bearer' ) {
-			return `Bearer ${ this.bearerToken }`;
+			const bearerToken = await this.getBearerToken();
+			return `Bearer ${ bearerToken }`;
 		}
 
 		throw new Error( 'Unsupported authorization scheme specified.' );

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -12,6 +12,8 @@ import type {
 	CalypsoPreferencesResponse,
 	ErrorResponse,
 	AccountCredentials,
+	NewSiteResponse,
+	NewSiteParams,
 } from './types';
 import type { BodyInit, HeadersInit, RequestInit } from 'node-fetch';
 
@@ -171,6 +173,41 @@ export class RestAPIClient {
 		};
 
 		const response = await this.sendRequest( this.getRequestURL( '1.1', '/me/sites' ), params );
+
+		if ( response.hasOwnProperty( 'error' ) ) {
+			throw new Error(
+				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
+			);
+		}
+
+		return response;
+	}
+
+	/**
+	 * Given parameters, create a new site.
+	 *
+	 * @param {NewSiteParams} newSiteParams Details for the new site.
+	 * @returns {Promise<NewSiteResponse>} Confirmation details for the new site.
+	 * @throws {ErrorResponse} If API responded with an error.
+	 */
+	async createSite( newSiteParams: NewSiteParams ): Promise< NewSiteResponse > {
+		const body = {
+			client_id: SecretsManager.secrets.calypsoOauthApplication.client_id,
+			client_secret: SecretsManager.secrets.calypsoOauthApplication.client_secret,
+			blog_name: newSiteParams.name,
+			blog_title: newSiteParams.title,
+		};
+
+		const params: RequestParams = {
+			method: 'post',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+			body: JSON.stringify( body ),
+		};
+
+		const response = await this.sendRequest( this.getRequestURL( '1.1', '/sites/new' ), params );
 
 		if ( response.hasOwnProperty( 'error' ) ) {
 			throw new Error(

--- a/packages/calypso-e2e/src/test/rest-api-client.getBearerToken.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.getBearerToken.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test, jest } from '@jest/globals';
+import nock from 'nock';
+import { RestAPIClient, BEARER_TOKEN_URL } from '../rest-api-client';
+import { SecretsManager } from '../secrets';
+import type { Secrets } from '../secrets';
+
+const fakeSecrets = {
+	calypsoOauthApplication: {
+		client_id: 'some_value',
+		client_secret: 'some_value',
+	},
+	testAccounts: {
+		basicUser: {
+			username: 'wpcomuser2',
+			password: 'hunter2',
+			primarySite: 'wpcomuser.wordpress.com/',
+		},
+		noUrlUser: {
+			username: 'nourluser',
+			password: 'password1234',
+		},
+	},
+} as unknown as Secrets;
+
+jest.spyOn( SecretsManager, 'secrets', 'get' ).mockImplementation( () => fakeSecrets );
+
+describe( 'RestAPIClient: getBearerToken', function () {
+	test( 'Bearer Token is returned upon successful request', async function () {
+		const mockedToken = 'abcdefghijklmn';
+
+		nock( BEARER_TOKEN_URL )
+			.post( /.*/ )
+			.reply( 200, {
+				success: true,
+				data: {
+					bearer_token: mockedToken,
+					token_links: [ 'link_1', 'link_2' ],
+				},
+			} );
+
+		const restAPIClient = new RestAPIClient( {
+			username: 'user',
+			password: 'password',
+		} );
+		const bearerToken = await restAPIClient.getBearerToken();
+
+		expect( bearerToken ).toBeDefined();
+		expect( bearerToken ).toBe( mockedToken );
+		expect( typeof bearerToken ).toBe( 'string' );
+	} );
+
+	test.each( [
+		{
+			code: 'incorrect_password',
+			message: `Oops, that's not the right password. Please try again!`,
+		},
+		{
+			code: 'invalid_username',
+			message: `We don't seem to have an account with that name. Double-check the spelling and try again!`,
+		},
+	] )( `Throws error with expected code and message ($code)`, async function ( { code, message } ) {
+		nock( BEARER_TOKEN_URL )
+			.post( /.*/ )
+			.reply( 200, {
+				success: false,
+				data: {
+					errors: [
+						{
+							code: code,
+							message: message,
+						},
+					],
+				},
+			} );
+
+		const restAPIClient = new RestAPIClient( {
+			username: 'fake_user',
+			password: 'fake_password',
+		} );
+
+		await expect( restAPIClient.getBearerToken() ).rejects.toThrowError(
+			`${ code }: ${ message }`
+		);
+	} );
+} );

--- a/packages/calypso-e2e/src/test/rest-api-client.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.test.ts
@@ -139,15 +139,12 @@ describe( 'RestAPIClient: createSite', function () {
 
 	test( 'Site metadata is returned on successful request', async function () {
 		const testResponse = {
-			code: 200,
-			body: {
-				success: true,
-				blog_details: {
-					url: 'https://fakeblog.blog.com',
-					blogid: '420',
-					blogname: 'fake_blog_name',
-					site_slug: 'fakeblog.blog.com',
-				},
+			success: true,
+			blog_details: {
+				url: 'https://fakeblog.blog.com',
+				blogid: '420',
+				blogname: 'fake_blog_name',
+				site_slug: 'fakeblog.blog.com',
 			},
 		};
 

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -12,6 +12,11 @@ export interface SiteDetails {
 	name: string;
 }
 
+export interface NewSiteParams {
+	name: string;
+	title: string;
+}
+
 /* Response Interfaces */
 
 export interface BearerTokenResponse {

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -64,15 +64,12 @@ export interface NewUserResponse {
 	};
 }
 export interface NewSiteResponse {
-	code: number;
-	body: {
-		success: boolean;
-		blog_details: {
-			url: string;
-			blogid: string;
-			blogname: string;
-			site_slug: string;
-		};
+	success: boolean;
+	blog_details: {
+		url: string;
+		blogid: string;
+		blogname: string;
+		site_slug: string;
 	};
 }
 export interface SiteDeletionResponse {

--- a/test/e2e/specs/plans/plans__existing-free-site-upgrade.ts
+++ b/test/e2e/specs/plans/plans__existing-free-site-upgrade.ts
@@ -11,6 +11,7 @@ import {
 	TestAccount,
 	RestAPIClient,
 	BrowserManager,
+	SecretsManager,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import type { NewSiteResponse } from '@automattic/calypso-e2e';
@@ -28,15 +29,40 @@ describe(
 		let restAPIClient: RestAPIClient;
 		let page: Page;
 
-		beforeAll( async function () {
+		// beforeAll( async function () {
+		// 	// Set up the test site programmatically.
+		// 	const credentials = SecretsManager.secrets.testAccounts.simpleSiteFreePlanUser;
+		// 	restAPIClient = new RestAPIClient( credentials );
+
+		// 	const response = await restAPIClient.createSite( {
+		// 		name: blogName,
+		// 		title: blogName,
+		// 	} );
+
+		// 	if ( ! response.body.success ) {
+		// 		throw new Error( `Failed to create new site via REST API.\nHTTP response: ${ response }` );
+		// 	}
+		// 	newSite = response;
+		// 	siteCreatedFlag = response.body.success;
+
+		// 	// Authenticate as user.
+		// 	page = await browser.newPage();
+
+		// 	const testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
+		// 	await testAccount.authenticate( page );
+		// } );
+
+		test( 'step', async function () {
 			// Set up the test site programmatically.
-			const credentials = DataHelper.getAccountCredential( 'simpleSiteFreePlanUser' );
+			const credentials = SecretsManager.secrets.testAccounts.simpleSiteFreePlanUser;
 			restAPIClient = new RestAPIClient( credentials );
 
 			const response = await restAPIClient.createSite( {
 				name: blogName,
 				title: blogName,
 			} );
+
+			console.log( response );
 
 			if ( ! response.body.success ) {
 				throw new Error( `Failed to create new site via REST API.\nHTTP response: ${ response }` );

--- a/test/e2e/specs/plans/plans__existing-free-site-upgrade.ts
+++ b/test/e2e/specs/plans/plans__existing-free-site-upgrade.ts
@@ -1,0 +1,142 @@
+/**
+ * @group calypso-pr
+ */
+
+import {
+	DataHelper,
+	CheckoutThankYouPage,
+	SidebarComponent,
+	PlansPage,
+	CartCheckoutPage,
+	TestAccount,
+	RestAPIClient,
+	BrowserManager,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+import type { NewSiteResponse } from '@automattic/calypso-e2e';
+
+declare const browser: Browser;
+
+describe(
+	DataHelper.createSuiteTitle(
+		'Plans: Upgrade exising WordPress.com Free site to WordPress.com Pro'
+	),
+	function () {
+		const blogName = DataHelper.getBlogName();
+		let siteCreatedFlag: boolean;
+		let newSite: NewSiteResponse;
+		let restAPIClient: RestAPIClient;
+		let page: Page;
+
+		beforeAll( async function () {
+			// Set up the test site programmatically.
+			const credentials = DataHelper.getAccountCredential( 'simpleSiteFreePlanUser' );
+			restAPIClient = new RestAPIClient( credentials );
+
+			const response = await restAPIClient.createSite( {
+				name: blogName,
+				title: blogName,
+			} );
+
+			if ( ! response.body.success ) {
+				throw new Error( `Failed to create new site via REST API.\nHTTP response: ${ response }` );
+			}
+			newSite = response;
+			siteCreatedFlag = response.body.success;
+
+			// Authenticate as user.
+			page = await browser.newPage();
+
+			const testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
+			await testAccount.authenticate( page );
+		} );
+
+		describe( 'Upgrade to WordPress.com Pro', function () {
+			let cartCheckoutPage: CartCheckoutPage;
+			let plansPage: PlansPage;
+
+			beforeAll( async function () {
+				await BrowserManager.setStoreCookie( page );
+			} );
+
+			it( 'Navigate to Upgrades > Plans', async function () {
+				await page.goto(
+					DataHelper.getCalypsoURL( `/plans/${ newSite.body.blog_details.site_slug }` )
+				);
+			} );
+
+			it( 'View available plans', async function () {
+				plansPage = new PlansPage( page, 'current' );
+				await plansPage.showPlanComparison();
+			} );
+
+			it( 'Click button to upgrade to WordPress.com Pro', async function () {
+				await plansPage.selectPlan( 'Pro' );
+			} );
+
+			it( 'WordPress.com Pro is added to cart', async function () {
+				cartCheckoutPage = new CartCheckoutPage( page );
+				await cartCheckoutPage.validateCartItem( `WordPress.com Pro` );
+			} );
+
+			it( 'Make purchase', async function () {
+				await cartCheckoutPage.purchase();
+			} );
+
+			it( 'Enter billing and payment details', async function () {
+				await cartCheckoutPage.selectSavedCard( 'End to End Testing' );
+			} );
+
+			it( 'View new features', async function () {
+				const checkoutThankYouPage = new CheckoutThankYouPage( page );
+				await checkoutThankYouPage.clickButton( 'View my new features' );
+			} );
+		} );
+
+		describe( 'Validate WordPress.com Pro functionality', function () {
+			let sidebarComponent: SidebarComponent;
+
+			it( 'Sidebar states user is on WordPress.com Pro plan', async function () {
+				sidebarComponent = new SidebarComponent( page );
+				const plan = await sidebarComponent.getCurrentPlanName();
+				expect( plan ).toBe( 'Pro' );
+			} );
+
+			it( 'Navigate to Upgrades > Plans', async function () {
+				sidebarComponent = new SidebarComponent( page );
+				await sidebarComponent.navigate( 'Upgrades', 'Plans' );
+			} );
+
+			it( 'Plans page states user is on WordPress.com Pro plan', async function () {
+				const plansPage = new PlansPage( page, 'current' );
+				await plansPage.validateActivePlan( 'Pro' );
+			} );
+		} );
+
+		afterAll( async function () {
+			if ( ! siteCreatedFlag ) {
+				return;
+			}
+
+			const response = await restAPIClient.deleteSite( {
+				url: newSite.body.blog_details.url,
+				id: newSite.body.blog_details.blogid,
+				name: newSite.body.blog_details.blogname,
+			} );
+
+			// If the response is `null` then no action has been
+			// performed.
+			if ( response ) {
+				// The only correct response is the string
+				// "deleted".
+				if ( response.status !== 'deleted' ) {
+					console.warn(
+						`Failed to delete siteID ${ newSite.body.blog_details.blogid }.\nExpected: "deleted", Got: ${ response.status }`
+					);
+				} else {
+					console.log( `Successfully deleted siteID ${ newSite.body.blog_details.blogid }.` );
+				}
+			}
+		} );
+	}
+);

--- a/test/e2e/specs/plans/plans__existing-free-site-upgrade.ts
+++ b/test/e2e/specs/plans/plans__existing-free-site-upgrade.ts
@@ -91,12 +91,6 @@ describe(
 		describe( 'Validate WordPress.com Pro functionality', function () {
 			let sidebarComponent: SidebarComponent;
 
-			it( 'Sidebar states user is on WordPress.com Pro plan', async function () {
-				sidebarComponent = new SidebarComponent( page );
-				const plan = await sidebarComponent.getCurrentPlanName();
-				expect( plan ).toBe( 'Pro' );
-			} );
-
 			it( 'Navigate to Upgrades > Plans', async function () {
 				sidebarComponent = new SidebarComponent( page );
 				await sidebarComponent.navigate( 'Upgrades', 'Plans' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds coverage for the scenario where a user of an existing Free site upgrades to the Pro plan.

Key changes:
- addition of methods in RestAPIClient to support creation of a site;
- reworking the existing spec `Plans: Add Upgrade to Cart` to a new spec `Plans: Upgrade exising WordPress.com Free site to WordPress.com Pro`;

#### Testing instructions

Ensure the following:
  - [x] Pre-Release E2E

Related to https://github.com/Automattic/wp-calypso/issues/62492.
Depends on https://github.com/Automattic/wp-calypso/pull/63981.