### PR TITLE
Site Setup Flow: Always check locale for site-vertical step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -10,7 +10,7 @@ import DesignPicker, {
 	getDesignPreviewUrl,
 	useDesignsBySite,
 } from '@automattic/design-picker';
-import { useLocale, englishLocales } from '@automattic/i18n-utils';
+import { useLocale, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { shuffle } from '@automattic/js-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
@@ -49,6 +49,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	const { goBack, submit, exitFlow } = navigation;
 	const translate = useTranslate();
 	const locale = useLocale();
+	const isEnglishLocale = useIsEnglishLocale();
 	const site = useSite();
 	const { setSelectedDesign, setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
@@ -89,8 +90,12 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		[ staticDesigns ]
 	);
 
+	const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnglishLocale;
+
 	const enabledGeneratedDesigns =
-		isEnabled( 'signup/design-picker-generated-designs' ) && intent === 'build';
+		verticalsStepEnabled &&
+		isEnabled( 'signup/design-picker-generated-designs' ) &&
+		intent === 'build';
 
 	const { data: generatedDesigns = [], isLoading: isLoadingGeneratedDesigns } =
 		useStarterDesignsGeneratedQuery(
@@ -152,7 +157,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 
 		const text = translate( 'Choose a starting theme. You can change it later.' );
 
-		if ( englishLocales.includes( locale ) ) {
+		if ( isEnglishLocale ) {
 			// An English only trick so the line wraps between sentences.
 			return ( text as string )
 				.replace( /\s/g, '\xa0' ) // Replace all spaces with non-breaking spaces

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { isEnabled } from '@automattic/calypso-config';
-import { englishLocales, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { IntentScreen, StepContainer } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -20,6 +20,7 @@ import './style.scss';
  */
 const IntentStep: Step = function IntentStep( { navigation } ) {
 	const { goBack, goNext, submit } = navigation;
+	const isEnglishLocale = useIsEnglishLocale();
 	const translate = useTranslate();
 	const headerText = translate( 'Where will you start?' );
 	const subHeaderText = translate( 'You can change your mind at any time.' );
@@ -52,12 +53,7 @@ const IntentStep: Step = function IntentStep( { navigation } ) {
 			goNext={ goNext }
 			skipLabelText={ translate( 'Skip to dashboard' ) }
 			skipButtonAlign={ 'top' }
-			hideBack={
-				! (
-					isEnabled( 'signup/site-vertical-step' ) &&
-					englishLocales.includes( translate.localeSlug || i18nDefaultLocaleSlug )
-				)
-			}
+			hideBack={ ! ( isEnabled( 'signup/site-vertical-step' ) && isEnglishLocale ) }
 			isHorizontalLayout={ true }
 			formattedHeader={
 				<FormattedHeader

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { useDesignsBySite } from '@automattic/design-picker';
-import { useLocale, englishLocales } from '@automattic/i18n-utils';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -29,12 +29,11 @@ export const siteSetupFlow: Flow = {
 	name: 'site-setup',
 
 	useSteps() {
-		const locale = useLocale();
-		const isEnglishLocales = englishLocales.includes( locale );
+		const isEnglishLocale = useIsEnglishLocale();
 
 		return [
 			...( isEnabled( 'signup/goals-step' ) ? [ 'goals' ] : [] ),
-			...( isEnabled( 'signup/site-vertical-step' ) && isEnglishLocales ? [ 'vertical' ] : [] ),
+			...( isEnabled( 'signup/site-vertical-step' ) && isEnglishLocale ? [ 'vertical' ] : [] ),
 			'intent',
 			'options',
 			'designSetup',
@@ -77,6 +76,7 @@ export const siteSetupFlow: Flow = {
 		const siteSlugParam = useSiteSlugParam();
 		const site = useSite();
 		const currentUser = useSelector( getCurrentUser );
+		const isEnglishLocale = useIsEnglishLocale();
 
 		let siteSlug: string | null = null;
 		if ( siteSlugParam ) {
@@ -96,6 +96,7 @@ export const siteSetupFlow: Flow = {
 		const { setIntentOnSite } = useDispatch( SITE_STORE );
 		const { FSEActive } = useFSEStatus();
 		const dispatch = reduxDispatch();
+		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnglishLocale;
 
 		// Set up Step progress for Woo flow - "Step 2 of 4"
 		if ( intent === 'sell' && storeType === 'power' ) {
@@ -208,7 +209,6 @@ export const siteSetupFlow: Flow = {
 						return exitFlow( `/start/website-design-services/?siteSlug=${ siteSlug }` );
 					}
 
-					const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' );
 					if ( verticalsStepEnabled ) {
 						return navigate( 'vertical' );
 					}
@@ -353,7 +353,7 @@ export const siteSetupFlow: Flow = {
 					return navigate( 'options' );
 
 				case 'intent':
-					return navigate( isEnabled( 'signup/site-vertical-step' ) ? 'vertical' : 'intent' );
+					return navigate( verticalsStepEnabled ? 'vertical' : 'intent' );
 
 				case 'storeFeatures':
 					return navigate( 'options' );
@@ -380,7 +380,7 @@ export const siteSetupFlow: Flow = {
 					}
 
 					if ( isEnabled( 'signup/goals-step' ) ) {
-						if ( isEnabled( 'signup/site-vertical-step' ) ) {
+						if ( verticalsStepEnabled ) {
 							return navigate( 'vertical' );
 						}
 						return navigate( 'goals' );
@@ -414,7 +414,7 @@ export const siteSetupFlow: Flow = {
 				case 'import':
 					if ( isEnabled( 'signup/goals-step' ) ) {
 						// This can be unchecked when import step is shown after verticals.
-						// if ( isEnabled( 'signup/site-vertical-step' ) ) {
+						// if ( verticalsStepEnabled ) {
 						// 	return navigate( 'vertical' );
 						// }
 						return navigate( 'goals' );

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -1,5 +1,5 @@
 export { localizeUrl, useLocalizeUrl, withLocalizeUrl } from './localize-url';
-export { LocaleProvider, useLocale, withLocale } from './locale-context';
+export { LocaleProvider, useLocale, withLocale, useIsEnglishLocale } from './locale-context';
 export * from './locales';
 export { default as guessTimezone } from './guess-timezone';
 export * from './utils';

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -2,6 +2,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import * as i18n from '@wordpress/i18n';
 import { createContext, useContext, useEffect, useState } from 'react';
 import * as React from 'react';
+import { englishLocales } from './locales';
 import type { Locale } from './locales';
 
 export const localeContext = createContext< string | null >( null );
@@ -99,3 +100,19 @@ export const withLocale = createHigherOrderComponent< { locale: string } >( ( In
 		return <InnerComponent { ...innerProps } />;
 	};
 }, 'withLocale' );
+
+/**
+ * React hook providing whether the current locale slug belongs to English or not
+ *
+ * @example
+ *
+ * import { useIsEnglishLocale } from '@automattic/i18n-utils';
+ * function MyComponent() {
+ *   const isEnglishLocale = useIsEnglishLocale();
+ *   return <div>The current locale is English: { isEnglishLocale }</div>;
+ * }
+ */
+export function useIsEnglishLocale(): boolean {
+	const locale = useLocale();
+	return englishLocales.includes( locale );
+}


### PR DESCRIPTION
#### Proposed Changes

* As we will ship `site-vertical` step to English-only users first, we have to check both the feature flag and locale to see whether the step is enabled or not.
* Besides, I think the generated design picker is enabled only when the `site-vertical` step is enabled, so I also add the check there

**English users**

https://user-images.githubusercontent.com/13596067/174763502-9cef6923-0ad1-4e07-9707-fc09b93d79f1.mov

**non-English users**

https://user-images.githubusercontent.com/13596067/174763474-cf18d2ce-7ece-45d5-b80a-b02f7e7e2812.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Site Setup Flow: `/setup?flags=signup/goals-step&siteSlug=<your_site>` with a English user
* Submit any intent, and you'll land on the `site-vertical` step
* Go to Site Setup Flow again with a non-English user
* Submit any intent and you won't land on the `site-vertical` step

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/64729
