### PR TITLE
Update Jetpack Search heading font & logo.

### DIFF
--- a/client/my-sites/jetpack-search/content.tsx
+++ b/client/my-sites/jetpack-search/content.tsx
@@ -1,7 +1,9 @@
 import { Button, Card } from '@automattic/components';
+import classNames from 'classnames';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { FunctionComponent, ReactNode, Fragment } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 interface Props {
 	bodyText: TranslateResult | ReactNode;
@@ -24,16 +26,24 @@ const JetpackSearchContent: FunctionComponent< Props > = ( {
 
 	return (
 		<Fragment>
-			<FormattedHeader
-				headerText={ translate( 'Jetpack Search' ) }
-				id="jetpack-search-header"
-				align="left"
-				brandFont
-			/>
+			{ ! isJetpackCloud() && (
+				<FormattedHeader
+					headerText={ translate( 'Jetpack Search' ) }
+					id="jetpack-search-header"
+					align="left"
+					brandFont
+				/>
+			) }
 			<Card>
 				<div className="jetpack-search__content">
-					{ iconComponent }
-					{ headerText && <h1 className="jetpack-search__header">{ headerText }</h1> }
+					<div className="jetpack-search__logo">{ iconComponent }</div>
+					<h2
+						className={ classNames( 'jetpack-search__header', {
+							'wp-brand-font': ! isJetpackCloud(),
+						} ) }
+					>
+						{ headerText }
+					</h2>
 					<p>{ bodyText }</p>
 					<Button
 						primary

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -1,3 +1,4 @@
+import { ProductIcon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
@@ -18,7 +19,6 @@ import {
 } from 'calypso/state/ui/selectors';
 import JetpackSearchContent from './content';
 import JetpackSearchFooter from './footer';
-import JetpackSearchLogo from './logo';
 
 import './style.scss';
 
@@ -68,7 +68,7 @@ export default function SearchMain(): ReactElement {
 				buttonLink={ settingsUrl }
 				buttonText={ translate( 'Settings' ) }
 				onClick={ onSettingsClick }
-				iconComponent={ <JetpackSearchLogo /> }
+				iconComponent={ <ProductIcon slug={ 'jetpack_search' } /> }
 			/>
 
 			<JetpackSearchFooter />

--- a/client/my-sites/jetpack-search/style.scss
+++ b/client/my-sites/jetpack-search/style.scss
@@ -49,14 +49,11 @@
 }
 
 .jetpack-search__header {
-	color: var( --studio-black );
-	font-size: $font-title-medium;
-	font-weight: 600;
-	line-height: 1;
+	font-size: $font-title-small;
 	margin: 16px 0;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: $font-headline-small;
+		font-size: $font-title-medium;
 		margin: 20px 0 24px;
 	}
 }
@@ -76,7 +73,7 @@
 }
 
 .jetpack-search__button {
-	margin: 16px 0;
+	margin-top: 16px;
 	width: 100%;
 	text-align: center;
 


### PR DESCRIPTION
#### Proposed Changes

This PR updates Search UI logo and heading font as per recommended [here](https://github.com/Automattic/wp-calypso/issues/59431#issuecomment-1154526550) in #59431.

Closes: #59431

#### Screenshots: 

**Calypso Blue:**

**Before**                                 |  **After**
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/11078128/173911994-73a2c50e-02ea-44f7-b080-f1fff22a73b3.png)  |  ![](https://user-images.githubusercontent.com/11078128/173912044-a88cac77-7f1e-4e30-bb96-724dd2cfcb40.png)

**Calypso Green (Jetpack Cloud):**

**Before**                                 |  **After**
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/11078128/173912437-c7f78036-2c4a-4486-b50f-94d58f946719.png)  |  ![](https://user-images.githubusercontent.com/11078128/173912467-461e8ec8-9c43-48f7-8771-a8991fda685a.png)

#### Testing Instructions

1. Make sure you have a Jetpack site that owns a subscription to Jetpack Search, if you don't have one, you can create a new JN site and purchase it. Also, bonus if you have a simple site with Search activated.
1. Open the _**Calypso Live**_ link below, --or checkout this PR and spin up Calypso blue (`yarn start`).
1. Navigate to Jetpack --> Search (`/jetpack-search/:site`).
1. Verify that the UI looks like the Calypso blue "After" screenshot above. You can compare the differences with wordpress.com production. You should see the Jetpack Search product logo and the heading font ("Recoleta") and size should be consistent with many other UI sections throughout Calypso blue.
1. Also view in mobile viewport sizes to verify everything looks good.

1. Open the _**Jetpack Cloud Live**_ link below, --or checkout this PR and spin up Calypso green (`yarn start-jetpack-cloud`).
1. Navigate to Jetpack --> Search (`/jetpack-search/:site`).
1. Verify that the UI looks like the Calypso green "After" screenshot above. You can compare the differences with cloud.jetpack.com production. You should see the Jetpack Search product logo and the heading font size has been scaled down some. You'll also notice that the "Jetpack Search" page heading has been removed also, which is consistent with the other product sections (Backup & Scan) in Calypso Green.
1. Also view in mobile viewport sizes to verify everything looks good.

