### PR TITLE
Design Picker: Adding pricing description to the new design

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -497,6 +497,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			onSelect={ pickDesign }
 			onPreview={ previewDesign }
 			onUpgrade={ upgradePlan }
+			onCheckout={ goToCheckout }
 			className={ classnames( {
 				'design-setup__has-categories': showDesignPickerCategories,
 			} ) }

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -4,6 +4,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { MShotsImage } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -58,6 +59,7 @@ interface DesignButtonProps {
 	hideDesignTitle?: boolean;
 	hasDesignOptionHeader?: boolean;
 	isPremiumThemeAvailable?: boolean;
+	onCheckout?: any;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -70,6 +72,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	hideDesignTitle,
 	hasDesignOptionHeader = true,
 	isPremiumThemeAvailable = false,
+	onCheckout = undefined,
 } ) => {
 	const { __ } = useI18n();
 
@@ -86,6 +89,43 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	) : (
 		<BadgeContainer badgeType={ badgeType } isPremiumThemeAvailable={ isPremiumThemeAvailable } />
 	);
+
+	const shouldUpgrade = design.is_premium && ! isPremiumThemeAvailable;
+
+	function getPricingDescription() {
+		if ( ! isEnabled( 'signup/theme-preview-screen' ) ) {
+			return null;
+		}
+
+		let text: any = __( 'Free' );
+
+		if ( design.is_premium ) {
+			text = createInterpolateElement(
+				shouldUpgrade
+					? sprintf(
+							/* translators: %(price)s - the price of the theme */
+							__( '%(price)s per year or <a>included in the Pro plan</a>' ),
+							{
+								price: design.price,
+							}
+					  )
+					: __( 'Included in the Pro plan' ),
+				{
+					a: (
+						<a
+							href="javascript:void(0)"
+							onClick={ ( e ) => {
+								e.stopPropagation();
+								onCheckout?.();
+							} }
+						/>
+					),
+				}
+			);
+		}
+
+		return <div className="design-picker__pricing-description">{ text }</div>;
+	}
 
 	return (
 		<button
@@ -133,6 +173,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 					) }
 					{ badgeContainer }
 				</span>
+				{ getPricingDescription() }
 			</span>
 		</button>
 	);
@@ -234,6 +275,7 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 			) }
 			<DesignButton
 				{ ...props }
+				isPremiumThemeAvailable={ isPremiumThemeAvailable }
 				onSelect={ previewOnly ? onPreview : noop }
 				disabled={ ! isBlankCanvas && ! previewOnly }
 			/>
@@ -262,6 +304,7 @@ export interface DesignPickerProps {
 	isPremiumThemeAvailable?: boolean;
 	previewOnly?: boolean;
 	hasDesignOptionHeader?: boolean;
+	onCheckout?: any;
 }
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
@@ -287,6 +330,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isPremiumThemeAvailable,
 	previewOnly = false,
 	hasDesignOptionHeader = true,
+	onCheckout = undefined,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const filteredDesigns = useMemo( () => {
@@ -331,6 +375,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						isPremiumThemeAvailable={ isPremiumThemeAvailable }
 						previewOnly={ previewOnly }
 						hasDesignOptionHeader={ hasDesignOptionHeader }
+						onCheckout={ onCheckout }
 					/>
 				) ) }
 			</div>

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -104,17 +104,18 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 				shouldUpgrade
 					? sprintf(
 							/* translators: %(price)s - the price of the theme */
-							__( '%(price)s per year or <a>included in the Pro plan</a>' ),
+							__( '%(price)s per year or <button>included in the Pro plan</button>' ),
 							{
 								price: design.price,
 							}
 					  )
 					: __( 'Included in the Pro plan' ),
 				{
-					a: (
-						<a
-							href="javascript:void(0)"
-							onClick={ ( e ) => {
+					button: (
+						<Button
+							isLink={ true }
+							className="design-picker__button-link"
+							onClick={ ( e: any ) => {
 								e.stopPropagation();
 								onCheckout?.();
 							} }

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -222,12 +222,17 @@
 		font-weight: 500; /* stylelint-disable-line scales/font-weights */
 		margin-top: -0.1em;
 	}
-	
+
 	.design-picker__pricing-description {
 		text-align: left;
 		color: #50575e;
 		z-index: 1;
 		position: absolute;
+	}
+
+
+	.design-picker__button-link.components-button.is-link {
+		text-decoration: none;
 	}
 }
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -222,6 +222,13 @@
 		font-weight: 500; /* stylelint-disable-line scales/font-weights */
 		margin-top: -0.1em;
 	}
+	
+	.design-picker__pricing-description {
+		text-align: left;
+		color: #50575e;
+		z-index: 1;
+		position: absolute;
+	}
 }
 
 // dark theme styles

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -52,7 +52,7 @@ export function useThemeDesignsQuery(
 	);
 }
 
-function apiThemeToDesign( { id, name, taxonomies, stylesheet }: any ): Design {
+function apiThemeToDesign( { id, name, taxonomies, stylesheet, price }: any ): Design {
 	// Designs use a "featured" term in the theme_picks taxonomy. For example: Blank Canvas
 	const isFeaturedPicks = !! taxonomies?.theme_picks?.find(
 		( { slug }: any ) => slug === 'featured'
@@ -72,7 +72,7 @@ function apiThemeToDesign( { id, name, taxonomies, stylesheet }: any ): Design {
 		is_featured_picks: isFeaturedPicks,
 		showFirst: isFeaturedPicks,
 		...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
-		design_type: is_premium ? 'premium' : 'standard',
+		price,
 
 		// Deprecated; used for /start flow
 		stylesheet,

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -42,6 +42,7 @@ export interface Design {
 	showFirst?: boolean; // Whether this design will appear at the top, regardless of category
 	preview?: 'static';
 	design_type?: DesignType;
+	price?: string;
 
 	/** @deprecated used for Gutenboarding (/new flow) */
 	stylesheet?: string;


### PR DESCRIPTION
#### Proposed Changes

* Adds the bottom pricing description as part of the new design for the Design Picker screen.

<img width="1207" alt="Screen Shot 2022-06-29 at 16 34 52" src="https://user-images.githubusercontent.com/1234758/176522274-e65b7040-531a-4200-b200-faf002c0671c.png">

<img width="640" alt="Screen Shot 2022-06-29 at 16 38 33" src="https://user-images.githubusercontent.com/1234758/176522388-850ad488-9c0b-4233-835d-863972279e8f.png">



#### Testing Instructions

* Go to `setup/designSetup?siteSlug=<SITE-SLUG>&flags=signup/theme-preview-screen`.
* You'll see the pricing description below the Design name.

Related to #64715
