### PR TITLE
WebPreview: Add timeout period to wait for the embedded page to send messages

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -13,7 +13,7 @@ import Toolbar from './toolbar';
 
 import './style.scss';
 
-const loadingTimeout = 5000;
+const loadingTimeout = 3000;
 const debug = debugModule( 'calypso:web-preview' );
 const noop = () => {};
 
@@ -272,18 +272,20 @@ export default class WebPreviewContent extends Component {
 			debug( 'preview loaded for url:', this.state.iframeUrl );
 		}
 		if ( this.checkForIframeLoadFailure( caller ) ) {
-			if ( this.props.showClose ) {
-				window.open( this.state.iframeUrl, '_blank' );
-				this.props.onClose();
-			} else {
-				// To prevent iframe firing the onload event before the embedded page sends the
-				// partially-loaded message, we add a waiting period here.
-				debug( `preview not loaded yet, waiting ${ loadingTimeout }ms` );
-				this.loadingTimeoutTimer = setTimeout( () => {
-					debug( 'preview loading timeout' );
+			debug( `preview not loaded yet, waiting ${ loadingTimeout }ms` );
+
+			// To prevent iframe firing the onload event before the embedded page sends the
+			// partially-loaded message, we add a waiting period here.
+			this.loadingTimeoutTimer = setTimeout( () => {
+				debug( 'preview loading timeout' );
+
+				if ( this.props.showClose ) {
+					window.open( this.state.iframeUrl, '_blank' );
+					this.props.onClose();
+				} else {
 					window.location.replace( this.state.iframeUrl );
-				}, loadingTimeout );
-			}
+				}
+			}, loadingTimeout );
 		} else {
 			this.setState( { loaded: true, isLoadingSubpage: false } );
 

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -273,6 +273,7 @@ export default class WebPreviewContent extends Component {
 		}
 		if ( this.checkForIframeLoadFailure( caller ) ) {
 			debug( `preview not loaded yet, waiting ${ loadingTimeout }ms` );
+			clearTimeout( this.loadingTimeoutTimer );
 
 			// To prevent iframe firing the onload event before the embedded page sends the
 			// partially-loaded message, we add a waiting period here.


### PR DESCRIPTION
#### Proposed Changes
In the current implementation, the `WebPreview` component will fail if the iframe fires the `load` event before the embedded page dispatches [messages](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage). This PR adds a waiting period to prevent this scenario which can lead to false-positives, where the embedded page successfully loads, but `WebPreview` considers it as a loading failure.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Safari, head to the generated design picker `/setup/designSetup?siteSlug=${site_slug}` with an eligible vertical.
* Open up dev tools, and enter the following line to enable debug messages `localStorage.setItem( 'debug', 'calypso:web-preview' );`
* Refresh the page until you see the following messages:
![Screen Shot 2022-06-29 at 10 36 51 AM](https://user-images.githubusercontent.com/797888/176343318-0787fac3-d0ac-4f6d-9194-c75c6c43e9ad.png)

`preview not loaded yet, waiting 3000ms`: The iframe fired the `load` event first, and we wait if the embedded page dispatches any messages.
`preview loaded before timeout`: The embedded page dispatched a message saying that it has loaded successfully.
 
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#64919](https://github.com/Automattic/wp-calypso/issues/64919)
