### PR TITLE
popup-monitor: Declare missing peer dependency on `@babel/runtime`

### DIFF
--- a/packages/popup-monitor/CHANGELOG.md
+++ b/packages/popup-monitor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.2 - unreleased
+
+### Added
+
+- Declare an optional peer dependency on `@babel/runtime`, for CommonJS environments. This dependency already existed previously, it just wasn't declared.
+
 ## 1.0.1 - 2022-05-13
 
 ### Added

--- a/packages/popup-monitor/package.json
+++ b/packages/popup-monitor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/popup-monitor",
-	"version": "1.0.1",
+	"version": "1.0.2-alpha",
 	"description": "Utility to facilitate the monitoring of a popup window close action.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
@@ -37,5 +37,13 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^"
+	},
+	"peerDependencies": {
+		"@babel/runtime": "^7"
+	},
+	"peerDependenciesMeta": {
+		"@babel/runtime": {
+			"optional": true
+		}
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,6 +1098,11 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     events: ^3.3.0
     lodash: ^4.17.21
+  peerDependencies:
+    "@babel/runtime": ^7
+  peerDependenciesMeta:
+    "@babel/runtime":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Due to use of `@babel/plugin-transform-runtime` in calypso-babel-config,
the built file at `dist/cjs/index.js` has a dependency on
`@babel/runtime`. This dependency needs to be declared.

Since it's not needed in ESM environments, declare it as an optional
peer.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Nothing should change within Calypso due to this.
* You might see if you can still reproduce #64034 with this in place. Note you'll probably have to complicate it slightly by putting the test in a workspace so the installed peer dep doesn't get found at the monorepo root, and do a little work to get i.e. <details><summary>yarn</summary>

   1. `cd` to an empty test directory.
   2. `echo '{"private":true,"workspaces":["a"]}' > package.json`
   3. `yarn set version stable`
   4. `mkdir a; echo '{"name":"a","version":"0.0.0"}' > a/package.json`
   5. `cd a`
   6. `yarn add @babel/runtime @automattic/popup-monitor`
   7. `yarn node -e 'const x = require( "@automattic/popup-monitor" ); console.log( typeof x );'`, confirm the error
   8. `yarn add @automattic/popup-monitor@file:/path/to/wp-calypso/packages/popup-monitor`
   9. `yarn node -e 'const x = require( "@automattic/popup-monitor" ); console.log( typeof x );'`, should work now

  </details><details><summary>pnpm 7</summary>

   1. `cd` to an empty test directory.
   2. `echo 'hoist-pattern=[]' > .npmrc; echo 'packages: [ a ]' > pnpm-workspace.yaml`
   4. `mkdir a; echo '{"name":"a"}' > a/package.json`
   5. `cd a`
   6. `pnpm add @babel/runtime @automattic/popup-monitor`
   7. `node -e 'const x = require( "@automattic/popup-monitor" ); console.log( typeof x );'`, confirm the error
   8. `pnpm add @automattic/popup-monitor@file:/path/to/wp-calypso/packages/popup-monitor`
   9. `node -e 'const x = require( "@automattic/popup-monitor" ); console.log( typeof x );'`, should work now

  </details>

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #64034
