### PR TITLE
Fix/update faq section on plans page

### DIFF
--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -19,7 +19,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 
 	const themesAnswer = isEnabled( 'themes/premium' )
 		? translate(
-				"Yes! With the WordPress.com Pro plan you can install any theme you'd like." +
+				"Yes! With the WordPress.com Business or eCommerce plan you can install any theme you'd like." +
 					' All plans give you access to our {{a}}directory of free and premium themes{{/a}}.' +
 					' These are among the highest-quality WordPress themes, hand-picked and reviewed by our team.',
 				{
@@ -27,7 +27,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 				}
 		  )
 		: translate(
-				"Yes! With the WordPress.com Pro plan you can install any theme you'd like." +
+				"Yes! With the WordPress.com Business or eCommerce plan you can install any theme you'd like." +
 					' All plans give you access to our {{a}}directory of free themes{{/a}}.' +
 					' These are among the highest-quality WordPress themes, hand-picked and reviewed by our team.',
 				{
@@ -40,7 +40,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 			<FAQItem
 				question={ translate( 'Do you sell domains?' ) }
 				answer={ translate(
-					'Yes! The Pro plan include a free custom domain for one year. ' +
+					'Yes! Annual and biannual Personal, Premium, Business, and eCommerce plans include a free custom domain for one year. ' +
 						'That includes new domains purchased through WordPress.com or your own existing domain that you can map' +
 						' to your WordPress.com site. Does not apply to premium domains. Domain name should be' +
 						' registered within one year of the purchase of the plan to use this promotion. Registered' +
@@ -62,7 +62,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 			<FAQItem
 				question={ translate( 'Can I install plugins?' ) }
 				answer={ translate(
-					'Yes! With the WordPress.com Pro plan you can search for and install external plugins.' +
+					'Yes! With the WordPress.com Business or eCommerce plan you can search for and install external plugins.' +
 						' All plans already come with a custom set of plugins tailored just for them.' +
 						' {{a}}Find out more about plugins{{/a}}.',
 					{
@@ -86,7 +86,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 				answer={ translate(
 					'No. All WordPress.com sites include our specially tailored WordPress hosting to ensure' +
 						' your site stays available and secure at all times. You can even use your own domain' +
-						' when you upgrade to the Pro plan.'
+						' when you upgrade to the Personal, Premium, Business, or eCommerce plan.'
 				) }
 			/>
 


### PR DESCRIPTION
#### Proposed Changes

* This change swaps out the copy used in several of the FAQ sections that reference the Pro Plan. 
* Copy has been changed back to a previous state and now mentioned the other old plans instead of the Pro Plan 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch locally
* Go to /plans/ with a free site
* All references to the Pro plan should now be reverted back to the previous copy which now mentions the old plans

**Before**
<img width="1638" alt="172305962-ced6e9be-3028-4675-b6d5-20d89f1ea290" src="https://user-images.githubusercontent.com/48809176/172755962-277023bb-5675-41c5-bcce-8f2af70208b8.png">


**After**
<img width="1917" alt="Screen Shot 2022-06-08 at 9 06 16 PM" src="https://user-images.githubusercontent.com/48809176/172755989-a13b5773-c128-4840-8e08-2488499e767f.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#789
