### PR TITLE
Redirect Jetpack legacy plans to pricing page

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -490,6 +490,4 @@ export function redirectToSiteLessCheckout( context, next ) {
 
 export function redirectToCloudPricingPage() {
 	window.location.href = JETPACK_PRICING_PAGE;
-
-	return;
 }

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -29,6 +29,7 @@ import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { navigate } from 'calypso/lib/navigate';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
+import { JETPACK_PRICING_PAGE } from 'calypso/lib/url/support';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { startAuthorizeStep } from 'calypso/state/jetpack-connect/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -485,4 +486,10 @@ export function redirectToSiteLessCheckout( context, next ) {
 	}
 
 	next();
+}
+
+export function redirectToCloudPricingPage() {
+	window.location.href = JETPACK_PRICING_PAGE;
+
+	return;
 }

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -14,10 +14,14 @@ import './style.scss';
 export default function () {
 	const locale = getLanguageRouteParam( 'locale' );
 
+	const legacyPlans = [ 'personal', 'premium', 'pro' ].join( '|' );
+
+	page(
+		`/jetpack/connect/:type(${ legacyPlans })/:interval(yearly|monthly)?/${ locale }`,
+		controller.redirectToCloudPricingPage
+	);
+
 	const planTypeString = [
-		'personal',
-		'premium',
-		'pro',
 		'backup',
 		'scan',
 		'realtimebackup',


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a redirect to the pricing page in Jetpack cloud, from the following URLs:

- https://wordpress.com/jetpack/connect/personal
- https://wordpress.com/jetpack/connect/premium
- https://wordpress.com/jetpack/connect/pro

Context: 1201210512993648-as-1202421295669245

### Testing instructions

- Spin up Calypso blue with this branch
- Make sure each of these routes redirect to `cloud.jetpack.com/pricing`:
  - `/jetpack/connect/personal`
  - `/jetpack/connect/premium`
  - `/jetpack/connect/pro`
- Check that the behaviour for other plans/products is not broken: e.g. `/jetpack/connect/backup` should lead to the checkout page