### PR TITLE
HelpCenter: add atomic check before contact form

### DIFF
--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -9,6 +9,7 @@ type ResponseType< T extends 'CHAT' | 'OTHER' > = T extends 'CHAT'
 export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	supportType: SUPPORT_TYPE
 ) {
+	const isSimpleSite = window.location.host.endsWith( 'wordpress.com' );
 	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >(
 		supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability',
 		async () =>
@@ -17,6 +18,7 @@ export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 				apiVersion: '1.1',
 			} ),
 		{
+			enabled: isSimpleSite,
 			refetchOnWindowFocus: false,
 			keepPreviousData: true,
 		}

--- a/packages/happychat-connection/src/use-happychat-available.ts
+++ b/packages/happychat-connection/src/use-happychat-available.ts
@@ -6,12 +6,13 @@ let cachedAvailableValue: boolean | undefined = undefined;
 
 export function useHappychatAvailable() {
 	const [ available, setIsAvailable ] = useState< boolean | undefined >( cachedAvailableValue );
+	const isSimpleSite = window.location.host.endsWith( 'wordpress.com' );
 	const { data: dataAuth, isLoading: isLoadingAuth } = useHappychatAuth(
 		cachedAvailableValue === undefined
 	);
 
 	useEffect( () => {
-		if ( ! isLoadingAuth && dataAuth && cachedAvailableValue === undefined ) {
+		if ( isSimpleSite && ! isLoadingAuth && dataAuth && cachedAvailableValue === undefined ) {
 			const connection = buildConnection( {
 				receiveAccept: ( receivedAvailability ) => {
 					cachedAvailableValue = receivedAvailability;
@@ -24,7 +25,7 @@ export function useHappychatAvailable() {
 			} );
 			connection.init( ( value: unknown ) => value, Promise.resolve( dataAuth ) );
 		}
-	}, [ dataAuth, isLoadingAuth ] );
+	}, [ dataAuth, isLoadingAuth, isSimpleSite ] );
 
 	return { available: Boolean( available ), isLoading: available === undefined };
 }

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -87,6 +87,7 @@ export const HelpCenterContactPage: React.FC = () => {
 export const HelpCenterContactButton: React.FC = () => {
 	const { __ } = useI18n();
 	const url = useStillNeedHelpURL();
+	const hasCookies = true;
 
 	const trackContactButtonClicked = () => {
 		recordTracksEvent( 'calypso_inlinehelp_morehelp_click', {
@@ -96,7 +97,7 @@ export const HelpCenterContactButton: React.FC = () => {
 
 	return (
 		<Link
-			to={ url }
+			to={ hasCookies ? url : { pathname: url } }
 			onClick={ trackContactButtonClicked }
 			className="button help-center-contact-page__button"
 		>

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -87,7 +87,7 @@ export const HelpCenterContactPage: React.FC = () => {
 export const HelpCenterContactButton: React.FC = () => {
 	const { __ } = useI18n();
 	const url = useStillNeedHelpURL();
-	const hasCookies = true;
+	const redirectToWpcom = url === 'https://wordpress.com/help/contact';
 
 	const trackContactButtonClicked = () => {
 		recordTracksEvent( 'calypso_inlinehelp_morehelp_click', {
@@ -97,7 +97,8 @@ export const HelpCenterContactButton: React.FC = () => {
 
 	return (
 		<Link
-			to={ hasCookies ? url : { pathname: url } }
+			to={ redirectToWpcom ? { pathname: url } : url }
+			target={ redirectToWpcom ? '_blank' : '_self' }
 			onClick={ trackContactButtonClicked }
 			className="button help-center-contact-page__button"
 		>

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -24,6 +24,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
 
 	const siteId = useSelector( getSelectedSiteId );
+	const isSimpleSite = window.location.host.endsWith( 'wordpress.com' );
 
 	// prefetch the current site and user
 	const site = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
@@ -45,13 +46,11 @@ const HelpCenter: React.FC< Container > = ( { handleClose } ) => {
 		}
 	}, [ supportData, setDirectlyData ] );
 
-	const isLoading = [
-		! site,
-		! user,
-		isSupportDataLoading,
-		isLoadingChat,
-		isLoadingChatAvailable,
-	].some( Boolean );
+	const isLoading = isSimpleSite
+		? [ ! site, ! user, isSupportDataLoading, isLoadingChat, isLoadingChatAvailable ].some(
+				Boolean
+		  )
+		: false;
 
 	useEffect( () => {
 		const classes = [ 'help-center' ];

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -3,16 +3,13 @@ import { useHas3PC, useSupportAvailability } from '@automattic/data-stores';
 export function useStillNeedHelpURL() {
 	const { data: supportAvailability } = useSupportAvailability( 'OTHER' );
 	const { hasCookies } = useHas3PC();
-	const hostname = window.location.host;
-	const isWpcom =
-		( hostname.split( '.' ).length > 2 && 'wordpress' === hostname.split( '.' )[ 1 ] ) ||
-		'wordpress' === hostname;
+	const isSimpleSite = window.location.host.endsWith( 'wordpress.com' );
 
 	// email support is available for all non-free users, let's use it as a proxy for free users
 	// TODO: check purchases instead
 	const isFreeUser = ! supportAvailability?.is_user_eligible_for_kayako;
 
-	if ( ! hasCookies && ! isWpcom ) {
+	if ( ! isSimpleSite && ! hasCookies ) {
 		return 'https://wordpress.com/help/contact';
 	}
 

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -3,13 +3,23 @@ import { useHas3PC, useSupportAvailability } from '@automattic/data-stores';
 export function useStillNeedHelpURL() {
 	const { data: supportAvailability } = useSupportAvailability( 'OTHER' );
 	const { hasCookies } = useHas3PC();
+	const hostname = window.location.host;
+	const isWpcom =
+		( hostname.split( '.' ).length > 2 && 'wordpress' === hostname.split( '.' )[ 1 ] ) ||
+		'wordpress' === hostname;
+
 	// email support is available for all non-free users, let's use it as a proxy for free users
 	// TODO: check purchases instead
 	const isFreeUser = ! supportAvailability?.is_user_eligible_for_kayako;
 
+	if ( ! hasCookies && ! isWpcom ) {
+		return 'https://wordpress.com/help/contact';
+	}
+
 	if ( ! isFreeUser ) {
 		return '/contact-options';
 	}
+
 	if ( supportAvailability?.is_user_eligible_for_directly && hasCookies ) {
 		return '/contact-form?mode=DIRECTLY';
 	}

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -9,7 +9,7 @@ export function useStillNeedHelpURL() {
 	// TODO: check purchases instead
 	const isFreeUser = ! supportAvailability?.is_user_eligible_for_kayako;
 
-	if ( ! isSimpleSite && ! hasCookies ) {
+	if ( ! isSimpleSite || ! hasCookies ) {
 		return 'https://wordpress.com/help/contact';
 	}
 

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -9,7 +9,7 @@ export function useStillNeedHelpURL() {
 	// TODO: check purchases instead
 	const isFreeUser = ! supportAvailability?.is_user_eligible_for_kayako;
 
-	if ( ! isSimpleSite || ! hasCookies ) {
+	if ( ! isSimpleSite ) {
 		return 'https://wordpress.com/help/contact';
 	}
 


### PR DESCRIPTION
## Proposed Changes

This adds a check for the website n to determine if the website is Atomic. If it is, at the moment we don't have the ability to show support options and the contact form, so we will open `https://wordpress.com/help/contact` in another tab.

## Testing Instructions

1. Pull branch
2. Add the plugin to an Atomic website
3. Check that you are redirect when clicking `Still need help?`
4. `yarn dev --sync` from `apps/editing-toolkit`
5. Test a not atomic website, you shouldn't be redirected

Related to #64519
Related to #64520
Closes #64519
Closes #64520
