### PR TITLE
StatsPeriodNavigation: Fix the behavior of the arrows in RTL Languages

### DIFF
--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -76,31 +76,36 @@ class StatsPeriodNavigation extends PureComponent {
 			addQueryPrefix: true,
 		} );
 
+		const previousDayComponent = (
+			<a
+				className={ classNames( 'stats-period-navigation__previous', {
+					'is-disabled': hidePreviousArrow,
+				} ) }
+				href={ `${ url }${ previousDayQuery }` }
+				onClick={ this.handleClickPrevious }
+			>
+				<Gridicon icon={ 'arrow-left' } size={ 18 } />
+			</a>
+		);
+		const nextDayComponent = (
+			<a
+				className={ classNames( 'stats-period-navigation__next', {
+					'is-disabled': hideNextArrow || isToday,
+				} ) }
+				href={ `${ url }${ nextDayQuery }` }
+				onClick={ this.handleClickNext }
+			>
+				<Gridicon icon={ 'arrow-right' } size={ 18 } />
+			</a>
+		);
+
 		return (
 			<div className="stats-period-navigation">
-				{
-					<a
-						className={ classNames( 'stats-period-navigation__previous', {
-							'is-disabled': hidePreviousArrow,
-						} ) }
-						href={ `${ url }${ previousDayQuery }` }
-						onClick={ this.handleClickPrevious }
-					>
-						<Gridicon icon={ isRtl ? 'arrow-right' : 'arrow-left' } size={ 18 } />
-					</a>
-				}
+				{ isRtl ? nextDayComponent : previousDayComponent }
+
 				<div className="stats-period-navigation__children">{ children }</div>
-				{
-					<a
-						className={ classNames( 'stats-period-navigation__next', {
-							'is-disabled': hideNextArrow || isToday,
-						} ) }
-						href={ `${ url }${ nextDayQuery }` }
-						onClick={ this.handleClickNext }
-					>
-						<Gridicon icon={ isRtl ? 'arrow-left' : 'arrow-right' } size={ 18 } />
-					</a>
-				}
+
+				{ isRtl ? previousDayComponent : nextDayComponent }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -53,17 +53,8 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	render() {
-		const {
-			children,
-			date,
-			moment,
-			period,
-			url,
-			hidePreviousArrow,
-			hideNextArrow,
-			isRtl,
-			queryParams,
-		} = this.props;
+		const { children, date, moment, period, url, hidePreviousArrow, hideNextArrow, queryParams } =
+			this.props;
 
 		const isToday = moment( date ).isSame( moment(), period );
 		const previousDay = moment( date ).subtract( 1, period ).format( 'YYYY-MM-DD' );
@@ -76,36 +67,31 @@ class StatsPeriodNavigation extends PureComponent {
 			addQueryPrefix: true,
 		} );
 
-		const previousDayComponent = (
-			<a
-				className={ classNames( 'stats-period-navigation__previous', {
-					'is-disabled': hidePreviousArrow,
-				} ) }
-				href={ `${ url }${ previousDayQuery }` }
-				onClick={ this.handleClickPrevious }
-			>
-				<Gridicon icon={ 'arrow-left' } size={ 18 } />
-			</a>
-		);
-		const nextDayComponent = (
-			<a
-				className={ classNames( 'stats-period-navigation__next', {
-					'is-disabled': hideNextArrow || isToday,
-				} ) }
-				href={ `${ url }${ nextDayQuery }` }
-				onClick={ this.handleClickNext }
-			>
-				<Gridicon icon={ 'arrow-right' } size={ 18 } />
-			</a>
-		);
-
 		return (
 			<div className="stats-period-navigation">
-				{ isRtl ? nextDayComponent : previousDayComponent }
-
+				{
+					<a
+						className={ classNames( 'stats-period-navigation__previous', {
+							'is-disabled': hidePreviousArrow,
+						} ) }
+						href={ `${ url }${ previousDayQuery }` }
+						onClick={ this.handleClickPrevious }
+					>
+						<Gridicon icon={ 'arrow-left' } size={ 18 } />
+					</a>
+				}
 				<div className="stats-period-navigation__children">{ children }</div>
-
-				{ isRtl ? previousDayComponent : nextDayComponent }
+				{
+					<a
+						className={ classNames( 'stats-period-navigation__next', {
+							'is-disabled': hideNextArrow || isToday,
+						} ) }
+						href={ `${ url }${ nextDayQuery }` }
+						onClick={ this.handleClickNext }
+					>
+						<Gridicon icon={ 'arrow-right' } size={ 18 } />
+					</a>
+				}
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The arrows on the stats screen move the dates in the opposite direction to which they point in RTL languages. 
This was previously fixed in https://github.com/Automattic/wp-calypso/pull/20557
![Incorrect RTL behavior](https://user-images.githubusercontent.com/36699353/169327822-d901d446-381c-40ce-ac3c-e20ba1224629.gif)

#### Testing instructions

1. Load the stats screen in Calypso.
2. Verify that the arrow behavior is correct in LTR language.
3. Switch to an RTL Language like Arabic.
4. Verify that the arrow behavior is correct in RTL Language.


Related to 438-gh-Automattic/i18n-issues