### PR TITLE
DIFM: Show Premium plan copy if flag disabled

### DIFF
--- a/client/signup/steps/choose-service/index.tsx
+++ b/client/signup/steps/choose-service/index.tsx
@@ -1,4 +1,10 @@
-import { getPlan, PLAN_WPCOM_PRO, WPCOM_DIFM_LITE } from '@automattic/calypso-products';
+import { isEnabled } from '@automattic/calypso-config';
+import {
+	getPlan,
+	PLAN_PREMIUM,
+	PLAN_WPCOM_PRO,
+	WPCOM_DIFM_LITE,
+} from '@automattic/calypso-products';
 import { IntentScreen } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -55,7 +61,9 @@ export default function ChooseServiceStep( props: Props ): React.ReactNode {
 					args: {
 						displayCost,
 						fulfillmentDays: 4,
-						plan: getPlan( PLAN_WPCOM_PRO )?.getTitle(),
+						plan: isEnabled( 'plans/pro-plan' )
+							? getPlan( PLAN_WPCOM_PRO )?.getTitle()
+							: getPlan( PLAN_PREMIUM )?.getTitle(),
 					},
 					components: {
 						PriceWrapper: isLoading ? <Placeholder /> : <strong />,


### PR DESCRIPTION
#### Proposed Changes

Related to 779-gh-Automattic/martech

* Use Pro plan copy if the feature flag `plans/pro-plan` is enabled, else use the Premium plan copy. We don't use the `isEligibleForProPlan` function here since site data may not be available.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/website-design-services/choose-service?siteSlug=<site slug>`. Confirm that the description for the "Do It For Me" option references the Pro plan.
* Disable the feature flag in the development environment here:
https://github.com/Automattic/wp-calypso/blob/b8ddcefd8927674fc7af930e6342a2ec52636092/config/development.json#L117
* Go to `/start/website-design-services/choose-service?siteSlug=<site slug>`. Confirm that the description for the "Do It For Me" option references the Premium plan.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

