### PR TITLE
Convert `EmailForwardingAddNewCompactList` to functional component

### DIFF
--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.jsx
@@ -113,8 +113,9 @@ const EmailForwardingAddNewCompactList = ( {
 
 			<div className="email-forwarding-add-new-compact-list__actions">
 				<Button
-					primary
+					busy={ isSubmittingEmailForward }
 					disabled={ ! hasValidEmailForwards() || isSubmittingEmailForward }
+					primary
 					type="submit"
 				>
 					{ translate( 'Add' ) }

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.tsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.tsx
@@ -89,8 +89,7 @@ const EmailForwardingAddNewCompactList = ( {
 		name: 'destination' | 'mailbox',
 		value: string
 	) => {
-		// eslint-disable-next-line prefer-const
-		let newEmailForwards = [ ...emailForwards ];
+		const newEmailForwards = [ ...emailForwards ];
 		newEmailForwards[ index ][ name ] = value;
 
 		const validEmailForward = validateAllFields( newEmailForwards[ index ] );

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact.jsx
@@ -25,7 +25,6 @@ class EmailForwardingAddNewCompact extends Component {
 		super( props );
 
 		this.state = {
-			formSubmitting: false,
 			fields: this.props.fields,
 		};
 
@@ -91,7 +90,7 @@ class EmailForwardingAddNewCompact extends Component {
 				<FormFieldset>
 					<FormLabel>{ translate( 'Emails sent to' ) }</FormLabel>
 					<FormTextInputWithAffixes
-						disabled={ this.state.formSubmitting }
+						disabled={ this.props.disabled }
 						name="mailbox"
 						onChange={ ( event ) => this.onChange( event, index ) }
 						isError={ ! isValidMailbox }
@@ -104,7 +103,7 @@ class EmailForwardingAddNewCompact extends Component {
 				<FormFieldset>
 					<FormLabel>{ translate( 'Will be forwarded to this email address' ) }</FormLabel>
 					<FormTextInput
-						disabled={ this.state.formSubmitting }
+						disabled={ this.props.disabled }
 						name="destination"
 						onChange={ ( event ) => this.onChange( event, index ) }
 						isError={ ! isValidDestination }

--- a/client/my-sites/email/email-forwards-add/style.scss
+++ b/client/my-sites/email/email-forwards-add/style.scss
@@ -1,5 +1,5 @@
 .email-forwarding__add-new {
-	margin-bottom: 1em;
+	margin-bottom: 28px;
 
 	.email-forwarding__add-new .email-forwarding__form-content {
 		border-top: none;

--- a/client/my-sites/email/email-forwards-add/style.scss
+++ b/client/my-sites/email/email-forwards-add/style.scss
@@ -1,8 +1,5 @@
-.email-forwards-add {
-	.email-forwarding__add-new-separator {
-		height: 0;
-		margin-bottom: 1em;
-	}
+.email-forwarding__add-new {
+	margin-bottom: 1em;
 
 	.email-forwarding__add-new .email-forwarding__form-content {
 		border-top: none;


### PR DESCRIPTION
#### Proposed Changes

- Converted `EmailForwardingAddNewCompactList` to a functional component to enable the use of react-query hooks for data fetching
- Converted the associated form to an actual `<form>` element, with an `onSubmit` handler (previously just an `onClick` handler on the "Add" button)
- Updated the associated form controls to be disabled while the form is being submitted

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this branch
2. Have a domain with email forwards
3. Navigate to `/email/:domain/forwarding/add/:site_slug`
4. Add a new email forward
5. Ensure that the form controls are disabled while the form is being submitted
6. Ensure that the email forward is added properly

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
