### PR TITLE
Tour kit: tweak spotlight interactivity css selectors

### DIFF
--- a/packages/tour-kit/src/components/tour-kit-spotlight-interactivity.tsx
+++ b/packages/tour-kit/src/components/tour-kit-spotlight-interactivity.tsx
@@ -20,15 +20,15 @@ export const SpotlightInteractivity: React.VFC< SpotlightInteractivityConfigurat
 		<style>
 			{ `
     .${ SPOTLIT_ELEMENT_CLASS }, .${ SPOTLIT_ELEMENT_CLASS } * {
-        pointer-events: auto !important;
+        pointer-events: auto;
     }
     .tour-kit-frame__container button {
-        pointer-events: auto !important;
+        pointer-events: auto;
     }
     .tour-kit-spotlight, .tour-kit-overlay {
-        pointer-events: none !important;
+        pointer-events: none;
     }
-    ${ rootElementSelector } :not(${ SPOTLIT_ELEMENT_CLASS }) {
+    ${ rootElementSelector } :not(.${ SPOTLIT_ELEMENT_CLASS }, .${ SPOTLIT_ELEMENT_CLASS } *) {
         pointer-events: none;
     }
     ` }


### PR DESCRIPTION
Previous set of CSS selectors interfered with children of the spotlit elements that also had pointer-events CSS styles

This change removes '!important' which allows more specific selectors to override `pointer-events: none`
