### PR TITLE
Tutorials: unblock deployment by not loading new files

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -435,4 +435,5 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_description_links' );
 function load_tutorials() {
 	require_once __DIR__ . '/tutorials/tutorials.php';
 }
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tutorials' );
+// Commented out to simplify non-atomc wpcom deployment, nothing depends on this yet.
+// add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tutorials' );.


### PR DESCRIPTION
Nothing depends on tutorials yet, this will sync up dotcom ETK deploys

#### Proposed Changes

* Don't load Tutorials

#### Testing Instructions

Tests pass


