### PR TITLE
Upgrade banner: Account for paid plugins on Starter

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_INSTALL_PLUGINS,
 	findFirstSimilarPlanKey,
@@ -603,7 +604,7 @@ const PluginBrowserContent = ( props ) => {
 			{ ! props.jetpackNonAtomic && (
 				<>
 					<div className="plugins-browser__upgrade-banner">
-						{ eligibleForProPlan && ! isLegacyPlan ? (
+						{ isEnabled( 'marketplace-starter-plan' ) && eligibleForProPlan && ! isLegacyPlan ? (
 							<UpgradeNudgePaid { ...props } />
 						) : (
 							<UpgradeNudge { ...props } />
@@ -612,7 +613,9 @@ const PluginBrowserContent = ( props ) => {
 					<PluginSingleListView { ...props } category="paid" />
 				</>
 			) }
-			{ eligibleForProPlan && ! isLegacyPlan && <UpgradeNudge { ...props } /> }
+			{ isEnabled( 'marketplace-starter-plan' ) && eligibleForProPlan && ! isLegacyPlan && (
+				<UpgradeNudge { ...props } />
+			) }
 			<PluginSingleListView { ...props } category="featured" />
 			<PluginSingleListView { ...props } category="popular" />
 		</>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -588,7 +588,8 @@ const PluginBrowserContent = ( props ) => {
 	);
 
 	const isLegacyPlan =
-		isBlogger( props.sitePlan ) || isPersonal( props.sitePlan ) || isPremium( props.sitePlan );
+		props.sitePlan &&
+		( isBlogger( props.sitePlan ) || isPersonal( props.sitePlan ) || isPremium( props.sitePlan ) );
 
 	if ( props.search ) {
 		return <SearchListView { ...props } />;

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -665,7 +665,7 @@ const UpgradeNudgePaid = ( props ) => {
 		<UpsellNudge
 			event="calypso_plugins_browser_upgrade_nudge"
 			showIcon={ true }
-			//		href={ `/checkout/${ props.siteSlug }/starter` }
+			href={ `/checkout/${ props.siteSlug }/starter` }
 			feature={ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS }
 			plan={ plan }
 			title={ translate( 'Upgrade to the Starter plan to install paid plugins.' ) }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,6 +1,9 @@
 import {
 	FEATURE_INSTALL_PLUGINS,
 	findFirstSimilarPlanKey,
+	isBlogger,
+	isPersonal,
+	isPremium,
 	TYPE_BUSINESS,
 	TYPE_STARTER,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
@@ -584,6 +587,9 @@ const PluginBrowserContent = ( props ) => {
 		isEligibleForProPlan( state, props.selectedSite?.ID )
 	);
 
+	const isLegacyPlan =
+		isBlogger( props.sitePlan ) || isPersonal( props.sitePlan ) || isPremium( props.sitePlan );
+
 	if ( props.search ) {
 		return <SearchListView { ...props } />;
 	}
@@ -596,7 +602,7 @@ const PluginBrowserContent = ( props ) => {
 			{ ! props.jetpackNonAtomic && (
 				<>
 					<div className="plugins-browser__upgrade-banner">
-						{ eligibleForProPlan ? (
+						{ eligibleForProPlan && ! isLegacyPlan ? (
 							<UpgradeNudgePaid { ...props } />
 						) : (
 							<UpgradeNudge { ...props } />
@@ -605,7 +611,7 @@ const PluginBrowserContent = ( props ) => {
 					<PluginSingleListView { ...props } category="paid" />
 				</>
 			) }
-			{ eligibleForProPlan && <UpgradeNudge { ...props } /> }
+			{ eligibleForProPlan && ! isLegacyPlan && <UpgradeNudge { ...props } /> }
 			<PluginSingleListView { ...props } category="featured" />
 			<PluginSingleListView { ...props } category="popular" />
 		</>
@@ -621,16 +627,17 @@ const UpgradeNudge = ( { selectedSite, sitePlan, isVip, jetpackNonAtomic, siteSl
 	if ( ! selectedSite?.ID || ! sitePlan || isVip || jetpackNonAtomic ) {
 		return null;
 	}
-
-	const checkoutPlan = eligibleForProPlan ? 'pro' : 'business';
+	const isLegacyPlan = isBlogger( sitePlan ) || isPersonal( sitePlan ) || isPremium( sitePlan );
+	const checkoutPlan = eligibleForProPlan && ! isLegacyPlan ? 'pro' : 'business';
 	const bannerURL = `/checkout/${ siteSlug }/${ checkoutPlan }`;
 	const plan = findFirstSimilarPlanKey( sitePlan.product_slug, {
 		type: TYPE_BUSINESS,
 	} );
 
-	const title = eligibleForProPlan
-		? translate( 'Upgrade to the Pro plan to install plugins.' )
-		: translate( 'Upgrade to the Business plan to install plugins.' );
+	const title =
+		eligibleForProPlan && ! isLegacyPlan
+			? translate( 'Upgrade to the Pro plan to install plugins.' )
+			: translate( 'Upgrade to the Business plan to install plugins.' );
 
 	return (
 		<UpsellNudge

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -53,3 +53,8 @@
 		border-top: 1px solid #eeeeee;
 	}
 }
+
+.plugins-browser__upgrade-banner {
+	display: table;
+	width: 100%;
+}

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -57,4 +57,8 @@
 .plugins-browser__upgrade-banner {
 	display: table;
 	width: 100%;
+
+	.banner.card {
+		margin: 48px 0 0;
+	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Rearranges upgrade banners from the top of the plugins screen to right before the appropriate sections.
* Adds a separate upgrade banner for paid plugins (since they'll be available on a different tier)

Plan | Before | After
--- | --- | ---
Blogger/Personal/Premium | <img width="1510" alt="Screen Shot 2022-06-27 at 11 34 42 AM" src="https://user-images.githubusercontent.com/1398304/176011799-5ccda9cb-8467-4f06-89a6-7addf40839ed.png"> | <img width="1510" alt="Screen Shot 2022-06-27 at 11 49 44 AM" src="https://user-images.githubusercontent.com/1398304/176014291-8b4d1f2e-2cd7-42f4-895d-c8f4221235f6.png">
Free | <img width="1510" alt="Screen Shot 2022-06-27 at 11 39 13 AM" src="https://user-images.githubusercontent.com/1398304/176012376-3b99260d-9ce8-415f-b009-749ad5aa1a66.png"> | <img width="1510" alt="Screen Shot 2022-06-27 at 11 50 30 AM" src="https://user-images.githubusercontent.com/1398304/176014308-878fdf31-0620-4f9d-a579-1f38a5177426.png">

#### Testing Instructions


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Apply D83198-code and sandbox public-api 
* Navigate to the plugins screen and verify you see the correct upgrade banners based on the site's plan:

Plan | Paid Plugins Upgrade Banner | Free Plugin Upgrade Banner
--- | --- | ---
Free | ✅ Starter Plan | ✅ Pro Plan
Starter | 🚫 | ✅ Pro Plan
Blogger | ✅ Business Plan | 🚫 
Personal | ✅ Business Plan | 🚫 
Premium | ✅ Business Plan | 🚫 
Pro | 🚫 | 🚫 
Business | 🚫 | 🚫 
eCommerce  | 🚫 | 🚫 
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/55917


