### PR TITLE
Plugin Install: Add more additional messages

### DIFF
--- a/client/my-sites/marketplace/components/progressbar/index.tsx
+++ b/client/my-sites/marketplace/components/progressbar/index.tsx
@@ -31,6 +31,7 @@ export default function MarketplaceProgressBar( {
 	const translate = useTranslate();
 	const [ stepValue, setStepValue ] = useState( steps[ currentStep ] );
 	const [ additionalStepsTimeoutId, setAdditionalStepsTimeoutId ] = useState< NodeJS.Timeout >();
+	const [ currentAdditionalSteps, setCurrentAdditionalSteps ] = useState< TranslateResult[] >( [] );
 	const [ simulatedProgressPercentage, setSimulatedProgressPercentage ] = useState( 1 );
 	useEffect( () => {
 		const timeOutReference = setTimeout( () => {
@@ -51,15 +52,26 @@ export default function MarketplaceProgressBar( {
 		setAdditionalStepsTimeoutId( undefined );
 	}, [ steps, currentStep ] );
 
-	// Show additional messages when available
+	/**
+	 * If the current list of additional steps is empty,
+	 * restart it with a shuffled version of the additional steps
+	 */
+	useEffect( () => {
+		if ( currentAdditionalSteps.length === 0 && additionalSteps?.length ) {
+			const newAdditionalSteps = [ ...additionalSteps ];
+			newAdditionalSteps.sort( () => 0.5 - Math.random() );
+			setCurrentAdditionalSteps( newAdditionalSteps );
+		}
+	} );
+
+	// Show additional messages in order when available
 	useEffect( () => {
 		function updateStepValueAfterTimeout() {
-			if ( additionalSteps?.length ) {
+			if ( currentAdditionalSteps?.length ) {
 				const timeoutId = setTimeout( () => {
-					const randomIndex = Math.floor( Math.random() * additionalSteps.length );
-					const newValue = additionalSteps[ randomIndex ];
+					const newValue = currentAdditionalSteps.shift();
 
-					if ( newValue !== stepValue ) {
+					if ( newValue && newValue !== stepValue ) {
 						setStepValue( newValue );
 					}
 

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -261,6 +261,14 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 			translate( 'Still working' ),
 			translate( 'Wheels are in motion' ),
 			translate( 'Working magic' ),
+			translate( 'Putting the pieces together' ),
+			translate( 'Assembling the parts' ),
+			translate( 'Stacking the building blocks' ),
+			translate( 'Getting our ducks in a row' ),
+			translate( 'Initiating countdown' ),
+			translate( 'Flipping the switches' ),
+			translate( 'Unlocking potential' ),
+			translate( 'Gears are turning' ),
 		],
 		[ translate ]
 	);


### PR DESCRIPTION
### Description
A small tweak on the logic to show all messages before repeating and addition of more messages (ty @jeremyanderberg)

Follow up of #64087

#### List of messages
**Step descriptions**
* Uploading plugin 
* Setting up plugin installation
* Installing plugin
* Activating plugin

**Additional messages to be rotated when the actual step is taking too long**
* Connecting the dots
* Still working
* Wheels are in motion
* Working magic
* **Putting the pieces together**
* **Assembling the parts**
* **Stacking the building blocks**
* **Getting our ducks in a row**
* **Initiating countdown**
* **Flipping the switches**
* **Unlocking potential**
* **Gears are turning**

PS: All messages in bold are new phrases
PS2: All of those phases are translatable

### Proposed Changes

* Add more messages
* Show all messages in a shuffled order before repeating

### Testing Instructions
![Kapture 2022-06-10 at 14 38 14](https://user-images.githubusercontent.com/5039531/173134094-eb9c8706-a26c-40b1-932e-152d17fbcfb4.gif)

