### PR TITLE
Plugin Details: Retrieve product list when plugin is not found on WPorg

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -46,6 +46,7 @@ import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/w
 import {
 	isFetching as isWporgPluginFetchingSelector,
 	isFetched as isWporgPluginFetchedSelector,
+	hasError as isWporgPluginErrorSelector,
 	getPlugin as getWporgPluginSelector,
 } from 'calypso/state/plugins/wporg/selectors';
 import {
@@ -94,6 +95,10 @@ function PluginDetails( props ) {
 	const isWporgPluginFetched = useSelector( ( state ) =>
 		isWporgPluginFetchedSelector( state, props.pluginSlug )
 	);
+	const wporgPluginError = useSelector( ( state ) =>
+		isWporgPluginErrorSelector( state, props.pluginSlug )
+	);
+	const wporgPluginNotFound = wporgPluginError?.response?.status === 404;
 	const sitePlugin = useSelector( ( state ) =>
 		getPluginOnSite( state, selectedSite?.ID, props.pluginSlug )
 	);
@@ -277,7 +282,7 @@ function PluginDetails( props ) {
 			<QueryJetpackPlugins siteIds={ siteIds } />
 			<QueryEligibility siteId={ selectedSite?.ID } />
 			<QuerySiteFeatures siteIds={ selectedOrAllSites.map( ( site ) => site.ID ) } />
-			<QueryProductsList persist />
+			<QueryProductsList persist={ ! wporgPluginNotFound } />
 			<FixedNavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs } />
 
 			<PluginNotices

--- a/client/state/plugins/wporg/reducer.js
+++ b/client/state/plugins/wporg/reducer.js
@@ -61,7 +61,7 @@ export function items( state = {}, action ) {
 			return updatePluginState(
 				state,
 				pluginSlug,
-				Object.assign( { fetched: false, wporg: false } )
+				Object.assign( { fetched: false, wporg: false, error: action.error } )
 			);
 		default:
 			return state;

--- a/client/state/plugins/wporg/selectors.js
+++ b/client/state/plugins/wporg/selectors.js
@@ -13,6 +13,11 @@ export function isFetching( state, pluginSlug ) {
 	return state?.plugins.wporg.fetchingItems[ pluginSlug ] ?? false;
 }
 
+export function hasError( state, pluginSlug ) {
+	const plugin = getPlugin( state, pluginSlug );
+	return plugin?.error ?? null;
+}
+
 export function isFetched( state, pluginSlug ) {
 	const plugin = getPlugin( state, pluginSlug );
 	return plugin ? !! plugin.fetched : false;


### PR DESCRIPTION

#### Proposed Changes

Stop using the persistent mode on QueryProductsList when the plugin is not found on WP.org.

It should reload the product list when the plugin is not found on WP.org repository, which might mean the current product list is out of date.

#### Testing Instructions

- Open the Browser dev tools and go the `Network` tab
-  Go to a plugin details page (`/plugins/{plugin_slug}`) of a an existing plugin. Ex: `/plugins/woocommerce`
- It should show the plugin and don't make any requests to the products list (`https://public-api.wordpress.com/rest/v1.1/products`)
- Go to a non-existent plugin details page, it should emulate a recently added plugin. Ex: `/plugins/abc`
- The page should be blank. (To be addressed by the follow up: #64872)
-  You should see a request to the products list (`https://public-api.wordpress.com/rest/v1.1/products`)

---

Fixes #64161