### PR TITLE
Refactor condition that hides AMP settings for deprecated sites

### DIFF
--- a/client/my-sites/site-settings/amp/wpcom.jsx
+++ b/client/my-sites/site-settings/amp/wpcom.jsx
@@ -48,7 +48,11 @@ class AmpWpcom extends Component {
 
 	render() {
 		const {
-			fields: { amp_is_supported: ampIsSupported, amp_is_enabled: ampIsEnabled },
+			fields: {
+				amp_is_supported: ampIsSupported,
+				amp_is_deprecated: ampIsDeprecated,
+				amp_is_enabled: ampIsEnabled,
+			},
 			isRequestingSettings,
 			isSavingSettings,
 			siteSlug,
@@ -58,7 +62,7 @@ class AmpWpcom extends Component {
 		const isDisabled = isRequestingSettings || isSavingSettings;
 		const isCustomizeEnabled = ! isDisabled && ampIsEnabled;
 
-		if ( ! ampIsSupported ) {
+		if ( ! ampIsSupported || ampIsDeprecated ) {
 			return null;
 		}
 

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -179,6 +179,7 @@ const getFormSettings = ( settings ) =>
 	pick( settings, [
 		'amp_is_enabled',
 		'amp_is_supported',
+		'amp_is_deprecated',
 		'instant_search_enabled',
 		'jetpack_search_enabled',
 		'jetpack_search_supported',


### PR DESCRIPTION
#### Proposed Changes

* This PR changes the condition that hides AMP settings for deprecated sites to account for changes done on the REST API side.

I do this to prepare the code for incoming UI changes that need to display different copy for site with deprecated AMP and for site that has it not supported (eg. private site).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Prerequisites

* have two sandboxed simple sites: one with an older id, one with a newer
* pull patch to the sandbox D83017-code
* optionally, if older site is not available, adjust `$_end_of_amp_support_blog_id` in `amp-loader.php` to the value between two site ids

##### Check if AMP settings are removed from the newer site

1. Navigate to WP Admin of the site that was created after AMP was deprecated
2. Check that UI in "WP Admin -> Settings -> Performance" is gone

![Screen Shot 2022-06-22 at 18 01 20](https://user-images.githubusercontent.com/727413/175078453-90927902-a673-44dd-9105-76d664731c97.png)

#####  Check if AMP is still available for the older site

1. Navigate to WP Admin of the site that was created before AMP was deprecated
2. Check that UI in "WP Admin -> Settings -> Performance" is still available

![Screen Shot 2022-06-22 at 18 01 10](https://user-images.githubusercontent.com/727413/175078499-24c2b169-f694-4927-a3fa-8fb7e5d61338.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64731
This PR should be deployed after D83017-code