### PR TITLE
Hook to retrieve theme details from the API

### DIFF
--- a/client/landing/stepper/hooks/use-theme-details.ts
+++ b/client/landing/stepper/hooks/use-theme-details.ts
@@ -1,0 +1,31 @@
+import { useQuery, UseQueryResult, UseQueryOptions } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+type Theme = {
+	id: string;
+	name: string;
+	author: string;
+	author_uri: string;
+	description: string;
+	date_updated: string;
+	taxonomies: Record< string, [] >;
+};
+
+export function useThemeDetails(
+	slug: string,
+	queryOptions: UseQueryOptions< any, unknown, Theme > = {}
+): UseQueryResult< Theme > {
+	return useQuery< any, unknown, Theme >(
+		'theme-details',
+		() => wpcom.req.get( `/themes/${ slug }`, { apiVersion: '1.1' } ),
+		{
+			staleTime: Infinity,
+			refetchOnWindowFocus: false,
+			refetchOnReconnect: false,
+			...queryOptions,
+			meta: {
+				...queryOptions.meta,
+			},
+		}
+	);
+}


### PR DESCRIPTION
#### Proposed Changes

A simple hook to retrieve a theme's details from the API. Uses `useQuery` so results are cached.
