### PR TITLE
Checkout: Fix and reenable the contact step cached details tests

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -255,11 +255,7 @@ describe( 'Checkout contact step', () => {
 		expect( screen.queryByTestId( 'payment-method-step--visible' ) ).not.toBeInTheDocument();
 	} );
 
-	/**
-	 * TODO: Restore these tests, which were failing for some reason on #64718
-	 */
-	/* eslint-disable jest/no-disabled-tests */
-	it.skip( 'autocompletes the contact step when there are valid cached details', async () => {
+	it( 'autocompletes the contact step when there are valid cached details', async () => {
 		mockCachedContactDetailsEndpoint( {
 			country_code: 'US',
 			postal_code: '10001',
@@ -269,12 +265,13 @@ describe( 'Checkout contact step', () => {
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
-		// Wait for the validation to complete
-		await waitForElementToBeRemoved( () => screen.queryAllByText( 'Please wait…' ) );
-		expect( screen.queryByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
+		// Wait for the validation to complete, then check we've advanced to the next payment step
+		await waitFor( () =>
+			expect( screen.queryByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument()
+		);
 	} );
 
-	it.skip( 'does not autocomplete the contact step when there are invalid cached details', async () => {
+	it( 'does not autocomplete the contact step when there are invalid cached details', async () => {
 		mockCachedContactDetailsEndpoint( {
 			country_code: 'US',
 			postal_code: 'ABCD',
@@ -284,8 +281,7 @@ describe( 'Checkout contact step', () => {
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
-		// Wait for the validation to complete
-		await waitForElementToBeRemoved( () => screen.queryAllByText( 'Please wait…' ) );
+		// Check that we never advance to the next payment step
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
 	} );
 


### PR DESCRIPTION
#### Proposed Changes

Two of the contact step cached details tests were flaky and appeared to be failing randomly (and often) on trunk.  As a result, they were eventually disabled as part of https://github.com/Automattic/wp-calypso/pull/64718.

The root cause seems to be that tests were waiting for "Please wait" text to appear and then disappear, but it had already disappeared by the time the tests started waiting.

This pull request fixes that by just waiting for the final result instead, and not bothering to check for the "Please wait" text at all.

#### Testing Instructions

Run the following a bunch of times and make sure it always passes:

```
yarn run test-client client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
```

For the last failing test (the one with `toNeverAppear()` in it), as far as I can tell the "never" in `toNeverAppear()` is actually 1 second in practice :smile:  So I was a little worried that maybe we're now waiting for too many things, and the test could pass even if it should have failed because the element appeared after more than 1 second.

I am not sure if there's a better way to handle that?  However, when I tried reversing the tests (and moving the `toNeverAppear()` expectation to the previous test instead, which is testing the opposite behavior) I was able to get that test to consistently fail, which I guess is a good sign that this is not a major concern in practice.