### PR TITLE
Show plugin active state in Boost & Social product cards.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/jetpack-boost-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-boost-free-card/index.tsx
@@ -1,17 +1,14 @@
 import { TERM_ANNUALLY } from '@automattic/calypso-products';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo } from 'react';
-import { useDispatch } from 'react-redux';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { ITEM_TYPE_PRODUCT } from 'calypso/my-sites/plans/jetpack-plans/constants';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import isJetpackConnectionPluginActive from 'calypso/state/sites/selectors/is-jetpack-connection-plugin-active';
+import useBoostFreeButtonProps from './use-boost-free-button-props';
 import type { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
-
-const BOOST_FREE_URL = isJetpackCloud()
-	? '/pricing/jetpack-boost/welcome'
-	: 'https://wordpress.org/plugins/jetpack-boost/';
 
 const useBoostFreeItem = (): SelectorProduct => {
 	const translate = useTranslate();
@@ -47,15 +44,16 @@ export type CardWithPriceProps = {
 const CardWithPrice: React.FC< CardWithPriceProps > = ( { siteId } ) => {
 	const translate = useTranslate();
 	const boostFreeProduct = useBoostFreeItem();
+	const boostPluginActive =
+		useSelector( ( state ) => isJetpackConnectionPluginActive( state, siteId, 'jetpack-boost' ) ) ||
+		false;
 
-	const dispatch = useDispatch();
-	const onButtonClick = useCallback( () => {
-		dispatch(
-			recordTracksEvent( 'calypso_product_jpboostfree_click', {
-				site_id: siteId ?? undefined,
-			} )
-		);
-	}, [ dispatch, siteId ] );
+	const {
+		primary: buttonPrimary,
+		href: buttonHref,
+		label: buttonLabel,
+		onClick: onButtonClick,
+	} = useBoostFreeButtonProps( siteId, boostPluginActive );
 
 	return (
 		<JetpackProductCard
@@ -65,15 +63,16 @@ const CardWithPrice: React.FC< CardWithPriceProps > = ( { siteId } ) => {
 			hideSavingLabel
 			showNewLabel
 			showAbovePriceText
-			buttonPrimary
+			buttonPrimary={ buttonPrimary }
 			item={ boostFreeProduct }
 			headerLevel={ 3 }
 			description={ translate(
 				'All of the essential tools to speed up your site — no developer required.'
 			) }
-			buttonLabel={ translate( 'Get Boost' ) }
-			buttonURL={ BOOST_FREE_URL }
+			buttonLabel={ buttonLabel }
+			buttonURL={ buttonHref }
 			onButtonClick={ onButtonClick }
+			isOwned={ boostPluginActive }
 			collapseFeaturesOnMobile
 		/>
 	);

--- a/client/my-sites/plans/jetpack-plans/jetpack-boost-free-card/use-boost-free-button-props.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-boost-free-card/use-boost-free-button-props.ts
@@ -1,0 +1,54 @@
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
+
+type SiteId = number | null;
+
+interface Props {
+	primary: boolean;
+	href: string;
+	label: TranslateResult;
+	onClick: React.MouseEventHandler;
+}
+
+const JETPACK_BOOST_PAGE = 'https://jetpack.com/boost/';
+const CALYPSO_BOOST_LANDING_PAGE = '/pricing/jetpack-boost/welcome';
+
+export default function useBoostFreeButtonProps( siteId: SiteId, isOwned: boolean ): Props {
+	const translate = useTranslate();
+	const siteWpAdminUrl = useSelector( ( state ) =>
+		getSiteAdminUrl( state, siteId, 'admin.php?page=jetpack-boost' )
+	);
+
+	const primary = ! isOwned;
+
+	const href = useMemo( () => {
+		if ( isOwned && siteWpAdminUrl ) {
+			return siteWpAdminUrl;
+		}
+		if ( isJetpackCloud() ) {
+			return CALYPSO_BOOST_LANDING_PAGE;
+		}
+		return JETPACK_BOOST_PAGE;
+	}, [ isOwned, siteWpAdminUrl ] );
+
+	const label = isOwned ? translate( 'Manage plugin' ) : translate( 'Get Boost' );
+
+	const trackCallback = useTrackCallback( undefined, 'calypso_product_jpboost_free_click', {
+		site_id: siteId || undefined,
+	} );
+
+	const onClick = useCallback( () => {
+		trackCallback();
+	}, [ trackCallback ] );
+
+	return {
+		primary,
+		href,
+		label,
+		onClick,
+	};
+}

--- a/client/my-sites/plans/jetpack-plans/jetpack-boost-free-card/use-boost-free-button-props.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-boost-free-card/use-boost-free-button-props.ts
@@ -1,8 +1,8 @@
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 
 type SiteId = number | null;
@@ -19,6 +19,7 @@ const CALYPSO_BOOST_LANDING_PAGE = '/pricing/jetpack-boost/welcome';
 
 export default function useBoostFreeButtonProps( siteId: SiteId, isOwned: boolean ): Props {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const siteWpAdminUrl = useSelector( ( state ) =>
 		getSiteAdminUrl( state, siteId, 'admin.php?page=jetpack-boost' )
 	);
@@ -37,13 +38,14 @@ export default function useBoostFreeButtonProps( siteId: SiteId, isOwned: boolea
 
 	const label = isOwned ? translate( 'Manage plugin' ) : translate( 'Get Boost' );
 
-	const trackCallback = useTrackCallback( undefined, 'calypso_product_jpboost_free_click', {
-		site_id: siteId || undefined,
-	} );
-
 	const onClick = useCallback( () => {
-		trackCallback();
-	}, [ trackCallback ] );
+		dispatch(
+			recordTracksEvent( 'calypso_product_jpboost_free_click', {
+				site_id: siteId ?? undefined,
+				is_owned: !! isOwned,
+			} )
+		);
+	}, [ dispatch, siteId, isOwned ] );
 
 	return {
 		primary,

--- a/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/index.tsx
@@ -1,17 +1,14 @@
 import { TERM_ANNUALLY } from '@automattic/calypso-products';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo } from 'react';
-import { useDispatch } from 'react-redux';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import JetpackProductCard from 'calypso/components/jetpack/card/jetpack-product-card';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { ITEM_TYPE_PRODUCT } from 'calypso/my-sites/plans/jetpack-plans/constants';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import isJetpackConnectionPluginActive from 'calypso/state/sites/selectors/is-jetpack-connection-plugin-active';
+import useSocialFreeButtonProps from './use-social-free-button-props';
 import type { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
-
-const SOCIAL_FREE_URL = isJetpackCloud()
-	? '/pricing/jetpack-social/welcome'
-	: 'https://wordpress.org/plugins/jetpack-social/'; // This may need to be updated (page doesn't exist yet).
 
 const useSocialFreeItem = (): SelectorProduct => {
 	const translate = useTranslate();
@@ -51,14 +48,17 @@ const CardWithPrice: React.FC< CardWithPriceProps > = ( { siteId } ) => {
 	const translate = useTranslate();
 	const socialFreeProduct = useSocialFreeItem();
 
-	const dispatch = useDispatch();
-	const onButtonClick = useCallback( () => {
-		dispatch(
-			recordTracksEvent( 'calypso_product_jpsocialfree_click', {
-				site_id: siteId ?? undefined,
-			} )
-		);
-	}, [ dispatch, siteId ] );
+	const socialPluginActive =
+		useSelector( ( state ) =>
+			isJetpackConnectionPluginActive( state, siteId, 'jetpack-social' )
+		) || false;
+
+	const {
+		primary: buttonPrimary,
+		href: buttonHref,
+		label: buttonLabel,
+		onClick: onButtonClick,
+	} = useSocialFreeButtonProps( siteId, socialPluginActive );
 
 	return (
 		<JetpackProductCard
@@ -68,15 +68,16 @@ const CardWithPrice: React.FC< CardWithPriceProps > = ( { siteId } ) => {
 			hideSavingLabel
 			showNewLabel
 			showAbovePriceText
-			buttonPrimary
+			buttonPrimary={ buttonPrimary }
 			item={ socialFreeProduct }
 			headerLevel={ 3 }
 			description={ translate(
 				'Easily share your website content on your social media channels.'
 			) }
-			buttonLabel={ translate( 'Get Social' ) }
-			buttonURL={ SOCIAL_FREE_URL }
+			buttonLabel={ buttonLabel }
+			buttonURL={ buttonHref }
 			onButtonClick={ onButtonClick }
+			isOwned={ socialPluginActive }
 			collapseFeaturesOnMobile
 		/>
 	);

--- a/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/use-social-free-button-props.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/use-social-free-button-props.ts
@@ -1,8 +1,8 @@
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 
 type SiteId = number | null;
@@ -19,6 +19,7 @@ const CALYPSO_SOCIAL_LANDING_PAGE = '/pricing/jetpack-social/welcome';
 
 export default function useSocialFreeButtonProps( siteId: SiteId, isOwned: boolean ): Props {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const siteWpAdminUrl = useSelector( ( state ) =>
 		getSiteAdminUrl( state, siteId, 'admin.php?page=jetpack-social' )
 	);
@@ -37,13 +38,14 @@ export default function useSocialFreeButtonProps( siteId: SiteId, isOwned: boole
 
 	const label = isOwned ? translate( 'Manage plugin' ) : translate( 'Get Social' );
 
-	const trackCallback = useTrackCallback( undefined, 'calypso_product_jpsocial_free_click', {
-		site_id: siteId || undefined,
-	} );
-
 	const onClick = useCallback( () => {
-		trackCallback();
-	}, [ trackCallback ] );
+		dispatch(
+			recordTracksEvent( 'calypso_product_jpsocial_free_click', {
+				site_id: siteId ?? undefined,
+				is_owned: !! isOwned,
+			} )
+		);
+	}, [ dispatch, siteId, isOwned ] );
 
 	return {
 		primary,

--- a/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/use-social-free-button-props.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-social-free-card/use-social-free-button-props.ts
@@ -1,0 +1,54 @@
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
+
+type SiteId = number | null;
+
+interface Props {
+	primary: boolean;
+	href: string;
+	label: TranslateResult;
+	onClick: React.MouseEventHandler;
+}
+
+const JETPACK_SOCIAL_PAGE = 'https://jetpack.com/social/';
+const CALYPSO_SOCIAL_LANDING_PAGE = '/pricing/jetpack-social/welcome';
+
+export default function useSocialFreeButtonProps( siteId: SiteId, isOwned: boolean ): Props {
+	const translate = useTranslate();
+	const siteWpAdminUrl = useSelector( ( state ) =>
+		getSiteAdminUrl( state, siteId, 'admin.php?page=jetpack-social' )
+	);
+
+	const primary = ! isOwned;
+
+	const href = useMemo( () => {
+		if ( isOwned && siteWpAdminUrl ) {
+			return siteWpAdminUrl;
+		}
+		if ( isJetpackCloud() ) {
+			return CALYPSO_SOCIAL_LANDING_PAGE;
+		}
+		return JETPACK_SOCIAL_PAGE;
+	}, [ isOwned, siteWpAdminUrl ] );
+
+	const label = isOwned ? translate( 'Manage plugin' ) : translate( 'Get Social' );
+
+	const trackCallback = useTrackCallback( undefined, 'calypso_product_jpsocial_free_click', {
+		site_id: siteId || undefined,
+	} );
+
+	const onClick = useCallback( () => {
+		trackCallback();
+	}, [ trackCallback ] );
+
+	return {
+		primary,
+		href,
+		label,
+		onClick,
+	};
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR allows the Boost and Social Free cards to show their "Active" state if the user is logged in and they have either Boost or Social installed & activated on their site. (See screenshot)

Project Thread: p1HpG7-g29-p2
Asana task: 1202316834912830-as-1202332690796697/f

Boost free            |  Social free
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/11078128/171040233-049ad116-3e7a-4a24-8dfe-60cf17ea0a99.png)  |  ![](https://user-images.githubusercontent.com/11078128/171040259-2ef6c43f-363c-4253-a260-da1c20f64c7c.png)
 



####  Testing instructions
1. Checkout this PR and spin up Calypso blue and green concurrently (`yarn start` and `yarn start-jetpack-cloud-p`).
1. Go to jurassic.ninja, select More Options link. Include Jetpack Beta and add Jetpack Boost branch (master - bleeding edge), and add Jetpack Social branch (master - bleeding edge). Then click the "Launch Single Site" link. and when its created, go to your site.
1. Connect Jetpack.
1. When you redirected to the `/jetpack/connect/plans/:site/...` page, in the url, replace `https://wordpress.com` with `http://calypso.localhost:3000` and reload the page.
1. In the bottom row of the "More Products" section, verify you see Boost and Social as "Active on your site". (see screenshot below)
1. ![Markup 2022-05-30 at 14 15 47](https://user-images.githubusercontent.com/11078128/171043661-e5876c48-2c80-4160-8137-2154e57f1a0d.png)
1. Select "Jetpack Free" to get back to your site.
1. On your site, go to Jetpack --> Dashboard. In the dashboard nav bar, click on the "Plans" tab/link. (this will take you to the Jetpack Cloud pricing page.)
1. In the url, replace `https://cloud.jetpack.com` with `http://jetpack.cloud.localhost:3001` and reload the page.
1. Verify you see the Boost and Social product cards as "Active on your site", same as before.
1. Verify the "Manage plugin" buttons point to the plugin wp-admin Boost or Social page respectively.
1. Goto http://jetpack.cloud.localhost:3001/pricing (with no site in context). Verify the Boost and Social cards CTA point to either `/pricing/jetpack-boost/welcome` or `/pricing/jetpack-social/welcome` respectively.
