### PR TITLE
Revert "Update Plans (legacy) page to use productDisplayPrice"

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -450,7 +450,6 @@ export class PlanFeaturesHeader extends Component {
 			plansWithScroll,
 			isInVerticalScrollingPlansExperiment,
 			isLoggedInMonthlyPricing,
-			productDisplayPrice,
 		} = this.props;
 		const displayFlatPrice =
 			isInSignup && ! plansWithScroll && ! isInVerticalScrollingPlansExperiment;
@@ -465,7 +464,6 @@ export class PlanFeaturesHeader extends Component {
 							displayFlatPrice={ displayFlatPrice }
 							displayPerMonthNotation={ true }
 							original
-							productDisplayPrice={ productDisplayPrice }
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
@@ -473,7 +471,6 @@ export class PlanFeaturesHeader extends Component {
 							displayFlatPrice={ displayFlatPrice }
 							displayPerMonthNotation={ true }
 							discounted
-							productDisplayPrice={ productDisplayPrice }
 						/>
 					</div>
 					{ plansWithScroll ? null : this.renderCreditLabel() }
@@ -487,7 +484,6 @@ export class PlanFeaturesHeader extends Component {
 				rawPrice={ fullPrice }
 				displayFlatPrice={ displayFlatPrice }
 				displayPerMonthNotation={ isInSignup || isLoggedInMonthlyPricing }
-				productDisplayPrice={ productDisplayPrice }
 			/>
 		);
 	}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -364,7 +364,6 @@ export class PlanFeatures extends Component {
 				bestValue,
 				relatedMonthlyPlan,
 				primaryUpgrade,
-				productDisplayPrice,
 				isPlaceholder,
 				hideMonthly,
 			} = properties;
@@ -385,7 +384,6 @@ export class PlanFeatures extends Component {
 						title={ planConstantObj.getTitle() }
 						planType={ planName }
 						rawPrice={ rawPrice }
-						productDisplayPrice={ productDisplayPrice }
 						discountPrice={ discountPrice }
 						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
 						hideMonthly={ hideMonthly }
@@ -468,7 +466,6 @@ export class PlanFeatures extends Component {
 				isPlaceholder,
 				hideMonthly,
 				rawPrice,
-				productDisplayPrice,
 				isMonthlyPlan,
 			} = properties;
 			let { discountPrice } = properties;
@@ -517,7 +514,6 @@ export class PlanFeatures extends Component {
 						planType={ planName }
 						popular={ popular }
 						rawPrice={ rawPrice }
-						productDisplayPrice={ productDisplayPrice }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 						selectedPlan={ selectedPlan }
 						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
@@ -904,7 +900,6 @@ const ConnectedPlanFeatures = connect(
 				const isLoadingSitePlans = selectedSiteId && ! sitePlans.hasLoadedFromServer;
 				const isMonthlyPlan = isMonthly( plan );
 				const showMonthly = ! isMonthlyPlan;
-				const productDisplayPrice = planObject.product_display_price;
 				const availableForPurchase = isInSignup
 					? true
 					: canUpgradeToPlan( state, selectedSiteId, plan ) && canPurchase;
@@ -995,7 +990,6 @@ const ConnectedPlanFeatures = connect(
 					planName: plan,
 					planObject: planObject,
 					popular,
-					productDisplayPrice,
 					productSlug: get( planObject, 'product_slug' ),
 					newPlan: newPlan,
 					bestValue: bestValue,

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -61,10 +61,6 @@
 	font-weight: 400;
 }
 
-.plan-price__integer abbr {
-	font-size: 1rem;
-	vertical-align: text-top;
-}
 .plan-price__fraction {
 	font-weight: 600;
 }

--- a/client/state/plans/schema.js
+++ b/client/state/plans/schema.js
@@ -32,7 +32,6 @@ export const itemsSchema = {
 			product_name: { type: 'string' },
 			product_name_en: { type: 'string' },
 			product_name_short: { type: [ 'string', 'null' ] },
-			product_display_price: { type: 'string' },
 			product_slug: { type: 'string' },
 			product_type: { type: 'string' },
 			raw_price: { type: 'number' },


### PR DESCRIPTION
Reverts Automattic/wp-calypso#63783

This broke the /plans page for Atomic sites.

See: p1654278982740649-slack-C02FMH4G8

To test:
- on an Atomic site, visit the /plans page
- verify that the "$-- per month, billed monthly" is correct
- repeat on a simple site