### PR TITLE
Plugins: Check install capability based on plugin type

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -55,14 +55,13 @@ const PluginDetailsCTA = ( {
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
 	const isFreePlan = selectedSite && isFreePlanProduct( selectedSite.plan );
+	const pluginFeature = isMarketplaceProduct
+		? WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS
+		: FEATURE_INSTALL_PLUGINS;
 
 	const shouldUpgrade =
-		useSelector(
-			( state ) =>
-				( isMarketplaceProduct &&
-					! siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS ) ) ||
-				! siteHasFeature( state, selectedSite?.ID, FEATURE_INSTALL_PLUGINS )
-		) && ! isJetpackSelfHosted;
+		useSelector( ( state ) => ! siteHasFeature( state, selectedSite?.ID, pluginFeature ) ) &&
+		! isJetpackSelfHosted;
 
 	// Eligibilities for Simple Sites.
 	const { eligibilityHolds, eligibilityWarnings } = useSelector( ( state ) =>

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -1,5 +1,6 @@
 import {
 	isFreePlanProduct,
+	FEATURE_INSTALL_PLUGINS,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
@@ -58,7 +59,9 @@ const PluginDetailsCTA = ( {
 	const shouldUpgrade =
 		useSelector(
 			( state ) =>
-				! siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS )
+				( isMarketplaceProduct &&
+					! siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS ) ) ||
+				! siteHasFeature( state, selectedSite?.ID, FEATURE_INSTALL_PLUGINS )
 		) && ! isJetpackSelfHosted;
 
 	// Eligibilities for Simple Sites.


### PR DESCRIPTION
#### Proposed Changes

* Switches feature to check based on whether the current plugin is a marketplace plugin or not.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/plugins/<site>` on a variety of simple sites: Pro, Business, Ecommerce, Starter, Free.
  * The Pro, Business and Ecommerce plans should be able to buy and install plugins.
  * Starter and Free should not.
  * **Behavior should be the same as production.**

In conjunction with D82976-code and https://github.com/Automattic/wp-calypso/pull/64908 it should allow the purchase and installation of marketplace plugins on Starter plan, but not plugins from the Plugin Directory

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #