### PR TITLE
Help Center: Defer opening socket to happychat

### DIFF
--- a/packages/happychat-connection/src/types.ts
+++ b/packages/happychat-connection/src/types.ts
@@ -41,6 +41,11 @@ export interface ConnectionProps {
 	requestTranscript?: () => void;
 }
 
+export interface AvailabilityConnectionProps {
+	receiveAccept?: ( accept: boolean ) => void;
+	receiveUnauthorized?: ( message: string ) => void;
+}
+
 export interface HappychatAuth {
 	url: string | Socket;
 	user: {

--- a/packages/happychat-connection/src/use-happychat-available.ts
+++ b/packages/happychat-connection/src/use-happychat-available.ts
@@ -1,25 +1,19 @@
 import { useEffect, useState } from 'react';
-import buildConnection from './connection';
+import { buildConnectionForCheckingAvailability } from './connection';
 import useHappychatAuth from './use-happychat-auth';
 
-let cachedAvailableValue: boolean | undefined = undefined;
-
 export function useHappychatAvailable() {
-	const [ available, setIsAvailable ] = useState< boolean | undefined >( cachedAvailableValue );
+	const [ available, setIsAvailable ] = useState< boolean | undefined >( undefined );
 	const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );
-	const { data: dataAuth, isLoading: isLoadingAuth } = useHappychatAuth(
-		cachedAvailableValue === undefined
-	);
+	const { data: dataAuth, isLoading: isLoadingAuth } = useHappychatAuth();
 
 	useEffect( () => {
-		if ( isSimpleSite && ! isLoadingAuth && dataAuth && cachedAvailableValue === undefined ) {
-			const connection = buildConnection( {
+		if ( isSimpleSite && ! isLoadingAuth && dataAuth ) {
+			const connection = buildConnectionForCheckingAvailability( {
 				receiveAccept: ( receivedAvailability ) => {
-					cachedAvailableValue = receivedAvailability;
 					setIsAvailable( receivedAvailability );
 				},
 				receiveUnauthorized: () => {
-					cachedAvailableValue = false;
 					setIsAvailable( false );
 				},
 			} );

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Spinner } from '@automattic/components';
 import { Icon, comment } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -23,6 +24,14 @@ export const HelpCenterContactPage: React.FC = () => {
 
 	const renderEmail = useShouldRenderEmailOption();
 	const renderChat = useShouldRenderChatOption();
+
+	if ( renderChat.isLoading ) {
+		return (
+			<div className="help-center-contact-page__loading">
+				<Spinner baseClassName="" />
+			</div>
+		);
+	}
 
 	return (
 		<div className="help-center-contact-page">

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -3,7 +3,6 @@
  * External Dependencies
  */
 import { useSupportAvailability } from '@automattic/data-stores';
-import { useHappychatAvailable } from '@automattic/happychat-connection';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createPortal, useEffect, useRef } from '@wordpress/element';
 import { useSelector } from 'react-redux';
@@ -31,7 +30,6 @@ const HelpCenter: React.FC< Container > = ( { handleClose } ) => {
 	const user = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const { setDirectlyData } = useDispatch( HELP_CENTER_STORE );
 	const { isLoading: isLoadingChat } = useSupportAvailability( 'CHAT' );
-	const { isLoading: isLoadingChatAvailable } = useHappychatAvailable();
 	const { data: supportData, isLoading: isSupportDataLoading } = useSupportAvailability( 'OTHER' );
 	useStillNeedHelpURL();
 
@@ -47,9 +45,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose } ) => {
 	}, [ supportData, setDirectlyData ] );
 
 	const isLoading = isSimpleSite
-		? [ ! site, ! user, isSupportDataLoading, isLoadingChat, isLoadingChatAvailable ].some(
-				Boolean
-		  )
+		? [ ! site, ! user, isSupportDataLoading, isLoadingChat ].some( Boolean )
 		: false;
 
 	useEffect( () => {

--- a/packages/help-center/src/hooks/use-should-render-chat-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-chat-option.tsx
@@ -4,29 +4,34 @@ import { useHappychatAvailable } from '@automattic/happychat-connection';
 type Result = {
 	render: boolean;
 	state?: 'AVAILABLE' | 'UNAVAILABLE' | 'CLOSED';
+	isLoading: boolean;
 };
 
 export function useShouldRenderChatOption(): Result {
 	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
-	const chatAvailable = useHappychatAvailable();
+	const { available, isLoading } = useHappychatAvailable();
 
 	if ( ! chatStatus?.isUserEligible ) {
 		return {
 			render: false,
+			isLoading,
 		};
 	} else if ( chatStatus?.isClosed ) {
 		return {
 			render: true,
 			state: 'CLOSED',
+			isLoading,
 		};
-	} else if ( chatAvailable.available ) {
+	} else if ( available ) {
 		return {
 			render: true,
 			state: 'AVAILABLE',
+			isLoading,
 		};
 	}
 	return {
 		render: true,
 		state: 'UNAVAILABLE',
+		isLoading,
 	};
 }

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -259,13 +259,12 @@ button.button.back-button__help-center.is-borderless {
 	padding-top: 0;
 }
 
-.help-center-container__loading {
+.help-center-container__loading, .help-center-contact-page__loading {
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	height: 100%;
-}
-.help-center-container__spinner {
+
 	.spinner__outer {
 		border-top-color: var( --wp-admin-theme-color );
 	}


### PR DESCRIPTION
#### Proposed Changes

Now we open a socket connection to happychat, to check for chat availability, first thing when the user opens the Help Center.
@klimeryk suggested that this is a bad practice, as it could easily lead to socket exhaustion, as we open connections even if the user has not intention of using the chat.

So this PR:
- moves the call to `useHappychatAvailable`, which opens that socket, after clicking on the `Still need help?` button.
- when opening the aforementioned socket for checking availability, we now close it after that.
- no more caching of the result of `useHappychatAvailable`, to better reflect the actual situation in the HE availability

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* `yarn dev --sync` from `apps/editing-toolkit`
* Open Browser console -> Network
* Check that a socket isn't opened when you enter Help Center
* Check that the socket is opened only after clicking on `Still need help?`, and it's closed after the check is completed.
* Change this [line](https://github.com/Automattic/wp-calypso/blob/update/help-center-socket-exhaustion/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js#L7) value to `https://happychat-io-staging.go-vip.co/customer`, connect to `https://hud-staging.happychat.io/` and try to see if the check can correctly attest whether there are HEs available.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


