### PR TITLE
Update/plan overhaul revert seo upsell preview

### DIFF
--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -1,8 +1,6 @@
 import {
-	isWpComAnnualPlan,
 	findFirstSimilarPlanKey,
 	TERM_ANNUALLY,
-	TYPE_PRO,
 	TYPE_BUSINESS,
 	TYPE_SECURITY_DAILY,
 	FEATURE_SEO_PREVIEW_TOOLS,
@@ -29,10 +27,6 @@ export const SeoPreviewNudge = ( {
 	site,
 	isJetpack = false,
 } ) => {
-	const upsellType = site && isWpComAnnualPlan( site.plan.product_slug ) ? TYPE_PRO : TYPE_BUSINESS;
-	const planName =
-		upsellType === TYPE_PRO ? translate( 'a Pro plan' ) : translate( 'a Business plan' );
-
 	return (
 		<div className="preview-upgrade-nudge">
 			<QueryPlans />
@@ -44,17 +38,14 @@ export const SeoPreviewNudge = ( {
 					site &&
 					findFirstSimilarPlanKey(
 						site.plan.product_slug,
-						isJetpack ? { type: TYPE_SECURITY_DAILY, term: TERM_ANNUALLY } : { type: upsellType }
+						isJetpack ? { type: TYPE_SECURITY_DAILY, term: TERM_ANNUALLY } : { type: TYPE_BUSINESS }
 					)
 				}
 				title={
 					canCurrentUserUpgrade
-						? translate( 'Upgrade to %(planName)s to unlock the power of our SEO tools!', {
-								args: { planName },
-						  } )
+						? translate( 'Upgrade to a Business plan to unlock the power of our SEO tools!' )
 						: translate(
-								"Unlock powerful SEO tools! Contact your site's administrator to upgrade to %(planName)s.",
-								{ args: { planName } }
+								"Unlock powerful SEO tools! Contact your site's administrator to upgrade to a Business plan."
 						  )
 				}
 				forceDisplay

--- a/client/components/seo/preview-upgrade-nudge/test/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/test/index.jsx
@@ -13,7 +13,6 @@ import {
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_BLOGGER,
 	PLAN_BLOGGER_2_YEARS,
-	PLAN_WPCOM_PRO,
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
@@ -22,6 +21,7 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PLAN_JETPACK_SECURITY_DAILY,
 	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+	PLAN_BUSINESS,
 } from '@automattic/calypso-products';
 import { shallow } from 'enzyme';
 import { SeoPreviewNudge } from '../index';
@@ -52,7 +52,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 				<SeoPreviewNudge { ...props } isJetpack={ false } site={ { plan: { product_slug } } } />
 			);
 			expect( comp.find( 'UpsellNudge' ).length ).toBe( 1 );
-			expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( PLAN_WPCOM_PRO );
+			expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( PLAN_BUSINESS );
 		} );
 	} );
 


### PR DESCRIPTION
#### Proposed Changes

* This updates the upsell CTA in SEO previews to go to the Business plan

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Automated tests passing

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64370

Fixes Automattic/martech#798