### PR TITLE
E2E: temporarily disable specs that touch on the overhauled Plans.

### DIFF
--- a/test/e2e/specs/plans/plans__add-upgrade-cart.ts
+++ b/test/e2e/specs/plans/plans__add-upgrade-cart.ts
@@ -1,5 +1,4 @@
 /**
- * @group calypso-pr
  */
 
 import {

--- a/test/e2e/specs/plans/plans__signup-free.ts
+++ b/test/e2e/specs/plans/plans__signup-free.ts
@@ -1,5 +1,4 @@
 /**
- * @group calypso-release
  */
 
 import {

--- a/test/e2e/specs/plans/plans__signup-pro.ts
+++ b/test/e2e/specs/plans/plans__signup-pro.ts
@@ -1,5 +1,4 @@
 /**
- * @group calypso-release
  */
 
 import {


### PR DESCRIPTION
#### Proposed Changes

Context: p58i-cuY-p2

This PR temporarily disables specs that interact with the overhauled (Free/Starter/Pro) Plans.

Notably, this excludes specs in the MarTech folder. The decision was made as only two specs were affected for MarTech ToS specs and updating the flow with the Legacy Plans will be quite straightforward.

#### Testing Instructions

Ensure the following:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

Related to 773-gh-Automattic/martech.