### PR TITLE
Performance: Account for non-Atomic Jetpack sites

### DIFF
--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -94,7 +94,7 @@ class SiteSettingsPerformance extends Component {
 
 				{ showCloudflare && ! siteIsJetpackNonAtomic && <Cloudflare /> }
 
-				{ siteIsJetpack && hasManagePluginsFeature && (
+				{ ( siteIsJetpackNonAtomic || hasManagePluginsFeature ) && (
 					<Fragment>
 						<QueryJetpackModules siteId={ siteId } />
 
@@ -134,7 +134,7 @@ class SiteSettingsPerformance extends Component {
 					</Fragment>
 				) }
 
-				{ siteIsJetpack && hasManagePluginsFeature ? (
+				{ siteIsJetpackNonAtomic || hasManagePluginsFeature ? (
 					<AmpJetpack />
 				) : (
 					<AmpWpcom

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -94,7 +94,7 @@ class SiteSettingsPerformance extends Component {
 
 				{ showCloudflare && ! siteIsJetpackNonAtomic && <Cloudflare /> }
 
-				{ ( siteIsJetpackNonAtomic || hasManagePluginsFeature ) && (
+				{ ( siteIsJetpackNonAtomic || ( siteIsAtomic && hasManagePluginsFeature ) ) && (
 					<Fragment>
 						<QueryJetpackModules siteId={ siteId } />
 
@@ -134,7 +134,7 @@ class SiteSettingsPerformance extends Component {
 					</Fragment>
 				) }
 
-				{ siteIsJetpackNonAtomic || hasManagePluginsFeature ? (
+				{ siteIsJetpackNonAtomic || ( siteIsAtomic && hasManagePluginsFeature ) ? (
 					<AmpJetpack />
 				) : (
 					<AmpWpcom


### PR DESCRIPTION
#### Proposed Changes

* Updates condition to include standalone Jetpack sites and wpcom sites with the Manage Plugins feature.

Before | After
--- | ---
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/1398304/176493195-554e9584-2d78-451e-8275-34e296ca62db.png"> | <img width="1510" alt="image" src="https://user-images.githubusercontent.com/1398304/176493239-dc1c6200-7d80-4d1b-a8c0-0a564513608f.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site on Atomic with a Free, Starter, Personal, or Premium plan.
* Navigate to Settings > Performance ([Calypso Live link](https://container-thirsty-jang.calypso.live/settings/performance))
* Verify that Performance & Speed and AMP sections are not visible.
* Switch to a standalone Jetpack site and make sure they _are_ visible.
* Switch to a WP.com site on Pro, Business, or eCommerce and make sure they still are visible.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #65077
