### PR TITLE
Add tracks event for viewing the generated design picker

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -126,9 +126,12 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	useEffect( () => {
 		if ( showGeneratedDesigns && ! hasTrackedView.current ) {
 			hasTrackedView.current = true;
-			recordTracksEvent( 'calypso_signup_generated_design_picker_view' );
+			recordTracksEvent( 'calypso_signup_generated_design_picker_view', {
+				vertical_id: siteVerticalId,
+				generated_designs: generatedDesigns?.map( ( design ) => design.slug ).join( ',' ),
+			} );
 		}
-	}, [ showGeneratedDesigns, hasTrackedView ] );
+	}, [ showGeneratedDesigns, hasTrackedView, generatedDesigns ] );
 
 	function headerText() {
 		if ( showGeneratedDesigns ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -17,7 +17,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useRef, useState, useEffect } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview/content';
 import { useNewSiteVisibility } from 'calypso/landing/gutenboarding/hooks/use-selected-plan';
@@ -121,6 +121,14 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	const visibility = useNewSiteVisibility();
 
 	const [ isSticky, setIsSticky ] = useState( false );
+
+	const hasTrackedView = useRef( false );
+	useEffect( () => {
+		if ( showGeneratedDesigns && ! hasTrackedView.current ) {
+			hasTrackedView.current = true;
+			recordTracksEvent( 'calypso_signup_view_generated_design_picker' );
+		}
+	}, [ showGeneratedDesigns, hasTrackedView ] );
 
 	function headerText() {
 		if ( showGeneratedDesigns ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -126,7 +126,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	useEffect( () => {
 		if ( showGeneratedDesigns && ! hasTrackedView.current ) {
 			hasTrackedView.current = true;
-			recordTracksEvent( 'calypso_signup_view_generated_design_picker' );
+			recordTracksEvent( 'calypso_signup_generated_design_picker_view' );
 		}
 	}, [ showGeneratedDesigns, hasTrackedView ] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
See 24-gh-Automattic/ganon-issues

I only recorded the event in the case that the user is viewing the _generated_ design picker. This was easier to implement than using a generic event for viewing both the static, and generated design pickers. That is because the `siteVerticalId` is not set the first time the page renders even if a vertical was selected.

This will be affected by https://github.com/Automattic/wp-calypso/pull/64140/files but will not require any code changes.

Code also prevents the event from firing twice if the user goes to the static design picker and then back to the generated design picker.

see slack discussion p1653883035118199/1653882942.705719-slack-CRWCHQGUB
#### Testing instructions
* Select a vertical and choose the build flow
* The generated DP will be loaded, a tracks event `calypso_signup_generated_design_picker_view` will be sent.
* Click "View More Options" to see the static design picker.
* Click "< Back"
* The event will not be sent again.

If you go all the way back to the intent gathering step, and select *Build* again, the event will be sent again. I believe this is acceptable.

fixes 24-gh-Automattic/ganon-issues