### PR TITLE
Add no retry flag as retry policy to get partner API

### DIFF
--- a/client/state/partner-portal/partner/handlers.ts
+++ b/client/state/partner-portal/partner/handlers.ts
@@ -2,6 +2,7 @@ import { AnyAction } from 'redux';
 import { formatApiPartner } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { JETPACK_PARTNER_PORTAL_PARTNER_REQUEST } from 'calypso/state/action-types';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { noRetry } from 'calypso/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 import { dispatchRequest as vanillaDispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { receivePartnerError, receivePartner } from 'calypso/state/partner-portal/partner/actions';
 import {
@@ -17,6 +18,10 @@ export function fetchPartnerHandler( action: AnyAction ): AnyAction {
 			method: 'GET',
 			apiNamespace: 'wpcom/v2',
 			path: '/jetpack-licensing/partner',
+			// Ignore type checking because TypeScript is incorrectly inferring the prop type due to .js usage in wpcom-http/actions
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			retryPolicy: noRetry(),
 		},
 		action
 	) as AnyAction;


### PR DESCRIPTION
#### Proposed Changes

As a part of the agency dashboard MVP, we have the following changes

- Wait for the partner API to complete the request
- Show a loader(Jetpack logo) when the API request is being made
- Redirect based on the partner type, if the type is agency then redirect to `/dashboard`  or else redirect to `/landing`

Since the API calls to GET `/partner` throws 404 for the non-partner Jetpack Cloud users and we have a retry(retry 3 times) mechanism implemented here which could be a bad UX for these users because they see the loader for sometime, we would like to add a `NO_RETRY` flag which for this API

#### Testing Instructions

- Create a new WPCOM test account.
- Visit http://jetpack.cloud.localhost:3000/ and login using the new one
- Make sure to keep your network tab open.
- Verify only one API call is being made to `/partner` which fails with 404 with the response
```
{"code":"no_partner_found","message":"No partner found","data":{"status":404}}
```