### PR TITLE
Jetpack Backup: Remove settings initialized check

### DIFF
--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -28,7 +28,6 @@ import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewin
 import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
 import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import isSiteSettingsInitialized from 'calypso/state/selectors/is-site-settings-initialized';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -162,14 +161,13 @@ const AdminContent = ( { selectedDate } ) => {
 const BackupStatus = ( { selectedDate, needCredentials, onDateChange } ) => {
 	const isFetchingSiteFeatures = useSelectedSiteSelector( isRequestingSiteFeatures );
 	const isPoliciesInitialized = useSelectedSiteSelector( isRewindPoliciesInitialized );
-	const isSettingsInitialized = useSelectedSiteSelector( isSiteSettingsInitialized );
 
 	const hasRealtimeBackups = useSelectedSiteSelector(
 		siteHasFeature,
 		WPCOM_FEATURES_REAL_TIME_BACKUPS
 	);
 
-	if ( isFetchingSiteFeatures || ! isPoliciesInitialized || ! isSettingsInitialized ) {
+	if ( isFetchingSiteFeatures || ! isPoliciesInitialized ) {
 		return <BackupPlaceholder showDatePicker={ true } />;
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Removed settings initialized check to avoid issues loading sites with only the Stand-alone backup plugin

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a JN site with only Jetpack Backup (Uncheck Jetpack, check Jetpack Beta, install latest Jetpack Backup)
* Add a backup plan and follow the link in the backup plugin to the cloud page
* The page shouldn't load
* Visit the page in the calypso live container and ensure it does load
