### PR TITLE
Stepper: Update stepper redirects to use navigate package.

### DIFF
--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -4,12 +4,9 @@ import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { redirect } from './internals/steps-repository/import/util';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
-
-function redirect( to: string ) {
-	window.location.href = to;
-}
 
 export const anchorFmFlow: Flow = {
 	name: 'anchor-fm',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-verify-email/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-verify-email/index.tsx
@@ -12,12 +12,9 @@ import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { UserData } from 'calypso/lib/user/user';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { redirect } from '../import/util';
 import type { Step } from '../../types';
 import './style.scss';
-
-function redirect( to: string ) {
-	window.location.href = to;
-}
 
 const WooVerifyEmail: Step = function WooVerifyEmail( { navigation } ) {
 	const { goBack, submit } = navigation;

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -11,6 +11,7 @@ import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { redirect } from './internals/steps-repository/import/util';
 import { ProcessingResult } from './internals/steps-repository/processing-step';
 import {
 	AssertConditionResult,
@@ -19,10 +20,6 @@ import {
 	ProvidedDependencies,
 } from './internals/types';
 import type { StepPath } from './internals/steps-repository';
-
-function redirect( to: string ) {
-	window.location.href = to;
-}
 
 export const siteSetupFlow: Flow = {
 	name: 'site-setup',


### PR DESCRIPTION
#### Proposed Changes

Switch from having multiple `redirect` functions in different places in the stepper to using the existing `steps-repository/import/util` `redirect` function.

#### Testing Instructions

1. Apply this branch.
2. Run through the stepper for either a seller or basic blog site (or an anchor site).
3. You should be directed to the site editor or dashboard at the end of the process.

Fixes #64459
