### PR TITLE
Stepper: Add check in the site-setup flow for site owner

### DIFF
--- a/client/landing/stepper/hooks/use-user-can-manage-options.ts
+++ b/client/landing/stepper/hooks/use-user-can-manage-options.ts
@@ -16,5 +16,5 @@ export function useCanUserManageOptions() {
 		canCurrentUser( state, siteId as number, 'manage_options' )
 	);
 
-	return isRequesting ? 'requesting' : hasManageOptionsCap;
+	return isRequesting ? 'requesting' : hasManageOptionsCap ?? false;
 }

--- a/client/landing/stepper/hooks/use-user-can-manage-options.ts
+++ b/client/landing/stepper/hooks/use-user-can-manage-options.ts
@@ -10,11 +10,11 @@ export function useCanUserManageOptions() {
 	const siteId = useSelect(
 		( select ) => siteSlug && select( SITE_STORE ).getSiteIdBySlug( siteSlug )
 	);
-	const isRequesting = useSelector( ( state ) => isRequestingSites( state ) );
 
+	const isRequesting = useSelector( ( state ) => isRequestingSites( state ) );
 	const hasManageOptionsCap = useSelector( ( state ) =>
 		canCurrentUser( state, siteId as number, 'manage_options' )
 	);
 
-	return isRequesting ? 'requesting' : hasManageOptionsCap ?? false;
+	return isRequesting ? 'requesting' : hasManageOptionsCap;
 }

--- a/client/landing/stepper/hooks/use-user-can-manage-options.ts
+++ b/client/landing/stepper/hooks/use-user-can-manage-options.ts
@@ -16,5 +16,7 @@ export function useCanUserManageOptions() {
 		canCurrentUser( state, siteId as number, 'manage_options' )
 	);
 
-	return isRequesting ? 'requesting' : hasManageOptionsCap ?? false;
+	if ( siteId ) {
+		return isRequesting ? 'requesting' : hasManageOptionsCap ?? false;
+	}
 }


### PR DESCRIPTION
Reverts undo of https://github.com/Automattic/wp-calypso/pull/64129. It was undone because pre-release tests where failing before deploying.

The error the CI was throwing was that after you sign-up for an account the siteSlug check seems to fail when it shouldn't.

<img width="772" alt="image" src="https://user-images.githubusercontent.com/375980/171415502-42f534c5-69d5-4a93-9bad-8ca31e8d1588.png">


https://github.com/Automattic/wp-calypso/issues/63687
