### PR TITLE
Checkout: Jetpack plan conflicts notices don't appear when jetpack plan in cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -73,20 +73,29 @@ const PrePurchaseNotices = () => {
 	/**
 	 * The active product on the current site that overlaps/conflicts with the plan currently in the cart.
 	 */
-	const siteProductThatOverlapsCartPlan = useSelector( () => {
+	const siteProductThatOverlapsCartPlan = useSelector( ( state ) => {
 		const planSlugInCart = cartItemSlugs.find( isJetpackPlanSlug );
 
 		if ( ! planSlugInCart ) return null;
 
-		if ( planHasFeature( planSlugInCart, WPCOM_FEATURES_BACKUPS ) ) {
+		if (
+			planHasFeature( planSlugInCart, WPCOM_FEATURES_BACKUPS ) &&
+			siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS )
+		) {
 			return currentSiteProducts.find( isJetpackBackup );
 		}
 
-		if ( planHasFeature( planSlugInCart, WPCOM_FEATURES_ANTISPAM ) ) {
+		if (
+			planHasFeature( planSlugInCart, WPCOM_FEATURES_ANTISPAM ) &&
+			siteHasFeature( state, siteId, WPCOM_FEATURES_ANTISPAM )
+		) {
 			return currentSiteProducts.find( isJetpackAntiSpam );
 		}
 
-		if ( planHasFeature( planSlugInCart, WPCOM_FEATURES_SCAN ) ) {
+		if (
+			planHasFeature( planSlugInCart, WPCOM_FEATURES_SCAN ) &&
+			siteHasFeature( state, siteId, WPCOM_FEATURES_SCAN )
+		) {
 			return currentSiteProducts.find( isJetpackScan );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR is follow-up PR which disabled jetpack plan conflict warning message when the user has feature but try to plan full plan. 
* This also fixes the issue of purchasing jetpack security and complete packages are impossible after deploying the previous PR. Related [slack convo](p1653896982500009-slack-CBG1CP4EN)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Similar as https://github.com/Automattic/wp-calypso/pull/64013

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4TIVU-a66-p2