### PR TITLE
Update plans references in upgrade nudges and CTAs

### DIFF
--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -1,9 +1,4 @@
-import {
-	getPlan,
-	PLAN_WPCOM_PRO,
-	PLAN_PERSONAL,
-	WPCOM_FEATURES_NO_ADVERTS,
-} from '@automattic/calypso-products';
+import { getPlan, PLAN_PERSONAL, WPCOM_FEATURES_NO_ADVERTS } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -69,10 +64,10 @@ class DomainToPlanNudge extends Component {
 					translate( 'Access unlimited customer support via email' ),
 					translate( 'Use with your Current Custom Domain' ),
 				] }
-				plan={ PLAN_WPCOM_PRO }
+				plan={ PLAN_PERSONAL }
 				price={ prices }
 				showIcon
-				title={ translate( 'Upgrade to a Pro Plan and Save!' ) }
+				title={ translate( 'Upgrade to a Personal Plan and Save!' ) }
 			/>
 		);
 	}

--- a/client/blocks/import/ready/platform-details.tsx
+++ b/client/blocks/import/ready/platform-details.tsx
@@ -186,7 +186,7 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 								) ) }
 						</ul>
 						<div className={ 'import__details-footer' }>
-							<i>*{ __( 'Requires a Pro plan.' ) }</i>
+							<i>*{ __( 'Requires a Business plan.' ) }</i>
 						</div>
 					</div>
 				) }

--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -150,10 +150,10 @@ export const getAdminSections = createSelector(
 			{
 				title: translate( 'Earn money from my site' ),
 				description: translate(
-					"By upgrading to the Pro plan, you'll be able to monetize your site through the WordAds program."
+					"By upgrading to the Premium plan, you'll be able to monetize your site through the WordAds program."
 				),
 				link: `/earn/${ siteSlug }`,
-				synonyms: [ 'monetize', 'wordads', 'pro' ],
+				synonyms: [ 'monetize', 'wordads', 'premium' ],
 				icon: 'money',
 			},
 			{

--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -14,12 +14,12 @@ export default localize( ( { isEligiblePlan, selectedSite, translate } ) => {
 								'All WordPress.com advertising has been removed from your site so your brand can stand out without distractions.'
 						  )
 						: translate(
-								'All WordPress.com advertising has been removed from your site. Upgrade to Pro ' +
+								'All WordPress.com advertising has been removed from your site. Upgrade to Business ' +
 									'to remove the WordPress.com footer credit.'
 						  )
 				}
-				buttonText={ ! isEligiblePlan ? translate( 'Upgrade to Pro' ) : null }
-				href={ ! isEligiblePlan ? '/checkout/' + selectedSite.slug + '/pro' : null }
+				buttonText={ ! isEligiblePlan ? translate( 'Upgrade to Business' ) : null }
+				href={ ! isEligiblePlan ? '/checkout/' + selectedSite.slug + '/business' : null }
 			/>
 		</div>
 	);

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -43,7 +43,7 @@ class DomainProductPrice extends Component {
 				}
 				break;
 			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
-				message = translate( 'Pro plan required' );
+				message = translate( 'Personal plan required' );
 				break;
 		}
 

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -116,7 +116,7 @@ class DomainSearchResults extends Component {
 					);
 				} else {
 					offer = translate(
-						'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com Pro.',
+						'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com Premium.',
 						{ args: { domain }, components }
 					);
 				}

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -1,4 +1,4 @@
-import { PLAN_WPCOM_PRO, isPlan } from '@automattic/calypso-products';
+import { PLAN_PERSONAL, isPlan } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { withShoppingCart } from '@automattic/shopping-cart';
@@ -408,10 +408,10 @@ class TransferDomainStep extends Component {
 				<div>
 					<UpsellNudge
 						description={ translate(
-							'Only .blog domains are included with your plan, to use a different tld upgrade to a Pro plan.'
+							'Only .blog domains are included with your plan, to use a different tld upgrade to a Personal plan.'
 						) }
-						plan={ PLAN_WPCOM_PRO }
-						title={ translate( 'Pro plan required' ) }
+						plan={ PLAN_PERSONAL }
+						title={ translate( 'Personal plan required' ) }
 						showIcon={ true }
 					/>
 					{ content }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -292,7 +292,7 @@ export class Theme extends Component {
 					/>
 					<div className="theme__upsell-popover">
 						<h2 className="theme__upsell-heading">
-							{ translate( 'Use this theme at no extra cost on our Pro Plan' ) }
+							{ translate( 'Use this theme at no extra cost on our Premium or Business Plan' ) }
 						</h2>
 						<Button
 							onClick={ this.onUpsellClick }

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -73,16 +73,16 @@ export default function WPCOMUpsellPage(): ReactElement {
 				{ ! isAdmin && (
 					<Notice
 						status="is-warning"
-						text={ translate( 'Only site administrators can upgrade to the Pro plan.' ) }
+						text={ translate( 'Only site administrators can upgrade to the Business plan.' ) }
 						showDismiss={ false }
 					/>
 				) }
 				{ isAdmin && (
 					<PromoCardCTA
 						cta={ {
-							text: translate( 'Upgrade to Pro Plan' ),
+							text: translate( 'Upgrade to Business Plan' ),
 							action: {
-								url: `/checkout/${ siteSlug }/pro`,
+								url: `/checkout/${ siteSlug }/business`,
 								onClick: onUpgradeClick,
 								selfTarget: true,
 							},
@@ -93,7 +93,9 @@ export default function WPCOMUpsellPage(): ReactElement {
 
 			{ ! hasFullActivityLogFeature && (
 				<>
-					<h2 className="backup__subheader">{ translate( 'Also included in the Pro Plan' ) }</h2>
+					<h2 className="backup__subheader">
+						{ translate( 'Also included in the Business Plan' ) }
+					</h2>
 
 					<PromoSection { ...promos } />
 				</>

--- a/client/my-sites/checkout/checkout-thank-you/personal-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/personal-plan-details.jsx
@@ -37,7 +37,7 @@ const PersonalPlanDetails = ( { translate, selectedSite, sitePlans, purchases } 
 				title={ translate( 'Advertising Removed' ) }
 				description={ translate(
 					'With your plan, all WordPress.com advertising has been removed from your site. ' +
-						'You can upgrade to a Pro plan to also remove the WordPress.com footer credit.'
+						'You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
 				) }
 			/>
 		</div>

--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -7,9 +7,6 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 import './style.scss';
 
-// In the next iteration we should create a new upsell component specifically
-// for the Pro plan. We've repurposed it for now to simplify the necessary code change.
-
 export class BusinessPlanUpgradeUpsell extends PureComponent {
 	render() {
 		const { receiptId, translate } = this.props;
@@ -74,7 +71,7 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 						<p>
 							<b>
 								{ translate(
-									'Did you know that WordPress.com Pro plan customers can now upload any WordPress plugins they want?'
+									'Did you know that WordPress.com Business plan customers can now upload any WordPress plugins they want?'
 								) }
 							</b>
 						</p>
@@ -179,12 +176,12 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 						</ul>
 						<p>
 							{ translate(
-								'And access to the plugin library is just one of many benefits included with the Pro plan.'
+								'And access to the plugin library is just one of many benefits included with the Business plan.'
 							) }
 						</p>
 						<p>
 							{ translate(
-								'With our Pro plan you can upload any custom theme you want, have full access to your site with SFTP, and have full control of your data directly with phpMyAdmin.'
+								'With our Business plan you can upload any custom theme you want, have full access to your site with SFTP, and have full control of your data directly with phpMyAdmin.'
 							) }
 						</p>
 						<p>
@@ -194,7 +191,7 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 						</p>
 						<p>
 							{ translate(
-								'{{b}}But please note:{{/b}} you don’t currently have access to all these amazing features because they are only available to Pro plan customers and you haven’t upgraded yet.',
+								'{{b}}But please note:{{/b}} you don’t currently have access to all these amazing features because they are only available to Business plan customers and you haven’t upgraded yet.',
 								{
 									components: { b: <b /> },
 								}
@@ -204,8 +201,8 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 							{
 								// Using plural translation because some languages have multiple plural forms and no plural-agnostic.
 								translate(
-									'The good news is that you can upgrade your plan today and try the Pro plan risk-free thanks to our {{b}}%(days)d-day money-back guarantee{{/b}}.',
-									'The good news is that you can upgrade your plan today and try the Pro plan risk-free thanks to our {{b}}%(days)d-day money-back guarantee{{/b}}.',
+									'The good news is that you can upgrade your plan today and try the Business plan risk-free thanks to our {{b}}%(days)d-day money-back guarantee{{/b}}.',
+									'The good news is that you can upgrade your plan today and try the Business plan risk-free thanks to our {{b}}%(days)d-day money-back guarantee{{/b}}.',
 									{
 										count: hasSevenDayRefundPeriod ? 7 : 14,
 										components: { b: <b /> },
@@ -218,8 +215,8 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 							{
 								// Using plural translation because some languages have multiple plural forms and no plural-agnostic.
 								translate(
-									'Simply click the link below and select the Pro plan option to upgrade today {{b}}for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more{{/b}}. Once you upgrade, you’ll have %(days)d day to evaluate the plan and decide if it’s right for you.',
-									'Simply click the link below and select the Pro plan option to upgrade today {{b}}for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more{{/b}}. Once you upgrade, you’ll have %(days)d days to evaluate the plan and decide if it’s right for you.',
+									'Simply click the link below and select the Business plan option to upgrade today {{b}}for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more{{/b}}. Once you upgrade, you’ll have %(days)d day to evaluate the plan and decide if it’s right for you.',
+									'Simply click the link below and select the Business plan option to upgrade today {{b}}for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more{{/b}}. Once you upgrade, you’ll have %(days)d days to evaluate the plan and decide if it’s right for you.',
 									{
 										count: hasSevenDayRefundPeriod ? 7 : 14,
 										components: {

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -1,5 +1,5 @@
 import {
-	PLAN_WPCOM_PRO,
+	PLAN_PREMIUM,
 	PLAN_JETPACK_SECURITY_DAILY,
 	WPCOM_FEATURES_WORDADS,
 } from '@automattic/calypso-products';
@@ -189,14 +189,14 @@ class AdsWrapper extends Component {
 
 	renderUpsell() {
 		const { siteSlug, translate } = this.props;
-		const bannerURL = `/checkout/${ siteSlug }/pro`;
+		const bannerURL = `/checkout/${ siteSlug }/premium`;
 		return (
 			<UpsellNudge
 				callToAction={ translate( 'Upgrade' ) }
-				plan={ PLAN_WPCOM_PRO }
-				title={ translate( 'Upgrade to the Pro plan and start earning' ) }
+				plan={ PLAN_PREMIUM }
+				title={ translate( 'Upgrade to the Premium plan and start earning' ) }
 				description={ translate(
-					"By upgrading to the Pro plan, you'll be able to monetize your site through the WordAds program."
+					"By upgrading to the Premium plan, you'll be able to monetize your site through the WordAds program."
 				) }
 				feature={ WPCOM_FEATURES_WORDADS }
 				href={ bannerURL }

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -632,7 +632,7 @@ class MembershipsSection extends Component {
 					plan={ this.props.isJetpack ? PLAN_JETPACK_PERSONAL : PLAN_PERSONAL }
 					shouldDisplay={ () => true }
 					feature={ FEATURE_SIMPLE_PAYMENTS }
-					title={ this.props.translate( 'Upgrade to the Pro plan' ) }
+					title={ this.props.translate( 'Upgrade to the Personal plan' ) }
 					description={ this.props.translate( 'Upgrade to enable Payment Blocks.' ) }
 					showIcon={ true }
 					event="calypso_memberships_upsell_nudge"

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,4 +1,4 @@
-import { PLAN_WPCOM_PRO, FEATURE_SFTP } from '@automattic/calypso-products';
+import { PLAN_BUSINESS, FEATURE_SFTP } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import wrapWithClickOutside from 'react-click-outside';
@@ -66,10 +66,10 @@ class Hosting extends Component {
 
 		const getUpgradeBanner = () => (
 			<UpsellNudge
-				title={ translate( 'Upgrade to the Pro plan to access all hosting features' ) }
+				title={ translate( 'Upgrade to the Business plan to access all hosting features' ) }
 				event="calypso_hosting_configuration_upgrade_click"
-				href={ `/checkout/${ siteId }/pro` }
-				plan={ PLAN_WPCOM_PRO }
+				href={ `/checkout/${ siteId }/business` }
+				plan={ PLAN_BUSINESS }
 				feature={ FEATURE_SFTP }
 				showIcon={ true }
 			/>

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -273,10 +273,10 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 					illustration="/calypso/images/illustrations/error.svg"
 					title={ null }
 					line={ translate(
-						"Your current plan doesn't allow plugin installation. Please upgrade to Pro plan first."
+						"Your current plan doesn't allow plugin installation. Please upgrade to Business plan first."
 					) }
-					action={ translate( 'Upgrade to Pro Plan' ) }
-					actionURL={ `/checkout/${ selectedSite?.slug }/pro?redirect_to=/marketplace/${ productSlug }/install/${ selectedSite?.slug }#step2` }
+					action={ translate( 'Upgrade to Business Plan' ) }
+					actionURL={ `/checkout/${ selectedSite?.slug }/business?redirect_to=/marketplace/${ productSlug }/install/${ selectedSite?.slug }#step2` }
 				/>
 			);
 		}

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -162,8 +162,8 @@ export class MediaLibraryContent extends Component {
 					upgradeNudgeName = 'plan-media-storage-error-video';
 					upgradeNudgeFeature = 'video-upload';
 					message = translate(
-						'%d file could not be uploaded because your site does not support video files. Upgrade to a Pro plan for video support.',
-						'%d files could not be uploaded because your site does not support video files. Upgrade to a Pro plan for video support.',
+						'%d file could not be uploaded because your site does not support video files. Upgrade to a premium plan for video support.',
+						'%d files could not be uploaded because your site does not support video files. Upgrade to a premium plan for video support.',
 						i18nOptions
 					);
 					break;

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -96,7 +96,7 @@ class MediaLibraryListPlanPromo extends Component {
 
 	render() {
 		const action = (
-			<Button className="button is-primary" onClick={ this.viewPlansPage }>
+			<Button className="list-plan-promo__button button is-primary" onClick={ this.viewPlansPage }>
 				{ this.props.translate( 'See Plans' ) }
 			</Button>
 		);

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -52,7 +52,7 @@ class MediaLibraryListPlanPromo extends Component {
 						: this.props.translate( 'Uploading video requires a paid plan.' ) +
 								' ' +
 								this.props.translate(
-									'Contact your site administrator and ask them to upgrade this site to WordPress.com Pro.'
+									'Contact your site administrator and ask them to upgrade this site to WordPress.com Premium, Business, or eCommerce.'
 								),
 					2
 				);
@@ -67,7 +67,7 @@ class MediaLibraryListPlanPromo extends Component {
 						: this.props.translate( 'Uploading audio requires a paid plan.' ) +
 								' ' +
 								this.props.translate(
-									'Contact your site administrator and ask them to upgrade this site to WordPress.com Pro.'
+									'Contact your site administrator and ask them to upgrade this site to WordPress.com Premium, Business, or eCommerce.'
 								),
 					2
 				);

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -9,21 +9,21 @@ import ListPlanPromo from './list-plan-promo';
 
 function getTitle( filter, translate ) {
 	if ( filter === 'audio' ) {
-		return translate( 'Upgrade to the Pro Plan to Enable Audio Uploads' );
+		return translate( 'Upgrade to the Personal Plan to Enable Audio Uploads' );
 	}
 
-	return translate( 'Upgrade to the Pro Plan to Enable VideoPress' );
+	return translate( 'Upgrade to the Premium Plan to Enable VideoPress' );
 }
 
 function getSubtitle( filter, translate ) {
 	if ( filter === 'audio' ) {
 		return translate(
-			"By upgrading to the Pro plan, you'll enable audio upload support on your site."
+			"By upgrading to the Personal plan, you'll enable audio upload support on your site."
 		);
 	}
 
 	return translate(
-		"By upgrading to the Pro plan, you'll enable VideoPress support on your site."
+		"By upgrading to the Premium plan, you'll enable VideoPress support on your site."
 	);
 }
 

--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -51,7 +51,7 @@ class StepConfirmMigration extends Component {
 		return planSlug && planHasFeature( planSlug, FEATURE_UPLOAD_THEMES_PLUGINS );
 	}
 
-	renderCardProFooter() {
+	renderCardBusinessFooter() {
 		const { translate } = this.props;
 
 		// If the site is has an appropriate plan, no upgrade footer is required
@@ -63,7 +63,7 @@ class StepConfirmMigration extends Component {
 			<CompactCard className="migrate__card-footer">
 				<Gridicon className="migrate__card-footer-gridicon" icon="info-outline" size={ 12 } />
 				<span className="migrate__card-footer-text">
-					{ translate( 'A Pro Plan is required to import everything.' ) }
+					{ translate( 'A Business Plan is required to import everything.' ) }
 				</span>
 			</CompactCard>
 		);
@@ -138,7 +138,7 @@ class StepConfirmMigration extends Component {
 					</div>
 					{ this.renderMigrationButton() }
 				</CompactCard>
-				{ this.renderCardProFooter() }
+				{ this.renderCardBusinessFooter() }
 			</>
 		);
 	}

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -89,7 +89,7 @@ class StepImportOrMigrate extends Component {
 		}
 
 		if ( ! isTargetSiteAtomic ) {
-			return <p>{ translate( 'Import your entire site with the Pro Plan.' ) }</p>;
+			return <p>{ translate( 'Import your entire site with the Business Plan.' ) }</p>;
 		}
 	};
 

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -1,4 +1,4 @@
-import { getPlan, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
+import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { CompactCard, ProductIcon, Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -51,7 +51,9 @@ class StepUpgrade extends Component {
 				<HeaderCake backHref={ backHref }>{ translate( 'Import Everything' ) }</HeaderCake>
 
 				<CompactCard>
-					<CardHeading>{ translate( 'A Pro Plan is required to import everything.' ) }</CardHeading>
+					<CardHeading>
+						{ translate( 'A Business Plan is required to import everything.' ) }
+					</CardHeading>
 					<div>
 						{ translate(
 							'To import your themes, plugins, users, and settings from %(sourceSiteDomain)s we need to upgrade your WordPress.com site.',
@@ -105,7 +107,7 @@ class StepUpgrade extends Component {
 								<ProductIcon slug="business-bundle" />
 							</div>
 							<div className="migrate__plan-upsell-info">
-								<div className="migrate__plan-name">{ translate( 'WordPress.com Pro' ) }</div>
+								<div className="migrate__plan-name">{ translate( 'WordPress.com Business' ) }</div>
 								<div className="migrate__plan-price">
 									<PlanPrice rawPrice={ planPrice } currencyCode={ currency } />
 								</div>
@@ -127,7 +129,7 @@ class StepUpgrade extends Component {
 
 export default connect(
 	( state ) => {
-		const plan = getPlan( PLAN_WPCOM_PRO );
+		const plan = getPlan( PLAN_BUSINESS );
 		const planId = plan.getProductId();
 
 		return {

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -81,7 +81,7 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 				</p>
 				<PromoCardCTA
 					cta={ {
-						text: translate( 'Upgrade to Pro Plan' ),
+						text: translate( 'Upgrade to Business Plan' ),
 						action: {
 							url: `/checkout/${ siteSlug }/pro`,
 							onClick: onUpgradeClick,
@@ -93,7 +93,7 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 
 			{ filteredPromos.promos.length > 0 && (
 				<>
-					<h2 className="scan__subheader">{ translate( 'Also included in the Pro Plan' ) }</h2>
+					<h2 className="scan__subheader">{ translate( 'Also included in the Business Plan' ) }</h2>
 					<PromoSection { ...filteredPromos } />
 				</>
 			) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -658,7 +658,9 @@ export class SiteSettingsFormGeneral extends Component {
 							<UpsellNudge
 								feature={ WPCOM_FEATURES_NO_WPCOM_BRANDING }
 								plan={ PLAN_BUSINESS }
-								title={ translate( 'Remove the footer credit entirely with WordPress.com Pro' ) }
+								title={ translate(
+									'Remove the footer credit entirely with WordPress.com Business'
+								) }
 								description={ translate(
 									'Upgrade to remove the footer credit, use advanced SEO tools and more'
 								) }

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -1,4 +1,4 @@
-import { PLAN_WPCOM_PRO, WPCOM_FEATURES_UPLOAD_AUDIO_FILES } from '@automattic/calypso-products';
+import { PLAN_PERSONAL, WPCOM_FEATURES_UPLOAD_AUDIO_FILES } from '@automattic/calypso-products';
 import { Button, Card } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -220,8 +220,8 @@ class PodcastingDetails extends Component {
 					</HeaderCake>
 					{ ! error && plansDataLoaded && (
 						<UpsellNudge
-							plan={ PLAN_WPCOM_PRO }
-							title={ translate( 'Upload Audio with WordPress.com Pro' ) }
+							plan={ PLAN_PERSONAL }
+							title={ translate( 'Upload Audio with WordPress.com Personal' ) }
 							description={ translate(
 								'Embed podcast episodes directly from your media library.'
 							) }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -188,7 +188,9 @@ class StatsModule extends Component {
 					{ summary && 'countryviews' === path && (
 						<UpsellNudge
 							title={ translate( 'Add Google Analytics' ) }
-							description={ translate( 'Upgrade to a Pro Plan for Google Analytics integration.' ) }
+							description={ translate(
+								'Upgrade to a Premium Plan for Google Analytics integration.'
+							) }
 							event="googleAnalytics-stats-countries"
 							feature={ FEATURE_GOOGLE_ANALYTICS }
 							plan={ PLAN_PREMIUM }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1,7 +1,8 @@
 import config from '@automattic/calypso-config';
 import {
 	FEATURE_UPLOAD_THEMES,
-	PLAN_WPCOM_PRO,
+	PLAN_BUSINESS,
+	PLAN_PREMIUM,
 	WPCOM_FEATURES_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
 import { Button, Card, Gridicon } from '@automattic/components';
@@ -727,9 +728,9 @@ class ThemeSheet extends Component {
 		if ( hasWpComThemeUpsellBanner ) {
 			pageUpsellBanner = (
 				<UpsellNudge
-					plan={ PLAN_WPCOM_PRO }
+					plan={ PLAN_PREMIUM }
 					className="theme__page-upsell-banner"
-					title={ translate( 'Access this theme for FREE with a Pro plan!' ) }
+					title={ translate( 'Access this theme for FREE with a Premium or Business plan!' ) }
 					description={ preventWidows(
 						translate(
 							'Instantly unlock all premium themes, more storage space, advanced customization, video support, and more when you upgrade.'
@@ -747,9 +748,9 @@ class ThemeSheet extends Component {
 		if ( hasWpOrgThemeUpsellBanner || hasThemeUpsellBannerAtomic ) {
 			pageUpsellBanner = (
 				<UpsellNudge
-					plan={ PLAN_WPCOM_PRO }
+					plan={ PLAN_BUSINESS }
 					className="theme__page-upsell-banner"
-					title={ translate( 'Access this theme for FREE with a Pro plan!' ) }
+					title={ translate( 'Access this theme for FREE with a Business plan!' ) }
 					description={ preventWidows(
 						translate(
 							'Instantly unlock thousands of different themes and install your own when you upgrade.'

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -57,7 +57,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 			feature={ FEATURE_UPLOAD_THEMES }
 			plan={ PLAN_BUSINESS }
 			title={ translate(
-				'Unlock ALL premium themes and upload your own themes with our Pro plan!'
+				'Unlock ALL premium themes and upload your own themes with our Business and eCommerce plans!'
 			) }
 			forceHref={ true }
 			showIcon={ true }

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -4,7 +4,7 @@ import {
 	PLAN_FREE,
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
-	PLAN_WPCOM_PRO,
+	PLAN_BUSINESS,
 	WPCOM_FEATURES_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
 import { connect } from 'react-redux';
@@ -35,8 +35,8 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 						className="themes__showcase-banner"
 						event="calypso_themes_list_premium_themes"
 						feature={ WPCOM_FEATURES_PREMIUM_THEMES }
-						plan={ PLAN_WPCOM_PRO }
-						title={ translate( 'Unlock ALL premium themes with our Pro plan!' ) }
+						plan={ PLAN_PREMIUM }
+						title={ translate( 'Unlock ALL premium themes with our Premium and Business plans!' ) }
 						forceHref={ true }
 						showIcon={ true }
 					/>
@@ -49,8 +49,8 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 						className="themes__showcase-banner"
 						event="calypso_themes_list_install_themes"
 						feature={ FEATURE_UPLOAD_THEMES }
-						plan={ PLAN_WPCOM_PRO }
-						title={ translate( 'Upload your own themes with our Pro plan!' ) }
+						plan={ PLAN_BUSINESS }
+						title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
 						forceHref={ true }
 						showIcon={ true }
 					/>
@@ -62,8 +62,8 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 					className="themes__showcase-banner"
 					event="calypso_themes_list_install_themes"
 					feature={ FEATURE_UPLOAD_THEMES }
-					plan={ PLAN_WPCOM_PRO }
-					title={ translate( 'Upload your own themes with our Pro plan!' ) }
+					plan={ PLAN_BUSINESS }
+					title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
 					forceHref={ true }
 					showIcon={ true }
 				/>

--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -121,7 +121,7 @@ export class PlansAtomicStoreStep extends Component {
 		let headerText = translate( "Pick a plan that's right for you." );
 
 		if ( designType === DESIGN_TYPE_STORE ) {
-			headerText = translate( "You'll need the Pro plan." );
+			headerText = translate( "You'll need the eCommerce plan." );
 		}
 
 		return (

--- a/client/signup/steps/store-features/intents.tsx
+++ b/client/signup/steps/store-features/intents.tsx
@@ -26,7 +26,7 @@ export function useIntents(
 					<span className="store-features__requirements">
 						{ hasPaymentsFeature
 							? translate( 'Included in your plan' )
-							: translate( 'Requires a {{a}}Personal plan{{/a}}', {
+							: translate( 'Requires a {{a}}paid plan{{/a}}', {
 									components: {
 										a: (
 											<a

--- a/client/signup/steps/store-features/intents.tsx
+++ b/client/signup/steps/store-features/intents.tsx
@@ -26,7 +26,7 @@ export function useIntents(
 					<span className="store-features__requirements">
 						{ hasPaymentsFeature
 							? translate( 'Included in your plan' )
-							: translate( 'Requires a {{a}}Pro plan{{/a}}', {
+							: translate( 'Requires a {{a}}Personal plan{{/a}}', {
 									components: {
 										a: (
 											<a
@@ -81,7 +81,7 @@ export function useIntents(
 					<span className="store-features__requirements">
 						{ hasWooFeature
 							? translate( 'Included in your plan' )
-							: translate( 'Requires a {{a}}Pro plan{{/a}}', {
+							: translate( 'Requires a {{a}}Business plan{{/a}}', {
 									components: {
 										a: (
 											<a

--- a/packages/data-stores/src/contextual-help/contextual-help.tsx
+++ b/packages/data-stores/src/contextual-help/contextual-help.tsx
@@ -43,7 +43,7 @@ export const defaultFallbackLinks = [
 		},
 		get description() {
 			return __(
-				'Learn more about installing a custom theme or plugin using the Pro plan.',
+				'Learn more about installing a custom theme or plugin using the Business plan.',
 				__i18n_text_domain__
 			);
 		},
@@ -786,7 +786,7 @@ export const contextLinksForSection: Record< string, LinksForSection | LinksForS
 			get description() {
 				return __(
 					'On WordPress.com, we include the most popular plugin functionality within our ' +
-						'sites automatically. Additionally, the Pro plan allows you to choose from many ' +
+						'sites automatically. Additionally, the Business plan allows you to choose from many ' +
 						'thousands of plugins, and install them on your site.',
 					__i18n_text_domain__
 				);
@@ -817,7 +817,7 @@ export const contextLinksForSection: Record< string, LinksForSection | LinksForS
 			},
 			get description() {
 				return __(
-					'Along with all the tools and features built right into WordPress.com, the Pro plan ' +
+					'Along with all the tools and features built right into WordPress.com, the Business plan ' +
 						'allows you to install other plugins.',
 					__i18n_text_domain__
 				);
@@ -833,7 +833,7 @@ export const contextLinksForSection: Record< string, LinksForSection | LinksForS
 			},
 			get description() {
 				return __(
-					"When you want to build a one-of-a-kind website, it's time for WordPress.com Pro: " +
+					"When you want to build a one-of-a-kind website, it's time for WordPress.com Business: " +
 						'upload plugins and themes to create a truly tailored experience for your visitors.',
 					__i18n_text_domain__
 				);
@@ -1698,7 +1698,7 @@ export const contextLinksForSection: Record< string, LinksForSection | LinksForS
 			},
 			get description() {
 				return __(
-					'Sites on the Pro Plan using custom plugins and/or custom themes now have the option to switch PHP versions.',
+					'Sites on the Business Plan using custom plugins and/or custom themes and any site on the eCommerce Plan, now have the option to switch PHP versions.',
 					__i18n_text_domain__
 				);
 			},

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -393,7 +393,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 							<span>
 								{ createInterpolateElement(
 									__(
-										'Grow your business with <strong>WordPress.com Business</strong>',
+										'Grow your business with <strong>WordPress Business</strong>',
 										__i18n_text_domain__
 									),
 									{
@@ -477,7 +477,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 						<p className="focused-launch-summary__side-commentary-title">
 							{ createInterpolateElement(
 								__(
-									'Monetize your site with <strong>WordPress.com Premium</strong>',
+									'Monetize your site with <strong>WordPress Premium</strong>',
 									__i18n_text_domain__
 								),
 								{

--- a/packages/launch/src/focused-launch/summary/index.tsx
+++ b/packages/launch/src/focused-launch/summary/index.tsx
@@ -393,7 +393,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 							<span>
 								{ createInterpolateElement(
 									__(
-										'Grow your business with <strong>WordPress.com Pro</strong>',
+										'Grow your business with <strong>WordPress.com Business</strong>',
 										__i18n_text_domain__
 									),
 									{
@@ -477,7 +477,7 @@ const PlanStep: React.FunctionComponent< PlanStepProps > = ( {
 						<p className="focused-launch-summary__side-commentary-title">
 							{ createInterpolateElement(
 								__(
-									'Monetize your site with <strong>WordPress.com Pro</strong>',
+									'Monetize your site with <strong>WordPress.com Premium</strong>',
 									__i18n_text_domain__
 								),
 								{


### PR DESCRIPTION
#### Proposed Changes
This PR contains string references that are updated. Also see: https://github.com/Automattic/wp-calypso/pull/61595

These are, isolated, all a bunch of small changes - mainly for upsells and plan mentions. 

#### Testing Instructions
- Tests passing

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 797-automattic/martech
Fixes Automattic/martech#797
