### PR TITLE
VideoPress: Enable "Video Privacy" field in Media Library for Jetpack sites

### DIFF
--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -17,8 +17,9 @@ import { FormCheckbox } from 'calypso/devdocs/design/playground-scope';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { getMimePrefix, url } from 'calypso/lib/media/utils';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import versionCompare from 'calypso/lib/version-compare';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EditorMediaModalFieldset from '../fieldset';
 
@@ -353,8 +354,10 @@ class EditorMediaModalDetailFields extends Component {
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const isWpcom = ! isJetpackSite( state, siteId );
-	const hasVideoPrivacyFeature =
-		isWpcom && siteHasFeature( state, siteId, 'videopress-privacy-setting' );
+	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
+	const isJetpackPrivateVideoSupported =
+		siteJetpackVersion && versionCompare( siteJetpackVersion, '10.9', '>=' );
+	const hasVideoPrivacyFeature = isWpcom || isJetpackPrivateVideoSupported;
 
 	return {
 		siteId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Now that Jetpack version with support for private videos has been released, we can enable the "Video Privacy" field in the media library. Since it is only supported for version v10.9 and up we do a jetpack version check as well.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* pull pr, build and run
* Open the Media Library for a wpcom simple site, atomic site and Jetpack site at the latest version
* Select a media item
* The detail modal should have a "Privacy" field for all 3 sites
* For a Jetpack site at a lower version than 10.9 (or just edit the version number in code to a higher number `11.9` for example), open the media library
* Select a video, you should not see the "Privacy" field
* Also test as a non-a11n user, since the wpcom feature check endpoint is no longer used it should not block you from using the feature (cleaned up in D81813-code)

<img width="506" alt="Screen Shot 2022-05-31 at 5 07 35 PM" src="https://user-images.githubusercontent.com/4081020/171284633-e1edd323-4305-4643-890f-661137b302fe.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1204-gh-Automattic/greenhouse