### PR TITLE
Goals Capture: Add DIFM Link.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/difm-link.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/difm-link.scss
@@ -1,0 +1,64 @@
+@import '@wordpress/base-styles/_breakpoints.scss';
+@import '@wordpress/base-styles/_mixins.scss';
+@import '@automattic/typography/styles/fonts';
+
+.difm-link {
+	&__container {
+		display: flex;
+		align-items: flex-start;
+		position: relative;
+		padding: 8px 0;
+	}
+
+	@include break-small {
+		width: 342px;
+	}
+
+	@include break-medium {
+		width: 456px;
+	}
+
+	&__info-wrapper {
+		@include break-mobile {
+			display: flex;
+			align-items: flex-start;
+			width: 100%;
+		}
+	}
+
+	&__info {
+		flex: 1;
+		padding-right: 6px;
+	}
+
+	&__description {
+		font-size: $font-body-small;
+		color: #646970;
+		margin-bottom: 0;
+		margin-right: 0.2rem;
+	}
+
+	&__button {
+		margin-top: 8px;
+		padding: 0;
+		min-width: 130px;
+		border: none;
+		background: none;
+		color: #101517;
+		text-decoration: underline;
+		font-weight: 500; /* stylelint-disable-line scales/font-weights */
+		text-align: end;
+
+		@include break-mobile {
+			margin-top: 0;
+		}
+
+		&:not( [disabled] ):hover {
+			color: var( --color-neutral-70 );
+		}
+	}
+
+	&__disabled-info svg {
+		fill: var( --color-neutral-20 );
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/difm-link.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/difm-link.tsx
@@ -1,0 +1,24 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import './difm-link.scss';
+
+type DIFMLinkProps = {
+	onClick: () => void;
+};
+
+export const DIFMLink = ( { onClick }: DIFMLinkProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="difm-link__container">
+			<p className="difm-link__description">
+				{ translate( 'Hire our experts to create your dream site' ) }
+			</p>
+			<Button className="difm-link__button" onClick={ onClick }>
+				{ translate( 'Get Started' ) }
+			</Button>
+		</div>
+	);
+};
+
+export default DIFMLink;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -32,5 +32,7 @@ export const useGoals = (): Goal[] => {
 			key: SiteGoal.Other,
 			title: translate( 'Other' ),
 		},
-	].filter( ( { key } ) => key !== Onboard.SiteGoal.Import );
+	]
+		.filter( ( { key } ) => key !== Onboard.SiteGoal.Import )
+		.filter( ( { key } ) => key !== Onboard.SiteGoal.DIFM );
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -5,7 +5,7 @@ import type { Goal } from './types';
 const SiteGoal = Onboard.SiteGoal;
 const HIDE_GOALS = [ SiteGoal.DIFM, SiteGoal.Import ];
 
-const shouldHideGoal = ( { key }: Goal ) => HIDE_GOALS.includes( key );
+const shouldDisplayGoal = ( { key }: Goal ) => ! HIDE_GOALS.includes( key );
 
 export const useGoals = (): Goal[] => {
 	const translate = useTranslate();
@@ -35,5 +35,5 @@ export const useGoals = (): Goal[] => {
 			key: SiteGoal.Other,
 			title: translate( 'Other' ),
 		},
-	].filter( shouldHideGoal );
+	].filter( shouldDisplayGoal );
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -3,6 +3,9 @@ import { useTranslate } from 'i18n-calypso';
 import type { Goal } from './types';
 
 const SiteGoal = Onboard.SiteGoal;
+const HIDE_GOALS = [ SiteGoal.DIFM, SiteGoal.Import ];
+
+const shouldHideGoal = ( { key }: Goal ) => HIDE_GOALS.includes( key );
 
 export const useGoals = (): Goal[] => {
 	const translate = useTranslate();
@@ -32,7 +35,5 @@ export const useGoals = (): Goal[] => {
 			key: SiteGoal.Other,
 			title: translate( 'Other' ),
 		},
-	]
-		.filter( ( { key } ) => key !== Onboard.SiteGoal.Import )
-		.filter( ( { key } ) => key !== Onboard.SiteGoal.DIFM );
+	].filter( shouldHideGoal );
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -36,12 +36,16 @@ const GoalsStep: Step = ( { navigation } ) => {
 	const subHeaderText = translate( 'Tell us what would you like to accomplish with your website.' );
 
 	const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
-	const { setGoals, setIntent, clearImportGoal } = useDispatch( ONBOARD_STORE );
+	const { setGoals, setIntent, clearImportGoal, clearDIFMGoal } = useDispatch( ONBOARD_STORE );
 	const refParameter = getQueryArgs()?.ref;
 
 	useEffect( () => {
 		clearImportGoal();
 	}, [ clearImportGoal ] );
+
+	useEffect( () => {
+		clearDIFMGoal();
+	}, [ clearDIFMGoal ] );
 
 	const handleChange = ( goals: Onboard.SiteGoal[] ) => {
 		const intent = goalsToIntent( goals );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-card.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-card.tsx
@@ -31,7 +31,7 @@ const SelectCard = < T, >( {
 			onClickCapture={ handleClick }
 			role="presentation"
 		>
-			<CheckboxControl checked={ selected } id={ id } onChange={ () => undefined } />
+			<CheckboxControl aria-busy checked={ selected } id={ id } onChange={ () => undefined } />
 			<label className="select-card__label" htmlFor={ id }>
 				{ children }
 			</label>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-card.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-card.tsx
@@ -31,7 +31,7 @@ const SelectCard = < T, >( {
 			onClickCapture={ handleClick }
 			role="presentation"
 		>
-			<CheckboxControl aria-busy checked={ selected } id={ id } onChange={ () => undefined } />
+			<CheckboxControl checked={ selected } id={ id } onChange={ () => undefined } />
 			<label className="select-card__label" htmlFor={ id }>
 				{ children }
 			</label>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@automattic/components';
 import { Onboard } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import { useGoals } from './goals';
 import ImportLink from './import-link';
 import SelectCard from './select-card';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { Onboard } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
+import DIFMLink from './difm-link';
 import { useGoals } from './goals';
 import ImportLink from './import-link';
 import SelectCard from './select-card';
@@ -42,6 +43,11 @@ export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsP
 		const selectedGoalsWithImport = addGoal( SiteGoal.Import );
 		onSubmit( selectedGoalsWithImport );
 
+	const handleDIFMLinkClick = () => {
+		const selectedGoalsWithDIFM = addGoal( SiteGoal.DIFM );
+		onSubmit( selectedGoalsWithDIFM );
+	};
+
 	return (
 		<>
 			<div className="select-goals__cards-container">
@@ -62,6 +68,7 @@ export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsP
 
 			<div className="select-goals__actions-container">
 				<ImportLink onClick={ handleImportLinkClick } />
+				<DIFMLink onClick={ handleDIFMLinkClick } />
 				<Button primary onClick={ handleContinueButtonClick }>
 					{ translate( 'Continue' ) }
 				</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { Onboard } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import { useGoals } from './goals';
 import ImportLink from './import-link';
 import SelectCard from './select-card';
@@ -13,7 +14,6 @@ type SelectGoalsProps = {
 
 const SiteGoal = Onboard.SiteGoal;
 
-<<<<<<< HEAD
 export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsProps ) => {
 	const translate = useTranslate();
 	const goalOptions = useGoals();
@@ -42,30 +42,6 @@ export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsP
 	const handleImportLinkClick = () => {
 		const selectedGoalsWithImport = addGoal( SiteGoal.Import );
 		onSubmit( selectedGoalsWithImport );
-=======
-export const SelectGoals: React.FC< SelectGoalsProps > = ( {
-	onChange,
-	onSubmit,
-	selectedGoals,
-} ) => {
-	const translate = useTranslate();
-	const goalOptions = useGoals();
-
-	const handleChange = ( selected: boolean, goal: Onboard.SiteGoal ) => {
-		// Always remove potential duplicates
-		const newSelectedGoals = [ ...selectedGoals ];
-
-		// Add newly selected goal to the array
-		if ( selected ) {
-			newSelectedGoals.push( goal );
-		} else {
-			const goalIndex = newSelectedGoals.indexOf( goal );
-			newSelectedGoals.splice( goalIndex, 1 );
-		}
-
-		onChange( newSelectedGoals );
->>>>>>> 69596a337f (Refactor the PR and fix handling async store updates)
-	};
 
 	return (
 		<>
@@ -86,13 +62,8 @@ export const SelectGoals: React.FC< SelectGoalsProps > = ( {
 			</div>
 
 			<div className="select-goals__actions-container">
-<<<<<<< HEAD
 				<ImportLink onClick={ handleImportLinkClick } />
 				<Button primary onClick={ handleContinueButtonClick }>
-=======
-				<ImportLink onClick={ () => onSubmit( [ ...selectedGoals, SiteGoal.Import ] ) } />
-				<Button primary onClick={ () => onSubmit( [ ...selectedGoals ] ) }>
->>>>>>> 69596a337f (Refactor the PR and fix handling async store updates)
 					{ translate( 'Continue' ) }
 				</Button>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -46,19 +46,21 @@ export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsP
 	return (
 		<>
 			<div className="select-goals__cards-container">
-				{ goalOptions.map( ( { key, title, isPremium } ) => (
-					<SelectCard
-						key={ key }
-						onChange={ handleChange }
-						selected={ selectedGoals.includes( key ) }
-						value={ key }
-					>
-						<span className="select-goals__goal-title">{ title }</span>
-						{ isPremium && (
-							<span className="select-goals__premium-badge">{ translate( 'Premium' ) }</span>
-						) }
-					</SelectCard>
-				) ) }
+				{ goalOptions
+					.filter( ( { key } ) => key !== Onboard.SiteGoal.Import )
+					.map( ( { key, title, isPremium } ) => (
+						<SelectCard
+							key={ key }
+							onChange={ handleChange }
+							selected={ selectedGoals.includes( key ) }
+							value={ key }
+						>
+							<span className="select-goals__goal-title">{ title }</span>
+							{ isPremium && (
+								<span className="select-goals__premium-badge">{ translate( 'Premium' ) }</span>
+							) }
+						</SelectCard>
+					) ) }
 			</div>
 
 			<div className="select-goals__actions-container">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -42,6 +42,7 @@ export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsP
 	const handleImportLinkClick = () => {
 		const selectedGoalsWithImport = addGoal( SiteGoal.Import );
 		onSubmit( selectedGoalsWithImport );
+	};
 
 	const handleDIFMLinkClick = () => {
 		const selectedGoalsWithDIFM = addGoal( SiteGoal.DIFM );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -13,6 +13,7 @@ type SelectGoalsProps = {
 
 const SiteGoal = Onboard.SiteGoal;
 
+<<<<<<< HEAD
 export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsProps ) => {
 	const translate = useTranslate();
 	const goalOptions = useGoals();
@@ -41,31 +42,57 @@ export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsP
 	const handleImportLinkClick = () => {
 		const selectedGoalsWithImport = addGoal( SiteGoal.Import );
 		onSubmit( selectedGoalsWithImport );
+=======
+export const SelectGoals: React.FC< SelectGoalsProps > = ( {
+	onChange,
+	onSubmit,
+	selectedGoals,
+} ) => {
+	const translate = useTranslate();
+	const goalOptions = useGoals();
+
+	const handleChange = ( selected: boolean, goal: Onboard.SiteGoal ) => {
+		// Always remove potential duplicates
+		const newSelectedGoals = [ ...selectedGoals ];
+
+		// Add newly selected goal to the array
+		if ( selected ) {
+			newSelectedGoals.push( goal );
+		} else {
+			const goalIndex = newSelectedGoals.indexOf( goal );
+			newSelectedGoals.splice( goalIndex, 1 );
+		}
+
+		onChange( newSelectedGoals );
+>>>>>>> 69596a337f (Refactor the PR and fix handling async store updates)
 	};
 
 	return (
 		<>
 			<div className="select-goals__cards-container">
-				{ goalOptions
-					.filter( ( { key } ) => key !== Onboard.SiteGoal.Import )
-					.map( ( { key, title, isPremium } ) => (
-						<SelectCard
-							key={ key }
-							onChange={ handleChange }
-							selected={ selectedGoals.includes( key ) }
-							value={ key }
-						>
-							<span className="select-goals__goal-title">{ title }</span>
-							{ isPremium && (
-								<span className="select-goals__premium-badge">{ translate( 'Premium' ) }</span>
-							) }
-						</SelectCard>
-					) ) }
+				{ goalOptions.map( ( { key, title, isPremium } ) => (
+					<SelectCard
+						key={ key }
+						onChange={ handleChange }
+						selected={ selectedGoals.includes( key ) }
+						value={ key }
+					>
+						<span className="select-goals__goal-title">{ title }</span>
+						{ isPremium && (
+							<span className="select-goals__premium-badge">{ translate( 'Premium' ) }</span>
+						) }
+					</SelectCard>
+				) ) }
 			</div>
 
 			<div className="select-goals__actions-container">
+<<<<<<< HEAD
 				<ImportLink onClick={ handleImportLinkClick } />
 				<Button primary onClick={ handleContinueButtonClick }>
+=======
+				<ImportLink onClick={ () => onSubmit( [ ...selectedGoals, SiteGoal.Import ] ) } />
+				<Button primary onClick={ () => onSubmit( [ ...selectedGoals ] ) }>
+>>>>>>> 69596a337f (Refactor the PR and fix handling async store updates)
 					{ translate( 'Continue' ) }
 				</Button>
 			</div>

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -261,6 +261,10 @@ export const clearImportGoal = () => ( {
 	type: 'CLEAR_IMPORT_GOAL' as const,
 } );
 
+export const clearDIFMGoal = () => ( {
+	type: 'CLEAR_DIFM_GOAL' as const,
+} );
+
 export const setEditEmail = ( email: string ) => ( {
 	type: 'SET_EDIT_EMAIL' as const,
 	email,
@@ -299,5 +303,6 @@ export type OnboardAction = ReturnType<
 	| typeof setStepProgress
 	| typeof setGoals
 	| typeof clearImportGoal
+	| typeof clearDIFMGoal
 	| typeof setEditEmail
 >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -302,6 +302,9 @@ const goals: Reducer< SiteGoal[], OnboardAction > = ( state = [], action ) => {
 	if ( action.type === 'CLEAR_IMPORT_GOAL' ) {
 		return state.filter( ( goal ) => goal !== SiteGoal.Import );
 	}
+	if ( action.type === 'CLEAR_DIFM_GOAL' ) {
+		return state.filter( ( goal ) => goal !== SiteGoal.DIFM );
+	}
 	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return [];
 	}


### PR DESCRIPTION
**Important:** This is currently branched out from parent branch https://github.com/Automattic/wp-calypso/pull/64771.

#### Proposed Changes

* Adds the DIFM link to footer.
* Removes DIFM link from goals selection.

**Technical notes:**
- This PR is written with the "as long as it works" mindset hence:
   - DIFM & Import are decoupled 
   - CSS layout weirdness is ignored.

Further refactoring / fixes can be done in another PR.

#### Testing Instructions

* Set `signup/goals-step` to `true` in `config/development.json.
   * This is because when you enter DIFM page, the config flag is lost. Hitting back will go back to non goals flow.

##### Check Goals <> DIFM Flow
* Go to site setup flow `calypso.localhost:3000/setup/goals?siteSlug=yoursite.wordpress.com&flags=signup/goals-step`.
* Click on DIFM "Get Started" link.
  * It should go to DIFM page.
* Click on back button.
  * It should go to Goals page.

##### Check intent & goals selections
* Turn on localStorage.setItem( 'debug', 'calypso:analytics*' );
   * Use the analytics logging in Console to check:
      * if the right goals are selected
      * if the right intents are selected.
     
<img width="1343" alt="2022-06-21_07-43-07" src="https://user-images.githubusercontent.com/1287077/174725860-b542e5c9-d36f-4dd5-9470-0bdc528dc0c4.png">
<img width="1343" alt="2022-06-21_07-43-32" src="https://user-images.githubusercontent.com/1287077/174725870-ca428972-3729-4ee3-983c-c38676db248a.png">

