### PR TITLE
Fix a few minor issues in the agency dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -54,14 +54,14 @@ export default function SiteStatusContent( {
 
 	if ( type === 'site' ) {
 		// Site issues is the sum of scan threats and plugin updates
-		let siteIssues = rows.scan.threats + rows.plugin.updates;
+		let siteIssuesCount = rows.scan.threats + rows.plugin.updates;
 		let isHighSeverityError = !! rows.scan.threats;
 		if ( [ 'failed', 'warning' ].includes( rows.backup.status ) ) {
-			siteIssues = siteIssues + 1;
+			siteIssuesCount = siteIssuesCount + 1;
 			isHighSeverityError = isHighSeverityError || 'failed' === rows.backup.status;
 		}
 		if ( [ 'failed' ].includes( rows.monitor.status ) ) {
-			siteIssues = siteIssues + 1;
+			siteIssuesCount = siteIssuesCount + 1;
 			isHighSeverityError = true;
 		}
 		let errorContent;
@@ -71,7 +71,7 @@ export default function SiteStatusContent( {
 					<Gridicon size={ 24 } icon="notice-outline" />
 				</span>
 			);
-		} else if ( siteIssues ) {
+		} else if ( siteIssuesCount ) {
 			errorContent = (
 				<span
 					className={ classNames(
@@ -79,7 +79,7 @@ export default function SiteStatusContent( {
 						isHighSeverityError ? 'sites-overview__status-failed' : 'sites-overview__status-warning'
 					) }
 				>
-					{ siteIssues }
+					{ siteIssuesCount }
 				</span>
 			);
 		}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -54,7 +54,16 @@ export default function SiteStatusContent( {
 
 	if ( type === 'site' ) {
 		// Site issues is the sum of scan threats and plugin updates
-		const siteIssues = rows.scan.threats + rows.plugin.updates;
+		let siteIssues = rows.scan.threats + rows.plugin.updates;
+		let isFailed = !! rows.scan.threats;
+		if ( [ 'failed', 'warning' ].includes( rows.backup.status ) ) {
+			siteIssues = siteIssues + 1;
+			isFailed = isFailed || 'failed' === rows.backup.status;
+		}
+		if ( [ 'failed' ].includes( rows.monitor.status ) ) {
+			siteIssues = siteIssues + 1;
+			isFailed = true;
+		}
 		let errorContent;
 		if ( error ) {
 			errorContent = (
@@ -67,7 +76,7 @@ export default function SiteStatusContent( {
 				<span
 					className={ classNames(
 						'sites-overview__status-count',
-						rows.scan.threats ? 'sites-overview__status-failed' : 'sites-overview__status-warning'
+						isFailed ? 'sites-overview__status-failed' : 'sites-overview__status-warning'
 					) }
 				>
 					{ siteIssues }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -55,14 +55,14 @@ export default function SiteStatusContent( {
 	if ( type === 'site' ) {
 		// Site issues is the sum of scan threats and plugin updates
 		let siteIssues = rows.scan.threats + rows.plugin.updates;
-		let isFailed = !! rows.scan.threats;
+		let isHighSeverityError = !! rows.scan.threats;
 		if ( [ 'failed', 'warning' ].includes( rows.backup.status ) ) {
 			siteIssues = siteIssues + 1;
-			isFailed = isFailed || 'failed' === rows.backup.status;
+			isHighSeverityError = isHighSeverityError || 'failed' === rows.backup.status;
 		}
 		if ( [ 'failed' ].includes( rows.monitor.status ) ) {
 			siteIssues = siteIssues + 1;
-			isFailed = true;
+			isHighSeverityError = true;
 		}
 		let errorContent;
 		if ( error ) {
@@ -76,7 +76,7 @@ export default function SiteStatusContent( {
 				<span
 					className={ classNames(
 						'sites-overview__status-count',
-						isFailed ? 'sites-overview__status-failed' : 'sites-overview__status-warning'
+						isHighSeverityError ? 'sites-overview__status-failed' : 'sites-overview__status-warning'
 					) }
 				>
 					{ siteIssues }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -289,6 +289,8 @@ const formatBackupData = ( site: SiteData ) => {
 			break;
 		case 'rewind_backup_complete_warning':
 		case 'backup_only_complete_warning':
+		case 'rewind_backup_error_warning':
+		case 'backup_only_error_warning':
 			backup.status = 'warning';
 			backup.value = translate( 'Warning' );
 			break;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -91,6 +91,10 @@ const monitorEventNames: StatusEventNames = {
 		small_screen: 'calypso_jetpack_agency_dashboard_monitor_site_down_click_small_screen',
 		large_screen: 'calypso_jetpack_agency_dashboard_monitor_site_down_click_large_screen',
 	},
+	success: {
+		small_screen: 'calypso_jetpack_agency_dashboard_monitor_success_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_monitor_success_click_large_screen',
+	},
 };
 
 // Plugin updates status event names for large screen(>960px) and small screen(<960px)
@@ -210,7 +214,7 @@ const getLinks = (
 			if ( status === 'failed' ) {
 				link = `https://jptools.wordpress.com/debug/?url=${ siteUrl }`;
 				isExternalLink = true;
-			} else if ( status === 'disabled' ) {
+			} else {
 				link = `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack#/settings`;
 				isExternalLink = true;
 			}


### PR DESCRIPTION
#### Proposed Changes

This PR fixes a few minor issues in the agency dashboard

- Allowing clicking on monitor status when it is `success` and adding a track event to the same
- Showing alerts on the card header(small screen) when the backup status is `failed` or `warning` and the monitor status is `failed`.
- Add a few warning statutes to show warnings in the backup column

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/minor-issues-in-agency-dashboard` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard.
3. Verify that the monitor is clickable when the status is `success` (checkmark).
4. Verify that we are showing `warning` when the backup status is `rewind_backup_error_warning` or `backup_only_error_warning`
5. Switch to small screen view(<960px) using the toggle device toolbar in the dev tool(inspect)
6. Verify that the count is incremented when the backup status is `warning` or `failed` or the monitor status is `failed` and shown on the card header and the border color is yellow when everything is warning and red when there is some failed status.

<img width="320" alt="Screenshot 2022-06-08 at 12 09 31 PM" src="https://user-images.githubusercontent.com/10586875/172549048-e14f2adc-68e4-442e-9de9-8acf05208fa7.png">


Related to 1202076982646589-as-1202404806521219, 1202076982646589-as-1202404072732747 & 1202076982646589-as-1202403686601009