### PR TITLE
Help Center: Minimized now draggable and not in bottom

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -55,7 +55,6 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, isLoading } 
 	return (
 		<MemoryRouter>
 			<OptionalDraggable
-				disabled={ isMinimized }
 				draggable={ ! isMobile }
 				handle=".help-center__container-header"
 				bounds="body"

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -98,12 +98,6 @@ $head-foot-height: 50px;
 
 		&.is-minimized {
 			min-height: $head-foot-height;
-			top: unset;
-			bottom: 41px;
-			transform: unset !important; // revert dragging translation when minimized
-			.help-center__container-header {
-				cursor: default;
-			}
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

Addressing feedback from pdm0RZ-bG-p2#comment-362

The help center now:
- Is draggable even when minimized
- Do not defaults to the bottom right corner when minimized on desktop

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Pull branch
2. `cd apps/editing-toolkit && yarn dev --sync`
3. Test the changes