### PR TITLE
Enable white login reskin for user creation during partner-signup flow

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -49,6 +49,7 @@ import { recordTracksEventWithClientId } from 'calypso/state/analytics/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { createSocialUserFailed } from 'calypso/state/login/actions';
+import { isPartnerSignupQuery } from 'calypso/state/login/utils';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { getSectionName } from 'calypso/state/ui/selectors';
@@ -447,7 +448,7 @@ class SignupForm extends Component {
 			locale: this.props.locale,
 			oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
 			wccomFrom: this.props.wccomFrom,
-			isWhiteLogin: this.props.isReskinned,
+			isWhiteLogin: this.props.isReskinned || this.props.isPartnerSignup,
 			signupUrl: window.location.pathname + window.location.search,
 		} );
 	}
@@ -1059,7 +1060,7 @@ class SignupForm extends Component {
 							handleResponse={ this.props.handleSocialResponse }
 							socialService={ this.props.socialService }
 							socialServiceResponse={ this.props.socialServiceResponse }
-							isReskinned={ this.props.isReskinned }
+							isReskinned={ this.props.isReskinned || this.props.isPartnerSignup }
 						/>
 					) }
 					{ this.props.footerLink || this.footerLink() }
@@ -1097,7 +1098,7 @@ class SignupForm extends Component {
 						handleResponse={ this.props.handleSocialResponse }
 						socialService={ this.props.socialService }
 						socialServiceResponse={ this.props.socialServiceResponse }
-						isReskinned={ this.props.isReskinned }
+						isReskinned={ this.props.isReskinned || this.props.isPartnerSignup }
 					/>
 				) }
 
@@ -1127,6 +1128,7 @@ export default connect(
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 		isP2Flow:
 			isP2Flow( props.flowName ) || get( getCurrentQueryArguments( state ), 'from' ) === 'p2',
+		isPartnerSignup: isPartnerSignupQuery( getCurrentQueryArguments( state ) ),
 	} ),
 	{
 		trackLoginMidFlow: () => recordTracksEventWithClientId( 'calypso_signup_login_midflow' ),

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -33,6 +33,7 @@ import {
 } from 'calypso/signup/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isPartnerSignupQuery } from 'calypso/state/login/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -139,6 +140,7 @@ export class UserStep extends Component {
 			sectionName,
 			from,
 			locale,
+			isPartnerSignup,
 		} = this.props;
 
 		let subHeaderText = this.props.subHeaderText;
@@ -354,12 +356,20 @@ export class UserStep extends Component {
 	}
 
 	getHeaderText() {
-		const { flowName, oauth2Client, translate, headerText, wccomFrom } = this.props;
+		const { flowName, oauth2Client, translate, headerText, wccomFrom, isPartnerSignup } =
+			this.props;
 
 		if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
 			return translate( 'Sign up for Crowdsignal' );
 		}
 
+		// if ( isWooOAuth2Client( oauth2Client ) && isPartnerSignup ) {
+		// 	return (
+		// 		<div className={ classNames( 'signup-form__woocommerce-heading' ) }>
+		// 			{ translate( 'Create a WordPress.com account' ) }
+		// 		</div>
+		// 	);
+		// }
 		if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
 			return (
 				<Fragment>
@@ -394,7 +404,7 @@ export class UserStep extends Component {
 			);
 		}
 
-		if ( flowName === 'wpcc' && oauth2Client ) {
+		if ( flowName === 'wpcc' && oauth2Client && ! isPartnerSignup ) {
 			return translate( 'Sign up for %(clientTitle)s with a WordPress.com account', {
 				args: { clientTitle: oauth2Client.title },
 				comment:
@@ -424,7 +434,7 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, wccomFrom, isReskinned } = this.props;
+		const { oauth2Client, wccomFrom, isReskinned, isPartnerSignup } = this.props;
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
@@ -438,7 +448,7 @@ export class UserStep extends Component {
 			}
 		}
 
-		if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
+		if ( isWooOAuth2Client( oauth2Client ) && ( wccomFrom || isPartnerSignup ) ) {
 			isSocialSignupEnabled = true;
 		}
 
@@ -459,8 +469,8 @@ export class UserStep extends Component {
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
-					horizontal={ isReskinned }
-					isReskinned={ isReskinned }
+					horizontal={ isReskinned || isPartnerSignup }
+					isReskinned={ isReskinned || isPartnerSignup }
 				/>
 				<div id="g-recaptcha"></div>
 			</>
@@ -522,6 +532,7 @@ export default connect(
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 		from: get( getCurrentQueryArguments( state ), 'from' ),
 		userLoggedIn: isUserLoggedIn( state ),
+		isPartnerSignup: isPartnerSignupQuery( getCurrentQueryArguments( state ) ),
 	} ),
 	{
 		errorNotice,

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -460,7 +460,7 @@ body.is-section-signup.is-white-signup .layout:not( .dops ):not( .is-wccom-oauth
 		}
 	}
 
-	.signup__step.is-user {
+	.signup__step.is-user, .signup__step.is-wpcc {
 		.formatted-header {
 			.formatted-header__title {
 				text-align: center;


### PR DESCRIPTION
#### Proposed Changes

* Reskins the oauth user creation screen for the marketplace /partner-signup/ flow on woocommerce.com
* Branched off https://github.com/Automattic/wp-calypso/pull/64362

#### Testing Instructions

* Logged out on woocommerce.com and wordpress.com
* Visit https://woocommerce.com/partner-signup
* Get redirected to: http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dsnip%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dpartner-signup%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26redirect_to%3Dhttps%3A%2F%2Fwoocommerce.com%2Fpartner-signup%2F
* Click "Create account"

Fixes https://github.com/Automattic/wp-calypso/issues/64439 
