### PR TITLE
Add TypeScript support for ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,12 +3,14 @@
 .yarn
 /assets/
 /build/
+dist/
 /public/
 /vendor/
 node_modules/
 !.eslintrc.js
 /client/server/devdocs/search-index.js
 /packages/calypso-codemods/tests
+/packages/webpack-rtl-plugin/test/dist*/
 /packages/wp-babel-makepot/test/examples
 /packages/wpcom.js/webapp/tests/mocha.js
 /desktop/build/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ const reactVersion = require( './client/package.json' ).dependencies.react;
 
 module.exports = {
 	root: true,
+	parser: '@typescript-eslint/parser',
 	parserOptions: {
 		babelOptions: {
 			configFile: path.join( __dirname, './babel.config.js' ),

--- a/client/state/posts/counts/selectors.js
+++ b/client/state/posts/counts/selectors.js
@@ -21,7 +21,7 @@ export function isRequestingPostCounts( state, siteId, postType ) {
  * @param  {object} state    Global state tree
  * @param  {number} siteId   Site ID
  * @param  {string} postType Post type
- * @returns {Object.<string, number>}          Post counts, keyed by status
+ * @returns {Record<string, number>}          Post counts, keyed by status
  */
 export function getAllPostCounts( state, siteId, postType ) {
 	return get( state.posts.counts.counts, [ siteId, postType, 'all' ], null );

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 		"lint": "run-s -s 'lint:*'",
 		"lint:config-defaults": "node bin/validate-config-keys.js",
 		"lint:css": "stylelint \"**/*.scss\" --syntax scss",
-		"lint:js": "eslint --cache .",
+		"lint:js": "eslint --ext .js,.jsx,.ts,.tsx,.mjs,.json --cache .",
 		"lint:mixedindent": "mixedindentlint --ignore-comments \"client/**/*.scss\" \"assets/**/*.scss\" \"**/*.js\" \"**/*.jsx\" \"**/*.tsx\" \"**/*.tsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\" \"!client/config/index.js\"",
 		"start": "npx check-node-version --package && node bin/welcome.js && yarn run build && yarn run start-build",
 		"start-jetpack-cloud": "CALYPSO_ENV=jetpack-cloud-development yarn run start",

--- a/packages/webpack-rtl-plugin/tsconfig.json
+++ b/packages/webpack-rtl-plugin/tsconfig.json
@@ -2,5 +2,6 @@
 	"extends": "@automattic/calypso-typescript-config/js-package.json",
 	"compilerOptions": {
 		"types": [ "node" ]
-	}
+	},
+	"include": [ "src/", "index.js" ]
 }


### PR DESCRIPTION
When writing JSDoc types for function params, I often see the types like `object` being used. Type `object` is pretty vague and doesn't provide much information. It is better to use the TypeScript types like `Record<Keys, Type>` etc. for better type safety and auto-completion.

Currently, using TS types throws an error in ESLint because ESLint doesn't know about the TS types. So, this PR actually makes ESLint to be TS aware. More context here https://github.com/Automattic/wp-calypso/pull/64911#discussion_r905724666

#### Proposed Changes

* Update `.eslintrc.js` to use `@typescript-eslint/parser` as the default parser.
* Update `.eslintignore` to improve performance by adding auto-generated code paths to it.
* Update `lint:js` script in `package.json` to include all JS and TS file types
* Update `webpack-rtl-plugin/tsconfig.json` to improve VS Code performance by only including what is desired.

#### Testing Instructions

* Checkout this PR and run `yarn`
* Open the repo in VS Code
* Edit any js file with JSDoc comments
* Use any built-in TS type as param or return type. For example any [Utility type from here](https://www.typescriptlang.org/docs/handbook/utility-types.html).
* Confirm that you don't see any ESLint error for undefined typed
