### PR TITLE
Setup Flow: Fix the incorrect step when going back from the options step

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -426,12 +426,15 @@ export const siteSetupFlow: Flow = {
 					}
 
 				case 'options':
+					if ( goalsStepEnabled ) {
+						if ( verticalsStepEnabled ) {
+							return navigate( 'vertical' );
+						}
+						return navigate( 'goals' );
+					}
+
 				case 'import':
 					if ( goalsStepEnabled ) {
-						// This can be unchecked when import step is shown after verticals.
-						// if ( verticalsStepEnabled ) {
-						// 	return navigate( 'vertical' );
-						// }
 						return navigate( 'goals' );
 					}
 


### PR DESCRIPTION
#### Proposed Changes

* Fix the incorrect step after going back from the Options step

https://user-images.githubusercontent.com/13596067/175464474-d26e80d9-cf48-4551-a4c5-1bed98c347a9.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to setup flow:`/setup/goals?siteSlug=<your_site>`
* When you select "Write & Publish" goal, land on the Options step (First, let's give your blog a name), and click "Back" at the top-left corner, you have to see the Vertical step
* When you select "Sell online" goal, land on the Options step (First, let's give your store a name), and click "Back" at the top-left corner, you have to see the Vertical step
* When you select "Import your site content" and click "Back" at the top-left corner, you have to see the Goal step

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdDOJh-sJ-p2#comment-308