### PR TITLE
Promisify the setPrimaryDomain action

### DIFF
--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -371,17 +371,9 @@ export class SiteDomains extends Component {
 		);
 	}
 
-	setPrimaryDomain( domainName ) {
-		return new Promise( ( resolve, reject ) => {
-			this.props.setPrimaryDomain( this.props.selectedSite.ID, domainName, ( error, data ) => {
-				if ( ! error && data && data.success ) {
-					page.redirect( domainManagementList( this.props.selectedSite.slug ) );
-					resolve();
-				} else {
-					reject( error );
-				}
-			} );
-		} );
+	async setPrimaryDomain( domainName ) {
+		await this.props.setPrimaryDomain( this.props.selectedSite.ID, domainName );
+		page.redirect( domainManagementList( this.props.selectedSite.slug ) );
 	}
 
 	handleUpdatePrimaryDomainWpcom = ( domainName ) => {

--- a/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
@@ -83,17 +83,7 @@ const SetAsPrimary = ( { domain, selectedSite }: SetAsPrimaryProps ) => {
 			} )
 		);
 		try {
-			await new Promise( ( resolve, reject ) => {
-				dispatch(
-					setPrimaryDomain( selectedSite.ID, domain.name, ( error, data ) => {
-						if ( ! error && data && data.success ) {
-							resolve( null );
-						} else {
-							reject( error );
-						}
-					} )
-				);
-			} );
+			await dispatch( setPrimaryDomain( selectedSite.ID, domain.name ) );
 			dispatch( showUpdatePrimaryDomainSuccessNotice( domain.name ) );
 		} catch ( error ) {
 			dispatch( showUpdatePrimaryDomainErrorNotice( ( error as Error ).message ) );

--- a/client/state/site-address-change/actions.js
+++ b/client/state/site-address-change/actions.js
@@ -134,9 +134,11 @@ export const requestSiteAddressChange =
 			if ( newSlug ) {
 				dispatch( recordTracksEvent( 'calypso_siteaddresschange_success', eventProperties ) );
 
-				await dispatch( requestSite( siteId ) );
-				// Re-fetch domains, as we changed the primary domain name
-				await dispatch( fetchSiteDomains( siteId ) );
+				// Re-fetch site and domains, as we changed the primary domain name
+				await Promise.all( [
+					dispatch( requestSite( siteId ) ),
+					dispatch( fetchSiteDomains( siteId ) ),
+				] );
 
 				dispatch( {
 					type: SITE_ADDRESS_CHANGE_REQUEST_SUCCESS,

--- a/client/state/sites/domains/actions.js
+++ b/client/state/sites/domains/actions.js
@@ -21,7 +21,6 @@ import 'calypso/state/data-layer/wpcom/domains/privacy/index.js';
  * Module vars
  */
 const debug = debugFactory( 'calypso:state:sites:domains:actions' );
-const noop = () => {};
 
 /**
  * Action creator function
@@ -153,32 +152,15 @@ export function disableDomainPrivacy( siteId, domain ) {
 }
 
 /**
- * @callback onComplete
- * @param {any} error
- * @param {any} data
- * @returns {void}
- */
-
-/**
  * @param {number} siteId
  * @param {string} domain
- * @param {onComplete} onComplete
  */
-export const setPrimaryDomain =
-	( siteId, domain, onComplete = noop ) =>
-	( dispatch ) => {
-		debug( 'setPrimaryDomain', siteId, domain );
-		return wpcom.req.post( `/sites/${ siteId }/domains/primary`, { domain }, ( error, data ) => {
-			if ( error ) {
-				return onComplete( error, data );
-			}
-
-			return dispatch( fetchSiteDomains( siteId ) ).then( () => {
-				onComplete( null, data );
-				dispatch( requestSite( siteId ) );
-			} );
-		} );
-	};
+export const setPrimaryDomain = ( siteId, domain ) => async ( dispatch ) => {
+	debug( 'setPrimaryDomain', siteId, domain );
+	await wpcom.req.post( `/sites/${ siteId }/domains/primary`, { domain } );
+	await dispatch( fetchSiteDomains( siteId ) );
+	await dispatch( requestSite( siteId ) );
+};
 
 export function discloseDomainContactInfo( siteId, domain ) {
 	return {

--- a/client/state/sites/domains/actions.js
+++ b/client/state/sites/domains/actions.js
@@ -158,8 +158,10 @@ export function disableDomainPrivacy( siteId, domain ) {
 export const setPrimaryDomain = ( siteId, domain ) => async ( dispatch ) => {
 	debug( 'setPrimaryDomain', siteId, domain );
 	await wpcom.req.post( `/sites/${ siteId }/domains/primary`, { domain } );
-	await dispatch( fetchSiteDomains( siteId ) );
-	await dispatch( requestSite( siteId ) );
+	await Promise.all( [
+		dispatch( requestSite( siteId ) ),
+		dispatch( fetchSiteDomains( siteId ) ),
+	] );
 };
 
 export function discloseDomainContactInfo( siteId, domain ) {


### PR DESCRIPTION
The `setPrimaryDomain` action currently takes a Node-style completion callback and all usages convert the callback to a promise. This PR simplifies this logic by promisifying the action.

Note: we never need to look at the response data of the REST request and, e.g., check if `data.success === true`, because the endpoint always returns either `{ success: true }` or an `WP_Error`, nothing in between. If the promise resolves and `.then` is called, it was successful.

Part of #64069.

**How to test:**
Verify that you can set primary domain both from i) the popover menu in domains list, and ii) the "Set as primary" accordion on a domain settings page.