### PR TITLE
Site selection: add check for when site is null

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -476,10 +476,8 @@ export function siteSelection( context, next ) {
 		dispatch( requestSite( siteFragment ) )
 			.catch( () => null )
 			.then( ( site ) => {
-				let freshSiteId = getSiteId( getState(), siteFragment );
-
-				// If the fragment matches the *.wordpress.com domain for a site with a mapped domain, redirect to the mapped domain.
-				// e.g /site-editor/example.wordpress.com -> /site-editor/example.com
+				// If we found a site using the fragment and the fragment matches the *.wordpress.com domain for a site with a mapped domain,
+				// redirect to the mapped domain, e.g /site-editor/example.wordpress.com -> /site-editor/example.com
 				if ( site && site.ID ) {
 					const siteSlug = getSiteSlug( getState(), site.ID );
 					const unmappedSlug = withoutHttp( getSiteOption( getState(), site.ID, 'unmapped_url' ) );
@@ -489,6 +487,8 @@ export function siteSelection( context, next ) {
 						return page.redirect( `${ basePath }/${ siteSlug }` );
 					}
 				}
+
+				let freshSiteId = getSiteId( getState(), siteFragment );
 
 				if ( ! freshSiteId ) {
 					const wpcomStagingFragment = siteFragment.replace(

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -477,13 +477,17 @@ export function siteSelection( context, next ) {
 			.catch( () => null )
 			.then( ( site ) => {
 				let freshSiteId = getSiteId( getState(), siteFragment );
-				const siteSlug = getSiteSlug( getState(), site.ID );
-				const unmappedSlug = withoutHttp( getSiteOption( getState(), site.ID, 'unmapped_url' ) );
 
 				// If the fragment matches the *.wordpress.com domain for a site with a mapped domain, redirect to the mapped domain.
-				if ( ! freshSiteId && unmappedSlug !== siteSlug && unmappedSlug === siteFragment ) {
-					const basePath = sectionify( context.path, siteFragment );
-					return page.redirect( `${ basePath }/${ siteSlug }` );
+				// e.g /site-editor/example.wordpress.com -> /site-editor/example.com
+				if ( site && site.ID ) {
+					const siteSlug = getSiteSlug( getState(), site.ID );
+					const unmappedSlug = withoutHttp( getSiteOption( getState(), site.ID, 'unmapped_url' ) );
+
+					if ( unmappedSlug !== siteSlug && unmappedSlug === siteFragment ) {
+						const basePath = sectionify( context.path, siteFragment );
+						return page.redirect( `${ basePath }/${ siteSlug }` );
+					}
 				}
 
 				if ( ! freshSiteId ) {


### PR DESCRIPTION
#### Proposed Changes

* Updates the changes from #62964 to prevent [an error when site is null](https://sentry.io/share/issue/bad3ca5528a34f4e9f43cfe397e5f549/)

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/1699996/172913061-43f52f53-9790-48db-a278-e55f4630684f.png">


#### Testing Instructions

On a site with a mapped domain

- Visit /site-editor/example.wordpress.com (using the correct wordpress.com subdomain for the site)
- You should end up in the Site editor (`/site-editor/example.com`) rather than on a blank screen.
- Smoke test other routes in "My Sites" to make sure there are no errors.
