### PR TITLE
Generated Design Picker: Fix layout is broken on mobile if we have pre-selected design

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -115,7 +115,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		[ selectedDesign, generatedDesigns, isMobile ]
 	);
 
-	const isPreviewingGeneratedDesign = isMobile && showGeneratedDesigns && selectedDesign;
+	const isPreviewingGeneratedDesign = isMobile && showGeneratedDesigns && !! selectedDesign;
 
 	const visibility = useNewSiteVisibility();
 


### PR DESCRIPTION
#### Proposed Changes

* The `isPreviewingDesign` is initialized with `false` even if we have the pre-selected design. I change to use `selectedDesign` to detect whether the user is previewing the design or not as `isPreviewingDesign` is always true if we have the selected design and is always false if we don't have selected design.
* Putting the condition of the `isLoadingGeneratedDesigns` before rendering the preview of the static design as it also relies on `showGeneratedDesigns`.

https://user-images.githubusercontent.com/13596067/172352293-77615b7e-c100-4a61-89d6-37bd83d3786b.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/designSetup?siteSlug=<your_site>` on desktop resolution
* Click one onf the thumbnails to select the generated design
* Click the “Back” button
* Select intent screen
* Resize the window to the mobile resolution
* You will see the preview of the generated design on mobile and the UI won't be broken.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64401
