### PR TITLE
Google Sign-in: Migrate the Redirect flow to the new Google Identity Services API

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -68,7 +68,6 @@ class GoogleLoginButton extends Component {
 					auth_code: this.props.authCodeFromRedirect,
 					redirect_uri: this.props.redirectUri,
 				} );
-				return;
 			}
 
 			this.initializeGoogleSignIn();

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -13,6 +13,7 @@ import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/stat
 import { isFormDisabled } from 'calypso/state/login/selectors';
 import { getErrorFromHTTPError, postLoginRequest } from 'calypso/state/login/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 
 let auth2InitDone = false;
 
@@ -62,7 +63,16 @@ class GoogleLoginButton extends Component {
 
 	componentDidMount() {
 		if ( config.isEnabled( 'migration/sign-in-with-google' ) ) {
+			if ( this.props.authCodeFromRedirect ) {
+				this.handleAuthorizationCode( {
+					auth_code: this.props.authCodeFromRedirect,
+					redirect_uri: this.props.redirectUri,
+				} );
+				return;
+			}
+
 			this.initializeGoogleSignIn();
+
 			return;
 		}
 
@@ -87,7 +97,7 @@ class GoogleLoginButton extends Component {
 					return;
 				}
 
-				this.handleAuthorizationCode( response.code );
+				this.handleAuthorizationCode( { auth_code: response.code } );
 			},
 		} );
 
@@ -182,13 +192,14 @@ class GoogleLoginButton extends Component {
 		return this.initialized;
 	}
 
-	async handleAuthorizationCode( auth_code ) {
+	async handleAuthorizationCode( { auth_code, redirect_uri } ) {
 		let response;
 
 		try {
 			response = await postLoginRequest( 'exchange-social-auth-code', {
 				service: 'google',
 				auth_code,
+				redirect_uri,
 				client_id: config( 'wpcom_signup_id' ),
 				client_secret: config( 'wpcom_signup_key' ),
 			} );
@@ -341,6 +352,7 @@ class GoogleLoginButton extends Component {
 export default connect(
 	( state ) => ( {
 		isFormDisabled: isFormDisabled( state ),
+		authCodeFromRedirect: getInitialQueryArguments( state ).code,
 	} ),
 	{
 		recordTracksEvent,


### PR DESCRIPTION
### Proposed Changes

* Include the Google Sign-in redirection flow based on #64957 .

### Testing Instructions

- Check the testing instructions in #64957 are still working.

#### Prepare your sandbox
- Apply this diff if not deployed yet: D83472-code
- Apply this patch on your sanbox. This will open the like pop-up using wpcalypso url:
```diff
diff --git a/wp-content/js/likes-rest-nojquery.js b/wp-content/js/likes-rest-nojquery.js
index b61bdbb028b..2d95c0575ab 100644
--- a/wp-content/js/likes-rest-nojquery.js
+++ b/wp-content/js/likes-rest-nojquery.js
@@ -512,6 +512,8 @@ var wpLikes;
 				url += '&blog_id=' + encodeURIComponent( wpLikes.login_blog_id );
 			}
 
+			url = 'https://wpcalypso.wordpress.com/log-in?flags=migration/sign-in-with-google&redirect_to=https%3A%2F%2Fr-login.wordpress.com%2Fpublic.api%2Fconnect%2F%3Faction%3Dverify%26service%3Dwordpress%26blog_id%3D207969163&action=highlander-login&signup_flow=account'
+
 			extWin = window.open(
 				url,
 				'likeconn',
```
- Sandbox the static files ( s0.wp.com, s1.wp.com, s2.wp.com), this is to load `likes-rest-nojquery.js` from your sandbox.

#### Prepare your localhost
- Run `bin/calypso-secrets .config/secrets.php` in your WordPress.com sandbox;
- Copy the output of the script to `config/secrets.json` in your wp-calypso checkout;
- Apply this diff to force the redirection in any case:
```diff
diff --git a/client/blocks/login/login-form.jsx b/client/blocks/login/login-form.jsx
index e635c6dac7..1d264a1d11 100644
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -231,7 +231,7 @@ export class LoginForm extends Component {
 		}

 		// disable for oauth2 flows for now
-		return ! oauth2Client && isPopup;
+		return ( ! oauth2Client && isPopup ) || true;
 	}

 	savePasswordRef = ( input ) => {
```
- Build this branch with `NODE_ENV=production CALYPSO_ENV=production yarn run build`;
- Run these commands in the Calypso root folder so you can SSL the local version you just built:

```sh
openssl req \
    -newkey rsa:2048 \
    -x509 \
    -nodes \
    -keyout ./config/server/key.pem \
    -new \
    -out ./config/server/certificate.pem \
    -subj /CN=wordpress.com \
    -reqexts SAN \
    -extensions SAN \
    -config <(cat /System/Library/OpenSSL/openssl.cnf \
     <(printf '[SAN]\nsubjectAltName=DNS:wpcalypso.wordpress.com')) \
    -sha256 \
    -days 365
 
# Add it to the trusted certificates
sudo security add-trusted-cert -d -k $(security list-keychains | grep System | cut -d '"' -f 2 ) ./config/server/certificate.pem
```

- Kick off the server with `NODE_ENV=production HOST=wpcalypso.wordpress.com PORT=443 PROTOCOL=https CALYPSO_ENV=wpcalypso BUILD_TRANSLATION_CHUNKS=true node build/server.js`;
- Proxy `wpcalypso.wordpress.com` to `127.0.0.1`;

#### Verify the new redirection flow works

- Open an incognito window where you are not logged in WP.
- Access to any post with the like button activated. For example: pe4Chl-u-p2
- Click on the like button.
- Observe a new window is open to log-in to WP.
- This URL usually points to wordpress.com but in this case you should see wpcalypso.wordpress.com with the flag `migration/sign-in-with-google`
- The url should be very similar to this one:
  - `https://wpcalypso.wordpress.com/log-in?flags=migration/sign-in-with-google&redirect_to=https%3A%2F%2Fr-login.wordpress.com%2Fpublic.api%2Fconnect%2F%3Faction%3Dverify%26service%3Dwordpress%26blog_id%3D207969163&action=highlander-login&signup_flow=account`
- Open the dev tools  and observe that the google warning doesn't appear.
- Paste this code in the dev tools console `document.cookie='G_AUTH2_MIGRATION=informational'`
- Click on the Google Button `Continue with Google`
- Observe you are redirected to the google auth. No other popup is open.
- Complete the google flow
- Observe the popup closes and you are logged in the main window.

It should connect the account successfully.  The network tab in the DevTools should show that both the calls to `/wp-login.php?action=exchange-social-auth-code` and `/me/social-login/connect` were issued successfully.

<!--
#### Try again
- Go to `https://wpcalypso.wordpress.com/me/security/social-login?flags=migration/sign-in-with-google`
- Click `Disconnect` to unlink the previously connected Google account;
- Open the DevTools;
- Check that the feature was activated by the `Config flag enabled via URL: migration/sign-in-with-google` message in the console;
- Check that the deprecation notice is not there anymore;
- Click on `Connect` and choose an account not yet linked to any WPCOM account.
!-->

Solves #64789