### PR TITLE
Fix bad padding on thank you page after setting up a Titan mailbox

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -202,6 +202,7 @@ export default {
 				/>
 
 				<TitanSetUpThankYou
+					containerClassName="titan-set-up-thank-you__container_wrapped"
 					domainName={ pageContext.params.domain }
 					emailAddress={ pageContext.query.email }
 				/>

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -14,7 +14,6 @@ import {
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { Argument } from 'classnames';
 
 /**
  * Import styles
@@ -22,7 +21,7 @@ import type { Argument } from 'classnames';
 import './style.scss';
 
 type TitanSetUpThankYouProps = {
-	containerClassName?: Argument;
+	containerClassName?: string;
 	domainName: string;
 	emailAddress?: string;
 	title?: string;

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import thankYouEmail from 'calypso/assets/images/illustrations/thank-you-email.svg';
@@ -13,6 +14,7 @@ import {
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { Argument } from 'classnames';
 
 /**
  * Import styles
@@ -20,6 +22,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 type TitanSetUpThankYouProps = {
+	containerClassName?: Argument;
 	domainName: string;
 	emailAddress?: string;
 	title?: string;
@@ -27,6 +30,7 @@ type TitanSetUpThankYouProps = {
 };
 
 const TitanSetUpThankYou = ( {
+	containerClassName,
 	domainName,
 	emailAddress,
 	subtitle,
@@ -118,7 +122,7 @@ const TitanSetUpThankYou = ( {
 
 	return (
 		<ThankYou
-			containerClassName="titan-set-up-thank-you__container"
+			containerClassName={ classNames( 'titan-set-up-thank-you__container', containerClassName ) }
 			headerClassName={ 'titan-set-up-thank-you__header' }
 			sections={ [ titanThankYouSection ] }
 			showSupportSection={ true }

--- a/client/my-sites/email/titan-set-up-thank-you/style.scss
+++ b/client/my-sites/email/titan-set-up-thank-you/style.scss
@@ -1,6 +1,17 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+.titan-set-up-thank-you__container_wrapped {
+	@include break-small {
+		margin-left: -24px;
+		margin-right: -24px;
+	}
+	@include break-large {
+		margin-left: -32px;
+		margin-right: -32px;
+	}
+}
+
 .titan-set-up-thank-you__icon-external {
 	margin-left: 4px;
 }


### PR DESCRIPTION
#### Proposed Changes

When users have paid for a Titan mailbox and then remove it, they are entitled to set up a new mailbox that consumes the subscription they've paid for. That "setup process" ends on a screen where we display the same "thank you" component as we do after checkout (when users have purchased a Titan mailbox).

In the context of the "setup process" however, it looks like I introduced a styling regression in #64327. There is now some bad padding on the left/right sides of the "thank you" component.

With this PR, I've fixed that.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/1101677/173593184-e1ed96be-5952-4da2-942c-b5b0c2dc771c.png) | ![after](https://user-images.githubusercontent.com/1101677/173593208-fbeb9761-c587-4191-a343-a0217c04b0b9.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/email/:domain/titan/set-up-mailbox/thank-you/:site_slug`
2. Ensure that the page looks as the screenshot above (on a desktop sized monitor)
3. Shrink the browser viewport to ensure that the view also looks good on smaller screens, all the way down to mobile

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64327
