### PR TITLE
Jetpack: remove close button in checkout page

### DIFF
--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -80,7 +80,7 @@ const CheckoutMasterbar = ( {
 	return (
 		<Masterbar>
 			<div className="masterbar__secure-checkout">
-				{ isLeavingAllowed && (
+				{ isLeavingAllowed && ! isJetpack && (
 					<Item
 						icon="cross"
 						className="masterbar__close-button"

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -42,6 +42,7 @@ $masterbar-color-secondary: #101517;
 	}
 
 	.is-section-checkout.is-jetpack-site & {
+		padding-left: 8px;
 		background-color: var( --color-jetpack-masterbar-background );
 		border-bottom: 1px solid var( --color-jetpack-masterbar-border );
 		color: var( --color-jetpack-masterbar-text );


### PR DESCRIPTION
**DO NOT MERGE**

Conversation happening here: p1HpG7-gg7-p2

#### Proposed Changes

* Removes close button in checkout page for Jetpack sites.

Related to 1199980337313591-as-1200855424245106

#### Testing Instructions

* Fire up this PR.
* Test all purchase flows for Jetpack sites starting from Jetpack.com, WordPress.com, and wp-admin.
* Ensure the close button is never visible on the checkout page.
* Ensure there's no regression for dotcom or Atomic sites.

#### Screenshots
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/172379776-51934004-3da3-4367-8632-6437a4000954.png) | <img alt="image" src="https://user-images.githubusercontent.com/390760/172379762-526826b5-5dec-45fd-997e-a862654354e1.png">