### PR TITLE
E2E: implement function to return a new test user object.

### DIFF
--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -1,6 +1,7 @@
 import phrase from 'asana-phrase';
 import envVariables from './env-variables';
 import { SecretsManager, TestAccountName } from './secrets';
+import type { Secrets } from './secrets';
 
 export type DateFormat = 'ISO';
 
@@ -26,7 +27,44 @@ export interface RegistrarDetails {
 	postalCode: string;
 }
 
+export interface NewTestUser {
+	username: string;
+	password: string;
+	email: string;
+	siteName: string;
+}
+
 export type CreditCardIssuers = 'Visa';
+
+/**
+ * Returns a set of data required to sign up
+ * as a new user and create a new site.
+ *
+ * Note that this function only generates the test data;
+ * it does not actually create the test user.
+ *
+ * @returns {NewTestUser} Data for new test user.
+ */
+export function getNewTestUser( {
+	inbox = 'defaultUserInboxId',
+	usernamePrefix = '',
+}: { inbox?: keyof Secrets[ 'mailosaur' ]; usernamePrefix?: string } = {} ): NewTestUser {
+	const username = getUsername( { prefix: usernamePrefix } );
+	const password = SecretsManager.secrets.passwordForNewTestSignUps;
+
+	const email = getTestEmailAddress( {
+		inboxId: SecretsManager.secrets.mailosaur[ inbox ],
+		prefix: username,
+	} );
+	const siteName = getBlogName();
+
+	return {
+		username: username,
+		password: password,
+		email: email,
+		siteName: siteName,
+	};
+}
 
 /**
  * Generate a pseudo-random integer, inclusive on the lower bound and exclusive on the upper bound.
@@ -68,7 +106,7 @@ export function getTimestamp(): string {
 export function getUsername( { prefix = '' }: { prefix?: string } = {} ): string {
 	const timestamp = getTimestamp();
 	const randomNumber = getRandomInteger( 0, 999 );
-	return `e2eflowtesting${ prefix }-${ timestamp }-${ randomNumber }`;
+	return `e2eflowtesting${ prefix }${ timestamp }${ randomNumber }`;
 }
 
 /**

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -32,6 +32,7 @@ export interface NewTestUser {
 	password: string;
 	email: string;
 	siteName: string;
+	inboxId: string;
 }
 
 export type CreditCardIssuers = 'Visa';
@@ -43,17 +44,20 @@ export type CreditCardIssuers = 'Visa';
  * Note that this function only generates the test data;
  * it does not actually create the test user.
  *
+ * @param param0 Object parameter.
+ * @param {keyof Secrets['mailosaur']} [param0.mailosaurInbox] Optional key to specify the mailosaur server to use. Defaults to `signupInboxId`.
+ * @param {string} [param0.usernamePrefix] Optional key to specify the username prefix inserted between the `e2eflowtesting` and timestamp. Defaults to an empty string.
  * @returns {NewTestUser} Data for new test user.
  */
 export function getNewTestUser( {
-	inbox = 'defaultUserInboxId',
+	mailosaurInbox = 'signupInboxId',
 	usernamePrefix = '',
-}: { inbox?: keyof Secrets[ 'mailosaur' ]; usernamePrefix?: string } = {} ): NewTestUser {
+}: { mailosaurInbox?: keyof Secrets[ 'mailosaur' ]; usernamePrefix?: string } = {} ): NewTestUser {
 	const username = getUsername( { prefix: usernamePrefix } );
 	const password = SecretsManager.secrets.passwordForNewTestSignUps;
 
 	const email = getTestEmailAddress( {
-		inboxId: SecretsManager.secrets.mailosaur[ inbox ],
+		inboxId: SecretsManager.secrets.mailosaur[ mailosaurInbox ],
 		prefix: username,
 	} );
 	const siteName = getBlogName();
@@ -63,6 +67,7 @@ export function getNewTestUser( {
 		password: password,
 		email: email,
 		siteName: siteName,
+		inboxId: SecretsManager.secrets.mailosaur[ mailosaurInbox ],
 	};
 }
 

--- a/test/e2e/specs/onboarding/gutenboarding__happy-path.ts
+++ b/test/e2e/specs/onboarding/gutenboarding__happy-path.ts
@@ -7,19 +7,16 @@ import {
 	CloseAccountFlow,
 	GutenboardingFlow,
 	FullSiteEditorPage,
-	SecretsManager,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
-	const siteTitle = DataHelper.getBlogName();
-	const email = DataHelper.getTestEmailAddress( {
-		inboxId: SecretsManager.secrets.mailosaur.signupInboxId,
-		prefix: DataHelper.getUsername( { prefix: 'gutenboarding' } ),
+	const testUser = DataHelper.getNewTestUser( {
+		usernamePrefix: 'gutenboarding',
 	} );
-	const signupPassword = SecretsManager.secrets.passwordForNewTestSignUps;
+
 	const themeName = 'Twenty Twenty-Two Red';
 
 	let gutenboardingFlow: GutenboardingFlow;
@@ -36,13 +33,13 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 
 		it( 'Enter new site name', async function () {
 			gutenboardingFlow = new GutenboardingFlow( page );
-			await gutenboardingFlow.enterSiteTitle( siteTitle );
+			await gutenboardingFlow.enterSiteTitle( testUser.siteName );
 			await gutenboardingFlow.clickButton( 'Continue' );
 		} );
 
 		it( 'Search for and select a WordPress.com domain name', async function () {
-			await gutenboardingFlow.searchDomain( siteTitle );
-			await gutenboardingFlow.selectDomain( siteTitle.concat( '.wordpress.com' ) );
+			await gutenboardingFlow.searchDomain( testUser.siteName );
+			await gutenboardingFlow.selectDomain( testUser.siteName.concat( '.wordpress.com' ) );
 			await gutenboardingFlow.clickButton( 'Continue' );
 		} );
 
@@ -66,7 +63,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenboarding: Create' ), function () {
 		it( 'Create account', async function () {
 			await Promise.all( [
 				page.waitForNavigation( { waitUntil: 'networkidle' } ),
-				gutenboardingFlow.signup( email, signupPassword ),
+				gutenboardingFlow.signup( testUser.email, testUser.password ),
 			] );
 		} );
 

--- a/test/e2e/specs/onboarding/signup__domain.ts
+++ b/test/e2e/specs/onboarding/signup__domain.ts
@@ -65,7 +65,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), fu
 
 		it( 'Enter registrar details', async function () {
 			await cartCheckoutPage.enterDomainRegistrarDetails(
-				DataHelper.getTestDomainRegistrarDetails( email )
+				DataHelper.getTestDomainRegistrarDetails( testUser.email )
 			);
 		} );
 

--- a/test/e2e/specs/onboarding/signup__domain.ts
+++ b/test/e2e/specs/onboarding/signup__domain.ts
@@ -11,20 +11,15 @@ import {
 	CartCheckoutPage,
 	NavbarComponent,
 	IndividualPurchasePage,
-	SecretsManager,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), function () {
-	const inboxId = SecretsManager.secrets.mailosaur.signupInboxId;
-	const username = DataHelper.getUsername( { prefix: 'domainonly' } );
-	const email = DataHelper.getTestEmailAddress( {
-		inboxId: inboxId,
-		prefix: username,
+	const testUser = DataHelper.getNewTestUser( {
+		usernamePrefix: 'domainonly',
 	} );
-	const signupPassword = SecretsManager.secrets.passwordForNewTestSignUps;
 
 	let page: Page;
 	let selectedDomain: string;
@@ -46,7 +41,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), fu
 
 		it( 'Search for a domain', async function () {
 			domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.search( username + '.live' );
+			await domainSearchComponent.search( testUser.username + '.live' );
 		} );
 
 		it( 'Select a .live domain', async function () {
@@ -59,7 +54,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), fu
 
 		it( 'Sign up for a WordPress.com account', async function () {
 			const userSignupPage = new UserSignupPage( page );
-			await userSignupPage.signup( email, username, signupPassword );
+			await userSignupPage.signup( testUser.email, testUser.username, testUser.password );
 		} );
 
 		it( 'Land in checkout cart', async function () {

--- a/test/e2e/specs/onboarding/signup__paid.ts
+++ b/test/e2e/specs/onboarding/signup__paid.ts
@@ -30,14 +30,9 @@ const isStagingOrProd = DataHelper.getCalypsoURL()
 skipDescribeIf( isStagingOrProd )(
 	DataHelper.createSuiteTitle( 'Signup: WordPress.com Paid' ),
 	function () {
-		const inboxId = SecretsManager.secrets.mailosaur.inviteInboxId;
-		const username = DataHelper.getUsername( { prefix: 'paid' } );
-		const email = DataHelper.getTestEmailAddress( {
-			inboxId: inboxId,
-			prefix: username,
+		const testUser = DataHelper.getNewTestUser( {
+			usernamePrefix: 'paid',
 		} );
-		const signupPassword = SecretsManager.secrets.passwordForNewTestSignUps;
-		const blogName = DataHelper.getBlogName();
 		const theme = 'Zoologist';
 
 		let page: Page;
@@ -49,7 +44,7 @@ skipDescribeIf( isStagingOrProd )(
 		} );
 
 		describe( 'Signup and select plan', function () {
-			const targetDomain = `${ blogName }.live`;
+			const targetDomain = `${ testUser.siteName }.live`;
 
 			let cartCheckoutPage: CartCheckoutPage;
 
@@ -65,12 +60,12 @@ skipDescribeIf( isStagingOrProd )(
 
 			it( 'Sign up as new user', async function () {
 				const userSignupPage = new UserSignupPage( page );
-				await userSignupPage.signup( email, username, signupPassword );
+				await userSignupPage.signup( testUser.email, testUser.username, testUser.password );
 			} );
 
 			it( 'Select a .live domain', async function () {
 				const domainSearchComponent = new DomainSearchComponent( page );
-				await domainSearchComponent.search( blogName );
+				await domainSearchComponent.search( testUser.username );
 				await domainSearchComponent.selectDomain( targetDomain );
 			} );
 

--- a/test/e2e/specs/onboarding/signup__wpcc.ts
+++ b/test/e2e/specs/onboarding/signup__wpcc.ts
@@ -15,9 +15,7 @@ import { Page, Browser } from 'playwright';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com WPCC' ), function () {
-	const inbox = 'signupInboxId';
 	const testUser = DataHelper.getNewTestUser( {
-		inbox: inbox,
 		usernamePrefix: 'wpcc',
 	} );
 
@@ -50,7 +48,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com WPCC' ), function 
 		it( 'Get activation link', async function () {
 			const emailClient = new EmailClient();
 			const message = await emailClient.getLastEmail( {
-				inboxId: inbox,
+				inboxId: testUser.inboxId,
 				emailAddress: testUser.email,
 				subject: 'Activate',
 			} );

--- a/test/e2e/specs/onboarding/signup__wpcc.ts
+++ b/test/e2e/specs/onboarding/signup__wpcc.ts
@@ -15,13 +15,11 @@ import { Page, Browser } from 'playwright';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com WPCC' ), function () {
-	const inboxId = SecretsManager.secrets.mailosaur.signupInboxId;
-	const username = DataHelper.getUsername( { prefix: 'wpcc' } );
-	const email = DataHelper.getTestEmailAddress( {
-		inboxId: inboxId,
-		prefix: username,
+	const inbox = 'signupInboxId';
+	const testUser = DataHelper.getNewTestUser( {
+		inbox: inbox,
+		usernamePrefix: 'wpcc',
 	} );
-	const signupPassword = SecretsManager.secrets.passwordForNewTestSignUps;
 
 	let page: Page;
 
@@ -41,7 +39,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com WPCC' ), function 
 
 		it( 'Create a new WordPress.com account', async function () {
 			const userSignupPage = new UserSignupPage( page );
-			await userSignupPage.signupWPCC( email, signupPassword );
+			await userSignupPage.signupWPCC( testUser.email, testUser.password );
 		} );
 
 		it( 'User lands in CrowdSignal dashboard', async function () {
@@ -52,8 +50,8 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com WPCC' ), function 
 		it( 'Get activation link', async function () {
 			const emailClient = new EmailClient();
 			const message = await emailClient.getLastEmail( {
-				inboxId: inboxId,
-				emailAddress: email,
+				inboxId: inbox,
+				emailAddress: testUser.email,
 				subject: 'Activate',
 			} );
 			const links = await emailClient.getLinksFromMessage( message );
@@ -96,9 +94,9 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com WPCC' ), function 
 		} );
 
 		it( 'Ensure user is unable to log in', async function () {
-			await loginPage.fillUsername( email );
+			await loginPage.fillUsername( testUser.email );
 			await loginPage.clickSubmit();
-			await loginPage.fillPassword( signupPassword );
+			await loginPage.fillPassword( testUser.password );
 			await loginPage.clickSubmit();
 
 			await page.waitForSelector( 'text=This account has been closed' );

--- a/test/e2e/specs/plans/plans__signup-free.ts
+++ b/test/e2e/specs/plans/plans__signup-free.ts
@@ -7,7 +7,6 @@ import {
 	SignupPickPlanPage,
 	StartSiteFlow,
 	SidebarComponent,
-	SecretsManager,
 	PlansPage,
 	RestAPIClient,
 	UserSignupPage,
@@ -20,13 +19,9 @@ declare const browser: Browser;
 describe(
 	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Free site as a new user' ),
 	function () {
-		const username = DataHelper.getUsername( { prefix: 'freeplan' } );
-		const password = SecretsManager.secrets.passwordForNewTestSignUps;
-		const email = DataHelper.getTestEmailAddress( {
-			inboxId: SecretsManager.secrets.mailosaur.inviteInboxId,
-			prefix: username,
+		const testUser = DataHelper.getNewTestUser( {
+			usernamePrefix: 'signupfree',
 		} );
-		const blogName = DataHelper.getBlogName();
 
 		let page: Page;
 		let userID: number;
@@ -46,7 +41,11 @@ describe(
 
 			it( 'Sign up as new user', async function () {
 				const userSignupPage = new UserSignupPage( page );
-				const details = await userSignupPage.signup( email, username, password );
+				const details = await userSignupPage.signup(
+					testUser.email,
+					testUser.username,
+					testUser.password
+				);
 				userID = details.ID;
 				bearerToken = details.bearer_token;
 
@@ -57,7 +56,7 @@ describe(
 		describe( 'Onboarding', function () {
 			it( 'Select a free .wordpress.com domain', async function () {
 				const domainSearchComponent = new DomainSearchComponent( page );
-				await domainSearchComponent.search( blogName );
+				await domainSearchComponent.search( testUser.siteName );
 				await domainSearchComponent.selectDomain( '.wordpress.com' );
 			} );
 
@@ -101,14 +100,14 @@ describe(
 			}
 
 			const restAPIClient = new RestAPIClient(
-				{ username: username, password: password },
+				{ username: testUser.username, password: testUser.password },
 				bearerToken
 			);
 
 			const response = await restAPIClient.closeAccount( {
 				userID: userID,
-				username: username,
-				email: email,
+				username: testUser.username,
+				email: testUser.email,
 			} );
 
 			if ( response.success !== true ) {

--- a/test/e2e/specs/users/invite__new-user.ts
+++ b/test/e2e/specs/users/invite__new-user.ts
@@ -21,9 +21,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( `Invite: New User` ), function () {
 	const role = 'Editor';
 	const invitingUser = 'calypsoPreReleaseUser';
-	const inbox = 'signupInboxId';
 	const testUser = DataHelper.getNewTestUser( {
-		inbox: inbox,
 		usernamePrefix: 'invited',
 	} );
 
@@ -71,7 +69,7 @@ describe( DataHelper.createSuiteTitle( `Invite: New User` ), function () {
 		it( `Invite email was received for test user`, async function () {
 			const emailClient = new EmailClient();
 			const message = await emailClient.getLastEmail( {
-				inboxId: inbox,
+				inboxId: testUser.inboxId,
 				emailAddress: testUser.email,
 			} );
 			const links = await emailClient.getLinksFromMessage( message );

--- a/test/e2e/specs/users/invite__new-user.ts
+++ b/test/e2e/specs/users/invite__new-user.ts
@@ -13,22 +13,19 @@ import {
 	Roles,
 	CloseAccountFlow,
 	TestAccount,
-	SecretsManager,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( `Invite: New User` ), function () {
-	const inboxId = SecretsManager.secrets.mailosaur.inviteInboxId;
 	const role = 'Editor';
-	const username = DataHelper.getUsername( { prefix: 'invited-editor' } );
-	const email = DataHelper.getTestEmailAddress( {
-		inboxId: inboxId,
-		prefix: username,
-	} );
-	const signupPassword = SecretsManager.secrets.passwordForNewTestSignUps;
 	const invitingUser = 'calypsoPreReleaseUser';
+	const inbox = 'signupInboxId';
+	const testUser = DataHelper.getNewTestUser( {
+		inbox: inbox,
+		usernamePrefix: 'invited',
+	} );
 
 	let adjustedInviteLink: string;
 	let page: Page;
@@ -56,9 +53,8 @@ describe( DataHelper.createSuiteTitle( `Invite: New User` ), function () {
 			await peoplePage.clickInviteUser();
 
 			const invitePeoplePage = new InvitePeoplePage( page );
-			console.log( email );
 			await invitePeoplePage.invite( {
-				email: email,
+				email: testUser.email,
 				role: role as Roles,
 				message: `Test invite for role of ${ role }`,
 			} );
@@ -67,7 +63,7 @@ describe( DataHelper.createSuiteTitle( `Invite: New User` ), function () {
 		it( 'Confirm invite is pending', async function () {
 			await sidebarComponent.navigate( 'Users', 'All Users' );
 			await peoplePage.clickTab( 'Invites' );
-			await peoplePage.selectInvitedUser( email );
+			await peoplePage.selectInvitedUser( testUser.email );
 		} );
 	} );
 
@@ -75,8 +71,8 @@ describe( DataHelper.createSuiteTitle( `Invite: New User` ), function () {
 		it( `Invite email was received for test user`, async function () {
 			const emailClient = new EmailClient();
 			const message = await emailClient.getLastEmail( {
-				inboxId: inboxId,
-				emailAddress: email,
+				inboxId: inbox,
+				emailAddress: testUser.email,
 			} );
 			const links = await emailClient.getLinksFromMessage( message );
 			const acceptInviteLink = links.find( ( link: string ) =>
@@ -90,7 +86,7 @@ describe( DataHelper.createSuiteTitle( `Invite: New User` ), function () {
 			await page.goto( adjustedInviteLink );
 
 			const userSignupPage = new UserSignupPage( page );
-			await userSignupPage.signup( email, username, signupPassword );
+			await userSignupPage.signup( testUser.email, testUser.username, testUser.password );
 		} );
 
 		it( 'User sees welcome banner after signup', async function () {
@@ -118,7 +114,7 @@ describe( DataHelper.createSuiteTitle( `Invite: New User` ), function () {
 
 		it( 'View invited user in Team', async function () {
 			peoplePage = new PeoplePage( page );
-			await peoplePage.selectUser( username );
+			await peoplePage.selectUser( testUser.username );
 		} );
 
 		it( 'Remove invited user from site', async function () {
@@ -132,7 +128,7 @@ describe( DataHelper.createSuiteTitle( `Invite: New User` ), function () {
 			await loginPage.visit();
 			await Promise.all( [
 				page.waitForNavigation( { url: '**/read' } ),
-				loginPage.logInWithCredentials( email, signupPassword ),
+				loginPage.logInWithCredentials( testUser.email, testUser.password ),
 			] );
 		} );
 


### PR DESCRIPTION
#### Proposed Changes

This PR implements a new function within `DataHelper` to simplify the process of obtaining required test data for a new user.

Key changes:
- implement a new method which takes optional parameters, and returns an object that contains (email, username, password, siteName, inboxId);
- tweak the generated test user schema - WordPress.com drops all non-alphanumeric characters from usernames;
- update all existing specs to use the new test user generation method.

#### Testing Instructions

Ensure the following:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

Closes https://github.com/Automattic/wp-calypso/issues/64467, https://github.com/Automattic/wp-calypso/issues/64466.
