### PR TITLE
Set vertical title as site title when submitted

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -37,7 +37,10 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 			const { value = '', label = '' } = vertical || {};
 
 			setIsBusy( true );
-			await saveSiteSettings( site.ID, { site_vertical_id: value } );
+			await saveSiteSettings( site.ID, {
+				site_vertical_id: value,
+				blogname: label,
+			} );
 			recordTracksEvent( 'calypso_signup_site_vertical_submit', {
 				user_input: userInput,
 				vertical_id: value,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Set the `blogname` site options as the selected vertical title when the step is submitted, so that the title is set when the design is finally selected and Headstart is run.


#### Testing instructions

1. Apply this PR.
1. Open `http://calypso.localhost:3000/setup/vertical?siteSlug=<your-site-slug>`.
1. Select Build.
1. Select a vertical.
1. Choose a design. Click Continue.
1. Wait until you land to the site editor.
1. Verify that the site title is equal to the title of the vertical you selected.


<img width="1039" alt="image" src="https://user-images.githubusercontent.com/1525580/170980501-ea0ec019-c5bd-46d2-b77f-35f51a401889.png">


Related to:
- 42-gh-Automattic/ganon-issues