### PR TITLE
Components: Refactor `ReadmeViewer` tests to `@testing-library/react`

### DIFF
--- a/client/components/readme-viewer/test/index.js
+++ b/client/components/readme-viewer/test/index.js
@@ -1,4 +1,7 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
 import ReadmeViewer from 'calypso/components/readme-viewer';
 
 ReadmeViewer.prototype.componentDidMount = jest.fn( function () {
@@ -9,22 +12,22 @@ ReadmeViewer.prototype.componentDidMount = jest.fn( function () {
 
 describe( 'ReadmeViewer', () => {
 	test( 'should render README.md when given readmeFilePath', () => {
-		const readme = shallow( <ReadmeViewer readmeFilePath="foo2" /> );
-		expect( readme.hasClass( 'readme-viewer__wrapper' ) ).toBe( true );
+		const { container } = render( <ReadmeViewer readmeFilePath="foo2" /> );
+		expect( container.firstChild ).toHaveClass( 'readme-viewer__wrapper' );
 	} );
 
 	test( 'should not render a README.md when not given readmeFilePath', () => {
-		const readme = shallow( <ReadmeViewer /> );
-		expect( readme.hasClass( 'readme-viewer__wrapper' ) ).toBe( false );
+		const { container } = render( <ReadmeViewer /> );
+		expect( container.firstChild ).not.toBeInTheDocument();
 	} );
 
 	test( 'should render an edit link by default', () => {
-		const readme = shallow( <ReadmeViewer readmeFilePath="foo2" /> );
-		expect( readme.find( '.readme-viewer__doc-edit-link' ) ).toHaveLength( 1 );
+		render( <ReadmeViewer readmeFilePath="foo2" /> );
+		expect( screen.queryByRole( 'link' ) ).toBeVisible();
 	} );
 
 	test( 'should not render an edit link when showEditLink is false', () => {
-		const readme = shallow( <ReadmeViewer readmeFilePath="foo" showEditLink={ false } /> );
-		expect( readme.find( '.readme-viewer__doc-edit-link' ) ).toHaveLength( 0 );
+		render( <ReadmeViewer readmeFilePath="foo" showEditLink={ false } /> );
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `ReadmeViewer` component to use `@testing-library/react` instead of `enzyme`.

Part of #63409.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/components/readme-viewer/test/index.js`