### PR TITLE
Tour kit: fix missing configuration passthrough on spotlight live resize component

### DIFF
--- a/packages/tour-kit/CHANGELOG.md
+++ b/packages/tour-kit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Added missing configuration passthrough on spotlight live resize component
+
 ## 1.1.0
 
 - Added live resize functionality using ResizeObserver and MutationObserver

--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/tour-kit",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Tour lib for guided walkthroughs.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/tour-kit/src/components/tour-kit-frame.tsx
+++ b/packages/tour-kit/src/components/tour-kit-frame.tsx
@@ -227,6 +227,7 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 				{ showSpotlight() && (
 					<Spotlight
 						referenceElement={ referenceElement }
+						liveResize={ config.options?.effects?.liveResize || {} }
 						{ ...( config.options?.effects?.spotlight || {} ) }
 					/>
 				) }


### PR DESCRIPTION
#### Proposed Changes

* Added missing configuration passthrough on spotlight live resize component