### PR TITLE
HelpCenter: fix some accessibility bugs

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -35,13 +35,13 @@ function HelpCenterContent() {
 	};
 
 	const content = (
-		<span className="etk-help-center">
-			<Button
-				className={ cx( 'entry-point-button', { 'is-active': show } ) }
-				onClick={ handleToggleHelpCenter }
-				icon={ <HelpIcon newItems={ showHelpIconDot } /> }
-			></Button>
-		</span>
+		<Button
+			isPressed={ show }
+			className={ cx( 'entry-point-button', 'help-center', { 'is-active': show } ) }
+			onClick={ handleToggleHelpCenter }
+			icon={ <HelpIcon newItems={ showHelpIconDot } /> }
+			label="Help"
+		></Button>
 	);
 
 	return (

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -36,11 +36,12 @@ function HelpCenterContent() {
 
 	const content = (
 		<Button
-			isPressed={ show }
 			className={ cx( 'entry-point-button', 'help-center', { 'is-active': show } ) }
 			onClick={ handleToggleHelpCenter }
 			icon={ <HelpIcon newItems={ showHelpIconDot } /> }
 			label="Help"
+			aria-pressed={ show ? true : false }
+			aria-expanded={ show ? true : false }
 		></Button>
 	);
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
@@ -1,10 +1,9 @@
-.etk-help-center {
-	.entry-point-button {
-		&.is-active {
-			background: #1e1e1e;
-			svg {
-				fill: white;
-			}
+.help-center.entry-point-button {
+	&.is-active {
+		background: #1e1e1e;
+
+		svg {
+			fill: white;
 		}
 	}
 

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -72,7 +72,7 @@ const HelpCenterHeader: React.FC< Header > = ( {
 	return (
 		<CardHeader className={ classNames }>
 			<Flex>
-				<p className="help-center-header__text">
+				<p id="header-text" className="help-center-header__text">
 					{ isMinimized ? (
 						<Switch>
 							<Route path="/" exact>

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -372,7 +372,7 @@
 	/**
  	 * ARTICLE EMBED
  	 */
-	.help-center-embed-result {
+	.help-center-embed-result article {
 		h1.support-article-dialog__header-title > a {
 			font-size: $font-title-medium;
 		}

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -56,6 +56,9 @@ const HelpCenter: React.FC< Container > = ( { handleClose } ) => {
 		const classes = [ 'help-center' ];
 		portalParent.classList.add( ...classes );
 
+		portalParent.setAttribute( 'aria-modal', 'true' );
+		portalParent.setAttribute( 'aria-labelledby', 'header-text' );
+
 		document.body.appendChild( portalParent );
 
 		return () => {


### PR DESCRIPTION
## Proposed Changes

1. Changes the HelpCenter to be more accessible (aria attributes) and match the other buttons
2. Adjusts the styling for an article to show focus styling on the back button and external link.

## Testing Instructions

1. Checkout branch.
2. `yarn dev --sync` from `apps/editing-toolkit`.
3. Inspect the HelpCenter button and modal to make sure the appropriate labels exist
4. Use a voice assistant to verify the Help Center is named and the button as well
