### PR TITLE
Don't change locale on suggestion component mount

### DIFF
--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -40,8 +40,6 @@ export class LocaleSuggestions extends Component {
 				}
 			}
 		}
-
-		this.props.setLocale( locale );
 	}
 
 	componentDidUpdate( prevProps ) {


### PR DESCRIPTION
#### Proposed Changes

* Don't trigger a locale switch on component mount.

#### Testing Instructions

Use a "Change Language accept header" browser addon to set locales to: ja,en,es, set user locale to fr.

While logged out:

* http://calypso.localhost:3000/log-in - should load english.
* http://calypso.localhost:3000/log-in/en - should load english.
* http://calypso.localhost:3000/log-in/ja - should load japanese.
* Clicking language suggestions should load the correct locale.

While logged in: `/log-in` should render in the users locale. All others should render in the locale provided in the URL.

This is broken in production. In calypso.localhost this problem should be resolved. In calypso.live and production this change doesn't seem to have an effect.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to
https://github.com/Automattic/wp-calypso/pull/64680
https://github.com/Automattic/wp-calypso/pull/64695
https://github.com/Automattic/wp-calypso/pull/64727
