### PR TITLE
Tour kit: Add live resize functionality using ResizeObserver and MutationObserver

### DIFF
--- a/packages/tour-kit/CHANGELOG.md
+++ b/packages/tour-kit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Added live resize functionality using ResizeObserver and MutationObserver
+- Updated CSS selectors for spotlight interactivity so that they don't use !important
 ## 1.0.0
 
 - Initial release

--- a/packages/tour-kit/README.md
+++ b/packages/tour-kit/README.md
@@ -161,6 +161,7 @@ The main API for configuring a tour is the config object. See example usage and 
   - `arrowIndicator`: Adds an arrow tip pointing at the reference element when provided.
   - `overlay`: Includes the semi-transparent overlay for all the steps (also blocks interactions with the rest of the page)
   - `autoScroll`: The page scrolls up and down automatically such that the step target element is visible to the user.
+  - `liveResize`: Configures the behaviour for automatically resizing the tour kit elements (TourKitFrame and Spotlight). Defaults to disabled.
 
 - `callbacks`: An object of callbacks to handle side effects from various interactions (see [types.ts](./src/types.ts)).
 

--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/tour-kit",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "Tour lib for guided walkthroughs.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -43,6 +43,7 @@
 		"@wordpress/primitives": "^3.7.0",
 		"@wordpress/react-i18n": "^3.7.0",
 		"classnames": "^2.3.1",
+		"debug": "^4.3.4",
 		"react-popper": "^2.2.5"
 	},
 	"devDependencies": {

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
+import { useEffect, useState, useCallback, useMemo, useRef } from '@wordpress/element';
 import classnames from 'classnames';
 import { usePopper } from 'react-popper';
 /**
@@ -10,6 +10,7 @@ import { usePopper } from 'react-popper';
  */
 import useStepTracking from '../hooks/use-step-tracking';
 import { classParser } from '../utils';
+import { liveResizeModifier } from '../utils/live-resize-modifier';
 import KeyboardNavigation from './keyboard-navigation';
 import TourKitMinimized from './tour-kit-minimized';
 import Overlay from './tour-kit-overlay';
@@ -145,6 +146,10 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 					fallbackPlacements: [ 'top', 'left', 'right' ],
 				},
 			},
+			useMemo(
+				() => liveResizeModifier( config.options?.effects?.liveResize ),
+				[ config.options?.effects?.liveResize ]
+			),
 			...( config.options?.popperModifiers || [] ),
 		],
 	} );

--- a/packages/tour-kit/src/components/tour-kit-spotlight.tsx
+++ b/packages/tour-kit/src/components/tour-kit-spotlight.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useEffect } from '@wordpress/element';
 import classnames from 'classnames';
 import { usePopper } from 'react-popper';
+import { LiveResizeConfiguration, liveResizeModifier } from '../utils/live-resize-modifier';
 import Overlay from './tour-kit-overlay';
 import {
 	SpotlightInteractivity,
@@ -13,15 +14,18 @@ interface Props {
 	referenceElement: HTMLElement | null;
 	styles?: React.CSSProperties;
 	interactivity?: SpotlightInteractivityConfiguration;
+	liveResize?: LiveResizeConfiguration;
 }
 
 const TourKitSpotlight: React.FunctionComponent< Props > = ( {
 	referenceElement,
 	styles,
 	interactivity,
+	liveResize,
 } ) => {
 	const [ popperElement, sePopperElement ] = useState< HTMLElement | null >( null );
 	const referenceRect = referenceElement?.getBoundingClientRect();
+
 	const modifiers = [
 		{
 			name: 'flip',
@@ -55,6 +59,10 @@ const TourKitSpotlight: React.FunctionComponent< Props > = ( {
 			} ),
 			[]
 		),
+		// useMemo because https://popper.js.org/react-popper/v2/faq/#why-i-get-render-loop-whenever-i-put-a-function-inside-the-popper-configuration
+		useMemo( () => {
+			return liveResizeModifier( liveResize );
+		}, [ liveResize ] ),
 	];
 
 	const { styles: popperStyles, attributes: popperAttributes } = usePopper(

--- a/packages/tour-kit/src/storybook/index.stories.tsx
+++ b/packages/tour-kit/src/storybook/index.stories.tsx
@@ -8,7 +8,10 @@ const References = () => {
 	return (
 		<div className={ 'storybook__tourkit-references' }>
 			<div className={ 'storybook__tourkit-references-container' }>
-				<div className={ 'storybook__tourkit-references-a' }>
+				<div
+					style={ { resize: 'both', overflow: 'auto' } }
+					className={ 'storybook__tourkit-references-a' }
+				>
 					<p>Reference A</p>
 				</div>
 				<div className={ 'storybook__tourkit-references-b' }>
@@ -153,6 +156,16 @@ export const SpotlightInteractivity = () => (
 	<StoryTour
 		options={ {
 			effects: { spotlight: { interactivity: { rootElementSelector: '#root', enabled: true } } },
+		} }
+	/>
+);
+export const SpotlightInteractivityWithAutoResize = () => (
+	<StoryTour
+		options={ {
+			effects: {
+				spotlight: { interactivity: { rootElementSelector: '#root', enabled: true } },
+				liveResize: { mutation: true, resize: true, rootElementSelector: '#root' },
+			},
 		} }
 	/>
 );

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -1,6 +1,7 @@
 import * as PopperJS from '@popperjs/core';
 import React from 'react';
 import { SpotlightInteractivityConfiguration } from './components/tour-kit-spotlight-interactivity';
+import { LiveResizeConfiguration } from './utils/live-resize-modifier';
 import type { Modifier } from 'react-popper';
 
 export interface Step {
@@ -86,6 +87,8 @@ export interface Options {
 		overlay?: boolean;
 		/** Configures the autoscroll behaviour. Defaults to False. More information about the configuration at: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView */
 		autoScroll?: ScrollIntoViewOptions | boolean;
+		/** Configures the behaviour for automatically resizing the tour kit elements (TourKitFrame and Spotlight). Defaults to disabled. */
+		liveResize?: LiveResizeConfiguration;
 	};
 	popperModifiers?: PopperModifier[];
 	portalParentElement?: HTMLElement | null;

--- a/packages/tour-kit/src/utils/index.ts
+++ b/packages/tour-kit/src/utils/index.ts
@@ -1,3 +1,5 @@
+import debugFactory from 'debug';
+
 /**
  * Helper to convert CSV of `classes` to an array.
  *
@@ -11,3 +13,5 @@ export function classParser( classes?: string | string[] ): string[] | null {
 
 	return null;
 }
+
+export const debug = debugFactory( 'tour-kit' );

--- a/packages/tour-kit/src/utils/live-resize-modifier.tsx
+++ b/packages/tour-kit/src/utils/live-resize-modifier.tsx
@@ -1,0 +1,107 @@
+import { debug } from '../utils';
+import type { ModifierArguments, Options, State } from '@popperjs/core';
+import type { Modifier } from 'react-popper';
+
+// Adds the resizeObserver and mutationObserver properties to the popper effect function argument
+type ModifierArgumentsWithObserversProp = ModifierArguments< Options > & {
+	state: State & {
+		elements: State[ 'elements' ] & {
+			reference: State[ 'elements' ][ 'reference' ] & {
+				[ key: symbol ]: {
+					resizeObserver: ResizeObserver;
+					mutationObserver: MutationObserver;
+				};
+			};
+		};
+	};
+};
+
+export interface LiveResizeConfiguration {
+	/** CSS Selector for the the DOM node (and children) to observe for mutations */
+	rootElementSelector?: string;
+	/** True to enable update on reference element resize, defaults to false */
+	resize?: boolean;
+	/** True to enable update on node and subtree mutation, defaults to false. May be performance intensive */
+	mutation?: boolean;
+}
+
+type liveResizeModifierFactory = (
+	params: LiveResizeConfiguration | undefined
+) => Modifier< 'liveResizeModifier', Record< string, unknown > >;
+
+/**
+ * Function that returns a Popper modifier that observes the specified root element as well as
+ * reference element for any changes. The reason for being a currying function is so that
+ * we can customise the root element selector, otherwise observing at a higher than necessary
+ * level might cause unnecessary performance penalties.
+ *
+ * The Popper modifier queues an asynchronous update on the Popper instance whenever either of the
+ * Observers trigger its callback.
+ *
+ * @returns custom Popper modifier
+ */
+export const liveResizeModifier: liveResizeModifierFactory = (
+	{ rootElementSelector, mutation = false, resize = false }: LiveResizeConfiguration = {
+		mutation: false,
+		resize: false,
+	}
+) => ( {
+	name: 'liveResizeModifier',
+	enabled: true,
+	phase: 'main',
+	fn: () => {
+		return;
+	},
+	effect: ( arg0 ) => {
+		try {
+			const { state, instance } = arg0 as ModifierArgumentsWithObserversProp; // augment types here because we are mutating the properties on the argument that is passed in
+
+			const ObserversProp = Symbol(); // use a symbol here so that we don't clash with multiple poppers using this modifier on the same reference node
+			const { reference } = state.elements;
+
+			reference[ ObserversProp ] = {
+				resizeObserver: new ResizeObserver( () => {
+					instance.update();
+				} ),
+
+				mutationObserver: new MutationObserver( () => {
+					instance.update();
+				} ),
+			};
+
+			if ( resize ) {
+				if ( reference instanceof Element ) {
+					reference[ ObserversProp ].resizeObserver.observe( reference );
+				} else {
+					debug(
+						'Error: ResizeObserver does not work with virtual elements, Tour Kit will not resize automatically if the size of the referenced element changes.'
+					);
+				}
+			}
+
+			if ( mutation ) {
+				const rootElementNode = document.querySelector( rootElementSelector || '#wpwrap' );
+				if ( rootElementNode instanceof Element ) {
+					reference[ ObserversProp ].mutationObserver.observe( rootElementNode, {
+						attributes: true,
+						characterData: true,
+						childList: true,
+						subtree: true,
+					} );
+				} else {
+					debug(
+						`Error: ${ rootElementSelector } selector did not find a valid DOM element, Tour Kit will not update automatically if the DOM layout changes.`
+					);
+				}
+			}
+
+			return () => {
+				reference[ ObserversProp ].resizeObserver.disconnect();
+				reference[ ObserversProp ].mutationObserver.disconnect();
+				delete reference[ ObserversProp ];
+			};
+		} catch ( error ) {
+			debug( 'Error: Tour Kit live resize modifier failed unexpectedly:', error );
+		}
+	},
+} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,6 +1265,7 @@ __metadata:
     "@wordpress/primitives": ^3.7.0
     "@wordpress/react-i18n": ^3.7.0
     classnames: ^2.3.1
+    debug: ^4.3.4
     react-popper: ^2.2.5
     typescript: ^4.5.5
   peerDependencies:


### PR DESCRIPTION
#### Proposed Changes

Added a popper modifier that attaches ResizeObserver and MutationObserver to the referenced element, then observes the element as well as a subtree of the document for any mutations. Upon either of these triggering, the popper's update method is called asynchronously.

There was the option of doing this within React or as a popper modifier, but with the React method there was some flickering that's probably due to React creating and destroying the popper instance.

Before changes:

https://user-images.githubusercontent.com/27843274/173760213-3d9a24c7-4308-4682-8803-ce1f1ea19128.mp4

After changes:

https://user-images.githubusercontent.com/27843274/173760246-626086b6-d727-49d8-b65d-f548aa59c7de.mp4



#### Testing Instructions

* Run storybook in @automattic/tour-kit using `yarn workspace @automattic/tour-kit run storybook` and observe that the added storybook story works correctly.
