### PR TITLE
Components: Refactor `TranslatorInvite` tests to `@testing-library`

### DIFF
--- a/client/components/translator-invite/test/index.js
+++ b/client/components/translator-invite/test/index.js
@@ -1,8 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-
-import { shallow } from 'enzyme';
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { TranslatorInvite } from '../';
 
 describe( 'TranslatorInvite', () => {
@@ -33,12 +33,16 @@ describe( 'TranslatorInvite', () => {
 	};
 
 	test( 'should not render when no locale information present', () => {
-		const wrapper = shallow( <TranslatorInvite { ...defaultProps } /> );
-		expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 0 );
+		const { container } = renderWithProvider( <TranslatorInvite { ...defaultProps } /> );
+		expect( container.firstChild ).toBeEmptyDOMElement();
 	} );
 
 	test( 'should render when no locale information present', () => {
-		const wrapper = shallow( <TranslatorInvite { ...defaultProps } locale="tl" /> );
-		expect( wrapper.find( '.translator-invite__content' ) ).toHaveLength( 1 );
+		renderWithProvider( <TranslatorInvite { ...defaultProps } locale="tl" /> );
+		expect(
+			screen.getByText(
+				'Would you like to help us translate WordPress.com into {{a}}%(language)s{{/a}}?'
+			)
+		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `TranslatorInvite` component to use `@testing-library/react` instead of `enzyme`.

Part of #63409.

#### Testing instructions

Verify tests still pass: `yarn run test-client client/components/translator-invite/test/index.js`