### PR TITLE
build-languages: Include decimal point and thousands separator

### DIFF
--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -17,8 +17,10 @@ const OUTPUT_PATH = './public/languages';
 const langSlugs = languages.default.map( ( { langSlug } ) => langSlug );
 
 const CONFIG_BLOCK_KEY = '';
-const DECIMAL_POINT_KEY = 'number_format_decimal_point';
+const DECIMAL_POINT_KEY = 'number_format_decimals';
+const DECIMAL_POINT_TRANSLATION = 'number_format_decimal_point';
 const THOUSANDS_SEPARATOR_KEY = 'number_format_thousands_sep';
+const THOUSANDS_SEPARATOR_TRANSLATION = 'number_format_thousands_sep';
 
 // Create languages directory
 function createLanguagesDir() {
@@ -170,13 +172,13 @@ function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 				( chunk ) => path.parse( chunk ).name
 			);
 			const manifestJsonDataRaw = {
-				locale: _.pick( languageTranslations, [
-					CONFIG_BLOCK_KEY,
-					DECIMAL_POINT_KEY,
-					THOUSANDS_SEPARATOR_KEY,
-				] ),
+				locale: _.pick( languageTranslations, [ CONFIG_BLOCK_KEY ] ),
 				translatedChunks: translatedChunksKeys,
 			};
+			manifestJsonDataRaw.locale[ DECIMAL_POINT_KEY ] =
+				languageTranslations[ DECIMAL_POINT_TRANSLATION ];
+			manifestJsonDataRaw.locale[ THOUSANDS_SEPARATOR_KEY ] =
+				languageTranslations[ THOUSANDS_SEPARATOR_TRANSLATION ];
 			const manifestJsonDataFingerprint = JSON.stringify( manifestJsonDataRaw );
 
 			manifestJsonDataRaw.hash = crypto

--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -16,6 +16,10 @@ const LANGUAGE_MANIFEST_FILENAME = 'language-manifest.json';
 const OUTPUT_PATH = './public/languages';
 const langSlugs = languages.default.map( ( { langSlug } ) => langSlug );
 
+const CONFIG_BLOCK_KEY = '';
+const DECIMAL_POINT_KEY = 'number_format_decimal_point';
+const THOUSANDS_SEPARATOR_KEY = 'number_format_thousands_sep';
+
 // Create languages directory
 function createLanguagesDir() {
 	return mkdirp.sync( OUTPUT_PATH );
@@ -166,7 +170,11 @@ function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 				( chunk ) => path.parse( chunk ).name
 			);
 			const manifestJsonDataRaw = {
-				locale: _.pick( languageTranslations, [ '' ] ),
+				locale: _.pick( languageTranslations, [
+					CONFIG_BLOCK_KEY,
+					DECIMAL_POINT_KEY,
+					THOUSANDS_SEPARATOR_KEY,
+				] ),
 				translatedChunks: translatedChunksKeys,
 			};
 			const manifestJsonDataFingerprint = JSON.stringify( manifestJsonDataRaw );


### PR DESCRIPTION
#### Proposed Changes

* Include `number_format_decimal_point` and `number_format_thousands_sep` translation entries in the language manifest, as the following are being used by i18n-calypso's `numberFormat` method and therefore should be available in the translation data as soon as the language is loaded.

#### Testing Instructions

* Build locally, or use calypso.live image
* Confirm `/calypso/languages/{localeSlug}-language-manifest.json` file includes the `number_format_decimal_point` and `number_format_thousands_sep` entries.
* Change UI to a Mag-16 language with decimal point and thousands separator that are different than English (e.g. French)
* Confirm numbers are being rendered with the expected number formatting (e.g. `/stats/day/{site}`, `/stats/day/annualstats/{site}`, etc.)

Related to 448-gh-Automattic/i18n-issues
