### PR TITLE
Goals Capture: Create utility to resolve site intent base on site goals

### DIFF
--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -4,7 +4,14 @@ export enum GoalKey {
 	Write = 'write',
 	Sell = 'sell',
 	Promote = 'promote',
-	DIFM = 'difm',
+	DIFM = 'difm', // "Do It For Me"
 	Import = 'import',
 	Other = 'other',
+}
+
+export enum IntentKey {
+	Write = 'write',
+	Sell = 'sell',
+	Build = 'build',
+	DIFM = 'difm', // "Do It For Me"
 }

--- a/packages/data-stores/src/onboard/test/utils.ts
+++ b/packages/data-stores/src/onboard/test/utils.ts
@@ -1,0 +1,29 @@
+import { GoalKey, IntentKey } from '../constants';
+import { goalsToIntent } from '../utils';
+
+describe( 'Test onboard utils', () => {
+	it.each( [
+		{
+			goals: [],
+			expectedIntent: IntentKey.Build,
+		},
+		{
+			goals: [ GoalKey.Write, GoalKey.Import, GoalKey.DIFM ],
+			expectedIntent: IntentKey.DIFM,
+		},
+		{
+			goals: [ GoalKey.Write, GoalKey.Sell, GoalKey.Promote ],
+			expectedIntent: IntentKey.Write,
+		},
+		{
+			goals: [ GoalKey.Sell, GoalKey.Write, GoalKey.Promote ],
+			expectedIntent: IntentKey.Sell,
+		},
+		{
+			goals: [ GoalKey.Promote, GoalKey.Sell, GoalKey.Write ],
+			expectedIntent: IntentKey.Build,
+		},
+	] )( 'Should map the $goals to $expectedIntent intent', ( { goals, expectedIntent } ) => {
+		expect( goalsToIntent( goals ) ).toBe( expectedIntent );
+	} );
+} );

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -1,0 +1,27 @@
+import { GoalKey, IntentKey } from './constants';
+
+const INTENT_DECIDING_GOALS = [ GoalKey.Write, GoalKey.Sell, GoalKey.Promote ] as const;
+type IntentDecidingGoal = typeof INTENT_DECIDING_GOALS[ number ];
+
+const GOAL_TO_INSTANT_MAP: { [ key in IntentDecidingGoal ]: IntentKey } = {
+	[ GoalKey.Write ]: IntentKey.Write,
+	[ GoalKey.Sell ]: IntentKey.Sell,
+	[ GoalKey.Promote ]: IntentKey.Build,
+};
+
+export const goalsToIntent = ( goals: GoalKey[] ): IntentKey => {
+	// Including DIFM goal overwrites any other goal selection made
+	if ( goals.includes( GoalKey.DIFM ) ) {
+		return IntentKey.DIFM;
+	}
+
+	const intentDecidingGoal = ( goals as IntentDecidingGoal[] ).find( ( goal ) =>
+		INTENT_DECIDING_GOALS.includes( goal )
+	);
+
+	if ( intentDecidingGoal ) {
+		return GOAL_TO_INSTANT_MAP[ intentDecidingGoal ];
+	}
+
+	return IntentKey.Build;
+};

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -3,7 +3,7 @@ import { GoalKey, IntentKey } from './constants';
 const INTENT_DECIDING_GOALS = [ GoalKey.Write, GoalKey.Sell, GoalKey.Promote ] as const;
 type IntentDecidingGoal = typeof INTENT_DECIDING_GOALS[ number ];
 
-const GOAL_TO_INSTANT_MAP: { [ key in IntentDecidingGoal ]: IntentKey } = {
+const GOAL_TO_INTENT_MAP: { [ key in IntentDecidingGoal ]: IntentKey } = {
 	[ GoalKey.Write ]: IntentKey.Write,
 	[ GoalKey.Sell ]: IntentKey.Sell,
 	[ GoalKey.Promote ]: IntentKey.Build,
@@ -20,7 +20,7 @@ export const goalsToIntent = ( goals: GoalKey[] ): IntentKey => {
 	);
 
 	if ( intentDecidingGoal ) {
-		return GOAL_TO_INSTANT_MAP[ intentDecidingGoal ];
+		return GOAL_TO_INTENT_MAP[ intentDecidingGoal ];
 	}
 
 	return IntentKey.Build;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Create a utility to resolve site intent base on site goals

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run `yarn test-packages packages/data-stores/src/onboard`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/63915
