### PR TITLE
Add track events for agency dashboard filters

### DIFF
--- a/client/my-sites/activity/filterbar/type-selector/issue-type-selector.tsx
+++ b/client/my-sites/activity/filterbar/type-selector/issue-type-selector.tsx
@@ -1,5 +1,6 @@
 import { localize, translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { updateFilter } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { TypeSelector } from './type-selector';
 
@@ -42,6 +43,16 @@ const IssueTypeSelector: React.FunctionComponent< Props > = ( props ) => {
 };
 
 const selectIssueType = ( types: any ) => ( dispatch: any ) => {
+	if ( types.length ) {
+		const eventObj = types.reduce(
+			( acc: any, obj: any ) => ( {
+				...acc,
+				[ `issue_type_${ obj }` ]: true,
+			} ),
+			{}
+		);
+		dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_filter', eventObj ) );
+	}
 	return dispatch( updateFilter( types ) );
 };
 


### PR DESCRIPTION
#### Proposed Changes

* This PR adds track events to the filters for the agency dashboard

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb

**Instructions**

1. Run `git checkout add/track-events-for-agency-dashboard-filters` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard
3. Open the dev(inspect) tool -> Go to the Network tab -> Apply the filter `agency_dashboard` to filter only the event tracking network calls.

4. Apply a few filters. 
5. Verify that the API call is being made with the event name - `calypso_jetpack_agency_dashboard_filter`. Also, verify the applied filters are being sent as query params

<img width="250" alt="Screenshot 2022-06-02 at 7 14 48 PM" src="https://user-images.githubusercontent.com/10586875/171643383-c4df7bba-b267-4565-bfaf-9e52a5fe767a.png">

Related to 1202076982646589-as-1202381204692562