### PR TITLE
Create `SelectGoals` component

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -1,9 +1,10 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { Onboard } from 'calypso/../packages/data-stores/src';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import SelectCard from './select-card';
+import SelectGoals from './select-goals';
 import type { Step } from '../../types';
 import './style.scss';
 
@@ -17,15 +18,8 @@ const GoalsStep: Step = ( { navigation } ) => {
 	const subHeaderText = translate( 'Tell us what would you like to accomplish with your website.' );
 
 	// Mock step content
-	const [ selected, setSelected ] = useState( false );
-	const toggleSelected = () => {
-		setSelected( ! selected );
-	};
-	const stepContent = (
-		<SelectCard selected={ selected } value="build" onChange={ toggleSelected }>
-			Promote myself or my business
-		</SelectCard>
-	);
+	const [ selectedGoals, setSelectedGoals ] = useState< Onboard.GoalKey[] >( [] );
+	const stepContent = <SelectGoals selectedGoals={ selectedGoals } onChange={ setSelectedGoals } />;
 
 	return (
 		<StepContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -1,7 +1,7 @@
+import { Onboard } from '@automattic/data-stores';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { Onboard } from 'calypso/../packages/data-stores/src';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import SelectGoals from './select-goals';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-card.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-card.tsx
@@ -1,7 +1,6 @@
 import { CheckboxControl } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import classNames from 'classnames';
-import React from 'react';
 
 type SelectCardProps = {
 	children: React.ReactNode;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -1,0 +1,43 @@
+import { Onboard } from 'calypso/../packages/data-stores/src';
+import { useGoals } from './goals';
+import SelectCard from './select-card';
+
+type SelectGoalsProps = {
+	onChange: ( selectedGoals: Onboard.GoalKey[] ) => void;
+	selectedGoals: Onboard.GoalKey[];
+};
+
+export const SelectGoals: React.FC< SelectGoalsProps > = ( { onChange, selectedGoals } ) => {
+	const goals = useGoals();
+
+	const handleChange = ( selected: boolean, value: string ) => {
+		const newSelectedGoals = [ ...selectedGoals ];
+		const goalKey = value as Onboard.GoalKey;
+
+		if ( selected ) {
+			newSelectedGoals.push( goalKey );
+		} else {
+			const goalIndex = newSelectedGoals.indexOf( goalKey );
+			newSelectedGoals.splice( goalIndex, 1 );
+		}
+
+		onChange( newSelectedGoals );
+	};
+
+	return (
+		<div className="select-goals__container">
+			{ goals.map( ( goal ) => (
+				<SelectCard
+					onChange={ handleChange }
+					selected={ selectedGoals.includes( goal.key ) }
+					value={ goal.key }
+				>
+					{ goal.title }
+					{ goal.isPremium && <span className="select-goals__premium-badge">Premium</span> }
+				</SelectCard>
+			) ) }
+		</div>
+	);
+};
+
+export default SelectGoals;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -1,4 +1,4 @@
-import { Onboard } from 'calypso/../packages/data-stores/src';
+import { Onboard } from '@automattic/data-stores';
 import { useGoals } from './goals';
 import SelectCard from './select-card';
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -28,6 +28,7 @@ export const SelectGoals: React.FC< SelectGoalsProps > = ( { onChange, selectedG
 		<div className="select-goals__container">
 			{ goals.map( ( goal ) => (
 				<SelectCard
+					key={ goal.key }
 					onChange={ handleChange }
 					selected={ selectedGoals.includes( goal.key ) }
 					value={ goal.key }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -32,7 +32,7 @@ export const SelectGoals: React.FC< SelectGoalsProps > = ( { onChange, selectedG
 					selected={ selectedGoals.includes( goal.key ) }
 					value={ goal.key }
 				>
-					{ goal.title }
+					<span className="select-goals__goal-title">{ goal.title }</span>
 					{ goal.isPremium && <span className="select-goals__premium-badge">Premium</span> }
 				</SelectCard>
 			) ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -29,9 +29,8 @@
 		gap: 16px;
 		grid-template-columns: repeat( 1, 1fr );
 
-		.select-card__label {
-			display: inline-flex;
-			gap: 14px;
+		.select-goals__goal-title {
+			margin-right: 14px;
 		}
 
 		.select-goals__premium-badge {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -1,5 +1,6 @@
 @import '@wordpress/base-styles/_breakpoints.scss';
 @import '@wordpress/base-styles/_mixins.scss';
+@import '@automattic/typography/styles/fonts';
 
 .goals__container {
 	padding: 0 20px;
@@ -21,6 +22,33 @@
 			}
 		}
 	}
+
+	.select-goals__container {
+		font-family: 'Inter', $sans;
+		display: grid;
+		gap: 16px;
+		grid-template-columns: repeat( 1, 1fr );
+
+		.select-card__label {
+			display: inline-flex;
+			gap: 14px;
+		}
+
+		.select-goals__premium-badge {
+			display: inline-block;
+			background: #101517;
+			color: #ffffff;
+			border-radius: 4px;
+			font-weight: 500;
+			font-size: 0.75rem;
+			line-height: 20px;
+			padding: 0 10px;
+		}
+
+		@include break-small {
+			grid-template-columns: repeat( 2, 1fr );
+		}
+	}
 }
 
 .select-card__container {
@@ -30,6 +58,7 @@
 	font-size: 0.875rem;
 	cursor: pointer;
 	display: flex;
+	align-items: center;
 
 	.select-card__label {
 		pointer-events: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the **SelectGoals** component, it iterates over the goals list (from `useGoals`) and renders a `SelectCard` for each goal. The component checks if the goal is premium, if so a badge is rendered. We are not using the WordPress badge because the layout is different.

The mock on `GoalsStep` was also updated to display the component and handle the selection changes.

#### Testing instructions

1. Go to the [Goals Step url](http://calypso.localhost:3000/setup/goals?siteSlug=%5Bsiteaddress%5D&flags=signup/goals-step)
2. Check if the `SelectGoals` component was displayed
3. Select and deselect the goals to verify if the component works as expected
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/3113712/170524552-e1d209e8-c0ea-45cc-a59c-d18ae8ef5b13.png">

Related to #63920
Pairing with @ivan-ottinger 