### PR TITLE
Make all registered domains eligible for Google Workspace within 15 mins after purchase

### DIFF
--- a/client/lib/gsuite/gsuite-supported-domain.js
+++ b/client/lib/gsuite/gsuite-supported-domain.js
@@ -22,8 +22,8 @@ export function getGSuiteSupportedDomains( domains ) {
 		// If the domain is registered through us, there is a provisioning period when
 		// `hasWpcomNameservers` will be false. We still want to let users buy Google Workspace
 		// during that period, even if we normally wouldn't let them under these conditions.
-		// Therefore, we check those conditions and only return `gsuiteIsUnavailable` if the
-		// registration happened less than 15 minutes ago. 15 minutes is an arbitrary number.
+		// Therefore, we check those conditions and return true if the registration happened less
+		// than 15 minutes ago. 15 minutes is an arbitrary number.
 		if ( isRegisteredDomain( domain ) && ! domain.hasWpcomNameservers ) {
 			const registeredTimestamp = Date.parse( domain.registrationDate );
 			const timeSinceRegistration = Date.now() - registeredTimestamp;

--- a/client/lib/gsuite/gsuite-supported-domain.js
+++ b/client/lib/gsuite/gsuite-supported-domain.js
@@ -6,13 +6,27 @@ import { hasGSuiteWithUs } from './has-gsuite-with-us';
 /**
  * Filters a list of domains by the domains that eligible for G Suite.
  *
- * @param {Array} domains - list of domain objects
- * @returns {Array} - the list of domains that are eligible for G Suite
+ * @param {import('calypso/lib/domains/types').ResponseDomain[]} domains - list of domain objects
+ * @returns {import('calypso/lib/domains/types').ResponseDomain[]} - the list of domains that are eligible for G Suite
  */
 export function getGSuiteSupportedDomains( domains ) {
 	return domains.filter( function ( domain ) {
 		if ( hasGSuiteWithAnotherProvider( domain ) ) {
 			return false;
+		}
+
+		// If the domain is registered through us, there is a provisioning period when
+		// `hasWpcomNameservers` will be false. We still want to let users buy Google Workspace
+		// during that period, even if we normally wouldn't let them under these conditions.
+		// Therefore, we check those conditions and only return `gsuiteIsUnavailable` if the
+		// registration happened less than 15 minutes ago. 15 minutes is an arbitrary number.
+		if ( isRegisteredDomain( domain ) && ! domain.hasWpcomNameservers ) {
+			const registeredTimestamp = Date.parse( domain.registrationDate );
+			const timeSinceRegistration = Date.now() - registeredTimestamp;
+
+			if ( timeSinceRegistration < 15 * 60 * 1000 ) {
+				return true;
+			}
 		}
 
 		const isHostedOnWpcom =
@@ -29,7 +43,7 @@ export function getGSuiteSupportedDomains( domains ) {
 /**
  * Given a list of domains does one of them support G Suite
  *
- * @param {Array} domains - list of domain objects
+ * @param {import('calypso/lib/domains/types').ResponseDomain[]} domains - list of domain objects
  * @returns {boolean} - Does list of domains contain a G Suited supported domain
  */
 export function hasGSuiteSupportedDomain( domains ) {

--- a/client/lib/gsuite/gsuite-supported-domain.js
+++ b/client/lib/gsuite/gsuite-supported-domain.js
@@ -4,10 +4,14 @@ import { hasGSuiteWithAnotherProvider } from './has-gsuite-with-another-provider
 import { hasGSuiteWithUs } from './has-gsuite-with-us';
 
 /**
+ * @typedef { import('calypso/lib/domains/types').ResponseDomain } ResponseDomain domain object
+ */
+
+/**
  * Filters a list of domains by the domains that eligible for G Suite.
  *
- * @param {import('calypso/lib/domains/types').ResponseDomain[]} domains - list of domain objects
- * @returns {import('calypso/lib/domains/types').ResponseDomain[]} - the list of domains that are eligible for G Suite
+ * @param {ResponseDomain[]} domains - list of domain objects
+ * @returns {ResponseDomain[]} - the list of domains that are eligible for G Suite
  */
 export function getGSuiteSupportedDomains( domains ) {
 	return domains.filter( function ( domain ) {
@@ -43,7 +47,7 @@ export function getGSuiteSupportedDomains( domains ) {
 /**
  * Given a list of domains does one of them support G Suite
  *
- * @param {import('calypso/lib/domains/types').ResponseDomain[]} domains - list of domain objects
+ * @param {ResponseDomain[]} domains - list of domain objects
  * @returns {boolean} - Does list of domains contain a G Suited supported domain
  */
 export function hasGSuiteSupportedDomain( domains ) {

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -46,7 +46,7 @@ const GoogleWorkspacePrice = ( {
 
 	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
 
-	if ( ! domain && ! isDomainInCart ) {
+	if ( ! domain ) {
 		return null;
 	}
 


### PR DESCRIPTION
#### Proposed Changes

As it currently stands, when users buy a new domain, the post-checkout screen shows a CTA to "Add professional email". However, when users click that button and are taken to `/email/:domain/purchase/:site_slug`, they can't select Google Workspace. Instead of a "Select" button, they get a warning that says "Not available for this domain name".

The reason for this is that even though we can tell that the domain is registered with us, we can't yet tell that the nameservers are pointing to WordPress.com. This is normally a condition for buying Google Workspace.

With this PR, we add a time window of 15 minutes after the registration timestamp when we disregard the nameserver values (because we know that they are unreliable).

Fore more context, see pbLl1t-OI-p2

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Register a new domain
2. In the post-checkout upsell, click "Add professional email"
3. Ensure that Google Workspace is selectable on the next screen
4. Ensure that Google Workspace can be purchased for the domain in question

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #