### PR TITLE
Fix untranslated text on wordpress.com/plugins

### DIFF
--- a/client/my-sites/plugins/categories/responsive-toolbar-group/dropdown-group.tsx
+++ b/client/my-sites/plugins/categories/responsive-toolbar-group/dropdown-group.tsx
@@ -1,6 +1,7 @@
 import { ToolbarGroup, ToolbarButton, Dropdown, MenuItem, MenuGroup } from '@wordpress/components';
 import { Icon, chevronDown } from '@wordpress/icons';
 import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import { ReactChild, useCallback, useEffect, useRef, useState } from 'react';
 
 import './style.scss';
@@ -33,6 +34,7 @@ export default function DropdownGroup( {
 	const [ activeIndex, setActiveIndex ] = useState< number >( initialActiveIndex );
 	const [ groupedIndexes, setGroupedIndexes ] = useState< GroupedIndexStore >( {} );
 	const { current: shadowListItems } = useRef< HTMLButtonElement[] >( [] );
+	const translate = useTranslate();
 
 	const assignRef = ( index: number, element: HTMLButtonElement ) => {
 		shadowListItems[ index ] = element;
@@ -92,7 +94,7 @@ export default function DropdownGroup( {
 								onToggle();
 							} }
 						>
-							More
+							{ translate( 'More' ) }
 							<Icon icon={ chevronDown } />
 						</ToolbarButton>
 					) }


### PR DESCRIPTION
#### Proposed Changes

On https://wordpress.com/plugins/, the **More** button is not translated. This commit fixes the issue.


#### Testing Instructions

1. Change your user language to a mag-16 non-English language
2. Visit `/plugins`
3. Verify that the `More` dropdown is translated

Related to 444-gh-Automattic/i18n-issues