### PR TITLE
Roll back domain search copy before Pro plan overhaul

### DIFF
--- a/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-mapping-free-text.js
@@ -4,7 +4,6 @@ import {
 	isDomainMappingFree,
 	isNextDomainFree,
 } from 'calypso/lib/cart-values/cart-items';
-import { isStarterPlanEnabled } from 'calypso/my-sites/plans-comparison';
 
 export function getMappingFreeText( {
 	cart,
@@ -22,9 +21,7 @@ export function getMappingFreeText( {
 	) {
 		mappingFreeText = __( 'No additional charge with your plan' );
 	} else if ( primaryWithPlansOnly || isSignupStep ) {
-		mappingFreeText = isStarterPlanEnabled()
-			? __( 'Included in paid plans' )
-			: __( 'Included in Pro plan' );
+		mappingFreeText = __( 'Included in annual plans' );
 	}
 
 	return mappingFreeText;

--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -6,7 +6,6 @@ import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availabi
 import {
 	getMappingFreeText,
 	getTransferFreeText,
-	getTransferPriceText,
 	getTransferRestrictionMessage,
 	getTransferSalePriceText,
 	isFreeTransfer,
@@ -78,15 +77,7 @@ export function getOptionInfo( {
 		productsList,
 	} );
 
-	const transferPriceText = getTransferPriceText( {
-		cart,
-		currencyCode,
-		domain,
-		productsList,
-	} );
-
 	const transferPricing = {
-		cost: transferPriceText,
 		isFree: isFreeTransfer( { cart, domain } ),
 		sale: transferSalePriceText,
 		text: transferFreeText,

--- a/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
@@ -1,6 +1,5 @@
 import { __ } from '@wordpress/i18n';
 import { isDomainBundledWithPlan, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
-import { isStarterPlanEnabled } from 'calypso/my-sites/plans-comparison';
 
 export function getTransferFreeText( { cart, domain, isSignupStep, siteIsOnPaidPlan } ) {
 	const siteHasNoPaidPlan = ! siteIsOnPaidPlan || isSignupStep;
@@ -10,9 +9,7 @@ export function getTransferFreeText( { cart, domain, isSignupStep, siteIsOnPaidP
 	if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, domain ) ) {
 		domainProductFreeText = __( 'Free transfer with your plan' );
 	} else if ( siteHasNoPaidPlan ) {
-		domainProductFreeText = isStarterPlanEnabled()
-			? __( 'Included in paid plans' )
-			: __( 'Included in Pro plan' );
+		domainProductFreeText = __( 'Included in annual plans' );
 	}
 
 	return domainProductFreeText;

--- a/client/components/domains/use-my-domain/utilities/get-transfer-price-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-price-text.js
@@ -1,13 +1,12 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { isDomainBundledWithPlan, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
 import { getDomainPrice, getDomainProductSlug } from 'calypso/lib/domains';
-import { isStarterPlanEnabled } from 'calypso/my-sites/plans-comparison';
 
 export function getTransferPriceText( { cart, currencyCode, domain, productsList } ) {
 	const productSlug = getDomainProductSlug( domain );
 	const domainProductPrice = getDomainPrice( productSlug, productsList, currencyCode );
 
-	if ( ! domainProductPrice || isStarterPlanEnabled() ) {
+	if ( ! domainProductPrice ) {
 		return;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This replaces the mentioned Pro plan with the previous annual plans in Domain Transfer copy.
* goes back to the `Included in annual plans` copy that was changed in #62444
* keeps transfer price [hidden](https://github.com/Automattic/wp-calypso/pull/63861#issuecomment-1132819071) since it doesn't match with `Included in annual plans` copy

<img width="320" src="https://user-images.githubusercontent.com/2749938/169515665-a17bd90e-651f-4dfd-902d-d980a626d2e2.jpg" />

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/domains/use-your-domain`
* Submit a valid domain 
* The bottom paragraphs should mention `Included in annual plans`

<img width="420" alt="Screenshot on 2022-06-14 at 19-18-22" src="https://user-images.githubusercontent.com/2749938/173627218-54f84aaa-1ec3-47aa-b220-13707bb22a54.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

