### PR TITLE
Stepper - Seller Experience: Edit email step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/edit-email/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/edit-email/index.tsx
@@ -1,6 +1,6 @@
 import { FormInputValidation } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import emailValidator from 'email-validator';
 import React, { FormEvent, ReactElement, useState } from 'react';
@@ -19,16 +19,16 @@ import './style.scss';
 type FormFields = 'email' | 'password';
 
 const EditEmail: Step = function EditEmail( { navigation } ) {
-	const { goBack } = navigation;
+	const { goBack, submit } = navigation;
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const { __ } = useI18n();
 	const [ errors, setErrors ] = useState( {} as Record< FormFields, string > );
 	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
+	const { setEditEmail } = useDispatch( ONBOARD_STORE );
 	const [ email, setEmail ] = useState( '' );
-	const [ submitted, setSubmitted ] = useState( false );
 	const [ sendError, setSendError ] = useState( '' );
 
-	const headerText = __( 'Enter a new email address, and your current password' );
+	const headerText = __( 'Enter a new email address' );
 
 	const validate = (): boolean => {
 		const errors = {} as Record< FormFields, string >;
@@ -55,7 +55,9 @@ const EditEmail: Step = function EditEmail( { navigation } ) {
 				user_email: email,
 			} );
 
-			setSubmitted( true );
+			await setEditEmail( email );
+
+			submit?.();
 		} catch ( err: any ) {
 			setSendError( err.message );
 		}
@@ -81,24 +83,15 @@ const EditEmail: Step = function EditEmail( { navigation } ) {
 					</FormFieldset>
 
 					<ActionSection>
-						{ ! submitted && (
-							<StyledNextButton
-								type="submit"
-								disabled={ Object.values( errors ).filter( Boolean ).length > 0 }
-							>
-								{ __( 'Send a verification to my new email' ) }
-							</StyledNextButton>
-						) }
+						<StyledNextButton
+							type="submit"
+							disabled={ Object.values( errors ).filter( Boolean ).length > 0 }
+						>
+							{ __( 'Send a verification to my new email' ) }
+						</StyledNextButton>
 						{ sendError && (
 							<Notice className="edit-email__error" showDismiss={ false } status="is-error">
 								{ sendError }
-							</Notice>
-						) }
-						{ submitted && (
-							<Notice className="edit-email__notice" showDismiss={ false } status="is-info">
-								{ __(
-									'Your email change is pending. Please take a moment to check for an email with the subject "[WordPress.com] New Email Address" to confirm your change.'
-								) }
 							</Notice>
 						) }
 					</ActionSection>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/edit-email/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/edit-email/index.tsx
@@ -1,0 +1,142 @@
+import { FormInputValidation } from '@automattic/components';
+import { StepContainer } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import emailValidator from 'email-validator';
+import React, { FormEvent, ReactElement, useState } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormInput from 'calypso/components/forms/form-text-input';
+import Notice from 'calypso/components/notice';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
+import { ActionSection, StyledNextButton } from 'calypso/signup/steps/woocommerce-install';
+import type { Step } from '../../types';
+import './style.scss';
+
+type FormFields = 'email' | 'password';
+
+const EditEmail: Step = function EditEmail( { navigation } ) {
+	const { goBack } = navigation;
+	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
+	const { __ } = useI18n();
+	const [ errors, setErrors ] = useState( {} as Record< FormFields, string > );
+	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
+	const [ email, setEmail ] = useState( '' );
+	const [ submitted, setSubmitted ] = useState( false );
+	const [ sendError, setSendError ] = useState( '' );
+
+	const headerText = __( 'Enter a new email address, and your current password' );
+
+	const validate = (): boolean => {
+		const errors = {} as Record< FormFields, string >;
+
+		errors[ 'email' ] = ! emailValidator.validate( email )
+			? __( 'Please add a valid email address' )
+			: '';
+
+		setErrors( errors );
+
+		return Object.values( errors ).filter( Boolean ).length === 0;
+	};
+
+	const onSubmit = async ( event: FormEvent ) => {
+		event.preventDefault();
+
+		if ( ! validate() ) {
+			return;
+		}
+
+		try {
+			await wpcom.req.post( '/me/settings', {
+				apiVersion: '1.1',
+				user_email: email,
+			} );
+
+			setSubmitted( true );
+		} catch ( err: any ) {
+			setSendError( err.message );
+		}
+	};
+
+	const getContent = () => {
+		return (
+			<>
+				<form onSubmit={ onSubmit }>
+					<FormFieldset>
+						<FormLabel htmlFor="email">{ __( 'New email' ) }</FormLabel>
+						<FormInput
+							value={ email }
+							name="email"
+							id="email"
+							onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) => {
+								setErrors( {} as Record< FormFields, string > );
+								setEmail( e.target.value );
+							} }
+							className={ errors[ 'email' ] ? 'is-error' : '' }
+						/>
+						<ControlError error={ errors[ 'email' ] ?? '' } />
+					</FormFieldset>
+
+					<ActionSection>
+						{ ! submitted && (
+							<StyledNextButton
+								type="submit"
+								disabled={ Object.values( errors ).filter( Boolean ).length > 0 }
+							>
+								{ __( 'Send a verification to my new email' ) }
+							</StyledNextButton>
+						) }
+						{ sendError && (
+							<Notice className="edit-email__error" showDismiss={ false } status="is-error">
+								{ sendError }
+							</Notice>
+						) }
+						{ submitted && (
+							<Notice className="edit-email__notice" showDismiss={ false } status="is-info">
+								{ __(
+									'Your email change is pending. Please take a moment to check for an email with the subject "[WordPress.com] New Email Address" to confirm your change.'
+								) }
+							</Notice>
+						) }
+					</ActionSection>
+				</form>
+			</>
+		);
+	};
+
+	return (
+		<StepContainer
+			stepName={ 'edit-email' }
+			className={ `is-step-${ intent }` }
+			skipButtonAlign={ 'top' }
+			goBack={ goBack }
+			isHorizontalLayout={ true }
+			formattedHeader={
+				<FormattedHeader
+					id={ 'edit-email-header' }
+					headerText={ headerText }
+					subHeaderText={ __(
+						"We'll send you an email to the new address to verify that you own it."
+					) }
+					align={ 'left' }
+				/>
+			}
+			intent={ intent }
+			stepContent={ getContent() }
+			recordTracksEvent={ recordTracksEvent }
+			stepProgress={ stepProgress }
+		/>
+	);
+};
+
+function ControlError( { error }: { error: string } ): ReactElement | null {
+	if ( error ) {
+		return <FormInputValidation isError={ true } isValid={ false } text={ error } />;
+	}
+	return null;
+}
+
+export default EditEmail;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/edit-email/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/edit-email/style.scss
@@ -1,0 +1,39 @@
+@import '../style';
+
+.step-container.edit-email {
+	.components-combobox-control__input {
+		padding: 7px 14px;
+	}
+	.components-combobox-control__suggestions-container {
+		width: unset;
+		border-color: var( --color-neutral-10 );
+	}
+	.step-container__header {
+		flex: 1;
+	}
+	.step-container__content {
+		flex: 1;
+		@include break-mobile {
+			padding-left: 40px;
+		}
+	}
+
+	fieldset.edit-email__form-footer  {
+		position: relative;
+		padding-left: 19px;
+	}
+
+	fieldset.edit-email__form-footer  svg {
+		position: absolute;
+		top: 5px;
+		left: 0;
+	}
+
+	fieldset.edit-email__form-footer p {
+		font-size: 14px;
+	}
+
+	.edit-email__error {
+		margin-top: 1rem;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -28,6 +28,7 @@ export { default as processing } from './processing-step';
 export { default as error } from './error-step';
 export { default as wooConfirm } from './woo-confirm';
 export { default as wooVerifyEmail } from './woo-verify-email';
+export { default as editEmail } from './edit-email';
 
 export type StepPath =
 	| 'courses'
@@ -59,4 +60,5 @@ export type StepPath =
 	| 'wooInstallPlugins'
 	| 'error'
 	| 'wooConfirm'
-	| 'wooVerifyEmail';
+	| 'wooVerifyEmail'
+	| 'editEmail';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-verify-email/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-verify-email/index.tsx
@@ -1,11 +1,13 @@
 import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { UserData } from 'calypso/lib/user/user';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -17,18 +19,36 @@ function redirect( to: string ) {
 }
 
 const WooVerifyEmail: Step = function WooVerifyEmail( { navigation } ) {
-	const { goBack } = navigation;
+	const { goBack, submit } = navigation;
 	const { __ } = useI18n();
 	const user = useSelector( getCurrentUser ) as UserData;
+	const { setEditEmail } = useDispatch( ONBOARD_STORE );
+	const editEmail = useSelect( ( select ) => select( ONBOARD_STORE ).getEditEmail() );
 
 	function getContent() {
 		return (
 			<div className="woo-verify-email__content">
-				<Button className="woo-verify-email__button" primary>
+				<Button
+					className="woo-verify-email__button"
+					primary
+					onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
+						e.preventDefault();
+
+						setEditEmail( '' );
+					} }
+				>
 					{ __( 'Resend verification email' ) }
 				</Button>
 				<br />
-				<Button className="woo-verify-email__link" borderless href="#">
+				<Button
+					className="woo-verify-email__link"
+					borderless
+					onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
+						e.preventDefault();
+
+						submit?.( {}, 'edit-email' );
+					} }
+				>
 					{ __( 'Edit email address' ) }
 				</Button>
 			</div>
@@ -52,7 +72,7 @@ const WooVerifyEmail: Step = function WooVerifyEmail( { navigation } ) {
 			__(
 				'A verification email has been sent to %(userEmail)s. <br />Please continue your journey from the link sent.'
 			),
-			{ userEmail }
+			{ userEmail: editEmail.length > 0 ? editEmail : userEmail }
 		),
 		{ br: createElement( 'br' ) }
 	);

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -55,6 +55,8 @@ export const siteSetupFlow: Flow = {
 			'wooInstallPlugins',
 			...( isEnabled( 'signup/woo-verify-email' ) ? [ 'wooVerifyEmail' ] : [] ),
 			'wooConfirm',
+			'editEmail',
+			...( isEnabled( 'signup/woo-verify-email' ) ? [ 'editEmail' ] : [] ),
 		] as StepPath[];
 	},
 	useSideEffect() {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -252,6 +252,17 @@ export const siteSetupFlow: Flow = {
 				case 'wooInstallPlugins':
 					return navigate( 'processing' );
 
+				case 'editEmail':
+					return navigate( 'wooVerifyEmail' );
+
+				case 'wooVerifyEmail': {
+					if ( params[ 0 ] === 'edit-email' ) {
+						return navigate( 'editEmail' );
+					}
+
+					return navigate( 'wooVerifyEmail' );
+				}
+
 				case 'courses': {
 					return exitFlow( `/post/${ siteSlug }` );
 				}
@@ -311,6 +322,9 @@ export const siteSetupFlow: Flow = {
 						return navigate( 'bloggerStartingPoint' );
 					}
 					return navigate( 'intent' );
+
+				case 'editEmail':
+					return navigate( 'wooVerifyEmail' );
 
 				case 'importList':
 				case 'importReady':

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -257,6 +257,11 @@ export const setGoals = ( goals: GoalKey[] ) => ( {
 	goals,
 } );
 
+export const setEditEmail = ( email: string ) => ( {
+	type: 'SET_EDIT_EMAIL' as const,
+	email,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -289,4 +294,5 @@ export type OnboardAction = ReturnType<
 	| typeof setProgressTitle
 	| typeof setStepProgress
 	| typeof setGoals
+	| typeof setEditEmail
 >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -305,6 +305,16 @@ const goals: Reducer< GoalKey[], OnboardAction > = ( state = [], action ) => {
 	return state;
 };
 
+const editEmail: Reducer< string, OnboardAction > = ( state = [], action ) => {
+	if ( action.type === 'SET_EDIT_EMAIL' ) {
+		return action.email;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return '';
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	anchorPodcastId,
 	anchorEpisodeId,
@@ -333,6 +343,7 @@ const reducer = combineReducers( {
 	progressTitle,
 	stepProgress,
 	goals,
+	editEmail,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -305,7 +305,7 @@ const goals: Reducer< GoalKey[], OnboardAction > = ( state = [], action ) => {
 	return state;
 };
 
-const editEmail: Reducer< string, OnboardAction > = ( state = [], action ) => {
+const editEmail: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_EDIT_EMAIL' ) {
 		return action.email;
 	}

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -46,3 +46,5 @@ export const hasSelectedDesign = ( state: State ) => !! state.selectedDesign;
 
 export const hasSelectedDesignWithoutFonts = ( state: State ) =>
 	hasSelectedDesign( state ) && ! state.selectedFonts;
+
+export const getEditEmail = ( state: State ) => state.editEmail;


### PR DESCRIPTION
#### Proposed Changes

This adds a new step allowing the user to edit their account email address.

Clicking "Edit email" from `wooVerifyEmail` takes you to the `editEmail` step.

Success after clicking "Send a verification to my new email" takes the user back to `wooVerifyEmail`.

#### Testing Instructions

** Success testing **
1. Go to http://calypso.localhost:3000/setup/wooVerifyEmail?siteSlug=[slug]&flags=signup/woo-verify-email and click "Edit email address".
1. Enter a new, unique email address and click "Send a verification to my new email".
1. You should be taken back to the `wooVerifyEmail` step and should receive a verification email.

** Failure testing **
1. Go to http://calypso.localhost:3000/setup/wooVerifyEmail?siteSlug=[slug]&flags=signup/woo-verify-email and click "Edit email address".
1. Enter an email address that's already in use (like bobo@bob.com) and click "Send a verification to my new email".
1. You should see an error notice as pictured below.

Closes #64163

https://user-images.githubusercontent.com/917632/172869660-ccc6bc6b-5124-42cd-afa9-5b3b3afe9adb.mp4

** Initial view **
<img width="1418" alt="image" src="https://user-images.githubusercontent.com/917632/172689319-ab00f85d-c027-4d7d-92a0-5a1ef38603d6.png">

** Error sending verification email **
![CleanShot 2022-06-09 at 10 14 00](https://user-images.githubusercontent.com/917632/172869514-9d091442-01ab-422f-aed9-54a2d3039ee7.jpeg)