### PR TITLE
Editing Toolkit Plugin: Prevent phpcbf errors from stopping sync process

### DIFF
--- a/apps/editing-toolkit/bin/sync-newspack-blocks.sh
+++ b/apps/editing-toolkit/bin/sync-newspack-blocks.sh
@@ -134,6 +134,10 @@ echo -n "phpcbf: "
 
 if [ "$PHPCBF_ERRORED" = 1 ] ; then
 	echo '!! There was an error executing phpcbf!'
+
+	if [ "$MODE" != "npm" ] ; then
+		exit 1
+	fi
 fi
 
 if [ "$MODE" = "npm" ] ; then

--- a/apps/editing-toolkit/bin/sync-newspack-blocks.sh
+++ b/apps/editing-toolkit/bin/sync-newspack-blocks.sh
@@ -132,11 +132,6 @@ echo "done"
 echo -n "phpcbf: "
 ../../vendor/bin/phpcbf -q $TARGET | grep "A TOTAL OF" || PHPCBF_ERRORED=1
 
-if [ "$PHPCBF_ERRORED" = 1 ] ; then
-	echo '!! There was an error executing phpcbf!'
-	exit 1
-fi
-
 if [ "$MODE" = "npm" ] ; then
 	# Finds and prints the version of newspack from package.json
 	NEW_VERSION=v`sed -En 's|.*"@automattic/newspack-blocks": "\^#?(.*)".*|\1|p' package.json`

--- a/apps/editing-toolkit/bin/sync-newspack-blocks.sh
+++ b/apps/editing-toolkit/bin/sync-newspack-blocks.sh
@@ -132,6 +132,10 @@ echo "done"
 echo -n "phpcbf: "
 ../../vendor/bin/phpcbf -q $TARGET | grep "A TOTAL OF" || PHPCBF_ERRORED=1
 
+if [ "$PHPCBF_ERRORED" = 1 ] ; then
+	echo '!! There was an error executing phpcbf!'
+fi
+
 if [ "$MODE" = "npm" ] ; then
 	# Finds and prints the version of newspack from package.json
 	NEW_VERSION=v`sed -En 's|.*"@automattic/newspack-blocks": "\^#?(.*)".*|\1|p' package.json`


### PR DESCRIPTION
#### Discussion

After running into issues syncing the editing toolkit plugin, we went to troubleshoot the problem in p1655945457500979-slack-CHN6J22MP and p1656098373502459-slack-C7YPUHBB2. 

In our discussions, however, we didn't understand why a phpcbf runtime error would halt the entire syncing process for ETK. Because our understanding is that `sync-newspack-blocks.sh` is a script meant for development purposes, in this PR, we remove logic that exits the syncing execution thread when a phpcbf error is thrown.

#### Proposed Changes

* _Do not_ exit when a phpcbf error is thrown while syncing newspack blocks

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* In a terminal, navigate to `/apps/editing-toolkit` and run `yarn dev --sync`.
* Replace `apps/editing-toolkit/bin/sync-newspack-blocks.sh:135` with  `if true ; then` to force a phpcbf error 
* Verify that the syncing process does not end prematurely.