### PR TITLE
Design Selection: Add preview exception for Anchor

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -115,7 +115,8 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		[ selectedDesign, generatedDesigns, isMobile ]
 	);
 
-	const isPreviewingGeneratedDesign = isMobile && showGeneratedDesigns && !! selectedDesign;
+	const isPreviewingGeneratedDesign =
+		isMobile && showGeneratedDesigns && !! selectedDesign && ! isAnchorSite;
 
 	const visibility = useNewSiteVisibility();
 


### PR DESCRIPTION
#### Proposed Changes

* Fixes Anchor flow design selection step by adding an exception to Anchor for the preview logic.

#### Testing Instructions

* Switch to this PR, navigate to `/setup/?anchor_podcast=9370e048`
* Make sure you can complete the signup flow
* Make sure the flow at `/setup/?siteSlug=[your site]` still works as expected
