### PR TITLE
Show agency dashboard to beta agency users

### DIFF
--- a/client/state/partner-portal/partner/selectors.ts
+++ b/client/state/partner-portal/partner/selectors.ts
@@ -48,7 +48,7 @@ export function getPartnerRequestError( state: PartnerPortalStore ): APIError | 
 
 export function isAgencyUser( state: PartnerPortalStore ): boolean {
 	const partner = getCurrentPartner( state );
-	return partner?.partner_type === 'agency';
+	return partner?.partner_type === 'agency' || partner?.partner_type === 'agency_beta';
 }
 
 export function showAgencyDashboard( state: PartnerPortalStore ): boolean {


### PR DESCRIPTION
#### Proposed Changes

This PR includes changes to show the agency dashboard to beta agency users

#### Testing Instructions

**Prerequisites**

Set partner type as agency_beta - 2c49b-pb. Make sure to switch it back to the previous type.

1. Run `git checkout update/show-agency-dashboard-to-beta-agency-users` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to http://jetpack.cloud.localhost:3000/dashboard.
3. Verify that the dashboard loads fine.


Related to 1202076982646589-as-1202428436534841