### PR TITLE
Design Picker: Prevent selected design preview for Anchor.fm sites

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -345,7 +345,8 @@ const designSetup: Step = function DesignSetup( { navigation, flow } ) {
 		return null;
 	}
 
-	if ( selectedDesign && ! showGeneratedDesigns ) {
+	// In Anchor sites, full-screen design previews are disabled.
+	if ( selectedDesign && ! showGeneratedDesigns && ! isAnchorSite ) {
 		const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
 		const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
 		const shouldUpgrade = selectedDesign.is_premium && ! isPremiumThemeAvailable;


### PR DESCRIPTION
#### Proposed Changes

This PR fixes an issue where Anchor.fm sites would see the full-screen design preview when a design has been previously selected. This results in the `WebPreview` component breaking and redirecting users to the design demo site, thus breaking the Anchor.fm flow.

In practice, it's highly unlikely for users to enter the design picker with a design already selected, but it would be good to add a check to prevent this scenario, while making it clear for posteriority to be mindful of the Anchor.fm flow's idiosyncrasy.

cc: @sixhours 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/?anchor_podcast=9370e048`
* After entering a site title, click on "Continue" and expect to land on the design picker.
* Select a design, and expect to land on the FSE.
* Then head back to `/setup/?anchor_podcast=9370e048`, and head to the design picker again.
* Expect to see the list of thumbnails designs, and not the full-screen design preview.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/64402#issuecomment-1155311226