### PR TITLE
Jetpack Backup - Fix link for database warnings

### DIFF
--- a/client/components/jetpack/backup-warnings/backup-warnings.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warnings.jsx
@@ -66,7 +66,7 @@ const getWarningInfo = ( code, category ) => {
 				components: {
 					ExternalLink: (
 						<ExternalLink
-							href="https://jetpack.com/support/backup/backups-via-the-jetpack-plugin/adding-credentials-to-jetpack/#file-access-permissions"
+							href="https://jetpack.com/blog/error-establishing-database-connection-on-wordpress/"
 							target="_blank"
 							rel="noopener noreferrer"
 							icon={ false }


### PR DESCRIPTION
#### Proposed Changes

* Fixes an incorrect link to database credential documentation

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual check is probably fine but you can also view a site with a database warning
* I can add you to a JN site with a database warning if you don't have one
