### PR TITLE
chore: fix ESLint errors 2

### DIFF
--- a/packages/composite-checkout/src/lib/validation.ts
+++ b/packages/composite-checkout/src/lib/validation.ts
@@ -8,7 +8,7 @@ import {
 	ExternalLineItemAmount,
 } from '../types';
 
-export function validateArg< V extends unknown >(
+export function validateArg< V >(
 	value: V,
 	errorMessage: string
 ): asserts value is NonNullable< V > {
@@ -17,7 +17,7 @@ export function validateArg< V extends unknown >(
 	}
 }
 
-export function validateArgIfUndefined< V extends unknown >(
+export function validateArgIfUndefined< V >(
 	value: V,
 	errorMessage: string
 ): asserts value is Exclude< V, undefined > {

--- a/packages/eslint-plugin-wpcalypso/lib/util/test/get-i18n-string-from-node.js
+++ b/packages/eslint-plugin-wpcalypso/lib/util/test/get-i18n-string-from-node.js
@@ -5,7 +5,6 @@
  * See LICENSE.md file in root directory for full license.
  */
 
-const assert = require( 'assert' );
 const parser = require( '@babel/eslint-parser' );
 const getTextContentFromNode = require( '../../../lib/util/get-text-content-from-node.js' );
 
@@ -25,58 +24,56 @@ function parseExpressionStatement( code ) {
 
 describe( '#getStringFromNode', function () {
 	it( 'should return simple strings', function () {
-		assert.equal(
-			'a simple string',
-			getTextContentFromNode( parseExpressionStatement( "'a simple string'" ) )
-		);
+		const result = getTextContentFromNode( parseExpressionStatement( "'a simple string'" ) );
+		expect( result ).toEqual( 'a simple string' );
 	} );
 
 	it( 'should return concatentated strings', function () {
-		assert.equal(
-			'A string in two parts',
-			getTextContentFromNode( parseExpressionStatement( '"A string" + " in two parts"' ) )
+		const result = getTextContentFromNode(
+			parseExpressionStatement( '"A string" + " in two parts"' )
 		);
+		expect( result ).toEqual( 'A string in two parts' );
 	} );
 
 	it( 'should return more concatentated strings', function () {
-		assert.equal(
-			'A string in three parts',
-			getTextContentFromNode( parseExpressionStatement( '"A string" + " in " + "three parts"' ) )
+		const result = getTextContentFromNode(
+			parseExpressionStatement( '"A string" + " in " + "three parts"' )
 		);
+		expect( result ).toEqual( 'A string in three parts' );
 	} );
 
 	it( 'should return strings from template literals', function () {
-		assert.equal(
-			'A template literal string',
-			getTextContentFromNode( parseExpressionStatement( '`A template literal string`' ) )
+		const result = getTextContentFromNode(
+			parseExpressionStatement( '`A template literal string`' )
 		);
+		expect( result ).toEqual( 'A template literal string' );
 	} );
 
 	it( 'should handle different literal types', function () {
-		assert.equal(
-			'A template and a string',
-			getTextContentFromNode( parseExpressionStatement( '`A template` + " and a string"' ) )
+		const result = getTextContentFromNode(
+			parseExpressionStatement( '`A template` + " and a string"' )
 		);
+		expect( result ).toEqual( 'A template and a string' );
 	} );
 
 	it( 'should return false for functions', function () {
 		const functionNode = parseExpressionStatement( 'foo()' );
 
-		assert.strictEqual( false, getTextContentFromNode( functionNode ) );
+		expect( getTextContentFromNode( functionNode ) ).toStrictEqual( false );
 	} );
 
 	it( 'should return false for variable assignments', function () {
 		const variableDeclarationNode = parseCode( "var aVariable = 'a string to assign';" );
 		const variableDeclarator = variableDeclarationNode.declarations[ 0 ];
 
-		assert.strictEqual( false, getTextContentFromNode( variableDeclarationNode ) );
-		assert.strictEqual( false, getTextContentFromNode( variableDeclarator ) );
+		expect( getTextContentFromNode( variableDeclarationNode ) ).toStrictEqual( false );
+		expect( getTextContentFromNode( variableDeclarator ) ).toStrictEqual( false );
 	} );
 
 	it( 'should return false for a binary structure including invalid node types', function () {
-		assert.strictEqual(
-			false,
-			getTextContentFromNode( parseExpressionStatement( "'a string plus a function' + foo()" ) )
+		const result = getTextContentFromNode(
+			parseExpressionStatement( "'a string plus a function' + foo()" )
 		);
+		expect( result ).toStrictEqual( false );
 	} );
 } );

--- a/packages/eslint-plugin-wpcalypso/lib/util/test/sequence-callee.js
+++ b/packages/eslint-plugin-wpcalypso/lib/util/test/sequence-callee.js
@@ -5,7 +5,6 @@
  * See LICENSE.md file in root directory for full license.
  */
 
-const assert = require( 'assert' );
 const getCallee = require( '../get-callee' );
 
 describe( '#getCallee', function () {
@@ -19,7 +18,7 @@ describe( '#getCallee', function () {
 		};
 		const callee = getCallee( node );
 
-		assert.equal( callee, node.callee );
+		expect( callee ).toEqual( node.callee );
 	} );
 
 	it( 'should return first non-sequence callee expression', function () {
@@ -41,7 +40,7 @@ describe( '#getCallee', function () {
 		};
 		const callee = getCallee( node );
 
-		assert.equal( callee, node.callee.expressions[ 1 ] );
+		expect( callee ).toEqual( node.callee.expressions[ 1 ] );
 	} );
 
 	it( 'should return first non-sequence member property', function () {
@@ -59,7 +58,6 @@ describe( '#getCallee', function () {
 			},
 		};
 		const callee = getCallee( node );
-
-		assert.equal( callee, node.callee.property );
+		expect( callee ).toEqual( node.callee.property );
 	} );
 } );

--- a/packages/happychat-connection/package.json
+++ b/packages/happychat-connection/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@automattic/happychat-connection",
 	"version": "1.0.0",
-	"description": "Happychat connection manager",
+	"description": "Happychat connection manager.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic Inc.",

--- a/packages/site-picker/package.json
+++ b/packages/site-picker/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@automattic/site-picker",
 	"version": "1.0.0",
-	"description": "Automattic Site Picker",
+	"description": "Automattic Site Picker.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic Inc.",


### PR DESCRIPTION
#### Proposed Changes

This PR fixes some more ESLint errors.

Key changes:
- fix package names errors (`@automattic/json/description-format`);
- use Jest expect instead of assert (`eslint.rules.jest/expect-expect`);
- fix unnecessary type constraints (`eslint.rules.@typescript-eslint/no-unnecessary-type-constraint`);

#### Testing Instructions

Ensure the following:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [x] Code Style
  - [x] Check code style
  - [x] Unit Tests

Related to https://github.com/Automattic/wp-calypso/issues/56330.
