### PR TITLE
Add a link on the checkmark when there are no plugins updates

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -172,10 +172,8 @@ const getLinks = (
 			break;
 		}
 		case 'plugin': {
-			if ( status === 'warning' ) {
-				link = `https://wordpress.com/plugins/updates/${ siteUrl }`;
-				isExternalLink = true;
-			}
+			link = `https://wordpress.com/plugins/updates/${ siteUrl }`;
+			isExternalLink = true;
 			break;
 		}
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -94,6 +94,10 @@ const pluginEventNames: StatusEventNames = {
 		small_screen: 'calypso_jetpack_agency_dashboard_update_plugins_click_small_screen',
 		large_screen: 'calypso_jetpack_agency_dashboard_update_plugins_click_large_screen',
 	},
+	success: {
+		small_screen: 'calypso_jetpack_agency_dashboard_plugin_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_plugin_click_large_screen',
+	},
 };
 
 // Returns event name needed for all the feature state clicks on the agency dashboard


### PR DESCRIPTION
#### Proposed Changes

* This PR adds a link to the plugin updates when there are no plugin updates available

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/add-link-to-plugin-update-when-no-updates` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard.
3. Click on the checkmark on the Plugin Updates column, and verify that you are being redirected to https://wordpress.com/plugins/updates/:site in a new tab.

Note - Add a new site using JN if you don't have any site with no updates

<img width="309" alt="Screenshot 2022-06-06 at 6 58 59 PM" src="https://user-images.githubusercontent.com/10586875/172170052-68ed8315-0cfa-409c-9ad8-0738c6bf649b.png">

Related to 1202076982646589-as-1202396957069337