### PR TITLE
Include matching level 1 categories in the verticals suggestion list

### DIFF
--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -43,8 +43,8 @@ const SelectVertical: React.FC< Props > = ( {
 		const rootsAdded = {};
 		return suggestions?.reduce(
 			( suggestionsList: SiteVerticalsResponse[], vertical: SiteVerticalsResponse ) => {
-				if ( ! rootsAdded[ vertical.id ] ) {
-					rootsAdded[ vertical.id ] = vertical.root;
+				if ( ! rootsAdded[ vertical.root.id ] ) {
+					rootsAdded[ vertical.root.id ] = vertical.root;
 					suggestionsList.push( vertical.root );
 				}
 				suggestionsList.push( vertical );

--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -40,10 +40,10 @@ const SelectVertical: React.FC< Props > = ( {
 	} );
 
 	const suggestionsWithRoots = useMemo( () => {
-		const rootsAdded = {};
+		const rootsAdded: { [ index: string ]: SiteVerticalsResponse } = {};
 		return suggestions?.reduce(
 			( suggestionsList: SiteVerticalsResponse[], vertical: SiteVerticalsResponse ) => {
-				if ( ! rootsAdded[ vertical.root.id ] ) {
+				if ( vertical.root && ! rootsAdded[ vertical.root.id ] ) {
 					rootsAdded[ vertical.root.id ] = vertical.root;
 					suggestionsList.push( vertical.root );
 				}

--- a/client/components/select-vertical/index.tsx
+++ b/client/components/select-vertical/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useDebounce } from 'use-debounce';
 import FormLabel from 'calypso/components/forms/form-label';
 import {
@@ -39,6 +39,22 @@ const SelectVertical: React.FC< Props > = ( {
 		skip_synonyms: isSkipSynonyms,
 	} );
 
+	const suggestionsWithRoots = useMemo( () => {
+		const rootsAdded = {};
+		return suggestions?.reduce(
+			( suggestionsList: SiteVerticalsResponse[], vertical: SiteVerticalsResponse ) => {
+				if ( ! rootsAdded[ vertical.id ] ) {
+					rootsAdded[ vertical.id ] = vertical.root;
+					suggestionsList.push( vertical.root );
+				}
+				suggestionsList.push( vertical );
+
+				return suggestionsList;
+			},
+			[]
+		);
+	}, [ suggestions ] );
+
 	const { data: featured } = useSiteVerticalsFeatured();
 
 	const mapOneSiteVerticalsResponseToVertical = ( vertical: SiteVerticalsResponse ): Vertical => ( {
@@ -71,7 +87,7 @@ const SelectVertical: React.FC< Props > = ( {
 				suggestions={
 					! isDebouncing
 						? mapManySiteVerticalsResponseToVertical(
-								( ! hasUserInput ? featured : suggestions ) || []
+								( ! hasUserInput ? featured : suggestionsWithRoots ) || []
 						  )
 						: []
 				}

--- a/client/components/select-vertical/types.ts
+++ b/client/components/select-vertical/types.ts
@@ -2,4 +2,9 @@ export interface Vertical {
 	value: string;
 	label: string;
 	category?: string;
+	root?: {
+		value: string;
+		label: string;
+		category?: string;
+	};
 }

--- a/client/data/site-verticals/types.ts
+++ b/client/data/site-verticals/types.ts
@@ -2,6 +2,7 @@ export interface SiteVerticalsResponse {
 	id: string;
 	name: string;
 	title: string;
+	root: object;
 }
 
 export interface SiteVerticalQueryByIdParams {
@@ -12,4 +13,5 @@ export interface SiteVerticalsQueryParams {
 	term?: string;
 	limit?: number;
 	skip_synonyms?: boolean;
+	expand_root?: boolean;
 }

--- a/client/data/site-verticals/types.ts
+++ b/client/data/site-verticals/types.ts
@@ -2,7 +2,11 @@ export interface SiteVerticalsResponse {
 	id: string;
 	name: string;
 	title: string;
-	root: object;
+	root?: {
+		id: string;
+		name: string;
+		title: string;
+	};
 }
 
 export interface SiteVerticalQueryByIdParams {

--- a/client/data/site-verticals/use-site-verticals-query.ts
+++ b/client/data/site-verticals/use-site-verticals-query.ts
@@ -6,6 +6,7 @@ const defaults = {
 	term: '',
 	limit: 10,
 	skip_synonyms: false,
+	expand_root: true,
 };
 
 const useSiteVerticalsQuery = (


### PR DESCRIPTION
#### Proposed Changes
Work in Progress
* Use the `include_weighted_root` to get the `root` of the verticals to add their level 1 category to the suggestions list.

Please share your thoughts about how these features should work and how to implement them.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
It is required to use the API sandboxed from D83269-code
1. Navigate to /setup/vertical?siteSlug=<your_site>
2. Type "car" or other text to search for a vertical
3. Check that the level 1 category is shown Autos & Vehicles in the suggestions list or the correspondent to your search term

| Before | after |
| :-: | :-: |
| <img width="529" alt="Screen Shot 2565-06-27 at 13 28 55" src="https://user-images.githubusercontent.com/1881481/175931594-b5261f5d-4941-4808-882c-5290c4517f56.png"> |  <img width="535" alt="Screen Shot 2565-06-28 at 06 50 18" src="https://user-images.githubusercontent.com/1881481/176095520-b7e15595-5cf3-4ec7-8f79-b57b5a9a6b4b.png"> |
| <img width="544" alt="Screen Shot 2565-06-27 at 13 29 04" src="https://user-images.githubusercontent.com/1881481/175931587-e9fb7328-6f2f-4619-b2ad-5b62814a8a95.png">  |  <img width="540" alt="Screen Shot 2565-06-27 at 13 13 28" src="https://user-images.githubusercontent.com/1881481/175931598-f0b26b50-10aa-4dce-ae08-5abc998006cc.png"> |

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 71-gh-Automattic/ganon-issues