### PR TITLE
Me: Fix JavaScript error in the sidebar

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -70,7 +70,7 @@ class MeSidebar extends Component {
 							onClick={ this.onSignOut }
 							title={ translate( 'Log out of WordPress.com' ) }
 						>
-							<span class="sidebar__me-signout-text">{ translate( 'Log out' ) }</span>
+							<span className="sidebar__me-signout-text">{ translate( 'Log out' ) }</span>
 							<Gridicon icon="popout" size={ 16 } />
 						</Button>
 					</div>


### PR DESCRIPTION
```
react_devtools_backend.js:4026 Warning: Invalid DOM property `class`. Did you mean `className`?
```

<img width="1531" alt="image" src="https://user-images.githubusercontent.com/36432/176671078-d64265ca-b5bd-4a2b-ac14-04136c3c80e1.png">

All I have to blame is myself: https://github.com/Automattic/wp-calypso/blame/910a1d5e43da61b99560ca8bc690f680a195c060/client/me/sidebar/index.jsx#L73

Introduced in #64201

#### Testing Instructions

1. Navigate to `/me` in your local environment.
2. Observe JavaScript error.

