### PR TITLE
Tutorials: Add server side PHP API

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: DEV WordPress.com Editing Toolkit
+ * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
  * Version: 2.21
  * Author: Automattic

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WordPress.com Editing Toolkit
+ * Plugin Name: DEV WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
  * Version: 2.21
  * Author: Automattic
@@ -414,3 +414,11 @@ function load_block_description_links() {
 	require_once __DIR__ . '/wpcom-block-description-links/class-wpcom-block-description-links.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_description_links' );
+
+/**
+ * Load Tutorials API
+ */
+function load_tutorials() {
+	require_once __DIR__ . '/tutorials/tutorials.php';
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tutorials' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/phpunit.xml.dist
+++ b/apps/editing-toolkit/editing-toolkit-plugin/phpunit.xml.dist
@@ -22,5 +22,8 @@
 		<testsuite name="block-patterns">
 			<directory suffix="-test.php">./block-patterns/test/</directory>
 		</testsuite>
+		<testsuite name="tutorials">
+			<directory suffix="-test.php">./tutorials/test/</directory>
+		</testsuite>
 	</testsuites>
 </phpunit>

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
@@ -111,7 +111,7 @@ class WPCom_Tutorials {
 	 * @param string $id  The ID of the Tutorial to fetch.
 	 * @return null|array Tutorial associative array if found, null if not.
 	 */
-	public function get( $id ) {
+	public function get_tutorial( $id ) {
 		if ( ! isset( $this->registry[ $id ] ) ) {
 			return null;
 		}

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
@@ -51,7 +51,6 @@ class WPCom_Tutorials {
 	 * @return bool           True if successfully registered, false if it failed.
 	 */
 	public function register( $id, $options ) {
-		// @todo verify tasks strutcture
 		if ( ! $this->validate_options( $options ) ) {
 			return false;
 		}
@@ -184,6 +183,9 @@ class WPCom_Tutorials {
 		if ( ! $this->validate_status( $status ) ) {
 			return false;
 		}
+		if ( ! $this->task_exists( $tutorial_id, $task_id ) ) {
+			return false;
+		}
 
 		$statuses = $this->load_persisted_statuses();
 		if ( ! isset( $statuses[ $tutorial_id ] ) ) {
@@ -199,6 +201,23 @@ class WPCom_Tutorials {
 		}
 
 		return $this->persist_statuses( $statuses );
+	}
+
+	/**
+	 * Checks if a task exists for a registered tutorial.
+	 *
+	 * @param string $tutorial_id A tutorial ID.
+	 * @param string $task_id     A task ID.
+	 * @return bool True if it exists, otherwise false.
+	 */
+	private function task_exists( $tutorial_id, $task_id ) {
+		$tutorial = $this->get_tutorial( $tutorial_id );
+		foreach ( $tutorial['tasks'] as $task ) {
+			if ( $task_id === $task['id'] ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
@@ -101,7 +101,10 @@ class WPCom_Tutorials {
 	 * @return bool       Validation success.
 	 */
 	private function validate_task( $task ) {
-		return isset( $task['id'] ) && isset( $task['title'] );
+		return isset( $task['id'] )
+			&& is_string( $task['id'] )
+			&& isset( $task['title'] )
+			&& is_string( $task['title'] );
 	}
 
 	/**

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
@@ -30,7 +30,7 @@ class WPCom_Tutorials {
 	private $registry = array();
 
 	/**
-	 * Gets aour singleton instance, initiating it the first time.
+	 * Gets our singleton instance, initiating it the first time.
 	 *
 	 * @return WPCom_Tutorials instance.
 	 */

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
@@ -141,7 +141,11 @@ class WPCom_Tutorials {
 		$statuses            = $this->get_statuses( $tutorial['id'] );
 
 		foreach ( $tutorial['tasks'] as $task ) {
-			$task['status']        = isset( $statuses[ $task['id'] ] ) ? $statuses[ $task['id'] ] : 'pending';
+			// Default status is pending.
+			$task['status'] = 'pending';
+			if ( isset( $statuses[ $task['id'] ] ) ) {
+				$task['status'] = $statuses[ $task['id'] ];
+			}
 			$tasks_with_statuses[] = $task;
 		}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
@@ -66,6 +66,20 @@ class WPCom_Tutorials {
 	}
 
 	/**
+	 * Unregisters a registered Tutorial
+	 *
+	 * @param string $id Tutorial ID.
+	 * @return bool      True if successfully unregistered, false if not found.
+	 */
+	public function unregister( $id ) {
+		if ( ! isset( $this->registry[ $id ] ) ) {
+			return false;
+		}
+		unset( $this->registry[ $id ] );
+		return true;
+	}
+
+	/**
 	 * Validates the options passed in `WPCom_Tutorials::register`.
 	 *
 	 * @param array $options Associative array passed with registration.

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
@@ -4,7 +4,7 @@
  *
  * Each Tutorial contains a flat list of Tasks. Each Task may contain several Steps in
  * a `WpcomTourKit` component on the frontend, but we are only concerned with the top
- * two levels of Tutorial and its contained Steps, tracking Step completion status
+ * two levels of Tutorial and its contained Tasks, tracking Task completion status
  * on the backend. This API will be used to generate
  *
  * @package A8C\FSE

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
@@ -127,7 +127,7 @@ class WPCom_Tutorials {
 	 *
 	 * @return array list of registered Tutorial IDs.
 	 */
-	public function get_all() {
+	public function get_registered_ids() {
 		return array_keys( $this->registry );
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Tutorials (We would have called them Guided Tours but it's been done).
+ *
+ * Each Tutorial contains a flat list of Tasks. Each Task may contain several Steps in
+ * a `WpcomTourKit` component on the frontend, but we are only concerned with the top
+ * two levels of Tutorial and its contained Steps, tracking Step completion status
+ * on the backend. This API will be used to generate
+ *
+ * @package A8C\FSE
+ */
+
+/**
+ * WPCom_Tutorials class
+ */
+class WPCom_Tutorials {
+
+	/**
+	 * The WP option for storing our task progress status.
+	 */
+	const OPTION_NAME = 'wpcom_tutorials_status';
+
+	/**
+	 * Storage for our singleton instance.
+	 *
+	 * @var null|WPCom_Tutorials
+	 */
+	private static $instance = null;
+
+	/**
+	 * Internal storage for registered Tutorials.
+	 *
+	 * @var array
+	 */
+	private $registry = array();
+
+	/**
+	 * Gets aour singleton instance, initiating it the first time.
+	 *
+	 * @return WPCom_Tutorials instance.
+	 */
+	public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Registers a Tutorial.
+	 *
+	 * @param string $id      A unique ID for the Tutorial.
+	 * @param array  $options `title` and `tasks` required.
+	 *
+	 * @return bool           True if successfully registered, false if it failed.
+	 */
+	public function register( $id, $options ) {
+		// @todo verify tasks strutcture
+		if ( ! $this->validate_options( $options ) ) {
+			return false;
+		}
+		$options['id']         = $id;
+		$this->registry[ $id ] = $options;
+		return true;
+	}
+
+	/**
+	 * Validates the options passed in `WPCom_Tutorials::register`.
+	 *
+	 * @param array $options Associative array passed with registration.
+	 * @return bool          Validation success.
+	 */
+	private function validate_options( $options ) {
+		if ( ! isset( $options['title'] ) || ! is_string( $options['title'] ) ) {
+			return false;
+		}
+		if ( ! isset( $options['tasks'] ) || ! is_array( $options['tasks'] ) ) {
+			return false;
+		}
+		foreach ( $options['tasks'] as $task ) {
+			if ( ! $this->validate_task( $task ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Validates a single task for expected structure.
+	 *
+	 * @param array $task A single task (id and title).
+	 * @return bool       Validation success.
+	 */
+	private function validate_task( $task ) {
+		return isset( $task['id'] ) && isset( $task['title'] );
+	}
+
+	/**
+	 * Retrieves a Tutorial from the registry.
+	 *
+	 * @param string $id  The ID of the Tutorial to fetch.
+	 * @return null|array Tutorial associative array if found, null if not.
+	 */
+	public function get( $id ) {
+		if ( ! isset( $this->registry[ $id ] ) ) {
+			return null;
+		}
+		$tutorial = $this->registry[ $id ];
+
+		// Populating status at runtime so that any invalidations happen within the Options API.
+		$tutorial['tasks'] = $this->get_tasks( $tutorial );
+		return $tutorial;
+	}
+
+	/**
+	 * Retrives all registered Tutorial IDs
+	 *
+	 * @return array list of registered Tutorial IDs.
+	 */
+	public function get_all() {
+		return array_keys( $this->registry );
+	}
+
+	/**
+	 * Gets registered tasks for a Tutorial, with stored completion status.
+	 *
+	 * @param array $tutorial Tutorial object.
+	 * @return array          Tasks for Tutorial, with task completion status.
+	 */
+	private function get_tasks( $tutorial ) {
+		$tasks_with_statuses = array();
+		$statuses            = $this->get_statuses( $tutorial['id'] );
+
+		foreach ( $tutorial['tasks'] as $task ) {
+			$task['status']        = isset( $statuses[ $task['id'] ] ) ? $statuses[ $task['id'] ] : 'pending';
+			$tasks_with_statuses[] = $task;
+		}
+
+		return $tasks_with_statuses;
+	}
+
+	/**
+	 * Gets the completion statuses for a specific Tutorial.
+	 *
+	 * @param string $id Tutorial ID.
+	 * @return array     Completion statuses for Tutorial ID.
+	 */
+	public function get_statuses( $id ) {
+		$statuses = $this->load_all_statuses();
+		return isset( $statuses[ $id ] ) ? $statuses[ $id ] : array();
+	}
+
+	/**
+	 * Loads all Tutorial statuses.
+	 *
+	 * @return array All Tutorial completion statuses.
+	 */
+	private function load_all_statuses() {
+		return (array) get_option( self::OPTION_NAME, array() );
+	}
+
+	/**
+	 * Marks a task with a status.
+	 *
+	 * @param string $tutorial_id Tutorial ID.
+	 * @param string $task_id     Task ID.
+	 * @param string $status      Status for the task. Allowed: complete|skipped|pending.
+	 * @return bool               True if status is updated, false otherwise.
+	 */
+	public function mark_task( $tutorial_id, $task_id, $status ) {
+		if ( ! $this->validate_status( $status ) ) {
+			return false;
+		}
+
+		$statuses = $this->load_all_statuses();
+		if ( ! isset( $statuses[ $tutorial_id ] ) ) {
+			$statuses[ $tutorial_id ] = array();
+		}
+		// pending is the natural state with no stored status.
+		if ( 'pending' === $status ) {
+			if ( isset( $statuses[ $tutorial_id ][ $task_id ] ) ) {
+				unset( $statuses[ $tutorial_id ][ $task_id ] );
+			}
+		} else {
+			$statuses[ $tutorial_id ][ $task_id ] = $status;
+		}
+
+		return update_option( self::OPTION_NAME, $statuses );
+	}
+
+	/**
+	 * Checks if the status is valid.
+	 *
+	 * @param string $status A status to check. Allowed values: complete|pending|skipped.
+	 * @return bool          If status if valid, true, otherwise false.
+	 */
+	private function validate_status( $status ) {
+		$allowed = array( 'complete', 'pending', 'skipped' );
+		return in_array( $status, $allowed, true );
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/test/tutorials-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/test/tutorials-test.php
@@ -134,7 +134,7 @@ class WPCom_Tutorials_Test extends TestCase {
 		return empty( $filtered ) ? null : $filtered[0];
 	}
 
-	// boilerplace
+	// boilerplate
 	private function get_tasks() {
 		return array(
 			array(

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/test/tutorials-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/test/tutorials-test.php
@@ -1,0 +1,112 @@
+<?php
+// phpcs:ignoreFile
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __FILE__, 2 ) . '/tutorials.php';
+
+class WPCom_Tutorials_Test extends TestCase {
+
+	public function tearDown() {
+		// cleanse after each test
+		foreach ( wpcom_get_all_tutorials() as $id ) {
+			wpcom_tutorials()->unregister( $id );
+		}
+		// delete status storage
+		delete_option( WPCom_Tutorials::OPTION_NAME );
+	}
+
+	public function test_registered_tutorial_is_returned() {
+		wpcom_register_tutorial(
+			'foo',
+			array(
+				'title' => 'Foo',
+				'tasks' => $this->get_tasks(),
+			)
+		);
+
+		$return_tutorial = wpcom_get_tutorial( 'foo' );
+
+		$expected_tutorial = array(
+			'id'    => 'foo',
+			'title' => 'Foo',
+			'tasks' => $this->get_tasks_with_status(),
+		);
+
+		$this->assertEquals( $return_tutorial, $expected_tutorial );
+	}
+
+	public function test_all_registered_ids_are_returned() {
+		$this->assertEquals( wpcom_get_all_tutorials(), array() );
+
+		wpcom_register_tutorial(
+			'foo',
+			array(
+				'title' => 'Foo',
+				'tasks' => $this->get_tasks(),
+			)
+		);
+		wpcom_register_tutorial(
+			'bar',
+			array(
+				'title' => 'Bar',
+				'tasks' => $this->get_tasks(),
+			)
+		);
+		wpcom_register_tutorial(
+			'baz',
+			array(
+				'title' => 'Baz',
+				'tasks' => $this->get_tasks(),
+			)
+		);
+
+		$this->assertEquals( wpcom_get_all_tutorials(), array( 'foo', 'bar', 'baz' ) );
+	}
+
+	public function test_tutorial_with_malformed_options_fails() {
+		// empty option object
+		$foo1 = wpcom_register_tutorial( 'foo', array() );
+		$this->assertEmpty( wpcom_get_all_tutorials() );
+		$this->assertFalse( $foo1 );
+
+		// no title
+		$foo2 = wpcom_register_tutorial( 'foo', array( 'tasks' => $this->get_tasks() ) );
+		$this->assertEmpty( wpcom_get_all_tutorials() );
+		$this->assertFalse( $foo2 );
+
+		// no steps
+		$foo3 = wpcom_register_tutorial( 'foo', array( 'title' => 'Foo' ) );
+		$this->assertEmpty( wpcom_get_all_tutorials() );
+		$this->assertFalse( $foo3 );
+
+		// empty steps
+		$foo4 = wpcom_register_tutorial(
+			'foo',
+			array(
+				'title' => 'Foo',
+				'steps' => array(),
+			)
+		);
+		$this->assertEmpty( wpcom_get_all_tutorials() );
+		$this->assertFalse( $foo4 );
+	}
+
+	// boilerplace
+	private function get_tasks() {
+		return array(
+			array(
+				'id'    => 'bar',
+				'title' => 'Bar',
+			),
+		);
+	}
+
+	private function get_tasks_with_status( $status = 'pending' ) {
+		$tasks = $this->get_tasks();
+		foreach ( $tasks as $i => $task ) {
+			$tasks[ $i ]['status'] = $status;
+		}
+		return $tasks;
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/test/tutorials-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/test/tutorials-test.php
@@ -9,7 +9,7 @@ class WPCom_Tutorials_Test extends TestCase {
 
 	public function tearDown() {
 		// cleanse after each test
-		foreach ( wpcom_get_all_tutorials() as $id ) {
+		foreach ( wpcom_get_registered_tutorial_ids() as $id ) {
 			wpcom_tutorials()->unregister( $id );
 		}
 		// delete status storage
@@ -37,7 +37,7 @@ class WPCom_Tutorials_Test extends TestCase {
 	}
 
 	public function test_all_registered_ids_are_returned() {
-		$this->assertEquals( wpcom_get_all_tutorials(), array() );
+		$this->assertEquals( wpcom_get_registered_tutorial_ids(), array() );
 
 		wpcom_register_tutorial(
 			'foo',
@@ -61,23 +61,23 @@ class WPCom_Tutorials_Test extends TestCase {
 			)
 		);
 
-		$this->assertEquals( wpcom_get_all_tutorials(), array( 'foo', 'bar', 'baz' ) );
+		$this->assertEquals( wpcom_get_registered_tutorial_ids(), array( 'foo', 'bar', 'baz' ) );
 	}
 
 	public function test_tutorial_with_malformed_options_fails() {
 		// empty option object
 		$foo1 = wpcom_register_tutorial( 'foo', array() );
-		$this->assertEmpty( wpcom_get_all_tutorials() );
+		$this->assertEmpty( wpcom_get_registered_tutorial_ids() );
 		$this->assertFalse( $foo1 );
 
 		// no title
 		$foo2 = wpcom_register_tutorial( 'foo', array( 'tasks' => $this->get_tasks() ) );
-		$this->assertEmpty( wpcom_get_all_tutorials() );
+		$this->assertEmpty( wpcom_get_registered_tutorial_ids() );
 		$this->assertFalse( $foo2 );
 
 		// no steps
 		$foo3 = wpcom_register_tutorial( 'foo', array( 'title' => 'Foo' ) );
-		$this->assertEmpty( wpcom_get_all_tutorials() );
+		$this->assertEmpty( wpcom_get_registered_tutorial_ids() );
 		$this->assertFalse( $foo3 );
 
 		// empty steps
@@ -88,7 +88,7 @@ class WPCom_Tutorials_Test extends TestCase {
 				'steps' => array(),
 			)
 		);
-		$this->assertEmpty( wpcom_get_all_tutorials() );
+		$this->assertEmpty( wpcom_get_registered_tutorial_ids() );
 		$this->assertFalse( $foo4 );
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/tutorials.php
@@ -50,7 +50,7 @@ function wpcom_register_tutorial( $tutorial_id, $options ) {
  * @return null|array Tutorial associative array if found, null if not.
  */
 function wpcom_get_tutorial( $tutorial_id ) {
-	return wpcom_tutorials()->get( $tutorial_id );
+	return wpcom_tutorials()->get_tutorial( $tutorial_id );
 }
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/tutorials.php
@@ -70,6 +70,6 @@ function wpcom_tutorial_mark_task( $tutorial_id, $task_id, $status ) {
  *
  * @return array list of registered Tutorial IDs.
  */
-function wpcom_get_all_tutorials() {
-	return wpcom_tutorials()->get_all();
+function wpcom_get_registered_tutorial_ids() {
+	return wpcom_tutorials()->get_registered_ids();
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/tutorials.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Tutorials API
+ *
+ * @package A8C\FSE
+ */
+
+// Load the class we use. We also need this comment here to mollify PHPCS.
+require_once __DIR__ . '/class-wpcom-tutorials.php';
+
+/**
+ * Helper function to return a WPCom_Tutorials object
+ *
+ * @return WPCom_Tutorials instance object.
+ */
+function wpcom_tutorials() {
+	return WPCom_Tutorials::get_instance();
+}
+
+// phpcs:disable Squiz.Commenting.FunctionComment.ParamCommentFullStop
+// ^ it doesn't like the params for $options, despite this being Core style.
+/**
+ * Registers a Tutorial.
+ *
+ * @param string $tutorial_id  A unique ID for the Tutorial.
+ * @param array  $options {
+ *   Options for the Tutorial with the following shape.
+ *
+ *   @type string $title The displayed title for this Tutorial
+ *   @type array  $tasks {
+ *     An array of $tasks, each of which has:
+ *     {
+ *       @type string $id    A unique identifier for the Task
+ *       @type string $title What is displayed as the Task
+ *     }
+ *   }
+ * }
+ *
+ * @return bool True if successfully registered, false if it failed.
+ */
+function wpcom_register_tutorial( $tutorial_id, $options ) {
+	return wpcom_tutorials()->register( $tutorial_id, $options );
+}
+// phpcs:enable
+
+/**
+ * Retrieves a Tutorial from the registry.
+ *
+ * @param string $tutorial_id  The ID of the Tutorial to fetch.
+ * @return null|array Tutorial associative array if found, null if not.
+ */
+function wpcom_get_tutorial( $tutorial_id ) {
+	return wpcom_tutorials()->get( $tutorial_id );
+}
+
+/**
+ * Marks a task with a status.
+ *
+ * @param string $tutorial_id Tutorial ID.
+ * @param string $task_id     Task ID.
+ * @param string $status      Status for the task. Allowed: complete|skipped|pending.
+ * @return bool               True if status is updated, false otherwise.
+ */
+function wpcom_tutorial_mark_task( $tutorial_id, $task_id, $status ) {
+	return wpcom_tutorials()->mark_task( $tutorial_id, $task_id, $status );
+}
+
+/**
+ * Retrives all registered Tutorial IDs
+ *
+ * @return array list of registered Tutorial IDs.
+ */
+function wpcom_get_all_tutorials() {
+	return wpcom_tutorials()->get_all();
+}


### PR DESCRIPTION
#### Proposed Changes

* Add a Tutorials API

The main publicly defined functions are in [`tutorials/tutorials.php`](https://github.com/Automattic/wp-calypso/blob/5e1d753fb563a71eba81276cb3e179a6c780ca77/apps/editing-toolkit/editing-toolkit-plugin/tutorials/tutorials.php). 

#### Testing Instructions

Looks sane, unit tests pass

Fixes #64251
