### PR TITLE
Shopping Cart: Deprecate cost and coupon_savings properties in ResponseCartProduct

### DIFF
--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -66,7 +66,6 @@ export function getEmptyResponseCartProduct(): ResponseCartProduct {
 		months_per_bill_period: null,
 		uuid: 'product001',
 		cost: 0,
-		price: 0,
 		item_tax: 0,
 		product_type: 'test',
 		included_domain_purchase_amount: 0,

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -225,14 +225,14 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	cart_key: CartKey;
 	products: P[];
 	/**
-	 * @deprecated Use total_tax_integer or total_tax_display
+	 * @deprecated This is a float and is unreliable. Use total_tax_integer or total_tax_display.
 	 */
 	total_tax: string;
 	total_tax_integer: number;
 	total_tax_display: string;
 	total_tax_breakdown: TaxBreakdownItem[];
 	/**
-	 * @deprecated Use total_cost_integer or total_cost_display
+	 * @deprecated This is a float and is unreliable. Use total_cost_integer or total_cost_display.
 	 */
 	total_cost: number;
 	total_cost_integer: number;
@@ -329,12 +329,17 @@ export interface ResponseCartProduct {
 	current_quantity: number | null;
 	extra: ResponseCartProductExtra;
 	uuid: string;
+	/**
+	 * @deprecated This is a float and is unreliable. Use item_subtotal_integer or item_subtotal_display.
+	 */
 	cost: number;
 	cost_before_coupon?: number;
+	/**
+	 * @deprecated This is a float and is unreliable. Use coupon_savings_integer or coupon_savings_display.
+	 */
 	coupon_savings?: number;
 	coupon_savings_display?: string;
 	coupon_savings_integer?: number;
-	price: number;
 	item_tax: number;
 	product_type: string;
 	included_domain_purchase_amount: number;


### PR DESCRIPTION
#### Proposed Changes

This PR adds some deprecation notices to old price properties of `ResponseCartProduct` which represents shopping cart items returned by the server. These properties are floats, which are risky to use for two reasons:

1. Performing math on floats can produce unexpected results since floating point math on computers is unreliable (we return integer properties for every price for this reason that are in each currency's smallest unit). We don't want someone to end up with a price that's nonsensical or inaccurate, even by a few cents.
2. Localizing floats for display can be tricky due to the many various rules of formatting prices in different currencies (we return "display" properties for every price for this reason that have decimals and currency symbols already applied.)

This also removes the`price` property, because that doesn't actually exist.

#### Testing Instructions

None should be needed.