### PR TITLE
Stepper Framework: Record calypso_signup_step_start event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-step-start.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-step-start.ts
@@ -1,0 +1,17 @@
+import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+
+const recordStepStart = (
+	flow: string,
+	step: string,
+	optionalProps?: { [ key: string ]: unknown }
+) => {
+	recordTracksEvent( 'calypso_signup_step_start', {
+		flow,
+		step,
+		device: resolveDeviceTypeByViewPort(),
+		...optionalProps,
+	} );
+};
+
+export default recordStepStart;

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -3,10 +3,13 @@ import { useEffect } from 'react';
 import { Switch, Route, Redirect, generatePath, useHistory, useLocation } from 'react-router-dom';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import SignupHeader from 'calypso/signup/signup-header';
+import recordStepStart from './analytics/record-step-start';
 import * as Steps from './steps-repository';
 import { AssertConditionState, Flow } from './types';
 import type { StepPath } from './steps-repository';
 import './global.scss';
+
+const kebabCase = ( value: string ) => value.replace( /([a-z0-9])([A-Z])/g, '$1-$2' ).toLowerCase();
 
 /**
  * This component accepts a single flow property. It does the following:
@@ -32,14 +35,16 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 
 		history.push( _path, stepPaths );
 	} );
-	const pathToClass = ( path: string ) =>
-		path.replace( /([a-z0-9])([A-Z])/g, '$1-$2' ).toLowerCase();
 
 	flow.useSideEffect?.();
 
 	useEffect( () => {
 		window.scrollTo( 0, 0 );
 	}, [ location ] );
+
+	useEffect( () => {
+		recordStepStart( flow.name, kebabCase( currentRoute ) );
+	}, [ flow.name, currentRoute ] );
 
 	const assertCondition = flow.useAssertConditions?.() ?? { state: AssertConditionState.SUCCESS };
 
@@ -62,7 +67,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 			{ stepPaths.map( ( path ) => {
 				return (
 					<Route key={ path } path={ `/${ path }` }>
-						<div className={ classnames( flow.name, flow.classnames, pathToClass( path ) ) }>
+						<div className={ classnames( flow.name, flow.classnames, kebabCase( path ) ) }>
 							<SignupHeader />
 							{ renderStep( path ) }
 						</div>


### PR DESCRIPTION
#### Proposed Changes

* In our original framework, we have `calypso_signup_step_start` event so that we can track how many people go to a specific step and how many people submit the step or skip the step. However, our new Stepper Framework doesn't have this event, so I add this event back and then we can do further analysis.

![image](https://user-images.githubusercontent.com/13596067/173762625-50b2f555-b6c5-453e-9fdc-4df3fca98ef8.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Network Panel from the Developer DevTool
* Go to onboarding flow: `/setup?siteSlug=<your_site>`
* Check you can see the event `calypso_signup_step_start` at every step

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 43-gh-Automattic/ganon-issues