### PR TITLE
Default to the owned-by-me filter on the all domains page

### DIFF
--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -266,7 +266,7 @@ class AllDomains extends Component {
 
 		const { isSavingContactInfo } = this.state;
 
-		const selectedFilter = context?.query?.filter;
+		const selectedFilter = context?.query?.filter || 'owned-by-me';
 
 		const domains =
 			selectedFilter === 'domain-only'
@@ -587,20 +587,20 @@ class AllDomains extends Component {
 	renderDomainTableFilterButton() {
 		const { context, translate, sites } = this.props;
 
-		const selectedFilter = context?.query?.filter;
+		const selectedFilter = context?.query?.filter || 'owned-by-me';
 		const nonWpcomDomains = this.mergeFilteredDomainsWithDomainsDetails();
 
 		const filterOptions = [
 			{
 				label: translate( 'All domains' ),
-				value: '',
-				path: domainManagementRoot(),
+				value: 'all-domains',
+				path: domainManagementRoot() + '?' + stringify( { filter: 'all-domains' } ),
 				count: nonWpcomDomains?.length,
 			},
 			{
 				label: translate( 'Owned by me' ),
 				value: 'owned-by-me',
-				path: domainManagementRoot() + '?' + stringify( { filter: 'owned-by-me' } ),
+				path: domainManagementRoot(),
 				count: filterDomainsByOwner( nonWpcomDomains, 'owned-by-me' )?.length,
 			},
 			{
@@ -620,7 +620,7 @@ class AllDomains extends Component {
 		return (
 			<DomainsTableFilterButton
 				key="breadcrumb_button_2"
-				selectedFilter={ selectedFilter || '' }
+				selectedFilter={ selectedFilter }
 				filterOptions={ filterOptions }
 				isLoading={ this.isLoadingDomainDetails() }
 				disabled={ this.isLoadingDomainDetails() }


### PR DESCRIPTION
#### Proposed Changes

* It seems more convenient to default to the domains that are specifically owned by the current user on the all domains page.

#### Testing Instructions

- Visit `/domains/manage` and make sure that this defaults to the. "Owned by me" filter and the domain list is correctly filtered.
- Select the "All domains" filter. Make sure that the query string is correctly updated and that the domains list is correctly (un)filtered showing all domains on all sites the user is an admin on.
