### PR TITLE
Jetpack Agency Dashboard: use previous state to toggle issue types filter

### DIFF
--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -61,11 +61,11 @@ export class Filterbar extends Component {
 	};
 
 	toggleIssueTypesSelector = () => {
-		this.setState( {
+		this.setState( ( prevState ) => ( {
 			showActivityTypes: false,
 			showActivityDates: false,
-			showIssueTypes: ! this.state.showIssueTypes,
-		} );
+			showIssueTypes: ! prevState.showIssueTypes,
+		} ) );
 	};
 
 	closeIssueTypes = () => {


### PR DESCRIPTION
#### Proposed Changes

This PR updates the set state method in the fiterbar component to use the previous state to toggle issue types filter

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/use-prev-state-to-toggle-issue-types-filter` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that you are able to toggle the filter.

<img width="329" alt="Screenshot 2022-06-24 at 10 43 06 AM" src="https://user-images.githubusercontent.com/10586875/175471188-7e359def-3bac-436a-b917-f589460a3696.png">

4. Go to Activity Log of any site -> Verify that you are able to toggle the filters.

<img width="1238" alt="Screenshot 2022-06-24 at 10 42 55 AM" src="https://user-images.githubusercontent.com/10586875/175471272-a596e509-ee81-473a-bfc8-6e6813c0aec6.png">

Related to 1202076982646589-as-1202419589266159