### PR TITLE
Jetpack Licensing: Fix hosting provider redirected to payment method add form when issuing license

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -28,7 +28,10 @@ import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sid
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
-import { hasValidPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
+import {
+	hasValidPaymentMethod,
+	isAgencyUser,
+} from 'calypso/state/partner-portal/partner/selectors';
 import { fetchStoredCards } from 'calypso/state/partner-portal/stored-cards/actions';
 
 import './style.scss';
@@ -37,6 +40,7 @@ function PaymentMethodAdd(): ReactElement {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 	const hasPaymentMethod = useSelector( hasValidPaymentMethod );
+	const agencyUser = useSelector( isAgencyUser );
 	const { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } = useStripe();
 	const {
 		reload: reloadSetupIntentId,
@@ -57,7 +61,7 @@ function PaymentMethodAdd(): ReactElement {
 		select( 'credit-card' ).useAsPrimaryPaymentMethod()
 	);
 
-	useReturnUrl( hasPaymentMethod );
+	useReturnUrl( agencyUser && hasPaymentMethod );
 
 	const onGoToPaymentMethods = () => {
 		reduxDispatch(


### PR DESCRIPTION
#### Proposed Changes

* Fix hosting provider being redirected to payment method add form when trying to issue a license on the licensing portal.
* Resolves 👉🏻 1202074155672006-as-1202479958401732/f

#### Testing instructions

* Make sure to have a Partner Account 👉🏻 PCYsg-zPi-p2 
* Switch your partner account to hosting provider type
* Clean up your payment methods from record
* Issue some license (you should be able to assign the license right after)
* Switch your partner account to agency type
* Try to issue some license
* If you don't have any valid payment methods you will be redirected to the payment methods addition page
* If you try to access the license assignment page directly, you will be redirected to the payment methods addition page

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #