### PR TITLE
Update the BillingIntervalSwitcher to use a radio button.

### DIFF
--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -1,6 +1,9 @@
+import config from '@automattic/calypso-config';
 import { PlansIntervalToggle } from '@automattic/plans-grid/src';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormRadio from 'calypso/components/forms/form-radio';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { PluginAnnualSaving } from 'calypso/my-sites/plugins/plugin-saving';
 import { IntervalLength } from './constants';
@@ -31,6 +34,23 @@ const PluginAnnualSavingLabelDesktop = styled.span`
 	color: var( --studio-green-60 );
 `;
 
+const BillingIntervalSwitcherContainer = styled.div`
+	display: flex;
+	justify-content: space-between;
+	margin-top: -4px;
+	margin-bottom: 16px;
+`;
+
+const RadioButton = styled( FormRadio )`
+	&:checked:before {
+		background-color: var( --studio-gray-80 );
+	}
+`;
+
+const RadioButtonLabel = styled( FormLabel )`
+	color: var( --studio-gray-60 );
+`;
+
 type Props = {
 	onChange: ( selectedValue: 'MONTHLY' | 'ANNUALLY' ) => void;
 	billingPeriod: IntervalLength;
@@ -40,12 +60,55 @@ type Props = {
 	};
 };
 
-const BillingIntervalSwitcher: FunctionComponent< Props > = ( {
-	billingPeriod,
-	onChange,
-	compact,
-	plugin,
-} ) => {
+const BillingIntervalSwitcher: FunctionComponent< Props > = ( props: Props ) => {
+	const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
+
+	const { billingPeriod, onChange, plugin } = props;
+
+	const translate = useTranslate();
+	const monthlyLabel = translate( 'Monthly' );
+	const annualLabel = translate( 'Annually' );
+
+	if ( legacyVersion ) {
+		return <LegacyBillingIntervalSwitcher { ...props } />;
+	}
+
+	return (
+		<BillingIntervalSwitcherContainer>
+			<RadioButtonLabel>
+				<RadioButton
+					className="billing-interval-switcher__monthly-option"
+					checked={ billingPeriod === IntervalLength.MONTHLY }
+					onChange={ () => onChange( IntervalLength.MONTHLY ) }
+					label={ monthlyLabel }
+				/>
+			</RadioButtonLabel>
+			<RadioButtonLabel>
+				<RadioButton
+					className="billing-interval-switcher__yearly-option"
+					checked={ billingPeriod === IntervalLength.ANNUALLY }
+					onChange={ () => onChange( IntervalLength.ANNUALLY ) }
+					label={
+						<>
+							{ annualLabel }
+							<PluginAnnualSaving plugin={ plugin }>
+								{ ( annualSaving: { saving: string | null } ) =>
+									annualSaving.saving && (
+										<PluginAnnualSavingLabelMobile isSelected={ false }>
+											&nbsp;(-{ annualSaving.saving })
+										</PluginAnnualSavingLabelMobile>
+									)
+								}
+							</PluginAnnualSaving>
+						</>
+					}
+				/>
+			</RadioButtonLabel>
+		</BillingIntervalSwitcherContainer>
+	);
+};
+
+function LegacyBillingIntervalSwitcher( { billingPeriod, onChange, compact, plugin }: Props ) {
 	const translate = useTranslate();
 	const monthlyLabel = translate( 'Monthly price' );
 	const annualLabel = translate( 'Annual price' );
@@ -108,5 +171,5 @@ const BillingIntervalSwitcher: FunctionComponent< Props > = ( {
 			</PlansIntervalToggle>
 		</Container>
 	);
-};
+}
 export default BillingIntervalSwitcher;

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	isFreePlanProduct,
 	FEATURE_INSTALL_PLUGINS,
@@ -12,11 +13,13 @@ import { useSelector, useDispatch } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { businessPlanToAdd } from 'calypso/lib/plugins/utils';
 import { userCan } from 'calypso/lib/site/utils';
+import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
 import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
 import { isRequestingForSites } from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
@@ -45,6 +48,9 @@ const PluginDetailsCTA = ( {
 } ) => {
 	const pluginSlug = plugin.slug;
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const legacyVersion = ! config.isEnabled( 'plugins/plugin-details-layout' );
 
 	const requestingPluginsForSites = useSelector( ( state ) =>
 		isRequestingForSites( state, siteIds )
@@ -157,6 +163,13 @@ const PluginDetailsCTA = ( {
 					}
 				</PluginPrice>
 			</div>
+			{ ! legacyVersion && (
+				<BillingIntervalSwitcher
+					billingPeriod={ billingPeriod }
+					onChange={ ( interval ) => dispatch( setBillingInterval( interval ) ) }
+					plugin={ plugin }
+				/>
+			) }
 			<div className="plugin-details-CTA__install">
 				<CTAButton
 					plugin={ plugin }
@@ -204,7 +217,7 @@ const PluginDetailsCTA = ( {
 	);
 };
 
-const PluginDetailsCTAPlaceholder = () => {
+function PluginDetailsCTAPlaceholder() {
 	return (
 		<div className="plugin-details-CTA__container is-placeholder">
 			<div className="plugin-details-CTA__price">...</div>
@@ -212,9 +225,9 @@ const PluginDetailsCTAPlaceholder = () => {
 			<div className="plugin-details-CTA__t-and-c">...</div>
 		</div>
 	);
-};
+}
 
-const CTAButton = ( {
+function CTAButton( {
 	plugin,
 	selectedSite,
 	shouldUpgrade,
@@ -223,7 +236,7 @@ const CTAButton = ( {
 	billingPeriod,
 	isJetpackSelfHosted,
 	isSiteConnected,
-} ) => {
+} ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const [ showEligibility, setShowEligibility ] = useState( false );
@@ -360,7 +373,7 @@ const CTAButton = ( {
 			) }
 		</>
 	);
-};
+}
 
 function onClickInstallPlugin( {
 	dispatch,


### PR DESCRIPTION
#### Proposed Changes

* Update the BillingIntervalSwitcher to use a radio button.
* Show it below the CTA on the Plugin Details page.

#### Testing Instructions
* Enable the feature flag `plugins/plugin-details-layout`*
* Go to a paid plugin page. Ex: `/plugins/woocommerce-subscriptions/{site}`
* Check if the billing switcher is a radio button below the CTA

| Before  | After |
|---|----|
|<img width="1119" alt="Screen Shot 2022-06-28 at 16 45 37" src="https://user-images.githubusercontent.com/5039531/176285930-d5ea4057-96ff-4dab-83b3-4b112ecacc86.png">|<img width="1164" alt="Screen Shot 2022-06-29 at 11 05 07" src="https://user-images.githubusercontent.com/5039531/176470630-09f877d5-54a7-4a01-bdde-a6c9aea9b299.png">|


* Go to a free plugin page. Ex: `/plugins/woocommerce/{site}`
* You should NOT see the billing switcher.




\* To enable this feature flag add `?flags=plugins/plugin-details-layout` to the end of your URL or past the following code on the developer tools console `document.cookie = 'flags=plugins/plugin-details-layout;max-age=1209600;path=/'`

---

Fixes #63684
