### PR TITLE
Launching domain step skip option to all users.

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -1,34 +1,12 @@
 import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { isStarterPlanEnabled } from 'calypso/my-sites/plans-comparison';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
 class ReskinSideExplainer extends Component {
-	_isMounted = false;
-	constructor( props ) {
-		super( props );
-		this.state = {
-			experiment: null,
-		};
-	}
-	componentDidMount() {
-		this._isMounted = true;
-
-		loadExperimentAssignment( 'pricing_packaging_domains_pick_later' ).then( ( experimentName ) => {
-			if ( this._isMounted ) {
-				this.setState( { experiment: experimentName } );
-			}
-		} );
-	}
-
-	componentWillUnmount() {
-		this._isMounted = false;
-	}
-
 	getStarterPlanOverrides( isEnLocale ) {
 		const { translate } = this.props;
 
@@ -84,12 +62,7 @@ class ReskinSideExplainer extends Component {
 			subtitle2 = null;
 		}
 
-		const hasCta = i18n.hasTranslation( 'Choose my domain later' ) || isEnLocale;
-
-		const ctaText =
-			hasCta && this.state.experiment?.variationName === 'treatment'
-				? translate( 'Choose my domain later' )
-				: false;
+		const ctaText = translate( 'Choose my domain later' );
 
 		return { title, subtitle, subtitle2, ctaText };
 	}


### PR DESCRIPTION
#### Proposed Changes
This PR rolls out the test discussed at pdgrnI-1jU-p2 and implemented in #64455, which added a skip option to the domain step in signup. Test results were positive, so we're rolling it out to 100% of users.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and start Calypso.
* Navigate to `/start` with either a new or existing user account.
* Confirm that the skip option is present in the sidebar section.
* Click the link and confirm that you're taken to the Plans page.
* Select a plan and confirm that the checkout page loads properly.
* 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
