### PR TITLE
Revert "Anchor: Enable feature flag on production"

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -51,7 +51,7 @@ const FlowWrapper: React.FC< { user: UserStore.CurrentUser | undefined } > = ( {
 	const { anchorFmPodcastId } = useAnchorFmParams();
 	let flow = siteSetupFlow;
 
-	if ( anchorFmPodcastId ) {
+	if ( anchorFmPodcastId && config.isEnabled( 'signup/anchor-fm' ) ) {
 		flow = anchorFmFlow;
 	}
 

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,7 +83,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,
-		"signup/anchor-fm": true,
+		"signup/anchor-fm": false,
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,

--- a/config/production.json
+++ b/config/production.json
@@ -97,7 +97,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/anchor-fm": true,
+		"signup/anchor-fm": false,
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -97,7 +97,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/anchor-fm": true,
+		"signup/anchor-fm": false,
 		"signup/professional-email-step": false,
 		"signup/reskin": true,
 		"signup/social": true,

--- a/config/test.json
+++ b/config/test.json
@@ -73,7 +73,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"signup/anchor-fm": true,
+		"signup/anchor-fm": false,
 		"signup/inline-help": false,
 		"signup/social": true,
 		"signup/stepper-flow": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -107,7 +107,7 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/professional-email-step": false,
-		"signup/anchor-fm": true,
+		"signup/anchor-fm": false,
 		"signup/reskin": true,
 		"signup/social": true,
 		"signup/design-picker-categories": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#64157

This is a just-in-case PR in the event we encounter a critical bug in the new Anchor flow.