### PR TITLE
Jetpack Cloud: Fix the Social help link alignment

### DIFF
--- a/client/jetpack-cloud/sections/jetpack-social/style.scss
+++ b/client/jetpack-cloud/sections/jetpack-social/style.scss
@@ -1,3 +1,11 @@
+.connections__support-link {
+	.gridicons-help-outline {
+		position: relative;
+		top: 3px;
+		margin-left: 3px;
+	}
+}
+
 .sharing-service__name {
 	h2 {
 		font-size: $font-body;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The help link next to the Publicize section on the Social page was
misaligned. This change fixes tweaks the CSS to fix that.

#### Testing instructions
Load the Social section in Jetpack Cloud. Without this change the `?` link will be too high. With this change it should be aligned with the title.

###### Before
<img width="389" alt="image" src="https://user-images.githubusercontent.com/96462/171065462-ef85c370-81a3-4cdd-9281-65fa1a6f2c98.png">

###### After
<img width="389" alt="image" src="https://user-images.githubusercontent.com/96462/171065480-1692393c-347c-4675-a80d-25a6c5b3c6e7.png">
