### PR TITLE
Performance: Require Manage_Plugin feature to manage plugin features

### DIFF
--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
 import { CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { pick } from 'lodash';
@@ -23,6 +24,7 @@ import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form'
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -31,6 +33,7 @@ class SiteSettingsPerformance extends Component {
 		const {
 			fields,
 			handleAutosavingToggle,
+			hasManagePluginsFeature,
 			isRequestingSettings,
 			isSavingSettings,
 			onChangeField,
@@ -91,7 +94,7 @@ class SiteSettingsPerformance extends Component {
 
 				{ showCloudflare && ! siteIsJetpackNonAtomic && <Cloudflare /> }
 
-				{ siteIsJetpack && (
+				{ siteIsJetpack && hasManagePluginsFeature && (
 					<Fragment>
 						<QueryJetpackModules siteId={ siteId } />
 
@@ -131,7 +134,7 @@ class SiteSettingsPerformance extends Component {
 					</Fragment>
 				) }
 
-				{ siteIsJetpack ? (
+				{ siteIsJetpack && hasManagePluginsFeature ? (
 					<AmpJetpack />
 				) : (
 					<AmpWpcom
@@ -165,6 +168,7 @@ const connectComponent = connect( ( state ) => {
 	const showCloudflare = config.isEnabled( 'cloudflare' );
 
 	return {
+		hasManagePluginsFeature: siteHasFeature( state, siteId, WPCOM_FEATURES_MANAGE_PLUGINS ),
 		site,
 		siteIsJetpack,
 		siteIsAtomic,


### PR DESCRIPTION
#### Proposed Changes

* Adds a check for the Manage_Plugins feature that is required to activate/deactivate AMP and Jetpack modules.

Before | After
--- | ---
<img width="1510" alt="Screen Shot 2022-06-27 at 12 31 14 PM" src="https://user-images.githubusercontent.com/1398304/176021019-94afd0b3-98d4-47c7-aac6-37c2bd1433a9.png"> | <img width="1510" alt="Screen Shot 2022-06-27 at 12 30 40 PM" src="https://user-images.githubusercontent.com/1398304/176021062-e4f0dd95-8cee-454c-9c94-b8c85c9ad6da.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site on Atomic with a Free, Starter, Personal, or Premium plan.
* Navigate to Settings > Performance
* Compare the page with a Simple Site on the same plan and make sure they look the same.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #64635
Fixes #64950
