### PR TITLE
ToS screenshots: Wait for language picker selector before attempting reload

### DIFF
--- a/test/e2e/specs/martech/tos-screenshots__checkout.ts
+++ b/test/e2e/specs/martech/tos-screenshots__checkout.ts
@@ -95,6 +95,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 				page.setViewportSize( { width: 1280, height: 720 } );
 				await page.goto( DataHelper.getCalypsoURL( 'home' ), { waitUntil: 'networkidle' } );
 				await changeUILanguageFlow.changeUILanguage( locale as LanguageSlug );
+				await page.waitForSelector( '.account__settings .language-picker__name-label' );
 				await page.goto( DataHelper.getCalypsoURL( 'home' ) );
 				await page.reload( { waitUntil: 'networkidle' } );
 				await cartCheckoutPage.visit( blogName );


### PR DESCRIPTION
#### Proposed Changes

* Attempting to fix the following error seen in checkout:
```
page.goto: net::ERR_ABORTED at https://wordpress.com/home
=========================== logs ===========================
navigating to "https://wordpress.com/home", waiting until "load"
============================================================
at Object.<anonymous> (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/martech/tos-screenshots__checkout.ts:98:16)

```

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
