### PR TITLE
Send real viewport sizes to the preview endpoint

### DIFF
--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -56,4 +56,5 @@ export const ANCHORFM_FONT_PAIRINGS = [
  * mShot options
  */
 export const DEFAULT_VIEWPORT_WIDTH = 1600;
+export const DEFAULT_VIEWPORT_HEIGHT = 700;
 export const MOBILE_VIEWPORT_WIDTH = 599;

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -52,6 +52,7 @@ export interface DesignPreviewOptions {
 	language?: string;
 	verticalId?: string;
 	siteTitle?: string;
+	viewport_width?: number;
 	viewport_height?: number;
 }
 

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -52,6 +52,7 @@ export interface DesignPreviewOptions {
 	language?: string;
 	verticalId?: string;
 	siteTitle?: string;
+	viewport_height?: number;
 }
 
 /** @deprecated used for Gutenboarding (/new flow) */

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -1,4 +1,5 @@
 import { Design, DesignPreviewOptions } from '../../types';
+import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT } from '../constants';
 import { getDesignPreviewUrl } from '../designs';
 
 describe( 'Design Picker designs utils', () => {
@@ -13,7 +14,7 @@ describe( 'Design Picker designs utils', () => {
 
 		it( 'should return the block-previews/site endpoint with the correct query params', () => {
 			expect( getDesignPreviewUrl( design, {} ) ).toEqual(
-				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=700&source_site=patternboilerplates.wordpress.com&site_title=Zoologist'
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_width=${ DEFAULT_VIEWPORT_WIDTH }&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
 			);
 		} );
 
@@ -25,7 +26,7 @@ describe( 'Design Picker designs utils', () => {
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&vertical_id=3&language=id&viewport_height=700&source_site=patternboilerplates.wordpress.com&site_title=Design%20Title'
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&vertical_id=3&language=id&viewport_width=${ DEFAULT_VIEWPORT_WIDTH }&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Design%20Title`
 			);
 		} );
 
@@ -37,7 +38,7 @@ describe( 'Design Picker designs utils', () => {
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				'https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=700&source_site=patternboilerplates.wordpress.com&site_title=Mock%28Design%29%28Title%29'
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_width=${ DEFAULT_VIEWPORT_HEIGHT }&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Mock%28Design%29%28Title%29`
 			);
 		} );
 	} );

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -1,5 +1,5 @@
+import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT } from '../../constants';
 import { Design, DesignPreviewOptions } from '../../types';
-import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT } from '../constants';
 import { getDesignPreviewUrl } from '../designs';
 
 describe( 'Design Picker designs utils', () => {

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT } from '../../constants';
+import { DEFAULT_VIEWPORT_HEIGHT } from '../../constants';
 import { Design, DesignPreviewOptions } from '../../types';
 import { getDesignPreviewUrl } from '../designs';
 
@@ -13,8 +13,12 @@ describe( 'Design Picker designs utils', () => {
 		} as Design;
 
 		it( 'should return the block-previews/site endpoint with the correct query params', () => {
-			expect( getDesignPreviewUrl( design, {} ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_width=${ DEFAULT_VIEWPORT_WIDTH }&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
+			const options: DesignPreviewOptions = {
+				viewport_height: DEFAULT_VIEWPORT_HEIGHT,
+			};
+
+			expect( getDesignPreviewUrl( design, options ) ).toEqual(
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
 			);
 		} );
 
@@ -23,10 +27,11 @@ describe( 'Design Picker designs utils', () => {
 				language: 'id',
 				verticalId: '3',
 				siteTitle: 'Design Title',
+				viewport_height: DEFAULT_VIEWPORT_HEIGHT,
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&vertical_id=3&language=id&viewport_width=${ DEFAULT_VIEWPORT_WIDTH }&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Design%20Title`
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&vertical_id=3&language=id&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Design%20Title`
 			);
 		} );
 
@@ -35,10 +40,11 @@ describe( 'Design Picker designs utils', () => {
 		it( 'should escape parentheses within the site title', () => {
 			const options: DesignPreviewOptions = {
 				siteTitle: 'Mock(Design)(Title)',
+				viewport_height: DEFAULT_VIEWPORT_HEIGHT,
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_width=${ DEFAULT_VIEWPORT_HEIGHT }&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Mock%28Design%29%28Title%29`
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Mock%28Design%29%28Title%29`
 			);
 		} );
 	} );

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_VIEWPORT_HEIGHT } from '../../constants';
+import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT } from '../../constants';
 import { Design, DesignPreviewOptions } from '../../types';
 import { getDesignPreviewUrl } from '../designs';
 
@@ -14,11 +14,12 @@ describe( 'Design Picker designs utils', () => {
 
 		it( 'should return the block-previews/site endpoint with the correct query params', () => {
 			const options: DesignPreviewOptions = {
+				viewport_width: DEFAULT_VIEWPORT_WIDTH,
 				viewport_height: DEFAULT_VIEWPORT_HEIGHT,
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_width=${ DEFAULT_VIEWPORT_WIDTH }&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
 			);
 		} );
 
@@ -27,11 +28,12 @@ describe( 'Design Picker designs utils', () => {
 				language: 'id',
 				verticalId: '3',
 				siteTitle: 'Design Title',
-				viewport_height: DEFAULT_VIEWPORT_HEIGHT,
+				viewport_width: 1280,
+				viewport_height: 700,
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&vertical_id=3&language=id&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Design%20Title`
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&vertical_id=3&language=id&viewport_width=1280&viewport_height=700&source_site=patternboilerplates.wordpress.com&site_title=Design%20Title`
 			);
 		} );
 
@@ -40,11 +42,12 @@ describe( 'Design Picker designs utils', () => {
 		it( 'should escape parentheses within the site title', () => {
 			const options: DesignPreviewOptions = {
 				siteTitle: 'Mock(Design)(Title)',
+				viewport_width: DEFAULT_VIEWPORT_WIDTH,
 				viewport_height: DEFAULT_VIEWPORT_HEIGHT,
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Mock%28Design%29%28Title%29`
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_width=${ DEFAULT_VIEWPORT_WIDTH }&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Mock%28Design%29%28Title%29`
 			);
 		} );
 	} );

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -1,5 +1,5 @@
 import { addQueryArgs } from '@wordpress/url';
-import { DEFAULT_VIEWPORT_HEIGHT } from '../constants';
+import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT } from '../constants';
 import type { Design, DesignPreviewOptions } from '../types';
 
 export const getDesignPreviewUrl = (

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -21,8 +21,8 @@ export const getDesignPreviewUrl = (
 		pattern_ids: recipe?.pattern_ids?.join( ',' ),
 		vertical_id: options.verticalId,
 		language: options.language,
-		source_site: 'patternboilerplates.wordpress.com',
 		viewport_height,
+		source_site: 'patternboilerplates.wordpress.com',
 	} );
 
 	const siteTitle = options.siteTitle || design.title;

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -1,5 +1,5 @@
 import { addQueryArgs } from '@wordpress/url';
-import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT } from '../constants';
+import { DEFAULT_VIEWPORT_HEIGHT } from '../constants';
 import type { Design, DesignPreviewOptions } from '../types';
 
 export const getDesignPreviewUrl = (
@@ -7,12 +7,10 @@ export const getDesignPreviewUrl = (
 	options: DesignPreviewOptions = {}
 ): string => {
 	const { recipe, slug } = design;
-	let viewport = { width: DEFAULT_VIEWPORT_WIDTH, height: DEFAULT_VIEWPORT_HEIGHT };
-
-	if ( typeof window !== 'undefined' ) {
-		const { innerWidth: width, innerHeight: height } = window;
-		viewport = { width, height };
-	}
+	const viewport_height =
+		options.viewport_height ?? typeof window !== 'undefined'
+			? window.innerWidth
+			: DEFAULT_VIEWPORT_HEIGHT;
 
 	//Anchor.fm themes get previews from their starter sites, ${slug}starter.wordpress.com
 	if ( [ 'hannah', 'riley', 'gilbert' ].indexOf( slug ) >= 0 ) {
@@ -24,8 +22,7 @@ export const getDesignPreviewUrl = (
 		pattern_ids: recipe?.pattern_ids?.join( ',' ),
 		vertical_id: options.verticalId,
 		language: options.language,
-		viewport_width: viewport.width,
-		viewport_height: viewport.height,
+		viewport_height: viewport_height,
 		source_site: 'patternboilerplates.wordpress.com',
 	} );
 

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -8,9 +8,8 @@ export const getDesignPreviewUrl = (
 ): string => {
 	const { recipe, slug } = design;
 	const viewport_height =
-		options.viewport_height ?? typeof window !== 'undefined'
-			? window.innerWidth
-			: DEFAULT_VIEWPORT_HEIGHT;
+		options.viewport_height ??
+		( typeof window !== 'undefined' ? window.innerWidth : DEFAULT_VIEWPORT_HEIGHT );
 
 	//Anchor.fm themes get previews from their starter sites, ${slug}starter.wordpress.com
 	if ( [ 'hannah', 'riley', 'gilbert' ].indexOf( slug ) >= 0 ) {
@@ -22,8 +21,8 @@ export const getDesignPreviewUrl = (
 		pattern_ids: recipe?.pattern_ids?.join( ',' ),
 		vertical_id: options.verticalId,
 		language: options.language,
-		viewport_height: viewport_height,
 		source_site: 'patternboilerplates.wordpress.com',
+		viewport_height,
 	} );
 
 	const siteTitle = options.siteTitle || design.title;

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -7,9 +7,12 @@ export const getDesignPreviewUrl = (
 	options: DesignPreviewOptions = {}
 ): string => {
 	const { recipe, slug } = design;
+	const viewport_width =
+		options.viewport_width ??
+		( typeof window !== 'undefined' ? window.innerWidth : DEFAULT_VIEWPORT_WIDTH );
 	const viewport_height =
 		options.viewport_height ??
-		( typeof window !== 'undefined' ? window.innerWidth : DEFAULT_VIEWPORT_HEIGHT );
+		( typeof window !== 'undefined' ? window.innerHeight : DEFAULT_VIEWPORT_HEIGHT );
 
 	//Anchor.fm themes get previews from their starter sites, ${slug}starter.wordpress.com
 	if ( [ 'hannah', 'riley', 'gilbert' ].indexOf( slug ) >= 0 ) {
@@ -21,6 +24,7 @@ export const getDesignPreviewUrl = (
 		pattern_ids: recipe?.pattern_ids?.join( ',' ),
 		vertical_id: options.verticalId,
 		language: options.language,
+		viewport_width,
 		viewport_height,
 		source_site: 'patternboilerplates.wordpress.com',
 	} );

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -1,4 +1,5 @@
 import { addQueryArgs } from '@wordpress/url';
+import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT } from '../constants';
 import type { Design, DesignPreviewOptions } from '../types';
 
 export const getDesignPreviewUrl = (
@@ -6,17 +7,25 @@ export const getDesignPreviewUrl = (
 	options: DesignPreviewOptions = {}
 ): string => {
 	const { recipe, slug } = design;
+	let viewport = { width: DEFAULT_VIEWPORT_WIDTH, height: DEFAULT_VIEWPORT_HEIGHT };
+
+	if ( typeof window !== 'undefined' ) {
+		const { innerWidth: width, innerHeight: height } = window;
+		viewport = { width, height };
+	}
 
 	//Anchor.fm themes get previews from their starter sites, ${slug}starter.wordpress.com
 	if ( [ 'hannah', 'riley', 'gilbert' ].indexOf( slug ) >= 0 ) {
 		return `https://${ slug }starter.wordpress.com`;
 	}
+
 	let url = addQueryArgs( 'https://public-api.wordpress.com/wpcom/v2/block-previews/site', {
 		stylesheet: recipe?.stylesheet,
 		pattern_ids: recipe?.pattern_ids?.join( ',' ),
 		vertical_id: options.verticalId,
 		language: options.language,
-		viewport_height: 700,
+		viewport_width: viewport.width,
+		viewport_height: viewport.height,
 		source_site: 'patternboilerplates.wordpress.com',
 	} );
 


### PR DESCRIPTION
#### Proposed Changes

This PR changes the fixed viewport height value sent to the preview endpoint in favor of sending the real viewport dimensions. By sending actual viewport sizes, we want the preview to be as close as possible to the original design layout.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the generated design picker.
* Use the browser developer tools and check the mShots image URL.
* Expect that the following parameters are added to the mShots image URL:
  * `viewport_width`
  * `viewport_height`
* Expect that the value above match your browser viewport size.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#64518](https://github.com/Automattic/wp-calypso/issues/64518)
