### PR TITLE
ThemesList: refactor tests to `@testing-library/react`

### DIFF
--- a/client/components/themes-list/test/__snapshots__/index.jsx.snap
+++ b/client/components/themes-list/test/__snapshots__/index.jsx.snap
@@ -1,89 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ThemesList should render a div with a className of "themes-list" 1`] = `
-<div
-  className="themes-list"
->
-  <Connect(Localized(Theme))
-    actionLabel=""
-    active={false}
-    bookmarkRef={null}
-    index={0}
-    installing={false}
-    key="theme-1"
-    onScreenshotClick={[Function]}
-    price=""
-    theme={
-      Object {
-        "id": "1",
-        "name": "kubrick",
-        "screenshot": "/theme/kubrick/screenshot.png",
-      }
-    }
-  />
-  <Connect(Localized(Theme))
-    actionLabel=""
-    active={false}
-    bookmarkRef={null}
-    index={1}
-    installing={false}
-    key="theme-2"
-    onScreenshotClick={[Function]}
-    price=""
-    theme={
-      Object {
-        "id": "2",
-        "name": "picard",
-        "screenshot": "/theme/picard/screenshot.png",
-      }
-    }
-  />
+<div>
   <div
-    className="themes-list__spacer"
-    key="themes-list__spacer-0"
-  />
-  <div
-    className="themes-list__spacer"
-    key="themes-list__spacer-1"
-  />
-  <div
-    className="themes-list__spacer"
-    key="themes-list__spacer-2"
-  />
-  <div
-    className="themes-list__spacer"
-    key="themes-list__spacer-3"
-  />
-  <div
-    className="themes-list__spacer"
-    key="themes-list__spacer-4"
-  />
-  <div
-    className="themes-list__spacer"
-    key="themes-list__spacer-5"
-  />
-  <div
-    className="themes-list__spacer"
-    key="themes-list__spacer-6"
-  />
-  <div
-    className="themes-list__spacer"
-    key="themes-list__spacer-7"
-  />
-  <div
-    className="themes-list__spacer"
-    key="themes-list__spacer-8"
-  />
-  <div
-    className="themes-list__spacer"
-    key="themes-list__spacer-9"
-  />
-  <div
-    className="themes-list__spacer"
-    key="themes-list__spacer-10"
-  />
-  <InfiniteScroll
-    nextPageMethod={[Function]}
-  />
+    class="themes-list"
+  >
+    <div
+      data-testid="theme-1"
+    />
+    <div
+      data-testid="theme-2"
+    />
+    <div
+      class="themes-list__spacer"
+    />
+    <div
+      class="themes-list__spacer"
+    />
+    <div
+      class="themes-list__spacer"
+    />
+    <div
+      class="themes-list__spacer"
+    />
+    <div
+      class="themes-list__spacer"
+    />
+    <div
+      class="themes-list__spacer"
+    />
+    <div
+      class="themes-list__spacer"
+    />
+    <div
+      class="themes-list__spacer"
+    />
+    <div
+      class="themes-list__spacer"
+    />
+    <div
+      class="themes-list__spacer"
+    />
+    <div
+      class="themes-list__spacer"
+    />
+    <div />
+  </div>
 </div>
 `;

--- a/client/components/themes-list/test/index.jsx
+++ b/client/components/themes-list/test/index.jsx
@@ -2,13 +2,17 @@
  * @jest-environment jsdom
  */
 
+import { screen } from '@testing-library/react';
 import deepFreeze from 'deep-freeze';
-import { shallow } from 'enzyme';
-import EmptyContent from 'calypso/components/empty-content';
-import Theme from 'calypso/components/theme';
+import themes from 'calypso/state/themes/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ThemesList } from '../';
 
 const noop = () => {};
+
+jest.mock( 'calypso/components/theme', () => ( { theme } ) => (
+	<div data-testid={ `theme-${ theme.id }` } />
+) );
 
 const defaultProps = deepFreeze( {
 	themes: [
@@ -31,25 +35,22 @@ const defaultProps = deepFreeze( {
 	translate: ( string ) => string,
 } );
 
-describe( 'ThemesList', () => {
-	test( 'should declare propTypes', () => {
-		expect( ThemesList ).toHaveProperty( 'propTypes' );
-	} );
+const render = ( el, options ) => renderWithProvider( el, { ...options, reducers: { themes } } );
 
+describe( 'ThemesList', () => {
 	test( 'should render a div with a className of "themes-list"', () => {
-		const wrapper = shallow( <ThemesList { ...defaultProps } /> );
-		expect( wrapper ).toMatchSnapshot();
-		expect( wrapper.hasClass( 'themes-list' ) ).toBe( true );
-		expect( wrapper.find( Theme ) ).toHaveLength( defaultProps.themes.length );
+		const { container } = render( <ThemesList { ...defaultProps } /> );
+		expect( container ).toMatchSnapshot();
+		expect( container.firstChild ).toHaveClass( 'themes-list' );
 	} );
 
 	test( 'should render a <Theme /> child for each provided theme', () => {
-		const wrapper = shallow( <ThemesList { ...defaultProps } /> );
-		expect( wrapper.find( Theme ) ).toHaveLength( defaultProps.themes.length );
+		render( <ThemesList { ...defaultProps } /> );
+		expect( screen.getAllByTestId( /theme-/ ) ).toHaveLength( defaultProps.themes.length );
 	} );
 
 	test( 'should display the EmptyContent component when no themes are found', () => {
-		const wrapper = shallow( <ThemesList { ...defaultProps } themes={ [] } /> );
-		expect( wrapper.type() ).toBe( EmptyContent );
+		render( <ThemesList { ...defaultProps } themes={ [] } /> );
+		expect( screen.getByText( /no themes found/i ) ).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* ThemesList: refactor tests to `@testing-library/react`

#### Testing instructions

* Verify unit tests still pass

Related to #63409 
