### PR TITLE
Add scroll in add page modal layout options

### DIFF
--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -102,8 +102,6 @@ $sidebar-width-desktop: 324px;
 .page-pattern-modal__inner {
 	@media screen and ( min-width: $breakpoint-mobile ) {
 		padding: 0 20px;
-		max-height: 100%;
-		display: flex;
 	}
 }
 
@@ -218,11 +216,11 @@ $sidebar-width-desktop: 324px;
 		position: fixed;
 		width: $sidebar-width;
 		padding-right: 22px;
-		max-height: calc( 100% - 60px - 24px - 3px );
 		overflow: hidden;
 		display: flex;
 		flex-direction: column;
-
+		top: 63px;
+		bottom: 33px;
 		// Manually choosing when to enable/disable pointer events so that
 		// the scroll wheel behaviour feels natural when the mouse is over
 		// the sidebar. The sidebar is fixed position so it doesn't move when

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -102,6 +102,8 @@ $sidebar-width-desktop: 324px;
 .page-pattern-modal__inner {
 	@media screen and ( min-width: $breakpoint-mobile ) {
 		padding: 0 20px;
+		max-height: 100%;
+		display: flex;
 	}
 }
 
@@ -216,6 +218,10 @@ $sidebar-width-desktop: 324px;
 		position: fixed;
 		width: $sidebar-width;
 		padding-right: 22px;
+		max-height: calc( 100% - 60px - 24px );
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
 
 		// Manually choosing when to enable/disable pointer events so that
 		// the scroll wheel behaviour feels natural when the mouse is over
@@ -230,14 +236,6 @@ $sidebar-width-desktop: 324px;
 		> * {
 			pointer-events: auto;
 		}
-
-		.page-pattern-modal__category-list {
-			pointer-events: none;
-
-			.page-pattern-modal__category-button {
-				pointer-events: auto;
-			}
-		}
 	}
 	@media screen and ( min-width: $breakpoint-desktop ) {
 		width: $sidebar-width-desktop;
@@ -248,7 +246,8 @@ $sidebar-width-desktop: 324px;
 .page-pattern-modal__category-list {
 	display: none;
 	margin: 0;
-	padding-top: 35px;
+	margin-top: 35px;
+	overflow: auto;
 
 	@media screen and ( min-width: $breakpoint-mobile ) {
 		display: block;

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -218,7 +218,7 @@ $sidebar-width-desktop: 324px;
 		position: fixed;
 		width: $sidebar-width;
 		padding-right: 22px;
-		max-height: calc( 100% - 60px - 24px );
+		max-height: calc( 100% - 60px - 24px - 3px );
 		overflow: hidden;
 		display: flex;
 		flex-direction: column;
@@ -342,5 +342,6 @@ $sidebar-width-desktop: 324px;
 	}
 	@media screen and ( min-width: $breakpoint-desktop ) {
 		padding-left: $sidebar-width-desktop;
+		width: 100%;
 	}
 }

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -340,6 +340,5 @@ $sidebar-width-desktop: 324px;
 	}
 	@media screen and ( min-width: $breakpoint-desktop ) {
 		padding-left: $sidebar-width-desktop;
-		width: 100%;
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Only on desktop, add scroll in the list of layout options 

<img width="398" alt="Screen Shot 2565-06-23 at 00 50 26" src="https://user-images.githubusercontent.com/1881481/175167650-fdfe04e6-411c-4249-9e95-dd57d6579319.png">
<img width="391" alt="Screen Shot 2565-06-23 at 00 50 53" src="https://user-images.githubusercontent.com/1881481/175167565-56e98417-0de5-43d1-9c44-4b6d2e8502f2.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* From the admin dashboard
* Click on Add new page to open the modal 
* Resize the window to reduce the height until the list of layout options is partially hidden
* Scroll on the layout options list should be available

https://user-images.githubusercontent.com/1881481/175169216-1d42651f-eff8-43e3-9ba5-566c1dc82eb1.mp4

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#60695](https://github.com/Automattic/wp-calypso/issues/60695)
