### PR TITLE
Goals Capture: Enable goals capture step for english locale only

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-vertical/index.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -13,8 +14,6 @@ import SiteVerticalForm from './form';
 import type { Step } from '../../types';
 import type { Vertical } from 'calypso/components/select-vertical/types';
 
-const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' );
-
 const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const { goBack, goNext, submit } = navigation;
 	const [ vertical, setVertical ] = React.useState< Vertical | null >();
@@ -28,6 +27,8 @@ const SiteVertical: Step = function SiteVertical( { navigation } ) {
 	const headerText = translate( 'What’s your website about?' );
 	const subHeaderText = translate( 'Choose a category that defines your website the best.' );
 	const isSkipSynonyms = useQuery().get( 'isSkipSynonyms' );
+	const isEnglishLocale = useIsEnglishLocale();
+	const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' ) && isEnglishLocale;
 
 	const handleSiteVerticalSelect = ( vertical: Vertical ) => {
 		setVertical( vertical );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -32,7 +32,7 @@ export const siteSetupFlow: Flow = {
 		const isEnglishLocale = useIsEnglishLocale();
 
 		return [
-			...( isEnabled( 'signup/goals-step' ) ? [ 'goals' ] : [] ),
+			...( isEnabled( 'signup/goals-step' ) && isEnglishLocale ? [ 'goals' ] : [] ),
 			...( isEnabled( 'signup/site-vertical-step' ) && isEnglishLocale ? [ 'vertical' ] : [] ),
 			'intent',
 			'options',
@@ -97,6 +97,7 @@ export const siteSetupFlow: Flow = {
 		const { FSEActive } = useFSEStatus();
 		const dispatch = reduxDispatch();
 		const verticalsStepEnabled = isEnabled( 'signup/site-vertical-step' ) && isEnglishLocale;
+		const goalsStepEnabled = isEnabled( 'signup/goals-step' ) && isEnglishLocale;
 
 		// Set up Step progress for Woo flow - "Step 2 of 4"
 		if ( intent === 'sell' && storeType === 'power' ) {
@@ -309,9 +310,7 @@ export const siteSetupFlow: Flow = {
 				}
 
 				case 'vertical': {
-					const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' );
-
-					if ( goalsCaptureStepEnabled ) {
+					if ( goalsStepEnabled ) {
 						if ( goals.includes( SiteGoal.Import ) ) {
 							return navigate( 'import' );
 						}
@@ -379,7 +378,7 @@ export const siteSetupFlow: Flow = {
 						return navigate( 'bloggerStartingPoint' );
 					}
 
-					if ( isEnabled( 'signup/goals-step' ) ) {
+					if ( goalsStepEnabled ) {
 						if ( verticalsStepEnabled ) {
 							return navigate( 'vertical' );
 						}
@@ -406,13 +405,13 @@ export const siteSetupFlow: Flow = {
 					return navigate( 'import' );
 
 				case 'vertical':
-					if ( isEnabled( 'signup/goals-step' ) ) {
+					if ( goalsStepEnabled ) {
 						return navigate( 'goals' );
 					}
 
 				case 'options':
 				case 'import':
-					if ( isEnabled( 'signup/goals-step' ) ) {
+					if ( goalsStepEnabled ) {
 						// This can be unchecked when import step is shown after verticals.
 						// if ( verticalsStepEnabled ) {
 						// 	return navigate( 'vertical' );

--- a/client/signup/steps/choose-service/index.tsx
+++ b/client/signup/steps/choose-service/index.tsx
@@ -5,6 +5,7 @@ import {
 	PLAN_WPCOM_PRO,
 	WPCOM_DIFM_LITE,
 } from '@automattic/calypso-products';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { IntentScreen } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -37,13 +38,6 @@ interface Props {
 
 type DIFMOrBuiltByIntent = SelectItem< ChoiceType >;
 
-const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' );
-
-const getBackUrl = ( siteSlug?: string ) => {
-	const step = goalsCaptureStepEnabled ? 'goals' : 'intent';
-	return `/setup/${ step }?siteSlug=${ siteSlug }`;
-};
-
 const Placeholder = () => <span className="choose-service__placeholder">&nbsp;</span>;
 
 export default function ChooseServiceStep( props: Props ): React.ReactNode {
@@ -51,6 +45,13 @@ export default function ChooseServiceStep( props: Props ): React.ReactNode {
 	const translate = useTranslate();
 	const displayCost = useSelector( ( state ) => getProductDisplayCost( state, WPCOM_DIFM_LITE ) );
 	const isLoading = useSelector( isProductsListFetching );
+	const isEnglishLocale = useIsEnglishLocale();
+	const goalsCaptureStepEnabled = isEnabled( 'signup/goals-step' ) && isEnglishLocale;
+
+	const getBackUrl = ( siteSlug?: string ) => {
+		const step = goalsCaptureStepEnabled ? 'goals' : 'intent';
+		return `/setup/${ step }?siteSlug=${ siteSlug }`;
+	};
 
 	const headerText = translate( 'Let our experts create your dream site' );
 


### PR DESCRIPTION


#### Proposed Changes

* As we will ship `goals` capture step to English-only users first, we have to check both the feature flag and locale to see whether the step is enabled or not.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### English locale
1. Go to http://calypso.localhost:3000/setup?siteSlug=<your_site> when:
   * `signup/goals-step` is enabled
   * and your wp locale is set to `english`
2. The onboard flow should begin with `goals` capture screen

##### Non-english locale
1. Go to http://calypso.localhost:3000/setup?siteSlug=<your_site> when:
   * `signup/goals-step` is enabled
   * and your wp locale is set to something different than `english`
2. The onboard flow should begin with `intent` capture screen, and the `goals` step should not be accessible from within the onboard flow


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

