### PR TITLE
Fixes event prop for Community Translator events

### DIFF
--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -321,7 +321,7 @@ export function trackTranslatorStatus( isTranslatorEnabled ) {
 
 	if ( changed && _isTranslatorEnabled !== undefined ) {
 		debug( tracksEvent );
-		recordTracksEvent( tracksEvent, { locale: i18n.getLocaleSlug } );
+		recordTracksEvent( tracksEvent, { locale: i18n.getLocaleSlug() } );
 	}
 
 	_isTranslatorEnabled = newSetting;


### PR DESCRIPTION
#### Proposed Changes

* The `locale` prop for the `calypso_community_translator_disabled` and `calypso_community_translator_enabled` events is being incorrectly recorded since the function is not called. Please see 2c97e-pb/#plain for more details. This change fixes the behaviour.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the network inspector, switch to the "Img" tab and search for this text: `calypso_community_translator_disabled`.
* Go to `/home?flags=force-sympathy` and check the network request to `pixel.wp.com`.
* Confirm that the `locale` param is correct.
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/5436027/171818844-92a5e5df-97d6-470f-95cf-babf3592c834.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

