### PR TITLE
Limited atomic plugins: Fix autoupdate message

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -22,6 +22,7 @@ import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-t
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
+import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 
 import './style.scss';
 
@@ -228,6 +229,7 @@ class PluginItem extends Component {
 						disabled={ this.props.isSelectable }
 						site={ this.props.selectedSite }
 						wporg={ !! this.props.plugin.wporg }
+						isMarketplaceProduct={ this.props.isMarketplaceProduct }
 					/>
 				) }
 			</div>
@@ -319,5 +321,6 @@ export default connect( ( state, { plugin, sites } ) => {
 
 	return {
 		pluginsOnSites: getPluginOnSites( state, siteIds, plugin?.slug ),
+		isMarketplaceProduct: isMarketplaceProduct( state, plugin?.slug ),
 	};
 } )( localize( withLocalizedMoment( PluginItem ) ) );

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -5,6 +5,7 @@ import { get, includes, isEmpty, isEqual, range, reduce, sortBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import SectionHeader from 'calypso/components/section-header';
 import acceptDialog from 'calypso/lib/accept';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
@@ -480,6 +481,7 @@ export class PluginsList extends Component {
 
 		return (
 			<div className="plugins-list">
+				<QueryProductsList />
 				<PluginNotices sites={ this.getPluginsSites() } plugins={ this.props.plugins } />
 				<PluginsListHeader
 					label={ this.props.header }


### PR DESCRIPTION
#### Proposed Changes

* When viewing `/plugins/manage/<site>`, the disabled message for the autoupdate toggle will now correctly indicate that marketplace plugins are automatically managed by us

**BEFORE**
![2022-06-28_15-06](https://user-images.githubusercontent.com/937354/176278141-5ee6fffe-391f-4771-aa61-4d1a804058c4.png)
![2022-06-28_15-06_1](https://user-images.githubusercontent.com/937354/176278154-98f258c6-81c5-4493-adf8-8826d8e5cbe8.png)


**AFTER**
![2022-06-28_15-24](https://user-images.githubusercontent.com/937354/176278313-3c4763d2-a666-467b-84ca-4b3d80a11249.png)



#### Testing Instructions


* Create a starter site with a marketplace plugin ( dtkmj-dL-p2 )
* Visit `/plugins/manage/<site>` and check the reason autoupdates are disabled

