### PR TITLE
Stepper Framework: Remove a trailing slash from current route

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -29,7 +29,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 
 	const stepPaths = flow.useSteps();
 	const location = useLocation();
-	const currentRoute = location.pathname.substring( 1 ) as StepPath;
+	const currentRoute = location.pathname.substring( 1 ).replace( /\/+$/, '' ) as StepPath;
 	const history = useHistory();
 	const { search } = useLocation();
 	const stepNavigation = flow.useStepNavigation( currentRoute, ( path ) => {


### PR DESCRIPTION
#### Proposed Changes

* We use `location.pathname` as the current step. However, if the pathname contains a trailing slash, the current step would be weird. For example, if the URL is `https://horizon.wordpress.com/setup/verticals/?siteSlug=<your_site>`, then the current step would be `vertical/` and it leads the step of  `calypso_signup_step_start` to become `vertical/`. Hence, this PR is focusing on removing the trailing slash from the current route.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/verticals/?siteSlug=<your_site>`
* Open Network Panel from the DevTool
* See the payload of the `calypso_signup_step_start` event and check the step is `vertical` instead of `vertical/`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1656338203759239-slack-CRWCHQGUB