### PR TITLE
HelpCenter: fix locale check for Atomic users

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,11 +2,11 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 7.7
+ * Version: 2.21
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
- * Text Domain: test-full-site-editing
+ * Text Domain: full-site-editing
  *
  * @package A8C\FSE
  */
@@ -42,7 +42,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'A8C_ETK_PLUGIN_VERSION', '3.35485' );
+define( 'A8C_ETK_PLUGIN_VERSION', 'dev' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -394,7 +394,7 @@ function load_help_center() {
 	// only shipping to en locale for now.
 	$current_locale = get_locale();
 
-	if ( $is_proxied || ( 'en' === $current_locale && $user_segment < $current_segment ) ) {
+	if ( $is_proxied || ( str_starts_with( $current_locale, 'en' ) && $user_segment < $current_segment ) ) {
 		require_once __DIR__ . '/help-center/class-help-center.php';
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,11 +2,11 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.21
+ * Version: 7.7
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
- * Text Domain: full-site-editing
+ * Text Domain: test-full-site-editing
  *
  * @package A8C\FSE
  */
@@ -42,7 +42,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'A8C_ETK_PLUGIN_VERSION', 'dev' );
+define( 'A8C_ETK_PLUGIN_VERSION', '3.35485' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';
@@ -387,12 +387,13 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
  */
 function load_help_center() {
 	// enable help center for all proxied users.
-	$is_proxied = function_exists( 'wpcom_is_proxied_request' ) ? wpcom_is_proxied_request() : false;
+	$is_proxied = $_SERVER['A8C_PROXIED_REQUEST'] || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
+
+	// only shipping to en locale for now.
+	$current_locale = get_locale();
 
 	$current_segment = 10; // segment of existing users that will get the help center in %.
 	$user_segment    = get_current_user_id() % 100;
-	// only shipping to en locale for now.
-	$current_locale = get_locale();
 
 	if ( $is_proxied || ( str_starts_with( $current_locale, 'en' ) && $user_segment < $current_segment ) ) {
 		require_once __DIR__ . '/help-center/class-help-center.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
@@ -4,7 +4,7 @@ window.configData = {
 	google_analytics_key: 'UA-10673494-15',
 	client_slug: 'browser',
 	twemoji_cdn_url: 'https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/',
-	happychat_url: 'https://happychat-io-staging.go-vip.co/customer',
+	happychat_url: 'https://happychat.io/customer',
 	site_filter: [],
 	sections: {},
 	enable_all_sections: false,

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
@@ -4,7 +4,7 @@ window.configData = {
 	google_analytics_key: 'UA-10673494-15',
 	client_slug: 'browser',
 	twemoji_cdn_url: 'https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/',
-	happychat_url: 'https://happychat.io/customer',
+	happychat_url: 'https://happychat-io-staging.go-vip.co/customer',
 	site_filter: [],
 	sections: {},
 	enable_all_sections: false,


### PR DESCRIPTION
## Proposed Changes

The recent release to 10% of users was not loading in Atomic. This was due to the return difference of `lang` between Atomic and Simple sites. Atomic returns `en_US` while Simple returns just `en`.

| Simple | Atomic |
| - | - |
| <img width="496" alt="Markup 2022-06-21 at 11 55 04" src="https://user-images.githubusercontent.com/33258733/174773733-d7d9bc88-705a-4ee5-b67e-6e1aa60ea99b.png"> | <img width="631" alt="Markup 2022-06-21 at 11 54 46" src="https://user-images.githubusercontent.com/33258733/174773757-12d9452f-ecd9-4e29-9ad9-1b98eb927de0.png"> |


## Testing Instructions

1. [Download the ETK plugin from here](https://teamcity.a8c.com/repository/download/calypso_WPComPlugins_EditorToolKit/8096668:id/editing-toolkit.zip)
2. Go to an ATOMIC site and DELETE the current version of Full Site Editing/ Editing Toolkit
3. Install the test version
4. Verify the HelpCenter loads in the editor.