### PR TITLE
Add validator function to check for mailbox availability for Professional Email

### DIFF
--- a/client/my-sites/email/form/mailboxes/components/field.tsx
+++ b/client/my-sites/email/form/mailboxes/components/field.tsx
@@ -79,9 +79,16 @@ const MailboxField = ( {
 		return null;
 	}
 
-	const onBlur = () => {
-		onRequestFieldValidation( field );
+	field.dispatchState = () => {
 		setFieldState( { field } );
+	};
+
+	const onBlur = () => {
+		if ( ! field.isTouched ) {
+			field.isTouched = field.hasValidValue();
+		}
+		onRequestFieldValidation( field );
+		field.dispatchState();
 	};
 
 	const onChange = ( event: ChangeEvent< HTMLInputElement > ) => {
@@ -91,11 +98,11 @@ const MailboxField = ( {
 		}
 		field.value = value;
 
-		// Validate the field on the fly if there was already an error
-		if ( field.error ) {
+		// Validate the field on the fly if there was already an error, or the field was already touched
+		if ( field.error || field.isTouched ) {
 			onRequestFieldValidation( field );
 		}
-		setFieldState( { field } );
+		field.dispatchState();
 		onFieldValueChanged( field );
 	};
 

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -103,6 +103,9 @@ class MailboxForm< T extends EmailProvider > {
 		}
 	}
 
+	/**
+	 * Returns the mailbox field values in a shape that can be consumed by the shopping cart at checkout
+	 */
 	getAsCartItem(): Record< string, string | boolean | undefined > {
 		const commonFields = {
 			email: `${ this.getFieldValue< string >( FIELD_MAILBOX ) }@${ this.getFieldValue< string >(

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -2,6 +2,7 @@ import {
 	FIELD_ALTERNATIVE_EMAIL,
 	FIELD_DOMAIN,
 	FIELD_FIRSTNAME,
+	FIELD_IS_ADMIN,
 	FIELD_LASTNAME,
 	FIELD_MAILBOX,
 	FIELD_NAME,
@@ -18,10 +19,11 @@ import {
 	AlternateEmailValidator,
 	ExistingMailboxNamesValidator,
 	MailboxNameValidator,
-	PasswordValidator,
-	RequiredValidator,
-	RequiredIfVisibleValidator,
+	MailboxNameValidityValidator,
 	MaximumStringLengthValidator,
+	PasswordValidator,
+	RequiredIfVisibleValidator,
+	RequiredValidator,
 } from 'calypso/my-sites/email/form/mailboxes/validators';
 import type {
 	FormFieldNames,
@@ -74,6 +76,23 @@ class MailboxForm< T extends EmailProvider > {
 		];
 	}
 
+	/**
+	 * On demand validators may be async i.e. making network calls, or may require a set of conditions to be fulfilled
+	 *
+	 * @private
+	 */
+	private getOnDemandValidators(): Record< string, [ ValidatorFieldNames, Validator< unknown > ] > {
+		const domainField = this.getFormField< string >( FIELD_DOMAIN );
+		const domainName = domainField?.value ?? '';
+
+		return {
+			[ MailboxNameValidityValidator.name ]: [
+				FIELD_MAILBOX,
+				new MailboxNameValidityValidator( domainName, this.provider ),
+			],
+		};
+	}
+
 	clearErrors() {
 		for ( const field of Object.values( this.formFields ) ) {
 			if ( ! field ) {
@@ -82,6 +101,28 @@ class MailboxForm< T extends EmailProvider > {
 
 			field.error = null;
 		}
+	}
+
+	getAsCartItem(): Record< string, string | boolean | undefined > {
+		const commonFields = {
+			email: `${ this.getFieldValue< string >( FIELD_MAILBOX ) }@${ this.getFieldValue< string >(
+				FIELD_DOMAIN
+			) }`.toLowerCase(),
+			password: this.getFieldValue< string >( FIELD_PASSWORD ),
+		};
+
+		return this.provider === EmailProvider.Google
+			? {
+					...commonFields,
+					firstname: this.getFieldValue< string >( FIELD_FIRSTNAME ),
+					lastname: this.getFieldValue< string >( FIELD_LASTNAME ),
+			  }
+			: {
+					...commonFields,
+					alternative_email: this.getFieldValue< string >( FIELD_ALTERNATIVE_EMAIL ),
+					is_admin: this.getFieldValue< boolean >( FIELD_IS_ADMIN ),
+					name: this.getFieldValue< string >( FIELD_NAME ),
+			  };
 	}
 
 	getFieldValue< R >( fieldName: FormFieldNames ) {
@@ -94,6 +135,10 @@ class MailboxForm< T extends EmailProvider > {
 
 	getIsFieldRequired( fieldName: FormFieldNames ) {
 		return this.getFormField( fieldName )?.isRequired;
+	}
+
+	getIsFieldTouched( fieldName: FormFieldNames ) {
+		return this.getFormField( fieldName )?.isTouched;
 	}
 
 	getIsFieldVisible( fieldName: FormFieldNames ) {
@@ -135,16 +180,20 @@ class MailboxForm< T extends EmailProvider > {
 		}
 	}
 
-	validate() {
+	validate( skipInvisibleFields = false ) {
 		this.clearErrors();
 
 		for ( const [ fieldName, validator ] of this.getValidators() ) {
-			if ( ! fieldName ) {
+			if ( ! fieldName || ! validator ) {
 				continue;
 			}
 
 			const field = this.getFormField( fieldName );
 			if ( ! field || field.error ) {
+				continue;
+			}
+
+			if ( skipInvisibleFields && ! field.isVisible ) {
 				continue;
 			}
 
@@ -165,6 +214,22 @@ class MailboxForm< T extends EmailProvider > {
 		this.getValidators()
 			.filter( ( [ currentFieldName, validator ] ) => currentFieldName === fieldName && validator )
 			.forEach( ( [ , validator ] ) => validator.validate( field ) );
+	}
+
+	async validateOnDemand() {
+		this.clearErrors();
+
+		const promises = Promise.all(
+			Object.values( this.getOnDemandValidators() )
+				.filter(
+					( [ fieldName, validator ] ) => fieldName && this.getFormField( fieldName ) && validator
+				)
+				.map( ( [ fieldName, validator ] ) =>
+					validator.validate( this.getFormField( fieldName as FormFieldNames ) )
+				)
+		);
+
+		await promises;
 	}
 }
 

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -19,7 +19,7 @@ import {
 	AlternateEmailValidator,
 	ExistingMailboxNamesValidator,
 	MailboxNameValidator,
-	MailboxNameValidityValidator,
+	MailboxNameAvailabilityValidator,
 	MaximumStringLengthValidator,
 	PasswordValidator,
 	RequiredIfVisibleValidator,
@@ -86,9 +86,9 @@ class MailboxForm< T extends EmailProvider > {
 		const domainName = domainField?.value ?? '';
 
 		return {
-			[ MailboxNameValidityValidator.name ]: [
+			[ MailboxNameAvailabilityValidator.name ]: [
 				FIELD_MAILBOX,
-				new MailboxNameValidityValidator( domainName, this.provider ),
+				new MailboxNameAvailabilityValidator( domainName, this.provider ),
 			],
 		};
 	}
@@ -187,7 +187,7 @@ class MailboxForm< T extends EmailProvider > {
 		this.clearErrors();
 
 		for ( const [ fieldName, validator ] of this.getValidators() ) {
-			if ( ! fieldName || ! validator ) {
+			if ( ! fieldName ) {
 				continue;
 			}
 

--- a/client/my-sites/email/form/mailboxes/test/validators.ts
+++ b/client/my-sites/email/form/mailboxes/test/validators.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import nock from 'nock';
 import { MailboxForm } from 'calypso/my-sites/email/form/mailboxes';
 import {
 	FIELD_ALTERNATIVE_EMAIL,
@@ -16,6 +17,7 @@ import {
 	AlternateEmailValidator,
 	ExistingMailboxNamesValidator,
 	MailboxNameValidator,
+	MailboxNameValidityValidator,
 	MaximumStringLengthValidator,
 	PasswordValidator,
 	RequiredValidator,
@@ -301,8 +303,7 @@ describe( 'Mailbox form validation', () => {
 						fieldValue = fieldValue.value;
 					}
 
-					const field = Reflect.get( mailboxForm.formFields, key );
-					Reflect.set( field, 'value', fieldValue );
+					mailboxForm.setFieldValue( key as FormFieldNames, fieldValue );
 				}
 			} );
 
@@ -313,8 +314,9 @@ describe( 'Mailbox form validation', () => {
 					return;
 				}
 
-				const field = Reflect.get( mailboxForm.formFields, key );
-				expect( field.error ).toEqual( expectedFieldErrorMap[ key ] );
+				expect( mailboxForm.getFieldError( key as FormFieldNames ) ).toEqual(
+					expectedFieldErrorMap[ key ]
+				);
 			} );
 
 			const fieldErrorMap = Object.fromEntries(
@@ -325,6 +327,97 @@ describe( 'Mailbox form validation', () => {
 
 			expect( fieldErrorMap ).toStrictEqual( expectedFieldErrorMap );
 			expect( mailboxForm.hasErrors() ).toBe( Object.keys( expectedFieldErrorMap ).length > 0 );
+		}
+	);
+} );
+
+describe( 'Mailbox on demand form validation', () => {
+	const finalTestDataForOnDemandCases = [
+		provideGoogleTestData(
+			'Availability tests for not-existing mailbox names should pass for Google',
+			createTestDataForTitan( {
+				[ FIELD_MAILBOX ]: 'not-existing',
+			} ),
+			{
+				[ FIELD_MAILBOX ]: null,
+			}
+		),
+		provideGoogleTestData(
+			'Availability tests for existing mailbox names should pass for Google',
+			createTestDataForTitan( {
+				[ FIELD_MAILBOX ]: 'existing',
+			} ),
+			{
+				[ FIELD_MAILBOX ]: null,
+			}
+		),
+		provideTitanTestData(
+			'Availability tests for not-existing mailbox names should pass for Titan',
+			createTestDataForTitan( {
+				[ FIELD_MAILBOX ]: 'not-existing',
+			} ),
+			{
+				[ FIELD_MAILBOX ]: null,
+			}
+		),
+		provideTitanTestData(
+			'Availability tests for existing mailbox names should fail for Titan',
+			createTestDataForTitan( {
+				[ FIELD_MAILBOX ]: 'existing',
+			} ),
+			{
+				[ FIELD_MAILBOX ]: MailboxNameValidityValidator.getUnavailableMailboxError(
+					'existing',
+					'existing exists as email account'
+				),
+			}
+		),
+	];
+
+	beforeAll( () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( `/wpcom/v2/emails/titan/example.com/check-mailbox-availability/existing` )
+			.reply( 409, { message: 'existing exists as email account' } )
+			.get( `/wpcom/v2/emails/titan/example.com/check-mailbox-availability/not-existing` )
+			.reply( 200, { message: 'OK' } );
+	} );
+
+	afterAll( () => {
+		nock.cleanAll();
+	} );
+
+	it.each( finalTestDataForOnDemandCases )(
+		'$title',
+		async ( { provider, fieldValueMap, expectedFieldErrorMap } ) => {
+			const mailboxForm = new MailboxForm( provider, 'example.com' );
+
+			Object.keys( fieldValueMap ).forEach( ( key ) => {
+				if ( Reflect.has( mailboxForm.formFields, key ) ) {
+					let fieldValue = fieldValueMap[ key ];
+
+					if ( fieldValue && typeof fieldValue === 'object' ) {
+						if ( ! fieldValue.value ) {
+							return;
+						}
+
+						fieldValue = fieldValue.value;
+					}
+
+					mailboxForm.setFieldValue( key as FormFieldNames, fieldValue );
+				}
+			} );
+
+			await mailboxForm.validateOnDemand();
+
+			Object.keys( expectedFieldErrorMap ).forEach( ( key ) => {
+				if ( ! Reflect.has( mailboxForm.formFields, key ) ) {
+					return;
+				}
+
+				expect( mailboxForm.getFieldError( key as FormFieldNames ) ).toEqual(
+					expectedFieldErrorMap[ key ]
+				);
+			} );
 		}
 	);
 } );

--- a/client/my-sites/email/form/mailboxes/test/validators.ts
+++ b/client/my-sites/email/form/mailboxes/test/validators.ts
@@ -17,7 +17,7 @@ import {
 	AlternateEmailValidator,
 	ExistingMailboxNamesValidator,
 	MailboxNameValidator,
-	MailboxNameValidityValidator,
+	MailboxNameAvailabilityValidator,
 	MaximumStringLengthValidator,
 	PasswordValidator,
 	RequiredValidator,
@@ -366,7 +366,7 @@ describe( 'Mailbox on demand form validation', () => {
 				[ FIELD_MAILBOX ]: 'existing',
 			} ),
 			{
-				[ FIELD_MAILBOX ]: MailboxNameValidityValidator.getUnavailableMailboxError(
+				[ FIELD_MAILBOX ]: MailboxNameAvailabilityValidator.getUnavailableMailboxError(
 					'existing',
 					'existing exists as email account'
 				),

--- a/client/my-sites/email/form/mailboxes/types.ts
+++ b/client/my-sites/email/form/mailboxes/types.ts
@@ -20,8 +20,10 @@ enum EmailProvider {
 }
 
 interface MailboxFormField< Type > {
+	dispatchState: () => void;
 	error: FieldError;
 	isRequired: boolean;
+	isTouched: boolean;
 	isVisible: boolean;
 	readonly typeName: string;
 	value: Type;
@@ -43,9 +45,14 @@ abstract class MailboxFormFieldBase< T > implements MailboxFormField< T > {
 
 	value!: T;
 	isRequired;
+	isTouched = false;
 	isVisible = true;
 	fieldName: FormFieldNames;
 	readonly typeName = String.name.toLowerCase();
+
+	dispatchState = (): void => {
+		return;
+	};
 
 	constructor( fieldName: FormFieldNames, isRequired = true ) {
 		this.fieldName = fieldName;

--- a/client/my-sites/email/form/mailboxes/validators.ts
+++ b/client/my-sites/email/form/mailboxes/validators.ts
@@ -281,7 +281,7 @@ class ExistingMailboxNamesValidator extends BaseValidator< string > {
 	}
 }
 
-class MailboxNameValidityValidator extends BaseValidator< string > {
+class MailboxNameAvailabilityValidator extends BaseValidator< string > {
 	private readonly domainName: string;
 	private readonly provider: EmailProvider;
 
@@ -343,7 +343,10 @@ class MailboxNameValidityValidator extends BaseValidator< string > {
 
 		// If mailbox name is not available ...
 		if ( status !== 200 ) {
-			field.error = MailboxNameValidityValidator.getUnavailableMailboxError( field.value, message );
+			field.error = MailboxNameAvailabilityValidator.getUnavailableMailboxError(
+				field.value,
+				message
+			);
 		}
 	}
 }
@@ -354,7 +357,7 @@ export {
 	AlternateEmailValidator,
 	ExistingMailboxNamesValidator,
 	MailboxNameValidator,
-	MailboxNameValidityValidator,
+	MailboxNameAvailabilityValidator,
 	PasswordValidator,
 	RequiredValidator,
 	RequiredIfVisibleValidator,

--- a/client/my-sites/email/form/mailboxes/validators.ts
+++ b/client/my-sites/email/form/mailboxes/validators.ts
@@ -1,6 +1,8 @@
 import emailValidator from 'email-validator';
 import i18n from 'i18n-calypso';
-import React from 'react';
+import { createElement } from 'react';
+import wp from 'calypso/lib/wp';
+import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import type { FieldError, MailboxFormFieldBase } from 'calypso/my-sites/email/form/mailboxes/types';
 
 interface Validator< T > {
@@ -75,9 +77,9 @@ class MaximumStringLengthValidator extends BaseValidator< string > {
 }
 
 class MailboxNameValidator extends BaseValidator< string > {
-	areApostrophesSupported: boolean;
-	domainName: string;
-	mailboxHasDomainError: boolean;
+	private readonly areApostrophesSupported: boolean;
+	private readonly domainName: string;
+	private readonly mailboxHasDomainError: boolean;
 
 	constructor(
 		domainName: string,
@@ -126,7 +128,7 @@ class MailboxNameValidator extends BaseValidator< string > {
 }
 
 class AlternateEmailValidator extends BaseValidator< string > {
-	domainName: string;
+	private readonly domainName: string;
 
 	constructor( domainName: string ) {
 		super();
@@ -145,7 +147,7 @@ class AlternateEmailValidator extends BaseValidator< string > {
 					domain: domainName,
 				},
 				components: {
-					strong: React.createElement( 'strong' ),
+					strong: createElement( 'strong' ),
 				},
 			}
 		);
@@ -252,7 +254,7 @@ class PasswordValidator extends BaseValidator< string > {
 }
 
 class ExistingMailboxNamesValidator extends BaseValidator< string > {
-	existingMailboxNames: string[];
+	private readonly existingMailboxNames: string[];
 
 	constructor( existingMailboxNames: string[] ) {
 		super();
@@ -279,12 +281,80 @@ class ExistingMailboxNamesValidator extends BaseValidator< string > {
 	}
 }
 
+class MailboxNameValidityValidator extends BaseValidator< string > {
+	private readonly domainName: string;
+	private readonly provider: EmailProvider;
+
+	constructor( domainName: string, provider: EmailProvider ) {
+		super();
+		this.domainName = domainName;
+		this.provider = provider;
+	}
+
+	static getUnavailableMailboxError( mailboxName: string, message: string ): FieldError {
+		return i18n.translate( '{{strong}}%(mailbox)s{{/strong}} is not available: %(message)s', {
+			comment:
+				'%(mailbox)s is the local part of an email address. %(message)s is a translated message that gives context to why the mailbox is not available',
+			args: {
+				mailbox: mailboxName,
+				message,
+			},
+			components: {
+				strong: createElement( 'strong' ),
+			},
+		} );
+	}
+
+	async checkMailboxAvailability( domain: string, mailbox: string ) {
+		try {
+			const encDomain = encodeURIComponent( domain );
+			const encMailbox = encodeURIComponent( mailbox );
+			const response = await wp.req.get( {
+				path: `/emails/titan/${ encDomain }/check-mailbox-availability/${ encMailbox }`,
+				apiNamespace: 'wpcom/v2',
+			} );
+			return { message: response.message, status: 200 };
+		} catch ( error: any ) {
+			return { message: error?.message, status: error?.statusCode };
+		}
+	}
+
+	async validate( field?: MailboxFormFieldBase< string > ) {
+		if ( ! field || field.hasError() ) {
+			return;
+		}
+
+		await this.validateField( field );
+	}
+
+	async validateField( field: MailboxFormFieldBase< string > ) {
+		// Google has no mailbox name validator at this time
+		if ( this.provider === EmailProvider.Google ) {
+			return;
+		}
+
+		// There's nothing to validate if the field has no value
+		if ( ! field.value ) {
+			return;
+		}
+
+		// Check that this mailbox name is available against the domain
+		const { message, status } = await this.checkMailboxAvailability( this.domainName, field.value );
+
+		// If mailbox name is not available ...
+		if ( status !== 200 ) {
+			field.error = MailboxNameValidityValidator.getUnavailableMailboxError( field.value, message );
+		}
+	}
+}
+
 export type { Validator };
 
 export {
 	AlternateEmailValidator,
 	ExistingMailboxNamesValidator,
 	MailboxNameValidator,
+	MailboxNameValidityValidator,
 	PasswordValidator,
 	RequiredValidator,
 	RequiredIfVisibleValidator,


### PR DESCRIPTION
Add new validator function and tests.
#### Proposed Changes

* Adds `MailboxNameValidityValidator` validator, responsible for checking that potential mailbox names are valid while the user's on the form
* Adds a new boolean `isTouched` state to mailbox fields to mark mostly when the `onBlur` event has been fired over a field.
* Adds unit tests for the new validator

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There are no visible changes. Unit tests can be started thus:

`yarn test-client --testPathPattern=client/my-sites/email/form`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64343. This is actually split out from that PR to make this one smaller.
