### PR TITLE
Update `calypso-url` for publishing

### DIFF
--- a/packages/calypso-url/CHANGELOG.md
+++ b/packages/calypso-url/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial release

--- a/packages/calypso-url/package.json
+++ b/packages/calypso-url/package.json
@@ -34,7 +34,6 @@
 	"license": "GPL-2.0-or-later",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/calypso-url#readme",
-	"private": true,
 	"dependencies": {
 		"photon": "workspace:^"
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We need to publish `calypso-url`  to use a new version of `@automattic/components` because it's [`@automattic/components`'s dependency](https://github.com/Automattic/wp-calypso/blob/trunk/packages/components/package.json#L30).

* Add CHANGELOG.md to calypso-url 
* Remove `private: true` from calypso-url package.json

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review changes

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

