### PR TITLE
Marketplace: Clears search input when no search term is present in the URL

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -296,7 +296,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
 			/>
 
-			{ ! search && <Categories clearSearch={ clearSearch } selected={ category } /> }
+			{ ! search && <Categories selected={ category } /> }
 
 			<PluginBrowserContent
 				clearSearch={ clearSearch }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -77,7 +77,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 	const searchRef = useRef( null );
 
 	const clearSearch = useCallback( () => {
-		searchRef.current.setKeyword( '' );
+		searchRef?.current?.setKeyword( '' );
 	}, [ searchRef ] );
 
 	const breadcrumbs = useSelector( getBreadcrumbs );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -7,7 +7,7 @@ import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Icon, upload } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import announcementImage from 'calypso/assets/images/marketplace/diamond.svg';
 import AnnouncementModal from 'calypso/blocks/announcement-modal';
@@ -74,6 +74,11 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 		targetRef: searchHeaderRef,
 		referenceRef: navigationHeaderRef,
 	} = useScrollAboveElement();
+	const searchRef = useRef( null );
+
+	const clearSearch = useCallback( () => {
+		searchRef.current.setKeyword( '' );
+	}, [ searchRef ] );
 
 	const breadcrumbs = useSelector( getBreadcrumbs );
 
@@ -149,6 +154,12 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 
 	const categories = useCategories();
 	const categoryName = categories[ category ]?.name || translate( 'Plugins' );
+
+	useEffect( () => {
+		if ( ! search ) {
+			clearSearch();
+		}
+	}, [ clearSearch, search ] );
 
 	useEffect( () => {
 		const items = [
@@ -275,6 +286,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 			/>
 
 			<SearchBoxHeader
+				searchRef={ searchRef }
 				popularSearchesRef={ searchHeaderRef }
 				isSticky={ isAboveElement }
 				doSearch={ ( searchTerm ) => setQueryArgs( '' !== searchTerm ? { s: searchTerm } : {} ) }
@@ -284,9 +296,10 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
 			/>
 
-			{ ! search && <Categories selected={ category } /> }
+			{ ! search && <Categories clearSearch={ clearSearch } selected={ category } /> }
 
 			<PluginBrowserContent
+				clearSearch={ clearSearch }
 				pluginsByCategoryPopular={ pluginsByCategoryPopular }
 				isFetchingPluginsByCategoryPopular={ isFetchingPluginsByCategoryPopular }
 				isFetchingPluginsBySearchTerm={ isFetchingPluginsBySearchTerm }

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,6 +1,6 @@
 import Search from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
-import { useRef, Fragment } from 'react';
+import { Fragment } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
@@ -82,13 +82,20 @@ const PopularSearches = ( props ) => {
 };
 
 const SearchBoxHeader = ( props ) => {
-	const { doSearch, searchTerm, title, searchTerms, isSticky, popularSearchesRef, isSearching } =
-		props;
-	const searchBoxRef = useRef( null );
+	const {
+		doSearch,
+		searchTerm,
+		title,
+		searchTerms,
+		isSticky,
+		popularSearchesRef,
+		isSearching,
+		searchRef,
+	} = props;
 
 	// since the search input is an uncontrolled component we need to tap in into the component api and trigger an update
 	const updateSearchBox = ( keyword ) => {
-		searchBoxRef.current.setKeyword( keyword );
+		searchRef.current.setKeyword( keyword );
 		doSearch( keyword );
 	};
 
@@ -99,7 +106,7 @@ const SearchBoxHeader = ( props ) => {
 				<SearchBox
 					doSearch={ doSearch }
 					searchTerm={ searchTerm }
-					searchBoxRef={ searchBoxRef }
+					searchBoxRef={ searchRef }
 					isSearching={ isSearching }
 				/>
 			</div>


### PR DESCRIPTION
#### Proposed Changes

* Clears the search input when no search term is present in the URL

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the plugins marketplace.
* Do a search or click a popular search.
* Click the clear button
* Search input should be blank.
* Repeat instructions by clicking on a category and by clicking on the plugins breadcrumb after doing a search.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63789