### PR TITLE
Ensure that Calypso always displays a hierarchical view for pages

### DIFF
--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -69,7 +69,10 @@ class PagesMain extends Component {
 		/* Check if All Sites Mode */
 		const isAllSites = siteId ? 1 : 0;
 		const query = {
-			number: 20, // all-sites mode, i.e the /me/posts endpoint, only supports up to 20 results at a time
+			// all-sites mode, i.e the /me/posts endpoint, only supports up to 20 results at a time
+			// however, /sites/$site/posts/ endpoint used for single site supports up to 100,
+			// let's utilize that to always load hierarchical view by default then
+			number: siteId ? 100 : 20,
 			search,
 			site_visibility: ! siteId ? 'visible' : undefined,
 			author,

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -30,10 +30,6 @@ class PagesMain extends Component {
 		search: PropTypes.string,
 	};
 
-	static defaultProps = {
-		perPage: 20,
-	};
-
 	getAnalyticsPath() {
 		const { status, siteId } = this.props;
 		const basePath = '/pages';

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -71,8 +71,8 @@ class PagesMain extends Component {
 		const query = {
 			// all-sites mode, i.e the /me/posts endpoint, only supports up to 20 results at a time
 			// however, /sites/$site/posts/ endpoint used for single site supports up to 100,
-			// let's utilize that to always load hierarchical view by default then
-			number: siteId ? 100 : 20,
+			// let's utilize that to load hierarchical view by default for most of the sites
+			number: siteId ? 50 : 20,
 			search,
 			site_visibility: ! siteId ? 'visible' : undefined,
 			author,

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -263,13 +263,13 @@ class Pages extends Component {
 		const { site, lastPage, query, showPublishedStatus } = this.props;
 
 		// Pages only display hierarchically for published pages on single-sites when
-		// there are 100 or fewer pages and no more pages to load (last page).
+		// there are 50 or fewer pages and no more pages to load (last page).
 		// Pages are not displayed hierarchically for search.
 		const showHierarchical =
 			site &&
 			query.status === 'publish,private' &&
 			lastPage &&
-			pages.length <= 100 &&
+			pages.length <= 50 &&
 			! query.search;
 
 		return showHierarchical

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -90,7 +90,6 @@ class Pages extends Component {
 	};
 
 	static defaultProps = {
-		perPage: 100,
 		loading: false,
 		lastPage: false,
 		page: 0,


### PR DESCRIPTION
#### Proposed Changes

Currently, we display the hierarchical view for the site that has up to 100 pages. However, with an infinite scroll in place, the user sees a chronological view until all records all loaded, and then the view switches to hierarchical.

I try to improve this experience by loading all pages at once to trigger the hierarchical view immediately. During the tests, I reduced the number of pages to load from 100 to 50 for performance reasons.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Prerequisites

1. Pull the branch
2. Build and run Calypso
3. Prepare the simple site with >50 pages that use child hierarchy
4. Resize the browser window to ensure that the height is small enough to not trigger infinite scroll on the initial page load

The hierarchical view is used when the number of pages is lower or equal to 50. 

##### Load hierarchical view for a single site

Here we test if the user sees hierarchical mode immediately after loading the list of pages.

1. Open [http://calypso.localhost:3000/pages/my/#SITE SLUG#](http://calypso.localhost:3000/pages/my/longandnonmemorablename.wordpress.com)<SITE SLUG>
2. Open Developer tools, the “Network” tab 
3. Filter requests by “posts?”
4. Refresh the page
5. Scroll to the bottom of the page

Expected result:
- all records up to 50 are loaded at once
- the list is loaded in hierarchical mode
- there is only one “posts?” request and the “number” parameter used in the query is 50

##### Load chronological view for all sites (regression)

Here we test if we don’t break current behavior for all sites view, where the API endpoint supports a max of 20 records per page.

1. Open http://calypso.localhost:3000/pages
2. Open Developer tools, the “Network” tab 
3. Filter requests by “posts?”
4. Refresh the page
5. Scroll to the bottom of the page

Expected result:
- on the initial refresh in point 4), only one request with 20 pages is loaded
- the list is loaded in chronological mode
- while we scroll to the bottom, subsequent “posts?” requests are performed, and the “number” parameter used in the query is 20

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/60280
