### PR TITLE
TeamCity: Fix invalid character in TeamCity ID for Editor Tracking tests

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -130,7 +130,7 @@ fun editorTrackingBuildType( targetDevice: String, buildUuid: String, atomic: Bo
 	var edgeType = if (edge) "edge" else "production";
 
     return E2EBuildType (
-		buildId = "WPComTests_editor-tracking_${siteType}_${edgeType}_$targetDevice",
+		buildId = "WPComTests_editor_tracking_${siteType}_${edgeType}_$targetDevice",
 		buildUuid = buildUuid,
 		buildName = "Editor tracking $siteType E2E tests $edgeType ($targetDevice)",
 		buildDescription = "Runs editor tracking $siteType E2E tests on $targetDevice size",


### PR DESCRIPTION
#### Proposed Changes

😒 

Isn't only testing these new builds post-merge fun? 😆 

Apparently, you can't use "-" characters in ID fields. I've updated. Sorry! 🙇‍♂️ 

Related to #
