### PR TITLE
Fix: Upgrade now (to plans page) sometimes takes the user back to my-plan

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -1,11 +1,8 @@
-import { isPro } from '@automattic/calypso-products';
 import page from 'page';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
-import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { productSelect } from 'calypso/my-sites/plans/jetpack-plans/controller';
 import setJetpackPlansHeader from 'calypso/my-sites/plans/jetpack-plans/plans-header';
 import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
-import { getSite } from 'calypso/state/sites/selectors';
 import { default as getIsJetpackProductSite } from 'calypso/state/sites/selectors/is-jetpack-product-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Plans from './plans';
@@ -25,17 +22,6 @@ export function plans( context, next ) {
 		}
 		setJetpackPlansHeader( context );
 		return productSelect( '/plans' )( context, next );
-	}
-
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-	const selectedSite = getSite( state, siteId );
-	const eligibleForProPlan = isEligibleForProPlan( state, siteId );
-
-	if ( eligibleForProPlan && isPro( selectedSite.plan ) ) {
-		page.redirect( `/plans/my-plan/${ selectedSite.slug }` );
-
-		return null;
 	}
 
 	context.primary = (

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -1,12 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import {
-	getPlan,
-	getIntervalTypeForTerm,
-	PLAN_FREE,
-	PLAN_WPCOM_PRO,
-	PLAN_WPCOM_FLEXIBLE,
-	PLAN_WPCOM_STARTER,
-} from '@automattic/calypso-products';
+import { getPlan, getIntervalTypeForTerm, PLAN_FREE } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
@@ -26,7 +19,7 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import { useExperiment } from 'calypso/lib/explat';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
-import PlansComparison, { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import legacyPlanNotice from 'calypso/my-sites/plans/legacy-plan-notice';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
@@ -150,7 +143,7 @@ class Plans extends Component {
 	};
 
 	renderPlansMain() {
-		const { currentPlan, selectedSite, isWPForTeamsSite, eligibleForProPlan } = this.props;
+		const { currentPlan, selectedSite, isWPForTeamsSite } = this.props;
 
 		if ( ! this.props.plansLoaded || ! currentPlan ) {
 			// Maybe we should show a loading indicator here?
@@ -165,23 +158,6 @@ class Plans extends Component {
 					site={ selectedSite }
 					withDiscount={ this.props.withDiscount }
 					discountEndDate={ this.props.discountEndDate }
-				/>
-			);
-		}
-
-		if (
-			eligibleForProPlan &&
-			[ PLAN_FREE, PLAN_WPCOM_FLEXIBLE, PLAN_WPCOM_STARTER, PLAN_WPCOM_PRO ].includes(
-				currentPlan?.productSlug
-			)
-		) {
-			return (
-				<PlansComparison
-					purchaseId={ this.props.purchase?.id }
-					isInSignup={ false }
-					onSelectPlan={ this.onSelectPlan }
-					selectedSiteId={ selectedSite?.ID }
-					selectedSiteSlug={ selectedSite?.slug }
 				/>
 			);
 		}
@@ -233,8 +209,7 @@ class Plans extends Component {
 							<FormattedHeader
 								brandFont
 								headerText={ translate( 'Plans' ) }
-								subHeaderText={ ! eligibleForProPlan && description }
-								tooltipText={ eligibleForProPlan && description }
+								subHeaderText={ description }
 								align="left"
 							/>
 							<div id="plans" className="plans plans__has-sidebar">

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -1,4 +1,3 @@
-import { isFreePlanProduct, isFlexiblePlanProduct, isPro } from '@automattic/calypso-products';
 import { isMobile } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -8,10 +7,8 @@ import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { sectionify } from 'calypso/lib/route';
-import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import isSiteOnFreePlan from 'calypso/state/selectors/is-site-on-free-plan';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -39,7 +36,7 @@ class PlansNavigation extends Component {
 	}
 
 	render() {
-		const { site, shouldShowMyPlan, shouldShowPlans, translate } = this.props;
+		const { site, shouldShowMyPlan, translate } = this.props;
 		const path = sectionify( this.props.path );
 		const sectionTitle = this.getSectionTitle( path );
 		const hasPinnedItems = Boolean( site ) && isMobile();
@@ -56,16 +53,14 @@ class PlansNavigation extends Component {
 								{ translate( 'My Plan' ) }
 							</NavItem>
 						) }
-						{ shouldShowPlans && (
-							<NavItem
-								path={ `/plans/${ site.slug }` }
-								selected={
-									path === '/plans' || path === '/plans/monthly' || path === '/plans/yearly'
-								}
-							>
-								{ translate( 'Plans' ) }
-							</NavItem>
-						) }
+						<NavItem
+							path={ `/plans/${ site.slug }` }
+							selected={
+								path === '/plans' || path === '/plans/monthly' || path === '/plans/yearly'
+							}
+						>
+							{ translate( 'Plans' ) }
+						</NavItem>
 					</NavTabs>
 				</SectionNav>
 			)
@@ -79,24 +74,10 @@ export default connect( ( state ) => {
 	const isJetpack = isJetpackSite( state, siteId );
 	const isOnFreePlan = isSiteOnFreePlan( state, siteId );
 	const isAtomic = isAtomicSite( state, siteId );
-	const eligibleForProPlan = isEligibleForProPlan( state, siteId );
-	const currentPlan = getCurrentPlan( state, siteId );
-	let shouldShowMyPlan = ! isOnFreePlan || ( isJetpack && ! isAtomic );
-	let shouldShowPlans = true;
-	let isFreeOrFlexible = false;
 
-	// do not show the Plans tab if user is on a Pro plan
-	if ( eligibleForProPlan && currentPlan ) {
-		isFreeOrFlexible = isFreePlanProduct( currentPlan ) || isFlexiblePlanProduct( currentPlan );
-		shouldShowMyPlan = isFreeOrFlexible ? false : true;
-		shouldShowPlans = isFreeOrFlexible || ! isPro( currentPlan ) ? true : false;
-	}
 	return {
 		isJetpack,
-		shouldShowMyPlan,
-		shouldShowPlans,
+		shouldShowMyPlan: ! isOnFreePlan || ( isJetpack && ! isAtomic ),
 		site,
-		eligibleForProPlan,
-		isFreeOrFlexible,
 	};
 } )( localize( PlansNavigation ) );


### PR DESCRIPTION
#### Proposed Changes

This addresses an issue where canceling a Pro plan and clicking the `Upgrade now` button would redirect to the My Plan page (Free), instead of the Plans pages.
The fix is addressed by:
* removing obsolete Plan redirects, added in #61656
* preventing the overhauled plans grid from being rendered on the Plans page

Addresses 816-gh-Automattic/martech

#### Testing Instructions
* Cancel the Pro plan subscription for a site
* On the Purchases/Active Upgrades page click the `Upgrade now` button
<img width="420" alt="Screenshot on 2022-06-14 at 13-42-41" src="https://user-images.githubusercontent.com/2749938/173559484-c96b151d-9193-4d2b-9207-0477d1406256.png">

* You should be redirected to the Plans page
<img width="420" alt="Screenshot on 2022-06-14 at 13-43-00" src="https://user-images.githubusercontent.com/2749938/173559505-3eb356cf-56d3-4b6c-a708-658fc49ecd17.png">

* Try something similar with another type of plan (ex. Starter, or Business)
* Behaviour should be the same 
