### PR TITLE
Stepper: Added a new data store for internal stepper data

### DIFF
--- a/client/landing/stepper/stores.ts
+++ b/client/landing/stepper/stores.ts
@@ -5,9 +5,11 @@ import {
 	ProductsList,
 	User,
 	AutomatedTransferEligibility,
+	StepperInternal,
 } from '@automattic/data-stores';
 
 export const ONBOARD_STORE = Onboard.register();
+export const STEPPER_INTERNAL_STORE = StepperInternal.register();
 
 export const SITE_STORE = Site.register( {
 	client_id: config( 'wpcom_signup_id' ),

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -10,6 +10,7 @@ import * as Plans from './plans';
 import * as ProductsList from './products-list';
 import * as Reader from './reader';
 import * as Site from './site';
+import * as StepperInternal from './stepper-internal';
 import * as User from './user';
 import * as Verticals from './verticals';
 import * as VerticalsTemplates from './verticals-templates';
@@ -44,6 +45,7 @@ export {
 	persistenceConfigFactory,
 	ProductsList,
 	AutomatedTransferEligibility,
+	StepperInternal,
 };
 
 /**

--- a/packages/data-stores/src/stepper-internal/actions.ts
+++ b/packages/data-stores/src/stepper-internal/actions.ts
@@ -1,0 +1,13 @@
+export const setStepData = ( data: any ) => ( {
+	type: 'SET_STEP_DATA' as const,
+	data,
+} );
+
+export const clearStepData = () => ( {
+	type: 'CLEAR_STEP_DATA' as const,
+} );
+
+export type StepperInternalAction =
+	| ReturnType< typeof setStepData | typeof clearStepData >
+	// Type added so we can dispatch actions in tests, but has no runtime cost
+	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/stepper-internal/constants.ts
+++ b/packages/data-stores/src/stepper-internal/constants.ts
@@ -1,0 +1,1 @@
+export const STORE_KEY = 'automattic/stepper-internal';

--- a/packages/data-stores/src/stepper-internal/index.ts
+++ b/packages/data-stores/src/stepper-internal/index.ts
@@ -1,0 +1,29 @@
+import { plugins, registerStore, use } from '@wordpress/data';
+import { controls } from '@wordpress/data-controls';
+import * as actions from './actions';
+import { STORE_KEY } from './constants';
+import persistOptions from './persist';
+import reducer, { State } from './reducer';
+import * as selectors from './selectors';
+import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
+
+export type { State };
+
+export function register(): typeof STORE_KEY {
+	use( plugins.persistence, persistOptions );
+
+	registerStore< State >( STORE_KEY, {
+		actions,
+		controls,
+		reducer: reducer as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+		selectors,
+		persist: [ 'stepData' ],
+	} );
+
+	return STORE_KEY;
+}
+
+declare module '@wordpress/data' {
+	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
+}

--- a/packages/data-stores/src/stepper-internal/persist.ts
+++ b/packages/data-stores/src/stepper-internal/persist.ts
@@ -1,0 +1,3 @@
+import persistenceConfigFactory from '../persistence-config-factory';
+
+export default persistenceConfigFactory( 'WP_STEPPER_INTERNAL' );

--- a/packages/data-stores/src/stepper-internal/reducer.ts
+++ b/packages/data-stores/src/stepper-internal/reducer.ts
@@ -1,0 +1,21 @@
+import { combineReducers } from '@wordpress/data';
+import { StepperInternalAction } from './actions';
+import type { Reducer } from 'redux';
+
+export const stepData: Reducer< any, StepperInternalAction > = ( state = null, action ) => {
+	if ( action.type === 'SET_STEP_DATA' ) {
+		return action.data;
+	}
+	if ( action.type === 'CLEAR_STEP_DATA' ) {
+		return null;
+	}
+	return state;
+};
+
+const reducer = combineReducers( {
+	stepData,
+} );
+
+export type State = ReturnType< typeof reducer >;
+
+export default reducer;

--- a/packages/data-stores/src/stepper-internal/selectors.ts
+++ b/packages/data-stores/src/stepper-internal/selectors.ts
@@ -1,0 +1,4 @@
+import type { State } from './reducer';
+export const getState = ( state: State ) => state;
+
+export const getStepData = ( state: State ) => state.stepData;

--- a/packages/data-stores/src/stepper-internal/test/action.ts
+++ b/packages/data-stores/src/stepper-internal/test/action.ts
@@ -1,0 +1,22 @@
+import { setStepData, clearStepData } from '../actions';
+
+describe( 'StepperInternal actions', () => {
+	it( 'should return a SET_STEP_DATA Action', () => {
+		const data = {};
+
+		const expected = {
+			type: 'SET_STEP_DATA',
+			data,
+		};
+
+		expect( setStepData( data ) ).toEqual( expected );
+	} );
+
+	it( 'should return a CLEAR_STEP_DATA Action', () => {
+		const expected = {
+			type: 'CLEAR_STEP_DATA',
+		};
+
+		expect( clearStepData() ).toEqual( expected );
+	} );
+} );

--- a/packages/data-stores/src/stepper-internal/test/reducer.ts
+++ b/packages/data-stores/src/stepper-internal/test/reducer.ts
@@ -1,0 +1,33 @@
+/*
+ * These tests shouldn't require the jsdom environment,
+ * but we're waiting for this PR to merge:
+ * https://github.com/WordPress/gutenberg/pull/20486
+ *
+ * @jest-environment jsdom
+ */
+
+import { stepData } from '../reducer';
+
+describe( 'StepperInternal reducer', () => {
+	it( 'returns the correct default state', () => {
+		const state = stepData( null, { type: 'TEST_ACTION' } );
+		expect( state ).toEqual( null );
+	} );
+
+	it( 'returns stepper data', () => {
+		const data = { message: 'test' };
+
+		const state = stepData( null, {
+			type: 'SET_STEP_DATA',
+			data,
+		} );
+		expect( state ).toEqual( data );
+	} );
+
+	it( 'clears stepper data', () => {
+		const state = stepData( null, {
+			type: 'CLEAR_STEP_DATA',
+		} );
+		expect( state ).toEqual( null );
+	} );
+} );

--- a/packages/data-stores/src/stepper-internal/test/selectors.ts
+++ b/packages/data-stores/src/stepper-internal/test/selectors.ts
@@ -1,0 +1,29 @@
+/*
+ * These tests shouldn't require the jsdom environment,
+ * but we're waiting for this PR to merge:
+ * https://github.com/WordPress/gutenberg/pull/20486
+ *
+ * @jest-environment jsdom
+ */
+import { select, dispatch } from '@wordpress/data';
+import { register } from '..';
+
+let store: ReturnType< typeof register >;
+
+beforeAll( () => {
+	store = register();
+} );
+
+describe( 'StepperInternal selectors', () => {
+	it( 'can set the step data and retrieve it', async () => {
+		const data = { message: 'test' };
+
+		expect( select( store ).getStepData() ).toEqual( null );
+
+		dispatch( store ).setStepData( data );
+		expect( select( store ).getStepData() ).toEqual( data );
+
+		dispatch( store ).clearStepData();
+		expect( select( store ).getStepData() ).toEqual( null );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

Added a new data store for internal stepper data

This is primarily used of storing data that needs to be passed to a step via the `navigate()` function.

#### Testing Instructions

`yarn run test-packages packages/data-stores/src/stepper-internal/test`
