### PR TITLE
Refactor backup page to reduce and stabilise number of API calls

### DIFF
--- a/client/data/activity-log/use-activity-log-query.js
+++ b/client/data/activity-log/use-activity-log-query.js
@@ -42,7 +42,6 @@ export default function useActivityLogQuery( siteId, filter, options ) {
 				.then( fromActivityLogApi ),
 		{
 			refetchInterval: 5 * 60 * 1000,
-			refetchOnWindowFocus: false,
 			...options,
 		}
 	);

--- a/client/data/activity-log/use-activity-log-query.js
+++ b/client/data/activity-log/use-activity-log-query.js
@@ -42,6 +42,7 @@ export default function useActivityLogQuery( siteId, filter, options ) {
 				.then( fromActivityLogApi ),
 		{
 			refetchInterval: 5 * 60 * 1000,
+			refetchOnWindowFocus: false,
 			...options,
 		}
 	);

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -11,6 +11,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryRewindPolicies from 'calypso/components/data/query-rewind-policies';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
@@ -21,11 +22,13 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import isRewindPoliciesInitialized from 'calypso/state/rewind/selectors/is-rewind-policies-initialized';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
 import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteSettingsInitialized from 'calypso/state/selectors/is-site-settings-initialized';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -131,6 +134,7 @@ const AdminContent = ( { selectedDate } ) => {
 
 	return (
 		<>
+			<QuerySiteSettings siteId={ siteId } />
 			<QuerySiteFeatures siteIds={ [ siteId ] } />
 			<QueryRewindPolicies
 				siteId={ siteId } /* The policies inform the max visible limit for backups */
@@ -144,36 +148,45 @@ const AdminContent = ( { selectedDate } ) => {
 					<DocumentHead title={ translate( 'Latest backups' ) } />
 					<PageViewTracker path="/backup/:site" title="Backups" />
 
-					<div className="backup__main-wrap">
-						<div className="backup__last-backup-status">
-							{ needCredentials && <EnableRestoresBanner /> }
-
-							<BackupDatePicker onDateChange={ onDateChange } selectedDate={ selectedDate } />
-							<BackupStorageSpace />
-							<BackupStatus selectedDate={ selectedDate } />
-						</div>
-					</div>
+					<BackupStatus
+						onDateChange={ onDateChange }
+						selectedDate={ selectedDate }
+						needCredentials={ needCredentials }
+					/>
 				</>
 			) }
 		</>
 	);
 };
 
-const BackupStatus = ( { selectedDate } ) => {
+const BackupStatus = ( { selectedDate, needCredentials, onDateChange } ) => {
 	const isFetchingSiteFeatures = useSelectedSiteSelector( isRequestingSiteFeatures );
+	const isPoliciesInitialized = useSelectedSiteSelector( isRewindPoliciesInitialized );
+	const isSettingsInitialized = useSelectedSiteSelector( isSiteSettingsInitialized );
+
 	const hasRealtimeBackups = useSelectedSiteSelector(
 		siteHasFeature,
 		WPCOM_FEATURES_REAL_TIME_BACKUPS
 	);
 
-	if ( isFetchingSiteFeatures ) {
-		return <BackupPlaceholder showDatePicker={ false } />;
+	if ( isFetchingSiteFeatures || ! isPoliciesInitialized || ! isSettingsInitialized ) {
+		return <BackupPlaceholder showDatePicker={ true } />;
 	}
 
-	return hasRealtimeBackups ? (
-		<RealtimeStatus selectedDate={ selectedDate } />
-	) : (
-		<DailyStatus selectedDate={ selectedDate } />
+	return (
+		<div className="backup__main-wrap">
+			<div className="backup__last-backup-status">
+				{ needCredentials && <EnableRestoresBanner /> }
+
+				<BackupDatePicker onDateChange={ onDateChange } selectedDate={ selectedDate } />
+				<BackupStorageSpace />
+				{ hasRealtimeBackups ? (
+					<RealtimeStatus selectedDate={ selectedDate } />
+				) : (
+					<DailyStatus selectedDate={ selectedDate } />
+				) }
+			</div>
+		</div>
 	);
 };
 

--- a/client/state/rewind/policies/reducer.ts
+++ b/client/state/rewind/policies/reducer.ts
@@ -35,6 +35,7 @@ const policies = (
 		case REWIND_POLICIES_SET:
 			return {
 				requestStatus: state.requestStatus,
+				isInitialized: true,
 				...policies,
 			};
 	}

--- a/client/state/rewind/policies/reducer.ts
+++ b/client/state/rewind/policies/reducer.ts
@@ -30,6 +30,7 @@ const policies = (
 		case REWIND_POLICIES_REQUEST_FAILURE:
 			return {
 				...state,
+				isInitialized: true,
 				requestStatus: 'failure',
 			};
 		case REWIND_POLICIES_SET:

--- a/client/state/rewind/selectors/is-rewind-policies-initialized.ts
+++ b/client/state/rewind/selectors/is-rewind-policies-initialized.ts
@@ -1,0 +1,15 @@
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns whether or not Rewind policies are ever being
+ * requested for a given site ID. Means if fe ever called the API.
+ *
+ * @param state The application state.
+ * @param siteId The site for which to retrieve request status.
+ * @returns True if policies are being requested; otherwise, false.
+ */
+const isRewindPoliciesInitialized = ( state: AppState, siteId: number | null ): boolean => {
+	return state.rewind?.[ siteId as number ]?.policies?.isInitialized || false;
+};
+
+export default isRewindPoliciesInitialized;

--- a/client/state/selectors/is-site-settings-initialized.js
+++ b/client/state/selectors/is-site-settings-initialized.js
@@ -1,0 +1,10 @@
+/**
+ * Returns true if the settings for the site initialized and false otherwise
+ *
+ * @param  {object}   state  Global state tree
+ * @param  {number}   siteId Site ID
+ * @returns {boolean}        Whether settings for specific site are initialized
+ */
+export default function isSiteSettingsInitialized( state, siteId ) {
+	return !! state?.siteSettings?.items?.[ siteId ];
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR refactors the backup page to reduce and stabilise (currently it's fluctuating) the number of API calls. The number of calls now between 6 to 9 and with the changes reduced to 5. Some changes here:
- Disable `refetchOnWindowFocus` which actually triggers too many calls which are certainly not necessary.
- Check if `rewindPolicies` and and `siteSettings` are initialized before rendering elements. At present, this causes additional calls (not cached data) due to differences in timezone and some other data used inside.
- Added `isRewindPoliciesInitialized` and `isSiteSettingsInitialized` to keep track if these were ever requested.

#### Testing instructions
Update the branch locally or use the builds of this branch.

##### Realtime backups
-  Create a JN site (or use one) and purchase [backup](https://wordpress.com/checkout/jetpack/jetpack_backup_t1_yearly) plan.
- Make several actions on the site (install/activate plugins, add users).
- Run build locally `yarn start`
- Navigate to `http://calypso.localhost:3000/backup/--Your JN site--` and check that it displays correctly. You can compare to `http://wordpress.com/backup/--Your JN site--`. 
- Observe that number of calls is lower. You can check the network tab in dev tools and search for `activity?`. It should always be 5 for now (compared to 6-9 in wordpress.com). 
- Run `yarn start-jetpack-cloud-p` and check the same for `http://jetpack.cloud.localhost:3001/backup/--Your JN site--` and `https://cloud.jetpack.com/backup/--Your JN site--`

##### Daily backups
-  Create a JN site (or use one) and purchase `https://wordpress.com/checkout/jetpack_backup_daily/--Your JN site--` plan.
- Make several actions on the site (install/activate plugins, add users).
- Run build locally `yarn start`
- Navigate to `http://calypso.localhost:3000/backup/--Your JN site--` and check that it displays correctly. You can compare to `http://wordpress.com/backup/--Your JN site--`. 
- Observe that number of calls is lower. You can check the network tab in dev tools and search for `activity?`. It should always be 5 for now (compared to 6-9 in wordpress.com). 
- Run `yarn start-jetpack-cloud-p` and check the same for `http://jetpack.cloud.localhost:3001/backup/--Your JN site--` and `https://cloud.jetpack.com/backup/--Your JN site--` 

Related to #
1164141197617539-as-1201763904638117/f