### PR TITLE
CI: update Playwright to 1.22.2.

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -44,7 +44,7 @@
 		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",
-		"playwright": "^1.19.2",
+		"playwright": "1.22.2",
 		"postcss": "^8.4.5",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -44,7 +44,7 @@
 		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",
-		"playwright": "1.22.2",
+		"playwright": "^1.22.2",
 		"postcss": "^8.4.5",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"@types/totp-generator": "^0.0.3",
 		"mailosaur": "^7.3.1",
-		"playwright": "1.22.2",
+		"playwright": "^1.22.2",
 		"totp-generator": "^0.0.12"
 	},
 	"devDependencies": {

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"@types/totp-generator": "^0.0.3",
 		"mailosaur": "^7.3.1",
-		"playwright": "^1.19.2",
+		"playwright": "1.22.2",
 		"totp-generator": "^0.0.12"
 	},
 	"devDependencies": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -46,7 +46,7 @@
 		"lodash": "^4.17.20",
 		"mailosaur": "^4.0.0",
 		"node-fetch": "^2.6.1",
-		"playwright": "^1.19.2",
+		"playwright": "1.22.2",
 		"postcss": "^8.3.11"
 	}
 }

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -46,7 +46,7 @@
 		"lodash": "^4.17.20",
 		"mailosaur": "^4.0.0",
 		"node-fetch": "^2.6.1",
-		"playwright": "1.22.2",
+		"playwright": "^1.22.2",
 		"postcss": "^8.3.11"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,7 +246,7 @@ __metadata:
     asana-phrase: ^0.0.8
     mailosaur: ^7.3.1
     node-fetch: ^2.6.6
-    playwright: 1.22.2
+    playwright: ^1.22.2
     totp-generator: ^0.0.12
     typescript: ^4.5.5
   languageName: unknown
@@ -9982,7 +9982,7 @@ __metadata:
     keytar: ^7.7.0
     lodash: ^4.17.21
     make-dir: ^3.1.0
-    playwright: 1.22.2
+    playwright: ^1.22.2
     postcss: ^8.4.5
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -26879,7 +26879,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright@npm:1.22.2":
+"playwright@npm:^1.22.2":
   version: 1.22.2
   resolution: "playwright@npm:1.22.2"
   dependencies:
@@ -35963,7 +35963,7 @@ swiper@4.5.1:
     lodash: ^4.17.20
     mailosaur: ^4.0.0
     node-fetch: ^2.6.1
-    playwright: 1.22.2
+    playwright: ^1.22.2
     postcss: ^8.3.11
     webpack: ^5.63.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,7 +246,7 @@ __metadata:
     asana-phrase: ^0.0.8
     mailosaur: ^7.3.1
     node-fetch: ^2.6.6
-    playwright: ^1.19.2
+    playwright: 1.22.2
     totp-generator: ^0.0.12
     typescript: ^4.5.5
   languageName: unknown
@@ -9982,7 +9982,7 @@ __metadata:
     keytar: ^7.7.0
     lodash: ^4.17.21
     make-dir: ^3.1.0
-    playwright: ^1.19.2
+    playwright: 1.22.2
     postcss: ^8.4.5
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -10159,7 +10159,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:6, agent-base@npm:^6.0.2":
+"agent-base@npm:6":
   version: 6.0.2
   resolution: "agent-base@npm:6.0.2"
   dependencies:
@@ -13456,13 +13456,6 @@ __metadata:
   dependencies:
     graceful-readlink: ">= 1.0.0"
   checksum: 56bcda1e47f453016ed25d9f300bed9e622842a5515802658adb62792fa2ff9af6ee3f9ff16e058d7b20aacc78fb3baa3e02f982414bae1fb5f198c7cb41d5ad
-  languageName: node
-  linkType: hard
-
-"commander@npm:8.3.0":
-  version: 8.3.0
-  resolution: "commander@npm:8.3.0"
-  checksum: 8b043bb8322ea1c39664a1598a95e0495bfe4ca2fad0d84a92d7d1d8d213e2a155b441d2470c8e08de7c4a28cf2bc6e169211c49e1b21d9f7edc6ae4d9356060
   languageName: node
   linkType: hard
 
@@ -22143,13 +22136,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jpeg-js@npm:0.4.3":
-  version: 0.4.3
-  resolution: "jpeg-js@npm:0.4.3"
-  checksum: f1d6f38e5250e80f0ff9020f09f216f1493d4bd1ce091fff1ae361fcdab199df5df03a6d81a418964074b572b8f6ecfad3cf4ea807e5aa96477c092b3d247a12
-  languageName: node
-  linkType: hard
-
 "js-base64@npm:^2.6.1":
   version: 2.6.4
   resolution: "js-base64@npm:2.6.4"
@@ -24532,15 +24518,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime@npm:3.0.0":
-  version: 3.0.0
-  resolution: "mime@npm:3.0.0"
-  bin:
-    mime: cli.js
-  checksum: 402e792a8df1b2cc41cb77f0dcc46472b7944b7ec29cb5bbcd398624b6b97096728f1239766d3fdeb20551dd8d94738344c195a6ea10c4f906eb0356323b0531
-  languageName: node
-  linkType: hard
-
 "mime@npm:^2.0.3, mime@npm:^2.3.1, mime@npm:^2.4.1, mime@npm:^2.4.4, mime@npm:^2.4.6, mime@npm:^2.5.2":
   version: 2.6.0
   resolution: "mime@npm:2.6.0"
@@ -26893,40 +26870,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.19.2":
-  version: 1.19.2
-  resolution: "playwright-core@npm:1.19.2"
-  dependencies:
-    commander: 8.3.0
-    debug: 4.3.3
-    extract-zip: 2.0.1
-    https-proxy-agent: 5.0.0
-    jpeg-js: 0.4.3
-    mime: 3.0.0
-    pngjs: 6.0.0
-    progress: 2.0.3
-    proper-lockfile: 4.1.2
-    proxy-from-env: 1.1.0
-    rimraf: 3.0.2
-    socks-proxy-agent: 6.1.1
-    stack-utils: 2.0.5
-    ws: 8.4.2
-    yauzl: 2.10.0
-    yazl: 2.5.1
+"playwright-core@npm:1.22.2":
+  version: 1.22.2
+  resolution: "playwright-core@npm:1.22.2"
   bin:
     playwright: cli.js
-  checksum: ba2f402cd538a4b89b1ff084c32a21994eed4c5efff68017f3f79838a74e65e70d3cc53ba8a08c963ffd3f493d4818c0b7c7c1717b513892df53dafb56b2d6d1
+  checksum: 98935d7906d52093fe260cd2bc74924cad0abb908f96a92867aa71e26eb3ce45d79185280a361e16fab2422a86936dfa1bb7306c5629d5b276f0ce1c99928f04
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.19.2":
-  version: 1.19.2
-  resolution: "playwright@npm:1.19.2"
+"playwright@npm:1.22.2":
+  version: 1.22.2
+  resolution: "playwright@npm:1.22.2"
   dependencies:
-    playwright-core: 1.19.2
+    playwright-core: 1.22.2
   bin:
     playwright: cli.js
-  checksum: 16262c6955be5542215393ca25b5fdedad0a4943a9f1a1ed2ce560ba1404b7783e53517dea33716a8943283d5a48795f925b59a91de86877b1382f8fce7c916d
+  checksum: ca87a65ba16302dfe79e8576cbd9db9b26185512d4fdede94c68389837ab097c891852f966132d090e0c762abda209ba555bc7d5d49ed719cb149c5e8253b1c2
   languageName: node
   linkType: hard
 
@@ -26962,13 +26922,6 @@ __metadata:
   version: 1.1.0
   resolution: "pn@npm:1.1.0"
   checksum: d844a08d8f0952033f4824072487310e9c9941264968c14411d8f1089d51a60f26ca4866b5a4ecac4d1d12487158dcba75ed2009126c37e4e8efd8080a2cc7c0
-  languageName: node
-  linkType: hard
-
-"pngjs@npm:6.0.0":
-  version: 6.0.0
-  resolution: "pngjs@npm:6.0.0"
-  checksum: ac23ea329b1881d1a10575aff58116dc27b894ec3f5b84ba15c7f527d21e609fbce7ba16d48f8ccb86c7ce45ceed622472765476ab2875949d4bec55e153f87a
   languageName: node
   linkType: hard
 
@@ -28017,17 +27970,6 @@ __metadata:
   version: 2.0.1
   resolution: "propagate@npm:2.0.1"
   checksum: 01e1023b60ae4050d1a2783f976d7db702022dbdb70dba797cceedad8cfc01b3939c41e77032f8c32aa9d93192fe937ebba1345e8604e5ce61fd3b62ee3003b8
-  languageName: node
-  linkType: hard
-
-"proper-lockfile@npm:4.1.2":
-  version: 4.1.2
-  resolution: "proper-lockfile@npm:4.1.2"
-  dependencies:
-    graceful-fs: ^4.2.4
-    retry: ^0.12.0
-    signal-exit: ^3.0.2
-  checksum: 2f265dbad15897a43110a02dae55105c04d356ec4ed560723dcb9f0d34bc4fb2f13f79bb930e7561be10278e2314db5aca2527d5d3dcbbdee5e6b331d1571f6d
   languageName: node
   linkType: hard
 
@@ -31974,17 +31916,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:6.1.1":
-  version: 6.1.1
-  resolution: "socks-proxy-agent@npm:6.1.1"
-  dependencies:
-    agent-base: ^6.0.2
-    debug: ^4.3.1
-    socks: ^2.6.1
-  checksum: 4d2ff6af0a4c49aa0f5aa3847468a75667795bc72c8271f85ee4c0a121f13f610674da43a6cbe77275e51596022f59da744d58f57d722dafbd1f54208cfa427d
-  languageName: node
-  linkType: hard
-
 "socks-proxy-agent@npm:^5.0.0":
   version: 5.0.0
   resolution: "socks-proxy-agent@npm:5.0.0"
@@ -31996,7 +31927,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"socks@npm:^2.3.3, socks@npm:^2.6.1":
+"socks@npm:^2.3.3":
   version: 2.6.1
   resolution: "socks@npm:2.6.1"
   dependencies:
@@ -32307,19 +32238,19 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"stack-utils@npm:2.0.5, stack-utils@npm:^2.0.3":
+"stack-utils@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "stack-utils@npm:1.0.2"
+  checksum: 41b714acbb8d887ef7801010adf430a60db64e03e37953652ecbd17d5e67d59854691816baa7ad3bf8f1bb1863b8af083762fd1a560da68ee9151e81b122f77e
+  languageName: node
+  linkType: hard
+
+"stack-utils@npm:^2.0.3":
   version: 2.0.5
   resolution: "stack-utils@npm:2.0.5"
   dependencies:
     escape-string-regexp: ^2.0.0
   checksum: 059f828eed5b03b963e8200529c27bd92b105f2cac9dffc9edcbc739ea8fa108e4ec45d0da257d8e0f7b5ac98db5643a0787e5c25ceab1396f7123e1ee15a086
-  languageName: node
-  linkType: hard
-
-"stack-utils@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "stack-utils@npm:1.0.2"
-  checksum: 41b714acbb8d887ef7801010adf430a60db64e03e37953652ecbd17d5e67d59854691816baa7ad3bf8f1bb1863b8af083762fd1a560da68ee9151e81b122f77e
   languageName: node
   linkType: hard
 
@@ -36032,7 +35963,7 @@ swiper@4.5.1:
     lodash: ^4.17.20
     mailosaur: ^4.0.0
     node-fetch: ^2.6.1
-    playwright: ^1.19.2
+    playwright: 1.22.2
     postcss: ^8.3.11
     webpack: ^5.63.0
   languageName: unknown
@@ -36211,21 +36142,6 @@ swiper@4.5.1:
   dependencies:
     mkdirp: ^0.5.1
   checksum: 2ab5472e32ce2d25279a9d22365c5dd5b95fe40497ca43fa329aa61687fca56e36837615a1b6adfc4ca540389383185680a23497d75a1698b1dcbb52741d29a4
-  languageName: node
-  linkType: hard
-
-"ws@npm:8.4.2":
-  version: 8.4.2
-  resolution: "ws@npm:8.4.2"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 6ce80cc740f00103611918147ca486938b1f9080216b8c251e8f07378d23eecf187255ed857cdf673c0757e0f1999a91dd4bcbcc18e0073bb7b1f86033eafd8d
   languageName: node
   linkType: hard
 
@@ -36624,22 +36540,13 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
-"yauzl@npm:2.10.0, yauzl@npm:^2.10.0":
+"yauzl@npm:^2.10.0":
   version: 2.10.0
   resolution: "yauzl@npm:2.10.0"
   dependencies:
     buffer-crc32: ~0.2.3
     fd-slicer: ~1.1.0
   checksum: f265002af7541b9ec3589a27f5fb8f11cf348b53cc15e2751272e3c062cd73f3e715bc72d43257de71bbaecae446c3f1b14af7559e8ab0261625375541816422
-  languageName: node
-  linkType: hard
-
-"yazl@npm:2.5.1":
-  version: 2.5.1
-  resolution: "yazl@npm:2.5.1"
-  dependencies:
-    buffer-crc32: ~0.2.3
-  checksum: 61a14fcf47246f1a667509809e1034d9548ef7a57cec94bc0395fa0ba74beaa6a412783b99ae59ee33e26e611929b909734f0aa5d1b32f811b206917f85fe87a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Proposed Changes

This PR updates the Playwright version to 1.22.2.

#### Testing Instructions

Ensure the following:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [x] i18n E2E
