### PR TITLE
Vertical question screen: Show popular verticals whenever the input field value hasn't been changed by the user

### DIFF
--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -26,6 +26,7 @@ const SelectVertical: React.FC< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 	const [ searchTerm, setSearchTerm ] = useState( '' );
+	const [ hasUserInput, setHasUserInput ] = useState( false );
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 150 );
 	const isDebouncing = searchTerm !== debouncedSearchTerm;
 
@@ -70,13 +71,18 @@ const SelectVertical: React.FC< Props > = ( {
 				suggestions={
 					! isDebouncing
 						? mapManySiteVerticalsResponseToVertical(
-								( searchTerm === '' ? featured : suggestions ) || []
+								( ! hasUserInput ? featured : suggestions ) || []
 						  )
 						: []
 				}
 				isLoading={ isDebouncing || isLoadingDefaultVertical || isLoadingSuggestions }
+				isShowSkipOption={ hasUserInput }
 				isDisableInput={ isLoadingDefaultVertical }
+				onSuggestionsHide={ () => {
+					setHasUserInput( false );
+				} }
 				onInputChange={ ( searchTerm: string ) => {
+					setHasUserInput( searchTerm !== '' );
 					setSearchTerm( searchTerm );
 					onInputChange?.( searchTerm );
 				} }

--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -78,15 +78,13 @@ const SelectVertical: React.FC< Props > = ( {
 				isLoading={ isDebouncing || isLoadingDefaultVertical || isLoadingSuggestions }
 				isShowSkipOption={ hasUserInput }
 				isDisableInput={ isLoadingDefaultVertical }
-				onSuggestionsHide={ () => {
-					setHasUserInput( false );
-				} }
 				onInputChange={ ( searchTerm: string ) => {
 					setHasUserInput( searchTerm !== '' );
 					setSearchTerm( searchTerm );
 					onInputChange?.( searchTerm );
 				} }
 				onSelect={ ( vertical: Vertical ) => {
+					setHasUserInput( false );
 					setSearchTerm( vertical.label );
 					onSelect?.( vertical );
 				} }

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -14,7 +14,6 @@ interface Props {
 	isLoading?: boolean | undefined;
 	isShowSkipOption?: boolean | undefined;
 	isDisableInput?: boolean | undefined;
-	onSuggestionsHide?: () => void;
 	onInputChange?: ( value: string ) => void;
 	onSelect?: ( vertical: Vertical ) => void;
 }
@@ -26,7 +25,6 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 	isLoading,
 	isShowSkipOption,
 	isDisableInput,
-	onSuggestionsHide,
 	onInputChange,
 	onSelect,
 } ) => {
@@ -43,7 +41,6 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 
 	const hideSuggestions = () => {
 		setIsShowSuggestions( false );
-		onSuggestionsHide?.();
 	};
 
 	const handleTextInputBlur = ( event: React.FocusEvent ) => {

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -11,8 +11,10 @@ interface Props {
 	placeholder?: string;
 	searchTerm: string;
 	suggestions: Vertical[];
-	isDisableInput?: boolean | undefined;
 	isLoading?: boolean | undefined;
+	isShowSkipOption?: boolean | undefined;
+	isDisableInput?: boolean | undefined;
+	onSuggestionsHide?: () => void;
 	onInputChange?: ( value: string ) => void;
 	onSelect?: ( vertical: Vertical ) => void;
 }
@@ -21,8 +23,10 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 	placeholder,
 	searchTerm,
 	suggestions,
-	isDisableInput,
 	isLoading,
+	isShowSkipOption,
+	isDisableInput,
+	onSuggestionsHide,
 	onInputChange,
 	onSelect,
 } ) => {
@@ -33,18 +37,27 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 	const toggleIconRef = useRef( null );
 	const translate = useTranslate();
 
+	const showSuggestions = () => {
+		setIsShowSuggestions( true );
+	};
+
+	const hideSuggestions = () => {
+		setIsShowSuggestions( false );
+		onSuggestionsHide?.();
+	};
+
 	const handleTextInputBlur = ( event: React.FocusEvent ) => {
 		// Hide the suggestion dropdown unless the focus is moved to the toggle icon.
 		if ( event && event.relatedTarget?.contains( toggleIconRef.current ) ) {
 			return;
 		}
 
-		setIsShowSuggestions( false );
+		hideSuggestions();
 		setIsFocused( false );
 	};
 
 	const handleTextInputFocus = () => {
-		setIsShowSuggestions( true );
+		showSuggestions();
 		setIsFocused( true );
 	};
 
@@ -55,7 +68,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 			onSelect?.( { value: '', label: '' } );
 		}
 
-		setIsShowSuggestions( true );
+		showSuggestions();
 		onInputChange?.( event.target.value );
 	};
 
@@ -65,7 +78,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 			return;
 		}
 
-		setIsShowSuggestions( false );
+		hideSuggestions();
 		setIsFocused( false );
 	};
 
@@ -74,12 +87,16 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 			return;
 		}
 
-		setIsShowSuggestions( ! isShowSuggestions );
+		if ( isShowSuggestions ) {
+			hideSuggestions();
+		} else {
+			showSuggestions();
+		}
 	};
 
 	const handleToggleSuggestionsKeyDown = ( event: React.KeyboardEvent< HTMLButtonElement > ) => {
 		if ( event.key === 'Escape' || event.key === 'Tab' ) {
-			setIsShowSuggestions( false );
+			hideSuggestions();
 		}
 	};
 
@@ -89,7 +106,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 		}
 
 		if ( event.key === 'Escape' ) {
-			setIsShowSuggestions( false );
+			hideSuggestions();
 		}
 
 		if ( suggestionsRef.current ) {
@@ -98,7 +115,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 	};
 
 	const handleSuggestionsSelect = ( { label, value }: { label: string; value?: string } ) => {
-		setIsShowSuggestions( false );
+		hideSuggestions();
 		onSelect?.( { label, value } as Vertical );
 	};
 
@@ -107,7 +124,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 			return [];
 		}
 
-		if ( searchTerm === '' ) {
+		if ( ! isShowSkipOption ) {
 			return suggestions || [];
 		}
 
@@ -118,7 +135,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 				category: 0 < suggestions.length ? '—' : '',
 			},
 		] );
-	}, [ translate, searchTerm, suggestions, isLoading, isShowSuggestions ] );
+	}, [ translate, suggestions, isLoading, isShowSuggestions, isShowSkipOption ] );
 
 	return (
 		<div


### PR DESCRIPTION
#### Proposed Changes

This PR address the feedback from pdtkmj-ba-p2#comment-282:
> To keep helping customers with suggestions, I wonder if we should re-populate the full list of popular suggestions on a case if a user previously selected one (dropdown closes) and then re-activated the dropdown.
>
> And if they start deleting the copy or modifying it then we can get back to fine-tuning the list.

Old behavior:

https://user-images.githubusercontent.com/797888/171610569-c184e473-8ed4-430a-a5a8-b3edfe0e4077.mp4

New behavior:

https://user-images.githubusercontent.com/797888/171610348-b69f948f-3475-4fe6-9c88-60ebe10a435e.mp4

Note that this is currently just a proposal, we can ship it when we're in agreement.
cc'ing: @saygunnyc @that-mike-bal @autumnfjeld 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the vertical question screen `setup/vertical?siteSlug=${site_slug}`
* Test the following behaviors:
  * When user is typing, show suggestions based on user input.
  * When input field is blank, show popular suggestions.
  * When user has selected a vertical and then focuses again on the input field, show popular suggestions.
  * When a vertical has already been set and then the user focuses on the input field, show popular suggestions.
  * Essentially only show suggestions based on user input when the user is changing the input field text.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
