### PR TITLE
ETK Timeline: Use 'transparent' as `background` when color is removed

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/timeline-item.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/jetpack-timeline/blocks/src/timeline-item.js
@@ -82,8 +82,9 @@ export function registerTimelineItemBlock() {
 								title={ __( 'Color Settings', 'full-site-editing' ) }
 								colorSettings={ [
 									{
-										value: attributes.background,
-										onChange: ( background ) => setAttributes( { background } ),
+										value: attributes.background !== 'transparent' ? attributes.background : '',
+										onChange: ( background ) =>
+											setAttributes( { background: background ? background : 'transparent' } ),
 										label: __( 'Background Color', 'full-site-editing' ),
 									},
 								] }


### PR DESCRIPTION
#### Proposed Changes

When the background color is removed from a Timeline Entry Block, 'transparent' is stored as the `background` attribute value. While somewhat hacky, this prevents the block from ending up as crashed (see detailed explanation in https://github.com/Automattic/wp-calypso/issues/63626#issuecomment-1170591746)

Fixes #63626

#### Testing Instructions

Once the code is applied to your environment with your preferred approach...

1. Add a Timeline block to your Post:

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/36432/176563224-5df7420c-0b39-44f4-a77e-8ea47959d6bf.png">

2. Remove the default background color on the Timeline Entry Block:

<img width="1547" alt="image" src="https://user-images.githubusercontent.com/36432/176563294-e8d891b1-eb74-4eb0-becc-ed4d719fe5e4.png">

3. Observe the transparent background color for the Timeline Entry Block:

<img width="1559" alt="image" src="https://user-images.githubusercontent.com/36432/176563321-e751ab48-d384-4252-ab57-0ecc59d695b8.png">

4. Switch to the Code editor and observe `<!-- wp:jetpack/timeline-item {"background":"transparent"} -->` and `<li style="background-color:transparent" class="wp-block-jetpack-timeline-item">`:

<img width="1338" alt="image" src="https://user-images.githubusercontent.com/36432/176563359-20f8d29b-e997-4038-92d6-59db9917a16e.png">

5. Switch back to the Block editor and observe the Timeline Entry Block in a non-crashed state with no Background Color set:

<img width="1524" alt="image" src="https://user-images.githubusercontent.com/36432/176563468-8a18e16e-0955-4901-aca8-c0e9a24ae4dc.png">

