### PR TITLE
Vertical Step: Add x to clear input

### DIFF
--- a/client/components/select-vertical/style.scss
+++ b/client/components/select-vertical/style.scss
@@ -33,7 +33,7 @@
         }
 
         .components-button {
-            .gridicon {
+            .gridicons-chevron-down {
                 transform: rotate( -180deg );
             }
         }
@@ -44,7 +44,7 @@
         height: 44px;
         font-size: $font-body;
         line-height: 20px;
-        padding: 12px 86px 12px 16px;
+        padding: 12px 100px 12px 16px;
         transition: none;
         color: var( --studio-gray-90 );
 
@@ -54,9 +54,7 @@
     }
 
     .spinner {
-        position: absolute;
-        right: 50px;
-        top: 12px;
+        margin-right: 4px;
     }
 
     @include break-small() {
@@ -68,11 +66,18 @@
     position: relative;
     z-index: 20;
 
-    .components-button {
+    .select-vertical__suggestion-buttons {
         height: 100%;
         position: absolute;
-        right: 4px;
+        right: 16px;
         top: 0;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .components-button {
+        padding: 3px;
 
         &:focus:not( :disabled ) {
             box-shadow: none;
@@ -82,7 +87,7 @@
             box-shadow: inset 0 0 0 var( --wp-admin-border-width-focus ) var( --wp-admin-theme-color );
         }
 
-        .gridicon {
+        .gridicons-chevron-down {
             transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
         }
     }

--- a/client/components/select-vertical/suggestion-search.tsx
+++ b/client/components/select-vertical/suggestion-search.tsx
@@ -31,7 +31,7 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 } ) => {
 	const [ isShowSuggestions, setIsShowSuggestions ] = useState( false );
 	const [ isFocused, setIsFocused ] = useState( false );
-	const inputRef = useRef( null );
+	const inputRef = useRef< HTMLInputElement >( null );
 	const wrapperRef = useRef< HTMLDivElement >( null );
 	const suggestionsRef = useRef< Suggestions >( null );
 	const toggleIconRef = useRef( null );
@@ -62,12 +62,6 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 	};
 
 	const handleTextInputChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
-		// Reset the vertical selection if input field is empty.
-		// This is so users don't need to explicitly select "Something else" to clear previous selection.
-		if ( event.target.value.trim().length === 0 ) {
-			onSelect?.( { value: '', label: '' } );
-		}
-
 		showSuggestions();
 		onInputChange?.( event.target.value );
 	};
@@ -112,6 +106,11 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 		if ( suggestionsRef.current ) {
 			suggestionsRef.current.handleKeyEvent( event );
 		}
+	};
+
+	const handleTextInputClear = () => {
+		onInputChange?.( '' );
+		inputRef.current?.focus();
 	};
 
 	const handleSuggestionsSelect = ( { label, value }: { label: string; value?: string } ) => {
@@ -172,7 +171,6 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 			aria-expanded={ isShowSuggestions }
 		>
 			<div className="select-vertical__suggestion-input">
-				{ isLoading && isShowSuggestions && <Spinner /> }
 				<FormTextInput
 					inputRef={ inputRef }
 					value={ searchTerm }
@@ -184,15 +182,26 @@ const SelectVerticalSuggestionSearch: FC< Props > = ( {
 					onKeyDown={ handleTextInputKeyDown }
 					autoComplete="off"
 				/>
-				<Button
-					ref={ toggleIconRef }
-					onFocus={ () => setIsFocused( true ) }
-					onBlur={ handleToggleSuggestionsBlur }
-					onClick={ handleToggleSuggestionsClick }
-					onKeyDown={ handleToggleSuggestionsKeyDown }
-				>
-					<Gridicon size={ 18 } icon="chevron-down" />
-				</Button>
+				<div className="select-vertical__suggestion-buttons">
+					{ isLoading && isShowSuggestions && <Spinner /> }
+					{ !! searchTerm && (
+						<Button
+							aria-label={ translate( 'Clear Search' ) as string }
+							onClick={ handleTextInputClear }
+						>
+							<Gridicon size={ 18 } icon="cross-small" />
+						</Button>
+					) }
+					<Button
+						ref={ toggleIconRef }
+						onFocus={ () => setIsFocused( true ) }
+						onBlur={ handleToggleSuggestionsBlur }
+						onClick={ handleToggleSuggestionsClick }
+						onKeyDown={ handleToggleSuggestionsKeyDown }
+					>
+						<Gridicon size={ 18 } icon="chevron-down" />
+					</Button>
+				</div>
 			</div>
 			<Suggestions
 				className="select-vertical__suggestion-search-dropdown"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
@@ -27,6 +27,14 @@ const SiteVerticalForm: React.FC< Props > = ( {
 	const translate = useTranslate();
 	const [ userInput, setUserInput ] = React.useState( '' );
 
+	React.useEffect( () => {
+		// Reset the vertical selection if input field is empty.
+		// This is so users don't need to explicitly select "Something else" to clear previous selection.
+		if ( userInput.trim().length === 0 ) {
+			onSelect?.( { value: '', label: '' } );
+		}
+	}, [ userInput ] );
+
 	return (
 		<form
 			className="site-vertical__form"


### PR DESCRIPTION
#### Proposed Changes

* Add `X` button to the search input and the user can click to clear the input and reset the vertical

https://user-images.githubusercontent.com/13596067/174038229-f34a0b76-c8af-4fb1-ae4f-5b4a1bad6324.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the vertical step: `/setup/vertical?siteSlug=<your_site>`
* Type something or select a vertical
* Check `X` is showing and isn't overlapping with `spinner` or `chevron-down`
* Click `X` to clear input
* Make sure the input is clear and the selected vertical is reset to empty

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64371
