### PR TITLE
Add support for pre-loading existing mailboxes to ease validation

### DIFF
--- a/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
@@ -3,18 +3,11 @@ import { Fragment, useCallback } from '@wordpress/element';
 import classNames from 'classnames';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { FormEvent, useState } from 'react';
-import { useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
-import { useGetEmailAccountsQuery } from 'calypso/data/emails/use-get-email-accounts-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import {
-	EMAIL_ACCOUNT_TYPE_GOOGLE_WORKSPACE,
-	EMAIL_ACCOUNT_TYPE_GSUITE,
-	EMAIL_ACCOUNT_TYPE_TITAN_MAIL,
-	EMAIL_ACCOUNT_TYPE_TITAN_MAIL_EXTERNAL,
-} from 'calypso/lib/emails/email-provider-constants';
 import { MailboxForm } from 'calypso/my-sites/email/form/mailboxes';
 import { MailboxFormWrapper } from 'calypso/my-sites/email/form/mailboxes/components/mailbox-form-wrapper';
+import useGetExistingMailboxNames from 'calypso/my-sites/email/form/mailboxes/components/new-mailbox-list/use-get-existing-mailbox-names';
 import { MailboxOperations } from 'calypso/my-sites/email/form/mailboxes/components/utilities/mailbox-operations';
 import { sanitizeMailboxValue } from 'calypso/my-sites/email/form/mailboxes/components/utilities/sanitize-mailbox-value';
 import {
@@ -27,7 +20,6 @@ import {
 	MailboxFormFieldBase,
 	MutableFormFieldNames,
 } from 'calypso/my-sites/email/form/mailboxes/types';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -42,45 +34,6 @@ interface MailboxListProps {
 	showCancelButton?: boolean;
 	submitActionText?: TranslateResult;
 }
-
-interface ExistingMailAccount {
-	account_type: string;
-	emails: {
-		email_type: string;
-		mailbox: string;
-	}[];
-}
-
-const mapProviderToEmailAccountTypes = ( provider: EmailProvider ): string[] =>
-	( {
-		[ EmailProvider.Titan ]: [
-			EMAIL_ACCOUNT_TYPE_TITAN_MAIL,
-			EMAIL_ACCOUNT_TYPE_TITAN_MAIL_EXTERNAL,
-		],
-		[ EmailProvider.Google ]: [ EMAIL_ACCOUNT_TYPE_GOOGLE_WORKSPACE, EMAIL_ACCOUNT_TYPE_GSUITE ],
-	}[ provider ] );
-
-const useGetExistingMailboxNames = (
-	provider: EmailProvider,
-	selectedDomainName: string
-): string[] => {
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const {
-		data: { accounts } = {},
-		error,
-		isLoading,
-	} = useGetEmailAccountsQuery( selectedSiteId as number, selectedDomainName );
-
-	if ( error || isLoading || ! accounts ) {
-		return [];
-	}
-
-	const emailAccountTypes = mapProviderToEmailAccountTypes( provider );
-
-	return ( accounts as ExistingMailAccount[] )
-		.filter( ( { account_type } ) => emailAccountTypes.includes( account_type ) )
-		.flatMap( ( { emails } ) => emails.map( ( { mailbox } ) => mailbox ) );
-};
 
 const NewMailBoxList = (
 	props: MailboxListProps & { children?: JSX.Element }

--- a/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
@@ -66,12 +66,12 @@ const useGetExistingMailboxNames = (
 ): string[] => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const {
-		data: { accounts },
+		data: { accounts } = {},
 		error,
 		isLoading,
 	} = useGetEmailAccountsQuery( selectedSiteId as number, selectedDomainName );
 
-	if ( error || isLoading ) {
+	if ( error || isLoading || ! accounts ) {
 		return [];
 	}
 

--- a/client/my-sites/email/form/mailboxes/components/new-mailbox-list/use-get-existing-mailbox-names.ts
+++ b/client/my-sites/email/form/mailboxes/components/new-mailbox-list/use-get-existing-mailbox-names.ts
@@ -1,0 +1,51 @@
+import { useSelector } from 'react-redux';
+import { useGetEmailAccountsQuery } from 'calypso/data/emails/use-get-email-accounts-query';
+import {
+	EMAIL_ACCOUNT_TYPE_GOOGLE_WORKSPACE,
+	EMAIL_ACCOUNT_TYPE_GSUITE,
+	EMAIL_ACCOUNT_TYPE_TITAN_MAIL,
+	EMAIL_ACCOUNT_TYPE_TITAN_MAIL_EXTERNAL,
+} from 'calypso/lib/emails/email-provider-constants';
+import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+interface ExistingMailAccount {
+	account_type: string;
+	emails: {
+		email_type: string;
+		mailbox: string;
+	}[];
+}
+
+const mapProviderToEmailAccountTypes = ( provider: EmailProvider ): string[] =>
+	( {
+		[ EmailProvider.Titan ]: [
+			EMAIL_ACCOUNT_TYPE_TITAN_MAIL,
+			EMAIL_ACCOUNT_TYPE_TITAN_MAIL_EXTERNAL,
+		],
+		[ EmailProvider.Google ]: [ EMAIL_ACCOUNT_TYPE_GOOGLE_WORKSPACE, EMAIL_ACCOUNT_TYPE_GSUITE ],
+	}[ provider ] );
+
+const useGetExistingMailboxNames = (
+	provider: EmailProvider,
+	selectedDomainName: string
+): string[] => {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const {
+		data: { accounts } = {},
+		error,
+		isLoading,
+	} = useGetEmailAccountsQuery( selectedSiteId as number, selectedDomainName );
+
+	if ( error || isLoading || ! accounts ) {
+		return [];
+	}
+
+	const emailAccountTypes = mapProviderToEmailAccountTypes( provider );
+
+	return ( accounts as ExistingMailAccount[] )
+		.filter( ( { account_type } ) => emailAccountTypes.includes( account_type ) )
+		.flatMap( ( { emails } ) => emails.map( ( { mailbox } ) => mailbox ) );
+};
+
+export default useGetExistingMailboxNames;

--- a/client/my-sites/email/form/mailboxes/components/new-mailbox-list/use-get-existing-mailbox-names.ts
+++ b/client/my-sites/email/form/mailboxes/components/new-mailbox-list/use-get-existing-mailbox-names.ts
@@ -17,7 +17,7 @@ interface ExistingMailAccount {
 	}[];
 }
 
-const mapProviderToEmailAccountTypes = ( provider: EmailProvider ): string[] =>
+const getEmailAccountTypes = ( provider: EmailProvider ): string[] =>
 	( {
 		[ EmailProvider.Titan ]: [
 			EMAIL_ACCOUNT_TYPE_TITAN_MAIL,
@@ -41,7 +41,7 @@ const useGetExistingMailboxNames = (
 		return [];
 	}
 
-	const emailAccountTypes = mapProviderToEmailAccountTypes( provider );
+	const emailAccountTypes = getEmailAccountTypes( provider );
 
 	return ( accounts as ExistingMailAccount[] )
 		.filter( ( { account_type } ) => emailAccountTypes.includes( account_type ) )

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -65,7 +65,7 @@ class MailboxForm< T extends EmailProvider > {
 			[ FIELD_MAILBOX, new RequiredValidator< string >() ],
 			[ FIELD_NAME, new RequiredIfVisibleValidator() ],
 			[ FIELD_NAME, new MaximumStringLengthValidator( 60 ) ],
-			[ FIELD_MAILBOX, new ExistingMailboxNamesValidator( this.existingMailboxNames ) ],
+			[ FIELD_MAILBOX, new ExistingMailboxNamesValidator( domainName, this.existingMailboxNames ) ],
 			[
 				FIELD_MAILBOX,
 				new MailboxNameValidator( domainName, mailboxHasDomainError, areApostrophesSupported ),

--- a/client/my-sites/email/form/mailboxes/test/validators.ts
+++ b/client/my-sites/email/form/mailboxes/test/validators.ts
@@ -139,7 +139,7 @@ const finalTestDataForAllCases = [
 		'Existing mailboxes should fail validation',
 		createTestDataForGoogle(),
 		{
-			[ FIELD_MAILBOX ]: ExistingMailboxNamesValidator.getExistingMailboxError(),
+			[ FIELD_MAILBOX ]: ExistingMailboxNamesValidator.getExistingMailboxError( 'info' ),
 		},
 		[ 'info' ]
 	),
@@ -147,7 +147,7 @@ const finalTestDataForAllCases = [
 		'Existing mailboxes should fail validation',
 		createTestDataForTitan(),
 		{
-			[ FIELD_MAILBOX ]: ExistingMailboxNamesValidator.getExistingMailboxError(),
+			[ FIELD_MAILBOX ]: ExistingMailboxNamesValidator.getExistingMailboxError( 'info' ),
 		},
 		[ 'info' ]
 	),

--- a/client/my-sites/email/form/mailboxes/test/validators.ts
+++ b/client/my-sites/email/form/mailboxes/test/validators.ts
@@ -139,7 +139,10 @@ const finalTestDataForAllCases = [
 		'Existing mailboxes should fail validation',
 		createTestDataForGoogle(),
 		{
-			[ FIELD_MAILBOX ]: ExistingMailboxNamesValidator.getExistingMailboxError( 'info' ),
+			[ FIELD_MAILBOX ]: ExistingMailboxNamesValidator.getExistingMailboxError(
+				'example.com',
+				'info'
+			),
 		},
 		[ 'info' ]
 	),
@@ -147,7 +150,10 @@ const finalTestDataForAllCases = [
 		'Existing mailboxes should fail validation',
 		createTestDataForTitan(),
 		{
-			[ FIELD_MAILBOX ]: ExistingMailboxNamesValidator.getExistingMailboxError( 'info' ),
+			[ FIELD_MAILBOX ]: ExistingMailboxNamesValidator.getExistingMailboxError(
+				'example.com',
+				'info'
+			),
 		},
 		[ 'info' ]
 	),

--- a/client/my-sites/email/form/mailboxes/validators.ts
+++ b/client/my-sites/email/form/mailboxes/validators.ts
@@ -255,18 +255,19 @@ class PasswordValidator extends BaseValidator< string > {
 
 class ExistingMailboxNamesValidator extends BaseValidator< string > {
 	private readonly existingMailboxNames: string[];
+	private readonly domainName: string;
 
-	constructor( existingMailboxNames: string[] ) {
+	constructor( domainName: string, existingMailboxNames: string[] ) {
 		super();
+		this.domainName = domainName;
 		this.existingMailboxNames = existingMailboxNames;
 	}
 
-	static getExistingMailboxError( existingMailbox: string ): FieldError {
+	static getExistingMailboxError( domainName: string, existingMailbox: string ): FieldError {
 		return i18n.translate(
-			'Please use unique mailboxes. {{strong}}%(existingMailbox)s{{/strong}} already exists in your account',
+			'Please use unique email addresses. {{strong}}%(emailAddress)s{{/strong}} already exists in your account',
 			{
-				comment: '%(existingMailbox)s is the local part of an email address',
-				args: { existingMailbox },
+				args: { emailAddress: `${ existingMailbox }@${ domainName }` },
 				components: { strong: createElement( 'strong' ) },
 			}
 		);
@@ -283,7 +284,10 @@ class ExistingMailboxNamesValidator extends BaseValidator< string > {
 		if (
 			existingMailboxNames.map( ( item ) => item.toLowerCase() ).includes( fieldValueLowerCased )
 		) {
-			field.error = ExistingMailboxNamesValidator.getExistingMailboxError( fieldValueLowerCased );
+			field.error = ExistingMailboxNamesValidator.getExistingMailboxError(
+				this.domainName,
+				fieldValueLowerCased
+			);
 		}
 	}
 }

--- a/client/my-sites/email/form/mailboxes/validators.ts
+++ b/client/my-sites/email/form/mailboxes/validators.ts
@@ -261,22 +261,29 @@ class ExistingMailboxNamesValidator extends BaseValidator< string > {
 		this.existingMailboxNames = existingMailboxNames;
 	}
 
-	static getExistingMailboxError(): FieldError {
-		return i18n.translate( 'Please use unique mailboxes.' );
+	static getExistingMailboxError( existingMailbox: string ): FieldError {
+		return i18n.translate(
+			'Please use unique mailboxes. {{strong}}%(existingMailbox)s{{/strong}} already exists in your account',
+			{
+				comment: '%(existingMailbox)s is the local part of an email address',
+				args: { existingMailbox },
+				components: { strong: createElement( 'strong' ) },
+			}
+		);
 	}
 
 	validateField( field: MailboxFormFieldBase< string > ): void {
 		const existingMailboxNames = this.existingMailboxNames ?? [];
-		if ( ! existingMailboxNames ) {
+		if ( ! existingMailboxNames || field.value ) {
 			return;
 		}
 
+		const fieldValueLowerCased = field.value.toLowerCase();
+
 		if (
-			existingMailboxNames
-				.map( ( item ) => item.toLowerCase() )
-				.includes( field.value?.toLowerCase() ?? '' )
+			existingMailboxNames.map( ( item ) => item.toLowerCase() ).includes( fieldValueLowerCased )
 		) {
-			field.error = ExistingMailboxNamesValidator.getExistingMailboxError();
+			field.error = ExistingMailboxNamesValidator.getExistingMailboxError( fieldValueLowerCased );
 		}
 	}
 }

--- a/client/my-sites/email/form/mailboxes/validators.ts
+++ b/client/my-sites/email/form/mailboxes/validators.ts
@@ -265,7 +265,7 @@ class ExistingMailboxNamesValidator extends BaseValidator< string > {
 
 	static getExistingMailboxError( domainName: string, existingMailbox: string ): FieldError {
 		return i18n.translate(
-			'Please use unique email addresses. {{strong}}%(emailAddress)s{{/strong}} already exists in your account',
+			'Please use unique email addresses. {{strong}}%(emailAddress)s{{/strong}} already exists in your account.',
 			{
 				args: { emailAddress: `${ existingMailbox }@${ domainName }` },
 				components: { strong: createElement( 'strong' ) },

--- a/client/my-sites/email/form/mailboxes/validators.ts
+++ b/client/my-sites/email/form/mailboxes/validators.ts
@@ -274,7 +274,7 @@ class ExistingMailboxNamesValidator extends BaseValidator< string > {
 
 	validateField( field: MailboxFormFieldBase< string > ): void {
 		const existingMailboxNames = this.existingMailboxNames ?? [];
-		if ( ! existingMailboxNames || field.value ) {
+		if ( ! existingMailboxNames || ! field.value ) {
 			return;
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* Add a custom hook to preload existing mailboxes to make them available to validate against
* Use clearer messaging when user is about to create an already existing mailbox name
* Update tests

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

`yarn test-client --testPathPattern=client/my-sites/email/form `

#### Other Tests
- Ensure that you have a Professional Email subscription
- Navigate to the Email plan page i.e. [ **Upgrades** ] > [ **Emails** ] > [ **(email-domain.com)** ]
- Click the [ **Add new mailboxes** ] button/link
- Use the feature flag in the url : `?flags=unify-mailbox-forms`
- Once the view reloads, type in an existing mailbox
- Confirm that you get an error about the mailbox name already existing, and cannot proceed further.

<img width="1052" alt="Screenshot 2022-06-12 at 4 01 31 PM" src="https://user-images.githubusercontent.com/277661/173239354-22e9be52-9a84-4f76-b4a6-f6b41a963533.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


