### PR TITLE
Add querystring to login redirect when en locale for Partner Signup

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import page from 'page';
 import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { isPartnerSignupQuery } from 'calypso/state/login/utils';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
@@ -156,10 +157,14 @@ export function redirectDefaultLocale( context, next ) {
 		return next();
 	}
 
+	// Add querystring to redirect only comming from Partner Signup
+	const redirectQueryString = isPartnerSignupQuery( context.query )
+		? '?' + context.querystring
+		: '';
 	if ( context.params.isJetpack === 'jetpack' ) {
 		page.redirect( '/log-in/jetpack' );
 	} else {
-		page.redirect( '/log-in' );
+		page.redirect( '/log-in' + redirectQueryString );
 	}
 }
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -1,8 +1,8 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
+import { removeLocaleFromPath } from '@automattic/i18n-utils';
 import page from 'page';
 import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import { isPartnerSignupQuery } from 'calypso/state/login/utils';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
@@ -150,22 +150,14 @@ export function redirectDefaultLocale( context, next ) {
 		return next();
 	}
 
-	// Do not redirect if user is logged in and the locale is different than english
-	// so we force the page to display in english
+	// Allow logged in non-en user locales to load /log-in/en in english
+	// because /log-in won't render in english for these users.
 	const currentUserLocale = getCurrentUserLocale( context.store.getState() );
 	if ( currentUserLocale && currentUserLocale !== 'en' ) {
 		return next();
 	}
 
-	// Add querystring to redirect only comming from Partner Signup
-	const redirectQueryString = isPartnerSignupQuery( context.query )
-		? '?' + context.querystring
-		: '';
-	if ( context.params.isJetpack === 'jetpack' ) {
-		page.redirect( '/log-in/jetpack' );
-	} else {
-		page.redirect( '/log-in' + redirectQueryString );
-	}
+	page.redirect( removeLocaleFromPath( context.canonicalPath ) );
 }
 
 export function redirectJetpack( context, next ) {


### PR DESCRIPTION
@lupus2k - I was reopening https://github.com/Automattic/wp-calypso/pull/64680 but force pushed a rebase before doing so. Github forces me to create a new PR, so I've copied over the description.

----

When a user who is not logged in goes to https://woocommerce.com/partner-signup/, they are redirected to a `/log-in` page WordPress's styled and if this page suggests that there is an English version of this page when you click on it, the redirect loses all the WordPress style.

In other words, when navigating to `/log-in/en` and your browser has `en` as the default locale, it redirects you to `/log-in` but forget about all the query strings. Because of that, we need to keep the query strings but we only keep them if we came from Partner Signup.

#### Changes proposed
- Detect if the `redirect_to` query string is from Partner Signup and add all the query strings to the redirector.

#### Testing Instructions
- In development environments, the user bootstrapping is disabled so you need to comment from line 146 to line 151 from `client/login/controller.js`
- With a browser with english as default locale 
- Go to http://calypso.localhost:3000/log-in/en?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D0c93c6a2813d57a3173e48bbc7b7947cd2c189105501056f437d6b5406098384%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dpartner-signup%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26redirect_to%3Dhttps%3A%2F%2Fwoocommerce.com%2Fpartner-signup%2F
- You should be redirected to `/log-in` without `en` but keeping the WordPress style on the Login Form.

#### Screenshot
<img width="283" alt="image" src="https://user-images.githubusercontent.com/402286/173920740-1add6bf8-cfb5-4f40-88b4-dace1d457550.png">

Fixes #64598 
