### PR TITLE
Jetpack Backup: Add warning badge to side menu

### DIFF
--- a/client/components/jetpack/backup-badge/index.jsx
+++ b/client/components/jetpack/backup-badge/index.jsx
@@ -1,0 +1,68 @@
+import { ScreenReaderText } from '@automattic/components';
+import { useDailyBackupStatus } from 'calypso/my-sites/backup/status/hooks';
+import { useTranslate } from 'i18n-calypso';
+import Badge from 'calypso/components/badge';
+import { getBackupWarnings } from 'calypso/lib/jetpack/backup-utils';
+
+const BackupBadge = ( { siteId } ) => {
+	const translate = useTranslate();
+	const backupStatus = useDailyBackupStatus( siteId, 'today' );
+
+	let numWarningCache = null;
+
+	const numBackupWarnings = ( backup ) => {
+		if ( numWarningCache !== null ) {
+			return numWarningCache;
+		}
+
+		let numWarnings = 0;
+
+		const backupWarnings = getBackupWarnings( backup );
+		if ( ! backupWarnings ) {
+			return numWarnings;
+		}
+
+		Object.keys( backupWarnings ).forEach( ( key ) => {
+			if ( backupWarnings[ key ].items ) {
+				numWarnings += backupWarnings[ key ].items.length;
+			}
+		} );
+
+		numWarningCache = numWarnings;
+		return numWarnings;
+	};
+
+	if ( backupStatus.isLoading || numBackupWarnings( backupStatus.lastBackupAttemptOnDate ) === 0 ) {
+		return <></>;
+	}
+
+	return (
+		<Badge type="warning">
+			<span aria-hidden="true">
+				{ translate(
+					'%(number)d {{span}}warning{{/span}}',
+					'%(number)d {{span}}warnings{{/span}}',
+					{
+						count: numBackupWarnings( backupStatus.lastBackupAttemptOnDate ),
+						args: {
+							number: numBackupWarnings( backupStatus.lastBackupAttemptOnDate ),
+						},
+						components: {
+							span: <span className="backup-badge__words" />,
+						},
+					}
+				) }
+			</span>
+			<ScreenReaderText>
+				{ translate( '%(number)d warning', '%(number)d warnings', {
+					count: numBackupWarnings( backupStatus.lastBackupAttemptOnDate ),
+					args: {
+						number: numBackupWarnings( backupStatus.lastBackupAttemptOnDate ),
+					},
+				} ) }
+			</ScreenReaderText>
+		</Badge>
+	);
+};
+
+export default BackupBadge;

--- a/client/components/jetpack/backup-badge/index.jsx
+++ b/client/components/jetpack/backup-badge/index.jsx
@@ -1,8 +1,8 @@
 import { ScreenReaderText } from '@automattic/components';
-import { useDailyBackupStatus } from 'calypso/my-sites/backup/status/hooks';
 import { useTranslate } from 'i18n-calypso';
 import Badge from 'calypso/components/badge';
 import { getBackupWarnings } from 'calypso/lib/jetpack/backup-utils';
+import { useDailyBackupStatus } from 'calypso/my-sites/backup/status/hooks';
 
 const BackupBadge = ( { siteId } ) => {
 	const translate = useTranslate();

--- a/client/components/jetpack/backup-badge/style.scss
+++ b/client/components/jetpack/backup-badge/style.scss
@@ -1,0 +1,5 @@
+.backup-badge__words {
+	@include breakpoint-deprecated( '660px-960px' ) {
+		display: none;
+	}
+}

--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryScanState from 'calypso/components/data/query-jetpack-scan';
+import BackupBadge from 'calypso/components/jetpack/backup-badge';
 import ScanBadge from 'calypso/components/jetpack/scan-badge';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import { backupPath, scanPath } from 'calypso/lib/jetpack/paths';
@@ -26,6 +27,7 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 	const isWPForTeamsSite = useSelector( ( state ) => isSiteWPForTeams( state, siteId ) );
 
 	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
+
 	const scanProgress = useSelector( ( state ) => getSiteScanProgress( state, siteId ) );
 	const scanThreats = useSelector( ( state ) => getSiteScanThreats( state, siteId ) );
 
@@ -65,7 +67,9 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 					onNavigate={ onNavigate( tracksEventNames.backupClicked ) }
 					selected={ currentPathMatches( backupPath( siteSlug ) ) }
 					expandSection={ expandSection }
-				/>
+				>
+					<BackupBadge siteId={ siteId } />
+				</SidebarItem>
 			) }
 			{ isAdmin && ! isWPCOM && ! isWPForTeamsSite && (
 				<SidebarItem


### PR DESCRIPTION
#### Proposed Changes

* Adds a badge next to the Backup menu item indicating number of warnings on the most recent successful backup

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the generated live link below and navigate to a site with warnings (I can provide access to one)
* Ensure the badge exists for the site with warnings, and no badge is present on other sites
<img width="267" alt="Screen Shot 2022-06-07 at 1 33 43 PM" src="https://user-images.githubusercontent.com/1992658/172446510-069c0e24-b351-4ebe-a2d3-32e19f110564.png">

