### PR TITLE
Fix checkout cancel URL in Jetpack upsell flow

### DIFF
--- a/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
+++ b/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
@@ -104,8 +104,10 @@ export const buildUpsellURL = (
 
 	// If upsell exists
 	if ( product in PURCHASE_FLOW_UPSELLS_MATRIX ) {
-		if ( ! urlQueryArgs.checkoutBackUrl ) {
+		if ( isJetpackCloud() && ! urlQueryArgs.checkoutBackUrl ) {
 			urlQueryArgs.checkoutBackUrl = window.location.href;
+		} else if ( ! urlQueryArgs.cancel_to ) {
+			urlQueryArgs.cancel_to = `${ rootUrl.replace( /\/$/, '' ) }/${ siteSlug || '' }`;
 		}
 
 		return addQueryArgs(


### PR DESCRIPTION
### Changes proposed in this Pull Request

In the Jetpack upsell flow in Calypso blue, emptying the cart redirects the user to the upsell page, while it should redirect them to the pricing page. This PR fixes it.

### Testing instructions

#### Prerequisites

- Make sure you're assigned to the `treatment` variation of the experiment `calypso_jetpack_upsell_page_2022_06`, so that you go through the upsell page.

#### Regression testing

- Visit the pricing page in Jetpack cloud
- Select Backup, and select either product in the upsell page
- In the checkout page, click _Remove from cart_ under the selected item
- You should be redirected back to the pricing page

#### Calypso blue

- Visit the pricing page in Calypso blue, with a Jetpack site selected
- Select Backup, and select either product in the upsell page
- In the checkout page, click _Remove from cart_ under the selected item
- You should be redirected back to the pricing page

