### PR TITLE
Framework: Remove last usages of `sinon`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -180,7 +180,6 @@
 		"redux-dynamic-middlewares": "^2.0.0",
 		"redux-thunk": "^2.3.0",
 		"regenerator-runtime": "^0.13.9",
-		"sinon": "^12.0.1",
 		"social-logos": "^2.4.0",
 		"socket.io-client": "^2.3.0",
 		"source-map-support": "^0.5.19",

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -27,7 +27,13 @@ jest.mock( 'calypso/post-editor/media-modal/markup', () => ( {
 jest.mock( 'calypso/post-editor/media-modal/secondary-actions', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'calypso/lib/accept', () => require( 'sinon' ).stub().callsArgWithAsync( 1, true ) );
+jest.mock( 'calypso/lib/accept', () =>
+	jest.fn( ( message, callback ) => {
+		if ( callback ) {
+			callback( true );
+		}
+	} )
+);
 jest.mock( 'calypso/my-sites/media-library', () =>
 	require( 'calypso/components/empty-component' )
 );

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -4,7 +4,6 @@
 
 import { withStorageKey } from '@automattic/state-utils';
 import { mapKeys } from 'lodash';
-import { useFakeTimers } from 'sinon';
 import * as browserStorage from 'calypso/lib/browser-storage';
 import { isSupportSession } from 'calypso/lib/user/support-user-interop';
 import { createReduxStore } from 'calypso/state';
@@ -644,7 +643,6 @@ describe( 'initial-state', () => {
 
 	describe( '#persistOnChange()', () => {
 		let store;
-		let clock;
 		let setStoredItemSpy;
 		let stopPersisting;
 
@@ -671,7 +669,7 @@ describe( 'initial-state', () => {
 		beforeEach( async () => {
 			// we use fake timers from Sinon (aka Lolex) because `lodash.throttle` also uses `Date.now()`
 			// and relies on it returning a mocked value. Jest fake timers don't mock `Date`, Lolex does.
-			clock = useFakeTimers();
+			jest.useFakeTimers();
 			setStoredItemSpy = jest
 				.spyOn( browserStorage, 'setStoredItem' )
 				.mockImplementation( ( value ) => Promise.resolve( value ) );
@@ -681,7 +679,6 @@ describe( 'initial-state', () => {
 		} );
 
 		afterEach( () => {
-			clock.restore();
 			setStoredItemSpy.mockRestore();
 		} );
 
@@ -691,7 +688,7 @@ describe( 'initial-state', () => {
 				data: 1,
 			} );
 
-			clock.tick( SERIALIZE_THROTTLE );
+			jest.advanceTimersByTime( SERIALIZE_THROTTLE );
 
 			expect( setStoredItemSpy ).toHaveBeenCalledTimes( 1 );
 		} );
@@ -702,14 +699,14 @@ describe( 'initial-state', () => {
 				data: 1,
 			} );
 
-			clock.tick( SERIALIZE_THROTTLE );
+			jest.advanceTimersByTime( SERIALIZE_THROTTLE );
 
 			store.dispatch( {
 				type: 'foo',
 				data: 2,
 			} );
 
-			clock.tick( SERIALIZE_THROTTLE );
+			jest.advanceTimersByTime( SERIALIZE_THROTTLE );
 
 			expect( setStoredItemSpy ).toHaveBeenCalledTimes( 2 );
 		} );
@@ -720,14 +717,14 @@ describe( 'initial-state', () => {
 				data: 1,
 			} );
 
-			clock.tick( SERIALIZE_THROTTLE );
+			jest.advanceTimersByTime( SERIALIZE_THROTTLE );
 
 			store.dispatch( {
 				type: 'foo',
 				data: 1,
 			} );
 
-			clock.tick( SERIALIZE_THROTTLE );
+			jest.advanceTimersByTime( SERIALIZE_THROTTLE );
 
 			expect( setStoredItemSpy ).toHaveBeenCalledTimes( 1 );
 		} );
@@ -748,7 +745,7 @@ describe( 'initial-state', () => {
 				data: 3,
 			} );
 
-			clock.tick( SERIALIZE_THROTTLE );
+			jest.advanceTimersByTime( SERIALIZE_THROTTLE );
 
 			store.dispatch( {
 				type: 'foo',
@@ -760,7 +757,7 @@ describe( 'initial-state', () => {
 				data: 5,
 			} );
 
-			clock.tick( SERIALIZE_THROTTLE );
+			jest.advanceTimersByTime( SERIALIZE_THROTTLE );
 
 			expect( setStoredItemSpy ).toHaveBeenCalledTimes( 2 );
 			expect( setStoredItemSpy ).toHaveBeenCalledWith(
@@ -778,7 +775,7 @@ describe( 'initial-state', () => {
 				type: 'foo',
 				data: 1,
 			} );
-			clock.tick( SERIALIZE_THROTTLE );
+			jest.advanceTimersByTime( SERIALIZE_THROTTLE );
 			expect( setStoredItemSpy ).toHaveBeenCalledTimes( 1 );
 
 			stopPersisting();
@@ -787,7 +784,7 @@ describe( 'initial-state', () => {
 				type: 'foo',
 				data: 1,
 			} );
-			clock.tick( SERIALIZE_THROTTLE );
+			jest.advanceTimersByTime( SERIALIZE_THROTTLE );
 			expect( setStoredItemSpy ).toHaveBeenCalledTimes( 1 ); // no new call
 		} );
 	} );

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -80,11 +80,11 @@ Run
 yarn upgrade <package>
 
 # Example
-# yarn upgrade sinon
+# yarn upgrade react-query
 ```
 
-Note that this won't change the required range of `sinon` (i.e. it won't modify `package.json`). Instead, it will try to update `sinon` and any of its dependencies to the highest version that satisfies the specified range.
-For example, if we declare a dependency on `sinon@^7.5.0` it may update sinon to `7.5.1`, but never to `8.0.0`.
+Note that this won't change the required range of `react-query` (i.e. it won't modify `package.json`). Instead, it will try to update `react-query` and any of its dependencies to the highest version that satisfies the specified range.
+For example, if we declare a dependency on `react-query@^2.24.0` it may update react-query to `2.24.1`, but never to `3.0.0`.
 
 ### Update a dependency to a new range
 
@@ -94,10 +94,10 @@ Run
 yarn upgrade <package>@^<semver-range>
 
 # Example
-# yarn upgrade sinon@^9.0.0
+# yarn upgrade react-query@^3.0.0
 ```
 
-As before, it will update `sinon` and all its dependencies. But in this case, it _will_ change the required range (i.e. it will modify `package.json`)
+As before, it will update `react-query` and all its dependencies. But in this case, it _will_ change the required range (i.e. it will modify `package.json`)
 
 ### List oudated dependencies
 

--- a/docs/testing/faq.md
+++ b/docs/testing/faq.md
@@ -4,7 +4,7 @@
 
 We use [Jest](https://facebook.github.io/jest/) testing tool to execute all test configurations located in Calypso repository. It's highly recommended to use Jest's very flexible [API](https://facebook.github.io/jest/docs/en/api.html) together with [expect matchers](https://facebook.github.io/jest/docs/en/expect.html) and [mock functions](https://facebook.github.io/jest/docs/en/mock-function-api.html).
 
-Historically we have been using [Mocha](https://mochajs.org/) with [Chai assertions](http://chaijs.com/) and [Sinon mocks](http://sinonjs.org/). We still support Chai and Sinon for backward compatibility reasons, but Jest equivalents should be used whenever new tests are added.
+Historically we have been using [Mocha](https://mochajs.org/) with [Chai assertions](http://chaijs.com/) and [Sinon mocks](http://sinonjs.org/). We no longer support Chai and Sinon, so Jest equivalents must be used whenever new tests are added.
 
 End-to-end tests use [Playwright](https://playwright.dev/docs/intro) to interact with the browser, and Jest to write and drive the testing scripts.
 

--- a/package.json
+++ b/package.json
@@ -263,7 +263,6 @@
 		"sass": "^1.37.5",
 		"sass-loader": "^12.1.0",
 		"sharp": "^0.28",
-		"sinon": "^12.0.1",
 		"source-map": "^0.7.3",
 		"stackframe": "^1.1.1",
 		"stacktrace-gps": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4965,7 +4965,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/commons@npm:^1.6.0, @sinonjs/commons@npm:^1.7.0, @sinonjs/commons@npm:^1.8.3":
+"@sinonjs/commons@npm:^1.7.0":
   version: 1.8.3
   resolution: "@sinonjs/commons@npm:1.8.3"
   dependencies:
@@ -4974,39 +4974,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/fake-timers@npm:^7.0.4":
-  version: 7.1.2
-  resolution: "@sinonjs/fake-timers@npm:7.1.2"
-  dependencies:
-    "@sinonjs/commons": ^1.7.0
-  checksum: c94de47ff2eceb2a7009c970f932509e81e474b555ea994343aea4c87aed26844ba298a70d585c0769e63fe379ebae6aaad61d37b3bca71f740a8d3d49f1bc27
-  languageName: node
-  linkType: hard
-
-"@sinonjs/fake-timers@npm:^8.0.1, @sinonjs/fake-timers@npm:^8.1.0":
+"@sinonjs/fake-timers@npm:^8.0.1":
   version: 8.1.0
   resolution: "@sinonjs/fake-timers@npm:8.1.0"
   dependencies:
     "@sinonjs/commons": ^1.7.0
   checksum: d6b795f9ddaf044daf184c151555ca557ccd23636f2ee3d2f76a9d128329f81fc1aac412f6f67239ab92cb9390aad9955b71df93cf4bd442c68b1f341e381ab6
-  languageName: node
-  linkType: hard
-
-"@sinonjs/samsam@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "@sinonjs/samsam@npm:6.0.2"
-  dependencies:
-    "@sinonjs/commons": ^1.6.0
-    lodash.get: ^4.4.2
-    type-detect: ^4.0.8
-  checksum: a8a0835ec8709dceffd3cfeb182efe8523baea01608bb0a223c269062cc0afaf610cf58aaef63d9a17414e73508ef2ed8b40fcf2e4299285425e7906db5c5479
-  languageName: node
-  linkType: hard
-
-"@sinonjs/text-encoding@npm:^0.7.1":
-  version: 0.7.1
-  resolution: "@sinonjs/text-encoding@npm:0.7.1"
-  checksum: a55d2aa35f30efcafc8ca57841ee9a6c963e969be3ace0a9576f772790fedd36c22be5687df0ad55e1c5ce1961e05c496f2981f5ad3491802bd9212d91ca03e2
   languageName: node
   linkType: hard
 
@@ -12582,7 +12555,6 @@ __metadata:
     redux-mock-store: ^1.5.4
     redux-thunk: ^2.3.0
     regenerator-runtime: ^0.13.9
-    sinon: ^12.0.1
     social-logos: ^2.4.0
     socket.io-client: ^2.3.0
     source-map-support: ^0.5.19
@@ -15308,13 +15280,6 @@ __metadata:
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: 81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
-  languageName: node
-  linkType: hard
-
-"diff@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "diff@npm:5.0.0"
-  checksum: 08c5904779bbababcd31f1707657b1ad57f8a9b65e6f88d3fb501d09a965d5f8d73066898a7d3f35981f9e4101892c61d99175d421f3b759533213c253d91134
   languageName: node
   linkType: hard
 
@@ -22671,13 +22636,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"just-extend@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "just-extend@npm:4.0.2"
-  checksum: 92a1efd9ab30078e9bec97a5cc92d0762afcfe778450cc4a80c9202ffffd16a9155f6387792bd6f66edeb0527b5d621da07d681d19ce69f01562e56c4c0dbf2c
-  languageName: node
-  linkType: hard
-
 "jwt-decode@npm:^2.2.0":
   version: 2.2.0
   resolution: "jwt-decode@npm:2.2.0"
@@ -25212,19 +25170,6 @@ __metadata:
   version: 1.0.5
   resolution: "nice-try@npm:1.0.5"
   checksum: 95568c1b73e1d0d4069a3e3061a2102d854513d37bcfda73300015b7ba4868d3b27c198d1dbbd8ebdef4112fc2ed9e895d4a0f2e1cce0bd334f2a1346dc9205f
-  languageName: node
-  linkType: hard
-
-"nise@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "nise@npm:5.1.0"
-  dependencies:
-    "@sinonjs/commons": ^1.7.0
-    "@sinonjs/fake-timers": ^7.0.4
-    "@sinonjs/text-encoding": ^0.7.1
-    just-extend: ^4.0.2
-    path-to-regexp: ^1.7.0
-  checksum: bf04deaae65558f237aa8cd53e4b08252ecd4066a93b3f4d54d6d254ffb19ceb71e042bf1610b1c3e55156574a984da20dcc0c24361cbb1d2fc08e05f78a946f
   languageName: node
   linkType: hard
 
@@ -31838,20 +31783,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"sinon@npm:^12.0.1":
-  version: 12.0.1
-  resolution: "sinon@npm:12.0.1"
-  dependencies:
-    "@sinonjs/commons": ^1.8.3
-    "@sinonjs/fake-timers": ^8.1.0
-    "@sinonjs/samsam": ^6.0.2
-    diff: ^5.0.0
-    nise: ^5.1.0
-    supports-color: ^7.2.0
-  checksum: 35536057d9f4f38a16008e8463c41ba14f84cbc5ad9399da71c0490a242fd0fd34fb194ecc7092ed7d6b494e0cde8ae26050b3ab957703fb22147d9de1a3de2e
-  languageName: node
-  linkType: hard
-
 "sirv@npm:^1.0.7":
   version: 1.0.10
   resolution: "sirv@npm:1.0.10"
@@ -33170,7 +33101,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0, supports-color@npm:^7.2.0":
+"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
@@ -34197,7 +34128,7 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
-"type-detect@npm:4.0.8, type-detect@npm:^4.0.8":
+"type-detect@npm:4.0.8":
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 8fb9a51d3f365a7de84ab7f73b653534b61b622aa6800aecdb0f1095a4a646d3f5eb295322127b6573db7982afcd40ab492d038cf825a42093a58b1e1353e0bd
@@ -36050,7 +35981,6 @@ swiper@4.5.1:
     sass: ^1.37.5
     sass-loader: ^12.1.0
     sharp: ^0.28
-    sinon: ^12.0.1
     source-map: ^0.7.3
     stackframe: ^1.1.1
     stacktrace-gps: ^3.0.3


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is the culmination of the latest few PRs to remove `sinon` from Calypso in favor of `jest`.

Here we migrate the last 2 test suites that used `sinon` to use `jest` instead.

We also remove `sinon` as a dependency, and update some docs to reflect the change.

#### Testing instructions

* Verify Calypso builds without errors and smoke tests well.
* Verify all tests are passing.