### PR TITLE
Added auto-scaling of the iframe preview in the design picker

### DIFF
--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -59,6 +59,8 @@ export class WebPreviewModal extends Component {
 		fetchPriority: PropTypes.string,
 		// Set height based on page content. This requires the page to post it's dimensions as message.
 		autoHeight: PropTypes.bool,
+		// Fixes the viewport width of the iframe if provided.
+		fixedViewportWidth: PropTypes.number,
 	};
 
 	static defaultProps = {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -75,7 +75,7 @@ export default class WebPreviewContent extends Component {
 
 		// If the fixedViewportWidth changes, re-calculate the iframe styles.
 		if ( this.props.fixedViewportWidth !== prevProps.fixedViewportWidth ) {
-			if ( this.props.fixedViewportWidth ) {
+			if ( this.props.fixedViewportWidth && ! prevProps.fixedViewportWidth ) {
 				this.handleResize();
 				window.addEventListener( 'resize', this.handleResize );
 			} else {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -68,16 +68,20 @@ export default class WebPreviewContent extends Component {
 			debug( 'removing iframe contents' );
 			this.setIframeMarkup( '' );
 		}
-		// If the fixedViewportWidth changes, re-calculate the iframe styles.
-		if (
-			this.props.fixedViewportWidth &&
-			this.props.fixedViewportWidth !== prevProps.fixedViewportWidth
-		) {
-			this.handleResize();
-		}
 		// Focus preview when showing modal
 		if ( this.props.showPreview && ! prevProps.showPreview && this.state.loaded ) {
 			this.focusIfNeeded();
+		}
+
+		// If the fixedViewportWidth changes, re-calculate the iframe styles.
+		if ( this.props.fixedViewportWidth !== prevProps.fixedViewportWidth ) {
+			if ( this.props.fixedViewportWidth ) {
+				this.handleResize();
+				window.addEventListener( 'resize', this.handleResize );
+			} else {
+				this.resetResize();
+				window.removeEventListener( 'resize', this.handleResize );
+			}
 		}
 	}
 
@@ -134,7 +138,7 @@ export default class WebPreviewContent extends Component {
 		let iframeStyle = {};
 
 		if ( ! this.iframe.parentElement?.clientWidth ) {
-			this.setState( { iframeStyle, iframeScaleRatio } );
+			this.resetResize();
 			return;
 		}
 
@@ -145,6 +149,10 @@ export default class WebPreviewContent extends Component {
 		};
 
 		this.setState( { iframeStyle, iframeScaleRatio } );
+	};
+
+	resetResize = () => {
+		this.setState( { iframeStyle: {}, iframeScaleRatio: 1 } );
 	};
 
 	redirectToAuth() {

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -242,6 +242,12 @@ a.web-preview__external.button {
 	.is-seo & {
 		max-width: 865px;
 	}
+
+	.is-fixed-viewport-width & {
+		margin: 0;
+		max-width: none;
+		transform-origin: 0 0;
+	}
 }
 
 .web-preview__frame-wrapper {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -1,8 +1,4 @@
-import {
-	getDesignPreviewUrl,
-	DEFAULT_VIEWPORT_WIDTH,
-	MOBILE_VIEWPORT_WIDTH,
-} from '@automattic/design-picker';
+import { getDesignPreviewUrl, DEFAULT_VIEWPORT_WIDTH } from '@automattic/design-picker';
 import { useViewportMatch } from '@wordpress/compose';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -51,7 +47,7 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 			autoHeight
 			siteId={ site?.ID }
 			url={ site?.URL }
-			fixedViewportWidth={ ! isMobile ? DEFAULT_VIEWPORT_WIDTH : MOBILE_VIEWPORT_WIDTH }
+			fixedViewportWidth={ ! isMobile ? DEFAULT_VIEWPORT_WIDTH : undefined }
 			isPrivateAtomic={ isPrivateAtomic }
 			isStickyToolbar={ isSelected && isStickyToolbar }
 			translate={ translate }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -43,6 +43,7 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 			toolbarComponent={ PreviewToolbar }
 			fetchPriority={ isSelected ? 'high' : 'low' }
 			autoHeight
+			vpw={ 1600 }
 			siteId={ site?.ID }
 			url={ site?.URL }
 			isPrivateAtomic={ isPrivateAtomic }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -1,4 +1,9 @@
-import { getDesignPreviewUrl } from '@automattic/design-picker';
+import {
+	getDesignPreviewUrl,
+	DEFAULT_VIEWPORT_WIDTH,
+	MOBILE_VIEWPORT_WIDTH,
+} from '@automattic/design-picker';
+import { useViewportMatch } from '@wordpress/compose';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import WebPreview from 'calypso/components/web-preview/content';
@@ -28,6 +33,7 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 	recordTracksEvent,
 } ) => {
 	const translate = useTranslate();
+	const isMobile = ! useViewportMatch( 'small' );
 
 	return (
 		<WebPreview
@@ -43,9 +49,9 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 			toolbarComponent={ PreviewToolbar }
 			fetchPriority={ isSelected ? 'high' : 'low' }
 			autoHeight
-			vpw={ 1600 }
 			siteId={ site?.ID }
 			url={ site?.URL }
+			fixedViewportWidth={ ! isMobile ? DEFAULT_VIEWPORT_WIDTH : MOBILE_VIEWPORT_WIDTH }
 			isPrivateAtomic={ isPrivateAtomic }
 			isStickyToolbar={ isSelected && isStickyToolbar }
 			translate={ translate }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -154,7 +154,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 
 		if ( showGeneratedDesigns ) {
 			return translate(
-				'One of these homepage options could be great to start with. You can always change later.'
+				'Based on your input, these designs have been tailored for you. You can always change later.'
 			);
 		}
 
@@ -336,31 +336,22 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		is_generated_designs: showGeneratedDesigns,
 	} );
 
-	// Make sure people is at the top when switching between generated designs and static designs
+	// Make sure people is at the top when:
+	// 1. Switching between generated designs and static designs.
+	// 2. Entering/leaving preview mode.
 	useEffect( () => {
 		window.scrollTo( { top: 0 } );
-	}, [ isForceStaticDesigns ] );
-
-	useEffect( () => {
-		if ( showGeneratedDesigns ) {
-			window.scrollTo( { top: 0 } );
-		}
-	}, [ isPreviewingDesign, showGeneratedDesigns ] );
-
-	let previewUrl = null;
-
-	if ( selectedDesign ) {
-		previewUrl = getDesignPreviewUrl( selectedDesign, {
-			language: locale,
-			// If the user fills out the site title with write intent, we show it on the design preview
-			siteTitle: intent === 'write' ? siteTitle : undefined,
-		} );
-	}
+	}, [ isForceStaticDesigns, isPreviewingDesign ] );
 
 	if ( selectedDesign && isPreviewingDesign && ! showGeneratedDesigns ) {
 		const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
 		const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
 		const shouldUpgrade = selectedDesign.is_premium && ! isPremiumThemeAvailable;
+		const previewUrl = getDesignPreviewUrl( selectedDesign, {
+			language: locale,
+			// If the user fills out the site title with write intent, we show it on the design preview
+			siteTitle: intent === 'write' ? siteTitle : undefined,
+		} );
 
 		const stepContent = (
 			<WebPreview

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -341,15 +341,20 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		window.scrollTo( { top: 0 } );
 	}, [ isForceStaticDesigns ] );
 
-	if ( selectedDesign && isPreviewingDesign && ! showGeneratedDesigns ) {
-		const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
-		const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
-		const shouldUpgrade = selectedDesign.is_premium && ! isPremiumThemeAvailable;
-		const previewUrl = getDesignPreviewUrl( selectedDesign, {
+	let previewUrl = null;
+
+	if ( selectedDesign ) {
+		previewUrl = getDesignPreviewUrl( selectedDesign, {
 			language: locale,
 			// If the user fills out the site title with write intent, we show it on the design preview
 			siteTitle: intent === 'write' ? siteTitle : undefined,
 		} );
+	}
+
+	if ( selectedDesign && isPreviewingDesign && ! showGeneratedDesigns ) {
+		const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
+		const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
+		const shouldUpgrade = selectedDesign.is_premium && ! isPremiumThemeAvailable;
 
 		const stepContent = (
 			<WebPreview
@@ -441,6 +446,11 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 				<>
 					<div className={ classnames( 'step-container__header', 'design-setup__header' ) }>
 						{ heading }
+						{ previewUrl && (
+							<Button target="_blank" href={ previewUrl }>
+								{ translate( 'Preview' ) }
+							</Button>
+						) }
 						<Button primary onClick={ () => pickDesign( selectedGeneratedDesign, 'top' ) }>
 							{ translate( 'Continue' ) }
 						</Button>
@@ -460,6 +470,11 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 					} ) }
 				>
 					<div className="design-setup__footer-content">
+						{ previewUrl && (
+							<Button target="_blank" href={ previewUrl }>
+								{ translate( 'Preview' ) }
+							</Button>
+						) }
 						<Button primary onClick={ () => pickDesign( selectedGeneratedDesign, 'bottom' ) }>
 							{ translate( 'Continue' ) }
 						</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -341,6 +341,12 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		window.scrollTo( { top: 0 } );
 	}, [ isForceStaticDesigns ] );
 
+	useEffect( () => {
+		if ( showGeneratedDesigns ) {
+			window.scrollTo( { top: 0 } );
+		}
+	}, [ isPreviewingDesign, showGeneratedDesigns ] );
+
 	let previewUrl = null;
 
 	if ( selectedDesign ) {
@@ -446,11 +452,6 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 				<>
 					<div className={ classnames( 'step-container__header', 'design-setup__header' ) }>
 						{ heading }
-						{ previewUrl && (
-							<Button target="_blank" href={ previewUrl }>
-								{ translate( 'Preview' ) }
-							</Button>
-						) }
 						<Button primary onClick={ () => pickDesign( selectedGeneratedDesign, 'top' ) }>
 							{ translate( 'Continue' ) }
 						</Button>
@@ -470,11 +471,6 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 					} ) }
 				>
 					<div className="design-setup__footer-content">
-						{ previewUrl && (
-							<Button target="_blank" href={ previewUrl }>
-								{ translate( 'Preview' ) }
-							</Button>
-						) }
 						<Button primary onClick={ () => pickDesign( selectedGeneratedDesign, 'bottom' ) }>
 							{ translate( 'Continue' ) }
 						</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -372,7 +372,6 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 			border-radius: 4px;
 			font-weight: 500;
 			padding: 9px 48px;
-			margin-left: 15px;
 
 			// Override unnecessary super specificity added by another class.
 			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -372,6 +372,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 			border-radius: 4px;
 			font-weight: 500;
 			padding: 9px 48px;
+			margin-left: 15px;
 
 			// Override unnecessary super specificity added by another class.
 			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 ) !important;

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -11,7 +11,12 @@ export {
 	isBlankCanvasDesign,
 	getMShotOptions,
 } from './utils';
-export { FONT_PAIRINGS, ANCHORFM_FONT_PAIRINGS } from './constants';
+export {
+	FONT_PAIRINGS,
+	ANCHORFM_FONT_PAIRINGS,
+	DEFAULT_VIEWPORT_WIDTH,
+	MOBILE_VIEWPORT_WIDTH,
+} from './constants';
 export type { FontPair, Design, Category } from './types';
 export { useCategorization } from './hooks/use-categorization';
 export { useThemeDesignsQuery } from './hooks/use-theme-designs-query';


### PR DESCRIPTION
#### Proposed Changes
Here is a [recording](https://d.pr/v/pYoUaB) showing how it works.

* Scale the preview iframe with CSS so the width of the iframe does not affect how the embedded page preview is rendered. We do this by making the iframe in `WebPreview` able to have a fixed `vpw`.
* Add a button on the header and footer of the design picker to open the preview in a new window as suggested in [this comment](https://github.com/Automattic/wp-calypso/issues/64179#issuecomment-1143733304).

Copy changes:
![Screen Shot 2022-06-07 at 4 24 25 PM](https://user-images.githubusercontent.com/797888/172333150-b7411f38-0432-4be1-bbae-3364870b31b5.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that the iframe is scaled accordingly while showing the preview of the desktop layout
   - Resize the window to different sizes
   - Refresh the window
* Check that the button `Preview` appears on the header and the footer
   - Click on the button to check that the preview opens up in a new tab
   
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64179 https://github.com/Automattic/wp-calypso/pull/64224