### PR TITLE
atomic eligibility-warnings: Add more detailed message for excessive disk space

### DIFF
--- a/client/blocks/eligibility-warnings/excessive-disk-space.tsx
+++ b/client/blocks/eligibility-warnings/excessive-disk-space.tsx
@@ -1,0 +1,20 @@
+import { localize, LocalizeProps } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import PlanStorage from 'calypso/blocks/plan-storage';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const ExcessiveDiskSpace = ( { translate }: { translate: LocalizeProps[ 'translate' ] } ) => {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	return (
+		<div>
+			{ translate( "Your site's disk usage exceeds the amount provided by its plan." ) }
+			<div className="eligibility-warnings__plan-storage-wrapper">
+				<PlanStorage siteId={ selectedSiteId }>{ null }</PlanStorage>
+			</div>
+			{ translate(
+				'Please purchase a plan with additional storage or contact our support team for help.'
+			) }
+		</div>
+	);
+};
+export default localize( ExcessiveDiskSpace );

--- a/client/blocks/eligibility-warnings/excessive-disk-space.tsx
+++ b/client/blocks/eligibility-warnings/excessive-disk-space.tsx
@@ -21,7 +21,7 @@ const ExcessiveDiskSpace = ( { translate }: { translate: LocalizeProps[ 'transla
 
 	return (
 		<div>
-			{ translate( 'Your site does not have enough free disk space.' ) }
+			{ translate( 'Your site does not have enough free storage space.' ) }
 			<div className="eligibility-warnings__plan-storage-wrapper">
 				<PlanStorage siteId={ selectedSiteId }>{ null }</PlanStorage>
 			</div>

--- a/client/blocks/eligibility-warnings/excessive-disk-space.tsx
+++ b/client/blocks/eligibility-warnings/excessive-disk-space.tsx
@@ -21,7 +21,7 @@ const ExcessiveDiskSpace = ( { translate }: { translate: LocalizeProps[ 'transla
 
 	return (
 		<div>
-			{ translate( "Your site's disk usage exceeds the amount provided by its plan." ) }
+			{ translate( 'Your site does not have enough free disk space.' ) }
 			<div className="eligibility-warnings__plan-storage-wrapper">
 				<PlanStorage siteId={ selectedSiteId }>{ null }</PlanStorage>
 			</div>

--- a/client/blocks/eligibility-warnings/excessive-disk-space.tsx
+++ b/client/blocks/eligibility-warnings/excessive-disk-space.tsx
@@ -21,7 +21,7 @@ const ExcessiveDiskSpace = ( { translate }: { translate: LocalizeProps[ 'transla
 
 	return (
 		<div>
-			{ translate( 'Your site does not have enough free storage space.' ) }
+			{ translate( 'Your site does not have enough available storage space.' ) }
 			<div className="eligibility-warnings__plan-storage-wrapper">
 				<PlanStorage siteId={ selectedSiteId }>{ null }</PlanStorage>
 			</div>

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -86,7 +86,7 @@ function getHoldMessages(
 			supportUrl: null,
 		},
 		EXCESSIVE_DISK_SPACE: {
-			title: translate( 'Purchase or free up storage', {
+			title: translate( 'Increase storage space', {
 				comment:
 					'Message displayed when a Simple site cannot be transferred to Atomic because there is not enough disk space. It appears after the heading "To continue you\'ll need to: ", inside a list with actions to perform in order to proceed with the transfer.',
 			} ),

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -86,8 +86,10 @@ function getHoldMessages(
 			supportUrl: null,
 		},
 		EXCESSIVE_DISK_SPACE: {
-			// translators: "Meet disk quota" appears just after "To continue you'll need to: "
-			title: translate( 'Meet disk quota' ),
+			title: translate( 'Purchase or free up storage', {
+				comment:
+					'Message displayed when a Simple site cannot be transferred to Atomic because there is not enough disk space. It appears after the heading "To continue you\'ll need to: ", inside a list with actions to perform in order to proceed with the transfer.',
+			} ),
 			description: <ExcessiveDiskSpace />,
 			supportUrl: localizeUrl( 'https://wordpress.com/help/contact' ),
 		},

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { map } from 'lodash';
 import { useSelector } from 'react-redux';
+import ExcessiveDiskSpace from 'calypso/blocks/eligibility-warnings/excessive-disk-space';
 import CardHeading from 'calypso/components/card-heading';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
@@ -85,10 +86,8 @@ function getHoldMessages(
 			supportUrl: null,
 		},
 		EXCESSIVE_DISK_SPACE: {
-			title: translate( 'Upload not available' ),
-			description: translate(
-				'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
-			),
+			title: translate( 'Meet disk quota' ),
+			description: <ExcessiveDiskSpace />,
 			supportUrl: localizeUrl( 'https://wordpress.com/help/contact' ),
 		},
 	};

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -86,6 +86,7 @@ function getHoldMessages(
 			supportUrl: null,
 		},
 		EXCESSIVE_DISK_SPACE: {
+			// translators: "Meet disk quota" appears just after "To continue you'll need to: "
 			title: translate( 'Meet disk quota' ),
 			description: <ExcessiveDiskSpace />,
 			supportUrl: localizeUrl( 'https://wordpress.com/help/contact' ),

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -120,3 +120,9 @@
 .eligibility-warnings__hold-list-dim .eligibility-warnings__hold {
 	opacity: 0.2;
 }
+
+.eligibility-warnings__plan-storage-wrapper {
+	margin-top: 20px;
+	margin-bottom: 20px;
+	max-width: 300px;
+}


### PR DESCRIPTION
#### Proposed Changes

* When trying to transfer a site to atomic ("activate hosting features"), if it has excessive disk space preventing the transfer, provide a more detailed error message

**Before this PR**
![2022-06-06_15-34](https://user-images.githubusercontent.com/937354/172244217-1e7c1582-4793-4f00-a16f-d4893b570166.png)

**After this PR**
![2022-06-06_15-34_1](https://user-images.githubusercontent.com/937354/172244198-d8720223-4a26-4530-a9e9-52e6e5426dfe.png)

#### Mechanism/Considerations

First, I was considering having the eligibility endpoint also send the used/allowed space numbers:
![2022-06-06_15-36](https://user-images.githubusercontent.com/937354/172245164-2af7c67d-914b-43c4-b349-92c125d2179b.png)

But that information is already available via the media storage endpoint, used by the media library.


I did a quick wrapper of the media storage endpoint storage progress bar for this message:
![2022-06-06_15-41](https://user-images.githubusercontent.com/937354/172245361-d39ad12b-07e4-4845-8557-952b180773f8.png)

I realize it's not really a perfect match for this message, but I included it because it has [pro-plan specific logic](https://github.com/Automattic/wp-calypso/blob/889b30d3bb7292c861dd3af9b61e32a40a4d690f/client/blocks/plan-storage/index.jsx#L51-L72) that is not anywhere else, and I did not want to duplicate it.

Note that the wording is technically incorrect if the user is using 97% of their allowed space, and we require 94% or less. Not sure how to elegantly word this?

#### Testing Instructions


* Have an atomic capable site
* Sandbox API and hack the sandbox to think that all sites have excessive disk usage

```diff
diff --git a/wp-content/lib/atomic/woa.php b/wp-content/lib/atomic/woa.php
index 987f3b35a..accb4928e 100644
--- a/wp-content/lib/atomic/woa.php
+++ b/wp-content/lib/atomic/woa.php
@@ -2269,6 +2269,7 @@ function woa_unsuspend( $blog_id ) {
  * @return bool If disk usage is excessive and the site should not be transferred.
  */
 function woa_is_space_used_excessive( $blog_id ) {
+       return true;
        // The value returned by get_space_used_bytes() excludes transcoded media files, but includes the original media.
        $disk_space_used = get_space_used_bytes( $blog_id );
        if ( $disk_space_used > 150 * GB_IN_BYTES ) {
```

* Visit `http://calypso.localhost:3000/hosting-config/activate/<site>` and try to transfer to atomic
* To fake disk usage amounts, change the media storage endpoint:

```diff
diff --git a/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-media-storage-endpoint.php b/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-media-storage-endpoint.php
index 015c236c8..3ef4a7dc6 100644
--- a/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-media-storage-endpoint.php
+++ b/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-media-storage-endpoint.php
@@ -62,6 +62,7 @@ class WPCOM_JSON_API_Media_Storage_Endpoint extends WPCOM_JSON_API_Endpoint {
                        }
                }
 
+               $storage_used_bytes = 60 * 1024 * 1024 * 1024;
                return array(
                        'max_storage_bytes'  => $is_unlimited ? -1 : $max_storage_megabytes * 1024 * 1024,
                        'storage_used_bytes' => $storage_used_bytes,
```

Related to #
