### PR TITLE
Enable agency dashboard feature on staging

### DIFF
--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -35,7 +35,7 @@
 		"fullstory": true,
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
-		"jetpack/agency-dashboard": false,
+		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -48,7 +48,7 @@
 		"help": true,
 		"inline-help": true,
 		"i18n/empathy-mode": true,
-		"jetpack/agency-dashboard": false,
+		"jetpack/agency-dashboard": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/concierge-sessions": false,


### PR DESCRIPTION
#### Proposed Changes

* This PR enables agency dashboard on staging

#### Testing Instructions

Make sure the feature flag `jetpack/agency-dashboard` is set to `true` only in staging env files in this PR

Related to 1202076982646589-as-1202375025822867