### PR TITLE
Update: CODEOWNERS for test/e2e and packages/calypso-e2e

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -118,8 +118,8 @@
 /packages/languages @Automattic/i18n
 
 # E2E specs
-/test/e2e @WunderBart @Automattic/quality-squad
-/packages/calypso-e2e @Automattic/quality-squad
+/test/e2e @WunderBart @Automattic/kitkat
+/packages/calypso-e2e @Automattic/kitkat
 
 # Node updates
 /.nvmrc @Automattic/ground-control

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -118,8 +118,8 @@
 /packages/languages @Automattic/i18n
 
 # E2E specs
-/test/e2e @WunderBart @Automattic/kitkat
-/packages/calypso-e2e @Automattic/kitkat
+/test/e2e @WunderBart @Automattic/kitkat @worldomonation
+/packages/calypso-e2e @Automattic/kitkat @worldomonation
 
 # Node updates
 /.nvmrc @Automattic/ground-control


### PR DESCRIPTION
#### Proposed Changes

This PR updates the codeowners to include `@Automattic/kitkat` and `@worldomonation`.

#### Testing Instructions


Related to #
