### PR TITLE
Design Picker: Adds props to adapt to the new design picker screen

### DIFF
--- a/packages/design-picker/src/__tests__/integration.test.tsx
+++ b/packages/design-picker/src/__tests__/integration.test.tsx
@@ -18,6 +18,14 @@ jest.mock( '@automattic/calypso-config', () => ( {
 		return key;
 	},
 } ) );
+jest.mock( '@wordpress/compose', () => {
+	const originalModule = jest.requireActual( '@wordpress/compose' );
+	return {
+		__esModule: true,
+		...originalModule,
+		useViewportMatch: jest.fn( () => true ),
+	};
+} );
 
 const MOCK_LOCALE = 'en';
 const MOCK_DESIGN_TITLE = 'Cassel';
@@ -79,4 +87,35 @@ describe( '<DesignPicker /> integration', () => {
 			);
 		} )
 	);
+
+	it( 'Should not display the buttons inside the design picker', async () => {
+		const renderedContainer = render(
+			<DesignPicker
+				locale={ MOCK_LOCALE }
+				onSelect={ jest.fn() }
+				recommendedCategorySlug={ null }
+				previewOnly={ true }
+				onPreview={ () => true }
+			/>
+		);
+
+		expect(
+			renderedContainer.container.querySelectorAll( '.design-button-cover__button' ).length
+		).toBe( 0 );
+	} );
+
+	it( 'Should display the buttons inside the design picker', async () => {
+		const renderedContainer = render(
+			<DesignPicker
+				locale={ MOCK_LOCALE }
+				onSelect={ jest.fn() }
+				recommendedCategorySlug={ null }
+				onPreview={ () => true }
+			/>
+		);
+
+		expect(
+			renderedContainer.container.querySelectorAll( '.design-button-cover__button' ).length
+		).toBeGreaterThanOrEqual( 2 );
+	} );
 } );

--- a/packages/design-picker/src/__tests__/integration.test.tsx
+++ b/packages/design-picker/src/__tests__/integration.test.tsx
@@ -88,13 +88,14 @@ describe( '<DesignPicker /> integration', () => {
 		} )
 	);
 
-	it( 'Should not display the buttons inside the design picker', async () => {
+	it( 'Should not display the header and the buttons inside the design picker', async () => {
 		const renderedContainer = render(
 			<DesignPicker
 				locale={ MOCK_LOCALE }
 				onSelect={ jest.fn() }
 				recommendedCategorySlug={ null }
 				previewOnly={ true }
+				hasDesignOptionHeader={ false }
 				onPreview={ () => true }
 			/>
 		);
@@ -102,9 +103,13 @@ describe( '<DesignPicker /> integration', () => {
 		expect(
 			renderedContainer.container.querySelectorAll( '.design-button-cover__button' ).length
 		).toBe( 0 );
+
+		expect(
+			renderedContainer.container.querySelectorAll( '.design-picker__design-option-header' ).length
+		).toBe( 0 );
 	} );
 
-	it( 'Should display the buttons inside the design picker', async () => {
+	it( 'Should display the header and the buttons inside the design picker', async () => {
 		const renderedContainer = render(
 			<DesignPicker
 				locale={ MOCK_LOCALE }
@@ -117,5 +122,9 @@ describe( '<DesignPicker /> integration', () => {
 		expect(
 			renderedContainer.container.querySelectorAll( '.design-button-cover__button' ).length
 		).toBeGreaterThanOrEqual( 2 );
+
+		expect(
+			renderedContainer.container.querySelectorAll( '.design-picker__design-option-header' ).length
+		).toBeGreaterThanOrEqual( 1 );
 	} );
 } );

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -170,12 +170,14 @@ interface DesignButtonContainerProps extends DesignButtonProps {
 	isPremiumThemeAvailable?: boolean;
 	onPreview?: ( design: Design ) => void;
 	onUpgrade?: () => void;
+	previewOnly?: boolean;
 }
 
 const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	isPremiumThemeAvailable,
 	onPreview,
 	onUpgrade,
+	previewOnly = false,
 	...props
 } ) => {
 	const isDesktop = useViewportMatch( 'large' );
@@ -201,7 +203,7 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	// We don't need preview for blank canvas
 	return (
 		<div className="design-button-container">
-			{ ! isBlankCanvas && (
+			{ ! isBlankCanvas && ! previewOnly && (
 				<DesignButtonCover
 					design={ props.design }
 					isPremiumThemeAvailable={ isPremiumThemeAvailable }
@@ -234,6 +236,7 @@ export interface DesignPickerProps {
 	hideFullScreenPreview?: boolean;
 	hideDesignTitle?: boolean;
 	isPremiumThemeAvailable?: boolean;
+	previewOnly?: boolean;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
@@ -257,6 +260,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	hideDesignTitle,
 	recommendedCategorySlug,
 	isPremiumThemeAvailable,
+	previewOnly = false,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const filteredDesigns = useMemo( () => {
@@ -299,6 +303,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						hideFullScreenPreview={ hideFullScreenPreview }
 						hideDesignTitle={ hideDesignTitle }
 						isPremiumThemeAvailable={ isPremiumThemeAvailable }
+						previewOnly={ previewOnly }
 					/>
 				) ) }
 			</div>

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -53,6 +53,7 @@ interface DesignButtonProps {
 	disabled?: boolean;
 	hideFullScreenPreview?: boolean;
 	hideDesignTitle?: boolean;
+	hasDesignOptionHeader?: boolean;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -63,6 +64,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	highRes,
 	disabled,
 	hideDesignTitle,
+	hasDesignOptionHeader = true,
 } ) => {
 	const { __ } = useI18n();
 
@@ -79,21 +81,26 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 			data-e2e-button={ design.is_premium ? 'paidOption' : 'freeOption' }
 			onClick={ () => onSelect( design ) }
 		>
-			<span className="design-picker__design-option-header">
-				<svg width="28" height="6">
-					<g>
-						<rect width="6" height="6" rx="3" />
-						<rect x="11" width="6" height="6" rx="3" />
-						<rect x="22" width="6" height="6" rx="3" />
-					</g>
-				</svg>
-			</span>
+			{ hasDesignOptionHeader && (
+				<span className="design-picker__design-option-header">
+					<svg width="28" height="6">
+						<g>
+							<rect width="6" height="6" rx="3" />
+							<rect x="11" width="6" height="6" rx="3" />
+							<rect x="22" width="6" height="6" rx="3" />
+						</g>
+					</svg>
+				</span>
+			) }
 			<span
 				className={ classnames(
 					'design-picker__image-frame',
 					'design-picker__image-frame-landscape',
 					design.preview === 'static' ? 'design-picker__static' : 'design-picker__scrollable',
-					{ 'design-picker__image-frame-blank': isBlankCanvas }
+					{
+						'design-picker__image-frame-blank': isBlankCanvas,
+						'design-picker__image-frame-no-header': ! hasDesignOptionHeader,
+					}
 				) }
 			>
 				{ isBlankCanvas ? (
@@ -237,6 +244,7 @@ export interface DesignPickerProps {
 	hideDesignTitle?: boolean;
 	isPremiumThemeAvailable?: boolean;
 	previewOnly?: boolean;
+	hasDesignOptionHeader?: boolean;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
@@ -261,6 +269,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	recommendedCategorySlug,
 	isPremiumThemeAvailable,
 	previewOnly = false,
+	hasDesignOptionHeader = true,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const filteredDesigns = useMemo( () => {
@@ -304,6 +313,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						hideDesignTitle={ hideDesignTitle }
 						isPremiumThemeAvailable={ isPremiumThemeAvailable }
 						previewOnly={ previewOnly }
+						hasDesignOptionHeader={ hasDesignOptionHeader }
 					/>
 				) ) }
 			</div>

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -120,7 +120,14 @@
 		box-sizing: border-box;
 		position: relative;
 		overflow: hidden;
-		border-radius: 0 0 4px 4px; /* stylelint-disable-line scales/radii */
+
+		&:not( .design-picker__image-frame-no-header ) {
+			border-radius: 0 0 4px 4px; /* stylelint-disable-line scales/radii */
+		}
+
+		&.design-picker__image-frame-no-header {
+			border-radius: 0; /* stylelint-disable-line scales/radii */
+		}
 
 		img {
 			position: absolute;
@@ -140,12 +147,20 @@
 			width: 100%;
 			height: 100%;
 			border: 1px solid;
-			border-top-width: 0;
-			border-radius: 0 0 4px 4px; /* stylelint-disable-line scales/radii */
 			box-sizing: border-box;
 			background-color: transparent;
 			transition: border-color 0.15s ease-in-out, background-color 0.15s ease-in-out;
 		}
+
+		&:not( .design-picker__image-frame-no-header )::after {
+			border-top-width: 0;
+			border-radius: 0 0 4px 4px; /* stylelint-disable-line scales/radii */
+		}
+
+		&.design-picker__image-frame-no-header::after {
+			border-radius: 0; /* stylelint-disable-line scales/radii */
+		}
+
 	}
 
 	// The Aspect ratio trick: padding % is relative to width, so we use


### PR DESCRIPTION
#### Proposed Changes

* Add a prop called `previewOnly` that controls the visibility of the buttons inside the Design Picker component. We need this functionality because the users should always be redirected to the preview page in the new Design Picker screen.
* Add a prop called `hasDesignOptionHeader` to control the visibility of the header and also change the borders to match the new design when active.

#### Testing Instructions

* Run the following command: `yarn run test-packages packages/design-picker/src/__tests__/`
* You can also access the designSetup step at `/setup/designSetup?siteSlug=[SITE-SLUG]` and make sure that the buttons still show up when you hover a preview.

Related to #64715 #64816
