### PR TITLE
Design Picker: Add calypso_signup_design_type_submit event to track design_type

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-design-picker.tsx
@@ -14,7 +14,7 @@ import type { Step } from '../../types';
 import './style.scss';
 import type { Design } from '@automattic/design-picker';
 
-const AnchorFmDesignPicker: Step = ( { navigation } ) => {
+const AnchorFmDesignPicker: Step = ( { navigation, flow } ) => {
 	const { goBack, submit, goToStep } = navigation;
 	const translate = useTranslate();
 	const locale = useLocale();
@@ -66,6 +66,13 @@ const AnchorFmDesignPicker: Step = ( { navigation } ) => {
 
 			return setDesignOnSite( newSite.site_slug, _selectedDesign, '' );
 		} );
+
+		recordTracksEvent( 'calypso_signup_design_type_submit', {
+			flow,
+			intent: 'anchor-fm',
+			design_type: _selectedDesign.design_type,
+		} );
+
 		submit?.();
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-themes.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/anchor-fm-themes.ts
@@ -1,10 +1,12 @@
+import type { Design } from '@automattic/design-picker';
+
 /*
  * Anchor.fm themes are not actual themes as we understand them.
  * They're built at site setup from specialized Headstart annotations
  * using existing themes `spearhead` and `mayland`.
  * Therefore we hard-code their data since it's not available via the themes API.
  */
-export const ANCHOR_FM_THEMES = [
+export const ANCHOR_FM_THEMES: Design[] = [
 	{
 		title: 'Gilbert',
 		slug: 'gilbert',
@@ -17,6 +19,7 @@ export const ANCHOR_FM_THEMES = [
 		is_premium: false,
 		features: [ 'anchorfm' ],
 		categories: [],
+		design_type: 'anchor-fm',
 	},
 	{
 		title: 'Hannah',
@@ -30,6 +33,7 @@ export const ANCHOR_FM_THEMES = [
 		is_premium: false,
 		features: [ 'anchorfm' ],
 		categories: [],
+		design_type: 'anchor-fm',
 	},
 	{
 		title: 'Riley',
@@ -43,5 +47,6 @@ export const ANCHOR_FM_THEMES = [
 		is_premium: false,
 		features: [ 'anchorfm' ],
 		categories: [],
+		design_type: 'anchor-fm',
 	},
 ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -30,7 +30,7 @@ import { STEP_NAME } from './constants';
 import GeneratedDesignPickerWebPreview from './generated-design-picker-web-preview';
 import PreviewToolbar from './preview-toolbar';
 import StickyPositioner from './sticky-positioner';
-import type { Step } from '../../types';
+import type { Step, ProvidedDependencies } from '../../types';
 import './style.scss';
 import type { Design } from '@automattic/design-picker';
 
@@ -179,6 +179,18 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	);
 	const categorization = useCategorization( staticDesigns, categorizationOptions );
 
+	const handleSubmit = ( providedDependencies?: ProvidedDependencies ) => {
+		const _selectedDesign = providedDependencies?.selectedDesign as Design;
+
+		recordTracksEvent( 'calypso_signup_design_type_submit', {
+			flow,
+			intent,
+			design_type: _selectedDesign?.design_type ?? 'default',
+		} );
+
+		submit?.( providedDependencies );
+	};
+
 	function pickDesign(
 		_selectedDesign: Design | undefined = selectedDesign,
 		buttonLocation?: string
@@ -196,11 +208,10 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 				...( showGeneratedDesigns && positionIndex >= 0 && { position_index: positionIndex } ),
 			} );
 
-			const providedDependencies = {
+			handleSubmit( {
 				selectedDesign: _selectedDesign,
 				selectedSiteCategory: categorization.selection,
-			};
-			submit?.( providedDependencies );
+			} );
 		}
 	}
 
@@ -448,7 +459,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			skipLabelText={ intent === 'write' ? translate( 'Skip and draft first post' ) : undefined }
 			stepContent={ stepContent }
 			recordTracksEvent={ recordStepContainerTracksEvent }
-			goNext={ () => ( isPreviewingGeneratedDesign ? pickDesign() : submit?.() ) }
+			goNext={ isPreviewingGeneratedDesign ? pickDesign : handleSubmit }
 			goBack={ handleBackClick }
 		/>
 	);

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-generated-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-generated-query.ts
@@ -47,5 +47,6 @@ function apiStarterDesignsGeneratedToDesign( design: StarterDesignsGenerated ): 
 		features: [],
 		template: '',
 		theme: '',
+		design_type: 'vertical',
 	};
 }

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -58,18 +58,21 @@ function apiThemeToDesign( { id, name, taxonomies, stylesheet }: any ): Design {
 		( { slug }: any ) => slug === 'featured'
 	);
 
+	const is_premium = stylesheet && stylesheet.startsWith( 'premium/' );
+
 	return {
 		slug: id,
 		title: name,
 		recipe: {
 			stylesheet,
 		},
-		is_premium: stylesheet && stylesheet.startsWith( 'premium/' ),
+		is_premium,
 		categories: taxonomies?.theme_subject ?? [],
 		features: [],
 		is_featured_picks: isFeaturedPicks,
 		showFirst: isFeaturedPicks,
 		...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
+		design_type: is_premium ? 'premium' : 'standard',
 
 		// Deprecated; used for /start flow
 		stylesheet,

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -21,7 +21,15 @@ export interface DesignRecipe {
 
 export type DesignFeatures = 'anchorfm'; // For additional features, = 'anchorfm' | 'feature2' | 'feature3'
 
-export type DesignType = 'vertical' | 'premium' | 'standard' | 'default' | 'anchor-fm'; // For measuring what kind of the design user picked
+/**
+ * For measuring what kind of the design user picked.
+ */
+export type DesignType =
+	| 'vertical'
+	| 'premium'
+	| 'standard' // The design is free.
+	| 'default' // The default design and it means user skipped the step and didn't select any design.
+	| 'anchor-fm';
 
 export interface Design {
 	slug: string;

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -21,6 +21,8 @@ export interface DesignRecipe {
 
 export type DesignFeatures = 'anchorfm'; // For additional features, = 'anchorfm' | 'feature2' | 'feature3'
 
+export type DesignType = 'vertical' | 'premium' | 'standard' | 'default' | 'anchor-fm'; // For measuring what kind of the design user picked
+
 export interface Design {
 	slug: string;
 	title: string;
@@ -31,6 +33,7 @@ export interface Design {
 	is_featured_picks?: boolean; // Whether this design will be featured in the sidebar. Example: Blank Canvas
 	showFirst?: boolean; // Whether this design will appear at the top, regardless of category
 	preview?: 'static';
+	design_type?: DesignType;
 
 	/** @deprecated used for Gutenboarding (/new flow) */
 	stylesheet?: string;


### PR DESCRIPTION
#### Proposed Changes

* Add `calypso_signup_design_type_submit` when the user finishes the design step with or without selecting a design.
* Add `design_type` to the `Design` when handling the responses of the design, and then we can easily know the type of the design

> **Note**
> Remember to register the event

**Vertical Design Picker**
| Action | Event |
| - | - |
| Continue | ![image](https://user-images.githubusercontent.com/13596067/174009166-08874bed-11e8-44f6-83d0-5ea0c883c770.png) |
| Skip for now | ![image](https://user-images.githubusercontent.com/13596067/174008941-e9fd35f0-51bd-4da0-9d23-2c21569ac281.png) |

**Standard Design Picker**

| Action | Event |
| - | - |
| Start with XXX" that is "free" | ![image](https://user-images.githubusercontent.com/13596067/174010995-dd5ca1f4-0a3f-4153-83c8-208658532e60.png) |
| Start with XXX that is "premium" | ![image](https://user-images.githubusercontent.com/13596067/174009821-4b5e1e18-6648-4236-b8e9-a747191e35b4.png) |
| Skip for now | ![image](https://user-images.githubusercontent.com/13596067/174009042-4c5a716f-5f6a-4514-a17e-7b424908762d.png) |

**Preview Standard Design**
| Action | Event |
| - | - |
| Start with XXX" that is "free" | ![image](https://user-images.githubusercontent.com/13596067/174009648-ce661a36-514a-4ef1-80b2-04695a9e632d.png) |

**AnchorFm**
| Action | Event |
| - | - |
| Select a design | ![image](https://user-images.githubusercontent.com/13596067/174011321-c551086e-eaa0-4ff6-a67f-439c7f7556e5.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Vertical Design Picker**

* Go to `/setup/vertical?siteSlug=<your_site>`
* Select a vertical
* Select build
* In Design Picker
  * Select a vertical design and check the `design_type` of the event is `vertical`
  * Click "Skip for now" at the top-right corner and check the `design_type` of the event is `default`

**Standard Design Picker

* Go to `/setup/vertical?siteSlug=<your_site>`
* Select a vertical
* Select build
* Select "View more options" in Design Picker
  * Start with a free design and check the `design_type` of the event is `standard`
  * Start with a premium design and check the `design_type` of the event is `premium`
  * Preview a free design and click "Start with XXX" at the top-right corner and check the `design_type` of the event is `standard`
  * Preview a premium design and click "Start with XXX" at the top-right corner and check the `design_type` of the event is `premium`
  * Click "Skip for now" at the top-right corner and check the `design_type` of the event is `default`

**AnchorFm**

* Go to `/setup/?anchor_podcast=9370e048`
* Select a design and check the `design_type` of the event is `anchor-fm`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 67-gh-Automattic/ganon-issues