### PR TITLE
Enable "jetpack/pricing-add-boost-social" feature in production.

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -50,7 +50,7 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/magic-link-signup": true,
-		"jetpack/pricing-add-boost-social": false,
+		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -38,6 +38,7 @@
 		"jetpack-cloud": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/agency-dashboard": false,
+		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/production.json
+++ b/config/production.json
@@ -59,6 +59,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/magic-link-signup": true,
+		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jitms": true,


### PR DESCRIPTION
#### Proposed Changes

This PR enables the Jetpack.com Pricing Page update (add Boost & Social) project in the Production environment for all users.

Project Thread: p1HpG7-g29-p2
Asana card: 1202316834912830-as-1202364055219564/f

#### Testing instructions

1. Visually inspect the code & verify the `jetpack/pricing-add-boost-social` feature-flag is enabled in production for wordpress.com and cloud.jetpack.com, (and horizon because it was the last remaining environment that was set to false).
