### PR TITLE
Themes: Provide locale when fetching themes on SSR

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -22,7 +22,7 @@ export function fetchThemeDetailsData( context, next ) {
 	}
 
 	context.store
-		.dispatch( requestTheme( themeSlug, 'wpcom' ) )
+		.dispatch( requestTheme( themeSlug, 'wpcom', context.lang ) )
 		.then( () => {
 			const themeDetails = getTheme( context.store.getState(), 'wpcom', themeSlug );
 			if ( ! themeDetails ) {

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -61,7 +61,7 @@ export function fetchThemeData( context, next ) {
 		return next();
 	}
 
-	context.store.dispatch( requestThemes( siteId, query ) ).then( next ).catch( next );
+	context.store.dispatch( requestThemes( siteId, query, context.lang ) ).then( next ).catch( next );
 }
 
 export function fetchThemeFilters( context, next ) {

--- a/client/state/themes/actions/request-theme.js
+++ b/client/state/themes/actions/request-theme.js
@@ -22,9 +22,10 @@ import 'calypso/state/themes/init';
  *
  * @param  {string}   themeId Theme ID
  * @param  {number}   siteId  Site ID
+ * @param  {string}   locale  Locale slug
  * @returns {Function}         Action thunk
  */
-export function requestTheme( themeId, siteId ) {
+export function requestTheme( themeId, siteId, locale ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: THEME_REQUEST,
@@ -59,7 +60,10 @@ export function requestTheme( themeId, siteId ) {
 
 		if ( siteId === 'wpcom' ) {
 			return wpcom.req
-				.get( `/themes/${ themeId }`, { apiVersion: '1.2' } )
+				.get(
+					`/themes/${ themeId }`,
+					Object.assign( { apiVersion: '1.2' }, locale ? { locale } : null )
+				)
 				.then( ( theme ) => {
 					dispatch( receiveTheme( normalizeWpcomTheme( theme ), siteId ) );
 					dispatch( {

--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -24,9 +24,10 @@ import 'calypso/state/themes/init';
  * @param  {number}        query.number  How many themes to return per page
  * @param  {number}        query.offset  At which item to start the set of returned themes
  * @param  {number}        query.page    Which page of matching themes to return
+ * @param  {string}        locale        Locale slug
  * @returns {Function}                    Action thunk
  */
-export function requestThemes( siteId, query = {} ) {
+export function requestThemes( siteId, query = {}, locale ) {
 	return ( dispatch, getState ) => {
 		const startTime = new Date().getTime();
 
@@ -41,7 +42,11 @@ export function requestThemes( siteId, query = {} ) {
 		if ( siteId === 'wporg' ) {
 			request = () => fetchWporgThemesList( query );
 		} else if ( siteId === 'wpcom' ) {
-			request = () => wpcom.req.get( '/themes', { ...query, apiVersion: '1.2' } );
+			request = () =>
+				wpcom.req.get(
+					'/themes',
+					Object.assign( { ...query, apiVersion: '1.2' }, locale ? { locale } : null )
+				);
 		} else {
 			request = () => wpcom.req.get( `/sites/${ siteId }/themes`, { ...query, apiVersion: '1' } );
 		}


### PR DESCRIPTION
Currently, the `wpcom` REST API wrapper lib sets `locale` query parameter to the requests, reading the locale slug from the global `i18n-calypso`. However, the SSR creates [a new instance of i18n-calypso](https://github.com/Automattic/wp-calypso/pull/59903/files#diff-32f88ee173fb96376ffbc709283100315626ee072ee7bd6dc017334054b8ba9dR13) and uses it instead, and therefore the global instance remains in its default state and would always return the default `en` locale slug.

As a result, the themes data is always being requested in English on the server side and theme content (description, etc.) rendered on the page by the server is also in English.

#### Proposed Changes

* Provide the locale to the `requestTheme` and `requestThemes` actions from the context, similarly to how `requestThemeFilters` was fixed in https://github.com/Automattic/wp-calypso/pull/59903/files#diff-610ef48de8034f07a32053763f52996c70f427622e3baeecc6b6ba3fb7d0574fR81

#### Testing Instructions

* Use calypso.live build or boot locally
* Go to `/{locale}/theme/{theme}` (e.g. `/ja/theme/appleton`) and inspect the source code of the page to confirm that it has been rendered with theme data in the specified locale.

#### Related
pb5gDS-1Rf-p2