### PR TITLE
ETK Timeline: fix lines alignment

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/style.scss
@@ -78,6 +78,7 @@ $timeline-border-width: 4px;
 		// Bubbles.
 		.wp-block-jetpack-timeline-item {
 			width: calc( 50% - #{ $timeline-width } + #{ $timeline-border-width * 0.5 } );
+			box-sizing: border-box;
 		}
 
 		// Left aligned.


### PR DESCRIPTION
#### Proposed Changes

* Fix timeline lines alignment on editor preview

#### Screencasts

**Simple Sites**

* Create a new branch
* Run `install-plugin.sh editing-toolkit fix/jetpack-timline-preview`
* Sandbox your site and follow the testing instructions

 

https://user-images.githubusercontent.com/779993/176142911-04044c00-fb30-4a40-917c-60b3b8983942.mov



**Atomic Sites**

* Download the zip file from team city ( PCYsg-ly5-p2#etk-and-atomic-sites )
* Install the plugin on your atomic site
* Follow the testing instructions


https://user-images.githubusercontent.com/779993/176142894-6b6bfda1-9f93-42d8-8610-bb3984b5a557.mp4




#### Testing Instructions

This PR is a ETK update.

* In a simple or atomic site select the theme TwentyTwenty.
* Create a new page.
* Add the Timeline Block.
* Add at least three rows of content.
* Change the layout to alternate the rows alignment.
* Observe that the timeline is displayed correctly.


---

- Fixes #61490
