### PR TITLE
Update plan references in Marketing

### DIFF
--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -124,7 +124,7 @@ export const MarketingTools: FunctionComponent = () => {
 					<MarketingToolsFeature
 						title={ translate( 'Want to connect with your audience on Facebook and Instagram?' ) }
 						description={ translate(
-							'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on Business and eCommerce plans {{/em}}.',
+							'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on Business and eCommerce plans{{/em}}.',
 							{
 								components: {
 									em: <em />,

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -124,7 +124,7 @@ export const MarketingTools: FunctionComponent = () => {
 					<MarketingToolsFeature
 						title={ translate( 'Want to connect with your audience on Facebook and Instagram?' ) }
 						description={ translate(
-							'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on Pro plan{{/em}}.',
+							'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on Business and eCommerce plans {{/em}}.',
 							{
 								components: {
 									em: <em />,

--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -1,6 +1,6 @@
 import {
 	findFirstSimilarPlanKey,
-	TYPE_PRO,
+	TYPE_PREMIUM,
 	FEATURE_CLOUDFLARE_ANALYTICS,
 	FEATURE_GOOGLE_ANALYTICS,
 } from '@automattic/calypso-products';
@@ -117,10 +117,10 @@ export function CloudflareAnalyticsSettings( {
 	const renderForm = () => {
 		const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
 
-		const nudgeTitle = translate( 'Available with the Pro plan' );
+		const nudgeTitle = translate( 'Available with Premium plans or higher' );
 
 		const plan = findFirstSimilarPlanKey( site.plan.product_slug, {
-			type: TYPE_PRO,
+			type: TYPE_PREMIUM,
 		} );
 
 		const nudge = (

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -39,7 +39,7 @@ const GoogleAnalyticsSimpleForm = ( {
 } ) => {
 	const analyticsSupportUrl = localizeUrl( 'https://wordpress.com/support/google-analytics/' );
 	const nudgeTitle = translate(
-		'Connect your site to Google Analytics in seconds with the Pro plan'
+		'Connect your site to Google Analytics in seconds with the Premium plan'
 	);
 
 	useEffect( () => {

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -1,8 +1,7 @@
 import {
-	isWpComAnnualPlan,
 	FEATURE_ADVANCED_SEO,
+	FEATURE_SEO_PREVIEW_TOOLS,
 	TYPE_BUSINESS,
-	TYPE_PRO,
 	findFirstSimilarPlanKey,
 } from '@automattic/calypso-products';
 import { Card, Button, FormInputValidation } from '@automattic/components';
@@ -247,32 +246,22 @@ export class SiteSettingsFormSEO extends Component {
 
 		const generalTabUrl = getGeneralTabUrl( slug );
 
-		// the Pro plan only has an annual term for now.
-		const upsellType =
-			selectedSite.plan && isWpComAnnualPlan( selectedSite.plan.product_slug )
-				? TYPE_PRO
-				: TYPE_BUSINESS;
-		const upsellTitle =
-			upsellType === TYPE_PRO
-				? translate(
-						'Boost your search engine ranking with the powerful SEO tools in the Pro plan'
-				  )
-				: translate(
-						'Boost your search engine ranking with the powerful SEO tools in the Business plan'
-				  );
-
 		const upsellProps =
 			siteIsJetpack && ! isAtomic
 				? {
 						title: translate( 'Boost your search engine ranking' ),
+						feature: FEATURE_SEO_PREVIEW_TOOLS,
 						href: `/checkout/${ slug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_ADVANCED_SEO ] }`,
 				  }
 				: {
-						title: upsellTitle,
+						title: translate(
+							'Boost your search engine ranking with the powerful SEO tools in the Business plan'
+						),
+						feature: FEATURE_ADVANCED_SEO,
 						plan:
 							selectedSite.plan &&
 							findFirstSimilarPlanKey( selectedSite.plan.product_slug, {
-								type: upsellType,
+								type: TYPE_BUSINESS,
 							} ),
 				  };
 

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -12,7 +12,7 @@ import {
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
-	PLAN_WPCOM_PRO,
+	PLAN_BUSINESS,
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
@@ -159,7 +159,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 				<SeoForm { ...props } siteIsJetpack={ false } selectedSite={ { plan: { product_slug } } } />
 			);
 			expect( comp.find( 'UpsellNudge' ) ).toHaveLength( 1 );
-			expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( PLAN_WPCOM_PRO );
+			expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( PLAN_BUSINESS );
 		} );
 	} );
 


### PR DESCRIPTION
#### Proposed Changes

* Updates plan reference in Cloudflare upsell nudge.
* Updates plan reference in Google Analytics upsell nudge.
* Updates plan reference in SEO tools upsell nudge.
* Updates plan reference in Facebook audience block under Marketing > Tools.

Note: The checkout URL is wrong, we can set a `href` directly if needed.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Marketing using a free site

The upsells and the Facebook block should match the screenshots below:

<img width="1174" alt="Screenshot 2022-06-09 at 00 13 53" src="https://user-images.githubusercontent.com/52675688/172732381-9d5bf67e-3126-456c-a914-dda423f5331a.png">
<img width="797" alt="Screenshot 2022-06-09 at 01 08 37" src="https://user-images.githubusercontent.com/52675688/172732387-621c70e8-f8b0-4942-9334-210b34890f6e.png">
<img width="1184" alt="Screenshot 2022-06-09 at 01 08 49" src="https://user-images.githubusercontent.com/52675688/172732388-55c22ba8-b101-4c6b-9b17-9b4b2967d54b.png">



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 794-gh-martech
Fixes Automattic/martech#794