### PR TITLE
Goals Capture: Integrate GoalsStep with OnboardStore

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -1,8 +1,8 @@
-import { Onboard } from '@automattic/data-stores';
 import { StepContainer } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import SelectGoals from './select-goals';
 import type { Step } from '../../types';
@@ -17,9 +17,10 @@ const GoalsStep: Step = ( { navigation } ) => {
 	const headerText = translate( 'Welcome! What are your goals?' );
 	const subHeaderText = translate( 'Tell us what would you like to accomplish with your website.' );
 
-	// Mock step content
-	const [ selectedGoals, setSelectedGoals ] = useState< Onboard.GoalKey[] >( [] );
-	const stepContent = <SelectGoals selectedGoals={ selectedGoals } onChange={ setSelectedGoals } />;
+	const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
+	const { setGoals } = useDispatch( ONBOARD_STORE );
+
+	const stepContent = <SelectGoals selectedGoals={ goals } onChange={ setGoals } />;
 
 	return (
 		<StepContainer


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of #63920, the PR integrates the `GoalsStep` with the OnboardStore. It removes the previous useState mock, applies the `getGoals` selector, and dispatches a `setGoals` on every goal selection change. We didn't create a `GoalsScreen` component since that was a small implementation, but we can extract it if the implementation starts to grow.

#### Testing instructions

1. Go to the [Goals Step url](http://calypso.localhost:3000/setup/goals?siteSlug=%5Bsiteaddress%5D&flags=signup/goals-step)
2. Check if the SelectGoals component was displayed
3. Select and deselect the goals to verify if the component works as expected
4. Refresh the page to see if the selection persists

<img width="1059" alt="image" src="https://user-images.githubusercontent.com/3113712/170707297-4cba2e96-0003-41e1-b163-6541b03ff833.png">

5. Is also possible to use the [Redux DevTools](https://github.com/reduxjs/redux-devtools) to validate if the actions looks as expected

<img width="957" alt="image" src="https://user-images.githubusercontent.com/3113712/170707520-3551f137-8318-4f44-a8cc-01abdfb2420a.png">


Related to #63920
Pairing with @ivan-ottinger 