### PR TITLE
Vertical Step: Fix the dropdown height on mobile device

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -175,6 +175,9 @@ $z-layers: (
 		'.is-section-signup::before': -1,
 		'.layout__primary::before': -1,
 	),
+	'.is-section-stepper': (
+		'.step-container__navigation.action-buttons': 30,
+	),
 	'.ribbon': (
 		'.ribbon__title::before': -1,
 		'.ribbon__title::after': -1,

--- a/client/components/select-vertical/style.scss
+++ b/client/components/select-vertical/style.scss
@@ -7,6 +7,8 @@
  */
 
 .select-vertical__suggestion-search {
+    --select-vertical-search-dropdown-height: 40vh;
+
     position: relative;
     width: auto;
 
@@ -94,13 +96,14 @@
     border-width: 0 1px 1px;
     box-sizing: border-box;
     left: 0;
-    max-height: 420px;
+    max-height: var( --select-vertical-search-dropdown-height );
     overflow: auto;
     padding: 0 0 12px;
     position: absolute;
     right: 0;
     top: 40px;
     transition: none;
+	z-index: z-index( '.is-section-stepper', '.step-container__navigation.action-buttons' );
 
     .suggestions__category-heading {
         background-color: #fff;
@@ -123,5 +126,13 @@
         &.is-emphasized {
             font-weight: inherit;
         }
+    }
+
+    &:empty {
+        display: none;
+    }
+
+    @include break-small() {
+        --select-vertical-search-dropdown-height: 420px;
     }
 }

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -1,11 +1,15 @@
 import { Gridicon, Suggestions, Spinner } from '@automattic/components';
 import { Button } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { FC, useMemo, useRef, useState } from 'react';
+import { FC, useMemo, useRef, useState, useEffect } from 'react';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import type { Vertical } from './types';
 import './style.scss';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 interface Props {
 	placeholder?: string;
@@ -31,9 +35,11 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 	const [ isShowSuggestions, setIsShowSuggestions ] = useState( false );
 	const [ isFocused, setIsFocused ] = useState( false );
 	const inputRef = useRef( null );
-	const suggestionsRef = useRef( null );
+	const wrapperRef = useRef< HTMLDivElement >( null );
+	const suggestionsRef = useRef< Suggestions >( null );
 	const toggleIconRef = useRef( null );
 	const translate = useTranslate();
+	const isMobile = useViewportMatch( 'small', '<' );
 
 	const showSuggestions = () => {
 		setIsShowSuggestions( true );
@@ -107,7 +113,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 		}
 
 		if ( suggestionsRef.current ) {
-			( suggestionsRef.current as Suggestions ).handleKeyEvent( event );
+			suggestionsRef.current.handleKeyEvent( event );
 		}
 	};
 
@@ -134,12 +140,38 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 		] );
 	}, [ translate, suggestions, isLoading, isShowSuggestions, isShowSkipOption ] );
 
+	useEffect( () => {
+		if ( ! ( window.visualViewport && isMobile ) ) {
+			return noop;
+		}
+
+		const handleResize = () => {
+			if ( ! wrapperRef.current ) {
+				return;
+			}
+
+			wrapperRef.current.style.setProperty(
+				'--select-vertical-search-dropdown-height',
+				`${ window.visualViewport.height * 0.4 }px`
+			);
+		};
+
+		handleResize();
+
+		window.visualViewport.addEventListener( 'resize', handleResize );
+
+		return () => {
+			window.visualViewport.removeEventListener( 'resize', handleResize );
+		};
+	}, [ wrapperRef, isMobile ] );
+
 	return (
 		<div
 			className={ classnames( 'select-vertical__suggestion-search', {
 				'is-focused': isFocused,
 				'is-show-suggestions': isShowSuggestions && ! isLoading,
 			} ) }
+			ref={ wrapperRef }
 			aria-expanded={ isShowSuggestions }
 		>
 			<div className="select-vertical__suggestion-input">

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -8,9 +8,6 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import type { Vertical } from './types';
 import './style.scss';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
-
 interface Props {
 	placeholder?: string;
 	searchTerm: string;
@@ -142,7 +139,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 
 	useEffect( () => {
 		if ( ! ( window.visualViewport && isMobile ) ) {
-			return noop;
+			return;
 		}
 
 		const handleResize = () => {


### PR DESCRIPTION
#### Proposed Changes

* Use `visualViewport` to detect the real viewport height of the screen and use the CSS variable to limit the height of the dropdown on the mobile device.

https://user-images.githubusercontent.com/13596067/172829693-6bac2c42-e301-4fc5-8f93-562c1ef854e5.mp4

* But I found a weird behavior on my simulator. The viewport height changes when you're scrolling down and you will see the extra space below the navigation bar (or sticky footer). I'm not sure whether it happens on the real device or not 🤔

https://user-images.githubusercontent.com/13596067/172829710-ad5e4aa5-da48-4d75-8964-e374a631d983.mp4

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to vertical step: `/setup/vertical?siteSlug=<your_site>` on mobile devices
* Focus on the input to see the height of the dropdown is reasonable
* Click outside the input and click the dropdown icon again to see the height of the dropdown is reasonable

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64441
