### PR TITLE
Themes: Ensure the theme tier gets passed from the ThemeShowcase to the ThemeSearch card

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -293,7 +293,7 @@ class ThemeShowcase extends Component {
 			isMultisite,
 			locale,
 		} = this.props;
-		const tier = '';
+		const tier = this.props.tier || '';
 
 		const canonicalUrl = 'https://wordpress.com' + pathName;
 


### PR DESCRIPTION
#### Proposed Changes

The tier is set to `''` when the ThemeShowcase loads. This means, that when linking to free or premium themes directly, the tier option isn't selected in the ThemeSearch.

We now pass the theme tier down the component tree so the tier is correctly selected.

#### Testing Instructions

- Go to http://calypso.localhost:3000/themes/premium/[site-slug] and verify the "Premium" tier is selected.
- Go to http://calypso.localhost:3000/themes/free/[site-slug] and verify the "Free" tier is selected.

Fixes #64222
