### PR TITLE
Update yarn instructions

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -56,8 +56,10 @@ nvm use <node_version>
 
 5. install `yarn`.
 
+See [this guide](https://yarnpkg.com/getting-started/install).
+
 ```
-npm install yarn
+corepack enable
 ```
 
 6. clone this repository


### PR DESCRIPTION
#### Proposed Changes

Our yarn installation instructions in our E2E quickstart were out of date. Now, they're not!

#### Testing Instructions

[Look at the readme in the Calypso devdocs](https://container-funny-tharp.calypso.live/devdocs/test/e2e/README.md)

Related to #
