### PR TITLE
E2E: add WordPress.com Starter plan spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -8,7 +8,7 @@ type PlansGridVersion = 'current' | 'legacy';
 type PlansComparisonAction = 'show' | 'hide';
 
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
-export type Plans = 'Free' | 'Pro';
+export type Plans = 'Free' | 'Pro' | 'Starter';
 export type LegacyPlans = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
 export type PlansPageTab = 'My Plan' | 'Plans';
 export type PlanActionButton = 'Manage plan' | 'Upgrade';
@@ -147,19 +147,13 @@ export class PlansPage {
 	 * @param {PlansPageTab} targetTab Name of the tab.
 	 */
 	async clickTab( targetTab: PlansPageTab ): Promise< void > {
-		// Plans page against the current WordPress.com Plans do not
-		// require any clicking of navigation tabs.
-		if ( this.version === 'current' ) {
-			return;
-		}
-
 		// On mobile viewports, the way PlansPage loads its contents
 		// causes an event to fire which closes all open panes.
 		// Waiting for one of the last SVGs to load on the page is
 		// a hacky but effective workaround.
 		// See https://github.com/Automattic/wp-calypso/issues/64389
 		// and https://github.com/Automattic/wp-calypso/pull/64421#discussion_r892589761.
-		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+		if ( this.version === 'legacy' && envVariables.VIEWPORT_NAME === 'mobile' ) {
 			await this.page.waitForResponse( ( response ) =>
 				response.url().includes( '/images/wpcom-ecommerce' )
 			);

--- a/test/e2e/specs/plans/plans__signup-starter.ts
+++ b/test/e2e/specs/plans/plans__signup-starter.ts
@@ -1,0 +1,154 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	BrowserManager,
+	LoginPage,
+	UserSignupPage,
+	SignupPickPlanPage,
+	StartSiteFlow,
+	SidebarComponent,
+	PlansPage,
+	RestAPIClient,
+	CartCheckoutPage,
+	DomainSearchComponent,
+	IndividualPurchasePage,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+import { apiCloseAccount } from '../shared';
+import type { NewUserResponse } from '@automattic/calypso-e2e';
+
+declare const browser: Browser;
+
+describe(
+	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Starter site as new user' ),
+	function () {
+		const testUser = DataHelper.getNewTestUser( { usernamePrefix: 'free' } );
+		const blogName = DataHelper.getBlogName();
+
+		let page: Page;
+		let userDetails: NewUserResponse;
+		let userCreatedFlag = false;
+		let siteCreatedFlag = false;
+
+		beforeAll( async function () {
+			page = await browser.newPage();
+		} );
+
+		describe( 'Register as new user', function () {
+			it( 'Navigate to Signup page', async function () {
+				const loginPage = new LoginPage( page );
+				await loginPage.visit();
+				await loginPage.clickSignUp();
+			} );
+
+			it( 'Sign up as new user', async function () {
+				const userSignupPage = new UserSignupPage( page );
+				userDetails = await userSignupPage.signup(
+					testUser.email,
+					testUser.username,
+					testUser.password
+				);
+
+				userCreatedFlag = true;
+			} );
+		} );
+
+		describe( 'Create new site', function () {
+			let cartCheckoutPage: CartCheckoutPage;
+
+			beforeAll( async function () {
+				await BrowserManager.setStoreCookie( page );
+			} );
+
+			it( 'Select a .wordpres.com domain name', async function () {
+				const domainSearchComponent = new DomainSearchComponent( page );
+				await domainSearchComponent.search( blogName );
+				await domainSearchComponent.selectDomain( '.wordpress.com' );
+			} );
+
+			it( 'Select WordPress.com Pro plan', async function () {
+				const signupPickPlanPage = new SignupPickPlanPage( page );
+				await signupPickPlanPage.selectPlan( 'Starter' );
+
+				siteCreatedFlag = true;
+			} );
+
+			it( 'See secure checkout', async function () {
+				cartCheckoutPage = new CartCheckoutPage( page );
+				await cartCheckoutPage.validateCartItem( 'WordPress.com Starter' );
+			} );
+
+			it( 'Enter payment details', async function () {
+				const paymentDetails = DataHelper.getTestPaymentDetails();
+				await cartCheckoutPage.enterBillingDetails( paymentDetails );
+				await cartCheckoutPage.enterPaymentDetails( paymentDetails );
+			} );
+
+			it( 'Make purchase', async function () {
+				await cartCheckoutPage.purchase();
+			} );
+
+			it( 'Skip to dashboard', async function () {
+				const startSiteFlow = new StartSiteFlow( page );
+				await Promise.all( [
+					page.waitForNavigation( { url: /.*\/home\/.*/ } ),
+					startSiteFlow.clickButton( 'Skip to dashboard' ),
+				] );
+			} );
+		} );
+
+		describe( 'Validate WordPress.com Starter functionality', function () {
+			let sidebarComponent: SidebarComponent;
+
+			it( 'Sidebar states user is on WordPress.com Starter plan', async function () {
+				sidebarComponent = new SidebarComponent( page );
+				const plan = await sidebarComponent.getCurrentPlanName();
+				expect( plan ).toBe( 'Starter' );
+			} );
+
+			it( 'Navigate to Upgrades > Plans', async function () {
+				sidebarComponent = new SidebarComponent( page );
+				await sidebarComponent.navigate( 'Upgrades', 'Plans' );
+			} );
+
+			it( 'Plans page states user is on WordPress.com Starter plan', async function () {
+				const plansPage = new PlansPage( page, 'current' );
+				await plansPage.clickTab( 'My Plan' );
+				await plansPage.validateActivePlan( 'Starter' );
+			} );
+		} );
+
+		describe( 'Cancel Plan', function () {
+			it( 'View purchased upgrade details', async function () {
+				const plansPage = new PlansPage( page, 'current' );
+				await plansPage.clickManagePlan();
+			} );
+
+			it( 'Cancel WordPress.com Starter plan', async function () {
+				const individualPurchasePage = new IndividualPurchasePage( page );
+				await individualPurchasePage.cancelPurchase();
+			} );
+		} );
+
+		afterAll( async function () {
+			// Skip the cleanup if neither user nor site were created.
+			if ( ! userCreatedFlag && ! siteCreatedFlag ) {
+				return;
+			}
+
+			const restAPIClient = new RestAPIClient( {
+				username: testUser.username,
+				password: testUser.password,
+			} );
+
+			apiCloseAccount( restAPIClient, {
+				userID: userDetails.body.user_id,
+				username: testUser.username,
+				email: testUser.email,
+			} );
+		} );
+	}
+);

--- a/test/e2e/specs/plans/plans__signup-starter.ts
+++ b/test/e2e/specs/plans/plans__signup-starter.ts
@@ -69,7 +69,7 @@ describe(
 				await domainSearchComponent.selectDomain( '.wordpress.com' );
 			} );
 
-			it( 'Select WordPress.com Pro plan', async function () {
+			it( 'Select WordPress.com Starter plan', async function () {
 				const signupPickPlanPage = new SignupPickPlanPage( page );
 				await signupPickPlanPage.selectPlan( 'Starter' );
 
@@ -144,7 +144,7 @@ describe(
 				password: testUser.password,
 			} );
 
-			apiCloseAccount( restAPIClient, {
+			await apiCloseAccount( restAPIClient, {
 				userID: userDetails.body.user_id,
 				username: testUser.username,
 				email: testUser.email,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds end-to-end coverage for the WordPress.com Starter plan.

Key changes:
- new spec to sign up as a new user, going on to set up a new site using WordPress.com Starter plan.
- updates to the POMs to support the spec.

Other housekeeping changes:
- removal of short-circuit when clicking on the navigation tab for the current version of PlansPage.
- addition of `Starter` as valid plan type.
- addition of method to manage the existing plan.

#### Testing instructions

Ensure the following:
  - [ ] Calypso E2E (desktop)
  - [ ] Calypso E2E (mobile)
  - [ ] Pre-Release E2E

Related to https://github.com/Automattic/wp-calypso/issues/62492.
Depends on https://github.com/Automattic/wp-calypso/pull/63974.
