### PR TITLE
Goals Capture: Clear goals and intent selection after user completes onboard flow

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -92,7 +92,8 @@ export const siteSetupFlow: Flow = {
 			( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID )
 		);
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
-		const { setPendingAction, setStepProgress } = useDispatch( ONBOARD_STORE );
+		const { setPendingAction, setStepProgress, resetGoals, resetIntent } =
+			useDispatch( ONBOARD_STORE );
 		const { setIntentOnSite, setGoalsOnSite } = useDispatch( SITE_STORE );
 		const { FSEActive } = useFSEStatus();
 		const dispatch = reduxDispatch();
@@ -139,6 +140,10 @@ export const siteSetupFlow: Flow = {
 			} );
 
 			navigate( 'processing' );
+
+			// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
+			resetGoals();
+			resetIntent();
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -265,6 +265,14 @@ export const clearDIFMGoal = () => ( {
 	type: 'CLEAR_DIFM_GOAL' as const,
 } );
 
+export const resetGoals = () => ( {
+	type: 'RESET_GOALS' as const,
+} );
+
+export const resetIntent = () => ( {
+	type: 'RESET_INTENT' as const,
+} );
+
 export const setEditEmail = ( email: string ) => ( {
 	type: 'SET_EDIT_EMAIL' as const,
 	email,
@@ -304,5 +312,7 @@ export type OnboardAction = ReturnType<
 	| typeof setGoals
 	| typeof clearImportGoal
 	| typeof clearDIFMGoal
+	| typeof resetGoals
+	| typeof resetIntent
 	| typeof setEditEmail
 >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -226,7 +226,7 @@ const intent: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_INTENT' ) {
 		return action.intent;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( [ 'RESET_INTENT', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
 		return '';
 	}
 	return state;
@@ -305,7 +305,7 @@ const goals: Reducer< SiteGoal[], OnboardAction > = ( state = [], action ) => {
 	if ( action.type === 'CLEAR_DIFM_GOAL' ) {
 		return state.filter( ( goal ) => goal !== SiteGoal.DIFM );
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( [ 'RESET_GOALS', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
 		return [];
 	}
 	return state;


### PR DESCRIPTION
#### Proposed Changes

* Clear `goals` and `intent` selection from local + redux store once user completes the `site-setup-flow` (a.k.a onboard flow).

#### Testing Instructions

1. Navigate to `http://calypso.localhost:3000/setup/goals?siteSlug=<your-site>`
2. Complete the onboard flow in any possible way, but ensure to select some goals so that we can verify they are being reset, example: 
![Screenshot 2022-06-22 at 16 43 54](https://user-images.githubusercontent.com/2019970/175059818-36029b64-36e9-4f36-9cf3-2e457c3d328c.png)
![Screenshot 2022-06-22 at 16 44 08](https://user-images.githubusercontent.com/2019970/175059823-428f95d3-7ec2-4763-8412-1063e41dcc77.png)
![Screenshot 2022-06-22 at 16 44 15](https://user-images.githubusercontent.com/2019970/175059826-51f49023-f8b0-47f5-81e1-f0a1e1d78891.png)
![Screenshot 2022-06-22 at 16 44 24](https://user-images.githubusercontent.com/2019970/175059830-e14c695a-86c4-4868-84c9-ed261b5ff247.png)
![Screenshot 2022-06-22 at 16 44 40](https://user-images.githubusercontent.com/2019970/175059833-dab4c097-a1b2-492a-9afd-5a1c0203f698.png)
3. Ensure the correct `goals` and `intent` were sent to their respective remote api's:
4. Navigate back to `http://calypso.localhost:3000/setup/goals?siteSlug=<your-site>`. No goals should be pre-selected:

Related to #
