### PR TITLE
HelpCenter: hide "What's new" button for atomic sites

### DIFF
--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -11,6 +11,7 @@ import { Icon, captureVideo, desktop, formatListNumbered, video, external } from
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NewReleases from '../icons/new-releases';
 
@@ -24,16 +25,19 @@ export const HelpCenterMoreResources = () => {
 	const { __ } = useI18n();
 	const [ showWhatsNewDot, setShowWhatsNewDot ] = useState( false );
 
-	const { isBusinessOrEcomPlanUser, siteId } = useSelector( ( state ) => {
+	const { isBusinessOrEcomPlanUser, siteId, isSimpleSite } = useSelector( ( state ) => {
 		const purchases = getUserPurchases( state );
 		const purchaseSlugs = purchases && purchases.map( ( purchase ) => purchase.productSlug );
+		const siteId = getSelectedSiteId( state );
+		const site = getSite( state, siteId );
 
 		return {
 			isBusinessOrEcomPlanUser: !! (
 				purchaseSlugs &&
 				( purchaseSlugs.some( isWpComBusinessPlan ) || purchaseSlugs.some( isWpComEcommercePlan ) )
 			),
-			siteId: getSelectedSiteId( state ),
+			isSimpleSite: site && ! site.is_wpcom_atomic,
+			siteId: siteId,
 		};
 	} );
 	const { data, isLoading, setHasSeenWhatsNewModal } = useHasSeenWhatsNewModalQuery( siteId );
@@ -131,22 +135,24 @@ export const HelpCenterMoreResources = () => {
 						</a>
 					</div>
 				</li>
-				<li className="inline-help__resource-item">
-					<div className="inline-help__resource-cell">
-						<Button
-							isLink
-							onClick={ () => handleWhatsNewClick() }
-							className="inline-help__new-releases"
-						>
-							<Icon icon={ <NewReleases /> } size={ 24 } />
-							<span>{ __( "What's new" ) }</span>
-							{ showWhatsNewDot && (
-								<Icon className="inline-help__new-releases_dot" icon={ circle } size={ 16 } />
-							) }
-							<Icon icon={ external } size={ 20 } />
-						</Button>
-					</div>
-				</li>
+				{ isSimpleSite && (
+					<li className="inline-help__resource-item">
+						<div className="inline-help__resource-cell">
+							<Button
+								isLink
+								onClick={ () => handleWhatsNewClick() }
+								className="inline-help__new-releases"
+							>
+								<Icon icon={ <NewReleases /> } size={ 24 } />
+								<span>{ __( "What's new" ) }</span>
+								{ showWhatsNewDot && (
+									<Icon className="inline-help__new-releases_dot" icon={ circle } size={ 16 } />
+								) }
+								<Icon icon={ external } size={ 20 } />
+							</Button>
+						</div>
+					</li>
+				) }
 			</ul>
 			{ showGuide && <WhatsNewGuide onClose={ () => setShowGuide( false ) } /> }
 		</>

--- a/packages/help-center/src/components/index.d.ts
+++ b/packages/help-center/src/components/index.d.ts
@@ -30,6 +30,10 @@ declare module 'calypso/state/ui/selectors' {
 	export const getSectionName: ( state: unknown ) => string;
 }
 
+declare module 'calypso/state/sites/selectors' {
+	export const getSite: ( state: unknown, siteId: number ) => { is_wpcom_atomic: boolean };
+}
+
 declare module 'calypso/state/sites/hooks' {
 	export const useSiteOption: ( state: unknown ) => string;
 }


### PR DESCRIPTION
#### Proposed Changes

"What's New" feature currently works only on simple sites.
For the time being, we need to hide this button in the help center until support for AT sites is provided.

Selecting a site from state with `getSite` will not return anything for AT site.
Because of this using selectors to determine if a site is atomic will not work properly.
This PR reverses this check to check if this object is present and if it is atomic.

#### Testing Instructions
##### AT Site
- Download the ETK from [here](https://teamcity.a8c.com/repository/download/calypso_WPComPlugins_EditorToolKit/8113844:id/editing-toolkit.zip)
- Go to AT site and upload/replace the ETK plugin
- Go to the editor
- Open the help center
- Verify that the What's New button is not shown like here: https://d.pr/i/T39B8H
##### Simple Site
- Sync these changes on simple site
- Go to the editor
- Open the help center
- Verify that the What's New button is shown

Related to #64862