### PR TITLE
Show upgrade button on the /plans/<site> for Starter and Pro plans

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1254,6 +1254,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			[
 				PLAN_FREE,
 				PLAN_WPCOM_STARTER,
+				PLAN_WPCOM_PRO,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_MONTHLY,
@@ -1277,6 +1278,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			[
 				PLAN_FREE,
 				PLAN_WPCOM_STARTER,
+				PLAN_WPCOM_PRO,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_MONTHLY,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1253,6 +1253,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				PLAN_WPCOM_STARTER,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_MONTHLY,
@@ -1275,6 +1276,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				PLAN_WPCOM_STARTER,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_MONTHLY,
@@ -1321,6 +1323,8 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				PLAN_WPCOM_STARTER,
+				PLAN_WPCOM_PRO,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_MONTHLY,
@@ -1346,6 +1350,8 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				PLAN_WPCOM_STARTER,
+				PLAN_WPCOM_PRO,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_MONTHLY,


### PR DESCRIPTION
#### Proposed Changes

This shows the Upgrade button next to the Business and eCommerce plan if the current plan is Starter or Pro.

Addresses 807-gh-Automattic/martech

#### Testing Instructions

* Go to `/plans/[site]` on a Starter Plan site
* The Business and Ecommerce plans should show the Upgrade button
<img width="320" alt="Screenshot 2022-06-09 at 12 41 57" src="https://user-images.githubusercontent.com/2749938/172817709-dd313d2b-86ef-4700-8411-b1c876b54106.png">

* Go to `/plans/[site]` on a Pro Plan site
* The Business and Ecommerce plans should show the Upgrade button
<img width="320" alt="Screenshot 2022-06-09 at 12 41 35" src="https://user-images.githubusercontent.com/2749938/172817729-7e00f5f8-a481-40f9-bcc4-6e38a98f0181.png">

