### PR TITLE
Improve error messages in Wix Importer

### DIFF
--- a/client/my-sites/importer/site-importer/index.jsx
+++ b/client/my-sites/importer/site-importer/index.jsx
@@ -38,6 +38,7 @@ class SiteImporter extends PureComponent {
 			icon: PropTypes.string.isRequired,
 			description: PropTypes.node.isRequired,
 			uploadDescription: PropTypes.node,
+			engine: PropTypes.string.isRequired,
 		} ).isRequired,
 		importerStatus: PropTypes.shape( {
 			errorData: PropTypes.shape( {
@@ -71,7 +72,7 @@ class SiteImporter extends PureComponent {
 	};
 
 	render() {
-		const { title, icon, description, uploadDescription } = this.props.importerData;
+		const { title, icon, description, uploadDescription, engine } = this.props.importerData;
 		const { importerStatus } = this.props;
 		const isEnabled = appStates.DISABLED !== importerStatus.importerState;
 		const showStart = includes( compactStates, importerStatus.importerState );
@@ -108,7 +109,7 @@ class SiteImporter extends PureComponent {
 						importerStatus={ importerStatus }
 						onStartImport={ this.validateSite }
 						isEnabled={ isEnabled }
-						targetPlatform="wix"
+						targetPlatform={ engine }
 					/>
 				) }
 			</Card>

--- a/client/my-sites/importer/site-importer/index.jsx
+++ b/client/my-sites/importer/site-importer/index.jsx
@@ -108,6 +108,7 @@ class SiteImporter extends PureComponent {
 						importerStatus={ importerStatus }
 						onStartImport={ this.validateSite }
 						isEnabled={ isEnabled }
+						targetPlatform="wix"
 					/>
 				) }
 			</Card>

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -172,6 +172,7 @@ class SiteImporterInputPane extends Component {
 			},
 			site: this.props.site,
 			targetSiteUrl: urlForImport,
+			targetPlatform: 'wix',
 		} );
 	};
 

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -172,7 +172,7 @@ class SiteImporterInputPane extends Component {
 			},
 			site: this.props.site,
 			targetSiteUrl: urlForImport,
-			targetPlatform: 'wix',
+			targetPlatform: this.props.targetPlatform,
 		} );
 	};
 

--- a/client/state/imports/site-importer/actions.js
+++ b/client/state/imports/site-importer/actions.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from '@wordpress/i18n';
 import { get } from 'lodash';
 import { stringify } from 'qs';
 import { convertPlatformName } from 'calypso/blocks/import/util.ts';
@@ -224,13 +225,12 @@ export const validateSiteIsImportable =
 				targetPlatform &&
 				analyzeUrlResult?.value?.platform !== targetPlatform
 			) {
-				dispatch(
-					siteImporterIsSiteImportableFailed( {
-						message: `The URL you entered does not seem to be a ${ convertPlatformName(
-							targetPlatform
-						) } site.`,
-					} )
+				const message = sprintf(
+					/* translators: %s - the formatted website platform name (eg: Wix, Squarespace, Blogger, etc.) */
+					__( 'The URL you entered does not seem to be a %s site.' ),
+					convertPlatformName( targetPlatform )
 				);
+				dispatch( siteImporterIsSiteImportableFailed( { message } ) );
 			} else {
 				dispatch( siteImporterIsSiteImportableFailed( isSiteImportableResult.reason ) );
 			}

--- a/client/state/imports/site-importer/actions.js
+++ b/client/state/imports/site-importer/actions.js
@@ -1,5 +1,6 @@
 import { get } from 'lodash';
 import { stringify } from 'qs';
+import { convertPlatformName } from 'calypso/blocks/import/util.ts';
 import { prefetchmShotsPreview } from 'calypso/lib/mshots';
 import wpcom from 'calypso/lib/wp';
 import {
@@ -168,8 +169,8 @@ export const importSite =
 	};
 
 export const validateSiteIsImportable =
-	( { params, site, targetSiteUrl } ) =>
-	( dispatch ) => {
+	( { params, site, targetSiteUrl, targetPlatform } ) =>
+	async ( dispatch ) => {
 		const siteId = site.ID;
 
 		prefetchmShotsPreview( targetSiteUrl );
@@ -182,32 +183,60 @@ export const validateSiteIsImportable =
 		);
 		dispatch( startSiteImporterIsSiteImportable() );
 
-		return wpcom.req
-			.get( {
-				path: `/sites/${ siteId }/site-importer/is-site-importable?${ stringify( params ) }`,
-				apiNamespace: 'wpcom/v2',
-			} )
-			.then( ( response ) => {
+		const isSiteImportable = wpcom.req.get( {
+			path: `/sites/${ siteId }/site-importer/is-site-importable?${ stringify( params ) }`,
+			apiNamespace: 'wpcom/v2',
+		} );
+
+		const analyzeUrl = wpcom.req.get( {
+			path: `/imports/analyze-url?${ stringify( { site_url: targetSiteUrl } ) }`,
+			apiNamespace: 'wpcom/v2',
+		} );
+
+		const [ isSiteImportableResult, analyzeUrlResult ] = await Promise.allSettled( [
+			isSiteImportable,
+			analyzeUrl,
+		] );
+
+		if ( isSiteImportableResult.status === 'fulfilled' ) {
+			const response = isSiteImportableResult.value;
+			dispatch(
+				recordTracksEvent( 'calypso_site_importer_validate_site_success', {
+					blog_id: siteId,
+					site_url: response.site_url,
+					supported_content: sortAndStringify( response.supported_content ),
+					unsupported_content: sortAndStringify( response.unsupported_content ),
+					site_engine: response.engine,
+				} )
+			);
+			dispatch( siteImporterIsSiteImportableSuccessful( response ) );
+		} else {
+			dispatch(
+				recordTracksEvent( 'calypso_site_importer_validate_site_fail', {
+					blog_id: siteId,
+					site_url: targetSiteUrl,
+				} )
+			);
+
+			// do platform validation if param - targetPlatform is given
+			if (
+				isSiteImportableResult?.reason?.code === 1000002 &&
+				targetPlatform &&
+				analyzeUrlResult?.value?.platform !== targetPlatform
+			) {
 				dispatch(
-					recordTracksEvent( 'calypso_site_importer_validate_site_success', {
-						blog_id: siteId,
-						site_url: response.site_url,
-						supported_content: sortAndStringify( response.supported_content ),
-						unsupported_content: sortAndStringify( response.unsupported_content ),
-						site_engine: response.engine,
+					siteImporterIsSiteImportableFailed( {
+						message: `The URL you entered does not seem to be a ${ convertPlatformName(
+							targetPlatform
+						) } site.`,
 					} )
 				);
-				dispatch( siteImporterIsSiteImportableSuccessful( response ) );
-			} )
-			.catch( ( error ) => {
-				dispatch(
-					recordTracksEvent( 'calypso_site_importer_validate_site_fail', {
-						blog_id: siteId,
-						site_url: targetSiteUrl,
-					} )
-				);
-				dispatch( siteImporterIsSiteImportableFailed( error ) );
-			} );
+			} else {
+				dispatch( siteImporterIsSiteImportableFailed( isSiteImportableResult.reason ) );
+			}
+		}
+
+		return;
 	};
 
 export const resetSiteImporterImport = ( { importStage, site, targetSiteUrl } ) =>


### PR DESCRIPTION
#### Proposed Changes

* We can't identify the wrong platform error through the error response of the `/is-site-importable` API. Thus, this solution will recognize the platform of the given site URL via `/analyze-url` API when importing the site and display a user-friendly error message if the platform mismatching error occurs.

#### Testing Instructions

* Go to `/import/{YOUR_SITE}`
* Click on `Wix importer`
* Enter `oknalok.com`, which is a WordPress site
* Click the `continue` button to start the site importing
* After importing is finished, you should see the following error message:

<img width="827" alt="Screen Shot 2022-06-21 at 4 39 14 PM" src="https://user-images.githubusercontent.com/1024985/175197710-561afaaa-0dd3-4902-8ee7-575a16c074dd.png">

Related to https://github.com/Automattic/wp-calypso/issues/63122
