### PR TITLE
Add/jetpack pricing boostfree card

### DIFF
--- a/client/my-sites/plans/jetpack-plans/jetpack-boost-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-boost-free-card/index.tsx
@@ -1,0 +1,81 @@
+import { TERM_ANNUALLY } from '@automattic/calypso-products';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { ITEM_TYPE_PRODUCT } from 'calypso/my-sites/plans/jetpack-plans/constants';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import type { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+const BOOST_FREE_URL = isJetpackCloud()
+	? '/pricing/jetpack-boost/welcome'
+	: 'https://wordpress.org/plugins/jetpack-boost/';
+
+const useBoostFreeItem = (): SelectorProduct => {
+	const translate = useTranslate();
+
+	return useMemo(
+		() => ( {
+			productSlug: 'jetpack-boost-free',
+			isFree: true,
+			displayName: translate( 'Boost' ),
+			features: {
+				items: [
+					{ slug: 'not used', text: translate( 'Defer Non-Essential Javascript' ) },
+					{ slug: 'not used', text: translate( 'Optimize CSS Structure' ) },
+					{ slug: 'not used', text: translate( 'Lazy Image Loading' ) },
+				],
+			},
+			type: ITEM_TYPE_PRODUCT, // not used
+			term: TERM_ANNUALLY, // not used
+			iconSlug: 'not used',
+			shortName: 'not used',
+			tagline: 'not used',
+			description: 'not used',
+		} ),
+		[ translate ]
+	);
+};
+
+export type CardWithPriceProps = {
+	siteId: number | null;
+};
+
+const CardWithPrice: React.FC< CardWithPriceProps > = ( { siteId } ) => {
+	const translate = useTranslate();
+	const boostFreeProduct = useBoostFreeItem();
+
+	const dispatch = useDispatch();
+	const onButtonClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_product_jpboostfree_click', {
+				site_id: siteId ?? undefined,
+			} )
+		);
+	}, [ dispatch, siteId ] );
+
+	return (
+		<JetpackProductCard
+			className={ classNames( 'jetpack-boost-free-card', {
+				'is-jetpack-cloud': isJetpackCloud(),
+			} ) }
+			hideSavingLabel
+			showNewLabel
+			showAbovePriceText
+			buttonPrimary
+			item={ boostFreeProduct }
+			headerLevel={ 3 }
+			description={ translate(
+				"Boost gives your site the same performance advantages as the world's leading websites."
+			) }
+			buttonLabel={ translate( 'Get Boost' ) }
+			buttonURL={ BOOST_FREE_URL }
+			onButtonClick={ onButtonClick }
+			collapseFeaturesOnMobile
+		/>
+	);
+};
+
+export default CardWithPrice;

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -4,6 +4,8 @@ import {
 	PLAN_JETPACK_SECURITY_T1_MONTHLY,
 	PLAN_JETPACK_SECURITY_T2_YEARLY,
 	PLAN_JETPACK_SECURITY_T2_MONTHLY,
+	JETPACK_BOOST_PRODUCTS,
+	JETPACK_PERFORMANCE_CATEGORY,
 	JETPACK_SECURITY_CATEGORY,
 	JETPACK_GROWTH_CATEGORY,
 } from '@automattic/calypso-products';
@@ -19,6 +21,7 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selector
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import CategoryFilter from '../category-filter';
+import JetpackBoostFreeCard from '../jetpack-boost-free-card';
 import JetpackCrmFreeCard from '../jetpack-crm-free-card';
 import JetpackFreeCard from '../jetpack-free-card';
 import JetpackSocialFreeCard from '../jetpack-social-free-card';
@@ -139,6 +142,9 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	const { shouldWrap: shouldWrapGrid, gridRef } = useWrapGridForSmallScreens( 3 );
 	const { availableProducts, purchasedProducts, includedInPlanProducts } =
 		useGetPlansGridProducts( siteId );
+	const siteHasBoostPremium = purchasedProducts.some( ( product ) =>
+		( JETPACK_BOOST_PRODUCTS as ReadonlyArray< string > ).includes( product.productSlug )
+	);
 	const [ popularItems, otherItems ] = useMemo( () => {
 		const allItems = sortByGridPosition( [
 			...getProductsToDisplay( {
@@ -281,6 +287,13 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 					) }
 					<ul className="product-grid__product-grid">
 						{ filteredItems.map( getOtherItemsProductCard ) }
+						{ ( ! showProductCategories || category === JETPACK_PERFORMANCE_CATEGORY ) &&
+							showBoostAndSocialFree &&
+							! siteHasBoostPremium && (
+								<li>
+									<JetpackBoostFreeCard siteId={ siteId } />
+								</li>
+							) }
 						{ ( ! showProductCategories || category === JETPACK_GROWTH_CATEGORY ) && (
 							<>
 								{ showBoostAndSocialFree && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the Jetpack Social Free product card into the pricing page grid.

Project Thread: p1HpG7-g29-p2
Asana task: 1202316834912830-as-1202316834912851/f

#### Testing instructions

1. Checkout this PR and spin up Calypso blue and Calypso green concurrently (`yarn start`) and also (`yarn start-jetpack-cloud-p`).
3. Go to http://jetpack.cloud.localhost:3001/pricing and verify that the "Boost" free product card is displaying right after the VideoPress card.
4. Verify the Boost card and _copy_ match the Figma mockup: https://www.figma.com/file/lJK0hlU19QOhqub0uhlIWp/(WCEU)-Pricing-page-update?node-id=2381%3A8262
5. Verify the CTA points to: `/pricing/jetpack-boost/welcome` (this route may not be merged yet).
6. In mobile view, verify the Boost product is displayed when viewing the "Performance" filter, and does not display for other filters.
7. Also check the Boost card in Calypso blue at http://calypso.localhost:3000/plans/:site and http://calypso.localhost:3000/jetpack/connect/store. Verify the CTA points to the WordPress plugin repository (https://wordpress.org/plugins/jetpack-boost/).
8. Now with a JN site or a site you already have, Add the **Boost** product to your site using **Store Admin** (this is the Boost premium paid upgrade, it's just called "Boost" though) You can learn more about it here: pc9hqz-iD-p2
9. Go to http://jetpack.cloud.localhost:3001/pricing/:site (Replace **:site** with your site name(slug)).
10. Verify that the Boost paid upgrade version of the product card shows in place of the Boost Free product card. (See screenshot below).

**Additional note:** We may need to integrate the plugin state into the card. ie.- like show/hide the card (or show as owned) based on if the Boost stand-alone plugin is installed/active on the site. I'll address this in an upcoming PR.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Screenshots:

![Markup 2022-05-25 at 17 19 35](https://user-images.githubusercontent.com/11078128/170373296-8fd4354b-1c95-4e07-bf56-c4cc6b0432c3.png)

- If the site has the Boost Premium version, we show that, otherwise we show the Boost Free version.

![Markup 2022-05-25 at 17 33 13](https://user-images.githubusercontent.com/11078128/170373348-2bcd12e5-fad2-4843-8484-8f6ab9eaf848.png)

