### PR TITLE
Marketplace: Do not show eligibility modal when not needed

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -11,10 +11,7 @@ import { userCan } from 'calypso/lib/site/utils';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
-import {
-	getEligibility,
-	isEligibleForAutomatedTransfer,
-} from 'calypso/state/automated-transfer/selectors';
+import { getEligibility } from 'calypso/state/automated-transfer/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
 import { isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
@@ -64,14 +61,8 @@ const PluginDetailsCTA = ( {
 	const { eligibilityHolds, eligibilityWarnings } = useSelector( ( state ) =>
 		getEligibility( state, selectedSite?.ID )
 	);
-	const isEligible = useSelector( ( state ) =>
-		isEligibleForAutomatedTransfer( state, selectedSite?.ID )
-	);
 	const hasEligibilityMessages =
-		! isAtomic &&
-		! isJetpack &&
-		isEligible &&
-		( eligibilityHolds?.length || eligibilityWarnings?.length );
+		! isAtomic && ! isJetpack && ( eligibilityHolds?.length || eligibilityWarnings?.length );
 
 	if ( isPlaceholder ) {
 		return <PluginDetailsCTAPlaceholder />;

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -68,7 +68,10 @@ const PluginDetailsCTA = ( {
 		isEligibleForAutomatedTransfer( state, selectedSite?.ID )
 	);
 	const hasEligibilityMessages =
-		! isAtomic && ! isJetpack && ( eligibilityHolds || eligibilityWarnings || isEligible );
+		! isAtomic &&
+		! isJetpack &&
+		isEligible &&
+		( eligibilityHolds?.length || eligibilityWarnings?.length );
 
 	if ( isPlaceholder ) {
 		return <PluginDetailsCTAPlaceholder />;


### PR DESCRIPTION
The eligibility modal should not be displayed if there are no warnings
or additional messages to show

#### Proposed Changes

* Only show eligibility modal if there are messages to display

#### Testing Instructions

* Go to a **Simple** site that is eligible to install plugins. For example, a Business or Pro site that has not yet been transferred to Atomic
* Make sure the site has a domain, you can use a `.blog` domain for testing purposes
* Go to plugins and Install a Plugin, it can be either a Paid or Free plugin
* Make sure there is no additional modal displayed and the installation continues successfully or the checkout page is displayed. 

Fixes #62342
