### PR TITLE
Redirect to setup flow instead of the specific step after onboarding

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -79,7 +79,7 @@ function getSignupDestination( { domainItem, siteId, siteSlug, refParameter }, l
 	}
 
 	if ( isEnabled( 'signup/stepper-flow' ) ) {
-		return addQueryArgs( queryParam, '/setup/intent' );
+		return addQueryArgs( queryParam, '/setup' );
 	}
 
 	// Initially ship to English users only, then ship to all users when translations complete


### PR DESCRIPTION
#### Proposed Changes

* Redirect to the setup flow after onboarding and people will always land on the first step instead of the specific one.

https://user-images.githubusercontent.com/13596067/171548266-2e6e9eba-34b8-40dc-b376-af6a41a62619.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to new site flow: `/start/domains`
* After finishing the domain and plan step, you'll land on the vertical step instead of the intent step

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64275
