### PR TITLE
Authentication: revise the Magic Link spec.

### DIFF
--- a/test/e2e/specs/authentication/authentication__magic-link.ts
+++ b/test/e2e/specs/authentication/authentication__magic-link.ts
@@ -9,6 +9,7 @@ import type { Message } from 'mailosaur/lib/models';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Authentication: Magic Link' ), function () {
+	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
 	let page: Page;
 	let loginPage: LoginPage;
 	let emailClient: EmailClient;
@@ -26,19 +27,19 @@ describe( DataHelper.createSuiteTitle( 'Authentication: Magic Link' ), function 
 	} );
 
 	it( 'Request magic link', async function () {
-		const credentials = SecretsManager.secrets.testAccounts.defaultUser;
-
-		await loginPage.fillUsername( credentials.email );
+		// It is safe to add type assertion here, since the email
+		// field is defined for `defaultUser`.
+		await loginPage.fillUsername( credentials.email as string );
 		await loginPage.clickSubmit();
 
 		emailClient = new EmailClient();
 		magicLinkEmail = await emailClient.getLastEmail( {
 			inboxId: SecretsManager.secrets.mailosaur.defaultUserInboxId,
-			emailAddress: credentials.email,
+			emailAddress: credentials.email as string,
 			subject: 'Log in to WordPress.com',
 		} );
 		const links = await emailClient.getLinksFromMessage( magicLinkEmail );
-		magicLinkURL = links.find( ( link: string ) => link.includes( 'wpcom_email_click' ) );
+		magicLinkURL = links.find( ( link: string ) => link.includes( 'wpcom_email_click' ) ) as string;
 
 		expect( magicLinkURL ).toBeDefined();
 	} );


### PR DESCRIPTION
#### Proposed Changes

This PR adjusts the Authentication: Magic Link spec.

Key changes:
- revise how the `inboxId` and `userEmail` are handled - with the data now in the encrypted secrets file, we can retrieve these details from the SecretsManager instead;
- specify type for `link`;
- revise the confirmation in `Click the Continue to WordPress.com button` step to wait for the `/home` endpoint to be loaded.

#### Testing Instructions

Ensure the following:
  - [x] Pre-Release E2E

Project: pciE2j-18A-p2
Related to https://github.com/Automattic/wp-calypso/issues/64841