### PR TITLE
Help Center: HC only in simple sites

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -386,6 +386,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
  * At the moment we're showing only to 10% of the users. And to all proxied requests.
  */
 function load_help_center() {
+	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+		return;
+	}
+
 	// enable help center for all proxied users.
 	$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) : false || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -375,9 +375,14 @@ export default withCurrentRoute(
 		const locale = getCurrentLocaleSlug( state );
 		const isEditor = getSectionName( state ) === 'gutenberg-editor';
 		const isHelpCenterEnabled = config.isEnabled( 'editor/help-center' );
+		const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );
 
 		const disableFAB =
-			isHelpCenterEnabled && locale === 'en' && isEditor && userSegment < currentSegment;
+			isSimpleSite &&
+			isHelpCenterEnabled &&
+			locale === 'en' &&
+			isEditor &&
+			userSegment < currentSegment;
 
 		return {
 			masterbarIsHidden,

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -499,7 +499,7 @@ class MasterbarLoggedIn extends Component {
 		}
 		if ( isMobile ) {
 			const isHelpCenterEnabled = config.isEnabled( 'editor/help-center' );
-
+			const isSimpleSite = window.location.host.endsWith( '.wordpress.com' );
 			const currentSegment = 10; //percentage of users that will see the Help Center, not the FAB
 			const userSegment = this.props.user.ID % 100;
 
@@ -507,7 +507,8 @@ class MasterbarLoggedIn extends Component {
 				this.props.isInEditor &&
 				isHelpCenterEnabled &&
 				userSegment < currentSegment &&
-				this.props.locale === 'en'
+				this.props.locale === 'en' &&
+				isSimpleSite
 			) {
 				return (
 					<Masterbar>


### PR DESCRIPTION
#### Proposed Changes

After a problem in rendering embedded articles, we decided to quickly remove Help Center from Atomic websites, to have more time to understand the problem

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
