### PR TITLE
Prevent Safari's bounce scroll to go below the offset threshold

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/preview-toolbar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/preview-toolbar.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { STICKY_OFFSET_TOP } from '@automattic/design-picker';
 import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -61,7 +62,7 @@ const DesignPickerPreviewToolbar = ( {
 			setStickyStyle( {
 				position: 'fixed',
 				// Align with the sticky thumbnails
-				top: '109px',
+				top: `${ STICKY_OFFSET_TOP }px`,
 				left: `${ left }px`,
 				height: `${ headerRef.current.offsetHeight }px`,
 				width: `${ headerRef.current.offsetWidth }px`,

--- a/packages/design-picker/src/components/generated-design-picker.tsx
+++ b/packages/design-picker/src/components/generated-design-picker.tsx
@@ -11,6 +11,7 @@ import {
 	DEFAULT_VIEWPORT_WIDTH,
 	DEFAULT_VIEWPORT_HEIGHT,
 	MOBILE_VIEWPORT_WIDTH,
+	STICKY_OFFSET_TOP,
 } from '../constants';
 import { getDesignPreviewUrl, getMShotOptions } from '../utils';
 import type { Design } from '../types';
@@ -103,7 +104,10 @@ const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
 				return;
 			}
 
-			const offsetTop = wrapperRef.current.offsetTop - window.pageYOffset;
+			const offsetTop = Math.max(
+				wrapperRef.current.offsetTop - window.pageYOffset,
+				STICKY_OFFSET_TOP
+			);
 			wrapperRef.current.style.setProperty( 'height', `calc( 100vh - ${ offsetTop }px` );
 		};
 

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -58,3 +58,8 @@ export const ANCHORFM_FONT_PAIRINGS = [
 export const DEFAULT_VIEWPORT_WIDTH = 1600;
 export const DEFAULT_VIEWPORT_HEIGHT = 1040;
 export const MOBILE_VIEWPORT_WIDTH = 599;
+
+/**
+ * Generated design picker
+ */
+export const STICKY_OFFSET_TOP = 109;

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -18,6 +18,7 @@ export {
 	DEFAULT_VIEWPORT_WIDTH,
 	DEFAULT_VIEWPORT_HEIGHT,
 	MOBILE_VIEWPORT_WIDTH,
+	STICKY_OFFSET_TOP,
 } from './constants';
 export type { FontPair, Design, Category } from './types';
 export { useCategorization } from './hooks/use-categorization';


### PR DESCRIPTION
#### Proposed Changes

This PR addresses the issue where scrolling down the page in Safari would result in wrong calculation of the thumbnail section offset due to the browser's bouncy scroll. To fix this, we set a threshold to prevent the offset value to be affected by the browser's bouncy scroll.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Safari.
* Head to the generated design picker `/setup/designSetup?siteSlug=${site_slug}` using an eligible site vertical.
* Expect the thumbnail and large preview section's "stickiness" to be consistent with other browsers. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #[65073](https://github.com/Automattic/wp-calypso/issues/65073)
