### PR TITLE
Domain Settings Header: rewrite Redux connect to hooks

### DIFF
--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -25,7 +25,6 @@ type SettingsHeaderProps = {
 export default function SettingsHeader( { domain, site, purchase }: SettingsHeaderProps ) {
 	const { __ } = useI18n();
 	const isSiteDomainOnly = useSelector( ( state ) => isDomainOnlySite( state, site.ID ) );
-	let badgeCounter = 0;
 
 	const renderCircle = () => (
 		<SVG viewBox="0 0 24 24" height={ 8 } width={ 8 }>
@@ -34,10 +33,7 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 	);
 
 	const renderSuccessBadge = ( description: TranslateResult, icon?: JSX.Element ) => (
-		<Badge
-			className="settings-header__badge settings-header__badge--success"
-			key={ `badge${ badgeCounter++ }` }
-		>
+		<Badge className="settings-header__badge settings-header__badge--success">
 			{ icon ? (
 				<Icon icon={ icon } size={ 14 } />
 			) : (
@@ -48,30 +44,21 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 	);
 
 	const renderWarningBadge = ( description: TranslateResult ) => (
-		<Badge
-			className="settings-header__badge settings-header__badge--warning"
-			key={ `badge${ badgeCounter++ }` }
-		>
+		<Badge className="settings-header__badge settings-header__badge--warning">
 			<div className="settings-header__badge-indicator">{ renderCircle() }</div>
 			{ description }
 		</Badge>
 	);
 
 	const renderPremiumBadge = () => (
-		<Badge
-			className="settings-header__badge settings-header__badge--premium"
-			key={ `badge${ badgeCounter++ }` }
-		>
+		<Badge className="settings-header__badge settings-header__badge--premium">
 			{ __( 'Premium domain' ) }
 			<Icon icon={ info } size={ 17 } />
 		</Badge>
 	);
 
 	const renderNeutralBadge = ( description: TranslateResult ) => (
-		<Badge
-			className="settings-header__badge settings-header__badge--neutral"
-			key={ `badge${ badgeCounter++ }` }
-		>
+		<Badge className="settings-header__badge settings-header__badge--neutral">
 			{ description }
 		</Badge>
 	);
@@ -99,28 +86,22 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 	};
 
 	const renderBadges = () => {
-		const badges = [];
+		const showDomainType = [
+			DomainType.SITE_REDIRECT,
+			DomainType.MAPPED,
+			DomainType.TRANSFER,
+		].includes( domain.type );
 
-		if (
-			[ DomainType.SITE_REDIRECT, DomainType.MAPPED, DomainType.TRANSFER ].includes( domain.type )
-		) {
-			badges.push( renderDomainTypeBadge( domain.type ) );
-		}
+		const showPrimary = domain.isPrimary && ! isSiteDomainOnly;
 
-		const statusBadge = renderStatusBadge( domain );
-		if ( statusBadge ) {
-			badges.push( statusBadge );
-		}
-
-		if ( domain.isPrimary && ! isSiteDomainOnly ) {
-			badges.push( renderSuccessBadge( __( 'Primary site address' ), home ) );
-		}
-
-		if ( domain.isPremium ) {
-			badges.push( renderPremiumBadge() );
-		}
-
-		return <div className="settings-header__container-badges">{ badges }</div>;
+		return (
+			<div className="settings-header__container-badges">
+				{ showDomainType && renderDomainTypeBadge( domain.type ) }
+				{ renderStatusBadge( domain ) }
+				{ showPrimary && renderSuccessBadge( __( 'Primary site address' ), home ) }
+				{ domain.isPremium && renderPremiumBadge() }
+			</div>
+		);
 	};
 
 	const renderNotices = () => {

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -2,13 +2,11 @@ import { Circle, SVG } from '@wordpress/components';
 import { home, Icon, info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { resolveDomainStatus } from 'calypso/lib/domains';
 import { type as DomainType } from 'calypso/lib/domains/constants';
 import TransferConnectedDomainNudge from 'calypso/my-sites/domains/domain-management/components/transfer-connected-domain-nudge';
-import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { SiteData } from 'calypso/state/ui/selectors/site-data';
@@ -24,7 +22,6 @@ type SettingsHeaderProps = {
 
 export default function SettingsHeader( { domain, site, purchase }: SettingsHeaderProps ) {
 	const { __ } = useI18n();
-	const isSiteDomainOnly = useSelector( ( state ) => isDomainOnlySite( state, site.ID ) );
 
 	const renderCircle = () => (
 		<SVG viewBox="0 0 24 24" height={ 8 } width={ 8 }>
@@ -92,7 +89,7 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 			DomainType.TRANSFER,
 		].includes( domain.type );
 
-		const showPrimary = domain.isPrimary && ! isSiteDomainOnly;
+		const showPrimary = domain.isPrimary && ! site.options?.is_domain_only;
 
 		return (
 			<div className="settings-header__container-badges">

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -49,18 +49,6 @@ export type SettingsPageConnectedDispatchProps = {
 	recordTracksEvent: typeof recordTracksEvent;
 };
 
-export type SettingsHeaderOwnProps = {
-	domain: ResponseDomain;
-	site: SiteData;
-	purchase: Purchase | null;
-};
-
-export type SettingsHeaderConnectedProps = {
-	isDomainOnlySite: boolean;
-};
-
-export type SettingsHeaderProps = SettingsHeaderOwnProps & SettingsHeaderConnectedProps;
-
 export type SettingsPageProps = SettingsPagePassedProps &
 	SettingsPageConnectedProps &
 	SettingsPageConnectedDispatchProps &


### PR DESCRIPTION
Removes the `connect` call from the `SettingsHeader` component in favor of directly reading the `site.options.is_domain_only` field of the `site` object passed as prop. Simplifies the component implementation and mainly its types.

I'm also improving how badges are rendered. Instead of creating an array of badges, and creating keys for them with a `badgeCounter` variable, I'm passing all badges directly as children, and rendering them conditionally. The result is exactly the same, and the code is better.

Part of #64069.

**How to test:**
Verify that the Domain Settings Header is correctly displayed, with all the badges and notices:
<img width="805" alt="Screenshot 2022-05-27 at 10 04 12" src="https://user-images.githubusercontent.com/664258/170658483-5413a234-f7fb-4ee0-a37b-7afe5f8dfd1a.png">

