### PR TITLE
Add a link to add monitor when the monitor status is inactive

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -82,6 +82,10 @@ const scanEventNames: StatusEventNames = {
 
 // Montitor feature status event names for large screen(>960px) and small screen(<960px)
 const monitorEventNames: StatusEventNames = {
+	disabled: {
+		small_screen: 'calypso_jetpack_agency_dashboard_monitor_inactive_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_monitor_inactive_click_large_screen',
+	},
 	failed: {
 		small_screen: 'calypso_jetpack_agency_dashboard_monitor_site_down_click_small_screen',
 		large_screen: 'calypso_jetpack_agency_dashboard_monitor_site_down_click_large_screen',
@@ -129,6 +133,7 @@ const getLinks = (
 	type: AllowedTypes,
 	status: string,
 	siteUrl: string,
+	siteUrlWithScheme: string,
 	siteId: number
 ): {
 	tooltip: ReactChild | undefined;
@@ -164,6 +169,9 @@ const getLinks = (
 		case 'monitor': {
 			if ( status === 'failed' ) {
 				link = `https://jptools.wordpress.com/debug/?url=${ siteUrl }`;
+				isExternalLink = true;
+			} else if ( status === 'disabled' ) {
+				link = `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack#/settings`;
 				isExternalLink = true;
 			}
 			if ( status === 'success' ) {
@@ -202,9 +210,16 @@ export const getRowMetaData = (
 } => {
 	const row = rows[ type ];
 	const siteUrl = rows.site?.value?.url;
+	const siteUrlWithScheme = rows.site?.value?.url_with_scheme;
 	const siteError = rows.site.error;
 	const siteId = rows.site?.value?.blog_id;
-	const { link, tooltip, isExternalLink } = getLinks( type, row.status, siteUrl, siteId );
+	const { link, tooltip, isExternalLink } = getLinks(
+		type,
+		row.status,
+		siteUrl,
+		siteUrlWithScheme,
+		siteId
+	);
 	const eventName = getRowEventName( type, row.status, isLargeScreen );
 	return {
 		row,


### PR DESCRIPTION
#### Proposed Changes

* This PR adds a link to activate the monitor to the inactive monitor state.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/add-monitor-inactive-state-link` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard.
3. Click on `-` on the monitor column, and verify that you are being redirected to https://<site>/wp-admin/admin.php?page=jetpack#/settings in a new tab.

`Note` - Add a new site if the monitor is already active for your sites.

<img width="820" alt="Screenshot 2022-06-06 at 10 52 34 PM" src="https://user-images.githubusercontent.com/10586875/172212648-22189b1e-ca6d-4e2b-accd-a6b65deaabee.png">


Related to 1202076982646589-as-1202396957069327