### PR TITLE
Marketplace: Add support for Jetpack Search

### DIFF
--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -6,4 +6,5 @@ export const PREINSTALLED_PLUGINS = [
 	'full-site-editing',
 	'layout-grid',
 	'page-optimize',
+	'jetpack-search',
 ];

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -109,17 +109,15 @@ const PluginDetailsCTA = ( {
 		return null;
 	}
 
+	// Jetpack Search is a freemium plugin that comes preinstalled on WPCOM and also available on the WPORG repo.
+	// Because of its uniqueness, we display a custom CTA for sites that have it installed.
+	if ( plugin.slug === 'jetpack-search' && ( ! isJetpackSelfHosted || isPluginInstalledOnsite ) ) {
+		return <PluginDetailsCTAJetpackSearch pluginName={ plugin.name } />;
+	}
+
 	if ( isPluginInstalledOnsite ) {
 		// Check if already instlaled on the site
 		return null;
-	}
-
-	if ( ! isJetpackSelfHosted && plugin.slug === 'jetpack-search' ) {
-		return (
-			<div className="plugin-details-CTA__container">
-				<PluginDetailsCTAJetpackSearch pluginName={ plugin.name } />
-			</div>
-		);
 	}
 
 	// If we cannot retrieve plugin status through jetpack ( ! isJetpack ) and plugin is preinstalled.

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -112,7 +112,11 @@ const PluginDetailsCTA = ( {
 	// Jetpack Search is a freemium plugin that comes preinstalled on WPCOM and also available on the WPORG repo.
 	// Because of its uniqueness, we display a custom CTA for sites that have it installed.
 	if ( plugin.slug === 'jetpack-search' && ( ! isJetpackSelfHosted || isPluginInstalledOnsite ) ) {
-		return <PluginDetailsCTAJetpackSearch pluginName={ plugin.name } />;
+		return (
+			<div className="plugin-details-CTA__container">
+				<PluginDetailsCTAJetpackSearch pluginName={ plugin.name } />
+			</div>
+		);
 	}
 
 	if ( isPluginInstalledOnsite ) {

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -26,6 +26,8 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { PREINSTALLED_PLUGINS } from '../constants';
 import { PluginCustomDomainDialog } from '../plugin-custom-domain-dialog';
 import { PluginPrice, getPeriodVariationValue } from '../plugin-price';
+import PluginDetailsCTAJetpackSearch from './jetpack-search-cta';
+import PluginDetailsCTAPreinstalled from './preinstalled-cta';
 import USPS from './usps';
 import './style.scss';
 
@@ -112,14 +114,19 @@ const PluginDetailsCTA = ( {
 		return null;
 	}
 
+	if ( ! isJetpackSelfHosted && plugin.slug === 'jetpack-search' ) {
+		return (
+			<div className="plugin-details-CTA__container">
+				<PluginDetailsCTAJetpackSearch pluginName={ plugin.name } />
+			</div>
+		);
+	}
+
 	// If we cannot retrieve plugin status through jetpack ( ! isJetpack ) and plugin is preinstalled.
 	if ( ! isJetpack && PREINSTALLED_PLUGINS.includes( plugin.slug ) ) {
 		return (
 			<div className="plugin-details-CTA__container">
-				<div className="plugin-details-CTA__price">{ translate( 'Free' ) }</div>
-				<span className="plugin-details-CTA__preinstalled">
-					{ plugin.name + translate( ' is automatically managed for you.' ) }
-				</span>
+				<PluginDetailsCTAPreinstalled pluginName={ plugin.name } />
 			</div>
 		);
 	}

--- a/client/my-sites/plugins/plugin-details-CTA/jetpack-search-cta.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/jetpack-search-cta.jsx
@@ -1,0 +1,40 @@
+import { WPCOM_FEATURES_INSTANT_SEARCH } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import PreinstalledCTA from './preinstalled-cta';
+
+export default function PluginDetailsCTAJetpackSearch( { pluginName } ) {
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
+	const hasInstantSearch = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_INSTANT_SEARCH )
+	);
+	const wpAdminUrl = useSelector( ( state ) =>
+		getSiteAdminUrl( state, siteId, 'admin.php?page=jetpack-search' )
+	);
+
+	const translate = useTranslate();
+
+	const buttonLabel = hasInstantSearch
+		? translate( 'Settings' )
+		: translate( 'Settings (Upgrades available)' );
+
+	const buttonHref = isAtomic ? wpAdminUrl : `/settings/performance/${ siteSlug }`;
+
+	return (
+		<>
+			<PreinstalledCTA pluginName={ pluginName } />
+			<div className="plugin-details-CTA__jetpack-search">
+				<Button className="plugin-details-CTA__install-button" href={ buttonHref } primary>
+					{ buttonLabel }
+				</Button>
+			</div>
+		</>
+	);
+}

--- a/client/my-sites/plugins/plugin-details-CTA/jetpack-search-cta.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/jetpack-search-cta.jsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import PreinstalledCTA from './preinstalled-cta';
@@ -12,6 +13,8 @@ export default function PluginDetailsCTAJetpackSearch( { pluginName } ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isJetpackSelfHosted = siteId && isJetpack && ! isAtomic;
 	const hasInstantSearch = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_INSTANT_SEARCH )
 	);
@@ -28,13 +31,11 @@ export default function PluginDetailsCTAJetpackSearch( { pluginName } ) {
 	const buttonHref = isAtomic ? wpAdminUrl : `/settings/performance/${ siteSlug }`;
 
 	return (
-		<div className="plugin-details-CTA__container">
-			<PreinstalledCTA pluginName={ pluginName } />
-			<div className="plugin-details-CTA__jetpack-search">
-				<Button className="plugin-details-CTA__install-button" href={ buttonHref } primary>
-					{ buttonLabel }
-				</Button>
-			</div>
+		<div className="plugin-details-CTA__jetpack-search">
+			{ ! isJetpackSelfHosted && <PreinstalledCTA pluginName={ pluginName } /> }
+			<Button className="plugin-details-CTA__install-button" href={ buttonHref } primary>
+				{ buttonLabel }
+			</Button>
 		</div>
 	);
 }

--- a/client/my-sites/plugins/plugin-details-CTA/jetpack-search-cta.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/jetpack-search-cta.jsx
@@ -1,11 +1,13 @@
-import { WPCOM_FEATURES_INSTANT_SEARCH } from '@automattic/calypso-products';
+import {
+	PRODUCT_JETPACK_SEARCH_MONTHLY,
+	WPCOM_FEATURES_INSTANT_SEARCH,
+} from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import PreinstalledCTA from './preinstalled-cta';
 
@@ -18,24 +20,20 @@ export default function PluginDetailsCTAJetpackSearch( { pluginName } ) {
 	const hasInstantSearch = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_INSTANT_SEARCH )
 	);
-	const wpAdminUrl = useSelector( ( state ) =>
-		getSiteAdminUrl( state, siteId, 'admin.php?page=jetpack-search' )
-	);
-
 	const translate = useTranslate();
-
-	const buttonLabel = hasInstantSearch
-		? translate( 'Manage plugin' )
-		: translate( 'Manage plugin (upgrades available)' );
-
-	const buttonHref = isAtomic ? wpAdminUrl : `/settings/performance/${ siteSlug }`;
 
 	return (
 		<div className="plugin-details-CTA__jetpack-search">
 			{ ! isJetpackSelfHosted && <PreinstalledCTA pluginName={ pluginName } /> }
-			<Button className="plugin-details-CTA__install-button" href={ buttonHref } primary>
-				{ buttonLabel }
-			</Button>
+			{ ! hasInstantSearch && (
+				<Button
+					className="plugin-details-CTA__install-button"
+					href={ `/checkout/${ siteSlug }/${ PRODUCT_JETPACK_SEARCH_MONTHLY }` }
+					primary
+				>
+					{ translate( 'Upgrade Jetpack Search' ) }
+				</Button>
+			) }
 		</div>
 	);
 }

--- a/client/my-sites/plugins/plugin-details-CTA/jetpack-search-cta.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/jetpack-search-cta.jsx
@@ -25,8 +25,8 @@ export default function PluginDetailsCTAJetpackSearch( { pluginName } ) {
 	const translate = useTranslate();
 
 	const buttonLabel = hasInstantSearch
-		? translate( 'Settings' )
-		: translate( 'Settings (Upgrades available)' );
+		? translate( 'Manage plugin' )
+		: translate( 'Manage plugin (upgrades available)' );
 
 	const buttonHref = isAtomic ? wpAdminUrl : `/settings/performance/${ siteSlug }`;
 

--- a/client/my-sites/plugins/plugin-details-CTA/jetpack-search-cta.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/jetpack-search-cta.jsx
@@ -28,13 +28,13 @@ export default function PluginDetailsCTAJetpackSearch( { pluginName } ) {
 	const buttonHref = isAtomic ? wpAdminUrl : `/settings/performance/${ siteSlug }`;
 
 	return (
-		<>
+		<div className="plugin-details-CTA__container">
 			<PreinstalledCTA pluginName={ pluginName } />
 			<div className="plugin-details-CTA__jetpack-search">
 				<Button className="plugin-details-CTA__install-button" href={ buttonHref } primary>
 					{ buttonLabel }
 				</Button>
 			</div>
-		</>
+		</div>
 	);
 }

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-cta.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-cta.jsx
@@ -1,0 +1,13 @@
+import { useTranslate } from 'i18n-calypso';
+
+export default function PluginDetailsCTAPreinstalled( { pluginName } ) {
+	const translate = useTranslate();
+	return (
+		<div className="plugin-details-CTA__preinstalled">
+			<div className="plugin-details-CTA__price">{ translate( 'Free' ) }</div>
+			<span className="plugin-details-CTA__preinstalled">
+				{ pluginName + translate( ' is automatically managed for you.' ) }
+			</span>
+		</div>
+	);
+}

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-cta.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-cta.jsx
@@ -6,7 +6,7 @@ export default function PluginDetailsCTAPreinstalled( { pluginName } ) {
 		<>
 			<div className="plugin-details-CTA__price">{ translate( 'Free' ) }</div>
 			<span className="plugin-details-CTA__preinstalled">
-				{ pluginName + translate( ' is automatically managed for you.' ) }
+				{ translate( '%s is automatically managed for you.', { args: pluginName } ) }
 			</span>
 		</>
 	);

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-cta.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-cta.jsx
@@ -3,11 +3,11 @@ import { useTranslate } from 'i18n-calypso';
 export default function PluginDetailsCTAPreinstalled( { pluginName } ) {
 	const translate = useTranslate();
 	return (
-		<div className="plugin-details-CTA__preinstalled">
+		<>
 			<div className="plugin-details-CTA__price">{ translate( 'Free' ) }</div>
 			<span className="plugin-details-CTA__preinstalled">
 				{ pluginName + translate( ' is automatically managed for you.' ) }
 			</span>
-		</div>
+		</>
 	);
 }

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -59,10 +59,16 @@
 
 .plugin-details-CTA__install {
 	margin-bottom: 20px;
+}
+.plugin-details-CTA__install-button {
+	width: 100%;
+	padding: 12px 16px;
+}
 
+.plugin-details-CTA__jetpack-search {
+	margin-bottom: 20px;
 	.plugin-details-CTA__install-button {
-		width: 100%;
-		padding: 12px 16px;
+		margin-top: 32px;
 	}
 }
 


### PR DESCRIPTION
#### Proposed Changes

* Display a custom CTA for the Jetpack Search plugin in the Dotcom Marketplace.

JP Search is a unique freemium plugin, which comes both preinstalled on Dotcom and available on the Dotorg repository.

We can take advantage of its uniqueness and:
- Use the Dotorg API to retrieve the plugin details.
- Mark it as preinstalled on Dotcom.
- Suggest that upgrades are available to any site that has it installed but without premium upgrades (namely: the Instant Search feature).

This approach fixes a rather glaring issue:
- Dotcom sites won't be able to install the Dotorg Jetpack Search plugin anymore, which currently doesn't work for them. (Note: to fix this, the first commit of this PR should be enough).

This approach has some caveats to consider:
- It's a custom implementation which introduces technical debt, albeit minimal.
- On Dotcom sites, the plugin won't show up in both the Installed Plugins list.
- On Dotcom sites, the plugin won't show up in the "Installed On" list on the plugin page in the Dotcom Marketplace.
- Only self-hosted JP sites, the plugin will show up in the "Installed On" list, but won't have the "more menu" to manage the subscription on a per-site basis, like other paid plugins.

#### Feedback Wanted!

@Automattic/bespin Is this approach something that might work for you?

I'm not fond of adding "upgrades available" to the button, so I'm totally open to alternative ideas!

cc @SaxonF and @vinimotaa for design opinions.

#### Screenshots

(Please ignore any outdated copy)

| Site Type | Instant<br>Search? | Marketplace Plugin Page | CTA Target |
| - | - | - | - |
| Simple | ❌ | <img width="1123" alt="Screenshot 2022-06-22 at 14 11 21" src="https://user-images.githubusercontent.com/2070010/175038859-f3465a5e-88c4-466b-bdfb-c9aa964485b5.png"> | `/settings/performance/${ siteSlug }` |
| Simple | ✅ | <img width="1123" alt="Screenshot 2022-06-22 at 14 14 01" src="https://user-images.githubusercontent.com/2070010/175039404-67537b23-4124-4b60-ae05-063b7ae6d382.png"> | `/settings/performance/${ siteSlug }` |
| Atomic | ❌ | <img width="1124" alt="Screenshot 2022-06-22 at 14 13 09" src="https://user-images.githubusercontent.com/2070010/175039373-705a109e-5946-40fb-803a-9f7b8209fb24.png"> | `/wp-admin/admin.php?page=jetpack-search` |
| Atomic | ✅ | <img width="1122" alt="Screenshot 2022-06-22 at 14 11 06" src="https://user-images.githubusercontent.com/2070010/175038799-6c5b9a78-0544-47a0-a7cf-3a31ba2a4499.png"> | `/wp-admin/admin.php?page=jetpack-search` |
| Jetpack (plugin not installed) | ❌ | <img width="1124" alt="Screenshot 2022-06-22 at 14 12 03" src="https://user-images.githubusercontent.com/2070010/175039122-57e78aa9-381f-42f7-b5bd-f88f28397cdd.png"> | |
| Jetpack | ❌ | <img width="1123" alt="Screenshot 2022-06-22 at 14 23 39" src="https://user-images.githubusercontent.com/2070010/175039877-5e947108-4695-47c0-84a0-f68427133481.png"> | `/settings/performance/${ siteSlug }` |
| Jetpack | ✅ | <img width="1124" alt="Screenshot 2022-06-22 at 14 11 38" src="https://user-images.githubusercontent.com/2070010/175038922-ab99960d-b2bb-4888-a69e-6a10a9ecd4ac.png"> | `/settings/performance/${ siteSlug }` |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare Simple, Atomic, and Jetpack self-hosted test sites.
* Navigate to the Plugins section, and search for Jetpack Search.
* Compare the plugin page to the "Instant Search? ❌" screenshots below (ignore possibly outdated copy).
* Try purchasing Jetpack Search on each site.
* Compare the plugin page to the "Instant Search? ✅" screenshots below (ignore possibly outdated copy).
* Make sure the "Manage plugin" CTA target makes sense for each site type.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #62025
