### PR TITLE
Checkout: Add mismatched tax location logging to existing card processor

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -35,12 +35,31 @@ export default async function existingCardProcessor(
 	if ( ! isValidTransactionData( transactionData ) ) {
 		throw new Error( 'Required purchase data is missing' );
 	}
-	const { stripe, includeDomainDetails, includeGSuiteDetails, contactDetails, reduxDispatch } =
-		dataForProcessor;
+	const {
+		stripe,
+		includeDomainDetails,
+		includeGSuiteDetails,
+		contactDetails,
+		reduxDispatch,
+		responseCart,
+	} = dataForProcessor;
 	if ( ! stripe ) {
 		throw new Error( 'Stripe is required to submit an existing card payment' );
 	}
 	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId: 'existingCard' } ) );
+
+	const cartCountry = responseCart.tax.location.country_code ?? '';
+	const formCountry = contactDetails?.countryCode?.value ?? '';
+	if ( cartCountry !== formCountry ) {
+		// Changes to the contact form data should always be sent to the cart, so
+		// this should not be possible.
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_mismatched_tax_location', {
+				form_country: formCountry,
+				cart_country: cartCountry,
+			} )
+		);
+	}
 
 	const domainDetails = getDomainDetails( contactDetails, {
 		includeDomainDetails,
@@ -58,7 +77,7 @@ export default async function existingCardProcessor(
 		cart: createTransactionEndpointCartFromResponseCart( {
 			siteId: dataForProcessor.siteId ? String( dataForProcessor.siteId ) : undefined,
 			contactDetails: domainDetails ?? null,
-			responseCart: dataForProcessor.responseCart,
+			responseCart,
 		} ),
 		paymentMethodType: 'WPCOM_Billing_MoneyPress_Stored',
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is the same as https://github.com/Automattic/wp-calypso/pull/64041 but for stored cards.

There are a small number of transactions being processed through checkout where the tax location data is missing even though it has been entered into the form. However, there's no clear reason for why that happens.

This diff adds logging if the tax location data (the country code, specifically) being submitted to the transactions endpoint for a saved credit card purchase differs from the tax location (country code) in the form.

Unless the cart is somehow getting its tax location changed by something other than the form, this should never occur.

#### Testing instructions

Automated tests should prove that this does not break anything. Otherwise, this is hard to test because it should not be possible.