### PR TITLE
Revert "Goals Capture: Enable goals step on Horizon and WPCalypso env…

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -92,7 +92,6 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
 		"signup/inline-help": false,
-		"signup/goals-step": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -116,7 +116,6 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": false,
 		"signup/inline-help": false,
-		"signup/goals-step": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -27,7 +27,7 @@ const selectors = {
 	// Buttons
 	checkUrlButton: 'form.capture__input-wrapper button.action-buttons__next',
 	startBuildingButton: 'div.import__onboarding-page button.action-buttons__next',
-	startImportButton: 'button:text("Import your site content")',
+	startImportButton: 'button.select-items-alt__item-button:text("Import your site content")',
 	// And entry of the list of selectable importers
 	importerListButton: ( index: number ) =>
 		`div.list__importers-primary:nth-child(${ index + 1 }) .action-card__button-container button`,


### PR DESCRIPTION
…ironments. (#64818)"

This reverts commit 53ebf46e3a3eb65f9525b5abd6808ef2c8bc4851.

#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
