### PR TITLE
Goals Capture: Handle the `create-blog-lp` ref parameter

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -99,6 +99,14 @@ const GoalsStep: Step = ( { navigation } ) => {
 		<SelectGoals selectedGoals={ goals } onChange={ handleChange } onSubmit={ handleSubmit } />
 	);
 
+	useEffect( () => {
+		const comingFromCreateBlogLanding = refParameter === 'create-blog-lp';
+
+		if ( comingFromCreateBlogLanding && goals.length === 0 ) {
+			setGoals( [ Onboard.SiteGoal.Write ] );
+		}
+	}, [ refParameter ] );
+
 	return (
 		<StepContainer
 			stepName={ 'goals-step' }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -26,6 +26,10 @@ type TracksGoalsSelectEventProperties = {
 const SiteGoal = Onboard.SiteGoal;
 const { serializeGoals, goalsToIntent } = Onboard.utils;
 
+const refGoals: Record< string, Onboard.SiteGoal[] > = {
+	'create-blog-lp': [ SiteGoal.Write ],
+};
+
 /**
  * The goals capture step
  */
@@ -37,7 +41,7 @@ const GoalsStep: Step = ( { navigation } ) => {
 
 	const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
 	const { setGoals, setIntent, clearImportGoal, clearDIFMGoal } = useDispatch( ONBOARD_STORE );
-	const refParameter = getQueryArgs()?.ref;
+	const refParameter = getQueryArgs()?.ref as string;
 
 	useEffect( () => {
 		clearImportGoal();
@@ -100,12 +104,12 @@ const GoalsStep: Step = ( { navigation } ) => {
 	);
 
 	useEffect( () => {
-		const comingFromCreateBlogLanding = refParameter === 'create-blog-lp';
+		const isValidRef = Object.keys( refGoals ).includes( refParameter );
 
-		if ( comingFromCreateBlogLanding && goals.length === 0 ) {
-			setGoals( [ Onboard.SiteGoal.Write ] );
+		if ( isValidRef && goals.length === 0 ) {
+			setGoals( refGoals[ refParameter ] );
 		}
-	}, [ refParameter ] );
+	}, [ refParameter, refGoals ] );
 
 	return (
 		<StepContainer


### PR DESCRIPTION
#### Proposed Changes

This PR builds on top of https://github.com/Automattic/wp-calypso/pull/64145 and automatically selects the "Write" goal if the URL parameter `ref` equals to `create-blog-lp`.

|  Before | After |
| ------------- | ------------- |
| ![Markup on 2022-06-16 at 16:08:12](https://user-images.githubusercontent.com/25105483/174088600-0e068b32-175a-4319-a855-7e91fbb3f66e.png) | ![Markup on 2022-06-16 at 16:07:26](https://user-images.githubusercontent.com/25105483/174088607-0f07a476-f294-4cb2-8108-bef89041adbb.png) |

#### Testing Instructions

1. Go to `calypso.localhost:3000/setup/goals?siteSlug=[site_address]&flags=signup/goals-step&ref=create-blog-lp` where `[site_address]` is the address of the site in form of `something.wordpress.com`.
2. When the Goals Capture step displays, the "Write" goal should be selected automatically.
3. Explore the state through Redux DevTools → the "Write" goal should be selected there as well.
4. Click through other goals - they should get selected as expected.
5. Try to pass incorrect `ref` parameter value, or omit the `ref` parameter altogether. → The Goals step should render correctly without having any goal selected.