### PR TITLE
Show notice to users on Pro and Starter plans

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -10,6 +10,8 @@ import {
 	isPremiumPlan,
 	isBusinessPlan,
 	isEcommercePlan,
+	isProPlan,
+	isStarterPlan,
 	planMatches,
 	TYPE_FREE,
 	TYPE_BLOGGER,
@@ -163,6 +165,7 @@ export class PlansFeaturesMain extends Component {
 			isJetpack,
 			isLandingPage,
 			isLaunchPage,
+			isCurrentPlanRetired,
 			onUpgradeClick,
 			selectedFeature,
 			selectedPlan,
@@ -191,7 +194,19 @@ export class PlansFeaturesMain extends Component {
 				) }
 				data-e2e-plans="wpcom"
 			>
-				{ currentPurchaseIsInAppPurchase && (
+				{ isCurrentPlanRetired && (
+					<Notice
+						showDismiss={ false }
+						status="is-info"
+						text={ translate(
+							'Your current plan is no longer available for new subscriptions. ' +
+								'You’re all set to continue with the plan for as long as you like. ' +
+								'Alternatively, you can switch to any of our current plans by selecting it below. ' +
+								'Please keep in mind that switching plans will be irreversible.'
+						) }
+					/>
+				) }
+				{ ! isCurrentPlanRetired && currentPurchaseIsInAppPurchase && (
 					<Notice
 						showDismiss={ false }
 						status="is-info"
@@ -531,6 +546,7 @@ export default connect(
 		}
 
 		return {
+			isCurrentPlanRetired: isProPlan( sitePlanSlug ) || isStarterPlan( sitePlanSlug ),
 			currentPurchaseIsInAppPurchase: currentPurchase?.isInAppPurchase,
 			customerType,
 			domains: getDomainsBySiteId( state, siteId ),


### PR DESCRIPTION
#### Proposed Changes

* As we decided to revert current plans, we need to show users on the plans a message to let them know that their plans are not discontinued.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a site on Pro or Starter plan, you should be able to find the message banner as belows:
<img width="1276" alt="스크린샷 2022-06-09 오전 10 17 54" src="https://user-images.githubusercontent.com/212034/172780829-987b5762-0664-4eb0-8ad6-6d3c084da44f.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 791-gh-Automattic/martech
Fixes Automattic/martech#791