### PR TITLE
Vertical Step: Fix the color of the option is incorrect on iOS

### DIFF
--- a/client/components/select-vertical/style.scss
+++ b/client/components/select-vertical/style.scss
@@ -46,6 +46,7 @@
         line-height: 20px;
         padding: 12px 86px 12px 16px;
         transition: none;
+        color: var( --studio-gray-90 );
 
         &::placeholder {
             font-size: $font-body-small;
@@ -120,6 +121,7 @@
         font-size: $font-body;
         line-height: 20px;
         padding: 6px 16px;
+        color: var( --studio-gray-90 );
     }
 
     .suggestions__label {


### PR DESCRIPTION
#### Proposed Changes

* Specify the color to search input and `.suggestions__item` elements

<img width="300" src="https://user-images.githubusercontent.com/13596067/173334494-14570711-0198-4430-949e-67797e587979.png" />

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Vertical Step: `/setup/vertical?siteSlug=<your_site>` on iPhone
* Click search input
* The color of the suggestion items is correct

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64441
