### PR TITLE
E2E: use role-based selectors for scheduler related elements.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -44,10 +44,9 @@ const selectors = {
 
 	// Schedule
 	scheduleButton: `button.edit-post-post-schedule__toggle`,
-	scheduleInput: ( attribute: string ) => `input[name="${ attribute }"]`,
-	scheduleMeridianButton: ( meridian: 'am' | 'pm' ) =>
-		`button.components-datetime__time-${ meridian }-button`,
-	scheduleMonthSelect: `select[name="month"]`,
+	scheduleInput: ( attribute: string ) => `role=spinbutton[name="${ attribute }"i]`,
+	scheduleMeridianButton: ( meridian: 'am' | 'pm' ) => `role=button[name="${ meridian }"i]`,
+	scheduleMonthSelect: `role=combobox[name="month"i]`,
 
 	// Permalink
 	permalinkInput: '.components-base-control__field:has-text("URL Slug") input',
@@ -290,6 +289,12 @@ export class EditorSettingsSidebarComponent {
 				// 2 digits as required by the select.
 				const monthSelectLocator = this.editor.locator( selectors.scheduleMonthSelect );
 				await monthSelectLocator.selectOption( date[ key ].toString().padStart( 2, '0' ) );
+				continue;
+			}
+			if ( key === 'date' ) {
+				console.log( 'lkjwer' );
+				const daySelector = this.editor.locator( selectors.scheduleInput( 'day' ) );
+				await daySelector.fill( date[ key ].toString() );
 				continue;
 			}
 

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -292,7 +292,6 @@ export class EditorSettingsSidebarComponent {
 				continue;
 			}
 			if ( key === 'date' ) {
-				console.log( 'lkjwer' );
 				const daySelector = this.editor.locator( selectors.scheduleInput( 'day' ) );
 				await daySelector.fill( date[ key ].toString() );
 				continue;


### PR DESCRIPTION
#### Proposed Changes

This PR addresses issues observed in #64312 around the Editor: Scheduler spec.

Key changes:
- use role selectors for scheduler elements;
- add new if clause to handle "date" input

#### Testing Instructions

Ensure the following:
  - [x] Gutenberg E2E edge (desktop)
  - [x] Gutenberg E2E edge (mobile)
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)

Closes #64312
