### PR TITLE
Start Over: Implement user-facing feature that allows a user to delete all their content

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -32,7 +32,6 @@ export const INCOMING_DOMAIN_TRANSFER_SUPPORTED_TLDS = `${ root }/incoming-domai
 export const EDIT_PAYMENT_DETAILS = `${ root }/payment/#edit-payment-details`;
 export const EMAIL_FORWARDING = `${ root }/email-forwarding/`;
 export const EMAIL_VALIDATION_AND_VERIFICATION = `${ root }/domains/register-domain/#email-validation-and-verification`;
-export const EMPTY_SITE = `${ root }/empty-site/`;
 export const FORMS = `${ root }/forms/`;
 export const GDPR_POLICIES = `${ root }/your-site-and-the-gdpr/`;
 export const GSUITE_LEARNING_CENTER = 'https://workspace.google.com/learning-center/';

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -66,7 +66,7 @@ export function disconnectSiteConfirm( context, next ) {
 }
 
 export function startOver( context, next ) {
-	context.primary = <StartOver path={ context.path } />;
+	context.primary = <StartOver path={ context.path } queryParams={ context.query } />;
 	next();
 }
 

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -171,7 +171,7 @@ export default connect(
 			cloneUrl,
 			showChangeAddress: ! isJetpack && ! isVip && ! isP2,
 			showClone: 'active' === rewindState.state && ! isAtomic,
-			showDeleteContent: ! isJetpack && ! isVip && ! isP2Hub,
+			showDeleteContent: ( ! isJetpack || isAtomic ) && ! isVip && ! isP2Hub,
 			showDeleteSite: ( ! isJetpack || isAtomic ) && ! isVip && sitePurchasesLoaded,
 			showManageConnection: isJetpack && ! isAtomic,
 			siteId,

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -1,70 +1,157 @@
-import { Button, Gridicon } from '@automattic/components';
-import { useLocalizeUrl } from '@automattic/i18n-utils';
+import { Card } from '@automattic/components';
+import { CheckboxControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
+import { Component } from 'react';
 import { connect } from 'react-redux';
-import ActionPanel from 'calypso/components/action-panel';
-import ActionPanelBody from 'calypso/components/action-panel/body';
-import ActionPanelFigure from 'calypso/components/action-panel/figure';
-import ActionPanelFooter from 'calypso/components/action-panel/footer';
-import ActionPanelTitle from 'calypso/components/action-panel/title';
+import ExternalLink from 'calypso/components/external-link';
+import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
-import { EMPTY_SITE } from 'calypso/lib/url/support';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-const StartOver = ( { translate, selectedSiteSlug } ) => {
-	const localizeUrl = useLocalizeUrl();
-	return (
-		<div
-			className="main main-column" // eslint-disable-line wpcalypso/jsx-classname-namespace
-			role="main"
-		>
-			<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug }>
-				<h1>{ translate( 'Start Over' ) }</h1>
-			</HeaderCake>
-			<ActionPanel>
-				<ActionPanelBody>
-					<ActionPanelFigure inlineBodyText={ true }>
-						<img src="/calypso/images/wordpress/logo-stars.svg" alt="" width="170" height="143" />
-					</ActionPanelFigure>
-					<ActionPanelTitle>{ translate( 'Start Over' ) }</ActionPanelTitle>
-					<p>
-						{ translate(
-							"If you want a site but don't want any of the posts and pages you have now, our support " +
-								'team can delete your posts, pages, media, and comments for you.'
-						) }
-					</p>
-					<p>
-						{ translate(
-							'This will keep your site and URL active, but give you a fresh start on your content ' +
-								'creation. Just contact us to have your current content cleared out.'
-						) }
-					</p>
-					<p>
-						{ translate(
-							'Alternatively, you can delete all content from your site by following the steps here.'
-						) }
-					</p>
-				</ActionPanelBody>
-				<ActionPanelFooter>
-					<Button
-						className="action-panel__support-button is-external" // eslint-disable-line wpcalypso/jsx-classname-namespace
-						href={ localizeUrl( EMPTY_SITE ) }
-					>
-						{ translate( 'Follow the steps' ) }
-						<Gridicon icon="external" size={ 48 } />
-					</Button>
-					<Button
-						className="action-panel__support-button" // eslint-disable-line wpcalypso/jsx-classname-namespace
-						href="/help/contact"
-					>
-						{ translate( 'Contact support' ) }
-					</Button>
-				</ActionPanelFooter>
-			</ActionPanel>
-		</div>
-	);
-};
+class StartOver extends Component {
+	state = {
+		atomicRevertCheckOne: false,
+		atomicRevertCheckTwo: false,
+		simpleRevertCheckOne: false,
+		simpleRevertCheckTwo: false,
+	};
 
-export default connect( ( state ) => ( {
-	selectedSiteSlug: getSelectedSiteSlug( state ),
-} ) )( localize( StartOver ) );
+	static defaultProps = {
+		atomicTransfer: false,
+	};
+
+	getCheckboxConsent() {
+		const { translate } = this.props;
+		const {
+			atomicRevertCheckOne,
+			atomicRevertCheckTwo,
+			atomicTransfer,
+			simpleRevertCheckOne,
+			simpleRevertCheckTwo,
+		} = this.state;
+
+		if ( atomicTransfer ) {
+			return (
+				<>
+					<CheckboxControl
+						label={ translate(
+							'Any themes/plugins you have installed on the site will be removed, along with their data.'
+						) }
+						checked={ atomicRevertCheckOne }
+						onChange={ ( isChecked ) => this.setState( { atomicRevertCheckOne: isChecked } ) }
+					/>
+					<CheckboxControl
+						label={ translate(
+							'Your site will return to its original settings and theme right before the first plugin or custom theme was installed.'
+						) }
+						checked={ atomicRevertCheckTwo }
+						onChange={ ( isChecked ) => this.setState( { atomicRevertCheckTwo: isChecked } ) }
+					/>
+				</>
+			);
+		}
+
+		return (
+			<>
+				<CheckboxControl
+					label={ translate(
+						'All posts, pages, media, comments, tags, and themes will be deleted.'
+					) }
+					checked={ simpleRevertCheckOne }
+					onChange={ ( isChecked ) => this.setState( { simpleRevertCheckOne: isChecked } ) }
+				/>
+				<CheckboxControl
+					label={ translate(
+						'I understand that there is no way to retrieve my data unless I have downloaded a backup.'
+					) }
+					checked={ simpleRevertCheckTwo }
+					onChange={ ( isChecked ) => this.setState( { simpleRevertCheckTwo: isChecked } ) }
+				/>
+			</>
+		);
+	}
+
+	render() {
+		const atomicTransferDate = null;
+		const { selectedSiteSlug, translate, atomicTransfer } = this.props;
+
+		let subHeaderText;
+
+		if ( atomicTransfer ) {
+			subHeaderText = translate(
+				'After emptying your site, we will return your site back to the point when you installed your first plugin or custom theme or activated hosting features on {{strong}}%(atomicTransferDate)s{{/strong}}. All your posts, pages and media will be deleted.',
+				{
+					args: { atomicTransferDate },
+					components: {
+						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+						strong: <strong className="is-highlighted" />,
+					},
+				}
+			);
+		}
+
+		return (
+			<>
+				<div
+					className="main main-column start-over" // eslint-disable-line wpcalypso/jsx-classname-namespace
+					role="main"
+				>
+					<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug }>Start Over</HeaderCake>
+					<Card>
+						<h1>{ translate( 'Start Over' ) }</h1>
+						<p>
+							{ translate(
+								"If you want a site but don't want any of the posts and pages you have now, " +
+									'then proceed to delete your posts, pages, media, and comments.'
+							) }
+						</p>
+						<p>
+							{ translate(
+								'This will keep your site and URL active, but give you a fresh start on your content ' +
+									'creation.'
+							) }
+						</p>
+					</Card>
+				</div>
+				<div className=" main main-column start-over start-over__confirm">
+					<Card>
+						<FormattedHeader
+							brandFont
+							headerText={ translate( 'Proceed with caution' ) }
+							subHeaderText={ subHeaderText }
+						/>
+						<p>
+							{ translate(
+								'Please {{strong}}confirm and check{{/strong}} the following items before you continue with emptying your site:',
+								{ components: { strong: <strong /> } }
+							) }
+						</p>
+						{ this.getCheckboxConsent() }
+
+						<div className="start-over__backups">
+							<h4>{ translate( 'Would you like to download the backup of your site?' ) }</h4>
+							<p>
+								{ translate(
+									'If you change your mind later or want to secure your data, you can download a backup.'
+								) }
+							</p>
+							<ExternalLink icon href={ `/backup/${ selectedSiteSlug }` }>
+								{ translate( 'Go to your backups' ) }
+							</ExternalLink>
+						</div>
+					</Card>
+				</div>
+			</>
+		);
+	}
+}
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+		atomicTransfer: getAtomicTransfer( state, siteId ),
+	};
+} )( localize( StartOver ) );

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -6,16 +6,17 @@ import { connect } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import wpcom from 'calypso/lib/wp';
+import { fetchAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
 import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 class StartOver extends Component {
 	state = {
-		atomicRevertCheckOne: false,
-		atomicRevertCheckTwo: false,
-		simpleRevertCheckOne: false,
-		simpleRevertCheckTwo: false,
+		checkOne: false,
+		checkTwo: false,
 		isEmptyButtonBusy: false,
 	};
 
@@ -23,17 +24,24 @@ class StartOver extends Component {
 		atomicTransfer: false,
 	};
 
-	getCheckboxConsent() {
+	componentDidMount() {
+		const { siteId } = this.props;
+
+		if ( this.props.isAtomicSite && siteId ) {
+			this.props.fetchAtomicTransfer( siteId );
+		}
+	}
+
+	getCheckboxContent( hasAtomicTransferCompleted = false ) {
 		const { selectedSiteSlug, translate } = this.props;
 		const {
 			atomicRevertCheckOne,
 			atomicRevertCheckTwo,
-			atomicTransfer,
 			simpleRevertCheckOne,
 			simpleRevertCheckTwo,
 		} = this.state;
 
-		if ( atomicTransfer ) {
+		if ( hasAtomicTransferCompleted ) {
 			return (
 				<>
 					<CheckboxControl
@@ -42,7 +50,7 @@ class StartOver extends Component {
 							'Any themes/plugins you have installed on the site will be removed, along with their data.'
 						) }
 						checked={ atomicRevertCheckOne }
-						onChange={ ( isChecked ) => this.setState( { atomicRevertCheckOne: isChecked } ) }
+						onChange={ ( isChecked ) => this.setState( { checkOne: isChecked } ) }
 					/>
 					<CheckboxControl
 						className="start-over__checkbox-container"
@@ -50,7 +58,7 @@ class StartOver extends Component {
 							'Your site will return to its original settings and theme right before the first plugin or custom theme was installed.'
 						) }
 						checked={ atomicRevertCheckTwo }
-						onChange={ ( isChecked ) => this.setState( { atomicRevertCheckTwo: isChecked } ) }
+						onChange={ ( isChecked ) => this.setState( { checkTwo: isChecked } ) }
 					/>
 				</>
 			);
@@ -71,7 +79,7 @@ class StartOver extends Component {
 						}
 					) }
 					checked={ simpleRevertCheckOne }
-					onChange={ ( isChecked ) => this.setState( { simpleRevertCheckOne: isChecked } ) }
+					onChange={ ( isChecked ) => this.setState( { checkOne: isChecked } ) }
 				/>
 				<CheckboxControl
 					className="start-over__checkbox-container"
@@ -79,7 +87,7 @@ class StartOver extends Component {
 						'I understand that there is no way to retrieve my data unless I have downloaded a backup.'
 					) }
 					checked={ simpleRevertCheckTwo }
-					onChange={ ( isChecked ) => this.setState( { simpleRevertCheckTwo: isChecked } ) }
+					onChange={ ( isChecked ) => this.setState( { checkTwo: isChecked } ) }
 				/>
 			</>
 		);
@@ -107,34 +115,76 @@ class StartOver extends Component {
 		window.location.href = currentPageUrl.toString();
 	};
 
-	render() {
-		const atomicTransferDate = null;
-		const { selectedSiteSlug, translate, atomicTransfer } = this.props;
-		const {
-			atomicRevertCheckOne,
-			atomicRevertCheckTwo,
-			simpleRevertCheckOne,
-			simpleRevertCheckTwo,
-			isEmptyButtonBusy,
-		} = this.state;
-		let canClickEmptyButton;
-		let subHeaderText;
+	getSubheaderText( hasAtomicTransferCompleted = false ) {
+		const { atomicTransfer, moment, translate } = this.props;
+		const atomicTransferDate = moment( atomicTransfer.created_at ).format( 'LL' );
 
-		if ( Object.keys( atomicTransfer ).length ) {
-			canClickEmptyButton = atomicRevertCheckOne && atomicRevertCheckTwo;
-			subHeaderText = translate(
-				'After emptying your site, we will return your site back to the point when you installed your first plugin or custom theme or activated hosting features on {{strong}}%(atomicTransferDate)s{{/strong}}. All your posts, pages and media will be deleted.',
-				{
-					args: { atomicTransferDate },
-					components: {
-						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-						strong: <strong className="is-highlighted" />,
-					},
-				}
-			);
-		} else {
-			canClickEmptyButton = simpleRevertCheckOne && simpleRevertCheckTwo;
+		if ( ! hasAtomicTransferCompleted ) {
+			return;
 		}
+
+		return translate(
+			'After emptying your site, we will return your site back to the point when you installed your first plugin or custom theme or activated hosting features on {{strong}}%(atomicTransferDate)s{{/strong}}. All your posts, pages and media will be deleted.',
+			{
+				args: { atomicTransferDate },
+				components: {
+					// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+					strong: <strong className="is-highlighted" />,
+				},
+			}
+		);
+	}
+
+	renderEmptySiteConfirmationContent() {
+		const { translate, selectedSiteSlug, atomicTransfer } = this.props;
+		const { checkOne, checkTwo, isEmptyButtonBusy } = this.state;
+		const shouldEnableButton = checkOne && checkTwo;
+		const hasAtomicTransferCompleted = Object.keys( atomicTransfer ).length > 0;
+
+		return (
+			<div className=" main main-column start-over start-over__confirm">
+				<Card>
+					<FormattedHeader
+						brandFont
+						headerText={ translate( 'Proceed with caution - this will delete all your content' ) }
+						subHeaderText={ this.getSubheaderText( hasAtomicTransferCompleted ) }
+					/>
+					<p>
+						{ translate(
+							'Please {{strong}}confirm and check{{/strong}} the following items before you continue with emptying your site:',
+							{ components: { strong: <strong /> } }
+						) }
+					</p>
+					{ this.getCheckboxContent( hasAtomicTransferCompleted ) }
+
+					<div className="start-over__backups">
+						<h4>{ translate( 'Would you like to download the backup of your site?' ) }</h4>
+						<p>
+							{ translate(
+								'If you change your mind later or want to secure your data, you can download a backup.'
+							) }
+						</p>
+						<ExternalLink icon href={ `/backup/${ selectedSiteSlug }` }>
+							{ translate( 'Go to your backups' ) }
+						</ExternalLink>
+					</div>
+					<Button
+						primary
+						scary
+						disabled={ ! shouldEnableButton }
+						onClick={ this.clickEmptySiteButton }
+						className="start-over__empty-site-button"
+						busy={ isEmptyButtonBusy }
+					>
+						{ translate( 'Empty Site' ) }
+					</Button>
+				</Card>
+			</div>
+		);
+	}
+
+	render() {
+		const { selectedSiteSlug, translate } = this.props;
 
 		return (
 			<>
@@ -144,7 +194,7 @@ class StartOver extends Component {
 				>
 					<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug }>Start Over</HeaderCake>
 					<Card>
-						<FormattedHeader brandFont headerText={ translate( 'Start Over' ) } />
+						{ /* <FormattedHeader brandFont headerText={ translate( 'Start Over' ) } /> */ }
 						<p>
 							{ translate(
 								"If you want a site but don't want any of the posts and pages you have now, " +
@@ -159,55 +209,22 @@ class StartOver extends Component {
 						</p>
 					</Card>
 				</div>
-				<div className=" main main-column start-over start-over__confirm">
-					<Card>
-						<FormattedHeader
-							brandFont
-							headerText={ translate( 'Proceed with caution' ) }
-							subHeaderText={ subHeaderText }
-						/>
-						<p>
-							{ translate(
-								'Please {{strong}}confirm and check{{/strong}} the following items before you continue with emptying your site:',
-								{ components: { strong: <strong /> } }
-							) }
-						</p>
-						{ this.getCheckboxConsent() }
-
-						<div className="start-over__backups">
-							<h4>{ translate( 'Would you like to download the backup of your site?' ) }</h4>
-							<p>
-								{ translate(
-									'If you change your mind later or want to secure your data, you can download a backup.'
-								) }
-							</p>
-							<ExternalLink icon href={ `/backup/${ selectedSiteSlug }` }>
-								{ translate( 'Go to your backups' ) }
-							</ExternalLink>
-						</div>
-						<Button
-							primary
-							scary
-							disabled={ ! canClickEmptyButton }
-							onClick={ this.clickEmptySiteButton }
-							className="start-over__empty-site-button"
-							busy={ isEmptyButtonBusy }
-						>
-							{ translate( 'Empty Site' ) }
-						</Button>
-					</Card>
-				</div>
+				{ this.renderEmptySiteConfirmationContent() }
 			</>
 		);
 	}
 }
 
-export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
 
-	return {
-		selectedSiteSlug: getSelectedSiteSlug( state ),
-		atomicTransfer: getAtomicTransfer( state, siteId ),
-		siteId,
-	};
-} )( localize( StartOver ) );
+		return {
+			selectedSiteSlug: getSelectedSiteSlug( state ),
+			atomicTransfer: getAtomicTransfer( state, siteId ),
+			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
+			siteId,
+		};
+	},
+	{ fetchAtomicTransfer }
+)( localize( withLocalizedMoment( StartOver ) ) );

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -41,16 +41,11 @@ class StartOver extends Component {
 		}
 	}
 
-	getCheckboxContent( hasAtomicTransferCompleted = false ) {
-		const { selectedSiteSlug, translate } = this.props;
-		const {
-			atomicRevertCheckOne,
-			atomicRevertCheckTwo,
-			simpleRevertCheckOne,
-			simpleRevertCheckTwo,
-		} = this.state;
+	getCheckboxContent() {
+		const { selectedSiteSlug, isAtomicSite, translate } = this.props;
+		const { checkTwo, checkOne } = this.state;
 
-		if ( hasAtomicTransferCompleted ) {
+		if ( isAtomicSite ) {
 			return (
 				<>
 					<CheckboxControl
@@ -58,15 +53,15 @@ class StartOver extends Component {
 						label={ translate(
 							'Any themes/plugins you have installed on the site will be removed, along with their data.'
 						) }
-						checked={ atomicRevertCheckOne }
+						checked={ checkOne }
 						onChange={ ( isChecked ) => this.setState( { checkOne: isChecked } ) }
 					/>
 					<CheckboxControl
 						className="start-over__checkbox-container"
 						label={ translate(
-							'Your site will return to its original settings and theme right before the first plugin or custom theme was installed.'
+							"I understand that without taking a backup, my site's data such as posts, pages, media, comments, tags, and themes are permanently deleted and cannot be retrieved."
 						) }
-						checked={ atomicRevertCheckTwo }
+						checked={ checkTwo }
 						onChange={ ( isChecked ) => this.setState( { checkTwo: isChecked } ) }
 					/>
 				</>
@@ -87,15 +82,15 @@ class StartOver extends Component {
 							},
 						}
 					) }
-					checked={ simpleRevertCheckOne }
+					checked={ checkOne }
 					onChange={ ( isChecked ) => this.setState( { checkOne: isChecked } ) }
 				/>
 				<CheckboxControl
 					className="start-over__checkbox-container"
 					label={ translate(
-						'I understand that there is no way to retrieve my data unless I have downloaded a backup.'
+						"I understand that without taking a backup, my site's data is permanently deleted and cannot be retrieved."
 					) }
-					checked={ simpleRevertCheckTwo }
+					checked={ checkTwo }
 					onChange={ ( isChecked ) => this.setState( { checkTwo: isChecked } ) }
 				/>
 			</>
@@ -133,16 +128,17 @@ class StartOver extends Component {
 		}
 	};
 
-	getSubheaderText( hasAtomicTransferCompleted = false ) {
-		const { atomicTransfer, moment, translate } = this.props;
+	getSubheaderText() {
+		const { atomicTransfer, isAtomicSite, moment, translate } = this.props;
 		const atomicTransferDate = moment( atomicTransfer.created_at ).format( 'LL' );
 
-		if ( ! hasAtomicTransferCompleted ) {
+		if ( ! isAtomicSite ) {
 			return;
 		}
 
 		return translate(
-			'After emptying your site, we will return your site back to the point when you installed your first plugin or custom theme or activated hosting features on {{strong}}%(atomicTransferDate)s{{/strong}}. All your posts, pages and media will be deleted.',
+			'After emptying your site, we will return your site back to the point when you installed your first plugin or custom theme or activated ' +
+				'hosting features on {{strong}}%(atomicTransferDate)s{{/strong}}. All your posts, pages and media will be deleted.',
 			{
 				args: { atomicTransferDate },
 				components: {
@@ -154,10 +150,9 @@ class StartOver extends Component {
 	}
 
 	renderEmptySiteConfirmationContent() {
-		const { translate, selectedSiteSlug, atomicTransfer } = this.props;
+		const { translate, selectedSiteSlug } = this.props;
 		const { checkOne, checkTwo, isEmptyButtonBusy } = this.state;
 		const shouldEnableButton = checkOne && checkTwo;
-		const hasAtomicTransferCompleted = Object.keys( atomicTransfer ).length > 0;
 
 		return (
 			<div className=" main main-column start-over start-over__confirm">
@@ -165,7 +160,7 @@ class StartOver extends Component {
 					<FormattedHeader
 						brandFont
 						headerText={ translate( 'Proceed with caution - this will delete all your content' ) }
-						subHeaderText={ this.getSubheaderText( hasAtomicTransferCompleted ) }
+						subHeaderText={ this.getSubheaderText() }
 					/>
 					<p>
 						{ translate(
@@ -173,13 +168,13 @@ class StartOver extends Component {
 							{ components: { strong: <strong /> } }
 						) }
 					</p>
-					{ this.getCheckboxContent( hasAtomicTransferCompleted ) }
+					{ this.getCheckboxContent() }
 
 					<div className="start-over__backups">
 						<h4>{ translate( 'Would you like to download the backup of your site?' ) }</h4>
 						<p>
 							{ translate(
-								'If you change your mind later or want to secure your data, you can download a backup.'
+								'It is recommended that you backup your current data, so that you can restore it if you change your mind later.'
 							) }
 						</p>
 						<ExternalLink icon href={ `/backup/${ selectedSiteSlug }` }>

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -144,7 +144,7 @@ class StartOver extends Component {
 				>
 					<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug }>Start Over</HeaderCake>
 					<Card>
-						<h1>{ translate( 'Start Over' ) }</h1>
+						<FormattedHeader brandFont headerText={ translate( 'Start Over' ) } />
 						<p>
 							{ translate(
 								"If you want a site but don't want any of the posts and pages you have now, " +

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -124,7 +124,6 @@ class StartOver extends Component {
 			this.props.errorNotice(
 				this.props.translate( 'Looks like something went wrong. Try again or contact support.' )
 			);
-			throw error;
 		}
 	};
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -646,4 +646,26 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 			font-size: 1rem;
 		}
 	}
+
+	.start-over__empty-site-button {
+		width: 100%;
+		margin-top: 1.5rem;
+	}
+
+	.start-over__checkbox-container {
+		background-color: var( --studio-white );
+		padding: 0.8125rem 1.25rem;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 5px;
+		box-shadow: 0 1px 2px rgb( 0 0 0 / 5% );
+		border: 1px solid var( --studio-gray-5 );
+		display: flex;
+		align-items: center;
+		margin-bottom: 0.75rem;
+
+		.components-base-control__field {
+			display: flex;
+			align-items: center;
+		}
+	}
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -624,3 +624,26 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	margin-top: -16px;
 	margin-bottom: 16px;
 }
+
+.start-over {
+	.card h1 {
+		font-size: 1.5rem;
+	}
+
+	.start-over__backups {
+		background-color: var( --studio-blue-0 );
+		border: 1px solid var( --studio-blue-5 );
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 5px;
+		padding: 1.25rem;
+		margin-top: 2rem;
+		font-size: 0.875rem;
+
+		h4 {
+			color: var( --studio-gray-80 );
+			font-weight: 600;
+			margin-bottom: 0.5rem;
+			font-size: 1rem;
+		}
+	}
+}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -668,4 +668,12 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 			align-items: center;
 		}
 	}
+
+	strong.is-highlighted {
+		background-color: var( --studio-yellow-5 );
+		padding: 0.25rem 0.5rem;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 5px;
+		color: var( --stugio-gray-80 );
+	}
 }


### PR DESCRIPTION
#### Proposed Changes

* This PR implements a way for users on simple or atomic sites to delete all of their site's content such as posts, pages, themes, plugins, categories, and tags. 
* Related to p58i-cvT-p2.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

~Depends on D82117-code, please apply this patch.~

**Test delete on simple site**

1. On a simple site, head to Settings page at `/settings/general/{SITE_SLUG}`.
2. Select the "Delete your content" option.
3. Verify that the screen looks like this:
<img width="812" alt="Screenshot 2022-06-08 at 7 15 41 PM" src="https://user-images.githubusercontent.com/1269602/172653437-cc8d9bea-f0fb-46b5-ba1f-84e50ba829e8.png">

4. Verify that the "Empty Site" button is activated only when both the checkboxes are selected.
5. Verify that clicking "Empty Site" button will then empty all the contents including posts, pages, media, comments etc. After deletion, the success page should look like this:

<img width="1098" alt="Screenshot 2022-06-08 at 7 17 07 PM" src="https://user-images.githubusercontent.com/1269602/172653758-db5462db-c3e8-429a-8ee3-0273bcf7c38a.png">

6. Go to the delete contents page once again at `/settings/start-over/{SITE_SLUG}`. Try to return a WP_Error from the backend or a falsey value for the `success` response flag, and verify that the frontend shows an error state.
<img width="1070" alt="Screenshot 2022-06-08 at 7 19 08 PM" src="https://user-images.githubusercontent.com/1269602/172654297-f230029d-7676-4c38-bf86-b351d286ac3a.png">


**Test delete on an atomic site**

1. The steps are same as that explained above. Just ensure that you are testing on an atomic site. The "Start Over" page has different content for the checkboxes:
<img width="753" alt="Screenshot 2022-06-08 at 7 21 36 PM" src="https://user-images.githubusercontent.com/1269602/172654802-5d2754a5-35ed-4def-8293-23e19ee6dbe8.png">

2. In addition to posts, pages etc being deleted, also verify that custom plugins, themes etc are also deleted.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #32792
