### PR TITLE
Themes: Allow WoA sites to purchase premium themes

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -107,7 +107,6 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 							trackScrollPage={ props.trackScrollPage }
 							source="wpcom"
 							emptyContent={ emptyContent }
-							upsellUrl={ upsellUrl }
 						/>
 					</div>
 				) }

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -107,6 +107,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 							trackScrollPage={ props.trackScrollPage }
 							source="wpcom"
 							emptyContent={ emptyContent }
+							upsellUrl={ upsellUrl }
 						/>
 					</div>
 				) }

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -1,6 +1,7 @@
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getActiveTheme } from 'calypso/state/themes/selectors/get-active-theme';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -8,7 +9,7 @@ import SingleSiteThemeShowcaseJetpack from './single-site-jetpack';
 import SingleSiteThemeShowcaseWpcom from './single-site-wpcom';
 
 const SingleSiteThemeShowcaseWithOptions = ( props ) => {
-	const { activeTheme, isJetpack, siteId, translate } = props;
+	const { activeTheme, isAtomic, isJetpack, siteId, translate } = props;
 
 	const getScreenshotOption = ( themeId ) => {
 		return activeTheme === themeId ? 'customize' : 'info';
@@ -21,7 +22,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 		return <Main fullWidthLayout className="themes" />;
 	}
 
-	if ( isJetpack ) {
+	if ( isJetpack && ! isAtomic ) {
 		return (
 			<SingleSiteThemeShowcaseJetpack
 				{ ...props }
@@ -53,6 +54,7 @@ export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
 		siteId: selectedSiteId,
+		isAtomic: isSiteWpcomAtomic( state, selectedSiteId ),
 		isJetpack: isJetpackSite( state, selectedSiteId ),
 		activeTheme: getActiveTheme( state, selectedSiteId ),
 	};

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -7,6 +7,7 @@ import { localizeThemesPath } from 'calypso/my-sites/themes/helpers';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import {
 	activate as activateAction,
@@ -43,7 +44,7 @@ function getAllThemeOptions( { translate, blockEditorSettings } ) {
 		} ),
 		getUrl: getThemePurchaseUrl,
 		hideForTheme: ( state, themeId, siteId ) =>
-			isJetpackSite( state, siteId ) || // No individual theme purchase on a JP site
+			( isJetpackSite( state, siteId ) && ! isSiteWpcomAtomic( state, siteId ) ) || // No individual theme purchase on a JP site
 			! isUserLoggedIn( state ) || // Not logged in
 			! isThemePremium( state, themeId ) || // Not a premium theme
 			isPremiumThemeAvailable( state, themeId, siteId ) || // Already purchased individually, or thru a plan
@@ -65,6 +66,7 @@ function getAllThemeOptions( { translate, blockEditorSettings } ) {
 			getJetpackUpgradeUrlIfPremiumTheme( state, themeId, siteId ),
 		hideForTheme: ( state, themeId, siteId ) =>
 			! isJetpackSite( state, siteId ) ||
+			isSiteWpcomAtomic( state, siteId ) ||
 			! isUserLoggedIn( state ) ||
 			! isThemePremium( state, themeId ) ||
 			isThemeActive( state, themeId, siteId ) ||

--- a/client/state/themes/selectors/get-theme-purchase-url.js
+++ b/client/state/themes/selectors/get-theme-purchase-url.js
@@ -1,3 +1,4 @@
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 
@@ -12,7 +13,10 @@ import 'calypso/state/themes/init';
  * @returns {?string}         Theme purchase URL
  */
 export function getThemePurchaseUrl( state, themeId, siteId ) {
-	if ( isJetpackSite( state, siteId ) || ! isThemePremium( state, themeId ) ) {
+	if (
+		( isJetpackSite( state, siteId ) && ! isSiteWpcomAtomic( state, siteId ) ) ||
+		! isThemePremium( state, themeId )
+	) {
 		return null;
 	}
 	return `/checkout/${ getSiteSlug( state, siteId ) }/theme:${ themeId }`;


### PR DESCRIPTION
The theme showcase for Jetpack sites now also accounts for Atomic sites.

#### Proposed Changes

* Accounts for the subsection of Atomic sites when checking for Jetpack.
* Shows the wpcom theme showcase for Atomic sites.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [wordpress.com/themes/premium/](https://container-great-nightingale.calypso.live/themes/premium/) and select an Atomic site on a Personal or Free plan.
* Check that it shows the star icon upgrade banner between the price of the theme and the ellipsis menu:   <img width="266" alt="image" src="https://user-images.githubusercontent.com/1398304/174679482-1f40cc5c-54aa-4dc1-9074-b72231242a4d.png">
* Click on the ellipsis menu and check that it now has a "Purchase" option (previously "Upgrade to Activate") <img width="261" alt="image" src="https://user-images.githubusercontent.com/1398304/174679577-19338295-7d2c-4ccc-96b2-92ab9a313d6b.png">
* Click "Purchase" and verify that you can buy that theme.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #64119.
