### PR TITLE
Invalidate relevant queries when email forwards are removed

### DIFF
--- a/client/data/emails/use-get-email-accounts-query.ts
+++ b/client/data/emails/use-get-email-accounts-query.ts
@@ -1,7 +1,13 @@
 import { useQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 
-export const getCacheKey = ( siteId, domain ) => [ 'emailAccounts', siteId, domain ];
+type UseQueryParams = Parameters< typeof useQuery >;
+
+export const getCacheKey = ( siteId: number | null, domain: string ) => [
+	'emailAccounts',
+	siteId,
+	domain,
+];
 
 /**
  * Get the associated emails given a Site Identificator
@@ -13,7 +19,11 @@ export const getCacheKey = ( siteId, domain ) => [ 'emailAccounts', siteId, doma
  * @returns {data, error, isLoading} Returns and object with the
  * data associated to the SiteId & Domain
  */
-export const useEmailAccountsQuery = ( siteId, domain, queryOptions = {} ) => {
+export const useGetEmailAccountsQuery = (
+	siteId: number,
+	domain: string,
+	queryOptions?: UseQueryParams[ 2 ]
+) => {
 	return useQuery(
 		getCacheKey( siteId, domain ),
 		() =>

--- a/client/data/emails/use-get-email-accounts-query.ts
+++ b/client/data/emails/use-get-email-accounts-query.ts
@@ -24,7 +24,7 @@ export const useGetEmailAccountsQuery = (
 	domain: string,
 	queryOptions?: UseQueryParams[ 2 ]
 ) => {
-	return useQuery(
+	return useQuery< any >(
 		getCacheKey( siteId, domain ),
 		() =>
 			wpcom.req.get( {

--- a/client/data/emails/use-get-email-domains-query.ts
+++ b/client/data/emails/use-get-email-domains-query.ts
@@ -3,10 +3,7 @@ import wpcom from 'calypso/lib/wp';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { QueryOptions, UseQueryResult } from 'react-query';
 
-export const useGetEmailDomainsQueryCacheKey = ( siteId: number | null ) => [
-	'emails-management/domains',
-	siteId,
-];
+export const getCacheKey = ( siteId: number | null ) => [ 'emails-management/domains', siteId ];
 
 interface Options extends QueryOptions {
 	enabled?: boolean;
@@ -17,7 +14,7 @@ export const useGetEmailDomainsQuery = (
 	queryOptions: Options
 ): UseQueryResult< { domains: ResponseDomain[] } > => {
 	const { enabled = true } = queryOptions;
-	return useQuery( useGetEmailDomainsQueryCacheKey( siteId ), () => fetchEmailDomains( siteId ), {
+	return useQuery( getCacheKey( siteId ), () => fetchEmailDomains( siteId ), {
 		...queryOptions,
 		enabled: !! siteId && enabled,
 	} );

--- a/client/data/emails/use-remove-email-forward-mutation.ts
+++ b/client/data/emails/use-remove-email-forward-mutation.ts
@@ -2,8 +2,8 @@ import { useMutation, useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
 import wp from 'calypso/lib/wp';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getCacheKey as getuseGetEmailAccountsQueryKey } from './use-get-email-accounts-query';
-import { getCacheKey as getuseGetEmailDomainsQueryKey } from './use-get-email-domains-query';
+import { getCacheKey as getEmailAccountsQueryKey } from './use-get-email-accounts-query';
+import { getCacheKey as getEmailDomainsQueryKey } from './use-get-email-domains-query';
 import type { UseMutationOptions, UseMutationResult } from 'react-query';
 
 /**
@@ -23,8 +23,8 @@ export function useRemoveEmailForwardMutation(
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
 
-	const useEmailsQueryKey = getuseGetEmailAccountsQueryKey( selectedSiteId, domainName );
-	const useGetEmailDomainsQueryKey = getuseGetEmailDomainsQueryKey( selectedSiteId );
+	const useEmailsQueryKey = getEmailAccountsQueryKey( selectedSiteId, domainName );
+	const useGetEmailDomainsQueryKey = getEmailDomainsQueryKey( selectedSiteId );
 
 	mutationOptions.onSettled = async () => {
 		await Promise.all( [

--- a/client/data/emails/use-remove-email-forward-mutation.ts
+++ b/client/data/emails/use-remove-email-forward-mutation.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQueryClient } from 'react-query';
+import { useSelector } from 'react-redux';
+import wp from 'calypso/lib/wp';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getCacheKey as getuseGetEmailAccountsQueryKey } from './use-get-email-accounts-query';
+import { getCacheKey as getuseGetEmailDomainsQueryKey } from './use-get-email-domains-query';
+import type { UseMutationOptions, UseMutationResult } from 'react-query';
+
+/**
+ * Deletes a mailbox from a Professional Email (Titan) account
+ *
+ * @param domainName The domain name of the mailbox
+ * @param mailboxName The mailbox name
+ * @param mutationOptions Mutation options passed on to `useMutation`
+ * @returns {{ data, error, isLoading: boolean, removeTitanMailbox: Function, ...}} Returns various parameters piped from `useMutation`
+ */
+export function useRemoveEmailForwardMutation(
+	domainName: string,
+	mailboxName: string,
+	mutationOptions: UseMutationOptions = {}
+): UseMutationResult< unknown, unknown, void, unknown > {
+	const queryClient = useQueryClient();
+
+	const selectedSiteId = useSelector( getSelectedSiteId );
+
+	const useEmailsQueryKey = getuseGetEmailAccountsQueryKey( selectedSiteId, domainName );
+	const useGetEmailDomainsQueryKey = getuseGetEmailDomainsQueryKey( selectedSiteId );
+
+	mutationOptions.onSettled = async () => {
+		await Promise.all( [
+			queryClient.invalidateQueries( useEmailsQueryKey ),
+			queryClient.invalidateQueries( useGetEmailDomainsQueryKey ),
+		] );
+	};
+
+	return useMutation(
+		() =>
+			wp.req.get( {
+				path: `/domains/${ encodeURIComponent( domainName ) }/email/${ encodeURIComponent(
+					mailboxName
+				) }/delete`,
+				method: 'POST',
+			} ),
+		mutationOptions
+	);
+}

--- a/client/data/emails/use-remove-email-forward-mutation.ts
+++ b/client/data/emails/use-remove-email-forward-mutation.ts
@@ -26,7 +26,11 @@ export function useRemoveEmailForwardMutation(
 	const useEmailsQueryKey = getEmailAccountsQueryKey( selectedSiteId, domainName );
 	const useGetEmailDomainsQueryKey = getEmailDomainsQueryKey( selectedSiteId );
 
-	mutationOptions.onSettled = async () => {
+	const suppliedOnSettled = mutationOptions.onSettled;
+
+	mutationOptions.onSettled = async ( data, error, variables, context ) => {
+		suppliedOnSettled?.( data, error, variables, context );
+
 		await Promise.all( [
 			queryClient.invalidateQueries( useEmailsQueryKey ),
 			queryClient.invalidateQueries( useGetEmailDomainsQueryKey ),

--- a/client/data/emails/use-remove-email-forward-mutation.ts
+++ b/client/data/emails/use-remove-email-forward-mutation.ts
@@ -7,12 +7,12 @@ import { getCacheKey as getEmailDomainsQueryKey } from './use-get-email-domains-
 import type { UseMutationOptions, UseMutationResult } from 'react-query';
 
 /**
- * Deletes a mailbox from a Professional Email (Titan) account
+ * Deletes an email forward
  *
  * @param domainName The domain name of the mailbox
  * @param mailboxName The mailbox name
  * @param mutationOptions Mutation options passed on to `useMutation`
- * @returns {{ data, error, isLoading: boolean, removeTitanMailbox: Function, ...}} Returns various parameters piped from `useMutation`
+ * @returns Returns the result of the `useMutation` call
  */
 export function useRemoveEmailForwardMutation(
 	domainName: string,
@@ -23,7 +23,7 @@ export function useRemoveEmailForwardMutation(
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
 
-	const useEmailsQueryKey = getEmailAccountsQueryKey( selectedSiteId, domainName );
+	const useGetEmailAccountsQueryKey = getEmailAccountsQueryKey( selectedSiteId, domainName );
 	const useGetEmailDomainsQueryKey = getEmailDomainsQueryKey( selectedSiteId );
 
 	const suppliedOnSettled = mutationOptions.onSettled;
@@ -32,7 +32,7 @@ export function useRemoveEmailForwardMutation(
 		suppliedOnSettled?.( data, error, variables, context );
 
 		await Promise.all( [
-			queryClient.invalidateQueries( useEmailsQueryKey ),
+			queryClient.invalidateQueries( useGetEmailAccountsQueryKey ),
 			queryClient.invalidateQueries( useGetEmailDomainsQueryKey ),
 		] );
 	};

--- a/client/data/emails/use-remove-titan-mailbox-mutation.ts
+++ b/client/data/emails/use-remove-titan-mailbox-mutation.ts
@@ -1,16 +1,19 @@
-import { useCallback } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
 import wp from 'calypso/lib/wp';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getCacheKey } from './use-emails-query';
+import { getCacheKey } from './use-get-email-accounts-query';
+import type { QueryClient, QueryKey, UseMutationOptions, UseMutationResult } from 'react-query';
 
 const invalidationDelayTimeout = 5000;
-const noop = () => {};
 
-const getNumberOfMailboxes = ( queryClient, queryKey ) => {
-	const data = queryClient.getQueryData( queryKey );
+const getNumberOfMailboxes = ( queryClient: QueryClient, queryKey: QueryKey ) => {
+	const data = queryClient.getQueryData< any >( queryKey );
 	return data?.accounts?.[ 0 ].emails?.length || 0;
+};
+
+type MutationContext = {
+	previousNumberOfMailboxes: number;
 };
 
 /**
@@ -21,17 +24,19 @@ const getNumberOfMailboxes = ( queryClient, queryKey ) => {
  * @param {object} mutationOptions Mutation options passed on to `useMutation`
  * @returns {{ data, error, isLoading: boolean, removeTitanMailbox: Function, ...}} Returns various parameters piped from `useMutation`
  */
-export function useRemoveTitanMailboxMutation( domainName, mailboxName, mutationOptions = null ) {
+export function useRemoveTitanMailboxMutation(
+	domainName: string,
+	mailboxName: string,
+	mutationOptions: UseMutationOptions< unknown, unknown, void, MutationContext > = {}
+): UseMutationResult< unknown, unknown, void, unknown > {
 	const queryClient = useQueryClient();
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
 
 	const queryKey = getCacheKey( selectedSiteId, domainName );
 
-	mutationOptions = mutationOptions ?? {};
-
 	// Collect the supplied callback
-	const suppliedOnSettled = mutationOptions.onSettled ?? noop;
+	const suppliedOnSettled = mutationOptions.onSettled;
 
 	// Setup actions to happen before the mutation
 	mutationOptions.onMutate = async () => {
@@ -53,7 +58,7 @@ export function useRemoveTitanMailboxMutation( domainName, mailboxName, mutation
 			const numberOfMailboxes = getNumberOfMailboxes( queryClient, queryKey );
 
 			// Determine if we already have updated data, since the removal job is not synchronous
-			if ( numberOfMailboxes < context.previousNumberOfMailboxes ) {
+			if ( context && numberOfMailboxes < context.previousNumberOfMailboxes ) {
 				return;
 			}
 
@@ -63,7 +68,7 @@ export function useRemoveTitanMailboxMutation( domainName, mailboxName, mutation
 		} );
 	};
 
-	const mutation = useMutation(
+	return useMutation(
 		() =>
 			wp.req.get( {
 				path: `/emails/titan/${ encodeURIComponent( domainName ) }/mailbox/${ encodeURIComponent(
@@ -74,14 +79,4 @@ export function useRemoveTitanMailboxMutation( domainName, mailboxName, mutation
 			} ),
 		mutationOptions
 	);
-
-	const { mutate } = mutation;
-
-	// Memoize the `mutate` method into a callback
-	const removeTitanMailbox = useCallback( () => {
-		mutate( {} );
-	}, [ mutate ] );
-
-	// Bundle the callback to make it easy for downstream clients to invoke it
-	return { removeTitanMailbox, ...mutation };
 }

--- a/client/data/emails/use-remove-titan-mailbox-mutation.ts
+++ b/client/data/emails/use-remove-titan-mailbox-mutation.ts
@@ -19,10 +19,10 @@ type MutationContext = {
 /**
  * Deletes a mailbox from a Professional Email (Titan) account
  *
- * @param {string} domainName The domain name of the mailbox
- * @param {string} mailboxName The mailbox name
- * @param {object} mutationOptions Mutation options passed on to `useMutation`
- * @returns {{ data, error, isLoading: boolean, removeTitanMailbox: Function, ...}} Returns various parameters piped from `useMutation`
+ * @param domainName The domain name of the mailbox
+ * @param mailboxName The mailbox name
+ * @param mutationOptions Mutation options passed on to `useMutation`
+ * @returns Returns the result of the `useMutation` call
  */
 export function useRemoveTitanMailboxMutation(
 	domainName: string,

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import Count from 'calypso/components/count';
-import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
+import { useGetEmailAccountsQuery } from 'calypso/data/emails/use-get-email-accounts-query';
 import { canCurrentUserAddEmail } from 'calypso/lib/domains';
 import { type as domainType } from 'calypso/lib/domains/constants';
 import { getEmailAddress } from 'calypso/lib/emails';
@@ -12,7 +12,7 @@ import type { EmailAccount } from './types';
 const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ) => {
 	const translate = useTranslate();
 	const typesUnableToAddEmail = [ domainType.TRANSFER, domainType.SITE_REDIRECT ] as const;
-	const { data, error, isLoading } = useEmailAccountsQuery( selectedSite.ID, domain.name );
+	const { data, error, isLoading } = useGetEmailAccountsQuery( selectedSite.ID, domain.name );
 
 	let emailAddresses: string[] = [];
 

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
+import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
@@ -97,12 +98,21 @@ const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
 	const currentRoute = useSelector( ( state ) => getCurrentRoute( state ) );
 	const hasSitesLoaded = useSelector( ( state ) => hasLoadedSites( state ) );
 
-	const { data, isLoading: isSiteDomainLoading } = useGetEmailDomainsQuery(
-		selectedSite?.ID ?? null,
-		{
-			retry: false,
-		}
-	);
+	const {
+		data,
+		isLoading: isSiteDomainLoading,
+		remove: removeEmailDomainsCache,
+	} = useGetEmailDomainsQuery( selectedSite?.ID ?? null, {
+		retry: false,
+	} );
+
+	// Clear the query data when the component unmounts in order to prevent showing stale data when
+	// users return here after e.g. adding a new email forward.
+	useEffect( () => {
+		return () => {
+			removeEmailDomainsCache();
+		};
+	}, [] );
 
 	const domains = data?.domains?.map( createSiteDomainObject );
 

--- a/client/my-sites/email/email-management/home/email-list-active.jsx
+++ b/client/my-sites/email/email-management/home/email-list-active.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import MaterialIcon from 'calypso/components/material-icon';
 import SectionHeader from 'calypso/components/section-header';
-import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
+import { useGetEmailAccountsQuery } from 'calypso/data/emails/use-get-email-accounts-query';
 import EmailTypeIcon from 'calypso/my-sites/email/email-management/home/email-type-icon';
 import {
 	getNumberOfMailboxesText,
@@ -14,7 +14,7 @@ import {
 import { emailManagement } from 'calypso/my-sites/email/paths';
 
 const EmailListActiveWarning = ( { domain, selectedSiteId } ) => {
-	const { data, error, isLoading } = useEmailAccountsQuery( selectedSiteId, domain.name, {
+	const { data, error, isLoading } = useGetEmailAccountsQuery( selectedSiteId, domain.name, {
 		retry: false,
 	} );
 	let emailAccounts = null;

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -9,7 +9,7 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HeaderCake from 'calypso/components/header-cake';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
-import { useEmailAccountsQuery } from 'calypso/data/emails/use-emails-query';
+import { useGetEmailAccountsQuery } from 'calypso/data/emails/use-get-email-accounts-query';
 import {
 	getGoogleAdminUrl,
 	getGoogleMailServiceFamily,
@@ -271,7 +271,7 @@ function EmailPlan( { domain, selectedSite, source } ) {
 		);
 	}
 
-	const { data, isLoading } = useEmailAccountsQuery( selectedSite.ID, domain.name, {
+	const { data, isLoading } = useGetEmailAccountsQuery( selectedSite.ID, domain.name, {
 		retry: false,
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The email forward management in Calypso currently relies on both Redux and react-query. This causes confusion when email forwards are removed, because the mailbox is removed in Redux, but not in react-query. This results in the email forward not actually disappearing from the user's screen until the react-query queries are refreshed (which can take a very long time and I'm not sure it even happens automatically).

With this change, we add a react-query mutation that runs when an email forward is removed. In that mutation, we invalidate the relevant queries to fetch updated data at the right time.

I also made another change that invalidates the domain data fetched by the `useGetEmailDomainsQuery` hook when the `EmailHome` component unmounts. Why? When adding the first email forward for a domain, the UX gets a bit janky between clicking "Add" and seeing the email management screen for the email forwards. I recorded two screencasts that illustrate the difference. See my comment below.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a domain with one email forward
2. Navigate to the path `/email/{domain}/manage/{site_slug}`
3. Remove the one email forward
4. You should be presented with the following screen within about 2 seconds

![calypso localhost_3000_email_ com](https://user-images.githubusercontent.com/1101677/171145344-527ca6b0-9efc-4429-abdb-ec5b8406a85c.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
