### PR TITLE
Add Google Support to Mailbox Forms

### DIFF
--- a/client/my-sites/email/add-mailboxes/email-provider-pricing-notice.tsx
+++ b/client/my-sites/email/add-mailboxes/email-provider-pricing-notice.tsx
@@ -1,0 +1,65 @@
+import { isGoogleWorkspaceMonthly } from '@automattic/calypso-products';
+import { ResponseDomain } from 'calypso/lib/domains/types';
+import {
+	getGSuiteExpiryDate,
+	getGSuiteMailboxPurchaseCost,
+	getGSuiteMailboxRenewalCost,
+} from 'calypso/lib/gsuite';
+import {
+	getTitanExpiryDate,
+	getTitanMailboxPurchaseCost,
+	getTitanMailboxRenewalCost,
+	isTitanMonthlyProduct,
+} from 'calypso/lib/titan';
+import EmailPricingNotice from 'calypso/my-sites/email/email-pricing-notice';
+import { getMailProductProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-mail-product-properties';
+import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
+import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+
+interface ProviderPricingNoticeProps {
+	mailProduct: ProductListItem | null;
+	provider: EmailProvider;
+	selectedDomain: ResponseDomain;
+}
+
+export const EmailProviderPricingNotice = ( {
+	mailProduct,
+	provider,
+	selectedDomain,
+}: ProviderPricingNoticeProps ): JSX.Element | null => {
+	const { isExtraItemPurchase } = getMailProductProperties(
+		provider,
+		selectedDomain,
+		mailProduct as ProductListItem
+	);
+
+	if ( ! selectedDomain || ! mailProduct || ! isExtraItemPurchase ) {
+		return null;
+	}
+
+	if ( provider === EmailProvider.Titan ) {
+		return (
+			<EmailPricingNotice
+				domain={ selectedDomain }
+				expiryDate={ getTitanExpiryDate( selectedDomain ) }
+				mailboxRenewalCost={ getTitanMailboxRenewalCost( selectedDomain ) }
+				mailboxPurchaseCost={ getTitanMailboxPurchaseCost( selectedDomain ) }
+				product={ mailProduct }
+				isMonthlyBilling={ isTitanMonthlyProduct( mailProduct ) }
+			/>
+		);
+	}
+
+	return (
+		<EmailPricingNotice
+			domain={ selectedDomain }
+			expiryDate={ getGSuiteExpiryDate( selectedDomain ) }
+			mailboxRenewalCost={ getGSuiteMailboxRenewalCost( selectedDomain ) }
+			mailboxPurchaseCost={ getGSuiteMailboxPurchaseCost( selectedDomain ) }
+			product={ mailProduct }
+			isMonthlyBilling={ isGoogleWorkspaceMonthly( mailProduct ) }
+		/>
+	);
+};
+
+export default EmailProviderPricingNotice;

--- a/client/my-sites/email/add-mailboxes/email-provider-pricing-notice.tsx
+++ b/client/my-sites/email/add-mailboxes/email-provider-pricing-notice.tsx
@@ -16,7 +16,7 @@ import { getMailProductProperties } from 'calypso/my-sites/email/form/mailboxes/
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
-interface ProviderPricingNoticeProps {
+interface EmailProviderPricingNoticeProps {
 	emailProduct: ProductListItem | null;
 	provider: EmailProvider;
 	selectedDomain: ResponseDomain;
@@ -26,7 +26,7 @@ export const EmailProviderPricingNotice = ( {
 	emailProduct,
 	provider,
 	selectedDomain,
-}: ProviderPricingNoticeProps ): JSX.Element | null => {
+}: EmailProviderPricingNoticeProps ): JSX.Element | null => {
 	const { isAdditionalMailboxesPurchase } = getMailProductProperties(
 		provider,
 		selectedDomain,

--- a/client/my-sites/email/add-mailboxes/email-provider-pricing-notice.tsx
+++ b/client/my-sites/email/add-mailboxes/email-provider-pricing-notice.tsx
@@ -27,13 +27,13 @@ export const EmailProviderPricingNotice = ( {
 	provider,
 	selectedDomain,
 }: ProviderPricingNoticeProps ): JSX.Element | null => {
-	const { isExtraItemPurchase } = getMailProductProperties(
+	const { isAdditionalMailboxesPurchase } = getMailProductProperties(
 		provider,
 		selectedDomain,
 		emailProduct as ProductListItem
 	);
 
-	if ( ! selectedDomain || ! emailProduct || ! isExtraItemPurchase ) {
+	if ( ! selectedDomain || ! emailProduct || ! isAdditionalMailboxesPurchase ) {
 		return null;
 	}
 

--- a/client/my-sites/email/add-mailboxes/email-provider-pricing-notice.tsx
+++ b/client/my-sites/email/add-mailboxes/email-provider-pricing-notice.tsx
@@ -17,23 +17,23 @@ import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
 interface ProviderPricingNoticeProps {
-	mailProduct: ProductListItem | null;
+	emailProduct: ProductListItem | null;
 	provider: EmailProvider;
 	selectedDomain: ResponseDomain;
 }
 
 export const EmailProviderPricingNotice = ( {
-	mailProduct,
+	emailProduct,
 	provider,
 	selectedDomain,
 }: ProviderPricingNoticeProps ): JSX.Element | null => {
 	const { isExtraItemPurchase } = getMailProductProperties(
 		provider,
 		selectedDomain,
-		mailProduct as ProductListItem
+		emailProduct as ProductListItem
 	);
 
-	if ( ! selectedDomain || ! mailProduct || ! isExtraItemPurchase ) {
+	if ( ! selectedDomain || ! emailProduct || ! isExtraItemPurchase ) {
 		return null;
 	}
 
@@ -44,8 +44,8 @@ export const EmailProviderPricingNotice = ( {
 				expiryDate={ getTitanExpiryDate( selectedDomain ) }
 				mailboxRenewalCost={ getTitanMailboxRenewalCost( selectedDomain ) }
 				mailboxPurchaseCost={ getTitanMailboxPurchaseCost( selectedDomain ) }
-				product={ mailProduct }
-				isMonthlyBilling={ isTitanMonthlyProduct( mailProduct ) }
+				product={ emailProduct }
+				isMonthlyBilling={ isTitanMonthlyProduct( emailProduct ) }
 			/>
 		);
 	}
@@ -56,8 +56,8 @@ export const EmailProviderPricingNotice = ( {
 			expiryDate={ getGSuiteExpiryDate( selectedDomain ) }
 			mailboxRenewalCost={ getGSuiteMailboxRenewalCost( selectedDomain ) }
 			mailboxPurchaseCost={ getGSuiteMailboxPurchaseCost( selectedDomain ) }
-			product={ mailProduct }
-			isMonthlyBilling={ isGoogleWorkspaceMonthly( mailProduct ) }
+			product={ emailProduct }
+			isMonthlyBilling={ isGoogleWorkspaceMonthly( emailProduct ) }
 		/>
 	);
 };

--- a/client/my-sites/email/add-mailboxes/get-event-name.ts
+++ b/client/my-sites/email/add-mailboxes/get-event-name.ts
@@ -1,0 +1,22 @@
+import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
+
+export const EVENT_CONTINUE_BUTTON_CLICK = 'continue_button_click';
+export const EVENT_CANCEL_BUTTON_CLICK = 'cancel_button_click';
+
+export type EventName = typeof EVENT_CONTINUE_BUTTON_CLICK | typeof EVENT_CANCEL_BUTTON_CLICK;
+
+export const getEventName = ( provider: EmailProvider, genericName: EventName ): string => {
+	const providerIndex = provider === EmailProvider.Titan ? 0 : 1;
+	const eventNames = {
+		continue_button_click: [
+			'calypso_email_management_titan_add_mailboxes_continue_button_click',
+			'calypso_email_management_gsuite_add_users_continue_button_click',
+		],
+		cancel_button_click: [
+			'calypso_email_management_titan_add_mailboxes_cancel_button_click',
+			'calypso_email_management_gsuite_add_users_cancel_button_click',
+		],
+	};
+
+	return eventNames[ genericName ][ providerIndex ];
+};

--- a/client/my-sites/email/add-mailboxes/get-tracks-event-name.ts
+++ b/client/my-sites/email/add-mailboxes/get-tracks-event-name.ts
@@ -5,8 +5,7 @@ export const EVENT_CANCEL_BUTTON_CLICK = 'cancel_button_click';
 
 export type EventName = typeof EVENT_CONTINUE_BUTTON_CLICK | typeof EVENT_CANCEL_BUTTON_CLICK;
 
-export const getEventName = ( provider: EmailProvider, genericName: EventName ): string => {
-	const providerIndex = provider === EmailProvider.Titan ? 0 : 1;
+export const getTracksEventName = ( provider: EmailProvider, genericName: EventName ): string => {
 	const eventNames = {
 		continue_button_click: [
 			'calypso_email_management_titan_add_mailboxes_continue_button_click',
@@ -18,5 +17,6 @@ export const getEventName = ( provider: EmailProvider, genericName: EventName ):
 		],
 	};
 
+	const providerIndex = provider === EmailProvider.Titan ? 0 : 1;
 	return eventNames[ genericName ][ providerIndex ];
 };

--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -155,13 +155,13 @@ const WithVerificationGate = ( {
 const MailboxNotices = ( {
 	currentRoute,
 	isLoadingDomains,
-	mailProduct,
+	emailProduct,
 	provider,
 	selectedDomainName,
 	selectedDomain,
 	selectedSite,
 	source,
-}: AddMailboxesAdditionalProps & { mailProduct: ProductListItem | null } ): JSX.Element | null => {
+}: AddMailboxesAdditionalProps & { emailProduct: ProductListItem | null } ): JSX.Element | null => {
 	if ( isLoadingDomains ) {
 		return null;
 	}
@@ -169,7 +169,7 @@ const MailboxNotices = ( {
 	const { existingItemsCount } = getMailProductProperties(
 		provider,
 		selectedDomain,
-		mailProduct as ProductListItem
+		emailProduct as ProductListItem
 	);
 
 	const handleUnusedMailboxFinishSetupClick = (): void => {
@@ -194,7 +194,7 @@ const MailboxNotices = ( {
 			) }
 
 			<EmailProviderPricingNotice
-				mailProduct={ mailProduct }
+				emailProduct={ emailProduct }
 				provider={ provider }
 				selectedDomain={ selectedDomain }
 			/>
@@ -205,7 +205,7 @@ const MailboxNotices = ( {
 const MailboxesForm = ( {
 	goToEmail,
 	isLoadingDomains,
-	mailProduct,
+	emailProduct,
 	provider,
 	selectedDomain,
 	selectedDomainName,
@@ -213,7 +213,7 @@ const MailboxesForm = ( {
 	source,
 	translate,
 }: AddMailboxesAdditionalProps & {
-	mailProduct: ProductListItem | null;
+	emailProduct: ProductListItem | null;
 	goToEmail: () => void;
 } ): JSX.Element => {
 	const [ state, setState ] = useState( { isValidating: false, isAddingToCart: false } );
@@ -221,7 +221,7 @@ const MailboxesForm = ( {
 	const cartKey = useCartKey();
 	const cartManager = useShoppingCart( cartKey );
 
-	if ( isLoadingDomains || ! mailProduct ) {
+	if ( isLoadingDomains || ! emailProduct ) {
 		return <AddEmailAddressesCardPlaceholder />;
 	}
 
@@ -239,7 +239,7 @@ const MailboxesForm = ( {
 		const mailProperties = getMailProductProperties(
 			provider,
 			selectedDomain,
-			mailProduct,
+			emailProduct,
 			mailboxOperations.mailboxes.length
 		);
 
@@ -307,7 +307,7 @@ const AddMailboxes = ( props: AddMailboxesProps ): JSX.Element | null => {
 		translate,
 	} = additionalProps;
 
-	const mailProduct = useSelector( ( state ) =>
+	const emailProduct = useSelector( ( state ) =>
 		getMailProductForProvider( state, provider, selectedDomain )
 	);
 
@@ -315,7 +315,7 @@ const AddMailboxes = ( props: AddMailboxesProps ): JSX.Element | null => {
 
 	const productName = isTitan( provider )
 		? getTitanProductName()
-		: getGoogleMailServiceFamily( mailProduct?.product_slug );
+		: getGoogleMailServiceFamily( emailProduct?.product_slug );
 
 	const goToEmail = (): void => {
 		page(
@@ -348,11 +348,11 @@ const AddMailboxes = ( props: AddMailboxesProps ): JSX.Element | null => {
 				<HeaderCake onClick={ goToEmail }>{ productName + ': ' + selectedDomainName }</HeaderCake>
 
 				<WithVerificationGate productFamily={ `${ productName }` } provider={ provider }>
-					<MailboxNotices { ...additionalProps } mailProduct={ mailProduct } />
+					<MailboxNotices { ...additionalProps } emailProduct={ emailProduct } />
 					<MailboxesForm
 						{ ...additionalProps }
 						goToEmail={ goToEmail }
-						mailProduct={ mailProduct }
+						emailProduct={ emailProduct }
 					/>
 				</WithVerificationGate>
 			</Main>

--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -1,6 +1,6 @@
 import { Card } from '@automattic/components';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import { useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { PropsWithChildren, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -24,8 +24,8 @@ import EmailProviderPricingNotice from 'calypso/my-sites/email/add-mailboxes/ema
 import {
 	EVENT_CANCEL_BUTTON_CLICK,
 	EVENT_CONTINUE_BUTTON_CLICK,
-	getEventName,
-} from 'calypso/my-sites/email/add-mailboxes/get-event-name';
+	getTracksEventName,
+} from 'calypso/my-sites/email/add-mailboxes/get-tracks-event-name';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import { NewMailBoxList } from 'calypso/my-sites/email/form/mailboxes/components/new-mailbox-list';
 import getMailProductForProvider from 'calypso/my-sites/email/form/mailboxes/components/selectors/get-mail-product-for-provider';
@@ -130,7 +130,7 @@ const WithVerificationGate = ( {
 	productFamily,
 	provider,
 }: PropsWithChildren< {
-	productFamily: string;
+	productFamily: TranslateResult | string;
 	provider: EmailProvider;
 } > ) => {
 	const translate = useTranslate();
@@ -227,7 +227,7 @@ const MailboxesForm = ( {
 
 	const onCancel = () => {
 		recordClickEvent( {
-			eventName: getEventName( provider, EVENT_CANCEL_BUTTON_CLICK ),
+			eventName: getTracksEventName( provider, EVENT_CANCEL_BUTTON_CLICK ),
 			provider,
 			selectedDomainName,
 			source,
@@ -245,7 +245,7 @@ const MailboxesForm = ( {
 
 		const recordContinueEvent = ( { canContinue }: { canContinue: boolean } ) => {
 			recordClickEvent( {
-				eventName: getEventName( provider, EVENT_CONTINUE_BUTTON_CLICK ),
+				eventName: getTracksEventName( provider, EVENT_CONTINUE_BUTTON_CLICK ),
 				eventProps: {
 					can_continue: canContinue,
 					mailbox_count: mailboxOperations.mailboxes.length,
@@ -349,7 +349,7 @@ const AddMailboxes = ( props: AddMailboxesProps ): JSX.Element | null => {
 
 				<HeaderCake onClick={ goToEmail }>{ productName + ': ' + selectedDomainName }</HeaderCake>
 
-				<WithVerificationGate productFamily={ `${ productName }` } provider={ provider }>
+				<WithVerificationGate productFamily={ productName } provider={ provider }>
 					<MailboxNotices { ...additionalProps } emailProduct={ emailProduct } />
 					<MailboxesForm
 						{ ...additionalProps }

--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -257,7 +257,9 @@ const MailboxesForm = ( {
 		};
 
 		setState( { ...state, isValidating: true } );
-		if ( ! ( await mailboxOperations.validateAndCheck( mailProperties.isExtraItemPurchase ) ) ) {
+		if (
+			! ( await mailboxOperations.validateAndCheck( mailProperties.isAdditionalMailboxesPurchase ) )
+		) {
 			recordContinueEvent( { canContinue: false } );
 			setState( { ...state, isValidating: false } );
 			return;

--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -2,7 +2,7 @@ import { Card } from '@automattic/components';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useState } from 'react';
+import { PropsWithChildren, useState } from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -129,11 +129,10 @@ const WithVerificationGate = ( {
 	children,
 	productFamily,
 	provider,
-}: {
-	children: JSX.Element;
+}: PropsWithChildren< {
 	productFamily: string;
 	provider: EmailProvider;
-} ): JSX.Element => {
+} > ) => {
 	const translate = useTranslate();
 
 	if ( isTitan( provider ) ) {
@@ -349,14 +348,12 @@ const AddMailboxes = ( props: AddMailboxesProps ): JSX.Element | null => {
 				<HeaderCake onClick={ goToEmail }>{ productName + ': ' + selectedDomainName }</HeaderCake>
 
 				<WithVerificationGate productFamily={ `${ productName }` } provider={ provider }>
-					<>
-						<MailboxNotices { ...additionalProps } mailProduct={ mailProduct } />
-						<MailboxesForm
-							{ ...additionalProps }
-							goToEmail={ goToEmail }
-							mailProduct={ mailProduct }
-						/>
-					</>
+					<MailboxNotices { ...additionalProps } mailProduct={ mailProduct } />
+					<MailboxesForm
+						{ ...additionalProps }
+						goToEmail={ goToEmail }
+						mailProduct={ mailProduct }
+					/>
 				</WithVerificationGate>
 			</Main>
 		</>

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -11,6 +11,7 @@ import TitanManagementIframe from 'calypso/my-sites/email/email-management/titan
 import EmailProvidersInDepthComparison from 'calypso/my-sites/email/email-providers-comparison/in-depth';
 import { castIntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import EmailProvidersStackedComparison from 'calypso/my-sites/email/email-providers-stacked-comparison';
+import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import GSuiteAddUsers from 'calypso/my-sites/email/gsuite-add-users';
 import InboxManagement from 'calypso/my-sites/email/inbox';
 import * as paths from 'calypso/my-sites/email/paths';
@@ -38,6 +39,9 @@ export default {
 	},
 
 	emailManagementAddGSuiteUsers( pageContext, next ) {
+		const GSuiteAddMailboxesComponent = isEnabled( 'unify-mailbox-forms' )
+			? AddMailboxes
+			: GSuiteAddUsers;
 		pageContext.primary = (
 			<CalypsoShoppingCartProvider>
 				<PageViewTracker
@@ -45,7 +49,8 @@ export default {
 					title="Email Management > Add Google Users"
 				/>
 
-				<GSuiteAddUsers
+				<GSuiteAddMailboxesComponent
+					provider={ EmailProvider.Google }
 					source={ pageContext.query.source }
 					selectedDomainName={ pageContext.params.domain }
 				/>

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -39,9 +39,10 @@ export default {
 	},
 
 	emailManagementAddGSuiteUsers( pageContext, next ) {
-		const GSuiteAddMailboxesComponent = isEnabled( 'unify-mailbox-forms' )
-			? AddMailboxes
-			: GSuiteAddUsers;
+		const unifyMailboxForms = isEnabled( 'unify-mailbox-forms' );
+		const AddMailboxesComponent = unifyMailboxForms ? AddMailboxes : GSuiteAddUsers;
+		const extraProps = unifyMailboxForms ? { provider: EmailProvider.Google } : {};
+
 		pageContext.primary = (
 			<CalypsoShoppingCartProvider>
 				<PageViewTracker
@@ -49,10 +50,10 @@ export default {
 					title="Email Management > Add Google Users"
 				/>
 
-				<GSuiteAddMailboxesComponent
-					provider={ EmailProvider.Google }
+				<AddMailboxesComponent
 					source={ pageContext.query.source }
 					selectedDomainName={ pageContext.params.domain }
+					{ ...extraProps }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/my-sites/email/form/mailboxes/components/utilities/get-cart-items.ts
+++ b/client/my-sites/email/form/mailboxes/components/utilities/get-cart-items.ts
@@ -40,7 +40,7 @@ const getGSuiteCartItems = (
 	mailboxes: MailboxForm< EmailProvider >[],
 	mailProperties: MailProperties
 ) => {
-	const { isExtraItemPurchase, emailProduct, newQuantity, quantity } = mailProperties;
+	const { isAdditionalMailboxesPurchase, emailProduct, newQuantity, quantity } = mailProperties;
 
 	const users = mailboxes.map( ( mailbox ) =>
 		mailbox.getAsCartItem()
@@ -57,13 +57,13 @@ const getGSuiteCartItems = (
 
 	const productSlug = emailProduct.product_slug;
 
-	if ( isGSuiteProductSlug( productSlug ) && isExtraItemPurchase ) {
+	if ( isGSuiteProductSlug( productSlug ) && isAdditionalMailboxesPurchase ) {
 		return googleAppsExtraLicenses( properties );
 	}
 
 	properties = { ...properties, quantity };
 
-	if ( isExtraItemPurchase ) {
+	if ( isAdditionalMailboxesPurchase ) {
 		properties = { ...properties, new_quantity: newQuantity };
 	}
 

--- a/client/my-sites/email/form/mailboxes/components/utilities/get-cart-items.ts
+++ b/client/my-sites/email/form/mailboxes/components/utilities/get-cart-items.ts
@@ -16,13 +16,13 @@ const getTitanCartItems = (
 	mailboxes: MailboxForm< EmailProvider >[],
 	mailProperties: MailProperties
 ) => {
-	const { mailProduct, newQuantity, quantity } = mailProperties;
+	const { emailProduct, newQuantity, quantity } = mailProperties;
 
 	const email_users = mailboxes.map( ( mailbox ) =>
 		mailbox.getAsCartItem()
 	) as unknown as TitanProductUser[];
 
-	const cartItemFunction = isTitanMonthlyProduct( mailProduct )
+	const cartItemFunction = isTitanMonthlyProduct( emailProduct )
 		? titanMailMonthly
 		: titanMailYearly;
 
@@ -40,7 +40,7 @@ const getGSuiteCartItems = (
 	mailboxes: MailboxForm< EmailProvider >[],
 	mailProperties: MailProperties
 ) => {
-	const { isExtraItemPurchase, mailProduct, newQuantity, quantity } = mailProperties;
+	const { isExtraItemPurchase, emailProduct, newQuantity, quantity } = mailProperties;
 
 	const users = mailboxes.map( ( mailbox ) =>
 		mailbox.getAsCartItem()
@@ -55,7 +55,7 @@ const getGSuiteCartItems = (
 		users: GSuiteProductUser[];
 	} = { domain, users };
 
-	const productSlug = mailProduct.product_slug;
+	const productSlug = emailProduct.product_slug;
 
 	if ( isGSuiteProductSlug( productSlug ) && isExtraItemPurchase ) {
 		return googleAppsExtraLicenses( properties );

--- a/client/my-sites/email/form/mailboxes/components/utilities/get-mail-product-properties.ts
+++ b/client/my-sites/email/form/mailboxes/components/utilities/get-mail-product-properties.ts
@@ -7,7 +7,7 @@ import { ProductListItem } from 'calypso/state/products-list/selectors/get-produ
 type MailProperties = {
 	existingItemsCount: number;
 	isExtraItemPurchase: boolean;
-	mailProduct: ProductListItem;
+	emailProduct: ProductListItem;
 	newQuantity: number | undefined;
 	quantity: number;
 };
@@ -15,7 +15,7 @@ type MailProperties = {
 const getMailProductProperties = (
 	provider: EmailProvider,
 	domain: ResponseDomain,
-	mailProduct: ProductListItem,
+	emailProduct: ProductListItem,
 	newItemsCount = 1
 ): MailProperties => {
 	const isTitanProvider = provider === EmailProvider.Titan;
@@ -33,7 +33,7 @@ const getMailProductProperties = (
 	return {
 		existingItemsCount,
 		isExtraItemPurchase,
-		mailProduct,
+		emailProduct,
 		newQuantity,
 		quantity,
 	};

--- a/client/my-sites/email/form/mailboxes/components/utilities/get-mail-product-properties.ts
+++ b/client/my-sites/email/form/mailboxes/components/utilities/get-mail-product-properties.ts
@@ -6,7 +6,7 @@ import { ProductListItem } from 'calypso/state/products-list/selectors/get-produ
 
 type MailProperties = {
 	existingItemsCount: number;
-	isExtraItemPurchase: boolean;
+	isAdditionalMailboxesPurchase: boolean;
 	emailProduct: ProductListItem;
 	newQuantity: number | undefined;
 	quantity: number;
@@ -19,7 +19,7 @@ const getMailProductProperties = (
 	newItemsCount = 1
 ): MailProperties => {
 	const isTitanProvider = provider === EmailProvider.Titan;
-	const isExtraItemPurchase = isTitanProvider
+	const isAdditionalMailboxesPurchase = isTitanProvider
 		? hasTitanMailWithUs( domain )
 		: hasGSuiteWithUs( domain );
 
@@ -27,12 +27,14 @@ const getMailProductProperties = (
 		? getMaxTitanMailboxCount( domain )
 		: getGSuiteMailboxCount( domain );
 
-	const quantity = isExtraItemPurchase ? existingItemsCount + newItemsCount : newItemsCount;
-	const newQuantity = isExtraItemPurchase ? newItemsCount : undefined;
+	const quantity = isAdditionalMailboxesPurchase
+		? existingItemsCount + newItemsCount
+		: newItemsCount;
+	const newQuantity = isAdditionalMailboxesPurchase ? newItemsCount : undefined;
 
 	return {
 		existingItemsCount,
-		isExtraItemPurchase,
+		isAdditionalMailboxesPurchase,
 		emailProduct,
 		newQuantity,
 		quantity,


### PR DESCRIPTION
#### Proposed Changes

* Add support for Google Workspace to the `<AddMailboxes/>` component
* Send unique events per provider without breaking conformity. The events are backward compatible.

We are now able to collect data for both providers with unified validation using the `<AddMailboxes/>` component

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have/provision a Google Workspace subscription, and Professional Email subscription
* Visit the Email plan page for each of these subscriptions
* Click on [ **Add new mailboxes** ] for each subscription
* Activate the feature flag, by adding `?flags=unify-mailbox-forms` to each URL
* Ensure that the validation works for submission variants
* Ensure that the valuable events are sent for specific actions
* Upon checkout ensure that the mailboxes are provisioned properly

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64424
