### PR TITLE
Jetpack Agency Dashboard: Add partner key selection

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
@@ -3,7 +3,9 @@ import page from 'page';
 import { ReactElement, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import SelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/primary/select-partner-key';
 import {
+	hasActivePartnerKey,
 	hasFetchedPartner,
 	isFetchingPartner,
 	isAgencyUser,
@@ -21,6 +23,7 @@ export default function DashboardOverview( {
 }: SitesOverviewContextInterface ): ReactElement {
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
+	const hasActiveKey = useSelector( hasActivePartnerKey );
 	const isAgency = useSelector( isAgencyUser );
 	const isAgencyEnabled = config.isEnabled( 'jetpack/agency-dashboard' );
 
@@ -33,7 +36,11 @@ export default function DashboardOverview( {
 		}
 	}, [ hasFetched, isAgency, isAgencyEnabled ] );
 
-	if ( isAgencyEnabled && hasFetched && isAgency ) {
+	if ( hasFetched && ! hasActiveKey ) {
+		return <SelectPartnerKey />;
+	}
+
+	if ( hasFetched ) {
 		const context = {
 			search,
 			currentPage,

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -1,4 +1,5 @@
 import page from 'page';
+import LicenseSelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/license-select-partner-key';
 import AssignLicense from 'calypso/jetpack-cloud/sections/partner-portal/primary/assign-license';
 import BillingDashboard from 'calypso/jetpack-cloud/sections/partner-portal/primary/billing-dashboard';
 import CompanyDetailsDashboard from 'calypso/jetpack-cloud/sections/partner-portal/primary/company-details-dashboard';
@@ -9,7 +10,6 @@ import Licenses from 'calypso/jetpack-cloud/sections/partner-portal/primary/lice
 import PartnerAccess from 'calypso/jetpack-cloud/sections/partner-portal/primary/partner-access';
 import PaymentMethodAdd from 'calypso/jetpack-cloud/sections/partner-portal/primary/payment-method-add';
 import PaymentMethodList from 'calypso/jetpack-cloud/sections/partner-portal/primary/payment-method-list';
-import SelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/primary/select-partner-key';
 import TermsOfServiceConsent from 'calypso/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent';
 import PartnerPortalSidebar from 'calypso/jetpack-cloud/sections/partner-portal/sidebar';
 import {
@@ -49,7 +49,7 @@ export function termsOfServiceContext( context: PageJS.Context, next: () => void
 
 export function partnerKeyContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
-	context.primary = <SelectPartnerKey />;
+	context.primary = <LicenseSelectPartnerKey />;
 	next();
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/license-select-partner-key/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-select-partner-key/index.tsx
@@ -1,0 +1,41 @@
+import { Spinner } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { ReactElement } from 'react';
+import { useSelector } from 'react-redux';
+import CardHeading from 'calypso/components/card-heading';
+import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
+import Main from 'calypso/components/main';
+import { useReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import SelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/primary/select-partner-key';
+import {
+	isFetchingPartner,
+	getCurrentPartner,
+	hasActivePartnerKey,
+	hasFetchedPartner,
+} from 'calypso/state/partner-portal/partner/selectors';
+import { PartnerKey } from 'calypso/state/partner-portal/types';
+import './style.scss';
+
+export default function LicenseSelectPartnerKey(): ReactElement | null {
+	const translate = useTranslate();
+	const hasKey = useSelector( hasActivePartnerKey );
+	const hasFetched = useSelector( hasFetchedPartner );
+	const isFetching = useSelector( isFetchingPartner );
+	const partner = useSelector( getCurrentPartner );
+	const keys = ( partner?.keys || [] ) as PartnerKey[];
+	const showKeys = hasFetched && ! isFetching && keys.length > 0;
+
+	useReturnUrl( hasKey );
+
+	return (
+		<Main>
+			<QueryJetpackPartnerPortalPartner />
+
+			<CardHeading size={ 36 }>{ translate( 'Licensing' ) }</CardHeading>
+
+			{ isFetching && <Spinner /> }
+
+			{ showKeys && <SelectPartnerKey /> }
+		</Main>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/primary/select-partner-key/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/select-partner-key/index.tsx
@@ -1,61 +1,36 @@
-import { Button, Card, Spinner } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import CardHeading from 'calypso/components/card-heading';
-import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
-import Main from 'calypso/components/main';
-import { useReturnUrl } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setActivePartnerKey } from 'calypso/state/partner-portal/partner/actions';
-import {
-	isFetchingPartner,
-	getCurrentPartner,
-	hasActivePartnerKey,
-	hasFetchedPartner,
-} from 'calypso/state/partner-portal/partner/selectors';
+import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 import { PartnerKey } from 'calypso/state/partner-portal/types';
 import './style.scss';
 
 export default function SelectPartnerKey(): ReactElement | null {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const hasKey = useSelector( hasActivePartnerKey );
-	const hasFetched = useSelector( hasFetchedPartner );
-	const isFetching = useSelector( isFetchingPartner );
 	const partner = useSelector( getCurrentPartner );
 	const keys = ( partner?.keys || [] ) as PartnerKey[];
-	const showKeys = hasFetched && ! isFetching && keys.length > 0;
 
 	const onSelectPartnerKey = ( keyId: number ) => {
 		dispatch( setActivePartnerKey( keyId ) );
 		dispatch( recordTracksEvent( 'calypso_partner_portal_select_partner_key_click' ) );
 	};
 
-	useReturnUrl( hasKey );
-
 	return (
-		<Main className="select-partner-key">
-			<QueryJetpackPartnerPortalPartner />
+		<div className="select-partner-key">
+			<p>{ translate( 'Please select your partner key:' ) }</p>
 
-			<CardHeading size={ 36 }>{ translate( 'Licensing' ) }</CardHeading>
-
-			{ isFetching && <Spinner /> }
-
-			{ showKeys && (
-				<div>
-					<p>{ translate( 'Please select your partner key:' ) }</p>
-
-					{ keys.map( ( key ) => (
-						<Card key={ key.id } className="select-partner-key__card" compact>
-							<div className="select-partner-key__key-name">{ key.name }</div>
-							<Button primary onClick={ () => onSelectPartnerKey( key.id ) }>
-								{ translate( 'Select' ) }
-							</Button>
-						</Card>
-					) ) }
-				</div>
-			) }
-		</Main>
+			{ keys.map( ( key ) => (
+				<Card key={ key.id } className="select-partner-key__card" compact>
+					<div className="select-partner-key__key-name">{ key.name }</div>
+					<Button primary onClick={ () => onSelectPartnerKey( key.id ) }>
+						{ translate( 'Select' ) }
+					</Button>
+				</Card>
+			) ) }
+		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -42,7 +42,6 @@ export function getLicenseState(
  * This is a hack around TypeScript's poor support of enums as types.
  *
  * @example const enumMember = valueToEnum< SomeEnumType >( SomeEnumType, 'foo', SomeEnumType.SomeMember );
- *
  * @template T
  * @param {Record< string, * >} enumType Enum type to search in.
  * @param {*} value The enum value we are looking to get the member for.


### PR DESCRIPTION
#### Proposed Changes

When a user has multiple partner keys the sites will not load on the agency dashboard until one is selected. However there is no mechanism on the agency dashboard for selecting a key so the sites never load in this case.

This PR reuses the mechanism for selecting a partner key in the partner portal to make key selection possible on the agency dashboard.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. If you have a user with multiple partner key accounts, test with that. Alternatively you can comment out the [setActivePartnerKey call in the receivePartner action](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/partner-portal/partner/actions.ts#L67). This will create the same state that results if a user has multiple partner keys.
2. Visit `http://jetpack.cloud.localhost:3001/dashboard`. Verify that the partner key selection displays, and that when you select a key you see the appropriate sites load.
3. Visit `http://jetpack.cloud.localhost:3001/partner-portal/licenses`. Verify that you are redirected to `/partner-portal/partner-key`, and that when you select a key you are redirected back to `/partner-portal/licenses`.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202076982646589-as-1202520562528884