### PR TITLE
Repo gardening: update action, tasks, and requirements

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -1,27 +1,31 @@
 name: Repo gardening
 
 on:
-  # Listen to this event for PRs from forks (see Flag OSS and Notify tasks).
-  pull_request_target:
-    types: [opened, labeled]
-  # We need to listen to all these events to catch all scenarios
-  pull_request:
-    types: ['opened', 'synchronize', 'edited', 'closed', 'labeled']
+  pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
+    types: [opened, reopened, synchronize, edited, labeled, closed]
+  issues: # For auto-triage of issues.
+    types: [opened, reopened]
+concurrency:
+  # For pull_request_target, cancel any concurrent jobs with the same type (e.g. "opened", "labeled") and branch.
+  # Don't cancel any for other events, accomplished by grouping on the unique run_id.
+  group: gardening-${{ github.event_name }}-${{ github.event.action }}-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   repo-gardening:
     name: 'Assign issues, Clean up labels, and notify Design and Editorial when necessary'
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     timeout-minutes: 10
 
     steps:
      - name: Checkout
-       uses: actions/checkout@v2
+       uses: actions/checkout@v3
 
      - name: Setup Node
-       uses: actions/setup-node@v2
+       uses: actions/setup-node@v3
        with:
-         node-version: 12
+         node-version: 16
 
      - name: Wait for prior instances of the workflow to finish
        uses: softprops/turnstyle@v1
@@ -29,11 +33,11 @@ jobs:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
      - name: 'Run gardening action'
-       uses: automattic/action-repo-gardening@v1.3.0
+       uses: automattic/action-repo-gardening@trunk
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          slack_token: ${{ secrets.SLACK_TOKEN }}
          slack_design_channel: ${{ secrets.SLACK_DESIGN_CHANNEL }}
          slack_editorial_channel: ${{ secrets.SLACK_EDITORIAL_CHANNEL }}
          slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
-         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial,flagOss'
+         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial,flagOss,triageNewIssues'


### PR DESCRIPTION
#### Proposed Changes

- Update dependency action versions
- Update node version
- Update to use the development version of the action (trunk) to benefit from latest changes before a new version is tagged.
- Enable the `triageNewIssues` task to benefit from that in calypso as well. (see references: https://github.com/Automattic/jetpack/pull/20726 , https://github.com/Automattic/jetpack/pull/24841 )

#### Testing Instructions

This can only be tested once it will be merged, I'm afraid. You can see the action in action in the Jetpack repo above.

#### Product discussion

Internal reference: pciE2j-18N-p2
