### PR TITLE
Signup: Add more messages on the processing screen

### DIFF
--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -32,6 +32,8 @@ const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => 
 				hasPaidDomain && { title: __( 'Getting your domain' ) },
 				! isDestinationSetupSiteFlow && { title: __( 'Applying design' ) },
 				{ title: __( 'Turning on the lights' ) },
+				{ title: __( 'Making you cookies' ) },
+				{ title: __( 'Planning the next chess move' ) },
 			];
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Add more messages on the processing screen

https://user-images.githubusercontent.com/13596067/176587382-3e853cf4-b267-4090-a9fb-e9a43a8df812.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start`
* Finish the singup flow
* You will see following messages on the processing screen
  * Turning on the lights
  * Making you cookies
  * Planning the next chess move

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/65024#issuecomment-1169699188
