### PR TITLE
Generated Design Picker: Fix sticky footer is shown briefly when switching back

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -452,9 +452,11 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 						'is-visible': isSticky,
 					} ) }
 				>
-					<Button primary onClick={ () => pickDesign( selectedGeneratedDesign, 'bottom' ) }>
-						{ translate( 'Continue' ) }
-					</Button>
+					<div className="design-setup__footer-content">
+						<Button primary onClick={ () => pickDesign( selectedGeneratedDesign, 'bottom' ) }>
+							{ translate( 'Continue' ) }
+						</Button>
+					</div>
 				</div>
 			}
 			onPreview={ previewDesign }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/sticky-positioner.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/sticky-positioner.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 interface Props {
 	stickyOptions?: IntersectionObserverInit;
@@ -6,7 +6,6 @@ interface Props {
 }
 
 const StickyPositioner = ( { stickyOptions, onShouldStickyChange }: Props ) => {
-	const [ shouldSticky, setShouldSticky ] = useState( false );
 	const targetRef = useRef< HTMLDivElement >( null );
 	const observerRef = useRef< IntersectionObserver >();
 
@@ -21,18 +20,17 @@ const StickyPositioner = ( { stickyOptions, onShouldStickyChange }: Props ) => {
 			}
 
 			const [ entry ] = entries;
-			setShouldSticky( ! entry.isIntersecting );
+			onShouldStickyChange( ! entry.isIntersecting );
 		};
 
 		observerRef.current = new IntersectionObserver( handler, stickyOptions );
 		observerRef.current.observe( targetRef.current );
 
-		return () => observerRef.current?.disconnect?.();
+		return () => {
+			observerRef.current?.disconnect?.();
+			onShouldStickyChange( false );
+		};
 	}, [ stickyOptions ] );
-
-	useEffect( () => {
-		onShouldStickyChange( shouldSticky );
-	}, [ shouldSticky, onShouldStickyChange ] );
 
 	return <div ref={ targetRef } />;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -401,25 +401,32 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 	.design-setup__footer {
 		display: none;
 		position: relative;
-		margin: 0 auto;
 
-		@include break-small {
+		.design-setup__footer-content {
+			position: absolute;
+			top: 100%;
+			width: 100%;
+			height: 100%;
 			display: flex;
 			align-items: center;
 			justify-content: flex-end;
+			background-color: #ffffff;
+			opacity: 0;
+			pointer-events: none;
+			transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out;
+		}
+
+		@include break-small {
+			display: block;
 			position: sticky;
 			bottom: 0;
 			height: 118px;
-			background-color: #ffffff;
-			opacity: 0;
-			transform: translateY( 100% );
-			pointer-events: none;
-			transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out;
+			overflow: hidden;
 			z-index: 1;
 
-			&.is-visible {
+			&.is-visible .design-setup__footer-content {
 				opacity: 1;
-				transform: translateY( 0 );
+				transform: translateY( -100% );
 				pointer-events: auto;
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `StickyPositioner` fires `onShouldStickyChange` event when the element is unmounting
* Change to use `translateY(-100%)` to show the sticky footer so that it won't appear briefly at the beginning
* Also, adding the `design-setup__footer-content` div element to avoid the extra space when the iframe is loading as below
  <img src="https://user-images.githubusercontent.com/13596067/171337458-6f24e9eb-0f61-473c-92dc-028ae55b66fc.png" width="300" />

#### Screenshots

https://user-images.githubusercontent.com/13596067/171337447-d2b89a08-8334-466a-9fa6-6ef7861e06e9.mov

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/designSetup?<your_site>`
* Click the “View more options” button
* Click the “Back” button at the top-left corner
* You shall not see the sticky footer is shown briefly

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64188
