### PR TITLE
[ETK] Generate unminified `.js` and minified `.min.js` assets for ETK apps

### DIFF
--- a/apps/editing-toolkit/bin/sync-newspack-blocks.sh
+++ b/apps/editing-toolkit/bin/sync-newspack-blocks.sh
@@ -134,7 +134,7 @@ echo -n "phpcbf: "
 
 if [ "$PHPCBF_ERRORED" = 1 ] ; then
 	echo '!! There was an error executing phpcbf!'
-	exit 1
+	#exit 1
 fi
 
 if [ "$MODE" = "npm" ] ; then

--- a/apps/editing-toolkit/bin/sync-newspack-blocks.sh
+++ b/apps/editing-toolkit/bin/sync-newspack-blocks.sh
@@ -134,7 +134,7 @@ echo -n "phpcbf: "
 
 if [ "$PHPCBF_ERRORED" = 1 ] ; then
 	echo '!! There was an error executing phpcbf!'
-	#exit 1
+	exit 1
 fi
 
 if [ "$MODE" = "npm" ] ; then

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -132,6 +132,7 @@
 		"@types/wordpress__plugins": "^3.0.0",
 		"@wordpress/eslint-plugin": "^12.3.0",
 		"@wordpress/jest-preset-default": "^8.2.0",
+		"@wordpress/readable-js-assets-webpack-plugin": "^1.0.4",
 		"babel-jest": "^27.5.1",
 		"jest-teamcity": "^1.9.0",
 		"wait-for-expect": "^3.0.2",

--- a/apps/editing-toolkit/webpack.config.js
+++ b/apps/editing-toolkit/webpack.config.js
@@ -5,6 +5,7 @@
 const path = require( 'path' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const ReadableJsAssetsWebpackPlugin = require( '@wordpress/readable-js-assets-webpack-plugin' );
 const webpack = require( 'webpack' );
 
 const FSE_MODULE_PREFIX = 'a8c-fse';
@@ -108,6 +109,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 					}
 				},
 			} ),
+			new ReadableJsAssetsWebpackPlugin(),
 		],
 		devtool: isDevelopment ? 'inline-cheap-source-map' : 'source-map',
 		stats: 'minimal',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1550,6 +1550,7 @@ __metadata:
     "@wordpress/plugins": ^4.7.0
     "@wordpress/primitives": ^3.7.0
     "@wordpress/react-i18n": ^3.7.0
+    "@wordpress/readable-js-assets-webpack-plugin": ^1.0.4
     "@wordpress/rich-text": ^5.7.0
     "@wordpress/scripts": ^23.1.0
     "@wordpress/server-side-render": ^3.7.0
@@ -9563,6 +9564,15 @@ __metadata:
     "@wordpress/i18n": ^4.9.0
     utility-types: ^3.10.0
   checksum: 83bb2b485e33340a85e58e47aac7cb31141a70ed806bfe5c97b30bb5998be4f37ffbf295d29300bbe9a29b79729c11c004a4c2537c67c69c183cab28696e02ec
+  languageName: node
+  linkType: hard
+
+"@wordpress/readable-js-assets-webpack-plugin@npm:^1.0.4":
+  version: 1.0.5
+  resolution: "@wordpress/readable-js-assets-webpack-plugin@npm:1.0.5"
+  peerDependencies:
+    webpack: ^4.8.3 || ^5.0.0
+  checksum: 8550eb60b6fe02d9b36c98bf22c75c42a15fabb5f6bca83cbeb53d0950e1fafdac0a1ac50c6940f7d5ef0e0af28b9a8272e50e93c0575b1d8a990a0103d5b52c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Proposed Changes

### What

* Generate unminified `.js` and minified `.min.js` assets for ETK apps

### Why

The WPorg i18n machinery doesn't understand `.min.js` assets. It needs them to have an unprefixed `.js` extension. Also, it doesn't work well with minified JS assets.

More context in: p1655202616471329/1654854058.380239-slack-C02AED43D, onwards.

#### Testing Instructions

* Checkout this branch in your local Calypso repo dir, `cd` to `apps/editing-toolkit`
* Run `yarn dev build`
* Verify that each app has a `index.min.js` and `index.js` in its `dist/` directory


Related to D82584-code.