### PR TITLE
Change the label in the back button in Theme picker

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -429,6 +429,8 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		/>
 	);
 
+	const showPickAnotherBackLabel = isForceStaticDesigns || isPreviewingGeneratedDesign;
+
 	return (
 		<StepContainer
 			stepName={ STEP_NAME }
@@ -444,7 +446,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			hideNext={ ! isPreviewingGeneratedDesign }
 			skipButtonAlign={ 'top' }
 			hideFormattedHeader
-			backLabelText={ isPreviewingGeneratedDesign ? 'Pick another' : 'Back' }
+			backLabelText={ showPickAnotherBackLabel ? translate( 'Pick another' ) : translate( 'Back' ) }
 			skipLabelText={ intent === 'write' ? translate( 'Skip and draft first post' ) : undefined }
 			stepContent={ stepContent }
 			recordTracksEvent={ recordStepContainerTracksEvent }


### PR DESCRIPTION
#### Proposed Changes

* Reword the "Back" button to "Pick another" in the standard design picker because the button goes back to the verticalized design picker. 
* Translate the texts `Back` and `Pick another` 

#### Screenshots
<img width="440" alt="Screen Shot 2565-06-16 at 19 58 43" src="https://user-images.githubusercontent.com/1881481/174135742-ea670f34-e9c5-4f43-b66c-2106850d0395.png">
<img width="417" alt="Screen Shot 2565-06-16 at 19 38 49" src="https://user-images.githubusercontent.com/1881481/174135792-a64f0a7c-9cdf-4259-adff-710f208f33e7.png">

Recordings: [Mobile](https://user-images.githubusercontent.com/1881481/174133910-97e9b802-3fa7-45b8-9a7c-b33a994183db.mov) -  [Desktop](https://user-images.githubusercontent.com/1881481/174134338-4c5f53e9-2dbf-428d-8067-fdf7eddfce6f.mov)
#### Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /setup/vertical?siteSlug=<your_site>
- Select a vertical
- Select a build intent
- Click on "View More Options"
- Check that the "Back" button text changes to "Pick another"  

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64688
