### PR TITLE
popup-monitor: inline Emitter definition

### DIFF
--- a/packages/popup-monitor/src/emitter.js
+++ b/packages/popup-monitor/src/emitter.js
@@ -1,9 +1,0 @@
-import { EventEmitter } from 'events';
-
-export default function ( prototype ) {
-	Object.assign( prototype, EventEmitter.prototype );
-	prototype.emitChange = function () {
-		this.emit( 'change' );
-	};
-	prototype.off = prototype.removeListener;
-}

--- a/packages/popup-monitor/src/index.js
+++ b/packages/popup-monitor/src/index.js
@@ -1,4 +1,12 @@
-import Emitter from './emitter';
+import { EventEmitter } from 'events';
+
+function Emitter( prototype ) {
+	Object.assign( prototype, EventEmitter.prototype );
+	prototype.emitChange = function () {
+		this.emit( 'change' );
+	};
+	prototype.off = prototype.removeListener;
+}
 
 /**
  * PopupMonitor component


### PR DESCRIPTION
Alternative to #64158: by inlining the `Emitter` definition we eliminate the local `./emitter` import. That import, in the CJS build, is transpiled using an `interopRequireDefault` helper from `@babel/runtime`, adding a dependency on that package.

Eliminating the import eliminates the need for `@babel/runtime`, too.
