### PR TITLE
Stepper: Use siteId or siteSlug for exitFlow redirects

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -60,7 +60,7 @@ export const siteSetupFlow: Flow = {
 		const site = useSite();
 		const siteSlug = site ? new URL( site.URL ).host : null;
 		const adminUrl = useSelect(
-			( select ) => site && select( SITE_STORE ).getSiteOption( site.ID as number, 'admin_url' )
+			( select ) => site && select( SITE_STORE ).getSiteOption( site.ID, 'admin_url' )
 		);
 		const isAtomic = useSelect( ( select ) =>
 			select( SITE_STORE ).isSiteAtomic( site?.ID as number )

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -57,15 +57,13 @@ export const siteSetupFlow: Flow = {
 	useStepNavigation( currentStep, navigate ) {
 		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 		const startingPoint = useSelect( ( select ) => select( ONBOARD_STORE ).getStartingPoint() );
-		const siteSlug = useSiteSlugParam();
-		const siteId = useSelect(
-			( select ) => siteSlug && select( SITE_STORE ).getSiteIdBySlug( siteSlug )
-		);
+		const site = useSite();
+		const siteSlug = site ? new URL( site.URL ).host : null;
 		const adminUrl = useSelect(
-			( select ) => siteSlug && select( SITE_STORE ).getSiteOption( siteId as number, 'admin_url' )
+			( select ) => site && select( SITE_STORE ).getSiteOption( site.ID as number, 'admin_url' )
 		);
 		const isAtomic = useSelect( ( select ) =>
-			select( SITE_STORE ).isSiteAtomic( siteId as number )
+			select( SITE_STORE ).isSiteAtomic( site?.ID as number )
 		);
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
 		const { setPendingAction, setStepProgress } = useDispatch( ONBOARD_STORE );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When exiting any of the flows using `exitFlow`, we use the `siteSlug` query parameter in the redirect URLs. However, when coming to the intent screen after purchasing a custom domain, the `siteId` is used in the query params instead of the `siteSlug`. Due to this, the redirects from `exitFlow` work incorrectly. See #64054 for more details.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/setup/intent?siteId=<site id>`
- Select the "Write" intent.
- After filling in the site title, click on "Draft First Post".
- You should be redirected to https://wordpress.com/post/<site slug>
- 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #64054
