### PR TITLE
Emails: FIx Modal template

### DIFF
--- a/client/blocks/jitm/templates/modal-style.scss
+++ b/client/blocks/jitm/templates/modal-style.scss
@@ -41,12 +41,12 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 		button.components-button {
 			span {
 				.components-popover.components-tooltip {
-					left: unset!important;
+					left: unset !important;
 					right: -48px;
 
 					.components-popover__content {
-						overflow: visible!important;
-						max-width: unset!important;
+						overflow: visible !important;
+						max-width: unset !important;
 					}
 				}
 			}

--- a/client/blocks/jitm/templates/modal-style.scss
+++ b/client/blocks/jitm/templates/modal-style.scss
@@ -37,6 +37,20 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 	.components-modal__header {
 		display: flex;
 		position: absolute;
+
+		button.components-button {
+			span {
+				.components-popover.components-tooltip {
+					left: unset!important;
+					right: -48px;
+
+					.components-popover__content {
+						overflow: visible!important;
+						max-width: unset!important;
+					}
+				}
+			}
+		}
 	}
 
 	.components-guide__container {

--- a/client/blocks/jitm/templates/modal.jsx
+++ b/client/blocks/jitm/templates/modal.jsx
@@ -70,7 +70,6 @@ export default function ModalTemplate( {
 								<h1 className="modal__heading">{ message }</h1>
 								<p className="modal__text">
 									{ description }
-									<br />
 									<Button
 										href={ CTA.link }
 										isPrimary={ true }
@@ -78,6 +77,7 @@ export default function ModalTemplate( {
 											onClick();
 											setDismissed( isDismissed.concat( [ featureClass ] ) );
 										} }
+										tabindex={ -2 }
 									>
 										{ CTA.message }
 									</Button>


### PR DESCRIPTION
#### Proposed Changes

Fixes #65069

The modal template for JITM had several issues lingering around. After @Automattic/letero team has started to use it, we realised that there were exactly 2 issues with the modal.

1. The close modal button was not displayed correctly, and it was by default selected. So once the JITM was displayed, the button was focused and tooltip was shown.
2. The second issue is only FIREFOX related, where the text in the body is not correctly displayed as there were an extra BR tag that should not be there.

I did not find any other possible fix where the `!imporant` tag is not involved, and I mostly discourage using it unless it is totally impossible to find any other override for the CSS rule. Any feedback on that is appreciated.

#### Testing Instructions

For testing this you need a new site with a domain, where you have not bought yet any Email subscription yet.
As soon as you enter in your dashboard this popup should appear.

![image](https://user-images.githubusercontent.com/5689927/176416943-f2ad9984-be96-40f9-bf6c-0a4d16703848.png)
![image](https://user-images.githubusercontent.com/5689927/176427529-87f42c78-c319-4be5-9556-cc712ddef9cc.png)



For reference, the old behavior was presented in this way:
![image](https://user-images.githubusercontent.com/5689927/176417076-4deb1812-2188-4068-8d25-057630639cfa.png)
