### PR TITLE
Stats: Allow showing stats for "Home page / Archives"

### DIFF
--- a/client/components/data/query-post-stats/index.jsx
+++ b/client/components/data/query-post-stats/index.jsx
@@ -16,7 +16,7 @@ function QueryPostStats( { siteId, postId, fields } ) {
 	const memoizedFields = useMemoCompare( fields, ( a, b ) => a?.join() === b?.join() );
 
 	useEffect( () => {
-		if ( siteId && typeof postId === 'number' ) {
+		if ( siteId && postId > -1 ) {
 			dispatch( request( siteId, postId, memoizedFields ) );
 		}
 	}, [ dispatch, siteId, postId, memoizedFields ] );

--- a/client/components/data/query-post-stats/index.jsx
+++ b/client/components/data/query-post-stats/index.jsx
@@ -16,7 +16,7 @@ function QueryPostStats( { siteId, postId, fields } ) {
 	const memoizedFields = useMemoCompare( fields, ( a, b ) => a?.join() === b?.join() );
 
 	useEffect( () => {
-		if ( siteId && postId ) {
+		if ( siteId && typeof postId === 'number' ) {
 			dispatch( request( siteId, postId, memoizedFields ) );
 		}
 	}, [ dispatch, siteId, postId, memoizedFields ] );

--- a/client/components/data/query-posts/index.jsx
+++ b/client/components/data/query-posts/index.jsx
@@ -30,7 +30,7 @@ const request = ( siteId, postId, query ) => ( dispatch, getState ) => {
 		return;
 	}
 
-	if ( ! isRequestingSitePost( state, siteId, postId ) ) {
+	if ( ! isRequestingSitePost( state, siteId, postId ) && postId > 0 ) {
 		log( 'Request single post for site %d post %d', siteId, postId );
 		dispatch( requestSitePost( siteId, postId ) );
 	}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -155,7 +155,7 @@ class StatsSite extends Component {
 				description={ translate(
 					'Changing your site from private to public helps people find you and get more visitors. Don’t worry, you can keep working on your site.'
 				) }
-				disableCircle="true"
+				disableCircle={ true }
 				event="calypso_stats_private_site_banner"
 				dismissPreferenceName={ `stats-launch-private-site-${ siteId }` }
 				href={ `/settings/general/${ siteSlug }` }


### PR DESCRIPTION
#### Proposed Changes

The latest posts homepage is tracked with a post_id of 0,
so we need to change some things to allow querying stats for it.

Also add some checks to disable stuff for the home page, and
just show stats.

#### Testing Instructions

- Find a blog that has latest posts set as homepage
- Visit `/stats/day/{$blog}` for the chosen blog
- Click on "Home page / Archives"
- See stats

Previous behavior: 
- Only shows `We don't have that post on record yet.`
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Depends on D82314-code.

Fixes https://github.com/Automattic/wp-calypso/issues/60563
