### PR TITLE
Helper hook for sending an email verification message

### DIFF
--- a/client/landing/stepper/hooks/test/use-send-email-verification.jsx
+++ b/client/landing/stepper/hooks/test/use-send-email-verification.jsx
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import nock from 'nock';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { useSendEmailVerification } from '../use-send-email-verification';
+
+describe( 'use-send-email-verification hook', () => {
+	test( 'returns success from the api', async () => {
+		const queryClient = new QueryClient();
+		const wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+
+		const expected = {
+			success: true,
+		};
+
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/me/send-verification-email' )
+			.reply( 200, expected );
+
+		const { result } = renderHook( () => useSendEmailVerification(), {
+			wrapper,
+		} );
+
+		const sendEmailVerification = result.current;
+		const data = await sendEmailVerification();
+
+		expect( data ).toEqual( expected );
+	} );
+} );

--- a/client/landing/stepper/hooks/use-send-email-verification.ts
+++ b/client/landing/stepper/hooks/use-send-email-verification.ts
@@ -1,0 +1,9 @@
+import wpcom from 'calypso/lib/wp';
+
+export function useSendEmailVerification() {
+	const sendEmailVerification = async () => {
+		return wpcom.req.post( '/me/send-verification-email', { apiVersion: '1.1' } );
+	};
+
+	return sendEmailVerification;
+}


### PR DESCRIPTION
#### Proposed Changes
The `/me/send-verification-email` API endpoint triggers a verification email for the current account.

We're going to need to call this endpoint in a number of different places so this adds a hook which returns a function for calling the endpoint.


#### Testing Instructions

`yarn test-client ./client/landing/stepper/hooks/test/use-send-email-verification.jsx`


Related to #64163
