### PR TITLE
Enable `marketplace-starter-plan` on wpcalypso

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -654,6 +654,11 @@ const UpgradeNudge = ( { selectedSite, sitePlan, isVip, jetpackNonAtomic, siteSl
 
 const UpgradeNudgePaid = ( props ) => {
 	const translate = useTranslate();
+
+	if ( ! props.sitePlan ) {
+		return null;
+	}
+
 	const plan = findFirstSimilarPlanKey( props.sitePlan.product_slug, {
 		type: TYPE_STARTER,
 	} );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -76,6 +76,451 @@ import usePlugins from '../use-plugins';
  */
 const SHORT_LIST_LENGTH = 6;
 
+const ClearSearch = () => {
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const translate = useTranslate();
+
+	return (
+		<>
+			&nbsp;
+			<a
+				className={ 'plugins-browser__clear-filters' }
+				href={ '/plugins' + ( siteSlug ? '/' + siteSlug : '' ) }
+			>
+				{ translate( 'Clear' ) }
+			</a>
+		</>
+	);
+};
+const SearchListView = ( {
+	search: searchTerm,
+	pluginsPagination,
+	pluginsBySearchTerm,
+	fetchNextPage,
+	isFetchingPluginsBySearchTerm,
+	siteSlug,
+	siteId,
+	sites,
+	categoryName,
+} ) => {
+	const dispatch = useDispatch();
+
+	const translate = useTranslate();
+
+	useEffect( () => {
+		if ( searchTerm && pluginsPagination?.page === 1 ) {
+			dispatch(
+				recordTracksEvent( 'calypso_plugins_search_results_show', {
+					search_term: searchTerm,
+					results_count: pluginsPagination?.results,
+					blog_id: siteId,
+				} )
+			);
+		}
+
+		if ( searchTerm && pluginsPagination ) {
+			dispatch(
+				recordTracksEvent( 'calypso_plugins_search_results_page', {
+					search_term: searchTerm,
+					page: pluginsPagination.page,
+					results_count: pluginsPagination?.results,
+					blog_id: siteId,
+				} )
+			);
+		}
+	}, [ searchTerm, pluginsPagination, dispatch, siteId ] );
+
+	if ( pluginsBySearchTerm.length > 0 || isFetchingPluginsBySearchTerm ) {
+		let title = translate( 'Search results for "%(searchTerm)s"', {
+			textOnly: true,
+			args: { searchTerm },
+		} );
+
+		if ( pluginsPagination ) {
+			title = translate(
+				'Found %(total)s plugin for "%(searchTerm)s"',
+				'Found %(total)s plugins for "%(searchTerm)s"',
+				{
+					count: pluginsPagination.results,
+					textOnly: true,
+					args: {
+						total: pluginsPagination.results,
+						searchTerm,
+					},
+				}
+			);
+
+			if ( categoryName ) {
+				title = translate(
+					'Found %(total)s plugin for "%(searchTerm)s" under "%(categoryName)s"',
+					'Found %(total)s plugins for "%(searchTerm)s" under "%(categoryName)s"',
+					{
+						count: pluginsPagination.results,
+						textOnly: true,
+						args: {
+							total: pluginsPagination.results,
+							searchTerm,
+							categoryName,
+						},
+					}
+				);
+			}
+		}
+
+		return (
+			<>
+				<PluginsBrowserList
+					plugins={ pluginsBySearchTerm.filter( isNotBlocked ) }
+					listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
+					subtitle={
+						<>
+							{ title }
+							<ClearSearch />
+						</>
+					}
+					showReset={ true }
+					site={ siteSlug }
+					showPlaceholders={ isFetchingPluginsBySearchTerm }
+					currentSites={ sites }
+					variant={ PluginsBrowserListVariant.Paginated }
+					extended
+				/>
+				<InfiniteScroll nextPageMethod={ fetchNextPage } />
+			</>
+		);
+	}
+
+	return (
+		<div className="plugins-browser__no-results">
+			<NoResults
+				text={ translate( 'No plugins match your search for {{searchTerm/}}.', {
+					textOnly: true,
+					components: { searchTerm: <em>{ searchTerm }</em> },
+				} ) }
+			/>
+		</div>
+	);
+};
+
+const FullListView = ( { category, siteSlug, sites } ) => {
+	const { plugins, isFetching, fetchNextPage, pagination } = usePlugins( {
+		category,
+		infinite: true,
+	} );
+
+	const categories = useCategories();
+	const categoryName = categories[ category ]?.name || category;
+	const translate = useTranslate();
+
+	let title = '';
+	if ( categoryName && pagination ) {
+		title = translate(
+			'Found %(total)s plugin under "%(categoryName)s"',
+			'Found %(total)s plugins under "%(categoryName)s"',
+			{
+				count: pagination.results,
+				textOnly: true,
+				args: {
+					total: pagination.results,
+					categoryName,
+				},
+			}
+		);
+	}
+
+	return (
+		<>
+			<PluginsBrowserList
+				plugins={ plugins }
+				listName={ category }
+				subtitle={
+					<>
+						{ title }
+						<ClearSearch />
+					</>
+				}
+				site={ siteSlug }
+				showPlaceholders={ isFetching }
+				currentSites={ sites }
+				variant={ PluginsBrowserListVariant.InfiniteScroll }
+				extended
+			/>
+
+			<InfiniteScroll nextPageMethod={ fetchNextPage } />
+		</>
+	);
+};
+
+const PluginSingleListView = ( {
+	category,
+	pluginsByCategoryPopular,
+	isFetchingPluginsByCategoryPopular,
+	pluginsByCategoryFeatured,
+	isFetchingPluginsByCategoryFeatured,
+	paidPlugins,
+	isFetchingPaidPlugins,
+	siteSlug,
+	sites,
+} ) => {
+	const translate = useTranslate();
+
+	const siteId = useSelector( getSelectedSiteId );
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+
+	const categories = useCategories();
+	const categoryName = categories[ category ]?.name || translate( 'Plugins' );
+
+	const installedPlugins = useSelector( ( state ) =>
+		getPlugins( state, siteObjectsToSiteIds( sites ) )
+	);
+
+	let plugins;
+	let isFetching;
+	if ( category === 'popular' ) {
+		plugins = pluginsByCategoryPopular;
+		isFetching = isFetchingPluginsByCategoryPopular;
+	} else if ( category === 'featured' ) {
+		plugins = pluginsByCategoryFeatured;
+		isFetching = isFetchingPluginsByCategoryFeatured;
+	} else if ( category === 'paid' ) {
+		plugins = paidPlugins;
+		isFetching = isFetchingPaidPlugins;
+	} else {
+		return null;
+	}
+
+	plugins = plugins
+		.filter( isNotBlocked )
+		.filter( ( plugin ) => isNotInstalled( plugin, installedPlugins ) );
+
+	let listLink = '/plugins/browse/' + category;
+	if ( domain ) {
+		listLink = '/plugins/browse/' + category + '/' + domain;
+	}
+
+	if ( ! isFetching && plugins.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<PluginsBrowserList
+			plugins={ plugins.slice( 0, SHORT_LIST_LENGTH ) }
+			listName={ category }
+			title={ categoryName }
+			site={ siteSlug }
+			expandedListLink={ plugins.length > SHORT_LIST_LENGTH ? listLink : false }
+			size={ SHORT_LIST_LENGTH }
+			showPlaceholders={ isFetching }
+			currentSites={ sites }
+			variant={ PluginsBrowserListVariant.Fixed }
+			extended
+		/>
+	);
+};
+
+const UpgradeNudge = ( { selectedSite, sitePlan, isVip, jetpackNonAtomic, siteSlug } ) => {
+	const translate = useTranslate();
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, selectedSite?.ID )
+	);
+
+	if ( ! selectedSite?.ID || ! sitePlan || isVip || jetpackNonAtomic ) {
+		return null;
+	}
+	const isLegacyPlan = isBlogger( sitePlan ) || isPersonal( sitePlan ) || isPremium( sitePlan );
+	const checkoutPlan = eligibleForProPlan && ! isLegacyPlan ? 'pro' : 'business';
+	const bannerURL = `/checkout/${ siteSlug }/${ checkoutPlan }`;
+	const plan = findFirstSimilarPlanKey( sitePlan.product_slug, {
+		type: TYPE_BUSINESS,
+	} );
+
+	const title =
+		eligibleForProPlan && ! isLegacyPlan
+			? translate( 'Upgrade to the Pro plan to install plugins.' )
+			: translate( 'Upgrade to the Business plan to install plugins.' );
+
+	return (
+		<UpsellNudge
+			event="calypso_plugins_browser_upgrade_nudge"
+			showIcon={ true }
+			href={ bannerURL }
+			feature={ FEATURE_INSTALL_PLUGINS }
+			plan={ plan }
+			title={ title }
+		/>
+	);
+};
+
+const UpgradeNudgePaid = ( props ) => {
+	const translate = useTranslate();
+
+	if ( ! props.sitePlan ) {
+		return null;
+	}
+
+	const plan = findFirstSimilarPlanKey( props.sitePlan.product_slug, {
+		type: TYPE_STARTER,
+	} );
+
+	return (
+		<UpsellNudge
+			event="calypso_plugins_browser_upgrade_nudge"
+			showIcon={ true }
+			href={ `/checkout/${ props.siteSlug }/starter` }
+			feature={ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS }
+			plan={ plan }
+			title={ translate( 'Upgrade to the Starter plan to install paid plugins.' ) }
+		/>
+	);
+};
+
+const UploadPluginButton = ( { isMobile, siteSlug, hasUploadPlugins } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	if ( ! hasUploadPlugins ) {
+		return null;
+	}
+
+	const uploadUrl = '/plugins/upload' + ( siteSlug ? '/' + siteSlug : '' );
+	const handleUploadPluginButtonClick = () => {
+		dispatch( recordTracksEvent( 'calypso_click_plugin_upload' ) );
+		dispatch( recordGoogleEvent( 'Plugins', 'Clicked Plugin Upload Link' ) );
+	};
+
+	return (
+		<Button
+			className="plugins-browser__button"
+			onClick={ handleUploadPluginButtonClick }
+			href={ uploadUrl }
+		>
+			<Icon className="plugins-browser__button-icon" icon={ upload } width={ 18 } height={ 18 } />
+			{ ! isMobile && (
+				<span className="plugins-browser__button-text">{ translate( 'Upload' ) }</span>
+			) }
+		</Button>
+	);
+};
+
+const ManageButton = ( { shouldShowManageButton, siteAdminUrl, siteSlug, jetpackNonAtomic } ) => {
+	const translate = useTranslate();
+
+	if ( ! shouldShowManageButton ) {
+		return null;
+	}
+
+	const site = siteSlug ? '/' + siteSlug : '';
+
+	// When no site is selected eg `/plugins` or when Jetpack is self hosted
+	// show the Calypso Plugins Manage page.
+	// In any other case, redirect to current site WP Admin.
+	const managePluginsDestination =
+		! siteAdminUrl || jetpackNonAtomic
+			? `/plugins/manage${ site }`
+			: `${ siteAdminUrl }plugins.php`;
+
+	return (
+		<Button className="plugins-browser__button" href={ managePluginsDestination }>
+			<span className="plugins-browser__button-text">{ translate( 'Installed Plugins' ) }</span>
+		</Button>
+	);
+};
+
+const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews } ) => {
+	const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';
+	let analyticsPath = category ? `/plugins/browse/${ category }` : '/plugins';
+
+	if ( selectedSiteId ) {
+		analyticsPath += '/:site';
+	}
+
+	if ( trackPageViews ) {
+		return <PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />;
+	}
+
+	return null;
+};
+
+/**
+ * Filter the popular plugins list.
+ *
+ * Remove the incompatible plugins and the displayed featured
+ * plugins from the popular list to avoid showing them twice.
+ *
+ * @param {Array} popularPlugins
+ * @param {Array} featuredPlugins
+ */
+function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
+	const displayedFeaturedSlugsMap = new Map(
+		featuredPlugins
+			.slice( 0, SHORT_LIST_LENGTH ) // only displayed plugins
+			.map( ( plugin ) => [ plugin.slug, plugin.slug ] )
+	);
+
+	return popularPlugins.filter(
+		( plugin ) =>
+			! displayedFeaturedSlugsMap.has( plugin.slug ) && isCompatiblePlugin( plugin.slug )
+	);
+}
+
+const PLUGIN_SLUGS_BLOCKLIST = [];
+
+function isNotBlocked( plugin ) {
+	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;
+}
+
+/**
+ * Returns a boolean indicating if a plugin is already installed or not
+ *
+ * @param plugin plugin object to be tested
+ * @param installedPlugins list of installed plugins aggregated by plugin slug
+ * @returns Boolean weather a plugin is not installed on not
+ */
+function isNotInstalled( plugin, installedPlugins ) {
+	return ! installedPlugins.find( ( installedPlugin ) =>
+		isEqualSlugOrId( plugin.slug, installedPlugin )
+	);
+}
+
+const PluginBrowserContent = ( props ) => {
+	const eligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, props.selectedSite?.ID )
+	);
+
+	const isLegacyPlan =
+		props.sitePlan &&
+		( isBlogger( props.sitePlan ) || isPersonal( props.sitePlan ) || isPremium( props.sitePlan ) );
+
+	if ( props.search ) {
+		return <SearchListView { ...props } />;
+	}
+	if ( props.category ) {
+		return <FullListView { ...props } />;
+	}
+
+	return (
+		<>
+			{ ! props.jetpackNonAtomic && (
+				<>
+					<div className="plugins-browser__upgrade-banner">
+						{ isEnabled( 'marketplace-starter-plan' ) && eligibleForProPlan && ! isLegacyPlan ? (
+							<UpgradeNudgePaid { ...props } />
+						) : (
+							<UpgradeNudge { ...props } />
+						) }
+					</div>
+					<PluginSingleListView { ...props } category="paid" />
+				</>
+			) }
+			{ isEnabled( 'marketplace-starter-plan' ) && eligibleForProPlan && ! isLegacyPlan && (
+				<UpgradeNudge { ...props } />
+			) }
+			<PluginSingleListView { ...props } category="featured" />
+			<PluginSingleListView { ...props } category="popular" />
+		</>
+	);
+};
+
 const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle, hideHeader } ) => {
 	const {
 		isAboveElement,
@@ -337,450 +782,5 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, searchTitle,
 		</MainComponent>
 	);
 };
-
-const ClearSearch = () => {
-	const siteSlug = useSelector( getSelectedSiteSlug );
-	const translate = useTranslate();
-
-	return (
-		<>
-			&nbsp;
-			<a
-				className={ 'plugins-browser__clear-filters' }
-				href={ '/plugins' + ( siteSlug ? '/' + siteSlug : '' ) }
-			>
-				{ translate( 'Clear' ) }
-			</a>
-		</>
-	);
-};
-const SearchListView = ( {
-	search: searchTerm,
-	pluginsPagination,
-	pluginsBySearchTerm,
-	fetchNextPage,
-	isFetchingPluginsBySearchTerm,
-	siteSlug,
-	siteId,
-	sites,
-	categoryName,
-} ) => {
-	const dispatch = useDispatch();
-
-	const translate = useTranslate();
-
-	useEffect( () => {
-		if ( searchTerm && pluginsPagination?.page === 1 ) {
-			dispatch(
-				recordTracksEvent( 'calypso_plugins_search_results_show', {
-					search_term: searchTerm,
-					results_count: pluginsPagination?.results,
-					blog_id: siteId,
-				} )
-			);
-		}
-
-		if ( searchTerm && pluginsPagination ) {
-			dispatch(
-				recordTracksEvent( 'calypso_plugins_search_results_page', {
-					search_term: searchTerm,
-					page: pluginsPagination.page,
-					results_count: pluginsPagination?.results,
-					blog_id: siteId,
-				} )
-			);
-		}
-	}, [ searchTerm, pluginsPagination, dispatch, siteId ] );
-
-	if ( pluginsBySearchTerm.length > 0 || isFetchingPluginsBySearchTerm ) {
-		let title = translate( 'Search results for "%(searchTerm)s"', {
-			textOnly: true,
-			args: { searchTerm },
-		} );
-
-		if ( pluginsPagination ) {
-			title = translate(
-				'Found %(total)s plugin for "%(searchTerm)s"',
-				'Found %(total)s plugins for "%(searchTerm)s"',
-				{
-					count: pluginsPagination.results,
-					textOnly: true,
-					args: {
-						total: pluginsPagination.results,
-						searchTerm,
-					},
-				}
-			);
-
-			if ( categoryName ) {
-				title = translate(
-					'Found %(total)s plugin for "%(searchTerm)s" under "%(categoryName)s"',
-					'Found %(total)s plugins for "%(searchTerm)s" under "%(categoryName)s"',
-					{
-						count: pluginsPagination.results,
-						textOnly: true,
-						args: {
-							total: pluginsPagination.results,
-							searchTerm,
-							categoryName,
-						},
-					}
-				);
-			}
-		}
-
-		return (
-			<>
-				<PluginsBrowserList
-					plugins={ pluginsBySearchTerm.filter( isNotBlocked ) }
-					listName={ 'plugins-browser-list__search-for_' + searchTerm.replace( /\s/g, '-' ) }
-					subtitle={
-						<>
-							{ title }
-							<ClearSearch />
-						</>
-					}
-					showReset={ true }
-					site={ siteSlug }
-					showPlaceholders={ isFetchingPluginsBySearchTerm }
-					currentSites={ sites }
-					variant={ PluginsBrowserListVariant.Paginated }
-					extended
-				/>
-				<InfiniteScroll nextPageMethod={ fetchNextPage } />
-			</>
-		);
-	}
-
-	return (
-		<div className="plugins-browser__no-results">
-			<NoResults
-				text={ translate( 'No plugins match your search for {{searchTerm/}}.', {
-					textOnly: true,
-					components: { searchTerm: <em>{ searchTerm }</em> },
-				} ) }
-			/>
-		</div>
-	);
-};
-
-const FullListView = ( { category, siteSlug, sites } ) => {
-	const { plugins, isFetching, fetchNextPage, pagination } = usePlugins( {
-		category,
-		infinite: true,
-	} );
-
-	const categories = useCategories();
-	const categoryName = categories[ category ]?.name || category;
-	const translate = useTranslate();
-
-	let title = '';
-	if ( categoryName && pagination ) {
-		title = translate(
-			'Found %(total)s plugin under "%(categoryName)s"',
-			'Found %(total)s plugins under "%(categoryName)s"',
-			{
-				count: pagination.results,
-				textOnly: true,
-				args: {
-					total: pagination.results,
-					categoryName,
-				},
-			}
-		);
-	}
-
-	return (
-		<>
-			<PluginsBrowserList
-				plugins={ plugins }
-				listName={ category }
-				subtitle={
-					<>
-						{ title }
-						<ClearSearch />
-					</>
-				}
-				site={ siteSlug }
-				showPlaceholders={ isFetching }
-				currentSites={ sites }
-				variant={ PluginsBrowserListVariant.InfiniteScroll }
-				extended
-			/>
-
-			<InfiniteScroll nextPageMethod={ fetchNextPage } />
-		</>
-	);
-};
-
-const PluginSingleListView = ( {
-	category,
-	pluginsByCategoryPopular,
-	isFetchingPluginsByCategoryPopular,
-	pluginsByCategoryFeatured,
-	isFetchingPluginsByCategoryFeatured,
-	paidPlugins,
-	isFetchingPaidPlugins,
-	siteSlug,
-	sites,
-} ) => {
-	const translate = useTranslate();
-
-	const siteId = useSelector( getSelectedSiteId );
-	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
-
-	const categories = useCategories();
-	const categoryName = categories[ category ]?.name || translate( 'Plugins' );
-
-	const installedPlugins = useSelector( ( state ) =>
-		getPlugins( state, siteObjectsToSiteIds( sites ) )
-	);
-
-	let plugins;
-	let isFetching;
-	if ( category === 'popular' ) {
-		plugins = pluginsByCategoryPopular;
-		isFetching = isFetchingPluginsByCategoryPopular;
-	} else if ( category === 'featured' ) {
-		plugins = pluginsByCategoryFeatured;
-		isFetching = isFetchingPluginsByCategoryFeatured;
-	} else if ( category === 'paid' ) {
-		plugins = paidPlugins;
-		isFetching = isFetchingPaidPlugins;
-	} else {
-		return null;
-	}
-
-	plugins = plugins
-		.filter( isNotBlocked )
-		.filter( ( plugin ) => isNotInstalled( plugin, installedPlugins ) );
-
-	let listLink = '/plugins/browse/' + category;
-	if ( domain ) {
-		listLink = '/plugins/browse/' + category + '/' + domain;
-	}
-
-	if ( ! isFetching && plugins.length === 0 ) {
-		return null;
-	}
-
-	return (
-		<PluginsBrowserList
-			plugins={ plugins.slice( 0, SHORT_LIST_LENGTH ) }
-			listName={ category }
-			title={ categoryName }
-			site={ siteSlug }
-			expandedListLink={ plugins.length > SHORT_LIST_LENGTH ? listLink : false }
-			size={ SHORT_LIST_LENGTH }
-			showPlaceholders={ isFetching }
-			currentSites={ sites }
-			variant={ PluginsBrowserListVariant.Fixed }
-			extended
-		/>
-	);
-};
-
-const PluginBrowserContent = ( props ) => {
-	const eligibleForProPlan = useSelector( ( state ) =>
-		isEligibleForProPlan( state, props.selectedSite?.ID )
-	);
-
-	const isLegacyPlan =
-		props.sitePlan &&
-		( isBlogger( props.sitePlan ) || isPersonal( props.sitePlan ) || isPremium( props.sitePlan ) );
-
-	if ( props.search ) {
-		return <SearchListView { ...props } />;
-	}
-	if ( props.category ) {
-		return <FullListView { ...props } />;
-	}
-
-	return (
-		<>
-			{ ! props.jetpackNonAtomic && (
-				<>
-					<div className="plugins-browser__upgrade-banner">
-						{ isEnabled( 'marketplace-starter-plan' ) && eligibleForProPlan && ! isLegacyPlan ? (
-							<UpgradeNudgePaid { ...props } />
-						) : (
-							<UpgradeNudge { ...props } />
-						) }
-					</div>
-					<PluginSingleListView { ...props } category="paid" />
-				</>
-			) }
-			{ isEnabled( 'marketplace-starter-plan' ) && eligibleForProPlan && ! isLegacyPlan && (
-				<UpgradeNudge { ...props } />
-			) }
-			<PluginSingleListView { ...props } category="featured" />
-			<PluginSingleListView { ...props } category="popular" />
-		</>
-	);
-};
-
-const UpgradeNudge = ( { selectedSite, sitePlan, isVip, jetpackNonAtomic, siteSlug } ) => {
-	const translate = useTranslate();
-	const eligibleForProPlan = useSelector( ( state ) =>
-		isEligibleForProPlan( state, selectedSite?.ID )
-	);
-
-	if ( ! selectedSite?.ID || ! sitePlan || isVip || jetpackNonAtomic ) {
-		return null;
-	}
-	const isLegacyPlan = isBlogger( sitePlan ) || isPersonal( sitePlan ) || isPremium( sitePlan );
-	const checkoutPlan = eligibleForProPlan && ! isLegacyPlan ? 'pro' : 'business';
-	const bannerURL = `/checkout/${ siteSlug }/${ checkoutPlan }`;
-	const plan = findFirstSimilarPlanKey( sitePlan.product_slug, {
-		type: TYPE_BUSINESS,
-	} );
-
-	const title =
-		eligibleForProPlan && ! isLegacyPlan
-			? translate( 'Upgrade to the Pro plan to install plugins.' )
-			: translate( 'Upgrade to the Business plan to install plugins.' );
-
-	return (
-		<UpsellNudge
-			event="calypso_plugins_browser_upgrade_nudge"
-			showIcon={ true }
-			href={ bannerURL }
-			feature={ FEATURE_INSTALL_PLUGINS }
-			plan={ plan }
-			title={ title }
-		/>
-	);
-};
-
-const UpgradeNudgePaid = ( props ) => {
-	const translate = useTranslate();
-
-	if ( ! props.sitePlan ) {
-		return null;
-	}
-
-	const plan = findFirstSimilarPlanKey( props.sitePlan.product_slug, {
-		type: TYPE_STARTER,
-	} );
-
-	return (
-		<UpsellNudge
-			event="calypso_plugins_browser_upgrade_nudge"
-			showIcon={ true }
-			href={ `/checkout/${ props.siteSlug }/starter` }
-			feature={ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS }
-			plan={ plan }
-			title={ translate( 'Upgrade to the Starter plan to install paid plugins.' ) }
-		/>
-	);
-};
-
-const UploadPluginButton = ( { isMobile, siteSlug, hasUploadPlugins } ) => {
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-
-	if ( ! hasUploadPlugins ) {
-		return null;
-	}
-
-	const uploadUrl = '/plugins/upload' + ( siteSlug ? '/' + siteSlug : '' );
-	const handleUploadPluginButtonClick = () => {
-		dispatch( recordTracksEvent( 'calypso_click_plugin_upload' ) );
-		dispatch( recordGoogleEvent( 'Plugins', 'Clicked Plugin Upload Link' ) );
-	};
-
-	return (
-		<Button
-			className="plugins-browser__button"
-			onClick={ handleUploadPluginButtonClick }
-			href={ uploadUrl }
-		>
-			<Icon className="plugins-browser__button-icon" icon={ upload } width={ 18 } height={ 18 } />
-			{ ! isMobile && (
-				<span className="plugins-browser__button-text">{ translate( 'Upload' ) }</span>
-			) }
-		</Button>
-	);
-};
-
-const ManageButton = ( { shouldShowManageButton, siteAdminUrl, siteSlug, jetpackNonAtomic } ) => {
-	const translate = useTranslate();
-
-	if ( ! shouldShowManageButton ) {
-		return null;
-	}
-
-	const site = siteSlug ? '/' + siteSlug : '';
-
-	// When no site is selected eg `/plugins` or when Jetpack is self hosted
-	// show the Calypso Plugins Manage page.
-	// In any other case, redirect to current site WP Admin.
-	const managePluginsDestination =
-		! siteAdminUrl || jetpackNonAtomic
-			? `/plugins/manage${ site }`
-			: `${ siteAdminUrl }plugins.php`;
-
-	return (
-		<Button className="plugins-browser__button" href={ managePluginsDestination }>
-			<span className="plugins-browser__button-text">{ translate( 'Installed Plugins' ) }</span>
-		</Button>
-	);
-};
-
-const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews } ) => {
-	const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';
-	let analyticsPath = category ? `/plugins/browse/${ category }` : '/plugins';
-
-	if ( selectedSiteId ) {
-		analyticsPath += '/:site';
-	}
-
-	if ( trackPageViews ) {
-		return <PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />;
-	}
-
-	return null;
-};
-
-/**
- * Filter the popular plugins list.
- *
- * Remove the incompatible plugins and the displayed featured
- * plugins from the popular list to avoid showing them twice.
- *
- * @param {Array} popularPlugins
- * @param {Array} featuredPlugins
- */
-function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
-	const displayedFeaturedSlugsMap = new Map(
-		featuredPlugins
-			.slice( 0, SHORT_LIST_LENGTH ) // only displayed plugins
-			.map( ( plugin ) => [ plugin.slug, plugin.slug ] )
-	);
-
-	return popularPlugins.filter(
-		( plugin ) =>
-			! displayedFeaturedSlugsMap.has( plugin.slug ) && isCompatiblePlugin( plugin.slug )
-	);
-}
-
-const PLUGIN_SLUGS_BLOCKLIST = [];
-
-function isNotBlocked( plugin ) {
-	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;
-}
-
-/**
- * Returns a boolean indicating if a plugin is already installed or not
- *
- * @param plugin plugin object to be tested
- * @param installedPlugins list of installed plugins aggregated by plugin slug
- * @returns Boolean weather a plugin is not installed on not
- */
-function isNotInstalled( plugin, installedPlugins ) {
-	return ! installedPlugins.find( ( installedPlugin ) =>
-		isEqualSlugOrId( plugin.slug, installedPlugin )
-	);
-}
 
 export default PluginsBrowser;

--- a/config/test.json
+++ b/config/test.json
@@ -56,6 +56,7 @@
 		"legal-updates-banner": true,
 		"mailchimp": true,
 		"marketplace-jetpack-plugin-search": false,
+		"marketplace-starter-plan": true,
 		"me/account-close": true,
 		"me/vat-details": true,
 		"network-connection": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,6 +82,7 @@
 		"marketplace-test": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-jetpack-plugin-search": false,
+		"marketplace-starter-plan": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,


### PR DESCRIPTION
#### Proposed Changes

* Enables the `marketplace-starter-plan` feature flag on the wpcalypso environment, so folks can test the Marketplace plugins on the Starter plan (pdtkmj-dL-p2) more easily in wpcalypso.wordpress.com without manually activating the flag.

#### Testing Instructions

- Use the Calypso live link below (it uses the wpcalypso environment)
- Confirm you can purchase paid plugins on sites with the Starter plan.
- Make sure all unit and E2E tests pass