### PR TITLE
Marketplace: Adds background while hovering to categories menu items

### DIFF
--- a/client/my-sites/plugins/categories/responsive-toolbar-group/style.scss
+++ b/client/my-sites/plugins/categories/responsive-toolbar-group/style.scss
@@ -21,6 +21,12 @@
 		>div:last-of-type {
 			margin-right: -8px;
 		}
+
+		.responsive-toolbar-group__button-item:not( [class*='is-pressed'] ) {
+			&:hover::before {
+				background: #f6f7f7;
+			}
+		}
 	}
 
 	.is-visible {
@@ -47,12 +53,6 @@
 	// Remove on-focus, on-click border
 	.components-toolbar .components-button::before {
 		box-shadow: none;
-	}
-
-	.responsive-toolbar-group__more-item {
-		&::before {
-			background: #f6f7f7;
-		}
 	}
 }
 


### PR DESCRIPTION
#### Screencast
![Screen Capture on 2022-06-01 at 18-24-45](https://user-images.githubusercontent.com/1035546/171517664-20c3d63e-bcc3-4b36-8577-ab43a14570b2.gif)

#### Proposed Changes

*  Adds background while hovering to categories menu items

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate into the plugins marketplace.
* Hover over the categories menu items.
* Items background color should change.
* Selected items background color shouldn't change while hovering.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63838