### PR TITLE
Import: Fix import preview X-Frame-Options (#64182)

### DIFF
--- a/client/blocks/import/ready/preview.tsx
+++ b/client/blocks/import/ready/preview.tsx
@@ -1,4 +1,7 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { MShotParams } from '../types';
+import useWindowDimensions from '../windowDimensions.effect';
 import type { FunctionComponent } from 'react';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -10,7 +13,53 @@ interface Props {
 const protocolRgx = /(?<protocol>https?:\/\/)?(?<address>.*)/i;
 
 const ImportPreview: FunctionComponent< Props > = ( { website } ) => {
+	const [ mShotUrl, setMShotUrl ] = useState( '' );
+	const { width } = useWindowDimensions();
+	const mShotParams: MShotParams = {
+		scale: 2,
+		vpw: width <= 640 ? 640 : undefined,
+	};
 	const websiteMatch = website.match( protocolRgx );
+
+	const checkScreenshot = ( screenShotUrl: string ) => {
+		const http = new XMLHttpRequest();
+		http.open( 'GET', screenShotUrl );
+		http.onreadystatechange = () => {
+			if ( http.readyState !== http.HEADERS_RECEIVED ) {
+				return;
+			}
+
+			if ( http.getResponseHeader( 'Content-Type' ) !== 'image/jpeg' ) {
+				setTimeout( () => {
+					checkScreenshot( screenShotUrl );
+				}, 5000 );
+			} else {
+				setMShotUrl( screenShotUrl );
+			}
+		};
+		http.send();
+	};
+
+	checkScreenshot(
+		`https://s0.wp.com/mshots/v1/${ website }?${ Object.entries( mShotParams )
+			.filter( ( entry ) => !! entry[ 1 ] )
+			.map( ( [ key, val ] ) => key + '=' + val )
+			.join( '&' ) }`
+	);
+
+	const Screenshot = () => {
+		if ( mShotUrl !== '' ) {
+			return (
+				<img src={ mShotUrl } alt="Website screenshot preview" className={ 'import__screenshot' } />
+			);
+		}
+
+		return (
+			<div className="import__screenshot-loading">
+				<LoadingEllipsis />
+			</div>
+		);
+	};
 
 	return (
 		<div className={ `import__preview` }>
@@ -30,14 +79,7 @@ const ImportPreview: FunctionComponent< Props > = ( { website } ) => {
 						) }
 					</div>
 				}
-				{ /* iframe-mask is a transparent cover it disallows the user to navigate inside iframed website */ }
-				<div className="import__preview-iframe-mask" />
-				<iframe
-					title={ 'Preview' }
-					className="import__preview-iframe"
-					src={ website }
-					loading="eager"
-				/>
+				<Screenshot />
 			</div>
 		</div>
 	);

--- a/client/blocks/import/ready/style.scss
+++ b/client/blocks/import/ready/style.scss
@@ -115,30 +115,6 @@
 			}
 		}
 	}
-
-	.import__preview-iframe {
-		overflow: hidden;
-		width: 100%;
-		height: 100vh;
-		border: none;
-		margin-top: 15px;
-
-		@include break-small {
-			margin-top: 30px;
-		}
-	}
-
-	.import__preview-iframe-mask {
-		position: absolute;
-		width: 100%;
-		top: 15px;
-		height: calc( 100% - 15px );
-
-		@include break-small {
-			top: 35px;
-			height: calc( 100% - 35px );
-		}
-	}
 }
 
 .import__details-modal.components-modal__frame {


### PR DESCRIPTION
#### Proposed Changes

- Regarding the x-frame-options headers setting in other websites, it's unable to show a site preview via iframe.
- Revert import preview screenshot back to using mShots implementation. 

#### Testing Instructions

1. navigate to `/setup/import?siteSlug={SLUG}`.
2. Type in a site address with `x-frame-options` set in the header. (e.g. learn.wordpress.org)
3. Hit the enter button and see if the preview screenshot shows up on the page.

https://user-images.githubusercontent.com/4074459/176469862-77cc1c61-e75b-49fd-a1a2-f0acac81823f.mov

Related to #64182
