### PR TITLE
Purchases: Update the period checker for products not present on PRODUCT_LIST.

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -257,6 +257,10 @@ function PurchaseMetaPrice( { purchase } ) {
 		}
 	}
 
+	if ( typeof plan === 'string' && plan.endsWith( 'monthly' ) ) {
+		period = translate( 'month' );
+	}
+
 	if ( isEmailMonthly( purchase ) ) {
 		period = translate( 'month' );
 	}


### PR DESCRIPTION

#### Proposed Changes

Update the period checker for products not present on PRODUCT_LIST.

If the product is not on PRODUCT_LIST and it ends with "monthly" it is shown as "month" as the period.

#### Testing Instructions
* Go to a marketplace Plugin page and buy the monthly subscription. Ex: `/plugins/woocommerce-subscriptions`
* Go to the purchases page(`/me/purchases`) and select your plugin subscription.
* Check if the period next to the price show as **month**

| Before  | After |
| ------------- | ------------- |
|<img width="1039" alt="Screen Shot 2022-06-24 at 13 02 58" src="https://user-images.githubusercontent.com/5039531/175609555-898db74e-1092-4eaf-8178-d4b4070d216d.png">|<img width="1039" alt="Screen Shot 2022-06-24 at 13 03 28" src="https://user-images.githubusercontent.com/5039531/175609481-c70fe8e6-2d99-4a7a-9377-bd687307ae68.png">


---


Fixes #64923
