### PR TITLE
Marketplace: Updates copy in landing page.

### DIFF
--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -64,7 +64,7 @@ const EducationFooter = () => {
 					/>
 				</ThreeColumnContainer>
 			</Section>
-			<Section header={ __( 'Upgrade your WordPress site with confidence' ) } dark>
+			<Section header={ __( 'Add additional features to your WordPress site. Risk free.' ) } dark>
 				<ThreeColumnContainer>
 					<FeatureItem header={ __( 'Fully Managed' ) }>
 						{ __(


### PR DESCRIPTION
#### Proposed Changes

> On the Marketplace plugins page, the last section Upgrade your WordPress site with confidence, could we re-word it as usually Upgrade is related to plan payments.

Updates `Upgrade your WordPress site with confidence` to `Add additional features to your WordPress site. Risk free.`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Got to `wordpress.com/plugins`
* Check the area in the bottom for the updated copy

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Screenshot
<img width="1085" alt="Screen Shot 2022-06-23 at 14 17 39" src="https://user-images.githubusercontent.com/5039531/175367500-ee791734-d66c-4258-a40f-7cac833cc8ae.png">


Related to pdh6GB-1ex-p2#comment-1967