### PR TITLE
fix e2e onboarding e2e test when verticalization is enabled

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -1,6 +1,12 @@
 import { Frame, Page } from 'playwright';
-import { waitForElementEnabled } from '../../element-helper';
 import envVariables from '../../env-variables';
+
+/**
+ * Step name in site setup flow.
+ *
+ * @see client/landing/stepper/declarative-flow/site-setup-flow.ts for all step names
+ */
+export type StepName = 'goals' | 'vertical' | 'intent' | 'designSetup' | 'options';
 
 const selectors = {
 	// Generic
@@ -8,17 +14,27 @@ const selectors = {
 	backLink: 'button:text("Back")',
 
 	// Inputs
-	blogNameInput: 'input[name="siteTitle"]',
-	taglineInput: 'input[name="tagline"]',
+	blogNameInput: 'input[name="siteTitle"]:not(:disabled)',
+	taglineInput: 'input[name="tagline"]:not(:disabled)',
 	verticalInput: '.select-vertical__suggestion-input input',
 
 	// Themes
-	themePickerContainer: '.design-picker',
 	individualThemeContainer: ( name: string ) => `.design-button-container:has-text("${ name }")`,
 	previewThemeButtonDesktop: ( name: string ) => `button:has-text("Preview ${ name }")`,
 	previewThemeButtonMobile: ( name: string ) =>
 		`button.design-picker__design-option:has-text("${ name }")`,
 	themePreviewIframe: 'iframe[title=Preview]',
+
+	// Goals
+	goalButton: ( goal: string ) => `.select-card__container:has-text("${ goal }")`,
+	selectedGoalButton: ( goal: string ) => `.select-card__container.selected:has-text("${ goal }")`,
+
+	// Step containers
+	themePickerContainer: '.design-picker',
+	goalsStepContainer: '.goals-step',
+	verticalsStepContainer: '.site-vertical',
+	intentStepContainer: '.intent-step',
+	optionsStepContainer: '.is-step-write',
 };
 
 /**
@@ -46,6 +62,39 @@ export class StartSiteFlow {
 	}
 
 	/**
+	 * Returns the step name of the current page
+	 */
+	async getCurrentStep(): Promise< StepName > {
+		await this.page.waitForLoadState( 'networkidle' );
+		if ( ( await this.page.locator( selectors.goalsStepContainer ).count() ) > 0 ) {
+			return 'goals';
+		}
+		if ( ( await this.page.locator( selectors.verticalsStepContainer ).count() ) > 0 ) {
+			return 'vertical';
+		}
+		if ( ( await this.page.locator( selectors.intentStepContainer ).count() ) > 0 ) {
+			return 'intent';
+		}
+		if ( ( await this.page.locator( selectors.themePickerContainer ).count() ) > 0 ) {
+			return 'designSetup';
+		}
+		if ( ( await this.page.locator( selectors.optionsStepContainer ).count() ) > 0 ) {
+			return 'options';
+		}
+		throw new Error( `Unknown or invalid step` );
+	}
+
+	/**
+	 * Select a goal by text.
+	 *
+	 * @param {string} goal The goal to select
+	 */
+	async selectGoal( goal: string ): Promise< void > {
+		await this.page.click( selectors.goalButton( goal ) );
+		await this.page.waitForSelector( selectors.selectedGoalButton( goal ) );
+	}
+
+	/**
 	 * Enter site vertical.
 	 *
 	 * @param {string} vertical Name of the vertical to select
@@ -70,9 +119,7 @@ export class StartSiteFlow {
 	async enterBlogName( name: string ): Promise< void > {
 		await this.page.waitForLoadState( 'networkidle' );
 		const defaultInputlocator = this.page.locator( selectors.blogNameInput );
-		// try waiting for element to become enabled
-		// we've had issues with this before https://github.com/Automattic/wp-calypso/issues/64271
-		waitForElementEnabled( this.page, selectors.blogNameInput );
+
 		await defaultInputlocator.fill( name );
 
 		// Verify the data is saved as expected.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -89,7 +89,7 @@ cd test/e2e
 10. [decrypt](docs/test_environment.md) the secrets file.
 
 ```
-export E2E_SECRETS_KEY='<secret key from the Automattic secret store>'
+export E2E_SECRETS_KEY='Calypso E2E Config decode key from the Automattic secret store>'
 yarn decrypt-secrets
 ```
 

--- a/test/e2e/docs/test_environment.md
+++ b/test/e2e/docs/test_environment.md
@@ -48,10 +48,10 @@ if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
 
 Within `@automattic/calypso-e2e/src/secrets` is an encrypted file that holds various sensitive secrets, such as API keys and test account information. This must be decrypted prior to use.
 
-To decrypt the secrets, set the environment variable `E2E_SECRETS_KEY` to the secret from the Automattic secret store.
+To decrypt the secrets, set the environment variable `E2E_SECRETS_KEY` to the "Calypso E2E Config decode key" from the Automattic secret store.
 
 ```
-export E2E_SECRETS_KEY='<secret key from the secret store>'
+export E2E_SECRETS_KEY='<Calypso E2E Config decode key from the secret store>'
 ```
 
 Then, either here or in the `@automattic/calypso-e2e` workspace, run `yarn decrypt-secrets`.

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -76,25 +76,25 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ), function 
 			startSiteFlow = new StartSiteFlow( page );
 
 			await page.waitForLoadState( 'networkidle' );
-			const isGoalsStep = await page.isVisible( ':has-text("What are your goals")' );
+			const currentStep = await startSiteFlow.getCurrentStep();
 
-			if ( isGoalsStep ) {
-				await page.click( '.select-card__container:first-of-type' );
+			if ( currentStep === 'goals' ) {
+				await startSiteFlow.selectGoal( 'Write & Publish' );
 				await startSiteFlow.clickButton( 'Continue' );
 			}
 		} );
 
 		it( 'Select a vertical', async function () {
-			const isVerticalsStep = await page.isVisible( '.site-vertical' );
-			if ( isVerticalsStep ) {
+			const currentStep = await startSiteFlow.getCurrentStep();
+			if ( currentStep === 'vertical' ) {
 				await startSiteFlow.enterVertical( 'People & Society' );
 				await startSiteFlow.clickButton( 'Continue' );
 			}
 		} );
 
 		it( 'Select "write" path', async function () {
-			const isVerticalsStep = await page.isVisible( '.intent-step' );
-			if ( isVerticalsStep ) {
+			const currentStep = await startSiteFlow.getCurrentStep();
+			if ( currentStep === 'intent' ) {
 				await startSiteFlow.clickButton( 'Start writing' );
 			}
 		} );

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -72,7 +72,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ), function 
 	describe( 'Onboarding flow', function () {
 		let startSiteFlow: StartSiteFlow;
 
-		it( 'Select "write" path', async function () {
+		it( 'Skip goals step', async function () {
 			startSiteFlow = new StartSiteFlow( page );
 
 			await page.waitForLoadState( 'networkidle' );
@@ -81,7 +81,20 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Free' ), function 
 			if ( isGoalsStep ) {
 				await page.click( '.select-card__container:first-of-type' );
 				await startSiteFlow.clickButton( 'Continue' );
-			} else {
+			}
+		} );
+
+		it( 'Select a vertical', async function () {
+			const isVerticalsStep = await page.isVisible( '.site-vertical' );
+			if ( isVerticalsStep ) {
+				await startSiteFlow.enterVertical( 'People & Society' );
+				await startSiteFlow.clickButton( 'Continue' );
+			}
+		} );
+
+		it( 'Select "write" path', async function () {
+			const isVerticalsStep = await page.isVisible( '.intent-step' );
+			if ( isVerticalsStep ) {
 				await startSiteFlow.clickButton( 'Start writing' );
 			}
 		} );


### PR DESCRIPTION
#### Proposed Changes

Currently, when v13n is enabled, the test `specs/onboarding/signup__free` will fail. This test is not run as part of CI but needs to be run as part of the Pre-Release tests in TeamCity.

fix for goals screen https://github.com/Automattic/wp-calypso/pull/64829/files#diff-5fd720308095682e2cd4100ab6078deebb8c86ea241524478028c3bbe754bff7R77
slack discussion p1655851613524289-slack-CRWCHQGUB

Note: currently it appears that the `signup__paid` flow hasn't been working for a while? I'm working on fixing this as well and updating it to support the new v13n flow

#### Testing Instructions
run the e2e test locally 
```
yarn install
cd test/e2e
export E2E_SECRETS_KEY='Calypso E2E Config decode key from the Automattic secret store>'
yarn decrypt-secrets
 
yarn workspace @automattic/calypso-e2e build

# run the tests against different environments
CALYPSO_BASE_URL=https://horizon.wordpress.com yarn jest specs/onboarding
CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn jest specs/onboarding
CALYPSO_BASE_URL=https://wordpress.com yarn jest specs/onboarding
