### PR TITLE
Anchor: Add user checks to podcast title and design selection steps

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -46,7 +46,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	const [ isForceStaticDesigns, setIsForceStaticDesigns ] = useState( false );
 	// CSS breakpoints are set at 600px for mobile
 	const isMobile = ! useViewportMatch( 'small' );
-	const { goBack, submit } = navigation;
+	const { goBack, submit, goToStep } = navigation;
 	const translate = useTranslate();
 	const locale = useLocale();
 	const site = useSite();
@@ -168,7 +168,15 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	);
 	const categorization = useCategorization( staticDesigns, categorizationOptions );
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
+	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
 	const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) );
+
+	useEffect( () => {
+		if ( isAnchorSite && ! currentUser && ! newUser ) {
+			//Go to login
+			goToStep?.( 'login' );
+		}
+	}, [ currentUser, newUser ] );
 
 	function pickDesign(
 		_selectedDesign: Design | undefined = selectedDesign,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/podcast-title/index.tsx
@@ -11,23 +11,32 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import FormInput from 'calypso/components/forms/form-text-input';
 import getTextWidth from 'calypso/landing/gutenboarding/onboarding-block/acquire-intent/get-text-width';
 import usePodcastTitle from 'calypso/landing/stepper/hooks/use-podcast-title';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { tip } from 'calypso/signup/icons';
 import type { Step } from '../../types';
 import './style.scss';
 
 const PodcastTitleStep: Step = function PodcastTitleStep( { navigation } ) {
-	const { goBack, submit } = navigation;
+	const { goBack, submit, goToStep } = navigation;
 	const { __ } = useI18n();
 
 	const PodcastTitleForm: React.FC = () => {
 		//Get the podcast title from the API
 		const podcastTitle = usePodcastTitle();
 		const { siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+		const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
+		const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
 		const hasSiteTitle = siteTitle.length > 0;
 		const { setSiteTitle } = useDispatch( ONBOARD_STORE );
 		const [ formTouched, setFormTouched ] = useState( false );
+
+		useEffect( () => {
+			if ( ! currentUser && ! newUser ) {
+				//Go to login
+				goToStep?.( 'login' );
+			}
+		}, [ currentUser, newUser ] );
 
 		/*
 		 * If we don't have a custom title in the store and we haven't touched the form input,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make sure we either have a current user or new user in the user store before we show the Anchor flow steps; if not, redirect to the `login` step.

#### Testing instructions

* Sandbox the API and apply D80216-code to your sandbox; for the redirects to work correctly, you may need to update line 125, changing `is_automattician()` to `true`.
* Switch to this PR, navigate to `/setup/?anchor_podcast=[your podcast id]` when signed out of WordPress.com
* You should be redirected to the `login` step (Just a "Continue" button for now)
* Try to go to `/setup/podcastTitle?anchor_podcast=[your podcast id]` or `/setup/designSetup?anchor_podcast=[your podcast id]` directly in your browser
* You should be redirected to the `login` step when trying to access the flow directly when not logged in
* You should be able to access the flows as expected when logged in.
* When testing, don't forget to check `/setup/?siteSlug=yoursite.wordpress.com` to make sure the regular design selection step in the onboarding flow is working as intended.

Related to #63687
