### PR TITLE
Components: Refactor `UpgradeToPremiumNudgePure` tests to `@testing-library/react`

### DIFF
--- a/client/blocks/post-share/test/nudges.jsx
+++ b/client/blocks/post-share/test/nudges.jsx
@@ -1,7 +1,13 @@
+/**
+ * @jest-environment jsdom
+ */
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'calypso/blocks/upsell-nudge', () => 'UpsellNudge' );
+jest.mock( 'calypso/blocks/upsell-nudge', () => ( {
+	__esModule: true,
+	default: ( { plan } ) => <div data-testid="upsell-nudge-plan">{ plan }</div>,
+} ) );
 
 import {
 	PLAN_FREE,
@@ -24,7 +30,7 @@ import {
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
 } from '@automattic/calypso-products';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { UpgradeToPremiumNudgePure } from '../nudges';
 
 const props = {
@@ -34,8 +40,8 @@ const props = {
 
 describe( 'UpgradeToPremiumNudgePure basic tests', () => {
 	test( 'should not blow up', () => {
-		const comp = shallow( <UpgradeToPremiumNudgePure { ...props } /> );
-		expect( comp.find( 'UpsellNudge' ).length ).toBe( 1 );
+		render( <UpgradeToPremiumNudgePure { ...props } /> );
+		expect( screen.getByTestId( 'upsell-nudge-plan' ) ).toBeVisible();
 	} );
 
 	test( 'hide when user cannot upgrade', () => {
@@ -43,8 +49,8 @@ describe( 'UpgradeToPremiumNudgePure basic tests', () => {
 			translate: ( x ) => x,
 			canUserUpgrade: false,
 		};
-		const comp = shallow( <UpgradeToPremiumNudgePure { ...localProps } /> );
-		expect( comp.find( 'UpsellNudge' ).length ).toBe( 0 );
+		render( <UpgradeToPremiumNudgePure { ...localProps } /> );
+		expect( screen.queryByTestId( 'upsell-nudge-plan' ) ).not.toBeInTheDocument();
 	} );
 } );
 
@@ -71,10 +77,8 @@ describe( 'UpgradeToPremiumNudgePure.render()', () => {
 		PLAN_ECOMMERCE_2_YEARS,
 	].forEach( ( plan ) => {
 		test( `Should pass 2-years wp.com premium plan for 2-years plans ${ plan }`, () => {
-			const comp = shallow(
-				<UpgradeToPremiumNudgePure { ...props } isJetpack={ false } planSlug={ plan } />
-			);
-			expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( plan );
+			render( <UpgradeToPremiumNudgePure { ...props } isJetpack={ false } planSlug={ plan } /> );
+			expect( screen.getByTestId( 'upsell-nudge-plan' ) ).toHaveTextContent( plan );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `UpgradeToPremiumNudgePure` component to use `@testing-library/react` instead of `enzyme`.

Part of #63409.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/blocks/post-share/test/nudges.jsx`