### PR TITLE
Fix unnecessary logging of tracking events on clicking anywhere on UI

### DIFF
--- a/client/components/jetpack/profile-dropdown/index.tsx
+++ b/client/components/jetpack/profile-dropdown/index.tsx
@@ -4,8 +4,10 @@ import * as React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Gravatar from 'calypso/components/gravatar';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import useOutsideClickCallback from './use-outside-click-callback';
 import type { UserData } from 'calypso/lib/user/user';
 
@@ -17,23 +19,28 @@ const ProfileDropdown: React.FC = () => {
 	const ref = React.useRef( null );
 	const [ isExpanded, setExpanded ] = useState( false );
 	const user = useSelector( getCurrentUser ) as UserData;
+	const siteId = useSelector( getSelectedSiteId );
 
 	const toggle = useCallback( () => setExpanded( ! isExpanded ), [ isExpanded, setExpanded ] );
 	const close = useCallback( () => {
 		if ( isExpanded ) {
 			setExpanded( false );
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_masterbar_profile_close', {
+					site_id: siteId,
+				} )
+			);
 		}
-	}, [ isExpanded, setExpanded ] );
+	}, [ dispatch, isExpanded, siteId ] );
 
 	const trackedToggle = useTrackCallback( toggle, 'calypso_jetpack_masterbar_profile_toggle' );
-	const trackedClose = useTrackCallback( close, 'calypso_jetpack_masterbar_profile_close' );
 	const redirectToLogoutUrl = useCallback( () => dispatch( redirectToLogout() ), [ dispatch ] );
 	const trackedLogOut = useTrackCallback(
 		redirectToLogoutUrl,
 		'calypso_jetpack_settings_masterbar_logout'
 	);
 
-	useOutsideClickCallback( ref, trackedClose );
+	useOutsideClickCallback( ref, close );
 
 	return (
 		<nav


### PR DESCRIPTION
#### Proposed Changes

This PR fixes an issue where clicking anywhere on the UI is making unnecessary logging of track event `calypso_jetpack_masterbar_profile_close`

#### Testing Instructions

1) Run `git checkout fix/unnecessary-logging-track-events-on-clicking` and `yarn start-jetpack-cloud`
2) Visit http://jetpack.cloud.localhost:3000/
3) Click anywhere on the UI and verify no API call is being made to track events on click.
4) Click on the profile dropdown and verify it closes on clicking outside or pressing the ESC key.
5) Verify API call to track an event is being made when the profile dropdown is closed either by clicking outside or pressing the ESC key. 

**Screenshots**

Track events API call

<img width="937" alt="Screenshot 2022-06-14 at 11 36 18 AM" src="https://user-images.githubusercontent.com/10586875/173507935-c72730b9-8f69-449a-b2aa-6626dccbc0b2.png">

Profile dropdown

<img width="262" alt="Screenshot 2022-06-14 at 11 51 15 AM" src="https://user-images.githubusercontent.com/10586875/173507991-491d28d8-e98b-4e8f-bf03-c0a60b4db5bc.png">

Related to 1202076982646589-as-1202380134667661