### PR TITLE
Fix/product purchase feature list customize theme fse link

### DIFF
--- a/client/blocks/product-purchase-features-list/customize-theme.jsx
+++ b/client/blocks/product-purchase-features-list/customize-theme.jsx
@@ -1,24 +1,39 @@
 import { localize } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import customizeImage from 'calypso/assets/images/illustrations/dashboard.svg';
+import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import PurchaseDetail from 'calypso/components/purchase-detail';
+import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
+import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
+import { getActiveTheme } from 'calypso/state/themes/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-function getCustomizeLink( selectedSite ) {
-	return '/customize/' + selectedSite.slug;
-}
+const CustomizeTheme = ( { translate, blockEditorSettings, areBlockEditorSettingsLoading } ) => {
+	const isFSEActive = blockEditorSettings?.is_fse_active;
+	const siteId = useSelector( getSelectedSiteId );
+	const currentThemeId = useSelector( getActiveTheme );
+	const customizeLink = useSelector( ( state ) =>
+		getCustomizeUrl( state, currentThemeId, siteId, isFSEActive )
+	);
 
-export default localize( ( { selectedSite, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
+			<QueryActiveTheme siteId={ siteId } />
 			<PurchaseDetail
+				isSubmitting={ areBlockEditorSettingsLoading }
 				icon={ <img alt="" src={ customizeImage } /> }
 				title={ translate( 'Advanced customization' ) }
 				description={ translate(
 					"Change your site's appearance in a few clicks, with an expanded " +
 						'selection of fonts and colors.'
 				) }
-				buttonText={ translate( 'Start customizing' ) }
-				href={ getCustomizeLink( selectedSite ) }
+				buttonText={
+					areBlockEditorSettingsLoading ? translate( 'Loading…' ) : translate( 'Start customizing' )
+				}
+				href={ customizeLink }
 			/>
 		</div>
 	);
-} );
+};
+
+export default withBlockEditorSettings( localize( CustomizeTheme ) );

--- a/client/blocks/product-purchase-features-list/customize-theme.jsx
+++ b/client/blocks/product-purchase-features-list/customize-theme.jsx
@@ -11,7 +11,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 const CustomizeTheme = ( { translate, blockEditorSettings, areBlockEditorSettingsLoading } ) => {
 	const isFSEActive = blockEditorSettings?.is_fse_active;
 	const siteId = useSelector( getSelectedSiteId );
-	const currentThemeId = useSelector( getActiveTheme );
+	const currentThemeId = useSelector( ( state ) => getActiveTheme( state, siteId ) );
 	const customizeLink = useSelector( ( state ) =>
 		getCustomizeUrl( state, currentThemeId, siteId, isFSEActive )
 	);

--- a/client/blocks/product-purchase-features-list/customize-theme.jsx
+++ b/client/blocks/product-purchase-features-list/customize-theme.jsx
@@ -15,6 +15,9 @@ const CustomizeTheme = ( { translate, blockEditorSettings, areBlockEditorSetting
 	const customizeLink = useSelector( ( state ) =>
 		getCustomizeUrl( state, currentThemeId, siteId, isFSEActive )
 	);
+	const customizeThemeButtonText = isFSEActive
+		? translate( 'Edit site' )
+		: translate( 'Start customizing' );
 
 	return (
 		<div className="product-purchase-features-list__item">
@@ -28,7 +31,7 @@ const CustomizeTheme = ( { translate, blockEditorSettings, areBlockEditorSetting
 						'selection of fonts and colors.'
 				) }
 				buttonText={
-					areBlockEditorSettingsLoading ? translate( 'Loading…' ) : translate( 'Start customizing' )
+					areBlockEditorSettingsLoading ? translate( 'Loading…' ) : customizeThemeButtonText
 				}
 				href={ customizeLink }
 			/>


### PR DESCRIPTION
#### Proposed Changes

The customize theme link on the product purchase feature list page is redirecting the user to the customize flow instead of the site editor flow when the user has an active full site editor theme.

#### Testing Instructions

- Navigate to the Upgrades tab (/plans/my-plan/) and scroll down to the Advanced customization section
- To test the full site editor flow, change your theme to FSE enabled theme, such as 'Blockbase'
- To test the customizer editor flow, change your theme to non-FSE enabled theme, such as 'twenty twenty'

The FSE enabled theme should navigate to `/site-editor/SITE_SLUG` and the non-FSE theme should navigate to `/customize/SITE_SLUG`

![image](https://user-images.githubusercontent.com/10482592/172088447-f2e84a26-45c0-477e-a481-95f09df8ddbe.png)


Related to #57210 

Replacement for [#64361](https://github.com/Automattic/wp-calypso/pull/64361) because CI would not pass on pull request from a fork repository.