### PR TITLE
Fix js errors in /setup flow that affect FF

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
@@ -33,7 +33,7 @@ const IntentStep: Step = function IntentStep( { navigation } ) {
 
 	const intents = useIntents();
 	const site = useSite();
-	const canImport = Boolean( site?.capabilities.manage_options );
+	const canImport = Boolean( site?.capabilities?.manage_options );
 	const intentsAlt = useIntentsAlt( canImport );
 
 	const submitIntent = ( intent: string ) => {

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -46,11 +46,11 @@ export const isSiteLaunching = ( state: State, siteId: number ) => {
 };
 
 export const isSiteAtomic = ( state: State, siteId: number | string ) => {
-	return select( STORE_KEY ).getSite( siteId )?.options.is_wpcom_atomic === true;
+	return select( STORE_KEY ).getSite( siteId )?.options?.is_wpcom_atomic === true;
 };
 
 export const isSiteWPForTeams = ( state: State, siteId: number | string ) => {
-	return select( STORE_KEY ).getSite( siteId )?.options.is_wpforteams_site === true;
+	return select( STORE_KEY ).getSite( siteId )?.options?.is_wpforteams_site === true;
 };
 
 export const getSiteDomains = ( state: State, siteId: number ) => {


### PR DESCRIPTION
#### Proposed Changes
Fix a few null checks that cause a WSoD and other errors to be logged in Firefox, but not in chrome (I haven't tested other browsers)

#### Testing Instructions
Before applying this PR, In Firefox, Go directly to:
* `http://calypso.localhost:3000/setup/designSetup?siteSlug=$SITE_SLUG.wordpress.com`
  * You should see multiple errors in the console (related to `isAtomic` check)
* Use the built in "< Back" button
* You should see a WSoD and a JS error related to `site.capabilities` being null