### PR TITLE
Reader: Fix incorrect site id after redirecting to log-in page

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -105,7 +105,8 @@ export function redirectLoggedOut( context, next ) {
 	const userLoggedOut = ! isUserLoggedIn( state );
 
 	if ( userLoggedOut ) {
-		const siteFragment = context.params.site || getSiteFragment( context.path );
+		const siteFragment =
+			context.params.site || context.params.blog || getSiteFragment( context.path );
 
 		const loginParameters = {
 			redirectTo: context.path,

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -105,8 +105,8 @@ export function redirectLoggedOut( context, next ) {
 	const userLoggedOut = ! isUserLoggedIn( state );
 
 	if ( userLoggedOut ) {
-		const siteFragment =
-			context.params.site || context.params.blog || getSiteFragment( context.path );
+		const { site, blog, blog_id } = context.params;
+		const siteFragment = site || blog || blog_id || getSiteFragment( context.path );
 
 		const loginParameters = {
 			redirectTo: context.path,

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -318,3 +318,29 @@ export function readFollowingP2( context, next ) {
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 	next();
 }
+
+export async function blogDiscoveryByFeedId( context, next ) {
+	const { blog, feed_id } = context.params;
+
+	// If we have already had blog or we don't have feed_id, call `next()` immediately
+	if ( blog || ! feed_id ) {
+		next();
+		return;
+	}
+
+	// Query the site by feed_id and inject to the context params so that calypso can get correct site
+	// after redirecting the user to log-in page
+	context.queryClient
+		.fetchQuery(
+			[ '/read/feed/', feed_id ],
+			() => wpcom.req.get( `/read/feed/${ feed_id }` ).then( ( res ) => res.blog_ID ),
+			{ meta: { persist: false } }
+		)
+		.then( ( blog_id ) => {
+			context.params.blog = blog_id;
+			next();
+		} )
+		.catch( () => {
+			renderFeedError( context, next );
+		} );
+}

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -337,7 +337,7 @@ export async function blogDiscoveryByFeedId( context, next ) {
 			{ meta: { persist: false } }
 		)
 		.then( ( blog_id ) => {
-			context.params.blog = blog_id;
+			context.params.blog_id = blog_id;
 			next();
 		} )
 		.catch( () => {

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -1,12 +1,14 @@
 import page from 'page';
-import { makeLayout, render as clientRender } from 'calypso/controller';
-import { updateLastRoute, unmountSidebar } from 'calypso/reader/controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/controller';
+import { updateLastRoute, unmountSidebar, blogDiscoveryByFeedId } from 'calypso/reader/controller';
 import { blogPost, feedPost } from './controller';
 
 export default function () {
 	// Feed full post
 	page(
 		'/read/feeds/:feed/posts/:post',
+		blogDiscoveryByFeedId,
+		redirectLoggedOut,
 		updateLastRoute,
 		unmountSidebar,
 		feedPost,
@@ -17,6 +19,7 @@ export default function () {
 	// Blog full post
 	page(
 		'/read/blogs/:blog/posts/:post',
+		redirectLoggedOut,
 		updateLastRoute,
 		unmountSidebar,
 		blogPost,

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import page from 'page';
 import { addMiddleware } from 'redux-dynamic-middlewares';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/controller';
 import {
 	blogListing,
 	feedDiscovery,
@@ -14,6 +14,7 @@ import {
 	readFollowingP2,
 	sidebar,
 	updateLastRoute,
+	blogDiscoveryByFeedId,
 } from './controller';
 
 import './style.scss';
@@ -37,7 +38,15 @@ export default async function () {
 	await lazyLoadDependencies();
 
 	if ( config.isEnabled( 'reader' ) ) {
-		page( '/read', updateLastRoute, sidebar, following, makeLayout, clientRender );
+		page(
+			'/read',
+			redirectLoggedOut,
+			updateLastRoute,
+			sidebar,
+			following,
+			makeLayout,
+			clientRender
+		);
 
 		// Old and incomplete paths that should be redirected to /
 		page( '/read/following', '/read' );
@@ -52,6 +61,8 @@ export default async function () {
 		page( '/read/feeds/:feed_id/posts', incompleteUrlRedirects );
 		page(
 			'/read/feeds/:feed_id',
+			blogDiscoveryByFeedId,
+			redirectLoggedOut,
 			updateLastRoute,
 			prettyRedirects,
 			sidebar,
@@ -66,6 +77,7 @@ export default async function () {
 		page( '/read/blogs/:blog_id/posts', incompleteUrlRedirects );
 		page(
 			'/read/blogs/:blog_id',
+			redirectLoggedOut,
 			updateLastRoute,
 			prettyRedirects,
 			sidebar,
@@ -83,8 +95,25 @@ export default async function () {
 	}
 
 	// Automattic Employee Posts
-	page( '/read/a8c', updateLastRoute, sidebar, forceTeamA8C, readA8C, makeLayout, clientRender );
+	page(
+		'/read/a8c',
+		redirectLoggedOut,
+		updateLastRoute,
+		sidebar,
+		forceTeamA8C,
+		readA8C,
+		makeLayout,
+		clientRender
+	);
 
 	// new P2 Posts
-	page( '/read/p2', updateLastRoute, sidebar, readFollowingP2, makeLayout, clientRender );
+	page(
+		'/read/p2',
+		redirectLoggedOut,
+		updateLastRoute,
+		sidebar,
+		readFollowingP2,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -286,6 +286,7 @@ const sections = [
 		paths: [ '/read' ],
 		module: 'calypso/reader',
 		group: 'reader',
+		enableLoggedOut: true,
 		trackLoadPerformance: true,
 	},
 	{
@@ -299,6 +300,7 @@ const sections = [
 		],
 		module: 'calypso/reader',
 		group: 'reader',
+		enableLoggedOut: true,
 		trackLoadPerformance: true,
 	},
 	{
@@ -306,6 +308,7 @@ const sections = [
 		paths: [ '/read/feeds/[^\\/]+/posts/[^\\/]+', '/read/blogs/[^\\/]+/posts/[^\\/]+' ],
 		module: 'calypso/reader/full-post',
 		group: 'reader',
+		enableLoggedOut: true,
 		trackLoadPerformance: true,
 	},
 	{


### PR DESCRIPTION
#### Proposed Changes

* The `redirectLoggedOut` middleware runs before we register the real path (e.x. `/read/blogs/:blog/posts/:post`), so we cannot get the site id from `context.params`. It leads calypso to get the site id by the last and second-to-last piece but it's not the site id (it might be the post id or the feed id). Hence, this PR enables `enableLoggedOut` for the path starting with `/read` so that we can get the correct site id.
* Besides, the feed-related URLs might not contain the site id. Therefore, this PR also makes a middleware named `blogDiscoveryByFeedId` to resolve the site id by feed id and inject it to `context.params`. Finally, you can see the site id is correct after calypso redirects the user to the log-in page!

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* New Incognito Window without logged-in user
* Go to http://calypso.localhost:3000/read/blogs/3584907/posts/45907, it should redirect to the log-in page with `site=3584907`
* Go to http://calypso.localhost:3000/read/feeds/25823, it should redirect to the log-in page with `site=3584907`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/61729
