### PR TITLE
Shopping Cart: Deprecate total_tax and total_cost in ResponseCart type

### DIFF
--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -224,11 +224,17 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	create_new_blog: boolean;
 	cart_key: CartKey;
 	products: P[];
-	total_tax: string; // Please try not to use this
+	/**
+	 * @deprecated Use total_tax_integer or total_tax_display
+	 */
+	total_tax: string;
 	total_tax_integer: number;
 	total_tax_display: string;
 	total_tax_breakdown: TaxBreakdownItem[];
-	total_cost: number; // Please try not to use this
+	/**
+	 * @deprecated Use total_cost_integer or total_cost_display
+	 */
+	total_cost: number;
 	total_cost_integer: number;
 	total_cost_display: string;
 	coupon_savings_total_integer: number;


### PR DESCRIPTION
#### Proposed Changes

This just adds the `@deprecated` tag to the `total_tax` and `total_cost` properties of the `ResponseCart` type.

#### Testing Instructions

None.