### PR TITLE
Jetpack: update styling on free landing pages

### DIFF
--- a/client/components/jetpack/jetpack-free-welcome/style.scss
+++ b/client/components/jetpack/jetpack-free-welcome/style.scss
@@ -7,7 +7,7 @@
 		margin: 0 0 0 10px;
 		padding: 0 0 32px 5px;
 		@include break-mobile {
-			font-size: 18px; /* stylelint-disable-line */
+			font-size: $font-body;
 			line-height: 2rem;
 		}
 	}

--- a/client/components/jetpack/jetpack-welcome-page/style.scss
+++ b/client/components/jetpack/jetpack-welcome-page/style.scss
@@ -5,22 +5,27 @@
 .jetpack-welcome-page {
 	&.main.is-wide-layout {
 		max-width: 744px;
+		margin-top: 8vw;
 	}
-	&__card {
-		padding: 0;
-		box-shadow: 0 0 40px 0 #00000014;
 
+	&__card {
 		width: 100%;
 		max-width: none;
+		padding: 0;
+
+		border: 1px solid var( --color-border-subtle );
+		border-radius: ( 2px * 4 );
+		box-shadow: 0 4px 24px rgba( 0, 0, 0, 0.05 );
 
 		&--main,
 		&--footer {
 			box-sizing: border-box;
-			padding: 26px;
+			padding: 32px;
 			@include break-mobile {
-				padding: 76px;
+				padding: 64px;
 			}
 		}
+
 		&--footer {
 			padding-top: 0;
 		}
@@ -32,6 +37,7 @@
 		a {
 			text-decoration: underline;
 			color: var( --color-studio-black );
+
 			&:hover {
 				text-decoration: none;
 			}
@@ -39,15 +45,19 @@
 
 		h1 {
 			line-height: 1;
+			
 			@include break-mobile {
 				font-size: $font-headline-medium;
 			}
+
 			+ p {
-				font-size: 18px; /* stylelint-disable-line */
+				font-size: $font-title-small;
+				font-weight: 500;
 				line-height: 1.5rem;
+				letter-spacing: -1px;
+
 				@include break-mobile {
 					font-size: $font-title-medium;
-					line-height: 2rem;
 				}
 			}
 		}
@@ -80,10 +90,11 @@
 			&--content {
 				flex: 1;
 				padding: 0 10px 0 16px;
+
 				p {
 					@include break-mobile {
-						font-size: 18px; /* stylelint-disable-line */
-						line-height: 1.75rem;
+						font-size: $font-body;
+						line-height: 1.5rem;
 					}
 					margin: 0;
 				}
@@ -94,6 +105,7 @@
 			font-size: 2.25rem;
 			font-weight: 700;
 			margin-bottom: 24px;
+			letter-spacing: -1px;
 
 			@include break-mobile {
 				font-size: 3rem;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Increases top margin to the card isn't touching the edge
* Standardizes padding according to our latest patterns: https://www.figma.com/file/dRt1pX85T68o5UNYK6AZro/?node-id=924%3A2553
* Tweaks typography sizing, weight and spacing
* Replicates the same card styling we have on the pricing page for consistency

Tracked in 1164141197617539-as-1202335077123922/f
cc @jeffgolenski @madebynoam 

#### Testing instructions


* Fire up this PR.
* Go to http://jetpack.cloud.localhost:3000/pricing/jetpack-free/welcome
* Ensure the page looks like the screenshots below.
* Ensure the Boost and Social landing pages look identical — #64012.


### Screenshots

Before | After
--|--
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/390760/170670718-677d7b15-39e0-4810-9fd2-2f112d9ee88c.png"> | <img width="1726" alt="image" src="https://user-images.githubusercontent.com/390760/170670757-a91f9988-ff2d-40d6-bb25-3728578c00a1.png">
<img width="398" alt="image" src="https://user-images.githubusercontent.com/390760/170671762-9ba976c7-a917-40f1-a604-273e673fc3d3.png"> | <img width="396" alt="image" src="https://user-images.githubusercontent.com/390760/170671817-8d383c24-0b90-40c1-b723-e4ec3d94e5a7.png">
