### PR TITLE
Seller Experience: Break Theme Features into a shared component

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-features.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-features.scss
@@ -13,7 +13,12 @@
         border-radius: 4px;
         color: #2c3338;
         font-weight: 500;
-        font-size: $font-body-small;
+        font-size: $font-body-extra-small;
         line-height: 20px;
+    }
+
+    h2 {
+        font-size: $font-body-small;
+        margin-bottom: 0.5rem;
     }
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-features.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-features.scss
@@ -1,0 +1,19 @@
+.theme-features__features {
+    display: flex;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+
+    .theme-features__feature {
+        display: inline-block;
+        height: 20px;
+        padding: 0 10px;
+        margin-right: 7px;
+        margin-top: 7px;
+        background: #dcdcde;
+        border-radius: 4px;
+        color: #2c3338;
+        font-weight: 500;
+        font-size: $font-body-small;
+        line-height: 20px;
+    }
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-features.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-features.tsx
@@ -17,7 +17,7 @@ const ThemeFeatures = ( { classNames, features, heading }: FeaturesProps ) => {
 		<>
 			{ features.length > 0 && (
 				<div className={ classes }>
-					{ heading && <h3>${ heading }</h3> }
+					{ heading && <h2>{ heading }</h2> }
 					<div className="theme-features__features">
 						{ features.map( ( feature, idx ) => {
 							return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-features.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-features.tsx
@@ -1,0 +1,36 @@
+import classnames from 'classnames';
+import './theme-features.scss';
+
+interface Feature {
+	name: string;
+}
+
+interface FeaturesProps {
+	classNames?: string;
+	features: Feature[];
+	heading?: string;
+}
+
+const ThemeFeatures = ( { classNames, features, heading }: FeaturesProps ) => {
+	const classes = classnames( 'theme-features__features-wrap popup-item', classNames );
+	return (
+		<>
+			{ features.length > 0 && (
+				<div className={ classes }>
+					{ heading && `<h3>${ heading }</h3>` }
+					<div className="theme-features__features">
+						{ features.map( ( feature, idx ) => {
+							return (
+								<div className="theme-features__feature" key={ idx }>
+									{ feature.name }
+								</div>
+							);
+						} ) }
+					</div>
+				</div>
+			) }
+		</>
+	);
+};
+
+export default ThemeFeatures;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-features.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-features.tsx
@@ -17,7 +17,7 @@ const ThemeFeatures = ( { classNames, features, heading }: FeaturesProps ) => {
 		<>
 			{ features.length > 0 && (
 				<div className={ classes }>
-					{ heading && `<h3>${ heading }</h3>` }
+					{ heading && <h3>${ heading }</h3> }
 					<div className="theme-features__features">
 						{ features.map( ( feature, idx ) => {
 							return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/theme-info-popup.tsx
@@ -1,5 +1,6 @@
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useThemeDetails } from '../../../../hooks/use-theme-details';
+import ThemeFeatures from './theme-features';
 import './theme-info-popup.scss';
 
 interface Plugin {
@@ -14,14 +15,6 @@ interface ThemeInfoPopupProps {
 
 interface PluginListProps {
 	plugins: Plugin[];
-}
-
-interface Feature {
-	name: string;
-}
-
-interface FeaturesProps {
-	features: Feature[];
 }
 
 interface DescriptionProps {
@@ -48,27 +41,6 @@ const ThemeInfoPopup = ( { slug }: ThemeInfoPopupProps ) => {
 		);
 	};
 
-	const ThemeFeatures = ( { features }: FeaturesProps ) => {
-		return (
-			<>
-				{ features.length > 0 && (
-					<div className="theme-info-popup__features-wrap popup-item">
-						<h2>Features</h2>
-						<div className="theme-info-popup__features">
-							{ features.map( ( feature, idx ) => {
-								return (
-									<div className="theme-info-popup__feature" key={ idx }>
-										{ feature.name }
-									</div>
-								);
-							} ) }
-						</div>
-					</div>
-				) }
-			</>
-		);
-	};
-
 	const SupportLinks = () => {
 		return (
 			<div className="theme-info-popup__support-links popup-item">
@@ -92,7 +64,7 @@ const ThemeInfoPopup = ( { slug }: ThemeInfoPopupProps ) => {
 		<div className="theme-info-popup">
 			<ThemeDescription author_uri={ author_uri } author={ author } description={ description } />
 			<SupportLinks />
-			<ThemeFeatures features={ features } />
+			<ThemeFeatures features={ features } heading="Features" />
 		</div>
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

* Add a shared `ThemeFeatures` component for use in theme info dropdown and seller upgrade modal.
<img width="548" alt="Screen Shot 2022-06-22 at 12 11 57 PM" src="https://user-images.githubusercontent.com/2124984/175081125-b00339a0-e400-4be5-bcda-8a0ea7a05952.png">

#### Testing Instructions

* Visit `/setup/designSetup?siteSlug=[your-site-slug]&flags=signup/theme-preview-screen`
* Click on a theme to preview it
* Note the info popup; it should include the Features list at the bottom

Related to #64855
