### PR TITLE
Hide single site switch in dashboard context

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
@@ -34,7 +34,12 @@ const DashboardSidebar: FunctionComponent< Props > = ( { path } ) => {
 			<SiteSelector showAddNewSite showAllSites allSitesPath={ path } siteBasePath="/backup" />
 			<Sidebar className="sidebar__jetpack-cloud">
 				<SidebarRegion>
-					<CurrentSite />
+					<CurrentSite
+						// Ignore type checking because TypeScript is incorrectly inferring the prop type due to JSX usage in <CurrentSite /> component
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						forceAllSitesView
+					/>
 					<SidebarMenu>
 						<SidebarItem
 							customIcon={ <JetpackIcons icon="dashboard" /> }


### PR DESCRIPTION
#### Proposed Changes

* This PR adds a change that forces the component to hide the single site switch in the dashboard

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/hide-single-site-view-in-agency-dashboard` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard.
3. Click on Switch Site -> Click on any site from the list -> Click on Switch Site -> Click on All My Sites -> Verify that you can see `All My Sites` instead of a single-site switch view

**Before**

<img width="275" alt="Screenshot 2022-06-07 at 4 00 22 PM" src="https://user-images.githubusercontent.com/10586875/172359290-614ec48b-a6e6-469b-a87d-81b7143c37f6.png">

**After**

<img width="272" alt="Screenshot 2022-06-07 at 3 53 24 PM" src="https://user-images.githubusercontent.com/10586875/172357653-d5480799-0aef-433d-a2bf-671c561b56c7.png">

Related to 1202076982646589-as-1202402912194282