### PR TITLE
Reset the grid-template-columns property when in the legacy mode mobile.

### DIFF
--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -289,6 +289,8 @@ body.is-section-plugins header .select-dropdown__item {
 
 	.plugin-details__layout {
 		grid-template-areas: none;
+		grid-template-columns: initial;
+
 		@include breakpoint-deprecated( '>1040px' ) {
 			@include display-grid;
 			@include grid-template-columns( 3, 80px, 1fr );


### PR DESCRIPTION
#### Proposed Changes

Reset the grid-template-columns property when in the legacy mode mobile.

#### Testing Instructions

* without enabling any feature flag
* Go to a plugins page `/plugins/woocommerce-bookings/${site}`
* Check if the mobile layout is properly aligned (you can resize your screen or use the dev tools)
* Check if the desktop layout is well-aligned too

| Currently (production) | Fix (this branch) |
| ------------- | ------------- |
|<img width="670" alt="Screen Shot 2022-06-16 at 09 59 33" src="https://user-images.githubusercontent.com/5039531/174088194-61207349-a58a-4c42-85f6-5fb566c6ba3c.png">|<img width="670" alt="Screen Shot 2022-06-16 at 09 59 12" src="https://user-images.githubusercontent.com/5039531/174088521-26553d8b-df75-491d-a20f-77413dc6e7d3.png">|



PS: the feature flag `plugins/plugin-details-layout` must be disabled
