### PR TITLE
Update link on Premium Themes card within Plan Features

### DIFF
--- a/client/blocks/product-purchase-features-list/find-new-theme.jsx
+++ b/client/blocks/product-purchase-features-list/find-new-theme.jsx
@@ -12,7 +12,7 @@ export default localize( ( { selectedSite, translate } ) => {
 					'Access a diverse selection of beautifully designed premium themes included with your plan.'
 				) }
 				buttonText={ translate( 'Browse premium themes' ) }
-				href={ '/themes/' + selectedSite.slug }
+				href={ '/themes/premium/' + selectedSite.slug }
 			/>
 		</div>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -84,7 +84,7 @@ const PremiumPlanDetails = ( {
 						"You've now got access to every premium theme, at no extra cost. Give one a try!"
 					) }
 					buttonText={ translate( 'Browse premium themes' ) }
-					href={ '/themes/' + selectedSite.slug }
+					href={ '/themes/premium/' + selectedSite.slug }
 				/>
 			) }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the link to Premium themes to deeplink to /themes/premium/

#### Testing instructions

1. On a site with the Premium or Pro plan (where premium themes are included) go to Upgrades > Plan > My Plan
2. Click the button on the 'Premium Themes' card

Related to #63868
