### PR TITLE
Components: Refactor `FeatureExample` to `@testing-library`

### DIFF
--- a/client/components/feature-example/test/index.js
+++ b/client/components/feature-example/test/index.js
@@ -1,18 +1,23 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
 import FeatureExample from '../index';
 
 describe( 'Feature Example', () => {
 	test( 'should have Feature-example class', () => {
-		const featureExample = shallow( <FeatureExample /> );
-		expect( featureExample.find( '.feature-example' ).length ).toBe( 1 );
+		const { container } = render( <FeatureExample /> );
+		expect( container.firstChild ).toHaveClass( 'feature-example' );
 	} );
 
-	test( 'should contains the passed children wrapped by a feature-example div', () => {
-		const featureExample = shallow(
+	test( 'should contains the passed children wrapped by a feature-example__content div', () => {
+		render(
 			<FeatureExample>
-				<div>test</div>
+				<div>Test feature</div>
 			</FeatureExample>
 		);
-		expect( featureExample.contains( <div>test</div> ) ).toBe( true );
+		const textWrapper = screen.getByText( 'Test feature' );
+		expect( textWrapper ).toBeVisible();
+		expect( textWrapper.parentNode ).toHaveClass( 'feature-example__content' );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `FeatureExample` component to use `@testing-library/react` instead of `enzyme`.

Part of #63409.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/components/feature-example/test/index.js`