### PR TITLE
wporg Lib: Create a custom error class to return the response object

### DIFF
--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -1,6 +1,7 @@
 import languages from '@automattic/languages';
 import { find } from 'lodash';
 import { stringify as stringifyQs } from 'qs';
+import { RequestError } from './request-error';
 
 /**
  * Constants
@@ -32,7 +33,8 @@ async function getRequest( url, query ) {
 	if ( response.ok ) {
 		return await response.json();
 	}
-	throw new Error( await response.body );
+
+	throw new RequestError( await response.body, response );
 }
 
 /**

--- a/client/lib/wporg/request-error.js
+++ b/client/lib/wporg/request-error.js
@@ -1,0 +1,12 @@
+export class RequestError extends Error {
+	constructor( message, response ) {
+		super( message );
+		this.name = 'RequestError';
+		this.response = response;
+
+		// Maintains proper stack trace for where our error was thrown (only available on V8)
+		if ( Error.captureStackTrace ) {
+			Error.captureStackTrace( this, RequestError );
+		}
+	}
+}

--- a/client/lib/wporg/request-error.js
+++ b/client/lib/wporg/request-error.js
@@ -3,10 +3,5 @@ export class RequestError extends Error {
 		super( message );
 		this.name = 'RequestError';
 		this.response = response;
-
-		// Maintains proper stack trace for where our error was thrown (only available on V8)
-		if ( Error.captureStackTrace ) {
-			Error.captureStackTrace( this, RequestError );
-		}
 	}
 }


### PR DESCRIPTION
### Description
Create the error class `RequestError` to be thrown when an error is returned by the method `getRequest`. It allows us to have access to more data as the status code and URL requested.

A new field was added and can be accessed by this error, the `response` field is the response returned by the `fetch` method.

### Compatibility
It shouldn't break the older implementations as the passed message is the same.

---

This change is needed for https://github.com/Automattic/wp-calypso/issues/64161