### PR TITLE
Add upsell nudge for sites that have AMP deprecated.

### DIFF
--- a/client/my-sites/site-settings/amp/wpcom.jsx
+++ b/client/my-sites/site-settings/amp/wpcom.jsx
@@ -74,6 +74,9 @@ class AmpWpcom extends Component {
 				href={ `/checkout/${ siteSlug }/pro` }
 				showIcon={ true }
 				forceDisplay
+				tracksImpressionName="calypso_settings_amp_upsell_impression"
+				tracksClickName="calypso_settings_amp_upsell_click"
+				event="calypso_settings_amp_upsell"
 			/>
 		);
 	}

--- a/client/my-sites/site-settings/amp/wpcom.jsx
+++ b/client/my-sites/site-settings/amp/wpcom.jsx
@@ -1,3 +1,4 @@
+import { FEATURE_SFTP, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
 import { CompactCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
@@ -6,10 +7,12 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './wpcom.scss';
 
@@ -46,6 +49,35 @@ class AmpWpcom extends Component {
 		page( '/customize/amp/' + this.props.siteSlug );
 	};
 
+	renderUpgradeNotice() {
+		const { hasSftpFeature, siteSlug, translate } = this.props;
+
+		if ( hasSftpFeature ) {
+			return (
+				<UpsellNudge
+					title={ translate( 'Install AMP plugin.' ) }
+					description={ translate( 'Install AMP plugin to use AMP features.' ) }
+					plan={ PLAN_WPCOM_PRO }
+					href={ `/plugins/amp/${ siteSlug }` }
+					forceHref={ true }
+					showIcon={ true }
+					forceDisplay
+				/>
+			);
+		}
+
+		return (
+			<UpsellNudge
+				title={ translate( 'Available on the Pro plan' ) }
+				description={ translate( 'Upgrade to the Pro plan to install AMP plugin.' ) }
+				plan={ PLAN_WPCOM_PRO }
+				href={ `/checkout/${ siteSlug }/pro` }
+				showIcon={ true }
+				forceDisplay
+			/>
+		);
+	}
+
 	render() {
 		const {
 			fields: {
@@ -62,8 +94,17 @@ class AmpWpcom extends Component {
 		const isDisabled = isRequestingSettings || isSavingSettings;
 		const isCustomizeEnabled = ! isDisabled && ampIsEnabled;
 
-		if ( ! ampIsSupported || ampIsDeprecated ) {
+		if ( ! ampIsSupported ) {
 			return null;
+		}
+
+		if ( ampIsDeprecated ) {
+			return (
+				<div className="amp__main site-settings__traffic-settings">
+					<SettingsSectionHeader title={ translate( 'Accelerated Mobile Pages (AMP)' ) } />
+					{ this.renderUpgradeNotice() }
+				</div>
+			);
 		}
 
 		return (
@@ -109,8 +150,14 @@ class AmpWpcom extends Component {
 }
 
 export default connect(
-	( state ) => ( {
-		siteSlug: getSelectedSiteSlug( state ),
-	} ),
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
+
+		return {
+			siteSlug: getSelectedSiteSlug( state ),
+			hasSftpFeature,
+		};
+	},
 	{ recordTracksEvent }
 )( localize( AmpWpcom ) );

--- a/client/my-sites/site-settings/amp/wpcom.jsx
+++ b/client/my-sites/site-settings/amp/wpcom.jsx
@@ -51,32 +51,26 @@ class AmpWpcom extends Component {
 
 	renderUpgradeNotice() {
 		const { hasSftpFeature, siteSlug, translate } = this.props;
+		let tracksProps;
 
-		if ( hasSftpFeature ) {
-			return (
-				<UpsellNudge
-					title={ translate( 'Install AMP plugin.' ) }
-					description={ translate( 'Install AMP plugin to use AMP features.' ) }
-					plan={ PLAN_WPCOM_PRO }
-					href={ `/plugins/amp/${ siteSlug }` }
-					forceHref={ true }
-					showIcon={ true }
-					forceDisplay
-				/>
-			);
+		if ( ! hasSftpFeature ) {
+			tracksProps = {
+				tracksImpressionName: 'calypso_settings_amp_upsell_impression',
+				tracksClickName: 'calypso_settings_amp_upsell_click',
+				event: 'calypso_settings_amp_upsell',
+			};
 		}
 
 		return (
 			<UpsellNudge
-				title={ translate( 'Available on the Pro plan' ) }
-				description={ translate( 'Upgrade to the Pro plan to install AMP plugin.' ) }
+				title={ translate( 'Install AMP plugin.' ) }
+				description={ translate( 'Install AMP plugin to use AMP features.' ) }
 				plan={ PLAN_WPCOM_PRO }
-				href={ `/checkout/${ siteSlug }/pro` }
+				href={ `/plugins/amp/${ siteSlug }` }
+				forceHref={ true }
 				showIcon={ true }
 				forceDisplay
-				tracksImpressionName="calypso_settings_amp_upsell_impression"
-				tracksClickName="calypso_settings_amp_upsell_click"
-				event="calypso_settings_amp_upsell"
+				{ ...tracksProps }
 			/>
 		);
 	}

--- a/client/my-sites/site-settings/amp/wpcom.jsx
+++ b/client/my-sites/site-settings/amp/wpcom.jsx
@@ -63,7 +63,7 @@ class AmpWpcom extends Component {
 
 		return (
 			<UpsellNudge
-				title={ translate( 'Install AMP plugin' ) }
+				title={ translate( 'Install the AMP plugin' ) }
 				description={ translate(
 					'AMP enables the creation of websites and ads that load near instantly, ' +
 						'giving site visitors a smooth, more engaging experience on mobile and desktop.'

--- a/client/my-sites/site-settings/amp/wpcom.jsx
+++ b/client/my-sites/site-settings/amp/wpcom.jsx
@@ -63,8 +63,11 @@ class AmpWpcom extends Component {
 
 		return (
 			<UpsellNudge
-				title={ translate( 'Install AMP plugin.' ) }
-				description={ translate( 'Install AMP plugin to use AMP features.' ) }
+				title={ translate( 'Install AMP plugin' ) }
+				description={ translate(
+					'AMP enables the creation of websites and ads that load near instantly, ' +
+						'giving site visitors a smooth, more engaging experience on mobile and desktop.'
+				) }
 				plan={ PLAN_WPCOM_PRO }
 				href={ `/plugins/amp/${ siteSlug }` }
 				forceHref={ true }


### PR DESCRIPTION
#### Proposed Changes

We are in the process of removing AMP for Simple sites. As the option that disappeared from the settings may be confusing, we are adding a notice that displays a message asking to install the AMP plugin.

![amp-nudge](https://user-images.githubusercontent.com/727413/176371227-2c6ef84e-e2c5-47a7-a448-9fc820448763.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Preconditions
* ~~use sandbox with D83077-code applied (if it's not deployed yet)~~

##### Simple site with AMP deprecated, without a paid plan

1. Navigate to "WP Admin -> Settings -> Performance"
2. Confirm that the AMP box displays a message that asks to install the AMP plugin
3. Click on the message
4. Confirm that the AMP plugin is shown and CTA says "Upgrade and activate"

##### Simple site with AMP deprecated, with a paid plan

1. Navigate to "WP Admin -> Settings -> Performance"
2. Confirm that the AMP box displays a message that asks to install the AMP plugin
3. Click on the message
4. Confirm that the AMP plugin is shown and CTA says "Install and activate"

##### Simple site that is private

1. Navigate to "WP Admin -> Settings -> Performance"
2. Confirm that the AMP box is not displayed at all

##### Simple site with AMP not deprecated

1. Navigate to "WP Admin -> Settings -> Performance"
2. Confirm that the AMP settings are still there

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/64731