### PR TITLE
Jetpack: Add money back guarantee banner to mobile views

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -1,4 +1,3 @@
-import { useViewportMatch } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -26,7 +25,6 @@ interface Props {
 
 const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId = 'none' } ) => {
 	const translate = useTranslate();
-	const isNotNarrow = useViewportMatch( 'medium', '>=' );
 	const fullJetpackSaleDiscount = useSelector( getFullJetpackSaleCouponDiscountRatio ) * 100;
 	const hasRequestedCoupon = useSelector( getHasRequestedJetpackSaleCoupon );
 	const isRequestingIntroOffers = useSelector( ( state ) =>
@@ -70,42 +68,42 @@ const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId 
 			<div className="intro-pricing-banner__viewport-sentinel" { ...outerDivProps }></div>
 			<div className={ className }>
 				{ ( discountPercentage > 0 || isLoading ) && (
-					<div className="intro-pricing-banner__discount">
-						<img
-							src={ rocket }
-							alt={ translate( 'Rocket representing %(percent)d%% sale', {
-								args: { percent: discountPercentage },
-								textOnly: true,
-							} ) }
-						/>
-						<span>
-							{ preventWidows(
-								translate( 'Get up to %(percent)d%% off your first year.', {
-									args: {
-										percent: discountPercentage,
-									},
-								} )
-							) }
-						</span>
-					</div>
-				) }
-				{ ( isNotNarrow || ( discountPercentage <= 0 && ! isLoading ) ) && (
-					<div className="intro-pricing-banner__guarantee">
-						<img
-							src={ guaranteeBadge }
-							alt={ translate( 'Money Back %(days)d-Day Guarantee Badge', {
-								args: { days: GUARANTEE_DAYS },
-								textOnly: true,
-							} ) }
-						/>
-						<span>
-							{ preventWidows(
-								translate( '%(days)d day money back guarantee.', {
+					<>
+						<div className="intro-pricing-banner__discount">
+							<img
+								src={ rocket }
+								alt={ translate( 'Rocket representing %(percent)d%% sale', {
+									args: { percent: discountPercentage },
+									textOnly: true,
+								} ) }
+							/>
+							<span>
+								{ preventWidows(
+									translate( 'Get up to %(percent)d%% off your first year.', {
+										args: {
+											percent: discountPercentage,
+										},
+									} )
+								) }
+							</span>
+						</div>
+						<div className="intro-pricing-banner__guarantee">
+							<img
+								src={ guaranteeBadge }
+								alt={ translate( 'Money Back %(days)d-Day Guarantee Badge', {
 									args: { days: GUARANTEE_DAYS },
-								} )
-							) }
-						</span>
-					</div>
+									textOnly: true,
+								} ) }
+							/>
+							<span>
+								{ preventWidows(
+									translate( '%(days)d day money back guarantee.', {
+										args: { days: GUARANTEE_DAYS },
+									} )
+								) }
+							</span>
+						</div>
+					</>
 				) }
 			</div>
 		</>

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -2,8 +2,9 @@
 .intro-pricing-banner__sticky,
 .intro-pricing-banner__loading {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 
+	align-items: center;
 	justify-content: center;
 
 	.intro-pricing-banner__discount,
@@ -17,6 +18,10 @@
 
 	> :not( :last-child ) {
 		margin-right: 16px;
+	}
+
+	@include breakpoint-deprecated( '>660px' ) {
+		flex-direction: row;
 	}
 }
 
@@ -45,7 +50,11 @@
 	box-shadow: 0 4px 4px 0 #00000014;
 
 	z-index: 2;
-	height: 54px;
+	height: 74px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		height: 52px;
+	}
 }
 .is-section-jetpack-connect,
 .is-group-jetpack-cloud.is-section-jetpack-cloud-pricing {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds money back guarantee banner to mobile views.

Related to 1199980337313591-as-1202245666732955/f

#### Testing instructions

* Fire up this PR.
* Go to http://jetpack.cloud.localhost:3000/pricing
* Test the page thoroughly:
  * Pay close attention to the loading states.
  * Use a multitude of devices with varying screen sizes.
  * Scroll down and up the page to check the sticky state.
* Ensure the money back guarantee banner is always visible and well formatted.
* Ensure the logic is correct.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/171021090-b10ba77e-96b6-4355-a863-019f2bd98d1e.png) | ![image](https://user-images.githubusercontent.com/390760/171021106-86d63e8a-2590-452c-a8db-ae617550d084.png)
![image](https://user-images.githubusercontent.com/390760/171021125-51e5b352-b8d4-4eff-8d36-3a23f3d8777b.png) | ![image](https://user-images.githubusercontent.com/390760/171021147-f744bff0-5f2e-4793-b07d-eff95745ec26.png)
![image](https://user-images.githubusercontent.com/390760/171021168-b1b68179-603e-4dd7-933c-451b104fdf79.png) | ![image](https://user-images.githubusercontent.com/390760/171021175-036c6bb3-b57d-4523-8384-fcb7c9e4b8bf.png)
