### PR TITLE
Help Center: Ship to 10% of users

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -383,12 +383,18 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
 
 /**
  * Help center
+ * At the moment we're showing only to 10% of the users. And to all proxied requests.
  */
 function load_help_center() {
 	// enable help center for all proxied users.
 	$is_proxied = function_exists( 'wpcom_is_proxied_request' ) ? wpcom_is_proxied_request() : false;
 
-	if ( $is_proxied ) {
+	$current_segment = 10; // segment of existing users that will get the help center in %.
+	$user_segment    = get_current_user_id() % 100;
+	// only shipping to en locale for now
+	$current_locale = get_locale();
+
+	if ( $is_proxied || ( 'en' === $current_locale && $user_segment < $current_segment ) ) {
 		require_once __DIR__ . '/help-center/class-help-center.php';
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -391,7 +391,7 @@ function load_help_center() {
 
 	$current_segment = 10; // segment of existing users that will get the help center in %.
 	$user_segment    = get_current_user_id() % 100;
-	// only shipping to en locale for now
+	// only shipping to en locale for now.
 	$current_locale = get_locale();
 
 	if ( $is_proxied || ( 'en' === $current_locale && $user_segment < $current_segment ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
@@ -12,6 +12,11 @@
 	}
 }
 
+// If the help center is shipped in core, we hide the black fab button
+.a8c-faux-inline-help__button {
+	display: none;
+}
+
 .help-center__container {
 	&.is-mobile {
 		&.is-minimized {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -374,8 +374,10 @@ export default withCurrentRoute(
 		const userSegment = userId % 100;
 		const locale = getCurrentLocaleSlug( state );
 		const isEditor = getSectionName( state ) === 'gutenberg-editor';
+		const isHelpCenterEnabled = config.isEnabled( 'editor/help-center' );
 
-		const disableFAB = locale === 'en' && isEditor && userSegment < currentSegment;
+		const disableFAB =
+			isHelpCenterEnabled && locale === 'en' && isEditor && userSegment < currentSegment;
 
 		return {
 			masterbarIsHidden,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -25,16 +25,19 @@ import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import { isOffline } from 'calypso/state/application/selectors';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import {
 	getSelectedSiteId,
+	getSectionName,
 	masterbarIsVisible,
 	getSidebarIsCollapsed,
 } from 'calypso/state/ui/selectors';
@@ -240,7 +243,7 @@ class Layout extends Component {
 			};
 		};
 
-		const loadInlineHelp = this.shouldLoadInlineHelp();
+		const loadInlineHelp = this.shouldLoadInlineHelp() && ! this.props.disableFAB;
 
 		return (
 			<div className={ sectionClass }>
@@ -366,6 +369,14 @@ export default withCurrentRoute(
 		const sidebarIsHidden = ! secondary || isWcMobileApp();
 		const chatIsDocked = ! [ 'reader', 'theme' ].includes( sectionName ) && ! sidebarIsHidden;
 
+		const userId = getCurrentUserId( state );
+		const currentSegment = 10; //percentage of users that will not see the FAB, but the Help Center
+		const userSegment = userId % 100;
+		const locale = getCurrentLocaleSlug( state );
+		const isEditor = getSectionName( state ) === 'gutenberg-editor';
+
+		const disableFAB = locale === 'en' && isEditor && userSegment < currentSegment;
+
 		return {
 			masterbarIsHidden,
 			sidebarIsHidden,
@@ -395,6 +406,7 @@ export default withCurrentRoute(
 			// See https://github.com/Automattic/wp-calypso/pull/31277 for more details.
 			shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
 			sidebarIsCollapsed: getSidebarIsCollapsed( state ),
+			disableFAB,
 		};
 	} )( Layout )
 );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -21,6 +21,7 @@ import {
 } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/selectors';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getSiteMigrationStatus from 'calypso/state/selectors/get-site-migration-status';
@@ -498,7 +499,16 @@ class MasterbarLoggedIn extends Component {
 		}
 		if ( isMobile ) {
 			const isHelpCenterEnabled = config.isEnabled( 'editor/help-center' );
-			if ( this.props.isInEditor && isHelpCenterEnabled ) {
+
+			const currentSegment = 10; //percentage of users that will see the Help Center, not the FAB
+			const userSegment = this.props.user.ID % 100;
+
+			if (
+				this.props.isInEditor &&
+				isHelpCenterEnabled &&
+				userSegment < currentSegment &&
+				this.props.locale === 'en'
+			) {
 				return (
 					<Masterbar>
 						<div className="masterbar__section masterbar__section--left">
@@ -588,6 +598,7 @@ export default connect(
 			// If the user is newer than new navigation shipping date, don't tell them this nav is new. Everything is new to them.
 			isUserNewerThanNewNavigation:
 				new Date( getCurrentUserDate( state ) ).getTime() > NEW_MASTERBAR_SHIPPING_DATE,
+			locale: getCurrentLocaleSlug( state ),
 		};
 	},
 	{

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -26,7 +26,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"editor/help-center": false,
+		"editor/help-center": true,
 		"checkout/help-center": false,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/config/production.json
+++ b/config/production.json
@@ -29,7 +29,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"editor/help-center": false,
+		"editor/help-center": true,
 		"checkout/help-center": false,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -87,12 +87,6 @@ const HelpCenterHeader: React.FC< Header > = ( {
 					) : (
 						__( 'Help Center', __i18n_text_domain__ )
 					) }
-					<span
-						className="help-center-header__a8c-only-badge"
-						title="The help center is only visible to Automatticians at this stage."
-					>
-						a8c only
-					</span>
 					{ isMinimized && unreadCount ? (
 						<span className="help-center-header__unread-count">{ formattedUnreadCount }</span>
 					) : null }


### PR DESCRIPTION
DO NOT MERGE

#### Proposed Changes

With this PR we will release the Help Center to 10% of users, when in English locale (translations in progress) and in the editor.

The users with the Help Center won't see the old FAB.

Need to be tested better in Atomic sites

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* `yarn dev --sync` from `apps/editing-toolkit`
* Be sure not to be proxied
* If your user id last two digits are < 10, locale is in English, and you are in the editor (post, page and site), then you should see the help center and not the FAB.
* You can change the user segment number ( [here](https://github.com/Automattic/wp-calypso/pull/64737/files#diff-9ba754f27ecf58cc3b55d0d053194696397eda7210d9031798dd19167049a66bR389) and [here](https://github.com/Automattic/wp-calypso/pull/64737/files#diff-7d1eb73ef67c978553b9d47cf17a8f4b9d93bd396ee6cb5ce89e75aedb8b0f19R373) ) to include you user id.
