### PR TITLE
Fix link to premium theme upsell when siteSlug param is not set

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -277,8 +277,10 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			const params = new URLSearchParams();
 			params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
 
+			// The theme upsell link does not work with siteId and requires a siteSlug.
+			// See https://github.com/Automattic/wp-calypso/pull/64899
 			window.location.href = `/checkout/${ encodeURIComponent(
-				siteSlug || urlToSlug( site?.URL || '' )
+				siteSlug || urlToSlug( site?.URL ) || ''
 			) }/${ plan }?${ params.toString() }`;
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -21,6 +21,7 @@ import { useMemo, useRef, useState, useEffect } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import WebPreview from 'calypso/components/web-preview/content';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { urlToSlug } from 'calypso/lib/url';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
@@ -277,7 +278,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
 
 			window.location.href = `/checkout/${ encodeURIComponent(
-				siteSlugOrId
+				siteSlug || urlToSlug( site?.URL || '' )
 			) }/${ plan }?${ params.toString() }`;
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -280,7 +280,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			// The theme upsell link does not work with siteId and requires a siteSlug.
 			// See https://github.com/Automattic/wp-calypso/pull/64899
 			window.location.href = `/checkout/${ encodeURIComponent(
-				siteSlug || urlToSlug( site?.URL ) || ''
+				siteSlug || urlToSlug( site?.URL || '' ) || ''
 			) }/${ plan }?${ params.toString() }`;
 		}
 	}


### PR DESCRIPTION
#### Proposed Changes
In https://github.com/Automattic/wp-calypso/pull/64882 I added code to handle `siteId` being passed on the design picker page. But I made a mistake, the theme upsell link does not work with `siteId` and requires a `siteSlug`.

Another possible implementation was changing everything to use siteSlug. But I had a concern with that because if the primary domain changes between the page render and the click event, I believe that would result in an invalid url. That would be possible as well for the premium upsel case, but I think that it would be very rare and only affect the premium upsell link. p1655958550439389/1655949095.778589-slack-CRWCHQGUB

#### Testing Instructions
Enter the /start flow.
Choose a .blog domain and a paid plan
Select the build plan
You will be taken to `/setup/designSetup?siteId=<$site_id>`
Select the "Upgrade Plan" button for a premium theme
You should be taken to the correct URL `checkout/$siteSlug/pro`