### PR TITLE
Implement pagination for the agency dashboard

### DIFF
--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -25,6 +25,7 @@ const useFetchDashboardSites = ( searchQuery: string | null, currentPage: number
 				return {
 					sites: data.sites ? Object.values( data.sites ) : [],
 					total: data.total,
+					perPage: data.per_page,
 				};
 			},
 			refetchOnWindowFocus: false,

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -4,21 +4,29 @@ import { useDispatch } from 'react-redux';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
 
-const useFetchDashboardSites = ( searchQuery: string | null ) => {
+const useFetchDashboardSites = ( searchQuery: string | null, currentPage: number | null ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	return useQuery(
-		[ 'jetpack-cloud', 'agency-dashboard', 'sites', searchQuery ],
+		[ 'jetpack-cloud', 'agency-dashboard', 'sites', searchQuery, currentPage ],
 		() =>
 			wpcomJpl.req.get(
 				{
 					path: '/jetpack-agency/sites',
 					apiNamespace: 'wpcom/v2',
 				},
-				{ ...( searchQuery && { query: searchQuery } ) }
+				{
+					...( searchQuery && { query: searchQuery } ),
+					...( currentPage && { page: currentPage } ),
+				}
 			),
 		{
-			select: ( data ) => ( data.sites ? Object.values( data.sites ) : [] ),
+			select: ( data ) => {
+				return {
+					sites: data.sites ? Object.values( data.sites ) : [],
+					total: data.total,
+				};
+			},
 			refetchOnWindowFocus: false,
 			onError: () =>
 				dispatch(

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -23,7 +23,7 @@ const useFetchDashboardSites = ( searchQuery: string, currentPage: number ) => {
 		{
 			select: ( data ) => {
 				return {
-					sites: data.sites ? Object.values( data.sites ) : [],
+					sites: data.sites,
 					total: data.total,
 					perPage: data.per_page,
 				};

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
 
-const useFetchDashboardSites = ( searchQuery: string | null, currentPage: number | null ) => {
+const useFetchDashboardSites = ( searchQuery: string, currentPage: number ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	return useQuery(

--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -3,8 +3,10 @@ import Header from './header';
 import DashboardSidebar from './sidebar';
 
 export function agencyDashboardContext( context: PageJS.Context, next: () => void ): void {
+	const { s: search, page } = context.query;
+	const currentPage = parseInt( page ) || 1;
 	context.header = <Header />;
 	context.secondary = <DashboardSidebar path={ context.path } />;
-	context.primary = <DashboardOverview />;
+	context.primary = <DashboardOverview search={ search || '' } currentPage={ currentPage } />;
 	next();
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -7,6 +7,6 @@ export function agencyDashboardContext( context: PageJS.Context, next: () => voi
 	const currentPage = parseInt( page ) || 1;
 	context.header = <Header />;
 	context.secondary = <DashboardSidebar path={ context.path } />;
-	context.primary = <DashboardOverview search={ search || '' } currentPage={ currentPage } />;
+	context.primary = <DashboardOverview search={ search } currentPage={ currentPage } />;
 	next();
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
@@ -9,9 +9,10 @@ import {
 	isAgencyUser,
 } from 'calypso/state/partner-portal/partner/selectors';
 import SitesOverview from '../sites-overview';
-import '../style.scss';
 import SitesOverviewContext from '../sites-overview/context';
 import type { SitesOverviewContextInterface } from '../sites-overview/types';
+
+import '../style.scss';
 
 export default function DashboardOverview( {
 	search,

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from 'page';
-import { useEffect } from 'react';
+import { ReactElement, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import {
@@ -10,12 +10,18 @@ import {
 } from 'calypso/state/partner-portal/partner/selectors';
 import SitesOverview from '../sites-overview';
 import '../style.scss';
+import SitesOverviewContext from '../sites-overview/context';
+import type { SitesOverviewContextInterface } from '../sites-overview/types';
 
-export default function DashboardOverview() {
+export default function DashboardOverview( {
+	search,
+	currentPage,
+}: SitesOverviewContextInterface ): ReactElement {
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
 	const isAgency = useSelector( isAgencyUser );
 	const isAgencyEnabled = config.isEnabled( 'jetpack/agency-dashboard' );
+
 	useEffect( () => {
 		if ( hasFetched ) {
 			if ( ! isAgency || ! isAgencyEnabled ) {
@@ -26,7 +32,15 @@ export default function DashboardOverview() {
 	}, [ hasFetched, isAgency, isAgencyEnabled ] );
 
 	if ( isAgencyEnabled && hasFetched && isAgency ) {
-		return <SitesOverview />;
+		const context = {
+			search,
+			currentPage,
+		};
+		return (
+			<SitesOverviewContext.Provider value={ context }>
+				<SitesOverview />
+			</SitesOverviewContext.Provider>
+		);
 	}
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/context.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/context.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+import type { SitesOverviewContextInterface } from './types';
+
+const SitesOverviewContext = createContext< SitesOverviewContextInterface >( {
+	currentPage: 1,
+	search: '',
+} );
+
+export default SitesOverviewContext;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,6 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useContext } from 'react';
+import { ReactElement, useContext, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import SitesOverviewContext from './context';
 import SiteContent from './site-content';
 import SiteSearch from './site-search';
@@ -10,10 +12,15 @@ import './style.scss';
 
 export default function SitesOverview(): ReactElement {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const { search, currentPage } = useContext( SitesOverviewContext );
 
 	const { data, isError, isFetching } = useFetchDashboardSites( search, currentPage );
+
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_visit' ) );
+	}, [ dispatch ] );
 
 	return (
 		<div className="sites-overview">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,8 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useState, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { ReactElement, useContext } from 'react';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import SitesOverviewContext from './context';
 import SiteContent from './site-content';
 import SiteSearch from './site-search';
 import SiteWelcomeBanner from './site-welcome-banner';
@@ -11,25 +10,10 @@ import './style.scss';
 
 export default function SitesOverview(): ReactElement {
 	const translate = useTranslate();
-	const searchParam = new URLSearchParams( window.location.search ).get( 's' );
-	const pageParam = new URLSearchParams( window.location.search ).get( 'page' );
 
-	const [ searchQuery, setSearchQuery ] = useState( searchParam );
-	const [ pageNumber, setPageNumber ] = useState( Number( pageParam ) );
-	const { data, isError, isFetching } = useFetchDashboardSites( searchQuery, pageNumber );
+	const { search, currentPage } = useContext( SitesOverviewContext );
 
-	const handleSearch = ( query: string | null ) => {
-		setSearchQuery( query );
-	};
-	const dispatch = useDispatch();
-
-	useEffect( () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_visit' ) );
-	}, [ dispatch ] );
-
-	const handlePageChange = ( page: number ) => {
-		setPageNumber( page );
-	};
+	const { data, isError, isFetching } = useFetchDashboardSites( search, currentPage );
 
 	return (
 		<div className="sites-overview">
@@ -41,14 +25,13 @@ export default function SitesOverview(): ReactElement {
 				</div>
 			</div>
 			<div className="sites-overview__search">
-				<SiteSearch searchQuery={ searchParam } handleSearch={ handleSearch } />
+				<SiteSearch searchQuery={ search } currentPage={ currentPage } />
 			</div>
 			<SiteContent
 				data={ data }
 				isError={ isError }
 				isFetching={ isFetching }
-				currentPage={ pageNumber || 1 }
-				handlePageChange={ handlePageChange }
+				currentPage={ currentPage }
 			/>
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -12,9 +12,11 @@ import './style.scss';
 export default function SitesOverview(): ReactElement {
 	const translate = useTranslate();
 	const searchParam = new URLSearchParams( window.location.search ).get( 's' );
+	const pageParam = new URLSearchParams( window.location.search ).get( 'page' );
 
 	const [ searchQuery, setSearchQuery ] = useState( searchParam );
-	const { data, isError, isFetching } = useFetchDashboardSites( searchQuery );
+	const [ pageNumber, setPageNumber ] = useState( Number( pageParam ) );
+	const { data, isError, isFetching } = useFetchDashboardSites( searchQuery, pageNumber );
 
 	const handleSearch = ( query: string | null ) => {
 		setSearchQuery( query );
@@ -24,6 +26,10 @@ export default function SitesOverview(): ReactElement {
 	useEffect( () => {
 		dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_visit' ) );
 	}, [ dispatch ] );
+
+	const handlePageChange = ( page: number ) => {
+		setPageNumber( page );
+	};
 
 	return (
 		<div className="sites-overview">
@@ -35,9 +41,15 @@ export default function SitesOverview(): ReactElement {
 				</div>
 			</div>
 			<div className="sites-overview__search">
-				<SiteSearch searchQuery={ searchQuery } handleSearch={ handleSearch } />
+				<SiteSearch searchQuery={ searchParam } handleSearch={ handleSearch } />
 			</div>
-			<SiteContent data={ data } isError={ isError } isFetching={ isFetching } />
+			<SiteContent
+				data={ data }
+				isError={ isError }
+				isFetching={ isFetching }
+				currentPage={ pageNumber || 1 }
+				handlePageChange={ handlePageChange }
+			/>
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -1,23 +1,42 @@
 import { Card } from '@automattic/components';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import Pagination from 'calypso/components/pagination';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import { addQueryArgs } from 'calypso/lib/route';
 import SiteCard from '../site-card';
 import SiteTable from '../site-table';
-import { formatSites } from '../utils';
+import { formatSites, SITES_PER_PAGE } from '../utils';
 import type { ReactElement } from 'react';
 
 import './style.scss';
 
+const addPageArgs = ( pageNumber: number ) => {
+	const queryParams = { page: pageNumber };
+	const currentPath = window.location.pathname + window.location.search;
+	page( addQueryArgs( queryParams, currentPath ) );
+};
+
 interface Props {
-	data: Array< any > | undefined;
+	data: { sites: Array< any >; total: number } | undefined;
 	isError: boolean;
 	isFetching: boolean;
+	currentPage: number;
+	handlePageChange: ( pageNumber: number ) => void;
 }
 
-export default function SiteContent( { data, isError, isFetching }: Props ): ReactElement {
+export default function SiteContent( {
+	data,
+	isError,
+	isFetching,
+	currentPage,
+	handlePageChange,
+}: Props ): ReactElement {
 	const translate = useTranslate();
+	const isMobile = useMobileBreakpoint();
 
-	const sites = formatSites( data );
+	const sites = formatSites( data?.sites );
 
 	const columns = [
 		{
@@ -46,6 +65,11 @@ export default function SiteContent( { data, isError, isFetching }: Props ): Rea
 		return <div className="site-content__no-sites">{ translate( 'No active sites' ) }</div>;
 	}
 
+	const handlePageClick = ( pageNumber: number ) => {
+		addPageArgs( pageNumber );
+		handlePageChange( pageNumber );
+	};
+
 	return (
 		<>
 			<SiteTable isFetching={ isFetching } columns={ columns } items={ sites } />
@@ -65,6 +89,15 @@ export default function SiteContent( { data, isError, isFetching }: Props ): Rea
 					) }
 				</>
 			</div>
+			{ data?.total && (
+				<Pagination
+					compact={ isMobile }
+					page={ currentPage }
+					perPage={ SITES_PER_PAGE }
+					total={ data.total }
+					pageClick={ handlePageClick }
+				/>
+			) }
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -7,7 +7,7 @@ import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-
 import { addQueryArgs } from 'calypso/lib/route';
 import SiteCard from '../site-card';
 import SiteTable from '../site-table';
-import { formatSites, SITES_PER_PAGE } from '../utils';
+import { formatSites } from '../utils';
 import type { ReactElement } from 'react';
 
 import './style.scss';
@@ -19,7 +19,7 @@ const addPageArgs = ( pageNumber: number ) => {
 };
 
 interface Props {
-	data: { sites: Array< any >; total: number } | undefined;
+	data: { sites: Array< any >; total: number; perPage: number } | undefined;
 	isError: boolean;
 	isFetching: boolean;
 	currentPage: number;
@@ -93,7 +93,7 @@ export default function SiteContent( {
 				<Pagination
 					compact={ isMobile }
 					page={ currentPage }
-					perPage={ SITES_PER_PAGE }
+					perPage={ data.perPage }
 					total={ data.total }
 					pageClick={ handlePageClick }
 				/>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -23,7 +23,6 @@ interface Props {
 	isError: boolean;
 	isFetching: boolean;
 	currentPage: number;
-	handlePageChange: ( pageNumber: number ) => void;
 }
 
 export default function SiteContent( {
@@ -31,7 +30,6 @@ export default function SiteContent( {
 	isError,
 	isFetching,
 	currentPage,
-	handlePageChange,
 }: Props ): ReactElement {
 	const translate = useTranslate();
 	const isMobile = useMobileBreakpoint();
@@ -67,7 +65,6 @@ export default function SiteContent( {
 
 	const handlePageClick = ( pageNumber: number ) => {
 		addPageArgs( pageNumber );
-		handlePageChange( pageNumber );
 	};
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -86,7 +86,7 @@ export default function SiteContent( {
 					) }
 				</>
 			</div>
-			{ data?.total && (
+			{ data && data?.total > 0 && (
 				<Pagination
 					compact={ isMobile }
 					page={ currentPage }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -9,4 +9,5 @@
 	@include break-large() {
 		display: none;
 	}
+	margin-bottom: 1.5rem;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search/index.tsx
@@ -1,20 +1,23 @@
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import Search from 'calypso/components/search';
-import { setQueryArgs } from 'calypso/lib/query-args';
+import { addQueryArgs } from 'calypso/lib/route';
 import type { ReactElement } from 'react';
 
 export default function SiteSearch( {
 	searchQuery,
-	handleSearch,
 }: {
 	searchQuery: string | null;
-	handleSearch: ( query: string ) => void;
+	currentPage: number;
 } ): ReactElement {
 	const translate = useTranslate();
 
 	const handleSearchSites = ( query: string ) => {
-		setQueryArgs( '' !== query ? { s: query } : {} );
-		handleSearch( query );
+		const queryParams = {
+			...( query && { s: query } ),
+		};
+		const currentPath = window.location.pathname;
+		page( addQueryArgs( queryParams, currentPath ) );
 	};
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -45,3 +45,7 @@ export type AllowedActionTypes = 'issue_license' | 'view_activity' | 'view_site'
 export type ActionEventNames = {
 	[ key in AllowedActionTypes ]: { small_screen: string; large_screen: string };
 };
+export interface SitesOverviewContextInterface {
+	search: string;
+	currentPage: number;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds pagination to the agency dashboard

#### Testing instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb

**Instructions**

1. Run `git checkout add/pagination-for-agency-dashboard` and `yarn start-jetpack-cloud`
2. Apply D81701-code to your sandbox for the API to work.
3. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard.
4. Make sure you have more than 1 site(Currently the per page is set to 1 for testing purposes)
5. Make sure page numbers along with `Previous` & `Next` buttons are shown and work as expected.
6. Switch to the small screen(<960px) using the toggle device toolbar on the dev tool(inspect)
7. Make sure page numbers along with arrow icons for next and previous are shown and work as expected.
8. Enter some text in the search box -> Click on any page number except 1 -> Change the text in the search box or clear the text -> Current page should change to `1`.

Related to 1202076982646589-as-1202122273254277