### PR TITLE
Jetpack Agency Dashboard: refetch sites on window focus and show loader only when there are no sites

### DIFF
--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -44,7 +44,7 @@ const useFetchDashboardSites = (
 					perPage: data.per_page,
 				};
 			},
-			refetchOnWindowFocus: false,
+			refetchOnWindowFocus: true,
 			onError: () =>
 				dispatch(
 					errorNotice( translate( 'Failed to retrieve your sites. Please try again later.' ) )

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -44,7 +44,6 @@ const useFetchDashboardSites = (
 					perPage: data.per_page,
 				};
 			},
-			refetchOnWindowFocus: true,
 			onError: () =>
 				dispatch(
 					errorNotice( translate( 'Failed to retrieve your sites. Please try again later.' ) )

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -27,7 +27,7 @@ export default function SitesOverview(): ReactElement {
 
 	const { search, currentPage, filter } = useContext( SitesOverviewContext );
 
-	const { data, isError, isFetching, refetch } = useFetchDashboardSites(
+	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
 		isPartnerOAuthTokenLoaded,
 		search,
 		currentPage,
@@ -65,12 +65,12 @@ export default function SitesOverview(): ReactElement {
 					searchQuery={ search }
 					currentPage={ currentPage }
 					filter={ filter }
-					isFetching={ isFetching }
+					isLoading={ isLoading }
 				/>
 				<SiteContent
 					data={ data }
 					isError={ isError }
-					isFetching={ isFetching }
+					isLoading={ isLoading }
 					currentPage={ currentPage }
 				/>
 			</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -20,14 +20,14 @@ const addPageArgs = ( pageNumber: number ) => {
 interface Props {
 	data: { sites: Array< any >; total: number; perPage: number } | undefined;
 	isError: boolean;
-	isFetching: boolean;
+	isLoading: boolean;
 	currentPage: number;
 }
 
 export default function SiteContent( {
 	data,
 	isError,
-	isFetching,
+	isLoading,
 	currentPage,
 }: Props ): ReactElement {
 	const translate = useTranslate();
@@ -35,7 +35,7 @@ export default function SiteContent( {
 
 	const sites = formatSites( data?.sites );
 
-	if ( ! isFetching && ! isError && ! sites.length ) {
+	if ( ! isLoading && ! isError && ! sites.length ) {
 		return <div className="site-content__no-sites">{ translate( 'No active sites' ) }</div>;
 	}
 
@@ -43,14 +43,12 @@ export default function SiteContent( {
 		addPageArgs( pageNumber );
 	};
 
-	const showLoader = isFetching && ! sites.length;
-
 	return (
 		<>
-			<SiteTable isFetching={ showLoader } columns={ siteColumns } items={ sites } />
+			<SiteTable isLoading={ isLoading } columns={ siteColumns } items={ sites } />
 			<div className="site-content__mobile-view">
 				<>
-					{ showLoader ? (
+					{ isLoading ? (
 						<Card>
 							<TextPlaceholder />
 						</Card>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -43,12 +43,14 @@ export default function SiteContent( {
 		addPageArgs( pageNumber );
 	};
 
+	const showLoader = isFetching && ! sites.length;
+
 	return (
 		<>
-			<SiteTable isFetching={ isFetching } columns={ siteColumns } items={ sites } />
+			<SiteTable isFetching={ showLoader } columns={ siteColumns } items={ sites } />
 			<div className="site-content__mobile-view">
 				<>
-					{ isFetching ? (
+					{ showLoader ? (
 						<Card>
 							<TextPlaceholder />
 						</Card>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
@@ -17,7 +17,7 @@ describe( '<SiteContent>', () => {
 	let props = {
 		data: { sites, total: 1, perPage: 10 },
 		isError: false,
-		isFetching: false,
+		isLoading: false,
 		currentPage: 1,
 	};
 	const initialState = {};
@@ -51,7 +51,7 @@ describe( '<SiteContent>', () => {
 	test( 'should render correctly and show loading indicator', () => {
 		props = {
 			...props,
-			isFetching: true,
+			isLoading: true,
 		};
 		const { container } = render(
 			<Provider store={ store }>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-filters/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-filters/index.tsx
@@ -6,10 +6,10 @@ import type { ReactElement } from 'react';
 
 export default function SiteFilters( {
 	filter,
-	isFetching,
+	isLoading,
 }: {
 	filter: AgencyDashboardFilter;
-	isFetching: boolean;
+	isLoading: boolean;
 } ): ReactElement {
 	const dispatch = useDispatch();
 	const selectIssueTypes = ( types: AgencyDashboardFilterOption[] ) => {
@@ -23,7 +23,7 @@ export default function SiteFilters( {
 		<Filterbar
 			selectorTypes={ { issueType: true } }
 			filter={ filter }
-			isLoading={ isFetching }
+			isLoading={ isLoading }
 			isVisible={ true }
 			selectActionType={ selectIssueTypes }
 			resetFilters={ resetIssueTypes }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search-filter-container/SiteSearchFilterContainer.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search-filter-container/SiteSearchFilterContainer.tsx
@@ -9,14 +9,14 @@ interface Props {
 	searchQuery: string | null;
 	currentPage: number;
 	filter: AgencyDashboardFilter;
-	isFetching: boolean;
+	isLoading: boolean;
 }
 
 export default function SiteSearchFilterContainer( {
 	searchQuery,
 	currentPage,
 	filter,
-	isFetching,
+	isLoading,
 }: Props ): ReactElement {
 	return (
 		<div className="site-search-filter-container">
@@ -24,7 +24,7 @@ export default function SiteSearchFilterContainer( {
 				<SiteSearch searchQuery={ searchQuery } currentPage={ currentPage } />
 			</div>
 			<div className="site-search-filter-container__filter-bar">
-				<SiteFilters filter={ filter } isFetching={ isFetching } />
+				<SiteFilters filter={ filter } isLoading={ isLoading } />
 			</div>
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -9,12 +9,12 @@ import type { SiteData, SiteColumns } from '../types';
 import './style.scss';
 
 interface Props {
-	isFetching: boolean;
+	isLoading: boolean;
 	columns: SiteColumns;
 	items: Array< SiteData >;
 }
 
-export default function SiteTable( { isFetching, columns, items }: Props ): ReactElement {
+export default function SiteTable( { isLoading, columns, items }: Props ): ReactElement {
 	return (
 		<table className="site-table__table">
 			<thead>
@@ -26,7 +26,7 @@ export default function SiteTable( { isFetching, columns, items }: Props ): Reac
 				</tr>
 			</thead>
 			<tbody>
-				{ isFetching ? (
+				{ isLoading ? (
 					<tr>
 						{ columns.map( ( column ) => (
 							<td key={ column.key }>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -72,7 +72,7 @@ describe( '<SiteTable>', () => {
 	];
 	const props = {
 		items,
-		isFetching: false,
+		isLoading: false,
 		columns: siteColumns,
 	};
 	const initialState = {};


### PR DESCRIPTION
#### Proposed Changes

This PR adds the following changes

- Refetch sites on window focus
- Show loader only when no sites are available(loader will be shown only when a user searches for a site, applies a filter or navigates to any other page)

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you will have to set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/use-prev-state-to-toggle-issue-types-filter` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on Manage Sites -> Click on Dashboard -> Verify that API call is being made(using network tab in dev tool) to fetch sites and no loader is shown.
4. Apply any filter/search for any site/navigate to any other page -> Verify a loader is shown when fetching.
5. Verify step 3 & 4 in small screen(<960px) using dev tool. You can also use [mobile simulator extension](https://chrome.google.com/webstore/detail/mobile-simulator-responsi/ckejmhbmlajgoklhgbapkiccekfoccmk) to test this.

**Recordings**

Large screen

https://user-images.githubusercontent.com/10586875/175955947-4a9ebccc-a059-436a-9561-c98fb2a7d3f1.mov

Small screen

https://user-images.githubusercontent.com/10586875/175953906-0a747284-eabc-464b-95d4-abe8bd9f4894.mov

Related to 1202076982646589-as-1202402912194277