### PR TITLE
e2e - Remove check for legacy plan notice

### DIFF
--- a/test/e2e/specs/plans/plans__legacy-renew.ts
+++ b/test/e2e/specs/plans/plans__legacy-renew.ts
@@ -9,7 +9,6 @@ import {
 	IndividualPurchasePage,
 	CartCheckoutPage,
 	TestAccount,
-	NoticeComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
@@ -43,12 +42,6 @@ describe( DataHelper.createSuiteTitle( 'Plans (Legacy): Renew' ), function () {
 
 		it( `${ planName } is the active plan`, async function () {
 			await plansPage.validateActivePlan( planTier );
-		} );
-
-		it( 'Legacy plan notice is shown', async function () {
-			const noticeComponent = new NoticeComponent( page );
-			const message = `You’re currently on a legacy plan. If you’d like to learn about your eligibility to switch to a Pro plan please contact support.`;
-			await noticeComponent.noticeShown( message );
 		} );
 	} );
 


### PR DESCRIPTION
#### Proposed Changes

* Removing spec for legacy plan notice in the plans__legacy-renew.ts e2e


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* e2e should pass

Related to https://github.com/Automattic/wp-calypso/pull/64370