### PR TITLE
Refactor media modal detail tests to @testing-library/react

### DIFF
--- a/client/post-editor/media-modal/detail/test/index.jsx
+++ b/client/post-editor/media-modal/detail/test/index.jsx
@@ -11,9 +11,6 @@ import { EditorMediaModalDetailItem as DetailItem } from '../detail-item';
 jest.mock( 'calypso/post-editor/media-modal/detail/detail-fields', () =>
 	require( 'calypso/components/empty-component' )
 );
-jest.mock( 'calypso/post-editor/media-modal/detail/detail-file-info', () =>
-	require( 'calypso/components/empty-component' )
-);
 
 function renderWithRedux( ui ) {
 	return renderWithProvider( ui, {
@@ -64,7 +61,9 @@ describe( 'EditorMediaModalDetailItem', () => {
 			/>
 		);
 
-		expect( screen.queryAllByRole( 'button' ).length ).toBeGreaterThanOrEqual( 1 );
+		expect( screen.queryAllByRole( 'button', { name: /edit/i } ).length ).toBeGreaterThanOrEqual(
+			1
+		);
 	} );
 
 	test( 'should display at least one edit button for a VideoPress video on a private site', () => {
@@ -77,13 +76,17 @@ describe( 'EditorMediaModalDetailItem', () => {
 			/>
 		);
 
-		expect( screen.queryAllByRole( 'button' ).length ).toBeGreaterThanOrEqual( 1 );
+		expect( screen.queryAllByRole( 'button', { name: /edit/i } ).length ).toBeGreaterThanOrEqual(
+			1
+		);
 	} );
 
 	test( 'should display at least one edit button for an image on a public site', () => {
 		renderWithRedux( <DetailItem item={ DUMMY_IMAGE_MEDIA } { ...SHARED_PROPS } /> );
 
-		expect( screen.queryAllByRole( 'button' ).length ).toBeGreaterThanOrEqual( 1 );
+		expect( screen.queryAllByRole( 'button', { name: /edit/i } ).length ).toBeGreaterThanOrEqual(
+			1
+		);
 	} );
 
 	test( 'should not display edit button for an image on a private site', () => {
@@ -91,6 +94,6 @@ describe( 'EditorMediaModalDetailItem', () => {
 			<DetailItem item={ DUMMY_IMAGE_MEDIA } isSitePrivate={ true } { ...SHARED_PROPS } />
 		);
 
-		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /edit/i } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/post-editor/media-modal/detail/test/index.jsx
+++ b/client/post-editor/media-modal/detail/test/index.jsx
@@ -1,7 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-import { shallow } from 'enzyme';
+
+import { screen } from '@testing-library/react';
+import siteSettingsReducer from 'calypso/state/site-settings/reducer';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { EditorMediaModalDetailItem as DetailItem } from '../detail-item';
 
 jest.mock( 'calypso/post-editor/media-modal/detail/detail-fields', () =>
@@ -10,6 +14,15 @@ jest.mock( 'calypso/post-editor/media-modal/detail/detail-fields', () =>
 jest.mock( 'calypso/post-editor/media-modal/detail/detail-file-info', () =>
 	require( 'calypso/components/empty-component' )
 );
+
+function renderWithRedux( ui ) {
+	return renderWithProvider( ui, {
+		reducers: {
+			ui: uiReducer,
+			siteSettings: siteSettingsReducer,
+		},
+	} );
+}
 
 /**
  * Module variables
@@ -43,7 +56,7 @@ describe( 'EditorMediaModalDetailItem', () => {
 	const isVideoPressEnabled = jest.fn( () => true );
 
 	test( 'should display at least one edit button for a VideoPress video on a public site', () => {
-		const tree = shallow(
+		renderWithRedux(
 			<DetailItem
 				item={ DUMMY_VIDEO_MEDIA }
 				isVideoPressEnabled={ isVideoPressEnabled }
@@ -51,13 +64,11 @@ describe( 'EditorMediaModalDetailItem', () => {
 			/>
 		);
 
-		const editButton = tree.find( '.editor-media-modal-detail__edit' );
-
-		expect( editButton.length ).toBeGreaterThanOrEqual( 1 );
+		expect( screen.queryAllByRole( 'button' ).length ).toBeGreaterThanOrEqual( 1 );
 	} );
 
 	test( 'should display at least one edit button for a VideoPress video on a private site', () => {
-		const tree = shallow(
+		renderWithRedux(
 			<DetailItem
 				item={ DUMMY_VIDEO_MEDIA }
 				isVideoPressEnabled={ isVideoPressEnabled }
@@ -66,26 +77,20 @@ describe( 'EditorMediaModalDetailItem', () => {
 			/>
 		);
 
-		const editButton = tree.find( '.editor-media-modal-detail__edit' );
-
-		expect( editButton.length ).toBeGreaterThanOrEqual( 1 );
+		expect( screen.queryAllByRole( 'button' ).length ).toBeGreaterThanOrEqual( 1 );
 	} );
 
 	test( 'should display at least one edit button for an image on a public site', () => {
-		const tree = shallow( <DetailItem item={ DUMMY_IMAGE_MEDIA } { ...SHARED_PROPS } /> );
+		renderWithRedux( <DetailItem item={ DUMMY_IMAGE_MEDIA } { ...SHARED_PROPS } /> );
 
-		const editButton = tree.find( '.editor-media-modal-detail__edit' );
-
-		expect( editButton.length ).toBeGreaterThanOrEqual( 1 );
+		expect( screen.queryAllByRole( 'button' ).length ).toBeGreaterThanOrEqual( 1 );
 	} );
 
 	test( 'should not display edit button for an image on a private site', () => {
-		const tree = shallow(
+		renderWithRedux(
 			<DetailItem item={ DUMMY_IMAGE_MEDIA } isSitePrivate={ true } { ...SHARED_PROPS } />
 		);
 
-		const editButton = tree.find( '.editor-media-modal-detail__edit' );
-
-		expect( editButton ).toHaveLength( 0 );
+		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* This PR refactors media model detail to use `@testing-library/react` instead of `enzyme`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify tests still pass: `yarn test-client client/post-editor/media-modal/detail/test/index.jsx`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63409
