### PR TITLE
Show domain name when the site is already selected in assign license flow

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -30,7 +30,6 @@ import {
 } from 'calypso/state/partner-portal/partner/selectors';
 import { ToSConsent } from 'calypso/state/partner-portal/types';
 import getSites from 'calypso/state/selectors/get-sites';
-import getSitesItems from 'calypso/state/selectors/get-sites-items';
 import Header from './header';
 import type PageJS from 'page';
 
@@ -85,14 +84,15 @@ export function licensesContext( context: PageJS.Context, next: () => void ): vo
 }
 
 export function issueLicenseContext( context: PageJS.Context, next: () => void ): void {
-	const { site_id: siteId, product_slug: productSlug } = context.query;
+	const { site_id: siteId, product_slug: suggestedProduct } = context.query;
 	const state = context.store.getState();
-	const sites = getSitesItems( state );
-	const selectedSite = sites[ siteId ] ? siteId : null;
-
+	const sites = getSites( state );
+	const selectedSite = siteId ? sites.find( ( site ) => site?.ID === parseInt( siteId ) ) : null;
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
-	context.primary = <IssueLicense selectedSite={ selectedSite } productSlug={ productSlug } />;
+	context.primary = (
+		<IssueLicense selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />
+	);
 	next();
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-form/index.tsx
@@ -39,14 +39,17 @@ export default function IssueLicenseForm( {
 	const products = useProductsQuery( {
 		select: alphabeticallySortedProductOptions,
 	} );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
 
 	const assignLicense = useAssignLicenseMutation( {
 		onSuccess: ( license: any ) => {
+			setIsSubmitting( false );
 			page.redirect(
 				addQueryArgs( { highlight: license.license_key }, '/partner-portal/licenses' )
 			);
 		},
 		onError: ( error: Error ) => {
+			setIsSubmitting( false );
 			dispatch( errorNotice( error.message ) );
 		},
 	} );
@@ -56,6 +59,7 @@ export default function IssueLicenseForm( {
 			const licenseKey = license.license_key;
 			const selectedSiteId = selectedSite?.ID;
 			if ( selectedSiteId ) {
+				setIsSubmitting( true );
 				assignLicense.mutate( { licenseKey, selectedSite: selectedSiteId } );
 			} else {
 				page.redirect(
@@ -147,7 +151,7 @@ export default function IssueLicenseForm( {
 								primary
 								className="issue-license-form__select-license"
 								disabled={ ! product }
-								busy={ issueLicense.isLoading }
+								busy={ issueLicense.isLoading || isSubmitting }
 								onClick={ onIssueLicense }
 							>
 								{ translate( 'Select License' ) }

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -6,13 +6,12 @@ import Main from 'calypso/components/main';
 import IssueLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/issue-license-form';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import AssignLicenseStepProgress from '../../assign-license-step-progress';
+import { AssignLicenceProps } from '../../types';
 
-interface Props {
-	selectedSite?: number | null;
-	productSlug?: string | null;
-}
-
-export default function IssueLicense( { selectedSite, productSlug }: Props ): ReactElement {
+export default function IssueLicense( {
+	selectedSite,
+	suggestedProduct,
+}: AssignLicenceProps ): ReactElement {
 	const translate = useTranslate();
 
 	useEffect( () => {
@@ -33,7 +32,7 @@ export default function IssueLicense( { selectedSite, productSlug }: Props ): Re
 			<AssignLicenseStepProgress currentStep={ 1 } />
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
-			<IssueLicenseForm selectedSite={ selectedSite } suggestedProduct={ productSlug } />
+			<IssueLicenseForm selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />
 		</Main>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/types.ts
@@ -21,3 +21,8 @@ export enum LicenseSortDirection {
 	Ascending = 'asc',
 	Descending = 'desc',
 }
+
+export interface AssignLicenceProps {
+	selectedSite?: { ID: number; domain: string } | null;
+	suggestedProduct?: string | null;
+}


### PR DESCRIPTION
#### Proposed Changes

This PR adds the below changes 
- Show the domain name in the assign license flow when the site is already selected.
- Show a loading indicator on the button when the license is being assigned.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/show-site-name-in-assign-license-flow` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard.
4. Click on `+ Add` or `...` -> Issue New License -> Verify that the site URL is shown in the text `Select the Jetpack product you would like to add to {site-url}` on the screen.
5. Click on `Select License`, and verify that a loader is showing until the API request to assign a license is completed.
6. Go back to Dashboard -> Visit Licensing -> Licenses -> Issue New License -> Verify that the text shows `Select the Jetpack product you would like to issue a new license for` on the screen(when the site is not selected) -> Select a product and verify that you are able to issue the license.

Note - we are using `getSites` instead of `getSiteItems` since this doesn't give the domain name.

<img width="1093" alt="Screenshot 2022-06-07 at 12 36 41 PM" src="https://user-images.githubusercontent.com/10586875/172335724-09474e0b-ce4a-4aa9-9b34-f60cdcbea2fc.png">


<img width="235" alt="Screenshot 2022-06-07 at 2 01 14 PM" src="https://user-images.githubusercontent.com/10586875/172334733-75ae1b4d-fe4a-4065-8288-bff4c105590e.png">


Related to 1202076982646589-as-1202395639731519 & 1202076982646589-as-1202402912194287