### PR TITLE
Design Picker: Adding pricing description to the new design

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -433,6 +433,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			onSelect={ pickDesign }
 			onPreview={ previewDesign }
 			onUpgrade={ upgradePlan }
+			onCheckout={ goToCheckout }
 			className={ classnames( {
 				'design-setup__has-categories': showDesignPickerCategories,
 			} ) }

--- a/packages/design-picker/src/components/badge-container/__tests__/index.tsx
+++ b/packages/design-picker/src/components/badge-container/__tests__/index.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import BadgeContainer from '../index';
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn().mockImplementation( ( feature: string ) => {
+		switch ( feature ) {
+			case 'gutenboarding/alpha-templates':
+				return true;
+			default:
+				return false;
+		}
+	} ),
+	__esModule: true,
+	default: function config( key: string ) {
+		return key;
+	},
+} ) );
+
+describe( '<BadgeContainer /> integration', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should render the premium badge', async () => {
+		render( <BadgeContainer badgeType="premium" isPremiumThemeAvailable={ true } /> );
+
+		const premiumBadge = await screen.findByText( 'Premium' );
+
+		expect( premiumBadge ).toBeTruthy();
+	} );
+
+	it( 'should not render badges, but the svg', async () => {
+		const renderedContent = render( <BadgeContainer /> );
+
+		const foundSvg = renderedContent.container.querySelector( 'svg' );
+		const premiumBadge = renderedContent.container.querySelector( '.premium-badge' );
+
+		expect( foundSvg ).toBeTruthy();
+		expect( premiumBadge ).toBeFalsy();
+	} );
+} );

--- a/packages/design-picker/src/components/badge-container/index.tsx
+++ b/packages/design-picker/src/components/badge-container/index.tsx
@@ -1,0 +1,62 @@
+import PremiumBadge from '../premium-badge';
+import type { FunctionComponent } from 'react';
+
+import './style.scss';
+
+interface Props {
+	badgeType?: 'premium' | 'none';
+	isPremiumThemeAvailable?: boolean;
+}
+
+const BadgeContainer: FunctionComponent< Props > = ( {
+	badgeType = 'none',
+	isPremiumThemeAvailable = false,
+} ) => {
+	function getBadge() {
+		switch ( badgeType ) {
+			case 'premium':
+				return <PremiumBadge isPremiumThemeAvailable={ isPremiumThemeAvailable } />;
+			case 'none':
+				return null;
+			default:
+				throw new Error( 'Invalid badge type!' );
+		}
+	}
+
+	return (
+		<div className="badge-container">
+			<svg
+				width="16"
+				height="16"
+				viewBox="0 0 16 16"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path
+					d="M12.6667 2H3.33333C2.59695 2 2 2.59695 2 3.33333V12.6667C2 13.403 2.59695 14 3.33333 14H12.6667C13.403 14 14 13.403 14 12.6667V3.33333C14 2.59695 13.403 2 12.6667 2Z"
+					stroke="#50575E"
+					strokeWidth="1.5"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+				<path
+					d="M2 6H14"
+					stroke="#50575E"
+					strokeWidth="1.5"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+				<path
+					d="M6 14V6"
+					stroke="#50575E"
+					strokeWidth="1.5"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+			</svg>
+			{ getBadge() }
+		</div>
+	);
+};
+
+export default BadgeContainer;

--- a/packages/design-picker/src/components/badge-container/style.scss
+++ b/packages/design-picker/src/components/badge-container/style.scss
@@ -1,0 +1,6 @@
+.badge-container {
+	flex-grow: 1;
+	display: flex;
+    justify-content: right;
+    align-items: center;
+}

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -84,7 +84,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 
 		const text = __( 'Free' );
 
-		return <div>{ text }</div>;
+		return <div className="design-picker__pricing-description">{ text }</div>;
 	}
 
 	const badgeType = design.is_premium ? 'premium' : 'none';

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-
+import { isEnabled } from '@automattic/calypso-config';
 import { MShotsImage } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -74,6 +74,16 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	const blankCanvasTitle = __( 'Blank Canvas', __i18n_text_domain__ );
 	const designTitle = isBlankCanvas ? blankCanvasTitle : defaultTitle;
 
+	function getPricingDescription() {
+		if ( ! isEnabled( 'signup/theme-preview-screen' ) ) {
+			return null;
+		}
+
+		const text = __( 'Free' );
+
+		return <div>{ text }</div>;
+	}
+
 	return (
 		<button
 			className="design-picker__design-option"
@@ -120,6 +130,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 					) }
 					{ design.is_premium && premiumBadge }
 				</span>
+				{ getPricingDescription() }
 			</span>
 		</button>
 	);

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -3,6 +3,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { MShotsImage } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -82,7 +83,30 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 			return null;
 		}
 
-		const text = __( 'Free' );
+		let text: any = __( 'Free' );
+
+		if ( design.is_premium ) {
+			text = createInterpolateElement(
+				sprintf(
+					/* translators: %(price)s - the price of the theme */
+					__( '%(price)s per year or <a>included in the Pro plan</a>' ),
+					{
+						price: design.price,
+					}
+				),
+				{
+					a: (
+						<a
+							href="https://google.com"
+							target="__blank"
+							onClick={ ( e ) => {
+								e.stopPropagation();
+							} }
+						/>
+					),
+				}
+			);
+		}
 
 		return <div className="design-picker__pricing-description">{ text }</div>;
 	}

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -16,6 +16,7 @@ import {
 	sortDesigns,
 	excludeFseDesigns,
 } from '../utils';
+import BadgeContainer from './badge-container';
 import { DesignPickerCategoryFilter } from './design-picker-category-filter';
 import type { Categorization } from '../hooks/use-categorization';
 import type { Design } from '../types';
@@ -74,6 +75,8 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	const blankCanvasTitle = __( 'Blank Canvas', __i18n_text_domain__ );
 	const designTitle = isBlankCanvas ? blankCanvasTitle : defaultTitle;
 
+	const badgeType = design.is_premium ? 'premium' : 'none';
+
 	return (
 		<button
 			className="design-picker__design-option"
@@ -119,6 +122,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 						<span className="design-picker__option-name">{ designTitle }</span>
 					) }
 					{ design.is_premium && premiumBadge }
+					{ ! premiumBadge && <BadgeContainer badgeType={ badgeType } /> }
 				</span>
 			</span>
 		</button>

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -57,6 +57,7 @@ interface DesignButtonProps {
 	hideDesignTitle?: boolean;
 	hasDesignOptionHeader?: boolean;
 	isPremiumThemeAvailable?: boolean;
+	onCheckout?: any;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -69,6 +70,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	hideDesignTitle,
 	hasDesignOptionHeader = true,
 	isPremiumThemeAvailable = false,
+	onCheckout = undefined,
 } ) => {
 	const { __ } = useI18n();
 
@@ -77,6 +79,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	const defaultTitle = design.title;
 	const blankCanvasTitle = __( 'Blank Canvas', __i18n_text_domain__ );
 	const designTitle = isBlankCanvas ? blankCanvasTitle : defaultTitle;
+	const shouldUpgrade = design.is_premium && ! isPremiumThemeAvailable;
 
 	function getPricingDescription() {
 		if ( ! isEnabled( 'signup/theme-preview-screen' ) ) {
@@ -87,20 +90,22 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 
 		if ( design.is_premium ) {
 			text = createInterpolateElement(
-				sprintf(
-					/* translators: %(price)s - the price of the theme */
-					__( '%(price)s per year or <a>included in the Pro plan</a>' ),
-					{
-						price: design.price,
-					}
-				),
+				shouldUpgrade
+					? sprintf(
+							/* translators: %(price)s - the price of the theme */
+							__( '%(price)s per year or <a>included in the Pro plan</a>' ),
+							{
+								price: design.price,
+							}
+					  )
+					: __( 'Included in the Pro plan' ),
 				{
 					a: (
 						<a
-							href="https://google.com"
-							target="__blank"
+							href="javascript:void(0)"
 							onClick={ ( e ) => {
 								e.stopPropagation();
+								onCheckout?.();
 							} }
 						/>
 					),
@@ -265,7 +270,11 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 					onUpgrade={ onUpgrade }
 				/>
 			) }
-			<DesignButton { ...props } disabled={ ! isBlankCanvas } />
+			<DesignButton
+				{ ...props }
+				isPremiumThemeAvailable={ isPremiumThemeAvailable }
+				disabled={ ! isBlankCanvas }
+			/>
 		</div>
 	);
 };
@@ -291,6 +300,7 @@ export interface DesignPickerProps {
 	isPremiumThemeAvailable?: boolean;
 	previewOnly?: boolean;
 	hasDesignOptionHeader?: boolean;
+	onCheckout?: any;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
@@ -316,6 +326,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isPremiumThemeAvailable,
 	previewOnly = false,
 	hasDesignOptionHeader = true,
+	onCheckout = undefined,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const filteredDesigns = useMemo( () => {
@@ -360,6 +371,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						isPremiumThemeAvailable={ isPremiumThemeAvailable }
 						previewOnly={ previewOnly }
 						hasDesignOptionHeader={ hasDesignOptionHeader }
+						onCheckout={ onCheckout }
 					/>
 				) ) }
 			</div>

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -55,6 +55,7 @@ interface DesignButtonProps {
 	hideFullScreenPreview?: boolean;
 	hideDesignTitle?: boolean;
 	hasDesignOptionHeader?: boolean;
+	isPremiumThemeAvailable?: boolean;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -66,6 +67,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	disabled,
 	hideDesignTitle,
 	hasDesignOptionHeader = true,
+	isPremiumThemeAvailable = false,
 } ) => {
 	const { __ } = useI18n();
 
@@ -122,7 +124,12 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 						<span className="design-picker__option-name">{ designTitle }</span>
 					) }
 					{ design.is_premium && premiumBadge }
-					{ ! premiumBadge && <BadgeContainer badgeType={ badgeType } /> }
+					{ ! premiumBadge && (
+						<BadgeContainer
+							badgeType={ badgeType }
+							isPremiumThemeAvailable={ isPremiumThemeAvailable }
+						/>
+					) }
 				</span>
 			</span>
 		</button>

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -226,6 +226,8 @@
 	.design-picker__pricing-description {
 		text-align: left;
 		color: #50575e;
+		z-index: 1;
+		position: absolute;
 	}
 }
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -222,6 +222,11 @@
 		font-weight: 500; /* stylelint-disable-line scales/font-weights */
 		margin-top: -0.1em;
 	}
+
+	.design-picker__pricing-description {
+		text-align: left;
+		color: #50575e;
+	}
 }
 
 // dark theme styles

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -52,7 +52,7 @@ export function useThemeDesignsQuery(
 	);
 }
 
-function apiThemeToDesign( { id, name, taxonomies, stylesheet }: any ): Design {
+function apiThemeToDesign( { id, name, taxonomies, stylesheet, price }: any ): Design {
 	// Designs use a "featured" term in the theme_picks taxonomy. For example: Blank Canvas
 	const isFeaturedPicks = !! taxonomies?.theme_picks?.find(
 		( { slug }: any ) => slug === 'featured'
@@ -73,6 +73,7 @@ function apiThemeToDesign( { id, name, taxonomies, stylesheet }: any ): Design {
 		showFirst: isFeaturedPicks,
 		...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
 		design_type: is_premium ? 'premium' : 'standard',
+		price,
 
 		// Deprecated; used for /start flow
 		stylesheet,

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -2,6 +2,7 @@ export { default } from './components';
 export { default as GeneratedDesignPicker } from './components/generated-design-picker';
 export { default as FeaturedPicksButtons } from './components/featured-picks-buttons';
 export { default as PremiumBadge } from './components/premium-badge';
+export { default as BadgeContainer } from './components/badge-container';
 export {
 	availableDesignsConfig,
 	getAvailableDesigns,

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -42,6 +42,7 @@ export interface Design {
 	showFirst?: boolean; // Whether this design will appear at the top, regardless of category
 	preview?: 'static';
 	design_type?: DesignType;
+	price?: string;
 
 	/** @deprecated used for Gutenboarding (/new flow) */
 	stylesheet?: string;


### PR DESCRIPTION
#### Proposed Changes

* Adds the bottom pricing description as part of the new design for the Design Picker screen.

#### Testing Instructions

* Go to `setup/designSetup?siteSlug=<SITE-SLUG>&flags=signup/theme-preview-screen`.
* You'll see the pricing description below the Design name.

Related to #64715
