### PR TITLE
Refactor `UpgradeATStep` tests to @testing-library/react

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/upgrade-at-step.jsx
@@ -6,32 +6,39 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { UpgradeATStep } from '../upgrade-at-step';
 
+jest.mock( '@automattic/components/src/button', () => ( { href, onClick, children } ) => (
+	<a href={ href } onClick={ onClick }>
+		{ children }
+	</a>
+) );
+
 const noop = () => {};
 const props = {
 	recordTracksEvent: jest.fn(),
 	selectedSite: { slug: 'site_slug' },
-	translate: ( content ) => `Translated: ${ content }`,
+	translate: jest.fn( ( content ) => content ),
 };
 
 describe( 'UpgradeATStep', () => {
 	test( 'should render translated heading content', () => {
 		const { container } = render( <UpgradeATStep { ...props } recordTracksEvent={ noop } /> );
-		expect( container.firstChild ).toHaveTextContent(
-			'Translated: New! Install Custom Plugins and Themes'
-		);
+		expect( props.translate ).toHaveBeenCalled();
+		expect( container.firstChild ).toHaveTextContent( 'New! Install Custom Plugins and Themes' );
 	} );
 
 	test( 'should render translated link content', () => {
 		render( <UpgradeATStep { ...props } recordTracksEvent={ noop } /> );
+		expect( props.translate ).toHaveBeenCalled();
 		expect( screen.queryByRole( 'group' ) ).toHaveTextContent(
-			'Translated: Did you know that you can now use third-party plugins and themes on the WordPress.com Business plan? ' +
+			'Did you know that you can now use third-party plugins and themes on the WordPress.com Business plan? ' +
 				'Claim a 25% discount when you upgrade your site today - {{b}}enter the code BIZC25 at checkout{{/b}}.'
 		);
 	} );
 
 	test( 'should render translated confirmation content', () => {
 		render( <UpgradeATStep { ...props } recordTracksEvent={ noop } /> );
-		expect( screen.queryByRole( 'link' ) ).toHaveTextContent( 'Translated: Upgrade My Site' );
+		expect( props.translate ).toHaveBeenCalled();
+		expect( screen.queryByRole( 'link' ) ).toHaveTextContent( 'Upgrade My Site' );
 	} );
 
 	test( 'should render button with link to business plan checkout', () => {
@@ -48,10 +55,11 @@ describe( 'UpgradeATStep', () => {
 		render(
 			<UpgradeATStep { ...props } translate={ noop } recordTracksEvent={ recordTracksEvent } />
 		);
+		const user = userEvent.setup();
 		const btn = screen.queryByRole( 'link' );
 
 		btn.addEventListener( 'click', ( event ) => event.preventDefault(), false );
-		await userEvent.click( btn );
+		await user.click( btn );
 
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_cancellation_upgrade_at_step_upgrade_click'


### PR DESCRIPTION
#### Proposed Changes

* This PR refactors the `UpgradeATStep` component to use `@testing-library/react` instead of `enzyme`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify tests still pass: `yarn test-client client/components/marketing-survey/cancel-purchase-form/step-components/test/upgrade-at-step.jsx`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63409
