### PR TITLE
e2e: Add translation tests for Block Editor Welcome Guide

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -796,5 +796,12 @@ export class EditorPage {
 		return await this.editorGutenbergComponent.editorHasBlockWarning();
 	}
 
+	/**
+	 * Open the editor options menu.
+	 */
+	async openEditorOptionsMenu(): Promise< void > {
+		return this.editorToolbarComponent.openMoreOptionsMenu();
+	}
+
 	//#endregion
 }

--- a/packages/calypso-e2e/src/lib/utils/index.ts
+++ b/packages/calypso-e2e/src/lib/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './validate-translations';
 export * from './get-test-account-by-feature';
+export * from './translate';
 
 // Other items are exported for unit testing, we only care about the manager class.
 export { EditorTracksEventManager } from './editor-tracks-event-manager';

--- a/packages/calypso-e2e/src/lib/utils/translate.ts
+++ b/packages/calypso-e2e/src/lib/utils/translate.ts
@@ -1,0 +1,14 @@
+import { Locator } from 'playwright';
+
+/**
+ * Translate string by evaluating the `wp.i18n__` translate function from the page.
+ */
+export async function translateFromPage( locator: Locator, string: string ): Promise< string > {
+	return (
+		locator.evaluate(
+			// eslint-disable-next-line @wordpress/i18n-no-variables
+			( _el, string ) => ( window as any )?.wp?.i18n?.__( string ),
+			string
+		) || Promise.resolve( string )
+	);
+}

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -16,6 +16,13 @@ import type { LanguageSlug } from '@automattic/languages';
 
 type Translations = {
 	[ language in LanguageSlug ]?: Partial< {
+		etkPlugin: {
+			welcomeGuide: {
+				openGuideSelector: string;
+				welcomeTitleSelector: string;
+				closeButtonSelector: string;
+			};
+		};
 		blocks: {
 			blockName: string;
 			blockEditorSelector: string;
@@ -26,6 +33,15 @@ type Translations = {
 };
 const translations: Translations = {
 	en: {
+		etkPlugin: {
+			welcomeGuide: {
+				openGuideSelector:
+					'.interface-more-menu-dropdown__content button:has-text("Welcome Guide")',
+				welcomeTitleSelector:
+					'.wpcom-tour-kit-step-card__heading:has-text("Welcome to WordPress!")',
+				closeButtonSelector: '.wpcom-tour-kit button[aria-label="Close Tour"]',
+			},
+		},
 		blocks: [
 			// Core
 			{
@@ -86,6 +102,15 @@ const translations: Translations = {
 		],
 	},
 	fr: {
+		etkPlugin: {
+			welcomeGuide: {
+				openGuideSelector:
+					'.interface-more-menu-dropdown__content button:has-text("Guide de bienvenue")',
+				welcomeTitleSelector:
+					'.wpcom-tour-kit-step-card__heading:has-text("Bienvenue dans WordPress !")',
+				closeButtonSelector: '.wpcom-tour-kit button[aria-label="Fermer la visite"]',
+			},
+		},
 		blocks: [
 			// Core
 			{
@@ -148,6 +173,15 @@ const translations: Translations = {
 		],
 	},
 	he: {
+		etkPlugin: {
+			welcomeGuide: {
+				openGuideSelector:
+					'.interface-more-menu-dropdown__content button:has-text("מדריך ברוכים הבאים")',
+				welcomeTitleSelector:
+					'.wpcom-tour-kit-step-card__heading:has-text("ברוך בואך ל-WordPress!")',
+				closeButtonSelector: '.wpcom-tour-kit button[aria-label="לסגור את הסיור"]',
+			},
+		},
 		blocks: [
 			// Core
 			{
@@ -256,6 +290,25 @@ describe( 'I18N: Editor', function () {
 
 			it( 'Go to the new post page', async function () {
 				await editorPage.visit( 'post' );
+			} );
+		} );
+
+		describe( 'Editing Toolkit Plugin', function () {
+			it( 'Translations for Welcome Guide', async function () {
+				const frame = await editorPage.getEditorHandle();
+				const timeout = 10 * 1000;
+				// We know these are all defined because of the filtering above. Non-null asserting is safe here.
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				const etkTranslations = translations[ locale ]!.etkPlugin!;
+
+				await editorPage.openEditorOptionsMenu();
+				await frame.locator( etkTranslations.welcomeGuide.openGuideSelector ).click( { timeout } );
+				await frame.waitForSelector( etkTranslations.welcomeGuide.welcomeTitleSelector, {
+					timeout,
+				} );
+				await frame
+					.locator( etkTranslations.welcomeGuide.closeButtonSelector )
+					.click( { timeout } );
 			} );
 		} );
 


### PR DESCRIPTION
#### Proposed Changes

* Add i18n e2e tests for the Block Editor Welcome Guide

#### Testing Instructions

* Calypso e2e tests pass
* I18n e2e tests pass

