### PR TITLE
Pricing page: Make 'More products' section into 4 columns.

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -91,6 +91,7 @@
 	font-size: 2rem;
 	font-weight: 700;
 	line-height: 1.2;
+	letter-spacing: -0.049rem;
 
 	em {
 		font-style: normal;

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -275,45 +275,50 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 					/>
 				</div>
 			</ProductGridSection>
-			<ProductGridSection title={ translate( 'More Products' ) }>
-				<>
-					{ showProductCategories && (
-						<div className="product-grid__category-filter">
-							<CategoryFilter
-								defaultValue={ JETPACK_SECURITY_CATEGORY }
-								onChange={ onCategoryChange }
-							/>
-						</div>
-					) }
-					<ul className="product-grid__product-grid">
-						{ filteredItems.map( getOtherItemsProductCard ) }
-						{ ( ! showProductCategories || category === JETPACK_PERFORMANCE_CATEGORY ) &&
-							showBoostAndSocialFree &&
-							! siteHasBoostPremium && (
-								<li>
-									<JetpackBoostFreeCard siteId={ siteId } />
-								</li>
-							) }
-						{ ( ! showProductCategories || category === JETPACK_GROWTH_CATEGORY ) && (
-							<>
-								{ showBoostAndSocialFree && (
+			<div className={ classNames( { 'product-grid__fullwidth-wrapper': isJetpackCloud() } ) }>
+				<ProductGridSection
+					title={ translate( 'More Products' ) }
+					{ ...( isJetpackCloud() && { className: 'product-grid__wide-grid' } ) }
+				>
+					<>
+						{ showProductCategories && (
+							<div className="product-grid__category-filter">
+								<CategoryFilter
+									defaultValue={ JETPACK_SECURITY_CATEGORY }
+									onChange={ onCategoryChange }
+								/>
+							</div>
+						) }
+						<ul className="product-grid__product-grid">
+							{ filteredItems.map( getOtherItemsProductCard ) }
+							{ ( ! showProductCategories || category === JETPACK_PERFORMANCE_CATEGORY ) &&
+								showBoostAndSocialFree &&
+								! siteHasBoostPremium && (
 									<li>
-										<JetpackSocialFreeCard siteId={ siteId } />
+										<JetpackBoostFreeCard siteId={ siteId } />
 									</li>
 								) }
+							{ ( ! showProductCategories || category === JETPACK_GROWTH_CATEGORY ) && (
+								<>
+									{ showBoostAndSocialFree && (
+										<li>
+											<JetpackSocialFreeCard siteId={ siteId } />
+										</li>
+									) }
+									<li>
+										<JetpackCrmFreeCard siteId={ siteId } duration={ duration } />
+									</li>
+								</>
+							) }
+							{ showFreeCard && (
 								<li>
-									<JetpackCrmFreeCard siteId={ siteId } duration={ duration } />
+									<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
 								</li>
-							</>
-						) }
-						{ showFreeCard && (
-							<li>
-								<JetpackFreeCard siteId={ siteId } urlQueryArgs={ urlQueryArgs } />
-							</li>
-						) }
-					</ul>
-				</>
-			</ProductGridSection>
+							) }
+						</ul>
+					</>
+				</ProductGridSection>
+			</div>
 			<StoreFooter />
 		</>
 	);

--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -18,6 +18,7 @@ import IntroPricingBanner from 'calypso/components/jetpack/intro-pricing-banner'
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import CategoryFilter from '../category-filter';
@@ -119,6 +120,11 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const currentPlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const currentPlanSlug = currentPlan?.product_slug || null;
+	const currentRoute = useSelector( getCurrentRoute );
+
+	const isStoreLanding =
+		currentRoute === '/jetpack/connect/store' ||
+		currentRoute.match( new RegExp( '^/jetpack/connect/plans/[^/]+/?(monthly|annual)?$' ) );
 
 	// Retrieve and cache the plans array, which might be already translated.
 	useEffect( () => {
@@ -210,6 +216,8 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 		</li>
 	);
 
+	const showFourColumnGrid = isJetpackCloud() || isStoreLanding;
+
 	return (
 		<>
 			{ planRecommendation && (
@@ -275,10 +283,10 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 					/>
 				</div>
 			</ProductGridSection>
-			<div className={ classNames( { 'product-grid__fullwidth-wrapper': isJetpackCloud() } ) }>
+			<div className={ classNames( { 'product-grid__fullwidth-wrapper': showFourColumnGrid } ) }>
 				<ProductGridSection
 					title={ translate( 'More Products' ) }
-					{ ...( isJetpackCloud() && { className: 'product-grid__wide-grid' } ) }
+					{ ...( showFourColumnGrid && { className: 'product-grid__wide-grid' } ) }
 				>
 					<>
 						{ showProductCategories && (

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -1,6 +1,11 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+.product-grid__fullwidth-wrapper {
+	width: 100vw;
+	margin: 0 calc( 50% - 50vw );
+}
+
 .product-grid__section {
 	margin-bottom: 70px;
 	padding-left: 16px;
@@ -19,6 +24,14 @@
 		padding-left: 16px;
 		padding-right: 16px;
 	}
+}
+
+.is-jetpack-cloud.product-grid__wide-grid {
+	// 4 column product grid
+	max-width: 1312px;
+	margin: 0 auto;
+	padding-left: 32px;
+	padding-right: 32px;
 }
 
 .product-grid__section:first-of-type > .product-grid__section-title {

--- a/client/my-sites/plans/jetpack-plans/product-grid/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-grid/style.scss
@@ -26,7 +26,8 @@
 	}
 }
 
-.is-jetpack-cloud.product-grid__wide-grid {
+.is-jetpack-cloud.product-grid__wide-grid,
+.product-grid__wide-grid {
 	// 4 column product grid
 	max-width: 1312px;
 	margin: 0 auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes the "More Products" section to fit 4 product cards per row, instead of 3, on the Jetpack Cloud pricing page and the `/jetpack/connect/(store|plans)` pages. (See screenshots).

Project Thread: p1HpG7-g29-p2
Asana task: 1202316834912830-as-1202316834912853/f

#### Testing instructions

1. Checkout this PR and spin up Calypso blue and Calypso green concurrently (`yarn start`) and also (`yarn start-jetpack-cloud-p`).
3. Go to http://jetpack.cloud.localhost:3001/pricing (in desktop view) and verify that the "More Products" section has 4 product cards per row. Check responsiveness in all screen sizes to make sure the cards respond properly.
4. Also check http://calypso.localhost:3000/jetpack/connect/store and http://calypso.localhost:3000/jetpack/connect/plans/:site and confirm that the "More Products" section has 4 product cards per row.
5. Then check http://calypso.localhost:3000/plans:site and confirm that the Calypso blue pricing page columns **are unchanged**, and remain at 3 columns.

#### Screenshots

**Jetpack Cloud:**

![Screenshot on 2022-05-26 at 19-19-32](https://user-images.githubusercontent.com/11078128/170594876-97a1f6d2-6d92-424c-8391-aaccd70ce055.png)

.
**Wordpress.com (Calypso blue)** - http://calypso.localhost:3000/plans/:site  
Columns are unchanged.

![Screenshot on 2022-05-26 at 19-17-01](https://user-images.githubusercontent.com/11078128/170594710-e6ffe8f2-845d-4860-8107-e32677c1e63f.png)

