### PR TITLE
Added auto-scaling of the iframe preview in the design picker

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -2,7 +2,6 @@ import { getDesignPreviewUrl } from '@automattic/design-picker';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import WebPreview from 'calypso/components/web-preview/content';
-import PreviewToolbar from './preview-toolbar';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { Design } from '@automattic/design-picker';
 
@@ -40,7 +39,7 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 			loadingMessage={ translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
 				components: { strong: <strong /> },
 			} ) }
-			toolbarComponent={ PreviewToolbar }
+			toolbarComponent={ () => null }
 			fetchPriority={ isSelected ? 'high' : 'low' }
 			autoHeight
 			siteId={ site?.ID }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -424,6 +424,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	const stepContent = showGeneratedDesigns ? (
 		<GeneratedDesignPicker
+			isStickyToolbar={ ! isMobile && isSticky }
 			selectedDesign={ selectedGeneratedDesign }
 			designs={ generatedDesigns }
 			verticalId={ siteVerticalId }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -491,6 +491,15 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		}
 	}
 
+	.generated-design-picker__previews-scaled {
+		position: absolute;
+		top: 0;
+		right: 0;
+		width: 1160px;
+		transform: scale( 1 );
+		transform-origin: 100% 0;
+	}
+
 	.generated-design-picker__view-more {
 		border-radius: 4px;
 		font-weight: 500;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -402,12 +402,13 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		display: none;
 		position: relative;
 		margin: 0 auto;
-
+		
 		@include break-small {
 			display: flex;
 			align-items: center;
 			justify-content: flex-end;
-			position: sticky;
+			position: fixed;
+			width: calc( 100% - 376px );
 			bottom: 0;
 			height: 118px;
 			background-color: #ffffff;
@@ -422,6 +423,10 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 				transform: translateY( 0 );
 				pointer-events: auto;
 			}
+		}
+
+		@include onboarding-break-2k {
+			width: 1928px;
 		}
 	}
 
@@ -493,9 +498,9 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 	.generated-design-picker__previews-scaled {
 		position: absolute;
-		top: 0;
+		top: 40px;
 		right: 0;
-		width: 1160px;
+		width: 1600px;
 		transform: scale( 1 );
 		transform-origin: 100% 0;
 	}

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -5,6 +5,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect, useRef, useState } from 'react';
+import PreviewToolbar from '../../../../client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/preview-toolbar';
 import { getDesignPreviewUrl, getMShotOptions } from '../utils';
 import type { Design } from '../types';
 import './style.scss';
@@ -56,6 +57,7 @@ const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
 };
 
 export interface GeneratedDesignPickerProps {
+	isStickyToolbar: boolean;
 	selectedDesign?: Design;
 	designs: Design[];
 	previews: React.ReactElement[];
@@ -67,9 +69,10 @@ export interface GeneratedDesignPickerProps {
 	onViewMore: () => void;
 }
 
-const PREVIEW_INITIAL_WIDTH = 1160;
+const PREVIEW_INITIAL_WIDTH = 1600;
 
 const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
+	isStickyToolbar,
 	selectedDesign,
 	designs,
 	previews,
@@ -148,6 +151,7 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 				</div>
 				<div className="generated-design-picker__main">
 					<div className="generated-design-picker__previews" ref={ previewElement }>
+						<PreviewToolbar isSticky={ isStickyToolbar } />
 						<div
 							className="generated-design-picker__previews-scaled"
 							style={ { transform: `scale(${ scalePreview })` } }

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -1,11 +1,10 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-
 import { Button } from '@automattic/components';
 import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getDesignPreviewUrl, getMShotOptions } from '../utils';
 import type { Design } from '../types';
 import './style.scss';
@@ -68,6 +67,8 @@ export interface GeneratedDesignPickerProps {
 	onViewMore: () => void;
 }
 
+const PREVIEW_INITIAL_WIDTH = 1160;
+
 const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 	selectedDesign,
 	designs,
@@ -80,6 +81,21 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 	onViewMore,
 } ) => {
 	const { __ } = useI18n();
+	const [ scalePreview, setScalePreview ] = useState( 1 );
+	const previewElement = useRef< HTMLDivElement | null >( null );
+
+	useEffect( () => {
+		const handleScalePreview = () => {
+			if ( previewElement?.current )
+				setScalePreview( previewElement.current.clientWidth / PREVIEW_INITIAL_WIDTH );
+		};
+
+		handleScalePreview();
+
+		window.addEventListener( 'resize', handleScalePreview );
+
+		return () => window.removeEventListener( 'resize', handleScalePreview );
+	} );
 
 	const isMobile = useViewportMatch( 'small', '<' );
 
@@ -131,7 +147,14 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 					</Button>
 				</div>
 				<div className="generated-design-picker__main">
-					<div className="generated-design-picker__previews">{ previews }</div>
+					<div className="generated-design-picker__previews" ref={ previewElement }>
+						<div
+							className="generated-design-picker__previews-scaled"
+							style={ { transform: `scale(${ scalePreview })` } }
+						>
+							{ previews }
+						</div>
+					</div>
 					{ footer }
 				</div>
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Scale the preview iframe with CSS so the width of the iframe does not affect how the embedded page preview is rendered


https://user-images.githubusercontent.com/1881481/171334313-2f4920dd-ca0c-491f-a336-4a7b93c5ff9d.mp4



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Check that the iframe is scaled accordingly while showing the preview of the desktop layout 
* Resizing the window to different sizes 
* Refreshing the window 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64179
