### PR TITLE
HelpCenter: adjust focus stylings and tooltip

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -103,6 +103,7 @@ const HelpCenterHeader: React.FC< Header > = ( {
 							className={ 'help-center-header__maximize' }
 							label={ __( 'Maximize Help Center', __i18n_text_domain__ ) }
 							icon={ chevronUp }
+							tooltipPosition="top left"
 							onClick={ requestMaximize }
 						/>
 					) : (
@@ -110,6 +111,7 @@ const HelpCenterHeader: React.FC< Header > = ( {
 							className={ 'help-center-header__minimize' }
 							label={ __( 'Minimize Help Center', __i18n_text_domain__ ) }
 							icon={ lineSolid }
+							tooltipPosition="top left"
 							onClick={ onMinimize }
 						/>
 					) }
@@ -117,6 +119,7 @@ const HelpCenterHeader: React.FC< Header > = ( {
 					<Button
 						className={ 'help-center-header__close' }
 						label={ __( 'Close Help Center', __i18n_text_domain__ ) }
+						tooltipPosition="top left"
 						icon={ closeSmall }
 						onClick={ onDismiss }
 					/>

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -15,7 +15,6 @@
 }
 
 .help-center .help-center__container-content {
-
 	/**
  	 * SEARCH
  	 */
@@ -66,11 +65,6 @@
 						display: block;
 						align-self: center;
 					}
-
-					&:focus {
-						box-shadow: none;
-						outline: none;
-					}
 				}
 			}
 		}
@@ -79,13 +73,15 @@
 	/**
  	 * MORE RESOURCES
  	 */
-	.inline-help__more-resources {
+	.inline-help__more-resources,
+	.inline-help__results-list {
 		list-style: none;
 		text-align: left;
 		margin: 0;
 		padding: 0;
 
-		.inline-help__resource-item {
+		.inline-help__resource-item,
+		.inline-help__results-item {
 			margin: 0;
 			margin-bottom: 0.6em;
 			font-size: $font-body-small;
@@ -98,7 +94,8 @@
 				line-height: 1.3;
 			}
 
-			a {
+			a,
+			button {
 				color: #000;
 				text-decoration: none;
 				font-weight: normal;
@@ -128,8 +125,6 @@
 						color: var( --color-neutral );
 					}
 				}
-
-
 			}
 		}
 
@@ -359,11 +354,6 @@
 						display: block;
 						align-self: center;
 					}
-
-					&:focus {
-						box-shadow: none;
-						outline: none;
-					}
 				}
 			}
 		}
@@ -401,8 +391,10 @@
 
 		button.button.is-borderless:focus,
 		a.button.is-borderless:focus {
-			border: none;
-			box-shadow: none;
+			color: #043959;
+			box-shadow: 0 0 0 1px #4f94d4, 0 0 2px 1px rgba( 79, 148, 212, 0.8 );
+			outline: 1px solid transparent;
+			border-color: inherit;
 		}
 
 		a:not( .support-article-dialog__header-title-link ) {
@@ -548,6 +540,13 @@
 			border-color: var( --color-neutral-20 );
 			box-shadow: none;
 			outline: none;
+		}
+
+		&:focus {
+			color: #043959;
+			box-shadow: 0 0 0 1px #4f94d4, 0 0 2px 1px rgba( 79, 148, 212, 0.8 );
+			outline: 1px solid transparent;
+			border-color: inherit;
 		}
 
 		svg {

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -203,6 +203,14 @@ button.button.back-button__help-center.is-borderless {
 	align-items: center;
 	color: black;
 	font-size: $font-body-small;
+	padding-right: 5px;
+
+	&:focus {
+		color: #043959;
+		box-shadow: 0 0 0 1px #4f94d4, 0 0 2px 1px rgba( 79, 148, 212, 0.8 );
+		outline: 1px solid transparent;
+		border-color: inherit;
+	}
 }
 
 .help-center__container-content {
@@ -228,6 +236,10 @@ button.button.back-button__help-center.is-borderless {
 			color: var( --studio-gray-100 );
 			margin-bottom: 16px;
 			font-size: $font-body-small;
+
+			&:hover {
+				background: var( --color-neutral-0 );
+			}
 		}
 	}
 
@@ -297,7 +309,6 @@ button.button.back-button__help-center.is-borderless {
 		label {
 			cursor: pointer;
 		}
-
 
 		.help-center__container.is-desktop {
 			position: fixed;


### PR DESCRIPTION
## Proposed Changes

This adjusts the styling of the focus events on buttons and links in the help center. 

Also moves the hover tooltip location to prevent it from running off the screen.

## Testing Instructions

1. Pull branch
2. `cd apps/editing-toolkit && yarn dev --sync`
3. Tab through the help center and check all focus stylings
4. Hover over the maximize/minimize and close buttons, the tooltips should not fall off screen.