### PR TITLE
Redesign for the Plugin Details iteration header

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -158,22 +158,24 @@ const LegacyPluginDetailsHeader = ( { plugin } ) => {
 
 const LIMIT_OF_TAGS = 3;
 const Tags = ( { plugin } ) => {
+	const selectedSite = useSelector( getSelectedSite );
+
 	if ( ! plugin?.tags ) {
 		return null;
 	}
 
-	const tags = Object.values( plugin.tags || {} ).slice( 0, LIMIT_OF_TAGS );
+	const tagKeys = Object.keys( plugin.tags || {} ).slice( 0, LIMIT_OF_TAGS );
 
 	return (
 		<span className="plugin-details-header__tag-badge-container">
-			{ tags.map( ( tag ) => (
-				<Badge
-					key={ `badge-${ tag.replace( ' ', '' ) }` }
-					type="info"
+			{ tagKeys.map( ( tagKey ) => (
+				<a
+					key={ `badge-${ tagKey.replace( ' ', '' ) }` }
 					className="plugin-details-header__tag-badge"
+					href={ `/plugins/browse/${ tagKey }/${ selectedSite?.slug || '' }` }
 				>
-					{ tag }
-				</Badge>
+					<Badge type="info">{ plugin.tags[ tagKey ] }</Badge>
+				</a>
 			) ) }
 		</span>
 	);

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -165,7 +165,7 @@ const Tags = ( { plugin } ) => {
 	const tags = Object.values( plugin.tags || {} ).slice( 0, LIMIT_OF_TAGS );
 
 	return (
-		<span>
+		<span className="plugin-details-header__tag-badge-container">
 			{ tags.map( ( tag ) => (
 				<Badge
 					key={ `badge-${ tag.replace( ' ', '' ) }` }

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -17,6 +17,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 	const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
 
 	const selectedSite = useSelector( getSelectedSite );
+	const banner = plugin.banners?.high || plugin.banners?.low;
 
 	if ( isPlaceholder ) {
 		return <PluginDetailsHeaderPlaceholder />;
@@ -28,6 +29,11 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 
 	return (
 		<div className="plugin-details-header__container">
+			{ Boolean( banner ) && (
+				<div className="plugin-details-header__banner">
+					<img className="plugin-details-header__banner-image" alt={ plugin.name } src={ banner } />
+				</div>
+			) }
 			<div className="plugin-details-header__main-info">
 				<img className="plugin-details-header__icon" src={ plugin.icon } alt="" />
 				<div className="plugin-details-header__title-container">

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -1,6 +1,9 @@
+import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import Badge from 'calypso/components/badge';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import { preventWidows } from 'calypso/lib/formatting';
 import { getPluginAuthorKeyword } from 'calypso/lib/plugins/utils';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
@@ -11,63 +14,162 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder } ) => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 
+	const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
+
+	const selectedSite = useSelector( getSelectedSite );
+
+	if ( isPlaceholder ) {
+		return <PluginDetailsHeaderPlaceholder />;
+	}
+
+	if ( legacyVersion ) {
+		return <LegacyPluginDetailsHeader plugin={ plugin } />;
+	}
+
+	return (
+		<div className="plugin-details-header__container">
+			<div className="plugin-details-header__main-info">
+				<img className="plugin-details-header__icon" src={ plugin.icon } alt="" />
+				<div className="plugin-details-header__title-container">
+					<div className="plugin-details-header__name">{ plugin.name }</div>
+					<div className="plugin-details-header__subtitle">
+						<span className="plugin-details-header__author">
+							{ translate( 'By {{author/}}', {
+								components: {
+									author: (
+										<a
+											href={ `/plugins/${
+												selectedSite?.slug || ''
+											}?s=developer:"${ getPluginAuthorKeyword( plugin ) }"` }
+										>
+											{ plugin.author_name }
+										</a>
+									),
+								},
+							} ) }
+						</span>
+
+						<span className="plugin-details-header__subtitle-separator">·</span>
+
+						<Tags plugin={ plugin } />
+					</div>
+				</div>
+			</div>
+			<div className="plugin-details-header__description">
+				{ preventWidows( plugin.short_description || plugin.description ) }
+			</div>
+			<div className="plugin-details-header__additional-info">
+				{ !! plugin.rating && (
+					<div className="plugin-details-header__info">
+						<div className="plugin-details-header__info-title">{ translate( 'Ratings' ) }</div>
+						<div className="plugin-details-header__info-value">
+							<PluginRatings rating={ plugin.rating } />
+						</div>
+					</div>
+				) }
+				<div className="plugin-details-header__info">
+					<div className="plugin-details-header__info-title">{ translate( 'Last updated' ) }</div>
+					<div className="plugin-details-header__info-value">
+						{ moment.utc( plugin.last_updated, 'YYYY-MM-DD hh:mma' ).format( 'LL' ) }
+					</div>
+				</div>
+				<div className="plugin-details-header__info">
+					<div className="plugin-details-header__info-title">{ translate( 'Version' ) }</div>
+					<div className="plugin-details-header__info-value">{ plugin.version }</div>
+				</div>
+				{ Boolean( plugin.active_installs ) && (
+					<div className="plugin-details-header__info">
+						<div className="plugin-details-header__info-title">
+							{ translate( 'Active installations' ) }
+						</div>
+						<div className="plugin-details-header__info-value">
+							{ formatNumberMetric( plugin.active_installs, 0 ) }
+						</div>
+					</div>
+				) }
+			</div>
+		</div>
+	);
+};
+
+const LegacyPluginDetailsHeader = ( { plugin } ) => {
+	const moment = useLocalizedMoment();
+	const translate = useTranslate();
+
 	const selectedSite = useSelector( getSelectedSite );
 
 	const tags = Object.values( plugin?.tags || {} )
 		.slice( 0, 3 )
 		.join( ' · ' );
 
-	if ( isPlaceholder ) {
-		return <PluginDetailsHeaderPlaceholder />;
-	}
-
 	return (
-		<>
-			<div className="plugin-details-header__container">
-				<div className="plugin-details-header__tags">{ tags }</div>
-				<div className="plugin-details-header__main-info">
-					<img className="plugin-details-header__icon" src={ plugin.icon } alt="" />
-					<div className="plugin-details-header__title-container">
-						<div className="plugin-details-header__name">{ plugin.name }</div>
-						<div className="plugin-details-header__description">
-							{ preventWidows( plugin.short_description || plugin.description ) }
-						</div>
-					</div>
-				</div>
-				<div className="plugin-details-header__additional-info">
-					<div className="plugin-details-header__info">
-						<div className="plugin-details-header__info-title">{ translate( 'Developer' ) }</div>
-						<div className="plugin-details-header__info-value">
-							<a
-								href={ `/plugins/${
-									selectedSite?.slug || ''
-								}?s=developer:"${ getPluginAuthorKeyword( plugin ) }"` }
-							>
-								{ plugin.author_name }
-							</a>
-						</div>
-					</div>
-					{ !! plugin.rating && (
-						<div className="plugin-details-header__info">
-							<div className="plugin-details-header__info-title">{ translate( 'Ratings' ) }</div>
-							<div className="plugin-details-header__info-value">
-								<PluginRatings rating={ plugin.rating } />
-							</div>
-						</div>
-					) }
-					<div className="plugin-details-header__info">
-						<div className="plugin-details-header__info-title">{ translate( 'Last updated' ) }</div>
-						<div className="plugin-details-header__info-value">
-							{ moment.utc( plugin.last_updated, 'YYYY-MM-DD hh:mma' ).format( 'LL' ) }
-						</div>
-					</div>
-					<div className="plugin-details-header__info">
-						<div className="plugin-details-header__info-title">{ translate( 'Version' ) }</div>
-						<div className="plugin-details-header__info-value">{ plugin.version }</div>
+		<div className="plugin-details-header__container">
+			<div className="plugin-details-header__tags">{ tags }</div>
+			<div className="plugin-details-header__main-info">
+				<img className="plugin-details-header__icon" src={ plugin.icon } alt="" />
+				<div className="plugin-details-header__title-container">
+					<div className="plugin-details-header__name">{ plugin.name }</div>
+					<div className="plugin-details-header__description">
+						{ preventWidows( plugin.short_description || plugin.description ) }
 					</div>
 				</div>
 			</div>
-		</>
+			<div className="plugin-details-header__additional-info">
+				<div className="plugin-details-header__info">
+					<div className="plugin-details-header__info-title">{ translate( 'Developer' ) }</div>
+					<div className="plugin-details-header__info-value">
+						<a
+							href={ `/plugins/${ selectedSite?.slug || '' }?s=developer:"${ getPluginAuthorKeyword(
+								plugin
+							) }"` }
+						>
+							{ plugin.author_name }
+						</a>
+					</div>
+				</div>
+				{ !! plugin.rating && (
+					<div className="plugin-details-header__info">
+						<div className="plugin-details-header__info-title">{ translate( 'Ratings' ) }</div>
+						<div className="plugin-details-header__info-value">
+							<PluginRatings rating={ plugin.rating } />
+						</div>
+					</div>
+				) }
+				<div className="plugin-details-header__info">
+					<div className="plugin-details-header__info-title">{ translate( 'Last updated' ) }</div>
+					<div className="plugin-details-header__info-value">
+						{ moment.utc( plugin.last_updated, 'YYYY-MM-DD hh:mma' ).format( 'LL' ) }
+					</div>
+				</div>
+				<div className="plugin-details-header__info">
+					<div className="plugin-details-header__info-title">{ translate( 'Version' ) }</div>
+					<div className="plugin-details-header__info-value">{ plugin.version }</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+const LIMIT_OF_TAGS = 3;
+const Tags = ( { plugin } ) => {
+	if ( ! plugin?.tags ) {
+		return null;
+	}
+
+	const tags = Object.values( plugin.tags || {} ).slice( 0, LIMIT_OF_TAGS );
+
+	return (
+		<span>
+			{ tags.map( ( tag ) => (
+				<Badge
+					key={ `badge-${ tag.replace( ' ', '' ) }` }
+					type="info"
+					className="plugin-details-header__tag-badge"
+				>
+					{ tag }
+				</Badge>
+			) ) }
+		</span>
 	);
 };
 

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -119,7 +119,7 @@ $mobile-icon-height: 175px;
 		margin-left: 0;
 	}
 
-	&.badge {
+	.badge {
 		border-radius: 4px;
 	}
 }

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -18,7 +18,7 @@ $mobile-icon-height: 175px;
 
 	@include break-mobile {
 		flex-wrap: nowrap;
-		align-items: center;
+		align-items: flex-start;
 		justify-content: flex-start;
 	}
 	
@@ -46,6 +46,10 @@ $mobile-icon-height: 175px;
 
 .plugin-details-header__banner {
 	padding-bottom: 34px;
+
+	@include breakpoint-deprecated( '<960px' ) {
+		display: none;
+	}
 }
 
 .plugin-details-header__name {
@@ -61,8 +65,7 @@ $mobile-icon-height: 175px;
 }
 
 .plugin-details-header__subtitle-separator {
-	padding-left: 16px;
-	padding-right: 8px;
+	padding: 0 16px;
 	color: #dddddd;
 	font-size: $font-body;
 }
@@ -100,8 +103,25 @@ $mobile-icon-height: 175px;
 	}
 }
 
+.plugin-details-header__tag-badge-container {
+	display: inline-block;
+
+	@include breakpoint-deprecated( '<960px' ) {
+		margin-top: 12px;
+		display: block;
+	}
+}
+
 .plugin-details-header__tag-badge {
 	margin-left: 8px;
+
+	&:first-child {
+		margin-left: 0;
+	}
+
+	&.badge {
+		border-radius: 4px;
+	}
 }
 
 .is-placeholder {
@@ -150,9 +170,19 @@ $mobile-icon-height: 175px;
 
 	.plugin-details-header__info {
 		padding: 0 5px;
+
+		@media screen and ( max-width: 1040px ) {
+			padding-bottom: 12px;
+		}
 	}
 
 	.plugin-details-header__name {
 		line-height: 48px;
+	}
+
+	.plugin-details-header__main-info {
+		@include break-mobile {
+			align-items: center;
+		}
 	}
 }

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -44,6 +44,10 @@ $mobile-icon-height: 175px;
 	}
 }
 
+.plugin-details-header__banner {
+	padding-bottom: 34px;
+}
+
 .plugin-details-header__name {
 	font-family: $brand-serif;
 	font-size: $font-title-large;

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -151,4 +151,8 @@ $mobile-icon-height: 175px;
 	.plugin-details-header__info {
 		padding: 0 5px;
 	}
+
+	.plugin-details-header__name {
+		line-height: 48px;
+	}
 }

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -12,7 +12,6 @@ $mobile-icon-height: 175px;
 
 .plugin-details-header__main-info {
 	margin-top: 16px;
-	margin-bottom: 30px;
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: center;
@@ -25,8 +24,8 @@ $mobile-icon-height: 175px;
 	
 	.plugin-details-header__icon {
 		@include break-mobile {
-			width: 88px;
-			height: 88px;
+			width: 72px;
+			height: 72px;
 			margin-right: 20px;
 			margin-bottom: 0;
 		}
@@ -48,12 +47,26 @@ $mobile-icon-height: 175px;
 .plugin-details-header__name {
 	font-family: $brand-serif;
 	font-size: $font-title-large;
+	line-height: 40px;
 	color: var( --studio-gray-100 );
+}
+
+.plugin-details-header__author {
+	font-size: $font-body;
+	color: var( --studio-gray-60 );
+}
+
+.plugin-details-header__subtitle-separator {
+	padding-left: 16px;
+	padding-right: 8px;
+	color: #dddddd;
+	font-size: $font-body;
 }
 
 .plugin-details-header__description {
 	font-size: $font-title-small;
-	color: var( --studio-gray-70 );
+	color: var( --studio-gray-80 );
+	padding: 24px 0;
 }
 
 .plugin-details-header__additional-info {
@@ -63,7 +76,7 @@ $mobile-icon-height: 175px;
 	.plugin-details-header__info {
 		width: 25%;
 		box-sizing: border-box;
-		padding: 0 5px;
+		padding: 0;
 
 		@media screen and ( max-width: 1040px ) {
 			width: 50%;
@@ -83,16 +96,8 @@ $mobile-icon-height: 175px;
 	}
 }
 
-.plugin-details-header__tags {
-	position: absolute;
-    top: calc( $mobile-icon-height + 25px );
-	font-size: $font-body-extra-small;
-	color: var( --studio-gray-60 );
-
-	@include break-mobile {
-		position: relative;
-		top: 0;
-	}
+.plugin-details-header__tag-badge {
+	margin-left: 8px;
 }
 
 .is-placeholder {
@@ -105,5 +110,41 @@ $mobile-icon-height: 175px;
 	.plugin-details-header__tags {
 		@extend %placeholder;
 		width: 50%;
+	}
+}
+
+.legacy {
+	.plugin-details-header__icon {
+		@include break-mobile {
+			width: 88px;
+			height: 88px;
+		}
+		width: $mobile-icon-height;
+		height: $mobile-icon-height;
+	}
+
+	.plugin-details-header__tags {
+		position: absolute;
+		top: calc( $mobile-icon-height + 25px );
+		font-size: $font-body-extra-small;
+		color: var( --studio-gray-60 );
+	
+		@include break-mobile {
+			position: relative;
+			top: 0;
+		}
+	}
+
+	.plugin-details-header__main-info {
+		margin-bottom: 30px;
+	}
+	
+	.plugin-details-header__description {
+		color: var( --studio-gray-70 );
+		padding: 0;
+	}
+
+	.plugin-details-header__info {
+		padding: 0 5px;
 	}
 }

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Card, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -230,6 +231,7 @@ class PluginSections extends Component {
 		} );
 		const banner = this.props.plugin?.banners?.high || this.props.plugin?.banners?.low;
 		const videoUrl = this.props.plugin?.banner_video_src;
+		const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
 
 		/*eslint-disable react/no-danger*/
 		if (
@@ -271,13 +273,15 @@ class PluginSections extends Component {
 
 		return (
 			<div ref={ this.descriptionContent } className={ contentClasses }>
-				<div className="plugin-sections__banner">
-					<img
-						className="plugin-sections__banner-image"
-						alt={ this.props.plugin.name }
-						src={ banner }
-					/>
-				</div>
+				{ legacyVersion && (
+					<div className="plugin-sections__banner">
+						<img
+							className="plugin-sections__banner-image"
+							alt={ this.props.plugin.name }
+							src={ banner }
+						/>
+					</div>
+				) }
 				<div
 					// Sanitized in client/lib/plugins/utils.js with sanitizeHtml
 					dangerouslySetInnerHTML={ {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -120,6 +120,10 @@ body.is-section-plugins.theme-default.color-scheme {
 .plugin-details__layout {
 	padding-top: 54px;
 
+	@include breakpoint-deprecated( '<960px' ) {
+		padding-top: 0;
+	}
+
 	@include display-grid;
 	@include grid-template-columns( 3, 80px, 1fr );
 	grid-template-areas: 'header header actions'
@@ -144,6 +148,10 @@ body.is-section-plugins.theme-default.color-scheme {
 		grid-area: actions;
 		background-color: var( --studio-gray-0 );
 		padding: 20px;
+
+		@include breakpoint-deprecated( '<960px' ) {
+			margin-top: 40px;
+		}
 	}
 
 	.plugin-details__layout-col-left {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -118,6 +118,8 @@ body.is-section-plugins.theme-default.color-scheme {
 }
 
 .plugin-details__layout {
+	padding-top: 54px;
+
 	@include display-grid;
 	@include grid-template-columns( 3, 80px, 1fr );
 	grid-template-areas: 'header header actions'
@@ -135,6 +137,7 @@ body.is-section-plugins.theme-default.color-scheme {
 
 	.plugin-details__content {
 		grid-area: content;
+		padding-top: 50px;
 	}
 
 	.plugin-details__actions {
@@ -166,8 +169,6 @@ body.is-section-plugins.theme-default.color-scheme {
 
 .plugin-details__body {
 	.plugin-sections {
-		margin-top: 20px;
-
 		.section-nav {
 			box-shadow: none;
 		}
@@ -285,9 +286,14 @@ body.is-section-plugins header .select-dropdown__item {
 .legacy {
 	.plugin-details__body {
 		border-top: 1px solid var( --studio-gray-5 );
+
+		.plugin-sections {
+			margin-top: 20px;
+		}
 	}
 
 	.plugin-details__layout {
+		padding-top: 0;
 		grid-template-areas: none;
 		grid-template-columns: initial;
 


### PR DESCRIPTION
### Description
Update the Plugin Details page header to look like the figma layout: 84fqtCG4pCnCh2Hq0But5-fi-2009%3A23786 .
| Figma  | Branch version |
| ------------- | ------------- |
|<img width="603" alt="Screen Shot 2022-06-15 at 17 20 35" src="https://user-images.githubusercontent.com/5039531/173931993-bd969261-3e2c-4e87-a0a7-beb07349c7ca.png">|<img width="941" alt="Screen Shot 2022-06-15 at 16 25 22" src="https://user-images.githubusercontent.com/5039531/173932088-7c70b821-c833-4ca5-9a9a-0c2339bb4539.png">|


### Proposed Changes

* Update the Plugin header behind a feature flag
* Update the mobile layout for the header
* Update the badges to point to plugins search by category
* Show the banner on top of the header information when not in the legacy version
* Update distances on the main layout

### Testing Instructions
**Negative Validation**

* Without enabling any feature flags
* Check if the Plugin Details header of this branch looks the same as the one in production
* Test for paid and free plugins. Ex: `/plugins/woocommerce-bookings/{site}` and `/plugins/elementor/{site}`

**Positive validation**

* Enable the feature flag `plugins/plugin-details-layout`*
* Go to the plugin details page and check the layout is correspondent to the versions displayed below

| Banner  | Video | No banner or video
| ------------- | ------------- | -- |
|<img width="1128" alt="Screen Shot 2022-06-15 at 16 26 01" src="https://user-images.githubusercontent.com/5039531/173932368-bcba7e1f-2e0f-4682-8ba4-81fa49a0fc58.png">|<img width="1128" alt="Screen Shot 2022-06-15 at 16 26 44" src="https://user-images.githubusercontent.com/5039531/173932488-5c08d1cc-f417-4f79-a817-6d67bd0b10db.png">|<img width="1128" alt="Screen Shot 2022-06-15 at 16 26 29" src="https://user-images.githubusercontent.com/5039531/173932552-fecab574-3692-4f28-892c-245019a9494e.png">|



\* To enable this feature flag add `?flags=plugins/plugin-details-layout` to the end of your URL or past the following code on the developer tools console `document.cookie = 'flags=plugins/plugin-details-layout;max-age=1209600;path=/'`


----

Fixes #63715