### PR TITLE
Anchor: Submit data when user is logged in

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -404,7 +404,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 	// When the intent is build, we can potentially show the generated design picker.
 	// Don't render until we've fetched the generated designs from the backend.
-	if ( ! site || isLoadingGeneratedDesigns ) {
+	if ( ( ! site || isLoadingGeneratedDesigns ) && ! isAnchorSite ) {
 		return null;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/login/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/login/index.tsx
@@ -47,14 +47,21 @@ const LoginStep: Step = function LoginStep( { navigation } ) {
 	const [ emailVal, setEmailVal ] = useState( '' );
 	const [ passwordVal, setPasswordVal ] = useState( '' );
 
-	const handleSubmit = async ( event: FormEvent< HTMLFormElement > ) => {
-		event.preventDefault();
-
+	const submitAnchorDeps = () => {
 		const providedDependencies = {
 			anchorFmPodcastId,
 			anchorFmEpisodeId,
 			anchorFmSpotifyUrl,
 		};
+
+		setAnchorPodcastId( ! isAnchorFmPodcastIdError ? anchorFmPodcastId : null );
+		setAnchorEpisodeId( anchorFmEpisodeId );
+		setAnchorSpotifyUrl( anchorFmSpotifyUrl );
+		submit?.( providedDependencies );
+	};
+
+	const handleSubmit = async ( event: FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
 
 		let recaptchaToken;
 		let recaptchaError;
@@ -84,10 +91,7 @@ const LoginStep: Step = function LoginStep( { navigation } ) {
 		} );
 
 		if ( result.ok ) {
-			setAnchorPodcastId( ! isAnchorFmPodcastIdError ? anchorFmPodcastId : null );
-			setAnchorEpisodeId( anchorFmEpisodeId );
-			setAnchorSpotifyUrl( anchorFmSpotifyUrl );
-			submit?.( providedDependencies );
+			submitAnchorDeps();
 		} else {
 			recordOnboardingError( {
 				step: 'account_creation',
@@ -285,16 +289,8 @@ const LoginStep: Step = function LoginStep( { navigation } ) {
 	 * proceed to the next step; no need to log in.
 	 */
 	useEffect( () => {
-		const providedDependencies = {
-			anchorFmPodcastId,
-			anchorFmEpisodeId,
-			anchorFmSpotifyUrl,
-		};
 		if ( currentUser && userIsLoggedIn ) {
-			setAnchorPodcastId( ! isAnchorFmPodcastIdError ? anchorFmPodcastId : null );
-			setAnchorEpisodeId( anchorFmEpisodeId );
-			setAnchorSpotifyUrl( anchorFmSpotifyUrl );
-			submit?.( providedDependencies );
+			submitAnchorDeps();
 		}
 	}, [ currentUser, userIsLoggedIn ] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/login/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/login/index.tsx
@@ -26,7 +26,7 @@ import type { FormEvent } from 'react';
 import './style.scss';
 
 const LoginStep: Step = function LoginStep( { navigation } ) {
-	const { submit, goNext, goToStep } = navigation;
+	const { submit, goToStep } = navigation;
 	const { __ } = useI18n();
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
@@ -285,8 +285,16 @@ const LoginStep: Step = function LoginStep( { navigation } ) {
 	 * proceed to the next step; no need to log in.
 	 */
 	useEffect( () => {
+		const providedDependencies = {
+			anchorFmPodcastId,
+			anchorFmEpisodeId,
+			anchorFmSpotifyUrl,
+		};
 		if ( currentUser && userIsLoggedIn ) {
-			goNext?.();
+			setAnchorPodcastId( ! isAnchorFmPodcastIdError ? anchorFmPodcastId : null );
+			setAnchorEpisodeId( anchorFmEpisodeId );
+			setAnchorSpotifyUrl( anchorFmSpotifyUrl );
+			submit?.( providedDependencies );
 		}
 	}, [ currentUser, userIsLoggedIn ] );
 


### PR DESCRIPTION
#### Proposed Changes

* Make sure we pass along Anchor data to the onboard store when a user is already logged in.
* Fixes showing the design picker when in the Anchor flow.

#### Testing Instructions

* Switch to this PR
* Navigate to `/setup?anchor_podcast=[your podcast id]` as an already logged in user
* Check onboard store under Application tab in the browser inspector to see that your podcast data has been correctly added to the store via the query params
* Make sure your podcast data gets pulled in as expected when you finish signup
* Try the flow logged out to make sure podcast data still gets pulled through the flow.