### PR TITLE
e2e: Localize Editor Settings Toggle Selector

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -4,6 +4,7 @@ import envVariables from '../../env-variables';
 export type PreviewOptions = 'Desktop' | 'Mobile' | 'Tablet';
 
 const panel = 'div.interface-interface-skeleton__header';
+const settingsButtonLabel = 'Settings';
 const selectors = {
 	// Block Inserter
 	// Note the partial class match. This is to support site and post editor. We can't use aria-label because of i18n. :(
@@ -35,7 +36,8 @@ const selectors = {
 	detailsButton: `${ panel } button[aria-label="Details"]`,
 
 	// Editor settings
-	settingsButton: `${ panel } .edit-post-header__settings .interface-pinned-items button[aria-label="Settings"]`,
+	settingsButton: ( label = settingsButtonLabel ) =>
+		`${ panel } .edit-post-header__settings .interface-pinned-items button[aria-label="${ label }"]`,
 
 	// Undo/Redo
 	undoButton: 'button[aria-disabled=false][aria-label="Undo"]',
@@ -222,13 +224,26 @@ export class EditorToolbarComponent {
 	/* Editor Settings sidebar */
 
 	/**
+	 * Get localized settings button toggle label.
+	 */
+	async getLocalizedSettingsButtonLabel(): Promise< string > {
+		return this.editor.evaluate(
+			// eslint-disable-next-line @wordpress/i18n-no-variables
+			( _el, label ) => ( window as any )?.wp?.i18n?.__( label ),
+			settingsButtonLabel
+		);
+	}
+
+	/**
 	 * Opens the editor settings.
 	 */
 	async openSettings(): Promise< void > {
-		if ( await this.targetIsOpen( selectors.settingsButton ) ) {
+		const settingsLabel = await this.getLocalizedSettingsButtonLabel();
+
+		if ( await this.targetIsOpen( selectors.settingsButton( settingsLabel ) ) ) {
 			return;
 		}
-		const locator = this.editor.locator( selectors.settingsButton );
+		const locator = this.editor.locator( selectors.settingsButton( settingsLabel ) );
 		await locator.click();
 	}
 
@@ -236,10 +251,12 @@ export class EditorToolbarComponent {
 	 * Closes the editor settings.
 	 */
 	async closeSettings(): Promise< void > {
-		if ( ! ( await this.targetIsOpen( selectors.settingsButton ) ) ) {
+		const settingsLabel = await this.getLocalizedSettingsButtonLabel();
+
+		if ( ! ( await this.targetIsOpen( selectors.settingsButton( settingsLabel ) ) ) ) {
 			return;
 		}
-		const locator = this.editor.locator( selectors.settingsButton );
+		const locator = this.editor.locator( selectors.settingsButton( settingsLabel ) );
 		await locator.click();
 	}
 


### PR DESCRIPTION
The `settingsButton` selector used in `EditorToolbarComponent` has the English string for the `aria-label` attribute hardcoded, which makes it unusable with the translated editor UI.

#### Changes proposed in this Pull Request

* This PR translates the `Settings` string using the `wp.i18n.__` translate function within the block editor frame and then gets the computed settings toggle button selector using the translated label.

#### Testing instructions

* I18n e2e tests pass
