### PR TITLE
EmailPlan: migrate connect to useSelector

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -1,8 +1,8 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { localize, useTranslate } from 'i18n-calypso';
+import config from '@automattic/calypso-config';
+import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import titleCase from 'to-title-case';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
@@ -71,27 +71,36 @@ UpgradeNavItem.propTypes = {
 	selectedSiteSlug: PropTypes.string.isRequired,
 };
 
-const EmailPlan = ( props ) => {
-	function getAccount( data ) {
-		return data?.accounts?.[ 0 ];
-	}
+function getAccount( data ) {
+	return data?.accounts?.[ 0 ];
+}
 
-	function getMailboxes( data ) {
-		const account = getAccount( data );
+function getMailboxes( data ) {
+	const account = getAccount( data );
 
-		return account?.emails ?? [];
-	}
+	return account?.emails ?? [];
+}
+
+function EmailPlan( { domain, selectedSite, source } ) {
+	const translate = useTranslate();
+
+	const purchase = useSelector( ( state ) => getEmailPurchaseByDomain( state, domain ) );
+	const isLoadingPurchase = useSelector(
+		( state ) => isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state )
+	);
+	const currentRoute = useSelector( getCurrentRoute );
+
+	const canAddMailboxes =
+		( getGSuiteProductSlug( domain ) || getTitanProductSlug( domain ) ) &&
+		getGSuiteSubscriptionStatus( domain ) !== 'suspended';
+	const hasSubscription = hasEmailSubscription( domain );
 
 	const handleBack = () => {
-		const { selectedSite } = props;
-
 		page( emailManagement( selectedSite.slug ) );
 	};
 
 	const handleRenew = ( event ) => {
 		event.preventDefault();
-
-		const { purchase, selectedSite } = props;
 
 		handleRenewNowClick( purchase, selectedSite.slug, {
 			tracksProps: { source: 'email-plan-view' },
@@ -99,8 +108,6 @@ const EmailPlan = ( props ) => {
 	};
 
 	function getAddMailboxProps() {
-		const { currentRoute, domain, selectedSite, source } = props;
-
 		if ( hasGSuiteWithUs( domain ) ) {
 			return {
 				path: emailManagementAddGSuiteUsers(
@@ -125,7 +132,7 @@ const EmailPlan = ( props ) => {
 				};
 			}
 
-			const showExternalControlPanelLink = ! isEnabled( 'titan/iframe-control-panel' );
+			const showExternalControlPanelLink = ! config.isEnabled( 'titan/iframe-control-panel' );
 			const controlPanelUrl = showExternalControlPanelLink
 				? emailManagementTitanControlPanelRedirect( selectedSite.slug, domain.name, currentRoute, {
 						context: TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL,
@@ -146,8 +153,6 @@ const EmailPlan = ( props ) => {
 	}
 
 	function getHeaderText() {
-		const { domain, translate } = props;
-
 		if ( hasGSuiteWithUs( domain ) ) {
 			const googleMailService = getGoogleMailServiceFamily( getGSuiteProductSlug( domain ) );
 
@@ -173,8 +178,6 @@ const EmailPlan = ( props ) => {
 	}
 
 	function renderViewBillingAndPaymentSettingsNavItem() {
-		const { hasSubscription, purchase, selectedSite, translate } = props;
-
 		if ( ! hasSubscription ) {
 			return null;
 		}
@@ -193,8 +196,6 @@ const EmailPlan = ( props ) => {
 	}
 
 	function getManageAllNavItemProps() {
-		const { currentRoute, domain, selectedSite } = props;
-
 		if ( hasGSuiteWithUs( domain ) ) {
 			return {
 				external: true,
@@ -203,7 +204,7 @@ const EmailPlan = ( props ) => {
 		}
 
 		if ( hasTitanMailWithUs( domain ) ) {
-			if ( isEnabled( 'titan/iframe-control-panel' ) ) {
+			if ( config.isEnabled( 'titan/iframe-control-panel' ) ) {
 				return {
 					path: emailManagementManageTitanAccount( selectedSite.slug, domain.name, currentRoute ),
 				};
@@ -218,8 +219,6 @@ const EmailPlan = ( props ) => {
 	}
 
 	function renderManageAllMailboxesNavItem() {
-		const { translate } = props;
-
 		const manageAllNavItemProps = getManageAllNavItemProps();
 
 		if ( manageAllNavItemProps === null ) {
@@ -237,8 +236,6 @@ const EmailPlan = ( props ) => {
 	}
 
 	function renderAddNewMailboxesOrRenewNavItem() {
-		const { canAddMailboxes, domain, hasSubscription, purchase, translate } = props;
-
 		if ( hasTitanMailWithUs( domain ) && ! hasSubscription ) {
 			return (
 				<VerticalNavItem { ...getAddMailboxProps() }>
@@ -274,21 +271,15 @@ const EmailPlan = ( props ) => {
 		);
 	}
 
-	const { currentRoute, domain, selectedSite, hasSubscription, purchase, isLoadingPurchase } =
-		props;
-
-	const { data, isLoading } = useEmailAccountsQuery( props.selectedSite.ID, props.domain.name, {
+	const { data, isLoading } = useEmailAccountsQuery( selectedSite.ID, domain.name, {
 		retry: false,
 	} );
 
 	return (
 		<>
 			{ selectedSite && hasSubscription && <QuerySitePurchases siteId={ selectedSite.ID } /> }
-
 			<DocumentHead title={ titleCase( getHeaderText() ) } />
-
 			<HeaderCake onClick={ handleBack }>{ getHeaderText() }</HeaderCake>
-
 			<EmailPlanHeader
 				domain={ domain }
 				hasEmailSubscription={ hasSubscription }
@@ -298,55 +289,32 @@ const EmailPlan = ( props ) => {
 				selectedSite={ selectedSite }
 				emailAccount={ data?.accounts?.[ 0 ] || {} }
 			/>
-
 			<EmailPlanMailboxesList
 				account={ getAccount( data ) }
 				domain={ domain }
 				mailboxes={ getMailboxes( data ) }
 				isLoadingEmails={ isLoading }
 			/>
-
 			<div className="email-plan__actions">
 				<VerticalNav>
 					{ renderAddNewMailboxesOrRenewNavItem() }
-
 					<UpgradeNavItem
 						currentRoute={ currentRoute }
 						domain={ domain }
 						selectedSiteSlug={ selectedSite.slug }
 					/>
-
 					{ renderManageAllMailboxesNavItem() }
-
 					{ renderViewBillingAndPaymentSettingsNavItem() }
 				</VerticalNav>
 			</div>
 		</>
 	);
-};
+}
 
-EmailPlan.propType = {
+EmailPlan.propTypes = {
 	domain: PropTypes.object.isRequired,
 	selectedSite: PropTypes.object.isRequired,
 	source: PropTypes.string,
-
-	// Connected props
-	canAddMailboxes: PropTypes.bool,
-	currentRoute: PropTypes.string,
-	hasSubscription: PropTypes.bool,
-	isLoadingPurchase: PropTypes.bool,
-	purchase: PropTypes.object,
 };
 
-export default connect( ( state, ownProps ) => {
-	return {
-		canAddMailboxes:
-			( getGSuiteProductSlug( ownProps.domain ) || getTitanProductSlug( ownProps.domain ) ) &&
-			getGSuiteSubscriptionStatus( ownProps.domain ) !== 'suspended',
-		currentRoute: getCurrentRoute( state ),
-		isLoadingPurchase:
-			isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
-		purchase: getEmailPurchaseByDomain( state, ownProps.domain ),
-		hasSubscription: hasEmailSubscription( ownProps.domain ),
-	};
-} )( localize( EmailPlan ) );
+export default EmailPlan;

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import titleCase from 'to-title-case';
 import DocumentHead from 'calypso/components/data/document-head';
-import QueryEmailForwards from 'calypso/components/data/query-email-forwards';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HeaderCake from 'calypso/components/header-cake';
 import VerticalNav from 'calypso/components/vertical-nav';
@@ -49,8 +48,6 @@ import {
 	isFetchingSitePurchases,
 } from 'calypso/state/purchases/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getEmailForwards } from 'calypso/state/selectors/get-email-forwards';
-import isRequestingEmailForwards from 'calypso/state/selectors/is-requesting-email-forwards';
 
 const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
 	const translate = useTranslate();
@@ -75,10 +72,6 @@ UpgradeNavItem.propTypes = {
 };
 
 const EmailPlan = ( props ) => {
-	const shouldCheckForEmailForwards = ( domain ) => {
-		return ! hasGSuiteWithUs( domain ) && ! hasTitanMailWithUs( domain );
-	};
-
 	function getAccount( data ) {
 		return data?.accounts?.[ 0 ];
 	}
@@ -284,9 +277,6 @@ const EmailPlan = ( props ) => {
 	const { currentRoute, domain, selectedSite, hasSubscription, purchase, isLoadingPurchase } =
 		props;
 
-	// Ensure we check for email forwarding additions and removals
-	const shouldQueryEmailForwards = shouldCheckForEmailForwards( domain );
-
 	const { data, isLoading } = useEmailAccountsQuery( props.selectedSite.ID, props.domain.name, {
 		retry: false,
 	} );
@@ -294,8 +284,6 @@ const EmailPlan = ( props ) => {
 	return (
 		<>
 			{ selectedSite && hasSubscription && <QuerySitePurchases siteId={ selectedSite.ID } /> }
-
-			{ shouldQueryEmailForwards && <QueryEmailForwards domainName={ domain.name } /> }
 
 			<DocumentHead title={ titleCase( getHeaderText() ) } />
 
@@ -345,9 +333,7 @@ EmailPlan.propType = {
 	// Connected props
 	canAddMailboxes: PropTypes.bool,
 	currentRoute: PropTypes.string,
-	emailForwards: PropTypes.array,
 	hasSubscription: PropTypes.bool,
-	isLoadingEmailForwards: PropTypes.bool,
 	isLoadingPurchase: PropTypes.bool,
 	purchase: PropTypes.object,
 };
@@ -358,8 +344,6 @@ export default connect( ( state, ownProps ) => {
 			( getGSuiteProductSlug( ownProps.domain ) || getTitanProductSlug( ownProps.domain ) ) &&
 			getGSuiteSubscriptionStatus( ownProps.domain ) !== 'suspended',
 		currentRoute: getCurrentRoute( state ),
-		emailForwards: getEmailForwards( state, ownProps.domain.name ),
-		isLoadingEmailForwards: isRequestingEmailForwards( state, ownProps.domain.name ),
 		isLoadingPurchase:
 			isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
 		purchase: getEmailPurchaseByDomain( state, ownProps.domain ),


### PR DESCRIPTION
Two updates for the `EmailPlan` component:
- remove querying for `emailForwards` data as it's not used anywhere in the component: usage was removed in #54133.
- rewrite the `connect` call to `useSelector` hooks as the component is already functional.

Spinoff from #64069.

**How to test:**
Have a site with email support, and go to the email management page at `/email/:domain/manage/:site`. Verify that the `EmailPlan` component (i.e., most of that page's UI) still works correctly.