### PR TITLE
ensure video ref is not null before attempting to set the src

### DIFF
--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -77,7 +77,9 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 			// Potential solution to this is to prevent the `videopress_refresh_iframe` message from being SENT until
 			// the update has completed.
 			setTimeout( () => {
-				this.video.src += ''; // force reload of potentially cross-origin iframe
+				if ( null !== this.video ) {
+					this.video.src += ''; // force reload of potentially cross-origin iframe
+				}
 			}, 1000 );
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* wrap video player iframe "refresh" in a null check incase it no longer exists when the callback runs

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* pull pr and `yarn start`
* open a video in the media library for a site with VideoPress enabled
* change the privacy level and immediately close the modal
* you should NOT see an error in the console that `this.video is null`
* retry the above steps in prod or before pulling this PR will result in the error in the console (if you want to make sure you're testing fast enough to see the error)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 1212-gh-Automattic/greenhouse