### PR TITLE
Stepper: Fixes browser back behavior for DIFM step

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -135,7 +135,7 @@ export const siteSetupFlow: Flow = {
 					if ( siteSlug && goalsStepEnabled ) {
 						pendingActions.push( setGoalsOnSite( siteSlug, goals ) );
 					}
-					Promise.all( pendingActions ).then( () => redirect( to ) );
+					Promise.all( pendingActions ).then( () => window.location.replace( to ) );
 				} );
 			} );
 


### PR DESCRIPTION
#### Proposed Changes

Context: pdDOJh-sJ-p2#comment-336

* From the Goals step, clicking on the DIFM goal and then clicking on the browser back button currently does not take the user back to the Goals step. Instead, the user is navigated to `/setup/processing` and then navigated to My Home.
* This PR replaces the `redirect` call from the `processing` screen with a call to `window.location.replace`. This will replace the current URL (`/setup/processing`) from the browser history with the target URL. My reasoning is that a user will never have to visit the processing screen manually and it should not be present in browser history.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/goals?siteSlug=<site slug>`.
* Click on the DIFM goal (Hire our experts to create your dream site).
* After reaching the DIFM step, click on the browser back button.
* Confirm that you are taken to the Goals screen.

**Testing other goals**
* Go to `/setup/goals?siteSlug=<site slug>`.
* Select the "Write" goal and proceed through the steps until you land on the editor.
* Click on the browser back button should take you to the last step of the flow instead of (Processing -> My Home)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

https://user-images.githubusercontent.com/5436027/175481315-a97db5d0-8768-41a5-b610-a4dc5c0a9a2b.mp4


