### PR TITLE
Migrate Professional Email Upsell to NewMailboxList

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -183,11 +183,12 @@ const ProfessionalEmailUpsell = ( {
 				<div className="professional-email-upsell__form">
 					<NewMailBoxList
 						cancelActionText={ 'Skip for now' }
-						hiddenFieldNames={ [ FIELD_NAME, FIELD_ALTERNATIVE_EMAIL ] }
 						fieldLabelTexts={ {
 							[ FIELD_MAILBOX ]: translate( 'Enter email address' ),
 							[ FIELD_PASSWORD ]: translate( 'Set password' ),
 						} }
+						hiddenFieldNames={ [ FIELD_NAME, FIELD_ALTERNATIVE_EMAIL ] }
+						isInitialMailboxPurchase
 						onCancel={ handleClickDecline }
 						onSubmit={ onSubmit }
 						provider={ EmailProvider.Titan }

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -1,7 +1,6 @@
 import { TITAN_MAIL_MONTHLY_SLUG, TITAN_MAIL_YEARLY_SLUG } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
-import { TitanProductUser } from '@automattic/shopping-cart';
 import { MOBILE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
@@ -43,9 +42,7 @@ const getCartItems = (
 	mailboxes: MailboxForm< EmailProvider >[],
 	selectedIntervalLength: IntervalLength
 ) => {
-	const email_users = mailboxes.map( ( mailbox ) =>
-		mailbox.getAsCartItem()
-	) as unknown as TitanProductUser[];
+	const email_users = mailboxes.map( ( mailbox ) => mailbox.getAsCartItem() );
 
 	const cartItemFunction =
 		selectedIntervalLength === IntervalLength.MONTHLY ? titanMailMonthly : titanMailYearly;

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -182,7 +182,7 @@ const ProfessionalEmailUpsell = ( {
 				{ isMobileView && pricingComponent }
 				<div className="professional-email-upsell__form">
 					<NewMailBoxList
-						cancelActionText={ 'Skip for now' }
+						cancelActionText={ translate( 'Skip for now' ) }
 						fieldLabelTexts={ {
 							[ FIELD_MAILBOX ]: translate( 'Enter email address' ),
 							[ FIELD_PASSWORD ]: translate( 'Set password' ),

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
@@ -168,7 +168,7 @@
 		display: none;
 	}
 
-	.new-mailbox-list__supplied-actions.not-show-add-new-mailbox {
+	.new-mailbox-list__supplied-actions--disable-additional-mailboxes {
 		display: unset;
 	}
 

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
@@ -163,25 +163,21 @@
 	.form-text-input-with-affixes {
 		margin-top: 5px;
 	}
-}
 
-.professional-email-upsell__form-buttons {
-	display: flex;
-	flex-direction: column-reverse;
-	justify-content: space-between;
-
-	@include break-mobile {
-		flex-direction: row;
+	.new-mailbox-list__separator {
+		display: none;
 	}
 
-	.button:not( :first-of-type ) {
-		/* Note that we use margin-bottom because we're using column-reverse */
-		margin-bottom: 1em;
+	.new-mailbox-list__supplied-actions.not-show-add-new-mailbox {
+		display: unset;
+	}
 
-		@include break-mobile {
-			margin-bottom: 0;
-			margin-left: 0.5em;
-		}
+	.new-mailbox-list__main-actions {
+		justify-content: space-between;
+	}
+
+	.new-mailbox-list__main-actions .button:first-of-type {
+		margin-left: 0;
 	}
 }
 

--- a/client/my-sites/email/form/mailboxes/components/mailbox-field/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/mailbox-field/index.tsx
@@ -101,7 +101,7 @@ const MailboxField = ( {
 
 	const onBlur = () => {
 		if ( ! field.isTouched ) {
-			field.isTouched = field.hasValidValue();
+			field.isTouched = field.value?.length > 0;
 		}
 		if ( field.isTouched ) {
 			onRequestFieldValidation( field );

--- a/client/my-sites/email/form/mailboxes/components/mailbox-field/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/mailbox-field/index.tsx
@@ -103,7 +103,9 @@ const MailboxField = ( {
 		if ( ! field.isTouched ) {
 			field.isTouched = field.hasValidValue();
 		}
-		onRequestFieldValidation( field );
+		if ( field.isTouched ) {
+			onRequestFieldValidation( field );
+		}
 		field.dispatchState();
 	};
 

--- a/client/my-sites/email/form/mailboxes/components/mailbox-field/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/mailbox-field/index.tsx
@@ -1,4 +1,5 @@
 import { FormInputValidation } from '@automattic/components';
+import { TranslateResult } from 'i18n-calypso';
 import { InvalidEvent, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -16,6 +17,7 @@ import './style.scss';
 
 interface MailboxFormFieldProps {
 	field: MailboxFormFieldBase< string >;
+	fieldLabelText?: TranslateResult;
 	isAutoFocusEnabled?: boolean;
 	isFirstVisibleField?: boolean;
 	isPasswordField?: boolean;
@@ -75,15 +77,19 @@ const MailboxField = ( {
 	children,
 	...props
 }: MailboxFormFieldProps & { children?: JSX.Element } ): JSX.Element | null => {
+	const defaultFieldLabelText = useGetDefaultFieldLabelText(
+		props.field.fieldName as MutableFormFieldNames
+	);
+
 	const {
 		field: originalField,
+		fieldLabelText = defaultFieldLabelText,
 		lowerCaseChangeValue = false,
 		onRequestFieldValidation,
 		onFieldValueChanged = () => undefined,
 	} = props;
 
 	const [ { field }, setFieldState ] = useState( { field: originalField } );
-	const fieldLabelText = useGetDefaultFieldLabelText( field.fieldName as MutableFormFieldNames );
 
 	if ( ! field.isVisible ) {
 		return null;

--- a/client/my-sites/email/form/mailboxes/components/mailbox-form-wrapper/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/mailbox-form-wrapper/index.tsx
@@ -1,4 +1,4 @@
-import { useRtl } from 'i18n-calypso';
+import { TranslateResult, useRtl } from 'i18n-calypso';
 import { PropsWithChildren } from 'react';
 import { MailboxForm } from 'calypso/my-sites/email/form/mailboxes';
 import { MailboxField } from 'calypso/my-sites/email/form/mailboxes/components/mailbox-field';
@@ -7,10 +7,12 @@ import {
 	GoogleMailboxFormFields,
 	MailboxFormFieldBase,
 	MailboxFormFields,
+	MutableFormFieldNames,
 	TitanMailboxFormFields,
 } from 'calypso/my-sites/email/form/mailboxes/types';
 
 interface MailboxFormWrapperProps {
+	fieldLabelTexts: Partial< Record< MutableFormFieldNames, TranslateResult > >;
 	index: number;
 	isAutoFocusEnabled: boolean;
 	mailbox: MailboxForm< EmailProvider >;
@@ -21,6 +23,7 @@ type FieldValueChangedHandler = ( field: MailboxFormFieldBase< string > ) => voi
 
 interface CommonFieldProps {
 	field: MailboxFormFieldBase< string >;
+	fieldLabelText?: TranslateResult;
 	isFirstVisibleField: boolean;
 	onFieldValueChanged: FieldValueChangedHandler;
 	onRequestFieldValidation: () => void;
@@ -36,7 +39,11 @@ type MailboxFormWrapperWithCommonProps = MailboxFormWrapperProps & {
 	formFields: MailboxFormFields;
 };
 
-const createCommonFieldPropsHandler = ( formIndex: number, isAutoFocusEnabled: boolean ) => {
+const createCommonFieldPropsHandler = (
+	formIndex: number,
+	isAutoFocusEnabled: boolean,
+	fieldLabelTexts: Partial< Record< MutableFormFieldNames, TranslateResult > >
+) => {
 	let renderPosition = 0;
 
 	return (
@@ -50,6 +57,7 @@ const createCommonFieldPropsHandler = ( formIndex: number, isAutoFocusEnabled: b
 
 		return {
 			field,
+			fieldLabelText: fieldLabelTexts?.[ field.fieldName as MutableFormFieldNames ],
 			onFieldValueChanged,
 			onRequestFieldValidation: () => mailbox.validateField( field.fieldName ),
 			isAutoFocusEnabled,
@@ -140,8 +148,12 @@ const TitanFormFields = ( props: MailboxFormWrapperWithCommonProps ) => {
 };
 
 const MailboxFormWrapper = ( props: PropsWithChildren< MailboxFormWrapperProps > ): JSX.Element => {
-	const { children, index, isAutoFocusEnabled, mailbox } = props;
-	const getCommonFieldProps = createCommonFieldPropsHandler( index, isAutoFocusEnabled );
+	const { children, fieldLabelTexts, index, isAutoFocusEnabled, mailbox } = props;
+	const getCommonFieldProps = createCommonFieldPropsHandler(
+		index,
+		isAutoFocusEnabled,
+		fieldLabelTexts
+	);
 	const formFields = mailbox.formFields;
 	const commonProps = { ...props, formFields, getCommonFieldProps };
 

--- a/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
@@ -238,7 +238,8 @@ const NewMailBoxList = (
 
 				<div
 					className={ classNames( 'new-mailbox-list__supplied-actions', {
-						'not-show-add-new-mailbox': ! showAddNewMailboxButton,
+						'new-mailbox-list__supplied-actions--disable-additional-mailboxes':
+							! showAddNewMailboxButton,
 					} ) }
 				>
 					{ showAddNewMailboxButton && (

--- a/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
@@ -64,6 +64,8 @@ const setFieldsVisibilities = (
 
 interface MailboxListProps {
 	areButtonsBusy?: boolean;
+	cancelActionText?: TranslateResult;
+	fieldLabelTexts?: Partial< Record< MutableFormFieldNames, TranslateResult > >;
 	isAutoFocusEnabled?: boolean;
 	hiddenFieldNames?: HiddenFieldNames[];
 	initialFieldValues?: Partial< Record< HiddenFieldNames, string | boolean > >;
@@ -84,6 +86,8 @@ const NewMailBoxList = (
 
 	const {
 		areButtonsBusy = false,
+		cancelActionText = translate( 'Cancel' ),
+		fieldLabelTexts = {},
 		isAutoFocusEnabled = false,
 		children,
 		hiddenFieldNames = [],
@@ -208,6 +212,7 @@ const NewMailBoxList = (
 								</CardHeading>
 							) }
 							<MailboxFormWrapper
+								fieldLabelTexts={ fieldLabelTexts }
 								mailbox={ mailbox }
 								onFieldValueChanged={ onFieldValueChanged }
 								index={ index }
@@ -246,7 +251,7 @@ const NewMailBoxList = (
 					<div className="new-mailbox-list__main-actions">
 						{ showCancelButton && (
 							<Button onClick={ handleCancel } disabled={ areButtonsBusy }>
-								<span>{ translate( 'Cancel' ) }</span>
+								<span>{ cancelActionText }</span>
 							</Button>
 						) }
 						<Button busy={ areButtonsBusy } primary type="submit">

--- a/client/my-sites/email/form/mailboxes/components/new-mailbox-list/style.scss
+++ b/client/my-sites/email/form/mailboxes/components/new-mailbox-list/style.scss
@@ -31,10 +31,6 @@
 	flex-direction: column;
 	justify-content: space-between;
 
-	&.not-show-add-new-mailbox {
-		flex-direction: row-reverse;
-	}
-
 	@include break-mobile {
 		flex-direction: row;
 	}
@@ -47,6 +43,10 @@
 			margin-left: 1.5em;
 		}
 	}
+}
+
+.new-mailbox-list__supplied-actions--disable-additional-mailboxes {
+	flex-direction: row-reverse;
 }
 
 .new-mailbox-list__main-actions {

--- a/client/my-sites/email/form/mailboxes/components/test/field.tsx
+++ b/client/my-sites/email/form/mailboxes/components/test/field.tsx
@@ -68,11 +68,22 @@ describe( '<MailboxField /> suite', () => {
 		expect( defaultProps.field.error ).toBeNull();
 	} );
 
-	it( 'Input value should be validated when the element looses focus', () => {
+	it( 'Input value should be valid when the element is not touched and looses focus', () => {
+		const { defaultProps, element } = setup( FIELD_FIRSTNAME );
+
+		// A blur with no previous change
+		fireEvent.blur( element );
+
+		const error = defaultProps.field.error;
+
+		expect( error ).toBeNull();
+	} );
+
+	it( 'Input value should not be valid when the element is touched and looses focus with invalid value', () => {
 		const { defaultProps, element } = setup( FIELD_FIRSTNAME );
 
 		// Clear the field so that we can trigger a 'required' error
-		fireEvent.change( element, { target: { value: '' } } );
+		fireEvent.change( element, { target: { value: '  ' } } );
 		fireEvent.blur( element );
 
 		const error = defaultProps.field.error;
@@ -84,7 +95,7 @@ describe( '<MailboxField /> suite', () => {
 	it( 'Input element should fire off validation after an onblur event, or if an error is already displayed', () => {
 		const { defaultProps, element } = setup( FIELD_FIRSTNAME );
 
-		fireEvent.change( element, { target: { value: '' } } ); // Invalid value at first
+		fireEvent.change( element, { target: { value: '  ' } } ); // Invalid value at first
 		fireEvent.blur( element );
 
 		expect( defaultProps.field.error ).toBeTruthy(); // An error exists

--- a/client/my-sites/email/form/mailboxes/components/utilities/get-cart-items.ts
+++ b/client/my-sites/email/form/mailboxes/components/utilities/get-cart-items.ts
@@ -1,5 +1,4 @@
 import { isGSuiteProductSlug } from '@automattic/calypso-products';
-import { TitanProductUser } from '@automattic/shopping-cart';
 import {
 	googleApps,
 	googleAppsExtraLicenses,
@@ -18,9 +17,7 @@ const getTitanCartItems = (
 ) => {
 	const { emailProduct, newQuantity, quantity } = mailProperties;
 
-	const email_users = mailboxes.map( ( mailbox ) =>
-		mailbox.getAsCartItem()
-	) as unknown as TitanProductUser[];
+	const email_users = mailboxes.map( ( mailbox ) => mailbox.getAsCartItem() );
 
 	const cartItemFunction = isTitanMonthlyProduct( emailProduct )
 		? titanMailMonthly
@@ -42,9 +39,7 @@ const getGSuiteCartItems = (
 ) => {
 	const { isAdditionalMailboxesPurchase, emailProduct, newQuantity, quantity } = mailProperties;
 
-	const users = mailboxes.map( ( mailbox ) =>
-		mailbox.getAsCartItem()
-	) as unknown as GSuiteProductUser[];
+	const users = mailboxes.map( ( mailbox ) => <GSuiteProductUser>mailbox.getAsCartItem() );
 
 	const domain = mailboxes[ 0 ].formFields.domain.value;
 

--- a/client/my-sites/email/form/mailboxes/index.ts
+++ b/client/my-sites/email/form/mailboxes/index.ts
@@ -1,3 +1,4 @@
+import { GSuiteProductUser, TitanProductUser } from '@automattic/shopping-cart';
 import {
 	FIELD_ALTERNATIVE_EMAIL,
 	FIELD_DOMAIN,
@@ -121,7 +122,7 @@ class MailboxForm< T extends EmailProvider > {
 	/**
 	 * Returns the mailbox field values in a shape that can be consumed by the shopping cart at checkout
 	 */
-	getAsCartItem(): Record< string, string | boolean | undefined > {
+	getAsCartItem(): TitanProductUser | GSuiteProductUser {
 		const commonFields = {
 			email: `${ this.getFieldValue< string >( FIELD_MAILBOX ) }@${ this.getFieldValue< string >(
 				FIELD_DOMAIN


### PR DESCRIPTION
#### Proposed Changes

* Switches out inline uses of the bare form elements for accepting Professional Email data with `<NewMailBoxList/>`
* Curbs duplication of logic

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `git checkout update/migrate-professional-email-upsell-to-new-mailbox-list` and start your dev server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/64962#issuecomment-1166400945)
2. Log into a WordPress.com account that has a domain
3. Navigate to the [`Billing History` page](http://calypso.localhost:3000/purchases/billing-history)
4. Find a payment for your domain, and click the corresponding `View receipt` link
5. Note the receipt identifier
6. Use the domain name, receipt id, and site slug to build the url of the post-checkout upsell:
```
http://calypso.localhost:3000/checkout/offer-professional-email/:domain/:receipt_id/:site
```
7. Load that page, and assert that the form looks like, and behaves exactly like the its production counterpart


<img width="750" alt="Screenshot 2022-06-26 at 3 24 47 AM" src="https://user-images.githubusercontent.com/277661/175796738-5cb8c81f-b7ba-4960-a5bf-127506a0cf90.png">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64766
