### PR TITLE
Migrate the stacked comparison views to the new mailbox list

### DIFF
--- a/client/my-sites/email/add-mailboxes/email-provider-pricing-notice.tsx
+++ b/client/my-sites/email/add-mailboxes/email-provider-pricing-notice.tsx
@@ -12,7 +12,7 @@ import {
 	isTitanMonthlyProduct,
 } from 'calypso/lib/titan';
 import EmailPricingNotice from 'calypso/my-sites/email/email-pricing-notice';
-import { getMailProductProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-mail-product-properties';
+import { getEmailProductProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-email-product-properties';
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
@@ -27,7 +27,7 @@ export const EmailProviderPricingNotice = ( {
 	provider,
 	selectedDomain,
 }: EmailProviderPricingNoticeProps ): JSX.Element | null => {
-	const { isAdditionalMailboxesPurchase } = getMailProductProperties(
+	const { isAdditionalMailboxesPurchase } = getEmailProductProperties(
 		provider,
 		selectedDomain,
 		emailProduct as ProductListItem

--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -30,7 +30,7 @@ import EmailHeader from 'calypso/my-sites/email/email-header';
 import { NewMailBoxList } from 'calypso/my-sites/email/form/mailboxes/components/new-mailbox-list';
 import getMailProductForProvider from 'calypso/my-sites/email/form/mailboxes/components/selectors/get-mail-product-for-provider';
 import getCartItems from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-cart-items';
-import { getMailProductProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-mail-product-properties';
+import { getEmailProductProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-email-product-properties';
 import { MailboxOperations } from 'calypso/my-sites/email/form/mailboxes/components/utilities/mailbox-operations';
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { emailManagement, emailManagementTitanSetUpMailbox } from 'calypso/my-sites/email/paths';
@@ -166,7 +166,7 @@ const MailboxNotices = ( {
 		return null;
 	}
 
-	const { existingItemsCount } = getMailProductProperties(
+	const { existingItemsCount } = getEmailProductProperties(
 		provider,
 		selectedDomain,
 		emailProduct as ProductListItem
@@ -236,7 +236,7 @@ const MailboxesForm = ( {
 	};
 
 	const onSubmit = async ( mailboxOperations: MailboxOperations ) => {
-		const mailProperties = getMailProductProperties(
+		const mailProperties = getEmailProductProperties(
 			provider,
 			selectedDomain,
 			emailProduct,

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/get-on-submit-new-mailboxes-handler.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/get-on-submit-new-mailboxes-handler.ts
@@ -6,7 +6,7 @@ import { GOOGLE_PROVIDER_NAME } from 'calypso/lib/gsuite/constants';
 import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import { recordTracksEventAddToCartClick } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/utils';
 import getCartItems from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-cart-items';
-import { getMailProductProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-mail-product-properties';
+import { getEmailProductProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-email-product-properties';
 import { MailboxOperations } from 'calypso/my-sites/email/form/mailboxes/components/utilities/mailbox-operations';
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -68,7 +68,7 @@ const getOnSubmitNewMailboxesHandler =
 			return;
 		}
 
-		const emailProperties = getMailProductProperties(
+		const emailProperties = getEmailProductProperties(
 			provider,
 			domain,
 			emailProduct as ProductListItem,

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/get-on-submit-new-mailboxes-handler.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/get-on-submit-new-mailboxes-handler.ts
@@ -19,7 +19,7 @@ export type GetOnSubmitNewMailboxesHandlerProps = {
 	emailProduct: ProductListItem | null;
 	isDomainInCart?: boolean;
 	provider: EmailProvider;
-	setAddingToCart: ( addingToCard: boolean ) => void;
+	setAddingToCart: ( isAddingToCart: boolean ) => void;
 	shoppingCartManager: ShoppingCartManagerActions;
 	siteSlug: string;
 	source: string;
@@ -68,7 +68,7 @@ const getOnSubmitNewMailboxesHandler =
 			return;
 		}
 
-		const mailProperties = getMailProductProperties(
+		const emailProperties = getMailProductProperties(
 			provider,
 			domain,
 			emailProduct as ProductListItem,
@@ -76,7 +76,7 @@ const getOnSubmitNewMailboxesHandler =
 		);
 
 		shoppingCartManager
-			.addProductsToCart( [ getCartItems( mailboxOperations.mailboxes, mailProperties ) ] )
+			.addProductsToCart( [ getCartItems( mailboxOperations.mailboxes, emailProperties ) ] )
 			.then( () => {
 				page( '/checkout/' + siteSlug );
 			} )

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/get-on-submit-new-mailboxes-handler.ts
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/get-on-submit-new-mailboxes-handler.ts
@@ -1,0 +1,86 @@
+import { ShoppingCartManagerActions } from '@automattic/shopping-cart';
+import page from 'page';
+import { canCurrentUserAddEmail, getCurrentUserCannotAddEmailReason } from 'calypso/lib/domains';
+import { ResponseDomain } from 'calypso/lib/domains/types';
+import { GOOGLE_PROVIDER_NAME } from 'calypso/lib/gsuite/constants';
+import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
+import { recordTracksEventAddToCartClick } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/utils';
+import getCartItems from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-cart-items';
+import { getMailProductProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-mail-product-properties';
+import { MailboxOperations } from 'calypso/my-sites/email/form/mailboxes/components/utilities/mailbox-operations';
+import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+
+export type GetOnSubmitNewMailboxesHandlerProps = {
+	comparisonContext: string;
+	domain: ResponseDomain;
+	dispatch: ( action: unknown ) => void;
+	emailProduct: ProductListItem | null;
+	isDomainInCart?: boolean;
+	provider: EmailProvider;
+	setAddingToCart: ( addingToCard: boolean ) => void;
+	shoppingCartManager: ShoppingCartManagerActions;
+	siteSlug: string;
+	source: string;
+};
+
+const getOnSubmitNewMailboxesHandler =
+	( {
+		comparisonContext,
+		isDomainInCart,
+		dispatch,
+		domain,
+		emailProduct,
+		provider,
+		setAddingToCart,
+		shoppingCartManager,
+		siteSlug,
+		source,
+	}: GetOnSubmitNewMailboxesHandlerProps ) =>
+	async ( mailboxOperations: MailboxOperations ) => {
+		setAddingToCart( true );
+
+		const userCanAddEmail = isDomainInCart || canCurrentUserAddEmail( domain );
+		const userCannotAddEmailReason = userCanAddEmail
+			? null
+			: getCurrentUserCannotAddEmailReason( domain );
+
+		const validated = await mailboxOperations.validateAndCheck( false );
+
+		recordTracksEventAddToCartClick(
+			comparisonContext,
+			mailboxOperations.mailboxes.map( () => '' ),
+			validated,
+			provider === EmailProvider.Titan ? TITAN_PROVIDER_NAME : GOOGLE_PROVIDER_NAME,
+			source ?? '',
+			userCanAddEmail,
+			userCannotAddEmailReason
+		);
+
+		if ( ! userCanAddEmail || ! validated ) {
+			if ( ! userCanAddEmail ) {
+				dispatch( errorNotice( userCannotAddEmailReason ) );
+			}
+
+			setAddingToCart( false );
+
+			return;
+		}
+
+		const mailProperties = getMailProductProperties(
+			provider,
+			domain,
+			emailProduct as ProductListItem,
+			mailboxOperations.mailboxes.length
+		);
+
+		shoppingCartManager
+			.addProductsToCart( [ getCartItems( mailboxOperations.mailboxes, mailProperties ) ] )
+			.then( () => {
+				page( '/checkout/' + siteSlug );
+			} )
+			.finally( () => setAddingToCart( false ) );
+	};
+
+export default getOnSubmitNewMailboxesHandler;

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY,
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
@@ -5,7 +6,7 @@ import {
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { translate } from 'i18n-calypso';
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import GSuiteNewUserList from 'calypso/components/gsuite/gsuite-new-user-list';
@@ -23,6 +24,7 @@ import { getGoogleAppLogos } from 'calypso/my-sites/email/email-provider-feature
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import GoogleWorkspacePrice from 'calypso/my-sites/email/email-providers-comparison/price/google-workspace';
 import EmailProvidersStackedCard from 'calypso/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card';
+import getOnSubmitNewMailboxesHandler from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/get-on-submit-new-mailboxes-handler';
 import {
 	EmailProvidersStackedCardProps,
 	ProviderCardProps,
@@ -31,6 +33,8 @@ import {
 	addToCartAndCheckout,
 	recordTracksEventAddToCartClick,
 } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/utils';
+import { NewMailBoxList } from 'calypso/my-sites/email/form/mailboxes/components/new-mailbox-list';
+import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
@@ -41,9 +45,6 @@ import type { TranslateResult } from 'i18n-calypso';
 import type { ReactElement } from 'react';
 
 import './google-workspace-card.scss';
-
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
 
 function identityMap< T >( item: T ): T {
 	return item;
@@ -156,8 +157,6 @@ const GoogleWorkspaceCard = ( {
 		);
 	};
 
-	const onGoogleFormReturnKeyPress = noop;
-
 	const domainList = domain ? [ domain ] : [];
 
 	googleWorkspace.onExpandedChange = onExpandedChange;
@@ -169,7 +168,7 @@ const GoogleWorkspaceCard = ( {
 				onUsersChange={ setGoogleUsers }
 				selectedDomainName={ selectedDomainName }
 				users={ googleUsers }
-				onReturnKeyPress={ onGoogleFormReturnKeyPress }
+				onReturnKeyPress={ () => undefined }
 				showAddAnotherMailboxButton={ false }
 			>
 				<FullWidthButton
@@ -187,4 +186,78 @@ const GoogleWorkspaceCard = ( {
 	return <EmailProvidersStackedCard { ...googleWorkspace } />;
 };
 
-export default GoogleWorkspaceCard;
+const GoogleWorkspaceCardNew = ( props: EmailProvidersStackedCardProps ): ReactElement => {
+	const {
+		detailsExpanded,
+		intervalLength,
+		isDomainInCart = false,
+		onExpandedChange,
+		selectedDomainName,
+	} = props;
+	const selectedSite = useSelector( getSelectedSite );
+	const siteSlug = selectedSite?.slug ?? '';
+	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
+	const domain = getSelectedDomain( {
+		domains,
+		selectedDomainName: selectedDomainName,
+	} );
+
+	const cartKey = useCartKey();
+	const dispatch = useDispatch();
+	const shoppingCartManager = useShoppingCart( cartKey );
+
+	const gSuiteProduct = useSelector( ( state ) =>
+		getProductBySlug(
+			state,
+			intervalLength === IntervalLength.MONTHLY
+				? GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY
+				: GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+		)
+	);
+	const provider = EmailProvider.Google;
+
+	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
+
+	const [ addingToCart, setAddingToCart ] = useState( false );
+
+	const isGSuiteSupported =
+		canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );
+
+	const googleWorkspace: ProviderCardProps = { ...googleWorkspaceCardInformation };
+	googleWorkspace.detailsExpanded = isGSuiteSupported && detailsExpanded;
+	googleWorkspace.showExpandButton = isGSuiteSupported;
+	googleWorkspace.priceBadge = (
+		<GoogleWorkspacePrice
+			domain={ domain }
+			isDomainInCart={ isDomainInCart }
+			intervalLength={ intervalLength }
+		/>
+	);
+
+	const handleSubmit = getOnSubmitNewMailboxesHandler( {
+		...props,
+		dispatch,
+		domain,
+		emailProduct: gSuiteProduct,
+		provider,
+		setAddingToCart,
+		shoppingCartManager,
+		siteSlug,
+	} );
+
+	googleWorkspace.onExpandedChange = onExpandedChange;
+	googleWorkspace.formFields = (
+		<NewMailBoxList
+			areButtonsBusy={ addingToCart }
+			onSubmit={ handleSubmit }
+			provider={ provider }
+			selectedDomainName={ selectedDomainName }
+			showAddNewMailboxButton
+			submitActionText={ translate( 'Create your mailbox' ) }
+		/>
+	);
+
+	return <EmailProvidersStackedCard { ...googleWorkspace } />;
+};
+
+export default isEnabled( 'unify-mailbox-forms' ) ? GoogleWorkspaceCardNew : GoogleWorkspaceCard;

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/google-workspace-card.tsx
@@ -253,7 +253,7 @@ const GoogleWorkspaceCardNew = ( props: EmailProvidersStackedCardProps ): ReactE
 			provider={ provider }
 			selectedDomainName={ selectedDomainName }
 			showAddNewMailboxButton
-			submitActionText={ translate( 'Create your mailbox' ) }
+			submitActionText={ translate( 'Purchase' ) }
 		/>
 	);
 

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.scss
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.scss
@@ -12,3 +12,7 @@
 		padding-right: 12px;
 	}
 }
+
+.professional-email-card__change-it-button {
+	color: var( --color-link );
+}

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -1,8 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
-import { ShoppingCartManagerActions, useShoppingCart } from '@automattic/shopping-cart';
+import { useShoppingCart } from '@automattic/shopping-cart';
 import { translate, useTranslate } from 'i18n-calypso';
-import page from 'page';
 import { MouseEvent, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan-caps.svg';
@@ -17,7 +16,6 @@ import {
 	getCurrentUserCannotAddEmailReason,
 	getSelectedDomain,
 } from 'calypso/lib/domains';
-import { ResponseDomain } from 'calypso/lib/domains/types';
 import { getTitanProductName, getTitanProductSlug } from 'calypso/lib/titan';
 import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import {
@@ -30,6 +28,7 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 import ProfessionalEmailPrice from 'calypso/my-sites/email/email-providers-comparison/price/professional-email';
 import EmailProvidersStackedCard from 'calypso/my-sites/email/email-providers-stacked-comparison/email-provider-stacked-card';
+import getOnSubmitNewMailboxesHandler from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/get-on-submit-new-mailboxes-handler';
 import {
 	addToCartAndCheckout,
 	recordTracksEventAddToCartClick,
@@ -38,9 +37,6 @@ import {
 	HiddenFieldNames,
 	NewMailBoxList,
 } from 'calypso/my-sites/email/form/mailboxes/components/new-mailbox-list';
-import getCartItems from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-cart-items';
-import { getMailProductProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-mail-product-properties';
-import { MailboxOperations } from 'calypso/my-sites/email/form/mailboxes/components/utilities/mailbox-operations';
 import {
 	FIELD_ALTERNATIVE_EMAIL,
 	FIELD_NAME,
@@ -53,9 +49,7 @@ import {
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
-import { errorNotice } from 'calypso/state/notices/actions';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
-import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersStackedCardProps, ProviderCardProps } from './provider-card-props';
@@ -91,97 +85,23 @@ const professionalEmailCardInformation: ProviderCardProps = {
 	features: getTitanFeatures(),
 };
 
-const getOnSubmitNewMailboxes =
-	( {
-		comparisonContext,
-		isDomainInCart,
-		dispatch,
-		domain,
-		emailProduct,
-		provider,
-		setAddingToCart,
-		shoppingCartManager,
-		siteSlug,
-		source,
-	}: EmailProvidersStackedCardProps & {
-		domain: ResponseDomain;
-		dispatch: ( action: unknown ) => void;
-		emailProduct: ProductListItem | null;
-		provider: EmailProvider;
-		setAddingToCart: ( addingToCard: boolean ) => void;
-		shoppingCartManager: ShoppingCartManagerActions;
-		siteSlug: string;
-	} ) =>
-	async ( mailboxOperations: MailboxOperations ) => {
-		setAddingToCart( true );
-
-		const userCanAddEmail = isDomainInCart || canCurrentUserAddEmail( domain );
-		const userCannotAddEmailReason = userCanAddEmail
-			? null
-			: getCurrentUserCannotAddEmailReason( domain );
-
-		const validated = await mailboxOperations.validateAndCheck( false );
-
-		recordTracksEventAddToCartClick(
-			comparisonContext,
-			mailboxOperations.mailboxes.map( () => '' ),
-			validated,
-			TITAN_PROVIDER_NAME,
-			source ?? '',
-			userCanAddEmail,
-			userCannotAddEmailReason
-		);
-
-		if ( ! userCanAddEmail || ! validated ) {
-			if ( ! userCanAddEmail ) {
-				dispatch( errorNotice( userCannotAddEmailReason ) );
-			}
-
-			setAddingToCart( false );
-
-			return;
-		}
-
-		const mailProperties = getMailProductProperties(
-			provider,
-			domain,
-			emailProduct as ProductListItem,
-			mailboxOperations.mailboxes.length
-		);
-
-		shoppingCartManager
-			.addProductsToCart( [ getCartItems( mailboxOperations.mailboxes, mailProperties ) ] )
-			.then( () => {
-				page( '/checkout/' + siteSlug );
-			} )
-			.finally( () => setAddingToCart( false ) );
-	};
-
-const ProfessionalEmailCard = ( props: EmailProvidersStackedCardProps ): ReactElement => {
-	const {
-		comparisonContext,
-		detailsExpanded,
-		intervalLength,
-		isDomainInCart = false,
-		onExpandedChange,
-		selectedDomainName,
-		source,
-	} = props;
-	const translate = useTranslate();
+const ProfessionalEmailCard = ( {
+	comparisonContext,
+	detailsExpanded,
+	intervalLength,
+	isDomainInCart = false,
+	onExpandedChange,
+	selectedDomainName,
+	source,
+}: EmailProvidersStackedCardProps ): ReactElement => {
 	const selectedSite = useSelector( getSelectedSite );
-	const siteSlug = selectedSite?.slug ?? '';
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 	const domain = getSelectedDomain( {
 		domains,
 		selectedDomainName: selectedDomainName,
 	} );
-	const emailProduct = useSelector( ( state ) =>
-		getProductBySlug( state, getTitanProductSlug( domain ) as string )
-	);
-	const provider = EmailProvider.Titan;
 
 	const cartKey = useCartKey();
-	const dispatch = useDispatch();
 	const shoppingCartManager = useShoppingCart( cartKey );
 
 	const [ titanMailbox, setTitanMailbox ] = useState( [
@@ -190,18 +110,6 @@ const ProfessionalEmailCard = ( props: EmailProvidersStackedCardProps ): ReactEl
 	const [ addingToCart, setAddingToCart ] = useState( false );
 	const [ validatedTitanMailboxUuids, setValidatedTitanMailboxUuids ] = useState( [ '' ] );
 	const optionalFields = [ TITAN_PASSWORD_RESET_FIELD, TITAN_FULL_NAME_FIELD ];
-
-	const [ hiddenFieldNames, setHiddenFieldNames ] = useState< HiddenFieldNames[] >( [
-		FIELD_NAME,
-		FIELD_ALTERNATIVE_EMAIL,
-	] );
-
-	const userEmail = useSelector( getCurrentUserEmail );
-
-	const showAlternateEmailField = ( event: MouseEvent< HTMLElement > ) => {
-		event.preventDefault();
-		setHiddenFieldNames( [ FIELD_NAME ] );
-	};
 
 	const professionalEmail: ProviderCardProps = { ...professionalEmailCardInformation };
 	professionalEmail.detailsExpanded = detailsExpanded;
@@ -247,7 +155,12 @@ const ProfessionalEmailCard = ( props: EmailProvidersStackedCardProps ): ReactEl
 				? titanMailMonthly( props )
 				: titanMailYearly( props );
 
-		addToCartAndCheckout( shoppingCartManager, cartItem, setAddingToCart, siteSlug );
+		addToCartAndCheckout(
+			shoppingCartManager,
+			cartItem,
+			setAddingToCart,
+			selectedSite?.slug ?? ''
+		);
 	};
 
 	professionalEmail.onExpandedChange = onExpandedChange;
@@ -255,7 +168,76 @@ const ProfessionalEmailCard = ( props: EmailProvidersStackedCardProps ): ReactEl
 		<ProfessionalEmailPrice { ...{ domain, intervalLength, isDomainInCart } } />
 	);
 
-	const handleSubmit = getOnSubmitNewMailboxes( {
+	professionalEmail.formFields = (
+		<TitanNewMailboxList
+			onMailboxesChange={ setTitanMailbox }
+			mailboxes={ titanMailbox }
+			selectedDomainName={ selectedDomainName }
+			validatedMailboxUuids={ validatedTitanMailboxUuids }
+			showAddAnotherMailboxButton={ false }
+			hiddenFieldNames={ [ TITAN_FULL_NAME_FIELD, TITAN_PASSWORD_RESET_FIELD ] }
+		>
+			<FullWidthButton
+				className="professional-email-card__continue"
+				primary
+				busy={ addingToCart }
+				onClick={ onTitanConfirmNewMailboxes }
+			>
+				{ translate( 'Create your mailbox' ) }
+			</FullWidthButton>
+		</TitanNewMailboxList>
+	);
+
+	return <EmailProvidersStackedCard { ...professionalEmail } />;
+};
+
+const ProfessionalEmailCardNew = ( props: EmailProvidersStackedCardProps ): ReactElement => {
+	const {
+		detailsExpanded,
+		intervalLength,
+		isDomainInCart = false,
+		onExpandedChange,
+		selectedDomainName,
+	} = props;
+	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
+	const siteSlug = selectedSite?.slug ?? '';
+	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
+	const domain = getSelectedDomain( {
+		domains,
+		selectedDomainName: selectedDomainName,
+	} );
+	const emailProduct = useSelector( ( state ) =>
+		getProductBySlug( state, getTitanProductSlug( domain ) as string )
+	);
+	const provider = EmailProvider.Titan;
+
+	const cartKey = useCartKey();
+	const dispatch = useDispatch();
+	const shoppingCartManager = useShoppingCart( cartKey );
+	const [ addingToCart, setAddingToCart ] = useState( false );
+
+	const [ hiddenFieldNames, setHiddenFieldNames ] = useState< HiddenFieldNames[] >( [
+		FIELD_NAME,
+		FIELD_ALTERNATIVE_EMAIL,
+	] );
+
+	const userEmail = useSelector( getCurrentUserEmail );
+
+	const showAlternateEmailField = ( event: MouseEvent< HTMLElement > ) => {
+		event.preventDefault();
+		setHiddenFieldNames( [ FIELD_NAME ] );
+	};
+
+	const professionalEmail: ProviderCardProps = { ...professionalEmailCardInformation };
+	professionalEmail.detailsExpanded = detailsExpanded;
+
+	professionalEmail.onExpandedChange = onExpandedChange;
+	professionalEmail.priceBadge = (
+		<ProfessionalEmailPrice { ...{ domain, intervalLength, isDomainInCart } } />
+	);
+
+	const handleSubmit = getOnSubmitNewMailboxesHandler( {
 		...props,
 		dispatch,
 		domain,
@@ -298,7 +280,7 @@ const ProfessionalEmailCard = ( props: EmailProvidersStackedCardProps ): ReactEl
 		);
 	};
 
-	professionalEmail.formFields = isEnabled( 'unify-mailbox-forms' ) ? (
+	professionalEmail.formFields = (
 		<NewMailBoxList
 			areButtonsBusy={ addingToCart }
 			hiddenFieldNames={ hiddenFieldNames }
@@ -311,27 +293,11 @@ const ProfessionalEmailCard = ( props: EmailProvidersStackedCardProps ): ReactEl
 		>
 			<PasswordResetFieldTip />
 		</NewMailBoxList>
-	) : (
-		<TitanNewMailboxList
-			onMailboxesChange={ setTitanMailbox }
-			mailboxes={ titanMailbox }
-			selectedDomainName={ selectedDomainName }
-			validatedMailboxUuids={ validatedTitanMailboxUuids }
-			showAddAnotherMailboxButton={ false }
-			hiddenFieldNames={ [ TITAN_FULL_NAME_FIELD, TITAN_PASSWORD_RESET_FIELD ] }
-		>
-			<FullWidthButton
-				className="professional-email-card__continue"
-				primary
-				busy={ addingToCart }
-				onClick={ onTitanConfirmNewMailboxes }
-			>
-				{ translate( 'Create your mailbox' ) }
-			</FullWidthButton>
-		</TitanNewMailboxList>
 	);
 
 	return <EmailProvidersStackedCard { ...professionalEmail } />;
 };
 
-export default ProfessionalEmailCard;
+export default isEnabled( 'unify-mailbox-forms' )
+	? ProfessionalEmailCardNew
+	: ProfessionalEmailCard;

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -1,20 +1,24 @@
-import { Gridicon } from '@automattic/components';
-import { useShoppingCart } from '@automattic/shopping-cart';
-import { translate } from 'i18n-calypso';
-import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { isEnabled } from '@automattic/calypso-config';
+import { Button, Gridicon } from '@automattic/components';
+import { ShoppingCartManagerActions, useShoppingCart } from '@automattic/shopping-cart';
+import { translate, useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { MouseEvent, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan-caps.svg';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import {
 	titanMailMonthly,
 	titanMailYearly,
 	TitanProductProps,
 } from 'calypso/lib/cart-values/cart-items';
 import {
-	getSelectedDomain,
 	canCurrentUserAddEmail,
 	getCurrentUserCannotAddEmailReason,
+	getSelectedDomain,
 } from 'calypso/lib/domains';
-import { getTitanProductName } from 'calypso/lib/titan';
+import { ResponseDomain } from 'calypso/lib/domains/types';
+import { getTitanProductName, getTitanProductSlug } from 'calypso/lib/titan';
 import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import {
 	areAllMailboxesValid,
@@ -31,20 +35,33 @@ import {
 	recordTracksEventAddToCartClick,
 } from 'calypso/my-sites/email/email-providers-stacked-comparison/provider-cards/utils';
 import {
-	TITAN_PASSWORD_RESET_FIELD,
+	HiddenFieldNames,
+	NewMailBoxList,
+} from 'calypso/my-sites/email/form/mailboxes/components/new-mailbox-list';
+import getCartItems from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-cart-items';
+import { getMailProductProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-mail-product-properties';
+import { MailboxOperations } from 'calypso/my-sites/email/form/mailboxes/components/utilities/mailbox-operations';
+import {
+	FIELD_ALTERNATIVE_EMAIL,
+	FIELD_NAME,
+} from 'calypso/my-sites/email/form/mailboxes/constants';
+import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
+import {
 	TITAN_FULL_NAME_FIELD,
+	TITAN_PASSWORD_RESET_FIELD,
 } from 'calypso/my-sites/email/titan-new-mailbox';
 import TitanNewMailboxList from 'calypso/my-sites/email/titan-new-mailbox-list';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersStackedCardProps, ProviderCardProps } from './provider-card-props';
 import type { ReactElement } from 'react';
 
 import './professional-email-card.scss';
-
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
 
 const logo = <Gridicon className="professional-email-card__logo" icon="my-sites" />;
 const badge = (
@@ -74,23 +91,97 @@ const professionalEmailCardInformation: ProviderCardProps = {
 	features: getTitanFeatures(),
 };
 
-const ProfessionalEmailCard = ( {
-	comparisonContext,
-	detailsExpanded,
-	intervalLength,
-	isDomainInCart = false,
-	onExpandedChange,
-	selectedDomainName,
-	source,
-}: EmailProvidersStackedCardProps ): ReactElement => {
+const getOnSubmitNewMailboxes =
+	( {
+		comparisonContext,
+		isDomainInCart,
+		dispatch,
+		domain,
+		emailProduct,
+		provider,
+		setAddingToCart,
+		shoppingCartManager,
+		siteSlug,
+		source,
+	}: EmailProvidersStackedCardProps & {
+		domain: ResponseDomain;
+		dispatch: ( action: unknown ) => void;
+		emailProduct: ProductListItem | null;
+		provider: EmailProvider;
+		setAddingToCart: ( addingToCard: boolean ) => void;
+		shoppingCartManager: ShoppingCartManagerActions;
+		siteSlug: string;
+	} ) =>
+	async ( mailboxOperations: MailboxOperations ) => {
+		setAddingToCart( true );
+
+		const userCanAddEmail = isDomainInCart || canCurrentUserAddEmail( domain );
+		const userCannotAddEmailReason = userCanAddEmail
+			? null
+			: getCurrentUserCannotAddEmailReason( domain );
+
+		const validated = await mailboxOperations.validateAndCheck( false );
+
+		recordTracksEventAddToCartClick(
+			comparisonContext,
+			mailboxOperations.mailboxes.map( () => '' ),
+			validated,
+			TITAN_PROVIDER_NAME,
+			source ?? '',
+			userCanAddEmail,
+			userCannotAddEmailReason
+		);
+
+		if ( ! userCanAddEmail || ! validated ) {
+			if ( ! userCanAddEmail ) {
+				dispatch( errorNotice( userCannotAddEmailReason ) );
+			}
+
+			setAddingToCart( false );
+
+			return;
+		}
+
+		const mailProperties = getMailProductProperties(
+			provider,
+			domain,
+			emailProduct as ProductListItem,
+			mailboxOperations.mailboxes.length
+		);
+
+		shoppingCartManager
+			.addProductsToCart( [ getCartItems( mailboxOperations.mailboxes, mailProperties ) ] )
+			.then( () => {
+				page( '/checkout/' + siteSlug );
+			} )
+			.finally( () => setAddingToCart( false ) );
+	};
+
+const ProfessionalEmailCard = ( props: EmailProvidersStackedCardProps ): ReactElement => {
+	const {
+		comparisonContext,
+		detailsExpanded,
+		intervalLength,
+		isDomainInCart = false,
+		onExpandedChange,
+		selectedDomainName,
+		source,
+	} = props;
+	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite );
+	const siteSlug = selectedSite?.slug ?? '';
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 	const domain = getSelectedDomain( {
 		domains,
 		selectedDomainName: selectedDomainName,
 	} );
+	const emailProduct = useSelector( ( state ) =>
+		getProductBySlug( state, getTitanProductSlug( domain ) as string )
+	);
+	const provider = EmailProvider.Titan;
 
 	const cartKey = useCartKey();
+	const dispatch = useDispatch();
 	const shoppingCartManager = useShoppingCart( cartKey );
 
 	const [ titanMailbox, setTitanMailbox ] = useState( [
@@ -99,6 +190,18 @@ const ProfessionalEmailCard = ( {
 	const [ addingToCart, setAddingToCart ] = useState( false );
 	const [ validatedTitanMailboxUuids, setValidatedTitanMailboxUuids ] = useState( [ '' ] );
 	const optionalFields = [ TITAN_PASSWORD_RESET_FIELD, TITAN_FULL_NAME_FIELD ];
+
+	const [ hiddenFieldNames, setHiddenFieldNames ] = useState< HiddenFieldNames[] >( [
+		FIELD_NAME,
+		FIELD_ALTERNATIVE_EMAIL,
+	] );
+
+	const userEmail = useSelector( getCurrentUserEmail );
+
+	const showAlternateEmailField = ( event: MouseEvent< HTMLElement > ) => {
+		event.preventDefault();
+		setHiddenFieldNames( [ FIELD_NAME ] );
+	};
 
 	const professionalEmail: ProviderCardProps = { ...professionalEmailCardInformation };
 	professionalEmail.detailsExpanded = detailsExpanded;
@@ -144,27 +247,75 @@ const ProfessionalEmailCard = ( {
 				? titanMailMonthly( props )
 				: titanMailYearly( props );
 
-		addToCartAndCheckout(
-			shoppingCartManager,
-			cartItem,
-			setAddingToCart,
-			selectedSite?.slug ?? ''
-		);
+		addToCartAndCheckout( shoppingCartManager, cartItem, setAddingToCart, siteSlug );
 	};
-
-	const onTitanFormReturnKeyPress = noop;
 
 	professionalEmail.onExpandedChange = onExpandedChange;
 	professionalEmail.priceBadge = (
 		<ProfessionalEmailPrice { ...{ domain, intervalLength, isDomainInCart } } />
 	);
 
-	professionalEmail.formFields = (
+	const handleSubmit = getOnSubmitNewMailboxes( {
+		...props,
+		dispatch,
+		domain,
+		emailProduct,
+		provider,
+		setAddingToCart,
+		shoppingCartManager,
+		siteSlug,
+	} );
+
+	const PasswordResetFieldTip = () => {
+		const translate = useTranslate();
+
+		if ( ! hiddenFieldNames.includes( FIELD_ALTERNATIVE_EMAIL ) ) {
+			return null;
+		}
+
+		return (
+			<FormSettingExplanation>
+				{ translate(
+					'Your password reset email is {{strong}}%(userEmail)s{{/strong}}. {{a}}Change it{{/a}}.',
+					{
+						args: {
+							userEmail,
+						},
+						components: {
+							strong: <strong />,
+							a: (
+								<Button
+									href="#"
+									className="professional-email-card__change-it-button"
+									onClick={ showAlternateEmailField }
+									plain
+								/>
+							),
+						},
+					}
+				) }
+			</FormSettingExplanation>
+		);
+	};
+
+	professionalEmail.formFields = isEnabled( 'unify-mailbox-forms' ) ? (
+		<NewMailBoxList
+			areButtonsBusy={ addingToCart }
+			hiddenFieldNames={ hiddenFieldNames }
+			initialFieldValues={ { [ FIELD_ALTERNATIVE_EMAIL ]: userEmail } }
+			onSubmit={ handleSubmit }
+			provider={ provider }
+			selectedDomainName={ selectedDomainName }
+			showAddNewMailboxButton
+			submitActionText={ translate( 'Create your mailbox' ) }
+		>
+			<PasswordResetFieldTip />
+		</NewMailBoxList>
+	) : (
 		<TitanNewMailboxList
 			onMailboxesChange={ setTitanMailbox }
 			mailboxes={ titanMailbox }
 			selectedDomainName={ selectedDomainName }
-			onReturnKeyPress={ onTitanFormReturnKeyPress }
 			validatedMailboxUuids={ validatedTitanMailboxUuids }
 			showAddAnotherMailboxButton={ false }
 			hiddenFieldNames={ [ TITAN_FULL_NAME_FIELD, TITAN_PASSWORD_RESET_FIELD ] }

--- a/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-stacked-comparison/provider-cards/professional-email-card.tsx
@@ -289,7 +289,7 @@ const ProfessionalEmailCardNew = ( props: EmailProvidersStackedCardProps ): Reac
 			provider={ provider }
 			selectedDomainName={ selectedDomainName }
 			showAddNewMailboxButton
-			submitActionText={ translate( 'Create your mailbox' ) }
+			submitActionText={ translate( 'Purchase' ) }
 		>
 			<PasswordResetFieldTip />
 		</NewMailBoxList>

--- a/client/my-sites/email/form/mailboxes/components/mailbox-field/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/mailbox-field/index.tsx
@@ -16,7 +16,7 @@ import './style.scss';
 
 interface MailboxFormFieldProps {
 	field: MailboxFormFieldBase< string >;
-	isFirstField?: boolean;
+	isFirstVisibleField?: boolean;
 	isPasswordField?: boolean;
 	lowerCaseChangeValue?: boolean;
 	onFieldValueChanged?: ( field: MailboxFormFieldBase< string > ) => void;
@@ -27,7 +27,7 @@ interface MailboxFormFieldProps {
 
 const MailboxFieldInput = ( {
 	field,
-	isFirstField = false,
+	isFirstVisibleField = false,
 	isPasswordField = false,
 	onBlur,
 	onChange,
@@ -48,7 +48,7 @@ const MailboxFieldInput = ( {
 		onBlur,
 		onChange,
 		onInvalid,
-		...( isFirstField ? { autoFocus: true } : {} ),
+		...( isFirstVisibleField ? { autoFocus: true } : {} ),
 		required: field.isRequired,
 		value: field.value,
 	};

--- a/client/my-sites/email/form/mailboxes/components/mailbox-form-wrapper/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/mailbox-form-wrapper/index.tsx
@@ -30,11 +30,15 @@ const MailboxFormWrapper = ( {
 	let renderPosition = 0;
 
 	const commonFieldProps = ( field: MailboxFormFieldBase< string > ) => {
+		if ( field.isVisible ) {
+			++renderPosition;
+		}
+
 		return {
 			field,
 			onFieldValueChanged,
 			onRequestFieldValidation: () => mailbox.validateField( field.fieldName ),
-			isFirstField: ++renderPosition === 1,
+			isFirstVisibleField: renderPosition === 1,
 		};
 	};
 

--- a/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
-import { Fragment, useCallback } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import classNames from 'classnames';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { FormEvent, useState } from 'react';
@@ -183,7 +183,7 @@ const NewMailBoxList = (
 					};
 
 					return (
-						<Fragment key={ 'form-' + uuid }>
+						<div key={ 'form-' + uuid }>
 							{ index > 0 && (
 								<CardHeading
 									className="new-mailbox-list__numbered-heading"
@@ -212,7 +212,7 @@ const NewMailBoxList = (
 									<hr className="new-mailbox-list__separator" />
 								</>
 							</MailboxFormWrapper>
-						</Fragment>
+						</div>
 					);
 				} ) }
 

--- a/client/my-sites/email/form/mailboxes/components/utilities/get-cart-items.ts
+++ b/client/my-sites/email/form/mailboxes/components/utilities/get-cart-items.ts
@@ -9,12 +9,12 @@ import {
 import { GSuiteProductUser } from 'calypso/lib/gsuite/new-users';
 import { isTitanMonthlyProduct } from 'calypso/lib/titan';
 import { MailboxForm } from 'calypso/my-sites/email/form/mailboxes';
-import { MailProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-mail-product-properties';
+import { EmailProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-email-product-properties';
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 
 const getTitanCartItems = (
 	mailboxes: MailboxForm< EmailProvider >[],
-	mailProperties: MailProperties
+	mailProperties: EmailProperties
 ) => {
 	const { emailProduct, newQuantity, quantity } = mailProperties;
 
@@ -38,7 +38,7 @@ const getTitanCartItems = (
 
 const getGSuiteCartItems = (
 	mailboxes: MailboxForm< EmailProvider >[],
-	mailProperties: MailProperties
+	mailProperties: EmailProperties
 ) => {
 	const { isAdditionalMailboxesPurchase, emailProduct, newQuantity, quantity } = mailProperties;
 
@@ -72,7 +72,7 @@ const getGSuiteCartItems = (
 
 const getCartItems = (
 	mailboxes: MailboxForm< EmailProvider >[],
-	mailProperties: MailProperties
+	mailProperties: EmailProperties
 ) => {
 	const provider = mailboxes[ 0 ].provider;
 

--- a/client/my-sites/email/form/mailboxes/components/utilities/get-email-product-properties.ts
+++ b/client/my-sites/email/form/mailboxes/components/utilities/get-email-product-properties.ts
@@ -4,7 +4,7 @@ import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
-type MailProperties = {
+type EmailProperties = {
 	existingItemsCount: number;
 	isAdditionalMailboxesPurchase: boolean;
 	emailProduct: ProductListItem;
@@ -12,12 +12,12 @@ type MailProperties = {
 	quantity: number;
 };
 
-const getMailProductProperties = (
+const getEmailProductProperties = (
 	provider: EmailProvider,
 	domain: ResponseDomain,
 	emailProduct: ProductListItem,
 	newItemsCount = 1
-): MailProperties => {
+): EmailProperties => {
 	const isTitanProvider = provider === EmailProvider.Titan;
 	const isAdditionalMailboxesPurchase = isTitanProvider
 		? hasTitanMailWithUs( domain )
@@ -41,5 +41,5 @@ const getMailProductProperties = (
 	};
 };
 
-export { getMailProductProperties };
-export type { MailProperties };
+export { getEmailProductProperties };
+export type { EmailProperties };


### PR DESCRIPTION
#### Proposed Changes

* Conditionally converts components `<GoogleWorkspaceCard/>` and `<ProfessionalEmailCard/>` to use the `<NewMailBoxList/>` component, based on the `unify-mailbox-forms` feature flag

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure you have a domain without an email subscription
* Click on the [ **+Add** ] from the domain management view i.e. [ **Upgrades** ] > [ **Domains** ] > [ + **Add**  ] . Alternatively navigate to `/email/<:domain>/purchase/<:siteSlug>`
* Append `?flags=unify-mailbox-forms` to the end of the URL to activate the `unify-mailbox-forms` feature flag.
* Confirm that the form and validation works as usual.
* Confirm that you now see an option to add multiple mailboxes to the new subscription.
* Confirm that you can checkout successfully.

Note: Unique mailboxes on the same form are not validated yet.

##### The Professional Email view
<img width="700" alt="Screenshot 2022-06-21 at 8 00 13 AM" src="https://user-images.githubusercontent.com/277661/174736597-a01d6475-a5b7-433d-9356-fe125da9f4cf.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64424 and #64746
