### PR TITLE
Emails: Thank you pages are not correctly redirecting the user to the embedded Inbox page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
@@ -1,11 +1,13 @@
-import { Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { getTitanEmailUrl, useTitanAppsUrlPrefix } from 'calypso/lib/titan';
 import DomainMappingProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-mapping';
 import DomainRegistrationThankYouProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration';
 import DomainTransferProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-transfer';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
-import { emailManagementPurchaseNewEmailAccount } from 'calypso/my-sites/email/paths';
+import {
+	emailManagementInbox,
+	emailManagementPurchaseNewEmailAccount,
+} from 'calypso/my-sites/email/paths';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import type { ThankYouNextStepProps } from 'calypso/components/thank-you/types';
 import type {
@@ -23,17 +25,21 @@ const thankYouContentGetter: Record< DomainThankYouType, DomainThankYouPropsGett
 export default thankYouContentGetter;
 
 interface StepCTAProps {
-	domainType: DomainThankYouType;
+	siteName: string;
 	email?: string;
 	primary: boolean;
 }
 
-const StepCTA = ( { email, primary, domainType }: StepCTAProps ) => {
+const StepCTA = ( { email, primary, siteName }: StepCTAProps ) => {
 	const titanAppsUrlPrefix = useTitanAppsUrlPrefix();
+
+	const redirectUrl = `${ window.location.protocol }//${
+		window.location.host
+	}${ emailManagementInbox( siteName ) }`;
 
 	return (
 		<FullWidthButton
-			href={ getTitanEmailUrl( titanAppsUrlPrefix, email, true ) }
+			href={ getTitanEmailUrl( titanAppsUrlPrefix, email, true, redirectUrl ) }
 			primary={ primary }
 			onClick={ () => {
 				recordEmailAppLaunchEvent( {
@@ -44,7 +50,6 @@ const StepCTA = ( { email, primary, domainType }: StepCTAProps ) => {
 			} }
 		>
 			{ translate( 'Go to Inbox' ) }
-			<Gridicon className={ `domain-${ domainType }__icon-external` } icon="external" />
 		</FullWidthButton>
 	);
 };
@@ -97,6 +102,6 @@ export function buildDomainStepForProfessionalEmail(
 		stepKey: `domain_${ domainType }_whats_next_email_setup_view_inbox`,
 		stepTitle: translate( 'Access your inbox' ),
 		stepDescription: translate( 'Access your email from anywhere with our webmail.' ),
-		stepCta: <StepCTA email={ email } primary={ primary } domainType={ domainType } />,
+		stepCta: <StepCTA siteName={ selectedSiteSlug } email={ email } primary={ primary } />,
 	};
 }

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -112,6 +112,7 @@ function findPurchaseAndDomain( purchases, predicate ) {
 export class CheckoutThankYou extends Component {
 	static propTypes = {
 		domainOnlySiteFlow: PropTypes.bool.isRequired,
+		email: PropTypes.string,
 		failedPurchases: PropTypes.array,
 		isSimplified: PropTypes.bool,
 		receiptId: PropTypes.number,
@@ -371,7 +372,7 @@ export class CheckoutThankYou extends Component {
 	};
 
 	render() {
-		const { translate, isHappychatEligible } = this.props;
+		const { translate, isHappychatEligible, email } = this.props;
 		let purchases = [];
 		let failedPurchases = [];
 		let wasJetpackPlanPurchased = false;
@@ -475,12 +476,12 @@ export class CheckoutThankYou extends Component {
 				purchases
 			);
 
+			const emailFallback = email ? email : this.props.user?.email;
+
 			return (
 				<DomainThankYou
 					domain={ domainName }
-					email={
-						professionalEmailPurchase ? professionalEmailPurchase.meta : this.props.user?.email
-					}
+					email={ professionalEmailPurchase ? professionalEmailPurchase.meta : emailFallback }
 					hasProfessionalEmail={ wasTitanEmailProduct }
 					hideProfessionalEmailStep={ wasGSuiteOrGoogleWorkspace }
 					selectedSiteSlug={ this.props.selectedSiteSlug }
@@ -491,6 +492,7 @@ export class CheckoutThankYou extends Component {
 			return (
 				<TitanSetUpThankYou
 					domainName={ purchases[ 0 ].meta }
+					emailAddress={ email }
 					subtitle={ translate( 'You will receive an email confirmation shortly.' ) }
 					title={ translate( 'Congratulations on your purchase!' ) }
 				/>

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/get-thank-you-page-url.ts
@@ -8,6 +8,7 @@ import {
 	getPlan,
 	isPlan,
 	isWpComPremiumPlan,
+	isTitanMail,
 } from '@automattic/calypso-products';
 import {
 	URL_TYPE,
@@ -376,10 +377,24 @@ function getFallbackDestination( {
 			return `/plans/my-plan/${ siteSlug }?thank-you=true&install=all`;
 		}
 
+		const getSimpleThankYouUrl = (): string => {
+			debug( 'attempt to add extra information as url query string' );
+			const titanProducts = cart?.products?.filter( ( product ) => isTitanMail( product ) );
+
+			if ( titanProducts && titanProducts.length > 0 ) {
+				const emails = titanProducts[ 0 ].extra?.email_users;
+
+				if ( emails && emails.length > 0 ) {
+					return `/checkout/thank-you/${ siteSlug }/${ pendingOrReceiptId }?email=${ emails[ 0 ].email }`;
+				}
+			}
+			return `/checkout/thank-you/${ siteSlug }/${ pendingOrReceiptId }`;
+		};
+
 		const siteWithReceiptOrCartUrl =
 			feature && isValidFeatureKey( feature )
 				? `/checkout/thank-you/features/${ feature }/${ siteSlug }/${ pendingOrReceiptId }`
-				: `/checkout/thank-you/${ siteSlug }/${ pendingOrReceiptId }`;
+				: getSimpleThankYouUrl();
 		debug( 'site with receipt or cart; feature is', feature );
 
 		return siteWithReceiptOrCartUrl;

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -1067,6 +1067,31 @@ describe( 'getThankYouPageUrl', () => {
 			expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 		} );
 
+		it( 'Is not displayed if Professional Email is in the cart and email query parameter is present', () => {
+			const cart = {
+				products: [
+					{
+						product_slug: TITAN_MAIL_MONTHLY_SLUG,
+						extra: { email_users: [ { email: 'purchased_mailbox@foo.bar' } ] },
+					},
+				],
+			};
+
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				cart,
+				domains,
+				receiptId: '1234abcd',
+				siteSlug: 'foo.bar',
+			} );
+
+			expect( url ).toBe(
+				`/checkout/thank-you/foo.bar/1234abcd?email=${ encodeURIComponent(
+					'purchased_mailbox@foo.bar'
+				) }`
+			);
+		} );
+
 		it( 'Is not displayed if Premium plan is in the cart; we show the business upgrade instead', () => {
 			const cart = {
 				products: [

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -238,15 +238,16 @@ export function checkoutThankYou( context, next ) {
 			<CheckoutThankYouDocumentTitle />
 
 			<CheckoutThankYouComponent
-				receiptId={ receiptId }
-				gsuiteReceiptId={ gsuiteReceiptId }
-				domainOnlySiteFlow={ isEmpty( context.params.site ) }
-				selectedFeature={ context.params.feature }
-				redirectTo={ context.query.redirect_to }
-				upgradeIntent={ context.query.intent }
-				siteUnlaunchedBeforeUpgrade={ context.query.site_unlaunched_before_upgrade === 'true' }
-				selectedSite={ selectedSite }
 				displayMode={ displayMode }
+				domainOnlySiteFlow={ isEmpty( context.params.site ) }
+				email={ context.query.email }
+				gsuiteReceiptId={ gsuiteReceiptId }
+				receiptId={ receiptId }
+				redirectTo={ context.query.redirect_to }
+				selectedFeature={ context.params.feature }
+				selectedSite={ selectedSite }
+				siteUnlaunchedBeforeUpgrade={ context.query.site_unlaunched_before_upgrade === 'true' }
+				upgradeIntent={ context.query.intent }
 			/>
 		</>
 	);

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -281,9 +281,9 @@ export function emailManagementEdit(
 }
 
 /**
- * Retrieves the url of the Inbox page
+ * Retrieves the url of the Inbox page:
  *
- * https://wordpress.com/inbox/:siteName
+ *   https://wordpress.com/inbox/:siteName
  *
  * @param {string|null|undefined} siteName - slug of the current site
  * @returns {string} the corresponding url

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -280,6 +280,14 @@ export function emailManagementEdit(
 	);
 }
 
+/**
+ * Retrieves the url of the Inbox page
+ *
+ * https://wordpress.com/inbox/:siteName
+ *
+ * @param {string|null|undefined} siteName - slug of the current site
+ * @returns {string} the corresponding url
+ */
 export function emailManagementInbox( siteName = null ) {
 	if ( siteName ) {
 		return `/inbox/${ siteName }`;

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -70,7 +70,7 @@ const TitanSetUpThankYou = ( {
 						href={ getTitanEmailUrl(
 							titanAppsUrlPrefix,
 							emailAddress,
-							true,
+							false,
 							`${ window.location.protocol }//${ window.location.host }/${ emailManagementPath }`
 						) }
 						primary

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -9,6 +9,7 @@ import { TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP } from 'calypso/lib/titan/co
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import {
 	emailManagement,
+	emailManagementInbox,
 	emailManagementTitanControlPanelRedirect,
 } from 'calypso/my-sites/email/paths';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
@@ -42,6 +43,7 @@ const TitanSetUpThankYou = ( {
 	const translate = useTranslate();
 
 	const emailManagementPath = emailManagement( selectedSiteSlug, domainName, currentRoute );
+	const inboxPath = emailManagementInbox( selectedSiteSlug );
 
 	const thankYouImage = {
 		alt: translate( 'Thank you' ),
@@ -71,7 +73,7 @@ const TitanSetUpThankYou = ( {
 							titanAppsUrlPrefix,
 							emailAddress,
 							false,
-							`${ window.location.protocol }//${ window.location.host }/${ emailManagementPath }`
+							`${ window.location.protocol }//${ window.location.host }${ inboxPath }`
 						) }
 						primary
 						onClick={ () => {


### PR DESCRIPTION
#### Proposed Changes

This change updates the parameters in the URL to pass the previously purchased mailbox. This has to be done in this way because the receipt does not contain that information, that information is only provided in the Response Cart object, and it is removed between the transition from the completed checkout to the thank you page.

#### Testing Instructions

1. Buy a Professional Email subscription
2. On the Thank you Page, click on the "Go to Inbox" button
3. Assert that you are redirected to login into the Professional Email with the email field filled.
4. Buy a domain and add a Professional Email in the upsell step.
5. Complete checkout
6. Check that the "Go to inbox" button redirects you to the Professional Email client with the correct mailbox you bought.

Professional Email (Upgrade -> Email flow)
![image](https://user-images.githubusercontent.com/5689927/176447366-cc141cbf-17c5-471c-b943-8e9d197fd772.png)

Domains upsell flow (Upgrade -> Domain)
![image](https://user-images.githubusercontent.com/5689927/176650412-6c7a2a53-c5f5-49eb-bc8d-af672f28c4d3.png)
