### PR TITLE
Seller Experience: Fix `getProductBySlug` for use in reading plan/product data

### DIFF
--- a/packages/data-stores/src/products-list/selectors.ts
+++ b/packages/data-stores/src/products-list/selectors.ts
@@ -1,3 +1,5 @@
+import { select } from '@wordpress/data';
+import { STORE_KEY } from './constants';
 import type { State } from './reducer';
 
 export const getState = ( state: State ) => state;
@@ -6,6 +8,15 @@ export const getProductsList = ( state: State ) => {
 	return state.productsList;
 };
 
-export const getProductBySlug = ( state: State, slug: string ) => {
-	return state.productsList?.[ slug ];
+export const getProductBySlug = ( _state: State, slug: string ) => {
+	if ( ! slug ) {
+		return undefined;
+	}
+	const products = select( STORE_KEY ).getProductsList();
+
+	if ( ! products ) {
+		return undefined;
+	}
+
+	return products?.[ slug ];
 };

--- a/packages/data-stores/src/products-list/test/selectors.ts
+++ b/packages/data-stores/src/products-list/test/selectors.ts
@@ -64,5 +64,6 @@ describe( 'selectors', () => {
 		} );
 
 		expect( select( store ).getProductsList() ).toEqual( apiResponse );
+		expect( select( store ).getProductBySlug( 'free_plan' ) ).toEqual( apiResponse[ 'free_plan' ] );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* I couldn't get `getProductBySlug` to work by reading from `state` because `getProductsList` was never called. I couldn't find this selector used elsewhere so I updated it to call `getProductsList` and return the correct plan based on the slug provided.
* From here, we can fetch individual plan/product data!
* Not sure if this is the right approach or if I'm missing something... :) 

#### Testing Instructions

* Check out this branch
* Run `yarn test-packages packages/data-stores/src/products-list/test/`

Related to #64868
