### PR TITLE
Support placement for popper.js

### DIFF
--- a/packages/tour-kit/README.md
+++ b/packages/tour-kit/README.md
@@ -170,5 +170,5 @@ The main API for configuring a tour is the config object. See example usage and 
 
 - `portalElementId`: A string that lets you customize under which DOM element the Tour will be appended.
 
-`placement`: Describes the preferred placement of the popper. Possible values are left-start, left, left-end, top-start, top, top-end, right-start, right, right-end, bottom-start, bottom, and bottom-end.
+`placement` (Optional) : Describes the preferred placement of the popper. Possible values are left-start, left, left-end, top-start, top, top-end, right-start, right, right-end, bottom-start, bottom, and bottom-end.
 

--- a/packages/tour-kit/README.md
+++ b/packages/tour-kit/README.md
@@ -170,4 +170,5 @@ The main API for configuring a tour is the config object. See example usage and 
 
 - `portalElementId`: A string that lets you customize under which DOM element the Tour will be appended.
 
+`placement`: Describes the preferred placement of the popper. Possible values are left-start, left, left-end, top-start, top, top-end, right-start, right, right-end, bottom-start, bottom, and bottom-end.
 

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -118,7 +118,7 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 		update: popperUpdate,
 	} = usePopper( referenceElement, popperElement, {
 		strategy: 'fixed',
-		placement: 'bottom',
+		placement: config?.placement ?? 'bottom',
 		modifiers: [
 			{
 				name: 'preventOverflow',

--- a/packages/tour-kit/src/storybook/index.stories.tsx
+++ b/packages/tour-kit/src/storybook/index.stories.tsx
@@ -25,8 +25,17 @@ const References = () => {
 	);
 };
 
-const Tour = ( { onClose, options }: { onClose: () => void; options?: Config[ 'options' ] } ) => {
+const Tour = ( {
+	onClose,
+	options,
+	placement,
+}: {
+	onClose: () => void;
+	options?: Config[ 'options' ];
+	placement?: Config[ 'placement' ];
+} ) => {
 	const config: Config = {
+		placement: placement || 'bottom',
 		steps: [
 			{
 				referenceElements: {
@@ -114,14 +123,22 @@ const Tour = ( { onClose, options }: { onClose: () => void; options?: Config[ 'o
 	return <TourKit config={ config } />;
 };
 
-const StoryTour = ( { options = {} }: { options?: Config[ 'options' ] } ) => {
+const StoryTour = ( {
+	options = {},
+	placement,
+}: {
+	options?: Config[ 'options' ];
+	placement?: Config[ 'placement' ];
+} ) => {
 	const [ showTour, setShowTour ] = useState( false );
 
 	return (
 		<div className="storybook__tourkit">
 			<References />
 			{ ! showTour && <button onClick={ () => setShowTour( true ) }>Start Tour</button> }
-			{ showTour && <Tour onClose={ () => setShowTour( false ) } options={ options } /> }
+			{ showTour && (
+				<Tour onClose={ () => setShowTour( false ) } options={ options } placement={ placement } />
+			) }
 		</div>
 	);
 };
@@ -143,3 +160,5 @@ export const AutoScroll = () => (
 		/>
 	</>
 );
+
+export const Placement = () => <StoryTour placement={ 'left' } />;

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -1,3 +1,4 @@
+import * as PopperJS from '@popperjs/core';
 import React from 'react';
 import type { Modifier } from 'react-popper';
 
@@ -84,19 +85,7 @@ export interface Config {
 	closeHandler: CloseHandler;
 	isMinimized?: boolean;
 	options?: Options;
-	placement?:
-		| 'top-start'
-		| 'top'
-		| 'top-end'
-		| 'left-start'
-		| 'left'
-		| 'left-end'
-		| 'right-start'
-		| 'right'
-		| 'right-end'
-		| 'bottom-start'
-		| 'bottom'
-		| 'bottom-end';
+	placement?: PopperJS.Placement;
 }
 
 export type Tour = React.FunctionComponent< { config: Config } >;

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -84,6 +84,19 @@ export interface Config {
 	closeHandler: CloseHandler;
 	isMinimized?: boolean;
 	options?: Options;
+	placement?:
+		| 'top-start'
+		| 'top'
+		| 'top-end'
+		| 'left-start'
+		| 'left'
+		| 'left-end'
+		| 'right-start'
+		| 'right'
+		| 'right-end'
+		| 'bottom-start'
+		| 'bottom'
+		| 'bottom-end';
 }
 
 export type Tour = React.FunctionComponent< { config: Config } >;


### PR DESCRIPTION
#### Proposed Changes

* Add `placement` option to control popper.js placement.

#### Testing Instructions

- Run `yarn workspace @automattic/tour-kit run storybook`
- Go to `tour-kit > Placement`
- Click "Start Tour" and confirm the effect work

Fixes #64315 