### PR TITLE
[ETK/error-reporting] Disable tracing for Sentry on WPCOM/GB

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/browser';
-import { Integrations } from '@sentry/tracing';
 import apiFetch from '@wordpress/api-fetch';
 
 const shouldActivateSentry = window.A8C_ETK_ErrorReporting_Config?.shouldActivateSentry === 'true';
@@ -13,8 +12,6 @@ const headErrorHandler = window._headJsErrorHandler;
 function activateSentry() {
 	Sentry.init( {
 		dsn: 'https://658ae291b00242148af6b76494d4a49a@o248881.ingest.sentry.io/5876245',
-		integrations: [ new Integrations.BrowserTracing() ],
-
 		// Set tracesSampleRate to 1.0 to capture 100%
 		// of transactions for performance monitoring.
 		// We recommend adjusting this value in production

--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.js
@@ -19,7 +19,6 @@ function activateSentry() {
 		// of transactions for performance monitoring.
 		// We recommend adjusting this value in production
 		release: 'wpcom-test-01',
-		tracesSampleRate: 1.0,
 	} );
 
 	// We still need to report the head errors, if any.

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -71,7 +71,6 @@
 		"@emotion/react": "^11.4.1",
 		"@popperjs/core": "^2.10.2",
 		"@sentry/browser": "^6.19.6",
-		"@sentry/tracing": "^6.19.6",
 		"@wordpress/a11y": "^3.9.0",
 		"@wordpress/api-fetch": "^6.6.0",
 		"@wordpress/base-styles": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,7 +1513,6 @@ __metadata:
     "@emotion/react": ^11.4.1
     "@popperjs/core": ^2.10.2
     "@sentry/browser": ^6.19.6
-    "@sentry/tracing": ^6.19.6
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.3
     "@types/node": ^15.0.2
@@ -4867,19 +4866,6 @@ __metadata:
   peerDependencies:
     react: 15.x || 16.x || 17.x || 18.x
   checksum: 18f6a4bea654319fbb6682119cba2d5637bc20601df57e5a34675f2a9f49612a55144be1ca99d41b4722ae86e9b966ff9a74f881b247dd84db146902e8decfc7
-  languageName: node
-  linkType: hard
-
-"@sentry/tracing@npm:^6.19.6":
-  version: 6.19.6
-  resolution: "@sentry/tracing@npm:6.19.6"
-  dependencies:
-    "@sentry/hub": 6.19.6
-    "@sentry/minimal": 6.19.6
-    "@sentry/types": 6.19.6
-    "@sentry/utils": 6.19.6
-    tslib: ^1.9.3
-  checksum: 7ebefde852ad5943f055dc1cd865579a8b8d623a2600e764d80a95cc206e64bde3ab5c82b0aba474194422941dc899d22e45338e1502c654aeb4ec46c1d9580f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Proposed Changes

Tracing Docs: https://docs.sentry.io/platforms/javascript/performance/instrumentation/automatic-instrumentation.

it's not the focus of the integration now.

If we ever re-introduce it, Sentry recommends setting a lower sample rate (it shows 0.2 = 20% in the docs). The current 1.0 never caused any issue because as of this commit, Sentry is only activated for 10% of WPCOM simple users.

Calypso doesn't setup tracing for Sentry either, see: https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/sentry/index.ts.

**Or,** we might also decide to keep this, though if so, we should probably sample it to a lower pct. Up for discussion! 

#### Testing Instructions

* Use a sandboxed simple site that has Sentry enabled*;
* Build ETK locally from this branch, sync to your sandbox using `yarn dev --sync` from `wp-calypso/apps/editing-toolkit`;
* Force an error, you can do this by running the following snippet in the dev console:

```
var foo = document.createElement('script');
foo.innerHTML = "throw new Error('hi there!');"
document.body.appendChild(foo);
```

* Wait a few moments, open Sentry and this error should show up under the `wpcom-gutenberg-wp-admin` project.

_*Use `wp --url=<your-wpcom-test-site-url> blog-stickers add --sticker=error-reporting-use-sentry --who=<your-wpcom-username>` to force-enable Sentry on your test simple site._
