### PR TITLE
HelpCenter: fix global variable errors

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -387,7 +387,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
  */
 function load_help_center() {
 	// enable help center for all proxied users.
-	$is_proxied = $_SERVER['A8C_PROXIED_REQUEST'] || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
+	$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) : false || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
 
 	// only shipping to en locale for now.
 	$current_locale = get_locale();


### PR DESCRIPTION
## Proposed Changes

Fix PHPCS errors from deploying changes.

Using global variable required 3 items.

1. Check if ISSET
2. Sanitize with `sanitize_text_field`
3. Cleaned with `wp_unslash`
