### PR TITLE
Redirect ineligible users from setup flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -13,7 +13,7 @@ interface GeneratedDesignPickerWebPreviewProps {
 	locale: string;
 	verticalId: string;
 	isSelected: boolean;
-	isPrivateAtomic: boolean;
+	isPrivateAtomic?: boolean;
 	isStickyToolbar?: boolean;
 	recordTracksEvent: ( eventName: string, eventProperties: object ) => void;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -49,7 +49,7 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	const [ isForceStaticDesigns, setIsForceStaticDesigns ] = useState( false );
 	// CSS breakpoints are set at 600px for mobile
 	const isMobile = ! useViewportMatch( 'small' );
-	const { goBack, submit, goToStep } = navigation;
+	const { goBack, submit, goToStep, exitFlow } = navigation;
 	const translate = useTranslate();
 	const locale = useLocale();
 	const site = useSite();
@@ -65,7 +65,11 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 	const siteTitle = site?.name;
 	const isReskinned = true;
 	const isAtomic = useSelect( ( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID ) );
-	const isPrivateAtomic = Boolean( site?.launch_status === 'unlaunched' && isAtomic );
+	useEffect( () => {
+		if ( isAtomic ) {
+			exitFlow?.( `/site-editor/${ siteSlug }` );
+		}
+	}, [ isAtomic ] );
 	const isEligibleForProPlan = useSelect(
 		( select ) => site && select( SITE_STORE ).isEligibleForProPlan( site.ID )
 	);
@@ -368,7 +372,6 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 				} ) }
 				toolbarComponent={ PreviewToolbar }
 				siteId={ site?.ID }
-				isPrivateAtomic={ isPrivateAtomic }
 				url={ site?.URL }
 				translate={ translate }
 				recordTracksEvent={ recordTracksEvent }
@@ -430,7 +433,6 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 					locale={ locale }
 					verticalId={ siteVerticalId }
 					isSelected={ design.slug === selectedGeneratedDesign?.slug }
-					isPrivateAtomic={ isPrivateAtomic }
 					isStickyToolbar={ ! isMobile && isSticky }
 					recordTracksEvent={ recordTracksEvent }
 				/>

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -20,6 +20,10 @@ export type NavigationControls = {
 	 * Submits the answers provided in the flow
 	 */
 	submit?: ( providedDependencies?: ProvidedDependencies, ...params: string[] ) => void;
+	/**
+	 * Exits the flow and continue to the given path
+	 */
+	exitFlow?: ( to: string ) => void;
 };
 
 /**

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -371,7 +371,7 @@ export const siteSetupFlow: Flow = {
 			navigate( step );
 		};
 
-		return { goNext, goBack, goToStep, submit };
+		return { goNext, goBack, goToStep, submit, exitFlow };
 	},
 
 	useAssertConditions(): AssertConditionResult {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -378,6 +378,9 @@ export const siteSetupFlow: Flow = {
 		const siteSlug = useSiteSlugParam();
 		const siteId = useSiteIdParam();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+		const fetchingSiteError = useSelect( ( select ) =>
+			select( SITE_STORE ).getFetchingSiteError()
+		);
 
 		if ( ! userIsLoggedIn ) {
 			redirect( '/start' );
@@ -388,9 +391,18 @@ export const siteSetupFlow: Flow = {
 		}
 
 		if ( ! siteSlug && ! siteId ) {
+			redirect( '/' );
 			return {
 				state: AssertConditionState.FAILURE,
 				message: 'site-setup did not provide the site slug or site id it is configured to.',
+			};
+		}
+
+		if ( fetchingSiteError ) {
+			redirect( '/' );
+			return {
+				state: AssertConditionState.FAILURE,
+				message: fetchingSiteError.message,
 			};
 		}
 

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -106,7 +106,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		verticalId,
 	} );
 
-	const receiveSiteFailed = ( siteId: number, response: SiteError | undefined ) => ( {
+	const receiveSiteFailed = ( siteId: number, response: SiteError ) => ( {
 		type: 'RECEIVE_SITE_FAILED' as const,
 		siteId,
 		response,

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -3,6 +3,7 @@ import {
 	NewSiteBlogDetails,
 	NewSiteErrorResponse,
 	SiteDetails,
+	SiteError,
 	Domain,
 	SiteLaunchState,
 	SiteLaunchStatus,
@@ -63,6 +64,17 @@ export const isFetchingSite: Reducer< boolean | undefined, Action > = ( state = 
 		case 'RESET_SITE_STORE':
 		case 'RESET_RECEIVE_NEW_SITE_FAILED':
 			return false;
+	}
+	return state;
+};
+
+export const fetchingSiteError: Reducer< SiteError | undefined, Action > = ( state, action ) => {
+	switch ( action.type ) {
+		case 'RECEIVE_SITE_FAILED':
+			return {
+				error: action.response.error,
+				message: action.response.message,
+			};
 	}
 	return state;
 };
@@ -370,6 +382,7 @@ const newSite = combineReducers( {
 const reducer = combineReducers( {
 	isFetchingSiteDetails,
 	newSite,
+	fetchingSiteError,
 	sites,
 	launchStatus,
 	sitesDomains,

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -1,6 +1,6 @@
 // wpcomRequest is a temporary rename while we're working on migrating generators to thunks
 import wpcomRequest from 'wpcom-proxy-request';
-import type { SiteDetails, Domain, SiteSettings, Dispatch } from './types';
+import type { SiteDetails, Domain, SiteSettings, Dispatch, NewSiteErrorResponse } from './types';
 
 /**
  * Attempt to find a site based on its id, and if not return undefined.
@@ -21,7 +21,7 @@ export const getSite =
 			} );
 			dispatch.receiveSite( siteId, existingSite );
 		} catch ( err ) {
-			dispatch.receiveSiteFailed( siteId, undefined );
+			dispatch.receiveSiteFailed( siteId, err as NewSiteErrorResponse );
 		}
 	};
 

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -7,6 +7,7 @@ export const getState = ( state: State ) => state;
 export const getNewSite = ( state: State ) => state.newSite.data;
 export const getNewSiteError = ( state: State ) => state.newSite.error;
 export const isFetchingSite = ( state: State ) => state.newSite.isFetching;
+export const getFetchingSiteError = ( state: State ) => state.fetchingSiteError;
 export const isFetchingSiteDetails = ( state: State ) => state.isFetchingSiteDetails;
 export const isNewSite = ( state: State ) => !! state.newSite.data;
 


### PR DESCRIPTION
#### Proposed Changes
fixes 51-gh-Automattic/ganon-issues. CfT testers reported that the v13n flow throws errors for users of atomic sites and also that if an invalid blogId is used, the page will get "stuck" showing the wordpress logo.

This changes so that when a user with an atomic site accesses the design picker, they will be redirected to the editor.

It also adds a `fetchingSiteError` selector to use to determine if the user entered an invalid siteId or siteSlug. In this case, the user will be directed out of the flow and an error logged.

Also redirect users our of the flow if they do not pass a siteId or siteSlug parameter.

#### Testing Instructions
Use the siteSlug of an atomic site. You should be able to use the write flow and set your siteTitle but if you chose the build flow, you should be taken to the editor.

Set an invalid siteSlug. You should see an error logged in the console and be taken to the homepage.