### PR TITLE
Limited atomic plugins: Activate toggle looks for MANAGE_PLUGINS feature

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -13,6 +13,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
+import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
@@ -425,6 +426,7 @@ export class PluginsMain extends Component {
 			<Main wideLayout>
 				<DocumentHead title={ this.props.translate( 'Plugins', { textOnly: true } ) } />
 				<QueryJetpackPlugins siteIds={ this.props.siteIds } />
+				<QuerySiteFeatures siteIds={ this.props.siteIds } />
 				{ this.renderPageViewTracking() }
 				<FixedNavigationHeader
 					className="plugins__page-heading"

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -1,3 +1,4 @@
+import { WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -12,6 +13,8 @@ import SectionHeader from 'calypso/components/section-header';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import getSites from 'calypso/state/selectors/get-sites';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -109,10 +112,15 @@ export class PluginsListHeader extends PureComponent {
 	}
 
 	renderCurrentActionButtons() {
-		const { translate } = this.props;
+		const { hasManagePluginsFeature, translate } = this.props;
+		const buttons = [];
+
+		if ( ! hasManagePluginsFeature ) {
+			return buttons;
+		}
+
 		const isJetpackSelected = this.isJetpackSelected();
 		const needsRemoveButton = this.needsRemoveButton();
-		const buttons = [];
 		const rightSideButtons = [];
 		const leftSideButtons = [];
 		const autoupdateButtons = [];
@@ -368,4 +376,9 @@ export class PluginsListHeader extends PureComponent {
 
 export default connect( ( state ) => ( {
 	allSites: getSites( state ),
+	hasManagePluginsFeature: siteHasFeature(
+		state,
+		getSelectedSiteId( state ),
+		WPCOM_FEATURES_MANAGE_PLUGINS
+	),
 } ) )( localize( PluginsListHeader ) );

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -13,6 +13,7 @@ import SectionHeader from 'calypso/components/section-header';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import getSites from 'calypso/state/selectors/get-sites';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -33,7 +34,9 @@ export class PluginsListHeader extends PureComponent {
 
 	static propTypes = {
 		label: PropTypes.string,
+		hasManagePluginsFeature: PropTypes.bool,
 		isBulkManagementActive: PropTypes.bool,
+		isWpComAtomic: PropTypes.bool,
 		toggleBulkManagement: PropTypes.func.isRequired,
 		updateAllPlugins: PropTypes.func.isRequired,
 		updateSelected: PropTypes.func.isRequired,
@@ -112,10 +115,10 @@ export class PluginsListHeader extends PureComponent {
 	}
 
 	renderCurrentActionButtons() {
-		const { hasManagePluginsFeature, translate } = this.props;
+		const { hasManagePluginsFeature, isWpComAtomic, translate } = this.props;
 		const buttons = [];
 
-		if ( ! hasManagePluginsFeature ) {
+		if ( isWpComAtomic && ! hasManagePluginsFeature ) {
 			return buttons;
 		}
 
@@ -374,11 +377,12 @@ export class PluginsListHeader extends PureComponent {
 	}
 }
 
-export default connect( ( state ) => ( {
-	allSites: getSites( state ),
-	hasManagePluginsFeature: siteHasFeature(
-		state,
-		getSelectedSiteId( state ),
-		WPCOM_FEATURES_MANAGE_PLUGINS
-	),
-} ) )( localize( PluginsListHeader ) );
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		allSites: getSites( state ),
+		hasManagePluginsFeature: siteHasFeature( state, siteId, WPCOM_FEATURES_MANAGE_PLUGINS ),
+		isWpComAtomic: isSiteWpcomAtomic( state, siteId ),
+	};
+} )( localize( PluginsListHeader ) );

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -1,3 +1,4 @@
+import { WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -28,6 +29,7 @@ import {
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import getSites from 'calypso/state/selectors/get-sites';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -516,13 +518,14 @@ export class PluginsList extends Component {
 	}
 
 	getAllowedPluginActions( plugin ) {
+		const { hasManagePlugins } = this.props;
 		const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
 		const hiddenForAutomatedTransfer =
 			this.props.isSiteAutomatedTransfer && includes( autoManagedPlugins, plugin.slug );
 
 		return {
-			autoupdate: ! hiddenForAutomatedTransfer,
-			activation: ! hiddenForAutomatedTransfer,
+			autoupdate: ! hiddenForAutomatedTransfer && hasManagePlugins,
+			activation: ! hiddenForAutomatedTransfer && hasManagePlugins,
 		};
 	}
 
@@ -581,6 +584,7 @@ export default connect(
 			pluginsOnSites: getPluginsOnSites( state, plugins ),
 			selectedSite,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
+			hasManagePlugins: siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS ),
 			inProgressStatuses: getPluginStatusesByType( state, 'inProgress' ),
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, get( selectedSite, 'ID' ) ),
 		};

--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -32,6 +32,7 @@ describe( 'PluginsList', () => {
 				},
 				allSites: sites,
 				hasManagePlugins: true,
+				siteIsAtomic: true,
 			};
 		} );
 

--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -31,6 +31,7 @@ describe( 'PluginsList', () => {
 					jetpack: plugins[ 1 ],
 				},
 				allSites: sites,
+				hasManagePlugins: true,
 			};
 		} );
 


### PR DESCRIPTION
#### Proposed Changes

* When viewing `/plugins/manage/<site>`, the activation toggle will no longer be visible if the MANAGE_PLUGINS feature is missing

**BEFORE**
![2022-06-28_15-52](https://user-images.githubusercontent.com/937354/176285996-e0fc34b2-3c4d-4e0a-8b4a-d6f8adee3bba.png)


**AFTER**
![2022-06-28_15-52_1](https://user-images.githubusercontent.com/937354/176286041-3f0c8843-f0af-4ad6-9021-384ce94819d6.png)

* The 'Edit All' button is removed, too

**BEFORE**
![2022-06-28_16-18](https://user-images.githubusercontent.com/937354/176292331-328411e2-82fe-49c6-bb01-345bed32b98e.png)


**AFTER**
![2022-06-28_16-18_1](https://user-images.githubusercontent.com/937354/176292186-2a0d988d-f6d2-407b-8f79-8730b7db237b.png)



#### Testing Instructions

* Create a starter site with a marketplace plugin ( dtkmj-dL-p2 )
* Visit `/plugins/manage/<site>` and check the activation toggle no longer displays
* A site with a pro plan should continue to display the toggle as before
* Editing `class-wpcom-features.php` on the sandbox to give MANAGE_PLUGINS to the starter plan should restore the toggle

Related to #65028
