### PR TITLE
Use flex container to keep plan CTA aligned

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
@@ -17,6 +17,7 @@ const PlanTitle = styled.h2`
 	font-size: 1.125rem;
 	margin-bottom: 10px;
 	font-weight: 500;
+	line-height: 1.1;
 
 	@media screen and ( min-width: ${ SCREEN_BREAKPOINT_SIGNUP + 1 }px ) {
 		.is-section-signup & {
@@ -33,10 +34,17 @@ const PlanTitle = styled.h2`
 	}
 `;
 
+const FlexContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+`;
+
 const PlanDescription = styled.p`
 	font-size: 1rem;
 	font-weight: 400;
 	margin: 0 0 1.5rem;
+	flex: 1;
 
 	@media screen and ( max-width: ${ SCREEN_BREAKPOINT_SIGNUP }px ) {
 		.is-section-signup & {
@@ -82,38 +90,40 @@ export const PlansComparisonColHeader: React.FunctionComponent< Props > = ( {
 
 	return (
 		<th scope="col">
-			<PlanTitle>{ plan.getTitle() }</PlanTitle>
-			<PlanDescription>{ plan.getDescription() }</PlanDescription>
-			<PriceContainer>
-				{ isDiscounted && (
-					<>
-						<PlanPrice
-							currencyCode={ currencyCode }
-							rawPrice={ originalPrice }
-							displayFlatPrice={ true }
-							translate={ translate }
-							original
-						/>
+			<FlexContainer>
+				<PlanTitle>{ plan.getTitle() }</PlanTitle>
+				<PlanDescription>{ plan.getDescription() }</PlanDescription>
+				<PriceContainer>
+					{ isDiscounted && (
+						<>
+							<PlanPrice
+								currencyCode={ currencyCode }
+								rawPrice={ originalPrice }
+								displayFlatPrice={ true }
+								translate={ translate }
+								original
+							/>
+							<PlanPrice
+								currencyCode={ currencyCode }
+								displayFlatPrice={ true }
+								rawPrice={ price }
+								translate={ translate }
+								discounted
+							/>
+						</>
+					) }
+					{ ! isDiscounted && (
 						<PlanPrice
 							currencyCode={ currencyCode }
 							displayFlatPrice={ true }
 							rawPrice={ price }
 							translate={ translate }
-							discounted
 						/>
-					</>
-				) }
-				{ ! isDiscounted && (
-					<PlanPrice
-						currencyCode={ currencyCode }
-						displayFlatPrice={ true }
-						rawPrice={ price }
-						translate={ translate }
-					/>
-				) }
-			</PriceContainer>
-			<BillingTimeFrame>{ plan.getBillingTimeFrame() }</BillingTimeFrame>
-			{ children }
+					) }
+				</PriceContainer>
+				<BillingTimeFrame>{ plan.getBillingTimeFrame() }</BillingTimeFrame>
+				{ children }
+			</FlexContainer>
 		</th>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This encloses the Plan headers in a flex container which allows us to stretch the description paragraph so that the CTA buttons are always aligned.

#### Testing instructions

* Go to /start/plans
* Resize the window so that the Plans title and description have different heights
* The pricing and CTA should always be vertically aligned

<img width="320" alt="Screenshot on 2022-05-26 at 14-32-46" src="https://user-images.githubusercontent.com/2749938/170480098-6bfd58ef-0d06-4a7c-a1f1-0696dd63ef8f.png">

* Try with a different locale
<img width="320" alt="Screenshot on 2022-05-26 at 14-04-26" src="https://user-images.githubusercontent.com/2749938/170480880-ffca23f4-d2eb-48e9-8991-f7a4ed56be50.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64020
