### PR TITLE
Goals Capture: Add SelectCard component

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -1,9 +1,10 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import SelectCard from './select-card';
 import type { Step } from '../../types';
-
 import './style.scss';
 
 /**
@@ -14,7 +15,17 @@ const GoalsStep: Step = ( { navigation } ) => {
 	const translate = useTranslate();
 	const headerText = translate( 'Welcome! What are your goals?' );
 	const subHeaderText = translate( 'Tell us what would you like to accomplish with your website.' );
-	const stepContent = <p>stepContent goes here</p>;
+
+	// Mock step content
+	const [ selected, setSelected ] = useState( false );
+	const toggleSelected = () => {
+		setSelected( ! selected );
+	};
+	const stepContent = (
+		<SelectCard selected={ selected } value="build" onChange={ toggleSelected }>
+			Promote myself or my business
+		</SelectCard>
+	);
 
 	return (
 		<StepContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-card.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-card.tsx
@@ -1,0 +1,43 @@
+import { CheckboxControl } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import classNames from 'classnames';
+import React from 'react';
+
+type SelectCardProps = {
+	children: React.ReactNode;
+	className?: string;
+	onChange: ( checked: boolean, value: string ) => void;
+	selected: boolean;
+	value: string;
+};
+
+const SelectCard: React.FC< SelectCardProps > = ( {
+	children,
+	className,
+	onChange,
+	selected,
+	value,
+} ) => {
+	const handleClick = ( evt: React.MouseEvent ) => {
+		onChange( ! selected, value );
+		evt.stopPropagation();
+	};
+
+	const instanceId = useInstanceId( CheckboxControl );
+	const id = `select-card-checkbox-${ instanceId }`;
+
+	return (
+		<div
+			className={ classNames( 'select-card__container', className, { selected } ) }
+			onClickCapture={ handleClick }
+			role="presentation"
+		>
+			<CheckboxControl checked={ selected } id={ id } onChange={ () => undefined } />
+			<label className="select-card__label" htmlFor={ id }>
+				{ children }
+			</label>
+		</div>
+	);
+};
+
+export default SelectCard;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -22,3 +22,31 @@
 		}
 	}
 }
+
+.select-card__container {
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	padding: 17px 25px;
+	font-size: 0.875rem;
+	cursor: pointer;
+	display: flex;
+
+	.select-card__label {
+		pointer-events: none;
+		user-select: none;
+	}
+
+	&.selected {
+		border: 2px solid #0675c4;
+		background: linear-gradient( 180deg, rgba( 6, 117, 196, 0.2 ) -44.3%, rgba( 255, 255, 255, 0 ) 100% );
+		padding: 16px 24px;
+	}
+
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
+
+	.components-checkbox-control__input[type=checkbox] {
+		border-color: #a7aaad;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds the **SelectCard** component. It uses the `CheckboxControl` from `@wordpress/components`, overriding the checkbox `ID` to make it accessible with the children's text. The outer container is clickable, so the user can select a goal either by clicking on the check field or in any other area of the `SelectCard`. The `SelectCard` doesn't have a width definition, so it fills the available width and the containers can define the width later.

At first, I tried to use only the `CheckboxControl` changing the style in the outer container, but it has limitations on capturing click events. So I moved to the approach of handling the click actions directly in the `SelectCard` component, that's why have to pass an empty function to the checkbox (it doesn't have an uncontrolled option). In summary, I'm using the `CheckboxControl` only to display the checkbox layout, the same as in [Figma Design System](eqlepL7MHifK8Bgr1OWqLr-fi-47%3A2123).

This PR also updates the `stepContent` in the goals stepper for testing purposes.

#### Testing instructions
1. Go to the [Goals Step url](http://calypso.localhost:3000/setup/goals?siteSlug=[siteaddress]&flags=signup/goals-step)
2. Verify if the SelectCard component appears
<img width="677" alt="unselected" src="https://user-images.githubusercontent.com/3113712/170355837-978cd5d0-6a01-45ab-81fb-ebed26925c6e.png">
3. Click in any area of the component to see if the selected state changes
<img width="686" alt="selected" src="https://user-images.githubusercontent.com/3113712/170355849-5dc95022-c24b-4921-a38f-272c1c522283.png">

Related to #63916