### PR TITLE
Generated design picker: Fix mShots and iframe preview URL refreshing on browser resize

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -2,6 +2,7 @@ import {
 	getDesignPreviewUrl,
 	DEFAULT_VIEWPORT_WIDTH,
 	DEFAULT_VIEWPORT_HEIGHT,
+	MOBILE_VIEWPORT_WIDTH,
 } from '@automattic/design-picker';
 import { useViewportMatch } from '@wordpress/compose';
 import classnames from 'classnames';
@@ -45,7 +46,7 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 			previewUrl={ getDesignPreviewUrl( design, {
 				language: locale,
 				verticalId,
-				viewport_width: DEFAULT_VIEWPORT_WIDTH,
+				viewport_width: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
 				viewport_height: DEFAULT_VIEWPORT_HEIGHT,
 			} ) }
 			loadingMessage={ translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -11,6 +11,7 @@ interface GeneratedDesignPickerWebPreviewProps {
 	site?: SiteDetails | null;
 	design: Design;
 	locale: string;
+	viewport: { width: number; height: number } | null;
 	verticalId: string;
 	isSelected: boolean;
 	isPrivateAtomic?: boolean;
@@ -22,6 +23,7 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 	site,
 	design,
 	locale,
+	viewport,
 	verticalId,
 	isSelected,
 	isPrivateAtomic,
@@ -31,6 +33,10 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 	const translate = useTranslate();
 	const isMobile = ! useViewportMatch( 'small' );
 
+	if ( ! viewport ) {
+		return null;
+	}
+
 	return (
 		<WebPreview
 			className={ classnames( { 'is-selected': isSelected } ) }
@@ -38,7 +44,12 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 			showClose={ false }
 			showEdit={ false }
 			showDeviceSwitcher={ false }
-			previewUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
+			previewUrl={ getDesignPreviewUrl( design, {
+				language: locale,
+				verticalId,
+				viewport_width: viewport?.width,
+				viewport_height: viewport?.height,
+			} ) }
 			loadingMessage={ translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
 				components: { strong: <strong /> },
 			} ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/generated-design-picker-web-preview.tsx
@@ -1,4 +1,8 @@
-import { getDesignPreviewUrl, DEFAULT_VIEWPORT_WIDTH } from '@automattic/design-picker';
+import {
+	getDesignPreviewUrl,
+	DEFAULT_VIEWPORT_WIDTH,
+	DEFAULT_VIEWPORT_HEIGHT,
+} from '@automattic/design-picker';
 import { useViewportMatch } from '@wordpress/compose';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -11,7 +15,6 @@ interface GeneratedDesignPickerWebPreviewProps {
 	site?: SiteDetails | null;
 	design: Design;
 	locale: string;
-	viewport: { width: number; height: number } | null;
 	verticalId: string;
 	isSelected: boolean;
 	isPrivateAtomic?: boolean;
@@ -23,7 +26,6 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 	site,
 	design,
 	locale,
-	viewport,
 	verticalId,
 	isSelected,
 	isPrivateAtomic,
@@ -32,10 +34,6 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 } ) => {
 	const translate = useTranslate();
 	const isMobile = ! useViewportMatch( 'small' );
-
-	if ( ! viewport ) {
-		return null;
-	}
 
 	return (
 		<WebPreview
@@ -47,8 +45,8 @@ const GeneratedDesignPickerWebPreview: React.FC< GeneratedDesignPickerWebPreview
 			previewUrl={ getDesignPreviewUrl( design, {
 				language: locale,
 				verticalId,
-				viewport_width: viewport?.width,
-				viewport_height: viewport?.height,
+				viewport_width: DEFAULT_VIEWPORT_WIDTH,
+				viewport_height: DEFAULT_VIEWPORT_HEIGHT,
 			} ) }
 			loadingMessage={ translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
 				components: { strong: <strong /> },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -49,7 +49,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	const { goBack, submit, exitFlow } = navigation;
 	const translate = useTranslate();
 	const locale = useLocale();
-	const viewport = useRef( null );
+	const viewport = useRef< { width: number; height: number } | null >( null );
 	const site = useSite();
 	const { setSelectedDesign, setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -299,7 +299,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	useEffect( () => {
 		const { innerWidth: width, innerHeight: height } = window;
 		viewport.current = { width, height };
-	}, [] );
+	}, [ isMobile ] );
 
 	// When the intent is build, we can potentially show the generated design picker.
 	// Don't render until we've fetched the generated designs from the backend.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -49,6 +49,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	const { goBack, submit, exitFlow } = navigation;
 	const translate = useTranslate();
 	const locale = useLocale();
+	const viewport = useRef( null );
 	const site = useSite();
 	const { setSelectedDesign, setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
@@ -295,6 +296,11 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		window.scrollTo( { top: 0 } );
 	}, [ isForceStaticDesigns, !! selectedDesign ] );
 
+	useEffect( () => {
+		const { innerWidth: width, innerHeight: height } = window;
+		viewport.current = { width, height };
+	}, [] );
+
 	// When the intent is build, we can potentially show the generated design picker.
 	// Don't render until we've fetched the generated designs from the backend.
 	if ( ! site || isLoadingGeneratedDesigns ) {
@@ -376,12 +382,14 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			designs={ generatedDesigns }
 			verticalId={ siteVerticalId }
 			locale={ locale }
+			viewport={ viewport.current }
 			previews={ generatedDesigns.map( ( design ) => (
 				<GeneratedDesignPickerWebPreview
 					key={ design.slug }
 					site={ site }
 					design={ design }
 					locale={ locale }
+					viewport={ viewport.current }
 					verticalId={ siteVerticalId }
 					isSelected={ design.slug === selectedGeneratedDesign?.slug }
 					isStickyToolbar={ ! isMobile && isSticky }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -49,7 +49,6 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	const { goBack, submit, exitFlow } = navigation;
 	const translate = useTranslate();
 	const locale = useLocale();
-	const viewport = useRef< { width: number; height: number } | null >( null );
 	const site = useSite();
 	const { setSelectedDesign, setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
@@ -296,11 +295,6 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		window.scrollTo( { top: 0 } );
 	}, [ isForceStaticDesigns, !! selectedDesign ] );
 
-	useEffect( () => {
-		const { innerWidth: width, innerHeight: height } = window;
-		viewport.current = { width, height };
-	}, [ isMobile ] );
-
 	// When the intent is build, we can potentially show the generated design picker.
 	// Don't render until we've fetched the generated designs from the backend.
 	if ( ! site || isLoadingGeneratedDesigns ) {
@@ -382,14 +376,12 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			designs={ generatedDesigns }
 			verticalId={ siteVerticalId }
 			locale={ locale }
-			viewport={ viewport.current }
 			previews={ generatedDesigns.map( ( design ) => (
 				<GeneratedDesignPickerWebPreview
 					key={ design.slug }
 					site={ site }
 					design={ design }
 					locale={ locale }
-					viewport={ viewport.current }
 					verticalId={ siteVerticalId }
 					isSelected={ design.slug === selectedGeneratedDesign?.slug }
 					isStickyToolbar={ ! isMobile && isSticky }

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -6,6 +6,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect, useRef } from 'react';
+import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT } from '../constants';
 import { getDesignPreviewUrl, getMShotOptions } from '../utils';
 import type { Design } from '../types';
 import './style.scss';
@@ -62,7 +63,6 @@ export interface GeneratedDesignPickerProps {
 	previews: React.ReactElement[];
 	verticalId: string;
 	locale: string;
-	viewport: { width: number; height: number } | null;
 	heading?: React.ReactElement;
 	footer?: React.ReactElement;
 	onPreview: ( design: Design, positionIndex: number ) => void;
@@ -75,7 +75,6 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 	previews,
 	verticalId,
 	locale,
-	viewport,
 	heading,
 	footer,
 	onPreview,
@@ -111,10 +110,6 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 		};
 	}, [ isMobile ] );
 
-	if ( ! viewport ) {
-		return null;
-	}
-
 	return (
 		<div className="generated-design-picker">
 			{ heading }
@@ -128,8 +123,8 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 								thumbnailUrl={ getDesignPreviewUrl( design, {
 									language: locale,
 									verticalId,
-									viewport_width: viewport?.width,
-									viewport_height: viewport?.height,
+									viewport_width: DEFAULT_VIEWPORT_WIDTH,
+									viewport_height: DEFAULT_VIEWPORT_HEIGHT,
 								} ) }
 								isSelected={ selectedDesign?.slug === design.slug }
 								onPreview={ () => onPreview( design, index ) }

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -6,7 +6,11 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect, useRef } from 'react';
-import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT } from '../constants';
+import {
+	DEFAULT_VIEWPORT_WIDTH,
+	DEFAULT_VIEWPORT_HEIGHT,
+	MOBILE_VIEWPORT_WIDTH,
+} from '../constants';
 import { getDesignPreviewUrl, getMShotOptions } from '../utils';
 import type { Design } from '../types';
 import './style.scss';
@@ -123,7 +127,7 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 								thumbnailUrl={ getDesignPreviewUrl( design, {
 									language: locale,
 									verticalId,
-									viewport_width: DEFAULT_VIEWPORT_WIDTH,
+									viewport_width: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
 									viewport_height: DEFAULT_VIEWPORT_HEIGHT,
 								} ) }
 								isSelected={ selectedDesign?.slug === design.slug }

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -62,6 +62,7 @@ export interface GeneratedDesignPickerProps {
 	previews: React.ReactElement[];
 	verticalId: string;
 	locale: string;
+	viewport: { width: number; height: number } | null;
 	heading?: React.ReactElement;
 	footer?: React.ReactElement;
 	onPreview: ( design: Design, positionIndex: number ) => void;
@@ -74,15 +75,14 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 	previews,
 	verticalId,
 	locale,
+	viewport,
 	heading,
 	footer,
 	onPreview,
 	onViewMore,
 } ) => {
 	const { __ } = useI18n();
-
 	const isMobile = useViewportMatch( 'small', '<' );
-
 	const wrapperRef = useRef< HTMLDivElement >( null );
 
 	useEffect( () => {
@@ -111,6 +111,10 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 		};
 	}, [ isMobile ] );
 
+	if ( ! viewport ) {
+		return null;
+	}
+
 	return (
 		<div className="generated-design-picker">
 			{ heading }
@@ -121,7 +125,12 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 							<GeneratedDesignThumbnail
 								key={ design.slug }
 								slug={ design.slug }
-								thumbnailUrl={ getDesignPreviewUrl( design, { language: locale, verticalId } ) }
+								thumbnailUrl={ getDesignPreviewUrl( design, {
+									language: locale,
+									verticalId,
+									viewport_width: viewport?.width,
+									viewport_height: viewport?.height,
+								} ) }
 								isSelected={ selectedDesign?.slug === design.slug }
 								onPreview={ () => onPreview( design, index ) }
 							/>

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -56,5 +56,5 @@ export const ANCHORFM_FONT_PAIRINGS = [
  * mShot options
  */
 export const DEFAULT_VIEWPORT_WIDTH = 1600;
-export const DEFAULT_VIEWPORT_HEIGHT = 700;
+export const DEFAULT_VIEWPORT_HEIGHT = 1040;
 export const MOBILE_VIEWPORT_WIDTH = 599;

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -15,6 +15,7 @@ export {
 	FONT_PAIRINGS,
 	ANCHORFM_FONT_PAIRINGS,
 	DEFAULT_VIEWPORT_WIDTH,
+	DEFAULT_VIEWPORT_HEIGHT,
 	MOBILE_VIEWPORT_WIDTH,
 } from './constants';
 export type { FontPair, Design, Category } from './types';

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT } from '../../constants';
+import { DEFAULT_VIEWPORT_HEIGHT } from '../../constants';
 import { Design, DesignPreviewOptions } from '../../types';
 import { getDesignPreviewUrl } from '../designs';
 
@@ -13,13 +13,8 @@ describe( 'Design Picker designs utils', () => {
 		} as Design;
 
 		it( 'should return the block-previews/site endpoint with the correct query params', () => {
-			const options: DesignPreviewOptions = {
-				viewport_width: DEFAULT_VIEWPORT_WIDTH,
-				viewport_height: DEFAULT_VIEWPORT_HEIGHT,
-			};
-
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_width=${ DEFAULT_VIEWPORT_WIDTH }&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
 			);
 		} );
 
@@ -42,12 +37,10 @@ describe( 'Design Picker designs utils', () => {
 		it( 'should escape parentheses within the site title', () => {
 			const options: DesignPreviewOptions = {
 				siteTitle: 'Mock(Design)(Title)',
-				viewport_width: DEFAULT_VIEWPORT_WIDTH,
-				viewport_height: DEFAULT_VIEWPORT_HEIGHT,
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_width=${ DEFAULT_VIEWPORT_WIDTH }&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Mock%28Design%29%28Title%29`
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Mock%28Design%29%28Title%29`
 			);
 		} );
 	} );

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -13,7 +13,7 @@ describe( 'Design Picker designs utils', () => {
 		} as Design;
 
 		it( 'should return the block-previews/site endpoint with the correct query params', () => {
-			expect( getDesignPreviewUrl( design, options ) ).toEqual(
+			expect( getDesignPreviewUrl( design, {} ) ).toEqual(
 				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
 			);
 		} );

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -7,12 +7,6 @@ export const getDesignPreviewUrl = (
 	options: DesignPreviewOptions = {}
 ): string => {
 	const { recipe, slug } = design;
-	const viewport_width =
-		options.viewport_width ??
-		( typeof window !== 'undefined' ? window.innerWidth : DEFAULT_VIEWPORT_WIDTH );
-	const viewport_height =
-		options.viewport_height ??
-		( typeof window !== 'undefined' ? window.innerHeight : DEFAULT_VIEWPORT_HEIGHT );
 
 	//Anchor.fm themes get previews from their starter sites, ${slug}starter.wordpress.com
 	if ( [ 'hannah', 'riley', 'gilbert' ].indexOf( slug ) >= 0 ) {
@@ -24,8 +18,8 @@ export const getDesignPreviewUrl = (
 		pattern_ids: recipe?.pattern_ids?.join( ',' ),
 		vertical_id: options.verticalId,
 		language: options.language,
-		viewport_width,
-		viewport_height,
+		viewport_width: options.viewport_width || DEFAULT_VIEWPORT_WIDTH,
+		viewport_height: options.viewport_height || DEFAULT_VIEWPORT_HEIGHT,
 		source_site: 'patternboilerplates.wordpress.com',
 	} );
 

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -1,5 +1,5 @@
 import { addQueryArgs } from '@wordpress/url';
-import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT } from '../constants';
+import { DEFAULT_VIEWPORT_HEIGHT } from '../constants';
 import type { Design, DesignPreviewOptions } from '../types';
 
 export const getDesignPreviewUrl = (
@@ -18,7 +18,7 @@ export const getDesignPreviewUrl = (
 		pattern_ids: recipe?.pattern_ids?.join( ',' ),
 		vertical_id: options.verticalId,
 		language: options.language,
-		viewport_width: options.viewport_width || DEFAULT_VIEWPORT_WIDTH,
+		...( options.viewport_width && { viewport_width: options.viewport_width } ),
 		viewport_height: options.viewport_height || DEFAULT_VIEWPORT_HEIGHT,
 		source_site: 'patternboilerplates.wordpress.com',
 	} );


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the issue where mShots thumbnails and iframe pages would refresh as user resizes the browser. The problem is caused by the function that generated the preview URL automatically fetches the viewport size. As the browser is resized, the function would fetch the updated viewport size, causing the preview URL to be updated as well.  

This PR changes so that the `viewport_width` and `viewport_height` are explicitly passed as props to generate the mShots and iframe URL, thus avoiding unintended preview URL updates.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the generated design picker.
* Once the thumbnails and the iframe preview load, resize the browser.
* Expect the thumbnails and the iframe preview to not refresh.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64518
