### PR TITLE
Goals Capture: Integrate save site-goals api for when goals capture step enabled

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,4 +1,5 @@
 import { Design } from '@automattic/design-picker/src/types';
+import { SiteGoal } from '../onboard';
 import { wpcomRequest } from '../wpcom-request-controls';
 import {
 	SiteLaunchError,
@@ -234,6 +235,17 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		} catch ( e ) {}
 	}
 
+	function* setGoalsOnSite( siteSlug: string, goals: SiteGoal[] ) {
+		try {
+			yield wpcomRequest( {
+				path: `/sites/${ encodeURIComponent( siteSlug ) }/site-goals`,
+				apiNamespace: 'wpcom/v2',
+				body: { site_goals: goals },
+				method: 'POST',
+			} );
+		} catch ( e ) {}
+	}
+
 	function* saveSiteTitle( siteId: number, blogname: string | undefined ) {
 		yield saveSiteSettings( siteId, { blogname } );
 	}
@@ -459,6 +471,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		saveSiteTitle,
 		saveSiteSettings,
 		setIntentOnSite,
+		setGoalsOnSite,
 		receiveSiteTitle,
 		fetchNewSite,
 		fetchSite,


### PR DESCRIPTION
#### Proposed Changes

* When `signup/goals-step` is enabled then save `site-goals` remotely in site options on exit flow of `site-setup-flow`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
![Screenshot 2022-06-21 at 17 03 11](https://user-images.githubusercontent.com/2019970/174834892-bec72a78-3584-4d22-a8be-a51adfd8c7ba.png)
![Screenshot 2022-06-21 at 17 06 51](https://user-images.githubusercontent.com/2019970/174834902-a2b2f856-6237-4d53-bb2e-19de10135805.png)



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/63915
