### PR TITLE
E2E: eliminate flakiness in Signup: Free spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -49,11 +49,9 @@ export class StartSiteFlow {
 	 * @param {string} name Name for the blog.
 	 */
 	async enterBlogName( name: string ): Promise< void > {
+		await this.page.waitForLoadState( 'networkidle' );
 		const locator = this.page.locator( selectors.blogNameInput );
-		// Use the type method to simulate user interaction to avoid
-		// https://github.com/Automattic/wp-calypso/issues/64271.
-		await locator.fill( '' );
-		await locator.type( name );
+		await locator.fill( name );
 	}
 
 	/**
@@ -62,11 +60,9 @@ export class StartSiteFlow {
 	 * @param {string} tagline Tagline for the blog.
 	 */
 	async enterTagline( tagline: string ): Promise< void > {
+		await this.page.waitForLoadState( 'networkidle' );
 		const locator = this.page.locator( selectors.taglineInput );
-		// Use the type method to simulate user interaction to avoid
-		// https://github.com/Automattic/wp-calypso/issues/64271.
-		await locator.fill( '' );
-		await locator.type( tagline );
+		await locator.fill( tagline );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -49,7 +49,11 @@ export class StartSiteFlow {
 	 * @param {string} name Name for the blog.
 	 */
 	async enterBlogName( name: string ): Promise< void > {
-		await this.page.fill( selectors.blogNameInput, name );
+		const locator = this.page.locator( selectors.blogNameInput );
+		// Use the type method to simulate user interaction to avoid
+		// https://github.com/Automattic/wp-calypso/issues/64271.
+		await locator.fill( '' );
+		await locator.type( name );
 	}
 
 	/**
@@ -58,7 +62,11 @@ export class StartSiteFlow {
 	 * @param {string} tagline Tagline for the blog.
 	 */
 	async enterTagline( tagline: string ): Promise< void > {
-		await this.page.fill( selectors.taglineInput, tagline );
+		const locator = this.page.locator( selectors.taglineInput );
+		// Use the type method to simulate user interaction to avoid
+		// https://github.com/Automattic/wp-calypso/issues/64271.
+		await locator.fill( '' );
+		await locator.type( tagline );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -2,7 +2,7 @@ import fetch, { BodyInit, HeadersInit, RequestInit } from 'node-fetch';
 import { SecretsManager } from './secrets';
 import type { AccountCredentials } from './data-helper';
 
-interface AccountClosureDetails {
+export interface AccountClosureDetails {
 	userID: number;
 	username: string;
 	email: string;
@@ -71,6 +71,10 @@ interface SiteDeletionResponse {
 	ID: number;
 	name: string;
 	status: string;
+}
+
+export interface AccountClosureResponse {
+	success: boolean;
 }
 
 const BEARER_TOKEN_URL = 'https://wordpress.com/wp-login.php?action=login-endpoint';
@@ -311,7 +315,7 @@ export class RestAPIClient {
 	 */
 	async closeAccount(
 		expectedAccountDetails: AccountClosureDetails
-	): Promise< { success: boolean } > {
+	): Promise< AccountClosureResponse > {
 		const accountInformation = await this.getMyAccountInformation();
 
 		// Multiple guards to ensure we are operating on the

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -77,7 +77,6 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ), function 
 		it( 'Select "write" path', async function () {
 			startSiteFlow = new StartSiteFlow( page );
 			await startSiteFlow.clickButton( 'Start writing' );
-			await page.pause();
 		} );
 
 		it( 'Enter blog name', async function () {
@@ -93,7 +92,6 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ), function 
 		} );
 
 		it( 'Select "Choose a design" path', async function () {
-			await page.pause();
 			await startSiteFlow.clickButton( 'View designs' );
 		} );
 

--- a/test/e2e/specs/shared/api-close-account.ts
+++ b/test/e2e/specs/shared/api-close-account.ts
@@ -1,0 +1,27 @@
+import { RestAPIClient } from '@automattic/calypso-e2e';
+import type { AccountClosureResponse, AccountClosureDetails } from '@automattic/calypso-e2e';
+
+/**
+ * Makes an API request to close the user account.
+ *
+ * Note that closing an user account will also close any existing sites
+ * belonging to the user, thus it is not required to close sites if this
+ * function is called first.
+ *
+ * @param {RestAPIClient} client Client to interact with the WP REST API.
+ * @param {AccountClosureDetails} accountDetails Details of the account to close.
+ * @returns { AccountClosureResponse} Response denoting whether deletion was successful.
+ */
+export async function apiCloseAccount(
+	client: RestAPIClient,
+	accountDetails: AccountClosureDetails
+) {
+	const response: AccountClosureResponse = await client.closeAccount( accountDetails );
+
+	if ( response.success !== true ) {
+		console.warn( `Failed to delete user ID ${ accountDetails.userID }` );
+	} else {
+		console.log( `Successfully deleted user ID ${ accountDetails.userID }` );
+	}
+	return response;
+}

--- a/test/e2e/specs/shared/api-close-account.ts
+++ b/test/e2e/specs/shared/api-close-account.ts
@@ -15,7 +15,7 @@ import type { AccountClosureResponse, AccountClosureDetails } from '@automattic/
 export async function apiCloseAccount(
 	client: RestAPIClient,
 	accountDetails: AccountClosureDetails
-) {
+): Promise< void > {
 	const response: AccountClosureResponse = await client.closeAccount( accountDetails );
 
 	if ( response.success !== true ) {
@@ -23,5 +23,4 @@ export async function apiCloseAccount(
 	} else {
 		console.log( `Successfully deleted user ID ${ accountDetails.userID }` );
 	}
-	return response;
 }

--- a/test/e2e/specs/shared/api-delete-site.ts
+++ b/test/e2e/specs/shared/api-delete-site.ts
@@ -1,0 +1,23 @@
+import { RestAPIClient } from '@automattic/calypso-e2e';
+import type { SiteDetails } from '@automattic/calypso-e2e';
+
+export async function apiDeleteSite( client: RestAPIClient, siteDetails: SiteDetails ) {
+	const response = await client.deleteSite( siteDetails );
+
+	// If the response is `null` then no action has been
+	// performed.
+	if ( response ) {
+		// The only correct response is the string "deleted".
+		if ( response.status !== 'deleted' ) {
+			console.warn(
+				`Failed to delete siteID ${ siteDetails.id }.\nExpected: "deleted", Got: ${ response.status }`
+			);
+		} else {
+			console.log( `Successfully deleted siteID ${ siteDetails.id }.` );
+		}
+	} else {
+		console.log(
+			`Failed to delete site ID ${ siteDetails.id }; API call returned a null response.`
+		);
+	}
+}

--- a/test/e2e/specs/shared/api-delete-site.ts
+++ b/test/e2e/specs/shared/api-delete-site.ts
@@ -1,7 +1,16 @@
 import { RestAPIClient } from '@automattic/calypso-e2e';
 import type { SiteDetails } from '@automattic/calypso-e2e';
 
-export async function apiDeleteSite( client: RestAPIClient, siteDetails: SiteDetails ) {
+/**
+ * Makes an API request to delete a site.
+ *
+ * @param {RestAPIClient} client Client to interact with the WP REST API.
+ * @param { SiteDetails} siteDetails Details of the site to be closed.
+ */
+export async function apiDeleteSite(
+	client: RestAPIClient,
+	siteDetails: SiteDetails
+): Promise< void > {
 	const response = await client.deleteSite( siteDetails );
 
 	// If the response is `null` then no action has been

--- a/test/e2e/specs/shared/index.ts
+++ b/test/e2e/specs/shared/index.ts
@@ -1,0 +1,2 @@
+export * from './api-close-account';
+export * from './api-delete-site';


### PR DESCRIPTION
#### Proposed Changes

This PR is a collection of changes aimed at streamlining and reducing flakiness of the Signup: Free spec.

Key changes:
- extract the API client interactions in the afterAll hook to individual methods that can be reused;
- simplify the types being used;
- wait for the `networkidle` event to fire before filling the `site_name` and `site_tagline` fields.

#### Testing Instructions

Ensure the following:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

Related to https://github.com/Automattic/wp-calypso/issues/64271.