### PR TITLE
add _locale to generated designs query

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -103,6 +103,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 			{
 				vertical_id: siteVerticalId,
 				seed: siteSlug || undefined,
+				_locale: locale,
 			},
 			{ enabled: enabledGeneratedDesigns && !! siteVerticalId && ! isAnchorSite }
 		);

--- a/packages/data-stores/src/starter-designs-queries/types.ts
+++ b/packages/data-stores/src/starter-designs-queries/types.ts
@@ -3,6 +3,7 @@ import type { DesignRecipe } from '@automattic/design-picker/src/types';
 export interface StarterDesignsGeneratedQueryParams {
 	vertical_id: string;
 	seed?: string;
+	_locale: string;
 }
 
 export interface StarterDesignsGenerated {


### PR DESCRIPTION
#### Proposed Changes
Currently we have tranlations for the site title used in previews but we're not retrieving the translated title from the API
related to https://github.com/Automattic/wp-calypso/issues/63076#issuecomment-1144410868

Maybe there is a neater way to implement this, I'm not sure. I see that https://github.com/Automattic/wp-calypso/blob/trunk/client/data/site-verticals/use-site-verticals-query.ts#L31 uses wpcom.request.get which automatically appends the _locale param. But it seems to works a little differently to `wpcomRequest` (and appears older?) and I think it's better to keep it as is 🤷. 
<img width="908" alt="Screen Shot 2022-06-02 at 5 06 02 pm" src="https://user-images.githubusercontent.com/22446385/171573123-ea7d8429-c240-43ed-93c5-9e4d3c00e9a1.png">


#### Testing Instructions
Use a non english language on your test site.
Select a vertical for which translations exist
Go to the Design picker
Site titles should be translated in the previews

