### PR TITLE
Design Picker: Adds the badge container and apply changes for the new design

### DIFF
--- a/packages/design-picker/src/components/badge-container/__tests__/index.tsx
+++ b/packages/design-picker/src/components/badge-container/__tests__/index.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import BadgeContainer from '../index';
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn().mockImplementation( ( feature: string ) => {
+		switch ( feature ) {
+			case 'gutenboarding/alpha-templates':
+				return true;
+			default:
+				return false;
+		}
+	} ),
+	__esModule: true,
+	default: function config( key: string ) {
+		return key;
+	},
+} ) );
+
+describe( '<BadgeContainer /> integration', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should render the premium badge', async () => {
+		render( <BadgeContainer badgeType="premium" isPremiumThemeAvailable={ true } /> );
+
+		const premiumBadge = await screen.findByText( 'Premium' );
+
+		expect( premiumBadge ).toBeTruthy();
+	} );
+
+	it( 'should not render badges, but the svg', async () => {
+		const renderedContent = render( <BadgeContainer /> );
+
+		const foundSvg = renderedContent.container.querySelector( 'svg' );
+		const premiumBadge = renderedContent.container.querySelector( '.premium-badge' );
+
+		expect( foundSvg ).toBeTruthy();
+		expect( premiumBadge ).toBeFalsy();
+	} );
+} );

--- a/packages/design-picker/src/components/badge-container/index.tsx
+++ b/packages/design-picker/src/components/badge-container/index.tsx
@@ -1,0 +1,62 @@
+import PremiumBadge from '../premium-badge';
+import type { FunctionComponent } from 'react';
+
+import './style.scss';
+
+interface Props {
+	badgeType?: 'premium' | 'none';
+	isPremiumThemeAvailable?: boolean;
+}
+
+const BadgeContainer: FunctionComponent< Props > = ( {
+	badgeType = 'none',
+	isPremiumThemeAvailable = false,
+} ) => {
+	function getBadge() {
+		switch ( badgeType ) {
+			case 'premium':
+				return <PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } />;
+			case 'none':
+				return null;
+			default:
+				throw new Error( 'Invalid badge type!' );
+		}
+	}
+
+	return (
+		<div className="badge-container">
+			<svg
+				width="16"
+				height="16"
+				viewBox="0 0 16 16"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path
+					d="M12.6667 2H3.33333C2.59695 2 2 2.59695 2 3.33333V12.6667C2 13.403 2.59695 14 3.33333 14H12.6667C13.403 14 14 13.403 14 12.6667V3.33333C14 2.59695 13.403 2 12.6667 2Z"
+					stroke="#50575E"
+					strokeWidth="1.5"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+				<path
+					d="M2 6H14"
+					stroke="#50575E"
+					strokeWidth="1.5"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+				<path
+					d="M6 14V6"
+					stroke="#50575E"
+					strokeWidth="1.5"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+			</svg>
+			{ getBadge() }
+		</div>
+	);
+};
+
+export default BadgeContainer;

--- a/packages/design-picker/src/components/badge-container/style.scss
+++ b/packages/design-picker/src/components/badge-container/style.scss
@@ -1,0 +1,6 @@
+.badge-container {
+	flex-grow: 1;
+	display: flex;
+    justify-content: right;
+    align-items: center;
+}

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -16,6 +16,7 @@ import {
 	sortDesigns,
 	excludeFseDesigns,
 } from '../utils';
+import BadgeContainer from './badge-container';
 import { DesignPickerCategoryFilter } from './design-picker-category-filter';
 import type { Categorization } from '../hooks/use-categorization';
 import type { Design } from '../types';
@@ -74,6 +75,8 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	const blankCanvasTitle = __( 'Blank Canvas', __i18n_text_domain__ );
 	const designTitle = isBlankCanvas ? blankCanvasTitle : defaultTitle;
 
+	const badgeType = design.is_premium ? 'premium' : 'none';
+
 	return (
 		<button
 			className="design-picker__design-option"
@@ -119,6 +122,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 						<span className="design-picker__option-name">{ designTitle }</span>
 					) }
 					{ design.is_premium && premiumBadge }
+					{ ! premiumBadge && <BadgeContainer badgeType={ badgeType } /> }
 				</span>
 			</span>
 		</button>

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
+import { isEnabled } from '@automattic/calypso-config';
 import { MShotsImage } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -79,6 +80,12 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 
 	const badgeType = design.is_premium ? 'premium' : 'none';
 
+	const badgeContainer = ! isEnabled( 'signup/theme-preview-screen' ) ? (
+		design.is_premium && premiumBadge
+	) : (
+		<BadgeContainer badgeType={ badgeType } isPremiumThemeAvailable={ isPremiumThemeAvailable } />
+	);
+
 	return (
 		<button
 			className="design-picker__design-option"
@@ -123,13 +130,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 					{ ! hideDesignTitle && (
 						<span className="design-picker__option-name">{ designTitle }</span>
 					) }
-					{ design.is_premium && premiumBadge }
-					{ ! premiumBadge && (
-						<BadgeContainer
-							badgeType={ badgeType }
-							isPremiumThemeAvailable={ isPremiumThemeAvailable }
-						/>
-					) }
+					{ badgeContainer }
 				</span>
 			</span>
 		</button>

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -55,6 +55,7 @@ interface DesignButtonProps {
 	hideFullScreenPreview?: boolean;
 	hideDesignTitle?: boolean;
 	hasDesignOptionHeader?: boolean;
+	isPremiumThemeAvailable?: boolean;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -66,6 +67,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	disabled,
 	hideDesignTitle,
 	hasDesignOptionHeader = true,
+	isPremiumThemeAvailable = false,
 } ) => {
 	const { __ } = useI18n();
 
@@ -122,7 +124,12 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 						<span className="design-picker__option-name">{ designTitle }</span>
 					) }
 					{ design.is_premium && premiumBadge }
-					{ ! premiumBadge && <BadgeContainer badgeType={ badgeType } /> }
+					{ ! premiumBadge && (
+						<BadgeContainer
+							badgeType={ badgeType }
+							isPremiumThemeAvailable={ isPremiumThemeAvailable }
+						/>
+					) }
 				</span>
 			</span>
 		</button>

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -2,6 +2,7 @@ export { default } from './components';
 export { default as GeneratedDesignPicker } from './components/generated-design-picker';
 export { default as FeaturedPicksButtons } from './components/featured-picks-buttons';
 export { default as PremiumBadge } from './components/premium-badge';
+export { default as BadgeContainer } from './components/badge-container';
 export {
 	availableDesignsConfig,
 	getAvailableDesigns,


### PR DESCRIPTION
#### Proposed Changes

* Adds a new component that will display the badges for the new design picker UI. It also adds a layout icon next to the badge.
<img width="1512" alt="Screen Shot 2022-06-22 at 10 29 26" src="https://user-images.githubusercontent.com/1234758/175041052-07728fe0-7b16-4c26-bcb3-6e26d9e62d4e.png">

#### Testing Instructions

* Run `yarn run test-packages packages/design-picker/src/components/badge-container/` to run the tests for the new component.
* You can also comment the following line:
https://github.com/Automattic/wp-calypso/blob/f8edd552cfcb721e854b247061849420227b63b4/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx#L424
Then, you navigate to `/setup/designSetup?siteSlug=<SITE-SLUG>` and you will see the new design for the badge.

Related to #64715
