### PR TITLE
Disable refetchOnWindowFocus in CalypsoShoppingCartProvider

### DIFF
--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -10,7 +10,7 @@ import { cartManagerClient } from './cart-manager-client';
 export default function CalypsoShoppingCartProvider( { children }: PropsWithChildren< {} > ) {
 	const options = useMemo(
 		() => ( {
-			refetchOnWindowFocus: true,
+			refetchOnWindowFocus: false,
 		} ),
 		[]
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This disables the `refetchOnWindowFocus` property of `ShoppingCartProvider` as used in calypso. 

When true, this property refetches the cart when the calypso tab is refocused after a short delay (similar the the same property of `react-query`). Unfortunately this can create an unexpected situation in checkout if the refreshed cart contains a different tax location because the input fields on the checkout form are not responsive to the tax location from the cart; they will remain displaying the old location while the price will use the new (invisible) location.

#### Testing instructions

TBD