### PR TITLE
Add UI test cases for the components in the agency dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/test/site-actions.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/test/site-actions.tsx
@@ -41,7 +41,7 @@ describe( '<SiteActions>', () => {
 
 		expect( issueLicense ).toHaveProperty(
 			'href',
-			`https://example.com/partner-portal/issue-license/?site_id=${ site.value.blog_id }`
+			`https://example.com/partner-portal/issue-license/?site_id=${ site.value.blog_id }&source=dashboard`
 		);
 		expect( viewActivity ).toHaveProperty(
 			'href',

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/test/site-actions.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/test/site-actions.tsx
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import SiteActions from '../index';
+import type { SiteNode } from '../../types';
+
+describe( '<SiteActions>', () => {
+	test( 'should render correctly and have href for all the actions', () => {
+		const site: SiteNode = {
+			value: {
+				blog_id: 1234,
+				url: 'test.jurassic.ninja',
+				url_with_scheme: 'https://test.jurassic.ninja/',
+			},
+			error: false,
+			type: 'site',
+			status: '',
+		};
+		const initialState = {};
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+
+		const { container } = render(
+			<Provider store={ store }>
+				<SiteActions site={ site } siteError={ false } />
+			</Provider>
+		);
+
+		const [ button ] = container.getElementsByTagName( 'button' );
+		fireEvent.click( button );
+
+		const [ popoverMenu ] = container.parentElement.getElementsByClassName( 'popover__menu' );
+		expect( popoverMenu ).toBeInTheDocument();
+
+		const [ issueLicense, viewActivity, viewSite, visitWPAdmin ] =
+			popoverMenu.getElementsByClassName( 'site-actions__menu-item' );
+
+		expect( issueLicense ).toHaveProperty(
+			'href',
+			`https://example.com/partner-portal/issue-license/?site_id=${ site.value.blog_id }`
+		);
+		expect( viewActivity ).toHaveProperty(
+			'href',
+			`https://example.com/activity-log/${ site.value.url }`
+		);
+		expect( viewSite ).toHaveProperty( 'href', site.value.url_with_scheme );
+		expect( visitWPAdmin ).toHaveProperty(
+			'href',
+			`${ site.value.url_with_scheme }/wp-admin/admin.php?page=jetpack#/dashboard`
+		);
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { siteColumns } from '../../utils';
+import SiteCard from '../index';
+import type { SiteData } from '../../types';
+
+describe( '<SiteCard>', () => {
+	test( 'should render correctly and expand card on click', () => {
+		const rows: SiteData = {
+			site: {
+				value: {
+					blog_id: 1234,
+					url: 'test.jurassic.ninja',
+					url_with_scheme: 'https://test.jurassic.ninja/',
+				},
+				error: true,
+				type: 'site',
+				status: '',
+			},
+			backup: {
+				type: 'backup',
+			},
+			monitor: { error: '', type: 'monitor', status: '' },
+			scan: { threats: 3, type: 'scan', status: 'failed', value: '3 Threats' },
+			plugin: { updates: 3, type: 'plugin', status: 'warning', value: '3 Available' },
+		};
+		const initialState = {};
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+
+		const { container } = render(
+			<Provider store={ store }>
+				<SiteCard rows={ rows } columns={ siteColumns } />
+			</Provider>
+		);
+
+		const [ expandedContentBeforeClick ] = container.getElementsByClassName(
+			'site-card__expanded-content'
+		);
+		expect( expandedContentBeforeClick ).toBeFalsy();
+
+		const [ header ] = container.getElementsByClassName( 'site-card__title' );
+
+		fireEvent.click( header );
+
+		const [ expandedContent ] = container.getElementsByClassName( 'site-card__expanded-content' );
+
+		expect( expandedContent ).toBeInTheDocument();
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -7,7 +7,7 @@ import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-
 import { addQueryArgs } from 'calypso/lib/route';
 import SiteCard from '../site-card';
 import SiteTable from '../site-table';
-import { formatSites } from '../utils';
+import { formatSites, siteColumns } from '../utils';
 import type { ReactElement } from 'react';
 import './style.scss';
 
@@ -35,29 +35,6 @@ export default function SiteContent( {
 
 	const sites = formatSites( data?.sites );
 
-	const columns = [
-		{
-			key: 'site',
-			title: translate( 'Site' ),
-		},
-		{
-			key: 'backup',
-			title: translate( 'Backup' ),
-		},
-		{
-			key: 'scan',
-			title: translate( 'Scan' ),
-		},
-		{
-			key: 'monitor',
-			title: translate( 'Monitor' ),
-		},
-		{
-			key: 'plugin',
-			title: translate( 'Plugin Updates' ),
-		},
-	];
-
 	if ( ! isFetching && ! isError && ! sites.length ) {
 		return <div className="site-content__no-sites">{ translate( 'No active sites' ) }</div>;
 	}
@@ -68,7 +45,7 @@ export default function SiteContent( {
 
 	return (
 		<>
-			<SiteTable isFetching={ isFetching } columns={ columns } items={ sites } />
+			<SiteTable isFetching={ isFetching } columns={ siteColumns } items={ sites } />
 			<div className="site-content__mobile-view">
 				<>
 					{ isFetching ? (
@@ -79,7 +56,7 @@ export default function SiteContent( {
 						<>
 							{ sites.length > 0 &&
 								sites.map( ( rows, index ) => (
-									<SiteCard key={ index } columns={ columns } rows={ rows } />
+									<SiteCard key={ index } columns={ siteColumns } rows={ rows } />
 								) ) }
 						</>
 					) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import SiteContent from '../index';
+
+describe( '<SiteContent>', () => {
+	const sites = [
+		{
+			blog_id: 1234,
+			url: 'test.jurassic.ninja',
+		},
+	];
+	let props = {
+		data: { sites, total: 1, perPage: 10 },
+		isError: false,
+		isFetching: false,
+		currentPage: 1,
+	};
+	const initialState = {};
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+
+	test( 'should render correctly and show table', () => {
+		const { container } = render(
+			<Provider store={ store }>
+				<SiteContent { ...props } />
+			</Provider>
+		);
+		const [ tableContent ] = container.getElementsByClassName( 'site-table__table' );
+		expect( tableContent ).toBeInTheDocument();
+	} );
+	test( 'should render correctly and no sites', () => {
+		props = {
+			...props,
+			data: {
+				...props.data,
+				sites: [],
+			},
+		};
+		const { getByText } = render(
+			<Provider store={ store }>
+				<SiteContent { ...props } />
+			</Provider>
+		);
+		expect( getByText( 'No active sites' ) ).toBeInTheDocument();
+	} );
+	test( 'should render correctly and show loading indicator', () => {
+		props = {
+			...props,
+			isFetching: true,
+		};
+		const { container } = render(
+			<Provider store={ store }>
+				<SiteContent { ...props } />
+			</Provider>
+		);
+		const [ loadinContent ] = container.getElementsByClassName( 'partner-portal-text-placeholder' );
+		expect( loadinContent ).toBeInTheDocument();
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -144,7 +144,13 @@ export default function SiteStatusContent( {
 			rel = 'noreferrer';
 		}
 		updatedContent = (
-			<a target={ target } rel={ rel } onClick={ handleClickRowAction } href={ link }>
+			<a
+				data-testid={ `row-${ tooltipId }` }
+				target={ target }
+				rel={ rel }
+				onClick={ handleClickRowAction }
+				href={ link }
+			>
 				{ content }
 			</a>
 		);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import { translate } from 'i18n-calypso';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { siteColumns } from '../../utils';
+import SiteTable from '../index';
+import type { SiteData } from '../../types';
+
+describe( '<SiteTable>', () => {
+	const scanThreats = 4;
+	const blogId = 1234;
+	const pluginUpdates = [ 'plugin-1', 'plugin-2', 'plugin-3' ];
+	const siteUrl = 'test.jurassic.ninja';
+	const items: Array< SiteData > = [
+		{
+			site: {
+				value: {
+					blog_id: blogId,
+					url: siteUrl,
+					url_with_scheme: `https://${ siteUrl }/`,
+				},
+				error: false,
+				type: 'site',
+				status: '',
+			},
+			backup: {
+				type: 'backup',
+				value: translate( 'Failed' ),
+				status: 'failed',
+			},
+			monitor: {
+				error: false,
+				status: 'failed',
+				type: 'monitor',
+				value: translate( 'Site Down' ),
+			},
+			scan: {
+				threats: 4,
+				type: 'scan',
+				status: 'failed',
+				value: translate(
+					'%(threats)d Threat',
+					'%(threats)d Threats', // plural version of the string
+					{
+						count: scanThreats,
+						args: {
+							threats: scanThreats,
+						},
+					}
+				),
+			},
+			plugin: {
+				updates: pluginUpdates.length,
+				type: 'plugin',
+				value: `${ pluginUpdates.length } ${ translate( 'Available' ) }`,
+				status: 'warning',
+			},
+		},
+	];
+	const props = {
+		items,
+		isFetching: false,
+		columns: siteColumns,
+	};
+	const initialState = {};
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+
+	const { getByTestId } = render(
+		<Provider store={ store }>
+			<SiteTable { ...props } />
+		</Provider>
+	);
+
+	test( 'should render correctly and have href and status for each row', () => {
+		const backupEle = getByTestId( `row-${ blogId }-backup` );
+		expect( backupEle.getAttribute( 'href' ) ).toEqual( `/backup/${ siteUrl }` );
+		expect( backupEle.getElementsByClassName( 'sites-overview__badge' )[ 0 ].textContent ).toEqual(
+			'Failed'
+		);
+
+		const scanEle = getByTestId( `row-${ blogId }-scan` );
+		expect( scanEle.getAttribute( 'href' ) ).toEqual( `/scan/${ siteUrl }` );
+		expect( scanEle.getElementsByClassName( 'sites-overview__badge' )[ 0 ].textContent ).toEqual(
+			`${ scanThreats } Threats`
+		);
+
+		const monitorEle = getByTestId( `row-${ blogId }-monitor` );
+		expect( monitorEle.getAttribute( 'href' ) ).toEqual(
+			`https://jptools.wordpress.com/debug/?url=${ siteUrl }`
+		);
+		expect( monitorEle.getElementsByClassName( 'sites-overview__badge' )[ 0 ].textContent ).toEqual(
+			'Site Down'
+		);
+
+		const pluginEle = getByTestId( `row-${ blogId }-plugin` );
+		expect( pluginEle.getAttribute( 'href' ) ).toEqual(
+			`https://wordpress.com/plugins/updates/${ siteUrl }`
+		);
+		expect( pluginEle.getElementsByClassName( 'sites-overview__badge' )[ 0 ].textContent ).toEqual(
+			`${ pluginUpdates.length } Available`
+		);
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/site-error-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/site-error-content.tsx
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import SiteErrorContent from '../site-error-content';
+
+describe( '<SiteErrorContent>', () => {
+	const siteUrl = 'test.jurassic.ninja';
+
+	const initialState = {};
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+
+	const { container } = render(
+		<Provider store={ store }>
+			<SiteErrorContent siteUrl={ siteUrl } />
+		</Provider>
+	);
+
+	test( 'should render correctly and have href for Fix Now', () => {
+		const [ fixNow ] = container.getElementsByClassName( 'sites-overview__error-message-link' );
+		expect( fixNow ).toHaveProperty(
+			'href',
+			`https://example.com/settings/disconnect-site/${ siteUrl }?type=down`
+		);
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -6,11 +6,13 @@ export type AllowedTypes = 'site' | 'backup' | 'scan' | 'monitor' | 'plugin';
 // Site column object which holds key and title of each column
 export type SiteColumns = Array< { key: string; title: ReactChild } >;
 
+export type AllowedStatusTypes = 'inactive' | 'progress' | 'failed' | 'warning' | 'success';
+
 export interface SiteNode {
 	value: { blog_id: number; url: string; url_with_scheme: string };
 	error: boolean;
 	type: AllowedTypes;
-	status: string;
+	status: AllowedStatusTypes | string;
 }
 export interface SiteData {
 	site: SiteNode;
@@ -33,8 +35,6 @@ export type FormattedRowObj = {
 	threats?: number;
 	error?: boolean;
 };
-
-export type AllowedStatusTypes = 'inactive' | 'progress' | 'failed' | 'warning' | 'success';
 
 export type StatusEventNames = {
 	[ key in AllowedStatusTypes | string ]: { small_screen: string; large_screen: string };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -11,6 +11,29 @@ import type {
 } from './types';
 import type { ReactChild } from 'react';
 
+export const siteColumns = [
+	{
+		key: 'site',
+		title: translate( 'Site' ),
+	},
+	{
+		key: 'backup',
+		title: translate( 'Backup' ),
+	},
+	{
+		key: 'scan',
+		title: translate( 'Scan' ),
+	},
+	{
+		key: 'monitor',
+		title: translate( 'Monitor' ),
+	},
+	{
+		key: 'plugin',
+		title: translate( 'Plugin Updates' ),
+	},
+];
+
 // Event names for all actions for large screen(>960px) and small screen(<960px)
 export const actionEventNames: ActionEventNames = {
 	issue_license: {
@@ -366,10 +389,10 @@ export const formatSites = ( sites: Array< any > = [] ): Array< any > => {
 			scan: formatScanData( site ),
 			monitor: formatMonitorData( site ),
 			plugin: {
-				value: `${ pluginUpdates.length } ${ translate( 'Available' ) }`,
-				status: pluginUpdates.length > 0 ? 'warning' : 'success',
+				value: `${ pluginUpdates?.length } ${ translate( 'Available' ) }`,
+				status: pluginUpdates?.length > 0 ? 'warning' : 'success',
 				type: 'plugin',
-				updates: pluginUpdates.length,
+				updates: pluginUpdates?.length,
 			},
 		};
 	} );


### PR DESCRIPTION
#### Proposed Changes

This PR adds test cases to components that were added as a part of the agency dashboard MVP

#### Testing Instructions

- Run `git checkout add/update-ui-test-cases-for-agency-dashboard && git pull`
- Run `yarn run test-client client/jetpack-cloud/sections/agency-dashboard/sites-overview` to run the tests.
- Verify the tests are passing and code changes make sense

Related to 1202076982646589-as-1202320172683179