### PR TITLE
Anchor: Ensure processing step takes up 100% width

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -49,6 +49,7 @@ $progress-duration: 800ms;
 		transition: transform $progress-duration ease-out;
 	}
 }
-.site-setup.processing .step-container__content {
+.site-setup.processing .step-container__content,
+.anchor-fm.processing .step-container__content {
 	width: 100%;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add selector to target the Anchor flow in addition to the site setup flow on the processing step.

**Before**

<img width="1765" alt="170352880-55a14477-ac65-441b-8afb-a0d1c99a13e8" src="https://user-images.githubusercontent.com/2124984/171036830-373ad92d-4183-449c-9058-e9f10ea5bb48.png">

**After**

<img width="1343" alt="Screen Shot 2022-05-30 at 1 12 14 PM" src="https://user-images.githubusercontent.com/2124984/171036762-e343bd22-d5b7-431c-bc2c-2f63771816c7.png">

#### Testing instructions

* Switch to this PR, navigate to `/setup/?anchor_podcast=[your podcast id]`
* Go through the signup flow
* The processing step should have text centered in the screen

Fixes #64039