### PR TITLE
Jetpack Cloud: Ensure data is available for Social connections

### DIFF
--- a/client/jetpack-cloud/sections/jetpack-social/connections.jsx
+++ b/client/jetpack-cloud/sections/jetpack-social/connections.jsx
@@ -4,6 +4,8 @@ import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
+import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
+import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import QueryPublicizeConnections from 'calypso/components/data/query-publicize-connections';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
@@ -31,6 +33,8 @@ export const Connections = ( { siteId, translate } ) => {
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Main wideLayout className="connections__sharing-settings connections__sharing-connections">
 			<DocumentHead title={ titleHeader } />
+			<QueryKeyringConnections />
+			<QueryKeyringServices />
 			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
 			{ siteId && <QueryPublicizeConnections siteId={ siteId } /> }
 			<FormattedHeader


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When disconnecting connections on load, or quickly attempting to connect
an account, there would be an error, or the process would silently fail.
This appears to be because the data wasn't available in the store.

This change adds the two query components in use on the
`/marketing/connections` screen, that weren't on the Jetpack Social
equivalent, which fixes the issue.


#### Testing instructions

- Go to https://cloud.jetpack.com/jetpack-social/<Jetpack site domain>
- As quickly as possible click on a connect button. The modal will appear without you connecting to your account, or if you have no connections available for the site, the service button will just return to the 'Connect' state.
- Ensure you have a connection
- Hard refresh the page
- Click the 'Disconnect' button for any connection and you should receive an error about the service not being able to be disconnected, but a refresh of the page will show that it has been.
- Go through the same steps with this PR and it should fix these issues.


https://user-images.githubusercontent.com/96462/170469457-7e80f4be-3fa4-49bd-b33e-7ea7b0650754.mov

An example of the connection issue

https://user-images.githubusercontent.com/96462/170469543-ad865ca7-dbdc-4e10-ad30-907165ee7ddd.mov

An example of the disconnection issue
