### PR TITLE
Checkout: Change inactive tax info step to display tax location from cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form-summary.tsx
@@ -137,20 +137,24 @@ function AddressSummary( {
 	areThereDomainProductsInCart: boolean;
 	isRenewal: boolean;
 } ) {
-	// We display the postal code and country from the cart's tax location rather
-	// than what is stored in the contact details just in case they differ (eg:
-	// if the tax location has been changed in another tab) so that what is
-	// displayed always matches what the cart is using to calculate taxes. This
-	// does mean that the summary won't display the postal code and country that
-	// will be sent to the transactions endpoint for a domain product (it will be
-	// whatever was entered in the form) but that is less risky since it will be
-	// validated before the transaction completes and it will not affect the
-	// price like the tax location will.
-	const postalAndCountry = joinNonEmptyValues(
-		', ',
-		responseCart.tax.location.postal_code,
-		responseCart.tax.location.country_code
-	);
+	// For carts which could be taxed, we display the postal code and country
+	// from the cart's tax location rather than what is stored in the contact
+	// details just in case they differ (eg: if the tax location has been changed
+	// in another tab) so that what is displayed always matches what the cart is
+	// using to calculate taxes. This does mean that the summary won't display
+	// the postal code and country that will be sent to the transactions endpoint
+	// for a domain product (it will be whatever was entered in the form) but
+	// that is less risky since it will be validated before the transaction
+	// completes and it will not affect the price like the tax location will.
+	const postalCode =
+		responseCart.total_cost_integer > 0
+			? responseCart.tax.location.postal_code
+			: contactInfo.postalCode?.value;
+	const countryCode =
+		responseCart.total_cost_integer > 0
+			? responseCart.tax.location.country_code
+			: contactInfo.countryCode?.value;
+	const postalAndCountry = joinNonEmptyValues( ', ', postalCode, countryCode );
 
 	if ( ! areThereDomainProductsInCart || isRenewal ) {
 		return (

--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form-summary.tsx
@@ -1,9 +1,10 @@
-import { ResponseCart, useShoppingCart } from '@automattic/shopping-cart';
+import { useShoppingCart } from '@automattic/shopping-cart';
 import styled from '@emotion/styled';
 import { useSelect } from '@wordpress/data';
 import { hasOnlyRenewalItems } from 'calypso/lib/cart-values/cart-items';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { SummaryLine, SummaryDetails } from './summary-details';
+import type { ResponseCart } from '@automattic/shopping-cart';
 import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
 
 const GridRow = styled.div`


### PR DESCRIPTION
#### The problem

One way of looking at the checkout form in calypso is that it is a representation of the data returned by the `/me/shopping-cart` endpoint; particularly the list of cart items and their prices along with the taxes and total. The checkout page also includes a tax location form (country code and postal code, which is sometimes part of the domain details contact form); when the user edits the tax location, it sends the new location to the cart endpoint.

However, the location _returned from the cart endpoint is not actually displayed anywhere_. Typically this is not an issue because it is usually only updated by the form itself, but it's certainly possible for the cart to have changed for some other reason (eg: updating the location in another tab). If that happens, the tax location used to calculate the prices that will be displayed _will be different than the one shown in the form_.

#### Changes proposed in this Pull Request

In this PR, we change the inactive tax location step of checkout so that it displays the postal code and country from the cart rather than from the form's internal storage. That way the user will always see the tax location that is being used for the taxes being charged. If it differs from the form location and the user edits the form location, that will update the cart to match.

<img width="574" alt="Screen Shot 2022-05-31 at 5 56 18 PM" src="https://user-images.githubusercontent.com/2036909/171290926-5d648366-7284-4f00-8737-efca9d9c3529.png">

Depends on https://github.com/Automattic/wp-calypso/pull/64216

#### Testing instructions

1. Add a product to your cart with this branch running and visit checkout.
1. Edit the tax location in the form to change it to `10001` in the US and press "Continue".
1. Duplicate the checkout tab. In the second tab, change the tax location to the postal code `90210` and press "Continue".
1. Wait about a minute and then refocus the first checkout tab.
1. Verify that the displayed postal code has changed to `90210`. (Note that if you edit that step the form will read `10001` again, but this is expected if not ideal.)