### PR TITLE
Help Center: handle 3rd party cookies blockage in happy chat

### DIFF
--- a/apps/happychat/package.json
+++ b/apps/happychat/package.json
@@ -26,6 +26,10 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-polyfills": "workspace:^",
+		"@automattic/components": "workspace:^",
+		"@automattic/happychat-connection": "workspace:^",
+		"@wordpress/data": "^6.7.0",
+		"@wordpress/icons": "^8.3.0",
 		"calypso": "workspace:^",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/apps/happychat/src/app.jsx
+++ b/apps/happychat/src/app.jsx
@@ -3,13 +3,15 @@
  */
 import '@automattic/calypso-polyfills';
 
+import { requestHappyChatAuth } from '@automattic/happychat-connection';
+import { Icon, warning } from '@wordpress/icons';
 import ReactDom from 'react-dom';
 import { Provider } from 'react-redux';
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import { initializeAnalytics } from 'calypso/lib/analytics/init';
 import getSuperProps from 'calypso/lib/analytics/super-props';
-import { rawCurrentUserFetch, filterUserObject } from 'calypso/lib/user/shared-utils';
+import { filterUserObject } from 'calypso/lib/user/shared-utils';
 import analyticsMiddleware from 'calypso/state/analytics/middleware';
 import consoleDispatcher from 'calypso/state/console-dispatch';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
@@ -17,12 +19,13 @@ import currentUser from 'calypso/state/current-user/reducer';
 import wpcomApiMiddleware from 'calypso/state/data-layer/wpcom-api-middleware';
 import happychatMiddleware from 'calypso/state/happychat/middleware';
 import { openChat } from 'calypso/state/happychat/ui/actions';
-import { requestHappychatEligibility } from 'calypso/state/happychat/user/actions';
 import { setStore } from 'calypso/state/redux-store';
 import sites from 'calypso/state/sites/reducer';
 import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
 import 'calypso/assets/stylesheets/style.scss';
 import Happychat from './happychat';
+import { requestDataFromParent } from './request-auth-data-from-parent';
+import './happychat.scss';
 
 async function AppBoot() {
 	const rootReducer = combineReducers( {
@@ -45,18 +48,45 @@ async function AppBoot() {
 	);
 
 	setStore( store );
-	const user = await rawCurrentUserFetch().then( filterUserObject );
+
+	let auth;
+	let user;
+
+	try {
+		auth = await requestHappyChatAuth();
+		user = filterUserObject( auth.fullUser );
+	} catch ( error ) {
+		// this error most likely means we couldn't auth the user due to 3rd party cookies blockage
+		// attempt to get auth information from the parent window (when this is opened in an iframe)
+		try {
+			const authFromParent = await requestDataFromParent();
+			auth = authFromParent;
+			user = filterUserObject( auth.fullUser );
+		} catch ( _error ) {
+			// there are no 3rd party cookies nor auth data from the parent
+			ReactDom.render(
+				<div className="happy-chat-error-screen">
+					<Icon icon={ warning } />
+					<p>
+						This app isn't meant to run independently when 3rd party cookies are blocked. Please
+						either allow third party cookies, or open this app from the help center.
+					</p>
+				</div>,
+				document.getElementById( 'wpcom' )
+			);
+			return;
+		}
+	}
+
+	initializeAnalytics( user || undefined, getSuperProps( store ) );
 	if ( user ) {
 		store.dispatch( setCurrentUser( user ) );
+		store.dispatch( openChat() );
 	}
-	initializeAnalytics( user || undefined, getSuperProps( store ) );
-
-	store.dispatch( requestHappychatEligibility() );
-	store.dispatch( openChat() );
 
 	ReactDom.render(
 		<Provider store={ store }>
-			<Happychat />
+			<Happychat auth={ auth } />
 		</Provider>,
 		document.getElementById( 'wpcom' )
 	);

--- a/apps/happychat/src/happychat.jsx
+++ b/apps/happychat/src/happychat.jsx
@@ -153,7 +153,6 @@ function ParentConnection( { chatStatus, timeline, connectionStatus } ) {
 		);
 	}, [ blurredAt, timeline ] );
 
-	/*
 	useEffect( () => {
 		// blurredAt is 0 when the user is looking
 		if ( blurredAt ) {
@@ -162,7 +161,7 @@ function ParentConnection( { chatStatus, timeline, connectionStatus } ) {
 			dispatch( sendEvent( `Started looking at Happychat` ) );
 		}
 	}, [ blurredAt, dispatch ] );
-	*/
+
 	return null;
 }
 

--- a/apps/happychat/src/happychat.scss
+++ b/apps/happychat/src/happychat.scss
@@ -4,3 +4,29 @@
 	flex-direction: column;
 	overflow: hidden;
 }
+.happychat__loading-screen {
+	display: flex;
+	height: 100%;
+	width: 100%;
+	align-items: center;
+	justify-content: center;
+}
+.happy-chat-error-screen {
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 10px;
+	flex-direction: column;
+	box-sizing: border-box;
+
+	svg {
+		width: 100px;
+		height: 100px;
+	}
+}
+
+.container {
+	height: 100%;
+}

--- a/apps/happychat/src/index.ejs
+++ b/apps/happychat/src/index.ejs
@@ -1,44 +1,49 @@
 <!DOCTYPE html>
 <html>
+	<head>
+		<meta charset="utf-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=9" />
+		<title>Happychat</title>
+		<meta
+			name="viewport"
+			content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+		/>
+		<meta name="mobile-web-app-capable" content="yes" />
+		<link
+			rel="stylesheet"
+			href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap"
+		/>
+		<% htmlWebpackPlugin.files.css.forEach( ( style ) => { if ( ! style.includes( '.rtl.css' ) ) {
+		%>
+		<link rel="stylesheet" href="<%= style %>" />
+		<% } } ) %>
+	</head>
 
-<head>
-	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=9">
-	<title>Happychat</title>
-	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-	<meta name="mobile-web-app-capable" content="yes">
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap">
-  <% htmlWebpackPlugin.files.css.forEach( ( style ) => {
-    if ( ! style.includes( '.rtl.css' ) ) {
-      %><link rel="stylesheet" href="<%= style %>"><%
-    }
-  } ) %>
-</head>
-
-<body>
-	<div id="wpcom"></div>
-  <script>
-    window.configData = {
-      env_id: 'development',
-      i18n_default_locale_slug: 'en',
-      google_analytics_key: 'UA-10673494-15',
-      client_slug: 'browser',
-      happychat_url: 'https://happychat.io/customer',
-      site_filter: [],
-      sections: {},
-      enable_all_sections: false,
-      livechat_support_locales: [ 'en' ],
-			upwork_support_locales: [ 'de' ],
-      jetpack_support_blog: 'jetpackme.wordpress.com',
-      wpcom_support_blog: 'en.support.wordpress.com',
-			gutenboarding_url: '/new',
-      hostname: 'widgets.wp.com',
-      features: {
-        happychat: true,
-      }
-    };
-  </script>
-	<% htmlWebpackPlugin.files.js.forEach( function( script ) { %><script charset="UTF-8" src="<%= script %>"></script><% } ) %>
-</body>
-
+	<body>
+		<div id="wpcom" class="container"></div>
+		<script>
+			window.configData = {
+				env_id: 'development',
+				i18n_default_locale_slug: 'en',
+				google_analytics_key: 'UA-10673494-15',
+				client_slug: 'browser',
+				happychat_url: 'https://happychat-io-staging.go-vip.co/customer',
+				site_filter: [],
+				sections: {},
+				enable_all_sections: false,
+				livechat_support_locales: [ 'en' ],
+				upwork_support_locales: [ 'de' ],
+				jetpack_support_blog: 'jetpackme.wordpress.com',
+				wpcom_support_blog: 'en.support.wordpress.com',
+				gutenboarding_url: '/new',
+				hostname: 'widgets.wp.com',
+				features: {
+					happychat: true,
+				},
+			};
+		</script>
+		<% htmlWebpackPlugin.files.js.forEach( function( script ) { %>
+		<script charset="UTF-8" src="<%= script %>"></script>
+		<% } ) %>
+	</body>
 </html>

--- a/apps/happychat/src/request-auth-data-from-parent.ts
+++ b/apps/happychat/src/request-auth-data-from-parent.ts
@@ -1,0 +1,36 @@
+import { reject } from 'lodash';
+
+type User = {
+	ID: number;
+	display_name: string;
+	username: string;
+	avatar_URL: string;
+	email: string;
+};
+
+type HappyChatAuthData = {
+	jwt: string;
+	user: User;
+};
+
+export function requestDataFromParent(): Promise< HappyChatAuthData > {
+	return new Promise( function ( resolve ) {
+		function handler( event: MessageEvent ) {
+			if ( event.data?.type === 'happy-chat-authentication-data' ) {
+				resolve( event.data.authData );
+				window.removeEventListener( 'message', handler );
+			}
+		}
+		const parent = window.opener || window.parent;
+		if ( ! parent ) {
+			return reject( new Error( 'This is not running neither inside an iframe or a popup.' ) );
+		}
+		parent.postMessage(
+			{
+				type: 'happy-chat-authentication-data',
+			},
+			'*'
+		);
+		window.addEventListener( 'message', handler );
+	} );
+}

--- a/client/components/happychat/connection-connected.jsx
+++ b/client/components/happychat/connection-connected.jsx
@@ -6,8 +6,8 @@ import isHappychatConnectionUninitialized from 'calypso/state/happychat/selector
 import { getHappychatAuth } from 'calypso/state/happychat/utils';
 
 export default connect(
-	( state ) => ( {
-		getAuth: getHappychatAuth( state ),
+	( state, ownProps ) => ( {
+		getAuth: ownProps.getAuth || getHappychatAuth( state ),
 		isConnectionUninitialized: isHappychatConnectionUninitialized( state ),
 		isHappychatEnabled: config.isEnabled( 'happychat' ),
 	} ),

--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -179,17 +179,18 @@ const groupMessages = ( messages ) => {
 	let user_id;
 	let type;
 	let source;
-
-	messages.forEach( ( message ) => {
-		if ( user_id !== message.user_id || type !== message.type || source !== message.source ) {
-			// This message is not like the others in this group, start a new group...
-			groups.push( [] );
-			// ... and update the comparison variables to what we expect to find in this new group.
-			( { user_id, type, source } = message );
-		}
-		// Add this message to the last group.
-		groups[ groups.length - 1 ].push( message );
-	} );
+	messages
+		.filter( ( message ) => !! message.message )
+		.forEach( ( message ) => {
+			if ( user_id !== message.user_id || type !== message.type || source !== message.source ) {
+				// This message is not like the others in this group, start a new group...
+				groups.push( [] );
+				// ... and update the comparison variables to what we expect to find in this new group.
+				( { user_id, type, source } = message );
+			}
+			// Add this message to the last group.
+			groups[ groups.length - 1 ].push( message );
+		} );
 
 	return groups;
 };

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -70,9 +70,10 @@ export const socketMiddleware = ( connection = null ) => {
 				connection.init( store.dispatch, action.auth );
 				break;
 
-			case HAPPYCHAT_IO_REQUEST_TRANSCRIPT:
+			case HAPPYCHAT_IO_REQUEST_TRANSCRIPT: {
 				connection.request( action, action.timeout );
 				break;
+			}
 
 			case HAPPYCHAT_IO_SEND_MESSAGE_USERINFO:
 				// When user info is sent, pass it through in a message...

--- a/packages/happychat-connection/src/index.ts
+++ b/packages/happychat-connection/src/index.ts
@@ -1,4 +1,4 @@
 export { default } from './connection-async';
 export { default as buildConnection } from './connection';
 export { default as useHappychatAvailable } from './use-happychat-available';
-export { default as useHappychatAuth } from './use-happychat-auth';
+export { default as useHappychatAuth, requestHappyChatAuth } from './use-happychat-auth';

--- a/packages/happychat-connection/src/use-happychat-auth.ts
+++ b/packages/happychat-connection/src/use-happychat-auth.ts
@@ -4,49 +4,47 @@ import { useQuery } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { HappychatSession, HappychatUser, User, HappychatAuth } from './types';
 
-export default function useHappychatAuth( enabled = true ) {
-	return useQuery< HappychatAuth, typeof Error >(
-		'getHappychatAuth',
-		async () => {
-			const user: User = await wpcomRequest( {
-				path: '/me',
-				apiVersion: '1.1',
-			} );
+export async function requestHappyChatAuth() {
+	const user: User = await wpcomRequest( {
+		path: '/me',
+		apiVersion: '1.1',
+	} );
 
-			const url: string = config( 'happychat_url' );
-			const locale = getLocaleSlug();
+	const url: string = config( 'happychat_url' );
+	const locale = getLocaleSlug();
 
-			const happychatUser: HappychatUser = {
-				signer_user_id: user.ID,
-				locale,
-				groups: [ 'WP.com' ],
-				skills: {
-					product: [ 'WP.com' ],
-				},
-			};
-			const session: HappychatSession = await wpcomRequest( {
-				path: '/happychat/session',
-				apiVersion: '1.1',
-				method: 'POST',
-			} );
-			const { session_id, geo_location } = session;
-			happychatUser.geoLocation = geo_location;
-
-			const sign: { jwt: string } = await wpcomRequest( {
-				path: '/jwt/sign',
-				apiVersion: '1.1',
-				method: 'POST',
-				body: { payload: JSON.stringify( { user, session_id } ) },
-			} );
-
-			const { jwt } = sign;
-
-			return { url, user: { jwt, ...happychatUser } };
+	const happychatUser: HappychatUser = {
+		signer_user_id: user.ID,
+		locale,
+		groups: [ 'WP.com' ],
+		skills: {
+			product: [ 'WP.com' ],
 		},
-		{
-			refetchOnWindowFocus: false,
-			keepPreviousData: true,
-			enabled,
-		}
-	);
+	};
+	const session: HappychatSession = await wpcomRequest( {
+		path: '/happychat/session',
+		apiVersion: '1.1',
+		method: 'POST',
+	} );
+	const { session_id, geo_location } = session;
+	happychatUser.geoLocation = geo_location;
+
+	const sign: { jwt: string } = await wpcomRequest( {
+		path: '/jwt/sign',
+		apiVersion: '1.1',
+		method: 'POST',
+		body: { payload: JSON.stringify( { user, session_id } ) },
+	} );
+
+	const { jwt } = sign;
+
+	return { url, user: { jwt, ...happychatUser }, fullUser: user };
+}
+
+export default function useHappychatAuth( enabled = true ) {
+	return useQuery< HappychatAuth, typeof Error >( 'getHappychatAuth', requestHappyChatAuth, {
+		refetchOnWindowFocus: false,
+		keepPreviousData: true,
+		enabled,
+	} );
 }

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -112,31 +112,8 @@ const titles: {
 };
 
 type Mode = 'CHAT' | 'EMAIL' | 'DIRECTLY' | 'FORUM';
-const POPUP_TOP_BAR_HEIGHT = 60;
 
-function openPopup( event: React.MouseEvent< HTMLButtonElement > ): Window {
-	const helpCenterContainer = event.currentTarget.closest(
-		'.help-center__container'
-	) as HTMLDivElement;
-
-	const HCRect = helpCenterContainer.getBoundingClientRect();
-	const windowTop = event.screenY - event.clientY;
-
-	const popupTop = windowTop + HCRect.top - POPUP_TOP_BAR_HEIGHT;
-	const popupLeft = window.screenLeft + HCRect.left;
-	const popupWidth = HCRect.width;
-	const popupHeight = HCRect.height - POPUP_TOP_BAR_HEIGHT;
-
-	const popup = window.open(
-		'https://widgets.wp.com/calypso-happychat/',
-		'happy-chat-window',
-		`toolbar=no,scrollbars=yes,location=no,addressbar=no,width=${ popupWidth },height=${ popupHeight },left=${ popupLeft },top=${ popupTop }`
-	) as Window;
-
-	return popup;
-}
-
-export const HelpCenterContactForm: React.FC = () => {
+export const HelpCenterContactForm = () => {
 	const { search } = useLocation();
 	const params = new URLSearchParams( search );
 	const mode = params.get( 'mode' ) as Mode;
@@ -170,7 +147,6 @@ export const HelpCenterContactForm: React.FC = () => {
 		setUserDeclaredSite,
 		setSubject,
 		setMessage,
-		setPopup,
 	} = useDispatch( STORE_KEY );
 
 	const {
@@ -193,7 +169,7 @@ export const HelpCenterContactForm: React.FC = () => {
 		}
 	}, [ directlyData, setShowHelpCenter ] );
 
-	const { hasCookies, isLoading: loadingCookies } = useHas3PC();
+	const { isLoading: loadingCookies } = useHas3PC();
 
 	const isSubmitting = submittingTicket || submittingTopic;
 	const isLoading = loadingCookies || isSubmitting;
@@ -213,19 +189,12 @@ export const HelpCenterContactForm: React.FC = () => {
 		supportSite = selectedSite || currentSite;
 	}
 
-	function handleCTA( event: React.MouseEvent< HTMLButtonElement > ) {
+	function handleCTA() {
 		switch ( mode ) {
 			case 'CHAT': {
 				if ( supportSite ) {
-					if ( hasCookies ) {
-						history.push( '/inline-chat' );
-						break;
-					} else {
-						const popup = openPopup( event );
-						setPopup( popup );
-						// go home once popup is open
-						history.push( '/' );
-					}
+					history.push( '/inline-chat' );
+					break;
 				}
 				break;
 			}
@@ -398,7 +367,7 @@ export const HelpCenterContactForm: React.FC = () => {
 					id="help-center-contact-form__message"
 					rows={ 10 }
 					value={ message ?? '' }
-					onChange={ ( event ) => setMessage( event.target.value ) }
+					onInput={ ( event ) => setMessage( event.currentTarget.value ) }
 					className="help-center-contact-form__message"
 				/>
 			</section>

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -3,7 +3,6 @@
  */
 import { Button, FormInputValidation, Popover } from '@automattic/components';
 import {
-	useHas3PC,
 	useSubmitTicketMutation,
 	useSubmitForumsMutation,
 	useSiteAnalysis,
@@ -169,10 +168,7 @@ export const HelpCenterContactForm = () => {
 		}
 	}, [ directlyData, setShowHelpCenter ] );
 
-	const { isLoading: loadingCookies } = useHas3PC();
-
 	const isSubmitting = submittingTicket || submittingTopic;
-	const isLoading = loadingCookies || isSubmitting;
 
 	const formTitles = titles[ mode ];
 
@@ -281,7 +277,7 @@ export const HelpCenterContactForm = () => {
 	};
 
 	const isCTADisabled = () => {
-		if ( isLoading || ! message ) {
+		if ( isSubmitting || ! message ) {
 			return true;
 		}
 

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -3,7 +3,7 @@ import { useSelect } from '@wordpress/data';
 import { closeSmall, chevronUp, lineSolid, commentContent, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { ReactElement, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Route, Switch, useLocation } from 'react-router-dom';
 import { useHCWindowCommunicator } from '../happychat-window-communicator';
 import { STORE_KEY } from '../store';

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -8,6 +8,7 @@ import { Route, Switch, useLocation } from 'react-router-dom';
 import { useHCWindowCommunicator } from '../happychat-window-communicator';
 import { STORE_KEY } from '../store';
 import type { Header, WindowState } from '../types';
+import type { ReactElement } from 'react';
 
 export function ArticleTitle() {
 	const { search } = useLocation();

--- a/packages/help-center/src/components/help-center-sibyl-articles.tsx
+++ b/packages/help-center/src/components/help-center-sibyl-articles.tsx
@@ -72,9 +72,9 @@ export function SibylArticles( { message = '', supportSite }: Props ) {
 				className="help-center-sibyl-articles__list"
 				aria-labelledby="help-center--contextual_help"
 			>
-				{ articles.map( ( article: Article ) => (
+				{ articles.map( ( article ) => (
 					<li>
-						<Link to={ getPostUrl( article, message ) }>
+						<Link to={ getPostUrl( article as Article, message ) }>
 							<Icon icon={ page } />
 							{ article.title }
 						</Link>

--- a/packages/help-center/src/components/help-center-sibyl-articles.tsx
+++ b/packages/help-center/src/components/help-center-sibyl-articles.tsx
@@ -34,6 +34,7 @@ function getPostUrl( article: Article, query: string ) {
 		}
 
 		const search = params.toString();
+
 		return {
 			pathname: '/post',
 			search,
@@ -71,9 +72,9 @@ export function SibylArticles( { message = '', supportSite }: Props ) {
 				className="help-center-sibyl-articles__list"
 				aria-labelledby="help-center--contextual_help"
 			>
-				{ articles.map( ( article ) => (
+				{ articles.map( ( article: Article ) => (
 					<li>
-						<Link to={ getPostUrl( article as Article, message ) }>
+						<Link to={ getPostUrl( article, message ) }>
 							<Icon icon={ page } />
 							{ article.title }
 						</Link>

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -27,8 +27,8 @@ const HelpCenter: React.FC< Container > = ( { handleClose } ) => {
 	const { isLoading: isLoadingChat } = useSupportAvailability( 'CHAT' );
 	const { isLoading: isLoadingChatAvailable } = useHappychatAvailable();
 	const { data: supportData, isLoading: isSupportDataLoading } = useSupportAvailability( 'OTHER' );
-
 	useStillNeedHelpURL();
+
 	useEffect( () => {
 		if ( supportData?.is_user_eligible_for_directly ) {
 			execute( [

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,8 +614,12 @@ __metadata:
     "@automattic/calypso-babel-config": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-polyfills": "workspace:^"
+    "@automattic/components": "workspace:^"
+    "@automattic/happychat-connection": "workspace:^"
     "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"
     "@automattic/webpack-inline-constant-exports-plugin": "workspace:^"
+    "@wordpress/data": ^6.7.0
+    "@wordpress/icons": ^8.3.0
     autoprefixer: ^10.2.5
     calypso: "workspace:^"
     enzyme: ^3.11.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR changes the https://widgets.wp.com/calypso-happychat/ app to support two modes of authentication. 
   - Normal request to public API when 3rd party cookies are available.
   - Asking the parent window to forward the user's auth info using `postMessage` when not.
   - This is required to get a working chat in the help center that lives in wp-admin (under non wpcom domains).
* It also changes the help-center to respond to auth-data requests if they come from trusted widgets.wp.com.
* This PR is needed because we were mistaken to think that https://widgets.wp.com/calypso-happychat/ will work in a popup when 3PCs are blocked. In retrospect, it obviously won't. So, this removes the popup chat variation and only keeps the iframe.

#### Testing instructions

1. Checkout this branch.
2. Run `yarn dev --sync` in `apps/editing-toolkit`.
2. Run `yarn dev --sync` in `apps/happychat`.
3. Go to the editor and open the help-center/
4. Block 3rd party cookies and refresh the page.
5. Login to https://hud-staging.happychat.io/ to respond to your own chat.
6. Start a chat.
7. All should work.
