### PR TITLE
Email Verification: update notice text to be more consistent

### DIFF
--- a/client/me/account/email-not-verified-notice.tsx
+++ b/client/me/account/email-not-verified-notice.tsx
@@ -23,7 +23,7 @@ const EmailNotVerifiedNotice = () => {
 			const result = await resendEmail();
 			if ( result.success ) {
 				dispatch(
-					successNotice( __( 'The verification email has been sent.' ), {
+					successNotice( __( 'Verification email resent. Please check your inbox.' ), {
 						id: resendEmailNotice,
 						duration: 4000,
 					} )
@@ -32,7 +32,7 @@ const EmailNotVerifiedNotice = () => {
 			}
 		} catch ( Error ) {}
 		dispatch(
-			errorNotice( __( 'An error has occurred, please check your connection and retry.' ), {
+			errorNotice( __( "Couldn't resend verification email. Please try again." ), {
 				id: resendEmailNotice,
 			} )
 		);

--- a/client/me/account/test/email-not-verified-notice.js
+++ b/client/me/account/test/email-not-verified-notice.js
@@ -52,7 +52,9 @@ describe( 'EmailNotVerifiedNotice', () => {
 		expect( useSendEmailVerification ).toHaveBeenCalled();
 		await waitFor( () => {
 			expect(
-				dispatch.mock.calls[ 0 ][ 0 ].notice.text.includes( 'The verification email has been sent' )
+				dispatch.mock.calls[ 0 ][ 0 ].notice.text.includes(
+					'Verification email resent. Please check your inbox.'
+				)
 			).toBeTruthy();
 		} );
 	} );
@@ -82,7 +84,7 @@ describe( 'EmailNotVerifiedNotice', () => {
 		await waitFor( () => {
 			expect(
 				dispatch.mock.calls[ 0 ][ 0 ].notice.text.includes(
-					'An error has occurred, please check your connection and retry.'
+					"Couldn't resend verification email. Please try again."
 				)
 			).toBeTruthy();
 		} );


### PR DESCRIPTION
#### Proposed Changes

A small follow-up to #64970 that reuses existing text for the email resend success and error notices.

#### Testing Instructions

- Create a new user and do not verify the email
- Go to `/me/account`
- You should see a notice below the email address field with a link to resend the email.
- Click on "Resend email" and you should see a notice: "Verification email resent. Please check your inbox."
- Block the request in browser dev tools or disconnect your internet and click on "Resend email" again, and you should see a notice: "Couldn't resend verification email. Please try again."

Related to https://github.com/Automattic/wp-calypso/issues/64345
