### PR TITLE
Signup: Update the copy of the processing screen

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -621,12 +621,15 @@ class Signup extends Component {
 			const domainItem = get( this.props, 'signupDependencies.domainItem', {} );
 			const hasPaidDomain = isDomainRegistration( domainItem );
 			const destination = this.signupFlowController.getDestination();
+			const setupSiteFlowPath = config.isEnabled( 'signup/stepper-flow' )
+				? '/setup'
+				: '/start/setup-site';
 
 			return (
 				<ReskinnedProcessingScreen
 					flowName={ this.props.flowName }
 					hasPaidDomain={ hasPaidDomain }
-					isDestinationSetupSiteFlow={ destination.startsWith( '/start/setup-site' ) }
+					isDestinationSetupSiteFlow={ destination.startsWith( setupSiteFlowPath ) }
 				/>
 			);
 		}

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -31,6 +31,7 @@ const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => 
 				! isDestinationSetupSiteFlow && { title: __( 'Building your site' ) },
 				hasPaidDomain && { title: __( 'Getting your domain' ) },
 				! isDestinationSetupSiteFlow && { title: __( 'Applying design' ) },
+				{ title: __( 'Turning on the lights' ) },
 			];
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Fix `isDestinationSetupSiteFlow` is incorrect as the URL has changed
* Use "Turning on the lights" as the default message for the processing screen

https://user-images.githubusercontent.com/13596067/176382575-71fb1179-77cd-446e-acc3-e85faf418aaa.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start`
* Finish the signup flow and you will see "Turning on the lights" shown on the processing screen

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/65024
