### PR TITLE
Fix bug in storage graph in media library

### DIFF
--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -14,7 +14,6 @@ import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import useMediaStorageQuery from 'calypso/data/media-storage/use-media-storage-query';
-import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isLegacySiteWithHigherLimits from 'calypso/state/selectors/is-legacy-site-with-higher-limits';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -35,7 +34,6 @@ export function PlanStorage( { children, className, siteId } ) {
 	const canViewBar = useSelector( ( state ) => canCurrentUser( state, siteId, 'publish_posts' ) );
 	const translate = useTranslate();
 	const { data: mediaStorage } = useMediaStorageQuery( siteId );
-	const eligibleForProPlan = useSelector( ( state ) => isEligibleForProPlan( state, siteId ) );
 	const legacySiteWithHigherLimits = useSelector( ( state ) =>
 		isLegacySiteWithHigherLimits( state, siteId )
 	);
@@ -48,7 +46,7 @@ export function PlanStorage( { children, className, siteId } ) {
 		return null;
 	}
 
-	if ( eligibleForProPlan && mediaStorage ) {
+	if ( mediaStorage ) {
 		// Only override the storage for non-legacy sites that are on a free
 		// plan. Even if the site is on a free plan, it could have a space
 		// upgrade product on top of that, so also check that it is using the


### PR DESCRIPTION
#### Proposed Changes

* Free sites show the incorrect storage amount if the env variable for enabling Pro plan is toggled off.
* I'm removing the check for `isEligibleForProPlan` here.

#### Testing Instructions

* Create a new free site, you should see 1 GB
* Open an old free site, you should see 3 GB
* A starter plan site should see 6 GB
* A Pro plan site should see 50 GB
* A Business plan site should see 200 GB
* A site with storage addon should reflect the added storage

<img width="1238" alt="Screenshot 2022-06-10 at 00 29 33" src="https://user-images.githubusercontent.com/52675688/172957154-1c9bd02a-c383-4b44-b6db-c13bc89a922e.png">
<img width="1239" alt="Screenshot 2022-06-10 at 00 30 31" src="https://user-images.githubusercontent.com/52675688/172957161-1e50e2a7-51b0-443b-8676-ca4a65d8fcfd.png">
<img width="1243" alt="Screenshot 2022-06-10 at 00 31 25" src="https://user-images.githubusercontent.com/52675688/172957164-11ed6fb8-4451-42e4-bccd-84afe3cc84ef.png">
<img width="707" alt="Screenshot 2022-06-10 at 00 31 55" src="https://user-images.githubusercontent.com/52675688/172957169-ad5c2813-2e10-4a6c-b838-49d0a6a46cc2.png">
<img width="1232" alt="Screenshot 2022-06-10 at 00 47 07" src="https://user-images.githubusercontent.com/52675688/172957817-811fe2c5-3cf6-40b5-9889-a340c960c5aa.png">



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/64484
Fixes 811-gh-Automattic/martech