### PR TITLE
Replace the 'intent' route with a 'goals'

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -43,7 +43,7 @@ export function generateStepPath(
 	stepName: string | StepPath,
 	stepSectionName?: string
 ): StepPath {
-	if ( stepName === 'intent' ) return 'intent';
+	if ( stepName === 'intent' ) return 'goals';
 	else if ( stepName === 'capture' ) return BASE_ROUTE;
 
 	const routes = [ BASE_ROUTE, stepName, stepSectionName ];


### PR DESCRIPTION
#### Proposed Changes

* Replace 'intent' route with a 'goals'

#### Testing Instructions

* Go to `/setup/import?siteSlug={SLUG}`
* Enter your existing wpcom website
* The "Your site is already on WordPress.com" screen will be shown
* Check if "Start building" button leads to the "Goals" page

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
<img width="762" alt="Screenshot 2022-06-23 at 14 58 51" src="https://user-images.githubusercontent.com/1241413/175304339-bc057e20-b289-49fc-ba0c-021253906ff6.png">

