### PR TITLE
Design Picker: Add use_screenshot_overrides attr for MShotsImage

### DIFF
--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -133,6 +133,7 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 									verticalId,
 									viewport_width: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
 									viewport_height: DEFAULT_VIEWPORT_HEIGHT,
+									use_screenshot_overrides: true,
 								} ) }
 								isSelected={ selectedDesign?.slug === design.slug }
 								onPreview={ () => onPreview( design, index ) }

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -36,7 +36,7 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( { design, loca
 
 	return (
 		<MShotsImage
-			url={ getDesignPreviewUrl( design, { language: locale } ) }
+			url={ getDesignPreviewUrl( design, { language: locale, use_screenshot_overrides: true } ) }
 			aria-labelledby={ makeOptionId( design ) }
 			alt=""
 			options={ getMShotOptions( { scrollable, highRes, isMobile } ) }

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -65,6 +65,7 @@ export interface DesignPreviewOptions {
 	siteTitle?: string;
 	viewport_width?: number;
 	viewport_height?: number;
+	use_screenshot_overrides?: boolean;
 }
 
 /** @deprecated used for Gutenboarding (/new flow) */

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -21,6 +21,7 @@ export const getDesignPreviewUrl = (
 		...( options.viewport_width && { viewport_width: options.viewport_width } ),
 		viewport_height: options.viewport_height || DEFAULT_VIEWPORT_HEIGHT,
 		source_site: 'patternboilerplates.wordpress.com',
+		use_screenshot_overrides: options.use_screenshot_overrides,
 	} );
 
 	const siteTitle = options.siteTitle || design.title;


### PR DESCRIPTION
#### Proposed Changes

* This is a follow-up PR for D83169-code. Set `use_screenshot_overrides` to true when we need to show the preview as the screenshot.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Design Picker step: `/setup/designSetup?siteSlug=<your_site>`
* Check the screenshots of both "Videomaker" and "Videomaker White" are correct
* Preview both "Videomaker" and "Videomaker White" and check the video works well.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/62176, D83169-code