### PR TITLE
Add tracking events to upsell page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/upsell/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/upsell/index.tsx
@@ -7,6 +7,7 @@ import {
 	getJetpackProductsDisplayNames,
 } from '@automattic/calypso-products';
 import { Gridicon, Button } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import page from 'page';
@@ -111,15 +112,11 @@ const JetpackUpsellPage: React.FC< Props > = ( {
 	const priceDelta =
 		( upsellPriceObj?.discountedPrice || upsellPriceObj?.originalPrice ) -
 		( productPriceObj?.discountedPrice || productPriceObj?.originalPrice );
+	const originalPriceDelta =
+		upsellPriceObj?.originalPrice -
+		( productPriceObj?.discountedPrice || productPriceObj?.originalPrice );
 	const isLoadingPrice = productPriceObj?.isFetching || upsellPriceObj?.isFetching;
 	const showPrice = ! isLoadingPrice && priceDelta > 0;
-
-	useEffect( () => {
-		// Because .layout__content has padding, we need to make sure that this upsell page has
-		// enough height available to display the color blobs without cropping them. This causes
-		// the scroll bar to appear in Calypso blue. Here we make sure we see the top of the page.
-		window.scrollTo( 0, 0 );
-	}, [] );
 
 	useEffect( () => {
 		if ( ! isLoadingUpsellPageExperiment && experimentAssignment?.variationName !== 'treatment' ) {
@@ -146,7 +143,7 @@ const JetpackUpsellPage: React.FC< Props > = ( {
 	return (
 		<>
 			{ siteId && <QuerySiteProducts siteId={ siteId } /> }
-			<QueryIntroOffers siteId={ siteId ?? 'none' } />
+			{ siteId && <QueryIntroOffers siteId={ siteId } /> }
 
 			<main className="jetpack-upsell">
 				<div className="jetpack-upsell__blobs">
@@ -203,13 +200,13 @@ const JetpackUpsellPage: React.FC< Props > = ( {
 								<div className="jetpack-upsell__price-skeleton">
 									<div></div>
 									<div></div>
+									<div></div>
 								</div>
 							) }
 							{ showPrice && (
 								<div className="jetpack-upsell__cost-info">
 									{ cta && <p>{ cta }</p> }
 									<div className="jetpack-upsell__price-ctn">
-										<span className="jetpack-upsell__price-plus">+</span>
 										<PlanPrice
 											className="jetpack-upsell__price"
 											rawPrice={ priceDelta }
@@ -219,6 +216,22 @@ const JetpackUpsellPage: React.FC< Props > = ( {
 											{ translate( '/month, paid yearly' ) }
 										</span>
 									</div>
+									{ originalPriceDelta > priceDelta && (
+										<div className="jetpack-upsell__normal-price-ctn">
+											{ translate( 'Normally {{price/}}', {
+												components: {
+													price: (
+														<span className="jetpack-upsell__normal-price">
+															{ formatCurrency( originalPriceDelta, currencyCode as string, {
+																precision: 2,
+																stripZeros: true,
+															} ) }
+														</span>
+													),
+												},
+											} ) }
+										</div>
+									) }
 								</div>
 							) }
 							<div className="jetpack-upsell__actions">

--- a/client/my-sites/plans/jetpack-plans/upsell/style.scss
+++ b/client/my-sites/plans/jetpack-plans/upsell/style.scss
@@ -20,8 +20,8 @@
 			rgba( 255, 255, 255, 0 ) 25%
 		),
 		radial-gradient(
-			circle at 28% 58%,
-			rgba( 206, 217, 242, 0.7 ) 0%,
+			circle at 35% 70%,
+			rgba( 206, 217, 242, 0.6 ) 5%,
 			rgba( 255, 255, 255, 0 ) 30%
 		),
 		radial-gradient(
@@ -36,8 +36,7 @@
 }
 
 .jetpack-upsell__heading {
-	margin-top: 1.5rem;
-	margin-bottom: 1rem;
+	margin-top: 2.5rem;
 
 	font-size: 1.75rem;
 	font-weight: 700;
@@ -58,7 +57,7 @@
 	display: flex;
 	align-items: center;
 
-	padding: 0.75rem 7.5%;
+	padding: 0.5rem 2%;
 
 	background-color: var( --studio-jetpack-green-5 );
 
@@ -80,7 +79,7 @@
 }
 
 .jetpack-upsell__product-name {
-	margin-bottom: 1rem;
+	margin-bottom: 0.25rem;
 
 	color: var( --studio-gray-100 );
 
@@ -94,7 +93,7 @@
 	color: var( --studio-gray-100 );
 	list-style-type: none;
 
-	font-weight: 400;
+	font-weight: 300;
 
 	> li {
 		margin: 0.5rem 0;
@@ -138,6 +137,7 @@
 
 .jetpack-upsell__action-yes {
 	width: 100%;
+	max-width: 425px;
 	padding: 0.4375rem 1rem;
 
 	font-size: 1rem;
@@ -173,7 +173,7 @@
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 1px var( --studio-gray-100 );
+		box-shadow: 0 0 0 1pt var( --studio-gray-100 );
 		outline: none;
 
 		text-decoration: none;
@@ -182,7 +182,7 @@
 
 .jetpack-upsell__cost-info,
 .jetpack-upsell__price-skeleton {
-	min-height: 6.5rem;
+	min-height: 135px;
 }
 
 .jetpack-upsell__price-skeleton {
@@ -190,15 +190,20 @@
 		@include placeholder();
 
 		&:nth-child( 1 ) {
-			width: 23.5rem;
-			height: 1.25rem;
-			margin-bottom: 1.25rem;
+			width: 375px;
+			height: 20px;
+			margin-bottom: 20px;
 		}
 
 		&:nth-child( 2 ) {
-			width: 3.125rem;
-			height: 3.125rem;
-			margin-bottom: 1.25rem;
+			width: 50px;
+			height: 50px;
+			margin-bottom: 20px;
+		}
+
+		&:nth-child( 3 ) {
+			width: 100px;
+			height: 20px;
 		}
 	}
 }
@@ -206,15 +211,6 @@
 .jetpack-upsell__price-ctn {
 	display: flex;
 	align-items: flex-end;
-}
-
-.jetpack-upsell__price-plus {
-	margin-bottom: 0.5rem;
-	margin-inline-end: 0.5rem;
-
-	font-size: 28px;
-	font-weight: 700;
-	line-height: 1;
 }
 
 .jetpack-upsell__price {
@@ -252,6 +248,18 @@
 	color: var( --studio-gray-50 );
 
 	font-weight: 500;
+}
+
+.jetpack-upsell__normal-price-ctn {
+	margin-top: 1rem;
+
+	color: var( --studio-gray-50 );
+
+	font-size: 0.875rem;
+}
+
+.jetpack-upsell__normal-price {
+	color: var( --studio-gray-100 );
 }
 
 .jetpack-upsell__footer {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds tracking events to the CTAs of the new upsell page implemented in #63828.

### Testing instructions

#### Prerequisites
- Make sure you've got a Jetpack site with no subscription
- Assign yourself to the `treatment` variation of the experiment `jetpack_upsell_page_2022_05 `
- Make sure the Network tab of your browser preserves log

#### Test plan
- Run Calypso blue with this branch
- Visit `/plans/:site`
- Select Backup
- You should land on the upsell page
- Click on any of the 2 buttons
- Check in the Network panel that a tracking pixel with the event name `calypso_jetpack_upsell_page_product_click` was requested (see capture below)
- Verify that the values for `product_slug`, `path`, and `is_upsell` are correct
- Repeat with the second button

### Screenshots
<img width="520" alt="Screen Shot 2022-06-09 at 2 36 30 PM" src="https://user-images.githubusercontent.com/1620183/172921284-46c93e39-0773-445b-8057-cf9a342acbae.png">

