### PR TITLE
Replace Editor Help Link for Widgets with WPcom

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/class-wpcom-documentation-links.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/class-wpcom-documentation-links.php
@@ -53,6 +53,13 @@ class WPCOM_Documentation_Links {
 			true
 		);
 
+		wp_enqueue_style(
+			'wpcom-documentation-links-styles',
+			plugins_url( '/dist/wpcom-documentation-links.css', __FILE__ ),
+			array(),
+			$version
+		);
+
 		wp_localize_script(
 			'wpcom-documentation-links-script',
 			'wpcomDocumentationLinksAssetsUrl',

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
@@ -12,6 +12,8 @@ function overrideCoreDocumentationLinksToWpcom( translation: string, text: strin
 			return 'https://wordpress.com/support/site-editor/';
 		case 'https://wordpress.org/support/article/block-based-widgets-editor/':
 			return 'https://wordpress.com/support/widgets/';
+		case 'https://wordpress.org/plugins/classic-widgets/':
+			return 'https://wordpress.com/plugins/classic-widgets';
 	}
 
 	return translation;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
@@ -1,4 +1,12 @@
 import { addFilter } from '@wordpress/hooks';
+import './style.css';
+
+declare global {
+	interface Window {
+		_currentSiteId: number;
+		_currentSiteType: string;
+	}
+}
 
 function overrideCoreDocumentationLinksToWpcom( translation: string, text: string ) {
 	switch ( text ) {
@@ -19,8 +27,31 @@ function overrideCoreDocumentationLinksToWpcom( translation: string, text: strin
 	return translation;
 }
 
+function hideSimpleSiteTranslations( translation: string, text: string ) {
+	switch ( text ) {
+		case 'https://wordpress.org/plugins/classic-widgets/':
+			return '';
+		case 'Want to stick with the old widgets?':
+			return '';
+		case 'Get the Classic Widgets plugin.':
+			return '';
+	}
+
+	return translation;
+}
+
 addFilter(
 	'i18n.gettext_default',
 	'full-site-editing/override-core-docs-to-wpcom',
-	overrideCoreDocumentationLinksToWpcom
+	overrideCoreDocumentationLinksToWpcom,
+	9
 );
+
+if ( window?._currentSiteType === 'simple' ) {
+	addFilter(
+		'i18n.gettext_default',
+		'full-site-editing/override-core-docs-to-wpcom',
+		hideSimpleSiteTranslations,
+		10
+	);
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/index.tsx
@@ -10,6 +10,8 @@ function overrideCoreDocumentationLinksToWpcom( translation: string, text: strin
 			return 'https://wordpress.com/support/wordpress-editor/';
 		case 'https://wordpress.org/support/article/site-editor/':
 			return 'https://wordpress.com/support/site-editor/';
+		case 'https://wordpress.org/support/article/block-based-widgets-editor/':
+			return 'https://wordpress.com/support/widgets/';
 	}
 
 	return translation;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/style.css
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/src/style.css
@@ -1,0 +1,8 @@
+/*
+ For simple sites in "Customize Widgets" we override translations with empty strings.
+ This will result in empty link in that section shown without text and href. The CSS will hide those.
+ */
+.customize-widgets-welcome-guide__more-info a[href=''] {
+	display: none;
+}
+


### PR DESCRIPTION
#### Proposed Changes

When customizing widgets we had a link that we failed to override. 
This PR adds an override for `https://wordpress.org/support/article/block-based-widgets-editor/` to be replaced with 
`https://wordpress.com/support/widgets/`

#### Testing Instructions
1. Change to a theme that allows widget customizations. Example: 'Twenty Eleven'
1. Go to Appearance → Customize → Widgets
2. Click on one of the widget customization areas.
3. Click on "Got It" to dismiss the info <img width="340" alt="Screenshot 2022-06-23 at 16 12 10" src="https://user-images.githubusercontent.com/7000684/175320316-2a5ef727-f93a-4293-aeb1-349577f5c857.png">
4. Click the ... (ellipses) menu
5. Click 'Help'
6. Verify that the link `https://wordpress.com/support/widgets/` opens in a new window.

Fixes: https://github.com/Automattic/wp-calypso/issues/56161