### PR TITLE
CI: Update the format used for Slack notifier feature on Pre-Release Tests.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -775,8 +775,11 @@ object PreReleaseE2ETests : E2EBuildType(
 			notifierSettings = slackNotifier {
 				connection = "PROJECT_EXT_11"
 				sendTo = "#e2eflowtesting-notif"
-				messageFormat = simpleMessageFormat()
+				messageFormat = verboseMessageFormat {
+					addStatusText = true
+				}
 			}
+			branchFilter = "+:<default>"
 			buildFailedToStart = true
 			buildFailed = true
 			buildFinishedSuccessfully = true


### PR DESCRIPTION
#### Proposed Changes

This PR modifies the formatting of notifications sent by the Pre-Release Tests on Slack.

The changes are meant to improve the legibility of the notifications, which currently lack context on the branch or the kind of failure:

![](https://user-images.githubusercontent.com/6549265/171694172-afb8c67f-4162-4d11-a937-90e332b5aaff.png)

Key changes:
- change to a verbose message format;
- add the status text;
- filter to just the default branch;

#### Testing Instructions

None.

Closes https://github.com/Automattic/wp-calypso/issues/64304.