### PR TITLE
Generated Design Picker: Show only when we can get designs from current vertical

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -91,18 +91,20 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		[ staticDesigns ]
 	);
 
+	const enabledGeneratedDesigns =
+		isEnabled( 'signup/design-picker-generated-designs' ) && intent === 'build';
+
 	const { data: generatedDesigns = [], isLoading: isLoadingGeneratedDesigns } =
-		useStarterDesignsGeneratedQuery( {
-			vertical_id: siteVerticalId,
-			seed: siteSlug || undefined,
-		} );
+		useStarterDesignsGeneratedQuery(
+			{
+				vertical_id: siteVerticalId,
+				seed: siteSlug || undefined,
+			},
+			{ enabled: enabledGeneratedDesigns && !! siteVerticalId }
+		);
 
 	const showGeneratedDesigns =
-		isEnabled( 'signup/design-picker-generated-designs' ) &&
-		intent === 'build' &&
-		!! siteVerticalId &&
-		generatedDesigns.length > 0 &&
-		! isForceStaticDesigns;
+		enabledGeneratedDesigns && generatedDesigns.length > 0 && ! isForceStaticDesigns;
 
 	const selectedGeneratedDesign = useMemo(
 		() => selectedDesign ?? ( ! isMobile ? generatedDesigns[ 0 ] : undefined ),
@@ -374,7 +376,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	// When the intent is build, we can potentially show the generated design picker.
 	// Don't render until we've fetched the generated designs from the backend.
-	if ( showGeneratedDesigns && ( isLoadingGeneratedDesigns || ! siteVerticalId ) ) {
+	if ( enabledGeneratedDesigns && ( isLoadingGeneratedDesigns || ! siteVerticalId ) ) {
 		return null;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -374,7 +374,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	// When the intent is build, we can potentially show the generated design picker.
 	// Don't render until we've fetched the generated designs from the backend.
-	if ( showGeneratedDesigns && isLoadingGeneratedDesigns ) {
+	if ( showGeneratedDesigns && ( isLoadingGeneratedDesigns || ! siteVerticalId ) ) {
 		return null;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -73,11 +73,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	const showDesignPickerCategories =
 		isEnabled( 'signup/design-picker-categories' ) && ! isAnchorSite;
-	const showGeneratedDesigns =
-		isEnabled( 'signup/design-picker-generated-designs' ) &&
-		intent === 'build' &&
-		!! siteVerticalId &&
-		! isForceStaticDesigns;
+
 	const showDesignPickerCategoriesAllFilter = isEnabled( 'signup/design-picker-categories' );
 
 	const isPremiumThemeAvailable = Boolean(
@@ -100,6 +96,13 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 			vertical_id: siteVerticalId,
 			seed: siteSlug || undefined,
 		} );
+
+	const showGeneratedDesigns =
+		isEnabled( 'signup/design-picker-generated-designs' ) &&
+		intent === 'build' &&
+		!! siteVerticalId &&
+		generatedDesigns.length > 0 &&
+		! isForceStaticDesigns;
 
 	const selectedGeneratedDesign = useMemo(
 		() => selectedDesign ?? ( ! isMobile ? generatedDesigns[ 0 ] : undefined ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -68,7 +68,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	);
 
 	const siteVerticalId = useSelect(
-		( select ) => ( site && select( SITE_STORE ).getSiteVerticalId( site.ID ) ) || undefined
+		( select ) => ( site && select( SITE_STORE ).getSiteVerticalId( site.ID ) ) || ''
 	);
 
 	const showDesignPickerCategories =

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -242,11 +242,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		yield saveSiteSettings( siteId, { blogdescription } );
 	}
 
-	function* setDesignOnSite(
-		siteSlug: string,
-		selectedDesign: Design,
-		siteVerticalId: string | undefined
-	) {
+	function* setDesignOnSite( siteSlug: string, selectedDesign: Design, siteVerticalId: string ) {
 		const { theme, recipe } = selectedDesign;
 
 		yield wpcomRequest( {
@@ -268,7 +264,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 				body: {
 					trim_content: true,
 					pattern_ids: recipe?.pattern_ids,
-					vertical_id: siteVerticalId,
+					vertical_id: siteVerticalId || undefined,
 				},
 				method: 'POST',
 			} );

--- a/packages/data-stores/src/starter-designs-queries/types.ts
+++ b/packages/data-stores/src/starter-designs-queries/types.ts
@@ -1,7 +1,7 @@
 import type { DesignRecipe } from '@automattic/design-picker/src/types';
 
 export interface StarterDesignsGeneratedQueryParams {
-	vertical_id?: string;
+	vertical_id: string;
 	seed?: string;
 }
 

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-generated-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-generated-query.ts
@@ -1,21 +1,26 @@
 import { stringify } from 'qs';
-import { useQuery, UseQueryResult } from 'react-query';
+import { useQuery, UseQueryResult, QueryOptions } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { StarterDesignsGenerated, StarterDesignsGeneratedQueryParams } from './types';
 import type { Design } from '@automattic/design-picker/src/types';
 
+interface Options extends QueryOptions< StarterDesignsGenerated[], unknown > {
+	enabled?: boolean;
+}
+
 export function useStarterDesignsGeneratedQuery(
-	queryParams: StarterDesignsGeneratedQueryParams
+	queryParams: StarterDesignsGeneratedQueryParams,
+	queryOptions: Options = {}
 ): UseQueryResult< Design[] > {
-	const { vertical_id } = queryParams;
 	return useQuery(
 		[ 'starter-designs-generated', queryParams ],
 		() => fetchStarterDesignsGenerated( queryParams ),
 		{
-			select: ( response ) => response.map( apiStarterDesignsGeneratedToDesign ),
-			enabled: !! vertical_id,
+			select: ( response: StarterDesignsGenerated[] ) =>
+				response.map( apiStarterDesignsGeneratedToDesign ),
 			refetchOnMount: 'always',
 			staleTime: Infinity,
+			...queryOptions,
 		}
 	);
 }

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-generated-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-generated-query.ts
@@ -7,12 +7,13 @@ import type { Design } from '@automattic/design-picker/src/types';
 export function useStarterDesignsGeneratedQuery(
 	queryParams: StarterDesignsGeneratedQueryParams
 ): UseQueryResult< Design[] > {
+	const { vertical_id } = queryParams;
 	return useQuery(
 		[ 'starter-designs-generated', queryParams ],
 		() => fetchStarterDesignsGenerated( queryParams ),
 		{
 			select: ( response ) => response.map( apiStarterDesignsGeneratedToDesign ),
-			enabled: true,
+			enabled: !! vertical_id,
 			refetchOnMount: 'always',
 			staleTime: Infinity,
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We have to skip the v13n Design Picker if the designs from the current vertical return empty

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Vertical step: `/setup/vertical?siteSlug=<your_site>`
* Select a vertical which is not listed in the whitelist (See 40-gh-Automattic/ganon-issues). For example: `Comics`
* Select “build” intent
* You have to see the Static Design Picker
* Ensure the following behaviors work well
  * Refresh the page
  * Select any design to preview
  * Click “Back” to the Static Design Picker
  * Click “Back” to the intent step
* Back to the Vertical step and change to another vertical which is listed in the whitelist. For example: `Arts & Entertainment`
* Select “build” intent again
* Ensure you won't see the Static Design Picker at the beginning and the Generated Design Picker shows after loading

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 40-gh-Automattic/ganon-issues