### PR TITLE
Help Center: Order of help icon in site editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
@@ -8,7 +8,7 @@
 		}
 	}
 
-	.edit-site-header__actions & {
+	.interface-pinned-items & {
 		order: 4;
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
@@ -7,6 +7,10 @@
 			}
 		}
 	}
+
+	.edit-site-header__actions & {
+		order: 4;
+	}
 }
 
 .help-center__container {


### PR DESCRIPTION
#### Proposed Changes

Add a `order` css property to the help-icon when in site-editor, to have it on the far right next to the three dots menu.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/52076348/173794151-9aa8f993-4f60-4154-8e10-acfae0d88ed0.png) | ![image](https://user-images.githubusercontent.com/52076348/173793982-af46ed58-fbad-4db8-b64b-cd790f49adea.png)  |


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Sync ETK (`yarn dev --sync` from `apps/editing-toolkit`)
* Go in Site Editor and check that the help icon is in the right order

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64025
Fixes #64025
