### PR TITLE
Use the bill_period_label purchase property to define the period

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -7,6 +7,7 @@ function createPurchaseObject( purchase ) {
 		amount: Number( purchase.amount ),
 		attachedToPurchaseId: Number( purchase.attached_to_purchase_id ),
 		billPeriodDays: Number( purchase.bill_period_days ),
+		billPeriodLabel: purchase.bill_period_label,
 		mostRecentRenewDate: purchase.most_recent_renew_date,
 		canDisableAutoRenew: Boolean( purchase.can_disable_auto_renew ),
 		canReenableAutoRenewal: Boolean( purchase.can_reenable_auto_renewal ),

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -261,6 +261,23 @@ function PurchaseMetaPrice( { purchase } ) {
 		period = translate( 'month' );
 	}
 
+	if ( purchase.billPeriodLabel ) {
+		switch ( purchase.billPeriodLabel ) {
+			case 'per year':
+				period = translate( 'year' );
+				break;
+			case 'per month':
+				period = translate( 'month' );
+				break;
+			case 'per week':
+				period = translate( 'week' );
+				break;
+			case 'per day':
+				period = translate( 'day' );
+				break;
+		}
+	}
+
 	// translators: displayPrice is the price of the purchase with localized currency (i.e. "C$10"), %(period)s is how long the plan is active (i.e. "year")
 	return translate( '{{displayPrice/}} {{period}}/ %(period)s{{/period}}', {
 		args: { period },


### PR DESCRIPTION
#### Proposed Changes

If the property `bill_period_label` exists, it will be used to define the period.
Otherwise, the previous value (with other checks) will be used.

#### Testing Instructions

* Go to a marketplace Plugin page and buy the monthly subscription. Ex: `/plugins/woocommerce-subscriptions`
* Go to the purchases page(`/me/purchases`) and select your plugin subscription.
* Check if the period next to the price shown as **month**

| Before  | After |
| ------------- | ------------- |
|<img width="1039" alt="Screen Shot 2022-06-24 at 13 02 58" src="https://user-images.githubusercontent.com/5039531/175609555-898db74e-1092-4eaf-8178-d4b4070d216d.png">|<img width="1039" alt="Screen Shot 2022-06-24 at 13 03 28" src="https://user-images.githubusercontent.com/5039531/175609481-c70fe8e6-2d99-4a7a-9377-bd687307ae68.png">
---

Fixes #64923
