### PR TITLE
Checkout: add an "included with your purchase" item for No Ads

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -169,7 +169,7 @@ function CheckoutSummaryFeaturesList( props: {
 	const hasOnlyStarterPlan =
 		plans.filter( ( plan ) => isStarterPlan( plan.product_slug ) ).length === plans.length;
 
-	const hasNoAdsAddOn = responseCart.products.filter( ( product ) => isNoAds( product ) );
+	const hasNoAdsAddOn = responseCart.products.some( ( product ) => isNoAds( product ) );
 
 	return (
 		<CheckoutSummaryFeaturesListWrapper>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -5,6 +5,7 @@ import {
 	isDomainTransfer,
 	isGoogleWorkspace,
 	isMonthly,
+	isNoAds,
 	isPlan,
 	isTitanMail,
 	isWpComBusinessPlan,
@@ -168,6 +169,8 @@ function CheckoutSummaryFeaturesList( props: {
 	const hasOnlyStarterPlan =
 		plans.filter( ( plan ) => isStarterPlan( plan.product_slug ) ).length === plans.length;
 
+	const hasNoAdsAddOn = responseCart.products.filter( ( product ) => isNoAds( product ) );
+
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
 			{ hasDomainsInCart &&
@@ -180,6 +183,14 @@ function CheckoutSummaryFeaturesList( props: {
 					nextDomainIsFree={ nextDomainIsFree }
 				/>
 			) }
+
+			{ hasNoAdsAddOn && (
+				<CheckoutSummaryFeaturesListItem>
+					<WPCheckoutCheckIcon id="features-list-support-text" />
+					{ translate( 'Remove WordPress.com ads from your site' ) }
+				</CheckoutSummaryFeaturesListItem>
+			) }
+
 			{ ! hasOnlyStarterPlan && (
 				<CheckoutSummaryFeaturesListItem>
 					<WPCheckoutCheckIcon id="features-list-support-text" />

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -187,7 +187,7 @@ function CheckoutSummaryFeaturesList( props: {
 			{ hasNoAdsAddOn && (
 				<CheckoutSummaryFeaturesListItem>
 					<WPCheckoutCheckIcon id="features-list-support-text" />
-					{ translate( 'Remove WordPress.com ads from your site' ) }
+					{ translate( 'Remove ads from your site with the No Ads add-on' ) }
 				</CheckoutSummaryFeaturesListItem>
 			) }
 


### PR DESCRIPTION
#### Proposed Changes

This add an item to the "Included with your purchase" features list in Checkout for the No Ads product.

![Screen Shot 2022-06-03 at 2 03 46 PM](https://user-images.githubusercontent.com/942359/171921419-54e64e28-d6e4-468c-bdee-540c989e9b0b.png)

#### Testing Instructions

- on a free or Starter site, add the No Ads product by clicking the banner on Tools > Marketing or visiting `/checkout/{site}/no-ads`
- verify that the Checkout sidebar feature list has an item that reads "Remove WordPress.com ads from your site"
- test various cart combinations to make sure that the item only appears when the No Ads product is in the cart

Related to #64328
