### PR TITLE
Only load locale from path in one place

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -1,24 +1,10 @@
 import config from '@automattic/calypso-config';
-import {
-	isDefaultLocale,
-	isTranslatedIncompletely,
-	getLanguageSlugs,
-} from '@automattic/i18n-utils';
+import { isTranslatedIncompletely } from '@automattic/i18n-utils';
 import i18n from 'i18n-calypso';
 import { initLanguageEmpathyMode } from 'calypso/lib/i18n-utils/empathy-mode';
 import { loadUserUndeployedTranslations } from 'calypso/lib/i18n-utils/switch-locale';
 import { LOCALE_SET } from 'calypso/state/action-types';
 import { setLocale } from 'calypso/state/ui/language/actions';
-
-function getLocaleFromPathname() {
-	const pathname = window.location.pathname.replace( /\/$/, '' );
-	const lastPathSegment = pathname.substr( pathname.lastIndexOf( '/' ) + 1 );
-	const pathLocaleSlug =
-		getLanguageSlugs().includes( lastPathSegment ) &&
-		! isDefaultLocale( lastPathSegment ) &&
-		lastPathSegment;
-	return pathLocaleSlug;
-}
 
 export const setupLocale = ( currentUser, reduxStore ) => {
 	if ( config.isEnabled( 'i18n/empathy-mode' ) && currentUser.i18n_empathy_mode ) {
@@ -59,11 +45,9 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 	} else if ( bootstrappedLocaleSlug ) {
 		// Use locale slug from bootstrapped language manifest object
 		reduxStore.dispatch( setLocale( bootstrappedLocaleSlug ) );
-	} else {
-		// For logged out Calypso pages, set the locale from slug
-		const pathLocaleSlug = getLocaleFromPathname();
-		pathLocaleSlug && reduxStore.dispatch( setLocale( pathLocaleSlug, '' ) );
 	}
-
-	// If user is logged out and translations are not bootstrapped, we assume default locale
+	// else
+	// If user is logged out and translations are not bootstrapped, we assume default locale.
+	// Also, some logged out routes now choose to override this locale using a lang path param,
+	// for these routes, setLocale is dispatched inside setLocaleMiddleware (client/controller/shared.js)
 };

--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -11,14 +11,9 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		initLanguageEmpathyMode();
 	}
 
-	let userLocaleSlug = currentUser.localeVariant || currentUser.localeSlug;
 	const shouldUseFallbackLocale =
 		currentUser?.use_fallback_for_incomplete_languages &&
-		isTranslatedIncompletely( userLocaleSlug );
-
-	if ( shouldUseFallbackLocale ) {
-		userLocaleSlug = config( 'i18n_default_locale_slug' );
-	}
+		isTranslatedIncompletely( currentUser.localeVariant || currentUser.localeSlug );
 
 	const bootstrappedLocaleSlug = window?.i18nLanguageManifest?.locale?.[ '' ]?.localeSlug;
 
@@ -35,10 +30,7 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 			loadUserUndeployedTranslations( localeSlug );
 		}
 	} else if ( currentUser && currentUser.localeSlug ) {
-		if ( shouldUseFallbackLocale ) {
-			// Use user locale fallback slug
-			reduxStore.dispatch( setLocale( userLocaleSlug ) );
-		} else {
+		if ( ! shouldUseFallbackLocale ) {
 			// Use the current user's and load traslation data with a fetch request
 			reduxStore.dispatch( setLocale( currentUser.localeSlug, currentUser.localeVariant ) );
 		}


### PR DESCRIPTION
#### Proposed Changes

* Remove path based locale loading from boot
* Path based overrides are now done in the controller using [this middleware](https://github.com/Automattic/wp-calypso/blob/95fa44ce6e977a14499adad35b1d065cb3f3afa1/client/controller/shared.js#L61), the lang params are setup [like so](https://github.com/Automattic/wp-calypso/blob/3b92d10c073d89d0df221802785c9103fd465eff/client/login/index.web.js#L62-L67). 

Not sure if this is safe yet, was looking at doing this along side the related prs

#### Testing Instructions

*

Related to #
https://github.com/Automattic/wp-calypso/pull/64726
https://github.com/Automattic/wp-calypso/pull/64695
