### PR TITLE
Add `signup/goals-step-2` feature flag to all config .json files

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -148,7 +148,7 @@
 		"signup/design-picker-generated-designs": true,
 		"signup/inline-help": false,
 		"signup/goals-step": true,
-		"signup/goals-step-2": true,
+		"signup/goals-step-2": false,
 		"signup/hero-flow-non-en": true,
 		"signup/site-vertical-step": true,
 		"signup/starting-point-courses": true,

--- a/config/development.json
+++ b/config/development.json
@@ -148,6 +148,7 @@
 		"signup/design-picker-generated-designs": true,
 		"signup/inline-help": false,
 		"signup/goals-step": true,
+		"signup/goals-step-2": true,
 		"signup/hero-flow-non-en": true,
 		"signup/site-vertical-step": true,
 		"signup/starting-point-courses": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -95,6 +95,7 @@
 		"signup/design-picker-generated-designs": true,
 		"signup/inline-help": false,
 		"signup/goals-step": true,
+		"signup/goals-step-2": false,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": true,

--- a/config/production.json
+++ b/config/production.json
@@ -108,6 +108,7 @@
 		"signup/design-picker-generated-designs": true,
 		"signup/inline-help": false,
 		"signup/goals-step": true,
+		"signup/goals-step-2": false,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/site-vertical-step": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -107,6 +107,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-generated-designs": true,
 		"signup/goals-step": true,
+		"signup/goals-step-2": false,
 		"signup/inline-help": false,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,6 +119,7 @@
 		"signup/design-picker-generated-designs": true,
 		"signup/inline-help": false,
 		"signup/goals-step": true,
+		"signup/goals-step-2": false,
 		"signup/hero-flow-non-en": true,
 		"signup/starting-point-courses": true,
 		"signup/seller-upgrade-modal": false,


### PR DESCRIPTION
#### Proposed Changes

This PR adds `signup/goals-step-2` config feature flag which will be used for development of the Goals step - iteration 2.

The flag is set to `false` in all config files by default. We can enable it with `&flags=signup/goals-step-2` URL parameter.

Project thread: pdDOJh-lY-p2

#### Testing Instructions

Nothing to test, the PR only adds the flag with no observable difference.

Related to #64996