### PR TITLE
Fix/upload plugin on automated transfer

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -232,8 +232,11 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 	// Check completition of all flows and redirect to thank you page
 	useEffect( () => {
 		if (
+			// Default process
 			( installedPlugin && pluginActive ) ||
+			// Tranfer to atomic using a marketplace plugin
 			( atomicFlow && transferStates.COMPLETE === automatedTransferStatus ) ||
+			// Transfer to atomic uploading a zip plugin
 			( isUploadFlow && ! atomicFlow && transferStates.COMPLETE === automatedTransferStatus )
 		) {
 			waitFor( 1 ).then( () =>

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -233,16 +233,19 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 	useEffect( () => {
 		if (
 			( installedPlugin && pluginActive ) ||
-			( atomicFlow && transferStates.COMPLETE === automatedTransferStatus )
+			( atomicFlow && transferStates.COMPLETE === automatedTransferStatus ) ||
+			( isUploadFlow && ! atomicFlow && transferStates.COMPLETE === automatedTransferStatus )
 		) {
 			waitFor( 1 ).then( () =>
 				page.redirect(
-					`/marketplace/thank-you/${ installedPlugin?.slug || productSlug }/${ selectedSiteSlug }`
+					`/marketplace/thank-you/${
+						installedPlugin?.slug || productSlug || uploadedPluginSlug
+					}/${ selectedSiteSlug }`
 				)
 			);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ pluginActive, automatedTransferStatus ] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
+	}, [ pluginActive, automatedTransferStatus, atomicFlow, isUploadFlow ] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
 
 	const steps = useMemo(
 		() => [

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -237,7 +237,10 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 			// Transfer to atomic using a marketplace plugin
 			( atomicFlow && transferStates.COMPLETE === automatedTransferStatus ) ||
 			// Transfer to atomic uploading a zip plugin
-			( isUploadFlow && ! atomicFlow && transferStates.COMPLETE === automatedTransferStatus )
+			( uploadedPluginSlug &&
+				isUploadFlow &&
+				! isAtomic &&
+				transferStates.COMPLETE === automatedTransferStatus )
 		) {
 			waitFor( 1 ).then( () =>
 				page.redirect(
@@ -248,7 +251,7 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 			);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ pluginActive, automatedTransferStatus, atomicFlow, isUploadFlow ] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
+	}, [ pluginActive, automatedTransferStatus, atomicFlow, isUploadFlow, isAtomic ] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
 
 	const steps = useMemo(
 		() => [

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -234,7 +234,7 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 		if (
 			// Default process
 			( installedPlugin && pluginActive ) ||
-			// Tranfer to atomic using a marketplace plugin
+			// Transfer to atomic using a marketplace plugin
 			( atomicFlow && transferStates.COMPLETE === automatedTransferStatus ) ||
 			// Transfer to atomic uploading a zip plugin
 			( isUploadFlow && ! atomicFlow && transferStates.COMPLETE === automatedTransferStatus )


### PR DESCRIPTION
#### Description

Currently, there is an error when a user uploads a zip plugin on a simple site with Atomic compatibility. This PR fixes this issue #62928.

#### Proposed Changes

* Navigate to Thank you screen after uploading a zip plugin to a simple site.

#### Testing Instructions

* Grab any zip plugin. You can find one here: https://wordpress.org/plugins/
* On a simple site, buy a pro account 
* Navigate to Plugins > Upload
* Accept the notice about domain renaming
* Drop your zip plugin to start uploading it
* Wait until the process finishes
* Observe it finishes successfully and you see the thank you screen
* Go to Plugins > installed plugins and observe your installed plugin is active

#### Screenshots
Thank you Screen:
<img width="1904" alt="Screenshot 2022-06-09 at 11 42 24" src="https://user-images.githubusercontent.com/779993/172828877-046d5462-a824-4d4b-a3f9-046a52ea7266.png">

Screencast:



https://user-images.githubusercontent.com/779993/172831009-839bd72a-47aa-4584-a4fa-8e44952415bf.mov



---

- Fixes #62928
