### PR TITLE
Integrate new sites API and row status formatting for agency dashboard

### DIFF
--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -11,10 +11,11 @@ const useFetchDashboardSites = () => {
 		[ 'jetpack-cloud', 'agency-dashboard', 'sites' ],
 		() =>
 			wpcomJpl.req.get( {
-				path: '/jetpack-partner/dashboard/sites-mock',
+				path: '/jetpack-agency/sites',
 				apiNamespace: 'wpcom/v2',
 			} ),
 		{
+			select: ( data ) => ( data.sites ? Object.values( data.sites ) : [] ),
 			refetchOnWindowFocus: false,
 			onError: () =>
 				dispatch(

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -95,7 +95,7 @@ export default function SiteStatusContent( { rows, type }: Props ): ReactElement
 			content = <Gridicon icon="checkmark" size={ 18 } className="sites-overview__grey-icon" />;
 			break;
 		}
-		case 'active': {
+		case 'disabled': {
 			content = <Gridicon icon="minus-small" size={ 18 } className="sites-overview__icon-active" />;
 			break;
 		}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -25,3 +25,11 @@ export type Preference = {
 	dismiss?: boolean;
 	view?: boolean;
 };
+
+export type FormattedRowObj = {
+	value: ReactChild;
+	status: string;
+	type: string;
+	threats?: number;
+	error?: boolean;
+};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -1,5 +1,5 @@
 import { translate } from 'i18n-calypso';
-import type { AllowedTypes, SiteData } from './types';
+import type { AllowedTypes, SiteData, FormattedRowObj } from './types';
 import type { ReactChild } from 'react';
 
 /**
@@ -92,62 +92,102 @@ export const getRowMetaData = (
 	};
 };
 
+const formatBackupData = ( site: SiteData ) => {
+	const type = 'backup';
+	const backup: FormattedRowObj = {
+		value: '',
+		status: '',
+		type,
+	};
+	if ( ! site.has_backup ) {
+		backup.status = 'inactive';
+		return backup;
+	}
+	switch ( site.latest_backup_status ) {
+		case 'rewind_backup_complete':
+		case 'backup_only_complete':
+			backup.status = 'success';
+			break;
+		case 'rewind_backup_error':
+		case 'backup_only_error':
+			backup.status = 'failed';
+			backup.value = translate( 'Failed' );
+			break;
+		case 'rewind_backup_complete_warning':
+		case 'backup_only_complete_warning':
+			backup.status = 'warning';
+			backup.value = translate( 'Warning' );
+			break;
+		default:
+			backup.status = 'progress';
+			break;
+	}
+	return backup;
+};
+
+const formatScanData = ( site: SiteData ) => {
+	const type = 'scan';
+	const scan: FormattedRowObj = {
+		value: '',
+		status: '',
+		type,
+		threats: 0,
+	};
+	if ( ! site.has_scan ) {
+		scan.status = 'inactive';
+	} else if ( site.latest_scan_threats_found.length > 0 ) {
+		const scanThreats = site.latest_scan_threats_found.length;
+		scan.status = 'failed';
+		scan.value = translate(
+			'%(threats)d Threat',
+			'%(threats)d Threats', // plural version of the string
+			{
+				count: scanThreats,
+				args: {
+					threats: scanThreats,
+				},
+			}
+		);
+		scan.threats = scanThreats;
+	} else {
+		scan.status = 'success';
+	}
+	return scan;
+};
+
+const formatMonitorData = ( site: SiteData ) => {
+	const type = 'monitor';
+	const monitor: FormattedRowObj = { value: '', status: '', type, error: false };
+	if ( ! site.monitor_active ) {
+		monitor.status = 'disabled';
+	} else if ( ! site.monitor_site_status ) {
+		monitor.status = 'failed';
+		monitor.value = translate( 'Site Down' );
+	} else {
+		monitor.status = 'success';
+	}
+	return monitor;
+};
+
 /**
  * Returns formatted sites
  */
-export const formatSites = ( data: { items: Array< any > } ): Array< any > => {
-	const sites = data?.items || [];
+export const formatSites = ( sites: Array< any > = [] ): Array< any > => {
 	return sites.map( ( site ) => {
 		const pluginUpdates = site.awaiting_plugin_updates;
-		let scanValue;
-		if ( site.latest_scan_status === 'failed' ) {
-			scanValue = translate( 'Failed' );
-		}
-		const scanThreats = site.latest_scan_threats_found.length;
-		if ( scanThreats > 0 ) {
-			scanValue = translate(
-				'%(threats)d Threat',
-				'%(threats)d Threats', // plural version of the string
-				{
-					count: scanThreats,
-					args: {
-						threats: scanThreats,
-					},
-				}
-			);
-		}
-		const error =
-			! site.is_connection_healthy ||
-			! site.access_xmlrpc ||
-			! site.valid_xmlrpc ||
-			! site.authenticated_xmlrpc;
 		return {
 			site: {
 				value: site,
-				error,
+				error: ! site.is_connection_healthy,
 				status: '',
 				type: 'site',
 			},
-			backup: {
-				value: 'failed' === site.latest_backup_status ? translate( 'Failed' ) : '',
-				status: site.backup_enabled ? site.latest_backup_status : 'inactive',
-				type: 'backup',
-			},
-			scan: {
-				value: scanValue,
-				status: site.scan_enabled ? site.latest_scan_status : 'inactive',
-				type: 'scan',
-				threats: site.latest_scan_threats_found.length,
-			},
-			monitor: {
-				value: 'failed' === site.monitor_status ? translate( 'Site Down' ) : '',
-				status: site.monitor_status === 'accessible' ? 'success' : site.monitor_status,
-				type: 'monitor',
-				error: 'failed' === site.monitor_status,
-			},
+			backup: formatBackupData( site ),
+			scan: formatScanData( site ),
+			monitor: formatMonitorData( site ),
 			plugin: {
 				value: `${ pluginUpdates.length } ${ translate( 'Available' ) }`,
-				status: pluginUpdates.length > 0 ? 'warning' : 'active',
+				status: pluginUpdates.length > 0 ? 'warning' : 'success',
 				type: 'plugin',
 				updates: pluginUpdates.length,
 			},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -93,11 +93,10 @@ export const getRowMetaData = (
 };
 
 const formatBackupData = ( site: SiteData ) => {
-	const type = 'backup';
 	const backup: FormattedRowObj = {
 		value: '',
 		status: '',
-		type,
+		type: 'backup',
 	};
 	if ( ! site.has_backup ) {
 		backup.status = 'inactive';
@@ -126,11 +125,10 @@ const formatBackupData = ( site: SiteData ) => {
 };
 
 const formatScanData = ( site: SiteData ) => {
-	const type = 'scan';
 	const scan: FormattedRowObj = {
 		value: '',
 		status: '',
-		type,
+		type: 'scan',
 		threats: 0,
 	};
 	if ( ! site.has_scan ) {
@@ -156,8 +154,12 @@ const formatScanData = ( site: SiteData ) => {
 };
 
 const formatMonitorData = ( site: SiteData ) => {
-	const type = 'monitor';
-	const monitor: FormattedRowObj = { value: '', status: '', type, error: false };
+	const monitor: FormattedRowObj = {
+		value: '',
+		status: '',
+		type: 'monitor',
+		error: false,
+	};
 	if ( ! site.monitor_active ) {
 		monitor.status = 'disabled';
 	} else if ( ! site.monitor_site_status ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace the `sites-mock` API with the new `sites` API
* Format row values(feature states) according to the new keys and values

#### Testing instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb

**Instructions**

1. Run `git checkout update/integrate-new-sites-api` and `yarn start-jetpack-cloud`
2. Apply D81147-code to hit the new API
3. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard
4. Verify that all your sites are loading as expected
5. Verify all the feature(Backup, Scan, Monitor, Plugin Updates) status are shown 

Feature States(states are used only to show the UI)

**Backup** 
- success:  Backup working as expected
- failed: Backup failed
- warning: Something went with backup 
- progress: First backup in progress
- inactive: Backup not added

**Scan** 
- success: Scan working as expected
- failed: # Threats Found
- inactive: Scan not added

**Monitor** 
- success: No issues found
- failed: Site Down
- disabled: Monitor is disabled

**Plugin Updates** 
- warning: # Available
- success: No Updates

<img width="1163" alt="Screenshot 2022-05-26 at 11 39 17 AM" src="https://user-images.githubusercontent.com/10586875/170427745-f496c37f-11b4-4947-9367-6a7cba5a15df.png">


Related to 1202076982646589-as-1202339359890348