### PR TITLE
Theme Showcase: Add Atomic support for auto-loading homepage modal

### DIFF
--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -300,7 +300,7 @@ export default connect(
 			theme: installingThemeId && getCanonicalTheme( state, siteId, installingThemeId ),
 			isActivating: !! isActivatingTheme( state, siteId ),
 			hasActivated: !! hasActivatedTheme( state, siteId ),
-			hasAutoLoadingHomepage: themeHasAutoLoadingHomepage( state, installingThemeId ),
+			hasAutoLoadingHomepage: themeHasAutoLoadingHomepage( state, installingThemeId, siteId ),
 			isCurrentTheme: isThemeActive( state, installingThemeId, siteId ),
 			isVisible: shouldShowHomepageWarning( state, installingThemeId ),
 		};

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -291,7 +291,7 @@ const ConnectedThanksModal = connect(
 
 		const isAtomic = isSiteAtomic( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
-		const hasAutoLoadingHomepage = themeHasAutoLoadingHomepage( state, currentThemeId );
+		const hasAutoLoadingHomepage = themeHasAutoLoadingHomepage( state, currentThemeId, siteId );
 
 		// Atomic & Jetpack do not have auto-loading-homepage behavior, so we trigger the layout picker for them.
 		const customizeUrl =

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -4,13 +4,10 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import PulsingDot from 'calypso/components/pulsing-dot';
-import { addQueryArgs } from 'calypso/lib/route';
 import getCustomizeOrEditFrontPageUrl from 'calypso/state/selectors/get-customize-or-edit-front-page-url';
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
-import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import shouldCustomizeHomepageWithGutenberg from 'calypso/state/selectors/should-customize-homepage-with-gutenberg';
 import { requestSite } from 'calypso/state/sites/actions';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { clearActivated } from 'calypso/state/themes/actions';
 import {
 	getActiveTheme,
@@ -21,7 +18,6 @@ import {
 	hasActivatedTheme,
 	isWpcomTheme,
 } from 'calypso/state/themes/selectors';
-import { themeHasAutoLoadingHomepage } from 'calypso/state/themes/selectors/theme-has-auto-loading-homepage';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { trackClick } from './helpers';
 import { isFullSiteEditingTheme } from './is-full-site-editing-theme';
@@ -288,19 +284,12 @@ const ConnectedThanksModal = connect(
 
 		// Note: Gutenberg buttons will only show if the homepage is a page.
 		const shouldEditHomepageWithGutenberg = shouldCustomizeHomepageWithGutenberg( state, siteId );
-
-		const isAtomic = isSiteAtomic( state, siteId );
-		const isJetpack = isJetpackSite( state, siteId );
-		const hasAutoLoadingHomepage = themeHasAutoLoadingHomepage( state, currentThemeId, siteId );
-
-		// Atomic & Jetpack do not have auto-loading-homepage behavior, so we trigger the layout picker for them.
-		const customizeUrl =
-			( isAtomic || isJetpack ) && hasAutoLoadingHomepage
-				? addQueryArgs(
-						{ 'new-homepage': true },
-						getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId, isFSEActive )
-				  )
-				: getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId, isFSEActive );
+		const customizeUrl = getCustomizeOrEditFrontPageUrl(
+			state,
+			currentThemeId,
+			siteId,
+			isFSEActive
+		);
 
 		return {
 			siteId,

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -1,4 +1,3 @@
-import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { activateTheme } from 'calypso/state/themes/actions/activate-theme';
 import { installAndActivateTheme } from 'calypso/state/themes/actions/install-and-activate-theme';
@@ -37,9 +36,7 @@ export function activate(
 		 * allowing cancel it if it's desired.
 		 */
 		if (
-			themeHasAutoLoadingHomepage( getState(), themeId ) &&
-			! isJetpackSite( getState(), siteId ) &&
-			! isSiteAtomic( getState(), siteId ) &&
+			themeHasAutoLoadingHomepage( getState(), themeId, siteId ) &&
 			! hasAutoLoadingHomepageModalAccepted( getState(), themeId )
 		) {
 			return dispatch( showAutoLoadingHomepageWarning( themeId ) );

--- a/client/state/themes/selectors/theme-has-auto-loading-homepage.js
+++ b/client/state/themes/selectors/theme-has-auto-loading-homepage.js
@@ -25,7 +25,7 @@ export function themeHasAutoLoadingHomepage( state, themeId, siteId ) {
 		return atomicAutoLoading;
 	}
 
-	//If not, or if not Atomic, fall back to the full `wpcom` library
+	//Fall back to the full `wpcom` library
 	return includes(
 		getThemeTaxonomySlugs( getTheme( state, 'wpcom', themeId ), 'theme_feature' ),
 		'auto-loading-homepage'

--- a/client/state/themes/selectors/theme-has-auto-loading-homepage.js
+++ b/client/state/themes/selectors/theme-has-auto-loading-homepage.js
@@ -10,16 +10,24 @@ import 'calypso/state/themes/init';
  *
  * @param {object} state   Global state tree
  * @param {string} themeId An identifier for the theme
- * @param {number} siteId An identifier for the site
- * @returns {boolean} True if the theme has auto loading homepage. Otherwise, False.
+ * @param {number} siteId  An identifier for the site
+ * @returns {boolean}      True if the theme has auto loading homepage. Otherwise, False.
  */
 export function themeHasAutoLoadingHomepage( state, themeId, siteId ) {
-	if ( siteId && ! isSiteAtomic( state, siteId ) ) {
-		siteId = 'wpcom';
+	const atomic = isSiteAtomic( state, siteId );
+	const atomicAutoLoading = includes(
+		getThemeTaxonomySlugs( getTheme( state, siteId, themeId ), 'theme_feature' ),
+		'auto-loading-homepage'
+	);
+
+	//If the Atomic site has the theme in its library, use that value
+	if ( atomic && atomicAutoLoading ) {
+		return atomicAutoLoading;
 	}
 
+	//If not, or if not Atomic, fall back to the full `wpcom` library
 	return includes(
-		getThemeTaxonomySlugs( getTheme( state, siteId, themeId ), 'theme_feature' ),
+		getThemeTaxonomySlugs( getTheme( state, 'wpcom', themeId ), 'theme_feature' ),
 		'auto-loading-homepage'
 	);
 }

--- a/client/state/themes/selectors/theme-has-auto-loading-homepage.js
+++ b/client/state/themes/selectors/theme-has-auto-loading-homepage.js
@@ -1,4 +1,5 @@
 import { includes } from 'lodash';
+import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 import { getThemeTaxonomySlugs } from 'calypso/state/themes/utils';
 
@@ -9,11 +10,16 @@ import 'calypso/state/themes/init';
  *
  * @param {object} state   Global state tree
  * @param {string} themeId An identifier for the theme
+ * @param {number} siteId An identifier for the site
  * @returns {boolean} True if the theme has auto loading homepage. Otherwise, False.
  */
-export function themeHasAutoLoadingHomepage( state, themeId ) {
+export function themeHasAutoLoadingHomepage( state, themeId, siteId ) {
+	if ( siteId && ! isSiteAtomic( state, siteId ) ) {
+		siteId = 'wpcom';
+	}
+
 	return includes(
-		getThemeTaxonomySlugs( getTheme( state, 'wpcom', themeId ), 'theme_feature' ),
+		getThemeTaxonomySlugs( getTheme( state, siteId, themeId ), 'theme_feature' ),
 		'auto-loading-homepage'
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

* Following up on Andy's work, add the `siteId` param to `themeHasAutoLoadingHomepage` selector so we can check themes for the `auto-loading-homepage` tag whether on `wpcom` or individual Atomic sites
* Remove checks for `isJetpackSite`/`isAtomicSite` when using the auto-loading-homepage action since we no longer want to exclude them.
* Requires upcoming Jetpack changes that should be available to Atomic sites Wed. Jun 19 in https://github.com/Automattic/jetpack/pull/24818
* This shouldn't be deployed until after we have the functionality ready in wpcomsh.

#### Testing Instructions

* Switch to this PR, navigate to `/themes` on your Atomic site.
* Clicking on a theme should pop up the auto-loading home page modal (if the theme supports it -- some themes to try are Appleton, Dorna, Winkel):

<img width="791" alt="Screen Shot 2022-06-28 at 5 12 18 PM" src="https://user-images.githubusercontent.com/2124984/176288919-b6ccd18c-af97-4fbe-b924-f5299987d248.png">

* Older themes (like Dara or Hexa) should not display the modal; they should instead just activate.
* **The actual homepage switch won't work** until we use the new hook introduced in https://github.com/Automattic/jetpack/pull/24818 from within wpcomsh, which will require a separate diff.

Related to 997-gh-Automattic/wpcomsh and https://github.com/Automattic/jetpack/pull/24818 to fix #56869