### PR TITLE
Fix/pro plan ctas settings performance

### DIFF
--- a/client/my-sites/site-settings/cloudflare.js
+++ b/client/my-sites/site-settings/cloudflare.js
@@ -45,7 +45,7 @@ const Cloudflare = () => {
 								<p className="site-settings__cloudflare-title">
 									{ translate( 'Jetpack Site Accelerator' ) }
 								</p>
-								<p>{ translate( 'Comes built-in with the WordPress.com Pro plan.' ) }</p>
+								<p>{ translate( 'Comes built-in with WordPress.com Business plans.' ) }</p>
 								<p>
 									<a
 										onClick={ recordClick }
@@ -61,7 +61,7 @@ const Cloudflare = () => {
 					</CompactCard>
 					{ ! hasJetpackCDN && (
 						<UpsellNudge
-							title={ translate( 'Available on the Pro plan' ) }
+							title={ translate( 'Available on Business plan or higher' ) }
 							href={ upgradeLink }
 							event={ 'calypso_settings_cloudflare_cdn_upsell_nudge_click' }
 							showIcon={ true }
@@ -97,7 +97,7 @@ const Cloudflare = () => {
 					</CompactCard>
 					{ ! hasCloudflareCDN && (
 						<UpsellNudge
-							title={ translate( 'Available on the Pro plan' ) }
+							title={ translate( 'Available with Premium plans or higher' ) }
 							description={ translate(
 								'A CDN (Content Delivery Network) optimizes your content to provide users with the fastest experience.'
 							) }


### PR DESCRIPTION
#### Proposed Changes

* This change swaps out the copy used in several of the cards and upsell nudges that mentioned the Pro Plan.
* Copy has been changed back to a previous state and now mentioned the other old plans instead of the Pro Plan

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch locally
* Go to Settings --> Performance with a free site
* All references to the Pro plan in the `Jetpack Site Accelerator` card and two other upsell nudge links should now be reverted back to the previous copy which now mentions the old plans. 
* Link destinations for upsell should not change and should still direct users to the /plans/<site> page 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#801
