### PR TITLE
Site Editor Tracking: Fire event for click on '< Dashboard'

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -15,6 +15,7 @@ import wpcomBlockPremiumContentPlanUpgrade from './wpcom-block-premium-content-p
 import wpcomBlockPremiumContentStripeConnect from './wpcom-block-premium-content-stripe-connect';
 import wpcomInserterInlineSearchTerm from './wpcom-inserter-inline-search-term';
 import wpcomInserterTabPanelSelected from './wpcom-inserter-tab-panel-selected';
+import wpcomSiteEditorExitClick from './wpcom-site-editor-exit-click';
 import wpcomTemplatePartChooseExisting from './wpcom-template-part-choose-existing';
 import {
 	wpcomTemplatePartReplaceCapture,
@@ -65,6 +66,7 @@ const EVENTS_MAPPING = [
 	wpcomBlockEditorPostPublishAddNewClick(),
 	wpcomBlockEditorSaveClick(),
 	wpcomBlockEditorSaveDraftClick(),
+	wpcomSiteEditorExitClick(),
 ];
 const EVENTS_MAPPING_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => capture );
 const EVENTS_MAPPING_NON_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => ! capture );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-exit-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-exit-click.js
@@ -1,0 +1,13 @@
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Return the event definition object to track `wpcom_site_editor_exit_click`.
+ *
+ * @returns {import('./types').DelegateEventHandler} event object definition.
+ */
+export default () => ( {
+	id: 'wpcom-site-editor-exit-click',
+	selector: '.edit-site-navigation-panel .edit-site-navigation-panel__back-to-dashboard',
+	type: 'click',
+	handler: () => tracksRecordEvent( 'wpcom_site_editor_exit_click' ),
+} );


### PR DESCRIPTION
### Proposed Changes

Fires `wpcom_site_editor_exit_click` event when a user clicks on the '< Dashboard' in the Site Editor.

See #58123

<img width="745" alt="image" src="https://user-images.githubusercontent.com/36432/173464111-e4aaddf5-b391-49c2-a452-bdea8ef15cc3.png">

<img width="1319" alt="image" src="https://user-images.githubusercontent.com/36432/173464136-f7d7f419-6985-4cc9-a95c-7586025aacad.png">

### Testing Instructions

1. Navigate to 'Appearance -> Editor'.
2. Once in the Site Editor, click on the WordPress icon to open the left-hand drawer.
3. In the left-hand drawer, click on the  '< Dashboard' link.
4. Observe the `wpcom_site_editor_exit_click` event however you wish to debug (see 'Tracking events within the Block Editor on Dotcom' in the Field Guide for available options).