### PR TITLE
Jetpack Backup: Add tracking events for warnings clicks

### DIFF
--- a/client/components/jetpack/backup-warnings/backup-warning-retry.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warning-retry.jsx
@@ -22,7 +22,6 @@ export default function BackupWarningRetry( { siteId } ) {
 		requestBackupSite,
 		'calypso_jetpack_backup_retry_click'
 	);
-	const trackLearnWhy = recordTracksEvent( 'calypso_jetpack_backup_learn_why_click' );
 	const retryText = translate( 'Retry' );
 	const queuedText = translate( 'Retry queued' );
 	const enqueueRetry = () => {
@@ -43,7 +42,7 @@ export default function BackupWarningRetry( { siteId } ) {
 								target="_blank"
 								rel="noopener noreferrer"
 								icon={ false }
-								onClick={ trackLearnWhy }
+								onClick={ () => recordTracksEvent( 'calypso_jetpack_backup_learn_why_click' ) }
 							/>
 						),
 					},

--- a/client/components/jetpack/backup-warnings/backup-warning-retry.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warning-retry.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
@@ -21,6 +22,7 @@ export default function BackupWarningRetry( { siteId } ) {
 		requestBackupSite,
 		'calypso_jetpack_backup_retry_click'
 	);
+	const trackLearnWhy = recordTracksEvent( 'calypso_jetpack_backup_learn_why_click' );
 	const retryText = translate( 'Retry' );
 	const queuedText = translate( 'Retry queued' );
 	const enqueueRetry = () => {
@@ -41,6 +43,7 @@ export default function BackupWarningRetry( { siteId } ) {
 								target="_blank"
 								rel="noopener noreferrer"
 								icon={ false }
+								onClick={ trackLearnWhy }
 							/>
 						),
 					},

--- a/client/components/jetpack/backup-warnings/backup-warnings.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warnings.jsx
@@ -137,7 +137,6 @@ const BackupWarnings = ( { backup } ) => {
 
 	const warnings = getBackupWarnings( backup );
 	const hasWarnings = Object.keys( warnings ).length !== 0;
-	const trackExpandWarning = recordTracksEvent( 'calypso_jetpack_backup_expand_warning_click' );
 
 	if ( ! hasWarnings ) {
 		return <></>;
@@ -156,7 +155,7 @@ const BackupWarnings = ( { backup } ) => {
 				header={
 					<BackupWarningHeader warning={ warnings[ warningCode ] } warningCode={ warningCode } />
 				}
-				onOpen={ trackExpandWarning }
+				onOpen={ () => recordTracksEvent( 'calypso_jetpack_backup_expand_warning_click' ) }
 			>
 				<ul className="backup-warnings__file-list">{ fileList }</ul>
 				<div className="backup-warnings__info">

--- a/client/components/jetpack/backup-warnings/backup-warnings.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warnings.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -136,6 +137,7 @@ const BackupWarnings = ( { backup } ) => {
 
 	const warnings = getBackupWarnings( backup );
 	const hasWarnings = Object.keys( warnings ).length !== 0;
+	const trackExpandWarning = recordTracksEvent( 'calypso_jetpack_backup_expand_warning_click' );
 
 	if ( ! hasWarnings ) {
 		return <></>;
@@ -154,6 +156,7 @@ const BackupWarnings = ( { backup } ) => {
 				header={
 					<BackupWarningHeader warning={ warnings[ warningCode ] } warningCode={ warningCode } />
 				}
+				onOpen={ trackExpandWarning }
 			>
 				<ul className="backup-warnings__file-list">{ fileList }</ul>
 				<div className="backup-warnings__info">

--- a/client/components/jetpack/backup-warnings/backup-warnings.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warnings.jsx
@@ -66,7 +66,7 @@ const getWarningInfo = ( code, category ) => {
 				components: {
 					ExternalLink: (
 						<ExternalLink
-							href="https://jetpack.com/support/backup/backups-via-the-jetpack-plugin/adding-credentials-to-jetpack/#file-access-permissions"
+							href="https://jetpack.com/blog/error-establishing-database-connection-on-wordpress/"
 							target="_blank"
 							rel="noopener noreferrer"
 							icon={ false }

--- a/client/components/jetpack/log-item/index.tsx
+++ b/client/components/jetpack/log-item/index.tsx
@@ -16,6 +16,7 @@ export interface Props {
 	expandedSummary?: string | ReactNode;
 	clickableHeader?: boolean;
 	onClick?: () => void;
+	onOpen?: () => void;
 }
 
 class LogItem extends PureComponent< Props > {
@@ -34,8 +35,16 @@ class LogItem extends PureComponent< Props > {
 	}
 
 	render() {
-		const { clickableHeader, highlight, children, className, expandedSummary, summary, onClick } =
-			this.props;
+		const {
+			clickableHeader,
+			highlight,
+			children,
+			className,
+			expandedSummary,
+			summary,
+			onClick,
+			onOpen,
+		} = this.props;
 		return (
 			<FoldableCard
 				header={ this.renderHeader() }
@@ -45,6 +54,7 @@ class LogItem extends PureComponent< Props > {
 				summary={ summary }
 				clickableHeader={ clickableHeader }
 				onClick={ onClick }
+				onOpen={ onOpen }
 			>
 				{ children }
 			</FoldableCard>


### PR DESCRIPTION
#### Proposed Changes

* Adds tracking for Expand Warnings and Learn Why

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click the links and check that tracks events are fired