### PR TITLE
Disabled href in the dashboard view for banner

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner/index.tsx
@@ -98,6 +98,7 @@ export default function SiteWelcomeBanner( {
 			onClick={ isDashboardView ? dismissBanner : trackViewEvent }
 			dismissTemporary={ ! isDashboardView }
 			onDismiss={ dismissBanner }
+			disableHref={ isDashboardView }
 			dismissPreferenceName={ isDashboardView ? '' : preferenceName }
 		/>
 	);


### PR DESCRIPTION
#### Proposed Changes

* This PR fixes an issue where the welcome banner on the agency dashboard redirects the user to the pricing page.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/fix-agency-dashboard-banner-redirection` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard.
3. Click on `Got it` on the welcome banner on the agency dashboard

Note - you may not see the banner if you have already clicked on `Got it`

<img width="1521" alt="Screenshot 2022-06-06 at 6 18 25 PM" src="https://user-images.githubusercontent.com/10586875/172164016-49f5799a-cf7d-456b-a249-9d8dc62097ef.png">

Related to 1202076982646589-as-1202396899297954