### PR TITLE
Setting up AB test on domains step

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -1,12 +1,34 @@
 import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { isStarterPlanEnabled } from 'calypso/my-sites/plans-comparison';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
 class ReskinSideExplainer extends Component {
+	_isMounted = false;
+	constructor( props ) {
+		super( props );
+		this.state = {
+			experiment: null,
+		};
+	}
+	componentDidMount() {
+		this._isMounted = true;
+
+		loadExperimentAssignment( 'pricing_packaging_domains_pick_later' ).then( ( experimentName ) => {
+			if ( this._isMounted ) {
+				this.setState( { experiment: experimentName } );
+			}
+		} );
+	}
+
+	componentWillUnmount() {
+		this._isMounted = false;
+	}
+
 	getStarterPlanOverrides( isEnLocale ) {
 		const { translate } = this.props;
 
@@ -61,7 +83,15 @@ class ReskinSideExplainer extends Component {
 			subtitle = subtitle2;
 			subtitle2 = null;
 		}
-		return { title, subtitle, subtitle2, ctaText: false };
+
+		const hasCta = i18n.hasTranslation( 'Choose my domain later' ) || isEnLocale;
+
+		const ctaText =
+			hasCta && this.state.experiment?.variationName === 'treatment'
+				? translate( 'Choose my domain later' )
+				: false;
+
+		return { title, subtitle, subtitle2, ctaText };
 	}
 	getStrings() {
 		const { type, translate } = this.props;


### PR DESCRIPTION
#### Proposed Changes

This PR uses Explat (test name `pricing_packaging_domains_pick_later`) to test adding the skip option back to the domain step, which was removed during Phase 1 of the new plan rollout.

Here's a screenshot of the link back in place:
![CleanShot 2022-06-08 at 10 26 49@2x](https://user-images.githubusercontent.com/35781181/172642264-aa9856a9-8b77-47dc-a4bf-7284f68c68a7.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and start Calypso locally.
* Navigate to the Explat page for test name `pricing_packaging_domains_pick_later`.
* Assign yourself to the `treatment` variation (click link at the top of the Bookmarklet modal and assign your main username).
* If you have `public-api` sandboxed, ensure it's up-to-date.
* Navigate to startup in Calypso and confirm that the you see the link.
* Assign yourself to the `control` variation and confirm that you don't see the link.
* Click the link and confirm that you're brought to the plans page.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
