### PR TITLE
HelpCenter: add API call using JPOP::Client

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -104,6 +104,10 @@ class Help_Center {
 		require_once __DIR__ . '/class-wp-rest-help-center-search.php';
 		$controller = new WP_REST_Help_Center_Search();
 		$controller->register_rest_route();
+
+		require_once __DIR__ . '/class-wp-rest-help-center-fetch-post.php';
+		$controller = new WP_REST_Help_Center_Fetch_Post();
+		$controller->register_rest_route();
 	}
 }
 add_action( 'init', array( __NAMESPACE__ . '\Help_Center', 'init' ) );

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -94,11 +94,15 @@ class Help_Center {
 	}
 
 	/**
-	 * Register the WPCOM Block Editor NUX endpoints.
+	 * Register the Help Center endpoints.
 	 */
 	public function register_rest_api() {
 		require_once __DIR__ . '/class-wp-rest-help-center-support-availability.php';
 		$controller = new WP_REST_Help_Center_Support_Availability();
+		$controller->register_rest_route();
+
+		require_once __DIR__ . '/class-wp-rest-help-center-chat-availability.php';
+		$controller = new WP_REST_Help_Center_Chat_Availability();
 		$controller->register_rest_route();
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -101,8 +101,8 @@ class Help_Center {
 		$controller = new WP_REST_Help_Center_Support_Availability();
 		$controller->register_rest_route();
 
-		require_once __DIR__ . '/class-wp-rest-help-center-chat-availability.php';
-		$controller = new WP_REST_Help_Center_Chat_Availability();
+		require_once __DIR__ . '/class-wp-rest-help-center-search.php';
+		$controller = new WP_REST_Help_Center_Search();
 		$controller->register_rest_route();
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -23,6 +23,7 @@ class Help_Center {
 	 */
 	public function __construct() {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_script' ), 100 );
+		add_action( 'rest_api_init', array( $this, 'register_rest_api' ) );
 	}
 
 	/**
@@ -90,6 +91,15 @@ class Help_Center {
 		);
 
 		wp_set_script_translations( 'help-center-script', 'full-site-editing' );
+	}
+
+	/**
+	 * Register the WPCOM Block Editor NUX endpoints.
+	 */
+	public function register_rest_api() {
+		require_once __DIR__ . '/class-wp-rest-help-center-support-availability.php';
+		$controller = new WP_REST_Help_Center_Support_Availability();
+		$controller->register_rest_route();
 	}
 }
 add_action( 'init', array( __NAMESPACE__ . '\Help_Center', 'init' ) );

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-chat-availability.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-chat-availability.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WP_REST_Help_Center_Support_Availability file.
+ * WP_REST_Help_Center_Chat_Availability file.
  *
  * @package A8C\FSE
  */
@@ -11,16 +11,17 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Constants;
 
 /**
- * Class WP_REST_Help_Center_Support_Availability.
+ * Class WP_REST_Help_Center_Chat_Availability.
  */
-class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
+class WP_REST_Help_Center_Chat_Availability extends \WP_REST_Controller {
 	/**
 	 * WP_REST_Help_Center_Support_Availability constructor.
 	 */
 	public function __construct() {
 		$this->namespace                       = 'wpcom/v2';
-		$this->rest_base                       = 'help-center/support-availability';
+		$this->rest_base                       = 'help-center/chat-availability';
 		$this->wpcom_is_site_specific_endpoint = false;
+		$this->wpcom_is_wpcom_only_endpoint    = false;
 		$this->is_wpcom                        = false;
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -38,7 +39,7 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 			array(
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_support_availability' ),
+					'callback'            => array( $this, 'get_chat_availability' ),
 					'permission_callback' => array( $this, 'permission_callback' ),
 				),
 			)
@@ -55,12 +56,12 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 	}
 
 	/**
-	 * Should return the support availability
+	 * Should return the chat availability
 	 *
 	 * @return WP_REST_Response
 	 */
-	public function get_support_availability() {
-		$endpoint = 'help/eligibility/mine/all';
+	public function get_chat_availability() {
+		$endpoint = 'help/eligibility/mine/chat';
 		if ( $this->is_wpcom ) {
 			require_lib( 'wpcom-api-direct' );
 			$request          = array(

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-chat-availability.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-chat-availability.php
@@ -21,7 +21,6 @@ class WP_REST_Help_Center_Chat_Availability extends \WP_REST_Controller {
 		$this->namespace                       = 'wpcom/v2';
 		$this->rest_base                       = 'help-center/chat-availability';
 		$this->wpcom_is_site_specific_endpoint = false;
-		$this->wpcom_is_wpcom_only_endpoint    = false;
 		$this->is_wpcom                        = false;
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -64,7 +63,7 @@ class WP_REST_Help_Center_Chat_Availability extends \WP_REST_Controller {
 		$endpoint = 'help/eligibility/mine/chat';
 		if ( $this->is_wpcom ) {
 			require_lib( 'wpcom-api-direct' );
-			$request          = array(
+			$request  = array(
 				'url'    => sprintf(
 					'%s/%s/v%s/%s',
 					Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
@@ -74,14 +73,20 @@ class WP_REST_Help_Center_Chat_Availability extends \WP_REST_Controller {
 				),
 				'method' => 'GET',
 			);
-			$get_availability = \WPCOM_API_Direct::do_request( $request, null );
+			$response = \WPCOM_API_Direct::do_request( $request, null );
 		} else {
-			$get_availability = Client::wpcom_json_api_request_as_user( $endpoint );
+			$response = Client::wpcom_json_api_request_as_user( $endpoint );
 		}
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
 
 		return rest_ensure_response(
 			array(
-				'get_availability' => $get_availability,
+				'get_availability' => $body,
 			)
 		);
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * WP_REST_Help_Center_Fetch_Post file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WP_REST_Help_Center_Fetch_Post.
+ */
+class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
+	/**
+	 * WP_REST_Help_Center_Fetch_Post constructor.
+	 */
+	public function __construct() {
+		$this->namespace                       = 'wpcom/v2';
+		$this->rest_base                       = 'help-center/fetch-post';
+		$this->wpcom_is_site_specific_endpoint = false;
+		$this->is_wpcom                        = false;
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$this->is_wpcom = true;
+		}
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_post' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Callback to determine whether the request can proceed.
+	 *
+	 * @return boolean
+	 */
+	public function permission_callback() {
+		return current_user_can( 'read' );
+	}
+
+	/**
+	 * Should return the search results
+	 *
+	 * @param \WP_REST_Request $request    The request sent to the API.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_post( \WP_REST_Request $request ) {
+		$blog_id = $request->get_param( 'blog_id' );
+		$post_id = $request->get_param( 'post_id' );
+
+		l( 'ciao' );
+
+		if ( $this->is_wpcom ) {
+			$response = \WPCOM_Help_Search::get_search_results( $blog_id, $post_id );
+		} else {
+			$body = Client::wpcom_json_api_request_as_user( 'help/search?blogId=' . $blog_id );
+			if ( is_wp_error( $body ) ) {
+				return $body;
+			}
+			$response = json_decode( wp_remote_retrieve_body( $body ) );
+		}
+
+		return rest_ensure_response(
+			array(
+				'post' => $response,
+			)
+		);
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
@@ -67,6 +67,7 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 		l( 'ciao' );
 
 		if ( $this->is_wpcom ) {
+			require_once WP_CONTENT_DIR . '/lib/reader-site-post/class.wpcom-reader-site-post.php';
 			$response = \WPCOM_Reader_Site_Post::get_site_post( $blog_id, $post_id );
 		} else {
 			$body = Client::wpcom_json_api_request_as_user( 'help/support/article/' . $blog_id . '/' . $post_id );

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
@@ -67,19 +67,15 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 		l( 'ciao' );
 
 		if ( $this->is_wpcom ) {
-			$response = \WPCOM_Help_Search::get_search_results( $blog_id, $post_id );
+			$response = \WPCOM_Reader_Site_Post::get_site_post( $blog_id, $post_id );
 		} else {
-			$body = Client::wpcom_json_api_request_as_user( 'help/search?blogId=' . $blog_id );
+			$body = Client::wpcom_json_api_request_as_user( 'help/support/article/' . $blog_id . '/' . $post_id );
 			if ( is_wp_error( $body ) ) {
 				return $body;
 			}
 			$response = json_decode( wp_remote_retrieve_body( $body ) );
 		}
 
-		return rest_ensure_response(
-			array(
-				'post' => $response,
-			)
-		);
+		return rest_ensure_response( $response );
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-fetch-post.php
@@ -33,7 +33,7 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 	public function register_rest_route() {
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base,
+			'/' . $this->rest_base,
 			array(
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
@@ -61,16 +61,16 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_post( \WP_REST_Request $request ) {
-		$blog_id = $request->get_param( 'blog_id' );
-		$post_id = $request->get_param( 'post_id' );
-
-		l( 'ciao' );
+		$blog_id = $request['blog_id'];
+		$post_id = $request['post_id'];
 
 		if ( $this->is_wpcom ) {
 			require_once WP_CONTENT_DIR . '/lib/reader-site-post/class.wpcom-reader-site-post.php';
 			$response = \WPCOM_Reader_Site_Post::get_site_post( $blog_id, $post_id );
 		} else {
-			$body = Client::wpcom_json_api_request_as_user( 'help/support/article/' . $blog_id . '/' . $post_id );
+			$body = Client::wpcom_json_api_request_as_user(
+				'/help/support/article/' . $blog_id . '/' . $post_id
+			);
 			if ( is_wp_error( $body ) ) {
 				return $body;
 			}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
@@ -8,7 +8,6 @@
 namespace A8C\FSE;
 
 use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Constants;
 
 /**
  * Class WP_REST_Help_Center_Search.
@@ -58,16 +57,17 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 	 * Should return the search results
 	 *
 	 * @param \WP_REST_Request $request    The request sent to the API.
-	 * 
+	 *
 	 * @return WP_REST_Response
 	 */
-	public function get_search_results( \WP_REST_Request $request) {
-		$query = $request->get_param( 'query' );
+	public function get_search_results( \WP_REST_Request $request ) {
+		$query      = $request->get_param( 'query' );
+		$query_args = $request->get_params();
 
 		if ( $this->is_wpcom ) {
-			$response = \WPCOM_Help_Search::get_search_results( $query );
+			$response = \WPCOM_Help_Search::get_search_results( $query, $query_args );
 		} else {
-			$body = Client::wpcom_json_api_request_as_user( 'help/search/' . $query );
+			$body = Client::wpcom_json_api_request_as_user( 'help/search?query=' . $query );
 			if ( is_wp_error( $body ) ) {
 				return $body;
 			}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
@@ -61,13 +61,14 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_search_results( \WP_REST_Request $request ) {
-		$query      = $request->get_param( 'query' );
-		$query_args = $request->get_params();
+		$query           = $request->get_param( 'query' );
+		$locale          = $request->get_param( 'locale' );
+		$include_post_id = $request->get_param( 'include_post_id' );
 
 		if ( $this->is_wpcom ) {
-			$response = \WPCOM_Help_Search::get_search_results( $query, $query_args );
+			$response = \WPCOM_Help_Search::search_wpcom_support( $query, $locale, $include_post_id );
 		} else {
-			$body = Client::wpcom_json_api_request_as_user( 'help/search?query=' . $query );
+			$body = Client::wpcom_json_api_request_as_user( 'help/search?query=' . $query . '&locale=' . $locale . '&include_post_id=' . $include_post_id );
 			if ( is_wp_error( $body ) ) {
 				return $body;
 			}
@@ -76,7 +77,7 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 
 		return rest_ensure_response(
 			array(
-				'search_results' => $response,
+				'wordpress_support_links' => $response,
 			)
 		);
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
@@ -33,11 +33,23 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 	public function register_rest_route() {
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/(?P<system>\w+)',
+			$this->rest_base . '/all',
 			array(
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_support_availability' ),
+					'callback'            => array( $this, 'get_all_support_eligibility' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/chat',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_chat_support_eligibility' ),
 					'permission_callback' => array( $this, 'permission_callback' ),
 				),
 			)
@@ -54,29 +66,49 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 	}
 
 	/**
-	 * Should return the support availability
-	 *
-	 * @param \WP_REST_Request $request    The request sent to the API.
+	 * Should return the support eligibility
 	 *
 	 * @return WP_REST_Response
 	 */
-	public function get_support_availability( \WP_REST_Request $request ) {
-		$support_system_name = $request->get_param( 'system' );
-
+	public function get_all_support_eligibility() {
 		if ( $this->is_wpcom ) {
-			$response = \WPCOM_Help_Eligibility::check_support_eligibility( $support_system_name );
+			$other_eligibility  = \WPCOM_Help_Eligibility::get_user_other_support_eligibility();
+			$ticket_eligibility = \WPCOM_Help_Eligibility::get_user_tickets_support_eligibility();
+			$chat_eligibility   = \WPCOM_Help_Eligibility::get_user_chat_support_eligibility();
+
+			$response = array(
+				'is_user_eligible_for_upwork'   => $other_eligibility['upwork'],
+				'is_user_eligible_for_directly' => $other_eligibility['directly'],
+				'is_user_eligible_for_tickets'  => $ticket_eligibility['is_user_eligible'],
+				'is_user_eligible_for_chat'     => $chat_eligibility['is_user_eligible'],
+			);
 		} else {
-			$body = Client::wpcom_json_api_request_as_user( 'help/eligibility/' . $support_system_name . '/mine' );
+			$body = Client::wpcom_json_api_request_as_user( 'help/eligibility/all/mine' );
 			if ( is_wp_error( $body ) ) {
 				return $body;
 			}
 			$response = json_decode( wp_remote_retrieve_body( $body ) );
 		}
 
-		return rest_ensure_response(
-			array(
-				'get_availability' => $response,
-			)
-		);
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Should return the chat eligibility
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_chat_support_eligibility() {
+		if ( $this->is_wpcom ) {
+			$response = \WPCOM_Help_Eligibility::get_user_chat_support_eligibility();
+		} else {
+			$body = Client::wpcom_json_api_request_as_user( 'help/eligibility/chat/mine' );
+			if ( is_wp_error( $body ) ) {
+				return $body;
+			}
+			$response = json_decode( wp_remote_retrieve_body( $body ) );
+		}
+
+		return rest_ensure_response( $response );
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
@@ -66,7 +66,7 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 		if ( $this->is_wpcom ) {
 			$response = \WPCOM_Help_Eligibility::check_support_eligibility( $support_system_name );
 		} else {
-			$body = Client::wpcom_json_api_request_as_user( 'help/eligibility/mine/' . $support_system_name );
+			$body = Client::wpcom_json_api_request_as_user( 'help/eligibility/' . $support_system_name . '/mine' );
 			if ( is_wp_error( $body ) ) {
 				return $body;
 			}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
@@ -63,7 +63,7 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 		$endpoint = 'help/eligibility/mine/all';
 		if ( $this->is_wpcom ) {
 			require_lib( 'wpcom-api-direct' );
-			$request          = array(
+			$request  = array(
 				'url'    => sprintf(
 					'%s/%s/v%s/%s',
 					Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
@@ -73,14 +73,20 @@ class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
 				),
 				'method' => 'GET',
 			);
-			$get_availability = \WPCOM_API_Direct::do_request( $request, null );
+			$response = \WPCOM_API_Direct::do_request( $request, null );
 		} else {
-			$get_availability = Client::wpcom_json_api_request_as_user( $endpoint );
+			$response = Client::wpcom_json_api_request_as_user( $endpoint );
 		}
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
 
 		return rest_ensure_response(
 			array(
-				'get_availability' => $get_availability,
+				'get_availability' => $body,
 			)
 		);
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-support-availability.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * WP_REST_Help_Center_Support_Availability file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Connection;
+
+/**
+ * Class WP_REST_Help_Center_Support_Availability.
+ */
+class WP_REST_Help_Center_Support_Availability extends \WP_REST_Controller {
+	/**
+	 * WP_REST_Help_Center_Support_Availability constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'help-center/support-availability';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_support_availability' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Callback to determine whether the request can proceed.
+	 *
+	 * @return boolean
+	 */
+	public function permission_callback() {
+		return current_user_can( 'read' );
+	}
+
+	/**
+	 * Should we show the first post published modal
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_support_availability() {
+		$get_support_availability = Connection\Client::wpcom_json_api_request_as_user( '/help/tickets/all/mine' );
+
+		return rest_ensure_response(
+			array(
+				'get_support_availability' => $get_support_availability,
+			)
+		);
+	}
+}

--- a/client/components/data/query-reader-post/index.jsx
+++ b/client/components/data/query-reader-post/index.jsx
@@ -8,7 +8,7 @@ import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 class QueryReaderPost extends Component {
 	static propTypes = {
 		postKey: PropTypes.object.isRequired,
-		isHelpCenter: PropTypes.boolean,
+		isHelpCenter: PropTypes.bool,
 	};
 
 	componentDidMount() {

--- a/client/components/data/query-reader-post/index.jsx
+++ b/client/components/data/query-reader-post/index.jsx
@@ -8,6 +8,7 @@ import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 class QueryReaderPost extends Component {
 	static propTypes = {
 		postKey: PropTypes.object.isRequired,
+		isHelpCenter: PropTypes.boolean,
 	};
 
 	componentDidMount() {
@@ -19,10 +20,9 @@ class QueryReaderPost extends Component {
 	}
 
 	maybeFetch = () => {
-		const { post, postKey } = this.props;
-
+		const { post, postKey, isHelpCenter } = this.props;
 		if ( isPostKeyLike( postKey ) && ( ! post || post._state === 'minimal' ) ) {
-			this.props.fetchPost( postKey );
+			this.props.fetchPost( postKey, isHelpCenter );
 		}
 	};
 
@@ -34,6 +34,7 @@ class QueryReaderPost extends Component {
 export default connect(
 	( state, ownProps ) => ( {
 		post: getPostByKey( state, ownProps.postKey ),
+		isHelpCenter: ownProps.isHelpCenter,
 	} ),
 	{ fetchPost }
 )( QueryReaderPost );

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -1,6 +1,6 @@
+import apiFetch from '@wordpress/api-fetch';
 import { filter, forEach, compact, partition, get } from 'lodash';
 import { v4 as uuid } from 'uuid';
-import wpcomRequest from 'wpcom-proxy-request';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import wpcom from 'calypso/lib/wp';
 import readerContentWidth from 'calypso/reader/lib/content-width';
@@ -34,17 +34,10 @@ function fetchForKey( postKey, isHelpCenter ) {
 	}
 
 	if ( postKey.blogId ) {
-		const params = new URLSearchParams( {
-			blog_id: postKey.blogId,
-			post_id: postKey.postId,
-		} );
-
 		return isHelpCenter
-			? wpcomRequest( {
-					path: `help-center/fetch-post`,
-					query: params.toString(),
-					apiNamespace: 'wpcom/v2/',
-					apiVersion: '2',
+			? apiFetch( {
+					global: true,
+					path: `/wpcom/v2/help-center/fetch-post?post_id=${ postKey.postId }&blog_id=${ postKey.blogId }`,
 			  } )
 			: wpcom.req.get( `/read/sites/${ postKey.blogId }/posts/${ postKey.postId }`, query );
 	}

--- a/client/state/sites/selectors/is-simple-site.ts
+++ b/client/state/sites/selectors/is-simple-site.ts
@@ -10,6 +10,7 @@ import { AppState } from 'calypso/types';
  * @returns {?boolean}               Whether the current site is a simple site or not
  */
 export default createSelector(
-	( state: AppState, siteId = getSelectedSiteId( state ) ) => ! isJetpackSite( state, siteId ),
+	( state: AppState, siteId = getSelectedSiteId( state ) ) =>
+		siteId ? ! isJetpackSite( state, siteId ) : false,
 	( state: AppState, siteId = getSelectedSiteId( state ) ) => [ isJetpackSite( state, siteId ) ]
 );

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -56,3 +56,4 @@ export {
 export * from './mapped-types';
 export { getContextResults } from './contextual-help/contextual-help';
 export type { LinksForSection } from './contextual-help/contextual-help';
+export * from './contextual-help/constants';

--- a/packages/data-stores/src/support-queries/types.ts
+++ b/packages/data-stores/src/support-queries/types.ts
@@ -23,6 +23,6 @@ export interface HappyChatAvailability {
 
 export interface OtherSupportAvailability {
 	is_user_eligible_for_upwork: boolean;
-	is_user_eligible_for_kayako: boolean;
+	is_user_eligible_for_tickets: boolean;
 	is_user_eligible_for_directly: boolean;
 }

--- a/packages/data-stores/src/support-queries/types.ts
+++ b/packages/data-stores/src/support-queries/types.ts
@@ -5,7 +5,7 @@ interface Availability {
 
 export interface HappyChatAvailability {
 	locale: string;
-	isUserEligible: boolean;
+	is_user_eligible: boolean;
 	supportLevel:
 		| 'free'
 		| 'personal'
@@ -17,7 +17,7 @@ export interface HappyChatAvailability {
 		| 'jetpack-paid'
 		| 'p2-plus';
 	nickname: string;
-	isClosed: boolean;
+	is_chat_closed: boolean;
 	availability: Availability;
 }
 
@@ -25,4 +25,5 @@ export interface OtherSupportAvailability {
 	is_user_eligible_for_upwork: boolean;
 	is_user_eligible_for_tickets: boolean;
 	is_user_eligible_for_directly: boolean;
+	is_user_eligible_for_chat: boolean;
 }

--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -6,10 +6,6 @@ type ResponseType< T extends 'CHAT' | 'OTHER' > = T extends 'CHAT'
 	? HappyChatAvailability
 	: OtherSupportAvailability;
 
-interface APIResponse< T extends 'CHAT' | 'OTHER' > {
-	get_availability: ResponseType< T >;
-}
-
 export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	supportType: SUPPORT_TYPE,
 	enabled = true
@@ -17,11 +13,11 @@ export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >(
 		supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability',
 		async () =>
-			await wpcomRequest< APIResponse< SUPPORT_TYPE > >( {
+			await wpcomRequest( {
 				path: `help-center/support-availability/${ supportType === 'OTHER' ? 'all' : 'chat' }`,
 				apiNamespace: 'wpcom/v2/',
 				apiVersion: '2',
-			} ).then( ( response ) => response?.get_availability ),
+			} ),
 		{
 			enabled,
 			refetchOnWindowFocus: false,

--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -6,6 +6,12 @@ type ResponseType< T extends 'CHAT' | 'OTHER' > = T extends 'CHAT'
 	? HappyChatAvailability
 	: OtherSupportAvailability;
 
+interface Response {
+	get_availability: {
+		body: string;
+	};
+}
+
 export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	supportType: SUPPORT_TYPE,
 	enabled = true
@@ -13,10 +19,14 @@ export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >(
 		supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability',
 		async () =>
-			await wpcomRequest( {
-				path: supportType === 'OTHER' ? '/help/tickets/all/mine' : '/help/olark/mine',
-				apiVersion: '1.1',
-			} ),
+			await wpcomRequest< Response >( {
+				path:
+					supportType === 'OTHER'
+						? 'help-center/support-availability'
+						: 'help-center/chat-availability',
+				apiNamespace: 'wpcom/v2/',
+				apiVersion: '2',
+			} ).then( ( response ) => JSON.parse( response.get_availability.body ) ),
 		{
 			enabled,
 			refetchOnWindowFocus: false,

--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -18,10 +18,7 @@ export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 		supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability',
 		async () =>
 			await wpcomRequest< APIResponse< SUPPORT_TYPE > >( {
-				path:
-					supportType === 'OTHER'
-						? 'help-center/support-availability'
-						: 'help-center/chat-availability',
+				path: `help-center/support-availability/${ supportType === 'OTHER' ? 'all' : 'chat' }`,
 				apiNamespace: 'wpcom/v2/',
 				apiVersion: '2',
 			} ).then( ( response ) => response?.get_availability ),

--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -6,10 +6,8 @@ type ResponseType< T extends 'CHAT' | 'OTHER' > = T extends 'CHAT'
 	? HappyChatAvailability
 	: OtherSupportAvailability;
 
-interface Response {
-	get_availability: {
-		body: string;
-	};
+interface APIResponse< T extends 'CHAT' | 'OTHER' > {
+	get_availability: ResponseType< T >;
 }
 
 export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
@@ -19,14 +17,14 @@ export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >(
 		supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability',
 		async () =>
-			await wpcomRequest< Response >( {
+			await wpcomRequest< APIResponse< SUPPORT_TYPE > >( {
 				path:
 					supportType === 'OTHER'
 						? 'help-center/support-availability'
 						: 'help-center/chat-availability',
 				apiNamespace: 'wpcom/v2/',
 				apiVersion: '2',
-			} ).then( ( response ) => JSON.parse( response.get_availability.body ) ),
+			} ).then( ( response ) => response?.get_availability ),
 		{
 			enabled,
 			refetchOnWindowFocus: false,

--- a/packages/help-center/src/components/help-center-article-content.scss
+++ b/packages/help-center/src/components/help-center-article-content.scss
@@ -1,0 +1,214 @@
+@import '@automattic/typography/styles/variables';
+@import 'calypso/assets/stylesheets/shared/mixins/_breakpoints';
+
+.help-center-article-content__story-content {
+	color: var( --color-neutral-70 );
+	font-size: $font-body;
+	line-height: 1.7;
+	margin: 0;
+	padding-top: 16px;
+	position: relative;
+	overflow-wrap: break-word;
+	word-wrap: break-word;
+
+	h1 {
+		font-size: $font-title-large;
+		font-weight: 600;
+		margin: 0 0 16px;
+	}
+
+	h2 {
+		font-size: $font-title-medium;
+		font-weight: 600;
+		margin: 0 0 8px;
+	}
+
+	h3 {
+		font-size: $font-title-small;
+		font-weight: 600;
+		margin: 0 0 8px;
+	}
+
+	h4 {
+		font-size: $font-title-small;
+		font-weight: 600;
+		margin: 0 0 8px;
+	}
+
+	h5 {
+		font-weight: 600;
+	}
+
+	p, > div {
+		margin: 0 0 24px;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	blockquote {
+		padding: 0 24px 0 32px;
+		margin: 16px 0 32px;
+		border-left: 3px solid var( --color-neutral-0 );
+		color: var( --color-neutral-50 );
+		font-weight: 400;
+		background: transparent;
+	}
+
+	hr {
+		background: var( --color-neutral-0 );
+		margin: 24px 0;
+	}
+
+	img {
+		max-width: 100%;
+		height: auto;
+		display: inline;
+		margin: auto;
+		margin-bottom: 12px;
+	}
+
+	figure img {
+		display: inherit;
+		margin-bottom: 0;
+	}
+
+	audio {
+		display: block;
+		width: 100%;
+		margin: 24px auto;
+	}
+
+	iframe[class^='twitter-'],
+	iframe[class^='instagram-'],
+	.fb_iframe_widget {
+		display: block;
+		margin: 24px auto !important;
+	}
+
+	@include breakpoint-deprecated( '>660px' ) {
+		.alignleft {
+			max-width: 100%;
+			float: left;
+			margin-top: 12px;
+			margin-bottom: 12px;
+			margin-right: 32px;
+		}
+
+		.alignright {
+			max-width: 100%;
+			float: right;
+			margin-top: 12px;
+			margin-bottom: 12px;
+			margin-left: 32px;
+		}
+	}
+
+	@include breakpoint-deprecated( '<660px' ) {
+		.alignleft,
+		.alignright {
+			clear: both;
+			margin-top: 24px;
+			margin-bottom: 24px;
+		}
+	}
+
+	.aligncenter {
+		clear: both;
+		display: block;
+		margin-top: 24px;
+		margin-bottom: 24px;
+	}
+
+	.wp-caption.alignnone {
+		clear: both;
+		display: block;
+		margin-top: 24px;
+		margin-bottom: 24px;
+	}
+
+	.wp-caption {
+		position: relative;
+		max-width: 100%;
+
+		&.alignright {
+			float: right;
+		}
+
+		&.alignleft {
+			float: left;
+		}
+
+		&.alignright,
+		&.alignleft {
+			max-width: 100%;
+
+			@include breakpoint-deprecated( '>660px' ) {
+				max-width: 50%;
+			}
+
+			img.alignright,
+			img.alignleft {
+				float: none;
+			}
+		}
+
+		img {
+			display: block;
+			margin: 0 auto;
+		}
+	}
+
+	.wp-caption-text,
+	figure figcaption,
+	figure .caption,
+	.wp-caption .wp-media-credit {
+		padding: 12px;
+		margin: 0;
+		font-size: $font-body-small;
+		text-align: center;
+		color: var( --color-neutral-40 );
+	}
+
+	// placeholder for videopress videos
+	.video-plh-notice {
+		position: relative;
+		margin-bottom: 24px;
+		padding: 11px 24px;
+		border-radius: 2px;
+		background: var( --color-neutral-0 );
+		box-sizing: border-box;
+		font-size: $font-body-small;
+		line-height: 1.4285;
+		animation: appear 0.3s ease-in-out;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			padding: 13px 48px;
+			font-size: inherit;
+		}
+	}
+
+	sup, sub {
+		vertical-align: baseline;
+		position: relative;
+		font-size: $font-body-extra-small;
+	}
+
+	sup {
+		top: -0.4em;
+	}
+
+	sub {
+		bottom: -0.2em;
+	}
+
+	table th,
+	table td {
+		padding: 10px;
+	}
+
+	img:first-child {
+		margin-top: 0;
+	}
+}

--- a/packages/help-center/src/components/help-center-article-content.tsx
+++ b/packages/help-center/src/components/help-center-article-content.tsx
@@ -1,0 +1,90 @@
+/* eslint-disable no-restricted-imports */
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { SUPPORT_BLOG_ID } from 'calypso/blocks/inline-help/constants';
+import SupportArticleHeader from 'calypso/blocks/support-article-dialog/header';
+import QueryReaderPost from 'calypso/components/data/query-reader-post';
+import QueryReaderSite from 'calypso/components/data/query-reader-site';
+import EmbedContainer from 'calypso/components/embed-container';
+import useSupportArticleAlternatesQuery from 'calypso/data/support-article-alternates/use-support-article-alternates-query';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import Placeholders from './placeholder-lines';
+
+// import './style.scss';
+import './help-center-article-content.scss';
+
+const getPostKey = ( blogId: number, postId: number ) => ( { blogId, postId } );
+
+const useSupportArticleAlternatePostKey = ( blogId: number, postId: number ) => {
+	const supportArticleAlternates = useSupportArticleAlternatesQuery( blogId, postId );
+	if ( supportArticleAlternates.isLoading ) {
+		return null;
+	}
+
+	if ( ! supportArticleAlternates.data ) {
+		return getPostKey( blogId, postId );
+	}
+
+	return getPostKey( supportArticleAlternates.data.blog_id, supportArticleAlternates.data.page_id );
+};
+
+interface ArticleContent {
+	postId: number;
+	blogId?: string | null;
+	articleUrl?: string;
+}
+
+const ArticleContent = ( { postId, blogId, articleUrl }: ArticleContent ) => {
+	const postKey = useSupportArticleAlternatePostKey( +( blogId ?? SUPPORT_BLOG_ID ), postId );
+	const post = useSelector( ( state ) => getPostByKey( state, postKey ) );
+	const isLoading = ! post || ! postKey;
+	const siteId = post?.site_ID;
+	const shouldQueryReaderPost = ! post && postKey;
+
+	useEffect( () => {
+		//If a url includes an anchor, let's scroll this into view!
+		if (
+			typeof window !== 'undefined' &&
+			articleUrl &&
+			articleUrl.indexOf( '#' ) !== -1 &&
+			post?.content
+		) {
+			setTimeout( () => {
+				const anchorId = articleUrl.split( '#' ).pop();
+				if ( anchorId ) {
+					const element = document.getElementById( anchorId );
+					if ( element ) {
+						element.scrollIntoView();
+					}
+				}
+			}, 0 );
+		}
+	}, [ articleUrl, post ] );
+
+	return (
+		<>
+			{ siteId && <QueryReaderSite siteId={ +siteId } /> }
+			{ shouldQueryReaderPost && <QueryReaderPost postKey={ postKey } isHelpCenter /> }
+			<article className="help-center-article-content__story">
+				<SupportArticleHeader post={ post } isLoading={ isLoading } />
+				{
+					isLoading ? (
+						<Placeholders />
+					) : (
+						/*eslint-disable react/no-danger */
+
+						<EmbedContainer>
+							<div
+								className="help-center-article-content__story-content"
+								dangerouslySetInnerHTML={ { __html: post?.content } }
+							/>
+						</EmbedContainer>
+					)
+					/*eslint-enable react/no-danger */
+				}
+			</article>
+		</>
+	);
+};
+
+export default ArticleContent;

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -5,7 +5,7 @@ import { Spinner } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Card } from '@wordpress/components';
 import classnames from 'classnames';
-import { useState, FC } from 'react';
+import { useState, useRef, FC } from 'react';
 import Draggable, { DraggableProps } from 'react-draggable';
 import { MemoryRouter } from 'react-router-dom';
 /**
@@ -53,15 +53,20 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, isLoading } 
 		onAnimationEnd: toggleVisible,
 	};
 
+	// This is a workaround for an issue with Draggable in StrictMode
+	// https://github.com/react-grid-layout/react-draggable/blob/781ef77c86be9486400da9837f43b96186166e38/README.md
+	const nodeRef = useRef( null );
+
 	return (
 		<MemoryRouter>
 			<FeatureFlagProvider>
 				<OptionalDraggable
 					draggable={ ! isMobile }
+					nodeRef={ nodeRef }
 					handle=".help-center__container-header"
 					bounds="body"
 				>
-					<Card className={ classNames } { ...animationProps }>
+					<Card className={ classNames } { ...animationProps } ref={ nodeRef }>
 						<HelpCenterHeader
 							isMinimized={ isMinimized }
 							onMinimize={ () => setIsMinimized( true ) }

--- a/packages/help-center/src/components/help-center-embed-result.tsx
+++ b/packages/help-center/src/components/help-center-embed-result.tsx
@@ -7,9 +7,9 @@ import { Icon, external } from '@wordpress/icons';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation, useHistory } from 'react-router-dom';
-import ArticleContent from 'calypso/blocks/support-article-dialog/dialog-content';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import { BackButton } from './back-button';
+import ArticleContent from './help-center-article-content';
 
 export const HelpCenterEmbedResult: React.FC = () => {
 	const { search } = useLocation();
@@ -60,7 +60,7 @@ export const HelpCenterEmbedResult: React.FC = () => {
 					</Button>
 				</FlexItem>
 			</Flex>
-			<ArticleContent postId={ postId } blogId={ blogId } articleUrl={ null } />
+			{ postId && <ArticleContent postId={ +postId } blogId={ blogId } /> }
 		</div>
 	);
 };

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -1,0 +1,309 @@
+/* eslint-disable no-restricted-imports */
+import { Gridicon } from '@automattic/components';
+import {
+	getContextResults,
+	LinksForSection,
+	SUPPORT_TYPE_ADMIN_SECTION,
+	SUPPORT_TYPE_API_HELP,
+	SUPPORT_TYPE_CONTEXTUAL_HELP,
+} from '@automattic/data-stores';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { speak } from '@wordpress/a11y';
+import { Icon, page as pageIcon, arrowRight } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { debounce } from 'lodash';
+import page from 'page';
+import PropTypes from 'prop-types';
+import { Fragment, useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getAdminHelpResults from 'calypso/state/inline-help/selectors/get-admin-help-results';
+import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
+import { useSiteOption } from 'calypso/state/sites/hooks';
+import { getSectionName } from 'calypso/state/ui/selectors';
+import { useHelpSearchQuery } from '../hooks/use-help-search-query';
+import PlaceholderLines from './placeholder-lines';
+
+interface SearchResult {
+	link: string;
+	title: string | React.ReactChild;
+	icon?: string;
+	post_id?: number;
+}
+
+interface SearchResultsSection {
+	type: string;
+	title: string;
+	results: SearchResult[];
+	condition: boolean;
+}
+
+const noop = () => {
+	return;
+};
+
+function debounceSpeak( { message = '', priority = 'polite', timeout = 800 } ) {
+	return debounce( () => {
+		speak( message, priority );
+	}, timeout );
+}
+
+const loadingSpeak = debounceSpeak( { message: 'Loading search results.', timeout: 1500 } );
+
+const resultsSpeak = debounceSpeak( { message: 'Search results loaded.' } );
+
+const errorSpeak = debounceSpeak( { message: 'No search results found.' } );
+
+const filterManagePurchaseLink = ( hasPurchases: boolean, isPurchasesSection: boolean ) => {
+	if ( hasPurchases || isPurchasesSection ) {
+		return () => true;
+	}
+	return (
+		article:
+			| LinksForSection
+			| {
+					readonly link: string;
+					post_id: number;
+					readonly title: string;
+					readonly description: string;
+			  }
+			| {
+					type: string;
+					link: string;
+					readonly title: string;
+					readonly description: string;
+					post_id?: number;
+			  }
+	) => article.post_id !== 111349;
+};
+
+interface HelpSearchResults {
+	externalLinks?: boolean;
+	onSelect: (
+		event: React.MouseEvent< HTMLAnchorElement, MouseEvent >,
+		result: SearchResult
+	) => void;
+	onAdminSectionSelect?: ( event: React.MouseEvent< HTMLAnchorElement, MouseEvent > ) => void;
+	searchQuery: string;
+	placeholderLines: number;
+	openAdminInNewTab: boolean;
+	location: string;
+}
+
+function HelpSearchResults( {
+	externalLinks = false,
+	onSelect,
+	onAdminSectionSelect = noop,
+	searchQuery = '',
+	placeholderLines,
+	openAdminInNewTab = false,
+	location = 'inline-help-popover',
+}: HelpSearchResults ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const hasPurchases = useSelector( hasCancelableUserPurchases );
+	const sectionName = useSelector( getSectionName );
+	const isPurchasesSection = [ 'purchases', 'site-purchases' ].includes( sectionName );
+	const siteIntent = useSiteOption( 'site_intent' );
+	const rawContextualResults = useMemo(
+		() => getContextResults( sectionName, siteIntent ),
+		[ sectionName, siteIntent ]
+	);
+	const adminResults = useSelector( ( state ) => getAdminHelpResults( state, searchQuery, 3 ) );
+	const contextualResults = rawContextualResults.filter(
+		// Unless searching with Inline Help or on the Purchases section, hide the
+		// "Managing Purchases" documentation link for users who have not made a purchase.
+		filterManagePurchaseLink( hasPurchases, isPurchasesSection )
+	);
+	const { data: searchData, isLoading: isSearching } = useHelpSearchQuery( searchQuery );
+
+	const searchResults = searchData?.wordpress_support_links ?? [];
+	const hasAPIResults = searchResults.length > 0;
+
+	useEffect( () => {
+		// Cancel all queued speak messages.
+		loadingSpeak.cancel();
+		resultsSpeak.cancel();
+		errorSpeak.cancel();
+
+		// If there's no query, then we don't need to announce anything.
+		if ( ! searchQuery ) {
+			return;
+		}
+
+		if ( isSearching ) {
+			loadingSpeak();
+		} else if ( ! hasAPIResults ) {
+			errorSpeak();
+		} else if ( hasAPIResults ) {
+			resultsSpeak();
+		}
+	}, [ isSearching, hasAPIResults, searchQuery ] );
+
+	const onLinkClickHandler = (
+		event: React.MouseEvent< HTMLAnchorElement, MouseEvent >,
+		result: SearchResult,
+		type: string
+	) => {
+		const { link } = result;
+		// check and catch admin section links.
+		if ( type === SUPPORT_TYPE_ADMIN_SECTION && link ) {
+			// record track-event.
+			dispatch(
+				recordTracksEvent( 'calypso_inlinehelp_admin_section_visit', {
+					link: link,
+					search_term: searchQuery,
+					location,
+					section: sectionName,
+				} )
+			);
+
+			// push state only if it's internal link.
+			if ( ! /^http/.test( link ) ) {
+				event.preventDefault();
+				openAdminInNewTab ? window.open( 'https://wordpress.com' + link, '_blank' ) : page( link );
+				onAdminSectionSelect( event );
+			}
+
+			return;
+		}
+
+		onSelect( event, result );
+	};
+
+	const renderHelpLink = ( result: SearchResult, type: string ) => {
+		const { link, title, icon } = result;
+
+		const external = externalLinks && type !== SUPPORT_TYPE_ADMIN_SECTION;
+
+		const LinkIcon = () => {
+			if ( type === 'admin_section' ) {
+				return <Icon icon={ arrowRight } />;
+			}
+
+			if ( icon ) {
+				return <Gridicon icon={ icon } />;
+			}
+
+			return <Icon icon={ pageIcon } />;
+		};
+
+		return (
+			<Fragment key={ link ?? title }>
+				<li className="help-center-search-results__item">
+					<div className="help-center-search-results__cell">
+						<a
+							href={ localizeUrl( link ) }
+							onClick={ ( event ) => {
+								if ( ! external ) {
+									event.preventDefault();
+								}
+								onLinkClickHandler( event, result, type );
+							} }
+							{ ...( external && {
+								target: '_blank',
+								rel: 'noreferrer',
+							} ) }
+						>
+							{ /* Old stuff - leaving this incase we need to quick revert
+							{ icon && <Gridicon icon={ icon } size={ 18 } /> } */ }
+							<LinkIcon />
+							<span>{ preventWidows( decodeEntities( title ) ) }</span>
+						</a>
+					</div>
+				</li>
+			</Fragment>
+		);
+	};
+
+	const renderSearchResultsSection = ( {
+		type,
+		title,
+		results,
+		condition,
+	}: SearchResultsSection ) => {
+		const id = `inline-search--${ type }`;
+
+		return condition ? (
+			<Fragment key={ id }>
+				{ title ? (
+					<h3 id={ id } className="help-center-search-results__title">
+						{ title }
+					</h3>
+				) : null }
+				<ul className="help-center-search-results__list" aria-labelledby={ title ? id : undefined }>
+					{ results.map( ( result ) => renderHelpLink( result, type ) ) }
+				</ul>
+			</Fragment>
+		) : null;
+	};
+
+	const renderSearchSections = () => {
+		const sections = [
+			{
+				type: SUPPORT_TYPE_API_HELP,
+				title: translate( 'Recommended resources' ),
+				results: searchResults.slice( 0, 5 ),
+				condition: ! isSearching && searchResults.length > 0,
+			},
+			{
+				type: SUPPORT_TYPE_CONTEXTUAL_HELP,
+				title: ! searchQuery.length ? translate( 'Recommended resources' ) : '',
+				results: contextualResults.slice( 0, 6 ),
+				condition: ! isSearching && ! searchResults.length && contextualResults.length > 0,
+			},
+			{
+				type: SUPPORT_TYPE_ADMIN_SECTION,
+				title: translate( 'Show me where to' ),
+				results: adminResults,
+				condition: !! searchQuery && adminResults.length > 0,
+			},
+		];
+
+		return sections.map( renderSearchResultsSection );
+	};
+
+	const resultsLabel = hasAPIResults
+		? translate( 'Search Results' )
+		: translate( 'Helpful resources for this section' );
+
+	const renderSearchResults = () => {
+		if ( isSearching && ! searchResults.length && ! adminResults.length ) {
+			return <PlaceholderLines lines={ placeholderLines } />;
+		}
+
+		return (
+			<>
+				{ searchQuery && ! ( hasAPIResults || isSearching ) ? (
+					<p className="help-center-search-results__empty-results">
+						{ translate(
+							'Sorry, there were no matches. Here are some of the most searched for help pages for this section:'
+						) }
+					</p>
+				) : null }
+
+				<div className="help-center-search-results__results" aria-label={ resultsLabel }>
+					{ renderSearchSections() }
+				</div>
+			</>
+		);
+	};
+
+	return (
+		<>
+			<QueryUserPurchases />
+			{ renderSearchResults() }
+		</>
+	);
+}
+
+HelpSearchResults.propTypes = {
+	searchQuery: PropTypes.string,
+	onSelect: PropTypes.func.isRequired,
+	onAdminSectionSelect: PropTypes.func,
+};
+
+export default HelpSearchResults;

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -280,8 +280,7 @@ function HelpSearchResults( {
 				{ searchQuery && ! ( hasAPIResults || isSearching ) ? (
 					<p className="help-center-search-results__empty-results">
 						{ translate(
-							'Sorry, there were no matches. Here are some of the most searched for help pages for this section:',
-							__i18n_text_domain__
+							'Sorry, there were no matches. Here are some of the most searched for help pages for this section:'
 						) }
 					</p>
 				) : null }

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -280,7 +280,8 @@ function HelpSearchResults( {
 				{ searchQuery && ! ( hasAPIResults || isSearching ) ? (
 					<p className="help-center-search-results__empty-results">
 						{ translate(
-							'Sorry, there were no matches. Here are some of the most searched for help pages for this section:'
+							'Sorry, there were no matches. Here are some of the most searched for help pages for this section:',
+							__i18n_text_domain__
 						) }
 					</p>
 				) : null }

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -39,15 +39,100 @@
 			}
 		}
 
-		.inline-help__results {
+		.help-center-search-results__empty-results {
+			padding: 8px 16px 0;
+			margin: 0;
+			font-size: $font-body-small;
+			color: var( --color-text-subtle );
+			font-style: italic;
+			text-align: left;
+		
+			@media screen and ( min-width: 661px ) {
+				font-size: $font-body;
+			}
+		}
+
+		.help-center-search-results__cell {
+			width: 100%;
+		
+			svg {
+				overflow: visible;
+			}
+		}
+
+		.help-center-search-results__results {
+			padding: 8px 0;
+
 			li:last-child {
 				margin-bottom: 40px;
 			}
 
-			.inline-help__results-item {
+			.help-center-search-results__title {
+				font-weight: bold;
+				line-height: 1.4;
+				display: block;
+				padding: 8px 16px;
+				font-size: $font-body-small;
+				text-align: left;
+			
+				&::after {
+					content: ':';
+				}
+			}
+
+			.help-center-search-results__item {
+				margin: 0;
+				font-size: $font-body-small;
+			
+				@media screen and ( min-width: 661px ) {
+					font-size: $font-title-small;
+					line-height: 1.3;
+				}
+			
+				a {
+					text-decoration: underline;
+					font-weight: normal;
+					line-height: 1.4;
+					display: flex;
+					padding: 8px 16px;
+			
+					span {
+						flex-grow: 2;
+					}
+			
+					.gridicon {
+						align-self: baseline;
+						color: var( --color-neutral-light );
+						flex-shrink: 0;
+						margin-right: 8px;
+						position: relative;
+						top: 2px;
+					}
+			
+					&:hover {
+						cursor: pointer;
+						background: var( --color-neutral-0 );
+			
+						.gridicon {
+							color: var( --color-neutral );
+						}
+					}
+			
+					&:focus {
+						background: var( --color-primary );
+						color: var( --color-text-inverted );
+			
+						.gridicon {
+							color: var( --color-text-inverted );
+						}
+					}
+				}
+			}
+
+			.help-center-search-results__item {
 				margin-bottom: 16px;
 
-				.inline-help__results-cell a {
+				.help-center-search-results__cell a {
 					display: flex;
 					text-decoration: none;
 					color: var( --studio-gray-100 );
@@ -74,14 +159,14 @@
  	 * MORE RESOURCES
  	 */
 	.inline-help__more-resources,
-	.inline-help__results-list {
+	.help-center-search-results__list {
 		list-style: none;
 		text-align: left;
 		margin: 0;
 		padding: 0;
 
 		.inline-help__resource-item,
-		.inline-help__results-item {
+		.help-center-search-results__item {
 			margin: 0;
 			margin-bottom: 0.6em;
 			font-size: $font-body-small;
@@ -340,10 +425,10 @@
 				}
 			}
 
-			.inline-help__results-item {
+			.help-center-search-results__item {
 				margin-bottom: 16px;
 
-				.inline-help__results-cell a {
+				.help-center-search-results__cell a {
 					display: flex;
 
 					svg {

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -535,14 +535,14 @@
 			color: var( --studio-yellow-20 );
 		}
 
-		.support-article-dialog__story {
+		.help-center-article-content__story {
 			padding: 0;
 
 			.support-article-dialog__header {
 				margin-bottom: 0;
 			}
 
-			.support-article-dialog__story-content {
+			.help-center-article-content__story-content {
 				.wp-block-quote {
 					background-color: var( --color-neutral-0 );
 					border-left: none;

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -41,7 +41,7 @@
 
 		.help-center-search-results__empty-results {
 			padding: 8px 16px 0;
-			margin: 0;
+			margin: 1em 0;
 			font-size: $font-body-small;
 			color: var( --color-text-subtle );
 			font-style: italic;
@@ -61,17 +61,14 @@
 		}
 
 		.help-center-search-results__results {
-			padding: 8px 0;
-
 			li:last-child {
 				margin-bottom: 40px;
 			}
 
 			.help-center-search-results__title {
-				font-weight: bold;
+				font-weight: 500;
 				line-height: 1.4;
 				display: block;
-				padding: 8px 16px;
 				font-size: $font-body-small;
 				text-align: left;
 			
@@ -94,7 +91,6 @@
 					font-weight: normal;
 					line-height: 1.4;
 					display: flex;
-					padding: 8px 16px;
 			
 					span {
 						flex-grow: 2;
@@ -141,9 +137,9 @@
 					svg {
 						margin-right: 15px;
 						display: block;
-						padding: 8px;
 						background: var( --studio-gray-0 );
 						fill: var( --studio-blue-50 );
+						padding: 8px;
 					}
 
 					span {
@@ -435,7 +431,6 @@
 						margin-right: 15px;
 						border-radius: 2px;
 						display: block;
-						padding: 8px;
 						background: var( --studio-gray-0 );
 						fill: var( --studio-blue-50 );
 					}

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -3,9 +3,9 @@
 import { useState, useCallback } from '@wordpress/element';
 import { useHistory, useLocation } from 'react-router-dom';
 import InlineHelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
-import InlineHelpSearchResults from 'calypso/blocks/inline-help/inline-help-search-results';
-import './help-center-search.scss';
 import { HelpCenterMoreResources } from './help-center-more-resources';
+import HelpCenterSearchResults from './help-center-search-results';
+import './help-center-search.scss';
 import { SibylArticles } from './help-center-sibyl-articles';
 
 export const HelpCenterSearch = () => {
@@ -44,7 +44,7 @@ export const HelpCenterSearch = () => {
 				isVisible
 			/>
 			{ searchQuery && (
-				<InlineHelpSearchResults
+				<HelpCenterSearchResults
 					onSelect={ redirectToArticle }
 					searchQuery={ searchQuery }
 					openAdminInNewTab

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -5,7 +5,6 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useSupportAvailability } from '@automattic/data-stores';
-import apiFetch from '@wordpress/api-fetch';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createPortal, useEffect, useRef } from '@wordpress/element';
 import { useSelector } from 'react-redux';
@@ -22,10 +21,6 @@ import { SITE_STORE } from './help-center-contact-form';
 import HelpCenterContainer from './help-center-container';
 
 import '../styles.scss';
-
-apiFetch( { path: '/wpcom/v2/help-center/support-availability' } ).then( ( result ) =>
-	console.log( result )
-);
 
 const HelpCenter: React.FC< Container > = ( { handleClose } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable no-restricted-imports */
+/* eslint-disable no-console */
 /**
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useSupportAvailability } from '@automattic/data-stores';
+import apiFetch from '@wordpress/api-fetch';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createPortal, useEffect, useRef } from '@wordpress/element';
 import { useSelector } from 'react-redux';
@@ -20,6 +22,10 @@ import { SITE_STORE } from './help-center-contact-form';
 import HelpCenterContainer from './help-center-container';
 
 import '../styles.scss';
+
+apiFetch( { path: '/wpcom/v2/help-center/support-availability' } ).then( ( result ) =>
+	console.log( result )
+);
 
 const HelpCenter: React.FC< Container > = ( { handleClose } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;

--- a/packages/help-center/src/components/index.d.ts
+++ b/packages/help-center/src/components/index.d.ts
@@ -1,7 +1,12 @@
-declare module 'calypso/blocks/support-article-dialog/dialog-content' {
-	const ArticleContent: FC< { postId: number; blogId: number | null; articleUrl: string | null } >;
-	export = ArticleContent;
+declare module 'calypso/blocks/support-article-dialog/header' {
+	const SupportArticleHeader: FC< {
+		postId: number;
+		blogId: number | null;
+		articleUrl: string | null;
+	} >;
+	export default ArticleContent;
 }
+
 declare module 'calypso/components/search-card' {
 	const SearchCard: FC;
 	export = SearchCard;
@@ -21,6 +26,34 @@ declare module 'calypso/components/data/query-user-purchases' {
 	export const purchases: void;
 	export = QueryUserPurchases;
 }
+
+declare module 'calypso/components/data/query-reader-post' {
+	const QueryReaderPost: FC;
+	export default QueryReaderPost;
+}
+
+declare module 'calypso/components/data/query-reader-site' {
+	const QueryReaderSite: FC;
+	export default QueryReaderSite;
+}
+
+declare module 'calypso/components/embed-container' {
+	const EmbedContainer: FC;
+	export default EmbedContainer;
+}
+
+declare module 'calypso/data/support-article-alternates/use-support-article-alternates-query' {
+	const useSupportArticleAlternatesQuery: (
+		blogId: number,
+		postId: number
+	) => { isLoading: boolean; data?: { blog_id: number; page_id: number } };
+	export default useSupportArticleAlternatesQuery;
+}
+
+declare module 'calypso/state/reader/posts/selectors' {
+	export const getPostByKey;
+}
+
 declare module 'calypso/state/purchases/selectors' {
 	export const getUserPurchases: ( state: unknown ) => { productSlug: string }[];
 }

--- a/packages/help-center/src/components/index.d.ts
+++ b/packages/help-center/src/components/index.d.ts
@@ -55,10 +55,36 @@ declare module 'calypso/state/selectors/has-cancelable-user-purchases' {
 }
 
 declare module 'calypso/state/inline-help/selectors/get-admin-help-results' {
-	const getAdminHelpResults: ( state: unknown ) => unknown[];
+	const getAdminHelpResults: (
+		state: unknown,
+		searchQuery: string,
+		limit: number
+	) => {
+		title: string;
+		description: string;
+		link: string;
+		synonyms: string[];
+		icon: string;
+	}[];
 	export default getAdminHelpResults;
 }
 
-declare module '@automattic/state-utils' {
-	export const createSelector = unknown;
+declare module 'calypso/lib/formatting' {
+	export const decodeEntities: ( text: string | React.ReactChild ) => string;
+	export const preventWidows: ( text: string, wordsToKeep?: number ) => string;
+}
+
+declare module 'calypso/state/analytics/actions' {
+	export const recordTracksEvent: (
+		name: string,
+		properties: unknown
+	) => {
+		type: string;
+		meta: {
+			analytics: {
+				type: string;
+				payload: unknown;
+			}[];
+		};
+	};
 }

--- a/packages/help-center/src/components/placeholder-lines.scss
+++ b/packages/help-center/src/components/placeholder-lines.scss
@@ -1,0 +1,54 @@
+// PlaceholderLines component
+.placeholder-lines__help-center {
+	margin: 16px;
+	min-height: 120px;
+}
+
+.placeholder-lines__help-center-item {
+	height: 16px;
+	margin: 16px 0;
+	border-radius: 16px; /* stylelint-disable-line scales/radii */
+	background-color: var( --color-neutral-0 );
+	color: transparent;
+	animation: placeholder-lines__help-center-loading 2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 ) infinite;
+	animation-delay: 0s;
+
+	&:nth-child( 1 ) {
+		animation-delay: -1.3s;
+	}
+
+	&:nth-child( 2 ) {
+		animation-delay: -2.5s;
+	}
+
+	&:nth-child( 3 ) {
+		animation-delay: -3.8s;
+	}
+
+	&::after {
+		content: '\00a0';
+	}
+}
+
+@keyframes placeholder-lines__help-center-loading {
+	0% {
+		opacity: 0.3;
+		width: 65%;
+	}
+	25% {
+		opacity: 0.6;
+		width: 90%;
+	}
+	50% {
+		opacity: 0.5;
+		width: 18%;
+	}
+	75% {
+		opacity: 0.8;
+		width: 75%;
+	}
+	100% {
+		opacity: 0.3;
+		width: 65%;
+	}
+}

--- a/packages/help-center/src/components/placeholder-lines.tsx
+++ b/packages/help-center/src/components/placeholder-lines.tsx
@@ -1,0 +1,11 @@
+import './placeholder-lines.scss';
+
+export default function PlaceholderLines( { lines = 4 } ) {
+	return (
+		<div className="placeholder-lines__help-center">
+			{ Array.from( { length: lines }, ( _, n ) => (
+				<div key={ n } className="placeholder-lines__help-center-item" />
+			) ) }
+		</div>
+	);
+}

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -2,6 +2,13 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useQuery } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { LinksForSection } from '@automattic/data-stores';
+
+interface APIResponse {
+	search_results: {
+		wordpress_support_links: LinksForSection[];
+	};
+}
+
 export const useHelpSearchQuery = (
 	search: string,
 	queryOptions: Record< string, unknown > = {}
@@ -19,12 +26,12 @@ export const useHelpSearchQuery = (
 	return useQuery< { wordpress_support_links: LinksForSection[] } >(
 		[ 'help', search ],
 		() =>
-			wpcomRequest( {
+			wpcomRequest< APIResponse >( {
 				path: 'help-center/search',
 				query: params.toString(),
 				apiNamespace: 'wpcom/v2/',
 				apiVersion: '2',
-			} ),
+			} ).then( ( response ) => response?.search_results ),
 		{
 			enabled: !! search,
 			...queryOptions,

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -1,0 +1,33 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useQuery } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { LinksForSection } from '@automattic/data-stores';
+export const useHelpSearchQuery = (
+	search: string,
+	queryOptions: Record< string, unknown > = {}
+) => {
+	const locale = useLocale();
+	const params = new URLSearchParams( {
+		include_post_id: '1',
+		locale,
+	} );
+
+	if ( search ) {
+		params.append( 'query', search );
+	}
+
+	return useQuery< { wordpress_support_links: LinksForSection[] } >(
+		[ 'help', search ],
+		() =>
+			wpcomRequest( {
+				path: 'help-center/search',
+				query: params.toString(),
+				apiNamespace: 'wpcom/v2/',
+				apiVersion: '2',
+			} ),
+		{
+			enabled: !! search,
+			...queryOptions,
+		}
+	);
+};

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -1,30 +1,17 @@
-import { useLocale } from '@automattic/i18n-utils';
+import apiFetch from '@wordpress/api-fetch';
 import { useQuery } from 'react-query';
-import wpcomRequest from 'wpcom-proxy-request';
 import type { LinksForSection } from '@automattic/data-stores';
 
 export const useHelpSearchQuery = (
 	search: string,
 	queryOptions: Record< string, unknown > = {}
 ) => {
-	const locale = useLocale();
-	const params = new URLSearchParams( {
-		include_post_id: '1',
-		locale,
-	} );
-
-	if ( search ) {
-		params.append( 'query', search );
-	}
-
 	return useQuery< { wordpress_support_links: LinksForSection[] } >(
 		[ 'help', search ],
 		() =>
-			wpcomRequest( {
-				path: 'help-center/search',
-				query: params.toString(),
-				apiNamespace: 'wpcom/v2/',
-				apiVersion: '2',
+			apiFetch( {
+				global: true,
+				path: `/wpcom/v2/help-center/search?query=${ search }`,
 			} ),
 		{
 			enabled: !! search,

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -3,12 +3,6 @@ import { useQuery } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { LinksForSection } from '@automattic/data-stores';
 
-interface APIResponse {
-	search_results: {
-		wordpress_support_links: LinksForSection[];
-	};
-}
-
 export const useHelpSearchQuery = (
 	search: string,
 	queryOptions: Record< string, unknown > = {}
@@ -26,12 +20,12 @@ export const useHelpSearchQuery = (
 	return useQuery< { wordpress_support_links: LinksForSection[] } >(
 		[ 'help', search ],
 		() =>
-			wpcomRequest< APIResponse >( {
+			wpcomRequest( {
 				path: 'help-center/search',
 				query: params.toString(),
 				apiNamespace: 'wpcom/v2/',
 				apiVersion: '2',
-			} ).then( ( response ) => response?.search_results ),
+			} ),
 		{
 			enabled: !! search,
 			...queryOptions,

--- a/packages/help-center/src/hooks/use-should-render-chat-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-chat-option.tsx
@@ -11,12 +11,12 @@ export function useShouldRenderChatOption(): Result {
 	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
 	const { available, isLoading } = useHappychatAvailable();
 
-	if ( ! chatStatus?.isUserEligible ) {
+	if ( ! chatStatus?.is_user_eligible ) {
 		return {
 			render: false,
 			isLoading,
 		};
-	} else if ( chatStatus?.isClosed ) {
+	} else if ( chatStatus?.is_chat_closed ) {
 		return {
 			render: true,
 			state: 'CLOSED',

--- a/packages/help-center/src/hooks/use-should-render-email-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-email-option.tsx
@@ -3,7 +3,7 @@ import { useSupportAvailability } from '@automattic/data-stores';
 export function useShouldRenderEmailOption() {
 	const { data: supportAvailability } = useSupportAvailability( 'OTHER' );
 	if (
-		supportAvailability?.is_user_eligible_for_kayako ||
+		supportAvailability?.is_user_eligible_for_tickets ||
 		supportAvailability?.is_user_eligible_for_upwork
 	) {
 		return true;

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -10,7 +10,7 @@ export function useStillNeedHelpURL() {
 
 	// email support is available for all non-free users, let's use it as a proxy for free users
 	// TODO: check purchases instead
-	const isFreeUser = ! supportAvailability?.is_user_eligible_for_kayako;
+	const isFreeUser = ! supportAvailability?.is_user_eligible_for_tickets;
 
 	if ( ! isSimpleSite ) {
 		return 'https://wordpress.com/help/contact';

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -248,7 +248,7 @@ button.button.back-button__help-center.is-borderless {
 	}
 }
 
-.inline-help__results-title,
+.help-center-search-results__title,
 .help-center__section-title {
 	font-size: $font-body-small;
 	font-weight: 500;


### PR DESCRIPTION
## Proposed Changes

This is an experiment to add an API call using `wpcom_json_api_request_as_user` from `Automattic\Jetpack\Connection\Client`.

Along with this we will need to ensure all our API endpoints use v2 and are whitelisted with `	'allow_jetpack_site_auth' => true`