### PR TITLE
Vertical Step: Fix pre-selected vertical is cleared when going to next step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/form.tsx
@@ -27,13 +27,15 @@ const SiteVerticalForm: React.FC< Props > = ( {
 	const translate = useTranslate();
 	const [ userInput, setUserInput ] = React.useState( '' );
 
-	React.useEffect( () => {
+	const handleInputChange = ( value: string ) => {
+		setUserInput( value );
+
 		// Reset the vertical selection if input field is empty.
 		// This is so users don't need to explicitly select "Something else" to clear previous selection.
-		if ( userInput.trim().length === 0 ) {
+		if ( value.trim().length === 0 ) {
 			onSelect?.( { value: '', label: '' } );
 		}
-	}, [ userInput ] );
+	};
 
 	return (
 		<form
@@ -46,7 +48,7 @@ const SiteVerticalForm: React.FC< Props > = ( {
 				<SelectVertical
 					defaultVertical={ defaultVertical }
 					isSkipSynonyms={ isSkipSynonyms }
-					onInputChange={ setUserInput }
+					onInputChange={ handleInputChange }
 					onSelect={ onSelect }
 				/>
 				<FormSettingExplanation>


### PR DESCRIPTION
#### Proposed Changes

* Reset the selection only when the user input changed as the initial value of the user input is always empty.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/vertical?siteSlug=<your_site>`
* Select a vertical and continue
* Back to the Vertical step
* Continue to next step without changing the selected vertical
* Back to the Vertical step
* You will see the selected vertical is the same instead of empty (it would be empty before this PR)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64808, https://github.com/Automattic/wp-calypso/pull/64699
