### PR TITLE
"Add new subscription" open the payment modal

### DIFF
--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -112,7 +112,7 @@ class MembershipsProductsSection extends Component {
 						{ this.renderEllipsisMenu( product.ID ) }
 					</CompactCard>
 				) ) }
-				{ this.state.showAddEditDialog && (
+				{ this.state.showAddEditDialog && this.props.hasStripeFeature && (
 					<RecurringPaymentsPlanAddEditModal
 						closeDialog={ this.closeDialog }
 						product={ this.state.product }

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -28,7 +28,7 @@ import './style.scss';
 
 class MembershipsProductsSection extends Component {
 	state = {
-		showAddEditDialog: false,
+		showAddEditDialog: window.location.hash === '#add-new-payment-plan',
 		showDeleteDialog: false,
 		product: null,
 	};


### PR DESCRIPTION
#### Proposed Changes

For page /earn/payment-plans if user add hash #add-new-payment-plan to URL then modal with add new plan will be opened on page load

#### Testing Instructions

Go to page /earn/payment-plans/YOUR_SITE/
Check if page loads without opened modal popup.
Go to page /earn/payment-plans/YOUR_SITE/#add-new-payment-plan
Verify if page loads with opened modal popup to add new paid plan.

Related to https://github.com/Automattic/wp-calypso/issues/62888

<img width="1727" alt="Screenshot 2022-06-08 at 18 40 56" src="https://user-images.githubusercontent.com/82798599/172673864-6bb069c0-13f0-433a-bbb4-50fc994d436c.png">

