### PR TITLE
Add aria-label on design picker thumbnails

### DIFF
--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -18,6 +18,7 @@ interface GeneratedDesignThumbnailProps {
 	thumbnailUrl: string;
 	isSelected: boolean;
 	onPreview: () => void;
+	index: number;
 }
 
 const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
@@ -25,12 +26,14 @@ const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
 	thumbnailUrl,
 	isSelected,
 	onPreview,
+	index,
 } ) => {
 	const isMobile = useViewportMatch( 'small', '<' );
 
 	return (
 		<button
 			type="button"
+			aria-label={ `Preview design option ${ index }` }
 			className={ classnames( 'generated-design-thumbnail', { 'is-selected': isSelected } ) }
 			onClick={ onPreview }
 		>
@@ -124,6 +127,7 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 								thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
 								isSelected={ selectedDesign?.slug === design.slug }
 								onPreview={ () => onPreview( design, index ) }
+								index={ index + 1 }
 							/>
 						) ) }
 					<Button className="generated-design-picker__view-more" onClick={ onViewMore }>

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -19,7 +19,7 @@ interface GeneratedDesignThumbnailProps {
 	thumbnailUrl: string;
 	isSelected: boolean;
 	onPreview: () => void;
-	label: number;
+	label: string;
 }
 
 const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
@@ -30,13 +30,11 @@ const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
 	label,
 } ) => {
 	const isMobile = useViewportMatch( 'small', '<' );
-	const { __ } = useI18n();
 
 	return (
 		<button
 			type="button"
-			/* translators: %s: Option number. Ex. Preview design option 1. */
-			aria-label={ sprintf( __( 'Preview design option %s' ), label ) }
+			aria-label={ label }
 			className={ classnames( 'generated-design-thumbnail', { 'is-selected': isSelected } ) }
 			onClick={ onPreview }
 		>
@@ -130,7 +128,8 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 								thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
 								isSelected={ selectedDesign?.slug === design.slug }
 								onPreview={ () => onPreview( design, index ) }
-								label={ index + 1 }
+								/* translators: %s: Option number. Ex. Preview design option 1. */
+								label={ sprintf( __( 'Preview design option %s' ), index + 1 ) }
 							/>
 						) ) }
 					<Button className="generated-design-picker__view-more" onClick={ onViewMore }>

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@automattic/components';
 import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect, useRef } from 'react';
@@ -18,7 +19,7 @@ interface GeneratedDesignThumbnailProps {
 	thumbnailUrl: string;
 	isSelected: boolean;
 	onPreview: () => void;
-	index: number;
+	label: number;
 }
 
 const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
@@ -26,14 +27,16 @@ const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
 	thumbnailUrl,
 	isSelected,
 	onPreview,
-	index,
+	label,
 } ) => {
 	const isMobile = useViewportMatch( 'small', '<' );
+	const { __ } = useI18n();
 
 	return (
 		<button
 			type="button"
-			aria-label={ `Preview design option ${ index }` }
+			/* translators: %s: Option number. Ex. Preview design option 1. */
+			aria-label={ sprintf( __( 'Preview design option %s' ), label ) }
 			className={ classnames( 'generated-design-thumbnail', { 'is-selected': isSelected } ) }
 			onClick={ onPreview }
 		>
@@ -127,7 +130,7 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 								thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
 								isSelected={ selectedDesign?.slug === design.slug }
 								onPreview={ () => onPreview( design, index ) }
-								index={ index + 1 }
+								label={ index + 1 }
 							/>
 						) ) }
 					<Button className="generated-design-picker__view-more" onClick={ onViewMore }>


### PR DESCRIPTION
#### Proposed Changes

* Added the aria-label `Preview design option [n]` to describe the button action of the thumbnails in the design picker

https://user-images.githubusercontent.com/1881481/173863794-6d2de277-ca9b-4922-b276-18701baf74c4.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Using a screen reader navigate to `/setup/vertical?siteSlug=<your_site>`
* Select a vertical
* Select a build intent
* Set the focus on the first design thumbnail
* The screen reader should say `Preview design option 1`

<img width="907" alt="Screen Shot 2565-06-15 at 17 17 35" src="https://user-images.githubusercontent.com/1881481/173863881-9bb7eeb6-7d8d-483b-98de-d4bf1ebdf521.png">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [60-gh-Automattic/ganon-issues](60-gh-Automattic/ganon-issues)