### PR TITLE
Goals Capture: Fix `exitFlow` Promise Condition

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -131,7 +131,7 @@ export const siteSetupFlow: Flow = {
 				 */
 				return new Promise( () => {
 					const pendingActions = [ setIntentOnSite( siteSlug as string, intent ) ];
-					if ( siteSlug && isEnabled( 'signup/goals-step' ) ) {
+					if ( siteSlug && goalsStepEnabled ) {
 						pendingActions.push( setGoalsOnSite( siteSlug, goals ) );
 					}
 					Promise.all( pendingActions ).then( () => redirect( to ) );


### PR DESCRIPTION
#### Proposed Changes

The proposed change fixes the issue rose in pdDOJh-sJ-p2#comment-312 by replacing sole flag-check `isEnabled( 'signup/goals-step' )` with `goalsStepEnabled ` that includes the flag check and `isEnglishLocale` check.

#### Testing Instructions

1. Set your account to English locale (in `http://calypso.localhost:3000/me/account`):

![Markup on 2022-06-22 at 10:28:39](https://user-images.githubusercontent.com/25105483/174982087-e9d4612c-848e-423b-8fba-5064f740636f.png)

2. Create a new site at `http://calypso.localhost:3000/start` and follow the steps until you exit the flow
3. Review the Network tab in the Developer Console → there should be a site-goals request including the goals selected

![Markup on 2022-06-22 at 10:12:53](https://user-images.githubusercontent.com/25105483/174981262-ab1fcf86-a8f2-4d53-879d-69715c5b04c3.png)

5. Switch the locale to a non-English language
6. Go through the site setup flow again (starting at `http://calypso.localhost:3000/start`) until you exit the flow
7. Review the Network tab in the Developer Console → there should be no site-goals request present

![Markup on 2022-06-22 at 10:21:14](https://user-images.githubusercontent.com/25105483/174981274-89c6924d-8549-44d3-b2b6-d44e8f36194f.png)