### PR TITLE
`LoginForm`: refactor tests to `@testing-library/react`

### DIFF
--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -1,28 +1,26 @@
 /**
  * @jest-environment jsdom
  */
-import { shallow } from 'enzyme';
-import FormsButton from 'calypso/components/forms/form-button';
-import FormPasswordInput from 'calypso/components/forms/form-password-input';
-import FormTextInput from 'calypso/components/forms/form-text-input';
+import { screen } from '@testing-library/react';
+import LoginForm from 'calypso/blocks/login/login-form';
+import loginReducer from 'calypso/state/login/reducer';
+import routeReducer from 'calypso/state/route/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 
-const noop = () => {};
+const render = ( el, options ) =>
+	renderWithProvider( el, { ...options, reducers: { login: loginReducer, route: routeReducer } } );
 
 describe( 'LoginForm', () => {
-	let LoginForm;
+	test( 'displays a login form', async () => {
+		render( <LoginForm socialAccountLink={ { isLinking: false } } /> );
 
-	beforeAll( () => {
-		LoginForm = require( 'calypso/blocks/login/login-form' ).LoginForm;
-	} );
+		const username = screen.getByLabelText( /username/i );
+		expect( username ).toBeInTheDocument();
 
-	describe( 'component rendering', () => {
-		test( 'displays a login form', () => {
-			const wrapper = shallow(
-				<LoginForm translate={ noop } socialAccountLink={ { isLinking: false } } />
-			);
-			expect( wrapper.find( FormTextInput ).length ).toEqual( 1 );
-			expect( wrapper.find( FormPasswordInput ).length ).toEqual( 1 );
-			expect( wrapper.find( FormsButton ).length ).toEqual( 1 );
-		} );
+		const password = screen.getByLabelText( /password/i );
+		expect( password ).toBeInTheDocument();
+
+		const btn = screen.getByRole( 'button', { name: /continue$/i } );
+		expect( btn ).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* `LoginForm`: refactor tests to `@testing-library/react`

#### Testing Instructions

* Verify unit tests still pass

Related to #63409
