### PR TITLE
Ensure that data url for fallback flag SVG is URL-encoded

### DIFF
--- a/client/lib/flags/index.js
+++ b/client/lib/flags/index.js
@@ -33,6 +33,7 @@ export function flagUrl( countryCode ) {
 				</g>
 			</svg>`;
 
-		return 'data:image/svg+xml;utf8,' + svg;
+		// Ensure that we URI-encode the SVG content
+		return 'data:image/svg+xml;utf8,' + encodeURIComponent( svg );
 	}
 }

--- a/client/lib/flags/test/index.js
+++ b/client/lib/flags/test/index.js
@@ -23,8 +23,26 @@ describe( 'flagUrl', () => {
 					<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm0 18l2-2 1-1v-2h-2v-1l-1-1H9v3l2 2v1.93c-3.94-.494-7-3.858-7-7.93l1 1h2v-2h2l3-3V6h-2L9 5v-.41C9.927 4.21 10.94 4 12 4s2.073.212 3 .59V6l-1 1v2l1 1 3.13-3.13c.752.897 1.304 1.964 1.606 3.13H18l-2 2v2l1 1h2l.286.286C18.03 18.06 15.24 20 12 20z" />
 				</g>
 			</svg>`;
-		const globeSvg = 'data:image/svg+xml;utf8,' + gridicon;
+		const expectedGlobeSvg = 'data:image/svg+xml;utf8,' + encodeURIComponent( gridicon );
 
-		expect( flagUrl( 'blerg' ) ).toBe( globeSvg );
+		expect( flagUrl( 'blerg' ) ).toBe( expectedGlobeSvg );
+	} );
+
+	test( 'Given a country code without a flag, returns a fallback inline SVG', () => {
+		const gridicon = `
+			<svg
+				class="gridicon gridicons-globe"
+				height="24"
+				width="24"
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 3 24 18"
+			>
+				<g>
+					<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm0 18l2-2 1-1v-2h-2v-1l-1-1H9v3l2 2v1.93c-3.94-.494-7-3.858-7-7.93l1 1h2v-2h2l3-3V6h-2L9 5v-.41C9.927 4.21 10.94 4 12 4s2.073.212 3 .59V6l-1 1v2l1 1 3.13-3.13c.752.897 1.304 1.964 1.606 3.13H18l-2 2v2l1 1h2l.286.286C18.03 18.06 15.24 20 12 20z" />
+				</g>
+			</svg>`;
+		const expectedGlobeSvg = 'data:image/svg+xml;utf8,' + encodeURIComponent( gridicon );
+
+		expect( flagUrl( 'zz' ) ).toBe( expectedGlobeSvg );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* This PR ensures that when the `flagUrl` function in `client/lib/flags` can't locate a valid flag, it correctly URI-encodes the SVG content in the returned `data:` url

#### Testing Instructions

* This is easiest to test if you can set your back end up to return a country code of `ZZ` for the country views pages.
* Once your back end is configured to return `ZZ` as a country code, navigate to `/stats/week/[example.wordpress.com]`
* Verify that you can see an entry in the "Countries" section with "Unknown Region" as the location name, and a globe icon instead of a flag. (Prior to this change, there was no image due to the invalid `style` attribute that was created.)

##### Screenshot

<img width="331" alt="Screenshot 2022-06-15 at 15 55 28" src="https://user-images.githubusercontent.com/3376401/173845103-4988e264-7a46-41b6-b8ac-c9d25a251a9a.png">

Related to #55283 - this PR ensures that we show a flag when the viewer's region is unknown.