### PR TITLE
Marketplace: Add card bg color

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -2,6 +2,7 @@
 @import '@automattic/color-studio/dist/color-variables';
 
 .plugins-browser-item {
+	background-color: $studio-white;
 	box-sizing: border-box;
 	cursor: pointer;
 	display: block;
@@ -69,12 +70,8 @@
 			*:not( .plugins-browser-item__incompatible ) {
 				opacity: 0.6;
 			}
-
 		}
-
 	}
-
-
 }
 
 .plugins-browser-item__info {
@@ -203,7 +200,7 @@
 
 	.gridicon.checkmark--inactive {
 		color: var( --studio-gray-60 );
-		border: 2px solid  var( --studio-gray-60 );
+		border: 2px solid var( --studio-gray-60 );
 	}
 }
 


### PR DESCRIPTION
#### Proposed Changes

* Added a white bg color to the plugin result cards. The rest of the changes are auto-formatting.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /plugins and check that the cards have an #fff background and a #DCDCDE border.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #64448 
