### PR TITLE
Add backup block to handle localized dates on backup links

### DIFF
--- a/client/components/notes-formatted-block/blocks.jsx
+++ b/client/components/notes-formatted-block/blocks.jsx
@@ -1,5 +1,12 @@
 import { startsWith } from 'lodash';
+import { useSelector } from 'react-redux';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { applySiteOffset } from 'calypso/lib/site/timezone';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export const Strong = ( { children } ) => <strong>{ children }</strong>;
 
@@ -140,6 +147,31 @@ export const Theme = ( { content, onClick, meta, children } ) => {
 			onClick={ onClick }
 			data-activity={ meta.activity }
 			data-section="themes"
+			data-intent="view"
+		>
+			{ children }
+		</a>
+	);
+};
+
+export const Backup = ( { content, onClick, meta, children } ) => {
+	const moment = useLocalizedMoment();
+
+	const siteId = useSelector( getSelectedSiteId );
+	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
+	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
+
+	const rewindDateLocal = applySiteOffset( moment( content.rewindId * 1000 ), {
+		timezone,
+		gmtOffset,
+	} );
+
+	return (
+		<a
+			href={ `/backup/${ content.siteSlug }?date=` + rewindDateLocal.format( INDEX_FORMAT ) }
+			onClick={ onClick }
+			data-activity={ meta.activity }
+			data-section="backups"
 			data-intent="view"
 		>
 			{ children }

--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -36,6 +36,7 @@ const FormattedBlock = FormattedBlockRenderer( {
 	person: Blocks.Person,
 	plugin: Blocks.Plugin,
 	theme: Blocks.Theme,
+	backup: Blocks.Backup,
 } );
 
 export default FormattedBlock;

--- a/client/lib/notifications/note-block-parser.js
+++ b/client/lib/notifications/note-block-parser.js
@@ -146,6 +146,14 @@ const themeNode = ( { site_slug, slug, version, uri, intent, section } ) => ( {
 	section,
 } );
 
+const backupNode = ( { site_slug, rewind_id, intent, section } ) => ( {
+	type: 'backup',
+	siteSlug: site_slug,
+	rewindId: rewind_id,
+	intent,
+	section,
+} );
+
 const inferNode = ( range ) => {
 	const { type, url } = range;
 
@@ -189,6 +197,9 @@ const nodeMappings = ( type ) => {
 
 		case 'theme':
 			return themeNode;
+
+		case 'backup':
+			return backupNode;
 
 		default:
 			return inferNode;


### PR DESCRIPTION
#### Proposed Changes

* This PR creates a new block, "Backup", with the responsibility to create the links that redirect to the backup, based on the rewind_id creating the date considering the timezone of the site

#### Testing Instructions

* This PR requires change on the API side to test it
* Use a site with Backups with warnings
* Check in the ActivityLog the items about Backup that have warnings. Check the link, it must match the date on the link.
* Go to the General Settings and change the `Site timezone`. Try to use a timezone that change the day of the ActivityLog item
* Check again the ActivityLog. If the item changed the day, the same will happens with the link

<img width="613" alt="Screen Shot 2022-06-14 at 19 57 49" src="https://user-images.githubusercontent.com/2747834/173708606-95c777e0-3243-4688-9f4c-c89006a7b154.png">


