### PR TITLE
Testing new copy on the signup plans page

### DIFF
--- a/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
@@ -100,10 +100,11 @@ export const PlansComparisonColHeader: React.FunctionComponent< Props > = ( {
 					<>
 						<p>Great for blogs and simple sites:</p>
 						<ul>
-							<li>Custom website address.</li>
-							<li> Collect payments and donations.</li>
+							<li>Custom domain name.</li>
+							<li>Collect payments and donations.</li>
 							<li>6GB of storage for images.</li>
-							<li>Flexible upgrade options.</li>
+							<li>Automatic WordPress updates.</li>
+							<li>A la carte upgrades available.</li>
 						</ul>
 					</>
 				) }
@@ -113,9 +114,10 @@ export const PlansComparisonColHeader: React.FunctionComponent< Props > = ( {
 						<p>Great for business and custom sites:</p>
 						<ul>
 							<li>Unlock 50k+ plugins and themes.</li>
-							<li> Advanced ecommerce tools.</li>
+							<li>Advanced ecommerce tools.</li>
+							<li>Premium website themes.</li>
 							<li>50GB of media storage.</li>
-							<li>Premium live chat support.</li>
+							<li>24-hour live chat support.</li>
 						</ul>
 					</>
 				) }

--- a/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
@@ -9,6 +9,7 @@ interface Props {
 	plan: Plan;
 	price?: number;
 	originalPrice?: number;
+	isExperiment?: boolean;
 	onClick?: ( productSlug: string ) => void;
 	translate: typeof translate;
 }
@@ -51,6 +52,10 @@ const PlanDescription = styled.p`
 	}
 `;
 
+const PlanSubTitle = styled( PlanDescription )`
+	font-weight: 600;
+`;
+
 const PriceContainer = styled.div`
 	display: flex;
 	flex-direction: row;
@@ -77,12 +82,14 @@ export const PlansComparisonColHeader: React.FunctionComponent< Props > = ( {
 	originalPrice,
 	children,
 	translate,
+	isExperiment,
 } ) => {
 	const isDiscounted = typeof originalPrice === 'number';
 
 	return (
 		<th scope="col">
 			<PlanTitle>{ plan.getTitle() }</PlanTitle>
+			{ isExperiment && <PlanSubTitle>{ plan.getSubTitle() }</PlanSubTitle> }
 			<PlanDescription>{ plan.getDescription() }</PlanDescription>
 			<PriceContainer>
 				{ isDiscounted && (

--- a/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
@@ -35,17 +35,19 @@ const PlanTitle = styled.h2`
 	}
 `;
 
-const PlanDescription = styled.p`
+const PlanDescription = styled.div`
 	font-size: 1rem;
 	font-weight: 400;
 	margin: 0 0 1.5rem;
 
 	ul {
+		font-size: 0.875rem;
 		margin-left: 1rem;
 	}
 
 	p {
 		font-weight: 500;
+		margin-bottom: 0.75rem;
 	}
 
 	@media screen and ( max-width: ${ SCREEN_BREAKPOINT_SIGNUP }px ) {

--- a/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
@@ -1,3 +1,4 @@
+import { TYPE_PRO, TYPE_STARTER } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import { SCREEN_BREAKPOINT_SIGNUP, SCREEN_BREAKPOINT_PLANS } from './constant';
@@ -39,6 +40,14 @@ const PlanDescription = styled.p`
 	font-weight: 400;
 	margin: 0 0 1.5rem;
 
+	ul {
+		margin-left: 1rem;
+	}
+
+	p {
+		font-weight: 500;
+	}
+
 	@media screen and ( max-width: ${ SCREEN_BREAKPOINT_SIGNUP }px ) {
 		.is-section-signup & {
 			display: none;
@@ -50,10 +59,6 @@ const PlanDescription = styled.p`
 			display: none;
 		}
 	}
-`;
-
-const PlanSubTitle = styled( PlanDescription )`
-	font-weight: 600;
 `;
 
 const PriceContainer = styled.div`
@@ -89,8 +94,34 @@ export const PlansComparisonColHeader: React.FunctionComponent< Props > = ( {
 	return (
 		<th scope="col">
 			<PlanTitle>{ plan.getTitle() }</PlanTitle>
-			{ isExperiment && <PlanSubTitle>{ plan.getSubTitle() }</PlanSubTitle> }
-			<PlanDescription>{ plan.getDescription() }</PlanDescription>
+
+			<PlanDescription>
+				{ plan.type === TYPE_STARTER && isExperiment && (
+					<>
+						<p>Great for blogs and simple sites:</p>
+						<ul>
+							<li>Custom website address.</li>
+							<li> Collect payments and donations.</li>
+							<li>6GB of storage for images.</li>
+							<li>Flexible upgrade options.</li>
+						</ul>
+					</>
+				) }
+
+				{ plan.type === TYPE_PRO && isExperiment && (
+					<>
+						<p>Great for business and custom sites:</p>
+						<ul>
+							<li>Unlock 50k+ plugins and themes.</li>
+							<li> Advanced ecommerce tools.</li>
+							<li>50GB of media storage.</li>
+							<li>Premium live chat support.</li>
+						</ul>
+					</>
+				) }
+
+				{ ! isExperiment && plan.getDescription() }
+			</PlanDescription>
 			<PriceContainer>
 				{ isDiscounted && (
 					<>

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -103,7 +103,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 		get description() {
 			return translate(
-				'All WordPress.com plans include unlimited traffic, so you never have to worry about surprise charges.'
+				'All WordPress.com plans include unlimited traffic so you never have to worry about surprise charges.'
 			);
 		},
 		features: [ FEATURE_UNLIMITED_TRAFFIC ],
@@ -138,7 +138,9 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			return translate( 'Managed Hosting' );
 		},
 		get description() {
-			return translate( 'Managed hosting description' );
+			return translate(
+				'All plans include world-class managed hosting, including automatic updates, security, backups, and more.'
+			);
 		},
 		features: [ FEATURE_MANAGED_HOSTING ],
 		getCellText: ( feature, isMobile = false ) => {
@@ -172,7 +174,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			return translate( 'Free themes' );
 		},
 		get description() {
-			return translate( 'Hundreds of beautiful themes to choose from.' );
+			return translate( 'All WordPress.com plans include access to dozens of beautiful themes.' );
 		},
 		features: [ FEATURE_FREE_THEMES ],
 		getCellText: ( feature, isMobile = false ) => {
@@ -195,7 +197,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			}
 
 			return feature
-				? translate( 'Free themes included.' )
+				? translate( 'Dozens of free themes included' )
 				: translate( 'Free themes {{strong}}not{{/strong}} included', {
 						components: { strong: <strong /> },
 				  } );

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -20,6 +20,8 @@ import {
 	FEATURE_JETPACK_ESSENTIAL,
 	FEATURE_GOOGLE_ANALYTICS,
 	FEATURE_UNLIMITED_TRAFFIC,
+	FEATURE_FREE_THEMES,
+	FEATURE_MANAGED_HOSTING,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { translate, numberFormat } from 'i18n-calypso';
@@ -123,8 +125,76 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			}
 
 			return feature
-				? translate( 'Includes unlimited traffic.' )
+				? translate( 'Unlimited traffic included' )
 				: translate( 'Unlimited traffic is {{strong}}not{{/strong}} included', {
+						components: { strong: <strong /> },
+				  } );
+		},
+	},
+	{
+		get title() {
+			return translate( 'Managed Hosting' );
+		},
+		get description() {
+			return translate( 'Managed hosting description' );
+		},
+		features: [ FEATURE_MANAGED_HOSTING ],
+		getCellText: ( feature, isMobile = false ) => {
+			if ( ! isMobile ) {
+				if ( feature ) {
+					return (
+						<>
+							<Gridicon icon="checkmark" />
+							{ translate( 'Included' ) }
+						</>
+					);
+				}
+
+				return (
+					<>
+						<Gridicon icon="cross" />
+						{ translate( 'Not included' ) }
+					</>
+				);
+			}
+
+			return feature
+				? translate( 'Managed hosting included' )
+				: translate( 'Managed hosting is {{strong}}not{{/strong}} included', {
+						components: { strong: <strong /> },
+				  } );
+		},
+	},
+	{
+		get title() {
+			return translate( 'Free themes' );
+		},
+		get description() {
+			return translate( 'Hundreds of beautiful themes to choose from.' );
+		},
+		features: [ FEATURE_FREE_THEMES ],
+		getCellText: ( feature, isMobile = false ) => {
+			if ( ! isMobile ) {
+				if ( feature ) {
+					return (
+						<>
+							<Gridicon icon="checkmark" />
+							{ translate( 'Included' ) }
+						</>
+					);
+				}
+
+				return (
+					<>
+						<Gridicon icon="cross" />
+						{ translate( 'Not included' ) }
+					</>
+				);
+			}
+
+			return feature
+				? translate( 'Free themes included.' )
+				: translate( 'Free themes {{strong}}not{{/strong}} included', {
 						components: { strong: <strong /> },
 				  } );
 		},
@@ -382,13 +452,25 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 		features: [ FEATURE_PREMIUM_THEMES ],
 		getCellText: ( feature, isMobile = false ) => {
-			let cellText = defaultGetCellText( translate( 'Premium themes' ) )( feature, isMobile );
+			// let cellText = defaultGetCellText( translate( 'Premium themes' ) )( feature, isMobile );
+			let cellText = feature ? (
+				<>
+					<Gridicon icon="checkmark" />
+					{ translate( 'Included' ) }
+				</>
+			) : (
+				<>{ translate( 'Available for $50+ each' ) }</>
+			);
 			if ( isMobile ) {
-				cellText = feature
-					? translate( 'Premium themes are included' )
-					: translate( 'Premium themes are {{strong}}not{{/strong}} included', {
+				cellText = feature ? (
+					<>{ translate( 'Premium themes are included' ) }</>
+				) : (
+					<>
+						{ translate( 'Premium themes are {{strong}}not{{/strong}} included', {
 							components: { strong: <strong /> },
-					  } );
+						} ) }
+					</>
+				);
 			}
 			return cellText;
 		},
@@ -488,13 +570,25 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 		features: [ FEATURE_NO_ADS ],
 		getCellText: ( feature, isMobile = false ) => {
-			let cellText = defaultGetCellText( translate( 'Remove ads' ) )( feature, isMobile );
+			// let cellText = defaultGetCellText( translate( 'Remove ads' ) )( feature, isMobile );
+			let cellText = feature ? (
+				<>
+					<Gridicon icon="checkmark" />
+					{ translate( 'Included' ) }
+				</>
+			) : (
+				<>{ translate( 'Available for $2/month' ) }</>
+			);
 			if ( isMobile ) {
-				cellText = feature
-					? translate( 'Remove ads is included' )
-					: translate( 'Remove ads is {{strong}}not{{/strong}} included', {
+				cellText = feature ? (
+					<>{ translate( 'Remove ads is included' ) }</>
+				) : (
+					<>
+						{ translate( 'Remove ads for $2 per month', {
 							components: { strong: <strong /> },
-					  } );
+						} ) }
+					</>
+				);
 			}
 			return cellText;
 		},

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -102,7 +102,9 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			return translate( 'Unlimited Traffic' );
 		},
 		get description() {
-			return translate( 'Unlimited traffic description' );
+			return translate(
+				'All WordPress.com plans include unlimited traffic, so you never have to worry about surprise charges.'
+			);
 		},
 		features: [ FEATURE_UNLIMITED_TRAFFIC ],
 		getCellText: ( feature, isMobile = false ) => {
@@ -577,14 +579,14 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 					{ translate( 'Included' ) }
 				</>
 			) : (
-				<>{ translate( 'Available for $2/month' ) }</>
+				<>{ translate( 'Available for +$2/month' ) }</>
 			);
 			if ( isMobile ) {
 				cellText = feature ? (
 					<>{ translate( 'Remove ads is included' ) }</>
 				) : (
 					<>
-						{ translate( 'Remove ads for $2 per month', {
+						{ translate( 'Remove ads for +$2 per month', {
 							components: { strong: <strong /> },
 						} ) }
 					</>

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -19,6 +19,7 @@ import {
 	FEATURE_MONETISE,
 	FEATURE_JETPACK_ESSENTIAL,
 	FEATURE_GOOGLE_ANALYTICS,
+	FEATURE_UNLIMITED_TRAFFIC,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { translate, numberFormat } from 'i18n-calypso';
@@ -94,6 +95,40 @@ function defaultGetCellText(
 }
 
 export const planComparisonFeatures: PlanComparisonFeature[] = [
+	{
+		get title() {
+			return translate( 'Unlimited Traffic' );
+		},
+		get description() {
+			return translate( 'Unlimited traffic description' );
+		},
+		features: [ FEATURE_UNLIMITED_TRAFFIC ],
+		getCellText: ( feature, isMobile = false ) => {
+			if ( ! isMobile ) {
+				if ( feature ) {
+					return (
+						<>
+							<Gridicon icon="checkmark" />
+							{ translate( 'Included' ) }
+						</>
+					);
+				}
+
+				return (
+					<>
+						<Gridicon icon="cross" />
+						{ translate( 'Not included' ) }
+					</>
+				);
+			}
+
+			return feature
+				? translate( 'Includes unlimited traffic.' )
+				: translate( 'Unlimited traffic is {{strong}}not{{/strong}} included', {
+						components: { strong: <strong /> },
+				  } );
+		},
+	},
 	{
 		get title() {
 			return translate( 'Custom domain name' );

--- a/client/my-sites/plans-comparison/plans-comparison-row.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-row.tsx
@@ -67,11 +67,7 @@ export const PlansComparisonRow: React.FunctionComponent< Props > = ( {
 	feature,
 	plans,
 	isLegacySiteWithHigherLimits,
-	isExperiment = false,
 } ) => {
-	function getPlanFeatures( plan: WPComPlan, isExperiment: boolean ): string[] | undefined {
-		return isExperiment ? plan.getPlanCompareFeaturesTest?.() : plan.getPlanCompareFeatures?.();
-	}
 	return (
 		<tr>
 			<PlansComparisonRowHeader
@@ -82,7 +78,7 @@ export const PlansComparisonRow: React.FunctionComponent< Props > = ( {
 			/>
 			{ plans.map( ( plan ) => {
 				const includedFeature = intersection(
-					getPlanFeatures( plan, isExperiment ) || [],
+					plan.getPlanCompareFeatures?.() || [],
 					feature.features
 				)[ 0 ];
 

--- a/client/my-sites/plans-comparison/plans-comparison-row.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-row.tsx
@@ -8,6 +8,7 @@ interface Props {
 	feature: PlanComparisonFeature;
 	plans: WPComPlan[];
 	isLegacySiteWithHigherLimits: boolean;
+	isExperiment?: boolean;
 }
 
 export const DesktopContent = styled.div`
@@ -66,7 +67,11 @@ export const PlansComparisonRow: React.FunctionComponent< Props > = ( {
 	feature,
 	plans,
 	isLegacySiteWithHigherLimits,
+	isExperiment = false,
 } ) => {
+	function getPlanFeatures( plan: WPComPlan, isExperiment: boolean ): string[] | undefined {
+		return isExperiment ? plan.getPlanCompareFeaturesTest?.() : plan.getPlanCompareFeatures?.();
+	}
 	return (
 		<tr>
 			<PlansComparisonRowHeader
@@ -77,7 +82,7 @@ export const PlansComparisonRow: React.FunctionComponent< Props > = ( {
 			/>
 			{ plans.map( ( plan ) => {
 				const includedFeature = intersection(
-					plan.getPlanCompareFeatures?.() || [],
+					getPlanFeatures( plan, isExperiment ) || [],
 					feature.features
 				)[ 0 ];
 

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -1,10 +1,12 @@
-import { TYPE_FREE, TYPE_FLEXIBLE, TYPE_PRO } from '@automattic/calypso-products';
+import { TYPE_FREE, TYPE_FLEXIBLE, TYPE_PRO, TYPE_STARTER } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { css, Global } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useExperiment } from 'calypso/lib/explat';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import isLegacySiteWithHigherLimits from 'calypso/state/selectors/is-legacy-site-with-higher-limits';
@@ -349,7 +351,6 @@ const ComparisonTable = styled.table< TableProps >`
 `;
 
 const THead = styled.thead< { isInSignup: boolean } >`
-	position: sticky;
 	top: ${ ( { isInSignup } ) => ( isInSignup ? '0' : `var( --masterbar-height )` ) };
 `;
 
@@ -404,6 +405,35 @@ const PlansComparisonToggle = styled.tbody`
 		}
 	}
 `;
+
+const PlansHighlightFeatures = styled.div`
+	font-size: 1rem;
+	font-weight: 400;
+	margin: 1.5rem 0 1rem;
+
+	.gridicon.gridicon {
+		width: 1.1em;
+		height: 1.1em;
+
+		html[dir='ltr'] & {
+			margin: 0 5px -2px 0;
+		}
+		html[dir='rtl'] & {
+			margin: 0 0 -2px 5px;
+		}
+	}
+
+	.gridicons-checkmark {
+		fill: var( --studio-green-50 );
+	}
+`;
+
+const ComparisonHeader = styled( PlansComparisonRows )`
+	td {
+		font-size: 1rem;
+		font-weight: 500;
+	}
+`;
 interface Props {
 	isInSignup?: boolean;
 	selectedSiteId?: number;
@@ -434,6 +464,9 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	hideFreePlan,
 	onSelectPlan,
 } ) => {
+	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
+		'pricing_packaging_plans_page_copy_test'
+	);
 	const legacySiteWithHigherLimits = useSelector( ( state ) =>
 		isLegacySiteWithHigherLimits( state, selectedSiteId || 0 )
 	);
@@ -447,6 +480,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	const plans = usePlans( hideFreePlan );
 	const prices = usePlanPrices( plans );
 	const translate = useTranslate();
+	const isMobile = useBreakpoint( '769' );
 
 	const toggleCollapsibleRows = useCallback( () => {
 		setShowCollapsibleRows( ! showCollapsibleRows );
@@ -478,6 +512,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 								price={ prices[ index ].price }
 								originalPrice={ prices[ index ].originalPrice }
 								translate={ translate }
+								isExperiment={ 'treatment' === experimentAssignment?.variationName }
 							>
 								{ selectedDomainConnection && <PlansDomainConnectionInfo plan={ plan } /> }
 								<PlansComparisonAction
@@ -492,10 +527,74 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 									}
 									onClick={ () => onSelectPlan( planToCartItem( plan ) ) }
 								/>
+								{ plan.type === TYPE_STARTER &&
+								'treatment' === experimentAssignment?.variationName ? (
+									<PlansHighlightFeatures>
+										<p>
+											<b>Our favorite Starter features:</b>
+										</p>
+										<div>
+											<Gridicon icon="checkmark" />
+											Custom website address.
+										</div>
+										<div>
+											<Gridicon icon="checkmark" />
+											Professional site templates.
+										</div>
+										<div>
+											<Gridicon icon="checkmark" />
+											Customer support forums.
+										</div>
+										<div>
+											<Gridicon icon="checkmark" />
+											Automatic WordPress updates.
+										</div>
+										<div>
+											<Gridicon icon="checkmark" />
+											Flexible upgrade options.
+										</div>
+									</PlansHighlightFeatures>
+								) : null }
+
+								{ plan.type === TYPE_PRO && 'treatment' === experimentAssignment?.variationName ? (
+									<PlansHighlightFeatures>
+										<p>
+											<b>Our favorite Pro features:</b>
+										</p>
+										<div>
+											<Gridicon icon="checkmark" />
+											Unlimited traffic at blazing speeds.
+										</div>
+										<div>
+											<Gridicon icon="checkmark" />
+											Support for Plugins and Themes.
+										</div>
+										<div>
+											<Gridicon icon="checkmark" />
+											Real-time live chat support.
+										</div>
+										<div>
+											<Gridicon icon="checkmark" />
+											Unmatched managed hosting service.
+										</div>
+										<div>
+											<Gridicon icon="checkmark" />
+											SFTP and database access for devs.
+										</div>
+									</PlansHighlightFeatures>
+								) : null }
 							</PlansComparisonColHeader>
 						) ) }
 					</tr>
 				</THead>
+				{ /* { 'treatment' === experimentAssignment?.variationName && (
+					<ComparisonHeader>
+						<tr>
+							<td colSpan={ isMobile ? 1 : 2 }>Detailed plan comparison:</td>
+							<td>&nbsp;</td>
+						</tr>
+					</ComparisonHeader>
+				) } */ }
 				<PlansComparisonRows>
 					{ planComparisonFeatures.slice( 0, 8 ).map( ( feature ) => (
 						<PlansComparisonRow

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -1,6 +1,5 @@
 import { TYPE_FREE, TYPE_FLEXIBLE, TYPE_PRO, TYPE_STARTER } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
-import { useBreakpoint } from '@automattic/viewport-react';
 import { css, Global } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -428,12 +427,6 @@ const PlansHighlightFeatures = styled.div`
 	}
 `;
 
-const ComparisonHeader = styled( PlansComparisonRows )`
-	td {
-		font-size: 1rem;
-		font-weight: 500;
-	}
-`;
 interface Props {
 	isInSignup?: boolean;
 	selectedSiteId?: number;
@@ -480,7 +473,6 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	const plans = usePlans( hideFreePlan );
 	const prices = usePlanPrices( plans );
 	const translate = useTranslate();
-	const isMobile = useBreakpoint( '769' );
 
 	const toggleCollapsibleRows = useCallback( () => {
 		setShowCollapsibleRows( ! showCollapsibleRows );
@@ -528,61 +520,61 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 									onClick={ () => onSelectPlan( planToCartItem( plan ) ) }
 								/>
 								{ plan.type === TYPE_STARTER &&
-								'treatment' === experimentAssignment?.variationName ? (
-									<PlansHighlightFeatures>
-										<p>
-											<b>Our favorite Starter features:</b>
-										</p>
-										<div>
-											<Gridicon icon="checkmark" />
-											Custom website address.
-										</div>
-										<div>
-											<Gridicon icon="checkmark" />
-											Professional site templates.
-										</div>
-										<div>
-											<Gridicon icon="checkmark" />
-											Customer support forums.
-										</div>
-										<div>
-											<Gridicon icon="checkmark" />
-											Automatic WordPress updates.
-										</div>
-										<div>
-											<Gridicon icon="checkmark" />
-											Flexible upgrade options.
-										</div>
-									</PlansHighlightFeatures>
-								) : null }
+									'treatment' === experimentAssignment?.variationName && (
+										<PlansHighlightFeatures>
+											<p>
+												<b>Great for bloggers and simple sites:</b>
+											</p>
+											<div>
+												<Gridicon icon="checkmark" />
+												Custom website address.
+											</div>
+											<div>
+												<Gridicon icon="checkmark" />
+												Collect payments and donations.
+											</div>
+											<div>
+												<Gridicon icon="checkmark" />
+												6GB of storage for images.
+											</div>
+											<div>
+												<Gridicon icon="checkmark" />
+												Automatic WordPress updates.
+											</div>
+											<div>
+												<Gridicon icon="checkmark" />
+												Flexible upgrade options.
+											</div>
+										</PlansHighlightFeatures>
+									) }
 
-								{ plan.type === TYPE_PRO && 'treatment' === experimentAssignment?.variationName ? (
+								{ plan.type === TYPE_PRO && 'treatment' === experimentAssignment?.variationName && (
 									<PlansHighlightFeatures>
 										<p>
-											<b>Our favorite Pro features:</b>
+											<b>Great for pros and interactive sites:</b>
 										</p>
 										<div>
 											<Gridicon icon="checkmark" />
-											Unlimited traffic at blazing speeds.
+											Unlock 50k+ plugins and themes.
 										</div>
 										<div>
 											<Gridicon icon="checkmark" />
-											Support for Plugins and Themes.
+											Advanced ecommerce tools.
 										</div>
 										<div>
 											<Gridicon icon="checkmark" />
-											Real-time live chat support.
+											50GB of media storage.
 										</div>
 										<div>
 											<Gridicon icon="checkmark" />
-											Unmatched managed hosting service.
+											Premium live chat support.
 										</div>
 										<div>
 											<Gridicon icon="checkmark" />
 											SFTP and database access for devs.
 										</div>
 									</PlansHighlightFeatures>
-								) : null }
+								) }
 							</PlansComparisonColHeader>
 						) ) }
 					</tr>
@@ -602,6 +594,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 							plans={ plans }
 							isLegacySiteWithHigherLimits={ legacySiteWithHigherLimits }
 							key={ feature.features[ 0 ] }
+							isExperiment={ 'treatment' === experimentAssignment?.variationName }
 						/>
 					) ) }
 				</PlansComparisonRows>

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -1,4 +1,4 @@
-import { TYPE_FREE, TYPE_FLEXIBLE, TYPE_PRO, TYPE_STARTER } from '@automattic/calypso-products';
+import { TYPE_FREE, TYPE_FLEXIBLE, TYPE_PRO } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { css, Global } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -467,96 +467,90 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	return (
 		<>
 			<Global styles={ globalOverrides } />
-			<ComparisonTable
-				firstColWidth={ 31 }
-				planCount={ plans.length }
-				hideFreePlan={ hideFreePlan && ! isStarterPlanEnabled() }
-			>
-				<THead isInSignup={ isInSignup }>
-					<tr>
-						<td className={ `is-first` }>
-							<br />
-						</td>
-						{ plans.map( ( plan, index ) => (
-							<PlansComparisonColHeader
-								key={ plan.getProductId() }
-								plan={ plan }
-								currencyCode={ currencyCode }
-								price={ prices[ index ].price }
-								originalPrice={ prices[ index ].originalPrice }
-								translate={ translate }
-								isExperiment={ 'treatment' === experimentAssignment?.variationName }
-							>
-								{ selectedDomainConnection && <PlansDomainConnectionInfo plan={ plan } /> }
-								<PlansComparisonAction
-									currentSitePlanSlug={ sitePlan?.product_slug }
-									plan={ plan }
-									isInSignup={ isInSignup }
-									isPrimary={ plan.type === TYPE_PRO }
-									isCurrentPlan={ sitePlan?.product_slug === plan.getStoreSlug() }
-									manageHref={ manageHref }
-									disabled={
-										selectedDomainConnection && [ TYPE_FREE, TYPE_FLEXIBLE ].includes( plan.type )
-									}
-									onClick={ () => onSelectPlan( planToCartItem( plan ) ) }
-								/>
-							</PlansComparisonColHeader>
-						) ) }
-					</tr>
-				</THead>
-				{ /* { 'treatment' === experimentAssignment?.variationName && (
-					<ComparisonHeader>
+			{ ! isLoadingExperimentAssignment && (
+				<ComparisonTable
+					firstColWidth={ 31 }
+					planCount={ plans.length }
+					hideFreePlan={ hideFreePlan && ! isStarterPlanEnabled() }
+				>
+					<THead isInSignup={ isInSignup }>
 						<tr>
-							<td colSpan={ isMobile ? 1 : 2 }>Detailed plan comparison:</td>
-							<td>&nbsp;</td>
+							<td className={ `is-first` }>
+								<br />
+							</td>
+							{ plans.map( ( plan, index ) => (
+								<PlansComparisonColHeader
+									key={ plan.getProductId() }
+									plan={ plan }
+									currencyCode={ currencyCode }
+									price={ prices[ index ].price }
+									originalPrice={ prices[ index ].originalPrice }
+									translate={ translate }
+									isExperiment={ 'treatment' === experimentAssignment?.variationName }
+								>
+									{ selectedDomainConnection && <PlansDomainConnectionInfo plan={ plan } /> }
+									<PlansComparisonAction
+										currentSitePlanSlug={ sitePlan?.product_slug }
+										plan={ plan }
+										isInSignup={ isInSignup }
+										isPrimary={ plan.type === TYPE_PRO }
+										isCurrentPlan={ sitePlan?.product_slug === plan.getStoreSlug() }
+										manageHref={ manageHref }
+										disabled={
+											selectedDomainConnection && [ TYPE_FREE, TYPE_FLEXIBLE ].includes( plan.type )
+										}
+										onClick={ () => onSelectPlan( planToCartItem( plan ) ) }
+									/>
+								</PlansComparisonColHeader>
+							) ) }
 						</tr>
-					</ComparisonHeader>
-				) } */ }
-				<PlansComparisonRows>
-					{ planComparisonFeatures
-						.slice( featureSliceStart, featureSliceDefaultLength )
-						.map( ( feature ) => (
+					</THead>
+					<PlansComparisonRows>
+						{ planComparisonFeatures
+							.slice( featureSliceStart, featureSliceDefaultLength )
+							.map( ( feature ) => (
+								<PlansComparisonRow
+									feature={ feature }
+									plans={ plans }
+									isLegacySiteWithHigherLimits={ legacySiteWithHigherLimits }
+									key={ feature.features[ 0 ] }
+									isExperiment={ 'treatment' === experimentAssignment?.variationName }
+								/>
+							) ) }
+					</PlansComparisonRows>
+					<PlansComparisonCollapsibleRows collapsed={ showCollapsibleRows }>
+						{ planComparisonFeatures.slice( featureSliceDefaultLength ).map( ( feature ) => (
 							<PlansComparisonRow
 								feature={ feature }
 								plans={ plans }
 								isLegacySiteWithHigherLimits={ legacySiteWithHigherLimits }
 								key={ feature.features[ 0 ] }
-								isExperiment={ 'treatment' === experimentAssignment?.variationName }
 							/>
 						) ) }
-				</PlansComparisonRows>
-				<PlansComparisonCollapsibleRows collapsed={ showCollapsibleRows }>
-					{ planComparisonFeatures.slice( featureSliceDefaultLength ).map( ( feature ) => (
-						<PlansComparisonRow
-							feature={ feature }
-							plans={ plans }
-							isLegacySiteWithHigherLimits={ legacySiteWithHigherLimits }
-							key={ feature.features[ 0 ] }
-						/>
-					) ) }
-				</PlansComparisonCollapsibleRows>
-				<PlansComparisonToggle>
-					<tr>
-						{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-						<th className="is-first"></th>
-						<td colSpan={ 2 }>
-							<button onClick={ toggleCollapsibleRows }>
-								{ showCollapsibleRows ? (
-									<>
-										<Gridicon size={ 12 } icon="chevron-up" />
-										{ translate( 'Hide full plan comparison' ) }
-									</>
-								) : (
-									<>
-										<Gridicon size={ 12 } icon="chevron-down" />
-										{ translate( 'Show full plan comparison' ) }
-									</>
-								) }
-							</button>
-						</td>
-					</tr>
-				</PlansComparisonToggle>
-			</ComparisonTable>
+					</PlansComparisonCollapsibleRows>
+					<PlansComparisonToggle>
+						<tr>
+							{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+							<th className="is-first"></th>
+							<td colSpan={ 2 }>
+								<button onClick={ toggleCollapsibleRows }>
+									{ showCollapsibleRows ? (
+										<>
+											<Gridicon size={ 12 } icon="chevron-up" />
+											{ translate( 'Hide full plan comparison' ) }
+										</>
+									) : (
+										<>
+											<Gridicon size={ 12 } icon="chevron-down" />
+											{ translate( 'Show full plan comparison' ) }
+										</>
+									) }
+								</button>
+							</td>
+						</tr>
+					</PlansComparisonToggle>
+				</ComparisonTable>
+			) }
 		</>
 	);
 };

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -483,6 +483,9 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 			? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
 			: `/plans/${ selectedSiteSlug || '' }`;
 
+	const featureSliceStart = 'treatment' === experimentAssignment?.variationName ? 0 : 3;
+	const featureSliceDefaultLength = 'treatment' === experimentAssignment?.variationName ? 12 : 8;
+
 	return (
 		<>
 			<Global styles={ globalOverrides } />
@@ -539,10 +542,6 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 											</div>
 											<div>
 												<Gridicon icon="checkmark" />
-												Automatic WordPress updates.
-											</div>
-											<div>
-												<Gridicon icon="checkmark" />
 												Flexible upgrade options.
 											</div>
 										</PlansHighlightFeatures>
@@ -569,10 +568,6 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 											<Gridicon icon="checkmark" />
 											Premium live chat support.
 										</div>
-										<div>
-											<Gridicon icon="checkmark" />
-											SFTP and database access for devs.
-										</div>
 									</PlansHighlightFeatures>
 								) }
 							</PlansComparisonColHeader>
@@ -588,18 +583,20 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 					</ComparisonHeader>
 				) } */ }
 				<PlansComparisonRows>
-					{ planComparisonFeatures.slice( 0, 8 ).map( ( feature ) => (
-						<PlansComparisonRow
-							feature={ feature }
-							plans={ plans }
-							isLegacySiteWithHigherLimits={ legacySiteWithHigherLimits }
-							key={ feature.features[ 0 ] }
-							isExperiment={ 'treatment' === experimentAssignment?.variationName }
-						/>
-					) ) }
+					{ planComparisonFeatures
+						.slice( featureSliceStart, featureSliceDefaultLength )
+						.map( ( feature ) => (
+							<PlansComparisonRow
+								feature={ feature }
+								plans={ plans }
+								isLegacySiteWithHigherLimits={ legacySiteWithHigherLimits }
+								key={ feature.features[ 0 ] }
+								isExperiment={ 'treatment' === experimentAssignment?.variationName }
+							/>
+						) ) }
 				</PlansComparisonRows>
 				<PlansComparisonCollapsibleRows collapsed={ showCollapsibleRows }>
-					{ planComparisonFeatures.slice( 8 ).map( ( feature ) => (
+					{ planComparisonFeatures.slice( featureSliceDefaultLength ).map( ( feature ) => (
 						<PlansComparisonRow
 							feature={ feature }
 							plans={ plans }

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -405,28 +405,6 @@ const PlansComparisonToggle = styled.tbody`
 	}
 `;
 
-const PlansHighlightFeatures = styled.div`
-	font-size: 1rem;
-	font-weight: 400;
-	margin: 1.5rem 0 1rem;
-
-	.gridicon.gridicon {
-		width: 1.1em;
-		height: 1.1em;
-
-		html[dir='ltr'] & {
-			margin: 0 5px -2px 0;
-		}
-		html[dir='rtl'] & {
-			margin: 0 0 -2px 5px;
-		}
-	}
-
-	.gridicons-checkmark {
-		fill: var( --studio-green-50 );
-	}
-`;
-
 interface Props {
 	isInSignup?: boolean;
 	selectedSiteId?: number;
@@ -522,54 +500,6 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 									}
 									onClick={ () => onSelectPlan( planToCartItem( plan ) ) }
 								/>
-								{ plan.type === TYPE_STARTER &&
-									'treatment' === experimentAssignment?.variationName && (
-										<PlansHighlightFeatures>
-											<p>
-												<b>Great for bloggers and simple sites:</b>
-											</p>
-											<div>
-												<Gridicon icon="checkmark" />
-												Custom website address.
-											</div>
-											<div>
-												<Gridicon icon="checkmark" />
-												Collect payments and donations.
-											</div>
-											<div>
-												<Gridicon icon="checkmark" />
-												6GB of storage for images.
-											</div>
-											<div>
-												<Gridicon icon="checkmark" />
-												Flexible upgrade options.
-											</div>
-										</PlansHighlightFeatures>
-									) }
-
-								{ plan.type === TYPE_PRO && 'treatment' === experimentAssignment?.variationName && (
-									<PlansHighlightFeatures>
-										<p>
-											<b>Great for pros and interactive sites:</b>
-										</p>
-										<div>
-											<Gridicon icon="checkmark" />
-											Unlock 50k+ plugins and themes.
-										</div>
-										<div>
-											<Gridicon icon="checkmark" />
-											Advanced ecommerce tools.
-										</div>
-										<div>
-											<Gridicon icon="checkmark" />
-											50GB of media storage.
-										</div>
-										<div>
-											<Gridicon icon="checkmark" />
-											Premium live chat support.
-										</div>
-									</PlansHighlightFeatures>
-								) }
 							</PlansComparisonColHeader>
 						) ) }
 					</tr>

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -204,6 +204,7 @@ export const FEATURE_P2_PRIORITY_CHAT_EMAIL_SUPPORT = 'p2-priority-chat-email-su
 export const FEATURE_P2_ACTIVITY_OVERVIEW = 'p2-activity-overview';
 
 // New features Flexible and Pro plans introduced.
+export const FEATURE_UNLIMITED_TRAFFIC = 'unlimited-traffic';
 export const FEATURE_UNLIMITED_USERS = 'unlimited-users';
 export const FEATURE_UNLIMITED_POSTS_PAGES = 'unlimited-posts-pages';
 export const FEATURE_PAYMENT_BLOCKS = 'payment-blocks';

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -204,6 +204,7 @@ export const FEATURE_P2_PRIORITY_CHAT_EMAIL_SUPPORT = 'p2-priority-chat-email-su
 export const FEATURE_P2_ACTIVITY_OVERVIEW = 'p2-activity-overview';
 
 // New features Flexible and Pro plans introduced.
+export const FEATURE_MANAGED_HOSTING = 'managed-hosting';
 export const FEATURE_UNLIMITED_TRAFFIC = 'unlimited-traffic';
 export const FEATURE_UNLIMITED_USERS = 'unlimited-users';
 export const FEATURE_UNLIMITED_POSTS_PAGES = 'unlimited-posts-pages';

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -205,6 +205,7 @@ import {
 	WPCOM_FEATURES_SCAN,
 	WPCOM_FEATURES_ANTISPAM,
 	WPCOM_FEATURES_BACKUPS,
+	FEATURE_MANAGED_HOSTING,
 } from './constants';
 import type {
 	BillingTerm,
@@ -1637,15 +1638,9 @@ PLANS_LIST[ PLAN_WPCOM_STARTER ] = {
 	getSubTitle: () => i18n.translate( 'Essential features. Freedom to grow.' ),
 	getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
 	getPlanCompareFeatures: () => [
-		FEATURE_CUSTOM_DOMAIN,
-		FEATURE_UNLIMITED_ADMINS,
-		FEATURE_6GB_STORAGE,
-		FEATURE_GOOGLE_ANALYTICS,
-		FEATURE_PAYMENT_BLOCKS,
-		FEATURE_TITAN_EMAIL,
-	],
-	getPlanCompareFeaturesTest: () => [
 		FEATURE_UNLIMITED_TRAFFIC,
+		FEATURE_MANAGED_HOSTING,
+		FEATURE_FREE_THEMES,
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_UNLIMITED_ADMINS,
 		FEATURE_6GB_STORAGE,
@@ -1683,6 +1678,9 @@ PLANS_LIST[ PLAN_WPCOM_PRO ] = {
 	getSubTitle: () => i18n.translate( 'Unlimited features. Unbeatable value.' ),
 	getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
 	getPlanCompareFeatures: () => [
+		FEATURE_UNLIMITED_TRAFFIC,
+		FEATURE_MANAGED_HOSTING,
+		FEATURE_FREE_THEMES,
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_PREMIUM_THEMES,
 		FEATURE_INSTALL_PLUGINS,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1633,6 +1633,7 @@ PLANS_LIST[ PLAN_WPCOM_STARTER ] = {
 		[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
 			? i18n.translate( 'Start with a custom domain name, simple payments, and extra storage.' )
 			: i18n.translate( 'Start your WordPress.com website. Limited functionality and storage.' ),
+	getSubTitle: () => i18n.translate( 'The Essentials. No fluff.' ),
 	getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
 	getPlanCompareFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
@@ -1673,7 +1674,7 @@ PLANS_LIST[ PLAN_WPCOM_PRO ] = {
 					'Unlock the full power of WordPress with plugins, custom themes and much more.'
 			  )
 			: i18n.translate( 'The full power of modern WordPress hosting made easy.' ),
-
+	getSubTitle: () => i18n.translate( 'Unlimited Traffic. Revolutionary Price.' ),
 	getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
 	getPlanCompareFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -138,6 +138,7 @@ import {
 	FEATURE_WP_SUBDOMAIN,
 	FEATURE_WP_SUBDOMAIN_SIGNUP,
 	FEATURE_UNLIMITED_ADMINS,
+	FEATURE_UNLIMITED_TRAFFIC,
 	FEATURE_PAYMENT_BLOCKS,
 	FEATURE_WOOCOMMERCE,
 	GROUP_JETPACK,
@@ -1633,9 +1634,18 @@ PLANS_LIST[ PLAN_WPCOM_STARTER ] = {
 		[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
 			? i18n.translate( 'Start with a custom domain name, simple payments, and extra storage.' )
 			: i18n.translate( 'Start your WordPress.com website. Limited functionality and storage.' ),
-	getSubTitle: () => i18n.translate( 'The Essentials. No fluff.' ),
+	getSubTitle: () => i18n.translate( 'Essential features. Freedom to grow.' ),
 	getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
 	getPlanCompareFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_UNLIMITED_ADMINS,
+		FEATURE_6GB_STORAGE,
+		FEATURE_GOOGLE_ANALYTICS,
+		FEATURE_PAYMENT_BLOCKS,
+		FEATURE_TITAN_EMAIL,
+	],
+	getPlanCompareFeaturesTest: () => [
+		FEATURE_UNLIMITED_TRAFFIC,
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_UNLIMITED_ADMINS,
 		FEATURE_6GB_STORAGE,
@@ -1667,14 +1677,10 @@ PLANS_LIST[ PLAN_WPCOM_PRO ] = {
 	getStoreSlug: () => PLAN_WPCOM_PRO,
 	getPathSlug: () => 'pro',
 	getDescription: () =>
-		i18n.hasTranslation(
+		i18n.translate(
 			'Unlock the full power of WordPress with plugins, custom themes and much more.'
-		) || [ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
-			? i18n.translate(
-					'Unlock the full power of WordPress with plugins, custom themes and much more.'
-			  )
-			: i18n.translate( 'The full power of modern WordPress hosting made easy.' ),
-	getSubTitle: () => i18n.translate( 'Unlimited Traffic. Revolutionary Price.' ),
+		),
+	getSubTitle: () => i18n.translate( 'Unlimited features. Unbeatable value.' ),
 	getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
 	getPlanCompareFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -95,6 +95,7 @@ export type Plan = BillingTerm & {
 	getStoreSlug: () => PlanSlug;
 	getTitle: () => TranslateResult;
 	getDescription: () => TranslateResult;
+	getSubTitle?: () => TranslateResult;
 	getShortDescription?: () => TranslateResult;
 	getTagline?: () => TranslateResult;
 	getPlanCardFeatures?: () => Feature[];

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -25,7 +25,12 @@ export interface WPComPlan extends Plan {
 	getBlogAudience?: () => TranslateResult;
 	getPortfolioAudience?: () => TranslateResult;
 	getStoreAudience?: () => TranslateResult;
+	getSubTitle?: () => TranslateResult;
 	getPlanCompareFeatures?: (
+		experiment?: string,
+		options?: Record< string, string | boolean[] >
+	) => Feature[];
+	getPlanCompareFeaturesTest?: (
 		experiment?: string,
 		options?: Record< string, string | boolean[] >
 	) => Feature[];
@@ -95,7 +100,6 @@ export type Plan = BillingTerm & {
 	getStoreSlug: () => PlanSlug;
 	getTitle: () => TranslateResult;
 	getDescription: () => TranslateResult;
-	getSubTitle?: () => TranslateResult;
 	getShortDescription?: () => TranslateResult;
 	getTagline?: () => TranslateResult;
 	getPlanCardFeatures?: () => Feature[];

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -30,10 +30,6 @@ export interface WPComPlan extends Plan {
 		experiment?: string,
 		options?: Record< string, string | boolean[] >
 	) => Feature[];
-	getPlanCompareFeaturesTest?: (
-		experiment?: string,
-		options?: Record< string, string | boolean[] >
-	) => Feature[];
 	getSignupFeatures?: () => Feature[];
 	getBlogSignupFeatures?: () => Feature[];
 	getPortfolioSignupFeatures?: () => Feature[];


### PR DESCRIPTION
#### Proposed Changes

This PR includes copy changes to the the plans page shown in signup. The intent is to present each plan on its own merits, rather than shining such a negative light on Starter.

Here's a screenshot of the page:
![screencapture-calypso-localhost-3000-start-plans-2022-06-03-15_04_27](https://user-images.githubusercontent.com/35781181/171932502-4c9d2e7b-88da-41e0-8c74-b91209fb822c.png)

It is setup as an Explat test and restricted to EN + US so translations and local currency aren't an issue.

#### Testing Instructions
* Checkout this PR and start it locally.
* Assign yourself to the treatment in Explat experiment  `pricing_packaging_plans_page_copy_test`
* Navigate to signup in your local Calypso.
* You should see the updates on the plans step in Calypso.
* Try multiple viewports.
* Navigate to the plans page inside the the product to ensure it displays properly there as well.


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
