### PR TITLE
When user has a single domain that has email, auto-redirect to management screen

### DIFF
--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -185,11 +185,11 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 			( domainsWithEmail[ 0 ].titanMailSubscription?.maximumMailboxCount ?? 0 ) > 0 &&
 			domainsWithEmail[ 0 ].titanMailSubscription?.numberOfMailboxes === 0
 		) {
-			page( emailManagementTitanSetUpMailbox( selectedSite?.slug, selectedSite?.domain ) );
+			page( emailManagementTitanSetUpMailbox( selectedSite.slug, domainsWithEmail[ 0 ].domain ) );
 			return null;
 		}
 
-		page( emailManagement( selectedSite?.slug, selectedSite.domain ) );
+		page( emailManagement( selectedSite.slug, domainsWithEmail[ 0 ].domain ) );
 	}
 
 	return (

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -79,7 +79,7 @@ interface EmailManagementHomeProps {
 const domainHasEmail = ( domain: ResponseDomain ) =>
 	hasTitanMailWithUs( domain ) || hasGSuiteWithUs( domain ) || hasEmailForwards( domain );
 
-const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
+const EmailHome = ( props: EmailManagementHomeProps ) => {
 	const {
 		emailListInactiveHeader,
 		selectedEmailProviderSlug,
@@ -148,6 +148,10 @@ const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
 			<ContentWithHeader>
 				<EmailPlan
 					domain={ selectedDomain }
+					// When users have a single domain with email, they are auto-redirected from the
+					// `/email/:site_slug` page to `/email/:domain/manage/:site_slug`. That's why
+					// we also hide the back button, to avoid scenarios where clicking "Back"
+					// redirects users to the same page as they are currently on.
 					hideHeaderCake={ isSingleDomainThatHasEmail }
 					selectedSite={ selectedSite }
 					source={ source }
@@ -182,9 +186,10 @@ const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
 			domainsWithEmail[ 0 ].titanMailSubscription?.numberOfMailboxes === 0
 		) {
 			page( emailManagementTitanSetUpMailbox( selectedSite?.slug, selectedSite?.domain ) );
-		} else {
-			page( emailManagement( selectedSite?.slug, selectedSite.domain ) );
+			return null;
 		}
+
+		page( emailManagement( selectedSite?.slug, selectedSite.domain ) );
 	}
 
 	return (

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -118,9 +118,7 @@ const EmailHome = ( props: EmailManagementHomeProps ): ReactElement => {
 	const domainsWithNoEmail = nonWpcomDomains.filter( ( domain ) => ! domainHasEmail( domain ) );
 
 	const isSingleDomainThatHasEmail =
-		domainsWithEmail.length === 1 &&
-		domainsWithNoEmail.length === 0 &&
-		domainsWithEmail[ 0 ].domain === selectedSite?.domain;
+		domainsWithEmail.length === 1 && domainsWithNoEmail.length === 0;
 
 	if ( isSiteDomainLoading || ! hasSitesLoaded || ! selectedSite || ! domains ) {
 		return <LoadingPlaceholder />;

--- a/client/my-sites/email/email-management/home/email-plan.jsx
+++ b/client/my-sites/email/email-management/home/email-plan.jsx
@@ -83,7 +83,7 @@ function getMailboxes( data ) {
 	return account?.emails ?? [];
 }
 
-function EmailPlan( { domain, selectedSite, source } ) {
+function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -292,7 +292,7 @@ function EmailPlan( { domain, selectedSite, source } ) {
 		<>
 			{ selectedSite && hasSubscription && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 			<DocumentHead title={ titleCase( getHeaderText() ) } />
-			<HeaderCake onClick={ handleBack }>{ getHeaderText() }</HeaderCake>
+			{ ! hideHeaderCake && <HeaderCake onClick={ handleBack }>{ getHeaderText() }</HeaderCake> }
 			<EmailPlanHeader
 				domain={ domain }
 				hasEmailSubscription={ hasSubscription }
@@ -326,6 +326,7 @@ function EmailPlan( { domain, selectedSite, source } ) {
 
 EmailPlan.propTypes = {
 	domain: PropTypes.object.isRequired,
+	hideHeaderCake: PropTypes.bool,
 	selectedSite: PropTypes.object.isRequired,
 	source: PropTypes.string,
 };


### PR DESCRIPTION
#### Proposed Changes

When users have a single domain and they have email for that domain, we should automatically take them to `/email/:domain/manage/:site_slug` as opposed to `/email/:site_slug` when they click Upgrades > Email in the sidebar.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a site with a single domain and an email solution for that domain
2. Click Upgrades > Emails in the sidebar
3. Ensure that you are taken directly to `/email/:domain/manage/:site_slug`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
