### PR TITLE
E2E: make `StartSiteFlow` methods for intent capture to be more resilient.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -7,8 +7,8 @@ const selectors = {
 	backLink: 'button:text("Back")',
 
 	// Inputs
-	blogNameInput: 'input#siteTitle:not(:disabled)',
-	taglineInput: 'input#tagline:not(:disabled)',
+	blogNameInput: 'input[name="siteTitle"]',
+	taglineInput: 'input[name="tagline"]',
 
 	// Themes
 	themePickerContainer: '.design-picker',
@@ -51,7 +51,13 @@ export class StartSiteFlow {
 	async enterBlogName( name: string ): Promise< void > {
 		await this.page.waitForLoadState( 'networkidle' );
 		const locator = this.page.locator( selectors.blogNameInput );
+		await locator.fill( '' );
 		await locator.fill( name );
+
+		const readBack = await locator.inputValue();
+		if ( readBack !== name ) {
+			throw new Error( `Failed to set blog name: expected ${ name }, got ${ readBack }` );
+		}
 	}
 
 	/**
@@ -62,7 +68,13 @@ export class StartSiteFlow {
 	async enterTagline( tagline: string ): Promise< void > {
 		await this.page.waitForLoadState( 'networkidle' );
 		const locator = this.page.locator( selectors.taglineInput );
+		await locator.fill( '' );
 		await locator.fill( tagline );
+
+		const readBack = await locator.inputValue();
+		if ( readBack !== tagline ) {
+			throw new Error( `Failed to set blog tagline: expected ${ tagline }, got ${ readBack }` );
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -7,7 +7,7 @@ const selectors = {
 	backLink: 'button:text("Back")',
 
 	// Inputs
-	blogNameInput: 'input[name="siteTitle"]',
+	blogNameInput: ( value: string ) => `input[name="siteTitle"][value="${ value }"]`,
 	taglineInput: 'input[name="tagline"]',
 
 	// Themes
@@ -50,11 +50,14 @@ export class StartSiteFlow {
 	 */
 	async enterBlogName( name: string ): Promise< void > {
 		await this.page.waitForLoadState( 'networkidle' );
-		const locator = this.page.locator( selectors.blogNameInput );
-		await locator.fill( '' );
-		await locator.fill( name );
+		// Wait for the input to be populated with the default value `Site Title`.
+		// See https://github.com/Automattic/wp-calypso/issues/64271.
+		const defaultInputlocator = this.page.locator( selectors.blogNameInput( 'Site Title' ) );
+		await defaultInputlocator.fill( name );
 
-		const readBack = await locator.inputValue();
+		// Verify the data is saved as expected.
+		const filledInputLocator = this.page.locator( selectors.blogNameInput( name ) );
+		const readBack = await filledInputLocator.inputValue();
 		if ( readBack !== name ) {
 			throw new Error( `Failed to set blog name: expected ${ name }, got ${ readBack }` );
 		}
@@ -68,9 +71,9 @@ export class StartSiteFlow {
 	async enterTagline( tagline: string ): Promise< void > {
 		await this.page.waitForLoadState( 'networkidle' );
 		const locator = this.page.locator( selectors.taglineInput );
-		await locator.fill( '' );
 		await locator.fill( tagline );
 
+		// Verify the data is saved as expected.
 		const readBack = await locator.inputValue();
 		if ( readBack !== tagline ) {
 			throw new Error( `Failed to set blog tagline: expected ${ tagline }, got ${ readBack }` );


### PR DESCRIPTION
#### Proposed Changes

This PR is attempt 2 at making the `StartSiteFlow.enterBlogName` and `StartSIteFlow.enterBlogTagline` methods to be more reliable.

The previous attempt https://github.com/Automattic/wp-calypso/pull/64307 appeared to have solved the problem in testing on branch, but this particular issue resurfaced in the second Pre-Release Test run after it was merged into `trunk`:

![image](https://user-images.githubusercontent.com/6549265/172664897-c3f23bab-5624-4512-a8f9-a6f07153fd02.png)

Key changes:
- update the selector;
- fill with an empty string first;
- add checks to ensure the input value has not been reset to default;

#### Testing Instructions

Ensure the following:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

Related to https://github.com/Automattic/wp-calypso/issues/64271.
