### PR TITLE
Marketplace: Use wpcom.req client for search endpoint

### DIFF
--- a/client/data/marketplace/constants.ts
+++ b/client/data/marketplace/constants.ts
@@ -8,11 +8,6 @@ export const WCCOM_PLUGINS_BLOG_ID = '113771570';
 
 export const WPORG_CACHE_KEY = 'wporg-plugins';
 
-const PUBLIC_WPCOM_REST = 'https://public-api.wordpress.com';
-const REST_API_VERSION = '/rest/v1.3';
-const MARKETPLACE_URL_PATH = '/marketplace/search';
-export const MARKETPLACE_SEARCH_URL = PUBLIC_WPCOM_REST + REST_API_VERSION + MARKETPLACE_URL_PATH;
-
 // TODO: Only include the required fields here
 export const RETURNABLE_FIELDS = [
 	'blog_icon_url',

--- a/client/data/marketplace/site-search-api.ts
+++ b/client/data/marketplace/site-search-api.ts
@@ -1,5 +1,5 @@
-import qs from 'qs';
-import { RETURNABLE_FIELDS, MARKETPLACE_SEARCH_URL } from './constants';
+import wpcom from 'calypso/lib/wp';
+import { RETURNABLE_FIELDS } from './constants';
 import type { SearchParams } from './types';
 
 // Maps sort values to values expected by the API
@@ -56,8 +56,11 @@ function generateApiQueryString( { query, groupId, pageHandle, pageSize, locale 
 	// if ( author ) {
 	// }
 
-	return qs.stringify( params, { arrayFormat: 'brackets' } );
+	return params;
 }
+
+const marketplaceSearchApiBase = '/marketplace/search';
+const apiVersion = '1.3';
 
 /**
  * Perform a search.
@@ -68,20 +71,10 @@ function generateApiQueryString( { query, groupId, pageHandle, pageSize, locale 
 export function search( options: SearchParams ) {
 	const queryString = generateApiQueryString( options );
 
-	const url = `${ MARKETPLACE_SEARCH_URL }?${ queryString }`;
-
-	// NOTE: API Nonce is necessary to authenticate requests to class-wpcom-rest-api-v2-endpoint-search.php.
-	return fetch( url, {
-		headers: {},
-		credentials: 'same-origin',
-	} )
-		.then( ( response ) => {
-			if ( response.status !== 200 ) {
-				return Promise.reject(
-					`Unexpected response from API with status code ${ response.status }.`
-				);
-			}
-			return response;
-		} )
-		.then( ( r ) => r.json() );
+	return wpcom.req.get(
+		{
+			path: marketplaceSearchApiBase,
+		},
+		{ ...queryString, apiVersion }
+	);
 }


### PR DESCRIPTION
#### Proposed Changes

Use `wpcom.req` client to read the `/marketplace/search` endpoint so we can get the benefits of using it. 
- Replace the existing `fetch` by `wpcom.req.get`. 
- Previous URL constants are not required anymore.

#### Testing Instructions

- Enable the feature flag `marketplace-jetpack-plugin-search`. One option is to use `?flags=marketplace-jetpack-plugin-search` query parameter in the url.
- Go to `/plugins/<your-site>`, add a search term and press Enter
- Make sure results are displayed. Please note that Icons and Ratings are not yet displayed.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/64802
