### PR TITLE
Help Center: Redirect to search from article/ Create new event

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -4,10 +4,10 @@ import HelpCenter, { HelpIcon } from '@automattic/help-center';
 import { Button } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
 import { PinnedItems } from '@wordpress/interface';
 import { registerPlugin } from '@wordpress/plugins';
 import cx from 'classnames';
-import { useEffect, useState } from 'react';
 import { QueryClientProvider } from 'react-query';
 import { whatsNewQueryClient } from '../../common/what-new-query-client';
 import CalypsoStateProvider from './CalypsoStateProvider';
@@ -16,6 +16,7 @@ import './help-center.scss';
 function HelpCenterContent() {
 	const isDesktop = useMediaQuery( '(min-width: 480px)' );
 	const show = useSelect( ( select ) => select( 'automattic/help-center' ).isHelpCenterShown() );
+	const [ showHelpIcon, setShowHelpIcon ] = useState( false );
 	const { setShowHelpCenter } = useDispatch( 'automattic/help-center' );
 	const [ showHelpIconDot, setShowHelpIconDot ] = useState( false );
 	const { data, isLoading } = useHasSeenWhatsNewModalQuery( window._currentSiteId );
@@ -34,6 +35,11 @@ function HelpCenterContent() {
 		setShowHelpCenter( ! show );
 	};
 
+	useEffect( () => {
+		const timeout = setTimeout( () => setShowHelpIcon( true ), 0 );
+		return () => clearTimeout( timeout );
+	}, [] );
+
 	const content = (
 		<span className="etk-help-center">
 			<Button
@@ -46,7 +52,7 @@ function HelpCenterContent() {
 
 	return (
 		<>
-			{ isDesktop && (
+			{ isDesktop && showHelpIcon && (
 				<>
 					<PinnedItems scope="core/edit-post">{ content }</PinnedItems>
 					<PinnedItems scope="core/edit-site">{ content }</PinnedItems>

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
@@ -7,10 +7,6 @@
 			}
 		}
 	}
-
-	.interface-pinned-items & {
-		order: 4;
-	}
 }
 
 .help-center__container {

--- a/packages/help-center/src/components/help-center-embed-result.tsx
+++ b/packages/help-center/src/components/help-center-embed-result.tsx
@@ -4,13 +4,14 @@ import { Flex, FlexItem } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { Icon, external } from '@wordpress/icons';
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 // eslint-disable-next-line no-restricted-imports
 import ArticleContent from 'calypso/blocks/support-article-dialog/dialog-content';
 import { BackButton } from './back-button';
 
 export const HelpCenterEmbedResult: React.FC = () => {
 	const { search } = useLocation();
+	const history = useHistory();
 	const params = new URLSearchParams( search );
 	const postId = params.get( 'postId' );
 	const blogId = params.get( 'blogId' );
@@ -27,11 +28,22 @@ export const HelpCenterEmbedResult: React.FC = () => {
 		recordTracksEvent( `calypso_inlinehelp_article_open`, tracksData );
 	}, [ query, link ] );
 
+	const redirectToSearchOrHome = () => {
+		if ( query ) {
+			const search = new URLSearchParams( {
+				query,
+			} ).toString();
+			history.push( `/?${ search }` );
+		} else {
+			history.push( '/' );
+		}
+	};
+
 	return (
 		<div className="help-center-embed-result">
 			<Flex justify="space-between">
 				<FlexItem>
-					<BackButton />
+					<BackButton onClick={ redirectToSearchOrHome } />
 				</FlexItem>
 				<FlexItem>
 					<Button

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -45,10 +45,18 @@ export const HelpCenterMoreResources = () => {
 
 	const [ showGuide, setShowGuide ] = useState( false );
 
-	const trackCoursesButtonClick = () => {
+	const trackMoreResourcesButtonClick = ( resource: string ) => {
+		recordTracksEvent( 'calypso_help_moreresources_click', {
+			is_business_or_ecommerce_plan_user: isBusinessOrEcomPlanUser,
+			resource: resource,
+		} );
+	};
+
+	const trackWebinairsButtonClick = () => {
 		recordTracksEvent( 'calypso_help_courses_click', {
 			is_business_or_ecommerce_plan_user: isBusinessOrEcomPlanUser,
 		} );
+		trackMoreResourcesButtonClick( 'webinairs' );
 	};
 
 	const handleWhatsNewClick = () => {
@@ -56,6 +64,7 @@ export const HelpCenterMoreResources = () => {
 			setHasSeenWhatsNewModal( true );
 		}
 		setShowGuide( true );
+		trackMoreResourcesButtonClick( 'whats-new' );
 	};
 
 	return (
@@ -69,6 +78,7 @@ export const HelpCenterMoreResources = () => {
 							rel="noreferrer"
 							target="_blank"
 							className="inline-help__video"
+							onClick={ () => trackMoreResourcesButtonClick( 'video' ) }
 						>
 							<Icon icon={ video } size={ 24 } />
 							<span>{ __( 'Video tutorials' ) }</span>
@@ -81,7 +91,7 @@ export const HelpCenterMoreResources = () => {
 							href={ localizeUrl( 'https://wordpress.com/webinars' ) }
 							rel="noreferrer"
 							target="_blank"
-							onClick={ trackCoursesButtonClick }
+							onClick={ trackWebinairsButtonClick }
 							className="inline-help__capture-video"
 						>
 							<Icon icon={ captureVideo } size={ 24 } />
@@ -96,6 +106,7 @@ export const HelpCenterMoreResources = () => {
 							rel="noreferrer"
 							target="_blank"
 							className="inline-help__desktop"
+							onClick={ () => trackMoreResourcesButtonClick( 'courses' ) }
 						>
 							<Icon icon={ desktop } size={ 24 } />
 							<span>{ __( 'Courses' ) }</span>
@@ -109,6 +120,7 @@ export const HelpCenterMoreResources = () => {
 							rel="noreferrer"
 							target="_blank"
 							className="inline-help__format-list-numbered"
+							onClick={ () => trackMoreResourcesButtonClick( 'guides' ) }
 						>
 							<Icon icon={ formatListNumbered } size={ 24 } />
 							<span>{ __( 'Step-by-step guides' ) }</span>

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -7,7 +7,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import WhatsNewGuide from '@automattic/whats-new';
 import { Button, SVG, Circle } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
-import { Icon, captureVideo, desktop, formatListNumbered, video } from '@wordpress/icons';
+import { Icon, captureVideo, desktop, formatListNumbered, video, external } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
@@ -82,6 +82,7 @@ export const HelpCenterMoreResources = () => {
 						>
 							<Icon icon={ video } size={ 24 } />
 							<span>{ __( 'Video tutorials' ) }</span>
+							<Icon icon={ external } size={ 20 } />
 						</a>
 					</div>
 				</li>
@@ -96,6 +97,7 @@ export const HelpCenterMoreResources = () => {
 						>
 							<Icon icon={ captureVideo } size={ 24 } />
 							<span>{ __( 'Webinars' ) }</span>
+							<Icon icon={ external } size={ 20 } />
 						</a>
 					</div>
 				</li>
@@ -110,6 +112,7 @@ export const HelpCenterMoreResources = () => {
 						>
 							<Icon icon={ desktop } size={ 24 } />
 							<span>{ __( 'Courses' ) }</span>
+							<Icon icon={ external } size={ 20 } />
 						</a>
 					</div>
 				</li>
@@ -124,6 +127,7 @@ export const HelpCenterMoreResources = () => {
 						>
 							<Icon icon={ formatListNumbered } size={ 24 } />
 							<span>{ __( 'Step-by-step guides' ) }</span>
+							<Icon icon={ external } size={ 20 } />
 						</a>
 					</div>
 				</li>
@@ -136,7 +140,10 @@ export const HelpCenterMoreResources = () => {
 						>
 							<Icon icon={ <NewReleases /> } size={ 24 } />
 							<span>{ __( "What's new" ) }</span>
-							{ showWhatsNewDot && <Icon icon={ circle } size={ 16 } /> }
+							{ showWhatsNewDot && (
+								<Icon className="inline-help__new-releases_dot" icon={ circle } size={ 16 } />
+							) }
+							<Icon icon={ external } size={ 20 } />
 						</Button>
 					</div>
 				</li>

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -15,7 +15,6 @@
 }
 
 .help-center .help-center__container-content {
-
 	/**
  	 * SEARCH
  	 */
@@ -128,8 +127,6 @@
 						color: var( --color-neutral );
 					}
 				}
-
-
 			}
 		}
 
@@ -192,7 +189,7 @@
 						color: var( --studio-gray-100 );
 					}
 
-					> svg:last-child {
+					.inline-help__new-releases_dot {
 						align-self: auto;
 						background: none;
 						color: var( --color-masterbar-unread-dot-background );
@@ -204,6 +201,11 @@
 						box-shadow: 0 0 0 1px var( --studio-blue-30 ), 0 0 2px 1px rgb( 79 148 212 / 80% );
 						outline: 1px solid transparent;
 					}
+				}
+
+				> svg:last-child {
+					fill: unset;
+					margin-left: auto;
 				}
 			}
 		}

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 /* eslint-disable no-restricted-imports */
 import { useState, useCallback } from '@wordpress/element';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import InlineHelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
 import InlineHelpSearchResults from 'calypso/blocks/inline-help/inline-help-search-results';
 import './help-center-search.scss';
@@ -9,8 +9,12 @@ import { HelpCenterMoreResources } from './help-center-more-resources';
 import { SibylArticles } from './help-center-sibyl-articles';
 
 export const HelpCenterSearch = () => {
-	const [ searchQuery, setSearchQuery ] = useState( '' );
 	const history = useHistory();
+	const { search } = useLocation();
+	const params = new URLSearchParams( search );
+	const query = params.get( 'query' );
+
+	const [ searchQuery, setSearchQuery ] = useState( query || '' );
 
 	const redirectToArticle = useCallback(
 		( event, result ) => {

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -20,14 +20,17 @@ export const HelpCenterSearch = () => {
 		( event, result ) => {
 			const search = new URLSearchParams( {
 				postId: result.post_id,
-				blogId: result.blog_id,
 				query: searchQuery,
 				link: result.link ?? '',
 				title: result.title,
-			} ).toString();
+			} );
+
+			if ( result.blog_id ) {
+				search.append( 'blogId', result.blog_id );
+			}
 
 			event.preventDefault();
-			history.push( `/post/?${ search }` );
+			history.push( `/post/?${ search.toString() }` );
 		},
 		[ history, searchQuery ]
 	);


### PR DESCRIPTION
#### Proposed Changes

When you are in an embedded article, reached after searching in the help center, and click “Back”,  you are not taken to your search, but the starting point for the help center.
Now we maintain the search when you go back.

Added `calypso_help_moreresources_click` event when clicking on a link in the 'More Resources' section:

Added external icons to `More Resources` links
![image](https://user-images.githubusercontent.com/52076348/174336651-2b57f597-8357-417d-ae86-c25e37c83423.png)

Modified the render of the help icon, to not use flex property order ( bad for accessibility ), but instead wait using `setTimeout` and so being written as last.

Fixed a bug that caused articles to not show if clicked from the Recommended ones when there are no search results.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch.
* `yarn dev --sync` from `apps/editing-toolkit`.
* Search something in the help center, visit an article and then click `Back`. You should be back in your search.
* Visit an article without searching for something before. Go back and you should be in the help center home.
* In the console, send `localStorage.setItem('debug', 'calypso:analytics');`, refresh the page, open the console and verify that the events are fired when clicking on a link in the `More Resources` section.