### PR TITLE
Goals Capture: Enable goals step on Horizon and WPCalypso environments.

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -92,6 +92,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
 		"signup/inline-help": false,
+		"signup/goals-step": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -116,6 +116,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": false,
 		"signup/inline-help": false,
+		"signup/goals-step": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -27,7 +27,7 @@ const selectors = {
 	// Buttons
 	checkUrlButton: 'form.capture__input-wrapper button.action-buttons__next',
 	startBuildingButton: 'div.import__onboarding-page button.action-buttons__next',
-	startImportButton: 'button.import-link__button:text("Import your site content")',
+	startImportButton: 'button:text("Import your site content")',
 	// And entry of the list of selectable importers
 	importerListButton: ( index: number ) =>
 		`div.list__importers-primary:nth-child(${ index + 1 }) .action-card__button-container button`,

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -160,7 +160,7 @@ export class StartImportFlow {
 	 * @param {string} siteSlug The site slug URL.
 	 */
 	async startSetup( siteSlug: string ): Promise< void > {
-		const route = '/setup/goals';
+		const route = this.framework === 'signup' ? '/start/setup-site/intent' : '/setup/intent';
 
 		await this.page.goto( DataHelper.getCalypsoURL( route, { siteSlug } ) );
 		await this.validateSetupPage();

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -27,7 +27,7 @@ const selectors = {
 	// Buttons
 	checkUrlButton: 'form.capture__input-wrapper button.action-buttons__next',
 	startBuildingButton: 'div.import__onboarding-page button.action-buttons__next',
-	startImportButton: 'button.select-items-alt__item-button:text("Import your site content")',
+	startImportButton: 'button.import-link__button:text("Import your site content")',
 	// And entry of the list of selectable importers
 	importerListButton: ( index: number ) =>
 		`div.list__importers-primary:nth-child(${ index + 1 }) .action-card__button-container button`,
@@ -160,7 +160,7 @@ export class StartImportFlow {
 	 * @param {string} siteSlug The site slug URL.
 	 */
 	async startSetup( siteSlug: string ): Promise< void > {
-		const route = this.framework === 'signup' ? '/start/setup-site/intent' : '/setup/intent';
+		const route = '/setup/goals';
 
 		await this.page.goto( DataHelper.getCalypsoURL( route, { siteSlug } ) );
 		await this.validateSetupPage();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR enables `signup/goals-step` feature flag on Horizon and WPCalypso environments, allowing us to test the **Goals Capture step** on testing envs.