### PR TITLE
Marketplace: Add the background change on content to the marketplace to match design

### DIFF
--- a/client/my-sites/plugins/categories/responsive-toolbar-group/style.scss
+++ b/client/my-sites/plugins/categories/responsive-toolbar-group/style.scss
@@ -2,17 +2,6 @@
 	position: relative;
 	padding-bottom: 24px;
 
-	&::before {
-		box-sizing: border-box;
-		content: '';
-		position: absolute;
-		height: 100%;
-		width: 200vw;
-		left: -100vw;
-		z-index: -1;
-		border-bottom: 1px solid #eeeeee;
-	}
-
 	.responsive-toolbar-group__grouped-list {
 		justify-content: space-between;
 		flex-wrap: nowrap;

--- a/client/my-sites/plugins/categories/responsive-toolbar-group/style.scss
+++ b/client/my-sites/plugins/categories/responsive-toolbar-group/style.scss
@@ -1,5 +1,17 @@
 .responsive-toolbar-group__dropdown {
 	position: relative;
+	padding-bottom: 24px;
+
+	&::before {
+		box-sizing: border-box;
+		content: '';
+		position: absolute;
+		height: 100%;
+		width: 200vw;
+		left: -100vw;
+		z-index: -1;
+		border-bottom: 1px solid #eeeeee;
+	}
 
 	.responsive-toolbar-group__grouped-list {
 		justify-content: space-between;

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -10,7 +10,6 @@
 		width: 200vw;
 		left: -100vw;
 		z-index: -1;
-		border-top: 1px solid #eeeeee;
 	}
 	.feature-example & {
 		margin: 0;
@@ -42,7 +41,7 @@
 	justify-content: space-between;
 	flex-wrap: wrap;
 
-	padding-top: 16px;
+	padding-top: 48px;
 	.plugins-browser-list__titles {
 		padding-bottom: 10px;
 

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -1,6 +1,17 @@
 .plugins-browser-list {
 	margin-bottom: 16px;
 
+	&::before {
+		box-sizing: border-box;
+		content: '';
+		background-color: #fdfdfd;
+		position: absolute;
+		height: 100%;
+		width: 200vw;
+		left: -100vw;
+		z-index: -1;
+		border-top: 1px solid #eeeeee;
+	}
 	.feature-example & {
 		margin: 0;
 	}
@@ -32,7 +43,6 @@
 	flex-wrap: wrap;
 
 	padding-top: 16px;
-
 	.plugins-browser-list__titles {
 		padding-bottom: 10px;
 

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -1,16 +1,6 @@
 .plugins-browser-list {
 	margin-bottom: 16px;
 
-	&::before {
-		box-sizing: border-box;
-		content: '';
-		background-color: #fdfdfd;
-		position: absolute;
-		height: 100%;
-		width: 200vw;
-		left: -100vw;
-		z-index: -1;
-	}
 	.feature-example & {
 		margin: 0;
 	}

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -298,26 +298,28 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 
 			{ ! search && <Categories selected={ category } /> }
 
-			<PluginBrowserContent
-				clearSearch={ clearSearch }
-				pluginsByCategoryPopular={ pluginsByCategoryPopular }
-				isFetchingPluginsByCategoryPopular={ isFetchingPluginsByCategoryPopular }
-				isFetchingPluginsBySearchTerm={ isFetchingPluginsBySearchTerm }
-				fetchNextPage={ fetchNextPage }
-				pluginsBySearchTerm={ pluginsBySearchTerm }
-				pluginsPagination={ pluginsPagination }
-				pluginsByCategoryFeatured={ pluginsByCategoryFeatured }
-				isFetchingPluginsByCategoryFeatured={ isFetchingPluginsByCategoryFeatured }
-				search={ search }
-				category={ category }
-				paidPlugins={ paidPlugins }
-				isFetchingPaidPlugins={ isFetchingPaidPlugins }
-				sites={ sites }
-				searchTitle={ searchTitle }
-				siteSlug={ siteSlug }
-				siteId={ siteId }
-				jetpackNonAtomic={ jetpackNonAtomic }
-			/>
+			<div className="plugins-browser__main-container">
+				<PluginBrowserContent
+					clearSearch={ clearSearch }
+					pluginsByCategoryPopular={ pluginsByCategoryPopular }
+					isFetchingPluginsByCategoryPopular={ isFetchingPluginsByCategoryPopular }
+					isFetchingPluginsBySearchTerm={ isFetchingPluginsBySearchTerm }
+					fetchNextPage={ fetchNextPage }
+					pluginsBySearchTerm={ pluginsBySearchTerm }
+					pluginsPagination={ pluginsPagination }
+					pluginsByCategoryFeatured={ pluginsByCategoryFeatured }
+					isFetchingPluginsByCategoryFeatured={ isFetchingPluginsByCategoryFeatured }
+					search={ search }
+					category={ category }
+					paidPlugins={ paidPlugins }
+					isFetchingPaidPlugins={ isFetchingPaidPlugins }
+					sites={ sites }
+					searchTitle={ searchTitle }
+					siteSlug={ siteSlug }
+					siteId={ siteId }
+					jetpackNonAtomic={ jetpackNonAtomic }
+				/>
+			</div>
 			{ ! category && ! search && <EducationFooter /> }
 		</MainComponent>
 	);

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -40,3 +40,16 @@
 		margin: 0 16px;
 	}
 }
+.plugins-browser__main-container {
+	&::before {
+		box-sizing: border-box;
+		content: '';
+		background-color: #fdfdfd;
+		position: absolute;
+		height: 100%;
+		width: 200vw;
+		left: -100vw;
+		z-index: -1;
+		border-top: 1px solid #eeeeee;
+	}
+}


### PR DESCRIPTION
#### Proposed Changes
Add the background change on content to the marketplace to match design

#### Testing Instructions

1. Go to /plugins
2. Check the background color of the search header (#FFFFFF) and plugins list (#FDFDFD) to match Figma

#### Screenshots

##### Desktop
<img width="1140" alt="image" src="https://user-images.githubusercontent.com/402286/171521038-f17d8e2e-757b-4e9f-8dcb-2280a63706e7.png">

##### Mobile
<img width="272" alt="image" src="https://user-images.githubusercontent.com/402286/171521079-356a890d-8962-4ac8-a31c-a1d272d5002d.png">


Figma File: [f84fqtCG4pCnCh2Hq0But5-fi-2011%3A26631](https://href.li/?https://www.figma.com/file/f84fqtCG4pCnCh2Hq0But5/?node-id=2011%3A26631)

Related to #63837 
