### PR TITLE
[calypso/client][etk] Update Sentry packages

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -70,7 +70,7 @@
 		"@babel/core": "^7.17.5",
 		"@emotion/react": "^11.4.1",
 		"@popperjs/core": "^2.10.2",
-		"@sentry/browser": "^7.1.1",
+		"@sentry/browser": "^7.3.1",
 		"@wordpress/a11y": "^3.9.0",
 		"@wordpress/api-fetch": "^6.6.0",
 		"@wordpress/base-styles": "^4.5.0",

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -70,7 +70,7 @@
 		"@babel/core": "^7.17.5",
 		"@emotion/react": "^11.4.1",
 		"@popperjs/core": "^2.10.2",
-		"@sentry/browser": "^6.19.6",
+		"@sentry/browser": "^7.1.1",
 		"@wordpress/a11y": "^3.9.0",
 		"@wordpress/api-fetch": "^6.6.0",
 		"@wordpress/base-styles": "^4.5.0",

--- a/client/package.json
+++ b/client/package.json
@@ -64,7 +64,7 @@
 		"@emotion/react": "^11.4.1",
 		"@emotion/styled": "^11.3.0",
 		"@github/webauthn-json": "^0.4.1",
-		"@sentry/react": "^7.1.1",
+		"@sentry/react": "^7.3.1",
 		"@stripe/react-stripe-js": "^1.4.1",
 		"@stripe/stripe-js": "^1.17.1",
 		"@wordpress/a11y": "^3.9.0",

--- a/client/package.json
+++ b/client/package.json
@@ -64,7 +64,7 @@
 		"@emotion/react": "^11.4.1",
 		"@emotion/styled": "^11.3.0",
 		"@github/webauthn-json": "^0.4.1",
-		"@sentry/react": "^6.19.4",
+		"@sentry/react": "^7.1.1",
 		"@stripe/react-stripe-js": "^1.4.1",
 		"@stripe/stripe-js": "^1.17.1",
 		"@wordpress/a11y": "^3.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1525,7 +1525,7 @@ __metadata:
     "@babel/core": ^7.17.5
     "@emotion/react": ^11.4.1
     "@popperjs/core": ^2.10.2
-    "@sentry/browser": ^6.19.6
+    "@sentry/browser": ^7.1.1
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.3
     "@types/node": ^15.0.2
@@ -4803,15 +4803,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:6.19.6, @sentry/browser@npm:^6.19.6":
-  version: 6.19.6
-  resolution: "@sentry/browser@npm:6.19.6"
+"@sentry/browser@npm:7.1.1, @sentry/browser@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "@sentry/browser@npm:7.1.1"
   dependencies:
-    "@sentry/core": 6.19.6
-    "@sentry/types": 6.19.6
-    "@sentry/utils": 6.19.6
+    "@sentry/core": 7.1.1
+    "@sentry/types": 7.1.1
+    "@sentry/utils": 7.1.1
     tslib: ^1.9.3
-  checksum: 3ba9df43455835465d73427b91f4a54511ed022944bf7a3e07102965088017aac9eff608ccea1c119be6716249e7ef3867771ba8604b20922f3bcb4ac860cd93
+  checksum: 3b98a7826e01e8b6a20a69655a78c820c75e3c0bc8e1c35b841c68bcaf975f739e43fd46f2e359a74c0dddaeaeefbd7845c6cdabd3c4b8846727782997442b7f
   languageName: node
   linkType: hard
 
@@ -4832,71 +4832,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:6.19.6":
-  version: 6.19.6
-  resolution: "@sentry/core@npm:6.19.6"
+"@sentry/core@npm:7.1.1":
+  version: 7.1.1
+  resolution: "@sentry/core@npm:7.1.1"
   dependencies:
-    "@sentry/hub": 6.19.6
-    "@sentry/minimal": 6.19.6
-    "@sentry/types": 6.19.6
-    "@sentry/utils": 6.19.6
+    "@sentry/hub": 7.1.1
+    "@sentry/types": 7.1.1
+    "@sentry/utils": 7.1.1
     tslib: ^1.9.3
-  checksum: d86a79e43b36c2d17acd9d90effb9ae532c9fb2a7d9a133ea858e5b52030526064e964e4a852757ee5683ae5971786192c2c061676f00b62f52661e79100114a
+  checksum: cfad6a2172bc53e4827024c6632c70125d65d8668a3fd19b6d0087372675cfb4da8f9af16d7f7594c92f758252b025aa6d339916df62e8417473b9be34554ce2
   languageName: node
   linkType: hard
 
-"@sentry/hub@npm:6.19.6":
-  version: 6.19.6
-  resolution: "@sentry/hub@npm:6.19.6"
+"@sentry/hub@npm:7.1.1":
+  version: 7.1.1
+  resolution: "@sentry/hub@npm:7.1.1"
   dependencies:
-    "@sentry/types": 6.19.6
-    "@sentry/utils": 6.19.6
+    "@sentry/types": 7.1.1
+    "@sentry/utils": 7.1.1
     tslib: ^1.9.3
-  checksum: c85fbb10a4125f532dcd94b4c394250e1ae8a051c0dc48f31df47eb765299f64438b78337463927e950e902c20b6ca05c6f0fae14579e5762f7219acd482c893
+  checksum: 374a2dc3398f45328ea2dcca8bc8c7e2ba4a20912afd5ebeb9ddaf7e37f4c73cc13318509558d4482685e742c0b1c356fcd031605f3432b4ff8d29daf327656f
   languageName: node
   linkType: hard
 
-"@sentry/minimal@npm:6.19.6":
-  version: 6.19.6
-  resolution: "@sentry/minimal@npm:6.19.6"
+"@sentry/react@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "@sentry/react@npm:7.1.1"
   dependencies:
-    "@sentry/hub": 6.19.6
-    "@sentry/types": 6.19.6
-    tslib: ^1.9.3
-  checksum: ab748fbceac0d142d70f2a8c79456876b46c6c5b2640c709aaa20c4421def96339620584a8780ae3de97b07322cf0a7d2a8bb659e3359794993c5e1706c532e1
-  languageName: node
-  linkType: hard
-
-"@sentry/react@npm:^6.19.4":
-  version: 6.19.6
-  resolution: "@sentry/react@npm:6.19.6"
-  dependencies:
-    "@sentry/browser": 6.19.6
-    "@sentry/minimal": 6.19.6
-    "@sentry/types": 6.19.6
-    "@sentry/utils": 6.19.6
+    "@sentry/browser": 7.1.1
+    "@sentry/types": 7.1.1
+    "@sentry/utils": 7.1.1
     hoist-non-react-statics: ^3.3.2
     tslib: ^1.9.3
   peerDependencies:
     react: 15.x || 16.x || 17.x || 18.x
-  checksum: 18f6a4bea654319fbb6682119cba2d5637bc20601df57e5a34675f2a9f49612a55144be1ca99d41b4722ae86e9b966ff9a74f881b247dd84db146902e8decfc7
+  checksum: 5c8dec361f7501ca5fde03d50eda5e6b6f983379e72c818de3038c23d024c2def092375ee04d2aac31eb935d88b943c1f64105ed837488307df4b4417e32f26b
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:6.19.6":
-  version: 6.19.6
-  resolution: "@sentry/types@npm:6.19.6"
-  checksum: f51ca59e092a13c95fa60c075348633d9f9defd406073e8502f86c2b7b00eb74469fcda64549284fb9ad034ceae798ec9dffbb12c77941708fe71e9fb68b9865
+"@sentry/types@npm:7.1.1":
+  version: 7.1.1
+  resolution: "@sentry/types@npm:7.1.1"
+  checksum: 70d44abac63b9f37842780a3298b92837db34ae949574a2246887a956deaca342e3430886b23ecd14492bc9078923a999e8378666c6704c9bfcc757e3858cbff
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:6.19.6":
-  version: 6.19.6
-  resolution: "@sentry/utils@npm:6.19.6"
+"@sentry/utils@npm:7.1.1":
+  version: 7.1.1
+  resolution: "@sentry/utils@npm:7.1.1"
   dependencies:
-    "@sentry/types": 6.19.6
+    "@sentry/types": 7.1.1
     tslib: ^1.9.3
-  checksum: 4e7afdf023f93ef7ddccd85ad7847342b030bdc1189110eeb7cb53349f89882e6184149ec29182e41d7fc45f161e19196f2b488138e75185b3fd114f84dac0d6
+  checksum: 229b98f7d0ccb3faa29b3da4bc6d4b53fe412b3e960383e2168d0973538a5f46a2729f2156357497505a134c15479f9e4154f423ee0dfd5606af898c66f7683c
   languageName: node
   linkType: hard
 
@@ -12442,7 +12429,7 @@ __metadata:
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
     "@github/webauthn-json": ^0.4.1
-    "@sentry/react": ^6.19.4
+    "@sentry/react": ^7.1.1
     "@sentry/webpack-plugin": ^1.18.8
     "@stripe/react-stripe-js": ^1.4.1
     "@stripe/stripe-js": ^1.17.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1525,7 +1525,7 @@ __metadata:
     "@babel/core": ^7.17.5
     "@emotion/react": ^11.4.1
     "@popperjs/core": ^2.10.2
-    "@sentry/browser": ^7.1.1
+    "@sentry/browser": ^7.3.1
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.3
     "@types/node": ^15.0.2
@@ -4803,15 +4803,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:7.1.1, @sentry/browser@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "@sentry/browser@npm:7.1.1"
+"@sentry/browser@npm:7.3.1, @sentry/browser@npm:^7.3.1":
+  version: 7.3.1
+  resolution: "@sentry/browser@npm:7.3.1"
   dependencies:
-    "@sentry/core": 7.1.1
-    "@sentry/types": 7.1.1
-    "@sentry/utils": 7.1.1
+    "@sentry/core": 7.3.1
+    "@sentry/types": 7.3.1
+    "@sentry/utils": 7.3.1
     tslib: ^1.9.3
-  checksum: 3b98a7826e01e8b6a20a69655a78c820c75e3c0bc8e1c35b841c68bcaf975f739e43fd46f2e359a74c0dddaeaeefbd7845c6cdabd3c4b8846727782997442b7f
+  checksum: 333d74b6960f89562af335e5ebf217e36f74c56271e700f17ba39a56829bbc31ee07a4ecdcf4fa499ec75c450209369a3e52759572d08a450fe7e405cc3fecb2
   languageName: node
   linkType: hard
 
@@ -4832,58 +4832,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:7.1.1":
-  version: 7.1.1
-  resolution: "@sentry/core@npm:7.1.1"
+"@sentry/core@npm:7.3.1":
+  version: 7.3.1
+  resolution: "@sentry/core@npm:7.3.1"
   dependencies:
-    "@sentry/hub": 7.1.1
-    "@sentry/types": 7.1.1
-    "@sentry/utils": 7.1.1
+    "@sentry/hub": 7.3.1
+    "@sentry/types": 7.3.1
+    "@sentry/utils": 7.3.1
     tslib: ^1.9.3
-  checksum: cfad6a2172bc53e4827024c6632c70125d65d8668a3fd19b6d0087372675cfb4da8f9af16d7f7594c92f758252b025aa6d339916df62e8417473b9be34554ce2
+  checksum: e8b44b68046227c465908f6f075de7c31369d55ad35c9e71a1a27df5f84b36f57fc84f1f383fbd0873e0fef8c545cefb63472258e2593c860b8a110e1efd619a
   languageName: node
   linkType: hard
 
-"@sentry/hub@npm:7.1.1":
-  version: 7.1.1
-  resolution: "@sentry/hub@npm:7.1.1"
+"@sentry/hub@npm:7.3.1":
+  version: 7.3.1
+  resolution: "@sentry/hub@npm:7.3.1"
   dependencies:
-    "@sentry/types": 7.1.1
-    "@sentry/utils": 7.1.1
+    "@sentry/types": 7.3.1
+    "@sentry/utils": 7.3.1
     tslib: ^1.9.3
-  checksum: 374a2dc3398f45328ea2dcca8bc8c7e2ba4a20912afd5ebeb9ddaf7e37f4c73cc13318509558d4482685e742c0b1c356fcd031605f3432b4ff8d29daf327656f
+  checksum: 5ce3c68f694d2c18848b0e677bdbbe4ec8213750fa2fdeca43391c8d60ed7058d955528fbaf78f045284a78db0478e7d2e2f5e740b61e14248946c0a8085a045
   languageName: node
   linkType: hard
 
-"@sentry/react@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "@sentry/react@npm:7.1.1"
+"@sentry/react@npm:^7.3.1":
+  version: 7.3.1
+  resolution: "@sentry/react@npm:7.3.1"
   dependencies:
-    "@sentry/browser": 7.1.1
-    "@sentry/types": 7.1.1
-    "@sentry/utils": 7.1.1
+    "@sentry/browser": 7.3.1
+    "@sentry/types": 7.3.1
+    "@sentry/utils": 7.3.1
     hoist-non-react-statics: ^3.3.2
     tslib: ^1.9.3
   peerDependencies:
     react: 15.x || 16.x || 17.x || 18.x
-  checksum: 5c8dec361f7501ca5fde03d50eda5e6b6f983379e72c818de3038c23d024c2def092375ee04d2aac31eb935d88b943c1f64105ed837488307df4b4417e32f26b
+  checksum: a7390ce78069407b6cabee6c4049725bff5b5cbd9494f809e6567bc7926e91f3cca685b4481b82c5676639dbb2f5ccfa4eb1d195202fd6600af54a20621c2578
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:7.1.1":
-  version: 7.1.1
-  resolution: "@sentry/types@npm:7.1.1"
-  checksum: 70d44abac63b9f37842780a3298b92837db34ae949574a2246887a956deaca342e3430886b23ecd14492bc9078923a999e8378666c6704c9bfcc757e3858cbff
+"@sentry/types@npm:7.3.1":
+  version: 7.3.1
+  resolution: "@sentry/types@npm:7.3.1"
+  checksum: 94d17eab574945b3ccd11cba5d63c55337e530067532a3e620de4ddb10b9977e9144ece00aee1b60c4edc9140ebf3be9f7943d0ed089407c9e1dd2abf6c206b6
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:7.1.1":
-  version: 7.1.1
-  resolution: "@sentry/utils@npm:7.1.1"
+"@sentry/utils@npm:7.3.1":
+  version: 7.3.1
+  resolution: "@sentry/utils@npm:7.3.1"
   dependencies:
-    "@sentry/types": 7.1.1
+    "@sentry/types": 7.3.1
     tslib: ^1.9.3
-  checksum: 229b98f7d0ccb3faa29b3da4bc6d4b53fe412b3e960383e2168d0973538a5f46a2729f2156357497505a134c15479f9e4154f423ee0dfd5606af898c66f7683c
+  checksum: 899cadf323c6b53c528392b5897477b9f0423b9f637900572abff1efda467a2bde2c2eeaae41df3b1275a9af9b109321ad6a0aab8e150814bd6de5875d387d8d
   languageName: node
   linkType: hard
 
@@ -12429,7 +12429,7 @@ __metadata:
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
     "@github/webauthn-json": ^0.4.1
-    "@sentry/react": ^7.1.1
+    "@sentry/react": ^7.3.1
     "@sentry/webpack-plugin": ^1.18.8
     "@stripe/react-stripe-js": ^1.4.1
     "@stripe/stripe-js": ^1.17.1


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update Sentry npm packages to their latest versions on Calypso client and ETK.

#### Testing instructions

Build and sync this version of ETK to your sandbox and trigger an error manually. Just fire-up the console and run this JS snippet (make sure you select the WPadmin iframe):

```
var foo = document.createElement('script');
foo.innerHTML = "throw new Error('hi there!');"
document.body.appendChild(foo);
```
Do the same thing from a local Calypso instance, make sure the top-level frame is selected.

You should see the error in Sentry in their corresponding projects.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

