### PR TITLE
Jetpack Cloud: Enable Jetpack Social in production

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -65,6 +65,7 @@
 		"jetpack-cloud-pricing": true,
 		"jetpack-cloud-settings": true,
 		"jetpack-search": true,
+		"jetpack-social": true,
 		"scan": true,
 		"site-purchases": true
 	},


### PR DESCRIPTION
While we've been developing the plugin, we've kept the Jetpack Social
connections screen to the development and staging environments. Now that
the plugin is about to be released, we should enable it in production.

#### Changes proposed in this Pull Request

This PR updates the config to enable the Jetpack Social section in production.

#### Testing instructions
I'm struggling to find a way to test this properly as I don't think we can run the production environment locally. I think we just need to verify that the `jetpack-social` section has been added to the Jetpack Cloud production config file correctly.

