### PR TITLE
Auto-select the product when clicked on add from agency dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -141,7 +141,7 @@ const getLinks = (
 	switch ( type ) {
 		case 'backup': {
 			if ( status === 'inactive' ) {
-				link = `/partner-portal/issue-license/?site_id=${ siteId }`;
+				link = `/partner-portal/issue-license/?site_id=${ siteId }&product_slug=jetpack-backup-realtime`;
 			} else {
 				link = `/backup/${ siteUrl }`;
 			}
@@ -152,7 +152,7 @@ const getLinks = (
 		}
 		case 'scan': {
 			if ( status === 'inactive' ) {
-				link = `/partner-portal/issue-license/?site_id=${ siteId }`;
+				link = `/partner-portal/issue-license/?site_id=${ siteId }&product_slug=jetpack-scan`;
 			} else {
 				link = `/scan/${ siteUrl }`;
 			}

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -85,14 +85,14 @@ export function licensesContext( context: PageJS.Context, next: () => void ): vo
 }
 
 export function issueLicenseContext( context: PageJS.Context, next: () => void ): void {
-	const { site_id: siteId } = context.query;
+	const { site_id: siteId, product_slug: productSlug } = context.query;
 	const state = context.store.getState();
 	const sites = getSitesItems( state );
 	const selectedSite = sites[ siteId ] ? siteId : null;
 
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
-	context.primary = <IssueLicense selectedSite={ selectedSite } />;
+	context.primary = <IssueLicense selectedSite={ selectedSite } productSlug={ productSlug } />;
 	next();
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -30,9 +30,13 @@ function alphabeticallySortedProductOptions(
 
 interface Props {
 	selectedSite?: number | null;
+	suggestedProduct?: string | null;
 }
 
-export default function IssueLicenseForm( { selectedSite }: Props ): ReactElement {
+export default function IssueLicenseForm( {
+	selectedSite,
+	suggestedProduct,
+}: Props ): ReactElement {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const products = useProductsQuery( {
@@ -109,6 +113,7 @@ export default function IssueLicenseForm( { selectedSite }: Props ): ReactElemen
 				onSelectProduct={ onSelectProduct }
 				isSelected={ productOption.slug === product }
 				tabIndex={ 100 + i }
+				suggestedProduct={ suggestedProduct }
 			/>
 		) );
 

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -2,7 +2,7 @@ import { Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement, useCallback } from 'react';
+import { ReactElement, useCallback, useEffect } from 'react';
 import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
 import './style.scss';
 
@@ -11,10 +11,11 @@ interface Props {
 	product: APIProductFamilyProduct;
 	isSelected: boolean;
 	onSelectProduct: ( value: string ) => void | null;
+	suggestedProduct?: string | null;
 }
 
 export default function LicenseProductCard( props: Props ): ReactElement {
-	const { tabIndex, product, isSelected, onSelectProduct } = props;
+	const { tabIndex, product, isSelected, onSelectProduct, suggestedProduct } = props;
 	const productTitle = product.name.replace( 'Jetpack ', '' ).replace( '(', '' ).replace( ')', '' );
 	const translate = useTranslate();
 
@@ -31,6 +32,14 @@ export default function LicenseProductCard( props: Props ): ReactElement {
 		},
 		[ onSelect ]
 	);
+
+	useEffect( () => {
+		if ( suggestedProduct ) {
+			if ( product.slug === suggestedProduct ) {
+				onSelect();
+			}
+		}
+	}, [ onSelect, product, suggestedProduct ] );
 
 	return (
 		<div

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -9,9 +9,10 @@ import AssignLicenseStepProgress from '../../assign-license-step-progress';
 
 interface Props {
 	selectedSite?: number | null;
+	productSlug?: string | null;
 }
 
-export default function IssueLicense( { selectedSite }: Props ): ReactElement {
+export default function IssueLicense( { selectedSite, productSlug }: Props ): ReactElement {
 	const translate = useTranslate();
 
 	useEffect( () => {
@@ -32,7 +33,7 @@ export default function IssueLicense( { selectedSite }: Props ): ReactElement {
 			<AssignLicenseStepProgress currentStep={ 1 } />
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
-			<IssueLicenseForm selectedSite={ selectedSite } />
+			<IssueLicenseForm selectedSite={ selectedSite } suggestedProduct={ productSlug } />
 		</Main>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR includes changes that auto-selects the licenses when clicked on `Add +` from the agency dashboard

#### Testing instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to previous type

**Instructions**

1. Run `git checkout update/highlight-and-select-license` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard.
3. Click on `Add +` on Backup or Scan on any site available or [create a new JN site](https://jurassic.ninja/specialops/), activate Jetpack and make sure you don't choose `Backup` or `Scan` so that we can see the `Add +` butto. Now, refresh the page for the newly added site to appear.
4. When clicking on `Add +` on Backup, you should be taken to the assign license page and the `Backup Real-time` should be auto-selected
5. When clicking on `Add +` on Scan, you should be taken to the assign license page and the Scan Daily should be auto-selected

**Screenshot**

<img width="1656" alt="Screenshot 2022-05-31 at 2 03 42 PM" src="https://user-images.githubusercontent.com/10586875/171131939-91361d16-5e8c-44b1-b66f-fef2117bb60e.png">

Related to 1202076982646589-as-1202228745081095