### PR TITLE
Stepper Seller Experience - Cleanup email field UX on Store Address step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
@@ -17,4 +17,10 @@
 			padding-left: 40px;
 		}
 	}
+
+	.store-address__set-store-email {
+		color: var( --wp-admin-theme-color-darker-10 );
+		text-decoration: underline;
+		cursor: pointer;
+	}
 }


### PR DESCRIPTION
#### Proposed Changes

We've updated the label to make the purpose of the email address more clean and added a button to allow the user to easily use their WordPress.com email.

<img width="646" alt="image" src="https://user-images.githubusercontent.com/917632/176210857-8cc03635-97b0-423a-a0d6-e58e34c7b637.png">


#### Testing Instructions
- Check out this branch
- Go to http://calypso.localhost:3000/setup/storeAddress?siteSlug=mbb0621a.wordpress.com
- Verify the email field matches the above screenshot
- Verify clicking "(Use my WordPress.com email)" populates the email address field with the correct address.

Fixes #64202
