### PR TITLE
Dashboard: Add `/sites-dashboard` section available behind a feature flag

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -19,6 +19,12 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'sites-dashboard',
+		paths: [ '/sites-dashboard' ],
+		module: 'calypso/sites-dashboard',
+		group: 'sites-dashboard',
+	},
+	{
 		name: 'account',
 		paths: [ '/me/account' ],
 		module: 'calypso/me/account',

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,0 +1,3 @@
+export function SitesDashboard() {
+	return <h1>Hello, world!</h1>;
+}

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -1,0 +1,8 @@
+import { SitesDashboard } from './components/sites-dashboard';
+import type { Context as PageJSContext } from 'page';
+import './sites-dashboard.scss';
+
+export function sitesDashboard( context: PageJSContext, next: () => void ) {
+	context.primary = <SitesDashboard />;
+	next();
+}

--- a/client/sites-dashboard/index.ts
+++ b/client/sites-dashboard/index.ts
@@ -1,0 +1,13 @@
+import { isEnabled } from '@automattic/calypso-config';
+import page from 'page';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sitesDashboard } from './controller';
+
+export default function () {
+	if ( ! isEnabled( 'build/sites-dashboard' ) ) {
+		page( '/sites-dashboard', '/sites' );
+		return;
+	}
+
+	page( '/sites-dashboard', sitesDashboard, makeLayout, clientRender );
+}

--- a/client/sites-dashboard/sites-dashboard.scss
+++ b/client/sites-dashboard/sites-dashboard.scss
@@ -1,0 +1,3 @@
+body.is-group-sites-dashboard {
+	background: #fdfdfd;
+}

--- a/config/development.json
+++ b/config/development.json
@@ -27,6 +27,7 @@
 	"olark_chat_identity": "7089-503-10-5123",
 	"features": {
 		"ad-tracking": false,
+		"build/sites-dashboard": true,
 		"calypsoify/plugins": true,
 		"cloudflare": true,
 		"comments/filters-in-posts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -12,6 +12,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
 		"ad-tracking": false,
+		"build/sites-dashboard": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"cloudflare": true,

--- a/config/test.json
+++ b/config/test.json
@@ -24,6 +24,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
 		"ad-tracking": false,
+		"build/sites-dashboard": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
 		"cloudflare": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -15,6 +15,7 @@
 	"olark_chat_identity": "7089-503-10-5123",
 	"features": {
 		"ad-tracking": false,
+		"build/sites-dashboard": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"cloudflare": true,


### PR DESCRIPTION
With more plans for the dashboard being posted(pdKhl6-on-p2) some folks on @Automattic/build will probably start doing technical prototypes soon.

This PR creates a placeholder area where that work can be done. That way we're not stepping on each other's toes too much when we get started (or minimise it at least, there's always a bit of that as a project gets bootstrapped).

![CleanShot 2022-06-27 at 15 37 57@2x](https://user-images.githubusercontent.com/1500769/175855510-216358d4-73d9-4539-9b98-44c8f2d20a27.png)

The design calls for the dashboard to be found at the `/sites` URL, but there's an existing UI here. As the site progresses we might want to have `/sites` point to our new interface for all a12s to help with testing. But in the meantime only people who really want to see the dashboard should see it, so you'll have to navigate directly to `/multisite-dashboard`.

What do you think @Automattic/build? I want to keep this PR pretty small and let follow-up ones start laying the actual foundations. But what do people think about the naming etc.? Is `multisite-dashboard` a good identifier for this feature in the codebase? 

#### Proposed Changes

* Creates `multisite-dashboard` feature flag
   * Flag is enabled by default in local development, `wpcalypso.wordpress.com` and `horizon.wordpress.com`
   * Flag is disabled in production, staging and Jetpack Cloud
   * Flag is enabled in e2e test environments otherwise we won't be able to write any for the dashboard
* Create a `/multisite-dashboard` section in Calypso
   * If the feature flag is disabled it'll redirect away to `/sites`
   * Otherwise renders a placeholder `<MultisiteDashboard>` component
* Make the background gray (we might want to settle on something standard like `var( --studio-gray-0 )`, but this shows how the colour can be changed for the whole section)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `calypso.localhost:3000/multisite-dashboard` and you should see the placeholder component get rendered
* When testing on staging going to `/multisite-dashboard` will redirect to the existing `/sites` URL
* The feature flag can be forced on using the `?flags=multisite-dashboard` query param

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: #64867