### PR TITLE
Remove Pro plan from top storage plan list

### DIFF
--- a/client/blocks/eligibility-warnings/excessive-disk-space.tsx
+++ b/client/blocks/eligibility-warnings/excessive-disk-space.tsx
@@ -1,4 +1,4 @@
-import { isBusinessPlan, isEcommercePlan, isProPlan } from '@automattic/calypso-products';
+import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import PlanStorage from 'calypso/blocks/plan-storage';
@@ -15,8 +15,7 @@ const ExcessiveDiskSpace = ( { translate }: { translate: LocalizeProps[ 'transla
 	);
 	const sitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, selectedSiteId ) ?? '' );
 
-	const planHasTopStorageSpace =
-		isBusinessPlan( sitePlanSlug ) || isEcommercePlan( sitePlanSlug ) || isProPlan( sitePlanSlug );
+	const planHasTopStorageSpace = isBusinessPlan( sitePlanSlug ) || isEcommercePlan( sitePlanSlug );
 	const displayUpgradeLink = canUserUpgrade && ! planHasTopStorageSpace;
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

This is a follow-up change for the Excessive disk space message changes added in #64388.
With reversion of the legacy plans, we'll want to allow users to upgrade from Pro plan, to other higher storage plans (ie. Business, eCommerce).
This PR removes the Pro plan from the top storage plan list.

#### Testing Instructions

* Have a Pro plan site
* Sandbox API and hack the sandbox to think that all sites have excessive disk usage

```diff
diff --git a/wp-content/lib/atomic/woa.php b/wp-content/lib/atomic/woa.php
index 987f3b35a..accb4928e 100644
--- a/wp-content/lib/atomic/woa.php
+++ b/wp-content/lib/atomic/woa.php
@@ -2269,6 +2269,7 @@ function woa_unsuspend( $blog_id ) {
  * @return bool If disk usage is excessive and the site should not be transferred.
  */
 function woa_is_space_used_excessive( $blog_id ) {
+       return true;
        // The value returned by get_space_used_bytes() excludes transcoded media files, but includes the original media.
        $disk_space_used = get_space_used_bytes( $blog_id );
        if ( $disk_space_used > 150 * GB_IN_BYTES ) {
```

* Visit `http://calypso.localhost:3000/hosting-config/activate/<site>` and try to transfer to atomic
* You should see this image, nugding you to purchase a plan with additional storage:
<img width="420" alt="Screenshot on 2022-06-15 at 15-11-55" src="https://user-images.githubusercontent.com/2749938/173825231-7e92a81e-1cbe-4780-85e4-26a55271de12.png">

* Repeat this for a Business/eCommerce site
* You should see this image, telling you to contact support:

<img width="420" alt="Screenshot on 2022-06-15 at 15-22-15" src="https://user-images.githubusercontent.com/2749938/173825757-c9e6e722-b723-4deb-9414-d17b00c19610.png">
 