### PR TITLE
Goals Capture: Record calypso_signup_goals_select tracks event.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -43,7 +43,7 @@ const GoalsStep: Step = ( { navigation } ) => {
 		};
 
 		goals.forEach( ( goal, i ) => {
-			eventProperties[ goal ] = i;
+			eventProperties[ goal ] = i + 1;
 		} );
 
 		// TODO: Add ref prop in another PR.

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -10,6 +10,7 @@ import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 export type { State };
 
 export { SiteGoal, SiteIntent } from './constants';
+export * as utils from './utils';
 
 /**
  * Onboard store depends on site-store. You should register the site before using this store.

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -29,7 +29,9 @@ export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
 export const serializeGoals = ( goals: SiteGoal[] ): string => {
 	// Serialize goals by first + alphabetical order.
 	const firstGoal = goals.find( ( goal ) =>
-		[ SiteGoal.Write, SiteGoal.Sell, SiteGoal.Promote, SiteGoal.DIFM ].includes( goal )
+		[ SiteGoal.Write, SiteGoal.Sell, SiteGoal.Promote, SiteGoal.DIFM, SiteGoal.Import ].includes(
+			goal
+		)
 	);
 
 	return ( firstGoal ? [ firstGoal ] : [] )

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -25,3 +25,14 @@ export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
 
 	return SiteIntent.Build;
 };
+
+export const serializeGoals = ( goals: SiteGoal[] ): string => {
+	// Serialize goals by first + alphabetical order.
+	const firstGoal = goals.find( ( goal ) =>
+		[ SiteGoal.Write, SiteGoal.Sell, SiteGoal.Promote, SiteGoal.DIFM ].includes( goal )
+	);
+
+	return ( firstGoal ? [ firstGoal ] : [] )
+		.concat( goals.filter( ( goal ) => goal !== firstGoal ).sort() )
+		.join( ',' );
+};


### PR DESCRIPTION
#### Proposed Changes

When user clicks on the **Continue** button, record `calypso_signup_goals_select` tracks event.

TODO: Adding automated tests for `serializeGoals()` (@mashikag - in a separate PR).
TODO: Add `ref` to event props (@ivan-ottinger - in a separate PR once https://github.com/Automattic/wp-calypso/pull/64701 is ready).

#### Testing Instructions

1. Go to the Goals Step via `/setup/goals?siteSlug=your_site_here.wordpress.com&flags=signup/goals-step`.
2. Run `localStorage.setItem( 'debug', 'calypso:analytics*' );` in the devtool console.
3. Select one goal, multiple goals, no goals and click on the Continue button.
4. From the devtool console, you should be able to inspect the values of the tracks event.
    - Verify that the `goals` prop is serialized by first+alphabetical order (See pdDOJh-qI-p2#serializing-goals-using-first-alphabetical-order).
    - Verify that the individual props keyed by goals contain the right order number on them.

#### Screenshot
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/1287077/174215060-1b261c9b-9fef-472e-8f64-6654af8f9614.png">