### PR TITLE
Jetpack Backup: Show warnings if followed by a real-time success

### DIFF
--- a/client/components/jetpack/backup-warnings/backup-warnings.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warnings.jsx
@@ -5,6 +5,7 @@ import BackupWarningHeader from 'calypso/components/jetpack/backup-warnings/back
 import BackupWarningListHeader from 'calypso/components/jetpack/backup-warnings/backup-warning-list-header';
 import LogItem from 'calypso/components/jetpack/log-item';
 import { getBackupWarnings } from 'calypso/lib/jetpack/backup-utils';
+import { useDailyBackupStatus } from 'calypso/my-sites/backup/status/hooks';
 
 import './style.scss';
 
@@ -85,10 +86,14 @@ const getWarningInfo = ( code, category ) => {
 	return warningInfo;
 };
 
-const BackupWarnings = ( { backup } ) => {
-	if ( ! backup ) {
+const BackupWarnings = ( { siteId, selectedDate } ) => {
+	const backupStatus = useDailyBackupStatus( siteId, selectedDate );
+
+	if ( ! backupStatus.lastBackupAttemptOnDate ) {
 		return <></>;
 	}
+
+	const backup = backupStatus.lastBackupAttemptOnDate;
 
 	const warnings = getBackupWarnings( backup );
 	const hasWarnings = Object.keys( warnings ).length !== 0;

--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -157,7 +157,7 @@ const Wrapper = ( props ) => {
 				<QueryRewindBackups siteId={ siteId } />
 				<DailyBackupStatus { ...props } />
 			</Card>
-			<BackupWarnings backup={ props.backup } />
+			<BackupWarnings selectedDate={ props.selectedDate } siteId={ siteId } />
 		</>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -9,6 +9,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { useActionableRewindId } from 'calypso/lib/jetpack/actionable-rewind-id';
 import { getBackupWarnings } from 'calypso/lib/jetpack/backup-utils';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
+import { useDailyBackupStatus } from 'calypso/my-sites/backup/status/hooks';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -30,7 +31,8 @@ const BackupSuccessful = ( { backup, deltas, selectedDate } ) => {
 		siteHasFeature( state, siteId, WPCOM_FEATURES_REAL_TIME_BACKUPS )
 	);
 
-	const warnings = getBackupWarnings( backup );
+	const backupStatus = useDailyBackupStatus( siteId, selectedDate );
+	const warnings = getBackupWarnings( backupStatus.lastBackupAttemptOnDate );
 	const hasWarnings = Object.keys( warnings ).length !== 0;
 
 	const moment = useLocalizedMoment();


### PR DESCRIPTION
#### Proposed Changes

* Currently when there is a more recent realtime backup the warnings aren't displayed because the most recent "backup" was a success.
* This displays the warnings, letting the user know there are still issues, and allows a retry of a full backup.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a site from the live links below with warnings on a day, but a more recent realtime backup and ensure warnings are show below the real-time event (as pictures)
* If you need access to a site with warnings, let me know.

<img width="774" alt="Screen Shot 2022-06-09 at 11 07 37 AM" src="https://user-images.githubusercontent.com/1992658/172880544-241942c6-cf50-4f71-b55f-e90529f91b06.png">

