### PR TITLE
i18n: Use getters to make translations dynamic

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -51,7 +51,9 @@ export interface CancellationReason extends CancellationReasonBase {
  */
 export const PLACEHOLDER: CancellationReason = {
 	value: '',
-	label: translate( 'Select your reason' ),
+	get label() {
+		return translate( 'Select your reason' );
+	},
 	disabled: true,
 };
 
@@ -60,119 +62,171 @@ export const PLACEHOLDER: CancellationReason = {
  */
 export const LAST_REASON: CancellationReason = {
 	value: 'anotherReasonOne',
-	label: translate( 'Another reason…' ),
-	textPlaceholder: translate( 'Can you please specify?' ),
+	get label() {
+		return translate( 'Another reason…' );
+	},
+	get textPlaceholder() {
+		return translate( 'Can you please specify?' );
+	},
 };
 
 export const CANCELLATION_REASONS: CancellationReason[] = [
 	{
 		value: 'price/budget',
-		label: translate( 'Price/Budget' ),
+		get label() {
+			return translate( 'Price/Budget' );
+		},
 		selectOptions: [
 			PLACEHOLDER,
 			{
 				value: 'tooExpensive',
-				label: translate( 'It’s too expensive.' ),
+				get label() {
+					return translate( 'It’s too expensive.' );
+				},
 			},
 			{
 				value: 'wantCheaperPlan',
-				label: translate( 'I want a cheaper plan.' ),
+				get label() {
+					return translate( 'I want a cheaper plan.' );
+				},
 			},
 			{
 				value: 'freeIsGoodEnough',
-				label: translate( 'Free is good enough for me.' ),
+				get label() {
+					return translate( 'Free is good enough for me.' );
+				},
 			},
 		],
 	},
 	{
 		value: 'couldNotFinish',
-		label: translate( 'Couldn’t finish my site' ),
+		get label() {
+			return translate( 'Couldn’t finish my site' );
+		},
 		selectOptions: [
 			PLACEHOLDER,
 			{
 				value: 'noTime',
-				label: translate( 'I don’t have time.' ),
+				get label() {
+					return translate( 'I don’t have time.' );
+				},
 			},
 			{
 				value: 'needProfessionalHelp',
-				label: translate( 'Need professional help to build my site.' ),
+				get label() {
+					return translate( 'Need professional help to build my site.' );
+				},
 			},
 			{
 				value: 'siteIsNotReady',
-				label: translate( 'My site is not ready.' ),
+				get label() {
+					return translate( 'My site is not ready.' );
+				},
 			},
 			{
 				value: 'cannotFindWhatIWanted',
-				label: translate( 'Couldn’t find what I wanted.' ),
+				get label() {
+					return translate( 'Couldn’t find what I wanted.' );
+				},
 			},
 		],
 	},
 	{
 		value: 'missingFeatures',
-		label: translate( 'Missing features' ),
+		get label() {
+			return translate( 'Missing features' );
+		},
 		selectOptions: [
 			PLACEHOLDER,
 			{
 				value: 'otherFeatures',
-				label: translate( 'Other features' ),
+				get label() {
+					return translate( 'Other features' );
+				},
 			},
 			{
 				value: 'eCommerceFeatures',
-				label: translate( 'eCommerce features' ),
+				get label() {
+					return translate( 'eCommerce features' );
+				},
 			},
 			{
 				value: 'customization',
-				label: translate( 'Customization / CSS' ),
+				get label() {
+					return translate( 'Customization / CSS' );
+				},
 			},
 			{
 				value: 'cannotUsePlugin',
-				label: translate( 'Can’t use a plugin' ),
+				get label() {
+					return translate( 'Can’t use a plugin' );
+				},
 			},
 			{
 				value: 'cannotUseTheme',
-				label: translate( 'Can’t use a theme' ),
+				get label() {
+					return translate( 'Can’t use a theme' );
+				},
 			},
 			{
 				value: 'loadingTime',
-				label: translate( 'Loading time' ),
+				get label() {
+					return translate( 'Loading time' );
+				},
 			},
 		],
 	},
 	{
 		value: 'technicalIssues',
-		label: translate( 'Technical issues' ),
+		get label() {
+			return translate( 'Technical issues' );
+		},
 		selectOptions: [
 			PLACEHOLDER,
 			{
 				value: 'tooComplicated',
-				label: translate( 'It’s too complicated for me.' ),
+				get label() {
+					return translate( 'It’s too complicated for me.' );
+				},
 			},
 			{
 				value: 'seoIssues',
-				label: translate( 'SEO issues' ),
+				get label() {
+					return translate( 'SEO issues' );
+				},
 			},
 			{
 				value: 'loadingTime',
-				label: translate( 'Loading time' ),
+				get label() {
+					return translate( 'Loading time' );
+				},
 			},
 		],
 	},
 	{
 		value: 'domain',
-		label: translate( 'Domain' ),
+		get label() {
+			return translate( 'Domain' );
+		},
 		selectOptions: [
 			PLACEHOLDER,
 			{
 				value: 'didNotGetFreeDomain',
-				label: translate( 'I didn’t get a free domain.' ),
+				get label() {
+					return translate( 'I didn’t get a free domain.' );
+				},
 			},
 			{
 				value: 'otherDomainIssues',
-				label: translate( 'Other domain issues' ),
+				get label() {
+					return translate( 'Other domain issues' );
+				},
 			},
 			{
 				value: 'domainConnection',
-				label: translate( 'Problem connecting my domain' ),
+				get label() {
+					return translate( 'Problem connecting my domain' );
+				},
 			},
 		],
 	},
@@ -181,33 +235,51 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 export const JETPACK_CANCELLATION_REASONS: CancellationReason[] = [
 	{
 		value: 'didNotInclude',
-		label: translate( "This upgrade didn't include what I needed." ),
-		textPlaceholder: translate( 'What are we missing that you need?' ),
+		get label() {
+			return translate( "This upgrade didn't include what I needed." );
+		},
+		get textPlaceholder() {
+			return translate( 'What are we missing that you need?' );
+		},
 	},
 	{
 		value: 'onlyNeedFree',
-		label: translate( 'The plan was too expensive.' ),
-		textPlaceholder: translate( 'How can we improve our upgrades?' ),
+		get label() {
+			return translate( 'The plan was too expensive.' );
+		},
+		get textPlaceholder() {
+			return translate( 'How can we improve our upgrades?' );
+		},
 	},
 	{
 		value: 'couldNotActivate',
-		label: translate( 'I was unable to activate or use the product.' ),
-		textPlaceholder: translate( 'Where did you run into problems?' ),
+		get label() {
+			return translate( 'I was unable to activate or use the product.' );
+		},
+		get textPlaceholder() {
+			return translate( 'Where did you run into problems?' );
+		},
 	},
 ];
 
 export const DOMAIN_TRANSFER_CANCELLATION_REASONS: CancellationReason[] = [
 	{
 		value: 'noLongerWantToTransfer',
-		label: translate( 'I no longer want to transfer my domain.' ),
+		get label() {
+			return translate( 'I no longer want to transfer my domain.' );
+		},
 	},
 	{
 		value: 'couldNotCompleteTransfer',
-		label: translate( 'Something went wrong and I could not complete the transfer.' ),
+		get label() {
+			return translate( 'Something went wrong and I could not complete the transfer.' );
+		},
 	},
 	{
 		value: 'useDomainWithoutTransferring',
-		label: translate( 'I’m going to use my domain with WordPress.com without transferring it.' ),
+		get label() {
+			return translate( 'I’m going to use my domain with WordPress.com without transferring it.' );
+		},
 	},
 ];
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The label and textPlaceholder property on the CancellationReason
objects were initialized to English values. Using JavaScript's
getter method allows these properties to be accessed dynamically,
thus showing the correct translations at runtime.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set language to one of mag-16 languages.
2. From https://wordpress.com/me/purchases, choose the site you want to remove a plan from.
3. Click "Remove (plan Name)", the last option on the page.
4. Verify that the placeholder text and the dropdown menu of the first option is translated.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 442-gh-Automattic/i18n-issues