### PR TITLE
Add style for backup with warnings on ActivityLog for calypso green jetpack cloud)

### DIFF
--- a/client/components/activity-card/index.tsx
+++ b/client/components/activity-card/index.tsx
@@ -54,12 +54,12 @@ const ActivityCard: React.FC< OwnProps > = ( { className, summarize, shareable, 
 	const backupTimeDisplay = useBackupTimeDisplay( activity.activityTs );
 
 	const showStreamsContent = showContent && activity.streams;
-	const hasActivityFailed = activity.activityStatus === 'error';
 
 	return (
 		<div
 			className={ classnames( className, 'activity-card', {
-				'with-error': hasActivityFailed,
+				'with-error': 'error' === activity.activityStatus,
+				'with-warning': 'warning' === activity.activityStatus,
 			} ) }
 		>
 			<QueryRewindState siteId={ siteId } />

--- a/client/components/activity-card/style.scss
+++ b/client/components/activity-card/style.scss
@@ -51,6 +51,20 @@
 			border: solid 1px var( --color-error );
 		}
 	}
+
+	&.with-warning {
+		.activity-card__time-icon {
+			fill: var( --color-warning );
+		}
+
+		.activity-card__time-text {
+			color: var( --color-warning );
+		}
+
+		.card {
+			border: solid 1px var( --color-warning );
+		}
+	}
 }
 
 .activity-card__header {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add style for backup with warnings on ActivityLog for calypso green (jetpack cloud): Color Yellow, exclamation icon

#### Testing instructions

* Warning functionality isn't live yet, so warnings will have to be artificially inserted into a site's activity log to test
* This can be done by adding warnings to the activity log output of a backup from a Jetpack Backup sandbox
* Instructions for introducing warnings to a backup in a sandbox can be found in patch D80570
* If you don't have access to a Backup sandbox, let a Backup dev know what site you'd like to test on
* This change will format the ActivityLog item for a backup on Calypso green (Jetpack cloud)

<img width="1208" alt="Screen Shot 2022-05-26 at 12 35 18" src="https://user-images.githubusercontent.com/2747834/170591898-3ab0a120-5b56-4736-b89e-e05e0cd334ff.png">


