### PR TITLE
E2E: revise `ElementHelper.clickTab` method to be more resilient against lazy-loading elements.

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -4,11 +4,8 @@ import envVariables from './env-variables';
 const navTabParent = 'div.section-nav';
 
 const selectors = {
-	// General
-	main: 'main[role="main"]',
-
 	// clickNavTab
-	navTabItem: ( { name = '', selected }: { name?: string; selected?: boolean } = {} ) =>
+	navTabItem: ( { name = '', selected = false }: { name?: string; selected?: boolean } = {} ) =>
 		`${ navTabParent } a[aria-current="${ selected }"]:has(span:has-text("${ name }"))`,
 	navTabMobileToggleButton: `${ navTabParent } button.section-nav__mobile-header`,
 };
@@ -68,13 +65,9 @@ export async function clickNavTab( page: Page, name: string ): Promise< void > {
 
 	// Mobile view - navtabs become a dropdown and thus it must be opened first.
 	if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-		// Layout can shift in certain pages (eg. PlansPage) as elements are lazy loaded.
-		const mainElement = await page.waitForSelector( selectors.main );
-		await Promise.all( [
-			page.waitForLoadState( 'networkidle' ),
-			mainElement.waitForElementState( 'stable' ),
-		] );
+		await page.waitForLoadState( 'networkidle' );
 
+		// Open the Navtabs which now act as a pseudo-dropdown menu.
 		const navTabsButtonLocator = page.locator( selectors.navTabMobileToggleButton );
 		await navTabsButtonLocator.click();
 

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -1,10 +1,16 @@
 import { Locator, Page } from 'playwright';
 import envVariables from './env-variables';
 
+const navTabParent = 'div.section-nav';
+
 const selectors = {
+	// General
+	main: 'main[role="main"]',
+
 	// clickNavTab
-	navTab: ( tab: string ) => `.section-nav-tab:has-text("${ tab }")`,
-	mobileNavTabsToggle: 'button.section-nav__mobile-header',
+	navTabItem: ( { name = '', selected }: { name?: string; selected?: boolean } = {} ) =>
+		`${ navTabParent } a[aria-current="${ selected }"]:has(span:has-text("${ name }"))`,
+	navTabMobileToggleButton: `${ navTabParent } button.section-nav__mobile-header`,
 };
 
 /**
@@ -41,41 +47,54 @@ export async function waitForElementEnabled(
 /**
  * Locates and clicks on a specified tab on the NavTab.
  *
- * NavTabs are used throughout calypso to contain multiple related but separate pages within the same
- * overall page. For instance, on the Media gallery page a NavTab is used to filter the gallery to
+ * NavTabs are used throughout calypso to contain sub-pages within the parent page.
+ * For instance, on the Media gallery page a NavTab is used to filter the gallery to
  * show a specific category of gallery items.
  *
  * @param {Page} page Underlying page on which interactions take place.
  * @param {string} name Name of the tab to be clicked.
+ * @throws {Error} If the tab name is not the active tab.
  */
 export async function clickNavTab( page: Page, name: string ): Promise< void > {
-	// Mobile view - navtabs become a dropdown.
-	if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-		await page.waitForLoadState( 'networkidle' );
-		const navTabsButtonLocator = page.locator( selectors.mobileNavTabsToggle );
-		await navTabsButtonLocator.click();
-		const navPanelLocator = page.locator( '.section-nav__panel' );
-		await navPanelLocator.waitFor( { state: 'visible' } );
-	}
+	const selectedTabLocator = page.locator( selectors.navTabItem( { selected: true } ) );
+	const selectedTabName = await selectedTabLocator.innerText();
 
-	// Get the current active tab, then check against the intended target.
-	// If active tab and intended tab are same, short circuit the operation.
-	// If target device is mobile, close the NavTab dropdown.
-	const currentTab = await page
-		.waitForSelector( 'a[aria-current="true"]' )
-		.then( ( element ) => element.innerText() );
-
-	if ( currentTab === name ) {
-		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			await page.click( selectors.mobileNavTabsToggle );
-		}
+	// Short circuit operation if the active tab and target tabs are the same.
+	if ( selectedTabName === name ) {
 		return;
 	}
 
-	// Click on the intended NavTab and wait for navigation to finish.
-	// This implicitly checks whether the intended tab is now active.
-	const elementHandle = await page.waitForSelector( selectors.navTab( name ) );
-	await Promise.all( [ page.waitForNavigation(), elementHandle.click() ] );
+	// Mobile view - navtabs become a dropdown and thus it must be opened first.
+	if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+		// Layout can shift in certain pages (eg. PlansPage) as elements are lazy loaded.
+		const mainElement = await page.waitForSelector( selectors.main );
+		await Promise.all( [
+			page.waitForLoadState( 'networkidle' ),
+			mainElement.waitForElementState( 'stable' ),
+		] );
+
+		const navTabsButtonLocator = page.locator( selectors.navTabMobileToggleButton );
+		await navTabsButtonLocator.click();
+
+		const navTabIsOpenLocator = page.locator( `${ navTabParent }.is-open` );
+		await navTabIsOpenLocator.waitFor();
+	}
+
+	// Click on the intended item and wait for navigation to finish.
+	const navTabItem = page.locator( selectors.navTabItem( { name: name, selected: false } ) );
+	await Promise.all( [ page.waitForNavigation(), navTabItem.click() ] );
+
+	// Final verification.
+	const newSelectedTabLocator = page.locator(
+		selectors.navTabItem( { name: name, selected: true } )
+	);
+	const newSelectedTabName = await newSelectedTabLocator.innerText();
+
+	if ( newSelectedTabName !== name ) {
+		throw new Error(
+			`Failed to confirm NavTab is active: expected ${ name }, got ${ newSelectedTabName }`
+		);
+	}
 }
 
 /**

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -60,7 +60,9 @@ export async function clickNavTab( page: Page, name: string ): Promise< void > {
 	const selectedTabName = await selectedTabLocator.innerText();
 
 	// Short circuit operation if the active tab and target tabs are the same.
-	if ( selectedTabName === name ) {
+	// Strip numerals from the extracted tab name to account for the slightly
+	// different implementation in PostsPage.
+	if ( selectedTabName.replace( /[0-9]/g, '' ) === name ) {
 		return;
 	}
 
@@ -90,7 +92,8 @@ export async function clickNavTab( page: Page, name: string ): Promise< void > {
 	);
 	const newSelectedTabName = await newSelectedTabLocator.innerText();
 
-	if ( newSelectedTabName !== name ) {
+	// Strip numerals from the extracted tab name, similar to above.
+	if ( newSelectedTabName.replace( /[0-9]/g, '' ) !== name ) {
 		throw new Error(
 			`Failed to confirm NavTab is active: expected ${ name }, got ${ newSelectedTabName }`
 		);

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -153,25 +153,18 @@ export class PlansPage {
 			return;
 		}
 
-		// If the target tab is already active, short circuit.
-		const currentSelectedLocator = this.page.locator( selectors.activeNavigationTab( targetTab ) );
-		if ( ( await currentSelectedLocator.count() ) > 0 ) {
-			return;
+		// On mobile viewports, the way PlansPage loads its contents
+		// causes an event to fire which closes all open panes.
+		// Waiting for one of the last SVGs to load on the page is
+		// a hacky but effective workaround.
+		// See https://github.com/Automattic/wp-calypso/issues/64389
+		// and https://github.com/Automattic/wp-calypso/pull/64421#discussion_r892589761.
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			await this.page.waitForResponse( ( response ) =>
+				response.url().includes( '/images/wpcom-ecommerce' )
+			);
 		}
 
-		if ( targetTab === 'My Plan' ) {
-			// User is currently on the Plans tab and going to My Plans.
-			// Wait for the Plans grid to fully render.
-			const plansGridLocator = this.page.locator( selectors.legacyPlansGrid );
-			await plansGridLocator.waitFor();
-		}
-		if ( targetTab === 'Plans' ) {
-			// User is currently on the My Plans tab and going to Plans.
-			// Wait for the detais of the current plan to complete rendering
-			// asynchronously.
-			const placeholderLocator = this.page.locator( `.my-plan-card${ selectors.placeholder }` );
-			await placeholderLocator.waitFor( { state: 'hidden' } );
-		}
 		await clickNavTab( this.page, targetTab );
 	}
 


### PR DESCRIPTION
#### Proposed Changes

This PR revises the behavior of `ElementHelper.clickTab` with more modern (Playwright 1.14+) conventions, in order to add resilience to the `clickTab` method that is used by multiple POMs to interact with the navtabs.

Key changes:
- move up the short-circuiting behavior to be the first check in the method;
- move selectors to the selectors object;
- add an explicit wait for the `main` element to stabilize for mobile viewports only.

Details:
The current implementation of `ElementHelper.clickTab` has several shortcomings that allow flakiness to surface when interacting with pages containing navtabs that also have lazy loading elements. The issue is described in https://github.com/Automattic/wp-calypso/issues/64395.

By first checking for the currently active tab against the target tab and short circuiting if the two are equal, we are able to eliminate redundant clicks, saving a few milliseconds.

By using `Locator` instead of `ElementHandle`, we are able to encapsulate logic to locate the element when the lookup occurs, avoiding one potential area of issue should the layout shift.


#### Testing Instructions

Ensure the following:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

Related to https://github.com/Automattic/wp-calypso/issues/64395.
Closes https://github.com/Automattic/wp-calypso/issues/64389.
