### PR TITLE
Domains: Refactor `RegistrantExtraInfo` tests to `@testing-library`

### DIFF
--- a/client/components/domains/registrant-extra-info/test/ca-form.js
+++ b/client/components/domains/registrant-extra-info/test/ca-form.js
@@ -1,4 +1,7 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
 import { RegistrantExtraInfoCaForm } from '../ca-form';
 
 const mockProps = {
@@ -9,7 +12,6 @@ const mockProps = {
 };
 
 describe( 'ca-form', () => {
-	// eslint-disable-next-line jest/expect-expect
 	test( 'should render without errors when extra is empty', () => {
 		const testProps = {
 			...mockProps,
@@ -17,6 +19,10 @@ describe( 'ca-form', () => {
 			ccTldDetails: {},
 		};
 
-		shallow( <RegistrantExtraInfoCaForm { ...testProps } /> );
+		render( <RegistrantExtraInfoCaForm { ...testProps } /> );
+
+		expect(
+			screen.getByText( 'Choose the option that best describes your Canadian presence:' )
+		).toBeVisible();
 	} );
 } );

--- a/client/components/domains/registrant-extra-info/test/index.js
+++ b/client/components/domains/registrant-extra-info/test/index.js
@@ -1,29 +1,33 @@
-import { shallow } from 'enzyme';
-import RegistrantExtraInfoCaForm from '../ca-form';
-import RegistrantExtraInfoFrForm from '../fr-form';
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
 import RegistrantExtraInfoForm from '../index';
-import RegistrantExtraInfoUkForm from '../uk-form';
+
+jest.mock( '../ca-form', () => () => <div data-testid="ca-form"></div> );
+jest.mock( '../fr-form', () => () => <div data-testid="fr-form"></div> );
+jest.mock( '../uk-form', () => () => <div data-testid="uk-form"></div> );
 
 describe( 'Switcher Form', () => {
 	test( 'should render correct form for fr', () => {
-		const wrapper = shallow( <RegistrantExtraInfoForm tld="fr" /> );
+		render( <RegistrantExtraInfoForm tld="fr" /> );
 
-		expect( wrapper.find( RegistrantExtraInfoFrForm ) ).toHaveLength( 1 );
-		expect( wrapper.find( RegistrantExtraInfoCaForm ) ).toHaveLength( 0 );
+		expect( screen.getByTestId( 'fr-form' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'ca-form' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'should render correct form for ca', () => {
-		const wrapper = shallow( <RegistrantExtraInfoForm tld="ca" /> );
+		render( <RegistrantExtraInfoForm tld="ca" /> );
 
-		expect( wrapper.find( RegistrantExtraInfoCaForm ) ).toHaveLength( 1 );
-		expect( wrapper.find( RegistrantExtraInfoFrForm ) ).toHaveLength( 0 );
+		expect( screen.getByTestId( 'ca-form' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'fr-form' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'should render correct form for uk', () => {
-		const wrapper = shallow( <RegistrantExtraInfoForm tld="uk" /> );
+		render( <RegistrantExtraInfoForm tld="uk" /> );
 
-		expect( wrapper.find( RegistrantExtraInfoCaForm ) ).toHaveLength( 0 );
-		expect( wrapper.find( RegistrantExtraInfoFrForm ) ).toHaveLength( 0 );
-		expect( wrapper.find( RegistrantExtraInfoUkForm ) ).toHaveLength( 1 );
+		expect( screen.queryByTestId( 'ca-form' ) ).not.toBeInTheDocument();
+		expect( screen.queryByTestId( 'fr-form' ) ).not.toBeInTheDocument();
+		expect( screen.getByTestId( 'uk-form' ) ).toBeVisible();
 	} );
 } );

--- a/client/components/domains/registrant-extra-info/test/uk-form.js
+++ b/client/components/domains/registrant-extra-info/test/uk-form.js
@@ -1,6 +1,12 @@
-import { FormInputValidation } from '@automattic/components';
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
 import { RegistrantExtraInfoUkForm } from '../uk-form';
+
+jest.mock( '@automattic/components', () => ( {
+	FormInputValidation: ( { text } ) => <div data-testid="test-validation">{ text }</div>,
+} ) );
 
 const mockProps = {
 	contactDetails: {},
@@ -24,9 +30,8 @@ describe( 'uk-form', () => {
 				},
 			};
 
-			const wrapper = shallow( <RegistrantExtraInfoUkForm { ...testProps } /> );
-			const error = wrapper.find( FormInputValidation );
-			expect( error.props() ).toHaveProperty( 'text', 'Test error message.' );
+			render( <RegistrantExtraInfoUkForm { ...testProps } /> );
+			expect( screen.getByTestId( 'test-validation' ) ).toHaveTextContent( 'Test error message.' );
 		} );
 
 		test( 'should render multiple registration errors', () => {
@@ -46,9 +51,8 @@ describe( 'uk-form', () => {
 				},
 			};
 
-			const wrapper = shallow( <RegistrantExtraInfoUkForm { ...testProps } /> );
-			const error = wrapper.find( FormInputValidation );
-			expect( error ).toHaveProperty( 'length', 3 );
+			render( <RegistrantExtraInfoUkForm { ...testProps } /> );
+			expect( screen.getAllByTestId( 'test-validation' ) ).toHaveLength( 3 );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `RegistrantExtraInfo` component tests to use `@testing-library/react` instead of `enzyme`.

Part of #63409 - ticks 3 items there.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/components/domains/registrant-extra-info`