### PR TITLE
Add sidebar navigation and document head title for agency dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,6 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement, useContext, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import DocumentHead from 'calypso/components/data/document-head';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import SitesOverviewContext from './context';
@@ -23,27 +25,33 @@ export default function SitesOverview(): ReactElement {
 		dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_visit' ) );
 	}, [ dispatch ] );
 
+	const pageTitle = translate( 'Dashboard' );
+
 	return (
 		<div className="sites-overview">
-			<SiteWelcomeBanner isDashboardView />
-			<div className="sites-overview__page-title-container">
-				<h2 className="sites-overview__page-title">{ translate( 'Dashboard' ) }</h2>
-				<div className="sites-overview__page-subtitle">
-					{ translate( 'Manage all your Jetpack sites from one location' ) }
+			<DocumentHead title={ pageTitle } />
+			<SidebarNavigation sectionTitle={ pageTitle } />
+			<div className="sites-overview__container">
+				<SiteWelcomeBanner isDashboardView />
+				<div className="sites-overview__page-title-container">
+					<h2 className="sites-overview__page-title">{ pageTitle }</h2>
+					<div className="sites-overview__page-subtitle">
+						{ translate( 'Manage all your Jetpack sites from one location' ) }
+					</div>
 				</div>
+				<div className="sites-overview__search">
+					<SiteSearch searchQuery={ search } currentPage={ currentPage } />
+				</div>
+				<div className="sites-overview__filter-bar">
+					<SiteFilters filter={ filter } isFetching={ isFetching } />
+				</div>
+				<SiteContent
+					data={ data }
+					isError={ isError }
+					isFetching={ isFetching }
+					currentPage={ currentPage }
+				/>
 			</div>
-			<div className="sites-overview__search">
-				<SiteSearch searchQuery={ search } currentPage={ currentPage } />
-			</div>
-			<div className="sites-overview__filter-bar">
-				<SiteFilters filter={ filter } isFetching={ isFetching } />
-			</div>
-			<SiteContent
-				data={ data }
-				isError={ isError }
-				isFetching={ isFetching }
-				currentPage={ currentPage }
-			/>
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -2,6 +2,11 @@
 @import '@wordpress/base-styles/mixins';
 
 .sites-overview {
+	.current-section {
+		padding: 0 16px;
+	}
+}
+.sites-overview__container {
 	padding: 16px;
 	max-width: 1500px;
 	margin: auto;


### PR DESCRIPTION
#### Proposed Changes

* This PR adds document head title and sidebar navigation to the agency dashboard(for mobile view)

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type

**Instructions**

1. Run `git checkout add/sidebar-navigation-for-agency-dashboard` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard.
3. Switch to the mobile view(320px) using the `toggle device toolbar` in the dev tool(inspect)
4. Make sure the hamburger icon for sidebar navigation is shown and you are able to switch sites as usual
5. Make sure this doesn't show up on any other device(>660px)

**Screenshots**

<img width="387" alt="Screenshot 2022-06-02 at 5 23 34 PM" src="https://user-images.githubusercontent.com/10586875/171625433-b8a47b33-9c4c-44af-9aaf-cba780355081.png">

<img width="391" alt="Screenshot 2022-06-02 at 5 23 39 PM" src="https://user-images.githubusercontent.com/10586875/171625449-b7b34faf-c84a-4477-8f28-6339e1b5ce01.png">

<img width="396" alt="Screenshot 2022-06-02 at 5 23 53 PM" src="https://user-images.githubusercontent.com/10586875/171625451-2633e420-2e68-404a-a6fb-25aa46a589c8.png">

Related to 1202076982646589-as-1202381858769564