### PR TITLE
Backup placeholders: correct width and progress bar re-render

### DIFF
--- a/client/components/backup-storage-space/index.tsx
+++ b/client/components/backup-storage-space/index.tsx
@@ -4,11 +4,9 @@ import { useSelector } from 'react-redux';
 import { useQueryRewindPolicies } from 'calypso/components/data/query-rewind-policies';
 import { useQueryRewindSize } from 'calypso/components/data/query-rewind-size';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
-import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import {
 	getRewindBytesAvailable,
 	getRewindBytesUsed,
-	isRequestingRewindPolicies,
 	isRequestingRewindSize,
 } from 'calypso/state/rewind/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
@@ -29,16 +27,7 @@ const BackupStorageSpace: React.FC = () => {
 	const usageLevel = getUsageLevel( bytesUsed, bytesAvailable ) ?? StorageUsageLevels.Normal;
 
 	const showWarning = usageLevel !== StorageUsageLevels.Normal;
-
-	const requestingPurchases = useSelector( isFetchingSitePurchases );
-	const requestingPolicies = useSelector( ( state ) =>
-		isRequestingRewindPolicies( state, siteId )
-	);
 	const requestingSize = useSelector( ( state ) => isRequestingRewindSize( state, siteId ) );
-
-	if ( requestingPolicies || requestingPurchases ) {
-		return <Card className="backup-storage-space__loading" />;
-	}
 
 	// Sites without a storage policy don't have a notion of "bytes available,"
 	// so this value will be undefined; if so, don't render

--- a/client/components/jetpack/backup-placeholder/style.scss
+++ b/client/components/jetpack/backup-placeholder/style.scss
@@ -22,8 +22,6 @@
 
 /* Jetpack.com-only changes */
 .is_jetpackcom .backup-placeholder {
-	margin-left: -16px;
-	margin-right: -16px;
 
 	@include breakpoint-deprecated( '<660px' ) {
 		background: var( --studio-white );


### PR DESCRIPTION
#### Proposed Changes

* Correct the width of the placeholder shown for the card with the backup details. 
* Correct double rendering of the Storage space. Since the UsageDisplay component has a `loading ` option, we can use this one instead of the empty placeholder. 

#### Testing Instructions

1- Open a site with backups on WordPress.com and Jetpack Cloud.
2- Visit the backups page. 
3- When the page is loading, confirm that the placeholders have the same size.
4- Confirm that the used space section does not load twice.

Before changes:
After the `Latest backup` component loads, `Storage space` is rendered again. 
![Screen Shot 2022-06-20 at 18 46 15](https://user-images.githubusercontent.com/16329583/174648933-742db750-6261-4612-a344-12d794df2485.png)



After changes:
<img width="846" alt="Screen Shot 2022-06-20 at 18 50 19" src="https://user-images.githubusercontent.com/16329583/174648635-46159ae9-f746-47ba-abec-02ea93540488.png">
<img width="1000" alt="Screen Shot 2022-06-20 at 18 50 02" src="https://user-images.githubusercontent.com/16329583/174648668-8f05a514-5aef-49a8-b388-4924a6292171.png">



The original report is here: https://wp.me/pbuNQi-2Tc