### PR TITLE
Jetpack cloud: update dropdown menu styles

### DIFF
--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -317,3 +317,20 @@ html {
 		height: 100px;
 	}
 }
+
+// Dropdown menu styles
+
+.section-nav.is-open {
+
+	.section-nav__panel {
+		padding-bottom: 0;
+		background: linear-gradient( to bottom, var( --color-neutral-0 ) 0, var( --color-surface ) 4px );
+		border: 1px solid var( --color-neutral-10 );
+		border-radius: 2px;
+		box-shadow: 0 2px 5px #0000001a, 0 0 56px rgb( 0 0 0 / 8% );
+	}
+
+	.section-nav-group {
+		margin-top: 0;
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

* Updates styles on dropdown menu.

Related to 1199980337313591-as-1202136520713469/f

#### Testing Instructions

* Fire up this PR.
* Open http://jetpack.cloud.localhost:3000/ in a mobile browser with an account that has access to the partner portal.
* Ensure the dropdown menu at the top looks like the screenshots below.

#### Screenshots

Before | After
--|--
<img width="375" alt="image" src="https://user-images.githubusercontent.com/390760/172127748-eca29c56-9789-487b-b4a2-afb3ed748c85.png"> | <img width="375" alt="image" src="https://user-images.githubusercontent.com/390760/172127728-3dd6b63d-74d4-4001-91fe-5ceec68d8170.png">


