### PR TITLE
Checkout: Fix missing descriptions and refund windows for various products (including No Ads)

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/get-refund-days.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-refund-days.ts
@@ -1,13 +1,11 @@
 import {
+	isChargeback,
 	isDomainProduct,
+	isDomainRedemption,
 	isDomainTransfer,
 	isGoogleWorkspace,
 	isGoogleWorkspaceExtraLicence,
-	isGoogleWorkspaceMonthly,
-	isMonthly,
-	isPlan,
-	isTitanMail,
-	isTitanMailMonthly,
+	isMonthlyProduct,
 } from '@automattic/calypso-products';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -22,21 +20,14 @@ export default function getRefundDays( product: ResponseCartProduct ): number {
 		return 4;
 	}
 
-	if ( isPlan( product ) ) {
-		return isMonthly( product.product_slug ) ? 7 : 14;
+	if ( isGoogleWorkspace( product ) && isGoogleWorkspaceExtraLicence( product ) ) {
+		return 0;
 	}
 
-	if ( isGoogleWorkspace( product ) ) {
-		if ( isGoogleWorkspaceExtraLicence( product ) ) {
-			return 0;
-		}
-
-		return isGoogleWorkspaceMonthly( product ) ? 7 : 14;
+	// These are fees, and therefore not refundable.
+	if ( isChargeback( product ) || isDomainRedemption( product ) ) {
+		return 0;
 	}
 
-	if ( isTitanMail( product ) ) {
-		return isTitanMailMonthly( product ) ? 7 : 14;
-	}
-
-	return 0;
+	return isMonthlyProduct( product ) ? 7 : 14;
 }

--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -1,6 +1,7 @@
 export const GROUP_WPCOM = 'GROUP_WPCOM';
 
 // Products
+export const PRODUCT_NO_ADS = 'no-adverts/no-adverts.php';
 export const PRODUCT_WPCOM_SEARCH = 'wpcom_search';
 export const PRODUCT_WPCOM_SEARCH_MONTHLY = 'wpcom_search_monthly';
 

--- a/packages/calypso-products/src/is-add-on.ts
+++ b/packages/calypso-products/src/is-add-on.ts
@@ -1,0 +1,8 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
+import { PRODUCT_NO_ADS } from './constants';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isAddOn( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	// Right now the definition of an "add-on" just comes from a hardcoded list.
+	return camelOrSnakeSlug( product ) === PRODUCT_NO_ADS;
+}

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -10,6 +10,7 @@ export { getProductTermVariants } from './get-product-term-variants';
 export { getProductYearlyVariant } from './get-product-yearly-variant';
 export { getProductFromSlug } from './get-product-from-slug';
 export { getProductsSlugs } from './get-products-slugs';
+export { isAddOn } from './is-add-on';
 export { isBiennially } from './is-biennially';
 export { isBlogger } from './is-blogger';
 export { isBundled } from './is-bundled';

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -1,4 +1,5 @@
 import {
+	isAddOn,
 	isPlan,
 	isDomainTransfer,
 	isDomainProduct,
@@ -8,6 +9,9 @@ import {
 	isTitanMail,
 	isP2Plus,
 	isJetpackProductSlug,
+	isMonthlyProduct,
+	isYearly,
+	isBiennially,
 } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import { isWpComProductRenewal as isRenewal } from './is-wpcom-product-renewal';
@@ -59,12 +63,24 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 		}
 	}
 
-	if ( ! isRenewalItem && serverCartItem.months_per_bill_period === 1 ) {
-		return String( translate( 'Billed monthly' ) );
+	if ( isAddOn( serverCartItem ) && ! isRenewalItem ) {
+		return String( translate( 'Add-On' ) );
 	}
 
 	if ( isRenewalItem ) {
 		return String( translate( 'Renewal' ) );
+	}
+
+	if ( isMonthlyProduct( serverCartItem ) ) {
+		return String( translate( 'Billed monthly' ) );
+	}
+
+	if ( isYearly( serverCartItem ) ) {
+		return String( translate( 'Billed annually' ) );
+	}
+
+	if ( isBiennially( serverCartItem ) ) {
+		return String( translate( 'Billed every two years' ) );
 	}
 
 	return '';

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1,4 +1,5 @@
 import {
+	isAddOn,
 	isDomainRegistration,
 	isPlan,
 	isMonthlyProduct,
@@ -569,7 +570,7 @@ function LineItemSublabelAndPrice( { product }: { product: ResponseCartProduct }
 	const productSlug = product.product_slug;
 	const sublabel = getSublabel( product );
 
-	if ( isPlan( product ) || isJetpackProductSlug( productSlug ) ) {
+	if ( isPlan( product ) || isAddOn( product ) || isJetpackProductSlug( productSlug ) ) {
 		if ( isP2Plus( product ) ) {
 			// This is the price for one item for products with a quantity (eg. seats in a license).
 			const itemPrice = product.item_original_cost_for_quantity_one_display;


### PR DESCRIPTION
#### Proposed Changes

It was discovered that there are various products we sell which show an empty "Included with your purchase" section in checkout (https://github.com/Automattic/wp-calypso/issues/64203) or no information about whether the product is billed annually/monthly/etc underneath the line item (p7DVsv-eDy-p2#comment-40986).  Note that the "Included with your purchase" section is also typically the only place in checkout where we mention the refund window, so having that be empty means some of those products don't clearly communicate the refund window while the user is buying it.

The fix here makes sure that we show something reasonable in almost all cases.  The biggest change is to show the refund window in the "Included with your purchase" section unless we explicitly exclude it, rather than the previous behavior of only showing it for products where it's explicitly **included**.  I think that makes sense and is completely consistent with our stated refund policies at https://wordpress.com/support/manage-purchases/#refund-policy and https://jetpack.com/support/refunds/, but this needs some careful review.

The issue is most prominent for the No Ads add-on, since it currently experiences both of the bugs.  But at least the empty "Included with your purchase" part can be seen for many other products: Search, Premium Themes, Jetpack non-plan products, etc., which are fixed by this pull request.  The screenshots below are for No Ads:

**Before:**

![before-no-adds](https://user-images.githubusercontent.com/235183/171869731-6adb73a6-71b6-4811-b885-39d8141b72b3.png)

**After:**

![after-no-ads](https://user-images.githubusercontent.com/235183/171869729-f44194c5-2c02-43fa-9512-c3662cbe5c37.png)

#### Testing Instructions

Put all different kinds of products into your shopping cart, and compare this pull request to the production behavior.  Some examples include plans, domains, Professional Email, Search, No Ads, premium themes (one time purchase), Jetpack plans and products on a Jetpack site, and the chargeback fee (the latter requires flagging the site for a chargeback server-side).

The checkout page should always look either the same, or slightly improved with more useful information for the customer.