### PR TITLE
Enable 'jetpack/pricing-add-boost-social' feature-flag in Staging.

### DIFF
--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -38,6 +38,7 @@
 		"jetpack/agency-dashboard": false,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/partner-portal-payment": true,
+		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/search-product": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -57,6 +57,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/magic-link-signup": true,
+		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR enables the Jetpack.com Pricing Page update (add Boost & Social) project in the Staging environment for all A18N's so that it can be easily tested and reviewed by Design and/or other stakeholders.

Project Thread: p1HpG7-g29-p2
Asana card: 1202316834912830-as-1202332690796695/f

#### Testing instructions

1. Visually inspect the code & verify the `jetpack/pricing-add-boost-social` feature-flag is enabled for wordpress.com Staging environment and also cloud.jetpack.com Staging environment.