### PR TITLE
Inline Help: fix pageicon smaller when large text in inline help

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -135,7 +135,7 @@ function HelpSearchResults( {
 				return <Gridicon icon={ icon } />;
 			}
 
-			return <Icon icon={ pageIcon } />;
+			return <Icon icon={ pageIcon } width={ 18 } height={ 18 } />;
 		};
 
 		return (

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -135,7 +135,7 @@ function HelpSearchResults( {
 				return <Gridicon icon={ icon } />;
 			}
 
-			return <Icon icon={ pageIcon } width={ 18 } height={ 18 } />;
+			return <Icon icon={ pageIcon } />;
 		};
 
 		return (

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -318,6 +318,10 @@
 
 .inline-help__results-cell {
 	width: 100%;
+
+	svg {
+		overflow: visible;
+	}
 }
 
 .inline-help__results-item {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the list below the search, results with long line-lengths end up reducing the width of the icon. This makes the list of results feel messy.

| Before  | After |
| ------------- | ------------- |
| <img width="200" alt="image" src="https://user-images.githubusercontent.com/52076348/170458383-863c9ea3-e085-42cc-81dc-0cef88c85489.png"> | <img width="200" alt="image" src="https://user-images.githubusercontent.com/52076348/170465697-80f6e2f0-cf96-4287-b72e-045b3fcd529b.png"> |


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch.
* `yarn start`
* Open the inline help and check that all the pageicon icons have the same size

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64031
Fixes #64031
