### PR TITLE
Update isEligibleForProPlan selector to check if siteId is Pro as well

### DIFF
--- a/client/my-sites/plans-comparison/is-eligible-for-pro-plan.ts
+++ b/client/my-sites/plans-comparison/is-eligible-for-pro-plan.ts
@@ -3,10 +3,11 @@ import { isPro } from '@automattic/calypso-products';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { AppState } from 'calypso/types';
 
-export function isEligibleForProPlan( state: AppState, siteId?: number ): boolean {
+export function isEligibleForProPlan( state: AppState, siteId?: number | null ): boolean {
 	if (
 		siteId &&
 		( ( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
@@ -14,8 +15,9 @@ export function isEligibleForProPlan( state: AppState, siteId?: number ): boolea
 	) {
 		return false;
 	}
-
-	const currentPlan = getCurrentPlan( state, siteId );
+	siteId = siteId || getSelectedSiteId( state );
+	const selectedSite = getSite( state, siteId || '' );
+	const currentPlan = getCurrentPlan( state, siteId ) || selectedSite?.plan;
 	if ( currentPlan && isPro( currentPlan ) ) {
 		return true;
 	}

--- a/client/my-sites/plans-comparison/is-eligible-for-pro-plan.ts
+++ b/client/my-sites/plans-comparison/is-eligible-for-pro-plan.ts
@@ -1,6 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { isPro } from '@automattic/calypso-products';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import type { AppState } from 'calypso/types';
 
@@ -11,6 +13,11 @@ export function isEligibleForProPlan( state: AppState, siteId?: number ): boolea
 			isSiteWPForTeams( state, siteId ) )
 	) {
 		return false;
+	}
+
+	const currentPlan = getCurrentPlan( state, siteId );
+	if ( currentPlan && isPro( currentPlan ) ) {
+		return true;
 	}
 
 	return isEnabled( 'plans/pro-plan' );

--- a/client/my-sites/plans-comparison/is-eligible-for-pro-plan.ts
+++ b/client/my-sites/plans-comparison/is-eligible-for-pro-plan.ts
@@ -2,7 +2,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import { isPro } from '@automattic/calypso-products';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite, getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { AppState } from 'calypso/types';
@@ -17,7 +16,7 @@ export function isEligibleForProPlan( state: AppState, siteId?: number | null ):
 	}
 	siteId = siteId || getSelectedSiteId( state );
 	const selectedSite = getSite( state, siteId || '' );
-	const currentPlan = getCurrentPlan( state, siteId ) || selectedSite?.plan;
+	const currentPlan = selectedSite?.plan;
 	if ( currentPlan && isPro( currentPlan ) ) {
 		return true;
 	}


### PR DESCRIPTION
#### Proposed Changes

This allows the `isEligibleForProPlan` to return true if the user is on Pro plan, event if the `plans/pro-plan` flag is disabled.
Without this, we can get inconsistent behavior and content with the current Pro plan.

<img width="320" src="https://user-images.githubusercontent.com/2749938/172661700-2d23db01-bc73-455c-b113-5175b4d45909.png" />
<img width="320" alt="Screenshot on 2022-06-08 at 18-50-21" src="https://user-images.githubusercontent.com/2749938/172661705-695a5694-8b6e-4a9a-a867-26999f02c25c.png">


Addresses #64450

#### Testing Instructions

* Go to the Plugins page on a Pro plan site
* Select a Plugin (ex. Yoast)
* You should see `Premium support` mentions on the right side

<img width="320" alt="Screenshot on 2022-06-08 at 18-40-56" src="https://user-images.githubusercontent.com/2749938/172660862-4928749a-2e37-413e-871d-41722600943a.png">

* Go to the `/plans/[siteId]` page
* You should be redirected to the My Plan page
<img width="320" alt="Screenshot on 2022-06-08 at 18-40-56" src="https://user-images.githubusercontent.com/2749938/172661102-ee76a3df-9264-443d-ab23-8c4d4b1a4d11.png">



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/64450