### PR TITLE
Jetpack Licensing: Update license issuing step progress with new steps for agency self serving

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -35,6 +35,17 @@ export default function ( { currentStep }: { currentStep: number } ): ReactEleme
 					<span>2</span>
 				</span>
 				<span className="assign-license-step-progress__step-name">
+					{ translate( 'Add Payment Method' ) }
+				</span>
+			</div>
+			<div className="assign-license-step-progress__step-separator" />
+			<div
+				className={ `assign-license-step-progress__step ${ getStepClassName( currentStep, 3 ) }` }
+			>
+				<span className="assign-license-step-progress__step-circle">
+					<span>3</span>
+				</span>
+				<span className="assign-license-step-progress__step-name">
 					{ translate( 'Assign license' ) }
 				</span>
 			</div>

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -12,6 +12,28 @@ function getStepClassName( currentStep: number, step: number ): any {
 	} );
 }
 
+function CheckMarkOrNumber( {
+	currentStep,
+	step,
+}: {
+	currentStep: number;
+	step: number;
+} ): ReactElement {
+	if ( currentStep > step ) {
+		return (
+			<span className="assign-license-step-progress__step-circle">
+				<Gridicon icon="checkmark" />
+			</span>
+		);
+	}
+
+	return (
+		<span className="assign-license-step-progress__step-circle">
+			<span>{ step }</span>
+		</span>
+	);
+}
+
 export default function ( { currentStep }: { currentStep: number } ): ReactElement {
 	const translate = useTranslate();
 
@@ -20,9 +42,7 @@ export default function ( { currentStep }: { currentStep: number } ): ReactEleme
 			<div
 				className={ `assign-license-step-progress__step ${ getStepClassName( currentStep, 1 ) }` }
 			>
-				<span className="assign-license-step-progress__step-circle">
-					<Gridicon icon="checkmark" />
-				</span>
+				<CheckMarkOrNumber currentStep={ currentStep } step={ 1 } />
 				<span className="assign-license-step-progress__step-name">
 					{ translate( 'Issue new license' ) }
 				</span>
@@ -31,9 +51,7 @@ export default function ( { currentStep }: { currentStep: number } ): ReactEleme
 			<div
 				className={ `assign-license-step-progress__step ${ getStepClassName( currentStep, 2 ) }` }
 			>
-				<span className="assign-license-step-progress__step-circle">
-					<span>2</span>
-				</span>
+				<CheckMarkOrNumber currentStep={ currentStep } step={ 2 } />
 				<span className="assign-license-step-progress__step-name">
 					{ translate( 'Add Payment Method' ) }
 				</span>
@@ -42,9 +60,7 @@ export default function ( { currentStep }: { currentStep: number } ): ReactEleme
 			<div
 				className={ `assign-license-step-progress__step ${ getStepClassName( currentStep, 3 ) }` }
 			>
-				<span className="assign-license-step-progress__step-circle">
-					<span>3</span>
-				</span>
+				<CheckMarkOrNumber currentStep={ currentStep } step={ 3 } />
 				<span className="assign-license-step-progress__step-name">
 					{ translate( 'Assign license' ) }
 				</span>

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -1,7 +1,12 @@
 import { Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { ReactElement } from 'react';
+import { useSelector } from 'react-redux';
+import {
+	hasValidPaymentMethod,
+	isAgencyUser,
+} from 'calypso/state/partner-portal/partner/selectors';
+import type { ReactChild, ReactElement } from 'react';
 import './style.scss';
 
 function getStepClassName( currentStep: number, step: number ): any {
@@ -34,37 +39,56 @@ function CheckMarkOrNumber( {
 	);
 }
 
-export default function ( { currentStep }: { currentStep: number } ): ReactElement {
+type StepKey = 'issueLicense' | 'addPaymentMethod' | 'assignLicense';
+
+interface Step {
+	key: StepKey;
+	label: ReactChild | null;
+}
+
+interface Props {
+	currentStep: StepKey;
+}
+
+export default function AssignLicenseStepProgress( { currentStep }: Props ): ReactElement {
 	const translate = useTranslate();
+	const isAgency = useSelector( isAgencyUser );
+	const hasPaymentMethod = useSelector( hasValidPaymentMethod );
+	const paymentMethodRequired = isAgency && ! hasPaymentMethod;
+
+	const steps: Step[] = [
+		{ key: 'issueLicense', label: translate( 'Issue new license' ) },
+		...( paymentMethodRequired
+			? [ { key: 'addPaymentMethod', label: translate( 'Add Payment Method' ) } as Step ]
+			: [] ),
+		{ key: 'assignLicense', label: translate( 'Assign license' ) },
+	];
+
+	const currentStepIndex = Math.max(
+		steps.findIndex( ( step ) => step.key === currentStep ),
+		0
+	);
 
 	return (
 		<div className="assign-license-step-progress">
-			<div
-				className={ `assign-license-step-progress__step ${ getStepClassName( currentStep, 1 ) }` }
-			>
-				<CheckMarkOrNumber currentStep={ currentStep } step={ 1 } />
-				<span className="assign-license-step-progress__step-name">
-					{ translate( 'Issue new license' ) }
-				</span>
-			</div>
-			<div className="assign-license-step-progress__step-separator" />
-			<div
-				className={ `assign-license-step-progress__step ${ getStepClassName( currentStep, 2 ) }` }
-			>
-				<CheckMarkOrNumber currentStep={ currentStep } step={ 2 } />
-				<span className="assign-license-step-progress__step-name">
-					{ translate( 'Add Payment Method' ) }
-				</span>
-			</div>
-			<div className="assign-license-step-progress__step-separator" />
-			<div
-				className={ `assign-license-step-progress__step ${ getStepClassName( currentStep, 3 ) }` }
-			>
-				<CheckMarkOrNumber currentStep={ currentStep } step={ 3 } />
-				<span className="assign-license-step-progress__step-name">
-					{ translate( 'Assign license' ) }
-				</span>
-			</div>
+			{ steps.map( ( { key, label }, index ) => (
+				<>
+					<div
+						key={ key }
+						className={ `assign-license-step-progress__step ${ getStepClassName(
+							currentStepIndex,
+							index
+						) }` }
+					>
+						<CheckMarkOrNumber currentStep={ currentStepIndex + 1 } step={ index + 1 } />
+						<span className="assign-license-step-progress__step-name">{ label }</span>
+					</div>
+
+					{ index < steps.length - 1 && (
+						<div className="assign-license-step-progress__step-separator" />
+					) }
+				</>
+			) ) }
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -27,7 +27,7 @@ function CheckMarkOrNumber( {
 	if ( currentStep > step ) {
 		return (
 			<span className="assign-license-step-progress__step-circle">
-				<Gridicon icon="checkmark" />
+				<Gridicon icon="checkmark" size={ 16 } />
 			</span>
 		);
 	}

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
@@ -3,13 +3,9 @@
 
 .assign-license-step-progress {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
     align-items: center;
     margin-bottom: 40px;
-
-    @include break-medium {
-        justify-content: flex-start;
-    }
 
     &__step {
         display: flex;
@@ -60,5 +56,23 @@
         background-color: var( --studio-jetpack-green-50 );
         border: 2px solid var( --studio-jetpack-green-50 );
         color: var( --studio-white );
+    }
+
+    &__step.step-next > &__step-name {
+        display: none;
+
+        @include break-medium {
+            display: flex;
+        }
+    }
+
+    &__step.step-complete > &__step-name,
+    &__step.step-complete > &__step-circle,
+    &__step.step-complete + &__step-separator {
+        display: none;
+
+        @include break-medium {
+            display: flex;
+        }
     }
 }

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
@@ -37,18 +37,18 @@
     }
 
     &__step-name {
-        margin-left: 1.125rem;
+        margin-left: 0.5rem;
         white-space: nowrap;
     }
 
     &__step.step-current > &__step-circle {
-        background-color: var( --studio-gray-80 );
-        border: 2px solid var( --studio-gray-80 );
+        background-color: var( --studio-gray-60 );
+        border: 2px solid var( --studio-gray-60 );
         color: var( --studio-white );
     }
 
     &__step.step-next > &__step-circle {
-        border: 2px solid var( --studio-gray-80 );
+        border: 2px solid var( --studio-gray-60 );
         color: var( --studio-gray-80 );
     }
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -33,7 +33,7 @@ export default function AssignLicense( {
 		<Main wideLayout className="assign-license">
 			<DocumentHead title={ translate( 'Assign your License' ) } />
 			<SidebarNavigation />
-			<AssignLicenseStepProgress currentStep={ 2 } />
+			<AssignLicenseStepProgress currentStep={ 3 } />
 			<CardHeading size={ 36 }>{ translate( 'Assign your License' ) }</CardHeading>
 
 			<AssignLicenseForm sites={ sites } currentPage={ currentPage } search={ search } />

--- a/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/assign-license/index.tsx
@@ -4,8 +4,8 @@ import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import AssignLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-form';
+import AssignLicenseStepProgress from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-step-progress';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
-import AssignLicenseStepProgress from '../../assign-license-step-progress';
 
 export default function AssignLicense( {
 	sites,
@@ -33,7 +33,7 @@ export default function AssignLicense( {
 		<Main wideLayout className="assign-license">
 			<DocumentHead title={ translate( 'Assign your License' ) } />
 			<SidebarNavigation />
-			<AssignLicenseStepProgress currentStep={ 3 } />
+			<AssignLicenseStepProgress currentStep="assignLicense" />
 			<CardHeading size={ 36 }>{ translate( 'Assign your License' ) }</CardHeading>
 
 			<AssignLicenseForm sites={ sites } currentPage={ currentPage } search={ search } />

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -3,9 +3,9 @@ import { ReactElement, useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+import AssignLicenseStepProgress from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-step-progress';
 import IssueLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/issue-license-form';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
-import AssignLicenseStepProgress from '../../assign-license-step-progress';
 import { AssignLicenceProps } from '../../types';
 
 export default function IssueLicense( {
@@ -29,7 +29,7 @@ export default function IssueLicense( {
 		<Main wideLayout className="issue-license">
 			<DocumentHead title={ translate( 'Issue a new License' ) } />
 			<SidebarNavigation />
-			<AssignLicenseStepProgress currentStep={ 1 } />
+			<AssignLicenseStepProgress currentStep="issueLicense" />
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
 			<IssueLicenseForm selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -18,6 +18,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+import AssignLicenseStepProgress from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-step-progress';
 import CreditCardLoading from 'calypso/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-loading';
 import PaymentMethodImage from 'calypso/jetpack-cloud/sections/partner-portal/credit-card-fields/payment-method-image';
 import { useReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
@@ -30,7 +31,6 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { hasValidPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
 import { fetchStoredCards } from 'calypso/state/partner-portal/stored-cards/actions';
-import AssignLicenseStepProgress from '../../assign-license-step-progress';
 
 import './style.scss';
 
@@ -127,7 +127,7 @@ function PaymentMethodAdd(): ReactElement {
 			<DocumentHead title={ translate( 'Payment Methods' ) } />
 			<SidebarNavigation />
 
-			{ returnQueryArg && <AssignLicenseStepProgress currentStep={ 2 } /> }
+			{ returnQueryArg && <AssignLicenseStepProgress currentStep="addPaymentMethod" /> }
 
 			<div className="payment-method-add__header">
 				<CardHeading size={ 36 }>{ translate( 'Payment Methods' ) }</CardHeading>

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -30,6 +30,7 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { hasValidPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
 import { fetchStoredCards } from 'calypso/state/partner-portal/stored-cards/actions';
+import AssignLicenseStepProgress from '../../assign-license-step-progress';
 
 import './style.scss';
 
@@ -55,6 +56,11 @@ function PaymentMethodAdd(): ReactElement {
 	);
 	const useAsPrimaryPaymentMethod = useSelect( ( select ) =>
 		select( 'credit-card' ).useAsPrimaryPaymentMethod()
+	);
+
+	const returnQueryArg = useMemo(
+		() => getQueryArg( window.location.href, 'return' ),
+		[ window.location.href, getQueryArg ]
 	);
 
 	useReturnUrl( hasPaymentMethod );
@@ -90,7 +96,7 @@ function PaymentMethodAdd(): ReactElement {
 	);
 
 	const successCallback = useCallback( () => {
-		if ( getQueryArg( window.location.href, 'return' ) ) {
+		if ( returnQueryArg ) {
 			reduxDispatch(
 				fetchStoredCards( {
 					startingAfter: '',
@@ -120,6 +126,8 @@ function PaymentMethodAdd(): ReactElement {
 		<Main wideLayout className="payment-method-add">
 			<DocumentHead title={ translate( 'Payment Methods' ) } />
 			<SidebarNavigation />
+
+			{ returnQueryArg && <AssignLicenseStepProgress currentStep={ 2 } /> }
 
 			<div className="payment-method-add__header">
 				<CardHeading size={ 36 }>{ translate( 'Payment Methods' ) }</CardHeading>


### PR DESCRIPTION
#### Proposed Changes

* Contextualize the step progress element to the agency self serving process;
* Have each step properly highlighted on every page of the steps;
* Resolve 👉🏻  1202074155672006-as-1202253703889513/f

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure to have a Partner Account 👉🏻 PCYsg-zPi-p2 
* Switch your partner account to agency type
* Clean up your payment methods from record

On the next steps of the flow you should be able to see the step progress component reflect which step you are on, like the following screenshots:

**Step 1 - License Issuing**

![image](https://user-images.githubusercontent.com/5550190/174855965-28e64fd3-30b6-45df-9a18-dfec3d4ac4cd.png)

**Step 2 - Adding a payment method**

![image](https://user-images.githubusercontent.com/5550190/174856102-7547eb89-3285-425e-9523-b5b462a90803.png)

**Step 3 - Assigning your license**

![image](https://user-images.githubusercontent.com/5550190/174856231-66de1c50-377a-4e36-896c-433726dbad45.png)


#### Mobile Screenshots

**Step 1**
![image](https://user-images.githubusercontent.com/5550190/174856632-7bbb9c28-00b7-41ad-b186-3679c06dfa8c.png)

**Step 2**
![image](https://user-images.githubusercontent.com/5550190/174856759-be118c49-b870-462a-91f8-ccbac11da7c9.png)

**Step 3**
![image](https://user-images.githubusercontent.com/5550190/174856872-93e4b169-28ca-4d3b-befa-6c60407d34c2.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->