### PR TITLE
Remove react & react-dom from tour-kit dependencies

### DIFF
--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -43,8 +43,6 @@
 		"@wordpress/primitives": "^3.5.0",
 		"@wordpress/react-i18n": "^3.0.4",
 		"classnames": "^2.3.1",
-		"react": "^17.0.2",
-		"react-dom": "^17.0.2",
 		"react-popper": "^2.2.5"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,8 +1253,6 @@ __metadata:
     "@wordpress/primitives": ^3.5.0
     "@wordpress/react-i18n": ^3.0.4
     classnames: ^2.3.1
-    react: ^17.0.2
-    react-dom: ^17.0.2
     react-popper: ^2.2.5
     typescript: ^4.5.5
   peerDependencies:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove react & react-dom from tour-kit dependencies

We should not include react & react-dom in dependencies. They should only be in peerDependencies.

Otherwise, we'll get the following error message when we use it in other projects (especially for projects that using pnpm):

```
There are three common reasons you might be seeing it:

You might have mismatching versions of React and React DOM.
You might be breaking the [Rules of Hooks](https://zh-hant.reactjs.org/docs/hooks-rules.html).
You might have more than one copy of React in the same app.

https://zh-hant.reactjs.org/warnings/invalid-hook-call-warning.html
```

`@automattic/components` also follows this practices: https://github.com/Automattic/wp-calypso/blob/trunk/packages/components/package.json#L29-L45

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


1. Checkout the branch
2. `yarn`
3. `yarn dev --sync` from apps/editing-toolkit to sync the welcome tour to the sandbox  (PCYsg-ly5-p2)
4. Go to the post editor
5. Check that the tour works fine

Looks like we can also use Calypso Live [(direct link)](https://calypso.live/?image=registry.a8c.com/calypso/app:commit-e532653f039a826aa890f4a6b78b6cdf97c40cc0) for testing.

![Screen Shot 2022-05-27 at 11 45 49](https://user-images.githubusercontent.com/4344253/170625165-42a8574e-f12d-48de-930d-750bb783f2e1.png)

