### PR TITLE
Generated Design Picker: Pass vertical_id to the generated designs endpoint to get vertical title

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -96,7 +96,10 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	);
 
 	const { data: generatedDesigns = [], isLoading: isLoadingGeneratedDesigns } =
-		useStarterDesignsGeneratedQuery( { seed: siteSlug || undefined } );
+		useStarterDesignsGeneratedQuery( {
+			vertical_id: siteVerticalId,
+			seed: siteSlug || undefined,
+		} );
 
 	const selectedGeneratedDesign = useMemo(
 		() => selectedDesign ?? ( ! isMobile ? generatedDesigns[ 0 ] : undefined ),

--- a/packages/data-stores/src/starter-designs-queries/types.ts
+++ b/packages/data-stores/src/starter-designs-queries/types.ts
@@ -1,6 +1,7 @@
 import type { DesignRecipe } from '@automattic/design-picker/src/types';
 
 export interface StarterDesignsGeneratedQueryParams {
+	vertical_id?: string;
 	seed?: string;
 }
 

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-generated-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-generated-query.ts
@@ -8,7 +8,7 @@ export function useStarterDesignsGeneratedQuery(
 	queryParams: StarterDesignsGeneratedQueryParams
 ): UseQueryResult< Design[] > {
 	return useQuery(
-		[ 'starter-designs-generated' ],
+		[ 'starter-designs-generated', queryParams ],
 		() => fetchStarterDesignsGenerated( queryParams ),
 		{
 			select: ( response ) => response.map( apiStarterDesignsGeneratedToDesign ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Pass `vertical_id` to `/wpcom/v2/starter-designs/generated` in v13n Design Picker. This new field will be picked up by D81630-code which will return the vertical title in the generated designs.

#### Testing instructions

1. Apply D81630-code to your sandbox.
2. Open `http://calypso.localhost:3000/setup/vertical?siteSlug=<your site slug>`.
3. Select a vertical.
4. Select Build intent.
5. Verify that the Design Picker shows the selected vertical title as the site title in the generated designs.

<img width="973" alt="image" src="https://user-images.githubusercontent.com/1525580/170656688-cbd3abf0-52e2-4969-8d4d-ca63f4c797bb.png">


Related to 31-gh-Automattic/ganon-issues