### PR TITLE
Launching treatment variation as new control 

### DIFF
--- a/client/data/plans/use-plans-comparison-meta.ts
+++ b/client/data/plans/use-plans-comparison-meta.ts
@@ -1,0 +1,23 @@
+import { useQuery } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+export type PlansComparisonMetaData = {
+	currency: string;
+	bottom_theme_price: number;
+	bottom_theme_price_display: string;
+	no_ads_monthly_cost: number;
+	no_ads_monthly_cost_display: string;
+};
+
+export default function usePlansComparisonMeta( currency: string ) {
+	return useQuery< unknown, unknown, PlansComparisonMetaData >(
+		[ 'plans-comparison-meta', currency ],
+		() =>
+			wpcom.req.get(
+				{
+					path: '/plans-comparison-meta',
+				},
+				{ apiVersion: '1.2' }
+			)
+	);
+}

--- a/client/data/plans/use-plans-comparison-meta.ts
+++ b/client/data/plans/use-plans-comparison-meta.ts
@@ -5,8 +5,6 @@ export type PlansComparisonMetaData = {
 	currency: string;
 	bottom_theme_price: number;
 	bottom_theme_price_display: string;
-	no_ads_monthly_cost: number;
-	no_ads_monthly_cost_display: string;
 };
 
 export default function usePlansComparisonMeta( currency: string ) {

--- a/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-col-header.tsx
@@ -1,4 +1,4 @@
-import { TYPE_PRO, TYPE_STARTER } from '@automattic/calypso-products';
+import { TYPE_STARTER } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import { SCREEN_BREAKPOINT_SIGNUP, SCREEN_BREAKPOINT_PLANS } from './constant';
@@ -10,7 +10,6 @@ interface Props {
 	plan: Plan;
 	price?: number;
 	originalPrice?: number;
-	isExperiment?: boolean;
 	onClick?: ( productSlug: string ) => void;
 	translate: typeof translate;
 }
@@ -89,7 +88,6 @@ export const PlansComparisonColHeader: React.FunctionComponent< Props > = ( {
 	originalPrice,
 	children,
 	translate,
-	isExperiment,
 } ) => {
 	const isDiscounted = typeof originalPrice === 'number';
 
@@ -98,7 +96,7 @@ export const PlansComparisonColHeader: React.FunctionComponent< Props > = ( {
 			<PlanTitle>{ plan.getTitle() }</PlanTitle>
 
 			<PlanDescription>
-				{ plan.type === TYPE_STARTER && isExperiment && (
+				{ plan.type === TYPE_STARTER ? (
 					<>
 						<p>{ translate( 'Great for blogs and simple sites:' ) }</p>
 						<ul>
@@ -109,9 +107,7 @@ export const PlansComparisonColHeader: React.FunctionComponent< Props > = ( {
 							<li>{ translate( 'A la carte upgrades available.' ) }</li>
 						</ul>
 					</>
-				) }
-
-				{ plan.type === TYPE_PRO && isExperiment && (
+				) : (
 					<>
 						<p>{ translate( 'Great for business and custom sites:' ) }</p>
 						<ul>
@@ -123,8 +119,6 @@ export const PlansComparisonColHeader: React.FunctionComponent< Props > = ( {
 						</ul>
 					</>
 				) }
-
-				{ ! isExperiment && plan.getDescription() }
 			</PlanDescription>
 			<PriceContainer>
 				{ isDiscounted && (

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -55,14 +55,12 @@ export interface PlanComparisonFeature {
 	 * @param {string} feature The feature constant. e.g. FEATURE_UNLIMITED_ADMINS
 	 * @param {boolean} isMobile Whether the text is displayed on mobile.
 	 * @param {boolean} isLegacySiteWithHigherLimits Whether the feature is being displayed in the context of a legacy site that is entitled to higher free plan limits.
-	 * @param {boolean} isExperiment Whether to show data associated with Explat experiment.
 	 * @returns {TranslateResult|TranslateResult[]} Array of text if there is an additional description.
 	 */
 	getCellText: (
 		feature: string | undefined,
 		isMobile: boolean,
 		isLegacySiteWithHigherLimits?: boolean,
-		isExperiment?: boolean,
 		extraArgs?: unknown
 	) => TranslateResult | [ TranslateResult, TranslateResult ];
 }
@@ -457,25 +455,16 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			);
 		},
 		features: [ FEATURE_PREMIUM_THEMES ],
-		getCellText: (
-			feature,
-			isMobile = false,
-			isLegacySiteWithHigherLimits = false,
-			isExperiment = false
-		) => {
-			let cellText;
-			if ( isExperiment && ! isLegacySiteWithHigherLimits ) {
-				cellText = feature ? (
-					<>
-						<Gridicon icon="checkmark" />
-						{ translate( 'Included' ) }
-					</>
-				) : (
-					<>{ translate( 'Available for $50+ each' ) }</>
-				);
-			} else {
-				cellText = defaultGetCellText( translate( 'Premium themes' ) )( feature, isMobile );
-			}
+		getCellText: ( feature, isMobile = false ) => {
+			let cellText = feature ? (
+				<>
+					<Gridicon icon="checkmark" />
+					{ translate( 'Included' ) }
+				</>
+			) : (
+				<>{ translate( 'Available for $50+ each' ) }</>
+			);
+
 			if ( isMobile ) {
 				cellText = feature ? (
 					<>{ translate( 'Premium themes are included' ) }</>
@@ -584,25 +573,16 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			);
 		},
 		features: [ FEATURE_NO_ADS ],
-		getCellText: (
-			feature,
-			isMobile = false,
-			isLegacySiteWithHigherLimits = false,
-			isExperiment = false
-		) => {
-			let cellText;
-			if ( isExperiment && ! isLegacySiteWithHigherLimits ) {
-				cellText = feature ? (
-					<>
-						<Gridicon icon="checkmark" />
-						{ translate( 'Included' ) }
-					</>
-				) : (
-					<>{ translate( 'Available for +$2/month' ) }</>
-				);
-			} else {
-				cellText = defaultGetCellText( translate( 'Remove ads' ) )( feature, isMobile );
-			}
+		getCellText: ( feature, isMobile = false ) => {
+			let cellText = feature ? (
+				<>
+					<Gridicon icon="checkmark" />
+					{ translate( 'Included' ) }
+				</>
+			) : (
+				<>{ translate( 'Available for +$2/month' ) }</>
+			);
+
 			if ( isMobile ) {
 				cellText = feature ? (
 					<>{ translate( 'Remove ads is included' ) }</>

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -24,8 +24,10 @@ import {
 	FEATURE_MANAGED_HOSTING,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
 import { translate, numberFormat } from 'i18n-calypso';
 import isStarterPlanEnabled from './is-starter-plan-enabled';
+import type { PlansComparisonMetaData } from 'calypso/data/plans/use-plans-comparison-meta';
 import type { TranslateResult } from 'i18n-calypso';
 
 export interface PlanComparisonFeature {
@@ -455,14 +457,23 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			);
 		},
 		features: [ FEATURE_PREMIUM_THEMES ],
-		getCellText: ( feature, isMobile = false ) => {
+		getCellText: ( feature, isMobile = false, _, extraArgs: unknown ) => {
+			const meta = extraArgs as PlansComparisonMetaData;
+
 			let cellText = feature ? (
 				<>
 					<Gridicon icon="checkmark" />
 					{ translate( 'Included' ) }
 				</>
 			) : (
-				<>{ translate( 'Available for $50+ each' ) }</>
+				<>
+					{ translate( 'Available for %(price)s+ each', {
+						args: {
+							price: formatCurrency( meta.bottom_theme_price, meta.currency, { stripZeros: true } ),
+						},
+						comment: 'Translators: theme costs start from the _price_',
+					} ) }
+				</>
 			);
 
 			if ( isMobile ) {
@@ -476,6 +487,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 					</>
 				);
 			}
+
 			return cellText;
 		},
 	},
@@ -573,14 +585,25 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 			);
 		},
 		features: [ FEATURE_NO_ADS ],
-		getCellText: ( feature, isMobile = false ) => {
+		getCellText: ( feature, isMobile = false, _, extraArgs: unknown ) => {
+			const meta = extraArgs as PlansComparisonMetaData;
+
 			let cellText = feature ? (
 				<>
 					<Gridicon icon="checkmark" />
 					{ translate( 'Included' ) }
 				</>
 			) : (
-				<>{ translate( 'Available for +$2/month' ) }</>
+				<>
+					{ translate( 'Available for +%(price)s/month', {
+						args: {
+							price: formatCurrency( meta.no_ads_monthly_cost, meta.currency, {
+								stripZeros: true,
+							} ),
+						},
+						comment: 'Translators: The no-ads feature costs additional $2/month.',
+					} ) }
+				</>
 			);
 
 			if ( isMobile ) {

--- a/client/my-sites/plans-comparison/plans-comparison-features.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-features.tsx
@@ -30,6 +30,10 @@ import isStarterPlanEnabled from './is-starter-plan-enabled';
 import type { PlansComparisonMetaData } from 'calypso/data/plans/use-plans-comparison-meta';
 import type { TranslateResult } from 'i18n-calypso';
 
+type FeatureExtraArgs = PlansComparisonMetaData & {
+	no_ads_monthly_cost?: number;
+};
+
 export interface PlanComparisonFeature {
 	/**
 	 * Row header
@@ -458,7 +462,7 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 		features: [ FEATURE_PREMIUM_THEMES ],
 		getCellText: ( feature, isMobile = false, _, extraArgs: unknown ) => {
-			const meta = extraArgs as PlansComparisonMetaData;
+			const meta = extraArgs as FeatureExtraArgs;
 
 			let cellText = feature ? (
 				<>
@@ -586,25 +590,26 @@ export const planComparisonFeatures: PlanComparisonFeature[] = [
 		},
 		features: [ FEATURE_NO_ADS ],
 		getCellText: ( feature, isMobile = false, _, extraArgs: unknown ) => {
-			const meta = extraArgs as PlansComparisonMetaData;
+			const meta = extraArgs as FeatureExtraArgs;
 
-			let cellText = feature ? (
-				<>
-					<Gridicon icon="checkmark" />
-					{ translate( 'Included' ) }
-				</>
-			) : (
-				<>
-					{ translate( 'Available for +%(price)s/month', {
-						args: {
-							price: formatCurrency( meta.no_ads_monthly_cost, meta.currency, {
-								stripZeros: true,
-							} ),
-						},
-						comment: 'Translators: The no-ads feature costs additional $2/month.',
-					} ) }
-				</>
-			);
+			let cellText =
+				feature || ! meta.no_ads_monthly_cost ? (
+					<>
+						<Gridicon icon="checkmark" />
+						{ translate( 'Included' ) }
+					</>
+				) : (
+					<>
+						{ translate( 'Available for +%(price)s/month', {
+							args: {
+								price: formatCurrency( meta.no_ads_monthly_cost, meta.currency, {
+									stripZeros: true,
+								} ),
+							},
+							comment: 'Translators: The no-ads feature costs additional $2/month.',
+						} ) }
+					</>
+				);
 
 			if ( isMobile ) {
 				cellText = feature ? (

--- a/client/my-sites/plans-comparison/plans-comparison-row.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-row.tsx
@@ -8,7 +8,7 @@ interface Props {
 	feature: PlanComparisonFeature;
 	plans: WPComPlan[];
 	isLegacySiteWithHigherLimits: boolean;
-	isExperiment?: boolean;
+	meta?: Record< string, unknown >;
 }
 
 export const DesktopContent = styled.div`
@@ -67,7 +67,7 @@ export const PlansComparisonRow: React.FunctionComponent< Props > = ( {
 	feature,
 	plans,
 	isLegacySiteWithHigherLimits,
-	isExperiment = false,
+	meta,
 } ) => {
 	return (
 		<tr>
@@ -87,22 +87,12 @@ export const PlansComparisonRow: React.FunctionComponent< Props > = ( {
 					<td key={ plan.getProductId() }>
 						<DesktopContent>
 							{ renderContent(
-								feature.getCellText(
-									includedFeature,
-									false,
-									isLegacySiteWithHigherLimits,
-									isExperiment
-								)
+								feature.getCellText( includedFeature, false, isLegacySiteWithHigherLimits, meta )
 							) }
 						</DesktopContent>
 						<MobileContent>
 							{ renderContent(
-								feature.getCellText(
-									includedFeature,
-									true,
-									isLegacySiteWithHigherLimits,
-									isExperiment
-								)
+								feature.getCellText( includedFeature, true, isLegacySiteWithHigherLimits, meta )
 							) }
 						</MobileContent>
 					</td>

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
+import usePlansComparisonMeta from 'calypso/data/plans/use-plans-comparison-meta';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import isLegacySiteWithHigherLimits from 'calypso/state/selectors/is-legacy-site-with-higher-limits';
@@ -457,6 +458,13 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 			? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
 			: `/plans/${ selectedSiteSlug || '' }`;
 
+	const { status, data } = usePlansComparisonMeta( currencyCode );
+
+	if ( status === 'loading' || status === 'error' ) {
+		// TODO: it would be better to show a spinner here.
+		return null;
+	}
+
 	return (
 		<>
 			<Global styles={ globalOverrides } />
@@ -502,6 +510,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 							feature={ feature }
 							plans={ plans }
 							isLegacySiteWithHigherLimits={ legacySiteWithHigherLimits }
+							meta={ data }
 							key={ feature.features[ 0 ] }
 						/>
 					) ) }
@@ -512,6 +521,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 							feature={ feature }
 							plans={ plans }
 							isLegacySiteWithHigherLimits={ legacySiteWithHigherLimits }
+							meta={ data }
 							key={ feature.features[ 0 ] }
 						/>
 					) ) }

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -1,13 +1,20 @@
-import { TYPE_FREE, TYPE_FLEXIBLE, TYPE_PRO } from '@automattic/calypso-products';
+import {
+	TYPE_FREE,
+	TYPE_FLEXIBLE,
+	TYPE_PRO,
+	WPCOM_FEATURES_NO_ADVERTS,
+} from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { css, Global } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import usePlansComparisonMeta from 'calypso/data/plans/use-plans-comparison-meta';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import { getProductsList } from 'calypso/state/products-list/selectors';
 import isLegacySiteWithHigherLimits from 'calypso/state/selectors/is-legacy-site-with-higher-limits';
 import { getSitePlan } from 'calypso/state/sites/selectors';
 import { SCREEN_BREAKPOINT_SIGNUP, SCREEN_BREAKPOINT_PLANS } from './constant';
@@ -449,6 +456,8 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	const prices = usePlanPrices( plans );
 	const translate = useTranslate();
 
+	const noAdsMonthlyCost = useSelector( getProductsList )?.[ WPCOM_FEATURES_NO_ADVERTS ]?.cost / 12;
+
 	const toggleCollapsibleRows = useCallback( () => {
 		setShowCollapsibleRows( ! showCollapsibleRows );
 	}, [ showCollapsibleRows ] );
@@ -468,6 +477,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 	return (
 		<>
 			<Global styles={ globalOverrides } />
+			<QueryProductsList />
 			<ComparisonTable
 				firstColWidth={ 31 }
 				planCount={ plans.length }
@@ -510,7 +520,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 							feature={ feature }
 							plans={ plans }
 							isLegacySiteWithHigherLimits={ legacySiteWithHigherLimits }
-							meta={ data }
+							meta={ { ...data, no_ads_monthly_cost: noAdsMonthlyCost } }
 							key={ feature.features[ 0 ] }
 						/>
 					) ) }
@@ -521,7 +531,7 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 							feature={ feature }
 							plans={ plans }
 							isLegacySiteWithHigherLimits={ legacySiteWithHigherLimits }
-							meta={ data }
+							meta={ { ...data, no_ads_monthly_cost: noAdsMonthlyCost } }
 							key={ feature.features[ 0 ] }
 						/>
 					) ) }

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -25,7 +25,6 @@ export interface WPComPlan extends Plan {
 	getBlogAudience?: () => TranslateResult;
 	getPortfolioAudience?: () => TranslateResult;
 	getStoreAudience?: () => TranslateResult;
-	getSubTitle?: () => TranslateResult;
 	getPlanCompareFeatures?: (
 		experiment?: string,
 		options?: Record< string, string | boolean[] >

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -25,6 +25,7 @@ export interface WPComPlan extends Plan {
 	getBlogAudience?: () => TranslateResult;
 	getPortfolioAudience?: () => TranslateResult;
 	getStoreAudience?: () => TranslateResult;
+	getSubTitle?: () => TranslateResult;
 	getPlanCompareFeatures?: (
 		experiment?: string,
 		options?: Record< string, string | boolean[] >


### PR DESCRIPTION
#### Proposed Changes

* This PR launches the test variant in #64239 as the new control to everybody.
* This PR also removes the Explat config to provide a clean slate for the next test.

Screenshot:
![screencapture-calypso-localhost-3000-start-plans-2022-06-18-08_43_57](https://user-images.githubusercontent.com/35781181/174438222-481a19e0-8ba6-4b38-8e9b-00944ce27f0f.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D82921-code to your sandboxed `public-api.wordpress.com`.
* Checkout this PR and start Calypso locally.
* Navigate to the plans step in signup and confirm that the version in the screenshot shows for all regions.
* Confirm that add-on pricing shows the accurate price and currency for a number of locations.
* Confirm that the strings are properly translated in a number of languages.
* Test the page in both large and small viewports.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

fixed Automattic/martech#824