### PR TITLE
Import: update import flow tracking

### DIFF
--- a/client/blocks/import/capture/index.tsx
+++ b/client/blocks/import/capture/index.tsx
@@ -81,6 +81,10 @@ const CaptureStep: React.FunctionComponent< Props > = ( {
 		} );
 	};
 
+	const recordCaptureScreen = () => {
+		recordTracksEvent( trackEventName, trackEventParams );
+	};
+
 	const onInputChange = ( e: ChangeEvent< HTMLInputElement > ) => {
 		resetError();
 		setUrlValue( e.target.value );
@@ -99,9 +103,7 @@ const CaptureStep: React.FunctionComponent< Props > = ( {
 	 */
 	useEffect( recordScanningEvent, [ isAnalyzing ] );
 	useEffect( recordScanningErrorEvent, [ analyzerError ] );
-	useEffect( () => {
-		recordTracksEvent( trackEventName, trackEventParams );
-	}, [] );
+	useEffect( recordCaptureScreen, [] );
 
 	return (
 		<>

--- a/client/blocks/import/capture/index.tsx
+++ b/client/blocks/import/capture/index.tsx
@@ -99,6 +99,9 @@ const CaptureStep: React.FunctionComponent< Props > = ( {
 	 */
 	useEffect( recordScanningEvent, [ isAnalyzing ] );
 	useEffect( recordScanningErrorEvent, [ analyzerError ] );
+	useEffect( () => {
+		recordTracksEvent( trackEventName, trackEventParams );
+	}, [] );
 
 	return (
 		<>

--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -1,25 +1,33 @@
 import { Button } from '@automattic/components';
 import { Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import illustrationImg from 'calypso/assets/images/onboarding/import-1.svg';
 import ActionCard from 'calypso/components/action-card';
 import ImporterLogo from 'calypso/my-sites/importer/importer-logo';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { urlDataUpdate } from 'calypso/state/imports/url-analyzer/actions';
-import { GoToStep, ImporterPlatform, UrlData } from '../types';
-import type * as React from 'react';
+import { GoToStep, ImporterPlatform, UrlData, RecordTracksEvent } from '../types';
 import './style.scss';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
+const trackEventName = 'calypso_signup_step_start';
+const trackEventParams = {
+	flow: 'importer',
+	step: 'list',
+};
+
 interface Props {
 	goToStep: GoToStep;
 	urlDataUpdate: ( urlData: UrlData ) => void;
+	recordTracksEvent: RecordTracksEvent;
 }
 
 const ListStep: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { goToStep, urlDataUpdate } = props;
+	const { goToStep, urlDataUpdate, recordTracksEvent } = props;
 
 	const onButtonClick = ( platform: ImporterPlatform ): void => {
 		urlDataUpdate( {
@@ -32,6 +40,13 @@ const ListStep: React.FunctionComponent< Props > = ( props ) => {
 		} );
 		goToStep( `ready` );
 	};
+
+	/**
+	 ↓ Effects
+	 */
+	useEffect( () => {
+		recordTracksEvent( trackEventName, trackEventParams );
+	}, [] );
 
 	return (
 		<>
@@ -122,6 +137,7 @@ const ListStep: React.FunctionComponent< Props > = ( props ) => {
 
 const connector = connect( () => ( {} ), {
 	urlDataUpdate,
+	recordTracksEvent,
 } );
 
 export default connector( ListStep );

--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -41,12 +41,14 @@ const ListStep: React.FunctionComponent< Props > = ( props ) => {
 		goToStep( `ready` );
 	};
 
+	const recordImportList = () => {
+		recordTracksEvent( trackEventName, trackEventParams );
+	};
+
 	/**
 	 ↓ Effects
 	 */
-	useEffect( () => {
-		recordTracksEvent( trackEventName, trackEventParams );
-	}, [] );
+	useEffect( recordImportList, [] );
 
 	return (
 		<>

--- a/client/blocks/import/ready/index.tsx
+++ b/client/blocks/import/ready/index.tsx
@@ -263,9 +263,21 @@ const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( {
 		} );
 	};
 
+	const recordStartBuildingEvent = () => {
+		recordTracksEvent( trackEventName, {
+			...trackEventParams,
+			action: 'start-building',
+		} );
+	};
+
 	const onBackBtnClick = () => {
 		recordBackToStartEvent();
 		goToStep( 'capture' );
+	};
+
+	const onStartBuildingBtnClick = () => {
+		recordStartBuildingEvent();
+		goToStep( 'intent', '', 'setup-site' );
 	};
 
 	useEffect( recordReadyScreenEvent, [] );
@@ -291,9 +303,7 @@ const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( {
 					</SubTitle>
 
 					<div className="import__buttons-group">
-						<NextButton onClick={ () => goToStep( 'intent', '', 'setup-site' ) }>
-							{ __( 'Start building' ) }
-						</NextButton>
+						<NextButton onClick={ onStartBuildingBtnClick }>{ __( 'Start building' ) }</NextButton>
 						<div>
 							<BackButton onClick={ onBackBtnClick }>{ __( 'Back to start' ) }</BackButton>
 						</div>

--- a/client/blocks/import/ready/index.tsx
+++ b/client/blocks/import/ready/index.tsx
@@ -180,7 +180,18 @@ const ReadyStep: React.FunctionComponent< ReadyProps > = ( props ) => {
 		} );
 	};
 
+	const recordImportGuideEvent = () => {
+		if ( ! isModalDetailsOpen ) return;
+
+		recordTracksEvent( trackEventName, {
+			...trackEventParams,
+			action: 'guide-modal',
+			platform,
+		} );
+	};
+
 	useEffect( recordReadyScreenEvent, [] );
+	useEffect( recordImportGuideEvent, [ isModalDetailsOpen ] );
 
 	return (
 		<div className="import-layout__center">

--- a/client/blocks/importer/blogger/index.tsx
+++ b/client/blocks/importer/blogger/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import classnames from 'classnames';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -77,6 +78,11 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 		return checkProgress() || checkIsSuccess();
 	}
 
+	function onSiteViewClick() {
+		recordTracksEvent( 'calypso_site_importer_view_site' );
+		stepNavigator?.goToSiteViewPage?.();
+	}
+
 	return (
 		<>
 			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
@@ -90,7 +96,7 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 								siteSlug={ siteSlug }
 								job={ job as ImportJob }
 								resetImport={ resetImport }
-								onSiteViewClick={ stepNavigator?.goToSiteViewPage }
+								onSiteViewClick={ onSiteViewClick }
 							/>
 						);
 					} else if ( checkIsFailed() ) {

--- a/client/blocks/importer/components/complete-screen/index.tsx
+++ b/client/blocks/importer/components/complete-screen/index.tsx
@@ -1,6 +1,7 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Hooray, SubTitle, Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ImportJob } from '../../types';
 import DoneButton from '../done-button';
 
@@ -14,6 +15,10 @@ interface Props {
 const CompleteScreen: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
 	const { job, siteId, resetImport, onSiteViewClick } = props;
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_site_importer_start_import_success' );
+	}, [] );
 
 	return (
 		<Hooray>

--- a/client/blocks/importer/components/error-message/index.tsx
+++ b/client/blocks/importer/components/error-message/index.tsx
@@ -1,7 +1,8 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { BackButton, NextButton, SubTitle, Title } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import './style.scss';
 
@@ -15,6 +16,10 @@ interface Props {
 const ErrorMessage: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
 	const { onBackToStart, onStartBuilding } = props;
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_site_importer_start_import_failure' );
+	}, [] );
 
 	return (
 		<div className="import-layout__center">

--- a/client/blocks/importer/components/importing-pane/importing-pane.tsx
+++ b/client/blocks/importer/components/importing-pane/importing-pane.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { ProgressBar, Spinner } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -66,7 +67,10 @@ class ImportingPane extends ImportingPaneBase {
 					<AuthorMappingPane
 						hasSingleAuthor={ hasSingleAuthor }
 						onMap={ this.handleOnMap }
-						onStartImport={ () => this.props.startImporting( this.props.importerStatus ) }
+						onStartImport={ () => {
+							recordTracksEvent( 'calypso_site_importer_map_import_progress' );
+							this.props.startImporting( this.props.importerStatus );
+						} }
 						siteId={ siteId }
 						sourceType={ sourceType }
 						sourceAuthors={ customData.sourceAuthors }

--- a/client/blocks/importer/medium/index.tsx
+++ b/client/blocks/importer/medium/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import classnames from 'classnames';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -77,6 +78,11 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 		return checkProgress() || checkIsSuccess();
 	}
 
+	function onSiteViewClick() {
+		recordTracksEvent( 'calypso_site_importer_view_site' );
+		stepNavigator?.goToSiteViewPage?.();
+	}
+
 	return (
 		<>
 			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
@@ -90,7 +96,7 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 								siteSlug={ siteSlug }
 								job={ job as ImportJob }
 								resetImport={ resetImport }
-								onSiteViewClick={ stepNavigator?.goToSiteViewPage }
+								onSiteViewClick={ onSiteViewClick }
 							/>
 						);
 					} else if ( checkIsFailed() ) {

--- a/client/blocks/importer/squarespace/index.tsx
+++ b/client/blocks/importer/squarespace/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import classnames from 'classnames';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -77,6 +78,11 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 		return checkProgress() || checkIsSuccess();
 	}
 
+	function onSiteViewClick() {
+		recordTracksEvent( 'calypso_site_importer_view_site' );
+		stepNavigator?.goToSiteViewPage?.();
+	}
+
 	return (
 		<>
 			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
@@ -90,7 +96,7 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 								siteSlug={ siteSlug }
 								job={ job as ImportJob }
 								resetImport={ resetImport }
-								onSiteViewClick={ stepNavigator?.goToSiteViewPage }
+								onSiteViewClick={ onSiteViewClick }
 							/>
 						);
 					} else if ( checkIsFailed() ) {

--- a/client/blocks/importer/wix/index.tsx
+++ b/client/blocks/importer/wix/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import classnames from 'classnames';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -120,6 +121,11 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 		return checkProgress() || checkIsSuccess();
 	}
 
+	function onSiteViewClick() {
+		recordTracksEvent( 'calypso_site_importer_view_site' );
+		stepNavigator?.goToSiteViewPage?.();
+	}
+
 	return (
 		<>
 			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
@@ -140,7 +146,7 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 								siteSlug={ siteSlug }
 								job={ job as ImportJob }
 								resetImport={ resetImport }
-								onSiteViewClick={ stepNavigator?.goToSiteViewPage }
+								onSiteViewClick={ onSiteViewClick }
 							/>
 						);
 					}

--- a/client/blocks/importer/wordpress/content-chooser/index.tsx
+++ b/client/blocks/importer/wordpress/content-chooser/index.tsx
@@ -9,11 +9,18 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { preventWidows } from 'calypso/lib/formatting';
 import wpcom from 'calypso/lib/wp';
 import { jetpack } from 'calypso/signup/icons';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { SitesItem } from 'calypso/state/selectors/get-sites-items';
 import { requestSite } from 'calypso/state/sites/actions';
 
 import './style.scss';
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+
+const trackEventName = 'calypso_signup_actions_submit_step';
+const trackEventParams = {
+	intent: 'import',
+	step: 'importReadyPreview',
+};
 
 interface Props {
 	siteId: number;
@@ -56,6 +63,10 @@ export const ContentChooser: React.FunctionComponent< Props > = ( props ) => {
 
 		dispatch( requestSite( fromSite ) );
 	}, [ hasOriginSiteJetpackConnected ] );
+
+	useEffect( () => {
+		dispatch( recordTracksEvent( trackEventName, trackEventParams ) );
+	}, [] );
 
 	/**
 	 ↓ Methods

--- a/client/blocks/importer/wordpress/import-everything/confirm-upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm-upgrade-plan.tsx
@@ -1,9 +1,10 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { getPlan, PLAN_BUSINESS, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
 import { sprintf } from '@wordpress/i18n';
 import { check, plus, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import { getFeatureByKey } from 'calypso/lib/plans/features-list';
@@ -61,6 +62,10 @@ export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
 			</ul>
 		);
 	}
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_site_importer_migration_plan_display' );
+	}, [] );
 
 	return (
 		<div className={ classnames( 'import__upgrade-plan' ) }>

--- a/client/blocks/importer/wordpress/import-everything/confirm.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm.tsx
@@ -151,7 +151,13 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 				<ConfirmModal
 					siteSlug={ targetSiteSlug }
 					onConfirm={ startImport }
-					onClose={ () => setIsModalDetailsOpen( false ) }
+					onClose={ () => {
+						setIsModalDetailsOpen( false );
+						recordTracksEvent( 'calypso_signup_previous_step_button_click', {
+							flow: 'importer',
+							step: 'importerWordpress',
+						} );
+					} }
 				/>
 			) }
 		</>

--- a/client/blocks/importer/wordpress/import-everything/confirm.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm.tsx
@@ -1,9 +1,10 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Title, SubTitle, NextButton, Notice } from '@automattic/onboarding';
 import { sprintf } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
 import { convertToFriendlyWebsiteName } from 'calypso/blocks/import/util';
 import SiteIcon from 'calypso/blocks/site-icon';
@@ -40,6 +41,13 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 	} = props;
 	const [ isModalDetailsOpen, setIsModalDetailsOpen ] = useState( false );
 	const [ showUpgradePlanScreen, setShowUpgradePlanScreen ] = useState( false );
+
+	/**
+	 ↓ Effects
+	 */
+	useEffect( () => {
+		recordTracksEvent( 'calypso_site_importer_migration_confirmation' );
+	}, [] );
 
 	return (
 		<>

--- a/client/blocks/importer/wordpress/import-everything/confirm.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm.tsx
@@ -150,7 +150,14 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 			{ isModalDetailsOpen && (
 				<ConfirmModal
 					siteSlug={ targetSiteSlug }
-					onConfirm={ startImport }
+					onConfirm={ () => {
+						recordTracksEvent( 'calypso_signup_step_start', {
+							flow: 'importer',
+							step: 'importerWordpress',
+							action: 'importAndReplace',
+						} );
+						startImport();
+					} }
 					onClose={ () => {
 						setIsModalDetailsOpen( false );
 						recordTracksEvent( 'calypso_signup_previous_step_button_click', {

--- a/client/blocks/importer/wordpress/import-everything/confirm.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm.tsx
@@ -130,7 +130,16 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 						) }
 
 						{ isTargetSitePlanCompatible && (
-							<NextButton onClick={ () => setIsModalDetailsOpen( true ) }>
+							<NextButton
+								onClick={ () => {
+									recordTracksEvent( 'calypso_signup_step_start', {
+										flow: 'importer',
+										step: 'importerWordpress',
+										action: 'startImport',
+									} );
+									setIsModalDetailsOpen( true );
+								} }
+							>
 								{ __( 'Start import' ) }
 							</NextButton>
 						) }

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -40,34 +40,7 @@ interface State {
 export class ImportEverything extends SectionMigrate {
 	componentDidUpdate( prevProps: any, prevState: State ) {
 		super.componentDidUpdate( prevProps, prevState );
-
-		if (
-			prevState.migrationStatus !== MigrationStatus.BACKING_UP &&
-			this.state.migrationStatus === MigrationStatus.BACKING_UP
-		) {
-			recordTracksEvent( 'calypso_site_importer_import_progress_backing_up' );
-		}
-
-		if (
-			prevState.migrationStatus !== MigrationStatus.RESTORING &&
-			this.state.migrationStatus === MigrationStatus.RESTORING
-		) {
-			recordTracksEvent( 'calypso_site_importer_import_progress_restoring' );
-		}
-
-		if (
-			prevState.migrationStatus !== MigrationStatus.ERROR &&
-			this.state.migrationStatus === MigrationStatus.ERROR
-		) {
-			recordTracksEvent( 'calypso_site_importer_import_failure' );
-		}
-
-		if (
-			prevState.migrationStatus !== MigrationStatus.DONE &&
-			this.state.migrationStatus === MigrationStatus.DONE
-		) {
-			recordTracksEvent( 'calypso_site_importer_import_success' );
-		}
+		this.recordMigrationStatusChange( prevState );
 	}
 
 	goToCart = () => {
@@ -105,6 +78,36 @@ export class ImportEverything extends SectionMigrate {
 		this.props.requestSite( targetSiteId );
 
 		this.requestMigrationReset( targetSiteId );
+	};
+
+	recordMigrationStatusChange = ( prevState: State ) => {
+		if (
+			prevState.migrationStatus !== MigrationStatus.BACKING_UP &&
+			this.state.migrationStatus === MigrationStatus.BACKING_UP
+		) {
+			recordTracksEvent( 'calypso_site_importer_import_progress_backing_up' );
+		}
+
+		if (
+			prevState.migrationStatus !== MigrationStatus.RESTORING &&
+			this.state.migrationStatus === MigrationStatus.RESTORING
+		) {
+			recordTracksEvent( 'calypso_site_importer_import_progress_restoring' );
+		}
+
+		if (
+			prevState.migrationStatus !== MigrationStatus.ERROR &&
+			this.state.migrationStatus === MigrationStatus.ERROR
+		) {
+			recordTracksEvent( 'calypso_site_importer_import_failure' );
+		}
+
+		if (
+			prevState.migrationStatus !== MigrationStatus.DONE &&
+			this.state.migrationStatus === MigrationStatus.DONE
+		) {
+			recordTracksEvent( 'calypso_site_importer_import_success' );
+		}
 	};
 
 	renderLoading() {

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -181,7 +181,12 @@ export class ImportEverything extends SectionMigrate {
 					<SubTitle>
 						{ translate( 'Congratulations. Your content was successfully imported.' ) }
 					</SubTitle>
-					<DoneButton onSiteViewClick={ stepNavigator?.goToSiteViewPage } />
+					<DoneButton
+						onSiteViewClick={ () => {
+							recordTracksEvent( 'calypso_site_importer_view_site' );
+							stepNavigator?.goToSiteViewPage?.();
+						} }
+					/>
 				</Hooray>
 				<GettingStartedVideo />
 			</>

--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { convertToFriendlyWebsiteName } from 'calypso/blocks/import/util';
@@ -51,10 +52,12 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	 ↓ Methods
 	 */
 	function installJetpack() {
+		recordTracksEvent( 'calypso_site_importer_install_jetpack' );
 		window.open( `/jetpack/connect/?url=${ fromSite }`, '_blank' );
 	}
 
 	function switchToMigrationScreen() {
+		recordTracksEvent( 'calypso_site_importer_start_everything_import' );
 		updateCurrentPageQueryParam( { option: WPImportOption.EVERYTHING } );
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
@@ -49,7 +49,7 @@ const ImportReady: Step = function ImportStep( props ) {
 	 ↓ Renders
 	 */
 	return (
-		<ImportWrapper { ...props }>
+		<ImportWrapper { ...props } stepName="ready">
 			<ReadyStep
 				platform={ urlData?.platform }
 				goToImporterPage={ goToImporterPage }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -13,7 +13,7 @@ import './style.scss';
 
 export const ImportWrapper: Step = function ( props ) {
 	const { __ } = useI18n();
-	const { navigation, children } = props;
+	const { navigation, children, stepName } = props;
 	const currentRoute = useCurrentRoute();
 	const shouldHideSkipBtn = currentRoute !== BASE_ROUTE;
 
@@ -22,7 +22,8 @@ export const ImportWrapper: Step = function ( props ) {
 			<DocumentHead title={ __( 'Import your site content' ) } />
 
 			<StepContainer
-				stepName={ 'import-step' }
+				stepName={ stepName || 'import-step' }
+				flowName={ 'importer' }
 				className={ 'import__onboarding-page' }
 				hideSkip={ shouldHideSkipBtn }
 				hideFormattedHeader={ true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-medium/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-medium/index.tsx
@@ -3,9 +3,8 @@ import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { withImporterWrapper } from '../importer';
 import './style.scss';
 
+const Importer = withImporterWrapper( MediumImporter );
 const ImporterMedium: Step = function ( props ) {
-	const Importer = withImporterWrapper( MediumImporter );
-
 	return <Importer importer={ 'medium' } { ...props } />;
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/index.tsx
@@ -3,9 +3,9 @@ import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { withImporterWrapper } from '../importer';
 import './style.scss';
 
-const ImporterWordpress: Step = function ( props ) {
-	const Importer = withImporterWrapper( WordpressImporter );
+const Importer = withImporterWrapper( WordpressImporter );
 
+const ImporterWordpress: Step = function ( props ) {
 	return <Importer importer={ 'wordpress' } { ...props } />;
 };
 

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -53,6 +53,7 @@ export type Flow = {
 
 export type StepProps = {
 	navigation: NavigationControls;
+	stepName: string | null;
 	flow: string | null;
 };
 

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -53,7 +53,7 @@ export type Flow = {
 
 export type StepProps = {
 	navigation: NavigationControls;
-	stepName: string | null;
+	stepName?: string | null;
 	flow: string | null;
 };
 

--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -110,6 +111,10 @@ class AuthorMappingPane extends PureComponent {
 			);
 		}
 	};
+
+	componentDidMount() {
+		recordTracksEvent( 'calypso_site_importer_map_authors_single' );
+	}
 
 	render() {
 		const {

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -69,7 +69,8 @@ export class SectionMigrate extends Component {
 		this.updateFromAPI();
 	}
 
-	componentDidUpdate( prevProps ) {
+	/* eslint-disable no-unused-vars */
+	componentDidUpdate( prevProps, prevState ) {
 		if ( this.isNonAtomicJetpack() ) {
 			return page( `/import/${ this.props.targetSiteSlug }` );
 		}


### PR DESCRIPTION
### Proposed Changes

* Fix the invalid items of [the revalidation result of Full Import Flow](https://github.com/Automattic/wp-calypso/issues/64365#issuecomment-1156195594)
* [Create a new prop - stepName](https://github.com/Automattic/wp-calypso/commit/67d65d05d90efb95d0bc529727d8ed1b11c4daf5) for [ImportWrapper](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx#L14) in order to use [StepContainer built-in tracking function of NavigationLink](https://github.com/Automattic/wp-calypso/blob/trunk/packages/onboarding/src/step-container/index.tsx#L89)
* Apply HOC - `withImporterWrapper` [outside the component render function](https://github.com/Automattic/wp-calypso/commit/3e4e6fb7633a6fc55e41144afaf094e8ee5e9d13#diff-8f9acfaa7f17ed6d2efb8a011f5408389946da7a060a328bf5860437dce6521bR6) to prevent unnecessary re-mounting, which results in sending duplicated tracking events

before

<img width="792" alt="Screen Shot 2022-06-15 at 4 38 10 PM" src="https://user-images.githubusercontent.com/1024985/174020446-6b7509eb-f211-4a59-8ac4-ad447815ad06.png">

after

<img width="785" alt="migration_import_selector" src="https://user-images.githubusercontent.com/1024985/174020494-95f7dd8b-5b6d-4dd2-b2e9-85abf7948e4d.png">

### Testing Instructions

* Go to /setup/import?siteSlug={SITE}&from={FROM}
* This event should be sent out

<img width="784" alt="capture" src="https://user-images.githubusercontent.com/1024985/174021596-1f26668d-80d3-4d4a-9948-e58849ff83fc.png">

* Go to /setup/importList?siteSlug={SITE}&from={FROM}
* This event should be sent out

<img width="780" alt="importer_list" src="https://user-images.githubusercontent.com/1024985/174021797-19ff1ec1-f2b6-4192-8bf8-d953da41fb92.png">

* Go to /setup/importReady?siteSlug={SITE}&from={FROM}
* Click back button
* This event should be sent out

<img width="791" alt="back_ready_capture" src="https://user-images.githubusercontent.com/1024985/174022016-362d6a18-89e7-43eb-9de5-163cd4fd1ab1.png">

* Go to /setup/importReady?siteSlug={SITE}&from={FROM}
* Click `View the import guide` link
* This event should be sent out

<img width="794" alt="Import_guide_modal" src="https://user-images.githubusercontent.com/1024985/174022253-180d9882-fffb-404d-800e-b31f74627f16.png">

* Go to /setup/importerWordpress?siteSlug={SITE}&from={FROM}
* This event should be sent out

<img width="785" alt="migration_import_selector" src="https://user-images.githubusercontent.com/1024985/174022350-0f4f6bdf-3fe2-4c0a-bad0-e90f35211f81.png">



Related to https://github.com/Automattic/wp-calypso/issues/64365
