### PR TITLE
Components: Refactor `GlobalNotices` tests to `@testing-library/react`

### DIFF
--- a/client/components/global-notices/test/__snapshots__/index.js.snap
+++ b/client/components/global-notices/test/__snapshots__/index.js.snap
@@ -1,15 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<GlobalNotices /> should render notices with the expected structure 1`] = `
-<GlobalNoticesContainer
-  id="overlay-notices"
->
-  <Localized(Notice)
-    key="notice-testing-notice"
-    onDismissClick={[Function]}
-    showDismiss={true}
-    status="is-success"
-    text="A test notice"
-  />
-</GlobalNoticesContainer>
+<div>
+  <div
+    class="global-notices"
+    id="overlay-notices"
+  >
+    <div
+      aria-label="Notice"
+      class="notice is-success is-dismissable"
+      role="status"
+    >
+      <span
+        class="notice__icon-wrapper"
+      >
+        <svg
+          class="gridicon gridicons-checkmark notice__icon"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="gridicons.svg#gridicons-checkmark"
+          />
+        </svg>
+      </span>
+      <span
+        class="notice__content"
+      >
+        <span
+          class="notice__text"
+        >
+          A test notice
+        </span>
+      </span>
+      <button
+        aria-label="Dismiss"
+        class="notice__dismiss"
+      >
+        <svg
+          class="gridicon gridicons-cross"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="gridicons.svg#gridicons-cross"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
 `;

--- a/client/components/global-notices/test/index.js
+++ b/client/components/global-notices/test/index.js
@@ -1,6 +1,9 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import deepFreeze from 'deep-freeze';
-import { shallow } from 'enzyme';
-import Notice from 'calypso/components/notice';
 import { GlobalNotices } from '..';
 
 const baseProps = deepFreeze( {
@@ -12,8 +15,8 @@ beforeEach( jest.clearAllMocks );
 
 describe( '<GlobalNotices />', () => {
 	test( 'should not render without notices', () => {
-		const wrapper = shallow( <GlobalNotices { ...baseProps } /> );
-		expect( wrapper.type() ).toBeNull();
+		const { container } = render( <GlobalNotices { ...baseProps } /> );
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	test( 'should render notices with the expected structure', () => {
@@ -25,11 +28,11 @@ describe( '<GlobalNotices />', () => {
 				text: 'A test notice',
 			},
 		];
-		const wrapper = shallow( <GlobalNotices { ...baseProps } storeNotices={ notices } /> );
-		//expect( wrapper.hasClass( 'global-notices' ) ).toBe( true );
-		expect( wrapper.prop( 'id' ) ).toBe( 'overlay-notices' );
-		expect( wrapper.find( Notice ) ).toHaveLength( 1 );
-		expect( wrapper ).toMatchSnapshot();
+		const { container } = render( <GlobalNotices { ...baseProps } storeNotices={ notices } /> );
+		expect( container.firstChild ).toHaveClass( 'global-notices' );
+		expect( container.firstChild ).toHaveAttribute( 'id', 'overlay-notices' );
+		expect( screen.queryAllByRole( 'status' ) ).toHaveLength( 1 );
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should use provided id', () => {
@@ -41,13 +44,13 @@ describe( '<GlobalNotices />', () => {
 				text: 'A test notice',
 			},
 		];
-		const wrapper = shallow(
+		const { container } = render(
 			<GlobalNotices { ...baseProps } storeNotices={ notices } id="test-id" />
 		);
-		expect( wrapper.prop( 'id' ) ).toBe( 'test-id' );
+		expect( container.firstChild ).toHaveAttribute( 'id', 'test-id' );
 	} );
 
-	test( 'should call dismissals', () => {
+	test( 'should call dismissals', async () => {
 		const notices = [
 			{
 				noticeId: 'testing-notice',
@@ -58,11 +61,9 @@ describe( '<GlobalNotices />', () => {
 			},
 		];
 
-		const wrapper = shallow(
-			<GlobalNotices { ...baseProps } storeNotices={ notices } id="test-id" />
-		);
+		render( <GlobalNotices { ...baseProps } storeNotices={ notices } id="test-id" /> );
 
-		wrapper.find( Notice ).prop( 'onDismissClick' )();
+		await userEvent.click( screen.getByRole( 'button' ) );
 
 		expect( notices[ 0 ].onDismissClick ).toHaveBeenCalledTimes( 1 );
 		expect( baseProps.removeNotice ).toHaveBeenCalledTimes( 1 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `GlobalNotices` component tests to use `@testing-library/react` instead of `enzyme`.

Part of #63409.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/components/global-notices/test/index.js`