### PR TITLE
Fix issue loading design picker if no vertical was selected

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -404,11 +404,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	// When the intent is build, we can potentially show the generated design picker.
 	// Don't render until we've fetched the generated designs from the backend.
-	if (
-		enabledGeneratedDesigns &&
-		( isLoadingGeneratedDesigns || ! siteVerticalId ) &&
-		! isAnchorSite
-	) {
+	if ( enabledGeneratedDesigns && isLoadingGeneratedDesigns ) {
 		return null;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -404,7 +404,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	// When the intent is build, we can potentially show the generated design picker.
 	// Don't render until we've fetched the generated designs from the backend.
-	if ( enabledGeneratedDesigns && isLoadingGeneratedDesigns ) {
+	if ( isLoadingGeneratedDesigns && ! isAnchorSite ) {
 		return null;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -404,7 +404,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	// When the intent is build, we can potentially show the generated design picker.
 	// Don't render until we've fetched the generated designs from the backend.
-	if ( isLoadingGeneratedDesigns ) {
+	if ( ! site || isLoadingGeneratedDesigns ) {
 		return null;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -104,7 +104,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 				vertical_id: siteVerticalId,
 				seed: siteSlug || undefined,
 			},
-			{ enabled: enabledGeneratedDesigns && !! siteVerticalId }
+			{ enabled: enabledGeneratedDesigns && !! siteVerticalId && ! isAnchorSite }
 		);
 
 	const showGeneratedDesigns =
@@ -404,7 +404,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	// When the intent is build, we can potentially show the generated design picker.
 	// Don't render until we've fetched the generated designs from the backend.
-	if ( isLoadingGeneratedDesigns && ! isAnchorSite ) {
+	if ( isLoadingGeneratedDesigns ) {
 		return null;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reported in the CFT pdtkmj-ba-p2#comment-274 related to https://github.com/Automattic/wp-calypso/pull/64151

The recent change https://github.com/Automattic/wp-calypso/pull/64140 added a loading check which included not rendering the page if `enabledGeneratedDesigns` but `siteVerticalId` was falsy. But this can happen when the user doesn't select a vertical! which lead to a blank screen rather than showing the static design picker.

I'm not sure if this is the correct fix, but it allows the static design picker to load if the user didn't select a vertical as before. And I don't see any flashing of content when a vertical is selected. I also tested the anchorFm flow with `/setup?anchor_podcast=57a33f0c`

#### Testing instructions
Go to `/setup/vertical?siteSlug=$site` and select "Something Else"
Proceed to build step
You should see the static design picker