### PR TITLE
Fix Cancellation Flow survey dropdown padding

### DIFF
--- a/client/components/blank-canvas/style.scss
+++ b/client/components/blank-canvas/style.scss
@@ -54,7 +54,7 @@
 		.components-text-control__input,
 		.components-textarea-control__input {
 			background-color: var( --studio-white );
-			padding: 0.75rem 1rem;
+			padding: 0 1rem;
 			box-sizing: border-box;
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* The cancellation flow survey currently adds a top and bottom padding that makes the dropdown value to appear hidden. Here's how it looks:

### BEFORE

#### DESKTOP

<img width="695" alt="Screenshot 2022-06-06 at 5 35 10 PM" src="https://user-images.githubusercontent.com/1269602/172171213-be39821b-6bce-4d57-912c-00a2f18bf4b6.png">

#### MOBILE

<img width="324" alt="Screenshot 2022-06-06 at 5 38 14 PM" src="https://user-images.githubusercontent.com/1269602/172171727-2485cf3d-bd19-4aac-9e01-14bbb02b0099.png">


After the fix, here's how it looks:

### AFTER

#### DESKTOP
<img width="656" alt="Screenshot 2022-06-06 at 5 37 04 PM" src="https://user-images.githubusercontent.com/1269602/172171478-db39181f-1e9a-4c61-b9f7-c2434808e686.png">

#### MOBILE

<img width="345" alt="Screenshot 2022-06-06 at 5 39 22 PM" src="https://user-images.githubusercontent.com/1269602/172171895-2ad7f4c8-c039-4a92-af62-dfeaaf1f6b79.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a site with a paid plan, go to `/me/purchases` and cancel the plan.
* In the cancellation survey that follows, verify that the dropdown CSS issue reported above is fixed.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


