### PR TITLE
Licensing Portal: Fix typeof undefined not checking against a string

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -32,7 +32,7 @@ export default function AgencySignupForm(): ReactElement {
 		onError: ( error: APIError ) => {
 			let message = error.message;
 
-			if ( error.code === 'rest_invalid_param' && typeof error?.data?.params !== undefined ) {
+			if ( error.code === 'rest_invalid_param' && typeof error?.data?.params !== 'undefined' ) {
 				message = translateInvalidPartnerParameterError( error.data.params );
 			}
 

--- a/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
@@ -39,7 +39,7 @@ export default function UpdateCompanyDetailsForm(): ReactElement {
 		onError: ( error: APIError ) => {
 			let message = error.message;
 
-			if ( error.code === 'rest_invalid_param' && typeof error?.data?.params !== undefined ) {
+			if ( error.code === 'rest_invalid_param' && typeof error?.data?.params !== 'undefined' ) {
 				message = translateInvalidPartnerParameterError( error.data.params );
 			}
 


### PR DESCRIPTION
#### Proposed Changes

* Fix a typeof !== undefined check to use 'undefined'.

#### Testing Instructions

N/A - it's a self-explanatory typing mistake as typeof returns 'undefined' as a string.
If you really want to test you can follow the steps here: 2cb4b-pb