### PR TITLE
Agency Signup: Redirect existing partners away from the signup form

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -1,17 +1,21 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import CompanyDetailsForm from 'calypso/jetpack-cloud/sections/partner-portal/company-details-form';
+import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { formatApiPartner } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { partnerPortalBasePath } from 'calypso/lib/jetpack/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import { receivePartner } from 'calypso/state/partner-portal/partner/actions';
 import useCreatePartnerMutation from 'calypso/state/partner-portal/partner/hooks/use-create-partner-mutation';
-import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
+import {
+	getCurrentPartner,
+	hasFetchedPartner,
+} from 'calypso/state/partner-portal/partner/selectors';
 import { translateInvalidPartnerParameterError } from 'calypso/state/partner-portal/partner/utils';
 import type { APIError } from 'calypso/state/partner-portal/types';
 import type { ReactElement } from 'react';
@@ -21,13 +25,12 @@ export default function AgencySignupForm(): ReactElement {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const partner = useSelector( getCurrentPartner );
+	const hasFetched = useSelector( hasFetchedPartner );
 	const notificationId = 'partner-portal-agency-signup-form';
 
 	const createPartner = useCreatePartnerMutation( {
 		onSuccess: ( partner ) => {
 			dispatch( receivePartner( formatApiPartner( partner ) ) );
-
-			page.redirect( partnerPortalBasePath() );
 		},
 		onError: ( error: APIError ) => {
 			let message = error.message;
@@ -62,6 +65,13 @@ export default function AgencySignupForm(): ReactElement {
 		[ notificationId, partner?.id, createPartner.mutate, dispatch ]
 	);
 
+	// Redirect the user if they are already a partner or the form was submitted successfully.
+	useEffect( () => {
+		if ( partner ) {
+			page.redirect( partnerPortalBasePath() );
+		}
+	} );
+
 	return (
 		<Card className="agency-signup-form">
 			<svg
@@ -88,12 +98,16 @@ export default function AgencySignupForm(): ReactElement {
 				{ translate( 'Tell us about yourself and your business.' ) }
 			</h2>
 
-			<CompanyDetailsForm
-				includeTermsOfService={ true }
-				isLoading={ createPartner.isLoading }
-				onSubmit={ onSubmit }
-				submitLabel={ translate( 'Continue' ) }
-			/>
+			{ ( ! hasFetched || partner ) && <TextPlaceholder /> }
+
+			{ hasFetched && ! partner && (
+				<CompanyDetailsForm
+					includeTermsOfService={ true }
+					isLoading={ createPartner.isLoading }
+					onSubmit={ onSubmit }
+					submitLabel={ translate( 'Continue' ) }
+				/>
+			) }
 		</Card>
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

* Redirect users who are already registered as partners away from the agency signup form and to the Licensing Portal.

#### Testing Instructions

* If you don't have a partner account please reach out to team Avalon.
* Check out PR and run Jetpack Cloud.
* Open http://jetpack.cloud.localhost:3000/agency/signup
* You should be redirected to http://jetpack.cloud.localhost:3000/partner-portal since you are already a partner.

If you wish to test the registration flow itself to make sure the redirect works after registering you can use this snippet on your sandbox: 2cb4c-pb (please make sure you don't create too many test partner accounts).