### PR TITLE
Marketplace: Separates categories from plugins

### DIFF
--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -54,7 +54,7 @@ const Categories = ( { selected }: { selected?: string } ) => {
 
 		let url;
 		if ( category.slug !== 'discover' ) {
-			url = `/plugins/${ category.slug }/${ domain || '' }`;
+			url = `/plugins/browse/${ category.slug }/${ domain || '' }`;
 		} else {
 			url = `/plugins/${ domain || '' }`;
 		}

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -100,9 +100,7 @@ function plugin( context, next ) {
 export function browsePluginsOrPlugin( context, next ) {
 	const siteUrl = getSiteFragment( context.path );
 	if (
-		( context.params.plugin &&
-			( ( siteUrl && context.params.plugin === siteUrl.toString() ) ||
-				includes( ALLOWED_CATEGORIES, context.params.plugin ) ) ) ||
+		( context.params.plugin && siteUrl && context.params.plugin === siteUrl.toString() ) ||
 		context.query?.s
 	) {
 		browsePlugins( context, next );

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -33,6 +33,7 @@ export default function () {
 
 	page(
 		'/plugins/browse/:category/:site?',
+		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
 		browsePlugins,

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -31,15 +31,14 @@ export default function () {
 		clientRender
 	);
 
-	page( '/plugins/browse/:category/:site', ( context ) => {
-		const { category, site } = context.params;
-		page.redirect( `/plugins/${ category }/${ site }` );
-	} );
-
-	page( '/plugins/browse/:siteOrCategory?', ( context ) => {
-		const { siteOrCategory } = context.params;
-		page.redirect( '/plugins' + ( siteOrCategory ? '/' + siteOrCategory : '' ) );
-	} );
+	page(
+		'/plugins/browse/:category/:site?',
+		siteSelection,
+		navigation,
+		browsePlugins,
+		makeLayout,
+		clientRender
+	);
 
 	page( '/plugins/upload', scrollTopIfNoHash, siteSelection, sites, makeLayout, clientRender );
 	page(

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -542,9 +542,9 @@ const PluginSingleListView = ( {
 		.filter( isNotBlocked )
 		.filter( ( plugin ) => isNotInstalled( plugin, installedPlugins ) );
 
-	let listLink = '/plugins/' + category;
+	let listLink = '/plugins/browse/' + category;
 	if ( domain ) {
-		listLink = '/plugins/' + category + '/' + domain;
+		listLink = '/plugins/browse/' + category + '/' + domain;
 	}
 
 	if ( ! isFetching && plugins.length === 0 ) {
@@ -673,7 +673,7 @@ const ManageButton = ( { shouldShowManageButton, siteAdminUrl, siteSlug, jetpack
 
 const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews } ) => {
 	const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';
-	let analyticsPath = category ? `/plugins/${ category }` : '/plugins';
+	let analyticsPath = category ? `/plugins/browse/${ category }` : '/plugins';
 
 	if ( selectedSiteId ) {
 		analyticsPath += '/:site';

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -176,7 +176,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 		if ( category ) {
 			items.push( {
 				label: categoryName,
-				href: `/plugins/${ category }/${ siteSlug || '' }`,
+				href: `/plugins/browse/${ category }/${ siteSlug || '' }`,
 				id: 'category',
 			} );
 		}

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -15,7 +15,7 @@ const selectors = {
 	pluginTitleOnSection: ( section: string, plugin: string ) =>
 		`.plugins-browser-list:has(.plugins-browser-list__title.${ section }) :text-is("${ plugin }")`,
 	sectionTitles: '.plugins-browser-list__title',
-	browseAllPopular: 'a[href^="/plugins/popular"]',
+	browseAllPopular: 'a[href^="/plugins/browse/popular"]',
 	breadcrumb: ( section: string ) => `.plugins-browser__header a:text("${ section }") `,
 	pricingToggle: ':text("Monthly Price"), :text("Annual Price")',
 	monthlyPricingSelect: 'a[data-bold-text^="Monthly price"]',


### PR DESCRIPTION
#### Proposed Changes

* Moves categories under `plugins/browse/:category`.
* Updates breadcrumbs, categories and the discover lists to redirect to the new route.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the marketplace
* When clicking on a category it should navigate into `plugins/browse/:category/:site`.
* Inside the category do a search, the result should be a url like `plugins/browse/:category/:site`.
* Breadcrumbs should navigate to the correct page.
* Navigate to the plugin home, and check that the "Top Paid" and "Top Free" sections are correctly navigating to the new route.
* This `http://calypso.localhost:3000/plugins/booking/rolilinktestbusiness.wpcomstaging.com` url should go to the plugin instead of the category.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #63940