### PR TITLE
Playwright: eliminate username collision.

### DIFF
--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -51,6 +51,27 @@ export function getTimestamp(): string {
 }
 
 /**
+ * Returns a username.
+ *
+ * If optional parameter `prefix` is set, the value
+ * is inserted between the `e2eflowtesting` prefix
+ * and the timestamp.
+ *
+ * Example:
+ * 	e2eflowtesting-1654124900-728
+ * 	e2eflowtestingfree-1654124900-129
+ *
+ * @param param0 Object parameter.
+ * @param {string} param0.prefix Prefix for the username.
+ * @returns {string} Generated username.
+ */
+export function getUsername( { prefix = '' }: { prefix?: string } = {} ): string {
+	const timestamp = getTimestamp();
+	const randomNumber = getRandomInteger( 0, 999 );
+	return `e2eflowtesting${ prefix }-${ timestamp }-${ randomNumber }`;
+}
+
+/**
  * Returns the date string in the requested format.
  *
  * @param {DateFormat} format Date format supported by NodeJS.

--- a/test/e2e/specs/onboarding/gutenboarding__happy-path.ts
+++ b/test/e2e/specs/onboarding/gutenboarding__happy-path.ts
@@ -17,7 +17,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 	const siteTitle = DataHelper.getBlogName();
 	const email = DataHelper.getTestEmailAddress( {
 		inboxId: SecretsManager.secrets.mailosaur.signupInboxId,
-		prefix: `e2eflowtestinggutenboarding${ DataHelper.getTimestamp() }`,
+		prefix: DataHelper.getUsername( { prefix: 'gutenboarding' } ),
 	} );
 	const signupPassword = SecretsManager.secrets.passwordForNewTestSignUps;
 	const themeName = 'Twenty Twenty-Two Red';

--- a/test/e2e/specs/onboarding/signup__domain.ts
+++ b/test/e2e/specs/onboarding/signup__domain.ts
@@ -19,7 +19,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), function () {
 	const inboxId = SecretsManager.secrets.mailosaur.signupInboxId;
-	const username = `e2eflowtestingdomainonly${ DataHelper.getTimestamp() }`;
+	const username = DataHelper.getUsername( { prefix: 'domainonly' } );
 	const email = DataHelper.getTestEmailAddress( {
 		inboxId: inboxId,
 		prefix: username,

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -23,7 +23,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ), function () {
 	const inboxId = SecretsManager.secrets.mailosaur.inviteInboxId;
-	const username = `e2eflowtestingfree${ DataHelper.getTimestamp() }`;
+	const username = DataHelper.getUsername( { prefix: 'free' } );
 	const email = DataHelper.getTestEmailAddress( {
 		inboxId: inboxId,
 		prefix: username,

--- a/test/e2e/specs/onboarding/signup__paid.ts
+++ b/test/e2e/specs/onboarding/signup__paid.ts
@@ -31,7 +31,7 @@ skipDescribeIf( isStagingOrProd )(
 	DataHelper.createSuiteTitle( 'Signup: WordPress.com Paid' ),
 	function () {
 		const inboxId = SecretsManager.secrets.mailosaur.inviteInboxId;
-		const username = `e2eflowtestingpaid${ DataHelper.getTimestamp() }`;
+		const username = DataHelper.getUsername( { prefix: 'paid' } );
 		const email = DataHelper.getTestEmailAddress( {
 			inboxId: inboxId,
 			prefix: username,

--- a/test/e2e/specs/onboarding/signup__wpcc.ts
+++ b/test/e2e/specs/onboarding/signup__wpcc.ts
@@ -16,7 +16,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com WPCC' ), function () {
 	const inboxId = SecretsManager.secrets.mailosaur.signupInboxId;
-	const username = `e2eflowtestingwpcc${ DataHelper.getTimestamp() }`;
+	const username = DataHelper.getUsername( { prefix: 'wpcc' } );
 	const email = DataHelper.getTestEmailAddress( {
 		inboxId: inboxId,
 		prefix: username,

--- a/test/e2e/specs/plans/plans__signup-free.ts
+++ b/test/e2e/specs/plans/plans__signup-free.ts
@@ -21,7 +21,7 @@ declare const browser: Browser;
 describe(
 	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Free site as a new user' ),
 	function () {
-		const username = `e2eflowtestingfree${ DataHelper.getTimestamp() }`;
+		const username = DataHelper.getUsername( { prefix: 'freeplan' } );
 		const password = SecretsManager.secrets.passwordForNewTestSignUps;
 		const email = DataHelper.getTestEmailAddress( {
 			inboxId: SecretsManager.secrets.mailosaur.inviteInboxId,

--- a/test/e2e/specs/users/invite__new-user.ts
+++ b/test/e2e/specs/users/invite__new-user.ts
@@ -22,7 +22,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( `Invite: New User` ), function () {
 	const inboxId = SecretsManager.secrets.mailosaur.inviteInboxId;
 	const role = 'Editor';
-	const username = `e2eflowtestingeditor${ DataHelper.getTimestamp() }`;
+	const username = DataHelper.getUsername( { prefix: 'invited-editor' } );
 	const email = DataHelper.getTestEmailAddress( {
 		inboxId: inboxId,
 		prefix: username,


### PR DESCRIPTION
#### Proposed Changes

This PR addresses the username collision outlined in https://github.com/Automattic/wp-calypso/issues/64270.

Key changes:
- implement a new method to obtain a unique username;
- update existing specs where usernames are generated to use the new method.

With these changes, the likelihood of username collision should be nearly eliminated if not completely. 

#### Testing Instructions

Ensure the following:
  - [ ] Calypso E2E (desktop)
  - [ ] Calypso E2E (mobile)
  - [ ] Pre-Release E2E

Related to https://github.com/Automattic/wp-calypso/issues/64270.