### PR TITLE
Fix the Search upsell checkout url to checkout with Search (not Scan).

### DIFF
--- a/client/my-sites/jetpack-search/jetpack-search-upsell/index.tsx
+++ b/client/my-sites/jetpack-search/jetpack-search-upsell/index.tsx
@@ -105,7 +105,7 @@ export default function JetpackSearchUpsell(): ReactElement {
 									action: {
 										url:
 											siteId && selectedSiteSlug
-												? addQueryArgs( `/checkout/${ selectedSiteSlug }/jetpack_scan`, {
+												? addQueryArgs( `/checkout/${ selectedSiteSlug }/jetpack_search`, {
 														redirect_to: postCheckoutUrl,
 												  } )
 												: WPComUpgradeUrl,


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the Jetpack Search upsell checkout url to point to _Search_ checkout, instead of _Scan_ checkout.

#### Testing Instructions

1. Checkout this PR and `yarn start`. (or open the Calypso.live link below).
2. Open Calypso and select a Jetpack site without a Jetpack Search subscription (Or create a JN site).
3. Go to Jetpack --> Search.  You should then see the Search **Upsell** that says "Upgrade to Jetpack Search".
4. Click the "Upgrade to Jetpack Search" CTA and verify you are taken to checkout with Jetpack Search in your cart.
5. Compare with wordpress.com production to see that on production the Jetpack Search CTA is pointing to /checkout/:site/**jetpack_scan** which is not desired.  It should be jetpack_search.

Fixes: #64900 
