### PR TITLE
Record click events for more buttons in email management views

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -62,7 +62,7 @@ const GSuiteNewUserList = ( {
 
 	const onUserAdd = () => {
 		recordTracksEvent(
-			'calypso_email_management_google_workspace_add_mailboxes_add_another_mailbox_button_click',
+			'calypso_email_google_workspace_add_mailboxes_add_another_mailbox_button_click',
 			{ mailbox_count: users.length + 1 }
 		);
 
@@ -70,10 +70,9 @@ const GSuiteNewUserList = ( {
 	};
 
 	const onUserRemove = ( uuid: string ) => () => {
-		recordTracksEvent(
-			'calypso_email_management_google_workspace_add_mailboxes_remove_mailbox_button_click',
-			{ mailbox_count: users.length - 1 }
-		);
+		recordTracksEvent( 'calypso_email_google_workspace_add_mailboxes_remove_mailbox_button_click', {
+			mailbox_count: users.length - 1,
+		} );
 
 		const newUserList = users.filter( ( _user ) => _user.uuid !== uuid );
 

--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -1,6 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, ReactNode } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	newUser,
 	GSuiteNewUser as NewUser,
@@ -60,10 +61,20 @@ const GSuiteNewUserList = ( {
 		};
 
 	const onUserAdd = () => {
+		recordTracksEvent(
+			'calypso_email_management_google_workspace_add_mailboxes_add_another_mailbox_button_click',
+			{ mailbox_count: users.length + 1 }
+		);
+
 		onUsersChange( [ ...users, newUser( selectedDomainName ) ] );
 	};
 
 	const onUserRemove = ( uuid: string ) => () => {
+		recordTracksEvent(
+			'calypso_email_management_google_workspace_add_mailboxes_remove_mailbox_button_click',
+			{ mailbox_count: users.length - 1 }
+		);
+
 		const newUserList = users.filter( ( _user ) => _user.uuid !== uuid );
 
 		onUsersChange( 0 < newUserList.length ? newUserList : [ newUser( selectedDomainName ) ] );

--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -70,11 +70,11 @@ const GSuiteNewUserList = ( {
 	};
 
 	const onUserRemove = ( uuid: string ) => () => {
-		recordTracksEvent( 'calypso_email_google_workspace_add_mailboxes_remove_mailbox_button_click', {
-			mailbox_count: users.length - 1,
-		} );
-
 		const newUserList = users.filter( ( _user ) => _user.uuid !== uuid );
+
+		recordTracksEvent( 'calypso_email_google_workspace_add_mailboxes_remove_mailbox_button_click', {
+			mailbox_count: newUserList.length,
+		} );
 
 		onUsersChange( 0 < newUserList.length ? newUserList : [ newUser( selectedDomainName ) ] );
 	};

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -3,6 +3,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	hasUnusedMailboxWarning,
 	hasGoogleAccountTOSWarning,
@@ -39,7 +40,15 @@ class EmailPlanWarnings extends Component {
 		const { domain, translate } = this.props;
 
 		return (
-			<Button compact primary href={ getGoogleAdminWithTosUrl( domain.name ) } target="_blank">
+			<Button
+				compact
+				primary
+				href={ getGoogleAdminWithTosUrl( domain.name ) }
+				onClick={ () => {
+					recordTracksEvent( 'calypso_email_management_google_workspace_accept_tos_link_click' );
+				} }
+				target="_blank"
+			>
 				{ translate( 'Finish setup' ) }
 				<Gridicon icon="external" />
 			</Button>

--- a/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
+++ b/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
@@ -14,6 +14,7 @@ import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItemEnhanced from 'calypso/components/vertical-nav/item/enhanced';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import {
 	TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_CATCH_ALL_EMAIL,
@@ -83,6 +84,11 @@ class TitanManageMailboxes extends Component {
 		disabled: isDisabled,
 		materialIcon,
 		path: this.getPath( context ),
+		onClick: () => {
+			recordTracksEvent( 'calypso_email_management_titan_manage_mailboxes_link_click', {
+				context,
+			} );
+		},
 		text,
 	} );
 

--- a/client/my-sites/email/titan-new-mailbox-list/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox-list/index.jsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 import CardHeading from 'calypso/components/card-heading';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	buildNewTitanMailbox,
 	getMailboxPropTypeShape,
@@ -52,10 +53,19 @@ const TitanNewMailboxList = ( {
 	};
 
 	const onMailboxAdd = () => {
+		recordTracksEvent(
+			'calypso_email_management_titan_add_mailboxes_add_another_mailbox_button_click',
+			{ mailbox_count: mailboxes.length + 1 }
+		);
+
 		onMailboxesChange( [ ...mailboxes, buildNewTitanMailbox( selectedDomainName, false ) ] );
 	};
 
 	const onMailboxRemove = ( currentMailboxes, uuid ) => () => {
+		recordTracksEvent( 'calypso_email_management_titan_add_mailboxes_remove_mailbox_button_click', {
+			mailbox_count: mailboxes.length - 1,
+		} );
+
 		const remainingMailboxes = currentMailboxes.filter( ( mailbox ) => mailbox.uuid !== uuid );
 
 		const updatedMailboxes =

--- a/client/my-sites/email/titan-new-mailbox-list/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox-list/index.jsx
@@ -53,16 +53,15 @@ const TitanNewMailboxList = ( {
 	};
 
 	const onMailboxAdd = () => {
-		recordTracksEvent(
-			'calypso_email_management_titan_add_mailboxes_add_another_mailbox_button_click',
-			{ mailbox_count: mailboxes.length + 1 }
-		);
+		recordTracksEvent( 'calypso_email_titan_add_mailboxes_add_another_mailbox_button_click', {
+			mailbox_count: mailboxes.length + 1,
+		} );
 
 		onMailboxesChange( [ ...mailboxes, buildNewTitanMailbox( selectedDomainName, false ) ] );
 	};
 
 	const onMailboxRemove = ( currentMailboxes, uuid ) => () => {
-		recordTracksEvent( 'calypso_email_management_titan_add_mailboxes_remove_mailbox_button_click', {
+		recordTracksEvent( 'calypso_email_titan_add_mailboxes_remove_mailbox_button_click', {
 			mailbox_count: mailboxes.length - 1,
 		} );
 

--- a/client/my-sites/email/titan-new-mailbox-list/index.jsx
+++ b/client/my-sites/email/titan-new-mailbox-list/index.jsx
@@ -61,11 +61,11 @@ const TitanNewMailboxList = ( {
 	};
 
 	const onMailboxRemove = ( currentMailboxes, uuid ) => () => {
-		recordTracksEvent( 'calypso_email_titan_add_mailboxes_remove_mailbox_button_click', {
-			mailbox_count: mailboxes.length - 1,
-		} );
-
 		const remainingMailboxes = currentMailboxes.filter( ( mailbox ) => mailbox.uuid !== uuid );
+
+		recordTracksEvent( 'calypso_email_titan_add_mailboxes_remove_mailbox_button_click', {
+			mailbox_count: remainingMailboxes.length,
+		} );
 
 		const updatedMailboxes =
 			0 < remainingMailboxes.length


### PR DESCRIPTION
#### Proposed Changes

I've gone over the buttons in the email management views to ensure that we send click event to Tracks in all relevant cases. I've added the following events:

**`calypso_email_google_workspace_add_mailboxes_add_another_mailbox_button_click`**
Displayed both in the email upsell as part of the domain checkout flow and when adding new mailboxes in the email management view.

<img width="1442" alt="Screen Shot 2022-06-02 at 14 26 14" src="https://user-images.githubusercontent.com/1101677/171637659-8af30b0d-ae55-4eba-843f-076c898916d7.png">

**`calypso_email_google_workspace_add_mailboxes_remove_mailbox_button_click`**
Displayed both in the email upsell as part of the domain checkout flow and when adding new mailboxes in the email management view.

<img width="1442" alt="Screen Shot 2022-06-02 at 14 26 21" src="https://user-images.githubusercontent.com/1101677/171637697-7c70ba7a-407c-493b-963f-b77fe5d726e3.png">

**`calypso_email_titan_add_mailboxes_add_another_mailbox_button_click`**
Corresponds to Google Workspace equivalent.

**`calypso_email_titan_add_mailboxes_remove_mailbox_button_click`**
Corresponds to Google Workspace equivalent.

**`calypso_email_management_google_workspace_accept_tos_link_click`**
<img width="1442" alt="Screen Shot 2022-06-02 at 15 00 45" src="https://user-images.githubusercontent.com/1101677/171637824-2342a732-4c7b-468e-a36f-432b9933e96a.png">

**`calypso_email_management_titan_manage_mailboxes_link_click`**
Sends an event for each link in the screenshot below, using the `context` parameter to differentiate between the different links.

<img width="1442" alt="Screen Shot 2022-06-02 at 15 01 40" src="https://user-images.githubusercontent.com/1101677/171637863-53ef0323-7f75-4f4e-8e7a-786f61c7c1d8.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The [Tracks Vigilante browser extension](https://github.com/Automattic/tracks-chrome-extension) is helpful when testing these changes – it sniffs the network traffic and displays Tracks requests in a more readable manner than the DevTools Network panel.

Below is a summary of how to test each individual event:

**`calypso_email_google_workspace_add_mailboxes_add_another_mailbox_button_click`**
1. Navigate to `/domains/add/:site_slug`
2. Add a domain to your cart
3. In the next step, click "Add Google Workspace"
4. Click "Add another mailbox"
5. Ensure that the Tracks event has been sent

**`calypso_email_google_workspace_add_mailboxes_remove_mailbox_button_click`**
1. Repeat steps 1-4 from previous event
2. Click "Remove this mailbox"
3. Ensure that the Tracks event has been sent

**`calypso_email_titan_add_mailboxes_add_another_mailbox_button_click`**
1. Navigate to `/domains/add/:site_slug`
2. Add a domain to your cart
3. In the next step, ensure that Professional email is selected (not Google Workspace)
4. Click "Add another mailbox"
5. Ensure that the Tracks event has been sent

**`calypso_email_titan_add_mailboxes_remove_mailbox_button_click`**
1. Repeat steps 1-4 from previous event
2. Click "Remove this mailbox"
3. Ensure that the Tracks event has been sent

**`calypso_email_management_google_workspace_accept_tos_link_click`**
1. Have a freshly registered Google Workspace account (where ToS haven't yet been accepted)
2. Navigate to `/email/:domain/manage/:site_slug`
3. Click the "Finish setup" link
4. Ensure that the Tracks event has been sent

**`calypso_email_management_titan_manage_mailboxes_link_click`**
1. Have an account with Titan mailboxes (at least one)
2. Navigate to `/email/:domain/titan/manage-mailboxes/:site_slug`
3. Click "Configure desktop app"
4. Ensure that the Tracks event has been sent, including the parameter `context: configure_desktop_app`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
