### PR TITLE
Prevent transfer lock opt-out only for new domain registration

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -149,7 +149,6 @@ class EditContactInfoFormCard extends Component {
 		const registrationDatePlus60Days = moment
 			.utc( this.props.selectedDomain.registrationDate )
 			.add( 60, 'days' );
-		// .toISOString();
 		const isLocked = moment.utc().isSameOrBefore( registrationDatePlus60Days );
 
 		if ( ! isLocked ) {

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -148,11 +148,11 @@ class EditContactInfoFormCard extends Component {
 		const { domainRegistrationAgreementUrl, translate } = this.props;
 		const registrationDatePlus60Days = moment
 			.utc( this.props.selectedDomain.registrationDate )
-			.add( 60, 'days' )
-			.toISOString();
-		const newRegistrationLock = moment.utc().isSameOrBefore( registrationDatePlus60Days );
+			.add( 60, 'days' );
+		// .toISOString();
+		const isLocked = moment.utc().isSameOrBefore( registrationDatePlus60Days );
 
-		if ( ! newRegistrationLock ) {
+		if ( ! isLocked ) {
 			return (
 				<>
 					<TransferLockOptOutForm

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -150,9 +150,9 @@ class EditContactInfoFormCard extends Component {
 			.utc( this.props.selectedDomain.registrationDate )
 			.add( 60, 'days' )
 			.toISOString();
-		const newRegistration = moment.utc().isBefore( registrationDatePlus60Days );
+		const newRegistrationLock = moment.utc().isSameOrBefore( registrationDatePlus60Days );
 
-		if ( ! newRegistration ) {
+		if ( ! newRegistrationLock ) {
 			return (
 				<>
 					<TransferLockOptOutForm

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -2,6 +2,7 @@ import { Dialog } from '@automattic/components';
 import { camelToSnakeCase, mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
 import { get, isEmpty, isEqual, includes, snakeCase } from 'lodash';
+import moment from 'moment';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -145,9 +146,13 @@ class EditContactInfoFormCard extends Component {
 
 	renderTransferLockOptOut() {
 		const { domainRegistrationAgreementUrl, translate } = this.props;
-		const transferLockExpiration = this.props.selectedDomain.transferAwayEligibleAt;
+		const registrationDatePlus60Days = moment
+			.utc( this.props.selectedDomain.registrationDate )
+			.add( 60, 'days' )
+			.toISOString();
+		const newRegistration = moment.utc().isBefore( registrationDatePlus60Days );
 
-		if ( ! transferLockExpiration ) {
+		if ( ! newRegistration ) {
 			return (
 				<>
 					<TransferLockOptOutForm


### PR DESCRIPTION
## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/63784 added check in Calypso to only show the opt-out checkbox on the contact change form when the domain is not already locked. We should only prevent it from being shown when the domain is in the initial registration period in order to allow users who forget to check it to make a second change which will allow them to opt-out again.

This PR allows to always opt-out the transfer-lock for all the domains registered more than 60 days ago.

![transfer-lock-before](https://user-images.githubusercontent.com/2797601/172677156-2ee8a3e1-c33e-4cb8-b3f6-cddddd590088.png)

![transfer-lock-after](https://user-images.githubusercontent.com/2797601/172677170-2227681f-847f-4c3c-8506-1425a2f3495a.png)

## Testing Instructions
- Checkout this branch locally or open the Calypso link below
- Select a domain registered more than 60 days ago and update the contact info, WITHOUT flagging the transfer opt-out control
- Try to update again the contact info and verify that the opt-out option is still present.