### PR TITLE
Disable add/remove mailbox buttons based on user permissions

### DIFF
--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -70,6 +70,7 @@ const getTitanClickHandler = ( app ) => {
  * Returns the available menu items for Titan Emails
  *
  * @param {Object} titanMenuParams The argument for this function.
+ * @param {import('calypso/lib/domains/types').ResponseDomain} titanMenuParams.domain The domain object.
  * @param {Object} titanMenuParams.mailbox The mailbox object.
  * @param {Function} titanMenuParams.showRemoveMailboxDialog The function that removes modal dialogs for confirming mailbox removals
  * @param {string} titanMenuParams.titanAppsUrlPrefix The URL prefix for Titan Apps
@@ -77,6 +78,7 @@ const getTitanClickHandler = ( app ) => {
  * @returns Array of menu items
  */
 const getTitanMenuItems = ( {
+	domain,
 	mailbox,
 	showRemoveMailboxDialog,
 	titanAppsUrlPrefix,
@@ -112,20 +114,24 @@ const getTitanMenuItems = ( {
 			} ),
 			onClick: getTitanClickHandler( 'contacts' ),
 		},
-		{
-			isInternalLink: true,
-			materialIcon: 'delete',
-			onClick: () => {
-				showRemoveMailboxDialog?.();
+		...( domain.currentUserCanAddEmail
+			? [
+					{
+						isInternalLink: true,
+						materialIcon: 'delete',
+						onClick: () => {
+							showRemoveMailboxDialog?.();
 
-				recordTracksEvent( 'calypso_email_management_titan_remove_mailbox_click', {
-					domain_name: mailbox.domain,
-					mailbox: mailbox.mailbox,
-				} );
-			},
-			key: `remove_mailbox:${ mailbox.mailbox }`,
-			title: translate( 'Remove mailbox' ),
-		},
+							recordTracksEvent( 'calypso_email_management_titan_remove_mailbox_click', {
+								domain_name: mailbox.domain,
+								mailbox: mailbox.mailbox,
+							} );
+						},
+						key: `remove_mailbox:${ mailbox.mailbox }`,
+						title: translate( 'Remove mailbox' ),
+					},
+			  ]
+			: [] ),
 	];
 };
 
@@ -399,6 +405,7 @@ const EmailMailboxActionMenu = ( { account, domain, mailbox } ) => {
 	const getMenuItems = () => {
 		if ( domainHasTitanMailWithUs ) {
 			return getTitanMenuItems( {
+				domain,
 				mailbox,
 				showRemoveMailboxDialog: () => setRemoveTitanMailboxDialogVisible( true ),
 				titanAppsUrlPrefix,

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -449,7 +449,7 @@ const EmailMailboxActionMenu = ( { account, domain, mailbox } ) => {
 					successful={ emailForwardRemovalStatus === 'success' }
 				/>
 			) }
-			<EllipsisMenu position="bottom" className="email-mailbox-action-menu__main">
+			<EllipsisMenu position="bottom left" className="email-mailbox-action-menu__main">
 				{ menuItems.map(
 					( {
 						href,

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -19,6 +19,7 @@ import MaterialIcon from 'calypso/components/material-icon';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { useRemoveEmailForwardMutation } from 'calypso/data/emails/use-remove-email-forward-mutation';
 import { useRemoveTitanMailboxMutation } from 'calypso/data/emails/use-remove-titan-mailbox-mutation';
+import { canCurrentUserAddEmail } from 'calypso/lib/domains';
 import { hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import {
 	getEmailAddress,
@@ -114,7 +115,7 @@ const getTitanMenuItems = ( {
 			} ),
 			onClick: getTitanClickHandler( 'contacts' ),
 		},
-		...( domain.currentUserCanAddEmail
+		...( canCurrentUserAddEmail( domain )
 			? [
 					{
 						isInternalLink: true,

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -83,7 +83,9 @@ class EmailPlanWarnings extends Component {
 					<div className="email-plan-warnings__warning">
 						<div className="email-plan-warnings__message">
 							<span>
-								{ translate( 'Only the email subscription owner can add or remove mailboxes.' ) }
+								{ translate(
+									'This email subscription was purchased by a different WordPress.com account. To add or remove mailboxes, log in to that account or contact the account owner.'
+								) }
 							</span>
 						</div>
 					</div>

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -70,19 +70,32 @@ class EmailPlanWarnings extends Component {
 	}
 
 	render() {
-		const { warning } = this.props;
-		if ( ! warning ) {
+		const { domain, translate, warning } = this.props;
+
+		if ( ! warning && domain.currentUserCanAddEmail ) {
 			return null;
 		}
 
 		return (
 			<div className="email-plan-warnings__container">
-				<div className="email-plan-warnings__warning">
-					<div className="email-plan-warnings__message">
-						<span>{ warning.message }</span>
+				{ ! domain.currentUserCanAddEmail && (
+					<div className="email-plan-warnings__warning">
+						<div className="email-plan-warnings__message">
+							<span>
+								{ translate( 'Only the email subscription owner can add or remove mailboxes.' ) }
+							</span>
+						</div>
 					</div>
-					<div className="email-plan-warnings__cta">{ this.renderCTA() }</div>
-				</div>
+				) }
+
+				{ warning && (
+					<div className="email-plan-warnings__warning">
+						<div className="email-plan-warnings__message">
+							<span>{ warning.message }</span>
+						</div>
+						<div className="email-plan-warnings__cta">{ this.renderCTA() }</div>
+					</div>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/email/email-management/home/email-plan-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { canCurrentUserAddEmail } from 'calypso/lib/domains';
 import {
 	hasUnusedMailboxWarning,
 	hasGoogleAccountTOSWarning,
@@ -72,13 +73,13 @@ class EmailPlanWarnings extends Component {
 	render() {
 		const { domain, translate, warning } = this.props;
 
-		if ( ! warning && domain.currentUserCanAddEmail ) {
+		if ( ! warning && canCurrentUserAddEmail( domain ) ) {
 			return null;
 		}
 
 		return (
 			<div className="email-plan-warnings__container">
-				{ ! domain.currentUserCanAddEmail && (
+				{ ! canCurrentUserAddEmail( domain ) && (
 					<div className="email-plan-warnings__warning">
 						<div className="email-plan-warnings__message">
 							<span>

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -10,6 +10,7 @@ import HeaderCake from 'calypso/components/header-cake';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { useGetEmailAccountsQuery } from 'calypso/data/emails/use-get-email-accounts-query';
+import { canCurrentUserAddEmail } from 'calypso/lib/domains';
 import {
 	getGoogleAdminUrl,
 	getGoogleMailServiceFamily,
@@ -94,7 +95,7 @@ function EmailPlan( { domain, selectedSite, source } ) {
 	const canAddMailboxes =
 		( getGSuiteProductSlug( domain ) || getTitanProductSlug( domain ) ) &&
 		getGSuiteSubscriptionStatus( domain ) !== 'suspended' &&
-		domain.currentUserCanAddEmail;
+		canCurrentUserAddEmail( domain );
 	const hasSubscription = hasEmailSubscription( domain );
 
 	const handleBack = () => {

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -93,7 +93,8 @@ function EmailPlan( { domain, selectedSite, source } ) {
 
 	const canAddMailboxes =
 		( getGSuiteProductSlug( domain ) || getTitanProductSlug( domain ) ) &&
-		getGSuiteSubscriptionStatus( domain ) !== 'suspended';
+		getGSuiteSubscriptionStatus( domain ) !== 'suspended' &&
+		domain.currentUserCanAddEmail;
 	const hasSubscription = hasEmailSubscription( domain );
 
 	const handleBack = () => {

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -233,7 +233,9 @@
 		margin-right: 8px;
 	}
 
-	&:hover {
+	&.is-selected,
+	&:hover,
+	&:focus {
 		> img {
 			filter: grayscale( 100% ) brightness( 0.2 ) invert( 1 );
 		}
@@ -420,10 +422,10 @@
 	width: 100%;
 
 	.email-plan-warnings__warning {
-		padding-top: 30px;
+		padding-top: 24px;
 
 		.email-plan-warnings__cta {
-			margin-top: 25px;
+			margin-top: 16px;
 
 			.button {
 				font-size: $font-body-small;


### PR DESCRIPTION
#### Proposed Changes

For sites with multiple users, only the owner of the Titan/Google Workspace subscription is allowed to add/remove mailboxes. Currently, there is no preemptive warning to users about this. This means that they can click the button to add/remove mailboxes, but the action will fail.

With this change, the "Remove mailbox" button is hidden entirely and the "Add new mailboxes" button is disabled if the current user isn't allowed to perform those actions. We also display an explanation in `EmailPlanHeader` for why the buttons are disabled.

<img width="1442" alt="Screen Shot 2022-06-03 at 10 08 49" src="https://user-images.githubusercontent.com/1101677/171819929-db186358-a555-44c4-b568-d3b49c3245aa.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a site with at least two users and a Titan/Google Workspace subscription. The secondary user should be an administrator.
2. Log in as the secondary user
3. Navigate to `/email/:domain/manage/:site_slug`
4. Verify that the action menu for each mailbox does not contain a "Remove mailbox" button
5. Verify that the "Add new mailboxes" button is disabled
6. Verify that there is a warning text in the header that says `Only the email subscription owner can add or remove mailboxes.`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
