### PR TITLE
Tour Kit: Add autoScroll effect

### DIFF
--- a/packages/tour-kit/README.md
+++ b/packages/tour-kit/README.md
@@ -158,6 +158,7 @@ The main API for configuring a tour is the config object. See example usage and 
   - `spotlight`: Adds a semi-transparent overlay and highlights the reference element when provided with a transparent box over it. Expects an object with optional styles to override the default highlight/spotlight behavior when provided (default: spotlight wraps the entire reference element).
   - `arrowIndicator`: Adds an arrow tip pointing at the reference element when provided.
   - `overlay`: Includes the semi-transparent overlay for all the steps (also blocks interactions with the rest of the page)
+  - `autoScroll`: The page scrolls up and down automatically such that the step target element is visible to the user.
 
 - `callbacks`: An object of callbacks to handle side effects from various interactions (see [types.ts](./src/types.ts)).
 

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -192,6 +192,12 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 		}
 	}, [ popperUpdate, referenceElement ] );
 
+	useEffect( () => {
+		if ( referenceElement && config.options?.effects?.autoScroll ) {
+			referenceElement.scrollIntoView( config.options.effects.autoScroll );
+		}
+	}, [ config.options?.effects?.autoScroll, referenceElement ] );
+
 	const classes = classnames(
 		'tour-kit-frame',
 		isMobile ? 'is-mobile' : 'is-desktop',

--- a/packages/tour-kit/src/storybook/index.stories.tsx
+++ b/packages/tour-kit/src/storybook/index.stories.tsx
@@ -129,3 +129,17 @@ const StoryTour = ( { options = {} }: { options?: Config[ 'options' ] } ) => {
 export const Default = () => <StoryTour />;
 export const Overlay = () => <StoryTour options={ { effects: { overlay: true } } } />;
 export const Spotlight = () => <StoryTour options={ { effects: { spotlight: {} } } } />;
+export const AutoScroll = () => (
+	<>
+		<div style={ { height: '10vh' } }></div>
+		<StoryTour
+			options={ {
+				effects: {
+					autoScroll: {
+						behavior: 'smooth',
+					},
+				},
+			} }
+		/>
+	</>
+);

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -68,6 +68,8 @@ export interface Options {
 		spotlight?: { styles?: React.CSSProperties };
 		arrowIndicator?: boolean; // defaults to true
 		overlay?: boolean;
+		// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+		autoScroll?: ScrollIntoViewOptions | boolean;
 	};
 	popperModifiers?: PopperModifier[];
 	portalParentElement?: HTMLElement | null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Add autoScroll effect to automatically scroll the page such that the step target element is visible to the user.


https://user-images.githubusercontent.com/4344253/171351764-b052f01c-2b90-4788-bd63-12fdf8b39a8b.mov



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn workspace @automattic/tour-kit run storybook`
* Go to `tour-kit > Auto Scroll`
* Click "Start Tour" and confirm the effect work

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/64184
Fixes 33-gh-woocommerce/team-ghidorah
