### PR TITLE
Show additional messages on Marketplace installation progress bar when the operation takes long

### DIFF
--- a/client/my-sites/marketplace/components/progressbar/index.tsx
+++ b/client/my-sites/marketplace/components/progressbar/index.tsx
@@ -20,11 +20,17 @@ const ACCELERATED_INCREMENT = 5;
 export default function MarketplaceProgressBar( {
 	steps,
 	currentStep,
+	additionalSteps,
+	additionalStepsTimeout = 7000,
 }: {
 	steps: TranslateResult[];
 	currentStep: number;
+	additionalSteps?: TranslateResult[];
+	additionalStepsTimeout?: number;
 } ) {
 	const translate = useTranslate();
+	const [ stepValue, setStepValue ] = useState( steps[ currentStep ] );
+	const [ additionalStepsTimeoutId, setAdditionalStepsTimeoutId ] = useState< NodeJS.Timeout >();
 	const [ simulatedProgressPercentage, setSimulatedProgressPercentage ] = useState( 1 );
 	useEffect( () => {
 		const timeOutReference = setTimeout( () => {
@@ -40,6 +46,42 @@ export default function MarketplaceProgressBar( {
 		return () => clearTimeout( timeOutReference );
 	}, [ simulatedProgressPercentage, steps, currentStep ] );
 
+	useEffect( () => {
+		setStepValue( steps[ currentStep ] );
+		setAdditionalStepsTimeoutId( undefined );
+	}, [ steps, currentStep ] );
+
+	// Show additional messages when available
+	useEffect( () => {
+		function updateStepValueAfterTimeout() {
+			if ( additionalSteps?.length ) {
+				const timeoutId = setTimeout( () => {
+					const randomIndex = Math.floor( Math.random() * additionalSteps.length );
+					const newValue = additionalSteps[ randomIndex ];
+
+					if ( newValue !== stepValue ) {
+						setStepValue( newValue );
+					}
+
+					updateStepValueAfterTimeout();
+				}, additionalStepsTimeout );
+
+				if ( additionalStepsTimeoutId ) {
+					clearTimeout( additionalStepsTimeoutId );
+				}
+				setAdditionalStepsTimeoutId( timeoutId );
+			}
+		}
+
+		updateStepValueAfterTimeout();
+
+		return () => {
+			if ( additionalStepsTimeoutId ) {
+				clearTimeout( additionalStepsTimeoutId );
+			}
+		};
+	}, [ additionalSteps, currentStep ] );
+
 	/* translators: %(currentStep)s  Is the current step number, given that steps are set of counting numbers representing each step starting from 1, %(stepCount)s  Is the total number of steps, Eg: Step 1 of 3  */
 	const stepIndication = translate( 'Step %(currentStep)s of %(stepCount)s', {
 		args: { currentStep: currentStep + 1, stepCount: steps.length },
@@ -47,7 +89,7 @@ export default function MarketplaceProgressBar( {
 
 	return (
 		<Container>
-			<Title className="progressbar__title wp-brand-font">{ steps[ currentStep ] }</Title>
+			<Title className="progressbar__title wp-brand-font">{ stepValue }</Title>
 			<StyledProgressBar
 				value={ simulatedProgressPercentage }
 				color="var( --studio-pink-50 )"

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -252,7 +252,7 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 			translate( 'Installing plugin' ),
 			translate( 'Activating plugin' ),
 		],
-		[ isUploadFlow ]
+		[ isUploadFlow, translate ]
 	);
 
 	const additionalSteps = useMemo(
@@ -262,7 +262,7 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 			translate( 'Wheels are in motion' ),
 			translate( 'Working magic' ),
 		],
-		[]
+		[ translate ]
 	);
 
 	const renderError = () => {

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -3,7 +3,7 @@ import { Button } from '@automattic/components';
 import { ThemeProvider } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useSelector, useDispatch, DefaultRootState } from 'react-redux';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -244,11 +244,26 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ pluginActive, automatedTransferStatus ] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
 
-	const steps = [
-		isUploadFlow ? translate( 'Uploading plugin' ) : translate( 'Setting up plugin installation' ),
-		translate( 'Installing plugin' ),
-		translate( 'Activating plugin' ),
-	];
+	const steps = useMemo(
+		() => [
+			isUploadFlow
+				? translate( 'Uploading plugin' )
+				: translate( 'Setting up plugin installation' ),
+			translate( 'Installing plugin' ),
+			translate( 'Activating plugin' ),
+		],
+		[ isUploadFlow ]
+	);
+
+	const additionalSteps = useMemo(
+		() => [
+			translate( 'Connecting the dots' ),
+			translate( 'Still working' ),
+			translate( 'Wheels are in motion' ),
+			translate( 'Working magic' ),
+		],
+		[]
+	);
 
 	const renderError = () => {
 		// Evaluate error causes in priority order
@@ -400,7 +415,13 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 				<Item>{ translate( 'Plugin installation' ) }</Item>
 			</Masterbar>
 			<div className="marketplace-plugin-install__root">
-				{ renderError() || <MarketplaceProgressBar steps={ steps } currentStep={ currentStep } /> }
+				{ renderError() || (
+					<MarketplaceProgressBar
+						steps={ steps }
+						currentStep={ currentStep }
+						additionalSteps={ additionalSteps }
+					/>
+				) }
 			</div>
 		</ThemeProvider>
 	);


### PR DESCRIPTION
### Description

Change the title of the progress bar steps every 7 seconds on the Marketplace Installation page.
The idea is to show the operation is still progressing even in big flows such as transferring a site to atomic.

Currently, the only messages being used are the step descriptions, after the change, those messages will be changed if one step is taking too long. But it will always return to the actual step description as soon as the process reaches the next step state.

#### Llist of messages
**Step descriptions**
* Uploading plugin 
* Setting up plugin installation
* Installing plugin
* Activating plugin

**Additional messages to be rotated when the actual step is taking too long**
* Connecting the dots
* Still working
* Wheels are in motion
* Working magic

PS: All of those phases are translatable

### Testing instructions
* Go to the installation URL (`/marketplace/{plugin_slug}/install/{site}`) of a plugin which should take a long time.
* Check if every 7 seconds the message is being changed

Example of a flow which usually takes long: Transferring a site to atomic
* From a free site, go to the plugin page
* Click on the CTA (upgrade and activate)
* After the purchase (if needed) you should see the Marketplace Installation page
* Check if every 7 seconds the message is being changed

![Kapture 2022-05-26 at 12 06 05](https://user-images.githubusercontent.com/5039531/170556001-083c6bd8-b881-4a67-bd19-fd7be9c5b2a8.gif)

---

Fixes #62067
