### PR TITLE
Add/resend email option

### DIFF
--- a/client/me/account/account-email-field.tsx
+++ b/client/me/account/account-email-field.tsx
@@ -19,6 +19,7 @@ import {
 	removeUnsavedUserSetting,
 	setUserSetting,
 } from 'calypso/state/user-settings/actions';
+import EmailNotVerifiedNotice from './email-not-verified-notice';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { UserSettingsType } from 'calypso/state/selectors/get-user-settings';
 import type { ChangeEvent } from 'react';
@@ -233,6 +234,8 @@ const AccountEmailField = ( {
 				<FormSettingExplanation>
 					{ translate( 'Will not be publicly displayed' ) }
 				</FormSettingExplanation>
+
+				<EmailNotVerifiedNotice />
 
 				<AccountEmailPendingEmailChangeNotice
 					unsavedUserSettings={ unsavedUserSettings }

--- a/client/me/account/email-not-verified-notice.scss
+++ b/client/me/account/email-not-verified-notice.scss
@@ -1,3 +1,3 @@
 .email-not-verified-notice {
-	margin-top:5px;
+	margin-top: 5px;
 }

--- a/client/me/account/email-not-verified-notice.scss
+++ b/client/me/account/email-not-verified-notice.scss
@@ -1,0 +1,3 @@
+.email-not-verified-notice {
+	margin-top:5px;
+}

--- a/client/me/account/email-not-verified-notice.tsx
+++ b/client/me/account/email-not-verified-notice.tsx
@@ -1,0 +1,53 @@
+import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelector } from 'react-redux';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { useSendEmailVerification } from '../../landing/stepper/hooks/use-send-email-verification';
+import { isEmailVerified } from '../../state/selectors/is-email-verified';
+import './email-not-verified-notice.scss';
+
+const resendEmailNotice = 'resend-verification-email';
+
+const EmailNotVerifiedNotice = () => {
+	const dispatch = useDispatch();
+	const resendEmail = useSendEmailVerification();
+	const isVerified = useSelector( isEmailVerified );
+
+	if ( isVerified ) {
+		return null;
+	}
+
+	const handleResend = async () => {
+		try {
+			const result = await resendEmail();
+			if ( result.success ) {
+				dispatch(
+					successNotice( __( 'The verification email has been sent.' ), {
+						id: resendEmailNotice,
+						duration: 4000,
+					} )
+				);
+				return;
+			}
+		} catch ( Error ) {}
+		dispatch(
+			errorNotice( __( 'There was an error processing your request.' ), {
+				id: resendEmailNotice,
+			} )
+		);
+	};
+
+	return (
+		<Notice
+			className="email-not-verified-notice"
+			showDismiss={ false }
+			status="is-warning"
+			text={ __( 'Your email has not been verified yet. ' ) }
+		>
+			<NoticeAction onClick={ handleResend }>{ __( 'Resend email' ) }</NoticeAction>
+		</Notice>
+	);
+};
+
+export default EmailNotVerifiedNotice;

--- a/client/me/account/email-not-verified-notice.tsx
+++ b/client/me/account/email-not-verified-notice.tsx
@@ -4,15 +4,15 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { useSendEmailVerification } from '../../landing/stepper/hooks/use-send-email-verification';
-import { isEmailVerified } from '../../state/selectors/is-email-verified';
 import './email-not-verified-notice.scss';
+import { isCurrentUserEmailVerified } from '../../state/current-user/selectors';
 
 const resendEmailNotice = 'resend-verification-email';
 
 const EmailNotVerifiedNotice = () => {
 	const dispatch = useDispatch();
 	const resendEmail = useSendEmailVerification();
-	const isVerified = useSelector( isEmailVerified );
+	const isVerified = useSelector( isCurrentUserEmailVerified );
 
 	if ( isVerified ) {
 		return null;
@@ -32,7 +32,7 @@ const EmailNotVerifiedNotice = () => {
 			}
 		} catch ( Error ) {}
 		dispatch(
-			errorNotice( __( 'There was an error processing your request.' ), {
+			errorNotice( __( 'An error has occurred, please check your connection and retry.' ), {
 				id: resendEmailNotice,
 			} )
 		);

--- a/client/me/account/test/email-not-verified-notice.js
+++ b/client/me/account/test/email-not-verified-notice.js
@@ -82,7 +82,7 @@ describe( 'EmailNotVerifiedNotice', () => {
 		await waitFor( () => {
 			expect(
 				dispatch.mock.calls[ 0 ][ 0 ].notice.text.includes(
-					'There was an error processing your request.'
+					'An error has occurred, please check your connection and retry.'
 				)
 			).toBeTruthy();
 		} );

--- a/client/me/account/test/email-not-verified-notice.js
+++ b/client/me/account/test/email-not-verified-notice.js
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as redux from 'react-redux';
+import { Provider as ReduxProvider } from 'react-redux';
+import { createReduxStore } from 'calypso/state';
+import * as sendEmail from '../../../landing/stepper/hooks/use-send-email-verification';
+import EmailNotVerifiedNotice from '../email-not-verified-notice';
+
+describe( 'EmailNotVerifiedNotice', () => {
+	it( 'does not show the notice if already verified', () => {
+		render(
+			<ReduxProvider store={ createTestStore( true ) }>
+				<EmailNotVerifiedNotice />
+			</ReduxProvider>
+		);
+		expect( screen.queryByText( /Your email has not been verified yet/ ) ).toBeNull();
+	} );
+
+	it( 'shows the notice if not verified', () => {
+		render(
+			<ReduxProvider store={ createTestStore( false ) }>
+				<EmailNotVerifiedNotice />
+			</ReduxProvider>
+		);
+		expect( screen.queryByText( /Your email has not been verified yet/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'fires success notice action when resend is successful', async () => {
+		const dispatch = jest.fn();
+
+		jest.spyOn( redux, 'useDispatch' ).mockReturnValue( dispatch );
+
+		const useSendEmailVerification = jest.spyOn( sendEmail, 'useSendEmailVerification' );
+		useSendEmailVerification.mockImplementation( () => () => {
+			return Promise.resolve( {
+				success: true,
+			} );
+		} );
+
+		render(
+			<ReduxProvider store={ createTestStore( false ) }>
+				<EmailNotVerifiedNotice />
+			</ReduxProvider>
+		);
+
+		const resendButton = screen.getByText( 'Resend email' );
+		await userEvent.click( resendButton );
+
+		expect( useSendEmailVerification ).toHaveBeenCalled();
+		await waitFor( () => {
+			expect(
+				dispatch.mock.calls[ 0 ][ 0 ].notice.text.includes( 'The verification email has been sent' )
+			).toBeTruthy();
+		} );
+	} );
+
+	it( 'fires error notice action when resend is unsuccessful', async () => {
+		const dispatch = jest.fn();
+
+		jest.spyOn( redux, 'useDispatch' ).mockReturnValue( dispatch );
+
+		const useSendEmailVerification = jest.spyOn( sendEmail, 'useSendEmailVerification' );
+		useSendEmailVerification.mockImplementation( () => () => {
+			return Promise.resolve( {
+				success: false,
+			} );
+		} );
+
+		render(
+			<ReduxProvider store={ createTestStore( false ) }>
+				<EmailNotVerifiedNotice />
+			</ReduxProvider>
+		);
+
+		const resendButton = screen.getByText( 'Resend email' );
+		await userEvent.click( resendButton );
+
+		expect( useSendEmailVerification ).toHaveBeenCalled();
+		await waitFor( () => {
+			expect(
+				dispatch.mock.calls[ 0 ][ 0 ].notice.text.includes(
+					'There was an error processing your request.'
+				)
+			).toBeTruthy();
+		} );
+	} );
+} );
+
+function createTestStore( verified ) {
+	return createReduxStore( {
+		currentUser: {
+			user: {
+				email_verified: verified,
+			},
+		},
+	} );
+}

--- a/client/my-sites/woocommerce/landing-page.tsx
+++ b/client/my-sites/woocommerce/landing-page.tsx
@@ -67,11 +67,13 @@ const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 	}
 
 	async function resendVerificationEmail() {
-		const response = await sendEmailVerification();
-		if ( response.success ) {
+		try {
+			await sendEmailVerification();
 			dispatch( successNotice( __( 'The verification email has been sent.' ) ) );
-		} else {
-			dispatch( errorNotice( __( 'There was an error processing your request.' ) ) );
+		} catch ( Error ) {
+			dispatch(
+				errorNotice( __( 'An error has occurred, please check your connection and retry.' ) )
+			);
 		}
 	}
 
@@ -140,7 +142,7 @@ const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 	let finalCTAHandler = onCTAClickHandler;
 	let displayData: DisplayData | null;
 
-	if ( ! isEmailVerified ) {
+	if ( ! false ) {
 		secondaryAction = (
 			<Button
 				className="landing-page__secondary empty-content__action"

--- a/client/my-sites/woocommerce/landing-page.tsx
+++ b/client/my-sites/woocommerce/landing-page.tsx
@@ -15,7 +15,7 @@ import WarningCard from 'calypso/components/warning-card';
 import { useSendEmailVerification } from 'calypso/landing/stepper/hooks/use-send-email-verification';
 import useScrollAboveElement from 'calypso/lib/use-scroll-above-element';
 import useWooCommerceOnPlansEligibility from 'calypso/signup/steps/woocommerce-install/hooks/use-woop-handling';
-import { successNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import WooCommerceColophon from './woocommerce-colophon';
 
@@ -67,8 +67,12 @@ const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 	}
 
 	async function resendVerificationEmail() {
-		await sendEmailVerification();
-		dispatch( successNotice( __( 'The verification email has been sent.' ) ) );
+		const response = await sendEmailVerification();
+		if ( response.success ) {
+			dispatch( successNotice( __( 'The verification email has been sent.' ) ) );
+		} else {
+			dispatch( errorNotice( __( 'There was an error processing your request.' ) ) );
+		}
 	}
 
 	function renderWarningNotice() {

--- a/client/my-sites/woocommerce/landing-page.tsx
+++ b/client/my-sites/woocommerce/landing-page.tsx
@@ -142,7 +142,7 @@ const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 	let finalCTAHandler = onCTAClickHandler;
 	let displayData: DisplayData | null;
 
-	if ( ! false ) {
+	if ( ! isEmailVerified ) {
 		secondaryAction = (
 			<Button
 				className="landing-page__secondary empty-content__action"

--- a/client/state/selectors/is-email-verified.js
+++ b/client/state/selectors/is-email-verified.js
@@ -1,6 +1,0 @@
-/**
- * Returns true if there is the user's email is verified, false if not.
- *
- * @param {state} state State object
- */
-export const isEmailVerified = ( state ) => state.currentUser.user.email_verified;

--- a/client/state/selectors/is-email-verified.js
+++ b/client/state/selectors/is-email-verified.js
@@ -1,0 +1,6 @@
+/**
+ * Returns true if there is the user's email is verified, false if not.
+ *
+ * @param {state} state State object
+ */
+export const isEmailVerified = ( state ) => state.currentUser.user.email_verified;

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -71,13 +71,14 @@ touch client/my-sites/hello-world/index.js
 Here we'll import the `page` module, the My Sites controller and our own controller, and write our main route handler:
 
 ```javascript
+import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection } from 'calypso/my-sites/controller';
 import { helloWorld } from './controller';
 
 export default () => {
-	if ( config.isEnabled( 'hello-world' ) ) {
+	if ( isEnabled( 'hello-world' ) ) {
 		page( '/hello-world/:site?', siteSelection, navigation, helloWorld, makeLayout, clientRender );
 	} else {
 		page.redirect( '/' );
@@ -101,8 +102,7 @@ You can read more about ES6 modules from Axel Rauschmayer's "[_ECMAScript 6 modu
 
 Now it's time to configure our section. Open `client/sections.js` and add the following code to the end of the `sections` array:
 
-```
-// in client/sections.js
+```javascript
 	{
 		name: 'hello-world',
 		paths: [ '/hello-world' ],
@@ -111,8 +111,7 @@ Now it's time to configure our section. Open `client/sections.js` and add the fo
 ```
 
 The array should look something like:
-
-```javascript
+```
 const sections = [
 	// All of the other sections are here
 	// ...

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -103,18 +103,9 @@ You can read more about ES6 modules from Axel Rauschmayer's "[_ECMAScript 6 modu
 Now it's time to configure our section. Open `client/sections.js` and add the following code to the end of the `sections` array:
 
 ```javascript
-	{
-		name: 'hello-world',
-		paths: [ '/hello-world' ],
-		module: 'calypso/my-sites/hello-world',
-	},
-```
-
-The array should look something like:
-```
 const sections = [
-	// All of the other sections are here
-	// ...
+	// ** lots of sections here **
+	// add new section:
 	{
 		name: 'hello-world',
 		paths: [ '/hello-world' ],


### PR DESCRIPTION
#### Proposed Changes

There should be an option to resend the verification email for unverified accounts. 

#### Testing Instructions

Note: this new notice is rendered on routes `/me/account` and `me/security/account-email` and can be tested at both locations. It's the same code running on each page. 

1. Create a new account and don't action the verification email. 
2. Navigate to `/me/account` and you should see a notice under "Email address" as shown:
![image](https://user-images.githubusercontent.com/6851384/175278696-e843b139-adcf-4005-bcdb-d83c9ee0d76c.png)
3. Click on "Resend email" and an email should be sent out. Don't verify though. Confirm positive feedback is shown:
![image](https://user-images.githubusercontent.com/6851384/175283314-9e5474e2-f72b-4ef1-8f1d-a12e21bdd57c.png)
4. Disable your network connection and then hit "Resend email" again"
5. Confirm negative feedback is shown:
![image](https://user-images.githubusercontent.com/6851384/175283349-0eb95c27-feb8-4dc0-818c-868300e63a9c.png)
6. Enable network and refresh the page.
7. Go to your Inbox and verify the email. 
8. Refresh the page and the notice should have disappeared. 


Fixes https://github.com/Automattic/wp-calypso/issues/64345
