### PR TITLE
i18n: Adjust input field font size to prevent truncation

### DIFF
--- a/client/blocks/import/capture/style.scss
+++ b/client/blocks/import/capture/style.scss
@@ -13,6 +13,10 @@ $placeholder-color: #909398;
 		margin: auto;
 		max-width: 500px;
 
+		@include break-medium {
+			max-width: 700px;
+		}
+
 		.components-button.action-buttons__next.is-primary {
 			position: absolute;
 			min-width: auto;
@@ -28,6 +32,11 @@ $placeholder-color: #909398;
 
 	.capture__input-wrapper-padding {
 		max-width: 450px;
+
+		@include break-medium {
+			max-width: 650px;
+		}
+
 		padding-right: 50px;
 	}
 
@@ -55,7 +64,7 @@ $placeholder-color: #909398;
 			display: none;
 		}
 
-		@include break-small {
+		@include break-medium {
 			font-size: 2.75rem; /* stylelint-disable-line */
 		}
 


### PR DESCRIPTION
#### Proposed Changes

In some languages (e.g. Spanish) the placeholder text is truncated on screens whose width was larger than `600px` (`break-small`). This occurred because we adjust the font-size to `2.75rem` on screens wider than `600px`.

This commit adjusts the breakpoint to `782px` (`break-medium`), which allows the translated placeholder text to fit on small ( <`600px`) and large (>`782px`)  screens.


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Change your user language to a language with know text expansion (Russian, German, Spanish...)
2. Go to /start
3. Create a new site (select domain + free plan)
4. Select the "Import your site's content" (last option on the Where to start page)
5. For longer languages (e.g. Spanish), the translated text "Enter your site address" should fit in the placeholder.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 441-gh-Automattic/i18n-issues