### PR TITLE
Editing Toolkit: Update 'Tested up to' to 6.0

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.5
-Tested up to: 5.6
+Tested up to: 6.0
 Stable tag: 2.21
 Requires PHP: 5.6.20
 License: GPLv2 or later


### PR DESCRIPTION
#### Proposed Changes

* Updates 'Tested up to' in Editing Toolkit to 6.0

Fixes this warning:

<img width="720" alt="image" src="https://user-images.githubusercontent.com/36432/171290161-d497254f-c283-4614-8ad6-f36cc3e8ad9f.png">
