### PR TITLE
Plugins Browser: Use the exact category keyword when the category passed is not mapped.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -458,7 +458,7 @@ const FullListView = ( { category, siteSlug, sites } ) => {
 	} );
 
 	const categories = useCategories();
-	const categoryName = categories[ category ]?.name;
+	const categoryName = categories[ category ]?.name || category;
 	const translate = useTranslate();
 
 	let title = '';

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -69,7 +69,7 @@ const usePlugins = ( {
 	let results = 0;
 
 	const categories = useCategories();
-	const categoryTags = categories[ category || '' ]?.tags || [];
+	const categoryTags = categories[ category || '' ]?.tags || [ category ];
 	const tag = categoryTags.join( ',' );
 
 	const searchHook =


### PR DESCRIPTION
#### Proposed Changes

* Use the exact category keyword when the category passed is not mapped.

#### Testing Instructions
* On the plugins search by category page `/plugins/browse/{category}`
* Set category as a not mapped category. Ex: `malware`
* You should NOT see all the paid plugins listed and only relevant plugins from the keyword passed

| Current version (production)  | Bugfix (this branch |
| ------------- | ------------- |
|<img width="876" alt="Screen Shot 2022-06-16 at 18 06 33" src="https://user-images.githubusercontent.com/5039531/174185690-9c25b7e8-908d-46e9-b3a0-e6e5a9fc94b6.png">|<img width="876" alt="Screen Shot 2022-06-16 at 18 05 45" src="https://user-images.githubusercontent.com/5039531/174185779-3e68d87c-d1ae-44c9-8cb7-de0f1652ac7d.png">|


---

Needed for #63715 