### PR TITLE
[Goals Capture] Display `Continue` button in goals capture screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -2,35 +2,35 @@ import { Onboard } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import type { Goal } from './types';
 
-const GoalKey = Onboard.GoalKey;
+const SiteGoal = Onboard.SiteGoal;
 
 export const useGoals = (): Goal[] => {
 	const translate = useTranslate();
 
 	const goals: Goal[] = [
 		{
-			key: GoalKey.Write,
+			key: SiteGoal.Write,
 			title: translate( 'Write and publish' ),
 		},
 		{
-			key: GoalKey.Sell,
+			key: SiteGoal.Sell,
 			title: translate( 'Sell goods or products' ),
 		},
 		{
-			key: GoalKey.Promote,
+			key: SiteGoal.Promote,
 			title: translate( 'Promote myself or my business' ),
 		},
 		{
-			key: GoalKey.DIFM,
+			key: SiteGoal.DIFM,
 			title: translate( 'Hire a professional to design my website' ),
 			isPremium: true,
 		},
 		{
-			key: GoalKey.Import,
+			key: SiteGoal.Import,
 			title: translate( 'Import my existing website content' ),
 		},
 		{
-			key: GoalKey.Other,
+			key: SiteGoal.Other,
 			title: translate( 'Other' ),
 		},
 	];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -18,9 +18,17 @@ const GoalsStep: Step = ( { navigation } ) => {
 	const subHeaderText = translate( 'Tell us what would you like to accomplish with your website.' );
 
 	const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
+	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const { setGoals } = useDispatch( ONBOARD_STORE );
-
-	const stepContent = <SelectGoals selectedGoals={ goals } onChange={ setGoals } />;
+	const stepContent = (
+		<SelectGoals
+			selectedGoals={ goals }
+			onChange={ setGoals }
+			onSubmit={ () => {
+				navigation.submit?.( { intent } );
+			} }
+		/>
+	);
 
 	return (
 		<StepContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-card.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-card.tsx
@@ -2,21 +2,21 @@ import { CheckboxControl } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import classNames from 'classnames';
 
-type SelectCardProps = {
+type SelectCardProps< T > = {
 	children: React.ReactNode;
 	className?: string;
-	onChange: ( checked: boolean, value: string ) => void;
+	onChange: ( checked: boolean, value: T ) => void;
 	selected: boolean;
-	value: string;
+	value: T;
 };
 
-const SelectCard: React.FC< SelectCardProps > = ( {
+const SelectCard = < T, >( {
 	children,
 	className,
 	onChange,
 	selected,
 	value,
-} ) => {
+}: SelectCardProps< T > ) => {
 	const handleClick = ( evt: React.MouseEvent ) => {
 		onChange( ! selected, value );
 		evt.stopPropagation();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -1,18 +1,26 @@
+import { Button } from '@automattic/components';
 import { Onboard } from '@automattic/data-stores';
+import { useTranslate } from 'i18n-calypso';
 import { useGoals } from './goals';
 import SelectCard from './select-card';
 
 type SelectGoalsProps = {
-	onChange: ( selectedGoals: Onboard.GoalKey[] ) => void;
-	selectedGoals: Onboard.GoalKey[];
+	onChange: ( selectedGoals: Onboard.SiteGoal[] ) => void;
+	onSubmit: () => void;
+	selectedGoals: Onboard.SiteGoal[];
 };
 
-export const SelectGoals: React.FC< SelectGoalsProps > = ( { onChange, selectedGoals } ) => {
-	const goals = useGoals();
+export const SelectGoals: React.FC< SelectGoalsProps > = ( {
+	onChange,
+	onSubmit,
+	selectedGoals,
+} ) => {
+	const translate = useTranslate();
+	const goalOptions = useGoals();
 
-	const handleChange = ( selected: boolean, value: string ) => {
+	const handleChange = ( selected: boolean, value: Onboard.SiteGoal ) => {
 		const newSelectedGoals = [ ...selectedGoals ];
-		const goalKey = value as Onboard.GoalKey;
+		const goalKey = value;
 
 		if ( selected ) {
 			newSelectedGoals.push( goalKey );
@@ -25,19 +33,29 @@ export const SelectGoals: React.FC< SelectGoalsProps > = ( { onChange, selectedG
 	};
 
 	return (
-		<div className="select-goals__container">
-			{ goals.map( ( goal ) => (
-				<SelectCard
-					key={ goal.key }
-					onChange={ handleChange }
-					selected={ selectedGoals.includes( goal.key ) }
-					value={ goal.key }
-				>
-					<span className="select-goals__goal-title">{ goal.title }</span>
-					{ goal.isPremium && <span className="select-goals__premium-badge">Premium</span> }
-				</SelectCard>
-			) ) }
-		</div>
+		<>
+			<div className="select-goals__cards-container">
+				{ goalOptions.map( ( { key, title, isPremium } ) => (
+					<SelectCard
+						key={ key }
+						onChange={ handleChange }
+						selected={ selectedGoals.includes( key ) }
+						value={ key }
+					>
+						<span className="select-goals__goal-title">{ title }</span>
+						{ isPremium && (
+							<span className="select-goals__premium-badge">{ translate( 'Premium' ) }</span>
+						) }
+					</SelectCard>
+				) ) }
+			</div>
+
+			<div className="select-goals__actions-container">
+				<Button primary onClick={ onSubmit }>
+					{ translate( 'Continue' ) }
+				</Button>
+			</div>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -23,7 +23,7 @@
 		}
 	}
 
-	.select-goals__container {
+	.select-goals__cards-container {
 		font-family: 'Inter', $sans;
 		display: grid;
 		gap: 16px;
@@ -46,6 +46,23 @@
 
 		@include break-small {
 			grid-template-columns: repeat( 2, 1fr );
+		}
+	}
+
+	.select-goals__actions-container {
+		padding-top: 48px;
+		display: flex;
+		flex-direction: row;
+		justify-content: left;
+
+		button {
+			width: 130px;
+			height: 44px;
+			border-radius: 4px;
+		}
+
+		@include break-small {
+			justify-content: center;
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/types.ts
@@ -1,7 +1,7 @@
 import { Onboard } from '@automattic/data-stores';
 
 export type Goal = {
-	key: Onboard.GoalKey;
+	key: Onboard.SiteGoal;
 	title: React.ReactChild | string;
 	isPremium?: boolean;
 };

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -5,7 +5,7 @@ import { DomainSuggestion } from '../domain-suggestions/types';
 import { STORE_KEY as SITE_STORE } from '../site';
 import { CreateSiteParams, Visibility, NewSiteBlogDetails } from '../site/types';
 import { FeatureId } from '../wpcom-features/types';
-import { GoalKey, STORE_KEY } from './constants';
+import { SiteGoal, STORE_KEY } from './constants';
 import type { State } from '.';
 // somewhat hacky, but resolves the circular dependency issue
 import type { Design, FontPair } from '@automattic/design-picker/src/types';
@@ -252,7 +252,7 @@ export const setStepProgress = (
 	stepProgress,
 } );
 
-export const setGoals = ( goals: GoalKey[] ) => ( {
+export const setGoals = ( goals: SiteGoal[] ) => ( {
 	type: 'SET_GOALS' as const,
 	goals,
 } );

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -1,6 +1,6 @@
 export const STORE_KEY = 'automattic/onboard';
 
-export enum GoalKey {
+export enum SiteGoal {
 	Write = 'write',
 	Sell = 'sell',
 	Promote = 'promote',
@@ -9,9 +9,10 @@ export enum GoalKey {
 	Other = 'other',
 }
 
-export enum IntentKey {
+export enum SiteIntent {
 	Write = 'write',
 	Sell = 'sell',
 	Build = 'build',
 	DIFM = 'difm', // "Do It For Me"
+	WpAdmin = 'wpadmin',
 }

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -9,7 +9,7 @@ import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 
 export type { State };
 
-export { GoalKey } from './constants';
+export { SiteGoal, SiteIntent } from './constants';
 
 /**
  * Onboard store depends on site-store. You should register the site before using this store.

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -1,5 +1,5 @@
 import { combineReducers } from '@wordpress/data';
-import { GoalKey } from './constants';
+import { SiteGoal } from './constants';
 import { goalsToIntent } from './utils';
 import type { DomainSuggestion } from '../domain-suggestions/types';
 import type { FeatureId } from '../wpcom-features/types';
@@ -299,7 +299,7 @@ const stepProgress: Reducer< { count: number; progress: number } | undefined, On
 	return state;
 };
 
-const goals: Reducer< GoalKey[], OnboardAction > = ( state = [], action ) => {
+const goals: Reducer< SiteGoal[], OnboardAction > = ( state = [], action ) => {
 	if ( action.type === 'SET_GOALS' ) {
 		return action.goals;
 	}

--- a/packages/data-stores/src/onboard/test/utils.ts
+++ b/packages/data-stores/src/onboard/test/utils.ts
@@ -1,27 +1,27 @@
-import { GoalKey, IntentKey } from '../constants';
+import { SiteGoal, SiteIntent } from '../constants';
 import { goalsToIntent } from '../utils';
 
 describe( 'Test onboard utils', () => {
 	it.each( [
 		{
 			goals: [],
-			expectedIntent: IntentKey.Build,
+			expectedIntent: SiteIntent.Build,
 		},
 		{
-			goals: [ GoalKey.Write, GoalKey.Import, GoalKey.DIFM ],
-			expectedIntent: IntentKey.DIFM,
+			goals: [ SiteGoal.Write, SiteGoal.Import, SiteGoal.DIFM ],
+			expectedIntent: SiteIntent.DIFM,
 		},
 		{
-			goals: [ GoalKey.Write, GoalKey.Sell, GoalKey.Promote ],
-			expectedIntent: IntentKey.Write,
+			goals: [ SiteGoal.Write, SiteGoal.Sell, SiteGoal.Promote ],
+			expectedIntent: SiteIntent.Write,
 		},
 		{
-			goals: [ GoalKey.Sell, GoalKey.Write, GoalKey.Promote ],
-			expectedIntent: IntentKey.Sell,
+			goals: [ SiteGoal.Sell, SiteGoal.Write, SiteGoal.Promote ],
+			expectedIntent: SiteIntent.Sell,
 		},
 		{
-			goals: [ GoalKey.Promote, GoalKey.Sell, GoalKey.Write ],
-			expectedIntent: IntentKey.Build,
+			goals: [ SiteGoal.Promote, SiteGoal.Sell, SiteGoal.Write ],
+			expectedIntent: SiteIntent.Build,
 		},
 	] )( 'Should map the $goals to $expectedIntent intent', ( { goals, expectedIntent } ) => {
 		expect( goalsToIntent( goals ) ).toBe( expectedIntent );

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -1,18 +1,18 @@
-import { GoalKey, IntentKey } from './constants';
+import { SiteGoal, SiteIntent } from './constants';
 
-const INTENT_DECIDING_GOALS = [ GoalKey.Write, GoalKey.Sell, GoalKey.Promote ] as const;
+const INTENT_DECIDING_GOALS = [ SiteGoal.Write, SiteGoal.Sell, SiteGoal.Promote ] as const;
 type IntentDecidingGoal = typeof INTENT_DECIDING_GOALS[ number ];
 
-const GOAL_TO_INTENT_MAP: { [ key in IntentDecidingGoal ]: IntentKey } = {
-	[ GoalKey.Write ]: IntentKey.Write,
-	[ GoalKey.Sell ]: IntentKey.Sell,
-	[ GoalKey.Promote ]: IntentKey.Build,
+const GOAL_TO_INTENT_MAP: { [ key in IntentDecidingGoal ]: SiteIntent } = {
+	[ SiteGoal.Write ]: SiteIntent.Write,
+	[ SiteGoal.Sell ]: SiteIntent.Sell,
+	[ SiteGoal.Promote ]: SiteIntent.Build,
 };
 
-export const goalsToIntent = ( goals: GoalKey[] ): IntentKey => {
+export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
 	// Including DIFM goal overwrites any other goal selection made
-	if ( goals.includes( GoalKey.DIFM ) ) {
-		return IntentKey.DIFM;
+	if ( goals.includes( SiteGoal.DIFM ) ) {
+		return SiteIntent.DIFM;
 	}
 
 	const intentDecidingGoal = ( goals as IntentDecidingGoal[] ).find( ( goal ) =>
@@ -23,5 +23,5 @@ export const goalsToIntent = ( goals: GoalKey[] ): IntentKey => {
 		return GOAL_TO_INTENT_MAP[ intentDecidingGoal ];
 	}
 
-	return IntentKey.Build;
+	return SiteIntent.Build;
 };


### PR DESCRIPTION
#### Proposed Changes

* Implement `Continue` button to goals capture screen

##### Before (Desktop and Mobile)
No `Continue` button at `Goals capture` step screen.
![Screenshot 2022-06-15 at 16 55 08](https://user-images.githubusercontent.com/2019970/173858881-31587997-6364-4d53-a576-0ff97a3dbfd1.png)
![Screenshot 2022-06-15 at 16 55 21](https://user-images.githubusercontent.com/2019970/173858888-0ae4f934-97c8-4745-b1a7-bd71cd4ed172.png)


##### After (Desktop and Mobile)
`Continue` button is present.
![Screenshot 2022-06-15 at 16 49 20](https://user-images.githubusercontent.com/2019970/173859048-a27f85ee-4096-461e-9acf-3c42de9d44ca.png)
![Screenshot 2022-06-15 at 16 49 41](https://user-images.githubusercontent.com/2019970/173859053-ce5f02f7-ce59-4c97-85c3-fdffc1e41c7f.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch locally.
2. In `config/development.json` set `signup/goals-step` property to `true`
3. Build and run `wp-calypso` locally.
4. Navigate to `http://calypso.localhost:3000/setup/goals?siteSlug=<YOUR SITE'S ADDRESS HERE>`, e.g.: http://calypso.localhost:3000/setup/goals?siteSlug=blajh198278453.wordpress.com
5. Test for `Continue` button being displayed.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/63921
