### PR TITLE
Goals Capture: Enable Goals Capture on Dev, Horizon & WPCalypso.

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -144,7 +144,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
 		"signup/inline-help": false,
-		"signup/goals-step": false,
+		"signup/goals-step": true,
 		"signup/hero-flow-non-en": true,
 		"signup/site-vertical-step": true,
 		"signup/starting-point-courses": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -92,6 +92,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
 		"signup/inline-help": false,
+		"signup/goals-step": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -116,6 +116,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": false,
 		"signup/inline-help": false,
+		"signup/goals-step": true,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": false,

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -27,7 +27,7 @@ const selectors = {
 	// Buttons
 	checkUrlButton: 'form.capture__input-wrapper button.action-buttons__next',
 	startBuildingButton: 'div.import__onboarding-page button.action-buttons__next',
-	startImportButton: 'button.select-items-alt__item-button:text("Import your site content")',
+	startImportButton: 'button:text("Import your site content")',
 	// And entry of the list of selectable importers
 	importerListButton: ( index: number ) =>
 		`div.list__importers-primary:nth-child(${ index + 1 }) .action-card__button-container button`,

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -74,7 +74,16 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ), function 
 
 		it( 'Select "write" path', async function () {
 			startSiteFlow = new StartSiteFlow( page );
-			await startSiteFlow.clickButton( 'Start writing' );
+
+			await page.waitForLoadState( 'networkidle' );
+			const isGoalsStep = await page.isVisible( ':has-text("What are your goals")' );
+
+			if ( isGoalsStep ) {
+				await page.click( '.select-card__container:first-of-type' );
+				await startSiteFlow.clickButton( 'Continue' );
+			} else {
+				await startSiteFlow.clickButton( 'Start writing' );
+			}
 		} );
 
 		it( 'Enter blog name', async function () {

--- a/test/e2e/specs/onboarding/signup__paid.ts
+++ b/test/e2e/specs/onboarding/signup__paid.ts
@@ -127,7 +127,15 @@ skipDescribeIf( isStagingOrProd )(
 		describe( 'Onboarding flow', function () {
 			it( 'Select "build" path', async function () {
 				startSiteFlow = new StartSiteFlow( page );
-				await startSiteFlow.clickButton( 'Start building' );
+
+				await page.waitForLoadState( 'networkidle' );
+				const isGoalsStep = await page.isVisible( ':has-text("What are your goals")' );
+
+				if ( isGoalsStep ) {
+					await startSiteFlow.clickButton( 'Continue' );
+				} else {
+					await startSiteFlow.clickButton( 'Start building' );
+				}
 			} );
 
 			it( 'Select a theme to preview', async function () {


### PR DESCRIPTION
#### Proposed Changes

* Enables Goals Capture on Dev/WPCalypso/Horizon environment.
* E2E updates to make them run.

#### Testing Instructions

* Run this PR against Pre-Release Test in Team City.
  * Click "..." then "Run Custom Build".
  * Under "Parameters", point the CALYPSO_BASE_URL to the Calypso live URL of this PR.
  * All tests should pass.
  
  
**Running tests locally:**

* Follow setup instructions in https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e.
* Disable V13N on `development.json`.
  * Set `signup/site-vertical-step` to `false`.
  * This is because the E2E tests hasn't been updated to work with V13N.
* Set `export CALYPSO_BASE_URL=http://calypso.localhost:3000` (see also [this doc]( https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/docs/tests_local.md)).
* Under `test/e2e` folder:
  * Run `yarn jest specs/onboarding/signup__free`.
  * ~Run `yarn jest specs/onboarding/signup__paid`~ (this doesn't work and looks like it's not running on Team City).
 