### PR TITLE
Tour kit: Added interactivity option to spotlight overlay

### DIFF
--- a/packages/tour-kit/README.md
+++ b/packages/tour-kit/README.md
@@ -156,6 +156,8 @@ The main API for configuring a tour is the config object. See example usage and 
 - `effects`: An object to enable/disable/combine various tour effects:
 
   - `spotlight`: Adds a semi-transparent overlay and highlights the reference element when provided with a transparent box over it. Expects an object with optional styles to override the default highlight/spotlight behavior when provided (default: spotlight wraps the entire reference element).
+	  - `interactivity`: An object that configures whether the user is allowed to interact with the referenced element during the tour
+	  - `styles`: CSS properties that configures the styles applied to the spotlight overlay
   - `arrowIndicator`: Adds an arrow tip pointing at the reference element when provided.
   - `overlay`: Includes the semi-transparent overlay for all the steps (also blocks interactions with the rest of the page)
   - `autoScroll`: The page scrolls up and down automatically such that the step target element is visible to the user.

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -222,7 +222,7 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 				{ showSpotlight() && (
 					<Spotlight
 						referenceElement={ referenceElement }
-						styles={ config.options?.effects?.spotlight?.styles }
+						{ ...( config.options?.effects?.spotlight || {} ) }
 					/>
 				) }
 				<div

--- a/packages/tour-kit/src/components/tour-kit-spotlight-interactivity.tsx
+++ b/packages/tour-kit/src/components/tour-kit-spotlight-interactivity.tsx
@@ -1,0 +1,37 @@
+import { SPOTLIT_ELEMENT_CLASS } from './tour-kit-spotlight';
+
+export interface SpotlightInteractivityConfiguration {
+	/** If true, the user will be allowed to interact with the spotlit element. Defaults to false. */
+	enabled?: boolean;
+	/** This element is the root element within which all children will have
+	 * pointer-events disabled during the tour. Defaults to '#wpwrap'
+	 */
+	rootElementSelector?: string;
+}
+
+export const SpotlightInteractivity: React.VFC< SpotlightInteractivityConfiguration > = ( {
+	enabled = false,
+	rootElementSelector = '#wpwrap',
+}: SpotlightInteractivityConfiguration ) => {
+	if ( ! enabled ) {
+		return null;
+	}
+	return (
+		<style>
+			{ `
+    .${ SPOTLIT_ELEMENT_CLASS }, .${ SPOTLIT_ELEMENT_CLASS } * {
+        pointer-events: auto !important;
+    }
+    .tour-kit-frame__container button {
+        pointer-events: auto !important;
+    }
+    .tour-kit-spotlight, .tour-kit-overlay {
+        pointer-events: none !important;
+    }
+    ${ rootElementSelector } :not(${ SPOTLIT_ELEMENT_CLASS }) {
+        pointer-events: none;
+    }
+    ` }
+		</style>
+	);
+};

--- a/packages/tour-kit/src/components/tour-kit-spotlight.tsx
+++ b/packages/tour-kit/src/components/tour-kit-spotlight.tsx
@@ -1,15 +1,25 @@
-import { useMemo, useState } from '@wordpress/element';
+import { useMemo, useState, useEffect } from '@wordpress/element';
 import classnames from 'classnames';
 import { usePopper } from 'react-popper';
 import Overlay from './tour-kit-overlay';
+import {
+	SpotlightInteractivity,
+	SpotlightInteractivityConfiguration,
+} from './tour-kit-spotlight-interactivity';
 import type { Rect, Placement } from '@popperjs/core';
 
+export const SPOTLIT_ELEMENT_CLASS = 'wp-tour-kit-spotlit';
 interface Props {
 	referenceElement: HTMLElement | null;
 	styles?: React.CSSProperties;
+	interactivity?: SpotlightInteractivityConfiguration;
 }
 
-const TourKitSpotlight: React.FunctionComponent< Props > = ( { referenceElement, styles } ) => {
+const TourKitSpotlight: React.FunctionComponent< Props > = ( {
+	referenceElement,
+	styles,
+	interactivity,
+} ) => {
 	const [ popperElement, sePopperElement ] = useState< HTMLElement | null >( null );
 	const referenceRect = referenceElement?.getBoundingClientRect();
 	const modifiers = [
@@ -75,8 +85,20 @@ const TourKitSpotlight: React.FunctionComponent< Props > = ( { referenceElement,
 		  }
 		: null;
 
+	/**
+	 * Add a .wp-spotlit class to the referenced element so that we can
+	 * apply CSS styles to it, for whatever purposes such as interactivity
+	 */
+	useEffect( () => {
+		referenceElement?.classList.add( SPOTLIT_ELEMENT_CLASS );
+		return () => {
+			referenceElement?.classList.remove( SPOTLIT_ELEMENT_CLASS );
+		};
+	}, [ referenceElement ] );
+
 	return (
 		<>
+			<SpotlightInteractivity { ...interactivity } />
 			<Overlay visible={ ! clipRepositionProps } />
 			<div
 				className={ classnames( 'tour-kit-spotlight', {

--- a/packages/tour-kit/src/storybook/index.stories.tsx
+++ b/packages/tour-kit/src/storybook/index.stories.tsx
@@ -13,6 +13,9 @@ const References = () => {
 				</div>
 				<div className={ 'storybook__tourkit-references-b' }>
 					<p>Reference B</p>
+					<div style={ { display: 'grid', placeItems: 'center' } }>
+						<input style={ { margin: 'auto', display: 'block' } }></input>
+					</div>
 				</div>
 				<div className={ 'storybook__tourkit-references-c' }>
 					<p>Reference C</p>
@@ -129,6 +132,13 @@ const StoryTour = ( { options = {} }: { options?: Config[ 'options' ] } ) => {
 export const Default = () => <StoryTour />;
 export const Overlay = () => <StoryTour options={ { effects: { overlay: true } } } />;
 export const Spotlight = () => <StoryTour options={ { effects: { spotlight: {} } } } />;
+export const SpotlightInteractivity = () => (
+	<StoryTour
+		options={ {
+			effects: { spotlight: { interactivity: { rootElementSelector: '#root', enabled: true } } },
+		} }
+	/>
+);
 export const AutoScroll = () => (
 	<>
 		<div style={ { height: '10vh' } }></div>

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SpotlightInteractivityConfiguration } from './components/tour-kit-spotlight-interactivity';
 import type { Modifier } from 'react-popper';
 
 export interface Step {
@@ -64,11 +65,25 @@ export interface Callbacks {
 export interface Options {
 	classNames?: string | string[];
 	callbacks?: Callbacks;
+	/** An object to enable/disable/combine various tour effects, such as spotlight, overlay, and autoscroll */
 	effects?: {
-		spotlight?: { styles?: React.CSSProperties };
-		arrowIndicator?: boolean; // defaults to true
+		/** Adds a semi-transparent overlay and highlights the reference element
+		 * 	when provided with a transparent box over it. The existence of this configuration
+		 *  key implies enabling the spotlight effect. */
+		spotlight?: {
+			/** An object that configures whether the user is allowed to interact with the referenced element during the tour */
+			interactivity?: SpotlightInteractivityConfiguration;
+			/** CSS properties that configures the styles applied to the spotlight overlay */
+			styles?: React.CSSProperties;
+		};
+		/** Shows a little triangle that points to the referenced element. Defaults to true */
+		arrowIndicator?: boolean;
+		/** Includes the semi-transparent overlay for all the steps Also blocks interactions for everything except the tour dialogues,
+		 *  including the referenced elements. Refer to spotlight interactivity configuration to affect this.
+		 *
+		 *  Defaults to false, but if spotlight is enabled it implies this is enabled as well. */
 		overlay?: boolean;
-		// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+		/** Configures the autoscroll behaviour. Defaults to False. More information about the configuration at: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView */
 		autoScroll?: ScrollIntoViewOptions | boolean;
 	};
 	popperModifiers?: PopperModifier[];


### PR DESCRIPTION
#### Proposed Changes

Added a feature to @automattic/tour-kit that allows the user to be able to interact with the spotlit element when the overlay covers the rest of the view.

This is implemented by rendering a `<style>` tag with some global styles that sets `pointer-events: none` to a subtree (default: everything under #wpwrap) of the DOM, when the spotlight overlay is on screen.

The configuration option for this is disabled by default so this is not a breaking change.

https://user-images.githubusercontent.com/27843274/171816287-920ea927-b4d0-4a5c-aab6-72768ef9b4e4.mp4


#### Testing Instructions
- Run yarn workspace @automattic/tour-kit run storybook
- Go to tour-kit > Spotlight Interactivity
- Click "Start Tour" and confirm that the spotlit input field in "Reference B" can be interacted with when it is the second step, and not interactive when it is not spotlit on the other steps

