### PR TITLE
Agency dashboard style fixes

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -77,6 +77,7 @@ export default function SiteStatusContent( {
 		return (
 			<>
 				<span className="sites-overview__row-text">{ value.url }</span>
+				<span className="sites-overview__overlay"></span>
 				{ errorContent }
 			</>
 		);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
@@ -66,5 +66,8 @@ td.site-table__td-with-error {
 		+ .site-table__connection-error {
 			background: var( --studio-gray-0 );
 		}
+		.sites-overview__overlay {
+			background: linear-gradient( to right, rgba( 246, 247, 247, 0.8 ) 30%, rgba( 246, 247, 247, 1 ) 100% );
+		}
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -102,6 +102,15 @@
 		font-size: 0.875rem;
 	}
 }
+.sites-overview__overlay {
+	display: block;
+	position: absolute;
+	height: 50px;
+	width: 20px;
+	right: 70px;
+	background: linear-gradient( to right, rgba( 255, 255, 255, 0.8 ) 30%, rgba( 255, 255, 255, 1 ) 100% );
+	top: 0;
+}
 .sites-overview__vertical-align-middle {
 	vertical-align: middle;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -105,11 +105,14 @@
 .sites-overview__overlay {
 	display: block;
 	position: absolute;
-	height: 50px;
+	height: 49px;
 	width: 20px;
-	right: 70px;
 	background: linear-gradient( to right, rgba( 255, 255, 255, 0.8 ) 30%, rgba( 255, 255, 255, 1 ) 100% );
 	top: 0;
+	right: 70px;
+	@include break-large() {
+		right: 0;
+	}
 }
 .sites-overview__vertical-align-middle {
 	vertical-align: middle;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -228,7 +228,10 @@
 	border-color:  var( --studio-yellow-20 );;
 }
 .sites-overview__filter-bar {
-	margin: 0 1px 8px;
+	margin: 0 0 8px;
+	@include break-large() {
+		margin: 0 1px 8px;
+	}
 	.filterbar__wrap.card {
 		overflow-x: scroll;
 		@include break-large() {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -23,6 +23,7 @@
 	}
 	.search.is-open {
 		margin-bottom: 8px;
+		box-shadow: 0 0 0 1px var( --color-neutral-5 );
 	}
 }
 .sites-overview__page-title-container {


### PR DESCRIPTION
#### Proposed Changes

* This PR fixes a few style issues reported on small and large screen devices 

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/mobile-view-styles-fixes` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard.
3. Switch to small screen view(<960px) using the toggle device toolbar in the dev tool(inspect)
4. Verify that the border style of search is similar to the filter and also the search, filter, etc are in-line 

**Before** 

<img width="324" alt="Screenshot 2022-06-07 at 9 58 27 PM" src="https://user-images.githubusercontent.com/10586875/172433967-7676d197-ef63-4eb4-ad14-2c522b625850.png">

**After**

<img width="314" alt="Screenshot 2022-06-07 at 9 57 42 PM" src="https://user-images.githubusercontent.com/10586875/172434017-1aa78e47-a646-4fe0-8723-f94db8967fbe.png">

5. Verify that an overlay is visible when the site name is overflowing instead of a sharp cut

**Before**

<img width="319" alt="Screenshot 2022-06-07 at 10 00 41 PM" src="https://user-images.githubusercontent.com/10586875/172434481-66eafe07-a3dd-4dc9-bde6-2902f9334b0c.png">

**After**

<img width="323" alt="Screenshot 2022-06-07 at 10 01 06 PM" src="https://user-images.githubusercontent.com/10586875/172434517-61e0e7f2-ff5c-44e4-b112-0b12029b8a86.png">

<img width="711" alt="Screenshot 2022-06-07 at 10 03 23 PM" src="https://user-images.githubusercontent.com/10586875/172434867-dc68e401-e484-47dd-a2ad-f166f4862172.png">

Related to 1202076982646589-as-1202403686601004 & 1202076982646589-as-1202402905764750