### PR TITLE
Goals Capture: Forward referral param from signup flow to onboarding flow.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -59,7 +59,7 @@ function getRedirectDestination( dependencies ) {
 	return '/';
 }
 
-function getSignupDestination( { domainItem, siteId, siteSlug }, localeSlug ) {
+function getSignupDestination( { domainItem, siteId, siteSlug, refParameter }, localeSlug ) {
 	if ( 'no-site' === siteSlug ) {
 		return '/home';
 	}
@@ -71,6 +71,11 @@ function getSignupDestination( { domainItem, siteId, siteSlug }, localeSlug ) {
 		// case we use the ID because we know it won't change depending on whether the user
 		// successfully completes the checkout process or not.
 		queryParam = { siteId };
+	}
+
+	// Add referral param to query args
+	if ( refParameter ) {
+		queryParam.ref = refParameter;
 	}
 
 	if ( isEnabled( 'signup/stepper-flow' ) ) {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -278,6 +278,12 @@ export default {
 			context.store.dispatch( setSelectedSiteId( null ) );
 		}
 
+		// Set referral parameter in signup dependency store so we can retrieve it in getSignupDestination().
+		const refParameter = query && query.ref;
+		if ( refParameter ) {
+			context.store.dispatch( updateDependencies( { refParameter } ) );
+		}
+
 		context.primary = createElement( SignupComponent, {
 			store: context.store,
 			path: context.path,
@@ -285,7 +291,7 @@ export default {
 			locale: context.params.lang,
 			flowName,
 			queryObject: query,
-			refParameter: query && query.ref,
+			refParameter,
 			stepName,
 			stepSectionName,
 			stepComponent,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This brings the referral param `ref=create-blog-lp` from marketing landing pages, e.g. wordpress.com/create-blog, from signup flow to onboarding flow.
* This is to enable Goals Capture to pre-select goals based on which landing page the user arrives from.

#### Testing instructions

1. Go to `calypso.localhost:3000/start/?ref=create-blog-lp`.
2. Create a free site.
3. When you land in the onboarding flow, you should see `ref=create-blog-lp` in the url, e.g. `calypso.localhost:3000/setup/intent?siteSlug=yoursitehere.wordpress.com&ref=create-blog-lp`.

