### PR TITLE
Plans overhaul: revert Pro upsell in posts list

### DIFF
--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -278,7 +278,7 @@ class PostTypeList extends Component {
 				{ posts.slice( 0, 10 ).map( this.renderPost ) }
 				{ showUpgradeNudge && (
 					<UpsellNudge
-						title={ translate( 'No Ads with WordPress.com Pro' ) }
+						title={ translate( 'No Ads with WordPress.com Premium' ) }
 						description={ translate( 'Prevent ads from showing on your site.' ) }
 						feature={ WPCOM_FEATURES_NO_ADVERTS }
 						event="published_posts_no_ads"


### PR DESCRIPTION
#### Proposed Changes

In `posts/[FREE_SITE]` with +10 posts, a "Pro" upsell shows, which redirects to `/plans`. Reverted to "Premium" (previous value).

#### Media

**Before**

<img width="700" alt="Screenshot 2022-06-15 at 4 27 44 PM" src="https://user-images.githubusercontent.com/1705499/173841901-19f97ddc-51ad-49a3-9990-c83ad99441ee.png">

**After**

<img width="454" alt="Screenshot 2022-06-15 at 4 40 55 PM" src="https://user-images.githubusercontent.com/1705499/173841926-e866540f-8fc0-4dbf-8c91-908eca41b34d.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `posts/[FREE_SITE]` with site having +10 posts
* Confirm "Premium" upsell shows instead.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
