### PR TITLE
Remove redirect middleware from /log-in/en to /log-in

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import page from 'page';
-import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
@@ -126,41 +125,6 @@ export function magicLoginUse( context, next ) {
 	);
 
 	next();
-}
-
-export function redirectDefaultLocale( context, next ) {
-	// Do not redirect if it's server side
-	if ( context.isServerSide ) {
-		return next();
-	}
-	// Only handle simple routes
-	if ( context.pathname !== '/log-in/en' && context.pathname !== '/log-in/jetpack/en' ) {
-		if ( ! isUserLoggedIn( context.store.getState() ) && ! context.params.lang ) {
-			context.params.lang = config( 'i18n_default_locale_slug' );
-		}
-		return next();
-	}
-
-	// Do not redirect if user bootrapping is disabled
-	if (
-		! isUserLoggedIn( context.store.getState() ) &&
-		! config.isEnabled( 'wpcom-user-bootstrap' )
-	) {
-		return next();
-	}
-
-	// Do not redirect if user is logged in and the locale is different than english
-	// so we force the page to display in english
-	const currentUserLocale = getCurrentUserLocale( context.store.getState() );
-	if ( currentUserLocale && currentUserLocale !== 'en' ) {
-		return next();
-	}
-
-	if ( context.params.isJetpack === 'jetpack' ) {
-		page.redirect( '/log-in/jetpack' );
-	} else {
-		page.redirect( '/log-in' );
-	}
 }
 
 export function redirectJetpack( context, next ) {

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -9,14 +9,7 @@ import {
 	makeLayoutMiddleware,
 } from 'calypso/controller/shared';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
-import {
-	login,
-	magicLogin,
-	qrCodeLogin,
-	magicLoginUse,
-	redirectJetpack,
-	redirectDefaultLocale,
-} from './controller';
+import { login, magicLogin, qrCodeLogin, magicLoginUse, redirectJetpack } from './controller';
 import redirectLoggedIn from './redirect-logged-in';
 import { setShouldServerSideRenderLogin } from './ssr';
 
@@ -104,7 +97,6 @@ export default ( router ) => {
 			`/log-in/${ lang }`,
 		],
 		redirectJetpack,
-		redirectDefaultLocale,
 		setLocaleMiddleware(),
 		setHrefLangLinks,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),


### PR DESCRIPTION
#### Proposed Changes

* Testing to see if we can just remove this redirect entirely as its not clear why it is required, discussed here https://github.com/Automattic/wp-calypso/pull/64680#discussion_r898776961

#### Testing Instructions

* /log-in
* /log-in/en
* /log-in/ja
* Logged in
* Logged out
* Logged in with non english locale
* Clicking the english link suggestion on localized page
* ssr / non ssr rendering (/log-in vs /log-in?test)
* Hydrated, non hydrated (wpcom-user-bootstrap)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #64598 
