### PR TITLE
ETK Help Center: Create a tabs panel for next steps tutorials

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -52,6 +52,7 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, isLoading } 
 		},
 		onAnimationEnd: toggleVisible,
 	};
+
 	return (
 		<MemoryRouter>
 			<FeatureFlagProvider>

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -3,7 +3,7 @@
  */
 import { Spinner } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { Card } from '@wordpress/components';
+import { Card, TabPanel } from '@wordpress/components';
 import classnames from 'classnames';
 import { useState, FC } from 'react';
 import Draggable, { DraggableProps } from 'react-draggable';
@@ -68,16 +68,41 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, isLoading } 
 							onMaximize={ () => setIsMinimized( false ) }
 							onDismiss={ onDismiss }
 						/>
-						{ isLoading ? (
-							<div className="help-center-container__loading">
-								<Spinner baseClassName="" className="help-center-container__spinner" />
-							</div>
-						) : (
-							<>
-								<HelpCenterContent isMinimized={ isMinimized } />
-								{ ! isMinimized && <HelpCenterFooter /> }
-							</>
-						) }
+						<TabPanel
+							className="help-center-container__tab-panel"
+							tabs={ [
+								{
+									name: 'nextSteps',
+									title: 'Next Steps',
+									className: 'help-center-container__next-steps-tab',
+								},
+								{
+									name: 'help',
+									title: 'Help',
+									className: 'help-center-container__help-tab',
+								},
+							] }
+						>
+							{ ( tab ) => {
+								switch ( tab.name ) {
+									case 'nextSteps':
+										return <p>test</p>;
+									case 'help':
+										return isLoading ? (
+											<div className="help-center-container__loading">
+												<Spinner baseClassName="" className="help-center-container__spinner" />
+											</div>
+										) : (
+											<>
+												<HelpCenterContent isMinimized={ isMinimized } />
+												{ ! isMinimized && <HelpCenterFooter /> }
+											</>
+										);
+									default:
+										return <></>;
+								}
+							} }
+						</TabPanel>
 					</Card>
 				</OptionalDraggable>
 			</FeatureFlagProvider>

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -3,7 +3,7 @@
  */
 import { Spinner } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { Card, TabPanel } from '@wordpress/components';
+import { Card } from '@wordpress/components';
 import classnames from 'classnames';
 import { useState, FC } from 'react';
 import Draggable, { DraggableProps } from 'react-draggable';
@@ -52,7 +52,6 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, isLoading } 
 		},
 		onAnimationEnd: toggleVisible,
 	};
-
 	return (
 		<MemoryRouter>
 			<FeatureFlagProvider>
@@ -68,41 +67,16 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, isLoading } 
 							onMaximize={ () => setIsMinimized( false ) }
 							onDismiss={ onDismiss }
 						/>
-						<TabPanel
-							className="help-center-container__tab-panel"
-							tabs={ [
-								{
-									name: 'nextSteps',
-									title: 'Next Steps',
-									className: 'help-center-container__next-steps-tab',
-								},
-								{
-									name: 'help',
-									title: 'Help',
-									className: 'help-center-container__help-tab',
-								},
-							] }
-						>
-							{ ( tab ) => {
-								switch ( tab.name ) {
-									case 'nextSteps':
-										return <p>test</p>;
-									case 'help':
-										return isLoading ? (
-											<div className="help-center-container__loading">
-												<Spinner baseClassName="" className="help-center-container__spinner" />
-											</div>
-										) : (
-											<>
-												<HelpCenterContent isMinimized={ isMinimized } />
-												{ ! isMinimized && <HelpCenterFooter /> }
-											</>
-										);
-									default:
-										return <></>;
-								}
-							} }
-						</TabPanel>
+						{ isLoading ? (
+							<div className="help-center-container__loading">
+								<Spinner baseClassName="" className="help-center-container__spinner" />
+							</div>
+						) : (
+							<>
+								<HelpCenterContent isMinimized={ isMinimized } />
+								{ ! isMinimized && <HelpCenterFooter /> }
+							</>
+						) }
 					</Card>
 				</OptionalDraggable>
 			</FeatureFlagProvider>

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -17,6 +17,7 @@ import { HelpCenterContactForm } from './help-center-contact-form';
 import { HelpCenterContactPage } from './help-center-contact-page';
 import { HelpCenterEmbedResult } from './help-center-embed-result';
 import InlineChat from './help-center-inline-chat';
+import { HelpCenterNextStepsTutorials } from './help-center-next-steps-tutorials';
 import { HelpCenterSearch } from './help-center-search';
 import { SuccessScreen } from './ticket-success-screen';
 
@@ -47,6 +48,9 @@ const HelpCenterContent: React.FC< Content > = ( { isMinimized } ) => {
 			</Route>
 			<Route path="/contact-form">
 				<HelpCenterContactForm />
+			</Route>
+			<Route path="/next-steps-tutorials">
+				<HelpCenterNextStepsTutorials />
 			</Route>
 			<Route path="/success">
 				<SuccessScreen />

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -1,9 +1,9 @@
-import { CardHeader, Button, Flex } from '@wordpress/components';
+import { CardHeader, Button, Flex, TabPanel } from '@wordpress/components';
 import { closeSmall, chevronUp, lineSolid, commentContent, page, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect, useState } from 'react';
-import { Route, Switch, useLocation } from 'react-router-dom';
+import { Route, Switch, useHistory, useLocation } from 'react-router-dom';
 import { useHCWindowCommunicator } from '../happychat-window-communicator';
 import type { Header, WindowState } from '../types';
 import type { ReactElement } from 'react';
@@ -54,6 +54,7 @@ const HelpCenterHeader: React.FC< Header > = ( {
 	const { __ } = useI18n();
 	const [ chatWindowStatus, setChatWindowStatus ] = useState< WindowState >( 'closed' );
 	const [ unreadCount, setUnreadCount ] = useState< number >( 0 );
+	const history = useHistory();
 	const formattedUnreadCount = unreadCount > 9 ? '9+' : unreadCount;
 
 	function requestMaximize() {
@@ -70,56 +71,87 @@ const HelpCenterHeader: React.FC< Header > = ( {
 	useHCWindowCommunicator( setChatWindowStatus, setUnreadCount );
 
 	return (
-		<CardHeader className={ classNames }>
-			<Flex>
-				<p id="header-text" className="help-center-header__text">
-					{ isMinimized ? (
-						<Switch>
-							<Route path="/" exact>
-								{ __( 'Help Center', __i18n_text_domain__ ) }
-							</Route>
-							<Route path="/contact-options">
-								{ __( 'Contact Options', __i18n_text_domain__ ) }
-							</Route>
-							<Route path="/contact-form" component={ SupportModeTitle }></Route>
-							<Route path="/post" component={ ArticleTitle }></Route>
-						</Switch>
-					) : (
-						__( 'Help Center', __i18n_text_domain__ )
-					) }
-					{ isMinimized && unreadCount ? (
-						<span className="help-center-header__unread-count">{ formattedUnreadCount }</span>
-					) : null }
-				</p>
-				<div>
-					{ isMinimized ? (
-						<Button
-							className={ 'help-center-header__maximize' }
-							label={ __( 'Maximize Help Center', __i18n_text_domain__ ) }
-							icon={ chevronUp }
-							tooltipPosition="top left"
-							onClick={ requestMaximize }
-						/>
-					) : (
-						<Button
-							className={ 'help-center-header__minimize' }
-							label={ __( 'Minimize Help Center', __i18n_text_domain__ ) }
-							icon={ lineSolid }
-							tooltipPosition="top left"
-							onClick={ onMinimize }
-						/>
-					) }
+		<>
+			<CardHeader className={ classNames }>
+				<Flex>
+					<p id="header-text" className="help-center-header__text">
+						{ isMinimized ? (
+							<Switch>
+								<Route path="/" exact>
+									{ __( 'Help Center', __i18n_text_domain__ ) }
+								</Route>
+								<Route path="/contact-options">
+									{ __( 'Contact Options', __i18n_text_domain__ ) }
+								</Route>
+								<Route path="/contact-form" component={ SupportModeTitle }></Route>
+								<Route path="/post" component={ ArticleTitle }></Route>
+							</Switch>
+						) : (
+							__( 'Help Center', __i18n_text_domain__ )
+						) }
+						{ isMinimized && unreadCount ? (
+							<span className="help-center-header__unread-count">{ formattedUnreadCount }</span>
+						) : null }
+					</p>
+					<div>
+						{ isMinimized ? (
+							<Button
+								className={ 'help-center-header__maximize' }
+								label={ __( 'Maximize Help Center', __i18n_text_domain__ ) }
+								icon={ chevronUp }
+								tooltipPosition="top left"
+								onClick={ requestMaximize }
+							/>
+						) : (
+							<Button
+								className={ 'help-center-header__minimize' }
+								label={ __( 'Minimize Help Center', __i18n_text_domain__ ) }
+								icon={ lineSolid }
+								tooltipPosition="top left"
+								onClick={ onMinimize }
+							/>
+						) }
 
-					<Button
-						className={ 'help-center-header__close' }
-						label={ __( 'Close Help Center', __i18n_text_domain__ ) }
-						tooltipPosition="top left"
-						icon={ closeSmall }
-						onClick={ onDismiss }
-					/>
-				</div>
-			</Flex>
-		</CardHeader>
+						<Button
+							className={ 'help-center-header__close' }
+							label={ __( 'Close Help Center', __i18n_text_domain__ ) }
+							tooltipPosition="top left"
+							icon={ closeSmall }
+							onClick={ onDismiss }
+						/>
+					</div>
+				</Flex>
+			</CardHeader>
+			{ ! isMinimized && (
+				<TabPanel
+					className="help-center-header__tab-panel"
+					initialTabName="help"
+					tabs={ [
+						{
+							name: 'nextSteps',
+							title: 'Next Steps',
+							className: 'help-center-container__next-steps-tab',
+						},
+						{
+							name: 'help',
+							title: 'Help',
+							className: 'help-center-container__help-tab',
+						},
+					] }
+					onSelect={ ( tab ) => {
+						if ( tab === 'nextSteps' ) {
+							history.push( '/next-steps-tutorials' );
+						} else if ( tab === 'help' ) {
+							history.push( '/' );
+						}
+					} }
+				>
+					{ () => {
+						return <></>;
+					} }
+				</TabPanel>
+			) }
+		</>
 	);
 };
 

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -9,10 +9,15 @@ import { useHCWindowCommunicator } from '../happychat-window-communicator';
 import type { Header, WindowState } from '../types';
 import type { ReactElement } from 'react';
 
+interface TabNameMap {
+	'/': string;
+	'/next-steps-tutorials': string;
+}
+
 const HELP_TAB_NAME = 'help';
 const NEXT_STEPS_TAB_NAME = 'next-steps-tutorials';
 
-function getInitialTabName( pathname = '' ): string {
+function getInitialTabName( pathname: keyof TabNameMap = '/' ): string {
 	const tabNameMap = {
 		'/': HELP_TAB_NAME,
 		'/next-steps-tutorials': NEXT_STEPS_TAB_NAME,

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -4,6 +4,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect, useState } from 'react';
 import { Route, Switch, useHistory, useLocation } from 'react-router-dom';
+import { useFeatureFlags } from '../contexts/FeatureFlagContext';
 import { useHCWindowCommunicator } from '../happychat-window-communicator';
 import type { Header, WindowState } from '../types';
 import type { ReactElement } from 'react';
@@ -70,6 +71,7 @@ const HelpCenterHeader: React.FC< Header > = ( {
 	const [ unreadCount, setUnreadCount ] = useState< number >( 0 );
 	const history = useHistory();
 	const { pathname } = useLocation();
+	const { loadNextStepsTutorial } = useFeatureFlags();
 
 	const initialTabName = getInitialTabName( pathname );
 	const formattedUnreadCount = unreadCount > 9 ? '9+' : unreadCount;
@@ -142,7 +144,7 @@ const HelpCenterHeader: React.FC< Header > = ( {
 					</div>
 				</Flex>
 			</CardHeader>
-			{ ! isMinimized && (
+			{ ! isMinimized && loadNextStepsTutorial && (
 				<TabPanel
 					className="help-center-header__tab-panel"
 					initialTabName={ initialTabName }

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -97,6 +97,9 @@ const HelpCenterHeader: React.FC< Header > = ( {
 								<Route path="/" exact>
 									{ __( 'Help Center', __i18n_text_domain__ ) }
 								</Route>
+								<Route path="/next-steps-tutorials" exact>
+									{ __( 'Help Center', __i18n_text_domain__ ) }
+								</Route>
 								<Route path="/contact-options">
 									{ __( 'Contact Options', __i18n_text_domain__ ) }
 								</Route>

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -8,6 +8,20 @@ import { useHCWindowCommunicator } from '../happychat-window-communicator';
 import type { Header, WindowState } from '../types';
 import type { ReactElement } from 'react';
 
+const HELP_TAB_NAME = 'help';
+const NEXT_STEPS_TAB_NAME = 'next-steps-tutorials';
+
+function getInitialTabName( pathname = '' ): string {
+	const tabNameMap = {
+		'/': HELP_TAB_NAME,
+		'/next-steps-tutorials': NEXT_STEPS_TAB_NAME,
+	};
+
+	if ( pathname in tabNameMap ) return tabNameMap[ pathname ];
+
+	return '/';
+}
+
 export function ArticleTitle() {
 	const { search } = useLocation();
 	const params = new URLSearchParams( search );
@@ -55,6 +69,9 @@ const HelpCenterHeader: React.FC< Header > = ( {
 	const [ chatWindowStatus, setChatWindowStatus ] = useState< WindowState >( 'closed' );
 	const [ unreadCount, setUnreadCount ] = useState< number >( 0 );
 	const history = useHistory();
+	const { pathname } = useLocation();
+
+	const initialTabName = getInitialTabName( pathname );
 	const formattedUnreadCount = unreadCount > 9 ? '9+' : unreadCount;
 
 	function requestMaximize() {
@@ -125,23 +142,23 @@ const HelpCenterHeader: React.FC< Header > = ( {
 			{ ! isMinimized && (
 				<TabPanel
 					className="help-center-header__tab-panel"
-					initialTabName="help"
+					initialTabName={ initialTabName }
 					tabs={ [
 						{
-							name: 'nextSteps',
+							name: NEXT_STEPS_TAB_NAME,
 							title: 'Next Steps',
 							className: 'help-center-container__next-steps-tab',
 						},
 						{
-							name: 'help',
+							name: HELP_TAB_NAME,
 							title: 'Help',
 							className: 'help-center-container__help-tab',
 						},
 					] }
 					onSelect={ ( tab ) => {
-						if ( tab === 'nextSteps' ) {
+						if ( tab === NEXT_STEPS_TAB_NAME ) {
 							history.push( '/next-steps-tutorials' );
-						} else if ( tab === 'help' ) {
+						} else if ( tab === HELP_TAB_NAME ) {
 							history.push( '/' );
 						}
 					} }

--- a/packages/help-center/src/components/help-center-next-steps-tutorials.tsx
+++ b/packages/help-center/src/components/help-center-next-steps-tutorials.tsx
@@ -1,0 +1,3 @@
+export function HelpCenterNextStepsTutorials() {
+	return <p>Placeholder</p>;
+}

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -34,6 +34,7 @@ $head-foot-height: 50px;
 	.help-center__container-header {
 		height: $head-foot-height;
 		padding: 16px 8px 16px 16px;
+		border-bottom: 0;
 
 		// This icon does not accept size prop due to a bug - https://github.com/WordPress/gutenberg/pull/40315
 		// We can remove this when the bug is fixed
@@ -59,6 +60,17 @@ $head-foot-height: 50px;
 				text-overflow: ellipsis;
 				max-width: 200px;
 			}
+		}
+	}
+
+	.help-center-header__tab-panel {
+		.components-tab-panel__tabs {
+			border-bottom: 1px solid rgba( 0, 0, 0, 0.1 );
+		}
+
+		.components-tab-panel__tabs-item.is-active {
+			box-shadow: inset 0 0 0 var( --wp-admin-border-width-focus ) transparent,
+				inset 0 -3px 0 0 var( --color-accent );
 		}
 	}
 
@@ -259,7 +271,8 @@ button.button.back-button__help-center.is-borderless {
 	padding-top: 0;
 }
 
-.help-center-container__loading, .help-center-contact-page__loading {
+.help-center-container__loading,
+.help-center-contact-page__loading {
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -68,9 +68,22 @@ $head-foot-height: 50px;
 			border-bottom: 1px solid rgba( 0, 0, 0, 0.1 );
 		}
 
-		.components-tab-panel__tabs-item.is-active {
-			box-shadow: inset 0 0 0 var( --wp-admin-border-width-focus ) transparent,
-				inset 0 -3px 0 0 var( --color-accent );
+		.components-tab-panel__tabs-item {
+			&.is-active:focus {
+				box-shadow: inset 0 0 0 var( --wp-admin-border-width-focus ) var( --wp-admin-theme-color ),
+					inset 0 -#{$border-width-tab * 2} 0 0 var( --wp-admin-theme-color );
+			}
+
+			&:focus {
+				box-shadow: inset 0 0 0 var( --wp-admin-border-width-focus ) var( --wp-admin-theme-color );
+			}
+
+			&.is-active {
+				// The transparent shadow ensures no jumpiness when focus animates on an active tab.
+				box-shadow: inset 0 0 0 var( --wp-admin-border-width-focus ) transparent,
+					inset 0 -3px 0 0 var( --color-accent );
+				position: relative;
+			}
 		}
 	}
 

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -81,7 +81,7 @@ $head-foot-height: 50px;
 			&.is-active {
 				// The transparent shadow ensures no jumpiness when focus animates on an active tab.
 				box-shadow: inset 0 0 0 var( --wp-admin-border-width-focus ) transparent,
-					inset 0 -3px 0 0 var( --color-accent );
+					inset 0 -3px 0 0 var( --wp-admin-theme-color );
 				position: relative;
 			}
 		}


### PR DESCRIPTION
#### Proposed Changes

* Add a tabs panel to the help center to prepare a new section for next steps tutorials

#### Mocks
 
<img width=316 src="https://user-images.githubusercontent.com/195089/171740786-c5e20605-9fec-45fa-94db-dab93d1c0b45.png" />

#### GIFs
![2022-06-24 11 48 08](https://user-images.githubusercontent.com/5414230/175646842-a65a9e39-75b7-46b2-b223-ef19ed9e90c2.gif)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox a site
* Navigate to `apps/editing-toolkit`
* You may need to run `yarn`
* Run `yarn dev --sync` 
* Navigate to sandboxed site in the browser
* Open the help center menu from the top right hand corner of the editor ( it's a question mark icon )

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64260/ and https://github.com/Automattic/wp-calypso/issues/64080
