### PR TITLE
Goals Capture: Fix Continue button focus border

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -61,10 +61,7 @@
 			width: 130px;
 			height: 44px;
 			border-radius: 4px;
-
-			&:focus {
-				box-shadow: 0 0 0 2px #fff, 0 0 0 4px var( --color-accent-60 );
-			}
+			box-shadow: 0 1px 2px rgb( 0 0 0 / 5% ) !important;
 		}
 
 		@include break-small {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -61,6 +61,10 @@
 			width: 130px;
 			height: 44px;
 			border-radius: 4px;
+
+			&:focus {
+				box-shadow: 0 0 0 2px #fff, 0 0 0 4px var( --color-accent-60 );
+			}
 		}
 
 		@include break-small {


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the Continue button focus border, removing the red outline that was appearing before.

**Before**
<img width="199" alt="image" src="https://user-images.githubusercontent.com/3113712/175376062-03d51dce-7d74-4ca3-8044-de6f5b28f327.png">

**After**
<img width="189" alt="image" src="https://user-images.githubusercontent.com/3113712/175615333-1470b40b-b6c6-4949-9c3c-86d0671c5767.png">

#### Testing Instructions
1. Go to http://calypso.localhost:3000/setup/goals?siteSlug=<YOUR-SITE>
2. Navigate using the keyboard
3. Press Tab until get the Continue button focused
4. Check if the button appears as expected