### PR TITLE
Checkout: Update tax form if cart tax location changes

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { useSelect } from '@wordpress/data';
 import useIsCachedContactFormValid from '../hooks/use-is-cached-contact-form-valid';
 import useSkipToLastStepIfFormComplete from '../hooks/use-skip-to-last-step-if-form-complete';
+import { useUpdateFormLocationIfCartChanges } from '../hooks/use-update-form-location-if-cart-changes';
 import ContactDetailsContainer from './contact-details-container';
 import type {
 	CountryListItem,
@@ -48,6 +49,7 @@ export default function WPContactForm( {
 	const isCachedContactFormValid = useIsCachedContactFormValid( contactValidationCallback );
 
 	useSkipToLastStepIfFormComplete( isCachedContactFormValid );
+	useUpdateFormLocationIfCartChanges();
 
 	return (
 		<BillingFormFields>

--- a/client/my-sites/checkout/composite-checkout/hooks/use-update-form-location-if-cart-changes.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-update-form-location-if-cart-changes.ts
@@ -1,0 +1,33 @@
+import { useShoppingCart } from '@automattic/shopping-cart';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
+
+export function useUpdateFormLocationIfCartChanges(): void {
+	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
+		select( 'wpcom-checkout' ).getContactInfo()
+	);
+	const checkoutStoreActions = useDispatch( 'wpcom-checkout' );
+	const { responseCart } = useShoppingCart();
+
+	if ( ! checkoutStoreActions?.updateCountryCode ) {
+		throw new Error(
+			'useUpdateFormLocationIfCartChanges must be run after the checkout data store has been initialized'
+		);
+	}
+	const { updateCountryCode, updatePostalCode } = checkoutStoreActions;
+
+	const cartCountry = responseCart.tax.location.country_code ?? '';
+	const cartPostal = responseCart.tax.location.postal_code ?? '';
+	const contactCountry = contactInfo.countryCode?.value ?? '';
+	const contactPostal = contactInfo.postalCode?.value ?? '';
+	const doesCartMatchContact = cartCountry === contactCountry && cartPostal === contactPostal;
+
+	useEffect( () => {
+		if ( doesCartMatchContact ) {
+			return;
+		}
+		updateCountryCode( cartCountry );
+		updatePostalCode( cartPostal );
+	}, [ cartCountry, cartPostal, doesCartMatchContact, updateCountryCode, updatePostalCode ] );
+}


### PR DESCRIPTION
#### The problem

One way of looking at the checkout form in calypso is that it is a representation of the data returned by the `/me/shopping-cart` endpoint; particularly the list of cart items and their prices along with the taxes and total. The checkout page also includes a tax location form (country code and postal code, which is sometimes part of the domain details contact form); when the user edits the tax location, it sends the new location to the cart endpoint.

However, the location _returned from the cart endpoint is not actually displayed anywhere_. Typically this is not an issue because it is usually only updated by the form itself, but it's certainly possible for the cart to have changed for some other reason (eg: updating the location in another tab). If that happens, the tax location used to calculate the prices that will be displayed _will be different than the one shown in the form_.

#### Changes proposed in this Pull Request

In this PR, we add a React hook, `useUpdateFormLocationIfCartChanges`, that will respond to changes in the cart's tax location and update the form to match.

#### Testing instructions

1. First, sandbox the API because you'll need to apply a patch.
2. Add a product to your cart with this branch running and visit checkout.
3. Edit the tax location in the form to change it to `10001` in the US and press "Continue".
4. Duplicate the checkout tab. In the second tab, change the tax location to the postal code `90210` and press "Continue".
5. Wait about a minute and then refocus the first checkout tab.
6. Verify that the displayed postal code has changed to `90210`.