### PR TITLE
Generated Design Picker: Fix responsive thumbnails

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -452,7 +452,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 						'is-visible': isSticky,
 					} ) }
 				>
-					<div className={ 'design-setup__footer-inner' }>
+					<div className="design-setup__footer-inner">
 						<Button primary onClick={ () => pickDesign( selectedGeneratedDesign, 'bottom' ) }>
 							{ translate( 'Continue' ) }
 						</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -452,11 +452,9 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 						'is-visible': isSticky,
 					} ) }
 				>
-					<div className="design-setup__footer-inner">
-						<Button primary onClick={ () => pickDesign( selectedGeneratedDesign, 'bottom' ) }>
-							{ translate( 'Continue' ) }
-						</Button>
-					</div>
+					<Button primary onClick={ () => pickDesign( selectedGeneratedDesign, 'bottom' ) }>
+						{ translate( 'Continue' ) }
+					</Button>
 				</div>
 			}
 			onPreview={ previewDesign }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -455,6 +455,7 @@ $design-setup-footer-height: 118px;
 			top: 109px;
 			flex: 0 154px;
 			padding-right: 1.5rem;
+			margin-bottom: 0;
 		}
 
 		@include break-medium {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -312,9 +312,12 @@ $design-setup-footer-height: 118px;
 			}
 		}
 
-		.generated-design-picker__previews {
+		.generated-design-picker__main {
 			flex: 1;
 			height: auto;
+		}
+
+		.generated-design-picker__previews {
 			min-height: calc( 100vh - 172px );
 			margin-bottom: 84px;
 		}
@@ -422,7 +425,6 @@ $design-setup-footer-height: 118px;
 			display: flex;
 			height: $design-setup-footer-height;
 			justify-content: flex-end;
-			margin-left: 154px;
 			position: sticky;
 			overflow: hidden;
 			z-index: 1;
@@ -432,10 +434,6 @@ $design-setup-footer-height: 118px;
 				transform: translateY( 0 );
 				pointer-events: auto;
 			}
-		}
-
-		@include break-medium {
-			margin-left: 248px;
 		}
 	}
 
@@ -468,7 +466,6 @@ $design-setup-footer-height: 118px;
 
 	.generated-design-picker__previews {
 		display: flex;
-		height: 0;
 		flex-direction: column;
 		row-gap: 24px;
 		position: relative;
@@ -503,20 +500,19 @@ $design-setup-footer-height: 118px;
 				min-height: 80vh;
 			}
 		}
-
-		@include break-small {
-			flex: 1;
-			height: auto;
-		}
 	}
 
 	.generated-design-picker__view-more {
 		border-radius: 4px;
 		font-weight: 500;
 		line-height: 1.25rem;
-		margin: 8px 0 48px;
+		margin: 8px 0 -6px;
 		width: 100%;
 		flex-shrink: 0;
+
+		@include break-small {
+			margin-bottom: 48px;
+		}
 	}
 
 	.step-container__content {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -446,8 +446,6 @@ $design-setup-footer-height: 118px;
 	}
 
 	.generated-design-picker__thumbnails {
-		position: sticky;
-		top: 109px;
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
@@ -455,6 +453,8 @@ $design-setup-footer-height: 118px;
 		row-gap: 24px;
 
 		@include break-small {
+			position: sticky;
+			top: 109px;
 			flex: 0 154px;
 			padding-right: 1.5rem;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -6,7 +6,6 @@
 $gray-100: #101517;
 $gray-60: #50575e;
 $design-button-primary-color: rgb( 17, 122, 201 );
-$design-setup-footer-height: 118px;
 
 .design-setup {
 	.step-container {
@@ -404,32 +403,21 @@ $design-setup-footer-height: 118px;
 		position: relative;
 		margin: 0 auto;
 
-		.design-setup__footer-inner {
-			align-self: stretch;
-			align-items: center;
-			background-color: #ffffff;
+		@include break-small {
 			display: flex;
+			align-items: center;
 			justify-content: flex-end;
-			position: absolute;
-			width: 100%;
-			height: $design-setup-footer-height;
+			position: sticky;
+			bottom: 0;
+			height: 118px;
+			background-color: #ffffff;
 			opacity: 0;
 			transform: translateY( 100% );
 			pointer-events: none;
 			transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out;
-		}
-
-		@include break-small {
-			align-items: center;
-			bottom: 0;
-			display: flex;
-			height: $design-setup-footer-height;
-			justify-content: flex-end;
-			position: sticky;
-			overflow: hidden;
 			z-index: 1;
 
-			&.is-visible .design-setup__footer-inner {
+			&.is-visible {
 				opacity: 1;
 				transform: translateY( 0 );
 				pointer-events: auto;

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -91,20 +91,23 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 			return noop;
 		}
 
-		const onResize = () => {
-			const { current: thumnbnailWrapper } = wrapperRef;
-			if ( ! thumnbnailWrapper ) {
+		const handleResponsive = () => {
+			if ( ! wrapperRef.current ) {
 				return;
 			}
 
-			thumnbnailWrapper.style.height = `calc( 100vh - ${ thumnbnailWrapper.offsetTop }px`;
+			const offsetTop = wrapperRef.current.offsetTop - window.pageYOffset;
+			wrapperRef.current.style.setProperty( 'height', `calc( 100vh - ${ offsetTop }px` );
 		};
 
-		window.addEventListener( 'resize', onResize );
-		onResize();
+		handleResponsive();
+
+		window.addEventListener( 'resize', handleResponsive );
+		window.addEventListener( 'scroll', handleResponsive );
 
 		return () => {
-			window.removeEventListener( 'resize', onResize );
+			window.removeEventListener( 'resize', handleResponsive );
+			window.removeEventListener( 'scroll', handleResponsive );
 		};
 	}, [ isMobile ] );
 
@@ -127,9 +130,11 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 						{ __( 'View more options' ) }
 					</Button>
 				</div>
-				<div className="generated-design-picker__previews">{ previews }</div>
+				<div className="generated-design-picker__main">
+					<div className="generated-design-picker__previews">{ previews }</div>
+					{ footer }
+				</div>
 			</div>
-			{ footer }
 		</div>
 	);
 };

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -10,6 +10,9 @@ import { getDesignPreviewUrl, getMShotOptions } from '../utils';
 import type { Design } from '../types';
 import './style.scss';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
 interface GeneratedDesignThumbnailProps {
 	slug: string;
 	thumbnailUrl: string;
@@ -78,9 +81,16 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 } ) => {
 	const { __ } = useI18n();
 
+	const isMobile = useViewportMatch( 'small', '<' );
+
 	const wrapperRef = useRef< HTMLDivElement >( null );
 
 	useEffect( () => {
+		if ( isMobile ) {
+			wrapperRef.current?.style.removeProperty( 'height' );
+			return noop;
+		}
+
 		const onResize = () => {
 			const { current: thumnbnailWrapper } = wrapperRef;
 			if ( ! thumnbnailWrapper ) {
@@ -96,7 +106,7 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 		return () => {
 			window.removeEventListener( 'resize', onResize );
 		};
-	}, [] );
+	}, [ isMobile ] );
 
 	return (
 		<div className="generated-design-picker">

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -476,6 +476,15 @@
 	}
 }
 
+.generated-design-picker__main {
+	height: 0;
+
+	@include break-small {
+		flex: 1;
+		height: auto;
+	}
+}
+
 .generated-design-preview {
 	.generated-design-preview__header {
 		align-items: center;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable responsive on mobile
* Handle the responsive behavior when scrolling
* Adjust the layout of the footer to make the thumbnails on the left side to avoid scrolling out of the viewport. If we keep the original layout, the content is out of viewport after scrolling to the bottom so that the thumbnails are also out of the viewport. Once we need the width of the footer to be screen width, we can change back and use `position: fixed` to solve it. Any thoughts?

https://user-images.githubusercontent.com/13596067/171094256-b73f8256-54e9-42be-b6f2-4faca53af8a3.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/designSetup?siteSlug=<your_site>
* Adjust window size to see whether the thumbnails are responsive
* Scroll to the bottom and resize again to see whether the size of the thumbnails is correct

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64178
