### PR TITLE
Update P2 e2e test for auto focus

### DIFF
--- a/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
@@ -40,6 +40,7 @@ export class IsolatedBlockEditorComponent {
 		// Click on the editor title. This has the effect of dismissing the block inserter
 		// if open, and restores focus back to the editor root container, allowing insertion
 		// of blocks.
+		await this.page.waitForSelector( 'p[role="document"].is-selected' );
 		await this.page.click( selectors.blockInserterToggle );
 		await this.page.fill( selectors.blockInserterSearch, blockName );
 		await this.page.click( `${ selectors.blockInserterResultItem } span:text("${ blockName }")` );

--- a/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
@@ -5,6 +5,9 @@ const selectors = {
 	blockInserterSearch: 'input[placeholder="Search"]',
 	blockInserterResultItem: '.block-editor-block-types-list__list-item',
 
+	// First paragraph in the editor
+	firstParagraph: 'p[role="document"].is-selected',
+
 	// Publish
 	postButton: 'button:text("Publish")',
 };
@@ -40,7 +43,7 @@ export class IsolatedBlockEditorComponent {
 		// Click on the editor title. This has the effect of dismissing the block inserter
 		// if open, and restores focus back to the editor root container, allowing insertion
 		// of blocks.
-		await this.page.waitForSelector( 'p[role="document"].is-selected' );
+		await this.page.waitForSelector( selectors.firstParagraph );
 		await this.page.click( selectors.blockInserterToggle );
 		await this.page.fill( selectors.blockInserterSearch, blockName );
 		await this.page.click( `${ selectors.blockInserterResultItem } span:text("${ blockName }")` );


### PR DESCRIPTION
#### Proposed Changes

P2 now auto-focuses the editor. Depending on browser timings this is happening after the e2e test clicks the block inserter. When the editor is auto focused the block inserter closes and and the rest of the test fails.

This waits for the `is-selected` selector, indicating that focus has been achieved.

#### Testing Instructions

Run the P2 e2e test and it should now pass.