### PR TITLE
Use `isNoAds()` in `isAddOn()`

### DIFF
--- a/packages/calypso-products/src/is-add-on.ts
+++ b/packages/calypso-products/src/is-add-on.ts
@@ -1,8 +1,7 @@
-import { camelOrSnakeSlug } from './camel-or-snake-slug';
-import { PRODUCT_NO_ADS } from './constants';
+import { isNoAds } from './is-no-ads';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isAddOn( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
 	// Right now the definition of an "add-on" just comes from a hardcoded list.
-	return camelOrSnakeSlug( product ) === PRODUCT_NO_ADS;
+	return isNoAds( product );
 }

--- a/packages/calypso-products/src/is-no-ads.ts
+++ b/packages/calypso-products/src/is-no-ads.ts
@@ -1,6 +1,7 @@
 import { camelOrSnakeSlug } from './camel-or-snake-slug';
+import { PRODUCT_NO_ADS } from './constants';
 import type { WithCamelCaseSlug, WithSnakeCaseSlug } from './types';
 
 export function isNoAds( product: WithCamelCaseSlug | WithSnakeCaseSlug ): boolean {
-	return 'no-adverts/no-adverts.php' === camelOrSnakeSlug( product );
+	return PRODUCT_NO_ADS === camelOrSnakeSlug( product );
 }


### PR DESCRIPTION
#### Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/64328 I added an `isAddOn()` method that checks for the No Ads add-on, but didn't realize there was an existing `isNoAds()` method already.

This pull request just merges the best parts of both of them.

#### Testing Instructions

Put the No Ads add-on in your shopping cart (e.g. by using the upgrade nudge on `/marketing/tools` for a site that doesn't have the No Ads feature) and make sure it looks the same in the cart with and without this pull request.