### PR TITLE
Vertical Step: Only enable for english locale

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { isEnabled } from '@automattic/calypso-config';
+import { englishLocales, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
 import { IntentScreen, StepContainer } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -51,7 +52,12 @@ const IntentStep: Step = function IntentStep( { navigation } ) {
 			goNext={ goNext }
 			skipLabelText={ translate( 'Skip to dashboard' ) }
 			skipButtonAlign={ 'top' }
-			hideBack={ ! isEnabled( 'signup/site-vertical-step' ) }
+			hideBack={
+				! (
+					isEnabled( 'signup/site-vertical-step' ) &&
+					englishLocales.includes( translate.localeSlug || i18nDefaultLocaleSlug )
+				)
+			}
 			isHorizontalLayout={ true }
 			formattedHeader={
 				<FormattedHeader

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useDesignsBySite } from '@automattic/design-picker';
+import { useLocale, englishLocales } from '@automattic/i18n-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useDispatch as reduxDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -26,8 +27,11 @@ export const siteSetupFlow: Flow = {
 	name: 'site-setup',
 
 	useSteps() {
+		const locale = useLocale();
+		const isEnglishLocales = englishLocales.includes( locale );
+
 		return [
-			...( isEnabled( 'signup/site-vertical-step' ) ? [ 'vertical' ] : [] ),
+			...( isEnabled( 'signup/site-vertical-step' ) && isEnglishLocales ? [ 'vertical' ] : [] ),
 			'intent',
 			...( isEnabled( 'signup/goals-step' ) ? [ 'goals' ] : [] ),
 			'options',


### PR DESCRIPTION
#### Proposed Changes

* Limit the Vertical step to English language users

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to site setup flow: `/setup/?siteSlug=<your_site>` with the English account, and you will see the vertical step
* Switch locales to non-English
* Go to site setup flow again, and you will see the intent step instead of the vertical step

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64185
