### PR TITLE
Stepper: Better assertion handling

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -50,7 +50,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 				return <WordPressLogo size={ 72 } className="wpcom-site__logo" />;
 			/* eslint-enable wpcalypso/jsx-classname-namespace */
 			case AssertConditionState.FAILURE:
-				throw new Error( assertCondition.message ?? 'Error in Stepper pre-conditions' );
+				throw new Error( assertCondition.message ?? 'An error has occurred.' );
 		}
 
 		const StepComponent = Steps[ path ];

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -33,7 +33,7 @@ export type UseStepNavigationHook = (
 	steps?: StepPath[]
 ) => NavigationControls;
 
-export type UseAssertConditionsHook = () => void;
+export type UseAssertConditionsHook = () => AssertConditionResult;
 
 export type Flow = {
 	name: string;
@@ -55,3 +55,14 @@ export type StepProps = {
 export type Step = React.FC< StepProps >;
 
 export type ProvidedDependencies = Record< string, unknown >;
+
+export enum AssertConditionState {
+	SUCCESS = 'success',
+	FAILURE = 'failure',
+	CHECKING = 'checking',
+}
+
+export type AssertConditionResult = {
+	state: AssertConditionState;
+	message?: string;
+};


### PR DESCRIPTION
Currently there's no way to handle `in-progress` state for the `useAssertConditions` method. If a check takes some time to resolve and then it turns out that the condition is not met, the user will see a flash of the original step to later be redirected to another place.

This PR adds a CHECKING state to the return value of `useAssertConditions` so the FlowRenderer can show a loading state while the condition is resolving.

### Testing
#### Way `#1`
You could check the behaviour by testing [this PR](https://github.com/Automattic/wp-calypso/pull/64129). If you are using a site you don't own you shouldn't see a flash of the `businessinfo` screen.
#### Way `#2`
1. Apply this PR.
2. Change the return value [here](https://github.com/Automattic/wp-calypso/pull/64170/files#diff-614cccce787b17e46e84a16af7865700992dfd374e701239023fd2e1feaa12a1R374) to verify the 3 possible states. What to expect:
2. 1. `AssertConditionState.FAILURE` will trigger an exception, you should see a blank screen.
2. 2. `AssertConditionState.SUCCESS` you should see the step you where trying to access. 
2. 3. `AssertConditionState.CHECKING` you should see a WordPress logo in the middle of the screen.