### PR TITLE
Enable Tus uploads only for VideoPress

### DIFF
--- a/client/data/media/use-add-media.js
+++ b/client/data/media/use-add-media.js
@@ -13,7 +13,9 @@ export const useAddMedia = () => {
 			( site.options.active_modules && site.options.active_modules.includes( 'videopress' ) );
 		const canUseVideopress = isVideoPressEnabled || isVideoPressModuleActive;
 
-		const fileCallback = ( fileObject ) => ( fileObject.canUseVideopress = canUseVideopress );
+		const fileCallback = ( fileObject ) => {
+			fileObject.canUseVideopress = canUseVideopress;
+		};
 
 		if ( isFileList( file ) ) {
 			Array.from( file ).forEach( fileCallback );

--- a/client/data/media/use-add-media.js
+++ b/client/data/media/use-add-media.js
@@ -1,12 +1,39 @@
 import { useCallback } from 'react';
 import { getFileUploader } from 'calypso/lib/media/utils';
+import { isFileList } from 'calypso/state/media/utils/is-file-list';
 import { useUploadMediaMutation } from './use-upload-media-mutation';
 
 export const useAddMedia = () => {
 	const { uploadMediaAsync } = useUploadMediaMutation();
+	const addVideopressStatusToFile = ( file, site ) => {
+		const isSiteJetpack = !! site.jetpack;
+		const isVideoPressEnabled = site.options && site.options.videopress_enabled;
+		const isVideoPressModuleActive =
+			! isSiteJetpack ||
+			( site.options.active_modules && site.options.active_modules.includes( 'videopress' ) );
+		const canUseVideopress = isVideoPressEnabled || isVideoPressModuleActive;
+
+		const fileCallback = ( fileObject ) => ( fileObject.canUseVideopress = canUseVideopress );
+
+		if ( isFileList( file ) ) {
+			Array.from( file ).forEach( fileCallback );
+		} else if ( Array.isArray( file ) ) {
+			file.forEach( fileCallback );
+		} else if ( 'object' === typeof file ) {
+			fileCallback( file );
+		}
+
+		return file;
+	};
+
 	const addMedia = useCallback(
 		( file, site, postId ) => {
-			return uploadMediaAsync( file, site, postId, getFileUploader );
+			return uploadMediaAsync(
+				addVideopressStatusToFile( file, site ),
+				site,
+				postId,
+				getFileUploader
+			);
 		},
 		[ uploadMediaAsync ]
 	);

--- a/client/data/media/use-add-media.js
+++ b/client/data/media/use-add-media.js
@@ -1,28 +1,23 @@
 import { useCallback } from 'react';
-import { getFileUploader } from 'calypso/lib/media/utils';
+import { getFileUploader, canUseVideoPress } from 'calypso/lib/media/utils';
 import { isFileList } from 'calypso/state/media/utils/is-file-list';
 import { useUploadMediaMutation } from './use-upload-media-mutation';
 
 export const useAddMedia = () => {
 	const { uploadMediaAsync } = useUploadMediaMutation();
 	const addVideopressStatusToFile = ( file, site ) => {
-		const isSiteJetpack = !! site.jetpack;
-		const isVideoPressEnabled = site.options && site.options.videopress_enabled;
-		const isVideoPressModuleActive =
-			! isSiteJetpack ||
-			( site.options.active_modules && site.options.active_modules.includes( 'videopress' ) );
-		const canUseVideopress = isVideoPressEnabled || isVideoPressModuleActive;
+		const siteCanUseVideoPress = canUseVideoPress( site );
 
-		const fileCallback = ( fileObject ) => {
-			fileObject.canUseVideopress = canUseVideopress;
+		const addVideoPressStatusToFileObject = ( fileObject ) => {
+			fileObject.canUseVideoPress = siteCanUseVideoPress;
 		};
 
 		if ( isFileList( file ) ) {
-			Array.from( file ).forEach( fileCallback );
+			Array.from( file ).forEach( addVideoPressStatusToFileObject );
 		} else if ( Array.isArray( file ) ) {
-			file.forEach( fileCallback );
+			file.forEach( addVideoPressStatusToFileObject );
 		} else if ( 'object' === typeof file ) {
-			fileCallback( file );
+			addVideoPressStatusToFileObject( file );
 		}
 
 		return file;

--- a/client/lib/media/utils/can-use-videopress.js
+++ b/client/lib/media/utils/can-use-videopress.js
@@ -1,0 +1,15 @@
+/**
+ * Returns whether a site can use VideoPress.
+ *
+ * @param {object} site Site object
+ * @returns {boolean}
+ */
+export function canUseVideoPress( site ) {
+	const isSiteJetpack = !! site.jetpack;
+	const isVideoPressEnabled = site.options && site.options.videopress_enabled;
+	const isVideoPressModuleActive =
+		! isSiteJetpack ||
+		( site.options.active_modules && site.options.active_modules.includes( 'videopress' ) );
+
+	return isVideoPressEnabled || isVideoPressModuleActive;
+}

--- a/client/lib/media/utils/index.js
+++ b/client/lib/media/utils/index.js
@@ -1,4 +1,5 @@
 export { canUserDeleteItem } from 'calypso/lib/media/utils/can-user-delete-item';
+export { canUseVideoPress } from 'calypso/lib/media/utils/can-use-videopress';
 export { canvasToBlob } from 'calypso/lib/media/utils/canvas-to-blob';
 export { createTransientMedia } from 'calypso/lib/media/utils/create-transient-media';
 export { filterItemsByMimePrefix } from 'calypso/lib/media/utils/filter-items-by-mime-prefix';

--- a/packages/wpcom.js/src/lib/site.media.js
+++ b/packages/wpcom.js/src/lib/site.media.js
@@ -158,7 +158,7 @@ Media.prototype.addFiles = function ( query, files, fn ) {
 	files = isArray ? files : [ files ];
 
 	files = files.filter( ( file ) => {
-		if ( !! file.type && file.type.startsWith( 'video/' ) ) {
+		if ( !! file.canUseVideopress && !! file.type && file.type.startsWith( 'video/' ) ) {
 			videoFiles.push( file );
 			return false;
 		}

--- a/packages/wpcom.js/src/lib/site.media.js
+++ b/packages/wpcom.js/src/lib/site.media.js
@@ -153,18 +153,11 @@ Media.prototype.addFiles = function ( query, files, fn ) {
 		}
 	}
 
-	const videoFiles = [];
-	const isArray = Array.isArray( files );
-	files = isArray ? files : [ files ];
+	if ( ! Array.isArray( files ) ) {
+		files = [ files ];
+	}
 
-	files = files.filter( ( file ) => {
-		if ( !! file.canUseVideopress && !! file.type && file.type.startsWith( 'video/' ) ) {
-			videoFiles.push( file );
-			return false;
-		}
-		return true;
-	} );
-
+	const videoFiles = this.filterFilesUploadableOnVideoPress( files );
 	if ( videoFiles.length ) {
 		const uploader = new TusUploader( this.wpcom, this._sid );
 		return uploader.startUpload( videoFiles );
@@ -176,6 +169,26 @@ Media.prototype.addFiles = function ( query, files, fn ) {
 	};
 
 	return this.wpcom.req.post( params, query, null, fn );
+};
+
+/**
+ * Filters an array to only return files that can use VideoPress for upload.
+ *
+ * @param {Array} files An array of file objects
+ * @returns {Array}
+ */
+Media.prototype.filterFilesUploadableOnVideoPress = function ( files ) {
+	return files.filter( ( file ) => this.fileCanBeUploadedOnVideoPress( file ) );
+};
+
+/**
+ * Checks whether a media file can use VideoPress for upload.
+ *
+ * @param {object} file A file object
+ * @returns {boolean}
+ */
+Media.prototype.fileCanBeUploadedOnVideoPress = function ( file ) {
+	return !! file.canUseVideoPress && !! file.type && file.type.startsWith( 'video/' );
 };
 
 /**


### PR DESCRIPTION
#### Proposed Changes
This PR adds the current VideoPress status in files to be uploaded, in order to only use Tus resumable uploads for VideoPress-enabled sites.

#### Testing Instructions

* Apply this patch
* Sandbox public api
* On your sandbox `tail -f /tmp/php-errors`
* `yarn start`
* On a jetpack site without a VideoPress plan
* `http://calypso.localhost:3000/media/<your_jetpack_site>`
* Try uploading a video in your media library
* ✅ The upload should succeed
* ✅ No Tus logs should happen in the php-errors log
* Add a VideoPress plan (or use a Jetpack site with a VideoPress plan)
* Enable VideoPress
* `http://calypso.localhost:3000/media/<your_jetpack_site>`
* Try uploading a video in your media library
* ✅ The upload should succeed 
* ✅ Tus logs should be visible in the php-errors log
* Disable VideoPress
* `http://calypso.localhost:3000/media/<your_jetpack_site>`
* Try uploading a video in your media library
* ✅ The upload should succeed
* ✅ No Tus logs should happen in the php-errors log
* Replicate tests on free & business wpcom
* Replicate tests on atomic

Fixes Automattic/greenhouse#1214