### PR TITLE
Fix RTL issues in onboarding flow

### DIFF
--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -35,11 +35,11 @@
 	}
 
 	&.is-left-align {
-		text-align: left;
+		text-align: start;
 	}
 
 	&.is-right-align {
-		text-align: right;
+		text-align: end;
 	}
 }
 
@@ -80,7 +80,7 @@
 // Compact header on small screens
 .formatted-header.is-compact-on-mobile {
 	@include breakpoint-deprecated( '<660px' ) {
-		text-align: left;
+		text-align: start;
 
 		.formatted-header__title {
 			font-size: 17px;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -81,16 +81,16 @@ button {
 	.signup-header {
 		.wordpress-logo {
 			position: absolute;
-			left: 20px;
-			top: 20px;
+			inset-inline-start: 20px;
+			inset-block-start: 20px;
 			fill: var( --color-text );
 			stroke: var( --color-text );
 			transform-origin: 0 0;
 		}
 
 		.signup-header__right {
-			top: 22px;
-			right: 20px;
+			inset-block-start: 22px;
+			inset-inline-start: 20px;
 
 			.flow-progress-indicator {
 				font-weight: 500;
@@ -102,11 +102,11 @@ button {
 
 		@include break-small {
 			.wordpress-logo {
-				left: 24px;
+				inset-inline-start: 24px;
 			}
 
 			.signup-header__right {
-				right: 24px;
+				inset-inline-end: 24px;
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -9,8 +9,8 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 .design-setup {
 	.step-container {
-		padding-left: 20px;
-		padding-right: 20px;
+		padding-inline-start: 20px;
+		padding-inline-end: 20px;
 		max-width: 1440px;
 
 		.step-container__content {
@@ -18,8 +18,8 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		}
 
 		@include break-small {
-			padding-left: 48px;
-			padding-right: 48px;
+			padding-inline-start: 48px;
+			padding-inline-end: 48px;
 		}
 	}
 
@@ -54,7 +54,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		.formatted-header {
 			margin: 0;
 			flex-grow: 1;
-			text-align: left;
+			text-align: start;
 
 			&.anchor-fm-design-picker__header {
 				flex-basis: 100%;
@@ -69,7 +69,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 				font-size: 2.15rem; /* stylelint-disable-line */
 				font-weight: 400;
 				padding: 0;
-				text-align: left;
+				text-align: start;
 				margin: 0;
 
 				@include break-xlarge {
@@ -79,7 +79,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 			.formatted-header__subtitle {
 				padding: 0;
-				text-align: left;
+				text-align: start;
 				color: $gray-60;
 				font-size: 1rem;
 				margin: 12px 0 32px;
@@ -290,14 +290,14 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 		@include onboarding-break-full-hd {
 			.generated-design-picker__thumbnails {
-				padding-right: 4rem;
+				padding-inline-end: 4rem;
 			}
 		}
 
 		@include onboarding-break-2k {
 			max-width: 2240px;
-			padding-left: 0;
-			padding-right: 0;
+			padding-inline-start: 0;
+			padding-inline-end: 0;
 		}
 	}
 
@@ -346,7 +346,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 				svg {
 					height: 6px;
-					left: 12px;
+					inset-inline-start: 12px;
 
 					rect {
 						height: 6px;
@@ -449,14 +449,14 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 			position: sticky;
 			top: 109px;
 			flex: 0 154px;
-			padding-right: 1.5rem;
+			padding-inline-end: 1.5rem;
 			margin-bottom: 0;
 		}
 
 		@include break-medium {
 			flex: 0 248px;
 			margin-bottom: 0;
-			padding-right: 2rem;
+			padding-inline-end: 2rem;
 		}
 	}
 
@@ -468,11 +468,11 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 		.web-preview__inner {
 			opacity: 0;
-			left: 0;
+			inset-inline-start: 0;
 			overflow: hidden;
 			pointer-events: none;
 			position: absolute;
-			right: 0;
+			inset-inline-end: 0;
 			top: 0;
 			transition: opacity 0.15s ease-in-out;
 
@@ -487,7 +487,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 				height: 34px;
 
 				svg {
-					left: 12px;
+					inset-inline-start: 12px;
 				}
 			}
 

--- a/client/signup/signup-header/style.scss
+++ b/client/signup/signup-header/style.scss
@@ -2,9 +2,9 @@
 // the signup flow.
 .signup-header {
 	position: absolute;
-	top: 0;
-	right: 0;
-	left: 0;
+	inset-block-start: 0;
+	inset-inline-start: 0;
+	inset-inline-end: 0;
 	z-index: -1;
 	color: var( --color-text-inverted );
 
@@ -32,13 +32,13 @@
 
 	.signup-header__left {
 		position: absolute;
-		top: 12px;
-		left: 16px;
+		inset-block-start: 12px;
+		inset-inline-start: 16px;
 	}
 
 	.signup-header__right {
 		position: absolute;
-		top: 12px;
-		right: 16px;
+		inset-block-start: 12px;
+		inset-inline-end: 16px;
 	}
 }

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -338,15 +338,15 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 	.signup-header {
 		.wordpress-logo {
 			position: absolute;
-			left: 20px;
-			top: 20px;
+			inset-inline-start: 20px;
+			inset-block-start: 20px;
 			fill: var( --color-text );
 			stroke: var( --color-text );
 			transform-origin: 0 0;
 		}
 		.signup-header__right {
-			top: 22px;
-			right: 20px;
+			inset-block-start: 22px;
+			inset-inline-end: 20px;
 
 			.flow-progress-indicator {
 				font-weight: 500; /* stylelint-disable-line */
@@ -357,11 +357,11 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 
 		@include break-small {
 			.wordpress-logo {
-				left: 24px;
+				inset-inline-start: 24px;
 			}
 
 			.signup-header__right {
-				right: 24px;
+				inset-inline-end: 24px;
 			}
 		}
 	}
@@ -388,8 +388,8 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 
 		@include break-small {
-			left: 72px;
-			right: 24px;
+			inset-inline-start: 72px;
+			inset-inline-end: 24px;
 		}
 	}
 
@@ -516,7 +516,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 
 		.social-buttons__button {
-			text-align: left;
+			text-align: start;
 			padding-left: 0;
 			padding-bottom: 0;
 			border: 0;
@@ -680,18 +680,18 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 				&::before {
 					position: absolute;
 					content: '';
-					border-left: 0;
-					border-top: $separator-style;
-					top: 50%;
-					left: 0;
+					border-inline-start: 0;
+					border-block-start: $separator-style;
+					inset-block-start: 50%;
+					inset-inline-start: 0;
 					height: 0;
 					width: 100%;
 
 					@include break-medium {
-						border-left: $separator-style;
-						border-top: 0;
-						top: 0;
-						left: 50%;
+						border-inline-start: $separator-style;
+						border-block-start: 0;
+						inset-block-start: 0;
+						inset-inline-start: 50%;
 						height: 100%;
 					}
 				}
@@ -712,13 +712,13 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 			}
 
 			.social-buttons__service-name {
-				margin-left: 12px;
+				margin-inline-start: 12px;
 			}
 
 			p.signup-form__social-buttons-tos {
 				font-size: 0.75rem;
-				text-align: left;
-				padding-left: 0;
+				text-align: start;
+				padding-inline-start: 0;
 				margin-top: 19px;
 
 				@include break-small {
@@ -726,7 +726,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 				}
 
 				@include break-medium {
-					text-align: left;
+					text-align: start;
 				}
 			}
 		}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -447,7 +447,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 			.formatted-header__title,
 			.formatted-header__subtitle {
 				padding: 0;
-				text-align: left;
+				text-align: start;
 			}
 		}
 
@@ -455,7 +455,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 			.formatted-header__title,
 			.formatted-header__subtitle {
 				padding: 0;
-				text-align: right;
+				text-align: end;
 			}
 		}
 	}
@@ -529,7 +529,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 			}
 
 			@include break-medium {
-				text-align: left;
+				text-align: start;
 			}
 
 			> svg {
@@ -540,7 +540,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 
 		.signup-form__terms-of-service-link {
-			text-align: left;
+			text-align: start;
 			font-size: 0.875rem;
 			margin-bottom: 32px;
 		}
@@ -628,7 +628,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 				.logged-out-form__links {
 					margin: 0;
 					padding: 0;
-					text-align: left;
+					text-align: start;
 
 					&::before {
 						content: none;
@@ -639,7 +639,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 					}
 
 					@include break-medium {
-						text-align: left;
+						text-align: end;
 					}
 				}
 			}
@@ -657,7 +657,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 			}
 
 			.signup-form__social p {
-				text-align: left;
+				text-align: start;
 			}
 
 			.signup-form__social > p {
@@ -756,18 +756,18 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 
 		@include break-wide {
-			padding-left: 20px;
+			padding-inline-start: 20px;
 		}
 		.is-wide-layout {
 			max-width: 1280px;
 		}
 
 		.formatted-header__subtitle {
-			text-align: left;
+			text-align: start;
 		}
 
 		.formatted-header__title {
-			text-align: left;
+			text-align: start;
 		}
 	}
 

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -639,7 +639,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 					}
 
 					@include break-medium {
-						text-align: end;
+						text-align: start;
 					}
 				}
 			}

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -38,7 +38,7 @@
 
 			.step-container__header {
 				margin-top: 0;
-				padding-right: 20px;
+				padding-inline-end: 20px;
 			}
 		}
 	}
@@ -97,7 +97,7 @@
 
 			.formatted-header__subtitle {
 				padding: 0;
-				text-align: left;
+				text-align: start;
 				color: var( --studio-gray-60 );
 				font-size: 1rem;
 				margin-top: 16px;
@@ -186,7 +186,7 @@
 
 		.step-container__navigation-link.forward,
 		.step-container__skip-wrapper {
-			margin-left: auto;
+			margin-inline-start: auto;
 		}
 
 		.step-container__skip-heading {
@@ -197,7 +197,7 @@
 			display: none;
 			// Align with wordpress logo in signup-header
 			margin-top: 1px;
-			margin-right: 24px;
+			margin-inline-end: 24px;
 			fill: var( --color-text );
 			stroke: var( --color-text );
 

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -148,8 +148,8 @@
 		font-size: 0.875rem;
 		position: fixed;
 		z-index: 30;
-		left: 0;
-		right: 0;
+		inset-inline-start: 0;
+		inset-inline-end: 0;
 		bottom: 0;
 		padding: 0 20px;
 		margin: 0;
@@ -209,8 +209,8 @@
 		@include break-small {
 			position: absolute;
 			top: 0;
-			left: 72px;
-			right: 24px;
+			inset-inline-start: 72px;
+			inset-inline-end: 24px;
 			// Align with wordpress logo in signup-header
 			padding: 1px 0 0;
 			background-color: transparent;
@@ -219,10 +219,10 @@
 
 			&.should-sticky-nav-buttons {
 				position: fixed;
-				left: 0;
-				right: 0;
-				padding-left: 24px;
-				padding-right: 24px;
+				inset-inline-start: 0;
+				inset-inline-end: 0;
+				padding-inline-start: 24px;
+				padding-inline-end: 24px;
 				background-color: $white;
 			}
 

--- a/packages/onboarding/src/step-navigation-link/style.scss
+++ b/packages/onboarding/src/step-navigation-link/style.scss
@@ -15,6 +15,9 @@ $font-body-small: 14px !default;
 			top: 5px;
 			margin-right: 2px;
 			fill: #101517;
+			.rtl & {
+				transform: scaleX( -1 );
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

This commit fixes the following issues with the onboarding flow:

1. The Back and Skip buttons at the top of the page are squeezed together. 
2. The arrow for the back button is ltr and not rtl
3. Heading and subheading on theme selection page is not right aligned

![Incorrect RTL alignment](https://user-images.githubusercontent.com/36699353/169067861-32ef70c4-9652-4119-9eaa-bf3e046191ae.png)

These issues are solved using [CSS Logical Properties and Values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties). Instead of relying on the
`@automattic/webpack-rtl-plugin` to transform `text-align: left` to
 `text-align: right`, logical values like `start` and `end` will display element
with the correct alignment.  Similarly, positional properties like `left` and `right`
are replaced with `inset-inline-start` and `inset-inline-end`.

#### Testing

1. Set language to Arabic or Hebrew
2. Create new site at /start
3. Select domain and free plan
5. Select "Build" from the Where to start page.
6. Verify issues have been fixed.

Related to 437-gh-Automattic/i18n-issues