### PR TITLE
Cloud: Show Agency Signup form in staging

### DIFF
--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -62,6 +62,7 @@
 		"backup": true,
 		"jetpack-cloud": true,
 		"jetpack-cloud-agency-dashboard": true,
+		"jetpack-cloud-agency-signup": true,
 		"jetpack-cloud-auth": true,
 		"jetpack-cloud-partner-portal": true,
 		"jetpack-cloud-pricing": true,


### PR DESCRIPTION
#### Proposed Changes

* Show "Agency Signup" form on staging environments so business, design and other teams can test it before going live.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

None. Merge and deploy this PR and go to `https://cloud.jetpack.com/agency/signup` with a "non-partner" WPCOM account (while behind proxy).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

* https://github.com/Automattic/wp-calypso/pull/63970/