### PR TITLE
Update link in UpsellNudge

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -3,7 +3,6 @@ import {
 	isBloggerPlan,
 	isPersonalPlan,
 	isPremiumPlan,
-	isFreePlan,
 	isBusinessPlan,
 	isEcommercePlan,
 	GROUP_JETPACK,
@@ -35,7 +34,6 @@ export const UpsellNudge = ( {
 	canUserUpgrade,
 	className,
 	compact,
-	currentPlan,
 	customerType,
 	description,
 	disableHref,
@@ -93,21 +91,9 @@ export const UpsellNudge = ( {
 	}
 
 	if ( ! href && siteSlug && canUserUpgrade ) {
-		const currentPlanSlug = currentPlan?.productSlug;
-
-		// Redirect to the checkout page in case the Plans page can't be accessed by the plan.
-		if (
-			isFreePlan( currentPlanSlug ) ||
-			isBloggerPlan( currentPlanSlug ) ||
-			isPremiumPlan( currentPlanSlug ) ||
-			isPersonalPlan( currentPlanSlug )
-		) {
-			href = `/checkout/${ siteSlug }/pro`;
-		} else {
-			href = addQueryArgs( { feature, plan }, `/plans/${ siteSlug }` );
-			if ( customerType ) {
-				href = `/plans/${ siteSlug }?customerType=${ customerType }`;
-			}
+		href = addQueryArgs( { feature, plan }, `/plans/${ siteSlug }` );
+		if ( customerType ) {
+			href = `/plans/${ siteSlug }?customerType=${ customerType }`;
 		}
 	}
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -1,9 +1,4 @@
-import {
-	isWpComAnnualPlan,
-	PLAN_BUSINESS,
-	PLAN_WPCOM_PRO,
-	WPCOM_FEATURES_NO_WPCOM_BRANDING,
-} from '@automattic/calypso-products';
+import { PLAN_BUSINESS, WPCOM_FEATURES_NO_WPCOM_BRANDING } from '@automattic/calypso-products';
 import { Card, CompactCard, Button, Gridicon } from '@automattic/components';
 import { guessTimezone } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
@@ -614,9 +609,6 @@ export class SiteSettingsFormGeneral extends Component {
 			'is-loading': isRequestingSettings,
 		} );
 
-		// We currently don't have a monthly or a biennial pro plan, hence keeping the business plan upsell for those cases.
-		const upsellPlan = isWpComAnnualPlan( site.plan.product_slug ) ? PLAN_WPCOM_PRO : PLAN_BUSINESS;
-
 		return (
 			<div className={ classNames( classes ) }>
 				{ site && <QuerySiteSettings siteId={ site.ID } /> }
@@ -665,7 +657,7 @@ export class SiteSettingsFormGeneral extends Component {
 						{ ! hasNoWpcomBranding && (
 							<UpsellNudge
 								feature={ WPCOM_FEATURES_NO_WPCOM_BRANDING }
-								plan={ upsellPlan }
+								plan={ PLAN_BUSINESS }
 								title={ translate( 'Remove the footer credit entirely with WordPress.com Pro' ) }
 								description={ translate(
 									'Upgrade to remove the footer credit, use advanced SEO tools and more'

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -19,7 +19,6 @@ import {
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
-	PLAN_WPCOM_PRO,
 } from '@automattic/calypso-products';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -103,7 +102,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 					/>
 				);
 				expect( screen.queryByTestId( 'upsell-nudge' ) ).toBeVisible();
-				expect( screen.queryByTestId( 'upsell-nudge' ).textContent ).toBe( PLAN_WPCOM_PRO );
+				expect( screen.queryByTestId( 'upsell-nudge' ).textContent ).toBe( PLAN_BUSINESS );
 			} );
 		} );
 


### PR DESCRIPTION
#### Proposed Changes

* This PR updates the destination when a user clicks on the various UpsellNudge instances.

Examples:
- I.e. in settings > general for footer credit removal
- Inside of the Jetpack tab
- Inside of the media gallery upsells
- The texts/titles on the various CTAs are addressed in #64484, so they can be disregarded for testing this.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the above examples with a free plan
* Verify that you're sent to the `/plans/<site>` route, and not to the checkout page for the Pro plan
* This should have no adverse effects on Pro plan users.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64484
Fixes Automattic/martech#809