### PR TITLE
i18n-utils: Add `localizeUrl` handling for apps.wordpress.com

### DIFF
--- a/packages/i18n-utils/CHANGELOG.md
+++ b/packages/i18n-utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+
+Add support for `https://apps.wordpress.com` URLs
+
 ## 1.0.1
 
 Add missing dependencies - @automattic/languages

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-utils",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "WordPress.com i18n utils.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -120,6 +120,7 @@ const urlLocalizationMapping: UrlLocalizationMapping = {
 	'jetpack.com': setLocalizedUrlHost( 'jetpack.com', jetpackComLocales ),
 	'en.support.wordpress.com': setLocalizedWpComPath( '/support', supportSiteLocales ),
 	'en.blog.wordpress.com': setLocalizedWpComPath( '/blog', localesWithBlog, /^\/$/ ),
+	'apps.wordpress.com': prefixLocalizedUrlPath( magnificentNonEnLocales ),
 	'en.forums.wordpress.com': setLocalizedWpComPath( '/forums', forumLocales ),
 	'automattic.com/privacy/': prefixLocalizedUrlPath( localesWithPrivacyPolicy ),
 	'automattic.com/cookies/': prefixLocalizedUrlPath( localesWithCookiePolicy ),

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -425,4 +425,31 @@ describe( '#localizeUrl', () => {
 			'https://wordpress.com/support/contact/'
 		);
 	} );
+
+	test( 'apps', () => {
+		expect( localizeUrl( 'https://apps.wordpress.com', 'de' ) ).toEqual(
+			'https://apps.wordpress.com/de/'
+		);
+		expect( localizeUrl( 'https://apps.wordpress.com', 'es' ) ).toEqual(
+			'https://apps.wordpress.com/es/'
+		);
+		expect( localizeUrl( 'https://apps.wordpress.com/support/desktop/', 'de' ) ).toEqual(
+			'https://apps.wordpress.com/de/support/desktop/'
+		);
+		expect( localizeUrl( 'https://apps.wordpress.com/support/desktop/', 'es' ) ).toEqual(
+			'https://apps.wordpress.com/es/support/desktop/'
+		);
+		expect( localizeUrl( 'https://apps.wordpress.com/d/osx/?ref=getapps', 'de' ) ).toEqual(
+			'https://apps.wordpress.com/de/d/osx/?ref=getapps'
+		);
+		expect( localizeUrl( 'https://apps.wordpress.com/d/osx/?ref=getapps', 'es' ) ).toEqual(
+			'https://apps.wordpress.com/es/d/osx/?ref=getapps'
+		);
+		expect( localizeUrl( 'https://apps.wordpress.com', 'en' ) ).toEqual(
+			'https://apps.wordpress.com/'
+		);
+		expect( localizeUrl( 'https://apps.wordpress.com/support/desktop/', 'en' ) ).toEqual(
+			'https://apps.wordpress.com/support/desktop/'
+		);
+	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* Add URL mapping for `apps.wordpress.com` in `localizeUrl`

#### Testing Instructions

* Code review
* Unit tests pass

Related to 450-gh-Automattic/i18n-issues
