### PR TITLE
Help Center: Added dot to improve security

### DIFF
--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -9,7 +9,7 @@ type ResponseType< T extends 'CHAT' | 'OTHER' > = T extends 'CHAT'
 export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	supportType: SUPPORT_TYPE
 ) {
-	const isSimpleSite = window.location.host.endsWith( 'wordpress.com' );
+	const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );
 	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >(
 		supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability',
 		async () =>

--- a/packages/happychat-connection/src/use-happychat-available.ts
+++ b/packages/happychat-connection/src/use-happychat-available.ts
@@ -6,7 +6,7 @@ let cachedAvailableValue: boolean | undefined = undefined;
 
 export function useHappychatAvailable() {
 	const [ available, setIsAvailable ] = useState< boolean | undefined >( cachedAvailableValue );
-	const isSimpleSite = window.location.host.endsWith( 'wordpress.com' );
+	const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );
 	const { data: dataAuth, isLoading: isLoadingAuth } = useHappychatAuth(
 		cachedAvailableValue === undefined
 	);

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -24,7 +24,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
 
 	const siteId = useSelector( getSelectedSiteId );
-	const isSimpleSite = window.location.host.endsWith( 'wordpress.com' );
+	const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );
 
 	// prefetch the current site and user
 	const site = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -3,7 +3,7 @@ import { useHas3PC, useSupportAvailability } from '@automattic/data-stores';
 export function useStillNeedHelpURL() {
 	const { data: supportAvailability } = useSupportAvailability( 'OTHER' );
 	const { hasCookies } = useHas3PC();
-	const isSimpleSite = window.location.host.endsWith( 'wordpress.com' );
+	const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );
 
 	// email support is available for all non-free users, let's use it as a proxy for free users
 	// TODO: check purchases instead


### PR DESCRIPTION
#### Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/64562, we introduced 
`const isSimpleSite = window.location.host.endsWith( 'wordpress.com' );`

For security reasons, as there could be sites like `vulnerablewordpress.com` or `my.evilwordpress.com`, it's better to change the code to (adding the `.` before wordpress):

`const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* Test that on Atomic it still sends you to 'https://wordpress.com/help/contact' after clicking on `Still need help?`
* On simple sites you should be able to see the contact options page 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64720
Fixes #64720
