### PR TITLE
eslint-plugin-wpcalypso: Add missing peer dep on eslint-plugin-react

### DIFF
--- a/packages/eslint-plugin-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-plugin-wpcalypso/CHANGELOG.md
@@ -1,5 +1,10 @@
 #### Unreleased
 
+#### v6.0.1 (unreleased)
+
+- Add missing optional peer dependency on `eslint-plugin-react`.
+- Mark the peer dependency on `eslint-plugin-react-hooks` as optional to match that on `eslint-plugin-react`.
+
 #### v6.0.0 (2022-05-13)
 
 - Breaking: Migrated from `babel-eslint` to `@babel/eslint-parser`. This requires `@babel/core` to be

--- a/packages/eslint-plugin-wpcalypso/README.md
+++ b/packages/eslint-plugin-wpcalypso/README.md
@@ -11,10 +11,10 @@ Install [ESLint](http://eslint.org) and `eslint-plugin-wpcalypso`
 $ yarn add --dev eslint eslint-plugin-wpcalypso
 ```
 
-If you're planning to use the React superset of rules, you should also install `eslint-plugin-react`:
+If you're planning to use the React superset of rules, you should also install `eslint-plugin-react` and `eslint-plugin-react-hooks`:
 
 ```
-yarn add --dev eslint-plugin-react
+yarn add --dev eslint-plugin-react eslint-plugin-react-hooks
 ```
 
 ## Usage

--- a/packages/eslint-plugin-wpcalypso/package.json
+++ b/packages/eslint-plugin-wpcalypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-plugin-wpcalypso",
-	"version": "6.0.0",
+	"version": "6.0.1-alpha",
 	"description": "Custom ESLint rules for the WordPress.com Calypso project.",
 	"repository": {
 		"type": "git",
@@ -28,7 +28,16 @@
 		"eslint": ">=8.6.0",
 		"eslint-plugin-inclusive-language": "^2.2.0",
 		"eslint-plugin-jsdoc": "^37.5.1",
+		"eslint-plugin-react": "^7.28.0",
 		"eslint-plugin-react-hooks": "^4.3.0"
+	},
+	"peerDependenciesMeta": {
+		"eslint-plugin-react": {
+			"optional": true
+		},
+		"eslint-plugin-react-hooks": {
+			"optional": true
+		}
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16782,7 +16782,13 @@ __metadata:
     eslint: ">=8.6.0"
     eslint-plugin-inclusive-language: ^2.2.0
     eslint-plugin-jsdoc: ^37.5.1
+    eslint-plugin-react: ^7.28.0
     eslint-plugin-react-hooks: ^4.3.0
+  peerDependenciesMeta:
+    eslint-plugin-react:
+      optional: true
+    eslint-plugin-react-hooks:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
#### Proposed Changes

Add missing peer dep on eslint-plugin-react.

Without the peer dep being declared, it won't be found when using yarn's
p'n'p or pnpm with hoisting disabled.

As it's already documented as optional in README.md, mark it as such in
package.json. And mark the eslint-plugin-react-hooks dep optional too,
as it's only needed under the same conditions as eslint-plugin-react.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Everything should continue working as it did before.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->