### PR TITLE
Onboarding progress bar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -70,6 +70,15 @@ button {
 		}
 	}
 
+	.progress-bar {
+		position: absolute;
+		top: 0;
+		right: 0;
+		left: 0;
+		border-radius: 0;
+		z-index: 99;
+	}
+
 	.import-step,
 	.importer-step {
 		@include onboarding-block-margin;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -78,6 +78,7 @@ button {
 		left: 0;
 		border-radius: 0;
 		z-index: 99;
+		height: 8px;
 		background-color: transparent;
 
 		.progress-bar__progress {

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -5,6 +5,7 @@
 @import '@automattic/calypso-color-schemes';
 @import '@automattic/typography/styles/fonts';
 @import '@automattic/onboarding/styles/mixins';
+@import '@automattic/onboarding/styles/variables';
 
 /**
  * General onboarding styling
@@ -77,6 +78,12 @@ button {
 		left: 0;
 		border-radius: 0;
 		z-index: 99;
+		background-color: transparent;
+
+		.progress-bar__progress {
+			background-color: $onboarding-accent-blue;
+			border-radius: 0;
+		}
 	}
 
 	.import-step,

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -72,7 +72,7 @@ button {
 	}
 
 	.progress-bar {
-		position: absolute;
+		position: fixed;
 		top: 0;
 		right: 0;
 		left: 0;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -72,7 +72,7 @@ button {
 	}
 
 	.progress-bar {
-		position: fixed;
+		position: absolute;
 		top: 0;
 		right: 0;
 		left: 0;

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,3 +1,4 @@
+import { ProgressBar } from '@automattic/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { useEffect } from 'react';
@@ -6,6 +7,7 @@ import { Switch, Route, Redirect, generatePath, useHistory, useLocation } from '
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
 import SignupHeader from 'calypso/signup/signup-header';
+import { ONBOARD_STORE } from '../../stores';
 import recordStepStart from './analytics/record-step-start';
 import * as Steps from './steps-repository';
 import { AssertConditionState, Flow } from './types';
@@ -62,6 +64,9 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 
 	const assertCondition = flow.useAssertConditions?.() ?? { state: AssertConditionState.SUCCESS };
 
+	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
+	const progressValue = stepProgress ? stepProgress.progress / stepProgress.count : 0;
+
 	const renderStep = ( path: StepPath ) => {
 		switch ( assertCondition.state ) {
 			case AssertConditionState.CHECKING:
@@ -82,6 +87,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 				return (
 					<Route key={ path } path={ `/${ path }` }>
 						<div className={ classnames( flow.name, flow.classnames, kebabCase( path ) ) }>
+							<ProgressBar value={ progressValue * 100 } total={ 100 } color="#1e81cc" />
 							<SignupHeader />
 							{ renderStep( path ) }
 						</div>

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -87,7 +87,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 				return (
 					<Route key={ path } path={ `/${ path }` }>
 						<div className={ classnames( flow.name, flow.classnames, kebabCase( path ) ) }>
-							<ProgressBar value={ progressValue * 100 } total={ 100 } color="#1e81cc" />
+							<ProgressBar value={ progressValue * 100 } total={ 100 } />
 							<SignupHeader />
 							{ renderStep( path ) }
 						</div>

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -11,6 +11,7 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { useUpdateFlowProgress } from '../hooks/use-update-flow-progress';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
@@ -100,32 +101,14 @@ export const siteSetupFlow: Flow = {
 			( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID )
 		);
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
-		const { setPendingAction, setStepProgress, resetGoals, resetIntent, resetSelectedDesign } =
+		const { setPendingAction, resetGoals, resetIntent, resetSelectedDesign } =
 			useDispatch( ONBOARD_STORE );
 		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
 		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;
 		const goalsStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
 
-		// Set up Step progress for Woo flow - "Step 2 of 4"
-		if ( intent === 'sell' && storeType === 'power' ) {
-			switch ( currentStep ) {
-				case 'storeAddress':
-					setStepProgress( { progress: 1, count: 4 } );
-					break;
-				case 'businessInfo':
-					setStepProgress( { progress: 2, count: 4 } );
-					break;
-				case 'wooConfirm':
-					setStepProgress( { progress: 3, count: 4 } );
-					break;
-				case 'processing':
-					setStepProgress( { progress: 4, count: 4 } );
-					break;
-			}
-		} else {
-			setStepProgress( undefined );
-		}
+		useUpdateFlowProgress( currentStep );
 
 		const exitFlow = ( to: string ) => {
 			setPendingAction( () => {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -10,8 +10,8 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
+import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
-import { useUpdateFlowProgress } from '../hooks/use-update-flow-progress';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
@@ -108,7 +108,7 @@ export const siteSetupFlow: Flow = {
 		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;
 		const goalsStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
 
-		const flowProgress = useUpdateFlowProgress( currentStep, intent, storeType );
+		const flowProgress = useSiteSetupFlowProgress( currentStep, intent, storeType );
 
 		if ( flowProgress ) {
 			setStepProgress( flowProgress );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -101,14 +101,18 @@ export const siteSetupFlow: Flow = {
 			( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID )
 		);
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
-		const { setPendingAction, resetGoals, resetIntent, resetSelectedDesign } =
+		const { setPendingAction, setStepProgress, resetGoals, resetIntent, resetSelectedDesign } =
 			useDispatch( ONBOARD_STORE );
 		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
 		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;
 		const goalsStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
 
-		useUpdateFlowProgress( currentStep );
+		const flowProgress = useUpdateFlowProgress( currentStep, intent, storeType );
+
+		if ( flowProgress ) {
+			setStepProgress( flowProgress );
+		}
 
 		const exitFlow = ( to: string ) => {
 			setPendingAction( () => {

--- a/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
+++ b/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
@@ -6,7 +6,11 @@ import type { StepPath } from '../declarative-flow/internals/steps-repository';
 const SiteIntent = Onboard.SiteIntent;
 const MAX_STEPS = 10;
 
-export function useSiteSetupFlowProgress( currentStep: StepPath, intent: string, storeType: string ) {
+export function useSiteSetupFlowProgress(
+	currentStep: StepPath,
+	intent: string,
+	storeType: string
+) {
 	const isEnglishLocale = useIsEnglishLocale();
 	const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 	const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;

--- a/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
+++ b/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
@@ -6,7 +6,7 @@ import type { StepPath } from '../declarative-flow/internals/steps-repository';
 const SiteIntent = Onboard.SiteIntent;
 const MAX_STEPS = 10;
 
-export function useUpdateFlowProgress( currentStep: StepPath, intent: string, storeType: string ) {
+export function useSiteSetupFlowProgress( currentStep: StepPath, intent: string, storeType: string ) {
 	const isEnglishLocale = useIsEnglishLocale();
 	const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 	const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;

--- a/client/landing/stepper/hooks/use-update-flow-progress.ts
+++ b/client/landing/stepper/hooks/use-update-flow-progress.ts
@@ -1,18 +1,12 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { ONBOARD_STORE } from '../stores';
 import type { StepPath } from '../declarative-flow/internals/steps-repository';
 
 const SiteIntent = Onboard.SiteIntent;
 const MAX_STEPS = 10;
 
-export function useUpdateFlowProgress( currentStep: StepPath ) {
-	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
-	const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
-	const { setStepProgress } = useDispatch( ONBOARD_STORE );
-
+export function useUpdateFlowProgress( currentStep: StepPath, intent: string, storeType: string ) {
 	const isEnglishLocale = useIsEnglishLocale();
 	const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
 	const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;
@@ -27,7 +21,6 @@ export function useUpdateFlowProgress( currentStep: StepPath ) {
 	let beginningSegment = ( beginningSteps.length - 1 ) / MAX_STEPS;
 	let middleSegment = 0;
 	let middleProgress: { progress: number; count: number } | null = null;
-	let endStep = false;
 	let flowProgress;
 
 	switch ( currentStep ) {
@@ -35,9 +28,6 @@ export function useUpdateFlowProgress( currentStep: StepPath ) {
 		case 'vertical':
 		case 'intent':
 			beginningSegment = beginningSteps.indexOf( currentStep ) / MAX_STEPS;
-			break;
-		case 'processing':
-			endStep = true;
 			break;
 	}
 
@@ -138,9 +128,9 @@ export function useUpdateFlowProgress( currentStep: StepPath ) {
 
 	flowProgress = beginningSegment + middleSegment;
 
-	if ( endStep ) {
+	if ( currentStep === 'processing' ) {
 		flowProgress = MAX_STEPS;
 	}
 
-	setStepProgress( { progress: flowProgress, count: MAX_STEPS } );
+	return { progress: flowProgress, count: MAX_STEPS };
 }

--- a/client/landing/stepper/hooks/use-update-flow-progress.ts
+++ b/client/landing/stepper/hooks/use-update-flow-progress.ts
@@ -1,0 +1,146 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { Onboard } from '@automattic/data-stores';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { ONBOARD_STORE } from '../stores';
+import type { StepPath } from '../declarative-flow/internals/steps-repository';
+
+const SiteIntent = Onboard.SiteIntent;
+const MAX_STEPS = 10;
+
+export function useUpdateFlowProgress( currentStep: StepPath ) {
+	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
+	const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
+	const { setStepProgress } = useDispatch( ONBOARD_STORE );
+
+	const isEnglishLocale = useIsEnglishLocale();
+	const isEnabledFTM = isEnabled( 'signup/ftm-flow-non-en' ) || isEnglishLocale;
+	const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnabledFTM;
+	const goalsStepEnabled = isEnabled( 'signup/goals-step' ) && isEnabledFTM;
+
+	const beginningSteps = [
+		...( goalsStepEnabled ? [ 'goals' ] : [] ),
+		...( verticalsStepEnabled ? [ 'vertical' ] : [] ),
+		...( ! goalsStepEnabled ? [ 'intent' ] : [] ),
+	];
+
+	let beginningSegment = ( beginningSteps.length - 1 ) / MAX_STEPS;
+	let middleSegment = 0;
+	let middleProgress: { progress: number; count: number } | null = null;
+	let endStep = false;
+	let flowProgress;
+
+	switch ( currentStep ) {
+		case 'goals':
+		case 'vertical':
+		case 'intent':
+			beginningSegment = beginningSteps.indexOf( currentStep ) / MAX_STEPS;
+			break;
+		case 'processing':
+			endStep = true;
+			break;
+	}
+
+	switch ( intent ) {
+		case SiteIntent.Write: {
+			switch ( currentStep ) {
+				case 'options':
+					middleProgress = { progress: 1, count: 4 };
+					break;
+				case 'bloggerStartingPoint':
+					middleProgress = { progress: 2, count: 4 };
+					break;
+				case 'courses':
+				case 'designSetup':
+					middleProgress = { progress: 3, count: 4 };
+					break;
+			}
+
+			break;
+		}
+		case SiteIntent.Build: {
+			switch ( currentStep ) {
+				case 'designSetup':
+					middleProgress = { progress: 1, count: 2 };
+					break;
+			}
+
+			break;
+		}
+		case SiteIntent.Sell: {
+			switch ( currentStep ) {
+				case 'options':
+					middleProgress = { progress: 1, count: 8 };
+					break;
+				case 'storeFeatures':
+					middleProgress = { progress: 2, count: 8 };
+					break;
+			}
+			if ( storeType === 'simple' ) {
+				switch ( currentStep ) {
+					case 'designSetup':
+						middleProgress = { progress: 3, count: 8 };
+						break;
+				}
+			} else if ( storeType === 'power' ) {
+				switch ( currentStep ) {
+					case 'storeAddress':
+						middleProgress = { progress: 3, count: 8 };
+						break;
+					case 'businessInfo':
+						middleProgress = { progress: 4, count: 8 };
+						break;
+					case 'wooConfirm':
+					case 'wooInstallPlugins':
+						middleProgress = { progress: 5, count: 8 };
+						break;
+					case 'wooTransfer':
+					case 'editEmail':
+						middleProgress = { progress: 6, count: 8 };
+						break;
+					case 'wooVerifyEmail':
+						middleProgress = { progress: 7, count: 8 };
+						break;
+				}
+			}
+
+			break;
+		}
+		case SiteIntent.Import: {
+			switch ( currentStep ) {
+				case 'import':
+					middleProgress = { progress: 1, count: 4 };
+					break;
+				case 'importList':
+				case 'importReady':
+				case 'importReadyNot':
+				case 'importReadyWpcom':
+				case 'importReadyPreview': {
+					middleProgress = { progress: 2, count: 4 };
+					break;
+				}
+				case 'importerWix':
+				case 'importerBlogger':
+				case 'importerMedium':
+				case 'importerSquarespace':
+				case 'importerWordpress':
+					middleProgress = { progress: 3, count: 4 };
+					break;
+			}
+
+			break;
+		}
+	}
+
+	if ( middleProgress ) {
+		middleSegment = ( middleProgress.progress / middleProgress.count ) * MAX_STEPS;
+	}
+
+	flowProgress = beginningSegment + middleSegment;
+
+	if ( endStep ) {
+		flowProgress = MAX_STEPS;
+	}
+
+	setStepProgress( { progress: flowProgress, count: MAX_STEPS } );
+}

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { ReactChild, ReactElement } from 'react';
 import ActionButtons from '../action-buttons';
-import FlowProgress from '../flow-progress';
 import StepNavigationLink from '../step-navigation-link';
 import './style.scss';
 
@@ -72,7 +71,6 @@ const StepContainer: React.FC< Props > = ( {
 	flowName,
 	intent,
 	stepSectionName,
-	stepProgress,
 	recordTracksEvent,
 } ) => {
 	const translate = useTranslate();
@@ -134,11 +132,6 @@ const StepContainer: React.FC< Props > = ( {
 		);
 	}
 
-	function ProgressIndicator() {
-		if ( ! stepProgress ) return null;
-		return <FlowProgress count={ stepProgress?.count } progress={ stepProgress?.progress } />;
-	}
-
 	function NextButton() {
 		if ( shouldHideNavButtons || ! goNext ) {
 			return null;
@@ -180,7 +173,6 @@ const StepContainer: React.FC< Props > = ( {
 				{ ! hideSkip && skipButtonAlign === 'top' && <SkipButton /> }
 				{ ! hideNext && <NextButton /> }
 				{ customizedActionButtons }
-				<ProgressIndicator />
 			</ActionButtons>
 			{ ! hideFormattedHeader && (
 				<div className="step-container__header">


### PR DESCRIPTION
#### Proposed Changes

- Add progress bar on top of step container
- Update the progress value based on currentStep
- The progress bar will be display on all onboarding flow, support both Intent (for non-English user) and Goals (for English user)

#### Testing Instructions

1. For English users
- Head to the Goals screen /setup/goals?siteSlug=${site_slug}.
- Select any goal and click the "Continue" button.
- The progress bar will be running from Vertical Question screen, and will reach 100% on the Processing screen

2. For non-English users
- Head to the Goals screen /setup/vertical?siteSlug=${site_slug}, choose vertical and click "Continue"
- Select any option on Intent Screen
- The progress bar will be running from Intent screen, and will reach 100% on the Processing screen

- Expect to see the progress bar showing the onboarding progress. Test that everything else works as before.

#### Notes
- [Woo flow progress indicator ](https://github.com/Automattic/wp-calypso/pull/63518)has been replace with the progress bar
- The progress bar of the Importer step is overlapped with the flow progress bar, this will be solved on #64960
- DIFM flow (Hire expert) navigate user to another route /start, which is belong to signup flow

Related to #63118 
