### PR TITLE
Goals Capture: Fix page title on Goals Capture screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -4,6 +4,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import intentImageUrl from 'calypso/assets/images/onboarding/intent.svg';
+import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -116,25 +117,29 @@ const GoalsStep: Step = ( { navigation } ) => {
 	}, [ refParameter, refGoals ] );
 
 	return (
-		<StepContainer
-			stepName={ 'goals-step' }
-			goNext={ navigation.goNext }
-			skipLabelText={ translate( 'Skip to dashboard' ) }
-			skipButtonAlign={ 'top' }
-			hideBack={ true }
-			isHorizontalLayout={ true }
-			headerImageUrl={ intentImageUrl }
-			className={ 'goals__container' }
-			formattedHeader={
-				<FormattedHeader
-					id={ 'goals-header' }
-					headerText={ headerText }
-					subHeaderText={ subHeaderText }
-				/>
-			}
-			stepContent={ stepContent }
-			recordTracksEvent={ recordTracksEvent }
-		/>
+		<>
+			<DocumentHead title={ translate( 'What are your goals?' ) } />
+
+			<StepContainer
+				stepName={ 'goals-step' }
+				goNext={ navigation.goNext }
+				skipLabelText={ translate( 'Skip to dashboard' ) }
+				skipButtonAlign={ 'top' }
+				hideBack={ true }
+				isHorizontalLayout={ true }
+				headerImageUrl={ intentImageUrl }
+				className={ 'goals__container' }
+				formattedHeader={
+					<FormattedHeader
+						id={ 'goals-header' }
+						headerText={ headerText }
+						subHeaderText={ subHeaderText }
+					/>
+				}
+				stepContent={ stepContent }
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -37,11 +37,13 @@ const refGoals: Record< string, Onboard.SiteGoal[] > = {
  */
 const GoalsStep: Step = ( { navigation } ) => {
 	const translate = useTranslate();
-	const headerText = translate( 'Welcome!{{br/}}What are your goals?', {
-		components: {
-			br: <br />,
-		},
-	} );
+	const welcomeText = translate( 'Welcome!' );
+	const whatAreYourGoalsText = translate( 'What are your goals?' );
+	const headerText = (
+		<>
+			{ welcomeText } <br /> { whatAreYourGoalsText }
+		</>
+	);
 	const subHeaderText = translate( 'Tell us what would you like to accomplish with your website.' );
 
 	const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
@@ -118,7 +120,7 @@ const GoalsStep: Step = ( { navigation } ) => {
 
 	return (
 		<>
-			<DocumentHead title={ translate( 'What are your goals?' ) } />
+			<DocumentHead title={ whatAreYourGoalsText } />
 
 			<StepContainer
 				stepName={ 'goals-step' }


### PR DESCRIPTION
#### Proposed Changes
This PR fixes the page title on Goals Capture step. It uses the `DocumentHead` component to make that change during render. The PR also splits the header text in order to reuse the **"What are your goals?"** string/translations in the page title.

<img width="270" alt="Screen Shot 2022-06-24 at 11 47 56" src="https://user-images.githubusercontent.com/3113712/175607580-9689b7f7-cd1b-4e50-a031-986621dbedaf.png">

#### Testing Instructions
1. Go to http://calypso.localhost:3000/setup/goals?siteSlug=YOUR-SITE
2. Verify if the page/tab title changes to **"What are your goals? — WordPress.com"**
3. Navigate to **Import your site content** and check if the title changed to **"Import your site content"**
4. Click on **Back** button and wait for the Goals Capture screen to be loaded
5. Check if the page title changed to **"What are your goals? — WordPress.com"** again