### PR TITLE
Stepper: Fix timing issue with the site options step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -23,6 +23,7 @@ const SiteOptions: Step = function SiteOptions( { navigation } ) {
 	const { goBack, goNext, submit } = navigation;
 	const [ siteTitle, setSiteTitle ] = React.useState( '' );
 	const [ tagline, setTagline ] = React.useState( '' );
+	const [ formTouched, setFormTouched ] = React.useState( false );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const translate = useTranslate();
 	const site = useSite();
@@ -34,9 +35,13 @@ const SiteOptions: Step = function SiteOptions( { navigation } ) {
 			return;
 		}
 
+		if ( formTouched ) {
+			return;
+		}
+
 		setSiteTitle( site.name || '' );
 		setTagline( site.description );
-	}, [ site ] );
+	}, [ site, formTouched ] );
 
 	const handleSubmit = async ( event: React.FormEvent ) => {
 		event.preventDefault();
@@ -55,6 +60,8 @@ const SiteOptions: Step = function SiteOptions( { navigation } ) {
 	};
 	const onChange = ( event: React.FormEvent< HTMLInputElement > ) => {
 		if ( site ) {
+			setFormTouched( true );
+
 			switch ( event.currentTarget.name ) {
 				case 'siteTitle':
 					return setSiteTitle( event.currentTarget.value );


### PR DESCRIPTION
#### Proposed Changes

On slow networks, it was possible for the user to edit the site name or tagline and then have that value overwritten by the value from the store.

There was a short window where the form inputs were accessible but the api call to retrieve the site hadn't finished yet. When the api call finished, the `useEffect` hook would overwrite the form input values with the data from the store.

Now we check to make sure the form inputs haven't changed before we default to the values from the store.

#### Testing Instructions

1. Go to http://calypso.localhost:3000/setup/options?siteSlug=[site slug]
    1. If you don't already have a site title/tagline entered, you'll need to enter one, hit "Continue", then go back to the options step.
1. In the browser developer tools, throttle the network to 2G or 3G.
1. Refresh the page.
1. As soon as the title/tagline form inputs are enabled, change the value of one of them.
1. Once the site API calls finishes, the value you entered in the previous step should still be there.

Fixes #64271
