### PR TITLE
Goals Capture: Add `ref` parameter to `calypso_signup_goals_select` event properties

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getQueryArgs } from 'calypso/lib/query-args';
 import SelectGoals from './select-goals';
 import type { Step } from '../../types';
 import './style.scss';
@@ -35,6 +36,7 @@ const GoalsStep: Step = ( { navigation } ) => {
 	const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const { setGoals } = useDispatch( ONBOARD_STORE );
+	const refParameter = getQueryArgs()?.ref;
 
 	const recordGoalsSelectTracksEvent = () => {
 		const { serializeGoals } = Onboard.utils;
@@ -48,7 +50,9 @@ const GoalsStep: Step = ( { navigation } ) => {
 			eventProperties[ goal ] = i + 1;
 		} );
 
-		// TODO: Add ref prop in another PR.
+		if ( refParameter ) {
+			eventProperties.ref = getQueryArgs()?.ref as string;
+		}
 
 		recordTracksEvent( 'calypso_signup_goals_select', eventProperties );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -51,7 +51,7 @@ const GoalsStep: Step = ( { navigation } ) => {
 		} );
 
 		if ( refParameter ) {
-			eventProperties.ref = getQueryArgs()?.ref as string;
+			eventProperties.ref = refParameter as string;
 		}
 
 		recordTracksEvent( 'calypso_signup_goals_select', eventProperties );


### PR DESCRIPTION
#### Proposed Changes

The proposed change builds on top of https://github.com/Automattic/wp-calypso/pull/64724 and adds the content of the `ref` URL parameter to `calypso_signup_goals_select` event properties for tracking purposes.

#### Testing Instructions

1. Go to `calypso.localhost:3000/setup/goals?siteSlug=[site_address]&flags=signup/goals-step&ref=create-blog-lp` where `[site_address]` is the address of the site in form of `something.wordpress.com`
2. Run `localStorage.setItem( 'debug', 'calypso:analytics*' );` in the DevTools console
3. Select one goal, multiple goals, no goals and click on the Continue button.
4. From the DevTools console, you should be able to inspect the values of the `calypso_signup_goals_select` tracks event
5. The value of the `ref` prop should match the value of `&ref=create-blog-lp` that was sent in the URL
6. You can also experiment with:
a. changing the value of the `ref` in the URL to something else
b. omitting the `ref` parameter completely
c. passing another parameter

Only the contents of the `ref` parameter should be added to the event properties:

![Markup on 2022-06-20 at 10:48:20](https://user-images.githubusercontent.com/25105483/174563184-09bba3c3-b26e-4f1d-a325-420276eecd1c.png)


