### PR TITLE
E2E: re-enable `Signup: Free` spec for standard platforms.

### DIFF
--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -161,8 +161,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ), function 
 			await domainSearchComponent.clickButton( 'Skip Purchase' );
 		} );
 
-		// eslint-disable-next-line jest/no-disabled-tests
-		it.skip( 'Keep free plan', async function () {
+		it( 'Keep free plan', async function () {
 			const signupPickPlanPage = new SignupPickPlanPage( page );
 			await signupPickPlanPage.selectPlan( 'Free' );
 		} );

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -18,173 +18,165 @@ import {
 	SecretsManager,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { skipDescribeIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
-const isStagingOrProd = DataHelper.getCalypsoURL()
-	.toLowerCase()
-	.includes( 'https://wordpress.com' );
+describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ), function () {
+	const inboxId = SecretsManager.secrets.mailosaur.inviteInboxId;
+	const username = `e2eflowtestingfree${ DataHelper.getTimestamp() }`;
+	const email = DataHelper.getTestEmailAddress( {
+		inboxId: inboxId,
+		prefix: username,
+	} );
+	const signupPassword = SecretsManager.secrets.passwordForNewTestSignUps;
+	const blogName = DataHelper.getBlogName();
+	const tagline = `${ blogName } tagline`;
 
-// Skipping while new onboarding flows are in transition and we map the new tests
-skipDescribeIf( isStagingOrProd )(
-	DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ),
-	function () {
-		const inboxId = SecretsManager.secrets.mailosaur.inviteInboxId;
-		const username = `e2eflowtestingfree${ DataHelper.getTimestamp() }`;
-		const email = DataHelper.getTestEmailAddress( {
-			inboxId: inboxId,
-			prefix: username,
-		} );
-		const signupPassword = SecretsManager.secrets.passwordForNewTestSignUps;
-		const blogName = DataHelper.getBlogName();
-		const tagline = `${ blogName } tagline`;
+	let page: Page;
+	let domainSearchComponent: DomainSearchComponent;
+	let editorPage: EditorPage;
+	let startSiteFlow: StartSiteFlow;
+	let generalSettingsPage: GeneralSettingsPage;
 
-		let page: Page;
-		let domainSearchComponent: DomainSearchComponent;
-		let editorPage: EditorPage;
-		let startSiteFlow: StartSiteFlow;
-		let generalSettingsPage: GeneralSettingsPage;
+	beforeAll( async () => {
+		page = await browser.newPage();
+	} );
 
-		beforeAll( async () => {
-			page = await browser.newPage();
-		} );
-
-		describe( 'Signup and select plan', function () {
-			it( 'Navigate to Signup page', async function () {
-				const loginPage = new LoginPage( page );
-				await loginPage.visit();
-				await loginPage.clickSignUp();
-			} );
-
-			it( 'Sign up as new user', async function () {
-				const userSignupPage = new UserSignupPage( page );
-				await userSignupPage.signup( email, username, signupPassword );
-			} );
-
-			it( 'Select a free .wordpress.com domain', async function () {
-				domainSearchComponent = new DomainSearchComponent( page );
-				await domainSearchComponent.search( blogName );
-				await domainSearchComponent.selectDomain( '.wordpress.com' );
-			} );
-
-			it( 'Select WordPress.com Free plan', async function () {
-				const signupPickPlanPage = new SignupPickPlanPage( page );
-				await signupPickPlanPage.selectPlan( 'Free' );
-			} );
+	describe( 'Signup and select plan', function () {
+		it( 'Navigate to Signup page', async function () {
+			const loginPage = new LoginPage( page );
+			await loginPage.visit();
+			await loginPage.clickSignUp();
 		} );
 
-		describe( 'Onboarding flow', function () {
-			it( 'Select "write" path', async function () {
-				startSiteFlow = new StartSiteFlow( page );
-				await startSiteFlow.clickButton( 'Start writing' );
-			} );
-
-			it( 'Enter blog name', async function () {
-				await startSiteFlow.enterBlogName( blogName );
-			} );
-
-			it( 'Enter tagline', async function () {
-				await startSiteFlow.enterTagline( tagline );
-			} );
-
-			it( 'Click continue', async function () {
-				await startSiteFlow.clickButton( 'Continue' );
-			} );
-
-			it( 'Select "Choose a design" path', async function () {
-				await startSiteFlow.clickButton( 'View designs' );
-			} );
-
-			it( 'See design picker screen', async function () {
-				await startSiteFlow.validateOnDesignPickerScreen();
-			} );
-
-			it( 'Navigate back', async function () {
-				await startSiteFlow.goBackOneScreen();
-			} );
-
-			it( 'Select "Draft your first post" path and land in editor', async function () {
-				const navigationTimeout = 2 * 60 * 1000;
-				// Let's add some resilience based on potential A/B test landing places for posts
-				const navigationPromise = Promise.race( [
-					page.waitForNavigation( { url: '**/post/**', timeout: navigationTimeout } ),
-					page.waitForNavigation( {
-						url: '**/wp-admin/post-new.php**',
-						timeout: navigationTimeout,
-					} ),
-				] );
-
-				await Promise.all( [ navigationPromise, startSiteFlow.clickButton( 'Start writing' ) ] );
-			} );
+		it( 'Sign up as new user', async function () {
+			const userSignupPage = new UserSignupPage( page );
+			await userSignupPage.signup( email, username, signupPassword );
 		} );
 
-		describe( 'Validate site metadata', function () {
-			it( 'Return to Calypso dashboard', async function () {
-				editorPage = new EditorPage( page );
-				// Force the flow back into the configured environment for the test suite e.g. wpcalypso or calypso.localhost
-				editorPage.visit();
-				await editorPage.exitEditor();
-			} );
-
-			it( 'Navigate to settings', async function () {
-				const sidebarComponent = new SidebarComponent( page );
-				await sidebarComponent.navigate( 'Settings', 'General' );
-			} );
-
-			it( 'Validate blog name and tagline', async function () {
-				generalSettingsPage = new GeneralSettingsPage( page );
-
-				await generalSettingsPage.validateSiteTitle( blogName );
-				await generalSettingsPage.validateSiteTagline( tagline );
-			} );
+		it( 'Select a free .wordpress.com domain', async function () {
+			domainSearchComponent = new DomainSearchComponent( page );
+			await domainSearchComponent.search( blogName );
+			await domainSearchComponent.selectDomain( '.wordpress.com' );
 		} );
 
-		describe( 'Launch site', function () {
-			it( 'Verify site is not yet launched', async function () {
-				const tmpPage = await browser.newPage();
-				// TODO: make a utility to obtain the blog URL.
-				await tmpPage.goto( `https://${ blogName }.wordpress.com` );
-				// View site without logging in.
-				const comingSoonPage = new ComingSoonPage( tmpPage );
-				await comingSoonPage.validateComingSoonState();
-				// Dispose the test page and context.
-				await tmpPage.close();
-			} );
+		it( 'Select WordPress.com Free plan', async function () {
+			const signupPickPlanPage = new SignupPickPlanPage( page );
+			await signupPickPlanPage.selectPlan( 'Free' );
+		} );
+	} );
 
-			it( 'Start site launch', async function () {
-				const sidebarComponent = new SidebarComponent( page );
-				await sidebarComponent.navigate( 'Settings', 'General' );
-				const generalSettingsPage = new GeneralSettingsPage( page );
-				await generalSettingsPage.launchSite();
-			} );
-
-			it( 'Search for a domain to reveal Skip Purchase button', async function () {
-				domainSearchComponent = new DomainSearchComponent( page );
-				await domainSearchComponent.search( username + '.live' );
-			} );
-
-			it( 'Skip domain purchasse', async function () {
-				const domainSearchComponent = new DomainSearchComponent( page );
-				await domainSearchComponent.clickButton( 'Skip Purchase' );
-			} );
-
-			it( 'Keep free plan', async function () {
-				const signupPickPlanPage = new SignupPickPlanPage( page );
-				await signupPickPlanPage.selectPlan( 'Free' );
-			} );
-
-			it( 'Confirm site is launched', async function () {
-				const myHomePage = new MyHomePage( page );
-				await myHomePage.validateTaskHeadingMessage( 'You launched your site!' );
-			} );
+	describe( 'Onboarding flow', function () {
+		it( 'Select "write" path', async function () {
+			startSiteFlow = new StartSiteFlow( page );
+			await startSiteFlow.clickButton( 'Start writing' );
 		} );
 
-		describe( 'Delete user account', function () {
-			it( 'Close account', async function () {
-				const closeAccountFlow = new CloseAccountFlow( page );
-				await closeAccountFlow.closeAccount();
-			} );
+		it( 'Enter blog name', async function () {
+			await startSiteFlow.enterBlogName( blogName );
 		} );
-	}
-);
+
+		it( 'Enter tagline', async function () {
+			await startSiteFlow.enterTagline( tagline );
+		} );
+
+		it( 'Click continue', async function () {
+			await startSiteFlow.clickButton( 'Continue' );
+		} );
+
+		it( 'Select "Choose a design" path', async function () {
+			await startSiteFlow.clickButton( 'View designs' );
+		} );
+
+		it( 'See design picker screen', async function () {
+			await startSiteFlow.validateOnDesignPickerScreen();
+		} );
+
+		it( 'Navigate back', async function () {
+			await startSiteFlow.goBackOneScreen();
+		} );
+
+		it( 'Select "Draft your first post" path and land in editor', async function () {
+			const navigationTimeout = 2 * 60 * 1000;
+			// Let's add some resilience based on potential A/B test landing places for posts
+			const navigationPromise = Promise.race( [
+				page.waitForNavigation( { url: '**/post/**', timeout: navigationTimeout } ),
+				page.waitForNavigation( {
+					url: '**/wp-admin/post-new.php**',
+					timeout: navigationTimeout,
+				} ),
+			] );
+
+			await Promise.all( [ navigationPromise, startSiteFlow.clickButton( 'Start writing' ) ] );
+		} );
+	} );
+
+	describe( 'Validate site metadata', function () {
+		it( 'Return to Calypso dashboard', async function () {
+			editorPage = new EditorPage( page );
+			// Force the flow back into the configured environment for the test suite e.g. wpcalypso or calypso.localhost
+			editorPage.visit();
+			await editorPage.exitEditor();
+		} );
+
+		it( 'Navigate to settings', async function () {
+			const sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Settings', 'General' );
+		} );
+
+		it( 'Validate blog name and tagline', async function () {
+			generalSettingsPage = new GeneralSettingsPage( page );
+
+			await generalSettingsPage.validateSiteTitle( blogName );
+			await generalSettingsPage.validateSiteTagline( tagline );
+		} );
+	} );
+
+	describe( 'Launch site', function () {
+		it( 'Verify site is not yet launched', async function () {
+			const tmpPage = await browser.newPage();
+			// TODO: make a utility to obtain the blog URL.
+			await tmpPage.goto( `https://${ blogName }.wordpress.com` );
+			// View site without logging in.
+			const comingSoonPage = new ComingSoonPage( tmpPage );
+			await comingSoonPage.validateComingSoonState();
+			// Dispose the test page and context.
+			await tmpPage.close();
+		} );
+
+		it( 'Start site launch', async function () {
+			const sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Settings', 'General' );
+			const generalSettingsPage = new GeneralSettingsPage( page );
+			await generalSettingsPage.launchSite();
+		} );
+
+		it( 'Search for a domain to reveal Skip Purchase button', async function () {
+			domainSearchComponent = new DomainSearchComponent( page );
+			await domainSearchComponent.search( username + '.live' );
+		} );
+
+		it( 'Skip domain purchasse', async function () {
+			const domainSearchComponent = new DomainSearchComponent( page );
+			await domainSearchComponent.clickButton( 'Skip Purchase' );
+		} );
+
+		// eslint-disable-next-line jest/no-disabled-tests
+		it.skip( 'Keep free plan', async function () {
+			const signupPickPlanPage = new SignupPickPlanPage( page );
+			await signupPickPlanPage.selectPlan( 'Free' );
+		} );
+
+		it( 'Confirm site is launched', async function () {
+			const myHomePage = new MyHomePage( page );
+			await myHomePage.validateTaskHeadingMessage( 'You launched your site!' );
+		} );
+	} );
+
+	describe( 'Delete user account', function () {
+		it( 'Close account', async function () {
+			const closeAccountFlow = new CloseAccountFlow( page );
+			await closeAccountFlow.closeAccount();
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR restores the Signup: Free spec to the standard target platforms.

It is suspected that the guard is responsible for the failure in https://github.com/Automattic/wp-calypso/issues/64212, and also discussed in p1654033059549799-slack-C031TFM2NKC.

In short, the step `Keep the free plan` was affected by an unexpected behavior change (that hasn't been entirely pinpointed to a cause) where the plan upsell when launching a site may not always show. 

It appears that by removing the `isStagingOrProd` guard and thereby restoring the normal `describe` block, the issue is resolved.

Key changes:
- remove the `isStagingOrProd` guard.

#### Testing instructions

Ensure the following:
  - [ ] Calypso E2E (desktop)
  - [ ] Calypso E2E (mobile)
  - [x] Pre-Release E2E

Related to https://github.com/Automattic/wp-calypso/issues/64212.
Depended on by https://github.com/Automattic/wp-calypso/pull/63974.