### PR TITLE
Jetpack Agency Dashboard: Add dashboard as top nav for Jetpack Cloud as a part of the agency dashboard

### DIFF
--- a/client/components/jetpack/portal-nav/style.scss
+++ b/client/components/jetpack/portal-nav/style.scss
@@ -2,7 +2,7 @@
 // specificity with .section-nav, since we can't rely on the order stylesheets are loaded.
 .portal-nav.section-nav {
 	flex: 1 1 180px;
-	max-width: 280px;
+	max-width: 400px;
 	margin: 0;
 	margin-right: auto;
 	background: none;

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -14,11 +14,8 @@ import Site from 'calypso/blocks/site';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import Search from 'calypso/components/search';
 import searchSites from 'calypso/components/search-sites';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { jetpackDashboardRedirectLink } from 'calypso/state/jetpack-agency-dashboard/selectors';
-import { showAgencyDashboard } from 'calypso/state/partner-portal/partner/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import areAllSitesSingleUser from 'calypso/state/selectors/are-all-sites-single-user';
 import getSites from 'calypso/state/selectors/get-sites';
@@ -467,9 +464,6 @@ const navigateToSite =
 	( dispatch, getState ) => {
 		const state = getState();
 		const site = getSite( state, siteId );
-		if ( isJetpackCloud() && ! site && showAgencyDashboard( state ) ) {
-			return page.redirect( jetpackDashboardRedirectLink( state ) );
-		}
 		const pathname = getPathnameForSite();
 		if ( pathname ) {
 			page( pathname );


### PR DESCRIPTION
#### Proposed Changes

This PR makes the following changes

1) Add Dashboard as top nav for the Jetpack Cloud visible only for agencies
2) Revert the logic which redirects clicking on Switch Site to the dashboard 
3) Increase the navbar max-width so that we can show 3 nav items on large screens

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/dashboard-as-top-nav` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that you can see a new navigation item for **Dashboard** in addition to **Manage Sites** and **Licenses**.

<img width="1920" alt="Screenshot 2022-06-23 at 3 56 40 PM" src="https://user-images.githubusercontent.com/10586875/175278408-8289d72e-8d43-4285-a9dd-23b62be24065.png">

4. Verify that clicking on **Manage Sites** takes you to `/landing`.
5. Click on Switch Sites from **Dashboard** or **Manage Sites** -> Select any site -> Click on **Switch Site** -> Click on **All My Sites** -> Verify that it shows site picker instead of redirecting to `/dashboard`.

<img width="1920" alt="Screenshot 2022-06-23 at 3 56 33 PM" src="https://user-images.githubusercontent.com/10586875/175278546-0bdfb170-45fb-4a4f-99f1-0cb20b0bd57b.png">

6. Verify the same in mobile view by switching to mobile view using dev tool

<img width="378" alt="Screenshot 2022-06-23 at 4 00 17 PM" src="https://user-images.githubusercontent.com/10586875/175279141-5b20b739-236d-4e5e-8427-c817465201c1.png">

7. Switch partner type(2c49b-pb) to non-agency and verify that the **Dashboard** nav item is not shown any more since this change is specifically made to the agency dashboard

<img width="690" alt="Screenshot 2022-06-23 at 4 02 55 PM" src="https://user-images.githubusercontent.com/10586875/175279432-b1b2d2b9-56a9-4b34-9e14-96ad20cc7665.png">

Related to 1202076982646589-as-1202436516884086