### PR TITLE
Removed is_fse_eligible checks

### DIFF
--- a/client/data/block-editor/use-block-editor-settings-query.ts
+++ b/client/data/block-editor/use-block-editor-settings-query.ts
@@ -9,7 +9,6 @@ type HomeTemplateSettings = {
 };
 
 export type BlockEditorSettings = {
-	is_fse_eligible: boolean;
 	is_fse_active: boolean;
 	home_template: HomeTemplateSettings;
 };

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -3,10 +3,8 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import * as React from 'react';
 import { useInterval } from '../../../../lib/interval/use-interval';
-import { FLOW_ID } from '../../constants';
 import { useSelectedPlan } from '../../hooks/use-selected-plan';
 import { useTrackStep } from '../../hooks/use-track-step';
-import { trackEventWithFlow } from '../../lib/analytics';
 import { ONBOARD_STORE } from '../../stores/onboard';
 
 import './style.scss';
@@ -30,12 +28,6 @@ const CreateSite: React.FunctionComponent = () => {
 	const totalSteps = steps.current.length;
 
 	const [ currentStep, setCurrentStep ] = React.useState( 0 );
-
-	// Gutenboarding now always enrolls the user in FSE, so this event should always fire on site
-	// creation.
-	React.useEffect( () => {
-		trackEventWithFlow( 'calypso_fse_enrolled', { site_enrolled: true, flow: FLOW_ID } );
-	}, [] );
 
 	/**
 	 * Completion progress: 0 <= progress <= 1

--- a/client/landing/stepper/hooks/use-fse-status.ts
+++ b/client/landing/stepper/hooks/use-fse-status.ts
@@ -3,7 +3,6 @@ import wpcomRequest from 'wpcom-proxy-request';
 import { useSite } from './use-site';
 
 type Response = {
-	is_fse_eligible: boolean;
 	is_fse_active: boolean;
 };
 
@@ -23,7 +22,6 @@ export function useFSEStatus() {
 	);
 
 	return {
-		FSEEligible: Boolean( data?.is_fse_eligible ),
 		FSEActive: Boolean( data?.is_fse_active ),
 		isLoading,
 	};

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -176,7 +176,6 @@ function getNewSiteParams( {
 			site_creation_flow: flowToCheck,
 			timezone_string: guessTimezone(),
 			wpcom_public_coming_soon: 1,
-			enable_fse: true,
 		},
 		validate: false,
 	};
@@ -280,11 +279,6 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 		saveToLocalStorageAndProceed( state, domainItem, themeItem, newSiteParams, callback );
 		return;
 	}
-
-	recordTracksEvent( 'calypso_fse_enrolled', {
-		flow: flowToCheck,
-		site_enrolled: !! newSiteParams.options.enable_fse,
-	} );
 
 	const locale = getLocaleSlug();
 

--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -1,7 +1,5 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useBlockEditorSettingsQuery } from 'calypso/data/block-editor/use-block-editor-settings-query';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getRecommendedThemes } from 'calypso/state/themes/actions';
 import {
 	getRecommendedThemes as getRecommendedThemesSelector,
@@ -11,12 +9,6 @@ import { ConnectedThemesSelection } from './themes-selection';
 
 const RecommendedThemes = ( props ) => {
 	const dispatch = useDispatch();
-	const userLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
-	const { siteId } = props;
-	const { isLoading: isLoadingBlockEditorSettings } = useBlockEditorSettingsQuery(
-		siteId,
-		userLoggedIn
-	);
 
 	const recommendedThemesFilter = 'full-site-editing';
 
@@ -29,15 +21,13 @@ const RecommendedThemes = ( props ) => {
 	);
 
 	useEffect( () => {
-		if ( ! isLoadingBlockEditorSettings ) {
-			dispatch( getRecommendedThemes( recommendedThemesFilter ) );
-		}
-	}, [ isLoadingBlockEditorSettings, recommendedThemesFilter, dispatch ] );
+		dispatch( getRecommendedThemes( recommendedThemesFilter ) );
+	}, [ recommendedThemesFilter, dispatch ] );
 
 	return (
 		<ConnectedThemesSelection
 			{ ...props }
-			isLoading={ isLoadingBlockEditorSettings || areThemesLoading }
+			isLoading={ areThemesLoading }
 			customizedThemesList={ customizedThemesList }
 		/>
 	);

--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -13,13 +13,12 @@ const RecommendedThemes = ( props ) => {
 	const dispatch = useDispatch();
 	const userLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
 	const { siteId } = props;
-	const { isLoading: isLoadingBlockEditorSettings, data } = useBlockEditorSettingsQuery(
+	const { isLoading: isLoadingBlockEditorSettings } = useBlockEditorSettingsQuery(
 		siteId,
 		userLoggedIn
 	);
 
-	const isFSEEligible = data?.is_fse_eligible ?? false;
-	const recommendedThemesFilter = isFSEEligible ? 'full-site-editing' : 'auto-loading-homepage';
+	const recommendedThemesFilter = 'full-site-editing';
 
 	const customizedThemesList = useSelector( ( state ) =>
 		getRecommendedThemesSelector( state, recommendedThemesFilter )

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -19,7 +19,6 @@ import { useEffect, useLayoutEffect, useMemo, useState, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview';
-import { useBlockEditorSettingsQuery } from 'calypso/data/block-editor/use-block-editor-settings-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import AsyncCheckoutModal from 'calypso/my-sites/checkout/modal/async';
 import { openCheckoutModal } from 'calypso/my-sites/checkout/modal/utils';
@@ -63,23 +62,13 @@ export default function DesignPickerStep( props ) {
 			? 'all'
 			: 'free';
 
-	// Limit themes to those that support the Site editor, if site is fse eligible
-	const { isLoading: blockEditorSettingsAreLoading } = useBlockEditorSettingsQuery(
-		siteId,
-		userLoggedIn && ! props.useDIFMThemes
-	);
-
 	const getThemeFilters = () => {
 		if ( props.useDIFMThemes ) return 'do-it-for-me';
 
 		return 'auto-loading-homepage,full-site-editing';
 	};
 
-	const { data: apiThemes = [] } = useThemeDesignsQuery(
-		{ filter: getThemeFilters(), tier },
-		// Wait until block editor settings have loaded to load themes
-		{ enabled: ! blockEditorSettingsAreLoading }
-	);
+	const { data: apiThemes = [] } = useThemeDesignsQuery( { filter: getThemeFilters(), tier } );
 
 	useEffect(
 		() => {

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -64,16 +64,15 @@ export default function DesignPickerStep( props ) {
 			: 'free';
 
 	// Limit themes to those that support the Site editor, if site is fse eligible
-	const { isLoading: blockEditorSettingsAreLoading, data: blockEditorSettings } =
-		useBlockEditorSettingsQuery( siteId, userLoggedIn && ! props.useDIFMThemes );
-	const isFSEEligible = blockEditorSettings?.is_fse_eligible ?? false;
+	const { isLoading: blockEditorSettingsAreLoading } = useBlockEditorSettingsQuery(
+		siteId,
+		userLoggedIn && ! props.useDIFMThemes
+	);
 
 	const getThemeFilters = () => {
 		if ( props.useDIFMThemes ) return 'do-it-for-me';
 
-		if ( isFSEEligible ) return 'auto-loading-homepage,full-site-editing';
-
-		return 'auto-loading-homepage';
+		return 'auto-loading-homepage,full-site-editing';
 	};
 
 	const { data: apiThemes = [] } = useThemeDesignsQuery(

--- a/packages/design-picker/src/hooks/use-designs-by-site.ts
+++ b/packages/design-picker/src/hooks/use-designs-by-site.ts
@@ -24,11 +24,7 @@ export function useDesignsBySite( site: SiteDetails | null ) {
 			? 'all'
 			: 'free';
 
-	const FSEEligible = site?.is_fse_eligible;
-
-	const themeFilters = FSEEligible
-		? 'auto-loading-homepage,full-site-editing'
-		: 'auto-loading-homepage';
+	const themeFilters = 'auto-loading-homepage,full-site-editing';
 
 	return useThemeDesignsQuery(
 		{ filter: themeFilters, tier },


### PR DESCRIPTION
#### Proposed Changes

Full Site Editing code clean up. 

- Removed usage of `is_fse_eligible` value
- Removed `enable_fse` parameter when a new site is created
- Deprecated / Removed `calypso_fse_enrolled` event
- Removed logic related to `is_fse_eligible` value for the "recommended themes" section to display full site editing enabled themes by default.
- Removed logic related to `is_fse_eligible` value for the new site "build design picker" flow to display full site editing enabled themes by default.

#### Testing Instructions

In order to test the "recommended themes" section changes, you will need to navigate: "Appearance" > "Themes" in the calypso left side menu. Click on "Recommended" tab link on the themes page. Filter by: "feature: full site editing" to only display full site editing enabled themes. 

Compare the themes displayed on your local calypso environment to the themes on production.

<img width="1225" alt="image" src="https://user-images.githubusercontent.com/10482592/175436111-c4810855-5df3-4379-a5dc-1abfe0b1902e.png">

---


In order to test the "build design picker" section changes, you will need to start the "create a new site" flow and navigate to the "build" step.
You can also directly navigate to the page that needs to tested here: [Build Design Picker](http://calypso.localhost:3000/setup/designSetup?siteSlug=agdesignpickertest1.wordpress.com)
 
Compare the themes displayed on your local calypso environment to the themes on production.

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/10482592/175436282-4ebf353a-0c99-4eb3-a77f-a530ea36a292.png">


Related to #61107 
