### PR TITLE
Use new pre-cancellation form for domains

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.tsx
@@ -1,5 +1,7 @@
 import { JETPACK_PRODUCTS_LIST } from '@automattic/calypso-products';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
+import { TRANSFER_DOMAIN_REGISTRATION, UPDATE_NAMESERVERS } from 'calypso/lib/url/support';
 import { DOWNGRADEABLE_PLANS_FROM_PLAN } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
 import type { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
@@ -31,6 +33,11 @@ export interface CancellationReason extends CancellationReasonBase {
 	textPlaceholder?: TranslateReturnType;
 
 	/**
+	 * Whether the additional input is required.
+	 */
+	isTextRequired?: boolean;
+
+	/**
 	 * Default value for the sub category select
 	 */
 	selectInitialValue?: string;
@@ -44,6 +51,16 @@ export interface CancellationReason extends CancellationReasonBase {
 	 * Options for the sub category select
 	 */
 	selectOptions?: CancellationReasonBase[];
+
+	/**
+	 * Text to show after a reason has been selected to provide additional help
+	 */
+	helpMessage?: TranslateReturnType;
+
+	/**
+	 * Whether the reason blocks the next step (effectively blocking the cancellation).
+	 */
+	isNextStepBlocked?: boolean;
 }
 
 /**
@@ -68,6 +85,7 @@ export const LAST_REASON: CancellationReason = {
 	get textPlaceholder() {
 		return translate( 'Can you please specify?' );
 	},
+	isTextRequired: true,
 };
 
 export const CANCELLATION_REASONS: CancellationReason[] = [
@@ -283,6 +301,93 @@ export const DOMAIN_TRANSFER_CANCELLATION_REASONS: CancellationReason[] = [
 	},
 ];
 
+export const DOMAIN_REGISTRATION_CANCELLATION_REASONS: CancellationReason[] = [
+	{
+		value: 'misspelled',
+		get label() {
+			return translate( 'I misspelled the domain' );
+		},
+		get helpMessage() {
+			return translate(
+				'If you misspelled the domain name you were attempting to purchase, it’s likely that others will as well, ' +
+					'and you might want to consider keeping the misspelled domain.'
+			);
+		},
+	},
+	{
+		value: 'other_host',
+		get label() {
+			return translate( 'I want to use the domain with another service or host' );
+		},
+		get helpMessage() {
+			return translate(
+				'Canceling a domain name causes the domain to become unavailable for a brief period. ' +
+					'Afterward, anyone can repurchase. If you wish to use the domain with another service, ' +
+					'you’ll want to {{a}}update your name servers{{/a}} instead.',
+				{
+					components: {
+						a: (
+							<a
+								href={ localizeUrl( UPDATE_NAMESERVERS ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+				}
+			);
+		},
+		isNextStepBlocked: true,
+	},
+	{
+		value: 'transfer',
+		get label() {
+			return translate( 'I want to transfer my domain to another registrar' );
+		},
+		get helpMessage() {
+			return translate(
+				'Canceling a domain name may cause the domain to become unavailable for a long time before it ' +
+					'can be purchased again, and someone may purchase it before you get a chance. Instead, ' +
+					'please {{a}}use our transfer out feature{{/a}} if you want to use this domain again in the future.',
+				{
+					components: {
+						a: (
+							<a
+								href={ localizeUrl( TRANSFER_DOMAIN_REGISTRATION ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+				}
+			);
+		},
+		isNextStepBlocked: true,
+	},
+	{
+		value: 'expectations',
+		get label() {
+			return translate( 'The service isn’t what I expected' );
+		},
+		get helpMessage() {
+			return translate(
+				'If you misspelled the domain name you were attempting to purchase, it’s likely that others will as well, ' +
+					'and you might want to consider keeping the misspelled domain.'
+			);
+		},
+	},
+	{
+		value: 'wanted_free',
+		get label() {
+			return translate( 'I meant to get a free blog' );
+		},
+		get textPlaceholder() {
+			return translate( 'Please provide a brief description of your reasons for canceling.' );
+		},
+		isTextRequired: true,
+	},
+];
+
 interface CancellationReasonsOptions {
 	/**
 	 * The slug of the product being removed.
@@ -306,6 +411,7 @@ export function getCancellationReasons(
 		...CANCELLATION_REASONS,
 		...JETPACK_CANCELLATION_REASONS,
 		...DOMAIN_TRANSFER_CANCELLATION_REASONS,
+		...DOMAIN_REGISTRATION_CANCELLATION_REASONS,
 		...getExtraJetpackReasons( opts ),
 	];
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -45,7 +45,7 @@ import FormTextarea from 'calypso/components/forms/form-textarea';
 import HappychatButton from 'calypso/components/happychat/button';
 import InfoPopover from 'calypso/components/info-popover';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { getName as getDomainName, getName, isRefundable } from 'calypso/lib/purchases';
+import { getName, isRefundable } from 'calypso/lib/purchases';
 import { submitSurvey } from 'calypso/lib/purchases/actions';
 import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -371,7 +371,7 @@ class CancelPurchaseForm extends Component {
 				confirm: true,
 				product_id: purchase.productId,
 				blog_id: purchase.siteId,
-				domain: getDomainName( purchase ),
+				domain: getName( purchase ),
 			};
 
 			this.setState( { submitting: true } );
@@ -1234,7 +1234,7 @@ class CancelPurchaseForm extends Component {
 			return (
 				<>
 					{ isRemoveFlow ? translate( 'Remove domain' ) : translate( 'Cancel domain' ) }
-					<span className="cancel-purchase-form__site-slug">{ getDomainName( purchase ) }</span>
+					<span className="cancel-purchase-form__site-slug">{ getName( purchase ) }</span>
 				</>
 			);
 		}

--- a/client/components/marketing-survey/cancel-purchase-form/is-survey-filled-in.js
+++ b/client/components/marketing-survey/cancel-purchase-form/is-survey-filled-in.js
@@ -1,7 +1,21 @@
-export default function isSurveyFilledIn( survey, isImport = false ) {
-	const answeredBothQuestions = survey.questionOneRadio && survey.questionTwoRadio;
+import { isDomainRegistration } from '@automattic/calypso-products';
+import { getCancellationReasons } from 'calypso/components/marketing-survey/cancel-purchase-form/cancellation-reasons';
 
-	if ( survey.questionOneRadio === 'anotherReasonOne' && survey.questionOneText === '' ) {
+export default function isSurveyFilledIn( survey, isImport = false, purchase = {} ) {
+	const answeredBothQuestions = survey.questionOneRadio && survey.questionTwoRadio;
+	const { productSlug } = purchase;
+	const reasons = getCancellationReasons( survey.questionOneOrder, { productSlug } );
+	const questionOneReason = reasons.find( ( { value } ) => value === survey.questionOneRadio );
+
+	if ( questionOneReason?.isTextRequired && survey.questionOneText === '' ) {
+		return false;
+	}
+
+	if ( questionOneReason?.isNextStepBlocked ) {
+		return false;
+	}
+
+	if ( isDomainRegistration( purchase ) && ! survey.questionOneConfirmed ) {
 		return false;
 	}
 

--- a/client/components/marketing-survey/cancel-purchase-form/options-for-product.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/options-for-product.ts
@@ -1,13 +1,17 @@
-import { isDomainTransfer, isJetpackPlan } from '@automattic/calypso-products';
+import {
+	isDomainRegistration,
+	isDomainTransfer,
+	isJetpackPlan,
+} from '@automattic/calypso-products';
 import {
 	CANCELLATION_REASONS,
 	DOMAIN_TRANSFER_CANCELLATION_REASONS,
+	DOMAIN_REGISTRATION_CANCELLATION_REASONS,
 	JETPACK_CANCELLATION_REASONS,
 } from './cancellation-reasons';
+import type { Purchase } from '@automattic/calypso-products';
 
-type WithProductSlug = Parameters< typeof isJetpackPlan >[ 0 ];
-
-export const cancellationOptionsForPurchase = ( purchase: WithProductSlug ) => {
+export const cancellationOptionsForPurchase = ( purchase: Purchase ) => {
 	if ( isJetpackPlan( purchase ) ) {
 		return [
 			...JETPACK_CANCELLATION_REASONS.map( ( { value } ) => value ),
@@ -19,15 +23,23 @@ export const cancellationOptionsForPurchase = ( purchase: WithProductSlug ) => {
 		return DOMAIN_TRANSFER_CANCELLATION_REASONS.map( ( { value } ) => value );
 	}
 
+	if ( isDomainRegistration( purchase ) ) {
+		return DOMAIN_REGISTRATION_CANCELLATION_REASONS.map( ( { value } ) => value );
+	}
+
 	return CANCELLATION_REASONS.map( ( { value } ) => value );
 };
 
-export const nextAdventureOptionsForPurchase = ( purchase: WithProductSlug ) => {
+export const nextAdventureOptionsForPurchase = ( purchase: Purchase ) => {
 	if ( isJetpackPlan( purchase ) ) {
 		return [ 'stayingHere', 'otherPlugin', 'leavingWP', 'noNeed' ];
 	}
 
 	if ( isDomainTransfer( purchase ) ) {
+		return [];
+	}
+
+	if ( isDomainRegistration( purchase ) ) {
 		return [];
 	}
 

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -62,9 +62,9 @@ class CancelPurchaseButton extends Component {
 	};
 
 	handleCancelPurchaseClick = () => {
-		if ( isDomainRegistration( this.props.purchase ) ) {
+		/*if ( isDomainRegistration( this.props.purchase ) ) {
 			return this.goToCancelConfirmation();
-		}
+		}*/
 
 		this.setState( {
 			showDialog: true,

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -15,6 +15,7 @@ import { connect } from 'react-redux';
 import CancelJetpackForm from 'calypso/components/marketing-survey/cancel-jetpack-form';
 import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
 import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	getName,
 	getSubscriptionEndDate,
@@ -31,7 +32,10 @@ import { confirmCancelDomain, purchasesRoot } from 'calypso/me/purchases/paths';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import { getDowngradePlanFromPurchase } from 'calypso/state/purchases/selectors';
+import isDomainOnly from 'calypso/state/selectors/is-domain-only-site';
+import { receiveDeletedSite } from 'calypso/state/sites/actions';
 import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
+import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import { cancellationEffectDetail, cancellationEffectHeadline } from './cancellation-effect';
 
 class CancelPurchaseButton extends Component {
@@ -155,29 +159,41 @@ class CancelPurchaseButton extends Component {
 		page.redirect( this.props.purchaseListUrl );
 	};
 
-	cancelAndRefund = () => {
-		const { purchase, cancelBundledDomain } = this.props;
+	cancelAndRefund = ( data ) => {
+		const { isDomainOnlySite, purchase, cancelBundledDomain } = this.props;
 
 		this.setDisabled( true );
 
-		cancelAndRefundPurchase(
-			purchase.id,
-			{ product_id: purchase.productId, cancel_bundled_domain: cancelBundledDomain ? 1 : 0 },
-			( error, response ) => {
-				this.setDisabled( false );
+		if ( ! data ) {
+			data = { product_id: purchase.productId, cancel_bundled_domain: cancelBundledDomain ? 1 : 0 };
+		}
 
-				if ( error ) {
-					this.props.errorNotice( error.message );
-					this.cancellationFailed();
-					return;
-				}
+		cancelAndRefundPurchase( purchase.id, data, ( error, response ) => {
+			this.setDisabled( false );
 
-				this.props.refreshSitePlans( purchase.siteId );
-				this.props.clearPurchases();
-				this.props.successNotice( response.message, { displayOnNextPage: true } );
-				page.redirect( this.props.purchaseListUrl );
+			if ( isDomainOnlySite ) {
+				this.props.receiveDeletedSite( purchase.siteId );
+				this.props.setAllSitesSelected();
 			}
-		);
+
+			if ( error ) {
+				this.props.errorNotice( error.message );
+				this.cancellationFailed();
+				return;
+			}
+
+			this.props.refreshSitePlans( purchase.siteId );
+			this.props.clearPurchases();
+
+			if ( isDomainRegistration( purchase ) ) {
+				recordTracksEvent( 'calypso_domain_cancel_form_submit', {
+					product_slug: purchase.productSlug,
+				} );
+			}
+
+			this.props.successNotice( response.message, { displayOnNextPage: true } );
+			page.redirect( this.props.purchaseListUrl );
+		} );
 	};
 
 	downgradeClick = ( upsell ) => {
@@ -234,11 +250,11 @@ class CancelPurchaseButton extends Component {
 		}
 	};
 
-	submitCancelAndRefundPurchase = () => {
+	submitCancelAndRefundPurchase = ( data ) => {
 		const refundable = hasAmountAvailableToRefund( this.props.purchase );
 
 		if ( refundable ) {
-			this.cancelAndRefund();
+			this.cancelAndRefund( data );
 		} else {
 			this.cancelPurchase();
 		}
@@ -347,11 +363,14 @@ class CancelPurchaseButton extends Component {
 export default connect(
 	( state, { purchase } ) => ( {
 		isJetpack: purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) ),
+		isDomainOnlySite: isDomainOnly( state, purchase.siteId ),
 	} ),
 	{
 		clearPurchases,
 		errorNotice,
 		successNotice,
 		refreshSitePlans,
+		receiveDeletedSite,
+		setAllSitesSelected,
 	}
 )( localize( CancelPurchaseButton ) );

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -28,7 +28,7 @@ import {
 	cancelPurchase,
 	extendPurchaseWithFreeMonth,
 } from 'calypso/lib/purchases/actions';
-import { confirmCancelDomain, purchasesRoot } from 'calypso/me/purchases/paths';
+import { purchasesRoot } from 'calypso/me/purchases/paths';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import { getDowngradePlanFromPurchase } from 'calypso/state/purchases/selectors';
@@ -42,7 +42,6 @@ class CancelPurchaseButton extends Component {
 	static propTypes = {
 		purchase: PropTypes.object.isRequired,
 		purchaseListUrl: PropTypes.string,
-		getConfirmCancelDomainUrlFor: PropTypes.func,
 		siteSlug: PropTypes.string.isRequired,
 		cancelBundledDomain: PropTypes.bool.isRequired,
 		includedDomainPurchase: PropTypes.object,
@@ -51,7 +50,6 @@ class CancelPurchaseButton extends Component {
 
 	static defaultProps = {
 		purchaseListUrl: purchasesRoot,
-		getConfirmCancelDomainUrlFor: confirmCancelDomain,
 	};
 
 	state = {
@@ -66,10 +64,6 @@ class CancelPurchaseButton extends Component {
 	};
 
 	handleCancelPurchaseClick = () => {
-		/*if ( isDomainRegistration( this.props.purchase ) ) {
-			return this.goToCancelConfirmation();
-		}*/
-
 		this.setState( {
 			showDialog: true,
 		} );
@@ -79,13 +73,6 @@ class CancelPurchaseButton extends Component {
 		this.setState( {
 			showDialog: false,
 		} );
-	};
-
-	goToCancelConfirmation = () => {
-		const { id } = this.props.purchase;
-		const slug = this.props.siteSlug;
-
-		page( this.props.getConfirmCancelDomainUrlFor( slug, id ) );
 	};
 
 	cancelPurchase = () => {

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -120,6 +120,11 @@ export type Plan = BillingTerm & {
 
 export type WithSnakeCaseSlug = { product_slug: string };
 export type WithCamelCaseSlug = { productSlug: string };
+export type WithSnakeCaseIsDomain = { is_domain_registration: boolean };
+export type WithCamelCaseIsDomain = { isDomainRegistration: boolean };
+
+export type Purchase = ( WithSnakeCaseSlug | WithCamelCaseSlug ) &
+	( WithSnakeCaseIsDomain | WithCamelCaseIsDomain );
 
 export interface PlanMatchesQuery {
 	term?: string;


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/56393

#### Proposed Changes

Changes the pre-cancellation form used for domains to the new one we introduced for plans in https://github.com/Automattic/wp-calypso/pull/56206, so the cancellation flow is consistent with across domains and plans.

Before | After
--- | ---
<img width="968" alt="Screen Shot 2022-06-20 at 16 17 09" src="https://user-images.githubusercontent.com/1233880/174621880-4328654b-746a-420f-b626-4e852196cb9b.png"> | <img width="1253" alt="Screen Shot 2022-06-20 at 16 17 20" src="https://user-images.githubusercontent.com/1233880/174621897-14a5420d-acd5-4e95-92e3-28419e667735.png">


#### Testing Instructions

TBD
