### PR TITLE
Anchor: Add exception for Anchor to generated designs logic

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -386,7 +386,11 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	// When the intent is build, we can potentially show the generated design picker.
 	// Don't render until we've fetched the generated designs from the backend.
-	if ( enabledGeneratedDesigns && ( isLoadingGeneratedDesigns || ! siteVerticalId ) ) {
+	if (
+		enabledGeneratedDesigns &&
+		( isLoadingGeneratedDesigns || ! siteVerticalId ) &&
+		! isAnchorSite
+	) {
 		return null;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Recent change in #64140 broke design selection for the Anchor flow; this adds an exception for Anchor so the design setup step does not return `null` in that case.
* Anchor should probably have its own design selection step to avoid issues like this, but we're too close to launch to rework it, and we've already spent too much time on this maintenance. 🙃 

**Before**

<img width="1345" alt="Screen Shot 2022-05-30 at 10 53 14 AM" src="https://user-images.githubusercontent.com/2124984/171017510-af9c44a4-3d62-48d0-9a7b-1f8f24080fed.png">

**After**

<img width="1343" alt="Screen Shot 2022-05-30 at 10 49 32 AM" src="https://user-images.githubusercontent.com/2124984/171016834-4e3bb322-c6e1-4cf2-b2aa-eb49f98f68b5.png">


#### Testing instructions

* Switch to this PR, navigate to `/setup/?anchor_podcast=[your podcast ID]`
* Fill in your podcast title, click Continue
* Make sure the design selection step loads with the three Anchor themes, and that you can successfully choose a theme
* Make sure design selection still works for the regular Build flow at `/setup`
