### PR TITLE
Help Center and Widgets Happychat: address feedback from #64143

### DIFF
--- a/apps/happychat/src/app.jsx
+++ b/apps/happychat/src/app.jsx
@@ -55,14 +55,14 @@ async function AppBoot() {
 	try {
 		auth = await requestHappyChatAuth();
 		user = filterUserObject( auth.fullUser );
-	} catch ( error ) {
+	} catch ( _error ) {
 		// this error most likely means we couldn't auth the user due to 3rd party cookies blockage
 		// attempt to get auth information from the parent window (when this is opened in an iframe)
 		try {
 			const authFromParent = await requestDataFromParent();
 			auth = authFromParent;
 			user = filterUserObject( auth.fullUser );
-		} catch ( _error ) {
+		} catch ( error ) {
 			// there are no 3rd party cookies nor auth data from the parent
 			ReactDom.render(
 				<div className="happy-chat-error-screen">
@@ -74,7 +74,8 @@ async function AppBoot() {
 				</div>,
 				document.getElementById( 'wpcom' )
 			);
-			return;
+			// throw the error to console log it and to stop execution
+			throw error;
 		}
 	}
 

--- a/apps/happychat/src/request-auth-data-from-parent.ts
+++ b/apps/happychat/src/request-auth-data-from-parent.ts
@@ -1,5 +1,3 @@
-import { reject } from 'lodash';
-
 type User = {
 	ID: number;
 	display_name: string;
@@ -13,18 +11,30 @@ type HappyChatAuthData = {
 	user: User;
 };
 
+const unresponsiveParentError = new Error(
+	`Parent window didn't respond to authentication requests.`
+);
+
+const parent = window.opener || window.parent;
+
 export function requestDataFromParent(): Promise< HappyChatAuthData > {
-	return new Promise( function ( resolve ) {
+	if ( ! parent ) {
+		throw new Error( 'This is not running neither inside an iframe or a popup.' );
+	}
+	return new Promise( function ( resolve, reject ) {
+		// Give the parent one second to respond, which is plenty of time, throw after then.
+		// If parent window is prepared to respond, it will probably respond in less than 100ms, if not, there is no reason to wait longer.
+		// It may be worth it to poll, though. So far, YAGNI.
+		const timeout = setTimeout( reject, 1000, unresponsiveParentError );
+
 		function handler( event: MessageEvent ) {
 			if ( event.data?.type === 'happy-chat-authentication-data' ) {
 				resolve( event.data.authData );
 				window.removeEventListener( 'message', handler );
+				clearTimeout( timeout );
 			}
 		}
-		const parent = window.opener || window.parent;
-		if ( ! parent ) {
-			return reject( new Error( 'This is not running neither inside an iframe or a popup.' ) );
-		}
+
 		parent.postMessage(
 			{
 				type: 'happy-chat-authentication-data',

--- a/packages/happychat-connection/src/types.ts
+++ b/packages/happychat-connection/src/types.ts
@@ -46,6 +46,7 @@ export interface HappychatAuth {
 	user: {
 		jwt: string;
 	} & HappychatUser;
+	fullUser: User;
 }
 
 export interface Action {

--- a/packages/happychat-connection/src/use-happychat-auth.ts
+++ b/packages/happychat-connection/src/use-happychat-auth.ts
@@ -4,7 +4,12 @@ import { useQuery } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { HappychatSession, HappychatUser, User, HappychatAuth } from './types';
 
+let cachedHappyChatAuth: HappychatAuth;
+
 export async function requestHappyChatAuth() {
+	if ( cachedHappyChatAuth ) {
+		return Promise.resolve( cachedHappyChatAuth );
+	}
 	const user: User = await wpcomRequest( {
 		path: '/me',
 		apiVersion: '1.1',
@@ -38,13 +43,13 @@ export async function requestHappyChatAuth() {
 
 	const { jwt } = sign;
 
-	return { url, user: { jwt, ...happychatUser }, fullUser: user };
+	cachedHappyChatAuth = { url, user: { jwt, ...happychatUser }, fullUser: user };
+	return cachedHappyChatAuth;
 }
 
 export default function useHappychatAuth( enabled = true ) {
-	return useQuery< HappychatAuth, typeof Error >( 'getHappychatAuth', requestHappyChatAuth, {
-		refetchOnWindowFocus: false,
-		keepPreviousData: true,
+	return useQuery< HappychatAuth >( 'getHappychatAuth', requestHappyChatAuth, {
+		staleTime: Infinity,
 		enabled,
 	} );
 }

--- a/packages/happychat-connection/src/use-happychat-auth.ts
+++ b/packages/happychat-connection/src/use-happychat-auth.ts
@@ -4,12 +4,7 @@ import { useQuery } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { HappychatSession, HappychatUser, User, HappychatAuth } from './types';
 
-let cachedHappyChatAuth: HappychatAuth;
-
 export async function requestHappyChatAuth() {
-	if ( cachedHappyChatAuth ) {
-		return Promise.resolve( cachedHappyChatAuth );
-	}
 	const user: User = await wpcomRequest( {
 		path: '/me',
 		apiVersion: '1.1',
@@ -43,8 +38,7 @@ export async function requestHappyChatAuth() {
 
 	const { jwt } = sign;
 
-	cachedHappyChatAuth = { url, user: { jwt, ...happychatUser }, fullUser: user };
-	return cachedHappyChatAuth;
+	return { url, user: { jwt, ...happychatUser }, fullUser: user };
 }
 
 export default function useHappychatAuth( enabled = true ) {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -20,7 +20,7 @@ import React, { useEffect, useState } from 'react';
  */
 import { useHistory, useLocation } from 'react-router-dom';
 import { askDirectlyQuestion, execute } from '../directly';
-import { STORE_KEY, USER_KEY } from '../store';
+import { HELP_CENTER_STORE, USER_STORE } from '../stores';
 import { getSupportVariationFromMode } from '../support-variations';
 import { SitePicker } from '../types';
 import { BackButton } from './back-button';
@@ -130,15 +130,15 @@ export const HelpCenterContactForm = () => {
 	const { selectedSite, subject, message, userDeclaredSiteUrl, directlyData } = useSelect(
 		( select ) => {
 			return {
-				selectedSite: select( STORE_KEY ).getSite(),
-				subject: select( STORE_KEY ).getSubject(),
-				message: select( STORE_KEY ).getMessage(),
-				userDeclaredSiteUrl: select( STORE_KEY ).getUserDeclaredSiteUrl(),
-				directlyData: select( STORE_KEY ).getDirectly(),
+				selectedSite: select( HELP_CENTER_STORE ).getSite(),
+				subject: select( HELP_CENTER_STORE ).getSubject(),
+				message: select( HELP_CENTER_STORE ).getMessage(),
+				userDeclaredSiteUrl: select( HELP_CENTER_STORE ).getUserDeclaredSiteUrl(),
+				directlyData: select( HELP_CENTER_STORE ).getDirectly(),
 			};
 		}
 	);
-	const userData = useSelect( ( select ) => select( USER_KEY ).getCurrentUser() );
+	const userData = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 
 	const {
 		setSite,
@@ -148,7 +148,7 @@ export const HelpCenterContactForm = () => {
 		setUserDeclaredSite,
 		setSubject,
 		setMessage,
-	} = useDispatch( STORE_KEY );
+	} = useDispatch( HELP_CENTER_STORE );
 
 	const {
 		result: ownershipResult,

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 import { useEffect, useState } from 'react';
 import { Route, Switch, useLocation } from 'react-router-dom';
 import { useHCWindowCommunicator } from '../happychat-window-communicator';
-import { STORE_KEY } from '../store';
+import { HELP_CENTER_STORE } from '../stores';
 import type { Header, WindowState } from '../types';
 import type { ReactElement } from 'react';
 
@@ -52,7 +52,7 @@ const HelpCenterHeader: React.FC< Header > = ( {
 	const [ chatWindowStatus, setChatWindowStatus ] = useState< WindowState >( 'closed' );
 	const [ unreadCount, setUnreadCount ] = useState< number >( 0 );
 	const formattedUnreadCount = unreadCount > 9 ? '9+' : unreadCount;
-	const popup = useSelect( ( select ) => select( STORE_KEY ).getPopup() );
+	const popup = useSelect( ( select ) => select( HELP_CENTER_STORE ).getPopup() );
 
 	useEffect( () => {
 		if ( chatWindowStatus === 'open' && popup ) {

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -1,12 +1,10 @@
 import { CardHeader, Button, Flex } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { closeSmall, chevronUp, lineSolid, commentContent, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect, useState } from 'react';
 import { Route, Switch, useLocation } from 'react-router-dom';
 import { useHCWindowCommunicator } from '../happychat-window-communicator';
-import { HELP_CENTER_STORE } from '../stores';
 import type { Header, WindowState } from '../types';
 import type { ReactElement } from 'react';
 
@@ -52,22 +50,9 @@ const HelpCenterHeader: React.FC< Header > = ( {
 	const [ chatWindowStatus, setChatWindowStatus ] = useState< WindowState >( 'closed' );
 	const [ unreadCount, setUnreadCount ] = useState< number >( 0 );
 	const formattedUnreadCount = unreadCount > 9 ? '9+' : unreadCount;
-	const popup = useSelect( ( select ) => select( HELP_CENTER_STORE ).getPopup() );
 
-	useEffect( () => {
-		if ( chatWindowStatus === 'open' && popup ) {
-			onMinimize?.();
-		}
-	}, [ chatWindowStatus, onMinimize, popup ] );
-
-	// if the chat is open in a popup, and the user tried to maximize the help-center
-	// show them the popup instead
 	function requestMaximize() {
-		if ( chatWindowStatus !== 'closed' && popup ) {
-			popup.focus();
-		} else {
-			onMaximize?.();
-		}
+		onMaximize?.();
 	}
 
 	// kill the help center when the user closes the popup chat window

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -10,7 +10,7 @@ import { createPortal, useEffect, useRef } from '@wordpress/element';
  */
 import { execute } from '../directly';
 import { useStillNeedHelpURL } from '../hooks/use-still-need-help-url';
-import { STORE_KEY, USER_KEY } from '../store';
+import { HELP_CENTER_STORE, USER_STORE } from '../stores';
 import { Container } from '../types';
 import { SITE_STORE } from './help-center-contact-form';
 import HelpCenterContainer from './help-center-container';
@@ -22,8 +22,8 @@ const HelpCenter: React.FC< Container > = ( { handleClose } ) => {
 
 	// prefetch the current site and user
 	const site = useSelect( ( select ) => select( SITE_STORE ).getSite( window._currentSiteId ) );
-	const user = useSelect( ( select ) => select( USER_KEY ).getCurrentUser() );
-	const { setDirectlyData } = useDispatch( STORE_KEY );
+	const user = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
+	const { setDirectlyData } = useDispatch( HELP_CENTER_STORE );
 	const { isLoading: isLoadingChat } = useSupportAvailability( 'CHAT' );
 	const { isLoading: isLoadingChatAvailable } = useHappychatAvailable();
 	const { data: supportData, isLoading: isSupportDataLoading } = useSupportAvailability( 'OTHER' );

--- a/packages/help-center/src/store.ts
+++ b/packages/help-center/src/store.ts
@@ -1,4 +1,0 @@
-import { HelpCenter, User } from '@automattic/data-stores';
-
-export const STORE_KEY = HelpCenter.register();
-export const USER_KEY = User.register( { client_id: '', client_secret: '' } );

--- a/packages/help-center/src/stores.ts
+++ b/packages/help-center/src/stores.ts
@@ -1,0 +1,7 @@
+import { HelpCenter, User, Site } from '@automattic/data-stores';
+
+export const HELP_CENTER_STORE = HelpCenter.register();
+
+// these creds are only needed when signing up users
+export const USER_STORE = User.register( { client_id: '', client_secret: '' } );
+export const SITE_STORE = Site.register( { client_id: '', client_secret: '' } );


### PR DESCRIPTION
#### Proposed Changes

* This PR handles the case when Happychat is indeed iframed, but the parent window isn't responsive to auth requests (1000ms timeout).
* It imports `SITE_STORE` properly. 
* It fixes the race condition in `happychat-window-communicator` by using `queryClient.fetchQuery` promise directly and waiting for it to resolve before responding to the auth request message. This makes sure it doesn't respond with unresolved query results (`undefined`).

#### Testing instructions

1. Checkout this branch.
2. Run `yarn dev --sync` in `apps/editing-toolkit`.
2. Run `yarn dev --sync` in `apps/happychat`.
3. Go to the editor and open the help-center/
4. Block 3rd party cookies and refresh the page.
5. Login to https://hud-staging.happychat.io/ to respond to your own chat.
6. Start a chat.
7. All should work.

#### Kudos
Thank you so much @jsnajdr for the review. Always helpful.

