### PR TITLE
Goals Capture: Prioritize sell flow (experimental).

### DIFF
--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -15,6 +15,11 @@ export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
 		return SiteIntent.DIFM;
 	}
 
+	// Prioritize sell flow. As long as user picks sell, redirect to sell flow.
+	if ( goals.includes( SiteGoal.Sell ) ) {
+		return SiteIntent.Sell;
+	}
+
 	const intentDecidingGoal = ( goals as IntentDecidingGoal[] ).find( ( goal ) =>
 		INTENT_DECIDING_GOALS.includes( goal )
 	);


### PR DESCRIPTION
#### Proposed Changes

**DO NOT MERGE** This PR prioritizes sell flow in Goals Capture. As long as user picks Sell, redirect user to Sell flow.

This PR is just preparing in advance for a potential conversation about goalsToIntent tweaking.

#### Testing Instructions

* Pick any goal in any order as long as Sell is picked.
* After clicking Continue, user goes into Sell flow.
