### PR TITLE
Activity Log: do not display upgrade banner on Multisite.

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -61,7 +61,7 @@ import {
 	getSiteSlug,
 	getSiteTitle,
 	isJetpackSite,
-	isJetpackSiteSecondaryNetworkSite as getIsJetpackSiteSecondaryNetworkSite,
+	isJetpackSiteMultiSite,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ActivityLogBanner from '../activity-log-banner';
@@ -118,7 +118,7 @@ class ActivityLog extends Component {
 		// localize
 		moment: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
-		isJetpackSiteSecondaryNetworkSite: PropTypes.bool,
+		isMultisite: PropTypes.bool,
 	};
 
 	state = {
@@ -427,7 +427,7 @@ class ActivityLog extends Component {
 			isAtomic,
 			isJetpack,
 			isIntroDismissed,
-			isJetpackSiteSecondaryNetworkSite,
+			isMultisite,
 		} = this.props;
 
 		const disableRestore =
@@ -491,7 +491,7 @@ class ActivityLog extends Component {
 					<RewindUnavailabilityNotice siteId={ siteId } />
 				) }
 				<IntroBanner siteId={ siteId } />
-				{ ! hasFullActivityLog && isIntroDismissed && ! isJetpackSiteSecondaryNetworkSite && (
+				{ ! hasFullActivityLog && isIntroDismissed && ! isMultisite && (
 					<UpgradeBanner siteId={ siteId } />
 				) }
 				{ siteId && isJetpack && <ActivityLogTasklist siteId={ siteId } /> }
@@ -686,7 +686,7 @@ export default connect(
 			timezone,
 			hasFullActivityLog: siteHasFeature( state, siteId, WPCOM_FEATURES_FULL_ACTIVITY_LOG ),
 			isIntroDismissed: getPreference( state, 'dismissible-card-activity-introduction-banner' ),
-			isJetpackSiteSecondaryNetworkSite: getIsJetpackSiteSecondaryNetworkSite( state, siteId ),
+			isMultisite: isJetpackSiteMultiSite( state, siteId ),
 		};
 	},
 	{


### PR DESCRIPTION
#### Proposed Changes

The Activity Log banner redirects you to a security plan, which cannot be purchased on multisite at the moment. We consequently should not be showing the banner on such sites.

#### Testing Instructions

* Start with a site that's part of a Multisite network, connected to WordPress.com, and without any Jetpack paid plan.
* Go to https://wordpress.com/activity-log/yoursite.com
* With this branch, you should not see an upgrade banner at the top of the page.
* On production, you should see the banner, redirecting you to a checkout page giving you an error.

**Before**
<img width="1115" alt="image" src="https://user-images.githubusercontent.com/426388/175607506-b20fe2b7-ecc7-4584-8ee9-a40b7c4733ff.png">


**After**

<img width="1133" alt="Screen Shot 2022-06-24 at 18 56 04" src="https://user-images.githubusercontent.com/426388/175607530-1f0c0d5e-649e-40ca-b719-3bc319467e12.png">

#### Discussion

p1656083583522389-slack-C01264051NE