### PR TITLE
Theme Showcase: Remove CSS forums card from theme support page

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -465,25 +465,6 @@ class ThemeSheet extends Component {
 		);
 	};
 
-	renderSupportCssCard = ( buttonCount ) => {
-		return (
-			<Card className="theme__sheet-card-support">
-				<Gridicon icon="briefcase" size={ 48 } />
-				<div className="theme__sheet-card-support-details">
-					{ this.props.translate( 'Need CSS help? ' ) }
-					<small>{ this.props.translate( 'Get help from the experts in our CSS forum' ) }</small>
-				</div>
-				<Button
-					primary={ buttonCount === 1 }
-					href="//en.forums.wordpress.com/forum/css-customization"
-					onClick={ this.trackCssClick }
-				>
-					{ this.props.translate( 'Visit forum' ) }
-				</Button>
-			</Card>
-		);
-	};
-
 	renderSupportTab = () => {
 		const {
 			author,
@@ -505,7 +486,6 @@ class ThemeSheet extends Component {
 						! isStandaloneJetpack &&
 						this.renderSupportContactUsCard( buttonCount++ ) }
 					{ forumUrl && this.renderSupportThemeForumCard( buttonCount++ ) }
-					{ isWpcomTheme && this.renderSupportCssCard( buttonCount++ ) }
 				</div>
 			);
 


### PR DESCRIPTION
#### Proposed Changes

* Removes the "Need CSS help?" card with link to the CSS forums from the theme Support page in the theme showcase

**Before - WPCOM Simple and Atomic sites**
![Appleton_Theme_‹_kokkiestrialtestsite_—_WordPress_com](https://user-images.githubusercontent.com/11873759/175896647-a904952b-0065-4194-8723-db8dd5472697.png)

**After**
![Appleton_Theme_‹_kokkiestrialtestsite_—_WordPress_com](https://user-images.githubusercontent.com/11873759/175896789-dd2f471d-ab4d-4554-818c-2501562d68ce.png)

**Before - Jetpack-connected site**
![Appleton_Theme_‹_My_Core_Sandbox_—_WordPress_com](https://user-images.githubusercontent.com/11873759/175896886-082c6fab-9405-414a-a2f2-0de20741cda0.png)

**After**
![Appleton_Theme_‹_My_Core_Sandbox_—_WordPress_com](https://user-images.githubusercontent.com/11873759/175896995-85cc6a03-1c34-43e2-a513-1a29f6c07f9f.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to /themes/[site] on a Simple, Atomic and Jetpack-connected site in turn
* Select a WordPress.com theme (simple or Premium), from the showcase
* On the theme description page, click on the Support tab
* There shouldn't be a card to get CSS support

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #64611
