### PR TITLE
Google Sign-in: Migrate the pop-up flow to the new Google Identity Services API

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -40,11 +40,9 @@ class SocialLoginForm extends Component {
 		const { onSuccess, socialService } = this.props;
 		let redirectTo = this.props.redirectTo;
 
-		if ( ! response.getAuthResponse ) {
-			return;
-		}
-
-		const tokens = response.getAuthResponse();
+		const tokens = config.isEnabled( 'migration/sign-in-with-google' )
+			? response // The `response` object itself holds the tokens, no need for any other method calls.
+			: response.getAuthResponse?.();
 
 		if ( ! tokens || ! tokens.access_token || ! tokens.id_token ) {
 			return;

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -38,11 +38,9 @@ class SocialSignupForm extends Component {
 	};
 
 	handleGoogleResponse = ( response, triggeredByUser = true ) => {
-		if ( ! response.getAuthResponse ) {
-			return;
-		}
-
-		const tokens = response.getAuthResponse();
+		const tokens = config.isEnabled( 'migration/sign-in-with-google' )
+			? response // The `response` object itself holds the tokens, no need for any other method calls.
+			: response.getAuthResponse?.();
 
 		if ( ! tokens || ! tokens.access_token || ! tokens.id_token ) {
 			return;

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -33,7 +33,9 @@ class GoogleLoginButton extends Component {
 	};
 
 	static defaultProps = {
-		scope: 'https://www.googleapis.com/auth/userinfo.profile',
+		scope: config.isEnabled( 'migration/sign-in-with-google' )
+			? 'openid profile email'
+			: 'https://www.googleapis.com/auth/userinfo.profile',
 		fetchBasicProfile: true,
 		onClick: noop,
 	};
@@ -197,6 +199,11 @@ class GoogleLoginButton extends Component {
 		this.props.onClick( event );
 
 		if ( this.state.error ) {
+			return;
+		}
+
+		if ( config.isEnabled( 'migration/sign-in-with-google' ) ) {
+			this.client.requestCode();
 			return;
 		}
 

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -11,6 +11,7 @@ import GoogleIcon from 'calypso/components/social-icons/google';
 import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isFormDisabled } from 'calypso/state/login/selectors';
+import { postLoginRequest } from 'calypso/state/login/utils';
 
 let auth2InitDone = false;
 
@@ -178,6 +179,19 @@ class GoogleLoginButton extends Component {
 			} );
 
 		return this.initialized;
+	}
+
+	async handleAuthorizationCode( auth_code ) {
+		const response = await postLoginRequest( 'exchange-social-auth-code', {
+			service: 'google',
+			auth_code,
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_key' ),
+		} );
+
+		const { access_token, id_token } = response.body.data;
+
+		this.props.responseHandler( { access_token, id_token } );
 	}
 
 	handleClick( event ) {

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -12,6 +12,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isFormDisabled } from 'calypso/state/login/selectors';
 import { getErrorFromHTTPError, postLoginRequest } from 'calypso/state/login/utils';
+import { errorNotice } from 'calypso/state/notices/actions';
 
 let auth2InitDone = false;
 
@@ -201,9 +202,9 @@ class GoogleLoginButton extends Component {
 				} );
 			}
 
-			this.setState( {
-				error: this.props.translate( 'An error has occurred. Please try again.' ),
-			} );
+			this.props.showErrorNotice(
+				this.props.translate( 'An error has occurred. Please try again.' )
+			);
 
 			return;
 		}
@@ -341,5 +342,6 @@ export default connect(
 	} ),
 	{
 		recordTracksEvent,
+		showErrorNotice: errorNotice,
 	}
 )( localize( GoogleLoginButton ) );

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -203,7 +203,9 @@ class GoogleLoginButton extends Component {
 			}
 
 			this.props.showErrorNotice(
-				this.props.translate( 'An error has occurred. Please try again.' )
+				this.props.translate(
+					'Something went wrong when trying to connect with Google. Please try again.'
+				)
 			);
 
 			return;

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -42,11 +42,9 @@ class SocialLoginActionButton extends Component {
 		};
 
 		if ( service === 'google' ) {
-			if ( ! response.getAuthResponse ) {
-				return;
-			}
-
-			const tokens = response.getAuthResponse();
+			const tokens = config.isEnabled( 'migration/sign-in-with-google' )
+				? response // The `response` object itself holds the tokens, no need for any other method calls.
+				: response.getAuthResponse?.();
 
 			if ( ! tokens || ! tokens.access_token || ! tokens.id_token ) {
 				return;

--- a/config/development.json
+++ b/config/development.json
@@ -108,6 +108,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
+		"migration/sign-in-with-google": false,
 		"network-connection": true,
 		"oauth": false,
 		"p2/p2-plus": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -66,6 +66,7 @@
 		"marketplace-jetpack-plugin-search": false,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
+		"migration/sign-in-with-google": false,
 		"network-connection": true,
 		"p2/p2-plus": true,
 		"plans/starter-plan": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -53,6 +53,7 @@
 		"layout/support-article-dialog": false,
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
+		"migration/sign-in-with-google": false,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -47,6 +47,7 @@
 		"layout/support-article-dialog": false,
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
+		"migration/sign-in-with-google": false,
 		"oauth": false,
 		"purchases/new-payment-methods": true,
 		"site-indicator": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -49,6 +49,7 @@
 		"layout/support-article-dialog": false,
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
+		"migration/sign-in-with-google": false,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -50,6 +50,7 @@
 		"layout/support-article-dialog": false,
 		"marketplace-test": false,
 		"marketplace-domain-bundle": false,
+		"migration/sign-in-with-google": false,
 		"oauth": true,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,

--- a/config/production.json
+++ b/config/production.json
@@ -77,6 +77,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
+		"migration/sign-in-with-google": false,
 		"p2/p2-plus": true,
 		"plans/starter-plan": true,
 		"plans/personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -75,6 +75,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
+		"migration/sign-in-with-google": false,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"plans/starter-plan": true,

--- a/config/test.json
+++ b/config/test.json
@@ -58,6 +58,7 @@
 		"marketplace-jetpack-plugin-search": false,
 		"me/account-close": true,
 		"me/vat-details": true,
+		"migration/sign-in-with-google": false,
 		"network-connection": true,
 		"plans/starter-plan": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -85,6 +85,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
+		"migration/sign-in-with-google": false,
 		"network-connection": true,
 		"p2/p2-plus": true,
 		"plans/starter-plan": true,


### PR DESCRIPTION
### Proposed Changes

We are migrating to the new Google Identity Services API. This PR migrates the pop-up flow behind a feature flag so existing users won't be affected. The redirect flow will be handled by another PR.

### Testing Instructions

In these instructions, we will link a WPCOM account to a Google account. This is the easier path to test as the others involve setting multiple Google accounts and that's less than desirable.

- Create and activate a WPCOM account using an e-mail (https://10minutemail.net) and a password (do NOT Google login);
- Run `bin/calypso-secrets .config/secrets.php` in your WordPress.com sandbox;
- Copy the output of the script to `config/secrets.json` in your wp-calypso checkout;
- Build this branch with `NODE_ENV=production CALYPSO_ENV=production yarn run build`;
- Run these commands in the Calypso root folder so you can SSL the local version you just built:

```sh
openssl req \
    -newkey rsa:2048 \
    -x509 \
    -nodes \
    -keyout ./config/server/key.pem \
    -new \
    -out ./config/server/certificate.pem \
    -subj /CN=wordpress.com \
    -reqexts SAN \
    -extensions SAN \
    -config <(cat /System/Library/OpenSSL/openssl.cnf \
     <(printf '[SAN]\nsubjectAltName=DNS:wpcalypso.wordpress.com')) \
    -sha256 \
    -days 365
 
# Add it to the trusted certificates
sudo security add-trusted-cert -d -k $(security list-keychains | grep System | cut -d '"' -f 2 ) ./config/server/certificate.pem
```

- Kick off the server with `NODE_ENV=production HOST=wpcalypso.wordpress.com PORT=443 PROTOCOL=https CALYPSO_ENV=wpcalypso BUILD_TRANSLATION_CHUNKS=true node build/server.js`;
- Proxy `wpcalypso.wordpress.com` to `127.0.0.1`;
- Open the dev tools and paste `document.cookie='G_AUTH2_MIGRATION=informational'`.

Keep the DevTools open to assert a few details below...

#### Verify that the current flow still works

- Open https://wpcalypso.wordpress.com/me/security/social-login;
- Open the DevTools and check that the [deprecation notice](https://github.com/Automattic/wp-calypso/issues/64538) shows up in the console;
- Click on `Connect` and choose a Google account not yet linked to any WPCOM account.

It should connect the account successfully. You should also be able to see that `/me/social-login/connect` was called successfully in the network tab in the DevTools.

#### Verify that the new flow works

- Open https://wpcalypso.wordpress.com/me/security/social-login?flags=migration/sign-in-with-google;
- Click `Disconnect` to unlink the previously connected Google account;
- Open the DevTools;
- Check that the feature was activated by the `Config flag enabled via URL: migration/sign-in-with-google` message in the console;
- Check that the deprecation notice is not there anymore;
- Click on `Connect` and choose an account not yet linked to any WPCOM account.

It should connect the account successfully.  The network tab in the DevTools should show that both the calls to `/wp-login.php?action=exchange-social-auth-code` and `/me/social-login/connect` were issued successfully.

---

#### Verifying that social sign-ups work

The new flow should work all across the application since they're using the same component. If you'd like to try a sign-up instead of a social connection, here's how you can do so:

- Open https://wpcalypso.wordpress.com/start/user?flags=migration/sign-in-with-google;
- Open the DevTools;
- Check that the feature was activated by the `Config flag enabled via URL: migration/sign-in-with-google` message in the console;
- Check that the deprecation notice is not there anymore;
- Click on `Continue With Google` and choose an account not yet registered to WPCOM.

You should be redirected to the `/start/domains` page. In the background, requests to `/wp-login.php?action=exchange-social-auth-code` and `/users/social/new` should've been successfully issued.

Related to #64788.