### PR TITLE
Require the Starter plan to purchase paid plugins from the marketplace

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
@@ -23,14 +24,32 @@ function getHoldMessages(
 ) {
 	return {
 		NO_BUSINESS_PLAN: {
-			title: eligibleForProPlan
-				? translate( 'Upgrade to a Pro plan' )
-				: translate( 'Upgrade to a Business plan' ),
+			title: ( function () {
+				if (
+					context === 'marketplace-product-details' &&
+					isEnabled( 'marketplace-starter-plan' )
+				) {
+					return translate( 'Upgrade to a Starter plan' );
+				}
+
+				if ( eligibleForProPlan ) {
+					return translate( 'Upgrade to a Pro plan' );
+				}
+
+				return translate( 'Upgrade to a Business plan' );
+			} )(),
 			description: ( function () {
 				if ( context === 'themes' ) {
 					return translate(
 						"You'll also get to install custom plugins, have more storage, and access live support."
 					);
+				}
+
+				if (
+					context === 'marketplace-product-details' &&
+					isEnabled( 'marketplace-starter-plan' )
+				) {
+					return translate( "You'll also get to collect payments and have more storage." );
 				}
 
 				if ( billingPeriod === IntervalLength.MONTHLY ) {

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -20,12 +20,13 @@ function getHoldMessages(
 	context: string | null,
 	translate: LocalizeProps[ 'translate' ],
 	eligibleForProPlan: boolean,
-	billingPeriod?: string
+	billingPeriod?: string,
+	isMarketplace?: boolean
 ) {
 	return {
 		NO_BUSINESS_PLAN: {
 			title: ( function () {
-				if ( context === 'marketplace-product' && isEnabled( 'marketplace-starter-plan' ) ) {
+				if ( isMarketplace && isEnabled( 'marketplace-starter-plan' ) ) {
 					return translate( 'Upgrade to a Starter plan' );
 				}
 
@@ -42,7 +43,7 @@ function getHoldMessages(
 					);
 				}
 
-				if ( context === 'marketplace-product' && isEnabled( 'marketplace-starter-plan' ) ) {
+				if ( isMarketplace && isEnabled( 'marketplace-starter-plan' ) ) {
 					return translate( "You'll also get to collect payments and have more storage." );
 				}
 
@@ -173,6 +174,7 @@ export function getBlockingMessages(
 interface ExternalProps {
 	context: string | null;
 	holds: string[];
+	isMarketplace?: boolean;
 	isPlaceholder: boolean;
 }
 
@@ -216,13 +218,19 @@ export const HardBlockingNotice = ( {
 	);
 };
 
-export const HoldList = ( { context, holds, isPlaceholder, translate }: Props ) => {
+export const HoldList = ( { context, holds, isMarketplace, isPlaceholder, translate }: Props ) => {
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
 	const eligibleForProPlan = useSelector( ( state ) =>
 		isEligibleForProPlan( state, selectedSite?.ID )
 	);
 	const billingPeriod = useSelector( getBillingInterval );
-	const holdMessages = getHoldMessages( context, translate, eligibleForProPlan, billingPeriod );
+	const holdMessages = getHoldMessages(
+		context,
+		translate,
+		eligibleForProPlan,
+		billingPeriod,
+		isMarketplace
+	);
 	const blockingMessages = getBlockingMessages( translate );
 
 	const blockingHold = holds.find( ( h ) => isHardBlockingHoldType( h, blockingMessages ) );

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { isBlogger, isPersonal, isPremium } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
@@ -21,16 +22,17 @@ function getHoldMessages(
 	translate: LocalizeProps[ 'translate' ],
 	eligibleForProPlan: boolean,
 	billingPeriod?: string,
-	isMarketplace?: boolean
+	isMarketplace?: boolean,
+	isLegacyPlan?: boolean
 ) {
 	return {
 		NO_BUSINESS_PLAN: {
 			title: ( function () {
-				if ( isMarketplace && isEnabled( 'marketplace-starter-plan' ) ) {
+				if ( ! isLegacyPlan && isMarketplace && isEnabled( 'marketplace-starter-plan' ) ) {
 					return translate( 'Upgrade to a Starter plan' );
 				}
 
-				if ( eligibleForProPlan ) {
+				if ( ! isLegacyPlan && eligibleForProPlan ) {
 					return translate( 'Upgrade to a Pro plan' );
 				}
 
@@ -220,6 +222,13 @@ export const HardBlockingNotice = ( {
 
 export const HoldList = ( { context, holds, isMarketplace, isPlaceholder, translate }: Props ) => {
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+
+	const plan = selectedSite?.plan;
+	let isLegacyPlan = false;
+	if ( typeof plan !== 'undefined' ) {
+		isLegacyPlan = isBlogger( plan ) || isPersonal( plan ) || isPremium( plan );
+	}
+
 	const eligibleForProPlan = useSelector( ( state ) =>
 		isEligibleForProPlan( state, selectedSite?.ID )
 	);
@@ -229,7 +238,8 @@ export const HoldList = ( { context, holds, isMarketplace, isPlaceholder, transl
 		translate,
 		eligibleForProPlan,
 		billingPeriod,
-		isMarketplace
+		isMarketplace,
+		isLegacyPlan
 	);
 	const blockingMessages = getBlockingMessages( translate );
 

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -25,10 +25,7 @@ function getHoldMessages(
 	return {
 		NO_BUSINESS_PLAN: {
 			title: ( function () {
-				if (
-					context === 'marketplace-product-details' &&
-					isEnabled( 'marketplace-starter-plan' )
-				) {
+				if ( context === 'marketplace-product' && isEnabled( 'marketplace-starter-plan' ) ) {
 					return translate( 'Upgrade to a Starter plan' );
 				}
 
@@ -45,10 +42,7 @@ function getHoldMessages(
 					);
 				}
 
-				if (
-					context === 'marketplace-product-details' &&
-					isEnabled( 'marketplace-starter-plan' )
-				) {
+				if ( context === 'marketplace-product' && isEnabled( 'marketplace-starter-plan' ) ) {
 					return translate( "You'll also get to collect payments and have more storage." );
 				}
 

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -261,7 +261,7 @@ function mergeProps(
 	let ctaName = '';
 	if (
 		ownProps.currentContext === 'plugin-details' ||
-		ownProps.currentContext === 'marketplace-product-details'
+		ownProps.currentContext === 'marketplace-product'
 	) {
 		context = ownProps.currentContext;
 		feature =

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -6,6 +6,7 @@ import {
 	FEATURE_INSTALL_PLUGINS,
 	PLAN_BUSINESS,
 	PLAN_WPCOM_PRO,
+	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
@@ -258,9 +259,15 @@ function mergeProps(
 	let context: string | null = null;
 	let feature = '';
 	let ctaName = '';
-	if ( ownProps.currentContext === 'plugin-details' ) {
+	if (
+		ownProps.currentContext === 'plugin-details' ||
+		ownProps.currentContext === 'marketplace-product-details'
+	) {
 		context = ownProps.currentContext;
-		feature = FEATURE_INSTALL_PLUGINS;
+		feature =
+			ownProps.currentContext === 'plugin-details'
+				? FEATURE_INSTALL_PLUGINS
+				: WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS;
 		ctaName = 'calypso-plugin-details-eligibility-upgrade-nudge';
 	} else if ( includes( ownProps.backUrl, 'plugins' ) ) {
 		context = 'plugins';

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -45,6 +45,7 @@ interface ExternalProps {
 	className?: string;
 	eligibilityData?: EligibilityData;
 	currentContext?: string;
+	isMarketplace?: boolean;
 }
 
 type Props = ExternalProps & ReturnType< typeof mergeProps > & LocalizeProps;
@@ -56,6 +57,7 @@ export const EligibilityWarnings = ( {
 	feature,
 	eligibilityData,
 	isEligible,
+	isMarketplace,
 	isPlaceholder,
 	onProceed,
 	standaloneProceed,
@@ -123,7 +125,12 @@ export const EligibilityWarnings = ( {
 
 			{ ( isPlaceholder || listHolds.length > 0 ) && (
 				<CompactCard>
-					<HoldList context={ context } holds={ listHolds } isPlaceholder={ isPlaceholder } />
+					<HoldList
+						context={ context }
+						holds={ listHolds }
+						isMarketplace={ isMarketplace }
+						isPlaceholder={ isPlaceholder }
+					/>
 				</CompactCard>
 			) }
 
@@ -259,15 +266,11 @@ function mergeProps(
 	let context: string | null = null;
 	let feature = '';
 	let ctaName = '';
-	if (
-		ownProps.currentContext === 'plugin-details' ||
-		ownProps.currentContext === 'marketplace-product'
-	) {
+	if ( ownProps.currentContext === 'plugin-details' ) {
 		context = ownProps.currentContext;
-		feature =
-			ownProps.currentContext === 'plugin-details'
-				? FEATURE_INSTALL_PLUGINS
-				: WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS;
+		feature = ownProps.isMarketplace
+			? WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS
+			: FEATURE_INSTALL_PLUGINS;
 		ctaName = 'calypso-plugin-details-eligibility-upgrade-nudge';
 	} else if ( includes( ownProps.backUrl, 'plugins' ) ) {
 		context = 'plugins';

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -27,7 +27,7 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 		{ map( warnings, ( { name, description, supportUrl }, index ) => (
 			<div className="eligibility-warnings__warning" key={ index }>
 				<div className="eligibility-warnings__message">
-					{ context !== 'plugin-details' && (
+					{ context !== 'plugin-details' && context !== 'marketplace-product-details' && (
 						<Fragment>
 							<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
 						</Fragment>
@@ -72,6 +72,7 @@ function getWarningDescription(
 		}
 	);
 	switch ( context ) {
+		case 'marketplace-product-details':
 		case 'plugin-details':
 		case 'plugins':
 			return translate(

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -27,7 +27,7 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 		{ map( warnings, ( { name, description, supportUrl }, index ) => (
 			<div className="eligibility-warnings__warning" key={ index }>
 				<div className="eligibility-warnings__message">
-					{ context !== 'plugin-details' && context !== 'marketplace-product-details' && (
+					{ context !== 'plugin-details' && context !== 'marketplace-product' && (
 						<Fragment>
 							<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
 						</Fragment>
@@ -72,9 +72,9 @@ function getWarningDescription(
 		}
 	);
 	switch ( context ) {
-		case 'marketplace-product-details':
 		case 'plugin-details':
 		case 'plugins':
+		case 'marketplace-product':
 			return translate(
 				'By installing a plugin the following change will be made to the site:',
 				'By installing a plugin the following changes will be made to the site:',

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -27,7 +27,7 @@ export const WarningList = ( { context, translate, warnings }: Props ) => (
 		{ map( warnings, ( { name, description, supportUrl }, index ) => (
 			<div className="eligibility-warnings__warning" key={ index }>
 				<div className="eligibility-warnings__message">
-					{ context !== 'plugin-details' && context !== 'marketplace-product' && (
+					{ context !== 'plugin-details' && (
 						<Fragment>
 							<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
 						</Fragment>
@@ -74,7 +74,6 @@ function getWarningDescription(
 	switch ( context ) {
 		case 'plugin-details':
 		case 'plugins':
-		case 'marketplace-product':
 			return translate(
 				'By installing a plugin the following change will be made to the site:',
 				'By installing a plugin the following changes will be made to the site:',

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -347,12 +347,7 @@ export function businessPlanToAdd(
 	eligibleForProPlan,
 	isMarketplace = false
 ) {
-	if ( isMarketplace && isEnabled( 'marketplace-starter-plan' ) ) {
-		return PLAN_WPCOM_STARTER;
-	}
-	if ( eligibleForProPlan ) {
-		return PLAN_WPCOM_PRO;
-	}
+	// Legacy plans always upgrade to business.
 	switch ( currentPlan.product_slug ) {
 		case PLAN_PERSONAL_2_YEARS:
 		case PLAN_PREMIUM_2_YEARS:
@@ -363,6 +358,13 @@ export function businessPlanToAdd(
 		case PLAN_BLOGGER:
 			return PLAN_BUSINESS;
 		default:
+			// Not on a legacy plan: Can upgrade to Starter, Pro, or Business depending on settings.
+			if ( isMarketplace && isEnabled( 'marketplace-starter-plan' ) ) {
+				return PLAN_WPCOM_STARTER;
+			}
+			if ( eligibleForProPlan ) {
+				return PLAN_WPCOM_PRO;
+			}
 			// Return annual plan if selected, monthly otherwise.
 			return pluginBillingPeriod === IntervalLength.ANNUALLY
 				? PLAN_BUSINESS

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -338,16 +338,16 @@ export function getPluginAuthorProfileKeyword( plugin ) {
  * @param currentPlan
  * @param pluginBillingPeriod
  * @param eligibleForProPlan
- * @param isMarketplaceProduct
+ * @param isMarketplace
  * @returns the correct business plan slug depending on current plan and pluginBillingPeriod
  */
 export function businessPlanToAdd(
 	currentPlan,
 	pluginBillingPeriod,
 	eligibleForProPlan,
-	isMarketplaceProduct = false
+	isMarketplace = false
 ) {
-	if ( isMarketplaceProduct && isEnabled( 'marketplace-starter-plan' ) ) {
+	if ( isMarketplace && isEnabled( 'marketplace-starter-plan' ) ) {
 		return PLAN_WPCOM_STARTER;
 	}
 	if ( eligibleForProPlan ) {

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS,
@@ -9,6 +10,7 @@ import {
 	PLAN_BLOGGER_2_YEARS,
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_WPCOM_PRO,
+	PLAN_WPCOM_STARTER,
 } from '@automattic/calypso-products';
 import { filter, map, pick, sortBy } from 'lodash';
 import { decodeEntities, parseHtml } from 'calypso/lib/formatting';
@@ -335,9 +337,19 @@ export function getPluginAuthorProfileKeyword( plugin ) {
 /**
  * @param currentPlan
  * @param pluginBillingPeriod
+ * @param eligibleForProPlan
+ * @param isMarketplaceProduct
  * @returns the correct business plan slug depending on current plan and pluginBillingPeriod
  */
-export function businessPlanToAdd( currentPlan, pluginBillingPeriod, eligibleForProPlan ) {
+export function businessPlanToAdd(
+	currentPlan,
+	pluginBillingPeriod,
+	eligibleForProPlan,
+	isMarketplaceProduct = false
+) {
+	if ( isMarketplaceProduct && isEnabled( 'marketplace-starter-plan' ) ) {
+		return PLAN_WPCOM_STARTER;
+	}
 	if ( eligibleForProPlan ) {
 		return PLAN_WPCOM_PRO;
 	}

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -293,7 +293,7 @@ const CTAButton = ( {
 				onClose={ () => setShowEligibility( false ) }
 			>
 				<EligibilityWarnings
-					currentContext={ isMarketplaceProduct ? 'marketplace-product-details' : 'plugin-details' }
+					currentContext={ isMarketplaceProduct ? 'marketplace-product' : 'plugin-details' }
 					standaloneProceed
 					onProceed={ () =>
 						onClickInstallPlugin( {

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -293,7 +293,7 @@ const CTAButton = ( {
 				onClose={ () => setShowEligibility( false ) }
 			>
 				<EligibilityWarnings
-					currentContext={ 'plugin-details' }
+					currentContext={ isMarketplaceProduct ? 'marketplace-product-details' : 'plugin-details' }
 					standaloneProceed
 					onProceed={ () =>
 						onClickInstallPlugin( {
@@ -404,7 +404,8 @@ function onClickInstallPlugin( {
 				`/checkout/${ selectedSite.slug }/${ businessPlanToAdd(
 					selectedSite?.plan,
 					billingPeriod,
-					eligibleForProPlan
+					eligibleForProPlan,
+					true
 				) },${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${
 					selectedSite.slug
 				}`

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -293,7 +293,8 @@ const CTAButton = ( {
 				onClose={ () => setShowEligibility( false ) }
 			>
 				<EligibilityWarnings
-					currentContext={ isMarketplaceProduct ? 'marketplace-product' : 'plugin-details' }
+					currentContext={ 'plugin-details' }
+					isMarketplace={ isMarketplaceProduct }
 					standaloneProceed
 					onProceed={ () =>
 						onClickInstallPlugin( {

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -4,6 +4,9 @@ import {
 	PLAN_BUSINESS,
 	PLAN_WPCOM_PRO,
 	PLAN_WPCOM_STARTER,
+	isBlogger,
+	isPersonal,
+	isPremium,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
@@ -63,11 +66,17 @@ const USPS: React.FC< Props > = ( {
 			return '';
 		}
 
-		if ( isMarketplaceProduct && isEnabled( 'marketplace-starter-plan' ) ) {
+		const plan = selectedSite?.plan;
+		let isLegacyPlan = false;
+		if ( typeof plan !== 'undefined' ) {
+			isLegacyPlan = isBlogger( plan ) || isPersonal( plan ) || isPremium( plan );
+		}
+
+		if ( ! isLegacyPlan && isMarketplaceProduct && isEnabled( 'marketplace-starter-plan' ) ) {
 			return PLAN_WPCOM_STARTER;
 		}
 
-		if ( isEligibleForProPlan( state, selectedSite?.ID ) ) {
+		if ( ! isLegacyPlan && isEligibleForProPlan( state, selectedSite?.ID ) ) {
 			return PLAN_WPCOM_PRO;
 		}
 

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -1,4 +1,10 @@
-import { PLAN_BUSINESS_MONTHLY, PLAN_BUSINESS, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
+import { isEnabled } from '@automattic/calypso-config';
+import {
+	PLAN_BUSINESS_MONTHLY,
+	PLAN_BUSINESS,
+	PLAN_WPCOM_PRO,
+	PLAN_WPCOM_STARTER,
+} from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -52,14 +58,44 @@ const USPS: React.FC< Props > = ( {
 	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
 
 	const selectedSite = useSelector( getSelectedSite );
-	const eligibleForProPlan = useSelector( ( state ) =>
-		isEligibleForProPlan( state, selectedSite?.ID )
-	);
+	const requiredPlan = useSelector( ( state ) => {
+		if ( ! shouldUpgrade ) {
+			return '';
+		}
+
+		if ( isMarketplaceProduct && isEnabled( 'marketplace-starter-plan' ) ) {
+			return PLAN_WPCOM_STARTER;
+		}
+
+		if ( isEligibleForProPlan( state, selectedSite?.ID ) ) {
+			return PLAN_WPCOM_PRO;
+		}
+
+		return isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY;
+	} );
 
 	const planDisplayCost = useSelector( ( state ) => {
-		const productSlug = isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY;
-		return getProductDisplayCost( state, eligibleForProPlan ? PLAN_WPCOM_PRO : productSlug );
+		return getProductDisplayCost( state, requiredPlan );
 	} );
+	let planText;
+	switch ( requiredPlan ) {
+		case PLAN_WPCOM_STARTER:
+			planText = translate( 'Included in the Starter plan (%s):', {
+				args: [ planDisplayCost ],
+			} );
+			break;
+		case PLAN_WPCOM_PRO:
+			planText = translate( 'Included in the Pro plan (%s):', {
+				args: [ planDisplayCost ],
+			} );
+			break;
+		case PLAN_BUSINESS:
+		case PLAN_BUSINESS_MONTHLY:
+			planText = translate( 'Included in the Business plan (%s):', {
+				args: [ planDisplayCost ],
+			} );
+			break;
+	}
 
 	const supportText = usePluginsSupportText();
 
@@ -91,13 +127,7 @@ const USPS: React.FC< Props > = ( {
 					{
 						id: 'plan',
 						className: 'title',
-						text: eligibleForProPlan
-							? translate( 'Included in the Pro plan (%s):', {
-									args: [ planDisplayCost ],
-							  } )
-							: translate( 'Included in the Business plan (%s):', {
-									args: [ planDisplayCost ],
-							  } ),
+						text: planText,
 						eligibilities: [ 'needs-upgrade' ],
 					},
 			  ]
@@ -112,7 +142,27 @@ const USPS: React.FC< Props > = ( {
 					},
 			  ]
 			: [] ),
-		...( shouldUpgrade
+		...( shouldUpgrade && requiredPlan === PLAN_WPCOM_STARTER
+			? [
+					{
+						id: 'collect-payments',
+						image: <Gridicon icon="money" size={ 16 } />,
+						text: translate( 'Payments collection' ),
+						eligibilities: [ 'needs-upgrade' ],
+					},
+			  ]
+			: [] ),
+		...( shouldUpgrade && requiredPlan === PLAN_WPCOM_STARTER
+			? [
+					{
+						id: 'storage',
+						image: <Gridicon icon="product" size={ 16 } />,
+						text: translate( '6GB of storage' ),
+						eligibilities: [ 'needs-upgrade' ],
+					},
+			  ]
+			: [] ),
+		...( shouldUpgrade && requiredPlan !== PLAN_WPCOM_STARTER
 			? [
 					{
 						id: 'hosting',
@@ -122,7 +172,7 @@ const USPS: React.FC< Props > = ( {
 					},
 			  ]
 			: [] ),
-		...( shouldUpgrade || isMarketplaceProduct
+		...( shouldUpgrade && requiredPlan !== PLAN_WPCOM_STARTER
 			? [
 					{
 						id: 'support',

--- a/config/development.json
+++ b/config/development.json
@@ -105,6 +105,7 @@
 		"marketplace-test": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-jetpack-plugin-search": false,
+		"marketplace-starter-plan": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/58998

#### Proposed Changes

* Introduces a new `marketplace-starter-plan` feature flag so we can ship small iterations expanding the marketplace addons to the Starter plan without affecting production.
* Changes the required plan to purchase paid plugins from the WP.com marketplace from Pro/Business to Starter (if the feature flag above is enabled). 

Before | After
--- | ---
<img width="982" alt="Screen Shot 2022-06-24 at 15 21 11" src="https://user-images.githubusercontent.com/1233880/175558081-fa5a82da-7d86-42dc-9023-8b415d8102df.png"> | <img width="983" alt="Screen Shot 2022-06-24 at 15 38 22" src="https://user-images.githubusercontent.com/1233880/175558125-ee3e2d90-0d78-4f11-afba-cc454e611a68.png">
<img width="813" alt="Screen Shot 2022-06-24 at 15 53 51" src="https://user-images.githubusercontent.com/1233880/175558199-3bdd2352-3948-4832-b7a1-30330d361ad5.png"> | <img width="810" alt="Screen Shot 2022-06-24 at 15 56 13" src="https://user-images.githubusercontent.com/1233880/175558297-1d9676c7-6e7e-4e1c-b401-5e0b15d18ca6.png">

#### Testing Instructions

* Apply D82976-code to your sandbox.
* Sandbox the API.
* Use the Calypso live link below.
* Activate the feature flag by adding `?flags=marketplace-starter-plan` to the URL.
* Switch to a Simple sites with a Free plan.
* Go to Plugins.
* Select a paid plugin.
* Make sure that info about the Starter plan is displayed below the "Purchase and activate" button.
* Click on the "Purchase and activate" button and proceed with the checkout process.
* Make sure you get the Starter plan. 
