### PR TITLE
Improve flow handling of pre-selected designs

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/site-setup-design-picker.tsx
@@ -47,6 +47,7 @@ const STICKY_OPTIONS = {
  * The site setup design picker
  */
 const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
+	const [ isPreviewingDesign, setIsPreviewingDesign ] = useState( false );
 	const [ isForceStaticDesigns, setIsForceStaticDesigns ] = useState( false );
 	const [ showUpgradeModal, setShowUpgradeModal ] = useState( false );
 	// CSS breakpoints are set at 600px for mobile
@@ -149,7 +150,8 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		[ selectedDesign, generatedDesigns, isMobile ]
 	);
 
-	const isPreviewingGeneratedDesign = isMobile && showGeneratedDesigns && !! selectedDesign;
+	const isPreviewingGeneratedDesign =
+		isMobile && showGeneratedDesigns && selectedDesign && isPreviewingDesign;
 
 	const [ isSticky, setIsSticky ] = useState( false );
 
@@ -268,12 +270,14 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		} );
 
 		setSelectedDesign( _selectedDesign );
+		setIsPreviewingDesign( true );
 	}
 
 	function viewMoreDesigns() {
 		recordTracksEvent( 'calypso_signup_design_view_more_select' );
 
 		setSelectedDesign( undefined );
+		setIsPreviewingDesign( false );
 		setIsForceStaticDesigns( true );
 	}
 
@@ -319,7 +323,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 			intent: intent,
 		};
 
-		if ( ! selectedDesign && isForceStaticDesigns ) {
+		if ( ! isPreviewingDesign && isForceStaticDesigns ) {
 			recordTracksEvent( 'calypso_signup_back_to_generated_design_step' );
 		}
 
@@ -327,8 +331,9 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	}
 
 	const handleBackClick = () => {
-		if ( selectedDesign && ( ! showGeneratedDesigns || isMobile ) ) {
+		if ( isPreviewingDesign && ( ! showGeneratedDesigns || isMobile ) ) {
 			setSelectedDesign( undefined );
+			setIsPreviewingDesign( false );
 			return;
 		}
 
@@ -345,7 +350,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	};
 
 	// Track scroll event to make sure people are scrolling on mobile.
-	useTrackScrollPageFromTop( isMobile && ! selectedDesign, flow || '', STEP_NAME, {
+	useTrackScrollPageFromTop( isMobile && ! isPreviewingDesign, flow || '', STEP_NAME, {
 		is_generated_designs: showGeneratedDesigns,
 	} );
 
@@ -354,7 +359,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 	// 2. Entering/leaving preview mode.
 	useEffect( () => {
 		window.scrollTo( { top: 0 } );
-	}, [ isForceStaticDesigns, !! selectedDesign ] );
+	}, [ isForceStaticDesigns, isPreviewingDesign ] );
 
 	// When the intent is build, we can potentially show the generated design picker.
 	// Don't render until we've fetched the generated designs from the backend.
@@ -362,7 +367,7 @@ const SiteSetupDesignPicker: Step = ( { navigation, flow } ) => {
 		return null;
 	}
 
-	if ( selectedDesign && ! showGeneratedDesigns ) {
+	if ( selectedDesign && isPreviewingDesign && ! showGeneratedDesigns ) {
 		const isBlankCanvas = isBlankCanvasDesign( selectedDesign );
 		const designTitle = isBlankCanvas ? translate( 'Blank Canvas' ) : selectedDesign.title;
 		const shouldUpgrade = selectedDesign.is_premium && ! isPremiumThemeAvailable;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -337,6 +337,15 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 		.generated-design-picker__previews {
 			min-height: calc( 100vh - 172px );
 			margin-bottom: 84px;
+
+			.web-preview__inner {
+				&.is-selected {
+					opacity: 1;
+					pointer-events: auto;
+					position: relative;
+					z-index: 1;
+				}
+			}
 		}
 	}
 
@@ -494,11 +503,13 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 			top: 0;
 			transition: opacity 0.15s ease-in-out;
 
-			&.is-selected {
-				opacity: 1;
-				pointer-events: auto;
-				position: relative;
-				z-index: 1;
+			@include break-small {
+				&.is-selected {
+					opacity: 1;
+					pointer-events: auto;
+					position: relative;
+					z-index: 1;
+				}
 			}
 
 			.preview-toolbar__browser-header {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -303,6 +303,18 @@ $design-button-primary-color: rgb( 17, 122, 201 );
  * Generated Design Picker
  */
 .design-picker__is-generated {
+
+	// Design preview work different between mobile and desktop views.
+	// In mobile, design preview only shows up when in preview mode.
+	// In desktop, design preview is always present next to the thumbnail.
+	// See: https://github.com/Automattic/wp-calypso/issues/65116
+	@mixin generated-design-picker-show-preview {
+		opacity: 1;
+		pointer-events: auto;
+		position: relative;
+		z-index: 1;
+	}
+
 	&.step-container {
 		max-width: none;
 
@@ -340,10 +352,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 			.web-preview__inner {
 				&.is-selected {
-					opacity: 1;
-					pointer-events: auto;
-					position: relative;
-					z-index: 1;
+					@include generated-design-picker-show-preview;
 				}
 			}
 		}
@@ -505,10 +514,7 @@ $design-button-primary-color: rgb( 17, 122, 201 );
 
 			@include break-small {
 				&.is-selected {
-					opacity: 1;
-					pointer-events: auto;
-					position: relative;
-					z-index: 1;
+					@include generated-design-picker-show-preview;
 				}
 			}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -92,7 +92,7 @@ export const siteSetupFlow: Flow = {
 			( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID )
 		);
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
-		const { setPendingAction, setStepProgress, resetGoals, resetIntent } =
+		const { setPendingAction, setStepProgress, resetGoals, resetIntent, resetSelectedDesign } =
 			useDispatch( ONBOARD_STORE );
 		const { setIntentOnSite, setGoalsOnSite } = useDispatch( SITE_STORE );
 		const { FSEActive } = useFSEStatus();
@@ -144,6 +144,7 @@ export const siteSetupFlow: Flow = {
 			// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
 			resetGoals();
 			resetIntent();
+			resetSelectedDesign();
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -273,6 +273,10 @@ export const resetIntent = () => ( {
 	type: 'RESET_INTENT' as const,
 } );
 
+export const resetSelectedDesign = () => ( {
+	type: 'RESET_SELECTED_DESIGN' as const,
+} );
+
 export const setEditEmail = ( email: string ) => ( {
 	type: 'SET_EDIT_EMAIL' as const,
 	email,
@@ -314,5 +318,6 @@ export type OnboardAction = ReturnType<
 	| typeof clearDIFMGoal
 	| typeof resetGoals
 	| typeof resetIntent
+	| typeof resetSelectedDesign
 	| typeof setEditEmail
 >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -106,7 +106,7 @@ const selectedDesign: Reducer< Design | undefined, OnboardAction > = ( state, ac
 	if ( action.type === 'SET_SELECTED_DESIGN' ) {
 		return action.selectedDesign;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( [ 'RESET_SELECTED_DESIGN', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
 		return undefined;
 	}
 	return state;


### PR DESCRIPTION
#### Proposed Changes

This PR improves how onboarding handles users having a pre-selected design, in two ways:
1. By clearing the selected design upon exit flow.
2. By having users having to explicitly click to preview the design.

This solves two areas in the current implementation:
1. The selected design is not reset after the user exits the onboarding flow.
2. Having a pre-selected design, the design picker would immediately show the design preview instead of the thumbnail list/grid, breaking the linearity of the onboarding flow. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test that the selected design is cleared:
* Head to the generated design picker, and pick either the middle or the bottom thumbnail.
* Once in the FSE, head back to the Goals Screen and start the onboarding flow again.
* Expect that when arriving to the generated design picker again, the previously selected design is no longer selected.

To test that the design picker doesn't immediately show the preview if a design has been pre-selected: 
* Head to the design picker, and Preview one of the designs.
* Refresh the page.
* Expect to see the thumbnail grid instead of the full-screen preview.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #65116
