### PR TITLE
Components: Migrate `Banner` tests to `@testing-library/react`

### DIFF
--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -1,5 +1,5 @@
 import { Card, Gridicon } from '@automattic/components';
-import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import QueryPreferences from 'calypso/components/data/query-preferences';
@@ -15,7 +15,7 @@ function DismissibleCard( { className, highlight, temporary, onClick, preference
 	const isDismissed = useSelector( ( state ) => getPreference( state, preference ) );
 	const hasReceivedPreferences = useSelector( hasReceivedRemotePreferences );
 	const dispatch = useDispatch();
-	const { __ } = useI18n();
+	const translate = useTranslate();
 
 	if ( isDismissed || ! hasReceivedPreferences ) {
 		return null;
@@ -32,7 +32,7 @@ function DismissibleCard( { className, highlight, temporary, onClick, preference
 			<button
 				className="dismissible-card__close-icon"
 				onClick={ handleClick }
-				aria-label={ __( 'Dismiss' ) }
+				aria-label={ translate( 'Dismiss' ) }
 			>
 				<Gridicon icon="cross" />
 			</button>

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -1,4 +1,5 @@
 import { Card, Gridicon } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import QueryPreferences from 'calypso/components/data/query-preferences';
@@ -14,6 +15,7 @@ function DismissibleCard( { className, highlight, temporary, onClick, preference
 	const isDismissed = useSelector( ( state ) => getPreference( state, preference ) );
 	const hasReceivedPreferences = useSelector( hasReceivedRemotePreferences );
 	const dispatch = useDispatch();
+	const { __ } = useI18n();
 
 	if ( isDismissed || ! hasReceivedPreferences ) {
 		return null;
@@ -27,7 +29,13 @@ function DismissibleCard( { className, highlight, temporary, onClick, preference
 	return (
 		<Card className={ className } highlight={ highlight }>
 			<QueryPreferences />
-			<Gridicon icon="cross" className="dismissible-card__close-icon" onClick={ handleClick } />
+			<button
+				className="dismissible-card__close-icon"
+				onClick={ handleClick }
+				aria-label={ __( 'Dismiss' ) }
+			>
+				<Gridicon icon="cross" />
+			</button>
 			{ children }
 		</Card>
 	);

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -30,7 +30,7 @@ function DismissibleCard( { className, highlight, temporary, onClick, preference
 		<Card className={ className } highlight={ highlight }>
 			<QueryPreferences />
 			<button
-				className="dismissible-card__close-icon"
+				className="dismissible-card__close-button"
 				onClick={ handleClick }
 				aria-label={ translate( 'Dismiss' ) }
 			>

--- a/client/blocks/dismissible-card/style.scss
+++ b/client/blocks/dismissible-card/style.scss
@@ -1,7 +1,7 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.dismissible-card__close-icon {
+.dismissible-card__close-button {
 	position: absolute;
 	width: 18px;
 	height: 18px;

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -18,7 +18,7 @@
 		margin-top: -2px;
 		margin-right: 0.25em;
 	}
-	.dismissible-card__close-icon {
+	.dismissible-card__close-button {
 		fill: var( --color-text-inverted );
 		margin-right: -6px;
 	}

--- a/client/blocks/upwork-banner/style.scss
+++ b/client/blocks/upwork-banner/style.scss
@@ -3,7 +3,7 @@
 		margin-top: 0;
 		margin-right: 28px;
 	}
-	.upwork-banner__troubleshooting .dismissible-card__close-icon {
+	.upwork-banner__troubleshooting .dismissible-card__close-button {
 		width: 16px;
 		height: 16px;
 		top: 50%;

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -254,14 +254,14 @@
 	}
 }
 
-.banner.is-compact .dismissible-card__close-icon {
+.banner.is-compact .dismissible-card__close-button {
 	width: 16px;
 	height: 16px;
 	top: 50%;
 	margin-top: -8px;
 }
 
-.is-horizontal .dismissible-card__close-icon, .is-horizontal .banner__close-icon {
+.is-horizontal .dismissible-card__close-button, .is-horizontal .banner__close-icon {
 	top: 50%;
 	margin-top: -12px;
 }

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -14,8 +14,9 @@ jest.mock( 'calypso/lib/analytics/track-component-view', () => {
 	};
 } );
 
-import { Card, Button } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { shallow } from 'enzyme';
 import { Banner } from '../index';
 
@@ -143,28 +144,45 @@ describe( 'Banner basic tests', () => {
 		expect( container.firstChild ).toHaveAttribute( 'href', '/' );
 	} );
 
-	test( 'should render Card with no href and CTA button with href if href prop is passed and callToAction is also passed', () => {
-		const comp = shallow( <Banner { ...props } href={ '/' } callToAction="Go WordPress!" /> );
-		expect( comp.find( Card ) ).toHaveLength( 1 );
-		expect( comp.find( Card ).props().href ).toBeNull();
-		expect( comp.find( Card ).props().onClick ).toBeNull();
+	test( 'should render Card with no href and CTA button with href if href prop is passed and callToAction is also passed', async () => {
+		const handleClick = jest.fn();
+		const { container } = render(
+			<Banner { ...props } href={ '/' } callToAction="Go WordPress!" onClick={ handleClick } />
+		);
 
-		expect( comp.find( Button ) ).toHaveLength( 1 );
-		expect( comp.find( Button ).props().href ).toBe( '/' );
-		expect( comp.find( Button ).props().children ).toBe( 'Go\xA0WordPress!' ); //preventwidows adds \xA0 non-breaking space;
-		expect( comp.find( Button ).props().onClick ).toBe( comp.instance().handleClick );
+		await userEvent.click( container.firstChild );
+		await userEvent.click( screen.getByText( 'Go WordPress!' ) );
+
+		expect( handleClick ).toHaveBeenCalledTimes( 1 );
+
+		expect( container.firstChild ).toHaveClass( 'card' );
+		expect( container.firstChild.href ).toBeUndefined();
+
+		expect( screen.getByText( 'Go WordPress!' ) ).toBeVisible();
+		expect( screen.getByText( 'Go WordPress!' ) ).toHaveAttribute( 'href', '/' );
 	} );
 
-	test( 'should render Card with href and CTA button with no href if href prop is passed and callToAction is also passed and forceHref is true', () => {
-		const comp = shallow(
-			<Banner { ...props } href={ '/' } callToAction="Go WordPress!" forceHref={ true } />
+	test( 'should render Card with href and CTA button with no href if href prop is passed and callToAction is also passed and forceHref is true', async () => {
+		const handleClick = jest.fn();
+		const { container } = render(
+			<Banner
+				{ ...props }
+				href={ '/' }
+				callToAction="Go WordPress!"
+				forceHref={ true }
+				onClick={ handleClick }
+			/>
 		);
-		expect( comp.find( Card ) ).toHaveLength( 1 );
-		expect( comp.find( Card ).props().href ).toBe( '/' );
-		expect( comp.find( Card ).props().onClick ).toBe( comp.instance().handleClick );
 
-		expect( comp.find( Button ) ).toHaveLength( 1 );
-		expect( comp.find( Button ).props().href ).toBeUndefined();
-		expect( comp.find( Button ).props().children ).toBe( 'Go\xA0WordPress!' ); //preventWidows adds \xA0 non-breaking space;
+		await userEvent.click( container.firstChild );
+
+		expect( handleClick ).toHaveBeenCalledTimes( 1 );
+
+		expect( container.firstChild ).toHaveClass( 'card' );
+		expect( container.firstChild ).toHaveAttribute( 'href', '/' );
+
+		expect( screen.getByRole( 'button' ) ).toBeVisible();
+		expect( screen.getByRole( 'button' ).href ).toBeUndefined();
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'Go WordPress!' );
 	} );
 } );

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 jest.mock( 'calypso/blocks/dismissible-card', () => {
 	return function DismissibleCard() {
 		return null;
@@ -11,6 +15,7 @@ jest.mock( 'calypso/lib/analytics/track-component-view', () => {
 } );
 
 import { Card, Button } from '@automattic/components';
+import { render } from '@testing-library/react';
 import { shallow } from 'enzyme';
 import PlanPrice from 'calypso/my-sites/plan-price/';
 import { Banner } from '../index';
@@ -22,8 +27,8 @@ const props = {
 
 describe( 'Banner basic tests', () => {
 	test( 'should not blow up and have proper CSS class', () => {
-		const comp = shallow( <Banner { ...props } /> );
-		expect( comp.find( '.banner' ) ).toHaveLength( 1 );
+		const { container } = render( <Banner { ...props } /> );
+		expect( container.getElementsByClassName( 'banner' ).length ).toBe( 1 );
 	} );
 
 	test( 'should render Card if dismissPreferenceName is null', () => {

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -124,18 +124,23 @@ describe( 'Banner basic tests', () => {
 	} );
 
 	test( 'should render Card with href if href prop is passed', () => {
-		render( <Banner { ...props } href={ '/' } /> );
-		expect( screen.queryByRole( 'link' ) ).toHaveAttribute( 'href', '/' );
+		const { container } = render( <Banner { ...props } href={ '/' } /> );
+		expect( container.firstChild ).toHaveClass( 'card' );
+		expect( container.firstChild ).toHaveAttribute( 'href', '/' );
 	} );
 
 	test( 'should render Card with no href if href prop is passed but disableHref is true', () => {
-		render( <Banner { ...props } href={ '/' } disableHref={ true } /> );
-		expect( screen.queryByRole( 'link' ) ).toBeNull();
+		const { container } = render( <Banner { ...props } href={ '/' } disableHref={ true } /> );
+		expect( container.firstChild ).toHaveClass( 'card' );
+		expect( container.firstChild ).not.toHaveAttribute( 'href', '/' );
 	} );
 
 	test( 'should render Card with href if href prop is passed but disableHref is true and forceHref is true', () => {
-		render( <Banner { ...props } href={ '/' } disableHref={ true } forceHref={ true } /> );
-		expect( screen.queryByRole( 'link' ) ).toHaveAttribute( 'href', '/' );
+		const { container } = render(
+			<Banner { ...props } href={ '/' } disableHref={ true } forceHref={ true } />
+		);
+		expect( container.firstChild ).toHaveClass( 'card' );
+		expect( container.firstChild ).toHaveAttribute( 'href', '/' );
 	} );
 
 	test( 'should render Card with no href and CTA button with href if href prop is passed and callToAction is also passed', () => {

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -15,9 +15,8 @@ jest.mock( 'calypso/lib/analytics/track-component-view', () => {
 } );
 
 import { Card, Button } from '@automattic/components';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { shallow } from 'enzyme';
-import PlanPrice from 'calypso/my-sites/plan-price/';
 import { Banner } from '../index';
 
 const props = {
@@ -28,13 +27,13 @@ const props = {
 describe( 'Banner basic tests', () => {
 	test( 'should not blow up and have proper CSS class', () => {
 		const { container } = render( <Banner { ...props } /> );
-		expect( container.getElementsByClassName( 'banner' ).length ).toBe( 1 );
+		expect( container.firstChild ).toHaveClass( 'banner' );
 	} );
 
 	test( 'should render Card if dismissPreferenceName is null', () => {
-		const comp = shallow( <Banner { ...props } dismissPreferenceName={ null } /> );
-		expect( comp.find( Card ) ).toHaveLength( 1 );
-		expect( comp.find( 'DismissibleCard' ) ).toHaveLength( 0 );
+		const { container } = render( <Banner { ...props } dismissPreferenceName={ null } /> );
+		expect( container.firstChild ).toHaveClass( 'card' );
+		expect( container.firstChild ).not.toHaveClass( 'is-dismissible' );
 	} );
 
 	test( 'should render DismissibleCard if dismissPreferenceName is defined', () => {
@@ -44,73 +43,74 @@ describe( 'Banner basic tests', () => {
 	} );
 
 	test( 'should have .has-call-to-action class if callToAction is defined', () => {
-		const comp = shallow( <Banner { ...props } callToAction={ 'Upgrade Now!' } /> );
-		expect( comp.find( '.has-call-to-action' ) ).toHaveLength( 1 );
+		const { container } = render( <Banner { ...props } callToAction={ 'Upgrade Now!' } /> );
+		expect( container.firstChild ).toHaveClass( 'has-call-to-action' );
 	} );
 
 	test( 'should not have .has-call-to-action class if callToAction is null', () => {
-		const comp = shallow( <Banner { ...props } callToAction={ null } /> );
-		expect( comp.find( '.has-call-to-action' ) ).toHaveLength( 0 );
+		const { container } = render( <Banner { ...props } callToAction={ null } /> );
+		expect( container.firstChild ).not.toHaveClass( 'has-call-to-action' );
 	} );
 
 	test( 'should render a <Button /> when callToAction is specified', () => {
-		const comp = shallow( <Banner { ...props } callToAction={ 'Buy something!' } /> );
-		expect( comp.find( Button ) ).toHaveLength( 1 );
+		render( <Banner { ...props } callToAction={ 'Buy something!' } /> );
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'Buy something!' );
 	} );
 
 	test( 'should not render a <Button /> when callToAction is not specified', () => {
-		const comp = shallow( <Banner { ...props } /> );
-		expect( comp.find( Button ) ).toHaveLength( 0 );
+		render( <Banner { ...props } /> );
+		expect( screen.queryByRole( 'button' ) ).toBeNull();
 	} );
 
 	test( 'should have .is-jetpack class and JetpackLogo if jetpack prop is defined', () => {
 		const { plan, ...propsWithoutPlan } = props;
-		const comp = shallow( <Banner { ...propsWithoutPlan } jetpack /> );
-		expect( comp.find( '.is-jetpack' ) ).toHaveLength( 1 );
-		expect( comp.find( 'JetpackLogo' ) ).toHaveLength( 1 );
+		const { container } = render( <Banner { ...propsWithoutPlan } jetpack /> );
+		expect( container.firstChild ).toHaveClass( 'is-jetpack' );
+		expect( container.getElementsByTagName( 'svg' ).length ).toBe( 1 );
 	} );
 
 	test( 'should render have .is-horizontal class if horizontal prop is defined', () => {
-		const comp = shallow( <Banner { ...props } horizontal /> );
-		expect( comp.find( '.is-horizontal' ) ).toHaveLength( 1 );
+		const { container } = render( <Banner { ...props } horizontal /> );
+		expect( container.getElementsByClassName( 'is-horizontal' ).length ).toBe( 1 );
 	} );
 
 	test( 'should render a <PlanPrice /> when price is specified', () => {
-		const comp = shallow( <Banner { ...props } price={ 100 } /> );
-		expect( comp.find( PlanPrice ) ).toHaveLength( 1 );
+		render( <Banner { ...props } price={ 100 } /> );
+		expect( screen.getByText( '100' ) ).toBeVisible();
 	} );
 
 	test( 'should render two <PlanPrice /> components when there are two prices', () => {
-		const comp = shallow( <Banner { ...props } price={ [ 100, 80 ] } /> );
-		expect( comp.find( PlanPrice ) ).toHaveLength( 2 );
+		render( <Banner { ...props } price={ [ 100, 80 ] } /> );
+		expect( screen.getByText( '100' ) ).toBeVisible();
+		expect( screen.getByText( '80' ) ).toBeVisible();
 	} );
 
 	test( 'should render no <PlanPrice /> components when there are no prices', () => {
-		const comp = shallow( <Banner { ...props } /> );
-		expect( comp.find( PlanPrice ) ).toHaveLength( 0 );
+		const { container } = render( <Banner { ...props } /> );
+		expect( container.getElementsByClassName( 'plan-price__integer' ).length ).toBe( 0 );
 	} );
 
 	test( 'should render a .banner__description when description is specified', () => {
-		const comp = shallow( <Banner { ...props } description="test" /> );
-		expect( comp.find( '.banner__description' ) ).toHaveLength( 1 );
+		render( <Banner { ...props } description="test" /> );
+		expect( screen.getByText( 'test' ) ).toBeVisible();
 	} );
 
 	test( 'should not render a .banner__description when description is not specified', () => {
-		const comp = shallow( <Banner { ...props } /> );
-		expect( comp.find( '.banner__description' ) ).toHaveLength( 0 );
+		const { container } = render( <Banner { ...props } /> );
+		expect( container.getElementsByClassName( 'banner__description"' ).length ).toBe( 0 );
 	} );
 
 	test( 'should render a .banner__list when list is specified', () => {
-		const comp = shallow( <Banner { ...props } list={ [ 'test1', 'test2' ] } /> );
-		expect( comp.find( '.banner__list' ) ).toHaveLength( 1 );
-		expect( comp.find( '.banner__list li' ) ).toHaveLength( 2 );
-		expect( comp.find( '.banner__list li' ).at( 0 ).text() ).toContain( 'test1' );
-		expect( comp.find( '.banner__list li' ).at( 1 ).text() ).toContain( 'test2' );
+		const { container } = render( <Banner { ...props } list={ [ 'test1', 'test2' ] } /> );
+		expect( container.querySelectorAll( '.banner__list' ).length ).toBe( 1 );
+		expect( container.querySelectorAll( '.banner__list li' ).length ).toBe( 2 );
+		expect( screen.getByText( 'test1' ) ).toBeVisible();
+		expect( screen.getByText( 'test2' ) ).toBeVisible();
 	} );
 
 	test( 'should not render a .banner__list when description is not specified', () => {
-		const comp = shallow( <Banner { ...props } /> );
-		expect( comp.find( '.banner__list' ) ).toHaveLength( 0 );
+		const { container } = render( <Banner { ...props } /> );
+		expect( container.getElementsByClassName( '.banner__list' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should record Tracks event when event is specified', () => {
@@ -124,23 +124,18 @@ describe( 'Banner basic tests', () => {
 	} );
 
 	test( 'should render Card with href if href prop is passed', () => {
-		const comp = shallow( <Banner { ...props } href={ '/' } /> );
-		expect( comp.find( Card ) ).toHaveLength( 1 );
-		expect( comp.find( Card ).props().href ).toBe( '/' );
+		render( <Banner { ...props } href={ '/' } /> );
+		expect( screen.queryByRole( 'link' ) ).toHaveAttribute( 'href', '/' );
 	} );
 
 	test( 'should render Card with no href if href prop is passed but disableHref is true', () => {
-		const comp = shallow( <Banner { ...props } href={ '/' } disableHref={ true } /> );
-		expect( comp.find( Card ) ).toHaveLength( 1 );
-		expect( comp.find( Card ).props().href ).toBeNull();
+		render( <Banner { ...props } href={ '/' } disableHref={ true } /> );
+		expect( screen.queryByRole( 'link' ) ).toBeNull();
 	} );
 
 	test( 'should render Card with href if href prop is passed but disableHref is true and forceHref is true', () => {
-		const comp = shallow(
-			<Banner { ...props } href={ '/' } disableHref={ true } forceHref={ true } />
-		);
-		expect( comp.find( Card ) ).toHaveLength( 1 );
-		expect( comp.find( Card ).props().href ).toBe( '/' );
+		render( <Banner { ...props } href={ '/' } disableHref={ true } forceHref={ true } /> );
+		expect( screen.queryByRole( 'link' ) ).toHaveAttribute( 'href', '/' );
 	} );
 
 	test( 'should render Card with no href and CTA button with href if href prop is passed and callToAction is also passed', () => {

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -9,6 +9,10 @@ import preferencesReducer from 'calypso/state/preferences/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { Banner } from '../index';
 
+jest.mock( 'calypso/my-sites/plan-price', () => ( props ) => (
+	<div data-testid="banner-price-plan-mock">{ props.rawPrice }</div>
+) );
+
 jest.mock( 'calypso/state/analytics/actions', () => ( {
 	recordTracksEvent: jest.fn( () => ( {
 		type: 'ANALYTICS_EVENT_RECORD',
@@ -69,18 +73,17 @@ describe( 'Banner basic tests', () => {
 
 	test( 'should render a <PlanPrice /> when price is specified', () => {
 		render( <Banner { ...props } price={ 100 } /> );
-		expect( screen.getByText( '100' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'banner-price-plan-mock' ) ).toHaveTextContent( '100' );
 	} );
 
 	test( 'should render two <PlanPrice /> components when there are two prices', () => {
 		render( <Banner { ...props } price={ [ 100, 80 ] } /> );
-		expect( screen.getByText( '100' ) ).toBeVisible();
-		expect( screen.getByText( '80' ) ).toBeVisible();
+		expect( screen.queryAllByTestId( 'banner-price-plan-mock' ) ).toHaveLength( 2 );
 	} );
 
 	test( 'should render no <PlanPrice /> components when there are no prices', () => {
-		const { container } = render( <Banner { ...props } /> );
-		expect( container.getElementsByClassName( 'plan-price' ) ).toHaveLength( 0 );
+		render( <Banner { ...props } /> );
+		expect( screen.queryByTestId( 'banner-price-plan-mock' ) ).toBeNull();
 	} );
 
 	test( 'should render a .banner__description when description is specified', () => {

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -2,17 +2,10 @@
  * @jest-environment jsdom
  */
 
-jest.mock( 'calypso/blocks/dismissible-card', () => {
-	return function DismissibleCard() {
-		return null;
-	};
-} );
-
-import { Card } from '@automattic/components';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { shallow } from 'enzyme';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import preferencesReducer from 'calypso/state/preferences/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { Banner } from '../index';
 
@@ -23,6 +16,15 @@ jest.mock( 'calypso/state/analytics/actions', () => {
 		} ) ),
 	};
 } );
+
+function renderWithRedux( ui ) {
+	return renderWithProvider( ui, {
+		reducers: {
+			preferences: preferencesReducer,
+		},
+		initialState: { preferences: { remoteValues: {} } },
+	} );
+}
 
 const props = {
 	callToAction: null,
@@ -46,9 +48,10 @@ describe( 'Banner basic tests', () => {
 	} );
 
 	test( 'should render DismissibleCard if dismissPreferenceName is defined', () => {
-		const comp = shallow( <Banner { ...props } dismissPreferenceName={ 'banner-test' } /> );
-		expect( comp.find( Card ) ).toHaveLength( 0 );
-		expect( comp.find( 'DismissibleCard' ) ).toHaveLength( 1 );
+		const { container } = renderWithRedux(
+			<Banner { ...props } dismissPreferenceName={ 'banner-test' } />
+		);
+		expect( container.firstChild ).toHaveClass( 'is-dismissible' );
 	} );
 
 	test( 'should have .has-call-to-action class if callToAction is defined', () => {

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -9,8 +9,13 @@ import preferencesReducer from 'calypso/state/preferences/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { Banner } from '../index';
 
-jest.mock( 'calypso/my-sites/plan-price', () => ( props ) => (
-	<div data-testid="banner-price-plan-mock">{ props.rawPrice }</div>
+jest.mock( 'calypso/my-sites/plan-price', () => ( { rawPrice, original } ) => (
+	<div
+		data-testid="banner-price-plan-mock"
+		className={ original ? 'is-original' : 'is-discounted' }
+	>
+		{ rawPrice }
+	</div>
 ) );
 
 jest.mock( 'calypso/state/analytics/actions', () => ( {
@@ -78,12 +83,17 @@ describe( 'Banner basic tests', () => {
 
 	test( 'should render two <PlanPrice /> components when there are two prices', () => {
 		render( <Banner { ...props } price={ [ 100, 80 ] } /> );
-		expect( screen.queryAllByTestId( 'banner-price-plan-mock' ) ).toHaveLength( 2 );
+		const planPriceMock = screen.queryAllByTestId( 'banner-price-plan-mock' );
+		expect( planPriceMock ).toHaveLength( 2 );
+		expect( planPriceMock[ 0 ] ).toHaveTextContent( 100 );
+		expect( planPriceMock[ 0 ] ).toHaveAttribute( 'class', 'is-original' );
+		expect( planPriceMock[ 1 ] ).toHaveTextContent( 80 );
+		expect( planPriceMock[ 1 ] ).toHaveAttribute( 'class', 'is-discounted' );
 	} );
 
 	test( 'should render no <PlanPrice /> components when there are no prices', () => {
 		render( <Banner { ...props } /> );
-		expect( screen.queryByTestId( 'banner-price-plan-mock' ) ).toBeNull();
+		expect( screen.queryByTestId( 'banner-price-plan-mock' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'should render a .banner__description when description is specified', () => {
@@ -100,8 +110,8 @@ describe( 'Banner basic tests', () => {
 		render( <Banner { ...props } list={ [ 'test1', 'test2' ] } /> );
 		expect( screen.queryByRole( 'list' ) ).toBeVisible();
 		expect( screen.queryAllByRole( 'listitem' ) ).toHaveLength( 2 );
-		expect( screen.getByText( 'test1' ) ).toBeVisible();
-		expect( screen.getByText( 'test2' ) ).toBeVisible();
+		expect( screen.queryAllByRole( 'listitem' )[ 0 ] ).toHaveTextContent( 'test1' );
+		expect( screen.queryAllByRole( 'listitem' )[ 1 ] ).toHaveTextContent( 'test2' );
 	} );
 
 	test( 'should not render a .banner__list when description is not specified', () => {

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -48,10 +48,8 @@ describe( 'Banner basic tests', () => {
 	} );
 
 	test( 'should render DismissibleCard if dismissPreferenceName is defined', () => {
-		const { container } = renderWithRedux(
-			<Banner { ...props } dismissPreferenceName={ 'banner-test' } />
-		);
-		expect( container.firstChild ).toHaveClass( 'is-dismissible' );
+		renderWithRedux( <Banner { ...props } dismissPreferenceName={ 'banner-test' } /> );
+		expect( screen.getByLabelText( 'Dismiss' ) ).toBeInTheDocument();
 	} );
 
 	test( 'should have .has-call-to-action class if callToAction is defined', () => {

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -36,7 +36,7 @@ describe( 'Banner basic tests', () => {
 		jest.clearAllMocks();
 	} );
 
-	test( 'should not blow up and have proper CSS class', () => {
+	test( 'should output Banner component with proper CSS class', () => {
 		const { container } = render( <Banner { ...props } /> );
 		expect( container.firstChild ).toHaveClass( 'banner' );
 	} );
@@ -76,12 +76,12 @@ describe( 'Banner basic tests', () => {
 		const { plan, ...propsWithoutPlan } = props;
 		const { container } = render( <Banner { ...propsWithoutPlan } jetpack /> );
 		expect( container.firstChild ).toHaveClass( 'is-jetpack' );
-		expect( container.getElementsByTagName( 'svg' ).length ).toBe( 1 );
+		expect( container.getElementsByTagName( 'svg' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render have .is-horizontal class if horizontal prop is defined', () => {
 		const { container } = render( <Banner { ...props } horizontal /> );
-		expect( container.getElementsByClassName( 'is-horizontal' ).length ).toBe( 1 );
+		expect( container.getElementsByClassName( 'is-horizontal' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render a <PlanPrice /> when price is specified', () => {
@@ -97,7 +97,7 @@ describe( 'Banner basic tests', () => {
 
 	test( 'should render no <PlanPrice /> components when there are no prices', () => {
 		const { container } = render( <Banner { ...props } /> );
-		expect( container.getElementsByClassName( 'plan-price__integer' ).length ).toBe( 0 );
+		expect( container.getElementsByClassName( 'plan-price__integer' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render a .banner__description when description is specified', () => {
@@ -107,13 +107,13 @@ describe( 'Banner basic tests', () => {
 
 	test( 'should not render a .banner__description when description is not specified', () => {
 		const { container } = render( <Banner { ...props } /> );
-		expect( container.getElementsByClassName( 'banner__description"' ).length ).toBe( 0 );
+		expect( container.getElementsByClassName( 'banner__description"' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render a .banner__list when list is specified', () => {
 		const { container } = render( <Banner { ...props } list={ [ 'test1', 'test2' ] } /> );
-		expect( container.querySelectorAll( '.banner__list' ).length ).toBe( 1 );
-		expect( container.querySelectorAll( '.banner__list li' ).length ).toBe( 2 );
+		expect( container.querySelectorAll( '.banner__list' ) ).toHaveLength( 1 );
+		expect( container.querySelectorAll( '.banner__list li' ) ).toHaveLength( 2 );
 		expect( screen.getByText( 'test1' ) ).toBeVisible();
 		expect( screen.getByText( 'test2' ) ).toBeVisible();
 	} );

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -340,7 +340,7 @@ $font-size: rem( 14px );
 		margin-left: 0;
 	}
 
-	.upsell-nudge.banner.card.is-compact .dismissible-card__close-icon {
+	.upsell-nudge.banner.card.is-compact .dismissible-card__close-button {
 		fill: var( --color-text );
 	}
 

--- a/client/my-sites/stats/stats-no-content-banner/style.scss
+++ b/client/my-sites/stats/stats-no-content-banner/style.scss
@@ -19,7 +19,7 @@
 		}
 	}
 
-	.dismissible-card__close-icon {
+	.dismissible-card__close-button {
 
 		@include break-mobile {
 			transform: translateY( -50% );

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -140,7 +140,7 @@
 		}
 	}
 
-	.dismissible-card__close-icon {
+	.dismissible-card__close-button {
 		transform: translateY( -50% );
 		-webkit-transform: translateY( -50% );
 		top: 50%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `Banner` component to use `@testing-library/react` instead of `enzyme`.

This also uses the opportunity to add a `<button>` and `aria-label` to the DismissibleCard component, which originally was just a clickable SVG. 

#### Testing instructions

Verify tests still pass: `yarn test-client client/components/banner`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63409
