### PR TITLE
Generated design picker: Support more desktop resolutions

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -296,7 +296,9 @@ $design-setup-footer-height: 118px;
 		}
 
 		@include onboarding-break-2k {
-			max-width: 2144px;
+			max-width: 2240px;
+			padding-left: 0;
+			padding-right: 0;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -286,6 +286,20 @@ $design-setup-footer-height: 118px;
  * Generated Design Picker
  */
 .design-picker__is-generated {
+	&.step-container {
+		max-width: none;
+
+		@include onboarding-break-full-hd {
+			.generated-design-picker__thumbnails {
+				padding-right: 4rem;
+			}
+		}
+
+		@include onboarding-break-2k {
+			max-width: 2144px;
+		}
+	}
+
 	&.design-picker__is-generated-previewing {
 		.design-setup__header,
 		.generated-design-picker__thumbnails {
@@ -406,7 +420,6 @@ $design-setup-footer-height: 118px;
 			display: flex;
 			height: $design-setup-footer-height;
 			justify-content: flex-end;
-			max-width: 1440px;
 			margin-left: 154px;
 			position: sticky;
 			overflow: hidden;

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -104,8 +104,15 @@
 	}
 }
 
+/* (2560x1440) 2K resolution */
+@mixin onboarding-break-2k() {
+	@media ( min-width: 2560px ) {
+		@content;
+	}
+}
+
 /* (1920x1080) Full HD Display */
-@mixin onboarding-break-gigantic() {
+@mixin onboarding-break-full-hd() {
 	@media ( min-width: 1920px ) {
 		@content;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds desktop breakpoints to the generated design picker as defined in 42PgVsdlQ1v2wpk6lmmrnq-fi-2473%3A62875 
![Screen Shot 2022-05-31 at 10 43 48 AM](https://user-images.githubusercontent.com/797888/171082502-b1fae981-9993-49b8-b615-934a3b90270e.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the generated design picker.
* Resolution at width 1280px:
  * Check that the left/right padding to the viewport is 48px.
  * Check that the thumbnail sections' right padding is 32px. 
* Resolution at width 1400px:
  * Check that the left/right padding to the viewport is 48px.
  * Check that the thumbnail sections' right padding is 32px. 
* Resolution at width 1920px:
  * Check that the left/right padding to the viewport is 48px.
  * Check that the thumbnail sections' right padding is 64px. 
* Resolution at width 2560px:
  * Check that the generated design picker has a max-width of 2144px + padding of 96px = 2240px.
  * Check that the thumbnail sections' right padding is 64px. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63795