### PR TITLE
Design Picker: Replace generated design thumbnails with iframe

### DIFF
--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { Button } from '@automattic/components';
-import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -12,7 +11,8 @@ import {
 	DEFAULT_VIEWPORT_HEIGHT,
 	MOBILE_VIEWPORT_WIDTH,
 } from '../constants';
-import { getDesignPreviewUrl, getMShotOptions } from '../utils';
+import { getDesignPreviewUrl } from '../utils';
+import ThemePreview from './theme-preview';
 import type { Design } from '../types';
 import './style.scss';
 
@@ -20,7 +20,6 @@ import './style.scss';
 const noop = () => {};
 
 interface GeneratedDesignThumbnailProps {
-	slug: string;
 	thumbnailUrl: string;
 	isSelected: boolean;
 	onPreview: () => void;
@@ -28,7 +27,6 @@ interface GeneratedDesignThumbnailProps {
 }
 
 const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
-	slug,
 	thumbnailUrl,
 	isSelected,
 	onPreview,
@@ -53,12 +51,9 @@ const GeneratedDesignThumbnail: React.FC< GeneratedDesignThumbnailProps > = ( {
 				</svg>
 			</span>
 			<span className="generated-design-thumbnail__image">
-				<MShotsImage
+				<ThemePreview
 					url={ thumbnailUrl }
-					alt=""
-					aria-labelledby={ `generated-design-thumbnail__image__${ slug }` }
-					options={ getMShotOptions( { isMobile } ) }
-					scrollable={ false }
+					viewportWidth={ isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH }
 				/>
 			</span>
 		</button>
@@ -127,7 +122,6 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 						designs.map( ( design, index ) => (
 							<GeneratedDesignThumbnail
 								key={ design.slug }
-								slug={ design.slug }
 								thumbnailUrl={ getDesignPreviewUrl( design, {
 									language: locale,
 									verticalId,

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -495,7 +495,6 @@
 		min-height: 100px;
 		max-height: 300px;
 		flex-basis: 100%;
-		padding: 8px;
 
 		.generated-design-thumbnail__header {
 			display: none;

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -1,0 +1,83 @@
+import { useResizeObserver } from '@wordpress/compose';
+import { useI18n } from '@wordpress/react-i18n';
+import { addQueryArgs } from '@wordpress/url';
+import classnames from 'classnames';
+import { useEffect, useMemo, useState } from 'react';
+import { v4 as uuid } from 'uuid';
+import './style.scss';
+
+interface Viewport {
+	width: number;
+	height: number;
+}
+
+interface Props {
+	url: string;
+	viewportWidth: number;
+}
+
+const ThemePreview = ( { url, viewportWidth }: Props ) => {
+	const { __ } = useI18n();
+	const calypso_token = useMemo( () => uuid(), [] );
+	const [ isLoaded, setIsLoaded ] = useState( false );
+	const [ viewport, setViewport ] = useState< Viewport >();
+
+	const [ containerResizeListener, { width: containerWidth } ] = useResizeObserver();
+
+	const scale = containerWidth ? containerWidth / viewportWidth : 1;
+
+	useEffect( () => {
+		const handleMessage = ( event: MessageEvent ) => {
+			let data;
+			try {
+				data = JSON.parse( event.data );
+			} catch ( err ) {
+				return;
+			}
+
+			if ( ! data || data.channel !== 'preview-' + calypso_token ) {
+				return;
+			}
+
+			switch ( data.type ) {
+				case 'partially-loaded':
+					setIsLoaded( true );
+				case 'page-dimensions-on-load':
+				case 'page-dimensions-on-resize':
+					setViewport( data.payload );
+					return;
+				default:
+					return;
+			}
+		};
+
+		window.addEventListener( 'message', handleMessage );
+
+		return () => {
+			window.removeEventListener( 'message', handleMessage );
+		};
+	}, [ setIsLoaded, setViewport ] );
+
+	return (
+		<div
+			className={ classnames( 'theme-preview__container', {
+				'theme-preview__container--loading': ! isLoaded,
+			} ) }
+		>
+			{ containerResizeListener }
+			<iframe
+				title={ __( 'Preview', __i18n_text_domain__ ) }
+				className="theme-preview__frame"
+				style={ {
+					width: viewportWidth,
+					height: viewport?.height,
+					transform: `scale(${ scale })`,
+				} }
+				src={ addQueryArgs( url, { calypso_token } ) }
+				scrolling="no"
+			/>
+		</div>
+	);
+};
+
+export default ThemePreview;

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -75,6 +75,7 @@ const ThemePreview = ( { url, viewportWidth }: Props ) => {
 				} }
 				src={ addQueryArgs( url, { calypso_token } ) }
 				scrolling="no"
+				tabIndex={ -1 }
 			/>
 		</div>
 	);

--- a/packages/design-picker/src/components/theme-preview/style.scss
+++ b/packages/design-picker/src/components/theme-preview/style.scss
@@ -1,0 +1,20 @@
+@import '@automattic/onboarding/styles/mixins';
+
+.theme-preview__container {
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	top: 0;
+	overflow: hidden;
+	pointer-events: none;
+
+	&--loading {
+		@include onboarding-placeholder();
+	}
+}
+
+.theme-preview__frame {
+	border: none;
+	transform-origin: 0 0;
+}


### PR DESCRIPTION
#### Proposed Changes

* This PR is focusing on the POC of using the `<iframe />` as the generated design thumbnail to see whether the resolution and performance are acceptable or not. Below are the demonstrations with/without sandboxed API.

**Comparison**

| | iframe | mShots without cache | mShots with cache |
| - | - | - | - |
| Resolution | Same | Same | Same |
| Performance | Faster | Slower | Faster |

As you see, if we use the `<iframe />` as the thumbnail, the resolution looks the same but the performance is better than the `mShots` without cache (the first one). When the `mShots` has a cache, the performance might be similar. Hence, I think it's good to replace the `mShots` with the iframe preview Any thoughts?

**Without sandboxed API**

| iframe | mShots |
| - | - |
| <video src="https://user-images.githubusercontent.com/13596067/175236151-86c45f1a-fc15-4828-84af-d4c4394db813.mov" /> | <video src="https://user-images.githubusercontent.com/13596067/175236188-2f5dba90-a5db-4f10-8c62-01ba93577d74.mov" /> |

**With Sandboxed API**

| iframe | mShots |
| - | - |
| <video src="https://user-images.githubusercontent.com/13596067/175236356-b850738f-f0f5-4d2b-a1d4-a00196bae830.mov" /> | <video src="https://user-images.githubusercontent.com/13596067/175236325-22e64c41-6b81-4cc0-bc1b-45f07f5afa12.mov" /> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Select "Promote myself or business" goal
* Select a vertical
* When you land on the Design Picker, the thumbnails have to look the same as the mShots image

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 68-gh-Automattic/ganon-issues