### PR TITLE
Seller experience: Redirect to email verification step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
@@ -159,12 +159,18 @@ const WooConfirm: Step = function WooCommerceConfirm( { navigation } ) {
 			! ( eligibilityWarnings && eligibilityWarnings?.length ); // there is no warnings from eligibility (warnings).
 	}
 
+	const flags = new URLSearchParams( window.location.search ).get( 'flags' );
+	const queryArgs = {
+		siteSlug: wpcomDomain,
+		...( flags ? { flags } : {} ),
+	};
+
 	const siteUpgrading = {
 		required: requiresUpgrade,
 		checkoutUrl: addQueryArgs(
 			{
-				redirect_to: addQueryArgs( { siteSlug: wpcomDomain }, '/setup/wooTransfer' ),
-				cancel_to: addQueryArgs( { siteSlug: wpcomDomain }, '/setup/wooConfirm' ),
+				redirect_to: addQueryArgs( queryArgs, '/setup/wooTransfer' ),
+				cancel_to: addQueryArgs( queryArgs, '/setup/wooConfirm' ),
 			},
 			`/checkout/${ wpcomDomain }/${ upgradingPlan?.product_slug ?? '' }`
 		),

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,8 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useDesignsBySite } from '@automattic/design-picker';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useDispatch as reduxDispatch } from 'react-redux';
+import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useFSEStatus } from '../hooks/use-fse-status';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
@@ -67,6 +68,7 @@ export const siteSetupFlow: Flow = {
 		const startingPoint = useSelect( ( select ) => select( ONBOARD_STORE ).getStartingPoint() );
 		const siteSlugParam = useSiteSlugParam();
 		const site = useSite();
+		const currentUser = useSelector( getCurrentUser );
 
 		let siteSlug: string | null = null;
 		if ( siteSlugParam ) {
@@ -152,6 +154,13 @@ export const siteSetupFlow: Flow = {
 					if ( storeType === 'power' ) {
 						dispatch( recordTracksEvent( 'calypso_woocommerce_dashboard_redirect' ) );
 
+						if (
+							isEnabled( 'signup/woo-verify-email' ) &&
+							currentUser &&
+							! currentUser.email_verified
+						) {
+							return navigate( 'wooVerifyEmail' );
+						}
 						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
 					}
 


### PR DESCRIPTION

#### Proposed Changes

* Keep the `flags` parameters in the URL after the redirecting for the checkout
* Redirect the user to the `wooVerifyEmail` step if the user has an unverified email.

#### Testing Instructions

* Create a new user and don't verify the email or sign in with a user that did not verify the email
* Go to `/setup?siteSlug=<YOUR-SITE>&flags=signup/woo-verify-email`.
* Continue through the Woo flow.
* You should be redirected to the `/wooVerifyEmail` step after the `processing` step.

Closes #61551
