### PR TITLE
Change Pro plan mention on domain search

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -1,127 +1,67 @@
-import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { isStarterPlanEnabled } from 'calypso/my-sites/plans-comparison';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
 class ReskinSideExplainer extends Component {
-	getStarterPlanOverrides( isEnLocale ) {
-		const { translate } = this.props;
-
-		const fallbackTitle = translate(
-			'Get a free one-year domain registration with any paid plan.'
-		);
-
-		const isPaidPlan = [ 'starter', 'pro' ].includes( this.props.flowName );
-		const hasFreeTitle =
-			i18n.hasTranslation(
-				'Get a {{b}}free{{/b}} one-year domain registration with any paid plan.'
-			) || isEnLocale;
-
-		const freeTitle = hasFreeTitle
-			? translate( 'Get a {{b}}free{{/b}} one-year domain registration with any paid plan.', {
-					components: { b: <strong /> },
-			  } )
-			: fallbackTitle;
-
-		const hasPaidTitle =
-			i18n.hasTranslation( 'Get a {{b}}free{{/b}} one-year domain registration with your plan.' ) ||
-			isEnLocale;
-
-		const paidTitle = hasPaidTitle
-			? translate( 'Get a {{b}}free{{/b}} one-year domain registration with your plan.', {
-					components: { b: <strong /> },
-			  } )
-			: fallbackTitle;
-
-		const title = isPaidPlan ? paidTitle : freeTitle;
-
-		const hasFreeSubtitle =
-			i18n.hasTranslation(
-				'Use the search tool on this page to find a domain you love, then select a paid plan.'
-			) || isEnLocale;
-
-		const freeSubtitle =
-			hasFreeSubtitle &&
-			translate(
-				'Use the search tool on this page to find a domain you love, then select a paid plan.'
-			);
-
-		const paidSubtitle = translate( 'Use the search tool on this page to find a domain you love.' );
-
-		let subtitle = isPaidPlan ? paidSubtitle : freeSubtitle;
-
-		let subtitle2 = translate(
-			'We’ll pay the first year’s domain registration fees for you, simple as that!'
-		);
-
-		if ( ! subtitle ) {
-			subtitle = subtitle2;
-			subtitle2 = null;
-		}
-		return { title, subtitle, subtitle2, ctaText: false };
-	}
 	getStrings() {
 		const { type, translate } = this.props;
 
 		let title;
+		let freeTitle;
+		let paidTitle;
 		let subtitle;
+		let freeSubtitle;
+		let paidSubtitle;
 		let subtitle2;
 		let ctaText;
 
-		const isEnLocale = [ 'en', 'en-gb' ].includes( getLocaleSlug() );
-		const showNewTitle =
-			i18n.hasTranslation( 'Get your domain {{b}}free{{/b}} with WordPress Pro' ) || isEnLocale;
-
-		const showNewSubtitle =
-			i18n.hasTranslation(
-				'Use the search tool on this page to find a domain you love, then select the {{b}}WordPress Pro{{/b}} plan.'
-			) || isEnLocale;
-
-		const newSubtitleCopy =
-			'pro' === this.props.flowName
-				? translate( 'Use the search tool on this page to find a domain you love.' )
-				: translate(
-						'Use the search tool on this page to find a domain you love, then select the {{b}}WordPress Pro{{/b}} plan.',
-						{
-							components: { b: <strong /> },
-						}
-				  );
+		const isPaidPlan = [
+			'starter',
+			'pro',
+			'personal',
+			'personal-monthly',
+			'premium',
+			'premium-monthly',
+			'business',
+			'business-monthly',
+			'ecommerce',
+			'ecommerce-monthly',
+			'domain',
+		].includes( this.props.flowName );
 
 		switch ( type ) {
 			case 'free-domain-explainer':
-				title = showNewTitle
-					? translate( 'Get your domain {{b}}free{{/b}} with WordPress Pro', {
-							components: { b: <strong /> },
-					  } )
-					: translate(
-							'Get a {{b}}free{{/b}} one-year domain registration with your WordPress Pro annual plan.',
-							{
-								components: { b: <strong /> },
-							}
-					  );
+				freeTitle = translate(
+					'Get a {{b}}free{{/b}} one-year domain registration with any paid plan.',
+					{
+						components: { b: <strong /> },
+					}
+				);
 
-				subtitle = showNewSubtitle
-					? newSubtitleCopy
-					: translate( "You can claim your free custom domain later if you aren't ready yet." );
+				paidTitle = translate(
+					'Get a {{b}}free{{/b}} one-year domain registration with your plan.',
+					{
+						components: { b: <strong /> },
+					}
+				);
 
-				subtitle2 =
-					showNewSubtitle &&
-					translate(
-						'We’ll pay the first year’s domain registration fees for you, simple as that!'
-					);
-				ctaText = ! showNewSubtitle && translate( 'Choose my domain later' );
+				title = isPaidPlan ? paidTitle : freeTitle;
 
-				//todo: use only getStarterPlanOverrides() after Starter plan deploy
-				if ( isStarterPlanEnabled() ) {
-					const overrides = this.getStarterPlanOverrides( isEnLocale );
-					title = overrides.title;
-					subtitle = overrides.subtitle;
-					subtitle2 = overrides.subtitle2;
-					ctaText = overrides.ctaText;
-				}
+				freeSubtitle = translate(
+					'Use the search tool on this page to find a domain you love, then select a paid plan.'
+				);
+
+				paidSubtitle = translate( 'Use the search tool on this page to find a domain you love.' );
+
+				subtitle = isPaidPlan ? paidSubtitle : freeSubtitle;
+
+				subtitle2 = translate(
+					'We’ll pay the first year’s domain registration fees for you, simple as that!'
+				);
+				ctaText = false;
 
 				break;
 

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -1,4 +1,4 @@
-import { localize } from 'i18n-calypso';
+import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -14,6 +14,7 @@ class ReskinSideExplainer extends Component {
 		let paidTitle;
 		let subtitle;
 		let freeSubtitle;
+		let hasFreeSubtitle;
 		let paidSubtitle;
 		let subtitle2;
 		let ctaText;
@@ -22,20 +23,18 @@ class ReskinSideExplainer extends Component {
 			'starter',
 			'pro',
 			'personal',
-			'personal-monthly',
 			'premium',
-			'premium-monthly',
 			'business',
-			'business-monthly',
 			'ecommerce',
-			'ecommerce-monthly',
 			'domain',
 		].includes( this.props.flowName );
+
+		const isEnLocale = [ 'en', 'en-gb' ].includes( getLocaleSlug() );
 
 		switch ( type ) {
 			case 'free-domain-explainer':
 				freeTitle = translate(
-					'Get a {{b}}free{{/b}} one-year domain registration with any paid plan.',
+					'Get a {{b}}free{{/b}} one-year domain registration with any paid annual plan.',
 					{
 						components: { b: <strong /> },
 					}
@@ -50,9 +49,16 @@ class ReskinSideExplainer extends Component {
 
 				title = isPaidPlan ? paidTitle : freeTitle;
 
-				freeSubtitle = translate(
-					'Use the search tool on this page to find a domain you love, then select a paid plan.'
-				);
+				hasFreeSubtitle =
+					i18n.hasTranslation(
+						'Use the search tool on this page to find a domain you love, then select any paid annual plan.'
+					) || isEnLocale;
+
+				freeSubtitle = hasFreeSubtitle
+					? translate(
+							'Use the search tool on this page to find a domain you love, then select any paid annual plan.'
+					  )
+					: null;
 
 				paidSubtitle = translate( 'Use the search tool on this page to find a domain you love.' );
 
@@ -61,6 +67,12 @@ class ReskinSideExplainer extends Component {
 				subtitle2 = translate(
 					'We’ll pay the first year’s domain registration fees for you, simple as that!'
 				);
+
+				if ( ! subtitle ) {
+					subtitle = subtitle2;
+					subtitle2 = null;
+				}
+
 				ctaText = false;
 
 				break;


### PR DESCRIPTION
#### Proposed Changes

This replaces `Pro plan` mentions with `Paid annual plans` by enforcing the Starter plan specific copy (added in #63772).

<img width="480" alt="173605442-41fd9028-a96a-4e44-b84d-09c962ff7870 (1)" src="https://user-images.githubusercontent.com/2749938/173617511-4e36252b-c556-4cc2-b732-c30fda56add8.png">

Addresses 817-gh-Automattic/martech


#### Testing Instructions
* Go `/start/domains`
* The right-hand copy shouldn't mention the WordPress Pro plan
* 
<img width="240" alt="Screenshot on 2022-06-14 at 18-55-42 (1)" src="https://user-images.githubusercontent.com/2749938/173622460-3ff9a0c8-124f-43f5-a549-724693f32135.png">


* Go `/start/pro`
* The right-hand copy should mention that current plan contains the free domain
<img width="240" alt="Screenshot on 2022-06-14 at 18-31-13" src="https://user-images.githubusercontent.com/2749938/173617284-21ef55f1-53b8-45ba-838b-19ded0e6fa7a.png">

* Double-check there's no untranslated strings on non-English locales( ie. the first subtitle for `/start/domains` will be missing since there's no translation ATM)

<img width="240" alt="Screenshot on 2022-06-14 at 18-55-51" src="https://user-images.githubusercontent.com/2749938/173622551-913713d4-867a-4cd5-bb01-2e6f2e4aa941.png">

<img width="240" alt="Screenshot on 2022-06-14 at 18-36-30" src="https://user-images.githubusercontent.com/2749938/173618436-506111db-570e-4e8a-a808-e2a801cc5939.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


