### PR TITLE
Server: Reduce default timeout to 20s

### DIFF
--- a/client/server/index.js
+++ b/client/server/index.js
@@ -63,7 +63,7 @@ function createServer() {
 
 const server = createServer();
 if ( process.env.NODE_ENV !== 'development' ) {
-	server.timeout = 50 * 1000; //50 seconds, in ms;
+	server.timeout = 20 * 1000; // 20 seconds, in ms;
 }
 
 process.on( 'uncaughtExceptionMonitor', ( err ) => {


### PR DESCRIPTION
#### Proposed Changes

This PR drops the default timeout of the server to 20s. See p1654403627771719-slack-C02AVAR9B for motivation.

