### PR TITLE
Migrate from Enzyme to React testing library for the Reader/Sidebar/Promo

### DIFF
--- a/client/reader/sidebar/test/promo.jsx
+++ b/client/reader/sidebar/test/promo.jsx
@@ -2,44 +2,17 @@
  * @jest-environment jsdom
  */
 
-import editorReducer from 'calypso/state/editor/reducer';
-import mediaReducer from 'calypso/state/media/reducer';
-import siteSettingsReducer from 'calypso/state/site-settings/reducer';
-import timezonesReducer from 'calypso/state/timezones/reducer';
-import uiReducer from 'calypso/state/ui/reducer';
+import userSettings from 'calypso/state/user-settings/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ReaderSidebarPromo, shouldRenderAppPromo } from '../promo';
 
-const initialState = {
-	siteSettings: {},
-	sites: {
-		items: [],
-	},
-	media: {
-		queries: {},
-	},
-	currentUser: {
-		capabilities: {},
-	},
-	editor: {
-		imageEditor: {},
-	},
-	timezones: {
-		labels: {},
-		byContinents: {},
-	},
-	ui: {},
-};
+const initialState = {};
 
 function renderWithRedux( ui ) {
 	return renderWithProvider( ui, {
 		initialState,
 		reducers: {
-			editor: editorReducer,
-			media: mediaReducer,
-			siteSettings: siteSettingsReducer,
-			timezones: timezonesReducer,
-			ui: uiReducer,
+			userSettings,
 		},
 	} );
 }
@@ -56,17 +29,14 @@ describe( 'ReaderSidebarPromo', () => {
 
 	test( 'should render the AppPromo when the shouldRenderAppPromo property is true', () => {
 		const adjustedProperties = { shouldRenderAppPromo: true };
-		const { wrapper } = renderWithRedux( <ReaderSidebarPromo { ...adjustedProperties } /> );
-		expect( wrapper.getElementsByClassName( 'sidebar__app-promo' ) ).toHaveLength( 1 );
+		const { container } = renderWithRedux( <ReaderSidebarPromo { ...adjustedProperties } /> );
+		expect( container.firstChild ).toHaveClass( 'sidebar__app-promo' );
 	} );
 
 	test( 'should not render the AppPromo when the shouldRenderAppPromo property is false', () => {
-		const adjustedProperties = {
-			shouldRenderAppPromo: false,
-		};
-		const { wrapper } = renderWithRedux( <ReaderSidebarPromo { ...adjustedProperties } /> );
-
-		expect( wrapper.getElementsByClassName( '.sidebar__app-promo' ) ).toHaveLength( 0 );
+		const adjustedProperties = { shouldRenderAppPromo: false };
+		const { container } = renderWithRedux( <ReaderSidebarPromo { ...adjustedProperties } /> );
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	describe( 'shouldRenderAppPromo', () => {

--- a/client/reader/sidebar/test/promo.jsx
+++ b/client/reader/sidebar/test/promo.jsx
@@ -2,8 +2,47 @@
  * @jest-environment jsdom
  */
 
-import { render } from '@testing-library/react';
+import editorReducer from 'calypso/state/editor/reducer';
+import mediaReducer from 'calypso/state/media/reducer';
+import siteSettingsReducer from 'calypso/state/site-settings/reducer';
+import timezonesReducer from 'calypso/state/timezones/reducer';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ReaderSidebarPromo, shouldRenderAppPromo } from '../promo';
+
+const initialState = {
+	siteSettings: {},
+	sites: {
+		items: [],
+	},
+	media: {
+		queries: {},
+	},
+	currentUser: {
+		capabilities: {},
+	},
+	editor: {
+		imageEditor: {},
+	},
+	timezones: {
+		labels: {},
+		byContinents: {},
+	},
+	ui: {},
+};
+
+function renderWithRedux( ui ) {
+	return renderWithProvider( ui, {
+		initialState,
+		reducers: {
+			editor: editorReducer,
+			media: mediaReducer,
+			siteSettings: siteSettingsReducer,
+			timezones: timezonesReducer,
+			ui: uiReducer,
+		},
+	} );
+}
 
 describe( 'ReaderSidebarPromo', () => {
 	const shouldRenderAppPromoDefaultProps = {
@@ -17,7 +56,7 @@ describe( 'ReaderSidebarPromo', () => {
 
 	test( 'should render the AppPromo when the shouldRenderAppPromo property is true', () => {
 		const adjustedProperties = { shouldRenderAppPromo: true };
-		const { wrapper } = render( <ReaderSidebarPromo { ...adjustedProperties } /> );
+		const { wrapper } = renderWithRedux( <ReaderSidebarPromo { ...adjustedProperties } /> );
 		expect( wrapper.getElementsByClassName( 'sidebar__app-promo' ) ).toHaveLength( 1 );
 	} );
 
@@ -25,7 +64,8 @@ describe( 'ReaderSidebarPromo', () => {
 		const adjustedProperties = {
 			shouldRenderAppPromo: false,
 		};
-		const { wrapper } = render( <ReaderSidebarPromo { ...adjustedProperties } /> );
+		const { wrapper } = renderWithRedux( <ReaderSidebarPromo { ...adjustedProperties } /> );
+
 		expect( wrapper.getElementsByClassName( '.sidebar__app-promo' ) ).toHaveLength( 0 );
 	} );
 

--- a/client/reader/sidebar/test/promo.jsx
+++ b/client/reader/sidebar/test/promo.jsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import { ReaderSidebarPromo, shouldRenderAppPromo } from '../promo';
 
 describe( 'ReaderSidebarPromo', () => {
@@ -17,16 +17,16 @@ describe( 'ReaderSidebarPromo', () => {
 
 	test( 'should render the AppPromo when the shouldRenderAppPromo property is true', () => {
 		const adjustedProperties = { shouldRenderAppPromo: true };
-		const wrapper = shallow( <ReaderSidebarPromo { ...adjustedProperties } /> );
-		expect( wrapper.find( '.sidebar__app-promo' ) ).toHaveLength( 1 );
+		const { wrapper } = render( <ReaderSidebarPromo { ...adjustedProperties } /> );
+		expect( wrapper.getElementsByClassName( 'sidebar__app-promo' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not render the AppPromo when the shouldRenderAppPromo property is false', () => {
 		const adjustedProperties = {
 			shouldRenderAppPromo: false,
 		};
-		const wrapper = shallow( <ReaderSidebarPromo { ...adjustedProperties } /> );
-		expect( wrapper.find( '.sidebar__app-promo' ) ).toHaveLength( 0 );
+		const { wrapper } = render( <ReaderSidebarPromo { ...adjustedProperties } /> );
+		expect( wrapper.getElementsByClassName( '.sidebar__app-promo' ) ).toHaveLength( 0 );
 	} );
 
 	describe( 'shouldRenderAppPromo', () => {


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR refactors the Reader sidebar component to use @testing-library/react instead of enzyme.

It also uses the opportunity to migrate chai assertions to jest.

## Testing instructions:

Verify tests still pass: yarn run test-client client/reader/sidebar/test/promo.jsx

Fixes #64049 
