### PR TITLE
Marketplace post-checkout: Fix a warning when polling Atomic transfer

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -60,7 +60,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		if ( ! siteId || transfer?.status === AtomicTransferComplete ) {
 			return;
 		}
-		waitFor( 2 ).then( () => dispatch( dispatch( requestLatestAtomicTransfer( siteId ) ) ) );
+		waitFor( 2 ).then( () => dispatch( requestLatestAtomicTransfer( siteId ) ) );
 	}, [ siteId, dispatch, transfer ] );
 
 	useEffect( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove some errors in the console when purchasing and activating a plugin

#### Testing instructions

- Go to marketplace
- Purchase plugin
- Purchase with credits at checkout
- Land at thank you page where main CTA keeps loading
- After some seconds, the main CTA button `Manage plugin` should be enabled and only one `404` error should be reported in the console
- Go to installed plugins and make sure the plugin is activated

![CleanShot 2022-05-30 at 17 57 57@2x](https://user-images.githubusercontent.com/3519124/171027890-d77f3375-5e07-4c2c-84f6-0b90647481ba.png)

![CleanShot 2022-05-30 at 18 00 40@2x](https://user-images.githubusercontent.com/3519124/171028200-d9f6d0be-6547-40e2-a402-8d9461db3e31.png)


Related to #63853
