### PR TITLE
DevDocs: Fix UpsellNudge discounted price example 

### DIFF
--- a/client/blocks/upsell-nudge/docs/example.jsx
+++ b/client/blocks/upsell-nudge/docs/example.jsx
@@ -48,7 +48,7 @@ const UpsellNudgeExample = () => (
 			callToAction="Upgrade"
 			title="Free domain with a plan! This is a dismissible nudge with a description, prices, and a list of features."
 			showIcon={ true }
-			price={ [ 48, 50 ] }
+			price={ [ 50, 48 ] }
 		/>
 		<UpsellNudge
 			forceDisplay


### PR DESCRIPTION
#### Proposed Changes

* A picky change, but it's a bit confusing when the discounted price is higher than the original price so proposing to swap the values. 

Before: 

<img width="276" alt="Screen Shot 2022-06-17 at 4 47 33 PM" src="https://user-images.githubusercontent.com/35543432/174415713-0e0c1cba-3548-4930-ae47-b7f17fe20d20.png">

After: 

<img width="258" alt="Screen Shot 2022-06-17 at 4 47 04 PM" src="https://user-images.githubusercontent.com/35543432/174415559-bffa3a5c-0d40-4271-9792-95655a9d2de0.png">

#### Testing Instructions

- Go to `DevDocs` and search for `UpsellNudge` under `Blocks` (`/devdocs/blocks/upsell-nudge`)
- Ensure that discounted price is lower than original price 