### PR TITLE
No Ads: Add a user-friendly checkout URL alias

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -397,6 +397,9 @@ function getProductSlugFromAlias( productAlias: string ): string {
 	if ( decodedAlias === 'domain-mapping' ) {
 		return 'domain_map';
 	}
+	if ( decodedAlias === 'no-ads' ) {
+		return 'no-adverts/no-adverts.php';
+	}
 	if ( decodedAlias === 'theme' ) {
 		return 'premium_theme';
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The No Ads product is currently purchased with an ugly checkout URL that has a `.php` extension in it.  This is for historical reasons and can't easily be fixed directly.  However, we can create a friendlier alias for it which can be used in user-facing checkout URLs instead.

The immediate motivation for this is that https://github.com/Automattic/wp-calypso/pull/63863 already assumes this URL alias exists and works.  So, here we will make it work :smile: 

See also: 748-gh-Automattic/martech

#### Testing instructions

* Visit `/checkout/[site]/no-ads` (with `[site]` replaced by your site address) and make sure the No Ads product is added to your shopping cart.
* Visiting the old URL (`/checkout/[site]/no-adverts%25no-adverts.php`) should continue to work also.