### PR TITLE
Checkout: Send tax location from form to transaction cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -103,7 +103,7 @@ export function createTransactionEndpointCartFromResponseCart( {
 			products: responseCart.products.map( ( item ) =>
 				addRegistrationDataToGSuiteCartProduct( item, contactDetails )
 			),
-			tax: createTransactionEndpointTaxFromResponseCartTax( responseCart.tax ),
+			tax: createTransactionEndpointTax( responseCart.tax, contactDetails ),
 		};
 	}
 
@@ -116,19 +116,20 @@ export function createTransactionEndpointCartFromResponseCart( {
 		products: responseCart.products.map( ( item ) =>
 			addRegistrationDataToGSuiteCartProduct( item, contactDetails )
 		),
-		tax: createTransactionEndpointTaxFromResponseCartTax( responseCart.tax ),
+		tax: createTransactionEndpointTax( responseCart.tax, contactDetails ),
 	};
 }
 
-function createTransactionEndpointTaxFromResponseCartTax(
-	tax: ResponseCartTaxData
+function createTransactionEndpointTax(
+	tax: ResponseCartTaxData,
+	contactDetails: DomainContactDetails | null
 ): RequestCartTaxData {
 	const { country_code, postal_code, subdivision_code } = tax.location;
 	return {
 		location: {
-			country_code,
-			postal_code,
-			subdivision_code,
+			country_code: contactDetails?.countryCode ?? country_code,
+			postal_code: contactDetails?.postalCode ?? postal_code,
+			subdivision_code: contactDetails?.state ?? subdivision_code,
 		},
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When submitting a transaction in checkout, we must also submit the final shopping cart object (of the type `RequestCart`) that we want to purchase. This cart object is taken from the most recent data (of type `ResponseCart`) returned from the shopping-cart endpoint. Sometimes, however, it's possible for the tax location information in the checkout form to have incorrectly been removed from the cart after it was added. We're still not certain what causes this but it appears to be a race condition with the database storage. In any case, the result is that the tax location submitted in the final cart does not include the tax location written in the form on the page. This causes taxes to be incorrectly charged.

In this PR, we modify the submission process so that we always default to the tax location information in the form first when we submit a transaction, ignoring the location saved in the cart. This approach should make sure that whatever the user has entered into the form will be the information with which they are charged.

There are downsides to this approach, though. If the cart response does not have the correct tax location, then the total price being displayed at checkout will not match what the user is charged.

To do:

- [ ] We need to use the `contactDetails` rather than the `domainDetails`.

#### Testing instructions

1. First, sandbox the API and apply D81809-code which will cause the cart endpoint to always return the tax location of `90210` and `US`.
1. Add a product to your cart and visit checkout with this PR applied.
1. Enter tax location information in the billing information/contact information step and click "Continue". Do not use `90210`.
1. Open your browser's devtools to examine the network tab.
1. Click to submit the transaction. We only need to see the data submitted so you can use a Stripe test card that will fail if you like.
3. Look at the data submitted to the `/me/transactions` endpoint using your browser's devtools and verify that the `cart.tax.location` data matches the second tax location you entered. Previously it would use `90210` no matter what.