### PR TITLE
Plugins: Remove upgrade banners

### DIFF
--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -42,17 +42,6 @@ jest.mock( '@automattic/languages', () => [
 	},
 ] );
 
-import {
-	PLAN_FREE,
-	PLAN_BUSINESS,
-	PLAN_BUSINESS_2_YEARS,
-	PLAN_PREMIUM,
-	PLAN_PREMIUM_2_YEARS,
-	PLAN_PERSONAL,
-	PLAN_PERSONAL_2_YEARS,
-	PLAN_BLOGGER,
-	PLAN_BLOGGER_2_YEARS,
-} from '@automattic/calypso-products';
 import { mount } from 'enzyme';
 import { merge } from 'lodash';
 import { Provider } from 'react-redux';
@@ -78,7 +67,7 @@ const initialReduxState = {
 	},
 	ui: { selectedSiteId: 1 },
 	sites: {
-		items: { 1: { ID: 1, title: 'Test Site', plan: { productSlug: PLAN_FREE } } },
+		items: { 1: { ID: 1, title: 'Test Site' } },
 		connection: { items: { 1: true } },
 	},
 	currentUser: { capabilities: { 1: { manage_options: true } } },
@@ -125,79 +114,10 @@ describe( 'Search view', () => {
 	} );
 } );
 
-describe( 'Upsell Nudge should get appropriate plan constant', () => {
-	[ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( ( product_slug ) => {
-		test( `Business 1 year for (${ product_slug })`, () => {
-			const comp = mountWithRedux( <PluginsBrowser />, {
-				sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
-			} );
-			expect(
-				comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-			).toBe( 1 );
-			expect(
-				comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
-			).toBe( PLAN_BUSINESS );
-		} );
-	} );
-
-	[ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ].forEach(
-		( product_slug ) => {
-			test( `Business 2 year for (${ product_slug })`, () => {
-				const comp = mountWithRedux( <PluginsBrowser />, {
-					sites: { items: { 1: { jetpack: false, plan: { product_slug } } } },
-				} );
-				expect(
-					comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-				).toBe( 1 );
-				expect(
-					comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
-				).toBe( PLAN_BUSINESS_2_YEARS );
-			} );
-		}
-	);
-} );
-
 describe( 'PluginsBrowser basic tests', () => {
 	test( 'should not blow up and have proper CSS class', () => {
 		const comp = mountWithRedux( <PluginsBrowser /> );
 		expect( comp.find( 'main' ).length ).toBe( 1 );
-	} );
-	test( 'should show upsell nudge when appropriate', () => {
-		const comp = mountWithRedux( <PluginsBrowser /> );
-		expect(
-			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-		).toBe( 1 );
-	} );
-	test( 'should not show upsell nudge if no site is selected', () => {
-		const comp = mountWithRedux( <PluginsBrowser />, { ui: { selectedSiteId: null } } );
-		expect(
-			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-		).toBe( 0 );
-	} );
-	test( 'should not show upsell nudge if no sitePlan', () => {
-		const comp = mountWithRedux( <PluginsBrowser />, {
-			ui: { selectedSiteId: 10 },
-			sites: { items: { 10: { ID: 10, plan: null } } },
-		} );
-		expect(
-			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-		).toBe( 0 );
-	} );
-	test( 'should not show upsell nudge if non-atomic jetpack site', () => {
-		const comp = mountWithRedux( <PluginsBrowser />, {
-			sites: { items: { 1: { jetpack: true } } },
-		} );
-		expect(
-			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-		).toBe( 0 );
-	} );
-	test( 'should not show upsell nudge has business plan', () => {
-		const comp = mountWithRedux( <PluginsBrowser />, {
-			sites: { items: { 1: { jetpack: true, plan: { productSlug: PLAN_PREMIUM } } } },
-		} );
-		expect(
-			comp.find( 'upsell-nudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
-		).toBe( 0 );
 	} );
 	test( 'should show notice if site is not connected to wpcom', () => {
 		const comp = mountWithRedux( <PluginsBrowser />, {


### PR DESCRIPTION
#### Proposed Changes

As advised in https://github.com/Automattic/wp-calypso/issues/65025, this PR removes the upgrade banners displayed in the Plugins browser page, while @vinimotaa works on re-designing the overall UX/flow of this page.

Before | After
--- | ---
<img width="1646" alt="Screen Shot 2022-06-30 at 15 38 13" src="https://user-images.githubusercontent.com/1233880/176692698-4b9197b5-9c83-4dae-9782-c430015524f9.png"> | <img width="1646" alt="Screen Shot 2022-06-30 at 15 37 34" src="https://user-images.githubusercontent.com/1233880/176692724-79a8906c-e438-4b6f-b6fc-098af5c244b6.png">


#### Testing Instructions

- Use the Calypso live link below.
- Go to Plugins.
- Mare sure there are no upgrade banners.
