### PR TITLE
Remove redux-bridge from lib/purchases: convert handlers to Redux actions

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { modeType, stepSlug } from 'calypso/components/domains/connect-domain-step/constants';
 import { isSubdomain } from 'calypso/lib/domains';
@@ -21,6 +20,8 @@ import {
 import { transferStatus, type as domainTypes, gdprConsentStatus } from './constants';
 import type { ResponseDomain } from './types';
 import type { Purchase } from 'calypso/lib/purchases/types';
+import type { CalypsoDispatch } from 'calypso/state/types';
+import type { I18N } from 'i18n-calypso';
 import type { ReactChild } from 'react';
 
 export type ResolveDomainStatusReturn =
@@ -53,6 +54,8 @@ export type ResolveDomainStatusOptionsBag = {
 export function resolveDomainStatus(
 	domain: ResponseDomain,
 	purchase: Purchase | null = null,
+	translate: I18N[ 'translate' ],
+	dispatch: CalypsoDispatch,
 	{
 		isJetpackSite = null,
 		isSiteAutomatedTransfer = null,
@@ -338,7 +341,10 @@ export function resolveDomainStatus(
 										components: {
 											strong: <strong />,
 											a: (
-												<Button plain onClick={ () => handleRenewNowClick( purchase, siteSlug ) } />
+												<Button
+													plain
+													onClick={ () => dispatch( handleRenewNowClick( purchase, siteSlug ) ) }
+												/>
 											),
 										},
 										args: { renewableUntil },
@@ -364,7 +370,10 @@ export function resolveDomainStatus(
 										components: {
 											strong: <strong />,
 											a: (
-												<Button plain onClick={ () => handleRenewNowClick( purchase, siteSlug ) } />
+												<Button
+													plain
+													onClick={ () => dispatch( handleRenewNowClick( purchase, siteSlug ) ) }
+												/>
 											),
 										},
 										args: { redeemableUntil },
@@ -422,7 +431,12 @@ export function resolveDomainStatus(
 					purchase && siteSlug && domain.currentUserIsOwner
 						? translate( '{{a}}Renew now{{/a}}', {
 								components: {
-									a: <Button plain onClick={ () => handleRenewNowClick( purchase, siteSlug ) } />,
+									a: (
+										<Button
+											plain
+											onClick={ () => dispatch( handleRenewNowClick( purchase, siteSlug ) ) }
+										/>
+									),
 								},
 						  } )
 						: translate( 'It can be renewed by the owner.' );

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -210,22 +210,25 @@ describe( 'index', () => {
 		const siteSlug = 'my-site.wordpress.com';
 
 		test( 'should redirect to the checkout page', () => {
-			handleRenewNowClick( purchase, siteSlug );
+			const dispatch = jest.fn();
+			handleRenewNowClick( purchase, siteSlug )( dispatch );
 			expect( page ).toHaveBeenCalledWith(
 				'/checkout/personal-bundle/renew/1/my-site.wordpress.com'
 			);
 		} );
 
 		test( 'should redirect to the checkout page with ?redirect_to', () => {
-			handleRenewNowClick( purchase, siteSlug, { redirectTo: '/me/purchases' } );
+			const dispatch = jest.fn();
+			handleRenewNowClick( purchase, siteSlug, { redirectTo: '/me/purchases' } )( dispatch );
 			expect( page ).toHaveBeenCalledWith(
 				'/checkout/personal-bundle/renew/1/my-site.wordpress.com?redirect_to=%2Fme%2Fpurchases'
 			);
 		} );
 
 		test( 'should send the tracks events', () => {
+			const dispatch = jest.fn();
 			const tracksProps = { extra: 'extra' };
-			handleRenewNowClick( purchase, siteSlug, { tracksProps } );
+			handleRenewNowClick( purchase, siteSlug, { tracksProps } )( dispatch );
 			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_purchases_renew_now_click', {
 				product_slug: 'personal-bundle',
 				extra: 'extra',
@@ -233,18 +236,32 @@ describe( 'index', () => {
 		} );
 
 		describe( 'when the purchase id does not exist', () => {
-			test( 'should reject', () => {
-				expect( () => handleRenewNowClick( { ...purchase, id: null }, siteSlug ) ).toThrowError(
-					'Could not find purchase id for renewal.'
+			test( 'should report error', () => {
+				const dispatch = jest.fn();
+				handleRenewNowClick( { ...purchase, id: null }, siteSlug )( dispatch );
+				expect( dispatch ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						notice: expect.objectContaining( {
+							status: 'is-error',
+							text: 'Could not find purchase id for renewal.',
+						} ),
+					} )
 				);
 			} );
 		} );
 
 		describe( 'when the product slug does not exist', () => {
-			test( 'should reject', () => {
-				expect( () =>
-					handleRenewNowClick( { ...purchase, productSlug: '' }, siteSlug )
-				).toThrowError( 'This product cannot be renewed.' );
+			test( 'should report error', () => {
+				const dispatch = jest.fn();
+				handleRenewNowClick( { ...purchase, productSlug: '' }, siteSlug )( dispatch );
+				expect( dispatch ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						notice: expect.objectContaining( {
+							status: 'is-error',
+							text: 'This product cannot be renewed.',
+						} ),
+					} )
+				);
 			} );
 		} );
 	} );
@@ -272,24 +289,33 @@ describe( 'index', () => {
 		];
 		const siteSlug = 'my-site.wordpress.com';
 		test( 'should redirect to the checkout page', () => {
-			handleRenewMultiplePurchasesClick( purchases, siteSlug );
+			const dispatch = jest.fn();
+			handleRenewMultiplePurchasesClick( purchases, siteSlug )( dispatch );
 			expect( page ).toHaveBeenCalledWith(
 				'/checkout/personal-bundle,dotlive_domain:personalsitetest1234.live/renew/1,2/my-site.wordpress.com'
 			);
 		} );
 		describe( 'when the none of the purchase ids exist', () => {
-			test( 'should reject', () => {
+			test( 'should report error', () => {
+				const dispatch = jest.fn();
 				const purchasesWithoutId = purchases.map( ( purchase ) => ( { ...purchase, id: null } ) );
-				expect( () =>
-					handleRenewMultiplePurchasesClick( purchasesWithoutId, siteSlug )
-				).toThrowError( 'Could not find product slug or purchase id for renewal.' );
+				handleRenewMultiplePurchasesClick( purchasesWithoutId, siteSlug )( dispatch );
+				expect( dispatch ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						notice: expect.objectContaining( {
+							status: 'is-error',
+							text: 'Could not find product slug or purchase id for renewal.',
+						} ),
+					} )
+				);
 			} );
 		} );
 
 		describe( 'when at least one purchase can be renewed', () => {
 			test( 'should redirect to checkout with only the valid purchases to renew', () => {
+				const dispatch = jest.fn();
 				const purchasesPartiallyValid = [ purchases[ 1 ], { ...purchases[ 0 ], id: null } ];
-				handleRenewMultiplePurchasesClick( purchasesPartiallyValid, siteSlug );
+				handleRenewMultiplePurchasesClick( purchasesPartiallyValid, siteSlug )( dispatch );
 				expect( page ).toHaveBeenCalledWith(
 					'/checkout/dotlive_domain:personalsitetest1234.live/renew/2/my-site.wordpress.com'
 				);

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -182,10 +182,10 @@ class ManagePurchase extends Component {
 	}
 
 	handleRenew = () => {
-		const { purchase, siteSlug, redirectTo } = this.props;
+		const { purchase, siteSlug, redirectTo, dispatch } = this.props;
 		const options = redirectTo ? { redirectTo } : undefined;
 
-		handleRenewNowClick( purchase, siteSlug, options );
+		dispatch( handleRenewNowClick( purchase, siteSlug, options ) );
 	};
 
 	handleRenewMonthly = () => {
@@ -208,9 +208,9 @@ class ManagePurchase extends Component {
 	};
 
 	handleRenewMultiplePurchases = ( purchases ) => {
-		const { siteSlug, redirectTo } = this.props;
+		const { siteSlug, redirectTo, dispatch } = this.props;
 		const options = redirectTo ? { redirectTo } : undefined;
-		handleRenewMultiplePurchasesClick( purchases, siteSlug, options );
+		dispatch( handleRenewMultiplePurchasesClick( purchases, siteSlug, options ) );
 	};
 
 	shouldShowNonPrimaryDomainWarning() {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -182,10 +182,10 @@ class ManagePurchase extends Component {
 	}
 
 	handleRenew = () => {
-		const { purchase, siteSlug, redirectTo, dispatch } = this.props;
+		const { purchase, siteSlug, redirectTo } = this.props;
 		const options = redirectTo ? { redirectTo } : undefined;
 
-		dispatch( handleRenewNowClick( purchase, siteSlug, options ) );
+		this.props.handleRenewNowClick( purchase, siteSlug, options );
 	};
 
 	handleRenewMonthly = () => {
@@ -208,9 +208,9 @@ class ManagePurchase extends Component {
 	};
 
 	handleRenewMultiplePurchases = ( purchases ) => {
-		const { siteSlug, redirectTo, dispatch } = this.props;
+		const { siteSlug, redirectTo } = this.props;
 		const options = redirectTo ? { redirectTo } : undefined;
-		dispatch( handleRenewMultiplePurchasesClick( purchases, siteSlug, options ) );
+		this.props.handleRenewMultiplePurchasesClick( purchases, siteSlug, options );
 	};
 
 	shouldShowNonPrimaryDomainWarning() {
@@ -981,51 +981,57 @@ function PurchasesQueryComponent( { isSiteLevel, selectedSiteId } ) {
 	return <QueryUserPurchases />;
 }
 
-export default connect( ( state, props ) => {
-	const purchase = getByPurchaseId( state, props.purchaseId );
-	const purchaseAttachedTo =
-		purchase && purchase.attachedToPurchaseId
-			? getByPurchaseId( state, purchase.attachedToPurchaseId )
-			: null;
-	const selectedSiteId = getSelectedSiteId( state );
-	const siteId = purchase?.siteId ?? null;
-	const purchases = purchase && getSitePurchases( state, purchase.siteId );
-	const userId = getCurrentUserId( state );
-	const isProductOwner = purchase && purchase.userId === userId;
-	const renewableSitePurchases = getRenewableSitePurchases( state, siteId );
-	const isPurchasePlan = purchase && isPlan( purchase );
-	const isPurchaseTheme = purchase && isTheme( purchase );
-	const productsList = getProductsList( state );
-	const site = getSite( state, siteId );
-	const hasLoadedSites = ! isRequestingSites( state );
-	const hasLoadedDomains = hasLoadedSiteDomains( state, siteId );
-	const relatedMonthlyPlanSlug = getMonthlyPlanByYearly( purchase?.productSlug );
-	const relatedMonthlyPlanPrice = getSitePlanRawPrice( state, siteId, relatedMonthlyPlanSlug );
-	return {
-		hasLoadedDomains,
-		hasLoadedSites,
-		hasLoadedPurchasesFromServer: props.isSiteLevel
-			? hasLoadedSitePurchasesFromServer( state )
-			: hasLoadedUserPurchasesFromServer( state ),
-		hasNonPrimaryDomainsFlag: getCurrentUser( state )
-			? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
-			: false,
-		hasCustomPrimaryDomain: hasCustomDomain( site ),
-		productsList,
-		purchase,
-		purchases,
-		purchaseAttachedTo,
-		siteId,
-		selectedSiteId,
-		isProductOwner,
-		site,
-		renewableSitePurchases,
-		plan: isPurchasePlan && applyTestFiltersToPlansList( purchase.productSlug, undefined ),
-		isPurchaseTheme,
-		theme: isPurchaseTheme && getCanonicalTheme( state, siteId, purchase.meta ),
-		isAtomicSite: isSiteAtomic( state, siteId ),
-		relatedMonthlyPlanSlug,
-		relatedMonthlyPlanPrice,
-		isJetpackTemporarySite: purchase && isJetpackTemporarySitePurchase( purchase.domain ),
-	};
-} )( localize( ManagePurchase ) );
+export default connect(
+	( state, props ) => {
+		const purchase = getByPurchaseId( state, props.purchaseId );
+		const purchaseAttachedTo =
+			purchase && purchase.attachedToPurchaseId
+				? getByPurchaseId( state, purchase.attachedToPurchaseId )
+				: null;
+		const selectedSiteId = getSelectedSiteId( state );
+		const siteId = purchase?.siteId ?? null;
+		const purchases = purchase && getSitePurchases( state, purchase.siteId );
+		const userId = getCurrentUserId( state );
+		const isProductOwner = purchase && purchase.userId === userId;
+		const renewableSitePurchases = getRenewableSitePurchases( state, siteId );
+		const isPurchasePlan = purchase && isPlan( purchase );
+		const isPurchaseTheme = purchase && isTheme( purchase );
+		const productsList = getProductsList( state );
+		const site = getSite( state, siteId );
+		const hasLoadedSites = ! isRequestingSites( state );
+		const hasLoadedDomains = hasLoadedSiteDomains( state, siteId );
+		const relatedMonthlyPlanSlug = getMonthlyPlanByYearly( purchase?.productSlug );
+		const relatedMonthlyPlanPrice = getSitePlanRawPrice( state, siteId, relatedMonthlyPlanSlug );
+		return {
+			hasLoadedDomains,
+			hasLoadedSites,
+			hasLoadedPurchasesFromServer: props.isSiteLevel
+				? hasLoadedSitePurchasesFromServer( state )
+				: hasLoadedUserPurchasesFromServer( state ),
+			hasNonPrimaryDomainsFlag: getCurrentUser( state )
+				? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
+				: false,
+			hasCustomPrimaryDomain: hasCustomDomain( site ),
+			productsList,
+			purchase,
+			purchases,
+			purchaseAttachedTo,
+			siteId,
+			selectedSiteId,
+			isProductOwner,
+			site,
+			renewableSitePurchases,
+			plan: isPurchasePlan && applyTestFiltersToPlansList( purchase.productSlug, undefined ),
+			isPurchaseTheme,
+			theme: isPurchaseTheme && getCanonicalTheme( state, siteId, purchase.meta ),
+			isAtomicSite: isSiteAtomic( state, siteId ),
+			relatedMonthlyPlanSlug,
+			relatedMonthlyPlanPrice,
+			isJetpackTemporarySite: purchase && isJetpackTemporarySitePurchase( purchase.domain ),
+		};
+	},
+	{
+		handleRenewNowClick,
+		handleRenewMultiplePurchasesClick,
+	}
+)( localize( ManagePurchase ) );

--- a/client/my-sites/domains/domain-management/edit/card/renew-button/index.tsx
+++ b/client/my-sites/domains/domain-management/edit/card/renew-button/index.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
 import { handleRenewNowClick, getRenewalPrice } from 'calypso/lib/purchases';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
@@ -36,6 +37,7 @@ function RenewButton( {
 	tracksProps,
 }: RenewButtonProps ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	if ( ! subscriptionId ) {
 		return null;
@@ -68,7 +70,7 @@ function RenewButton( {
 	}
 
 	function handleRenew() {
-		handleRenewNowClick( purchase as Purchase, selectedSite.slug, { tracksProps } );
+		dispatch( handleRenewNowClick( purchase as Purchase, selectedSite.slug, { tracksProps } ) );
 	}
 
 	return (

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -119,7 +119,7 @@ class MappedDomainType extends Component {
 			<div>
 				{ ( isLoadingPurchase || purchase ) && (
 					<RenewButton
-						compact={ true }
+						compact
 						purchase={ purchase }
 						selectedSite={ this.props.selectedSite }
 						subscriptionId={ parseInt( subscriptionId, 10 ) }
@@ -170,19 +170,32 @@ class MappedDomainType extends Component {
 	}
 
 	render() {
-		const { domain, selectedSite, purchase, mappingPurchase, isLoadingPurchase } = this.props;
-		const { name: domain_name } = domain;
+		const {
+			domain,
+			selectedSite,
+			purchase,
+			mappingPurchase,
+			isLoadingPurchase,
+			translate,
+			dispatch,
+		} = this.props;
 
-		const { statusText, statusClass, icon } = resolveDomainStatus( domain, purchase, {
-			isJetpackSite: this.props.isJetpackSite,
-			isSiteAutomatedTransfer: this.props.isSiteAutomatedTransfer,
-		} );
+		const { statusText, statusClass, icon } = resolveDomainStatus(
+			domain,
+			purchase,
+			translate,
+			dispatch,
+			{
+				isJetpackSite: this.props.isJetpackSite,
+				isSiteAutomatedTransfer: this.props.isSiteAutomatedTransfer,
+			}
+		);
 
 		return (
 			<div className="domain-types__container">
 				{ selectedSite.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 				<DomainStatus
-					header={ domain_name }
+					header={ domain.name }
 					statusText={ statusText }
 					statusClass={ statusClass }
 					icon={ icon }
@@ -200,14 +213,14 @@ class MappedDomainType extends Component {
 						domain={ domain }
 					/>
 				</DomainStatus>
-				<Card compact={ true } className="domain-types__expiration-row">
+				<Card compact className="domain-types__expiration-row">
 					<DomainExpiryOrRenewal { ...this.props } />
 					{ this.renderDefaultRenewButton() }
 					{ domain.currentUserCanManage && this.renderAutoRenew() }
 				</Card>
 				<DomainManagementNavigationEnhanced
 					domain={ domain }
-					selectedSite={ this.props.selectedSite }
+					selectedSite={ selectedSite }
 					purchase={ mappingPurchase }
 					isLoadingPurchase={ isLoadingPurchase }
 				/>

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -115,7 +115,7 @@ class RegisteredDomainType extends Component {
 					( isLoadingPurchase || purchase ) &&
 					( domain.isRenewable || domain.isRedeemable ) && (
 						<RenewButton
-							primary={ true }
+							primary
 							purchase={ purchase }
 							selectedSite={ this.props.selectedSite }
 							subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
@@ -196,7 +196,7 @@ class RegisteredDomainType extends Component {
 			<div>
 				{ ( isLoadingPurchase || purchase ) && (
 					<RenewButton
-						compact={ true }
+						compact
 						purchase={ purchase }
 						selectedSite={ this.props.selectedSite }
 						subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
@@ -271,12 +271,26 @@ class RegisteredDomainType extends Component {
 	}
 
 	render() {
-		const { domain, selectedSite, purchase, isLoadingPurchase, isDomainOnlySite } = this.props;
+		const {
+			domain,
+			selectedSite,
+			purchase,
+			isLoadingPurchase,
+			isDomainOnlySite,
+			translate,
+			dispatch,
+		} = this.props;
 		const { name: domain_name } = domain;
 
-		const { statusText, statusClass, icon } = resolveDomainStatus( domain, purchase, {
-			isDomainOnlySite,
-		} );
+		const { statusText, statusClass, icon } = resolveDomainStatus(
+			domain,
+			purchase,
+			translate,
+			dispatch,
+			{
+				isDomainOnlySite,
+			}
+		);
 
 		return (
 			<div className="domain-types__container">

--- a/client/my-sites/domains/domain-management/edit/domain-types/site-redirect-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/site-redirect-type.jsx
@@ -30,7 +30,7 @@ class SiteRedirectType extends Component {
 			<div>
 				{ ( isLoadingPurchase || purchase ) && (
 					<RenewButton
-						compact={ true }
+						compact
 						purchase={ purchase }
 						selectedSite={ this.props.selectedSite }
 						subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
@@ -76,10 +76,15 @@ class SiteRedirectType extends Component {
 	}
 
 	render() {
-		const { domain, selectedSite, purchase, isLoadingPurchase } = this.props;
+		const { domain, selectedSite, purchase, isLoadingPurchase, translate, dispatch } = this.props;
 		const { name: domain_name } = domain;
 
-		const { statusText, statusClass, icon } = resolveDomainStatus( domain, purchase );
+		const { statusText, statusClass, icon } = resolveDomainStatus(
+			domain,
+			purchase,
+			translate,
+			dispatch
+		);
 
 		return (
 			<div className="domain-types__container">

--- a/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
@@ -11,7 +11,6 @@ import { resolveDomainStatus } from 'calypso/lib/domains';
 import { transferStatus } from 'calypso/lib/domains/constants';
 import { INCOMING_DOMAIN_TRANSFER_STATUSES } from 'calypso/lib/url/support';
 import { domainUseMyDomain } from 'calypso/my-sites/domains/paths';
-import { errorNotice } from 'calypso/state/notices/actions';
 import {
 	getByPurchaseId,
 	hasLoadedSitePurchasesFromServer,
@@ -139,10 +138,15 @@ class TransferInDomainType extends Component {
 	}
 
 	render() {
-		const { domain, selectedSite, purchase, isLoadingPurchase } = this.props;
+		const { domain, selectedSite, purchase, isLoadingPurchase, translate, dispatch } = this.props;
 		const { name: domain_name } = domain;
 
-		const { statusText, statusClass, icon } = resolveDomainStatus( domain, purchase );
+		const { statusText, statusClass, icon } = resolveDomainStatus(
+			domain,
+			purchase,
+			translate,
+			dispatch
+		);
 
 		return (
 			<div className="domain-types__container">
@@ -166,16 +170,11 @@ class TransferInDomainType extends Component {
 	}
 }
 
-export default connect(
-	( state, ownProps ) => {
-		const { subscriptionId } = ownProps.domain;
-		return {
-			purchase: subscriptionId ? getByPurchaseId( state, parseInt( subscriptionId, 10 ) ) : null,
-			isLoadingPurchase:
-				isFetchingSitePurchases( state ) && ! hasLoadedSitePurchasesFromServer( state ),
-		};
-	},
-	{
-		errorNotice,
-	}
-)( withLocalizedMoment( localize( TransferInDomainType ) ) );
+export default connect( ( state, ownProps ) => {
+	const { subscriptionId } = ownProps.domain;
+	return {
+		purchase: subscriptionId ? getByPurchaseId( state, parseInt( subscriptionId, 10 ) ) : null,
+		isLoadingPurchase:
+			isFetchingSitePurchases( state ) && ! hasLoadedSitePurchasesFromServer( state ),
+	};
+} )( withLocalizedMoment( localize( TransferInDomainType ) ) );

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -25,11 +25,7 @@ import wpcom from 'calypso/lib/wp';
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
 import OptionsDomainButton from 'calypso/my-sites/domains/domain-management/list/options-domain-button';
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
-import {
-	composeAnalytics,
-	recordGoogleEvent,
-	recordTracksEvent,
-} from 'calypso/state/analytics/actions';
+import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { infoNotice } from 'calypso/state/notices/actions';
 import {
 	getUserPurchases,
@@ -263,8 +259,9 @@ class AllDomains extends Component {
 			context,
 			requestingSiteDomains,
 			hasLoadedUserPurchases,
-			translate,
 			isContactEmailEditContext,
+			translate,
+			dispatch,
 		} = this.props;
 
 		const { isSavingContactInfo } = this.state;
@@ -330,19 +327,31 @@ class AllDomains extends Component {
 				initialSortOrder: -1,
 				sortFunctions: [
 					( first, second, sortOrder ) => {
-						const { listStatusWeight: firstStatusWeight } = resolveDomainStatus( first, null, {
-							getMappingErrors: true,
-						} );
-						const { listStatusWeight: secondStatusWeight } = resolveDomainStatus( second, null, {
-							getMappingErrors: true,
-						} );
+						const { listStatusWeight: firstStatusWeight } = resolveDomainStatus(
+							first,
+							null,
+							translate,
+							dispatch,
+							{
+								getMappingErrors: true,
+							}
+						);
+						const { listStatusWeight: secondStatusWeight } = resolveDomainStatus(
+							second,
+							null,
+							translate,
+							dispatch,
+							{
+								getMappingErrors: true,
+							}
+						);
 						return ( ( firstStatusWeight ?? 0 ) - ( secondStatusWeight ?? 0 ) ) * sortOrder;
 					},
 					getReverseSimpleSortFunctionBy( 'domain' ),
 				],
 				bubble: countDomainsInOrangeStatus(
 					domains.map( ( domain ) =>
-						resolveDomainStatus( domain, null, {
+						resolveDomainStatus( domain, null, translate, dispatch, {
 							getMappingErrors: true,
 							siteSlug: sites[ domain.blogId ].slug,
 						} )
@@ -466,13 +475,21 @@ class AllDomains extends Component {
 
 		if ( selectedDomainNamesList.length === 0 ) {
 			this.setState( { isSavingContactInfo: false }, () =>
-				this.props.infoNotice( this.props.translate( 'No domains selected.' ) )
+				this.props.dispatch( infoNotice( this.props.translate( 'No domains selected.' ) ) )
 			);
 			return;
 		}
 
 		if ( this.props.isContactEmailEditContext ) {
-			this.props.saveContactEmailClick();
+			this.props.dispatch(
+				recordGoogleEvent(
+					'Domain Management',
+					'Clicked "Save contact info" Button in ListAll > Bulk edit email address'
+				)
+			);
+			this.props.dispatch(
+				recordTracksEvent( 'calypso_domain_management_list_all_save_contact_email_click' )
+			);
 		}
 
 		const saveWhoisPromises = selectedDomainNamesList.map( ( domainName ) => {
@@ -512,7 +529,9 @@ class AllDomains extends Component {
 
 		Promise.allSettled( saveWhoisPromises ).then( () => {
 			this.setState( { isSavingContactInfo: false }, () =>
-				this.props.infoNotice( this.props.translate( 'Saving contact info is complete.' ) )
+				this.props.dispatch(
+					infoNotice( this.props.translate( 'Saving contact info is complete.' ) )
+				)
 			);
 		} );
 	};
@@ -684,15 +703,6 @@ class AllDomains extends Component {
 	}
 }
 
-const saveContactEmailClick = () =>
-	composeAnalytics(
-		recordGoogleEvent(
-			'Domain Management',
-			'Clicked "Save contact info" Button in ListAll > Bulk edit email address'
-		),
-		recordTracksEvent( 'calypso_domain_management_list_all_save_contact_email_click' )
-	);
-
 const getSitesById = ( state ) => {
 	return ( getSites( state ) ?? [] ).reduce( ( result, site ) => {
 		result[ site.ID ] = site;
@@ -736,29 +746,23 @@ const getFilteredDomainsList = ( state, context ) => {
 	}
 };
 
-export default connect(
-	( state, { context } ) => {
-		const sites = getSitesById( state );
-		const action = parse( context.querystring )?.action;
+export default connect( ( state, { context } ) => {
+	const sites = getSitesById( state );
+	const action = parse( context.querystring )?.action;
 
-		return {
-			action,
-			canManageSitesMap: canCurrentUserForSites( state, Object.keys( sites ), 'manage_options' ),
-			currentRoute: getCurrentRoute( state ),
-			domainsList: getFlatDomainsList( state ),
-			domainsDetails: getAllDomains( state ),
-			filteredDomainsList: getFilteredDomainsList( state, context ),
-			hasAllSitesLoaded: hasAllSitesList( state ),
-			isContactEmailEditContext: ListAllActions.editContactEmail === action,
-			purchases: getUserPurchases( state ) || [],
-			hasLoadedUserPurchases: hasLoadedUserPurchasesFromServer( state ),
-			requestingFlatDomains: isRequestingAllDomains( state ),
-			requestingSiteDomains: getAllRequestingSiteDomains( state ),
-			sites,
-		};
-	},
-	{
-		saveContactEmailClick,
-		infoNotice,
-	}
-)( localize( AllDomains ) );
+	return {
+		action,
+		canManageSitesMap: canCurrentUserForSites( state, Object.keys( sites ), 'manage_options' ),
+		currentRoute: getCurrentRoute( state ),
+		domainsList: getFlatDomainsList( state ),
+		domainsDetails: getAllDomains( state ),
+		filteredDomainsList: getFilteredDomainsList( state, context ),
+		hasAllSitesLoaded: hasAllSitesList( state ),
+		isContactEmailEditContext: ListAllActions.editContactEmail === action,
+		purchases: getUserPurchases( state ) || [],
+		hasLoadedUserPurchases: hasLoadedUserPurchasesFromServer( state ),
+		requestingFlatDomains: isRequestingAllDomains( state ),
+		requestingSiteDomains: getAllRequestingSiteDomains( state ),
+		sites,
+	};
+} )( localize( AllDomains ) );

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -126,8 +126,8 @@ class DomainRow extends PureComponent {
 	}
 
 	renderDomainStatus() {
-		const { domain, site, isLoadingDomainDetails } = this.props;
-		const { status, statusClass } = resolveDomainStatus( domain, null, {
+		const { domain, site, isLoadingDomainDetails, translate, dispatch } = this.props;
+		const { status, statusClass } = resolveDomainStatus( domain, null, translate, dispatch, {
 			siteSlug: site?.slug,
 			getMappingErrors: true,
 		} );
@@ -302,10 +302,14 @@ class DomainRow extends PureComponent {
 	/* eslint-enable jsx-a11y/anchor-is-valid */
 
 	addEmailClick = ( event ) => {
-		const { currentRoute, domain, site, trackAddEmailClick } = this.props;
+		const { currentRoute, domain, site, dispatch } = this.props;
 		event.stopPropagation();
 
-		trackAddEmailClick( domain ); // analytics/tracks
+		dispatch(
+			recordTracksEvent( 'calypso_domain_management_domain_item_add_email_click', {
+				section: domain.type,
+			} )
+		);
 
 		this.goToEmailPage(
 			event,
@@ -448,13 +452,20 @@ class DomainRow extends PureComponent {
 	}
 
 	render() {
-		const { domain, isManagingAllSites, site, showCheckbox, purchase, translate } = this.props;
+		const { domain, isManagingAllSites, site, showCheckbox, purchase, translate, dispatch } =
+			this.props;
 		const domainTypeText = getDomainTypeText( domain, translate, domainInfoContext.DOMAIN_ROW );
 		const expiryDate = domain?.expiry ? moment.utc( domain?.expiry ) : null;
-		const { noticeText, statusClass } = resolveDomainStatus( domain, purchase, {
-			siteSlug: site?.slug,
-			getMappingErrors: true,
-		} );
+		const { noticeText, statusClass } = resolveDomainStatus(
+			domain,
+			purchase,
+			translate,
+			dispatch,
+			{
+				siteSlug: site?.slug,
+				getMappingErrors: true,
+			}
+		);
 
 		return (
 			<div className="domain-row">
@@ -502,11 +513,4 @@ class DomainRow extends PureComponent {
 	}
 }
 
-const trackAddEmailClick = ( domain ) =>
-	recordTracksEvent( 'calypso_domain_management_domain_item_add_email_click', {
-		section: domain.type,
-	} );
-
-export default connect( null, {
-	trackAddEmailClick,
-} )( localize( DomainRow ) );
+export default connect()( localize( DomainRow ) );

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -34,7 +34,6 @@ import {
 	showUpdatePrimaryDomainSuccessNotice,
 	showUpdatePrimaryDomainErrorNotice,
 } from 'calypso/state/domains/management/actions';
-import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { getPurchases, isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -59,7 +58,19 @@ import {
 import './style.scss';
 import 'calypso/my-sites/domains/style.scss';
 
-const noop = () => {};
+const changePrimary = ( domain, mode ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Changed Primary Domain to in List',
+			'Domain Name',
+			domain.name
+		),
+		recordTracksEvent( 'calypso_domain_management_list_change_primary_domain_click', {
+			section: domain.type,
+			mode,
+		} )
+	);
 
 export class SiteDomains extends Component {
 	static propTypes = {
@@ -68,10 +79,6 @@ export class SiteDomains extends Component {
 		isRequestingDomains: PropTypes.bool,
 		context: PropTypes.object,
 		renderAllSites: PropTypes.bool,
-	};
-
-	static defaultProps = {
-		changePrimary: noop,
 	};
 
 	state = {
@@ -93,6 +100,7 @@ export class SiteDomains extends Component {
 			selectedSite,
 			context,
 			translate,
+			dispatch,
 		} = this.props;
 		const { primaryDomainIndex, settingPrimaryDomain } = this.state;
 		const disabled = settingPrimaryDomain;
@@ -123,19 +131,27 @@ export class SiteDomains extends Component {
 				initialSortOrder: -1,
 				sortFunctions: [
 					( first, second, sortOrder ) => {
-						const { listStatusWeight: firstStatusWeight } = resolveDomainStatus( first, null, {
-							getMappingErrors: true,
-						} );
-						const { listStatusWeight: secondStatusWeight } = resolveDomainStatus( second, null, {
-							getMappingErrors: true,
-						} );
+						const { listStatusWeight: firstStatusWeight } = resolveDomainStatus(
+							first,
+							null,
+							translate,
+							dispatch,
+							{ getMappingErrors: true }
+						);
+						const { listStatusWeight: secondStatusWeight } = resolveDomainStatus(
+							second,
+							null,
+							translate,
+							dispatch,
+							{ getMappingErrors: true }
+						);
 						return ( ( firstStatusWeight ?? 0 ) - ( secondStatusWeight ?? 0 ) ) * sortOrder;
 					},
 					getReverseSimpleSortFunctionBy( 'domain' ),
 				],
 				bubble: countDomainsInOrangeStatus(
 					nonWpcomDomains.map( ( domain ) =>
-						resolveDomainStatus( domain, null, {
+						resolveDomainStatus( domain, null, translate, dispatch, {
 							getMappingErrors: true,
 							siteSlug: selectedSite.slug,
 						} )
@@ -372,7 +388,7 @@ export class SiteDomains extends Component {
 	}
 
 	async setPrimaryDomain( domainName ) {
-		await this.props.setPrimaryDomain( this.props.selectedSite.ID, domainName );
+		await this.props.dispatch( setPrimaryDomain( this.props.selectedSite.ID, domainName ) );
 		page.redirect( domainManagementList( this.props.selectedSite.slug ) );
 	}
 
@@ -381,7 +397,7 @@ export class SiteDomains extends Component {
 			return;
 		}
 
-		this.props.changePrimary( domainName, 'wpcom_domain_manage_click' );
+		this.props.dispatch( changePrimary( domainName, 'wpcom_domain_manage_click' ) );
 
 		const currentPrimaryIndex = this.props.domains.findIndex( ( { isPrimary } ) => isPrimary );
 		this.setState( { settingPrimaryDomain: true, primaryDomainIndex: -1 } );
@@ -390,10 +406,10 @@ export class SiteDomains extends Component {
 			.then(
 				() => {
 					this.setState( { primaryDomainIndex: -1 } );
-					this.props.showUpdatePrimaryDomainSuccessNotice( domainName );
+					this.props.dispatch( showUpdatePrimaryDomainSuccessNotice( domainName ) );
 				},
 				( error ) => {
-					this.props.showUpdatePrimaryDomainErrorNotice( error.message );
+					this.props.dispatch( showUpdatePrimaryDomainErrorNotice( error.message ) );
 					this.setState( { primaryDomainIndex: currentPrimaryIndex } );
 				}
 			)
@@ -409,7 +425,7 @@ export class SiteDomains extends Component {
 			return;
 		}
 
-		this.props.changePrimary( domain, mode );
+		this.props.dispatch( changePrimary( domain, mode ) );
 		const currentPrimaryIndex = this.props.domains.findIndex( ( { isPrimary } ) => isPrimary );
 		const currentPrimaryName = this.props.domains[ currentPrimaryIndex ].name;
 
@@ -429,14 +445,14 @@ export class SiteDomains extends Component {
 					settingPrimaryDomain: false,
 				} );
 
-				this.props.showUpdatePrimaryDomainSuccessNotice( domain.name );
+				this.props.dispatch( showUpdatePrimaryDomainSuccessNotice( domain.name ) );
 			},
 			( error ) => {
 				this.setState( {
 					settingPrimaryDomain: false,
 					primaryDomainIndex: currentPrimaryIndex,
 				} );
-				this.props.showUpdatePrimaryDomainErrorNotice( error.message );
+				this.props.dispatch( showUpdatePrimaryDomainErrorNotice( error.message ) );
 			}
 		);
 	};
@@ -464,51 +480,27 @@ export class SiteDomains extends Component {
 	};
 }
 
-const changePrimary = ( domain, mode ) =>
-	composeAnalytics(
-		recordGoogleEvent(
-			'Domain Management',
-			'Changed Primary Domain to in List',
-			'Domain Name',
-			domain.name
-		),
-		recordTracksEvent( 'calypso_domain_management_list_change_primary_domain_click', {
-			section: domain.type,
-			mode,
-		} )
-	);
+export default connect( ( state, ownProps ) => {
+	const siteId = ownProps?.selectedSite?.ID || null;
+	const userCanManageOptions = canCurrentUser( state, siteId, 'manage_options' );
+	const selectedSite = ownProps?.selectedSite || null;
+	const isOnFreePlan = selectedSite?.plan?.is_free || false;
+	const purchases = getPurchases( state );
+	const productsList = getProductsList( state );
 
-export default connect(
-	( state, ownProps ) => {
-		const siteId = ownProps?.selectedSite?.ID || null;
-		const userCanManageOptions = canCurrentUser( state, siteId, 'manage_options' );
-		const selectedSite = ownProps?.selectedSite || null;
-		const isOnFreePlan = selectedSite?.plan?.is_free || false;
-		const purchases = getPurchases( state );
-		const productsList = getProductsList( state );
-
-		return {
-			currentRoute: getCurrentRoute( state ),
-			hasDomainCredit: !! ownProps.selectedSite && hasDomainCredit( state, siteId ),
-			hasProductsList: 0 < ( Object.getOwnPropertyNames( productsList )?.length ?? 0 ),
-			isDomainOnly: isDomainOnlySite( state, siteId ),
-			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
-			hasNonPrimaryDomainsFlag: getCurrentUser( state )
-				? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
-				: false,
-			isOnFreePlan,
-			userCanManageOptions,
-			canSetPrimaryDomain: siteHasFeature( state, siteId, FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ),
-			purchases,
-			isFetchingPurchases: isFetchingSitePurchases( state ),
-		};
-	},
-	{
-		changePrimary,
-		errorNotice,
-		setPrimaryDomain,
-		showUpdatePrimaryDomainErrorNotice,
-		showUpdatePrimaryDomainSuccessNotice,
-		successNotice,
-	}
-)( localize( withLocalizedMoment( SiteDomains ) ) );
+	return {
+		currentRoute: getCurrentRoute( state ),
+		hasDomainCredit: !! ownProps.selectedSite && hasDomainCredit( state, siteId ),
+		hasProductsList: 0 < ( Object.getOwnPropertyNames( productsList )?.length ?? 0 ),
+		isDomainOnly: isDomainOnlySite( state, siteId ),
+		isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
+		hasNonPrimaryDomainsFlag: getCurrentUser( state )
+			? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
+			: false,
+		isOnFreePlan,
+		userCanManageOptions,
+		canSetPrimaryDomain: siteHasFeature( state, siteId, FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ),
+		purchases,
+		isFetchingPurchases: isFetchingSitePurchases( state ),
+	};
+} )( localize( withLocalizedMoment( SiteDomains ) ) );

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -2,6 +2,8 @@ import { Circle, SVG } from '@wordpress/components';
 import { home, Icon, info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
+import { useTranslate, type TranslateResult } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { resolveDomainStatus } from 'calypso/lib/domains';
@@ -10,7 +12,6 @@ import TransferConnectedDomainNudge from 'calypso/my-sites/domains/domain-manage
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
-import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 
@@ -22,6 +23,8 @@ type SettingsHeaderProps = {
 
 export default function SettingsHeader( { domain, site, purchase }: SettingsHeaderProps ) {
 	const { __ } = useI18n();
+	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const renderCircle = () => (
 		<SVG viewBox="0 0 24 24" height={ 8 } width={ 8 }>
@@ -73,7 +76,7 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 	};
 
 	const renderStatusBadge = ( domain: ResponseDomain ) => {
-		const { status, statusClass } = resolveDomainStatus( domain );
+		const { status, statusClass } = resolveDomainStatus( domain, null, translate, dispatch );
 
 		if ( status ) {
 			return statusClass === 'status-success'
@@ -102,10 +105,16 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 	};
 
 	const renderNotices = () => {
-		const { noticeText, statusClass } = resolveDomainStatus( domain, purchase, {
-			siteSlug: site?.slug,
-			getMappingErrors: true,
-		} );
+		const { noticeText, statusClass } = resolveDomainStatus(
+			domain,
+			purchase,
+			translate,
+			dispatch,
+			{
+				siteSlug: site.slug,
+				getMappingErrors: true,
+			}
+		);
 
 		if ( noticeText && statusClass )
 			return (

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import titleCase from 'to-title-case';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
@@ -83,6 +83,7 @@ function getMailboxes( data ) {
 
 function EmailPlan( { domain, selectedSite, source } ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const purchase = useSelector( ( state ) => getEmailPurchaseByDomain( state, domain ) );
 	const isLoadingPurchase = useSelector(
@@ -102,9 +103,11 @@ function EmailPlan( { domain, selectedSite, source } ) {
 	const handleRenew = ( event ) => {
 		event.preventDefault();
 
-		handleRenewNowClick( purchase, selectedSite.slug, {
-			tracksProps: { source: 'email-plan-view' },
-		} );
+		dispatch(
+			handleRenewNowClick( purchase, selectedSite.slug, {
+				tracksProps: { source: 'email-plan-view' },
+			} )
+		);
 	};
 
 	function getAddMailboxProps() {


### PR DESCRIPTION
This PR removes usage of `redux-bridge` from `lib/purchases`, namely from the `handleRenewNowClick` and `handleRenewMultiplePurchasesClick` functions that were converted to Redux thunk actions.

The change triggered an avalanche of related refactors. I'll be landing this work in a series of standalone PRs.