### PR TITLE
Jetpack Pricing page: Put 4 column grid behind config feature-flag.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-grid/index.tsx
@@ -216,7 +216,9 @@ const ProductGrid: React.FC< ProductsGridProps > = ( {
 		</li>
 	);
 
-	const showFourColumnGrid = isJetpackCloud() || isStoreLanding;
+	const showFourColumnGrid =
+		config.isEnabled( 'jetpack/pricing-add-boost-social' ) &&
+		( isJetpackCloud() || isStoreLanding );
 
 	return (
 		<>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

PR #64089 makes the 'More Products' section of the pricing page into 4 columns, instead of 3.  However the 4 column feature **should actually only be active when the feature flag is enabled**.

This PR fixes it so that the 4 column pricing cards are only displayed when the `jetpack/pricing-add-boost-social` feature-flag is enabled.

#### Testing instructions

1. Checkout this PR and spin up Calypso green (`yarn start-jetpack-cloud`).
Go to http://jetpack.cloud.localhost:3000/pricing (in desktop view) and verify that the "More Products" section has 4 product cards per row. 
2. Now manually turn off the feature-flag using the `flags` query arg. To do that, add `?flags=-jetpack/pricing-add-boost-social` to the url and reload the  page.  Full url is: :http://jetpack.cloud.localhost:3000/pricing?flags=-jetpack/pricing-add-boost-social
3. Verify the the "More Products" section is back to displaying 3 product cards per row.

