### PR TITLE
Upsell Nudge: fix nav routing logic (#64527)

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -78,7 +78,6 @@ class Hosting extends Component {
 			<UpsellNudge
 				title={ translate( 'Upgrade to the Pro plan to access all hosting features' ) }
 				event="calypso_hosting_configuration_upgrade_click"
-				href={ `/checkout/${ siteId }/pro` }
 				plan={ PLAN_WPCOM_PRO }
 				feature={ FEATURE_SFTP }
 				showIcon={ true }


### PR DESCRIPTION
#### Proposed Changes

Use the correct URL on Upsell Nudge component. Actually, as per @gmovr's suggestion, removing the `href` prop so the component uses the default was enough to fix the issue. 

#### Testing Instructions

Please follow "Steps to reproduce" on related issue #64527 and verify the issue is no longer present. 

