### PR TITLE
Fix overflowing site action popover & disable a few actions when the site is down

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -66,7 +66,7 @@ export default function SiteActions( {
 				context={ buttonActionRef.current }
 				isVisible={ isOpen }
 				onClose={ closeDropdown }
-				position="bottom"
+				position="bottom left"
 			>
 				{ ! siteError && (
 					<>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -308,6 +308,7 @@ const formatMonitorData = ( site: SiteData ) => {
 	} else if ( ! site.monitor_site_status ) {
 		monitor.status = 'failed';
 		monitor.value = translate( 'Site Down' );
+		monitor.error = true;
 	} else {
 		monitor.status = 'success';
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR fixes a couple of issues with the agency dashboard
- Overflowing site action by using the bottom left position for the popover.
- Disable actions when the site is down.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/fix-agency-dashboard-cft-bugs` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard.
3. Click on `...`, verify that the popover is not at the extreme right of the screen
4. Verify only actions like `Visit Site` & `Visit WP Admin` are shown and row value clicks are disabled when the site is down.

<img width="784" alt="Screenshot 2022-06-07 at 1 46 04 PM" src="https://user-images.githubusercontent.com/10586875/172331278-5bb68bdc-d045-406b-b176-d943ce60bf30.png">

Related to 1202076982646589-as-1202402905764743 & 1202076982646589-as-1202402905764748