### PR TITLE
Checkout: Allow product variant picker to display options even when siteId is undefined

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -55,7 +55,7 @@ export interface SitePlanData {
 	productSlug: string;
 }
 
-interface SitesPlansResult {
+export interface SitesPlansResult {
 	data: SitePlanData[];
 }
 
@@ -66,9 +66,7 @@ export function useGetProductVariants(
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 
-	const sitePlans: SitesPlansResult | null = useSelector( ( state ) =>
-		siteId ? getPlansBySiteId( state, siteId ) : null
-	);
+	const sitePlans: SitesPlansResult = useSelector( ( state ) => getPlansBySiteId( state, siteId ) );
 	const activePlan: SitePlanData | undefined = sitePlans?.data?.find(
 		( plan ) => plan.currentPlan
 	);

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -76,7 +76,7 @@ export function useGetProductVariants(
 	debug( 'variantProductSlugs', variantProductSlugs );
 
 	const variantsWithPrices: AvailableProductVariant[] = useSelector( ( state ) => {
-		return siteId ? computeProductsWithPrices( state, siteId, variantProductSlugs ) : [];
+		return computeProductsWithPrices( state, siteId, variantProductSlugs );
 	} );
 
 	const [ haveFetchedProducts, setHaveFetchedProducts ] = useState( false );

--- a/client/state/posts/counts/selectors.js
+++ b/client/state/posts/counts/selectors.js
@@ -19,7 +19,7 @@ export function isRequestingPostCounts( state, siteId, postType ) {
  * Returns post counts for all users on a site, filtered by post type.
  *
  * @param  {object} state    Global state tree
- * @param  {number} siteId   Site ID
+ * @param  {number|undefined} siteId   Site ID
  * @param  {string} postType Post type
  * @returns {Object.<string, number>}          Post counts, keyed by status
  */

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.ts
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.ts
@@ -34,7 +34,7 @@ type PlanObject = Optional< Pick< Plan, 'group' | 'getProductId' >, 'group' > & 
  */
 export const computeFullAndMonthlyPricesForPlan = (
 	state: AppState,
-	siteId: number,
+	siteId: number | undefined,
 	planObject: PlanObject
 ): FullAndMonthlyPrices => {
 	if ( planObject.group === GROUP_WPCOM ) {
@@ -85,7 +85,7 @@ function calculateSaleCouponCostForJetpackProduct(
  */
 function computePricesForWpComPlan(
 	state: AppState,
-	siteId: number,
+	siteId: number | undefined,
 	planObject: PlanObject
 ): FullAndMonthlyPrices {
 	const priceFull = getPlanRawPrice( state, planObject.getProductId(), false ) || 0;
@@ -103,7 +103,7 @@ function computePricesForWpComPlan(
  */
 function getSearchProductTierPrice(
 	state: AppState,
-	siteId: number,
+	siteId: number | undefined,
 	productSlug: string
 ): number | null {
 	const postsCounts = getAllPostCounts( state, siteId, 'post' );

--- a/client/state/products-list/selectors/compute-products-with-prices.ts
+++ b/client/state/products-list/selectors/compute-products-with-prices.ts
@@ -19,7 +19,7 @@ interface NonNullablePlanAndProduct extends PlanAndProduct {
  */
 export const computeProductsWithPrices = (
 	state: AppState,
-	siteId: number,
+	siteId: number | undefined,
 	planSlugs: string[]
 ): AvailableProductVariant[] => {
 	const products = getProductsList( state );

--- a/client/state/products-list/selectors/get-plan-price.js
+++ b/client/state/products-list/selectors/get-plan-price.js
@@ -5,7 +5,7 @@ import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
  * Computes a price based on plan slug/constant, including any discounts available.
  *
  * @param {object} state Current redux state
- * @param {number} siteId Site ID to consider
+ * @param {number|undefined} siteId Site ID to consider
  * @param {object} planObject Plan object returned by getPlan() from @automattic/calypso-products
  * @param {boolean} isMonthly Flag - should return a monthly price?
  * @returns {number} Requested price

--- a/client/state/selectors/get-intro-offer-is-eligible.ts
+++ b/client/state/selectors/get-intro-offer-is-eligible.ts
@@ -3,13 +3,13 @@ import type { AppState } from 'calypso/types';
 /**
  * @param  {object}  state       Global state tree
  * @param  {number}  productId   The productId to check for intro offers
- * @param  {number}  siteId      The ID of the site we're querying
+ * @param  {number|'none'|undefined}  siteId      The ID of the site we're querying
  * @returns {boolean}            True if the offer is eligible for an intro offer
  */
 export default function getIntroOfferIsEligible(
 	state: AppState,
 	productId: number,
-	siteId: number | 'none'
+	siteId: number | 'none' | undefined
 ): boolean {
 	const siteIdKey = siteId && typeof siteId === 'number' && siteId > 0 ? siteId : 'none';
 

--- a/client/state/selectors/get-intro-offer-price.ts
+++ b/client/state/selectors/get-intro-offer-price.ts
@@ -3,13 +3,13 @@ import type { AppState } from 'calypso/types';
 /**
  * @param  {object}  state       Global state tree
  * @param  {number}  productId   The productId to check for an intro offer
- * @param  {number}  siteId      The ID of the site we're querying
+ * @param  {number|'none'|undefined}  siteId      The ID of the site we're querying
  * @returns {number|null}        The raw price of intro offer, if available. null otherwise.
  */
 export default function getIntroOfferPrice(
 	state: AppState,
 	productId: number,
-	siteId: number | 'none'
+	siteId: number | 'none' | undefined
 ): number | null {
 	const siteIdKey = siteId && typeof siteId === 'number' && siteId > 0 ? siteId : 'none';
 

--- a/client/state/sites/plans/selectors/get-plan-discounted-raw-price.js
+++ b/client/state/sites/plans/selectors/get-plan-discounted-raw-price.js
@@ -6,7 +6,7 @@ import { isSitePlanDiscounted } from 'calypso/state/sites/plans/selectors/is-sit
  * Returns a plan price, including any applied discounts
  *
  * @param  {object}  state         global state
- * @param  {number}  siteId        the site id
+ * @param  {number|undefined}  siteId        the site id
  * @param  {string}  productSlug   the plan product slug
  * @param  {boolean} isMonthly     if true, returns monthly price
  * @returns {number}                plan discounted raw price

--- a/client/state/sites/plans/selectors/get-plans-by-site.js
+++ b/client/state/sites/plans/selectors/get-plans-by-site.js
@@ -7,6 +7,13 @@ export function getPlansBySite( state, site ) {
 	return getPlansBySiteId( state, site.ID );
 }
 
+/**
+ * Returns plans for a site Id
+ *
+ * @param  {object} state        global state
+ * @param  {number|undefined} siteId       the site id
+ * @returns {import('calypso/my-sites/checkout/composite-checkout/hooks/product-variants').SitesPlansResult} the matching plan
+ */
 export function getPlansBySiteId( state, siteId ) {
 	if ( ! siteId ) {
 		return initialSiteState;

--- a/client/state/sites/plans/selectors/get-site-plan.js
+++ b/client/state/sites/plans/selectors/get-site-plan.js
@@ -5,7 +5,7 @@ import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-
  * Returns a site specific plan
  *
  * @param  {object} state        global state
- * @param  {number} siteId       the site id
+ * @param  {number|undefined} siteId       the site id
  * @param  {string} productSlug  the plan product slug
  * @returns {object} the matching plan
  */

--- a/client/state/sites/plans/selectors/is-site-plan-discounted.js
+++ b/client/state/sites/plans/selectors/is-site-plan-discounted.js
@@ -5,7 +5,7 @@ import { getSitePlan } from 'calypso/state/sites/plans/selectors/get-site-plan';
  * Returns true if a plan is discounted
  *
  * @param  {object}   state         global state
- * @param  {number}   siteId        the site id
+ * @param  {number|undefined}   siteId        the site id
  * @param  {string}   productSlug   the plan product slug
  * @returns {?boolean}              true if a plan has a discount
  */


### PR DESCRIPTION
#### Proposed Changes

The code that generates product variant prices is complex and sometimes difficult to follow. This has caused some bugs to appear which were equally difficult to resolve. To help both of these situations, https://github.com/Automattic/wp-calypso/pull/64911 converts the calculation code to TypeScript. However, in so doing, it caused a regression.

Previously, product variant calculations were run even when there was no `siteId` (eg: in Jetpack siteless checkout) but that PR disabled that feature because there is a long function chain of selectors which claim to require a numeric `siteId`. It turns out that those functions type declarations are incorrect; they still work even with an undefined `siteId` (some of them accidentally, I suspect).

This PR changes the relevant function types so that they now clearly accept `siteId: number | undefined`. This then allows us to also fetch product variants even when logged-out.

#### Testing Instructions

Visit http://calypso.localhost:3000/checkout/jetpack/jetpack_backup_t1_yearly and verify that you see the product variant picker appear.

Before:
<img width="567" alt="Screen Shot 2022-06-27 at 12 53 34 PM" src="https://user-images.githubusercontent.com/2036909/175994554-e14be935-1d31-4081-af8b-76455938c319.png">



After:
<img width="571" alt="Screen Shot 2022-06-27 at 12 53 20 PM" src="https://user-images.githubusercontent.com/2036909/175994567-9517f550-c388-441a-bc68-553719781ea2.png">

