### PR TITLE
Woo on Stepper: Add placeholder verify email step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -27,6 +27,7 @@ export { default as wooInstallPlugins } from './woo-install-plugins';
 export { default as processing } from './processing-step';
 export { default as error } from './error-step';
 export { default as wooConfirm } from './woo-confirm';
+export { default as wooVerifyEmail } from './woo-verify-email';
 
 export type StepPath =
 	| 'courses'
@@ -57,4 +58,5 @@ export type StepPath =
 	| 'wooTransfer'
 	| 'wooInstallPlugins'
 	| 'error'
-	| 'wooConfirm';
+	| 'wooConfirm'
+	| 'wooVerifyEmail';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-verify-email/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-verify-email/index.tsx
@@ -1,0 +1,36 @@
+import { StepContainer } from '@automattic/onboarding';
+import FormattedHeader from 'calypso/components/formatted-header';
+import type { Step } from '../../types';
+
+const WooVerifyEmail: Step = function WooVerifyEmail( { navigation } ) {
+	const { goBack } = navigation;
+
+	function recordTracksEvent() {
+		return true;
+	}
+
+	function getContent() {
+		return <div>Content</div>;
+	}
+
+	return (
+		<StepContainer
+			stepName={ 'woo-verify-email' }
+			goBack={ goBack }
+			hideSkip
+			isHorizontalLayout={ true }
+			formattedHeader={
+				<FormattedHeader
+					id={ 'woo-verify-email' }
+					headerText={ "You're all set Vini!" }
+					subHeaderText={ '' }
+					align={ 'left' }
+				/>
+			}
+			stepContent={ getContent() }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default WooVerifyEmail;

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -53,6 +53,7 @@ export const siteSetupFlow: Flow = {
 			'error',
 			'wooTransfer',
 			'wooInstallPlugins',
+			...( isEnabled( 'signup/woo-verify-email' ) ? [ 'wooVerifyEmail' ] : [] ),
 			'wooConfirm',
 		] as StepPath[];
 	},

--- a/config/development.json
+++ b/config/development.json
@@ -148,6 +148,7 @@
 		"signup/site-vertical-step": true,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
+		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -96,6 +96,7 @@
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": true,
 		"signup/stepper-flow": true,
+		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/production.json
+++ b/config/production.json
@@ -110,6 +110,7 @@
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,
 		"signup/stepper-flow": true,
+		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -110,6 +110,7 @@
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,
 		"signup/stepper-flow": true,
+		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,6 +119,7 @@
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,
 		"signup/stepper-flow": true,
+		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,


### PR DESCRIPTION
Adds placeholder step for WC verify email.

#### Testing
1. Apply this PR.
2. Go to `http://calypso.localhost:3000/setup/wooVerifyEmail?siteSlug=[YOUR_SITE]&flags=signup/woo-verify-email`
3. Verify you see this:
<img width="1243" alt="image" src="https://user-images.githubusercontent.com/375980/172231020-50894a27-1d55-455b-8d69-8992be50d046.png">
4. Go to `http://calypso.localhost:3000/setup/wooVerifyEmail?siteSlug=[YOUR_SITE]` and verify you can't access the step.


Closes https://github.com/Automattic/wp-calypso/issues/64159