### PR TITLE
Me: Disable collapsed sidebar because it doesn't have design

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -231,8 +231,11 @@ class Layout extends Component {
 		const optionalBodyProps = () => {
 			const bodyClass = [ 'font-smoothing-antialiased' ];
 
-			if ( this.props.sidebarIsCollapsed && isWithinBreakpoint( '>800px' ) ) {
-				bodyClass.push( 'is-sidebar-collapsed' );
+			// /me section doesn't have design for a collapsed sidebar.
+			if ( 'me' !== this.props.sectionGroup ) {
+				if ( this.props.sidebarIsCollapsed && isWithinBreakpoint( '>800px' ) ) {
+					bodyClass.push( 'is-sidebar-collapsed' );
+				}
 			}
 
 			return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If the user's sidebar is collapsed, this pull request forces a full-size sidebar on the `/me` group of pages.

##### Before

<img width="617" alt="image" src="https://user-images.githubusercontent.com/36432/171213188-a9907f62-da17-4b1e-a093-43ed2d598ac5.png">

##### After

<img width="750" alt="image" src="https://user-images.githubusercontent.com/36432/171213131-69fd186d-1b3a-4271-8b86-1dfd45b60518.png">

#### Testing instructions

1. Navigate to http://calypso.localhost:3000/
2. Collapse the left-hand sidebar.
3. Verify the sidebar is collapsed.
4. Click on your avatar in the top right of the page.
5. Verify the sidebar remains expanded on http://calypso.localhost:3000/me

Related to #62985
Alternative to #64201
