### PR TITLE
Fix bad viewport overflow on checkout thank you page for email

### DIFF
--- a/client/my-sites/email/titan-set-up-thank-you/style.scss
+++ b/client/my-sites/email/titan-set-up-thank-you/style.scss
@@ -5,17 +5,6 @@
 	margin-left: 4px;
 }
 
-.thank-you__container.titan-set-up-thank-you__container {
-	margin-left: -33px;
-	margin-right: -32px;
-	padding-left: 33px;
-	padding-right: 32px;
-	@include breakpoint-deprecated( '>660px' ) {
-		padding-left: 0;
-		padding-right: 0;
-	}
-}
-
 .thank-you__step-cta {
 	width: 100%;
 	@include break-mobile {


### PR DESCRIPTION
#### Proposed Changes

After purchasing a professional email subscription, users are presented with a "Thank you" page. On a small laptop, this page has some bad horizontal viewport overflow. This seems to have been introduced in #56934. That PR was directed at two styling issues on this page, none of which seem to be impacted by removing the CSS that causes this overflow. So in this PR, I simply removed the relevant CSS 😌

See these screenshots for reference before/after:

##### Desktop

| Before | After |
| ------- | ----- |
| <img width="1442" alt="before desktop" src="https://user-images.githubusercontent.com/1101677/171864705-b89acea7-7630-4935-9072-c62dba7f5a8a.png"> |  <img width="1442" alt="after desktop" src="https://user-images.githubusercontent.com/1101677/171864729-75848828-ff1e-4171-8c3e-4d54523df9a6.png"> |

##### Mobile

This change has no visible impact at all on mobile.

| Before | After |
| ------- | ----- |
| ![before mobile](https://user-images.githubusercontent.com/1101677/171864823-809bf778-03bd-45b6-91de-c1b07eb02774.png) |  ![after mobile](https://user-images.githubusercontent.com/1101677/171864892-169596ac-3c3a-4b1e-add1-630fce461225.png) |


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Two ways to do it, one if you already have a professional email subscription, the other if you don't.**

1. Use a responsive view in the browser dev tools. Set the viewport size to 1440x900.
2. On Mac, scrollbars will be displayed as overlays by default. My advice is to temporarily disable this to more easily test this change. Open System Settings > General and set "Show scroll bars" to "Always"
3. Have a site with a professional email subscription
4. Navigate to `/purchases/billing-history/:site_slug`
5. Find the professional email purchase in the list
6. Click that purchase, then copy the `Receipt ID`
7. Navigate to `/checkout/thank-you/:site_slug/:receipt_id`
8. Ensure that there is no horizontal scroll bar for the entire viewport

**The other way:**

1. Follow steps 1 & 2 above
2. Have a site with a domain without a professional email subscription
3. Purchase *only* a professional email subscription for that domain
4. On the thank you page, ensure that there is no horizontal scroll bar for the entire viewport

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
