### PR TITLE
Create the plugin layout for the new Plugin Details page 

### DIFF
--- a/client/my-sites/plugins/_variables.scss
+++ b/client/my-sites/plugins/_variables.scss
@@ -12,6 +12,10 @@ $plugin-details-header-padding: 100px;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
+	padding: 0;
+}
+
+.legacy %plugin-header {
 	padding: $plugin-details-header-padding 0;
 
 	@media screen and ( max-width: 1040px ) {

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -2,6 +2,9 @@
 
 .plugin-details-CTA__container {
 	@extend %plugin-header;
+}
+
+.legacy .plugin-details-CTA__container {
 	padding-bottom: 0;
 }
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -118,9 +118,29 @@ body.is-section-plugins.theme-default.color-scheme {
 }
 
 .plugin-details__layout {
-	@include breakpoint-deprecated( '>1040px' ) {
-		@include display-grid;
-		@include grid-template-columns( 3, 80px, 1fr );
+	@include display-grid;
+	@include grid-template-columns( 3, 80px, 1fr );
+	grid-template-areas: 'header header actions'
+						'content content actions';
+
+	@include breakpoint-deprecated( '<960px' ) {
+		grid-template-areas: 'header header header'
+							'actions actions actions'
+							'content content content';
+	}
+
+	.plugin-details__header {
+		grid-area: header;
+	}
+
+	.plugin-details__content {
+		grid-area: content;
+	}
+
+	.plugin-details__actions {
+		grid-area: actions;
+		background-color: var( --studio-gray-0 );
+		padding: 20px;
 	}
 
 	.plugin-details__layout-col-left {
@@ -145,8 +165,6 @@ body.is-section-plugins.theme-default.color-scheme {
 }
 
 .plugin-details__body {
-	border-top: 1px solid var( --studio-gray-5 );
-
 	.plugin-sections {
 		margin-top: 20px;
 
@@ -262,4 +280,18 @@ body.is-section-plugins.theme-default.color-scheme {
 
 body.is-section-plugins header .select-dropdown__item {
 	padding: 0 0 0 16px !important;
+}
+
+.legacy {
+	.plugin-details__body {
+		border-top: 1px solid var( --studio-gray-5 );
+	}
+
+	.plugin-details__layout {
+		grid-template-areas: none;
+		@include breakpoint-deprecated( '>1040px' ) {
+			@include display-grid;
+			@include grid-template-columns( 3, 80px, 1fr );
+		}
+	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -115,6 +115,7 @@
 		"plans/starter-plan": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": true,
+		"plugins/plugin-details-layout": false,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,
 		"publicize-preview": true,

--- a/config/test.json
+++ b/config/test.json
@@ -62,6 +62,7 @@
 		"plans/starter-plan": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
+		"plugins/plugin-details-layout": false,
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -90,6 +90,7 @@
 		"plans/starter-plan": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": true,
+		"plugins/plugin-details-layout": false,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,
 		"publicize-preview": true,


### PR DESCRIPTION
P2: pdh6GB-1cy-p2

### Description 
Remodelation of the layout from the Plugin Details page behind the `plugins/plugin-details-layout` feature flag.

To achieve the layout on f84fqtCG4pCnCh2Hq0But5-fi-2009%3A23786 it was used a grid with the `grid-template-areas` pattern.

<img width="1236" alt="Screen Shot 2022-06-09 at 18 36 08" src="https://user-images.githubusercontent.com/5039531/172966368-474e3cb4-5378-42f2-b835-35899fd831c6.png">


The following areas are being used as template on the desktop, allowing the `actions` (sidebar) area to be kept on the right independent of the header and plugin content:
```
header  header   actions
content content  actions
```


The following areas are being used as template on the mobile, allowing the areas to be stacked but with the `actions`(sidebar) area to be in the middle
```
header   header   header
actions  actions  actions
content  content  content
```

Besides those changes, all the style exceptions made for the previous layout are behind a condition with the legacy check or on a CSS rule for the `.legacy` class, allowing it to be removed later down the line without many troubles for the new version.


### Proposed Changes

* [Create the "plugins/plugin-details-layout" feature flag.](https://github.com/Automattic/wp-calypso/pull/64419/commits/ed4af96c4dc1fc1f6adf558ef9883559953ba60a)
* [Add the remodeled Plugin Details layout behind a feature flag.](https://github.com/Automattic/wp-calypso/pull/64419/commits/b5ac7de9158148e09f846f5f8acf87e400bdf898)

### Testing Instructions
**Negative Validation**

* Without enabling any feature flags
* Check if the Plugin Details page of this branch looks the same as the one in production
* Test for paid and free plugins. Ex: `/plugins/woocommerce-bookings/{site}` and `/plugins/elementor/{site}`

**Positive validation**

* Enable the feature flag `plugins/plugin-details-layout`*
* Go to the plugin details page and check the layout is correspondent to the Desktop version bellow
* Resize your screen to mobile size and check if the layout is correspondent to Mobile version bellow

| Desktop  | Mobile |
| ------------- | ------------- |
|<img width="1234" alt="Screen Shot 2022-06-09 at 18 45 16" src="https://user-images.githubusercontent.com/5039531/172965558-87115098-5263-4f42-975a-96cb6042c64c.png">|<img width="521" alt="Screen Shot 2022-06-09 at 18 50 50" src="https://user-images.githubusercontent.com/5039531/172965599-bcfd7ef3-473c-4980-ba6f-7d854aa5e58c.png">|




\* To enable this feature flag add `?flags=plugins/plugin-details-layout` to the end of your URL or past the following code on the developer tools console `document.cookie = 'flags=plugins/plugin-details-layout;max-age=1209600;path=/'`






----

Fixes #63683