### PR TITLE
Show price in Google Workspace card in new email comparison view

### DIFF
--- a/client/lib/gsuite/gsuite-supported-domain.js
+++ b/client/lib/gsuite/gsuite-supported-domain.js
@@ -47,9 +47,9 @@ export function getGSuiteSupportedDomains( domains ) {
 /**
  * Given a list of domains does one of them support G Suite
  *
- * @param {ResponseDomain[]} domains - list of domain objects
+ * @param {ResponseDomain?[]} domains - list of domain objects
  * @returns {boolean} - Does list of domains contain a G Suited supported domain
  */
 export function hasGSuiteSupportedDomain( domains ) {
-	return getGSuiteSupportedDomains( domains ).length > 0;
+	return getGSuiteSupportedDomains( domains.filter( Boolean ) ).length > 0;
 }

--- a/client/lib/gsuite/test/index.js
+++ b/client/lib/gsuite/test/index.js
@@ -201,6 +201,10 @@ describe( 'index', () => {
 			expect( hasGSuiteSupportedDomain( [] ) ).toEqual( false );
 		} );
 
+		test( 'returns false if passed an array with a single undefined member', () => {
+			expect( hasGSuiteSupportedDomain( [ undefined ] ) ).toEqual( false );
+		} );
+
 		test( 'returns false if passed an array with invalid domains', () => {
 			expect(
 				hasGSuiteSupportedDomain( [

--- a/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/google-workspace.tsx
@@ -46,7 +46,7 @@ const GoogleWorkspacePrice = ( {
 
 	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
 
-	if ( ! domain ) {
+	if ( ! domain && ! isDomainInCart ) {
 		return null;
 	}
 


### PR DESCRIPTION
#### Proposed Changes

Fix regression introduced in #64822 where the price would no longer be displayed in the `GoogleWorkspaceCardNew` component.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add a domain to the cart
2. On the next page, append this query string to the URL `?flags=emails/show-new-comparison-component`
3. You should now be at the URL `/domains/add/:domain/email/:site_slug?flags=emails/show-new-comparison-component`
4. Ensure that the price of the Google Workspace subscription is correctly displayed

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64822
