### PR TITLE
Anchor: Enable feature flag on production

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -51,7 +51,7 @@ const FlowWrapper: React.FC< { user: UserStore.CurrentUser | undefined } > = ( {
 	const { anchorFmPodcastId } = useAnchorFmParams();
 	let flow = siteSetupFlow;
 
-	if ( anchorFmPodcastId && config.isEnabled( 'signup/anchor-fm' ) ) {
+	if ( anchorFmPodcastId ) {
 		flow = anchorFmFlow;
 	}
 

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,7 +83,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,
-		"signup/anchor-fm": false,
+		"signup/anchor-fm": true,
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,

--- a/config/production.json
+++ b/config/production.json
@@ -96,7 +96,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/anchor-fm": false,
+		"signup/anchor-fm": true,
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -96,7 +96,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/anchor-fm": false,
+		"signup/anchor-fm": true,
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,

--- a/config/test.json
+++ b/config/test.json
@@ -73,7 +73,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"signup/anchor-fm": false,
+		"signup/anchor-fm": true,
 		"signup/inline-help": false,
 		"signup/social": true,
 		"signup/stepper-flow": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -107,7 +107,7 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/professional-email-step": false,
-		"signup/anchor-fm": false,
+		"signup/anchor-fm": true,
 		"signup/reskin": true,
 		"signup/social": true,
 		"signup/design-picker-categories": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* **Before merging, merge and deploy D81728-code to ensure the back-end is open to all users.**
* Save this for launch day! This PR enables the new Anchor.fm flow front-end on production.


#### Testing instructions

* Switch to this PR
* Apply D81728-code to your sandbox and sandbox `public-api.wordpress.com`
* Make sure you can access `/setup/?anchor_podcast=[your podcast id]` from the Calypso Live link
* Make sure you can complete the signup flow for your Anchor site as expected
* Make sure other flows at `/setup` are working as expected