### PR TITLE
Fix wrong redirect from checkout page

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
@@ -9,6 +9,8 @@ const getAllowedHosts = ( siteSlug?: string ) => {
 		'jetpack.com',
 		'jetpack.cloud.localhost',
 		'cloud.jetpack.com',
+		'calypso.localhost',
+		'wordpress.com',
 		...( ( siteSlug && [ siteSlug ] ) || [] ),
 	];
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes the close button of the checkout page not redirecting to the URL passed as query param, in Calypso blue.

### Testing instructions

Make sure you have a Jetpack site available

To reproduce the issue:

- Visit http://calypso.localhost:3000/checkout/jetpack_scan/:site?checkoutBackUrl=https://wordpress.com/me
- Click the close button (see capture below)
- Note that you're redirected to the pricing page

To test the fix:
- Run this branch
- Visit http://calypso.localhost:3000/checkout/jetpack_scan/:site?checkoutBackUrl=https://wordpress.com/me
- Click the close button
- Note that you're redirected to https://wordpress.com/me

### Screenshots

_Close button in checkout page_
<img width="550" alt="Screen Shot 2022-06-14 at 4 20 54 PM" src="https://user-images.githubusercontent.com/1620183/173684613-f959839f-b4c4-4ad6-8997-ebb3bb7ee1f5.png">

