### PR TITLE
Marketplace: Add scripts to derive data snapshots from the top 100 searches

### DIFF
--- a/packages/calypso-mp-data-analysis/.gitignore
+++ b/packages/calypso-mp-data-analysis/.gitignore
@@ -7,5 +7,5 @@ npm-debug.log
 /tmp
 /gh-tmp
 
-top-100-terms.csv
+top-100-searches.csv
 /results

--- a/packages/calypso-mp-data-analysis/.gitignore
+++ b/packages/calypso-mp-data-analysis/.gitignore
@@ -1,0 +1,11 @@
+npm-debug.log
+.DS_Store
+.idea
+
+/node_modules
+/test/config.json
+/tmp
+/gh-tmp
+
+top-100-terms.csv
+/results

--- a/packages/calypso-mp-data-analysis/README.md
+++ b/packages/calypso-mp-data-analysis/README.md
@@ -1,0 +1,1 @@
+# calypso-mp-data-analysis

--- a/packages/calypso-mp-data-analysis/README.md
+++ b/packages/calypso-mp-data-analysis/README.md
@@ -1,1 +1,5 @@
 # calypso-mp-data-analysis
+
+This package derivates the top products from the `top-100-searches.csv` file. This file should be a csv containing a `search_term` column, a `count` column and a `language` column.
+
+To generate the csv reports navigate into this repo and run `yarn generate` the results will appear under `results/`.

--- a/packages/calypso-mp-data-analysis/get-top-categories.js
+++ b/packages/calypso-mp-data-analysis/get-top-categories.js
@@ -1,0 +1,255 @@
+// eslint-disable-next-line import/no-nodejs-modules
+const { get } = require( 'axios' );
+const { parse } = require( 'csv-parse/sync' );
+const { stringify } = require( 'csv-stringify/sync' );
+const fs = require( 'fs-extra' );
+
+// empty translation becaue laziness
+const __ = ( name ) => name;
+
+const categories = {
+	analytics: {
+		name: __( 'Analytics' ),
+		description: __( 'Analytics' ),
+		icon: 'grid',
+		slug: 'analytics',
+		tags: [ 'analytics' ],
+	},
+	booking: {
+		name: __( 'Booking & Scheduling' ),
+		description: __( 'Booking' ),
+		icon: 'grid',
+		slug: 'booking',
+		tags: [
+			'booking',
+			'scheduling',
+			'appointment',
+			'reservations',
+			'reservation',
+			'booking-calendar',
+		],
+	},
+	customer: {
+		name: __( 'Customer Service' ),
+		description: __( 'Customer Service' ),
+		icon: 'grid',
+		slug: 'customer',
+		tags: [ 'customer-service' ],
+	},
+	design: {
+		name: __( 'Design' ),
+		description: __( 'Design' ),
+		icon: 'grid',
+		slug: 'design',
+		tags: [ 'design' ],
+	},
+	donations: {
+		name: __( 'Donations' ),
+		description: __( 'Donations' ),
+		icon: 'grid',
+		slug: 'donations',
+		tags: [
+			'donation',
+			'donation-plugin',
+			'donations',
+			'donate',
+			'fundraising',
+			'crowdfunding',
+			'recurring-donations',
+			'charity',
+		],
+	},
+	ecommerce: {
+		name: __( 'Ecommerce & Business' ),
+		description: __( 'Ecommerce' ),
+		icon: 'grid',
+		slug: 'ecommerce',
+		tags: [ 'ecommerce', 'e-commerce', 'woocommerce', 'business', 'business-directory' ],
+	},
+	education: {
+		name: __( 'Education' ),
+		description: __( 'Education' ),
+		icon: 'grid',
+		slug: 'education',
+		tags: [ 'education' ],
+	},
+	email: {
+		name: __( 'Email' ),
+		description: __( 'Email' ),
+		icon: 'grid',
+		slug: 'email',
+		tags: [ 'email' ],
+	},
+	finance: {
+		name: __( 'Finance & Payments' ),
+		description: __( 'Finance' ),
+		icon: 'grid',
+		slug: 'finance',
+		tags: [ 'finance', 'payment', 'credit-card', 'payment-gateway' ],
+	},
+	marketing: {
+		name: __( 'Marketing' ),
+		description: __( 'Marketing' ),
+		icon: 'grid',
+		slug: 'marketing',
+		tags: [ 'marketing' ],
+	},
+	photo: {
+		name: __( 'Photo & Video' ),
+		description: __( 'Photo & Video' ),
+		icon: 'grid',
+		slug: 'photo',
+		tags: [ 'photo', 'video', 'media' ],
+	},
+	posts: {
+		name: __( 'Posts & Posting' ),
+		description: __( 'Posts & Posting' ),
+		icon: 'grid',
+		slug: 'posts',
+		tags: [ 'posts', 'post', 'page', 'pages' ],
+	},
+	seo: {
+		name: __( 'Search Optimization' ),
+		description: __( 'Search Optimization' ),
+		icon: 'grid',
+		slug: 'seo',
+		tags: [ 'seo' ],
+	},
+	security: {
+		name: __( 'Security' ),
+		description: __( 'Security' ),
+		icon: 'grid',
+		slug: 'security',
+		tags: [ 'security' ],
+	},
+	shipping: {
+		name: __( 'Shipping & Delivery' ),
+		description: __( 'Shipping & Delivery' ),
+		icon: 'grid',
+		slug: 'shipping',
+		tags: [
+			'shipping',
+			'usps',
+			'woocommerce-shipping',
+			'delivery',
+			'shipment-tracking',
+			'food-delivery',
+			'food-pickup',
+			'courier',
+		],
+	},
+	social: {
+		name: __( 'Social' ),
+		description: __( 'Social' ),
+		icon: 'grid',
+		slug: 'social',
+		tags: [ 'social', 'facebook', 'twitter', 'instagram', 'tiktok', 'youtube', 'pinterest' ],
+	},
+	widgets: {
+		name: __( 'Widgets' ),
+		description: __( 'Widgets' ),
+		icon: 'grid',
+		slug: 'widgets',
+		tags: [ 'widgets' ],
+	},
+};
+
+const getLocale = ( lang ) => {
+	if ( lang === 'en' ) {
+		return 'en_US';
+	}
+
+	if ( lang.length === 2 ) {
+		return `${ lang }_${ lang.toUpperCase() }`;
+	}
+
+	return lang.replace( '-', '_' );
+};
+
+const getTopTagsAndCategories = async () => {
+	const tagsCountMap = {};
+	const csvFileContent = await fs.readFile( './top-100-searches.csv', {
+		encoding: 'utf-8',
+	} );
+	const records = parse( csvFileContent, {
+		columns: true,
+		skip_empty_lines: true,
+	} );
+
+	for ( const record of records ) {
+		const { data: wporgData } = await get( 'https://api.wordpress.org/plugins/info/1.2/', {
+			params: {
+				action: 'query_plugins',
+				'request[page]': 1,
+				'request[per_page]': 24,
+				'request[search]': record.search_term,
+				'request[locale]': getLocale( record.language ),
+			},
+		} );
+
+		const { data: wpcomData } = await get(
+			'https://public-api.wordpress.com/wpcom/v2/marketplace/products',
+			{
+				params: {
+					type: 'all',
+					_envelope: 1,
+					q: record.search_term,
+				},
+			}
+		);
+
+		const wpcomPlugins = Object.values( wpcomData.body.results );
+		const wporgPlugins = Object.values( wporgData.plugins );
+
+		const plugins = [ ...wpcomPlugins, ...wporgPlugins ].slice( 0, 6 ); // show top 6 plugins
+
+		// eslint-disable-next-line no-console
+		console.log(
+			`fetched plugins for ${ record.search_term }: locale - ${ getLocale(
+				record.language
+			) } results - wpcom: ${ wpcomPlugins.length } | wporg: ${ wporgPlugins.length }`
+		);
+
+		plugins.forEach( ( plugin ) => {
+			Object.keys( plugin.tags || {} ).forEach( ( tag ) => {
+				tagsCountMap[ tag ] = tagsCountMap[ tag ]
+					? tagsCountMap[ tag ] + parseInt( record.count )
+					: parseInt( record.count );
+			} );
+		} );
+	}
+
+	const topTags = Object.keys( tagsCountMap )
+		.map( ( tag ) => ( {
+			tag: tag,
+			count: tagsCountMap[ tag ],
+		} ) )
+		.sort( ( a, b ) => a.count - b.count )
+		.reverse();
+
+	await fs.outputFile(
+		'results/top-tags.csv',
+		stringify( topTags, { columns: [ { key: 'tag' }, { key: 'count' } ] } )
+	);
+
+	const topCategories = Object.values( categories )
+		.map( ( category ) => {
+			const count = category.tags.reduce( ( acc, categoryTag ) => {
+				return acc + ( topTags.find( ( { tag } ) => tag === categoryTag )?.count ?? 0 );
+			}, 0 );
+
+			return {
+				category: category.slug,
+				count,
+			};
+		} )
+		.sort( ( a, b ) => a.count - b.count )
+		.reverse();
+
+	await fs.outputFile(
+		'results/top-categories.csv',
+		stringify( topCategories, { columns: [ { key: 'category' }, { key: 'count' } ] } )
+	);
+};
+
+getTopTagsAndCategories();

--- a/packages/calypso-mp-data-analysis/get-top-categories.js
+++ b/packages/calypso-mp-data-analysis/get-top-categories.js
@@ -229,7 +229,7 @@ const getTopTagsAndCategories = async () => {
 
 	await fs.outputFile(
 		'results/top-tags.csv',
-		stringify( topTags, { columns: [ { key: 'tag' }, { key: 'count' } ] } )
+		stringify( topTags, { columns: [ { key: 'tag' }, { key: 'count' } ], header: true } )
 	);
 
 	const topCategories = Object.values( categories )
@@ -248,7 +248,7 @@ const getTopTagsAndCategories = async () => {
 
 	await fs.outputFile(
 		'results/top-categories.csv',
-		stringify( topCategories, { columns: [ { key: 'category' }, { key: 'count' } ] } )
+		stringify( topCategories, { columns: [ { key: 'category' }, { key: 'count' } ], header: true } )
 	);
 };
 

--- a/packages/calypso-mp-data-analysis/get-top-products.js
+++ b/packages/calypso-mp-data-analysis/get-top-products.js
@@ -1,0 +1,88 @@
+// eslint-disable-next-line import/no-nodejs-modules
+const { get } = require( 'axios' );
+const { parse } = require( 'csv-parse/sync' );
+const { stringify } = require( 'csv-stringify/sync' );
+const fs = require( 'fs-extra' );
+
+const getLocale = ( lang ) => {
+	if ( lang === 'en' ) {
+		return 'en_US';
+	}
+
+	if ( lang.length === 2 ) {
+		return `${ lang }_${ lang.toUpperCase() }`;
+	}
+
+	return lang.replace( '-', '_' );
+};
+
+const getTopProducts = async () => {
+	const productsCountMap = {};
+	const csvFileContent = await fs.readFile( './top-100-searches.csv', {
+		encoding: 'utf-8',
+	} );
+	const records = parse( csvFileContent, {
+		columns: true,
+		skip_empty_lines: true,
+	} );
+
+	for ( const record of records ) {
+		const { data: wporgData } = await get( 'https://api.wordpress.org/plugins/info/1.2/', {
+			params: {
+				action: 'query_plugins',
+				'request[page]': 1,
+				'request[per_page]': 24,
+				'request[search]': record.search_term,
+				'request[locale]': getLocale( record.language ),
+			},
+		} );
+
+		const { data: wpcomData } = await get(
+			'https://public-api.wordpress.com/wpcom/v2/marketplace/products',
+			{
+				params: {
+					type: 'all',
+					_envelope: 1,
+					q: record.search_term,
+				},
+			}
+		);
+
+		const wpcomPlugins = Object.values( wpcomData.body.results );
+		const wporgPlugins = Object.values( wporgData.plugins );
+
+		const plugins = [ ...wpcomPlugins, ...wporgPlugins ].slice( 0, 6 ); // show top 6 plugins
+
+		// eslint-disable-next-line no-console
+		console.log(
+			`fetched plugins for ${ record.search_term }: locale - ${ getLocale(
+				record.language
+			) } results - wpcom: ${ wpcomPlugins.length } | wporg: ${ wporgPlugins.length }`
+		);
+
+		plugins.forEach( ( plugin ) => {
+			productsCountMap[ plugin.slug ] = {
+				count: productsCountMap[ plugin.slug ]
+					? productsCountMap[ plugin.slug ].count + parseInt( record.count )
+					: parseInt( record.count ),
+			};
+		} );
+	}
+
+	const results = Object.keys( productsCountMap )
+		.map( ( slug ) => ( {
+			product: slug,
+			count: productsCountMap[ slug ].count,
+			locales: productsCountMap[ slug ].locales,
+		} ) )
+		.sort( ( a, b ) => a.count - b.count )
+		.reverse()
+		.slice( 0, 250 ); // limit to 250 records
+
+	await fs.outputFile(
+		'results/top-products.csv',
+		stringify( results, { columns: [ { key: 'product' }, { key: 'count' } ] } )
+	);
+};
+
+getTopProducts();

--- a/packages/calypso-mp-data-analysis/get-top-products.js
+++ b/packages/calypso-mp-data-analysis/get-top-products.js
@@ -81,7 +81,7 @@ const getTopProducts = async () => {
 
 	await fs.outputFile(
 		'results/top-products.csv',
-		stringify( results, { columns: [ { key: 'product' }, { key: 'count' } ] } )
+		stringify( results, { columns: [ { key: 'product' }, { key: 'count' } ], header: true } )
 	);
 };
 

--- a/packages/calypso-mp-data-analysis/package.json
+++ b/packages/calypso-mp-data-analysis/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "@automattic/calypso-mp-data-analysis",
+	"version": "1.0.0",
+	"author": "Automattic Inc.",
+	"dependencies": {
+		"axios": "^0.27.2",
+		"csv-parse": "^5.1.0"
+	}
+}

--- a/packages/calypso-mp-data-analysis/package.json
+++ b/packages/calypso-mp-data-analysis/package.json
@@ -7,5 +7,8 @@
 		"csv-parse": "^5.1.0",
 		"csv-stringify": "^6.1.0",
 		"fs-extra": "^10.1.0"
+	},
+	"scripts": {
+		"generate": "node get-top-categories.js && node get-top-products.js"
 	}
 }

--- a/packages/calypso-mp-data-analysis/package.json
+++ b/packages/calypso-mp-data-analysis/package.json
@@ -4,6 +4,8 @@
 	"author": "Automattic Inc.",
 	"dependencies": {
 		"axios": "^0.27.2",
-		"csv-parse": "^5.1.0"
+		"csv-parse": "^5.1.0",
+		"csv-stringify": "^6.1.0",
+		"fs-extra": "^10.1.0"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,6 +281,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/calypso-mp-data-analysis@workspace:packages/calypso-mp-data-analysis":
+  version: 0.0.0-use.local
+  resolution: "@automattic/calypso-mp-data-analysis@workspace:packages/calypso-mp-data-analysis"
+  dependencies:
+    axios: ^0.27.2
+    csv-parse: ^5.1.0
+  languageName: unknown
+  linkType: soft
+
 "@automattic/calypso-polyfills@workspace:^, @automattic/calypso-polyfills@workspace:packages/calypso-polyfills":
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-polyfills@workspace:packages/calypso-polyfills"
@@ -11145,6 +11154,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^0.27.2":
+  version: 0.27.2
+  resolution: "axios@npm:0.27.2"
+  dependencies:
+    follow-redirects: ^1.14.9
+    form-data: ^4.0.0
+  checksum: 76d673d2a90629944b44d6f345f01e58e9174690f635115d5ffd4aca495d99bcd8f95c590d5ccb473513f5ebc1d1a6e8934580d0c57cdd0498c3a101313ef771
+  languageName: node
+  linkType: hard
+
 "axobject-query@npm:^2.2.0":
   version: 2.2.0
   resolution: "axobject-query@npm:2.2.0"
@@ -14662,6 +14681,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"csv-parse@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "csv-parse@npm:5.1.0"
+  checksum: 63a85f8a7b0df613e0c2039e3a62d3c3877f670952dc0c0dfc2ba642f5d8b5d33b1bfb6943c65bec5ea56bba39c3ae6d3b93cf649f436c3d6cc558aa98905653
+  languageName: node
+  linkType: hard
+
 "ctype@npm:0.5.3":
   version: 0.5.3
   resolution: "ctype@npm:0.5.3"
@@ -18007,6 +18033,16 @@ __metadata:
     debug:
       optional: true
   checksum: 08c465c17cbf3011ad16516609ee476abffa8fd1ff78c2082f1ff43614cb06586a0ccc8e99e5ebe13da06d064367cb269789e3ca0e93e2ad5b24fdc30b4294b6
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.14.9":
+  version: 1.15.1
+  resolution: "follow-redirects@npm:1.15.1"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: ea21337fe38eac8d75f5af12c425cc40e0bb44dcc3091fd0bde1c828596251a7a9638b5720fee5a0a5c62524450cbe16c52aae1dce88c6aee68577e441842e7f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,6 +287,8 @@ __metadata:
   dependencies:
     axios: ^0.27.2
     csv-parse: ^5.1.0
+    csv-stringify: ^6.1.0
+    fs-extra: ^10.1.0
   languageName: unknown
   linkType: soft
 
@@ -14688,6 +14690,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"csv-stringify@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "csv-stringify@npm:6.1.0"
+  checksum: 111ae51c5ecf9aab17f36775d18b1b2db64fb5593c195a69538a95459fee1a53ca67f0d0b37a1f763d76fdeb7e10991e1b6509b0511d9159d7dad4ff9d60718c
+  languageName: node
+  linkType: hard
+
 "ctype@npm:0.5.3":
   version: 0.5.3
   resolution: "ctype@npm:0.5.3"
@@ -18346,6 +18355,17 @@ __metadata:
     jsonfile: ^6.0.1
     universalify: ^2.0.0
   checksum: 85802f3d9e49d197744a8372f0d78d5a1faa3df73f4c5375d6366a4b9f745197d3da1f095841443d50f29a9f81cdc01363eb6d17bef2ba70c268559368211040
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "fs-extra@npm:10.1.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: 5f579466e7109719d162a9249abbeffe7f426eb133ea486e020b89bc6d67a741134076bf439983f2eb79276ceaf6bd7b7c1e43c3fd67fe889863e69072fb0a5e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18035,17 +18035,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.7":
-  version: 1.14.9
-  resolution: "follow-redirects@npm:1.14.9"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 08c465c17cbf3011ad16516609ee476abffa8fd1ff78c2082f1ff43614cb06586a0ccc8e99e5ebe13da06d064367cb269789e3ca0e93e2ad5b24fdc30b4294b6
-  languageName: node
-  linkType: hard
-
-"follow-redirects@npm:^1.14.9":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.7, follow-redirects@npm:^1.14.9":
   version: 1.15.1
   resolution: "follow-redirects@npm:1.15.1"
   peerDependenciesMeta:
@@ -18347,18 +18337,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "fs-extra@npm:10.0.0"
-  dependencies:
-    graceful-fs: ^4.2.0
-    jsonfile: ^6.0.1
-    universalify: ^2.0.0
-  checksum: 85802f3d9e49d197744a8372f0d78d5a1faa3df73f4c5375d6366a4b9f745197d3da1f095841443d50f29a9f81cdc01363eb6d17bef2ba70c268559368211040
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^10.1.0":
+"fs-extra@npm:^10.0.0, fs-extra@npm:^10.1.0":
   version: 10.1.0
   resolution: "fs-extra@npm:10.1.0"
   dependencies:


### PR DESCRIPTION
#### Proposed Changes

* Adds `mp-data-analysis` package to derivate data from top searches csv.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get the `top-searches-csv` file from here pdh6GB-1bw-p2 
* run `yarn:generate` inside the package.
* Look under `results/` it should generate a `top-products.csv`, `top-tags.csv` and `top-categories.csv` files.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->