### PR TITLE
Remove close button from Jetpack checkout

### DIFF
--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -76,11 +76,12 @@ const CheckoutMasterbar = ( {
 	const isHelpCenterEnabled = config.isEnabled( 'checkout/help-center' );
 
 	const newItems = ! isLoading && ! data?.has_seen_whats_new_modal;
+	const showCloseButton = isLeavingAllowed && ! isJetpack;
 
 	return (
 		<Masterbar>
 			<div className="masterbar__secure-checkout">
-				{ isLeavingAllowed && (
+				{ showCloseButton && (
 					<Item
 						icon="cross"
 						className="masterbar__close-button"

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -714,7 +714,7 @@ $masterbar-color-secondary: #101517;
 	svg {
 		overflow: overlay;
 	}
-	
+
 	.notifications-bell-icon__bubble {
 		animation: bubble-unread-indication 0.5s linear both;
 		transition: all 150ms ease-in;
@@ -846,7 +846,7 @@ a.masterbar__quick-language-switcher {
 
 	.masterbar__jetpack-wordmark {
 		height: 25px;
-		margin-right: 5px;
+		margin: 0 5px;
 	}
 
 	.masterbar__secure-checkout-text {
@@ -875,7 +875,7 @@ a.masterbar__quick-language-switcher {
 	svg {
 		fill: var( --color-masterbar-text );
 	}
-	
+
 	&.is-active {
 		background: #1e1e1e;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes the close button from the Jetpack checkout page.

We've noticed that many users leave the Jetpack purchase flow by clicking the close button in the checkout page. We hope that by removing it, conversion rate will increase. The Jetpack purchase flow doesn't really take advantage of the cart system (users coming from their wp-admin or visiting Jetpack.com will land on the checkout page right after selecting a Jetpack product), and the close button in that instance doesn't provide more than what the browser back button does.

Full context: p1HpG7-gg7-p2 

From[ this task](1161179020265237-as-1202403597036985):
> This will not be run as an A/B test. We will measure the conversion rate before and after.

### Testing instructions

- Spin up Calypso blue with this branch
- Select a Jetpack site
- Select a product in the pricing page to go to the checkout page
- Notice that the close button is not present anymore
- Select a simple site
- Repeat the same operation and verify that the close button is still present

### Screenshots

_Before_
<img width="133" alt="Screen Shot 2022-06-21 at 12 37 05 PM" src="https://user-images.githubusercontent.com/1620183/174852865-349e2ead-66e5-4dc0-ae94-52700c258cce.png">


_After_
<img width="110" alt="Screen Shot 2022-06-21 at 12 36 51 PM" src="https://user-images.githubusercontent.com/1620183/174852889-865aa2d3-a44f-4c5d-ab1b-1500a6fa2310.png">