### PR TITLE
Tutorials REST API first pass

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -435,5 +435,4 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_description_links' );
 function load_tutorials() {
 	require_once __DIR__ . '/tutorials/tutorials.php';
 }
-// Commented out to simplify non-atomc wpcom deployment, nothing depends on this yet.
-// add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tutorials' );.
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tutorials' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials-endpoint.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials-endpoint.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Tutorials endpoint (Think: "Guided Tours").
+ *
+ * @package A8C\FSE
+ */
+
+/**
+ * WPCom_Tutorials_Controller class
+ */
+class WPCom_Tutorials_Endpoint extends WP_REST_Controller {
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->namespace                       = 'wpcom/v2';
+		$this->rest_base                       = 'tutorials';
+		$this->wpcom_is_site_specific_endpoint = false;
+	}
+
+	/**
+	 * Callback for registering our REST routes
+	 */
+	public function register_rest_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_tutorials' ),
+					'permission_callback' => 'is_user_logged_in',
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/(?P<tutorial_id>[\w-]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_tutorial' ),
+					'permission_callback' => 'is_user_logged_in',
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_tutorial' ),
+					'permission_callback' => 'is_user_logged_in',
+					'args'                => $this->get_collection_params(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Callback for the `/tutorials` endpoint
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_tutorials() {
+		$tutorials = wpcom_get_registered_tutorial_ids();
+		return rest_ensure_response( compact( 'tutorials' ) );
+	}
+
+	/**
+	 * Callback for the GET `/tutorials/TUTORIAL_ID` endpoint
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_tutorial( $request ) {
+		$tutorial_id = $request['tutorial_id'];
+		$tutorial    = wpcom_get_tutorial( $tutorial_id );
+		return rest_ensure_response( $tutorial );
+	}
+
+	/**
+	 * Callback for the PUT `/tutorials/TUTORIAL_ID` endpoint
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function update_tutorial( $request ) {
+		$tutorial_id = $request['tutorial_id'];
+		$params      = $request->get_json_params();
+		$task        = $params['task'];
+
+		$success = wpcom_tutorial_mark_task( $tutorial_id, $task['id'], $task['status'] );
+		if ( ! $success ) {
+			return new WP_Error( 404, sprintf( 'The task with ID `%s` could not be updated', $task['id'] ) );
+		}
+		$tutorial = wpcom_get_tutorial( $tutorial_id );
+		// Although we should have already errored above if the Tutorial isn't registered, you never know.
+		if ( ! $tutorial ) {
+			return new WP_Error( 404, sprintf( 'The tutorial ID `%s` was not found', $tutorial_id ) );
+		}
+		// Success!
+		return rest_ensure_response( $tutorial );
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/class-wpcom-tutorials.php
@@ -119,7 +119,7 @@ class WPCom_Tutorials {
 		}
 		$tutorial = $this->registry[ $id ];
 
-		// Populating status at runtime so that any invalidations happen within the Options API.
+		// Populating status at runtime so that any cache invalidations happen within the User meta/attributes API.
 		$tutorial['tasks'] = $this->get_tasks( $tutorial );
 		return $tutorial;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/tutorials.php
@@ -73,3 +73,13 @@ function wpcom_tutorial_mark_task( $tutorial_id, $task_id, $status ) {
 function wpcom_get_registered_tutorial_ids() {
 	return wpcom_tutorials()->get_registered_ids();
 }
+
+/**
+ * Callback for registering the Tutorials endpoint.
+ */
+function wpcom_register_tutorials_endpoints() {
+	require_once __DIR__ . '/class-wpcom-tutorials-endpoint.php';
+	$tutorials_endpoint = new WPCom_Tutorials_Endpoint();
+	$tutorials_endpoint->register_rest_routes();
+}
+add_action( 'rest_api_init', 'wpcom_register_tutorials_endpoints' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/tutorials/tutorials.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/tutorials/tutorials.php
@@ -78,8 +78,12 @@ function wpcom_get_registered_tutorial_ids() {
  * Callback for registering the Tutorials endpoint.
  */
 function wpcom_register_tutorials_endpoints() {
-	require_once __DIR__ . '/class-wpcom-tutorials-endpoint.php';
-	$tutorials_endpoint = new WPCom_Tutorials_Endpoint();
-	$tutorials_endpoint->register_rest_routes();
+	$endpoint_file = __DIR__ . '/class-wpcom-tutorials-endpoint.php';
+	if ( file_exists( $endpoint_file ) ) {
+		require_once $endpoint_file;
+		$tutorials_endpoint = new WPCom_Tutorials_Endpoint();
+		$tutorials_endpoint->register_rest_routes();
+	}
+
 }
 add_action( 'rest_api_init', 'wpcom_register_tutorials_endpoints' );


### PR DESCRIPTION
#### Proposed Changes

* Introduce a `/tutorials` REST API endpoint

#### Testing Instructions

To come, once #64510 is merged and we can rebase this.

Still needs unit tests. Need to investigate how we do those for endpoints.

Fixes #64252
