### PR TITLE
Goals Capture: Modify setup flow navigation for when goals capture screen is enabled.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -12,8 +13,10 @@ import SiteVerticalForm from './form';
 import type { Step } from '../../types';
 import type { Vertical } from 'calypso/components/select-vertical/types';
 
+const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' );
+
 const SiteVertical: Step = function SiteVertical( { navigation } ) {
-	const { goNext, submit } = navigation;
+	const { goBack, goNext, submit } = navigation;
 	const [ vertical, setVertical ] = React.useState< Vertical | null >();
 	const [ isBusy, setIsBusy ] = React.useState( false );
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
@@ -58,12 +61,13 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	return (
 		<StepContainer
 			stepName={ 'site-vertical' }
+			goBack={ goalsCaptureStepEnabled ? goBack : undefined }
 			goNext={ goNext }
 			headerImageUrl={ siteVerticalImage }
 			skipLabelText={ translate( 'Skip to dashboard' ) }
 			skipButtonAlign={ 'top' }
 			isHorizontalLayout={ true }
-			hideBack={ true }
+			hideBack={ ! goalsCaptureStepEnabled }
 			formattedHeader={
 				<FormattedHeader
 					id={ 'site-vertical-header' }

--- a/client/signup/steps/choose-service/index.tsx
+++ b/client/signup/steps/choose-service/index.tsx
@@ -37,6 +37,13 @@ interface Props {
 
 type DIFMOrBuiltByIntent = SelectItem< ChoiceType >;
 
+const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' );
+
+const getBackUrl = ( siteSlug?: string ) => {
+	const step = goalsCaptureStepEnabled ? 'goals' : 'intent';
+	return `/setup/${ step }?siteSlug=${ siteSlug }`;
+};
+
 const Placeholder = () => <span className="choose-service__placeholder">&nbsp;</span>;
 
 export default function ChooseServiceStep( props: Props ): React.ReactNode {
@@ -131,7 +138,7 @@ export default function ChooseServiceStep( props: Props ): React.ReactNode {
 						intentsAlt={ [] }
 					/>
 				}
-				backUrl={ `/setup/intent?siteSlug=${ props.queryObject.siteSlug }` }
+				backUrl={ getBackUrl( props.queryObject.siteSlug ) }
 				hideBack={ false }
 				allowBackFirstStep={ true }
 				align={ 'left' }


### PR DESCRIPTION
#### Proposed Changes

##### When `Goals capture` enabled && `Verticals` enabled
* 1st step in the `setup` flow is `goals` capture step
* if `difm` goal is selected and `Continue` is clicked the `setup` flow exits out to `/start/website-design-services/?siteSlug=${ siteSlug }`
* if `difm` goal is not selected and `Continue` button is clicked next step is `verticals`
* when current step is `verticals` then navigation to the next step, when `Continue` button is clicked, is based on the stored site `intent` and `goals`, as follows:
  * if includes `import` goal then next step is `import`
  * else if intent is `Sell` or `Write` next step is `options`
  * else next step is `designSetup`
* since the `verticals` step is no longer the 1st step, introduce a back button that will navigate to `goals` capture screen

##### When `Goals capture` enabled && `Verticals` disabled
* 1st step in the `setup` flow is `goals` capture step
* if `difm` goal is selected and `Continue` is clicked the `setup` flow exits out to `/start/website-design-services/?siteSlug=${ siteSlug }`
* if selected goals resolve to the following intent:
  * `write` or `sell` then next step is `options`
  * `build` then next step is `designSetup`
* modify go back for `options`, `designSetup`, `import` and DIFM to bring the user back to `goals` step screen

##### When `Goals capture` disabled
* the `setup` flow navigation should be not affected, and should work just as before the PR

#### Testing instructions 
Test the PR with different combination of the two config flags:
1. `signup/goals-step`
2. `signup/site-vertical-step`
Modify them locally at `config/development.json`. Make sure to re-build and re-run your local `wp-calypso` instance every time you make an edit to the config.

To land at the goals capture screen you can either go to `http://calypso.localhost:3000/setup/goals?siteSlug=<YOUR-EXISTING-SITE'S-SLUG>`, or:
1. Open 
2. Got to create a new site.
3. Type in any domain
4. Select a free plan
5. You should be presented now with the goals screen.

![Screenshot 2022-06-17 at 14 12 02](https://user-images.githubusercontent.com/2019970/174295812-c26c800d-1ed1-4f79-9f46-ae7be3b09bf3.png)



Related to https://github.com/Automattic/wp-calypso/issues/64707
